### PR TITLE
fix(app-router): honor segment cache staleness

### DIFF
--- a/packages/vinext/src/client/navigation-runtime.ts
+++ b/packages/vinext/src/client/navigation-runtime.ts
@@ -53,6 +53,11 @@ export type NavigationRuntimeFunctions = {
     href: string,
     historyUpdateMode: NavigationRuntimeHistoryUpdateMode,
   ) => Promise<void>;
+  hasVisitedResponseCacheEntryForNavigation?: (
+    rscUrl: string,
+    interceptionContext: string | null,
+    mountedSlotsHeader: string | null,
+  ) => boolean;
   navigate?: NavigationRuntimeNavigate;
   /**
    * Called at the start of every App Router navigation so the <Link> shim can
@@ -113,6 +118,7 @@ function isNavigationRuntimeFunctions(value: unknown): value is NavigationRuntim
   return (
     isOptionalRuntimeFunction(Reflect.get(value, "clearNavigationCaches")) &&
     isOptionalRuntimeFunction(Reflect.get(value, "commitHashNavigation")) &&
+    isOptionalRuntimeFunction(Reflect.get(value, "hasVisitedResponseCacheEntryForNavigation")) &&
     isOptionalRuntimeFunction(Reflect.get(value, "navigateExternal")) &&
     isOptionalRuntimeFunction(Reflect.get(value, "navigate")) &&
     isOptionalRuntimeFunction(Reflect.get(value, "notifyLinkNavigationStart")) &&

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -124,6 +124,9 @@ import {
 import { AppBrowserHistoryController } from "./app-browser-history-controller.js";
 import {
   createVisitedResponseCacheEntry,
+  deleteVisitedResponseCacheEntry,
+  findVisitedResponseCacheEntry,
+  hasFreshVisitedResponseCacheEntryForNavigation,
   isVisitedResponseCacheEntryFresh,
   type VisitedResponseCacheEntry,
 } from "./app-visited-response-cache.js";
@@ -679,8 +682,8 @@ function readVisitedResponseCacheCandidate(
   navigationKind: NavigationKind,
 ): VisitedResponseCacheCandidate {
   const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
-  const cached = visitedResponseCache.get(cacheKey);
-  if (!cached) {
+  const match = findVisitedResponseCacheEntry(visitedResponseCache, rscUrl, interceptionContext);
+  if (!match) {
     return {
       cacheKey,
       entry: null,
@@ -692,15 +695,16 @@ function readVisitedResponseCacheCandidate(
   }
 
   return {
-    cacheKey,
-    entry: cached,
+    cacheKey: match.cacheKey,
+    entry: match.entry,
     facts: {
       candidate: "present",
-      fresh: isVisitedResponseCacheEntryFresh(cached, {
+      fresh: isVisitedResponseCacheEntryFresh(match.entry, {
         navigationKind,
         now: Date.now(),
       }),
-      mountedSlotsMatch: cached.mountedSlotsHeader === mountedSlotsHeader,
+      mountedSlotsMatch:
+        match.entry.elements !== undefined || match.entry.mountedSlotsHeader === mountedSlotsHeader,
       navigationKind,
     },
   };
@@ -731,7 +735,41 @@ function applyVisitedResponseCacheCandidateDecision(
 }
 
 function deleteVisitedResponse(rscUrl: string, interceptionContext: string | null): void {
-  visitedResponseCache.delete(AppElementsWire.encodeCacheKey(rscUrl, interceptionContext));
+  deleteVisitedResponseCacheEntry(visitedResponseCache, rscUrl, interceptionContext);
+}
+
+function createCommittedAppElements(state: AppRouterState): AppElements {
+  return {
+    ...state.elements,
+    [AppElementsWire.keys.layoutFlags]: state.layoutFlags,
+    [AppElementsWire.keys.layoutIds]: state.layoutIds,
+    [AppElementsWire.keys.skippedLayoutIds]: [],
+    [AppElementsWire.keys.slotBindings]: state.slotBindings,
+  } satisfies AppElements;
+}
+
+function putVisitedResponseEntry(options: {
+  elements?: AppElements;
+  interceptionContext: string | null;
+  mountedSlotsHeader?: string | null;
+  params: Record<string, string | string[]>;
+  prefetchFallbackTtlMs: number;
+  rscUrl: string;
+  snapshot: CachedRscResponse;
+}): VisitedResponseCacheEntry {
+  const cacheKey = AppElementsWire.encodeCacheKey(options.rscUrl, options.interceptionContext);
+  visitedResponseCache.delete(cacheKey);
+  evictVisitedResponseCacheIfNeeded();
+  const entry = createVisitedResponseCacheEntry({
+    fallbackTtlMs: options.prefetchFallbackTtlMs,
+    elements: options.elements,
+    now: Date.now(),
+    mountedSlotsHeader: options.mountedSlotsHeader ?? options.snapshot.mountedSlotsHeader ?? null,
+    params: options.params,
+    response: options.snapshot,
+  });
+  visitedResponseCache.set(cacheKey, entry);
+  return entry;
 }
 
 function storeVisitedResponseSnapshot(
@@ -744,18 +782,15 @@ function storeVisitedResponseSnapshot(
   elements?: AppElements,
 ): () => void {
   const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
-  visitedResponseCache.delete(cacheKey);
-  evictVisitedResponseCacheIfNeeded();
-  const now = Date.now();
-  const entry = createVisitedResponseCacheEntry({
-    fallbackTtlMs: prefetchFallbackTtlMs,
+  const entry = putVisitedResponseEntry({
     elements,
-    now,
+    interceptionContext,
     mountedSlotsHeader: requestMountedSlotsHeader,
     params,
-    response: snapshot,
+    prefetchFallbackTtlMs,
+    rscUrl,
+    snapshot,
   });
-  visitedResponseCache.set(cacheKey, entry);
   seedPrefetchResponseSnapshot(
     rscUrl,
     snapshot,
@@ -769,6 +804,57 @@ function storeVisitedResponseSnapshot(
     }
     deletePrefetchResponseSnapshot(rscUrl, snapshot, interceptionContext);
   };
+}
+
+function storeCommittedElementsVisitedResponseSnapshot(options: {
+  elements: AppElements;
+  interceptionContext: string | null;
+  mountedSlotsHeader: string | null;
+  navResponse: Response;
+  navResponseUrl: string | null;
+  params: Record<string, string | string[]>;
+  prefetchFallbackTtlMs: number;
+  rscUrl: string;
+}): void {
+  const metadata = AppElementsWire.readMetadata(options.elements);
+  if (isCacheRestorableAppPayloadMetadata(metadata)) return;
+
+  const responseSnapshot = createCachedRscResponseSnapshot(
+    options.navResponse,
+    new ArrayBuffer(0),
+    options.navResponseUrl,
+  );
+  const snapshot = {
+    ...responseSnapshot,
+    ...(responseSnapshot.dynamicStaleTimeSeconds === undefined &&
+    metadata.dynamicStaleTimeSeconds !== undefined
+      ? { dynamicStaleTimeSeconds: metadata.dynamicStaleTimeSeconds }
+      : {}),
+    mountedSlotsHeader: options.mountedSlotsHeader,
+  } satisfies CachedRscResponse;
+  putVisitedResponseEntry({
+    elements: options.elements,
+    interceptionContext: options.interceptionContext,
+    mountedSlotsHeader: options.mountedSlotsHeader,
+    params: options.params,
+    prefetchFallbackTtlMs: options.prefetchFallbackTtlMs,
+    rscUrl: options.rscUrl,
+    snapshot,
+  });
+}
+
+function hasVisitedResponseCacheEntryForNavigation(
+  rscUrl: string,
+  interceptionContext: string | null,
+  mountedSlotsHeader: string | null,
+): boolean {
+  return hasFreshVisitedResponseCacheEntryForNavigation(
+    visitedResponseCache,
+    rscUrl,
+    interceptionContext,
+    mountedSlotsHeader,
+    Date.now(),
+  );
 }
 
 // Build the absolute current-document href the early-intent planner compares
@@ -2105,6 +2191,22 @@ function bootstrapHydration(
           visibleCommitMode,
           (state) => {
             committedState = state;
+            const committedElements = createCommittedAppElements(state);
+            const metadata = AppElementsWire.readMetadata(committedElements);
+            const interceptionContext = resolveVisitedResponseInterceptionContext(
+              requestInterceptionContext,
+              metadata.interceptionContext,
+            );
+            storeCommittedElementsVisitedResponseSnapshot({
+              elements: committedElements,
+              interceptionContext,
+              mountedSlotsHeader: getMountedSlotIdsHeader(committedElements),
+              navResponse,
+              navResponseUrl,
+              params: navParams,
+              prefetchFallbackTtlMs: DYNAMIC_NAVIGATION_CACHE_TTL,
+              rscUrl,
+            });
             // Once React has committed this payload, its RSC stream owns the
             // mounted tree even if a Suspense boundary is still consuming it.
             // A later navigation may supersede future cache publication, but
@@ -2171,13 +2273,6 @@ function bootstrapHydration(
             getMountedSlotIdsHeader((committedState as AppRouterState).elements) === null
           ) {
             const state = committedState as AppRouterState;
-            const committedElements = {
-              ...state.elements,
-              [AppElementsWire.keys.layoutFlags]: state.layoutFlags,
-              [AppElementsWire.keys.layoutIds]: state.layoutIds,
-              [AppElementsWire.keys.skippedLayoutIds]: [],
-              [AppElementsWire.keys.slotBindings]: state.slotBindings,
-            } satisfies AppElements;
             if (navigationCacheGeneration !== clientNavigationCacheGeneration) return;
             storeVisitedResponseSnapshot(
               rscUrl,
@@ -2186,16 +2281,17 @@ function bootstrapHydration(
               navParams,
               DYNAMIC_NAVIGATION_CACHE_TTL,
               mountedSlotsHeader,
-              committedElements,
+              createCommittedAppElements(state),
             );
           } else {
             if (navigationCacheGeneration !== clientNavigationCacheGeneration) return;
-            seedPrefetchResponseSnapshot(
+            storeVisitedResponseSnapshot(
               rscUrl,
-              snapshot,
               interceptionContext,
-              mountedSlotsHeader,
+              snapshot,
+              navParams,
               DYNAMIC_NAVIGATION_CACHE_TTL,
+              mountedSlotsHeader,
             );
           }
         } catch {
@@ -2237,6 +2333,7 @@ function bootstrapHydration(
     clearNavigationCaches: clearClientNavigationCaches,
     commitHashNavigation: (href, historyUpdateMode, scroll) =>
       historyController.commitHashOnlyNavigation(href, historyUpdateMode, scroll),
+    hasVisitedResponseCacheEntryForNavigation,
     navigate: navigateRsc,
   });
 

--- a/packages/vinext/src/server/app-visited-response-cache.ts
+++ b/packages/vinext/src/server/app-visited-response-cache.ts
@@ -1,5 +1,6 @@
 import { resolveCachedRscResponseExpiresAt, type CachedRscResponse } from "vinext/shims/navigation";
-import type { AppElements } from "./app-elements.js";
+import { AppElementsWire, type AppElements } from "./app-elements.js";
+import { stripRscCacheBustingSearchParam } from "./app-rsc-cache-busting.js";
 
 type VisitedResponseCacheNavigationKind = "navigate" | "refresh" | "traverse";
 
@@ -53,4 +54,82 @@ export function isVisitedResponseCacheEntryFresh(
   }
 
   return entry.expiresAt > options.now;
+}
+
+function normalizeVisitedResponseCacheLookupUrl(rscUrl: string): string | null {
+  try {
+    const url = new URL(rscUrl, "http://vinext.local");
+    stripRscCacheBustingSearchParam(url);
+    return `${url.pathname}${url.search}`;
+  } catch {
+    return null;
+  }
+}
+
+function parseVisitedResponseCacheKey(cacheKey: string): {
+  interceptionContext: string | null;
+  rscUrl: string;
+} {
+  const separatorIndex = cacheKey.indexOf("\0");
+  if (separatorIndex === -1) {
+    return { interceptionContext: null, rscUrl: cacheKey };
+  }
+  return {
+    interceptionContext: cacheKey.slice(separatorIndex + 1),
+    rscUrl: cacheKey.slice(0, separatorIndex),
+  };
+}
+
+export function findVisitedResponseCacheEntry(
+  cache: Map<string, VisitedResponseCacheEntry>,
+  rscUrl: string,
+  interceptionContext: string | null,
+): { cacheKey: string; entry: VisitedResponseCacheEntry } | null {
+  const exactCacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
+  const exactEntry = cache.get(exactCacheKey);
+  if (exactEntry) {
+    return { cacheKey: exactCacheKey, entry: exactEntry };
+  }
+
+  const normalizedTarget = normalizeVisitedResponseCacheLookupUrl(rscUrl);
+  if (normalizedTarget === null) return null;
+
+  for (const [cacheKey, entry] of cache) {
+    const source = parseVisitedResponseCacheKey(cacheKey);
+    if (source.interceptionContext !== interceptionContext) continue;
+    if (normalizeVisitedResponseCacheLookupUrl(source.rscUrl) !== normalizedTarget) continue;
+    return { cacheKey, entry };
+  }
+
+  return null;
+}
+
+export function deleteVisitedResponseCacheEntry(
+  cache: Map<string, VisitedResponseCacheEntry>,
+  rscUrl: string,
+  interceptionContext: string | null,
+): boolean {
+  const match = findVisitedResponseCacheEntry(cache, rscUrl, interceptionContext);
+  if (!match) return false;
+  return cache.delete(match.cacheKey);
+}
+
+export function hasFreshVisitedResponseCacheEntryForNavigation(
+  cache: Map<string, VisitedResponseCacheEntry>,
+  rscUrl: string,
+  interceptionContext: string | null,
+  mountedSlotsHeader: string | null,
+  now: number,
+): boolean {
+  const match = findVisitedResponseCacheEntry(cache, rscUrl, interceptionContext);
+  if (!match) return false;
+
+  if (!isVisitedResponseCacheEntryFresh(match.entry, { navigationKind: "navigate", now })) {
+    cache.delete(match.cacheKey);
+    return false;
+  }
+
+  return (
+    match.entry.elements !== undefined || match.entry.mountedSlotsHeader === mountedSlotsHeader
+  );
 }

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -162,6 +162,7 @@ const __basePath: string = process.env.__NEXT_ROUTER_BASEPATH ?? "";
 const __trailingSlash: boolean = process.env.__VINEXT_TRAILING_SLASH === "true";
 const __prefetchInlining: boolean = process.env.__VINEXT_PREFETCH_INLINING === "true";
 const linkPrefetchRouteTrieCache = createRouteTrieCache<VinextLinkPrefetchRoute>();
+const activeNavigationPrefetchSuppressions = new Set<string>();
 
 function resolveHref(href: LinkProps["href"]): string {
   if (typeof href === "string") return href;
@@ -311,19 +312,58 @@ function getLinkPrefetchRouterMode(): LinkPrefetchRouterMode {
   return hasAppNavigationRuntime() ? "app" : "pages";
 }
 
+function toActiveNavigationPrefetchSuppressionKey(href: string): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const url = new URL(
+      toBrowserNavigationHref(href, window.location.href, __basePath),
+      window.location.href,
+    );
+    return `${url.origin}${url.pathname}${url.search}`;
+  } catch {
+    return null;
+  }
+}
+
+function addActiveNavigationPrefetchSuppression(href: string): string | null {
+  const key = toActiveNavigationPrefetchSuppressionKey(href);
+  if (key !== null) {
+    activeNavigationPrefetchSuppressions.add(key);
+  }
+  return key;
+}
+
+function clearActiveNavigationPrefetchSuppression(key: string | null): void {
+  if (key === null) return;
+  if (typeof window === "undefined") {
+    activeNavigationPrefetchSuppressions.delete(key);
+    return;
+  }
+  const clear = () => activeNavigationPrefetchSuppressions.delete(key);
+  (window.requestIdleCallback ?? ((fn: () => void) => globalThis.setTimeout(fn, 0)))(clear);
+}
+
+function isPrefetchSuppressedByActiveNavigation(href: string): boolean {
+  const key = toActiveNavigationPrefetchSuppressionKey(href);
+  return key !== null && activeNavigationPrefetchSuppressions.has(key);
+}
+
 function resolveMatchedAutoAppRoutePrefetch(route: VinextLinkPrefetchRoute): {
   cacheForNavigation: boolean;
+  minimumTtlMs: number | undefined;
   prefetchShellFirst: boolean;
   shouldPrefetch: boolean;
 } {
   const hasLoadingShell = route.canPrefetchLoadingShell;
+  const shouldCacheForNavigation = !hasLoadingShell;
   return {
     // Vinext does not yet have Next.js's per-segment runtime-prefetch hints.
     // Routes with loading boundaries prefetch a shell first so navigation can
     // commit loading.js immediately. Dynamic routes without loading-shell
     // fallbacks are treated as exact-URL full prefetches; the prefetch cache is
     // keyed by the concrete RSC URL, so this cannot reuse data across params.
-    cacheForNavigation: !hasLoadingShell,
+    cacheForNavigation: shouldCacheForNavigation,
+    minimumTtlMs: shouldCacheForNavigation ? 0 : undefined,
     prefetchShellFirst: !route.isDynamic,
     shouldPrefetch: true,
   };
@@ -346,26 +386,47 @@ export function canAutoPrefetchFullAppRoute(href: string): boolean {
 
 export function resolveAutoAppRoutePrefetch(href: string): {
   cacheForNavigation: boolean;
+  minimumTtlMs: number | undefined;
   prefetchShellFirst: boolean;
   shouldPrefetch: boolean;
 } {
   if (typeof window === "undefined") {
-    return { cacheForNavigation: false, prefetchShellFirst: false, shouldPrefetch: false };
+    return {
+      cacheForNavigation: false,
+      minimumTtlMs: undefined,
+      prefetchShellFirst: false,
+      shouldPrefetch: false,
+    };
   }
 
   const routes = window.__VINEXT_LINK_PREFETCH_ROUTES__;
   if (!routes) {
-    return { cacheForNavigation: false, prefetchShellFirst: false, shouldPrefetch: false };
+    return {
+      cacheForNavigation: false,
+      minimumTtlMs: undefined,
+      prefetchShellFirst: false,
+      shouldPrefetch: false,
+    };
   }
 
   const routeHref = toSameOriginRouteHref(href);
   if (routeHref === null) {
-    return { cacheForNavigation: false, prefetchShellFirst: false, shouldPrefetch: false };
+    return {
+      cacheForNavigation: false,
+      minimumTtlMs: undefined,
+      prefetchShellFirst: false,
+      shouldPrefetch: false,
+    };
   }
 
   const match = matchRouteWithTrie(routeHref, routes, linkPrefetchRouteTrieCache);
   if (!match) {
-    return { cacheForNavigation: false, prefetchShellFirst: false, shouldPrefetch: false };
+    return {
+      cacheForNavigation: false,
+      minimumTtlMs: undefined,
+      prefetchShellFirst: false,
+      shouldPrefetch: false,
+    };
   }
 
   return resolveMatchedAutoAppRoutePrefetch(match.route);
@@ -373,11 +434,13 @@ export function resolveAutoAppRoutePrefetch(href: string): {
 
 function resolveFullAppRoutePrefetch(): {
   cacheForNavigation: true;
+  minimumTtlMs: undefined;
   prefetchShellFirst: boolean;
   shouldPrefetch: true;
 } {
   return {
     cacheForNavigation: true,
+    minimumTtlMs: undefined,
     prefetchShellFirst: true,
     shouldPrefetch: true,
   };
@@ -469,6 +532,7 @@ function prefetchUrl(
           getPrefetchedUrls,
           getMountedSlotsHeader,
           hasPrefetchCacheEntryForNavigation,
+          DYNAMIC_NAVIGATION_CACHE_TTL,
           prefetchRscResponse,
           PREFETCH_CACHE_TTL,
         } = navigation;
@@ -489,9 +553,15 @@ function prefetchUrl(
           mode === "auto"
             ? resolveAutoAppRoutePrefetch(prefetchHref)
             : mode === "full-after-shell"
-              ? { cacheForNavigation: true, prefetchShellFirst: true, shouldPrefetch: true }
+              ? {
+                  cacheForNavigation: true,
+                  minimumTtlMs: undefined,
+                  prefetchShellFirst: true,
+                  shouldPrefetch: true,
+                }
               : resolveFullAppRoutePrefetch();
         if (!autoPrefetch.shouldPrefetch) return;
+        if (isPrefetchSuppressedByActiveNavigation(fullHref)) return;
 
         const interceptionContext = getPrefetchInterceptionContext(fullHref);
         const mountedSlotsHeader = getMountedSlotsHeader();
@@ -530,6 +600,16 @@ function prefetchUrl(
         if (
           autoPrefetch.cacheForNavigation &&
           hasPrefetchCacheEntryForNavigation(rscUrl, interceptionContext, mountedSlotsHeader)
+        ) {
+          return;
+        }
+        if (
+          autoPrefetch.cacheForNavigation &&
+          getNavigationRuntime()?.functions.hasVisitedResponseCacheEntryForNavigation?.(
+            rscUrl,
+            interceptionContext,
+            mountedSlotsHeader,
+          )
         ) {
           return;
         }
@@ -606,7 +686,9 @@ function prefetchUrl(
           undefined,
           {
             cacheForNavigation: autoPrefetch.cacheForNavigation,
+            dynamicFallbackTtlMs: DYNAMIC_NAVIGATION_CACHE_TTL,
             fallbackTtlMs: PREFETCH_CACHE_TTL,
+            minimumTtlMs: autoPrefetch.minimumTtlMs,
             optimisticRouteShell: isOptimisticRouteShellPrefetch,
           },
         );
@@ -1239,7 +1321,14 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
     // App Router: delegate to navigateClientSide which handles scroll save,
     // hash-only changes, RSC fetch, and two-phase URL commit.
     if (hasAppNavigationRuntime) {
-      const { navigateClientSide } = await import("./navigation.js");
+      const prefetchSuppressionKey = addActiveNavigationPrefetchSuppression(navigateHref);
+      let navigateClientSide: (typeof import("./navigation.js"))["navigateClientSide"];
+      try {
+        ({ navigateClientSide } = await import("./navigation.js"));
+      } catch (error) {
+        clearActiveNavigationPrefetchSuppression(prefetchSuppressionKey);
+        throw error;
+      }
       const setter = setPendingRef.current;
       // Register this link as the one driving the current navigation. This
       // resets any previously-pending link (e.g. a different link clicked
@@ -1249,6 +1338,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
       React.startTransition(() => {
         void navigateClientSide(navigateHref, replace ? "replace" : "push", scroll, true).finally(
           () => {
+            clearActiveNavigationPrefetchSuppression(prefetchSuppressionKey);
             if (mountedRef.current) setPending(false);
             if (setter) clearLinkForCurrentNavigation(setter);
           },

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -360,15 +360,16 @@ function resolvePrefetchedRscResponseExpiresAt(
   timestamp: number,
   cached: Pick<CachedRscResponse, "dynamicStaleTimeSeconds" | "expiresAt">,
   fallbackTtlMs: number,
+  minimumTtlMs: number = MIN_PREFETCH_STALE_TIME_MS,
 ): number {
   if (isCacheExpiresAt(cached.expiresAt)) {
     return cached.expiresAt;
   }
   const seconds = cached.dynamicStaleTimeSeconds;
   if (!isDynamicStaleTimeSeconds(seconds)) {
-    return timestamp + Math.max(fallbackTtlMs, MIN_PREFETCH_STALE_TIME_MS);
+    return timestamp + Math.max(fallbackTtlMs, minimumTtlMs);
   }
-  return timestamp + Math.max(seconds * 1000, MIN_PREFETCH_STALE_TIME_MS);
+  return timestamp + Math.max(seconds * 1000, minimumTtlMs);
 }
 
 function resolvePrefetchCacheEntryExpiresAt(entry: PrefetchCacheEntry): number {
@@ -772,6 +773,15 @@ export function restoreRscResponse(cached: CachedRscResponse, copy = true): Resp
   });
 }
 
+function isDynamicRscPrefetchResponse(response: Response): boolean {
+  return (
+    response.headers
+      .get("Cache-Control")
+      ?.split(",")
+      .some((directive) => directive.trim().toLowerCase() === "no-store") === true
+  );
+}
+
 /**
  * Prefetch an RSC response and snapshot it for later consumption.
  * Stores the in-flight promise so immediate clicks can await it instead
@@ -787,7 +797,9 @@ export function prefetchRscResponse(
   options?: PrefetchOptions,
   behavior: {
     cacheForNavigation?: boolean;
+    dynamicFallbackTtlMs?: number;
     fallbackTtlMs?: number;
+    minimumTtlMs?: number;
     optimisticRouteShell?: boolean;
   } = {},
 ): void {
@@ -808,11 +820,16 @@ export function prefetchRscResponse(
   entry.pending = fetchPromise
     .then(async (response) => {
       if (response.ok) {
+        const fallbackTtlMs =
+          isDynamicRscPrefetchResponse(response) && behavior.dynamicFallbackTtlMs !== undefined
+            ? behavior.dynamicFallbackTtlMs
+            : (behavior.fallbackTtlMs ?? PREFETCH_CACHE_TTL);
         entry.snapshot = await snapshotRscResponse(response);
         entry.expiresAt = resolvePrefetchedRscResponseExpiresAt(
           entry.timestamp,
           entry.snapshot,
-          behavior.fallbackTtlMs ?? PREFETCH_CACHE_TTL,
+          fallbackTtlMs,
+          behavior.minimumTtlMs,
         );
       } else {
         deletePrefetchCacheEntry(cache, prefetched, cacheKey, entry, false);

--- a/packages/vinext/src/shims/next-shims.d.ts
+++ b/packages/vinext/src/shims/next-shims.d.ts
@@ -291,7 +291,9 @@ declare module "next/navigation" {
     options?: { onInvalidate?: () => void },
     behavior?: {
       cacheForNavigation?: boolean;
+      dynamicFallbackTtlMs?: number;
       fallbackTtlMs?: number;
+      minimumTtlMs?: number;
       optimisticRouteShell?: boolean;
     },
   ): void;

--- a/tests/app-visited-response-cache.test.ts
+++ b/tests/app-visited-response-cache.test.ts
@@ -3,8 +3,12 @@ import {
   MAX_TRAVERSAL_CACHE_TTL,
   VISITED_RESPONSE_CACHE_TTL,
   createVisitedResponseCacheEntry,
+  deleteVisitedResponseCacheEntry,
+  findVisitedResponseCacheEntry,
+  hasFreshVisitedResponseCacheEntryForNavigation,
   isVisitedResponseCacheEntryFresh,
 } from "../packages/vinext/src/server/app-visited-response-cache.js";
+import { AppElementsWire } from "../packages/vinext/src/server/app-elements.js";
 import type { CachedRscResponse } from "../packages/vinext/src/shims/navigation.js";
 import type { AppElements } from "../packages/vinext/src/server/app-elements.js";
 
@@ -107,6 +111,7 @@ describe("visited response cache freshness", () => {
   });
 
   it("keeps traversal restores independent from dynamic stale expiry", () => {
+    // Ported from Next.js: test/e2e/app-dir/segment-cache/staleness/segment-cache-per-page-dynamic-stale-time.test.ts
     const now = 1_000_000;
     const entry = createVisitedResponseCacheEntry({
       now,
@@ -128,6 +133,59 @@ describe("visited response cache freshness", () => {
     ).toBe(false);
   });
 
+  it("finds equivalent RSC URL variants for BFCache restores", () => {
+    // Ported from Next.js: test/e2e/app-dir/segment-cache/staleness/segment-cache-per-page-dynamic-stale-time.test.ts
+    const cache = new Map();
+    const entry = createVisitedResponseCacheEntry({
+      elements: { "page:/per-page-config/dynamic-stale-60": "cached page" } satisfies AppElements,
+      now: 1_000_000,
+      params: {},
+      response: createCachedResponse({
+        dynamicStaleTimeSeconds: 60,
+        url: "/per-page-config/dynamic-stale-60?_rsc=prefetched",
+      }),
+    });
+    const cacheKey = AppElementsWire.encodeCacheKey(
+      "/per-page-config/dynamic-stale-60?_rsc=prefetched",
+      null,
+    );
+    cache.set(cacheKey, entry);
+
+    expect(
+      findVisitedResponseCacheEntry(
+        cache,
+        "/per-page-config/dynamic-stale-60?_rsc=navigation",
+        null,
+      ),
+    ).toEqual({ cacheKey, entry });
+  });
+
+  it("keeps interception contexts distinct when matching RSC URL variants", () => {
+    const cache = new Map();
+    const feedEntry = createVisitedResponseCacheEntry({
+      now: 1_000_000,
+      params: {},
+      response: createCachedResponse({ url: "/photos/1?_rsc=feed" }),
+    });
+    const galleryEntry = createVisitedResponseCacheEntry({
+      now: 1_000_000,
+      params: {},
+      response: createCachedResponse({ url: "/photos/1?_rsc=gallery" }),
+    });
+    const feedKey = AppElementsWire.encodeCacheKey("/photos/1?_rsc=feed", "/feed");
+    const galleryKey = AppElementsWire.encodeCacheKey("/photos/1?_rsc=gallery", "/gallery");
+    cache.set(feedKey, feedEntry);
+    cache.set(galleryKey, galleryEntry);
+
+    expect(findVisitedResponseCacheEntry(cache, "/photos/1?_rsc=next", "/feed")).toEqual({
+      cacheKey: feedKey,
+      entry: feedEntry,
+    });
+    expect(deleteVisitedResponseCacheEntry(cache, "/photos/1?_rsc=next", "/feed")).toBe(true);
+    expect(cache.has(feedKey)).toBe(false);
+    expect(cache.has(galleryKey)).toBe(true);
+  });
+
   it("never reuses visited responses for refresh navigations", () => {
     const now = 1_000_000;
     const entry = createVisitedResponseCacheEntry({
@@ -142,5 +200,73 @@ describe("visited response cache freshness", () => {
         now,
       }),
     ).toBe(false);
+  });
+
+  it("does not report stale visited responses as available for Link prefetch dedupe", () => {
+    // Ported from Next.js:
+    // test/e2e/app-dir/segment-cache/staleness/segment-cache-stale-time.test.ts
+    const now = 1_000_000;
+    const cache = new Map();
+    const rscUrl = "/stale-2-minutes?_rsc=old";
+    const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, null);
+    const entry = createVisitedResponseCacheEntry({
+      now,
+      mountedSlotsHeader: "slot:source",
+      params: {},
+      response: createCachedResponse({
+        dynamicStaleTimeSeconds: 120,
+        url: rscUrl,
+      }),
+    });
+    cache.set(cacheKey, entry);
+
+    expect(
+      hasFreshVisitedResponseCacheEntryForNavigation(
+        cache,
+        "/stale-2-minutes?_rsc=new",
+        null,
+        "slot:source",
+        now + 120_001,
+      ),
+    ).toBe(false);
+    expect(cache.has(cacheKey)).toBe(false);
+  });
+
+  it("reports fresh visited responses as available for compatible Link prefetch dedupe", () => {
+    const now = 1_000_000;
+    const cache = new Map();
+    const rscUrl = "/stale-4-minutes?_rsc=old";
+    const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, null);
+    const entry = createVisitedResponseCacheEntry({
+      now,
+      mountedSlotsHeader: "slot:source",
+      params: {},
+      response: createCachedResponse({
+        dynamicStaleTimeSeconds: 240,
+        url: rscUrl,
+      }),
+    });
+    cache.set(cacheKey, entry);
+
+    expect(
+      hasFreshVisitedResponseCacheEntryForNavigation(
+        cache,
+        "/stale-4-minutes?_rsc=new",
+        null,
+        "slot:source",
+        now + 120_001,
+      ),
+    ).toBe(true);
+    expect(cache.get(cacheKey)).toBe(entry);
+    expect(
+      hasFreshVisitedResponseCacheEntryForNavigation(
+        cache,
+        "/stale-4-minutes?_rsc=new",
+        null,
+        "slot:other",
+        now + 120_001,
+      ),
+    ).toBe(false);
+    expect(cache.get(cacheKey)).toBe(entry);
   });
 });

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -324,21 +324,25 @@ describe("Link App Router prefetch mode", () => {
     try {
       expect(resolveAutoAppRoutePrefetch("/about")).toEqual({
         cacheForNavigation: true,
+        minimumTtlMs: 0,
         prefetchShellFirst: true,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/blog/hello-world")).toEqual({
         cacheForNavigation: false,
+        minimumTtlMs: undefined,
         prefetchShellFirst: false,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/settings")).toEqual({
         cacheForNavigation: false,
+        minimumTtlMs: undefined,
         prefetchShellFirst: true,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/products/1")).toEqual({
         cacheForNavigation: true,
+        minimumTtlMs: 0,
         prefetchShellFirst: false,
         shouldPrefetch: true,
       });
@@ -347,11 +351,13 @@ describe("Link App Router prefetch mode", () => {
       // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/segment-cache/client-params/client-params.test.ts
       expect(resolveAutoAppRoutePrefetch("/clothing/1")).toEqual({
         cacheForNavigation: true,
+        minimumTtlMs: 0,
         prefetchShellFirst: false,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/missing")).toEqual({
         cacheForNavigation: false,
+        minimumTtlMs: undefined,
         prefetchShellFirst: false,
         shouldPrefetch: false,
       });

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -683,6 +683,95 @@ describe("prefetch cache eviction", () => {
       expect(nav.PREFETCH_CACHE_TTL).toBe(180_000);
     });
 
+    it("uses the dynamic fallback for no-store automatic prefetch responses", async () => {
+      // Ported from Next.js: test/e2e/app-dir/segment-cache/staleness/segment-cache-stale-time.test.ts
+      process.env.__NEXT_CLIENT_ROUTER_DYNAMIC_STALETIME = "30";
+      process.env.__NEXT_CLIENT_ROUTER_STATIC_STALETIME = "300";
+      vi.resetModules();
+      const nav = await import("../packages/vinext/src/shims/navigation.js");
+
+      const rscUrl = "/dynamic.rsc";
+      const now = 1_000_000;
+      vi.spyOn(Date, "now").mockReturnValue(now);
+      nav.prefetchRscResponse(
+        rscUrl,
+        Promise.resolve(
+          new Response("flight", {
+            headers: {
+              "Cache-Control": "no-store, must-revalidate",
+              "content-type": "text/x-component",
+            },
+          }),
+        ),
+        null,
+        null,
+        undefined,
+        {
+          cacheForNavigation: true,
+          dynamicFallbackTtlMs: nav.DYNAMIC_NAVIGATION_CACHE_TTL,
+          fallbackTtlMs: nav.PREFETCH_CACHE_TTL,
+          minimumTtlMs: 0,
+        },
+      );
+
+      await waitForPrefetchSetup(
+        () => nav.getPrefetchCache().get(rscUrl)?.outcome === "cache-seeded",
+      );
+
+      expect(nav.getPrefetchCache().get(rscUrl)?.expiresAt).toBe(now + 30_000);
+
+      vi.spyOn(Date, "now").mockReturnValue(now + 29_999);
+      expect(nav.hasPrefetchCacheEntryForNavigation(rscUrl, null, null)).toBe(true);
+
+      vi.spyOn(Date, "now").mockReturnValue(now + 30_000);
+      expect(nav.hasPrefetchCacheEntryForNavigation(rscUrl, null, null)).toBe(false);
+    });
+
+    it("allows per-page dynamic stale metadata below the historical 30s floor", async () => {
+      // Ported from Next.js: test/e2e/app-dir/segment-cache/staleness/segment-cache-per-page-dynamic-stale-time.test.ts
+      process.env.__NEXT_CLIENT_ROUTER_DYNAMIC_STALETIME = "30";
+      process.env.__NEXT_CLIENT_ROUTER_STATIC_STALETIME = "300";
+      vi.resetModules();
+      const nav = await import("../packages/vinext/src/shims/navigation.js");
+
+      const rscUrl = "/per-page-config/dynamic-stale-10.rsc";
+      const now = 1_000_000;
+      vi.spyOn(Date, "now").mockReturnValue(now);
+      nav.prefetchRscResponse(
+        rscUrl,
+        Promise.resolve(
+          new Response("flight", {
+            headers: {
+              "Cache-Control": "no-store, must-revalidate",
+              [VINEXT_DYNAMIC_STALE_TIME_HEADER]: "10",
+              "content-type": "text/x-component",
+            },
+          }),
+        ),
+        null,
+        null,
+        undefined,
+        {
+          cacheForNavigation: true,
+          dynamicFallbackTtlMs: nav.DYNAMIC_NAVIGATION_CACHE_TTL,
+          fallbackTtlMs: nav.PREFETCH_CACHE_TTL,
+          minimumTtlMs: 0,
+        },
+      );
+
+      await waitForPrefetchSetup(
+        () => nav.getPrefetchCache().get(rscUrl)?.outcome === "cache-seeded",
+      );
+
+      expect(nav.getPrefetchCache().get(rscUrl)?.expiresAt).toBe(now + 10_000);
+
+      vi.spyOn(Date, "now").mockReturnValue(now + 9_999);
+      expect(nav.hasPrefetchCacheEntryForNavigation(rscUrl, null, null)).toBe(true);
+
+      vi.spyOn(Date, "now").mockReturnValue(now + 10_000);
+      expect(nav.hasPrefetchCacheEntryForNavigation(rscUrl, null, null)).toBe(false);
+    });
+
     it("treats a freshly prefetched entry as reusable up to the configured TTL", async () => {
       process.env.__NEXT_CLIENT_ROUTER_STATIC_STALETIME = "180";
       vi.resetModules();


### PR DESCRIPTION
## Summary
- apply dynamic/per-page stale windows when reusing visited App Router responses
- allow visible links to prefetch again once the prior visited response is stale
- keep fresh compatible visited responses available for Link prefetch dedupe

## Validation
- vp test run tests/prefetch-cache.test.ts tests/link.test.ts tests/link-navigation.test.ts tests/app-visited-response-cache.test.ts
- vp check on changed source/tests
- targeted Next.js staleness cases passed except explicitly skipped cacheComponents/use-cache coverage and the separate parallel-routes gap
- independent re-review: NO FINDINGS