### PR TITLE
fix(app-router): prefetch root-param route trees

### DIFF
--- a/packages/vinext/src/client/vinext-next-data.ts
+++ b/packages/vinext/src/client/vinext-next-data.ts
@@ -13,6 +13,7 @@ export type VinextLinkPrefetchRoute = {
   documentOnly?: boolean;
   isDynamic: boolean;
   patternParts: string[];
+  shouldPrefetchRouteTree?: boolean;
 };
 
 /**

--- a/packages/vinext/src/entries/app-browser-entry.ts
+++ b/packages/vinext/src/entries/app-browser-entry.ts
@@ -62,6 +62,7 @@ export function toDocumentOnlyAppRoute(route: AppRoute): VinextLinkPrefetchRoute
     documentOnly: true,
     patternParts: [...route.patternParts],
     isDynamic: route.isDynamic,
+    shouldPrefetchRouteTree: (route.rootParamNames ?? []).length > 0,
   };
 }
 
@@ -71,6 +72,7 @@ export function toLinkPrefetchRoute(route: AppRoute): VinextLinkPrefetchRoute {
     canPrefetchLoadingShell: route.loadingPath !== null,
     patternParts: [...route.patternParts],
     isDynamic: route.isDynamic,
+    shouldPrefetchRouteTree: (route.rootParamNames ?? []).length > 0,
   };
 }
 

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -313,9 +313,19 @@ function getLinkPrefetchRouterMode(): LinkPrefetchRouterMode {
 
 function resolveMatchedAutoAppRoutePrefetch(route: VinextLinkPrefetchRoute): {
   cacheForNavigation: boolean;
+  prefetchRouteTree: boolean;
   prefetchShellFirst: boolean;
   shouldPrefetch: boolean;
 } {
+  if (route.shouldPrefetchRouteTree === true) {
+    return {
+      cacheForNavigation: true,
+      prefetchRouteTree: true,
+      prefetchShellFirst: true,
+      shouldPrefetch: true,
+    };
+  }
+
   const hasLoadingShell = route.canPrefetchLoadingShell;
   return {
     // Vinext does not yet have Next.js's per-segment runtime-prefetch hints.
@@ -324,6 +334,7 @@ function resolveMatchedAutoAppRoutePrefetch(route: VinextLinkPrefetchRoute): {
     // fallbacks are treated as exact-URL full prefetches; the prefetch cache is
     // keyed by the concrete RSC URL, so this cannot reuse data across params.
     cacheForNavigation: !hasLoadingShell,
+    prefetchRouteTree: false,
     prefetchShellFirst: !route.isDynamic,
     shouldPrefetch: true,
   };
@@ -346,26 +357,47 @@ export function canAutoPrefetchFullAppRoute(href: string): boolean {
 
 export function resolveAutoAppRoutePrefetch(href: string): {
   cacheForNavigation: boolean;
+  prefetchRouteTree: boolean;
   prefetchShellFirst: boolean;
   shouldPrefetch: boolean;
 } {
   if (typeof window === "undefined") {
-    return { cacheForNavigation: false, prefetchShellFirst: false, shouldPrefetch: false };
+    return {
+      cacheForNavigation: false,
+      prefetchRouteTree: false,
+      prefetchShellFirst: false,
+      shouldPrefetch: false,
+    };
   }
 
   const routes = window.__VINEXT_LINK_PREFETCH_ROUTES__;
   if (!routes) {
-    return { cacheForNavigation: false, prefetchShellFirst: false, shouldPrefetch: false };
+    return {
+      cacheForNavigation: false,
+      prefetchRouteTree: false,
+      prefetchShellFirst: false,
+      shouldPrefetch: false,
+    };
   }
 
   const routeHref = toSameOriginRouteHref(href);
   if (routeHref === null) {
-    return { cacheForNavigation: false, prefetchShellFirst: false, shouldPrefetch: false };
+    return {
+      cacheForNavigation: false,
+      prefetchRouteTree: false,
+      prefetchShellFirst: false,
+      shouldPrefetch: false,
+    };
   }
 
   const match = matchRouteWithTrie(routeHref, routes, linkPrefetchRouteTrieCache);
   if (!match) {
-    return { cacheForNavigation: false, prefetchShellFirst: false, shouldPrefetch: false };
+    return {
+      cacheForNavigation: false,
+      prefetchRouteTree: false,
+      prefetchShellFirst: false,
+      shouldPrefetch: false,
+    };
   }
 
   return resolveMatchedAutoAppRoutePrefetch(match.route);
@@ -373,11 +405,13 @@ export function resolveAutoAppRoutePrefetch(href: string): {
 
 function resolveFullAppRoutePrefetch(): {
   cacheForNavigation: true;
+  prefetchRouteTree: false;
   prefetchShellFirst: boolean;
   shouldPrefetch: true;
 } {
   return {
     cacheForNavigation: true,
+    prefetchRouteTree: false,
     prefetchShellFirst: true,
     shouldPrefetch: true,
   };
@@ -403,6 +437,7 @@ function prefetchUrl(
   mode: LinkPrefetchMode,
   priority: "low" | "high" = "low",
   pagesRouteHref?: string,
+  schedulePriority: "idle" | "immediate" = priority === "high" ? "immediate" : "idle",
 ): void {
   if (typeof window === "undefined") return;
 
@@ -437,7 +472,7 @@ function prefetchUrl(
   }
 
   const schedule =
-    priority === "high"
+    schedulePriority === "immediate"
       ? (fn: () => void) => {
           fn();
         }
@@ -473,7 +508,11 @@ function prefetchUrl(
           PREFETCH_CACHE_TTL,
         } = navigation;
         const { createRscRequestHeaders, createRscRequestUrl } = rscCacheBusting;
-        const { NEXT_ROUTER_PREFETCH_HEADER, VINEXT_MOUNTED_SLOTS_HEADER } = headersModule;
+        const {
+          NEXT_ROUTER_PREFETCH_HEADER,
+          NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
+          VINEXT_MOUNTED_SLOTS_HEADER,
+        } = headersModule;
         // Hybrid ownership: skip the App RSC prefetch when Pages owns the
         // URL. The App's `__VINEXT_LINK_PREFETCH_ROUTES__` may include an
         // App catch-all that also matches the same path, so a naive
@@ -489,7 +528,12 @@ function prefetchUrl(
           mode === "auto"
             ? resolveAutoAppRoutePrefetch(prefetchHref)
             : mode === "full-after-shell"
-              ? { cacheForNavigation: true, prefetchShellFirst: true, shouldPrefetch: true }
+              ? {
+                  cacheForNavigation: true,
+                  prefetchRouteTree: false,
+                  prefetchShellFirst: true,
+                  shouldPrefetch: true,
+                }
               : resolveFullAppRoutePrefetch();
         if (!autoPrefetch.shouldPrefetch) return;
 
@@ -508,6 +552,10 @@ function prefetchUrl(
         }
         if (isOptimisticRouteShellPrefetch) {
           headers.set(NEXT_ROUTER_PREFETCH_HEADER, "1");
+        }
+        if (autoPrefetch.prefetchRouteTree) {
+          headers.set(NEXT_ROUTER_PREFETCH_HEADER, "1");
+          headers.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "/_tree");
         }
         // Distinguish the same visible URL when it is prefetched from different
         // request contexts such as /feed vs /gallery or different mounted slots.
@@ -539,6 +587,7 @@ function prefetchUrl(
         // unified route payload, so gate that payload behind a loading-shell
         // request to preserve the same pending/dedup observable contract.
         const fetchPromise =
+          !autoPrefetch.prefetchRouteTree &&
           (mode === "full" || mode === "full-after-shell" || __prefetchInlining) &&
           autoPrefetch.cacheForNavigation &&
           autoPrefetch.prefetchShellFirst &&
@@ -696,6 +745,7 @@ type LinkPrefetchInstance = {
   isVisible: boolean;
   mode: LinkPrefetchMode;
   pagesRouteHref?: string;
+  prefetchRouteTree: boolean;
   routerMode: LinkPrefetchRouterMode;
   viewportPrefetched: boolean;
 };
@@ -708,7 +758,13 @@ function setVisibleLinkPrefetch(instance: LinkPrefetchInstance, isVisible: boole
   if (isVisible) {
     visibleLinkPrefetches.add(instance);
     if (instance.routerMode === "pages" && instance.viewportPrefetched) return;
-    prefetchUrl(instance.href, instance.mode, "low", instance.pagesRouteHref);
+    prefetchUrl(
+      instance.href,
+      instance.mode,
+      "low",
+      instance.pagesRouteHref,
+      instance.prefetchRouteTree ? "immediate" : "idle",
+    );
     instance.viewportPrefetched = true;
   } else {
     visibleLinkPrefetches.delete(instance);
@@ -1027,6 +1083,9 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
     if (!observer) return;
 
     registerVisibleLinkPing();
+    const routerMode = getLinkPrefetchRouterMode();
+    const prefetchRouteTree =
+      routerMode === "app" && resolveAutoAppRoutePrefetch(hrefToPrefetch).prefetchRouteTree;
     const instance: LinkPrefetchInstance = {
       href: hrefToPrefetch,
       isVisible: false,
@@ -1039,7 +1098,8 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
               basePath: __basePath,
               currentOrigin: window.location.origin,
             }) ?? undefined),
-      routerMode: getLinkPrefetchRouterMode(),
+      prefetchRouteTree,
+      routerMode,
       viewportPrefetched: false,
     };
     observedLinkPrefetches.set(node, instance);

--- a/tests/e2e/app-router/nextjs-compat/root-params-segment-prefetch.browser.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/root-params-segment-prefetch.browser.spec.ts
@@ -1,0 +1,231 @@
+import fs from "node:fs/promises";
+import type { Server } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { expect, test } from "@playwright/test";
+import { waitForAppRouterHydration } from "../../helpers";
+
+type ProductionApp = {
+  baseUrl: string;
+  fixtureRoot: string;
+  server: Server;
+};
+
+async function closeServer(server: Server): Promise<void> {
+  const closed = new Promise<void>((resolve) => server.close(() => resolve()));
+  server.closeIdleConnections();
+  server.closeAllConnections();
+  await closed;
+}
+
+async function linkFixtureNodeModules(fixtureRoot: string): Promise<void> {
+  const sourceNodeModules = path.resolve(process.cwd(), "tests/fixtures/app-basic/node_modules");
+  const targetNodeModules = path.join(fixtureRoot, "node_modules");
+  await fs.mkdir(targetNodeModules, { recursive: true });
+
+  for (const entry of await fs.readdir(sourceNodeModules, { withFileTypes: true })) {
+    if (entry.name === ".vite" || entry.name === ".vite-temp") continue;
+    await fs.symlink(
+      path.join(sourceNodeModules, entry.name),
+      path.join(targetNodeModules, entry.name),
+      entry.isDirectory() ? "junction" : "file",
+    );
+  }
+}
+
+async function writeFixture(fixtureRoot: string): Promise<void> {
+  const appDir = path.join(fixtureRoot, "app");
+  await fs.mkdir(path.join(appDir, "(main)", "root-params"), { recursive: true });
+  await fs.mkdir(path.join(appDir, "[rootParam]"), { recursive: true });
+  await fs.mkdir(path.join(fixtureRoot, "components"), { recursive: true });
+  await linkFixtureNodeModules(fixtureRoot);
+
+  await fs.writeFile(
+    path.join(fixtureRoot, "package.json"),
+    `${JSON.stringify({ type: "module", dependencies: {} }, null, 2)}\n`,
+  );
+  await fs.writeFile(
+    path.join(fixtureRoot, "next.config.ts"),
+    `const nextConfig = {
+  cacheComponents: true,
+  experimental: {
+    optimisticRouting: true,
+    varyParams: true,
+  },
+};
+
+export default nextConfig;
+`,
+  );
+  await fs.writeFile(
+    path.join(fixtureRoot, "components", "link-accordion.tsx"),
+    `"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+
+export function LinkAccordion({ href, children }: { href: string; children: React.ReactNode }) {
+  const [isVisible, setIsVisible] = useState(false);
+  return <>
+    <input
+      type="checkbox"
+      checked={isVisible}
+      onChange={() => setIsVisible(!isVisible)}
+      data-link-accordion={href}
+    />
+    {isVisible ? <Link href={href}>{children}</Link> : <>{children} (link is hidden)</>}
+  </>;
+}
+`,
+  );
+  await fs.writeFile(
+    path.join(appDir, "(main)", "layout.tsx"),
+    `import type { ReactNode } from "react";
+
+export default function MainLayout({ children }: { children: ReactNode }) {
+  return <html><body>{children}</body></html>;
+}
+`,
+  );
+  await fs.writeFile(
+    path.join(appDir, "(main)", "root-params", "page.tsx"),
+    `import { LinkAccordion } from "../../../components/link-accordion";
+
+export default function RootParamsIndexPage() {
+  return <main id="root-params-index">
+    <LinkAccordion href="/aaa">Root Param: aaa</LinkAccordion>
+    <LinkAccordion href="/bbb">Root Param: bbb</LinkAccordion>
+  </main>;
+}
+`,
+  );
+  await fs.writeFile(
+    path.join(appDir, "[rootParam]", "loading.tsx"),
+    `export default function Loading() {
+  return <div data-root-param-loading="true">Loading root param...</div>;
+}
+`,
+  );
+  await fs.writeFile(
+    path.join(appDir, "[rootParam]", "layout.tsx"),
+    `import { rootParam } from "next/root-params";
+import type { ReactNode } from "react";
+
+export function generateStaticParams() {
+  return [{ rootParam: "aaa" }, { rootParam: "bbb" }];
+}
+
+export default async function RootParamsLayout({ children }: { children: ReactNode }) {
+  const param = await rootParam();
+  return <html><body>
+    <div data-root-param={param}>{\`Root param layout - param: \${param}\`}</div>
+    {children}
+  </body></html>;
+}
+`,
+  );
+  await fs.writeFile(
+    path.join(appDir, "[rootParam]", "page.tsx"),
+    `import { rootParam } from "next/root-params";
+
+export default async function RootParamsPage() {
+  const param = await rootParam();
+  return <div id="root-params-page">{\`Root param page content - param: \${param}\`}</div>;
+}
+`,
+  );
+
+  const vinextSource = path.resolve(process.cwd(), "packages/vinext/src/index.ts");
+  await fs.writeFile(
+    path.join(fixtureRoot, "vite.config.ts"),
+    `import { defineConfig } from "vite";
+import vinext from ${JSON.stringify(pathToFileURL(vinextSource).href)};
+
+export default defineConfig({ plugins: [vinext({ appDir: import.meta.dirname })] });
+`,
+  );
+}
+
+async function buildAndServeFixture(): Promise<ProductionApp> {
+  const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-root-params-prefetch-"));
+  await writeFixture(fixtureRoot);
+
+  const { createBuilder } = await import("vite");
+  const builder = await createBuilder({
+    root: fixtureRoot,
+    configFile: path.join(fixtureRoot, "vite.config.ts"),
+    logLevel: "silent",
+  });
+  await builder.buildApp();
+
+  const { runPrerender } = await import(
+    pathToFileURL(path.resolve(process.cwd(), "packages/vinext/dist/build/run-prerender.js")).href
+  );
+  await runPrerender({ root: fixtureRoot });
+
+  const { startProdServer } = await import(
+    pathToFileURL(path.resolve(process.cwd(), "packages/vinext/dist/server/prod-server.js")).href
+  );
+  const started = await startProdServer({
+    host: "127.0.0.1",
+    port: 0,
+    outDir: path.join(fixtureRoot, "dist"),
+    noCompression: true,
+  });
+
+  return {
+    baseUrl: `http://127.0.0.1:${started.port}`,
+    fixtureRoot,
+    server: started.server,
+  };
+}
+
+test.setTimeout(90_000);
+
+// Ported from Next.js:
+// test/e2e/app-dir/segment-cache/vary-params/root-params-segment-prefetch.test.ts
+// https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/segment-cache/vary-params/root-params-segment-prefetch.test.ts
+test("root-param Link reveal issues concrete route-tree segment prefetches", async ({ page }) => {
+  const app = await buildAndServeFixture();
+
+  try {
+    await page.goto(`${app.baseUrl}/root-params`);
+    await waitForAppRouterHydration(page);
+
+    const prefetchRoutes = await page.evaluate(() => window.__VINEXT_LINK_PREFETCH_ROUTES__ ?? []);
+    expect(prefetchRoutes).toContainEqual(
+      expect.objectContaining({
+        patternParts: [":rootParam"],
+        shouldPrefetchRouteTree: true,
+      }),
+    );
+
+    async function revealAndReadSegmentPrefetch(href: string): Promise<string> {
+      const responsePromise = page.waitForResponse((response) => {
+        const request = response.request();
+        return (
+          new URL(response.url()).pathname === href &&
+          request.headers()["rsc"] === "1" &&
+          request.headers()["next-router-segment-prefetch"] === "/_tree"
+        );
+      });
+
+      await page.locator(`input[data-link-accordion="${href}"]`).click();
+      const response = await responsePromise;
+      expect(response.ok()).toBe(true);
+      return response.text();
+    }
+
+    const aaaBody = await revealAndReadSegmentPrefetch("/aaa");
+    expect(aaaBody).toContain("Root param page content - param: aaa");
+    expect(aaaBody).not.toContain("%5BrootParam%5D");
+
+    const bbbBody = await revealAndReadSegmentPrefetch("/bbb");
+    expect(bbbBody).toContain("Root param page content - param: bbb");
+    expect(bbbBody).not.toContain("%5BrootParam%5D");
+  } finally {
+    await closeServer(app.server);
+    await fs.rm(app.fixtureRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -11,6 +11,7 @@ import {
 import { APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL } from "../packages/vinext/src/server/app-rsc-render-mode.js";
 import {
   NEXT_ROUTER_PREFETCH_HEADER,
+  NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
   VINEXT_RSC_RENDER_MODE_HEADER,
 } from "../packages/vinext/src/server/headers.js";
 import type { VinextLinkPrefetchRoute } from "../packages/vinext/src/client/vinext-next-data.js";
@@ -55,6 +56,12 @@ const linkPrefetchRoutes = [
   { canPrefetchLoadingShell: true, patternParts: ["blog", ":slug"], isDynamic: true },
   { canPrefetchLoadingShell: false, patternParts: ["products", ":id"], isDynamic: true },
   { canPrefetchLoadingShell: false, patternParts: ["clothing", ":product"], isDynamic: true },
+  {
+    canPrefetchLoadingShell: true,
+    patternParts: [":rootParam"],
+    isDynamic: true,
+    shouldPrefetchRouteTree: true,
+  },
 ] satisfies VinextLinkPrefetchRoute[];
 
 function createTestNavigationRuntime(navigate: unknown) {
@@ -1905,6 +1912,97 @@ describe("Link prefetch scheduling", () => {
       expect((fetchInit?.headers as Headers | undefined)?.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBe(
         null,
       );
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("uses a route-tree segment prefetch for root-param routes", async () => {
+    const observer = stubIntersectionObserver();
+    const requestIdleCallback = vi.fn();
+    const result = await renderIsolatedLink({
+      href: "/aaa",
+      nodeEnv: "production",
+      windowOverrides: { requestIdleCallback },
+    });
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+      await flushPrefetchTasks();
+
+      expect(requestIdleCallback).not.toHaveBeenCalled();
+      expect(result.fetch).toHaveBeenCalledTimes(1);
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[0],
+        "/aaa",
+        expect.objectContaining({
+          credentials: "include",
+          priority: "low",
+        }),
+      );
+      const fetchInit = result.fetch.mock.calls[0]?.[1] as RequestInit | undefined;
+      const headers = fetchInit?.headers;
+      expect(headers).toBeInstanceOf(Headers);
+      if (!(headers instanceof Headers)) {
+        throw new Error("Expected root-param prefetch request headers");
+      }
+      expect(headers.get(NEXT_ROUTER_PREFETCH_HEADER)).toBe("1");
+      expect(headers.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER)).toBe("/_tree");
+      expect(headers.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBeNull();
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("waits for observer visibility before route-tree segment prefetches", async () => {
+    const observer = stubIntersectionObserver();
+    const animationFrameCallbacks: FrameRequestCallback[] = [];
+    const requestAnimationFrame = vi.fn((callback: FrameRequestCallback) => {
+      animationFrameCallbacks.push(callback);
+      return animationFrameCallbacks.length;
+    });
+    const result = await renderIsolatedLink({
+      href: "/aaa",
+      nodeEnv: "production",
+      windowOverrides: { requestAnimationFrame },
+    });
+
+    try {
+      Object.assign(result.anchor, {
+        getClientRects: vi.fn(() => [
+          {
+            bottom: 1500,
+            height: 20,
+            left: 0,
+            right: 100,
+            top: 1480,
+            width: 100,
+            x: 0,
+            y: 1480,
+            toJSON: () => ({}),
+          },
+        ]),
+      });
+
+      for (const callback of animationFrameCallbacks) {
+        callback(0);
+      }
+      await flushPrefetchTasks();
+
+      expect(result.fetch).not.toHaveBeenCalled();
+
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+
+      expect(result.fetch).toHaveBeenCalledTimes(1);
+      const fetchInit = result.fetch.mock.calls[0]?.[1] as RequestInit | undefined;
+      const headers = fetchInit?.headers;
+      expect(headers).toBeInstanceOf(Headers);
+      if (!(headers instanceof Headers)) {
+        throw new Error("Expected root-param prefetch request headers");
+      }
+      expect(headers.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER)).toBe("/_tree");
     } finally {
       result.restoreNodeEnv();
     }

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -317,6 +317,12 @@ describe("Link App Router prefetch mode", () => {
         { canPrefetchLoadingShell: true, patternParts: ["blog", ":slug"], isDynamic: true },
         { canPrefetchLoadingShell: false, patternParts: ["products", ":id"], isDynamic: true },
         { canPrefetchLoadingShell: false, patternParts: ["clothing", ":product"], isDynamic: true },
+        {
+          canPrefetchLoadingShell: true,
+          patternParts: [":rootParam"],
+          isDynamic: true,
+          shouldPrefetchRouteTree: true,
+        },
         { canPrefetchLoadingShell: true, patternParts: ["settings"], isDynamic: false },
       ],
     };
@@ -324,21 +330,25 @@ describe("Link App Router prefetch mode", () => {
     try {
       expect(resolveAutoAppRoutePrefetch("/about")).toEqual({
         cacheForNavigation: true,
+        prefetchRouteTree: false,
         prefetchShellFirst: true,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/blog/hello-world")).toEqual({
         cacheForNavigation: false,
+        prefetchRouteTree: false,
         prefetchShellFirst: false,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/settings")).toEqual({
         cacheForNavigation: false,
+        prefetchRouteTree: false,
         prefetchShellFirst: true,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/products/1")).toEqual({
         cacheForNavigation: true,
+        prefetchRouteTree: false,
         prefetchShellFirst: false,
         shouldPrefetch: true,
       });
@@ -347,11 +357,19 @@ describe("Link App Router prefetch mode", () => {
       // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/segment-cache/client-params/client-params.test.ts
       expect(resolveAutoAppRoutePrefetch("/clothing/1")).toEqual({
         cacheForNavigation: true,
+        prefetchRouteTree: false,
         prefetchShellFirst: false,
         shouldPrefetch: true,
       });
-      expect(resolveAutoAppRoutePrefetch("/missing")).toEqual({
+      expect(resolveAutoAppRoutePrefetch("/aaa")).toEqual({
+        cacheForNavigation: true,
+        prefetchRouteTree: true,
+        prefetchShellFirst: true,
+        shouldPrefetch: true,
+      });
+      expect(resolveAutoAppRoutePrefetch("/missing/deep")).toEqual({
         cacheForNavigation: false,
+        prefetchRouteTree: false,
         prefetchShellFirst: false,
         shouldPrefetch: false,
       });


### PR DESCRIPTION
## Summary
- emit root-param route-tree metadata to the App Router Link prefetch manifest
- request segment route-tree prefetches for root-param links without encoding placeholder segments
- keep viewport visibility gated through IntersectionObserver while scheduling the route-tree task immediately with low fetch priority

## Validation
- vp test run tests/link.test.ts tests/link-navigation.test.ts -t "root-param|Link App Router prefetch mode|route-tree segment prefetch"
- vp check on changed root-param files
- targeted Next.js e2e: test/e2e/app-dir/segment-cache/vary-params/root-params-segment-prefetch.test.ts
- independent final re-review: NO FINDINGS