### PR TITLE
fix(app-router): preserve active slots across segment-cache refresh

### DIFF
--- a/packages/vinext/src/client/navigation-runtime.ts
+++ b/packages/vinext/src/client/navigation-runtime.ts
@@ -54,6 +54,11 @@ export type NavigationRuntimeFunctions = {
     historyUpdateMode: NavigationRuntimeHistoryUpdateMode,
   ) => Promise<void>;
   navigate?: NavigationRuntimeNavigate;
+  hasVisitedResponseForPrefetch?: (
+    rscUrl: string,
+    interceptionContext: string | null,
+    mountedSlotsHeader: string | null,
+  ) => boolean;
   /**
    * Called at the start of every App Router navigation so the <Link> shim can
    * reset any link that is still showing a `useLinkStatus()` pending state but
@@ -115,6 +120,7 @@ function isNavigationRuntimeFunctions(value: unknown): value is NavigationRuntim
     isOptionalRuntimeFunction(Reflect.get(value, "commitHashNavigation")) &&
     isOptionalRuntimeFunction(Reflect.get(value, "navigateExternal")) &&
     isOptionalRuntimeFunction(Reflect.get(value, "navigate")) &&
+    isOptionalRuntimeFunction(Reflect.get(value, "hasVisitedResponseForPrefetch")) &&
     isOptionalRuntimeFunction(Reflect.get(value, "notifyLinkNavigationStart")) &&
     isOptionalRuntimeFunction(Reflect.get(value, "pingVisibleLinks"))
   );

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -606,6 +606,13 @@ function matchRoute(url) {
   return __routeMatcher.matchRoute(url);
 }
 
+function resolveRouteById(routeId) {
+  const parsed = __AppElementsWire.parseElementKey(routeId);
+  if (parsed?.kind !== "route") return null;
+  const match = matchRoute(parsed.path);
+  return match ? { route: match.route, params: match.params, routePath: parsed.path } : null;
+}
+
 /**
  * Check if a pathname matches any intercepting route.
  * Returns the match info or null.
@@ -633,6 +640,7 @@ async function buildPageElements(route, params, routePath, pageRequest, layoutPa
     basePath: __basePath,
     trailingSlash: __trailingSlash,
     htmlLimitedBots: __htmlLimitedBots,
+    resolveRouteById,
   });
 }
 
@@ -736,6 +744,7 @@ export default createAppRscHandler({
     isRscRequest,
     middlewareContext,
     mountedSlotsHeader,
+    mountedSlotActiveRoutesHeader,
     params,
     pprFallbackCacheShells,
     pprFallbackShell,
@@ -793,6 +802,7 @@ export default createAppRscHandler({
           isRscRequest,
           request,
           mountedSlotsHeader,
+          mountedSlotActiveRoutesHeader,
           renderMode,
           observeMetadataSearchParamsAccess: buildOptions?.observeMetadataSearchParamsAccess === true,
           observePageSearchParamsAccess: buildOptions?.observePageSearchParamsAccess === true,
@@ -849,6 +859,7 @@ export default createAppRscHandler({
       },
       middlewareContext,
       mountedSlotsHeader,
+      mountedSlotActiveRoutesHeader,
       params,
       pprFallbackCacheShells,
       pprFallbackShell,
@@ -1040,6 +1051,7 @@ export default createAppRscHandler({
     isRscRequest,
     middlewareContext,
     mountedSlotsHeader,
+    mountedSlotActiveRoutesHeader,
     request,
     searchParams,
   }) {
@@ -1068,6 +1080,7 @@ export default createAppRscHandler({
         isRscRequest: actionIsRscRequest,
         request: actionRequest,
         mountedSlotsHeader: actionMountedSlotsHeader,
+        mountedSlotActiveRoutesHeader: actionMountedSlotActiveRoutesHeader,
         renderMode: actionRenderMode,
         observeMetadataSearchParamsAccess,
         observePageSearchParamsAccess,
@@ -1078,6 +1091,7 @@ export default createAppRscHandler({
           isRscRequest: actionIsRscRequest,
           request: actionRequest,
           mountedSlotsHeader: actionMountedSlotsHeader,
+          mountedSlotActiveRoutesHeader: actionMountedSlotActiveRoutesHeader,
           renderMode: actionRenderMode,
           observeMetadataSearchParamsAccess: observeMetadataSearchParamsAccess === true,
           observePageSearchParamsAccess: observePageSearchParamsAccess === true,
@@ -1128,6 +1142,7 @@ export default createAppRscHandler({
       middlewareHeaders: middlewareContext.headers,
       middlewareStatus: middlewareContext.status,
       mountedSlotsHeader,
+      mountedSlotActiveRoutesHeader,
       readBodyWithLimit: __readBodyWithLimit,
       readFormDataWithLimit: __readFormDataWithLimit,
       renderToReadableStream,

--- a/packages/vinext/src/server/app-browser-action-result.ts
+++ b/packages/vinext/src/server/app-browser-action-result.ts
@@ -39,8 +39,11 @@ export function shouldClearClientNavigationCachesForServerActionResult<TRoot>(
   result: AppBrowserServerActionResult<TRoot> | TRoot,
   revalidation: ServerActionRevalidationKind = "none",
 ): boolean {
-  if (revalidation !== "none") {
+  if (revalidation === "staticAndDynamic") {
     return true;
+  }
+  if (revalidation === "dynamicOnly") {
+    return false;
   }
 
   if (!isServerActionResult<TRoot>(result)) {

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -45,6 +45,7 @@ import {
   saveScrollPosition,
   setClientParams,
   setPendingPathname,
+  setMountedSlotActiveRoutesHeader,
   setMountedSlotsHeader,
   setNavigationContext,
   useRouter,
@@ -106,11 +107,14 @@ import {
   type AppElements,
   type AppWireElements,
 } from "./app-elements.js";
+import { createMountedSlotActiveRoutesHeader } from "./app-mounted-slot-active-routes-header.js";
 import {
   COMMITTED_CACHE_APP_NAVIGATION_PAYLOAD_ORIGIN,
   FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
+  PREFETCH_CACHE_APP_NAVIGATION_PAYLOAD_ORIGIN,
   VISITED_CACHE_APP_NAVIGATION_PAYLOAD_ORIGIN,
   createBfcacheSegmentStateKeyMap,
+  createCommittedNavigationSnapshotElements,
   createInitialBfcacheIdMap,
   isCacheRestorableAppPayloadMetadata,
   isCompleteAppPayloadMetadata,
@@ -125,6 +129,7 @@ import { AppBrowserHistoryController } from "./app-browser-history-controller.js
 import {
   createVisitedResponseCacheEntry,
   isVisitedResponseCacheEntryFresh,
+  VISITED_RESPONSE_CACHE_TTL,
   type VisitedResponseCacheEntry,
 } from "./app-visited-response-cache.js";
 import {
@@ -730,8 +735,46 @@ function applyVisitedResponseCacheCandidateDecision(
   return null;
 }
 
+function hasVisitedResponseForPrefetch(
+  rscUrl: string,
+  interceptionContext: string | null,
+  mountedSlotsHeader: string | null,
+): boolean {
+  const candidate = readVisitedResponseCacheCandidate(
+    rscUrl,
+    interceptionContext,
+    mountedSlotsHeader,
+    "navigate",
+  );
+  return navigationPlanner.classifyVisitedResponseCacheCandidate(candidate.facts).kind === "reuse";
+}
+
 function deleteVisitedResponse(rscUrl: string, interceptionContext: string | null): void {
   visitedResponseCache.delete(AppElementsWire.encodeCacheKey(rscUrl, interceptionContext));
+}
+
+function hasObservedDynamicRenderWork(metadata: ReturnType<typeof AppElementsWire.readMetadata>) {
+  const observation = metadata.renderObservation;
+  return (
+    observation !== undefined &&
+    (observation.dynamicFetches.length > 0 ||
+      observation.requestApis.some((requestApi) => requestApi.status === "observed"))
+  );
+}
+
+function getCommittedVisitedResponseFallbackTtlMs(
+  metadata: ReturnType<typeof AppElementsWire.readMetadata>,
+): number {
+  if (isCacheRestorableAppPayloadMetadata(metadata)) {
+    return PREFETCH_CACHE_TTL;
+  }
+  if (metadata.renderObservation !== undefined && !hasObservedDynamicRenderWork(metadata)) {
+    return VISITED_RESPONSE_CACHE_TTL;
+  }
+  if (metadata.skippedLayoutIds.length > 0 && !hasObservedDynamicRenderWork(metadata)) {
+    return VISITED_RESPONSE_CACHE_TTL;
+  }
+  return DYNAMIC_NAVIGATION_CACHE_TTL;
 }
 
 function storeVisitedResponseSnapshot(
@@ -742,6 +785,7 @@ function storeVisitedResponseSnapshot(
   prefetchFallbackTtlMs: number = DYNAMIC_NAVIGATION_CACHE_TTL,
   requestMountedSlotsHeader: string | null = snapshot.mountedSlotsHeader ?? null,
   elements?: AppElements,
+  seedPrefetchCache: boolean = true,
 ): () => void {
   const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
   visitedResponseCache.delete(cacheKey);
@@ -756,18 +800,22 @@ function storeVisitedResponseSnapshot(
     response: snapshot,
   });
   visitedResponseCache.set(cacheKey, entry);
-  seedPrefetchResponseSnapshot(
-    rscUrl,
-    snapshot,
-    interceptionContext,
-    requestMountedSlotsHeader,
-    prefetchFallbackTtlMs,
-  );
+  if (seedPrefetchCache) {
+    seedPrefetchResponseSnapshot(
+      rscUrl,
+      snapshot,
+      interceptionContext,
+      requestMountedSlotsHeader,
+      prefetchFallbackTtlMs,
+    );
+  }
   return () => {
     if (visitedResponseCache.get(cacheKey) === entry) {
       visitedResponseCache.delete(cacheKey);
     }
-    deletePrefetchResponseSnapshot(rscUrl, snapshot, interceptionContext);
+    if (seedPrefetchCache) {
+      deletePrefetchResponseSnapshot(rscUrl, snapshot, interceptionContext);
+    }
   };
 }
 
@@ -1044,6 +1092,7 @@ function BrowserRoot({
       hydrationCachePublication.invalidate();
       registerNavigationRuntimeFunctions({ navigateExternal: undefined });
       detach();
+      setMountedSlotActiveRoutesHeader(null);
       setMountedSlotsHeader(null);
     };
   }, [hydrationCachePublication, setTreeStateValue]);
@@ -1074,13 +1123,18 @@ function BrowserRoot({
 
   useEffect(() => {
     setWindowNextInternalSourcePage(AppElementsWire.readMetadata(treeState.elements).sourcePage);
-  }, [treeState.elements]);
+  }, [treeState.elements, treeState.skipVisibleLinkPrefetchPing]);
 
   useLayoutEffect(() => {
+    setMountedSlotActiveRoutesHeader(
+      createMountedSlotActiveRoutesHeader(stateRef.current.slotBindings),
+    );
     setMountedSlotsHeader(getMountedSlotIdsHeader(stateRef.current.elements));
     removeStylesheetLinksCoveredByInlineCss();
-    getNavigationRuntime()?.functions.pingVisibleLinks?.();
-  }, [treeState.elements]);
+    if (!treeState.skipVisibleLinkPrefetchPing) {
+      getNavigationRuntime()?.functions.pingVisibleLinks?.();
+    }
+  }, [treeState.elements, treeState.skipVisibleLinkPrefetchPing]);
 
   useLayoutEffect(() => {
     if (treeState.renderId !== 0) {
@@ -1506,24 +1560,18 @@ function bootstrapHydration(
           : DYNAMIC_NAVIGATION_CACHE_TTL;
       hydrationCachePublication.publish(() => {
         if (cacheGeneration !== clientNavigationCacheGeneration) return () => {};
-        if (isCacheRestorableAppPayloadMetadata(metadata)) {
-          return storeVisitedResponseSnapshot(
-            rscUrl,
-            metadata.interceptionContext,
-            snapshot,
-            initialParams,
-            fallbackTtlMs,
-            mountedSlotsHeader,
-          );
-        }
-        seedPrefetchResponseSnapshot(
+        // Initial hydration seeds the visited/BFCache path, not Link's
+        // prefetch cache; a later visible Link should still prefetch.
+        return storeVisitedResponseSnapshot(
           rscUrl,
-          snapshot,
           metadata.interceptionContext,
-          mountedSlotsHeader,
+          snapshot,
+          initialParams,
           fallbackTtlMs,
+          mountedSlotsHeader,
+          undefined,
+          false,
         );
-        return () => deletePrefetchResponseSnapshot(rscUrl, snapshot, metadata.interceptionContext);
       });
     })
     .catch(() => {});
@@ -1695,6 +1743,10 @@ function bootstrapHydration(
         const routerStateAtNavStart = getBrowserRouterState();
         const elementsAtNavStart = routerStateAtNavStart.elements;
         const mountedSlotsHeader = getMountedSlotIdsHeader(elementsAtNavStart);
+        const mountedSlotActiveRoutesHeader =
+          navigationKind === "refresh" || navigationKind === "navigate"
+            ? createMountedSlotActiveRoutesHeader(routerStateAtNavStart.slotBindings)
+            : null;
         // Next.js refetches page segments for same-page search changes even
         // when a visible Link prefetched the target. Search params are a page
         // input, so a cached full-route payload is not authoritative here.
@@ -1726,6 +1778,7 @@ function bootstrapHydration(
         // pure waste on the cache-hit soft-nav path.
         const requestHeaders = createRscRequestHeaders({
           interceptionContext: requestInterceptionContext,
+          mountedSlotActiveRoutesHeader,
           mountedSlotsHeader,
           renderMode:
             navigationKind === "refresh" ? APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI : undefined,
@@ -1874,6 +1927,7 @@ function bootstrapHydration(
         let navResponse: Response | undefined;
         let navResponseExpiresAt: number | undefined;
         let navResponseUrl: string | null = null;
+        let didConsumePrefetchResponse = false;
         let fallbackReuseDecision = reuseDecision;
         if (reuseDecision.kind === "consumePrefetch") {
           const prefetchedResponse = await consumePrefetchResponseForNavigation(
@@ -1886,6 +1940,7 @@ function bootstrapHydration(
           );
           if (!browserNavigationController.isCurrentNavigation(navId)) return;
           if (prefetchedResponse) {
+            didConsumePrefetchResponse = true;
             navResponse = restoreRscResponse(prefetchedResponse, false);
             navResponseExpiresAt = prefetchedResponse.expiresAt;
             navResponseUrl = prefetchedResponse.url;
@@ -2095,7 +2150,9 @@ function bootstrapHydration(
           navParams,
           requestPreviousNextUrl,
           detachedNavigationCommits ? null : pendingRouterState,
-          FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
+          didConsumePrefetchResponse
+            ? PREFETCH_CACHE_APP_NAVIGATION_PAYLOAD_ORIGIN
+            : FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
           toActionType(navigationKind),
           toOperationLane(navigationKind),
           activeTraversalIntent,
@@ -2136,7 +2193,7 @@ function bootstrapHydration(
           );
           const { dynamicStaleTimeSeconds: _staticDynamicStaleTime, ...staticResponseSnapshot } =
             responseSnapshot;
-          const snapshot = {
+          const snapshot: CachedRscResponse = {
             ...(isCacheRestorableAppPayloadMetadata(metadata)
               ? staticResponseSnapshot
               : {
@@ -2156,35 +2213,24 @@ function bootstrapHydration(
             requestInterceptionContext,
             metadata.interceptionContext,
           );
-          if (isCacheRestorableAppPayloadMetadata(metadata)) {
-            if (navigationCacheGeneration !== clientNavigationCacheGeneration) return;
-            storeVisitedResponseSnapshot(
-              rscUrl,
-              interceptionContext,
-              snapshot,
-              navParams,
-              PREFETCH_CACHE_TTL,
-              mountedSlotsHeader,
-            );
-          } else if (
-            committedState !== null &&
-            getMountedSlotIdsHeader((committedState as AppRouterState).elements) === null
-          ) {
+          if (committedState !== null) {
             const state = committedState as AppRouterState;
-            const committedElements = {
-              ...state.elements,
-              [AppElementsWire.keys.layoutFlags]: state.layoutFlags,
-              [AppElementsWire.keys.layoutIds]: state.layoutIds,
-              [AppElementsWire.keys.skippedLayoutIds]: [],
-              [AppElementsWire.keys.slotBindings]: state.slotBindings,
-            } satisfies AppElements;
+            const {
+              dynamicStaleTimeSeconds: _committedDynamicStaleTime,
+              expiresAt: _committedExpiresAt,
+              ...committedResponseSnapshot
+            } = snapshot;
+            const committedElements = createCommittedNavigationSnapshotElements({
+              renderedElements,
+              state,
+            });
             if (navigationCacheGeneration !== clientNavigationCacheGeneration) return;
             storeVisitedResponseSnapshot(
               rscUrl,
               interceptionContext,
-              snapshot,
+              committedResponseSnapshot,
               navParams,
-              DYNAMIC_NAVIGATION_CACHE_TTL,
+              getCommittedVisitedResponseFallbackTtlMs(metadata),
               mountedSlotsHeader,
               committedElements,
             );
@@ -2237,6 +2283,7 @@ function bootstrapHydration(
     clearNavigationCaches: clearClientNavigationCaches,
     commitHashNavigation: (href, historyUpdateMode, scroll) =>
       historyController.commitHashOnlyNavigation(href, historyUpdateMode, scroll),
+    hasVisitedResponseForPrefetch,
     navigate: navigateRsc,
   });
 

--- a/packages/vinext/src/server/app-browser-server-action-client.ts
+++ b/packages/vinext/src/server/app-browser-server-action-client.ts
@@ -139,6 +139,7 @@ export async function invokeClientServerAction(
     basePath: deps.basePath,
     elements: actionInitiation.routerState.elements,
     previousNextUrl: actionInitiation.routerState.previousNextUrl,
+    slotBindings: actionInitiation.routerState.slotBindings,
   }).headers;
   const fetchResponse = await fetch(createServerActionRequestUrl(actionInitiation.path), {
     method: "POST",
@@ -177,7 +178,7 @@ export async function invokeClientServerAction(
   }
 
   const revalidation = parseServerActionRevalidationHeader(fetchResponse.headers);
-  if (revalidation !== "none") deps.clearClientNavigationCaches();
+  if (revalidation === "staticAndDynamic") deps.clearClientNavigationCaches();
   const invalidResponseError = await readInvalidServerActionResponseError(
     fetchResponse.clone(),
     actionRedirectTarget !== null,

--- a/packages/vinext/src/server/app-browser-state.ts
+++ b/packages/vinext/src/server/app-browser-state.ts
@@ -14,8 +14,10 @@ import {
   NEXT_ACTION_HEADER,
   RSC_ACTION_HEADER,
   VINEXT_INTERCEPTION_CONTEXT_HEADER,
+  VINEXT_MOUNTED_SLOT_ACTIVE_ROUTES_HEADER,
   VINEXT_MOUNTED_SLOTS_HEADER,
 } from "./headers.js";
+import { createMountedSlotActiveRoutesHeader } from "./app-mounted-slot-active-routes-header.js";
 import {
   NavigationTraceReasonCodes,
   createNavigationLifecycleTraceFields,
@@ -97,6 +99,7 @@ export type AppRouterState = {
   navigationSnapshot: ClientNavigationRenderSnapshot;
   rootLayoutTreePath: string | null;
   routeId: string;
+  skipVisibleLinkPrefetchPing?: boolean;
   slotBindings: readonly AppElementsSlotBinding[];
   visibleCommitVersion: number;
 };
@@ -116,6 +119,7 @@ export type AppRouterAction = {
   rootLayoutTreePath: string | null;
   reuseCurrentBfcacheIds: boolean;
   routeId: string;
+  skipVisibleLinkPrefetchPing?: boolean;
   skippedLayoutIds: readonly string[];
   slotBindings: readonly AppElementsSlotBinding[];
   type: "navigate" | "replace" | "traverse";
@@ -134,7 +138,10 @@ export type PendingNavigationCommit = {
 };
 
 export type AppNavigationPayloadOrigin = Readonly<
-  { origin: "committed-cache" } | { origin: "fresh" } | { origin: "visited-cache" }
+  | { origin: "committed-cache" }
+  | { origin: "fresh" }
+  | { origin: "prefetch-cache" }
+  | { origin: "visited-cache" }
 >;
 
 export const COMMITTED_CACHE_APP_NAVIGATION_PAYLOAD_ORIGIN: AppNavigationPayloadOrigin = {
@@ -143,6 +150,9 @@ export const COMMITTED_CACHE_APP_NAVIGATION_PAYLOAD_ORIGIN: AppNavigationPayload
 
 export const FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN: AppNavigationPayloadOrigin = {
   origin: "fresh",
+};
+export const PREFETCH_CACHE_APP_NAVIGATION_PAYLOAD_ORIGIN: AppNavigationPayloadOrigin = {
+  origin: "prefetch-cache",
 };
 export const VISITED_CACHE_APP_NAVIGATION_PAYLOAD_ORIGIN: AppNavigationPayloadOrigin = {
   origin: "visited-cache",
@@ -203,6 +213,7 @@ function requiresCacheEntryReuseProof(origin: AppNavigationPayloadOrigin): boole
   switch (origin.origin) {
     case "committed-cache":
     case "fresh":
+    case "prefetch-cache":
       return false;
     case "visited-cache":
       return true;
@@ -250,6 +261,7 @@ type ResolveServerActionRequestStateOptions = {
   basePath: string;
   elements: AppElements;
   previousNextUrl: string | null;
+  slotBindings?: readonly AppElementsSlotBinding[];
 };
 
 type ResolveServerActionRequestStateResult = {
@@ -287,7 +299,35 @@ export function resolveServerActionRequestState(
     headers.set(VINEXT_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
   }
 
+  const mountedSlotActiveRoutesHeader = createMountedSlotActiveRoutesHeader(
+    options.slotBindings ?? [],
+  );
+  if (mountedSlotActiveRoutesHeader !== null) {
+    headers.set(VINEXT_MOUNTED_SLOT_ACTIVE_ROUTES_HEADER, mountedSlotActiveRoutesHeader);
+  }
+
   return { headers };
+}
+
+export function createCommittedNavigationSnapshotElements(options: {
+  renderedElements: AppElements;
+  state: AppRouterState;
+}): AppElements {
+  const elements: Record<string, AppElements[keyof AppElements]> = {
+    ...options.state.elements,
+    [AppElementsWire.keys.layoutFlags]: options.state.layoutFlags,
+    [AppElementsWire.keys.layoutIds]: options.state.layoutIds,
+    [AppElementsWire.keys.skippedLayoutIds]: [],
+    [AppElementsWire.keys.slotBindings]: options.state.slotBindings,
+  };
+
+  for (const binding of options.state.slotBindings) {
+    if (binding.state !== "active" || !binding.activeRouteId) continue;
+    if (Object.hasOwn(options.renderedElements, binding.slotId)) continue;
+    delete elements[binding.slotId];
+  }
+
+  return elements;
 }
 
 export function resolvePendingNavigationCommitDispositionDecision(options: {
@@ -363,9 +403,14 @@ export function resolvePendingNavigationCommitDispositionDecision(options: {
     }),
   );
 
-  return mergeSkippedLayoutPreservation({
+  const withSkippedLayoutPreservation = mergeSkippedLayoutPreservation({
     currentState: options.currentState,
     decision,
+    pending: options.pending,
+  });
+  return mergeOmittedActiveSlotPreservation({
+    currentState: options.currentState,
+    decision: withSkippedLayoutPreservation,
     pending: options.pending,
   });
 }
@@ -632,6 +677,51 @@ function mergeSkippedLayoutSlotPreservation(options: {
   return preservePreviousSlotIds;
 }
 
+function mergeOmittedActiveSlotPreservation(options: {
+  currentState: AppRouterState;
+  decision: PendingNavigationCommitDispositionDecision;
+  pending: PendingNavigationCommit;
+}): PendingNavigationCommitDispositionDecision {
+  if (options.decision.disposition !== "dispatch") return options.decision;
+  if (options.pending.action.operation.lane === "refresh") return options.decision;
+
+  const currentBindingsBySlotId = new Map<string, AppElementsSlotBinding>();
+  for (const binding of options.currentState.slotBindings) {
+    if (binding.state !== "active" || !binding.activeRouteId) continue;
+    currentBindingsBySlotId.set(binding.slotId, binding);
+  }
+  if (currentBindingsBySlotId.size === 0) return options.decision;
+
+  const preservePreviousSlotIds = [...options.decision.preservePreviousSlotIds];
+  const seenSlotIds = new Set(preservePreviousSlotIds);
+  for (const binding of options.pending.action.slotBindings) {
+    if (binding.state !== "active" || !binding.activeRouteId) continue;
+    if (Object.hasOwn(options.pending.action.elements, binding.slotId)) continue;
+    if (!Object.hasOwn(options.currentState.elements, binding.slotId)) continue;
+
+    const currentBinding = currentBindingsBySlotId.get(binding.slotId);
+    if (
+      currentBinding?.activeRouteId !== binding.activeRouteId ||
+      currentBinding.ownerLayoutId !== binding.ownerLayoutId
+    ) {
+      continue;
+    }
+    if (seenSlotIds.has(binding.slotId)) continue;
+
+    preservePreviousSlotIds.push(binding.slotId);
+    seenSlotIds.add(binding.slotId);
+  }
+
+  if (preservePreviousSlotIds.length === options.decision.preservePreviousSlotIds.length) {
+    return options.decision;
+  }
+
+  return {
+    ...options.decision,
+    preservePreviousSlotIds,
+  };
+}
+
 export async function createPendingNavigationCommit(options: {
   currentState: AppRouterState;
   navigationCommitKind?: "authoritative" | "detached";
@@ -692,6 +782,7 @@ export async function createPendingNavigationCommit(options: {
       rootLayoutTreePath: metadata.rootLayoutTreePath,
       reuseCurrentBfcacheIds: options.reuseCurrentBfcacheIds ?? true,
       routeId: metadata.routeId,
+      ...(options.payloadOrigin.origin === "fresh" ? {} : { skipVisibleLinkPrefetchPing: true }),
       skippedLayoutIds: metadata.skippedLayoutIds,
       type: options.type,
     },

--- a/packages/vinext/src/server/app-browser-visible-commit.ts
+++ b/packages/vinext/src/server/app-browser-visible-commit.ts
@@ -164,14 +164,16 @@ function reduceApprovedVisibleCommitState(
             })
           : [];
       const preservedSlotOwnerElementIdSet = new Set(bfcacheCompatiblePreserveElementIds);
+      const targetLayoutIdSet = new Set(action.layoutIds);
       const preservePreviousSlotIds = action.reuseCurrentBfcacheIds
         ? commit.decision.preservePreviousSlotIds.filter((slotId) => {
             const targetBinding = action.slotBindings.find((binding) => binding.slotId === slotId);
-            return (
-              targetBinding?.ownerLayoutId !== null &&
-              targetBinding?.ownerLayoutId !== undefined &&
-              preservedSlotOwnerElementIdSet.has(targetBinding.ownerLayoutId)
-            );
+            const ownerLayoutId = targetBinding?.ownerLayoutId;
+            if (ownerLayoutId === null || ownerLayoutId === undefined) return false;
+            if (action.operation.lane === "hmr") {
+              return preservedSlotOwnerElementIdSet.has(ownerLayoutId);
+            }
+            return action.operation.lane !== "refresh" && targetLayoutIdSet.has(ownerLayoutId);
           })
         : [];
       const hmrPreservedSlotOwnerLayoutIds =
@@ -223,6 +225,7 @@ function reduceApprovedVisibleCommitState(
           renderId: action.renderId,
           rootLayoutTreePath: action.rootLayoutTreePath,
           routeId: action.routeId,
+          ...(action.skipVisibleLinkPrefetchPing ? { skipVisibleLinkPrefetchPing: true } : {}),
           slotBindings: mergeSlotBindings(
             state.slotBindings,
             action.slotBindings,

--- a/packages/vinext/src/server/app-elements-wire.ts
+++ b/packages/vinext/src/server/app-elements-wire.ts
@@ -198,6 +198,7 @@ type AppElementsMetadata = {
   interceptionContext: string | null;
   layoutIds: readonly string[];
   layoutFlags: LayoutFlags;
+  renderObservation?: RenderObservation;
   routeId: string;
   rootLayoutTreePath: string | null;
   skippedLayoutIds: readonly string[];
@@ -845,6 +846,7 @@ export function readAppElementsMetadata(
     dynamicStaleTime >= 0
       ? dynamicStaleTime
       : undefined;
+  const renderObservation = elements[APP_RENDER_OBSERVATION_KEY];
   const sourcePage = readSourcePageMetadata(elements[APP_SOURCE_PAGE_KEY]);
 
   return {
@@ -855,6 +857,9 @@ export function readAppElementsMetadata(
     interceptionContext: interceptionContext ?? null,
     layoutIds,
     layoutFlags,
+    ...(renderObservation && typeof renderObservation === "object"
+      ? { renderObservation: renderObservation as RenderObservation }
+      : {}),
     routeId,
     rootLayoutTreePath,
     skippedLayoutIds,

--- a/packages/vinext/src/server/app-elements-wire.ts
+++ b/packages/vinext/src/server/app-elements-wire.ts
@@ -803,6 +803,27 @@ function parseCacheEntryReuseProofMetadata(value: unknown): CacheEntryReuseProof
   return createMissingCacheEntryReuseProof();
 }
 
+function parseRenderObservationMetadata(value: unknown): RenderObservation | undefined {
+  if (value === undefined) return undefined;
+  if (!isUnknownRecord(value)) return undefined;
+  if (
+    typeof value.schemaVersion !== "number" ||
+    !isUnknownRecord(value.output) ||
+    typeof value.completeness !== "string" ||
+    !isUnknownRecord(value.boundaryOutcome) ||
+    !Array.isArray(value.requestApis) ||
+    !Array.isArray(value.dynamicFetches) ||
+    !Array.isArray(value.cacheTags) ||
+    !Array.isArray(value.pathTags) ||
+    typeof value.cacheability !== "string" ||
+    !isUnknownRecord(value.downgrade)
+  ) {
+    return undefined;
+  }
+
+  return value as RenderObservation;
+}
+
 export function readAppElementsMetadata(
   elements: Readonly<Record<string, unknown>>,
 ): AppElementsMetadata {
@@ -846,7 +867,7 @@ export function readAppElementsMetadata(
     dynamicStaleTime >= 0
       ? dynamicStaleTime
       : undefined;
-  const renderObservation = elements[APP_RENDER_OBSERVATION_KEY];
+  const renderObservation = parseRenderObservationMetadata(elements[APP_RENDER_OBSERVATION_KEY]);
   const sourcePage = readSourcePageMetadata(elements[APP_SOURCE_PAGE_KEY]);
 
   return {
@@ -857,9 +878,7 @@ export function readAppElementsMetadata(
     interceptionContext: interceptionContext ?? null,
     layoutIds,
     layoutFlags,
-    ...(renderObservation && typeof renderObservation === "object"
-      ? { renderObservation: renderObservation as RenderObservation }
-      : {}),
+    ...(renderObservation ? { renderObservation } : {}),
     routeId,
     rootLayoutTreePath,
     skippedLayoutIds,

--- a/packages/vinext/src/server/app-mounted-slot-active-routes-header.ts
+++ b/packages/vinext/src/server/app-mounted-slot-active-routes-header.ts
@@ -1,0 +1,85 @@
+/**
+ * Normalize the active-route side channel for mounted App Router slots.
+ *
+ * The browser sends this only for refresh/action rerender requests where the
+ * server must refresh a preserved parallel slot that is not part of the target
+ * route. The wire format is space-separated, URL-encoded `slotId=routeId`
+ * pairs sorted by slot id.
+ */
+
+import { AppElementsWire, type AppElementsSlotBinding } from "./app-elements-wire.js";
+
+const MAX_RAW_HEADER_LENGTH = 4096;
+const MAX_PAIR_LENGTH = 512;
+const MAX_SLOT_TOKENS = 16;
+
+function isRouteId(value: string): boolean {
+  return AppElementsWire.parseElementKey(value)?.kind === "route";
+}
+
+function decodePairToken(token: string): readonly [string, string] | null {
+  if (!token || token.length > MAX_PAIR_LENGTH) return null;
+  const separator = token.indexOf("=");
+  if (separator <= 0 || separator === token.length - 1) return null;
+
+  try {
+    const slotId = decodeURIComponent(token.slice(0, separator));
+    const routeId = decodeURIComponent(token.slice(separator + 1));
+    if (!AppElementsWire.isSlotId(slotId) || !isRouteId(routeId)) return null;
+    return [slotId, routeId];
+  } catch {
+    return null;
+  }
+}
+
+function encodePair(slotId: string, routeId: string): string {
+  return `${encodeURIComponent(slotId)}=${encodeURIComponent(routeId)}`;
+}
+
+export function normalizeMountedSlotActiveRoutesHeader(
+  raw: string | null | undefined,
+): string | null {
+  if (!raw) return null;
+  if (raw.length > MAX_RAW_HEADER_LENGTH) return null;
+
+  const pairs = new Map<string, string>();
+  for (const token of raw.split(/\s+/)) {
+    const pair = decodePairToken(token);
+    if (pair === null) continue;
+    pairs.set(pair[0], pair[1]);
+  }
+  if (pairs.size === 0) return null;
+
+  const normalized = Array.from(pairs.entries())
+    .sort(([left], [right]) => left.localeCompare(right))
+    .slice(0, MAX_SLOT_TOKENS)
+    .map(([slotId, routeId]) => encodePair(slotId, routeId))
+    .join(" ");
+  return normalized || null;
+}
+
+export function parseMountedSlotActiveRoutesHeader(
+  raw: string | null | undefined,
+): ReadonlyMap<string, string> | null {
+  const normalized = normalizeMountedSlotActiveRoutesHeader(raw);
+  if (normalized === null) return null;
+
+  const pairs = new Map<string, string>();
+  for (const token of normalized.split(" ")) {
+    const pair = decodePairToken(token);
+    if (pair !== null) pairs.set(pair[0], pair[1]);
+  }
+  return pairs.size > 0 ? pairs : null;
+}
+
+export function createMountedSlotActiveRoutesHeader(
+  slotBindings: readonly AppElementsSlotBinding[],
+): string | null {
+  const pairs: string[] = [];
+  for (const binding of slotBindings) {
+    if (binding.state !== "active" || !binding.activeRouteId) continue;
+    if (!AppElementsWire.isSlotId(binding.slotId) || !isRouteId(binding.activeRouteId)) continue;
+    pairs.push(encodePair(binding.slotId, binding.activeRouteId));
+  }
+  return normalizeMountedSlotActiveRoutesHeader(pairs.join(" "));
+}

--- a/packages/vinext/src/server/app-page-cache-finalizer.ts
+++ b/packages/vinext/src/server/app-page-cache-finalizer.ts
@@ -24,6 +24,7 @@ type AppPageRscCacheKeyBuilder = (
   mountedSlotsHeader?: string | null,
   renderMode?: AppRscRenderMode,
   interceptionContext?: string | null,
+  mountedSlotActiveRoutesHeader?: string | null,
 ) => string;
 type AppPageRequestCacheLife = {
   revalidate?: number;
@@ -69,6 +70,7 @@ type ScheduleAppPageRscCacheWriteOptions = {
   isrRscKey: AppPageRscCacheKeyBuilder;
   isrSet: AppPageCacheSetter;
   interceptionContext?: string | null;
+  mountedSlotActiveRoutesHeader?: string | null;
   mountedSlotsHeader?: string | null;
   renderMode?: AppRscRenderMode;
   preserveClientResponseHeaders?: boolean;
@@ -257,6 +259,7 @@ export function scheduleAppPageRscCacheWrite(
     options.mountedSlotsHeader,
     options.renderMode,
     options.interceptionContext,
+    options.mountedSlotActiveRoutesHeader,
   );
   const cachePromise = (async () => {
     try {

--- a/packages/vinext/src/server/app-page-cache.ts
+++ b/packages/vinext/src/server/app-page-cache.ts
@@ -36,6 +36,7 @@ type AppPageRscCacheKeyBuilder = (
   mountedSlotsHeader?: string | null,
   renderMode?: AppRscRenderMode,
   interceptionContext?: string | null,
+  mountedSlotActiveRoutesHeader?: string | null,
 ) => string;
 export type AppPageCacheOutcomeMetric = Readonly<{
   artifact: "html" | "rsc";
@@ -92,6 +93,7 @@ type ReadAppPageCacheResponseOptions = {
   hasRequestSearchParams?: boolean;
   middlewareHeaders?: Headers | null;
   middlewareStatus?: number | null;
+  mountedSlotActiveRoutesHeader?: string | null;
   mountedSlotsHeader?: string | null;
   recordCacheOutcome?: AppPageCacheOutcomeRecorder;
   renderMode?: AppRscRenderMode;
@@ -314,6 +316,7 @@ export async function readAppPageCacheResponse(
         options.mountedSlotsHeader,
         options.renderMode,
         options.interceptionContext,
+        options.mountedSlotActiveRoutesHeader,
       )
     : options.isrHtmlKey(options.cleanPathname);
   const artifact = options.isRscRequest ? "rsc" : "html";
@@ -410,6 +413,7 @@ export async function readAppPageCacheResponse(
                   options.mountedSlotsHeader,
                   options.renderMode,
                   options.interceptionContext,
+                  options.mountedSlotActiveRoutesHeader,
                 ),
             buildAppPageCacheValue(
               "",

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -288,6 +288,7 @@ export type DispatchAppPageOptions<TRoute extends AppPageDispatchRoute> = {
     mountedSlotsHeader?: string | null,
     renderMode?: AppRscRenderMode,
     interceptionContext?: string | null,
+    mountedSlotActiveRoutesHeader?: string | null,
   ) => string;
   isrSet: AppPageCacheSetter;
   loadSsrHandler: () => Promise<AppPageSsrHandler>;
@@ -629,6 +630,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
       interceptionContext: options.interceptionContext,
       middlewareHeaders: options.middlewareContext.headers,
       middlewareStatus: options.middlewareContext.status,
+      mountedSlotActiveRoutesHeader: options.mountedSlotActiveRoutesHeader,
       mountedSlotsHeader: options.mountedSlotsHeader,
       renderMode: options.renderMode,
       expireSeconds: options.expireSeconds,
@@ -1067,6 +1069,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
     },
     dynamicStaleTimeSeconds: options.dynamicStaleTimeSeconds,
     revalidateSeconds: currentRevalidateSeconds,
+    mountedSlotActiveRoutesHeader: options.mountedSlotActiveRoutesHeader,
     mountedSlotsHeader: options.mountedSlotsHeader,
     renderMode: options.renderMode ?? APP_RSC_RENDER_MODE_NAVIGATION,
     renderErrorBoundaryResponse(renderError, errorOrigin) {

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -293,6 +293,7 @@ export type DispatchAppPageOptions<TRoute extends AppPageDispatchRoute> = {
   loadSsrHandler: () => Promise<AppPageSsrHandler>;
   middlewareContext: AppPageMiddlewareContext;
   mountedSlotsHeader?: string | null;
+  mountedSlotActiveRoutesHeader?: string | null;
   params: AppPageParams;
   pprFallbackCacheShells?: readonly AppPagePprFallbackCacheShell[] | null;
   pprFallbackShell?: {

--- a/packages/vinext/src/server/app-page-element-builder.ts
+++ b/packages/vinext/src/server/app-page-element-builder.ts
@@ -16,11 +16,17 @@ import {
   type AppPageSlotOverride,
 } from "./app-page-route-wiring.js";
 import { AppElementsWire, type AppElements } from "./app-elements.js";
+import { parseMountedSlotActiveRoutesHeader } from "./app-mounted-slot-active-routes-header.js";
 import type { AppPageParams } from "./app-page-boundary.js";
 import { DEFAULT_GLOBAL_ERROR_MODULE } from "./default-global-error-module.js";
 import { matchRoutePattern } from "../routing/route-pattern.js";
 import type { MetadataFileRoute } from "./metadata-routes.js";
-import { APP_RSC_RENDER_MODE_NAVIGATION, type AppRscRenderMode } from "./app-rsc-render-mode.js";
+import {
+  APP_RSC_RENDER_MODE_ACTION_RERENDER_PRESERVE_UI,
+  APP_RSC_RENDER_MODE_NAVIGATION,
+  APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI,
+  type AppRscRenderMode,
+} from "./app-rsc-render-mode.js";
 import type { AppLayoutParamAccessTracker } from "./app-layout-param-observation.js";
 import { createAppPageRenderIdentity } from "./app-page-render-identity.js";
 import {
@@ -95,6 +101,8 @@ export type AppPagePageRequest<TModule extends AppPageModule = AppPageModule> = 
   request: Request;
   /** Normalized x-vinext-mounted-slots header value. */
   mountedSlotsHeader: string | null;
+  /** Normalized active route ids for mounted slots. */
+  mountedSlotActiveRoutesHeader?: string | null;
   /** Semantic RSC payload mode for this page render. */
   renderMode?: AppRscRenderMode;
   /** Observe page `searchParams` access for cache-safety classification. */
@@ -133,6 +141,11 @@ export type BuildPageElementsOptions<
   trailingSlash?: boolean;
   /** Serialized next.config `htmlLimitedBots` regexp source. */
   htmlLimitedBots?: string;
+  resolveRouteById?: (routeId: string) => {
+    params: AppPageParams;
+    route: AppPageBuildRoute<TModule, TErrorModule>;
+    routePath: string;
+  } | null;
 };
 
 type AppPageNavigationParamModule = {
@@ -141,13 +154,19 @@ type AppPageNavigationParamModule = {
 
 type AppPageNavigationParamSlot = {
   default?: AppPageNavigationParamModule | null;
+  id?: string | null;
+  layoutIndex?: number | null;
+  name?: string | null;
   page?: AppPageNavigationParamModule | null;
+  routeSegments?: readonly string[] | null;
   slotPatternParts?: readonly string[] | null;
   slotParamNames?: readonly string[] | null;
 };
 
 type AppPageNavigationParamRoute = {
+  layoutTreePositions?: readonly number[] | null;
   params?: readonly string[] | null;
+  routeSegments?: readonly string[] | null;
   slots?: Readonly<Record<string, AppPageNavigationParamSlot>> | null;
 };
 
@@ -195,6 +214,7 @@ export async function buildPageElements<
     searchParams,
     isRscRequest,
     mountedSlotsHeader,
+    mountedSlotActiveRoutesHeader,
     renderMode = APP_RSC_RENDER_MODE_NAVIGATION,
     observeMetadataSearchParamsAccess = false,
     observePageSearchParamsAccess = false,
@@ -356,7 +376,16 @@ export async function buildPageElements<
 
   const mountedSlotIds = mountedSlotsHeader ? new Set(mountedSlotsHeader.split(" ")) : null;
 
-  const slotOverrides = buildSlotOverrides(route, params, routePath, opts);
+  const slotOverrides = buildSlotOverrides(
+    route,
+    params,
+    routePath,
+    renderIdentity.routeId,
+    renderMode,
+    opts,
+    mountedSlotActiveRoutesHeader,
+    options.resolveRouteById,
+  );
   const metadataPlacement =
     hasDynamicMetadata &&
     shouldServeStreamingMetadata(
@@ -454,7 +483,15 @@ function buildSlotOverrides<TModule extends AppPageModule, TErrorModule extends 
   route: AppPageBuildRoute<TModule, TErrorModule>,
   routeParams: AppPageParams,
   routePath: string,
+  targetRouteId: string,
+  renderMode: AppRscRenderMode,
   opts?: AppPageInterceptOptions<TModule> | null,
+  mountedSlotActiveRoutesHeader?: string | null,
+  resolveRouteById?: (routeId: string) => {
+    params: AppPageParams;
+    route: AppPageBuildRoute<TModule, TErrorModule>;
+    routePath: string;
+  } | null,
 ): Readonly<Record<string, AppPageSlotOverride<TModule>>> | null {
   const overrides: Record<string, AppPageSlotOverride<TModule>> = {};
 
@@ -483,7 +520,84 @@ function buildSlotOverrides<TModule extends AppPageModule, TErrorModule extends 
     overrides[slotKey] = existing ? { ...existing, params: existing.params ?? params } : { params };
   }
 
+  const activeSlotRoutes = parseMountedSlotActiveRoutesHeader(mountedSlotActiveRoutesHeader);
+  if (activeSlotRoutes !== null) {
+    const shouldRerenderActiveSlots = shouldRerenderActiveMountedSlots(renderMode);
+    for (const [slotKey, slot] of Object.entries(route.slots ?? {})) {
+      const slotId = resolveRouteSlotId(route, slot);
+      const activeRouteId = activeSlotRoutes.get(slotId);
+      if (!activeRouteId) continue;
+
+      if (!shouldRerenderActiveSlots) {
+        const slotHasTargetPage = hasDefaultExport(slot.page);
+        if (activeRouteId === targetRouteId || !slotHasTargetPage) {
+          const existing = overrides[slotKey];
+          overrides[slotKey] = {
+            ...existing,
+            activeRouteId: existing?.activeRouteId ?? activeRouteId,
+            preserveMountedContent: existing?.preserveMountedContent ?? true,
+          };
+        }
+        continue;
+      }
+
+      if (!resolveRouteById) continue;
+      const activeRouteMatch = resolveRouteById(activeRouteId);
+      if (activeRouteMatch === null) continue;
+      const activeSlot = findRouteSlotById(activeRouteMatch.route, slotId);
+      if (!activeSlot?.slot.page) continue;
+
+      const activeSlotParams =
+        resolveSlotParamOverrides(activeRouteMatch.route, activeRouteMatch.routePath)?.[
+          activeSlot.slotKey
+        ] ?? activeRouteMatch.params;
+      const existing = overrides[slotKey];
+      overrides[slotKey] = {
+        ...existing,
+        activeRouteId: existing?.activeRouteId ?? activeRouteId,
+        pageModule: existing?.pageModule ?? activeSlot.slot.page,
+        params: existing?.params ?? activeSlotParams,
+        routeSegments: existing?.routeSegments ?? activeSlot.slot.routeSegments ?? null,
+      };
+    }
+  }
+
   return Object.keys(overrides).length > 0 ? overrides : null;
+}
+
+function shouldRerenderActiveMountedSlots(renderMode: AppRscRenderMode): boolean {
+  return (
+    renderMode === APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI ||
+    renderMode === APP_RSC_RENDER_MODE_ACTION_RERENDER_PRESERVE_UI
+  );
+}
+
+function resolveRouteSlotId(
+  route: AppPageNavigationParamRoute,
+  slot: AppPageNavigationParamSlot & { id?: string | null; layoutIndex?: number | null },
+): string {
+  if (slot.id) return slot.id;
+  const layoutIndex = slot.layoutIndex && slot.layoutIndex >= 0 ? slot.layoutIndex : 0;
+  const treePosition = route.layoutTreePositions?.[layoutIndex] ?? 0;
+  return AppElementsWire.encodeSlotId(
+    slot.name ?? "",
+    createAppPageTreePath(route.routeSegments, treePosition),
+  );
+}
+
+function findRouteSlotById<TModule extends AppPageModule, TErrorModule extends AppPageErrorModule>(
+  route: AppPageBuildRoute<TModule, TErrorModule>,
+  slotId: string,
+): {
+  slot: NonNullable<AppPageBuildRoute<TModule, TErrorModule>["slots"]>[string];
+  slotKey: string;
+} | null {
+  for (const [slotKey, slot] of Object.entries(route.slots ?? {})) {
+    if (resolveRouteSlotId(route, slot) === slotId) {
+      return { slot, slotKey };
+    }
+  }
+  return null;
 }
 
 export function resolveInterceptedSlotSegments(

--- a/packages/vinext/src/server/app-page-element-builder.ts
+++ b/packages/vinext/src/server/app-page-element-builder.ts
@@ -577,8 +577,12 @@ function resolveRouteSlotId(
   slot: AppPageNavigationParamSlot & { id?: string | null; layoutIndex?: number | null },
 ): string {
   if (slot.id) return slot.id;
-  const layoutIndex = slot.layoutIndex && slot.layoutIndex >= 0 ? slot.layoutIndex : 0;
-  const treePosition = route.layoutTreePositions?.[layoutIndex] ?? 0;
+  const layoutPositions = route.layoutTreePositions;
+  const layoutIndex =
+    typeof slot.layoutIndex === "number" && slot.layoutIndex >= 0
+      ? slot.layoutIndex
+      : Math.max((layoutPositions?.length ?? 1) - 1, 0);
+  const treePosition = layoutPositions?.[layoutIndex] ?? layoutPositions?.at(-1) ?? 0;
   return AppElementsWire.encodeSlotId(
     slot.name ?? "",
     createAppPageTreePath(route.routeSegments, treePosition),

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -154,6 +154,7 @@ type RenderAppPageLifecycleOptions = {
     mountedSlotsHeader?: string | null,
     renderMode?: AppRscRenderMode,
     interceptionContext?: string | null,
+    mountedSlotActiveRoutesHeader?: string | null,
   ) => string;
   isrSet: AppPageCacheSetter;
   interceptionContext?: string | null;
@@ -194,6 +195,7 @@ type RenderAppPageLifecycleOptions = {
   scriptNonce?: string;
   clientReuseManifest?: ClientReuseManifestParseResult;
   skipDisposition?: ClientReuseManifestSkipDisposition;
+  mountedSlotActiveRoutesHeader?: string | null;
   mountedSlotsHeader?: string | null;
   renderMode?: AppRscRenderMode;
   waitUntil?: (promise: Promise<void>) => void;
@@ -857,6 +859,7 @@ export async function renderAppPageLifecycle(
       isrRscKey: options.isrRscKey,
       isrSet: options.isrSet,
       interceptionContext: options.interceptionContext,
+      mountedSlotActiveRoutesHeader: options.mountedSlotActiveRoutesHeader,
       mountedSlotsHeader: options.mountedSlotsHeader,
       renderMode: options.renderMode,
       preserveClientResponseHeaders: rscResponsePolicy.cacheState !== "MISS",

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -163,6 +163,7 @@ export type AppPageRouteWiringRoute<
 };
 
 export type AppPageSlotOverride<TModule extends AppPageModule = AppPageModule> = {
+  activeRouteId?: string | null;
   branchSegments?: readonly string[] | null;
   layoutSegments?: readonly (readonly string[])[] | null;
   layoutModules?: readonly (TModule | null | undefined)[] | null;
@@ -173,6 +174,7 @@ export type AppPageSlotOverride<TModule extends AppPageModule = AppPageModule> =
    */
   pageModule?: TModule | null;
   params?: AppPageParams;
+  preserveMountedContent?: boolean;
   props?: Readonly<Record<string, unknown>>;
   routeSegments?: readonly string[] | null;
 };
@@ -473,6 +475,7 @@ function resolveAppPageSlotBindingState(
   slot: AppPageRouteWiringSlot,
   override: AppPageSlotOverride | undefined,
 ): AppElementsSlotBinding["state"] {
+  if (override?.activeRouteId) return "active";
   const pageComponent = getDefaultExport(override?.pageModule) ?? getDefaultExport(slot.page);
   if (pageComponent) return "active";
   if (getDefaultExport(slot.default)) return "default";
@@ -515,9 +518,11 @@ function createAppPageSlotBindings<
     const state = resolveAppPageSlotBindingState(slot, override);
     const activeRouteId =
       state === "active"
-        ? options.interception?.slotId === slotId
-          ? options.interception.targetRouteId
-          : AppElementsWire.encodeRouteId(options.routePath, null)
+        ? override?.activeRouteId !== undefined && override.activeRouteId !== null
+          ? override.activeRouteId
+          : options.interception?.slotId === slotId
+            ? options.interception.targetRouteId
+            : AppElementsWire.encodeRouteId(options.routePath, null)
         : null;
     bindings.push({
       ...(activeRouteId !== null ? { activeRouteId } : {}),
@@ -808,6 +813,14 @@ export function buildAppPageElements<
     const overrideOrPageComponent =
       getDefaultExport(slotOverride?.pageModule) ?? getDefaultExport(slot.page);
     const defaultComponent = getDefaultExport(slot.default);
+
+    if (
+      slotOverride?.preserveMountedContent &&
+      options.isRscRequest &&
+      options.mountedSlotIds?.has(slotId)
+    ) {
+      continue;
+    }
 
     // On soft nav (RSC): omit key when only default.tsx exists and the slot is
     // already mounted on the client. Absent key means the browser retains prior

--- a/packages/vinext/src/server/app-rsc-cache-busting.ts
+++ b/packages/vinext/src/server/app-rsc-cache-busting.ts
@@ -12,6 +12,7 @@ import {
   RSC_HEADER,
   VINEXT_CLIENT_REUSE_MANIFEST_HEADER,
   VINEXT_INTERCEPTION_CONTEXT_HEADER,
+  VINEXT_MOUNTED_SLOT_ACTIVE_ROUTES_HEADER,
   VINEXT_MOUNTED_SLOTS_HEADER,
   VINEXT_RSC_RENDER_MODE_HEADER,
 } from "./headers.js";
@@ -39,6 +40,7 @@ export const VINEXT_RSC_VARY_HEADER = [
   NEXT_URL_HEADER,
   VINEXT_INTERCEPTION_CONTEXT_HEADER,
   VINEXT_MOUNTED_SLOTS_HEADER,
+  VINEXT_MOUNTED_SLOT_ACTIVE_ROUTES_HEADER,
   VINEXT_RSC_RENDER_MODE_HEADER,
 ].join(", ");
 
@@ -48,6 +50,7 @@ const textEncoder = new TextEncoder();
 type CreateRscRequestHeadersOptions = {
   clientReuseManifestHeader?: string | null;
   interceptionContext?: string | null;
+  mountedSlotActiveRoutesHeader?: string | null;
   mountedSlotsHeader?: string | null;
   renderMode?: AppRscRenderMode;
 };
@@ -174,6 +177,7 @@ function createCacheBustingInput(
     headers.get(NEXT_URL_HEADER),
     headers.get(VINEXT_INTERCEPTION_CONTEXT_HEADER),
     headers.get(VINEXT_MOUNTED_SLOTS_HEADER),
+    headers.get(VINEXT_MOUNTED_SLOT_ACTIVE_ROUTES_HEADER),
     ...(options.includeRenderModeHeader === false
       ? []
       : [normalizeRenderModeHeaderValue(headers.get(VINEXT_RSC_RENDER_MODE_HEADER))]),
@@ -288,6 +292,13 @@ export function createRscRequestHeaders(options: CreateRscRequestHeadersOptions 
 
   if (options.mountedSlotsHeader !== undefined && options.mountedSlotsHeader !== null) {
     headers.set(VINEXT_MOUNTED_SLOTS_HEADER, options.mountedSlotsHeader);
+  }
+
+  if (
+    options.mountedSlotActiveRoutesHeader !== undefined &&
+    options.mountedSlotActiveRoutesHeader !== null
+  ) {
+    headers.set(VINEXT_MOUNTED_SLOT_ACTIVE_ROUTES_HEADER, options.mountedSlotActiveRoutesHeader);
   }
 
   if (

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -153,6 +153,7 @@ type DispatchMatchedPageOptions<TRoute> = {
   isRscRequest: boolean;
   middlewareContext: AppRscMiddlewareContext;
   mountedSlotsHeader: string | null;
+  mountedSlotActiveRoutesHeader: string | null;
   params: AppPageParams;
   pprFallbackCacheShells?:
     | readonly {
@@ -232,6 +233,7 @@ type HandleServerActionRequestOptions = {
   isRscRequest: boolean;
   middlewareContext: AppRscMiddlewareContext;
   mountedSlotsHeader: string | null;
+  mountedSlotActiveRoutesHeader: string | null;
   request: Request;
   searchParams: URLSearchParams;
 };
@@ -505,6 +507,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     isRscRequest,
     interceptionContextHeader,
     mountedSlotsHeader,
+    mountedSlotActiveRoutesHeader,
     renderMode,
     clientReuseManifest,
     hadBasePath,
@@ -797,6 +800,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
           isRscRequest,
           middlewareContext,
           mountedSlotsHeader,
+          mountedSlotActiveRoutesHeader,
           request,
           searchParams: getResolvedSearchParams(),
         })
@@ -1057,6 +1061,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     isRscRequest,
     middlewareContext,
     mountedSlotsHeader,
+    mountedSlotActiveRoutesHeader,
     params: renderParams,
     pprFallbackCacheShells: runtimeFallbackShells,
     pprFallbackShell: isPrerenderFallbackShell

--- a/packages/vinext/src/server/app-rsc-request-normalization.ts
+++ b/packages/vinext/src/server/app-rsc-request-normalization.ts
@@ -6,6 +6,7 @@ import {
   RSC_HEADER,
   VINEXT_CLIENT_REUSE_MANIFEST_HEADER,
   VINEXT_INTERCEPTION_CONTEXT_HEADER,
+  VINEXT_MOUNTED_SLOT_ACTIVE_ROUTES_HEADER,
   VINEXT_MOUNTED_SLOTS_HEADER,
   VINEXT_RSC_RENDER_MODE_HEADER,
 } from "./headers.js";
@@ -14,6 +15,7 @@ import {
   type ClientReuseManifestParseResult,
 } from "./client-reuse-manifest.js";
 import { normalizeInterceptionContextHeader } from "./app-interception-context-header.js";
+import { normalizeMountedSlotActiveRoutesHeader } from "./app-mounted-slot-active-routes-header.js";
 import { normalizeMountedSlotsHeader } from "./app-mounted-slots-header.js";
 import { stripRscSuffix, VINEXT_RSC_CACHE_BUSTING_SEARCH_PARAM } from "./app-rsc-cache-busting.js";
 import {
@@ -38,6 +40,8 @@ export type NormalizedRscRequest = {
   interceptionContextHeader: string | null;
   /** Normalized x-vinext-mounted-slots header (deduplicated, sorted). null when absent or blank. */
   mountedSlotsHeader: string | null;
+  /** Normalized active route ids for mounted slots. null when absent or blank. */
+  mountedSlotActiveRoutesHeader: string | null;
   /** Semantic RSC payload mode. HTML requests always normalize to "navigation". */
   renderMode: AppRscRenderMode;
   /** Parsed ClientReuseManifest hint. Verification and skip authorization happen later. */
@@ -137,6 +141,9 @@ export function normalizeRscRequest(
   const mountedSlotsHeader = normalizeMountedSlotsHeader(
     request.headers.get(VINEXT_MOUNTED_SLOTS_HEADER),
   );
+  const mountedSlotActiveRoutesHeader = normalizeMountedSlotActiveRoutesHeader(
+    request.headers.get(VINEXT_MOUNTED_SLOT_ACTIVE_ROUTES_HEADER),
+  );
   const renderMode = isRscRequest
     ? parseAppRscRenderMode(request.headers.get(VINEXT_RSC_RENDER_MODE_HEADER))
     : APP_RSC_RENDER_MODE_NAVIGATION;
@@ -153,6 +160,7 @@ export function normalizeRscRequest(
     isRscRequest,
     interceptionContextHeader,
     mountedSlotsHeader,
+    mountedSlotActiveRoutesHeader,
     renderMode,
   };
 }

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -171,6 +171,7 @@ type BuildServerActionPageElementOptions<TRoute extends AppServerActionRoute, TI
   cleanPathname: string;
   interceptOpts: TInterceptOpts | undefined;
   isRscRequest: boolean;
+  mountedSlotActiveRoutesHeader: string | null;
   mountedSlotsHeader: string | null;
   params: AppPageParams;
   request: Request;
@@ -279,6 +280,7 @@ export type HandleServerActionRscRequestOptions<
   maxActionBodySizeLabel: string;
   middlewareHeaders: Headers | null;
   middlewareStatus: number | null | undefined;
+  mountedSlotActiveRoutesHeader: string | null;
   mountedSlotsHeader: string | null;
   readBodyWithLimit: ReadBodyWithLimit;
   readFormDataWithLimit: ReadFormDataWithLimit;
@@ -378,6 +380,10 @@ function resolveActionRevalidationKind(hasModifiedCookies: boolean): ActionReval
   // this matches the max-precedence semantics in markActionRevalidation.
   if (hasModifiedCookies) return ACTION_DID_REVALIDATE_STATIC_AND_DYNAMIC;
   return revalidationKind;
+}
+
+function resolveActionRerenderRenderMode(): AppRscRenderMode {
+  return APP_RSC_RENDER_MODE_ACTION_RERENDER_PRESERVE_UI;
 }
 
 function clearRejectedActionSideEffects(getAndClearPendingCookies: () => string[]): void {
@@ -1332,6 +1338,7 @@ export async function handleServerActionRscRequest<
               cleanPathname: targetPathname,
               interceptOpts: undefined,
               isRscRequest: true,
+              mountedSlotActiveRoutesHeader: null,
               mountedSlotsHeader: null,
               params: targetMatch.params,
               request: redirectRenderRequest,
@@ -1473,17 +1480,19 @@ export async function handleServerActionRscRequest<
       setCurrentFetchSoftTags(
         buildServerActionPageTags(actionRerenderTarget.route, options.cleanPathname),
       );
+      const actionRerenderRenderMode = resolveActionRerenderRenderMode();
       const buildActionRerenderElement = () =>
         options.buildPageElement({
           cleanPathname: options.cleanPathname,
           interceptOpts: actionRerenderTarget.interceptOpts,
           isRscRequest: options.isRscRequest,
+          mountedSlotActiveRoutesHeader: options.mountedSlotActiveRoutesHeader,
           mountedSlotsHeader: options.mountedSlotsHeader,
           params: actionRerenderTarget.params,
           request: options.request,
           route: actionRerenderTarget.route,
           searchParams: actionRerenderSearchParams,
-          renderMode: APP_RSC_RENDER_MODE_ACTION_RERENDER_PRESERVE_UI,
+          renderMode: actionRerenderRenderMode,
           observeMetadataSearchParamsAccess: actionRerenderDynamicConfig !== "force-static",
           observePageSearchParamsAccess: actionRerenderDynamicConfig !== "force-static",
         });

--- a/packages/vinext/src/server/headers.ts
+++ b/packages/vinext/src/server/headers.ts
@@ -55,6 +55,9 @@ export const VINEXT_PARAMS_HEADER = "X-Vinext-Params";
 /** Deduplicated, sorted list of mounted layout slots for cache keying. */
 export const VINEXT_MOUNTED_SLOTS_HEADER = "X-Vinext-Mounted-Slots";
 
+/** Deduplicated, sorted active route ids for mounted layout slots. */
+export const VINEXT_MOUNTED_SLOT_ACTIVE_ROUTES_HEADER = "X-Vinext-Mounted-Slot-Active-Routes";
+
 /** Per-page dynamic stale time in seconds for App Router RSC responses. */
 export const VINEXT_DYNAMIC_STALE_TIME_HEADER = "X-Vinext-Dynamic-Stale-Time";
 

--- a/packages/vinext/src/server/isr-cache.ts
+++ b/packages/vinext/src/server/isr-cache.ts
@@ -23,6 +23,7 @@ import { getCdnCacheAdapter } from "vinext/shims/cdn-cache";
 import { fnv1a64 } from "../utils/hash.js";
 import { getRequestExecutionContext } from "vinext/shims/request-context";
 import { reportRequestError, type OnRequestErrorContext } from "./instrumentation.js";
+import { normalizeMountedSlotActiveRoutesHeader } from "./app-mounted-slot-active-routes-header.js";
 import { normalizeMountedSlotsHeader } from "./app-mounted-slots-header.js";
 import {
   APP_RSC_RENDER_MODE_NAVIGATION,
@@ -403,8 +404,12 @@ export function appIsrRscKey(
   mountedSlotsHeader?: string | null,
   renderMode: AppRscRenderMode = APP_RSC_RENDER_MODE_NAVIGATION,
   interceptionContext?: string | null,
+  mountedSlotActiveRoutesHeader?: string | null,
 ): string {
   const normalizedMountedSlotsHeader = normalizeMountedSlotsHeader(mountedSlotsHeader);
+  const normalizedMountedSlotActiveRoutesHeader = normalizeMountedSlotActiveRoutesHeader(
+    mountedSlotActiveRoutesHeader,
+  );
   const sourceVariant =
     interceptionContext === undefined || interceptionContext === null
       ? null
@@ -412,6 +417,9 @@ export function appIsrRscKey(
   const variant = [
     sourceVariant ? `source:${fnv1a64(sourceVariant)}` : null,
     normalizedMountedSlotsHeader ? `slots:${fnv1a64(normalizedMountedSlotsHeader)}` : null,
+    normalizedMountedSlotActiveRoutesHeader
+      ? `active:${fnv1a64(normalizedMountedSlotActiveRoutesHeader)}`
+      : null,
     getRscRenderModeCacheVariant(renderMode),
   ]
     .filter((part) => part !== null)

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -11,6 +11,7 @@ import React, {
   forwardRef,
   useRef,
   useEffect,
+  useLayoutEffect,
   useCallback,
   useContext,
   createContext,
@@ -162,6 +163,16 @@ const __basePath: string = process.env.__NEXT_ROUTER_BASEPATH ?? "";
 const __trailingSlash: boolean = process.env.__VINEXT_TRAILING_SLASH === "true";
 const __prefetchInlining: boolean = process.env.__VINEXT_PREFETCH_INLINING === "true";
 const linkPrefetchRouteTrieCache = createRouteTrieCache<VinextLinkPrefetchRoute>();
+const pendingAppPrefetchStarts = new Set<string>();
+
+function isCurrentBrowserHref(href: string): boolean {
+  const target = new URL(href, window.location.href);
+  return (
+    target.origin === window.location.origin &&
+    target.pathname === window.location.pathname &&
+    target.search === window.location.search
+  );
+}
 
 function resolveHref(href: LinkProps["href"]): string {
   if (typeof href === "string") return href;
@@ -383,8 +394,9 @@ export function resolveAutoAppRoutePrefetch(href: string): {
  * For Pages Router: warms the page chunk, prefetches data only for SSG pages,
  * and falls back to a document prefetch hint when no page loader matches.
  *
- * Uses `requestIdleCallback` (or `setTimeout` fallback) to avoid blocking
- * the main thread during initial page load.
+ * App Router and high-priority prefetches start immediately. Low-priority
+ * Pages Router fallback prefetches use `requestIdleCallback` (or `setTimeout`
+ * fallback) to avoid blocking the main thread during initial page load.
  */
 function prefetchUrl(
   href: string,
@@ -415,205 +427,250 @@ function prefetchUrl(
     window.location.href,
     __basePath,
   );
-  const target = new URL(fullHref, window.location.href);
-  if (
-    target.origin === window.location.origin &&
-    target.pathname === window.location.pathname &&
-    target.search === window.location.search
-  ) {
+  if (isCurrentBrowserHref(fullHref)) {
     return;
   }
 
-  const schedule =
-    priority === "high"
-      ? (fn: () => void) => {
-          fn();
-        }
-      : (window.requestIdleCallback ?? ((fn: () => void) => setTimeout(fn, 100)));
-
-  schedule(() => {
+  const startPrefetch = () => {
+    const pendingAppPrefetchKey = hasAppNavigationRuntime()
+      ? `${fullHref}\0${mode}\0${pagesRouteHref ?? ""}`
+      : null;
+    let releasePendingAppPrefetchKey = true;
+    if (pendingAppPrefetchKey !== null) {
+      if (pendingAppPrefetchStarts.has(pendingAppPrefetchKey)) return;
+      pendingAppPrefetchStarts.add(pendingAppPrefetchKey);
+    }
     void (async () => {
-      if (hasAppNavigationRuntime()) {
-        if (isBotUserAgent(window.navigator?.userAgent ?? "")) return;
+      try {
+        if (hasAppNavigationRuntime()) {
+          if (isBotUserAgent(window.navigator?.userAgent ?? "")) return;
 
-        const [
-          navigation,
-          { AppElementsWire },
-          rscCacheBusting,
-          { APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL },
-          headersModule,
-          { resolveHybridClientRouteOwner },
-        ] = await Promise.all([
-          import("./navigation.js"),
-          import("../server/app-elements.js"),
-          import("../server/app-rsc-cache-busting.js"),
-          import("../server/app-rsc-render-mode.js"),
-          import("../server/headers.js"),
-          import("./internal/hybrid-client-route-owner.js"),
-        ]);
-        const {
-          getPrefetchInterceptionContext,
-          getPrefetchCache,
-          getPrefetchedUrls,
-          getMountedSlotsHeader,
-          hasPrefetchCacheEntryForNavigation,
-          prefetchRscResponse,
-          PREFETCH_CACHE_TTL,
-        } = navigation;
-        const { createRscRequestHeaders, createRscRequestUrl } = rscCacheBusting;
-        const { NEXT_ROUTER_PREFETCH_HEADER, VINEXT_MOUNTED_SLOTS_HEADER } = headersModule;
-        // Hybrid ownership: skip the App RSC prefetch when Pages owns the
-        // URL. The App's `__VINEXT_LINK_PREFETCH_ROUTES__` may include an
-        // App catch-all that also matches the same path, so a naive
-        // prefetch would fetch an RSC stream for a Pages route — that
-        // stream is never consumed (the click path now hard-navigates to
-        // Pages) and would also race the request the browser will issue on
-        // the actual navigation.
-        const hybridOwner = resolveHybridClientRouteOwner(prefetchHref, __basePath);
-        if (hybridOwner === "pages" || hybridOwner === "document") {
-          return;
-        }
-        const autoPrefetch =
-          mode === "auto"
-            ? resolveAutoAppRoutePrefetch(prefetchHref)
-            : { cacheForNavigation: true, prefetchShellFirst: true, shouldPrefetch: true };
-        if (!autoPrefetch.shouldPrefetch) return;
-
-        const interceptionContext = getPrefetchInterceptionContext(fullHref);
-        const mountedSlotsHeader = getMountedSlotsHeader();
-        const isOptimisticRouteShellPrefetch = !autoPrefetch.cacheForNavigation;
-        if (isOptimisticRouteShellPrefetch && interceptionContext !== null) return;
-        const headers = createRscRequestHeaders({
-          interceptionContext,
-          renderMode: isOptimisticRouteShellPrefetch
-            ? APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL
-            : undefined,
-        });
-        if (mountedSlotsHeader) {
-          headers.set(VINEXT_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
-        }
-        if (isOptimisticRouteShellPrefetch) {
-          headers.set(NEXT_ROUTER_PREFETCH_HEADER, "1");
-        }
-        // Distinguish the same visible URL when it is prefetched from different
-        // request contexts such as /feed vs /gallery or different mounted slots.
-        const rscUrl = await createRscRequestUrl(fullHref, headers);
-        const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
-        const prefetched = getPrefetchedUrls();
-        if (prefetched.has(cacheKey)) {
-          if (!autoPrefetch.cacheForNavigation) {
+          const [
+            navigation,
+            { AppElementsWire },
+            rscCacheBusting,
+            { APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL },
+            headersModule,
+            { resolveHybridClientRouteOwner },
+          ] = await Promise.all([
+            import("./navigation.js"),
+            import("../server/app-elements.js"),
+            import("../server/app-rsc-cache-busting.js"),
+            import("../server/app-rsc-render-mode.js"),
+            import("../server/headers.js"),
+            import("./internal/hybrid-client-route-owner.js"),
+          ]);
+          const {
+            getPrefetchInterceptionContext,
+            getPrefetchCache,
+            getPrefetchedUrls,
+            getMountedSlotActiveRoutesHeader,
+            getMountedSlotsHeader,
+            hasPrefetchCacheEntryForNavigation,
+            prefetchRscResponse,
+            PREFETCH_CACHE_TTL,
+          } = navigation;
+          const { createRscRequestHeaders, createRscRequestUrl } = rscCacheBusting;
+          const {
+            NEXT_ROUTER_PREFETCH_HEADER,
+            VINEXT_MOUNTED_SLOT_ACTIVE_ROUTES_HEADER,
+            VINEXT_MOUNTED_SLOTS_HEADER,
+          } = headersModule;
+          if (isCurrentBrowserHref(fullHref)) return;
+          // Hybrid ownership: skip the App RSC prefetch when Pages owns the
+          // URL. The App's `__VINEXT_LINK_PREFETCH_ROUTES__` may include an
+          // App catch-all that also matches the same path, so a naive
+          // prefetch would fetch an RSC stream for a Pages route — that
+          // stream is never consumed (the click path now hard-navigates to
+          // Pages) and would also race the request the browser will issue on
+          // the actual navigation.
+          const hybridOwner = resolveHybridClientRouteOwner(prefetchHref, __basePath);
+          if (hybridOwner === "pages" || hybridOwner === "document") {
             return;
           }
+          const autoPrefetch =
+            mode === "auto"
+              ? resolveAutoAppRoutePrefetch(prefetchHref)
+              : { cacheForNavigation: true, prefetchShellFirst: true, shouldPrefetch: true };
+          if (!autoPrefetch.shouldPrefetch) return;
 
-          const existing = getPrefetchCache().get(cacheKey);
-          if (existing?.cacheForNavigation === false) {
-            existing.cacheForNavigation = true;
+          const interceptionContext = getPrefetchInterceptionContext(fullHref);
+          const mountedSlotActiveRoutesHeader = getMountedSlotActiveRoutesHeader();
+          const mountedSlotsHeader = getMountedSlotsHeader();
+          const isOptimisticRouteShellPrefetch = !autoPrefetch.cacheForNavigation;
+          if (isOptimisticRouteShellPrefetch && interceptionContext !== null) return;
+          const headers = createRscRequestHeaders({
+            interceptionContext,
+            mountedSlotActiveRoutesHeader,
+            renderMode: isOptimisticRouteShellPrefetch
+              ? APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL
+              : undefined,
+          });
+          if (mountedSlotsHeader) {
+            headers.set(VINEXT_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
           }
-        }
-        // A single freshness-aware gate covers both an exact prior prefetch and
-        // an equivalent `_rsc` variant; the helper also deletes any stale exact
-        // entry, so a stale `prefetched` member is harmlessly re-added below.
-        if (
-          autoPrefetch.cacheForNavigation &&
-          hasPrefetchCacheEntryForNavigation(rscUrl, interceptionContext, mountedSlotsHeader)
-        ) {
-          return;
-        }
-        prefetched.add(cacheKey);
-        // Next's `prefetchInlining` Segment Cache path reserves the final
-        // payload while a route-tree request is still pending. Vinext keeps a
-        // unified route payload, so gate that payload behind a loading-shell
-        // request to preserve the same pending/dedup observable contract.
-        const fetchPromise =
-          __prefetchInlining && autoPrefetch.cacheForNavigation && autoPrefetch.prefetchShellFirst
-            ? (async () => {
-                const shellHeaders = createRscRequestHeaders({
-                  interceptionContext,
-                  renderMode: APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
-                });
-                if (mountedSlotsHeader) {
-                  shellHeaders.set(VINEXT_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
-                }
-                const shellRscUrl = await createRscRequestUrl(fullHref, shellHeaders);
-                const shellResponse = await fetch(shellRscUrl, {
-                  headers: shellHeaders,
-                  credentials: "include",
-                  priority,
-                  // @ts-expect-error — purpose is a valid fetch option in some browsers
-                  purpose: "prefetch",
-                });
-                if (!shellResponse.ok) {
-                  return shellResponse;
-                }
-                await shellResponse.arrayBuffer().catch(() => {});
-                return fetch(rscUrl, {
+          if (mountedSlotActiveRoutesHeader) {
+            headers.set(VINEXT_MOUNTED_SLOT_ACTIVE_ROUTES_HEADER, mountedSlotActiveRoutesHeader);
+          }
+          if (isOptimisticRouteShellPrefetch) {
+            headers.set(NEXT_ROUTER_PREFETCH_HEADER, "1");
+          }
+          // Distinguish the same visible URL when it is prefetched from different
+          // request contexts such as /feed vs /gallery or different mounted slots.
+          const rscUrl = await createRscRequestUrl(fullHref, headers);
+          if (
+            autoPrefetch.cacheForNavigation &&
+            getNavigationRuntime()?.functions.hasVisitedResponseForPrefetch?.(
+              rscUrl,
+              interceptionContext,
+              mountedSlotsHeader,
+            )
+          ) {
+            return;
+          }
+          const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
+          const prefetched = getPrefetchedUrls();
+          if (prefetched.has(cacheKey)) {
+            if (!autoPrefetch.cacheForNavigation) {
+              return;
+            }
+
+            const existing = getPrefetchCache().get(cacheKey);
+            if (existing?.cacheForNavigation === false) {
+              existing.cacheForNavigation = true;
+            }
+          }
+          // A single freshness-aware gate covers both an exact prior prefetch and
+          // an equivalent `_rsc` variant; the helper also deletes any stale exact
+          // entry, so a stale `prefetched` member is harmlessly re-added below.
+          if (
+            autoPrefetch.cacheForNavigation &&
+            hasPrefetchCacheEntryForNavigation(rscUrl, interceptionContext, mountedSlotsHeader)
+          ) {
+            return;
+          }
+          prefetched.add(cacheKey);
+          // Next's `prefetchInlining` Segment Cache path reserves the final
+          // payload while a route-tree request is still pending. Vinext keeps a
+          // unified route payload, so gate that payload behind a loading-shell
+          // request to preserve the same pending/dedup observable contract.
+          const fetchPromise =
+            __prefetchInlining && autoPrefetch.cacheForNavigation && autoPrefetch.prefetchShellFirst
+              ? (async () => {
+                  const shellHeaders = createRscRequestHeaders({
+                    interceptionContext,
+                    mountedSlotActiveRoutesHeader,
+                    renderMode: APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+                  });
+                  if (mountedSlotsHeader) {
+                    shellHeaders.set(VINEXT_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
+                  }
+                  if (mountedSlotActiveRoutesHeader) {
+                    shellHeaders.set(
+                      VINEXT_MOUNTED_SLOT_ACTIVE_ROUTES_HEADER,
+                      mountedSlotActiveRoutesHeader,
+                    );
+                  }
+                  const shellRscUrl = await createRscRequestUrl(fullHref, shellHeaders);
+                  const shellResponse = await fetch(shellRscUrl, {
+                    headers: shellHeaders,
+                    credentials: "include",
+                    priority,
+                    // @ts-expect-error — purpose is a valid fetch option in some browsers
+                    purpose: "prefetch",
+                  });
+                  if (!shellResponse.ok) {
+                    return shellResponse;
+                  }
+                  await shellResponse.arrayBuffer().catch(() => {});
+                  return fetch(rscUrl, {
+                    headers,
+                    credentials: "include",
+                    priority,
+                    // @ts-expect-error — purpose is a valid fetch option in some browsers
+                    purpose: "prefetch",
+                  });
+                })()
+              : fetch(rscUrl, {
                   headers,
                   credentials: "include",
                   priority,
                   // @ts-expect-error — purpose is a valid fetch option in some browsers
                   purpose: "prefetch",
                 });
-              })()
-            : fetch(rscUrl, {
-                headers,
-                credentials: "include",
-                priority,
-                // @ts-expect-error — purpose is a valid fetch option in some browsers
-                purpose: "prefetch",
-              });
-        prefetchRscResponse(
-          rscUrl,
-          fetchPromise,
-          interceptionContext,
-          mountedSlotsHeader,
-          undefined,
-          {
-            cacheForNavigation: autoPrefetch.cacheForNavigation,
-            fallbackTtlMs: PREFETCH_CACHE_TTL,
-            optimisticRouteShell: isOptimisticRouteShellPrefetch,
-          },
-        );
-      } else if (HAS_PAGES_ROUTER && window.__NEXT_DATA__) {
-        // Pages Router prefetch. When a code-split loader is registered for
-        // the target route (prod builds expose them on window via the
-        // generated client entry), warm the page chunk and prefetch data JSON
-        // only for SSG routes. Otherwise (dev, or unmapped route) fall back
-        // to the legacy `<link rel="prefetch" as="document">` so the browser
-        // still preloads the HTML.
-        //
-        // The decision helper + prefetch action live in shims/internal/ so
-        // this file does not pull in the router shim at module init time,
-        // which would create a circular import and grow the SSR module graph.
-        const dataTarget = resolvePagesDataNavigationTarget(fullRouteHref, __basePath);
-        if (dataTarget) {
-          const middlewareDataHref =
-            fullRouteHref === fullHref
-              ? dataTarget.middlewareDataHref
-              : (getPagesMiddlewareDataHref(fullHref, __basePath) ?? undefined);
-          prefetchPagesData({ ...dataTarget, middlewareDataHref });
-        } else {
-          // The target is not a Pages Router route — mark it on the Pages
-          // Router `components` map if it matches an App Router route in the
-          // shared prefetch manifest. Mirrors Next.js's `_bfl` marker write at
-          // `packages/next/src/shared/lib/router/router.ts:2525`; the Next.js
-          // deploy test reads `window.next.router.components[<path>]` to
-          // assert prefetch detection. See issue #1526.
-          await markAppRouteDetectedOnPrefetch(fullHref, __basePath);
+          prefetchRscResponse(
+            rscUrl,
+            fetchPromise,
+            interceptionContext,
+            mountedSlotsHeader,
+            undefined,
+            {
+              cacheForNavigation: autoPrefetch.cacheForNavigation,
+              fallbackTtlMs: PREFETCH_CACHE_TTL,
+              optimisticRouteShell: isOptimisticRouteShellPrefetch,
+            },
+          );
+          const entry = getPrefetchCache().get(cacheKey);
+          if (pendingAppPrefetchKey !== null && entry?.pending !== undefined) {
+            releasePendingAppPrefetchKey = false;
+            void entry.pending.finally(() => {
+              pendingAppPrefetchStarts.delete(pendingAppPrefetchKey);
+            });
+          }
+        } else if (HAS_PAGES_ROUTER && window.__NEXT_DATA__) {
+          // Pages Router prefetch. When a code-split loader is registered for
+          // the target route (prod builds expose them on window via the
+          // generated client entry), warm the page chunk and prefetch data JSON
+          // only for SSG routes. Otherwise (dev, or unmapped route) fall back
+          // to the legacy `<link rel="prefetch" as="document">` so the browser
+          // still preloads the HTML.
+          //
+          // The decision helper + prefetch action live in shims/internal/ so
+          // this file does not pull in the router shim at module init time,
+          // which would create a circular import and grow the SSR module graph.
+          const dataTarget = resolvePagesDataNavigationTarget(fullRouteHref, __basePath);
+          if (dataTarget) {
+            const middlewareDataHref =
+              fullRouteHref === fullHref
+                ? dataTarget.middlewareDataHref
+                : (getPagesMiddlewareDataHref(fullHref, __basePath) ?? undefined);
+            prefetchPagesData({ ...dataTarget, middlewareDataHref });
+          } else {
+            // The target is not a Pages Router route — mark it on the Pages
+            // Router `components` map if it matches an App Router route in the
+            // shared prefetch manifest. Mirrors Next.js's `_bfl` marker write at
+            // `packages/next/src/shared/lib/router/router.ts:2525`; the Next.js
+            // deploy test reads `window.next.router.components[<path>]` to
+            // assert prefetch detection. See issue #1526.
+            await markAppRouteDetectedOnPrefetch(fullHref, __basePath);
 
-          // Legacy fallback: hint the browser to preload the HTML document.
-          // Used in dev (no loader map populated) and for routes not in the
-          // client loader map.
-          const link = document.createElement("link");
-          link.rel = "prefetch";
-          link.href = fullHref;
-          link.as = "document";
-          document.head.appendChild(link);
+            // Legacy fallback: hint the browser to preload the HTML document.
+            // Used in dev (no loader map populated) and for routes not in the
+            // client loader map.
+            const link = document.createElement("link");
+            link.rel = "prefetch";
+            link.href = fullHref;
+            link.as = "document";
+            document.head.appendChild(link);
+          }
+        }
+      } finally {
+        if (pendingAppPrefetchKey !== null && releasePendingAppPrefetchKey) {
+          pendingAppPrefetchStarts.delete(pendingAppPrefetchKey);
         }
       }
     })().catch((error) => {
       console.error("[vinext] RSC prefetch setup error:", error);
     });
-  });
+  };
+
+  if (priority === "high" || hasAppNavigationRuntime()) {
+    startPrefetch();
+    return;
+  }
+
+  const schedule = window.requestIdleCallback ?? ((fn: () => void) => setTimeout(fn, 100));
+  schedule(startPrefetch);
 }
 
 async function promotePrefetchEntriesForNavigation(href: string): Promise<void> {
@@ -974,7 +1031,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
     [forwardedRef],
   );
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!shouldViewportPrefetch || typeof window === "undefined") return;
     const node = internalRef.current;
     if (!node) return;

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -38,6 +38,7 @@ import {
 import { hasPendingAppRouterPageRedirect } from "../server/app-browser-mpa-navigation.js";
 import {
   VINEXT_DYNAMIC_STALE_TIME_HEADER,
+  VINEXT_MOUNTED_SLOT_ACTIVE_ROUTES_HEADER,
   VINEXT_MOUNTED_SLOTS_HEADER,
   VINEXT_PARAMS_HEADER,
 } from "../server/headers.js";
@@ -940,6 +941,7 @@ export async function consumePrefetchResponseForNavigation(
 
 type NavigationListener = () => void;
 const _CLIENT_NAV_STATE_KEY = Symbol.for("vinext.clientNavigationState");
+const _MOUNTED_SLOT_ACTIVE_ROUTES_HEADER_KEY = Symbol.for("vinext.mountedSlotActiveRoutesHeader");
 const _MOUNTED_SLOTS_HEADER_KEY = Symbol.for("vinext.mountedSlotsHeader");
 
 type ClientNavigationState = {
@@ -967,8 +969,21 @@ type CommitClientNavigationStateOptions = {
 
 type ClientNavigationGlobal = typeof globalThis & {
   [_CLIENT_NAV_STATE_KEY]?: ClientNavigationState;
+  [_MOUNTED_SLOT_ACTIVE_ROUTES_HEADER_KEY]?: string | null;
   [_MOUNTED_SLOTS_HEADER_KEY]?: string | null;
 };
+
+export function setMountedSlotActiveRoutesHeader(header: string | null): void {
+  if (isServer) return;
+  const globalState = window as ClientNavigationGlobal;
+  globalState[_MOUNTED_SLOT_ACTIVE_ROUTES_HEADER_KEY] = header;
+}
+
+export function getMountedSlotActiveRoutesHeader(): string | null {
+  if (isServer) return null;
+  const globalState = window as ClientNavigationGlobal;
+  return globalState[_MOUNTED_SLOT_ACTIVE_ROUTES_HEADER_KEY] ?? null;
+}
 
 export function setMountedSlotsHeader(header: string | null): void {
   if (isServer) return;
@@ -1959,10 +1974,17 @@ const _appRouter: AppRouterInstance = {
       // prefetchRscResponse only manages the cache Map, not the URL set.
       const fullHref = toBrowserNavigationHref(prefetchHref, window.location.href, __basePath);
       const interceptionContext = getPrefetchInterceptionContext(fullHref);
+      const mountedSlotActiveRoutesHeader = getMountedSlotActiveRoutesHeader();
       const mountedSlotsHeader = getMountedSlotsHeader();
-      const headers = createRscRequestHeaders({ interceptionContext });
+      const headers = createRscRequestHeaders({
+        interceptionContext,
+        mountedSlotActiveRoutesHeader,
+      });
       if (mountedSlotsHeader) {
         headers.set(VINEXT_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
+      }
+      if (mountedSlotActiveRoutesHeader) {
+        headers.set(VINEXT_MOUNTED_SLOT_ACTIVE_ROUTES_HEADER, mountedSlotActiveRoutesHeader);
       }
       const rscUrl = await createRscRequestUrl(fullHref, headers);
       const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -87,7 +87,9 @@ import {
   createInitialBfcacheIdMap,
   createNextBfcacheIdMap,
   FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
+  PREFETCH_CACHE_APP_NAVIGATION_PAYLOAD_ORIGIN,
   VISITED_CACHE_APP_NAVIGATION_PAYLOAD_ORIGIN,
+  createCommittedNavigationSnapshotElements,
   createPendingNavigationCommit,
   isCompleteAppPayloadMetadata,
   isCacheRestorableAppPayloadMetadata,
@@ -131,6 +133,7 @@ import {
   ACTION_REVALIDATED_HEADER,
   ACTION_REDIRECT_HEADER,
   ACTION_REDIRECT_TYPE_HEADER,
+  VINEXT_MOUNTED_SLOT_ACTIVE_ROUTES_HEADER,
   VINEXT_MOUNTED_SLOTS_HEADER,
   VINEXT_PARAMS_HEADER,
 } from "../packages/vinext/src/server/headers.js";
@@ -1221,7 +1224,16 @@ describe("app browser entry navigation scheduling", () => {
         },
         "dynamicOnly",
       ),
-    ).toBe(true);
+    ).toBe(false);
+    expect(
+      shouldClearClientNavigationCachesForServerActionResult(
+        {
+          root: createResolvedElements("route:/settings", "/"),
+          returnValue: { ok: true, data: "action-result" },
+        },
+        "dynamicOnly",
+      ),
+    ).toBe(false);
   });
 
   it("schedules discarded action refreshes only for revalidated actions", () => {
@@ -2002,6 +2014,59 @@ describe("app browser entry state helpers", () => {
         },
       },
     ]);
+  });
+
+  it("marks cache-origin pending commits to skip visible-link prefetch pings", async () => {
+    const currentState = createState();
+    const nextElements = Promise.resolve(
+      createResolvedElements("route:/dashboard/settings", "/", null, {
+        "page:/dashboard/settings": React.createElement("main", null, "settings"),
+      }),
+    );
+    const navigationSnapshot = createClientNavigationRenderSnapshot(
+      "https://example.com/dashboard/settings",
+      {},
+    );
+
+    const cachedPending = await createPendingNavigationCommit({
+      currentState,
+      nextElements,
+      navigationSnapshot,
+      operationLane: "navigation",
+      renderId: 2,
+      payloadOrigin: VISITED_CACHE_APP_NAVIGATION_PAYLOAD_ORIGIN,
+      type: "navigate",
+    });
+    const prefetchedPending = await createPendingNavigationCommit({
+      currentState,
+      nextElements: Promise.resolve(
+        createResolvedElements("route:/dashboard/settings", "/", null, {
+          "page:/dashboard/settings": React.createElement("main", null, "settings"),
+        }),
+      ),
+      navigationSnapshot,
+      operationLane: "navigation",
+      renderId: 3,
+      payloadOrigin: PREFETCH_CACHE_APP_NAVIGATION_PAYLOAD_ORIGIN,
+      type: "navigate",
+    });
+    const freshPending = await createPendingNavigationCommit({
+      currentState,
+      nextElements: Promise.resolve(
+        createResolvedElements("route:/dashboard/settings", "/", null, {
+          "page:/dashboard/settings": React.createElement("main", null, "settings"),
+        }),
+      ),
+      navigationSnapshot,
+      operationLane: "navigation",
+      renderId: 4,
+      payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
+      type: "navigate",
+    });
+
+    expect(cachedPending.action.skipVisibleLinkPrefetchPing).toBe(true);
+    expect(prefetchedPending.action.skipVisibleLinkPrefetchPing).toBe(true);
+    expect(freshPending.action.skipVisibleLinkPrefetchPing).toBeUndefined();
   });
 
   it("classifies complete dynamic payload metadata as client-cacheable", () => {
@@ -5723,6 +5788,235 @@ describe("app browser entry previousNextUrl helpers", () => {
     expect(nextState.slotBindings).toEqual([modalSlotBinding]);
   });
 
+  it("preserves omitted active parallel slots on approved navigate commits", async () => {
+    // Ported from Next.js:
+    // test/e2e/app-dir/segment-cache/refresh/segment-cache-refresh.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/refresh/segment-cache-refresh.test.ts
+    const dashboardLayoutId = "layout:/dashboard";
+    const navbarSlotId = "slot:navbar:/dashboard";
+    const mountedNavbar = React.createElement("nav", null, "mounted navbar");
+    const navbarBinding = {
+      activeRouteId: "route:/dashboard",
+      ownerLayoutId: dashboardLayoutId,
+      slotId: navbarSlotId,
+      state: "active",
+    } satisfies AppElementsSlotBinding;
+    const state = createState({
+      bfcacheIds: {
+        "layout:/": "0",
+        [dashboardLayoutId]: "_b_4_",
+        [navbarSlotId]: "_b_5_",
+      },
+      elements: createResolvedElements(
+        "route:/dashboard",
+        "/",
+        null,
+        {
+          "layout:/": React.createElement("div", null, "root layout"),
+          [dashboardLayoutId]: React.createElement("div", null, "dashboard layout"),
+          [navbarSlotId]: mountedNavbar,
+        },
+        ["layout:/", dashboardLayoutId],
+        [navbarBinding],
+      ),
+      layoutIds: ["layout:/", dashboardLayoutId],
+      navigationSnapshot: createClientNavigationRenderSnapshot("https://example.com/dashboard", {}),
+      routeId: "route:/dashboard",
+      slotBindings: [navbarBinding],
+    });
+    const pending = await createPendingNavigationCommit({
+      payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
+      currentState: state,
+      nextElements: Promise.resolve(
+        createResolvedElements(
+          "route:/dashboard/analytics",
+          "/",
+          null,
+          {
+            "page:/dashboard/analytics": React.createElement("main", null, "analytics"),
+          },
+          ["layout:/", dashboardLayoutId],
+          [navbarBinding],
+        ),
+      ),
+      navigationSnapshot: createClientNavigationRenderSnapshot(
+        "https://example.com/dashboard/analytics",
+        {},
+      ),
+      operationLane: "navigation",
+      renderId: 1,
+      type: "navigate",
+    });
+
+    const approval = approvePendingNavigationCommit({
+      activeNavigationId: 1,
+      currentState: state,
+      pending,
+      routeManifest: createRouteManifestForPendingCommit(state, pending),
+      startedNavigationId: 1,
+      targetHref: "https://example.com/dashboard/analytics",
+    });
+
+    expect(approval.decision.disposition).toBe("commit");
+    if (approval.decision.disposition !== "commit" || approval.approvedCommit === null) {
+      throw new Error("Expected approved visible commit");
+    }
+    expect(approval.decision.preservePreviousSlotIds).toContain(navbarSlotId);
+
+    const nextState = applyApprovedVisibleCommit(state, approval.approvedCommit);
+    expect(nextState.elements[navbarSlotId]).toBe(mountedNavbar);
+    expect(nextState.slotBindings).toEqual([navbarBinding]);
+  });
+
+  it("omits preserved active parallel slot content from committed cache snapshots", async () => {
+    // Ported from Next.js:
+    // test/e2e/app-dir/segment-cache/refresh/segment-cache-refresh.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/refresh/segment-cache-refresh.test.ts
+    const dashboardLayoutId = "layout:/dashboard";
+    const navbarSlotId = "slot:navbar:/dashboard";
+    const mountedNavbar = React.createElement("nav", null, "mounted navbar");
+    const navbarBinding = {
+      activeRouteId: "route:/dashboard",
+      ownerLayoutId: dashboardLayoutId,
+      slotId: navbarSlotId,
+      state: "active",
+    } satisfies AppElementsSlotBinding;
+    const state = createState({
+      elements: createResolvedElements(
+        "route:/dashboard/analytics",
+        "/",
+        null,
+        {
+          "layout:/": React.createElement("div", null, "root layout"),
+          [dashboardLayoutId]: React.createElement("div", null, "dashboard layout"),
+          [navbarSlotId]: mountedNavbar,
+        },
+        ["layout:/", dashboardLayoutId],
+        [navbarBinding],
+      ),
+      layoutIds: ["layout:/", dashboardLayoutId],
+      navigationSnapshot: createClientNavigationRenderSnapshot(
+        "https://example.com/dashboard/analytics",
+        {},
+      ),
+      routeId: "route:/dashboard/analytics",
+      slotBindings: [navbarBinding],
+    });
+    const renderedElements = createResolvedElements(
+      "route:/dashboard/analytics",
+      "/",
+      null,
+      {
+        "page:/dashboard/analytics": React.createElement("main", null, "analytics"),
+      },
+      ["layout:/", dashboardLayoutId],
+      [navbarBinding],
+    );
+
+    const cachedElements = createCommittedNavigationSnapshotElements({
+      renderedElements,
+      state,
+    });
+
+    expect(Object.hasOwn(cachedElements, navbarSlotId)).toBe(false);
+    expect(AppElementsWire.readMetadata(cachedElements).slotBindings).toEqual([navbarBinding]);
+  });
+
+  it("preserves planner-approved default parallel slots when the owner layout remounts", async () => {
+    const oldFeedLayout = React.createElement("div", null, "old feed layout");
+    const newFeedLayout = React.createElement("div", null, "new feed layout");
+    const mountedSlot = React.createElement("div", null, "modal");
+    const modalSlotBinding = {
+      ownerLayoutId: "layout:/feed",
+      slotId: "slot:modal:/feed",
+      state: "active",
+    } satisfies AppElementsSlotBinding;
+    const state = createState({
+      bfcacheIds: {
+        "layout:/": "0",
+        "layout:/feed": "_b_4_",
+        "slot:modal:/feed": "_b_5_",
+      },
+      elements: createResolvedElements(
+        "route:/feed",
+        "/",
+        null,
+        {
+          "layout:/": React.createElement("div", null, "root layout"),
+          "layout:/feed": oldFeedLayout,
+          "slot:modal:/feed": mountedSlot,
+        },
+        ["layout:/", "layout:/feed"],
+        [modalSlotBinding],
+      ),
+      layoutIds: ["layout:/", "layout:/feed"],
+      navigationSnapshot: createClientNavigationRenderSnapshot("https://example.com/feed", {}),
+      routeId: "route:/feed",
+      slotBindings: [modalSlotBinding],
+    });
+    const pending = await createPendingNavigationCommit({
+      payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
+      currentState: state,
+      navigationSnapshot: createClientNavigationRenderSnapshot(
+        "https://example.com/feed/comments",
+        {},
+      ),
+      nextElements: Promise.resolve(
+        createResolvedElements(
+          "route:/feed/comments",
+          "/",
+          null,
+          {
+            "layout:/feed": newFeedLayout,
+            "page:/feed/comments": React.createElement("main", null, "comments"),
+          },
+          ["layout:/", "layout:/feed"],
+          [
+            {
+              ownerLayoutId: "layout:/feed",
+              slotId: "slot:modal:/feed",
+              state: "default",
+            },
+          ],
+        ),
+      ),
+      operationLane: "navigation",
+      renderId: 1,
+      type: "navigate",
+    });
+    const approval = approvePendingNavigationCommit({
+      activeNavigationId: 1,
+      currentState: state,
+      pending,
+      routeManifest: createRouteManifestForPendingCommit(state, pending),
+      startedNavigationId: 1,
+      targetHref: "https://example.com/feed/comments",
+    });
+
+    expect(approval.decision.disposition).toBe("commit");
+    if (approval.decision.disposition !== "commit" || approval.approvedCommit === null) {
+      throw new Error("Expected approved visible commit");
+    }
+    expect(approval.decision.preserveElementIds).toContain("layout:/feed");
+    expect(approval.decision.preservePreviousSlotIds).toEqual(["slot:modal:/feed"]);
+
+    const commitWithRemountedOwnerLayout = {
+      ...approval.approvedCommit,
+      action: {
+        ...approval.approvedCommit.action,
+        bfcacheIds: {
+          ...approval.approvedCommit.action.bfcacheIds,
+          "layout:/feed": "_b_fresh_",
+        },
+      },
+    };
+    const nextState = applyApprovedVisibleCommit(state, commitWithRemountedOwnerLayout);
+
+    expect(nextState.elements["layout:/feed"]).toBe(newFeedLayout);
+    expect(nextState.elements["slot:modal:/feed"]).toBe(mountedSlot);
+    expect(nextState.slotBindings).toEqual([modalSlotBinding]);
+  });
+
   it("preserves bfcache ids for planner-approved default parallel slots", async () => {
     const modalSlotId = AppElementsWire.encodeSlotId("modal", "/feed");
     const mountedSlot = React.createElement("div", null, "modal");
@@ -8123,6 +8417,32 @@ describe("resolveServerActionRequestState", () => {
     expect(headers.get("X-Vinext-Mounted-Slots")).toBe(getMountedSlotIdsHeader(elements));
   });
 
+  it("derives mounted slot active routes from visible slot bindings", () => {
+    const slotId = "slot:navbar:/dashboard";
+    const elements: AppElements = createResolvedElements("route:/dashboard/analytics", "/", null, {
+      [slotId]: React.createElement("div", null, "navbar"),
+    });
+
+    const { headers } = resolveServerActionRequestState({
+      actionId: "action-z",
+      basePath: "",
+      elements,
+      previousNextUrl: null,
+      slotBindings: [
+        {
+          activeRouteId: "route:/dashboard",
+          ownerLayoutId: "layout:/dashboard",
+          slotId,
+          state: "active",
+        },
+      ],
+    });
+
+    expect(headers.get(VINEXT_MOUNTED_SLOT_ACTIVE_ROUTES_HEADER)).toBe(
+      "slot%3Anavbar%3A%2Fdashboard=route%3A%2Fdashboard",
+    );
+  });
+
   it("omits headers whose derived values are null", () => {
     const elements: AppElements = createResolvedElements("route:/settings", "/", null, {
       "slot:ghost:/": null,
@@ -8138,5 +8458,6 @@ describe("resolveServerActionRequestState", () => {
 
     expect(headers.has("X-Vinext-Interception-Context")).toBe(false);
     expect(headers.has("X-Vinext-Mounted-Slots")).toBe(false);
+    expect(headers.has(VINEXT_MOUNTED_SLOT_ACTIVE_ROUTES_HEADER)).toBe(false);
   });
 });

--- a/tests/app-elements.test.ts
+++ b/tests/app-elements.test.ts
@@ -970,6 +970,42 @@ describe("buildOutgoingAppPayload", () => {
     }
   });
 
+  it("reads only shape-safe render observation metadata", () => {
+    const renderObservation = buildRenderObservation({
+      boundaryOutcome: { kind: "success" },
+      cacheability: "public",
+      cacheTags: ["posts"],
+      completeness: "complete",
+      dynamicFetches: [],
+      output: {
+        kind: "app-rsc",
+        mountedSlotsFingerprint: null,
+        renderEpoch: null,
+        rootBoundaryId: "layout:/",
+        routeId: "route:/posts",
+      },
+      pathTags: ["/posts"],
+      requestApis: [{ kind: "headers", status: "notObserved" }],
+    });
+    const payload = {
+      [APP_ROUTE_KEY]: "route:/posts",
+      [APP_INTERCEPTION_CONTEXT_KEY]: null,
+      [APP_ROOT_LAYOUT_KEY]: "/",
+      [APP_RENDER_OBSERVATION_KEY]: renderObservation,
+    } satisfies Readonly<Record<string, unknown>>;
+
+    expect(AppElementsWire.readMetadata(payload).renderObservation).toEqual(renderObservation);
+    expect(
+      AppElementsWire.readMetadata({
+        ...payload,
+        [APP_RENDER_OBSERVATION_KEY]: {
+          ...renderObservation,
+          dynamicFetches: "https://api.example.test/posts",
+        },
+      }).renderObservation,
+    ).toBeUndefined();
+  });
+
   it("returns canonical record keys when no skip disposition is supplied", () => {
     const result = buildOutgoingAppPayload({
       element: { "layout:/": "root-layout", "page:/": "page" },

--- a/tests/app-page-cache.test.ts
+++ b/tests/app-page-cache.test.ts
@@ -551,6 +551,38 @@ describe("app page cache helpers", () => {
     expect(response?.headers.get("x-vinext-mounted-slots")).toBe("slot:auth:/");
   });
 
+  it("keys RSC cache reads by mounted-slot active-route header", async () => {
+    const response = await readAppPageCacheResponse({
+      cleanPathname: "/cached",
+      clearRequestContext() {},
+      isRscRequest: true,
+      async isrGet(key) {
+        expect(key).toBe("rsc:/cached:slot:auth:/:slot%3Aauth%3A%2F=route%3A%2Fdashboard");
+        return buildISRCacheEntry(
+          buildCachedAppPageValue("", new TextEncoder().encode("flight").buffer),
+        );
+      },
+      isrHtmlKey(pathname) {
+        return "html:" + pathname;
+      },
+      isrRscKey(pathname, mountedSlotsHeader, _renderMode, _interceptionContext, activeRoutes) {
+        return `rsc:${pathname}:${mountedSlotsHeader ?? "none"}:${activeRoutes ?? "none"}`;
+      },
+      async isrSet() {},
+      mountedSlotActiveRoutesHeader: "slot%3Aauth%3A%2F=route%3A%2Fdashboard",
+      mountedSlotsHeader: "slot:auth:/",
+      revalidateSeconds: 60,
+      async renderFreshPageForCache() {
+        throw new Error("should not render");
+      },
+      scheduleBackgroundRegeneration() {
+        throw new Error("should not schedule regeneration");
+      },
+    });
+
+    expect(response?.headers.get("x-vinext-cache")).toBe("HIT");
+  });
+
   it("serves stale RSC entries and regenerates only the matching RSC cache key", async () => {
     const scheduledRegenerations: Array<() => Promise<void>> = [];
     const isrRscKey = vi.fn(

--- a/tests/app-page-element-builder.test.ts
+++ b/tests/app-page-element-builder.test.ts
@@ -16,6 +16,7 @@ import { makeThenableParams } from "../packages/vinext/src/shims/thenable-params
 import { readStreamAsText } from "../packages/vinext/src/utils/text-stream.js";
 import { useSelectedLayoutSegments } from "../packages/vinext/src/shims/navigation.js";
 import { resolveAppPageRouteStateKey } from "../packages/vinext/src/server/app-page-segment-state.js";
+import { APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI } from "../packages/vinext/src/server/app-rsc-render-mode.js";
 
 // Import the function under test AFTER mocking dependencies.
 // eslint-disable-next-line import/first
@@ -74,7 +75,11 @@ function createBaseOptions(overrides?: {
   routePath?: string;
   opts?: Record<string, unknown> | null;
   searchParams?: URLSearchParams | null;
+  isRscRequest?: boolean;
   mountedSlotsHeader?: string | null;
+  mountedSlotActiveRoutesHeader?: string | null;
+  renderMode?: Parameters<typeof buildPageElements>[0]["pageRequest"]["renderMode"];
+  resolveRouteById?: Parameters<typeof buildPageElements>[0]["resolveRouteById"];
 }) {
   return {
     route:
@@ -84,15 +89,18 @@ function createBaseOptions(overrides?: {
     pageRequest: {
       opts: overrides?.opts ?? null,
       searchParams: overrides?.searchParams ?? null,
-      isRscRequest: false,
+      isRscRequest: overrides?.isRscRequest ?? false,
       request: new Request("http://localhost/test"),
       mountedSlotsHeader: overrides?.mountedSlotsHeader ?? null,
+      mountedSlotActiveRoutesHeader: overrides?.mountedSlotActiveRoutesHeader ?? null,
+      renderMode: overrides?.renderMode,
     },
     globalErrorModule: null,
     rootNotFoundModule: null,
     rootForbiddenModule: null,
     rootUnauthorizedModule: null,
     metadataRoutes: [],
+    resolveRouteById: overrides?.resolveRouteById,
   };
 }
 
@@ -650,6 +658,143 @@ describe("buildPageElements", () => {
         state: "active",
       },
     ]);
+  });
+
+  it("rerenders active mounted slots from their current route during refresh", async () => {
+    function Page(): React.ReactNode {
+      return React.createElement("div", null, "Page");
+    }
+    function Layout({
+      children,
+      navbar,
+    }: {
+      children?: React.ReactNode;
+      navbar?: React.ReactNode;
+    }): React.ReactNode {
+      return React.createElement("section", null, navbar, children);
+    }
+    function ActiveNavbar(): React.ReactNode {
+      return React.createElement("nav", null, "Active navbar");
+    }
+    function DefaultNavbar(): React.ReactNode {
+      return React.createElement("nav", null, "Default navbar");
+    }
+
+    const activeRoute = createSyntheticRoute({
+      page: createSyntheticPageModule(Page),
+      layouts: [createSyntheticPageModule(Layout), createSyntheticPageModule(Layout)],
+      layoutTreePositions: [0, 1],
+      routeSegments: ["dashboard"],
+      pattern: "/dashboard",
+      slots: {
+        "navbar@dashboard/@navbar": {
+          id: "slot:navbar:/dashboard",
+          name: "navbar",
+          layoutIndex: 1,
+          page: createSyntheticPageModule(ActiveNavbar),
+          routeSegments: ["dashboard"],
+        },
+      },
+    });
+    const targetRoute = createSyntheticRoute({
+      page: createSyntheticPageModule(Page),
+      layouts: [createSyntheticPageModule(Layout), createSyntheticPageModule(Layout)],
+      layoutTreePositions: [0, 1],
+      routeSegments: ["dashboard", "analytics"],
+      pattern: "/dashboard/analytics",
+      slots: {
+        "navbar@dashboard/@navbar": {
+          id: "slot:navbar:/dashboard",
+          name: "navbar",
+          default: createSyntheticPageModule(DefaultNavbar),
+          layoutIndex: 1,
+          routeSegments: null,
+        },
+      },
+    });
+
+    const result = await buildPageElements(
+      createBaseOptions({
+        route: targetRoute,
+        routePath: "/dashboard/analytics",
+        isRscRequest: true,
+        mountedSlotsHeader: "slot:navbar:/dashboard",
+        mountedSlotActiveRoutesHeader: "slot%3Anavbar%3A%2Fdashboard=route%3A%2Fdashboard",
+        renderMode: APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI,
+        resolveRouteById(routeId) {
+          return routeId === "route:/dashboard"
+            ? { route: activeRoute, params: {}, routePath: "/dashboard" }
+            : null;
+        },
+      }),
+    );
+
+    const html = await renderRouteEntry(result, "route:/dashboard/analytics");
+    expect(html).toContain("Active navbar");
+    expect(html).not.toContain("Default navbar");
+    expect((result as Record<string, unknown>)[APP_SLOT_BINDINGS_KEY]).toContainEqual({
+      activeRouteId: "route:/dashboard",
+      ownerLayoutId: "layout:/dashboard",
+      slotId: "slot:navbar:/dashboard",
+      state: "active",
+    });
+  });
+
+  it("preserves active mounted slots during ordinary navigation", async () => {
+    // Ported from Next.js:
+    // test/e2e/app-dir/segment-cache/refresh/segment-cache-refresh.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/refresh/segment-cache-refresh.test.ts
+    function Page(): React.ReactNode {
+      return React.createElement("div", null, "Page");
+    }
+    function Layout({
+      children,
+      navbar,
+    }: {
+      children?: React.ReactNode;
+      navbar?: React.ReactNode;
+    }): React.ReactNode {
+      return React.createElement("section", null, navbar, children);
+    }
+    function ActiveNavbar(): React.ReactNode {
+      return React.createElement("nav", null, "Fresh active navbar");
+    }
+
+    const route = createSyntheticRoute({
+      page: createSyntheticPageModule(Page),
+      layouts: [createSyntheticPageModule(Layout), createSyntheticPageModule(Layout)],
+      layoutTreePositions: [0, 1],
+      routeSegments: ["dashboard"],
+      pattern: "/dashboard",
+      slots: {
+        "navbar@dashboard/@navbar": {
+          id: "slot:navbar:/dashboard",
+          name: "navbar",
+          layoutIndex: 1,
+          page: createSyntheticPageModule(ActiveNavbar),
+          routeSegments: ["dashboard"],
+        },
+      },
+    });
+
+    const result = await buildPageElements(
+      createBaseOptions({
+        route,
+        routePath: "/dashboard",
+        isRscRequest: true,
+        mountedSlotsHeader: "slot:navbar:/dashboard",
+        mountedSlotActiveRoutesHeader: "slot%3Anavbar%3A%2Fdashboard=route%3A%2Fdashboard",
+      }),
+    );
+
+    const record = result as Record<string, unknown>;
+    expect(record["slot:navbar:/dashboard"]).toBeUndefined();
+    expect(record[APP_SLOT_BINDINGS_KEY]).toContainEqual({
+      activeRouteId: "route:/dashboard",
+      ownerLayoutId: "layout:/dashboard",
+      slotId: "slot:navbar:/dashboard",
+      state: "active",
+    });
   });
 
   it("marks intercepted slot override bindings as active", async () => {

--- a/tests/app-page-element-builder.test.ts
+++ b/tests/app-page-element-builder.test.ts
@@ -797,6 +797,59 @@ describe("buildPageElements", () => {
     });
   });
 
+  it("resolves active mounted slot ids from the last layout when graph slot ids are absent", async () => {
+    function Page(): React.ReactNode {
+      return React.createElement("div", null, "Page");
+    }
+    function Layout({
+      children,
+      navbar,
+    }: {
+      children?: React.ReactNode;
+      navbar?: React.ReactNode;
+    }): React.ReactNode {
+      return React.createElement("section", null, navbar, children);
+    }
+    function DefaultNavbar(): React.ReactNode {
+      return React.createElement("nav", null, "Default navbar");
+    }
+
+    const route = createSyntheticRoute({
+      page: createSyntheticPageModule(Page),
+      layouts: [createSyntheticPageModule(Layout), createSyntheticPageModule(Layout)],
+      layoutTreePositions: [0, 1],
+      routeSegments: ["dashboard", "settings"],
+      pattern: "/dashboard/settings",
+      slots: {
+        "navbar@dashboard/@navbar": {
+          name: "navbar",
+          default: createSyntheticPageModule(DefaultNavbar),
+          layoutIndex: -1,
+          routeSegments: null,
+        },
+      },
+    });
+
+    const result = await buildPageElements(
+      createBaseOptions({
+        route,
+        routePath: "/dashboard/settings",
+        isRscRequest: true,
+        mountedSlotsHeader: "slot:navbar:/dashboard",
+        mountedSlotActiveRoutesHeader: "slot%3Anavbar%3A%2Fdashboard=route%3A%2Fdashboard",
+      }),
+    );
+
+    const record = result as Record<string, unknown>;
+    expect(record["slot:navbar:/dashboard"]).toBeUndefined();
+    expect(record[APP_SLOT_BINDINGS_KEY]).toContainEqual({
+      activeRouteId: "route:/dashboard",
+      ownerLayoutId: "layout:/dashboard",
+      slotId: "slot:navbar:/dashboard",
+      state: "active",
+    });
+  });
+
   it("marks intercepted slot override bindings as active", async () => {
     function TestPage(): React.ReactNode {
       return React.createElement("div", null, "Hello");

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -21,6 +21,7 @@ import {
   VINEXT_RSC_COMPATIBILITY_ID_HEADER,
   VINEXT_RSC_VARY_HEADER,
 } from "../packages/vinext/src/server/app-rsc-cache-busting.js";
+import { APP_RSC_RENDER_MODE_ACTION_RERENDER_PRESERVE_UI } from "../packages/vinext/src/server/app-rsc-render-mode.js";
 import {
   getAndClearActionRevalidationKind,
   refresh,
@@ -270,6 +271,7 @@ function createRscOptions(
     },
     maxActionBodySize: 1024,
     maxActionBodySizeLabel: "1kb",
+    mountedSlotActiveRoutesHeader: null,
     middlewareHeaders: null,
     middlewareStatus: null,
     mountedSlotsHeader: null,
@@ -1441,8 +1443,10 @@ describe("app server action execution helpers", () => {
   // packages/next/src/server/app-render/action-handler.ts addRevalidationHeader()
   // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/action-handler.ts
   it("emits x-action-revalidated when a fetch action revalidates a path", async () => {
+    const buildPageElement = vi.fn(() => "dashboard:{}:none");
     const response = await handleServerActionRscRequest(
       createRscOptions({
+        buildPageElement,
         loadServerAction() {
           return Promise.resolve(async () => {
             await revalidatePath("/dashboard");
@@ -1454,6 +1458,11 @@ describe("app server action execution helpers", () => {
 
     expect(response?.status).toBe(200);
     expect(response?.headers.get("x-action-revalidated")).toBe("1");
+    expect(buildPageElement).toHaveBeenCalledWith(
+      expect.objectContaining({
+        renderMode: APP_RSC_RENDER_MODE_ACTION_RERENDER_PRESERVE_UI,
+      }),
+    );
   });
 
   it("renders same-origin action redirects as a single-pass Flight response", async () => {
@@ -1928,8 +1937,10 @@ describe("app server action execution helpers", () => {
   });
 
   it("emits dynamic-only x-action-revalidated when a fetch action refreshes", async () => {
+    const buildPageElement = vi.fn(() => "dashboard:{}:none");
     const response = await handleServerActionRscRequest(
       createRscOptions({
+        buildPageElement,
         loadServerAction() {
           return Promise.resolve(() => {
             refresh();
@@ -1941,6 +1952,11 @@ describe("app server action execution helpers", () => {
 
     expect(response?.status).toBe(200);
     expect(response?.headers.get("x-action-revalidated")).toBe("2");
+    expect(buildPageElement).toHaveBeenCalledWith(
+      expect.objectContaining({
+        renderMode: APP_RSC_RENDER_MODE_ACTION_RERENDER_PRESERVE_UI,
+      }),
+    );
   });
 
   // Ported from Next.js: test/e2e/app-dir/actions/app-action.test.ts

--- a/tests/isr-cache.test.ts
+++ b/tests/isr-cache.test.ts
@@ -169,6 +169,44 @@ describe("App Router ISR cache key primitives", () => {
     expect(first).toMatch(/^app:\/feed:rsc:slots:[a-z0-9]+$/);
   });
 
+  it("keys mounted-slot active route RSC variants by normalized active-route header", () => {
+    delete process.env.__VINEXT_BUILD_ID;
+
+    const modalSlot = "slot:modal:/feed";
+    const sidebarSlot = "slot:sidebar:/feed";
+    const modalRoute = "route:/photos/[id]";
+    const sidebarRoute = "route:/feed";
+    const first = appIsrRscKey(
+      "/feed",
+      "slot:modal:/feed slot:sidebar:/feed",
+      undefined,
+      undefined,
+      `${encodeURIComponent(sidebarSlot)}=${encodeURIComponent(sidebarRoute)} ${encodeURIComponent(
+        modalSlot,
+      )}=${encodeURIComponent(modalRoute)}`,
+    );
+    const second = appIsrRscKey(
+      "/feed",
+      "slot:sidebar:/feed slot:modal:/feed",
+      undefined,
+      undefined,
+      `${encodeURIComponent(modalSlot)}=${encodeURIComponent(modalRoute)} ${encodeURIComponent(
+        sidebarSlot,
+      )}=${encodeURIComponent(sidebarRoute)}`,
+    );
+    const differentActiveRoute = appIsrRscKey(
+      "/feed",
+      "slot:modal:/feed slot:sidebar:/feed",
+      undefined,
+      undefined,
+      `${encodeURIComponent(modalSlot)}=${encodeURIComponent(sidebarRoute)}`,
+    );
+
+    expect(first).toBe(second);
+    expect(first).not.toBe(differentActiveRoute);
+    expect(first).toMatch(/^app:\/feed:rsc:slots:[a-z0-9]+:active:[a-z0-9]+$/);
+  });
+
   it("bounds RSC cache-key cardinality against attacker-supplied mounted-slot values", () => {
     // SECURITY-AUDIT-2026-05 F-PROD-1: an attacker who forges
     // X-Vinext-Mounted-Slots: <unique-value> must not be able to fan out

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -11,6 +11,8 @@ import {
 import { APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL } from "../packages/vinext/src/server/app-rsc-render-mode.js";
 import {
   NEXT_ROUTER_PREFETCH_HEADER,
+  VINEXT_MOUNTED_SLOT_ACTIVE_ROUTES_HEADER,
+  VINEXT_MOUNTED_SLOTS_HEADER,
   VINEXT_RSC_RENDER_MODE_HEADER,
 } from "../packages/vinext/src/server/headers.js";
 import type { VinextLinkPrefetchRoute } from "../packages/vinext/src/client/vinext-next-data.js";
@@ -57,7 +59,7 @@ const linkPrefetchRoutes = [
   { canPrefetchLoadingShell: false, patternParts: ["clothing", ":product"], isDynamic: true },
 ] satisfies VinextLinkPrefetchRoute[];
 
-function createTestNavigationRuntime(navigate: unknown) {
+function createTestNavigationRuntime(navigate: unknown, functions: Record<string, unknown> = {}) {
   return {
     bootstrap: {
       routeManifest: null,
@@ -65,6 +67,7 @@ function createTestNavigationRuntime(navigate: unknown) {
     },
     functions: {
       navigate,
+      ...functions,
     },
   };
 }
@@ -85,6 +88,7 @@ function pingVisibleLinksFromRuntime(): void {
 type MockReactAnchorCaptureOptions = {
   captureAnchor(type: unknown, props: unknown): void;
   captureEffect?: (effect: CapturedEffect) => void;
+  captureLayoutEffect?: (effect: CapturedEffect) => void;
   startTransition?: (callback: () => void) => void;
 };
 
@@ -109,15 +113,19 @@ function mockReactAnchorCaptureForLinkOnly_DO_NOT_REUSE(
     }) as typeof actual.createElement;
 
     const mockDefault = { ...actual, createElement };
-    if (options.captureEffect !== undefined) {
+    if (options.captureEffect !== undefined || options.captureLayoutEffect !== undefined) {
       const useEffect = (effect: CapturedEffect) => {
         options.captureEffect?.(effect);
+      };
+      const useLayoutEffect = (effect: CapturedEffect) => {
+        (options.captureLayoutEffect ?? options.captureEffect)?.(effect);
       };
       return {
         ...actual,
         createElement,
         useEffect,
-        default: { ...mockDefault, useEffect },
+        useLayoutEffect,
+        default: { ...mockDefault, useEffect, useLayoutEffect },
       };
     }
 
@@ -1124,6 +1132,7 @@ async function renderIsolatedLink(options: {
   nodeEnv: string;
   props?: Record<string, unknown>;
   requireRef?: boolean;
+  runtimeFunctions?: Record<string, unknown>;
   windowOverrides?: Record<string, unknown>;
 }) {
   vi.resetModules();
@@ -1134,6 +1143,7 @@ async function renderIsolatedLink(options: {
   vi.stubEnv("NODE_ENV", options.nodeEnv);
 
   const effects: CapturedEffect[] = [];
+  const layoutEffects: CapturedEffect[] = [];
   let capturedAnchorProps: CapturedAnchorProps | undefined;
 
   const captureAnchor = (type: unknown, props: unknown) => {
@@ -1146,6 +1156,9 @@ async function renderIsolatedLink(options: {
     captureAnchor,
     captureEffect(effect) {
       effects.push(effect);
+    },
+    captureLayoutEffect(effect) {
+      layoutEffects.push(effect);
     },
   });
 
@@ -1161,7 +1174,9 @@ async function renderIsolatedLink(options: {
     search: "",
   };
   const navigationRuntime =
-    options.appNavigation === false ? undefined : createTestNavigationRuntime(navigate);
+    options.appNavigation === false
+      ? undefined
+      : createTestNavigationRuntime(navigate, options.runtimeFunctions);
 
   vi.stubGlobal("fetch", fetch);
   vi.stubGlobal("document", {
@@ -1211,17 +1226,39 @@ async function renderIsolatedLink(options: {
     const anchor = { href: options.href } as HTMLAnchorElement;
     capturedAnchorProps.ref?.(anchor);
 
-    for (const effect of effects) {
-      effect();
-    }
+    const layoutCleanups = layoutEffects
+      .map((effect) => effect())
+      .filter((cleanup): cleanup is () => void => typeof cleanup === "function");
+    const effectCleanups = effects
+      .map((effect) => effect())
+      .filter((cleanup): cleanup is () => void => typeof cleanup === "function");
+
+    const cleanupEffects = () => {
+      for (const cleanup of effectCleanups.slice().reverse()) cleanup();
+    };
+    const cleanupLayoutEffects = () => {
+      for (const cleanup of layoutCleanups.slice().reverse()) cleanup();
+    };
+    const cleanupAllEffects = () => {
+      cleanupEffects();
+      cleanupLayoutEffects();
+    };
+
+    const restore = () => {
+      cleanupAllEffects();
+      restoreNodeEnv();
+    };
 
     return {
       anchor,
       capturedAnchorProps,
+      cleanupEffects,
+      cleanupLayoutEffects,
+      cleanupAllEffects,
       fetch,
       navigate,
       pagePrefetchLinks,
-      restoreNodeEnv,
+      restoreNodeEnv: restore,
     };
   } catch (error) {
     restoreNodeEnv();
@@ -1297,6 +1334,67 @@ describe("Link prefetch scheduling", () => {
       await waitForFetchCalls(result.fetch, 1);
 
       expect(observer.unobserve).not.toHaveBeenCalledWith(result.anchor);
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[0],
+        "/viewport-prefetch-target",
+        expect.objectContaining({
+          credentials: "include",
+          priority: "low",
+        }),
+      );
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("does not prefetch visible links already reusable from the visited cache", async () => {
+    const observer = stubIntersectionObserver();
+    const hasVisitedResponseForPrefetch = vi.fn(
+      (_rscUrl: string, _interceptionContext: string | null, _mountedSlotsHeader: string | null) =>
+        true,
+    );
+
+    const result = await renderIsolatedLink({
+      href: "/viewport-prefetch-target",
+      nodeEnv: "production",
+      runtimeFunctions: { hasVisitedResponseForPrefetch },
+    });
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await flushPrefetchTasks();
+
+      expect(result.fetch).not.toHaveBeenCalled();
+      expect(hasVisitedResponseForPrefetch).toHaveBeenCalledTimes(1);
+      const call = hasVisitedResponseForPrefetch.mock.calls[0];
+      if (!call) throw new Error("Expected visited-cache prefetch predicate call");
+      const [rscUrl, interceptionContext, mountedSlotsHeader] = call;
+      expect(typeof rscUrl).toBe("string");
+      expect(new URL(String(rscUrl), "https://example.com").pathname).toBe(
+        "/viewport-prefetch-target",
+      );
+      expect(interceptionContext).toBeNull();
+      expect(mountedSlotsHeader).toBeNull();
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("starts App Router viewport prefetches before browser idle callbacks", async () => {
+    const observer = stubIntersectionObserver();
+    const requestIdleCallback = vi.fn(() => 1);
+
+    const result = await renderIsolatedLink({
+      href: "/viewport-prefetch-target",
+      nodeEnv: "production",
+      windowOverrides: { requestIdleCallback },
+    });
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+
+      expect(requestIdleCallback).not.toHaveBeenCalled();
       expectCanonicalRscFetchCall(
         result.fetch.mock.calls[0],
         "/viewport-prefetch-target",
@@ -1439,6 +1537,34 @@ describe("Link prefetch scheduling", () => {
       expect(result.fetch).toHaveBeenCalledTimes(2);
       expectCanonicalRscFetchCall(
         result.fetch.mock.calls[1],
+        "/viewport-prefetch-target",
+        expect.objectContaining({
+          credentials: "include",
+          priority: "low",
+        }),
+      );
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("coalesces same-tick visible App Router prefetch pings", async () => {
+    const observer = stubIntersectionObserver();
+
+    const result = await renderIsolatedLink({
+      href: "/viewport-prefetch-target",
+      nodeEnv: "production",
+    });
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      pingVisibleLinksFromRuntime();
+      await waitForFetchCalls(result.fetch, 1);
+      await flushPrefetchTasks();
+
+      expect(result.fetch).toHaveBeenCalledTimes(1);
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[0],
         "/viewport-prefetch-target",
         expect.objectContaining({
           credentials: "include",
@@ -1788,6 +1914,85 @@ describe("Link prefetch scheduling", () => {
       window.location.href = "https://example.com/intent-prefetch-target";
       window.location.pathname = "/intent-prefetch-target";
       window.location.search = "";
+
+      pingVisibleLinksFromRuntime();
+      await flushPrefetchTasks();
+
+      expect(result.fetch).not.toHaveBeenCalled();
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("includes mounted slot active routes on App Router prefetches", async () => {
+    const observer = stubIntersectionObserver();
+    const mountedSlotsHeader = "slot:navbar:/dashboard";
+    const mountedSlotActiveRoutesHeader = "slot%3Anavbar%3A%2Fdashboard=route%3A%2Fdashboard";
+    const result = await renderIsolatedLink({
+      href: "/intent-prefetch-target",
+      nodeEnv: "production",
+    });
+    const { setMountedSlotActiveRoutesHeader, setMountedSlotsHeader } =
+      await import("../packages/vinext/src/shims/navigation.js");
+
+    try {
+      setMountedSlotsHeader(mountedSlotsHeader);
+      setMountedSlotActiveRoutesHeader(mountedSlotActiveRoutesHeader);
+
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+
+      const init = result.fetch.mock.calls[0]?.[1];
+      expect(init?.headers).toBeInstanceOf(Headers);
+      if (!(init?.headers instanceof Headers)) {
+        throw new Error("Expected prefetch request headers");
+      }
+      expect(init.headers.get(VINEXT_MOUNTED_SLOTS_HEADER)).toBe(mountedSlotsHeader);
+      expect(init.headers.get(VINEXT_MOUNTED_SLOT_ACTIVE_ROUTES_HEADER)).toBe(
+        mountedSlotActiveRoutesHeader,
+      );
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("cancels a pending visible prefetch when navigation makes it the current URL", async () => {
+    const observer = stubIntersectionObserver();
+    const result = await renderIsolatedLink({
+      href: "/intent-prefetch-target",
+      nodeEnv: "production",
+    });
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      window.location.href = "https://example.com/intent-prefetch-target";
+      window.location.pathname = "/intent-prefetch-target";
+      window.location.search = "";
+      await flushPrefetchTasks();
+
+      expect(result.fetch).not.toHaveBeenCalled();
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("removes unmounted visible links before runtime prefetch pings", async () => {
+    const observer = stubIntersectionObserver();
+    const result = await renderIsolatedLink({
+      href: "/intent-prefetch-target",
+      nodeEnv: "production",
+    });
+    const { getPrefetchCache, getPrefetchedUrls } =
+      await import("../packages/vinext/src/shims/navigation.js");
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+
+      getPrefetchCache().clear();
+      getPrefetchedUrls().clear();
+      result.fetch.mockClear();
+      result.cleanupLayoutEffects();
 
       pingVisibleLinksFromRuntime();
       await flushPrefetchTasks();


### PR DESCRIPTION
## Summary
- preserve active parallel-slot state across App Router segment-cache refresh and prefetch paths
- include mounted-slot context in navigation, prefetch, and server-action refresh requests
- keep committed navigation snapshots reusable without losing active slot information

## Validation
- vp check on touched source/test groups
- focused Vitest coverage for mounted slots, action refresh, browser commit/cache state, and Link active-slot prefetch headers
- targeted Next.js e2e: test/e2e/app-dir/segment-cache/refresh/segment-cache-refresh.test.ts (3/3 passed)
- independent review: NO FINDINGS