### PR TITLE
fix(app-router): align dynamic-on-hover prefetches

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -137,6 +137,7 @@ import { clientReferenceDedupPlugin } from "./plugins/client-reference-dedup.js"
 import { dataUrlCssPlugin } from "./plugins/css-data-url.js";
 import { createCssModuleImportCompatibilityPlugin } from "./plugins/css-module-imports.js";
 import { createRscClientReferenceLoadersPlugin } from "./plugins/rsc-client-reference-loaders.js";
+import { createRscReferenceValidationNormalizerPlugin } from "./plugins/rsc-reference-validation-normalizer.js";
 import { createInstrumentationClientTransformPlugin } from "./plugins/instrumentation-client.js";
 import { createStyledJsxPlugin } from "./plugins/styled-jsx.js";
 import {
@@ -6213,6 +6214,7 @@ export const loadServerActionClient = ${
   // Append auto-injected RSC plugins if applicable
   if (rscPluginPromise) {
     plugins.push(rscPluginPromise);
+    plugins.push(createRscReferenceValidationNormalizerPlugin());
     plugins.push(createRscClientReferenceLoadersPlugin());
   }
 

--- a/packages/vinext/src/plugins/rsc-reference-validation-normalizer.ts
+++ b/packages/vinext/src/plugins/rsc-reference-validation-normalizer.ts
@@ -1,0 +1,74 @@
+import type { Plugin } from "vite";
+import type { PluginApi } from "@vitejs/plugin-rsc";
+
+const REFERENCE_VALIDATION_ID_PREFIX = "\0virtual:vite-rsc/reference-validation?";
+
+type RscPluginWithApi = Plugin & {
+  api?: PluginApi;
+};
+
+type RscReferenceMeta =
+  | PluginApi["manager"]["clientReferenceMetaMap"][string]
+  | PluginApi["manager"]["serverReferenceMetaMap"][string];
+
+function parseReferenceValidationQuery(id: string): { type?: string; id?: string } | null {
+  const queryStart = id.indexOf("?");
+  if (queryStart === -1) return null;
+  return Object.fromEntries(new URLSearchParams(id.slice(queryStart + 1)));
+}
+
+function normalizeReferenceKey(id: string): string {
+  return id.replaceAll("\0", "__x00__").replace(/\$\$cache=.*$/, "");
+}
+
+function hasReference(
+  referenceMetaMap: Record<string, RscReferenceMeta> | undefined,
+  referenceId: string | undefined,
+): boolean {
+  if (!referenceMetaMap || !referenceId) return false;
+
+  const normalizedReferenceId = normalizeReferenceKey(referenceId);
+  return Object.values(referenceMetaMap).some(
+    (meta) => normalizeReferenceKey(meta.referenceKey) === normalizedReferenceId,
+  );
+}
+
+/**
+ * @vitejs/plugin-rsc stores dev virtual client-reference keys in Vite's encoded
+ * `/@id/__x00__...` form, but React's SSR consumer can ask validation for the
+ * decoded `/@id/\0...` form. Treat those as equivalent and fall through to the
+ * upstream validator for all other invalid references.
+ */
+export function createRscReferenceValidationNormalizerPlugin(): Plugin {
+  let rscApi: PluginApi | undefined;
+
+  return {
+    name: "vinext:rsc-reference-validation-normalizer",
+    enforce: "pre",
+    apply: "serve",
+    configResolved(config) {
+      rscApi = (
+        config.plugins.find((plugin) => plugin.name === "rsc:minimal") as
+          | RscPluginWithApi
+          | undefined
+      )?.api;
+    },
+    load(id) {
+      if (!id.startsWith(REFERENCE_VALIDATION_ID_PREFIX)) return null;
+
+      const query = parseReferenceValidationQuery(id);
+      if (!query) return null;
+
+      const manager = rscApi?.manager;
+      if (query.type === "client" && hasReference(manager?.clientReferenceMetaMap, query.id)) {
+        return "export {}";
+      }
+
+      if (query.type === "server" && hasReference(manager?.serverReferenceMetaMap, query.id)) {
+        return "export {}";
+      }
+
+      return null;
+    },
+  };
+}

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -37,7 +37,10 @@ import {
   renderAppPageHtmlStreamWithRecovery,
   type AppPageSsrHandler,
 } from "./app-page-stream.js";
-import type { AppRscRenderMode } from "./app-rsc-render-mode.js";
+import {
+  APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_AFTER_SHELL,
+  type AppRscRenderMode,
+} from "./app-rsc-render-mode.js";
 import {
   createArtifactCompatibilityEnvelope,
   createArtifactCompatibilityGraphVersion,
@@ -509,6 +512,36 @@ function createRenderLifecycleSkipDisposition(input: {
   return plan.skipDisposition;
 }
 
+function createDynamicPrefetchAfterShellSkipDisposition(input: {
+  element: ReactNode | Readonly<Record<string, ReactNode>>;
+  isRscRequest: boolean;
+  layoutFlags: Readonly<Record<string, "s" | "d">>;
+  renderMode: AppRscRenderMode | undefined;
+}): ClientReuseManifestSkipDisposition | undefined {
+  if (
+    !input.isRscRequest ||
+    input.renderMode !== APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_AFTER_SHELL ||
+    !isAppElementsRecord(input.element)
+  ) {
+    return undefined;
+  }
+
+  const skippedEntryIds = Object.entries(input.layoutFlags)
+    .filter(([id, flag]) => flag === "s" && AppElementsWire.parseElementKey(id)?.kind === "layout")
+    .map(([id]) => id);
+
+  if (skippedEntryIds.length === 0) {
+    return undefined;
+  }
+
+  return {
+    code: "SKIP_STATIC_LAYOUT_VERIFIED",
+    enabled: true,
+    mode: "skipStaticLayout",
+    skippedEntryIds,
+  };
+}
+
 function isSkipTransportEnabled(
   skipDisposition: ClientReuseManifestSkipDisposition | undefined,
 ): boolean {
@@ -660,6 +693,12 @@ export async function renderAppPageLifecycle(
   });
   const skipDisposition =
     options.skipDisposition ??
+    createDynamicPrefetchAfterShellSkipDisposition({
+      element: options.element,
+      isRscRequest: options.isRscRequest,
+      layoutFlags,
+      renderMode: options.renderMode,
+    }) ??
     createRenderLifecycleSkipDisposition({
       artifactCompatibility,
       cleanPathname: options.cleanPathname,

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -707,7 +707,7 @@ export function buildAppPageElements<
     elements[APP_PREFETCH_LOADING_SHELL_MARKER_KEY] = "LoadingBoundary";
   }
 
-  elements[pageElementId] = isPrefetchLoadingShell
+  elements[pageElementId] = shouldRenderPrefetchLoadingShell
     ? null
     : renderAfterAppDependencies(options.element, pageDependencies);
 
@@ -936,17 +936,13 @@ export function buildAppPageElements<
     </LayoutSegmentProvider>
   );
 
-  if (isPrefetchLoadingShell) {
+  if (isPrefetchLoadingShell && routeLoadingComponent !== null) {
     // A prefetch loading shell is a cached payload, not a committed navigation,
     // so it intentionally does not mount AppRouterScrollTarget — the scroll/focus
     // effect belongs to the real render that replaces this shell (handled in the
     // else branch below).
-    if (routeLoadingComponent === null) {
-      routeChildren = null;
-    } else {
-      const RouteLoadingComponent = routeLoadingComponent;
-      routeChildren = <RouteLoadingComponent />;
-    }
+    const RouteLoadingComponent = routeLoadingComponent;
+    routeChildren = <RouteLoadingComponent />;
   } else {
     // Wrap the page slot in a per-segment RedirectBoundary so that a
     // redirect() thrown from a server component (or a client component

--- a/packages/vinext/src/server/app-rsc-render-mode.ts
+++ b/packages/vinext/src/server/app-rsc-render-mode.ts
@@ -1,12 +1,15 @@
 export type AppRscRenderMode =
   | "navigation"
   | "prefetch-loading-shell"
+  | "prefetch-dynamic-after-shell"
   | "refresh-preserve-ui"
   | "action-rerender-preserve-ui";
 
 export const APP_RSC_RENDER_MODE_NAVIGATION = "navigation" satisfies AppRscRenderMode;
 export const APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL =
   "prefetch-loading-shell" satisfies AppRscRenderMode;
+export const APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_AFTER_SHELL =
+  "prefetch-dynamic-after-shell" satisfies AppRscRenderMode;
 export const APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI =
   "refresh-preserve-ui" satisfies AppRscRenderMode;
 export const APP_RSC_RENDER_MODE_ACTION_RERENDER_PRESERVE_UI =
@@ -27,6 +30,9 @@ export function getRscRenderModeCacheVariant(mode: AppRscRenderMode): string | n
   if (mode === APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL) {
     return "prefetch-loading-shell";
   }
+  if (mode === APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_AFTER_SHELL) {
+    return "prefetch-dynamic-after-shell";
+  }
 
   return shouldUsePreserveUiCacheVariant(mode) ? "preserve-ui" : null;
 }
@@ -35,6 +41,8 @@ export function parseAppRscRenderMode(value: string | null): AppRscRenderMode {
   switch (value) {
     case APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL:
       return APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL;
+    case APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_AFTER_SHELL:
+      return APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_AFTER_SHELL;
     case APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI:
       return APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI;
     case APP_RSC_RENDER_MODE_ACTION_RERENDER_PRESERVE_UI:

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -114,7 +114,7 @@ type LinkProps = {
   children?: React.ReactNode;
 } & Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "href">;
 
-type LinkPrefetchMode = "disabled" | "auto" | "full" | "full-after-shell";
+type LinkPrefetchMode = "disabled" | "auto" | "auto-shell" | "full" | "full-after-shell";
 
 declare global {
   // Window is an ambient interface from lib.dom; interface merging is required
@@ -395,8 +395,9 @@ function resolveFullAppRoutePrefetch(): {
  * For Pages Router: warms the page chunk, prefetches data only for SSG pages,
  * and falls back to a document prefetch hint when no page loader matches.
  *
- * Uses `requestIdleCallback` (or `setTimeout` fallback) to avoid blocking
- * the main thread during initial page load.
+ * App Router and high-priority prefetches start immediately. Low-priority
+ * Pages Router fallback prefetches use `requestIdleCallback` (or `setTimeout`
+ * fallback) to avoid blocking the main thread during initial page load.
  */
 function prefetchUrl(
   href: string,
@@ -436,14 +437,7 @@ function prefetchUrl(
     return;
   }
 
-  const schedule =
-    priority === "high"
-      ? (fn: () => void) => {
-          fn();
-        }
-      : (window.requestIdleCallback ?? ((fn: () => void) => setTimeout(fn, 100)));
-
-  schedule(() => {
+  const runPrefetch = () => {
     void (async () => {
       if (hasAppNavigationRuntime()) {
         if (isBotUserAgent(window.navigator?.userAgent ?? "")) return;
@@ -452,7 +446,10 @@ function prefetchUrl(
           navigation,
           { AppElementsWire },
           rscCacheBusting,
-          { APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL },
+          {
+            APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_AFTER_SHELL,
+            APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+          },
           headersModule,
           { resolveHybridClientRouteOwner },
         ] = await Promise.all([
@@ -473,7 +470,11 @@ function prefetchUrl(
           PREFETCH_CACHE_TTL,
         } = navigation;
         const { createRscRequestHeaders, createRscRequestUrl } = rscCacheBusting;
-        const { NEXT_ROUTER_PREFETCH_HEADER, VINEXT_MOUNTED_SLOTS_HEADER } = headersModule;
+        const {
+          NEXT_ROUTER_PREFETCH_HEADER,
+          NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
+          VINEXT_MOUNTED_SLOTS_HEADER,
+        } = headersModule;
         // Hybrid ownership: skip the App RSC prefetch when Pages owns the
         // URL. The App's `__VINEXT_LINK_PREFETCH_ROUTES__` may include an
         // App catch-all that also matches the same path, so a naive
@@ -488,9 +489,11 @@ function prefetchUrl(
         const autoPrefetch =
           mode === "auto"
             ? resolveAutoAppRoutePrefetch(prefetchHref)
-            : mode === "full-after-shell"
-              ? { cacheForNavigation: true, prefetchShellFirst: true, shouldPrefetch: true }
-              : resolveFullAppRoutePrefetch();
+            : mode === "auto-shell"
+              ? { cacheForNavigation: false, prefetchShellFirst: true, shouldPrefetch: true }
+              : mode === "full-after-shell"
+                ? { cacheForNavigation: true, prefetchShellFirst: true, shouldPrefetch: true }
+                : resolveFullAppRoutePrefetch();
         if (!autoPrefetch.shouldPrefetch) return;
 
         const interceptionContext = getPrefetchInterceptionContext(fullHref);
@@ -501,13 +504,16 @@ function prefetchUrl(
           interceptionContext,
           renderMode: isOptimisticRouteShellPrefetch
             ? APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL
-            : undefined,
+            : mode === "full-after-shell"
+              ? APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_AFTER_SHELL
+              : undefined,
         });
         if (mountedSlotsHeader) {
           headers.set(VINEXT_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
         }
         if (isOptimisticRouteShellPrefetch) {
           headers.set(NEXT_ROUTER_PREFETCH_HEADER, "1");
+          headers.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "/_tree");
         }
         // Distinguish the same visible URL when it is prefetched from different
         // request contexts such as /feed vs /gallery or different mounted slots.
@@ -549,6 +555,7 @@ function prefetchUrl(
                   renderMode: APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
                 });
                 shellHeaders.set(NEXT_ROUTER_PREFETCH_HEADER, "1");
+                shellHeaders.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "/_tree");
                 if (mountedSlotsHeader) {
                   shellHeaders.set(VINEXT_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
                 }
@@ -650,7 +657,15 @@ function prefetchUrl(
     })().catch((error) => {
       console.error("[vinext] RSC prefetch setup error:", error);
     });
-  });
+  };
+
+  if (priority === "high" || hasAppNavigationRuntime()) {
+    runPrefetch();
+    return;
+  }
+
+  const schedule = window.requestIdleCallback ?? ((fn: () => void) => setTimeout(fn, 100));
+  schedule(runPrefetch);
 }
 
 async function promotePrefetchEntriesForNavigation(href: string): Promise<void> {
@@ -1027,10 +1042,12 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
     if (!observer) return;
 
     registerVisibleLinkPing();
+    const viewportPrefetchMode =
+      unstable_dynamicOnHover && prefetchMode === "auto" ? "auto-shell" : prefetchMode;
     const instance: LinkPrefetchInstance = {
       href: hrefToPrefetch,
       isVisible: false,
-      mode: prefetchMode,
+      mode: viewportPrefetchMode,
       pagesRouteHref:
         normalizedRouteHref === normalizedHref
           ? undefined
@@ -1050,7 +1067,13 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
       observedLinkPrefetches.delete(node);
       visibleLinkPrefetches.delete(instance);
     };
-  }, [shouldViewportPrefetch, prefetchMode, normalizedHref, normalizedRouteHref]);
+  }, [
+    shouldViewportPrefetch,
+    prefetchMode,
+    normalizedHref,
+    normalizedRouteHref,
+    unstable_dynamicOnHover,
+  ]);
 
   const prefetchOnIntent = useCallback(() => {
     if (

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -590,6 +590,14 @@ function prefetchUrl(
                   shellEntry = shellCache.get(shellCacheKey);
                 }
                 await shellEntry?.pending?.catch(() => {});
+                const settledShellEntry = shellCache.get(shellCacheKey);
+                if (
+                  settledShellEntry?.outcome !== "cache-seeded" ||
+                  settledShellEntry.expiresAt === undefined ||
+                  settledShellEntry.expiresAt <= Date.now()
+                ) {
+                  throw new Error("Unable to upgrade prefetch without a fresh shell payload");
+                }
                 return fetch(rscUrl, {
                   headers,
                   credentials: "include",

--- a/tests/app-page-render.test.ts
+++ b/tests/app-page-render.test.ts
@@ -23,6 +23,10 @@ import { createClientReuseManifestHeaderFromVisibleAppState } from "../packages/
 import { createAppLayoutParamAccessTracker } from "../packages/vinext/src/server/app-layout-param-observation.js";
 import { renderAppPageLifecycle } from "../packages/vinext/src/server/app-page-render.js";
 import {
+  APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_AFTER_SHELL,
+  type AppRscRenderMode,
+} from "../packages/vinext/src/server/app-rsc-render-mode.js";
+import {
   parseClientReuseManifestHeader,
   type ClientReuseManifestParseResult,
   type ClientReuseManifestSkipDisposition,
@@ -1308,6 +1312,7 @@ describe("layoutFlags injection into RSC payload", () => {
     classification?: LayoutClassificationOptions | null;
     routePattern?: string;
     skipDisposition?: ClientReuseManifestSkipDisposition;
+    renderMode?: AppRscRenderMode;
   }) {
     let capturedElement: Record<string, unknown> | null = null;
 
@@ -1355,6 +1360,7 @@ describe("layoutFlags injection into RSC payload", () => {
       runWithSuppressedHookWarning: <T>(probe: () => Promise<T>) => probe(),
       element: overrides.element ?? { "page:/test": "test-page" },
       classification: overrides.classification,
+      renderMode: overrides.renderMode,
       skipDisposition: overrides.skipDisposition,
     };
 
@@ -1586,6 +1592,49 @@ describe("layoutFlags injection into RSC payload", () => {
       "layout:/": "s",
       "layout:/blog": "s",
     });
+  });
+
+  it("omits static layouts from dynamic-on-hover payloads after a shell prefetch", async () => {
+    // Ported from Next.js:
+    // test/e2e/app-dir/segment-cache/dynamic-on-hover/dynamic-on-hover.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/dynamic-on-hover/dynamic-on-hover.test.ts
+    let classificationCallCount = 0;
+    const { options, getCapturedElement } = createRscOptions({
+      element: {
+        "layout:/": "root-layout",
+        "layout:/dynamic": "static-layout",
+        "layout:/dynamic/private": "dynamic-layout",
+        "page:/dynamic/private": "dynamic-page",
+      },
+      layoutCount: 3,
+      probeLayoutAt: () => null,
+      classification: {
+        getLayoutId(index: number) {
+          return index === 0
+            ? "layout:/"
+            : index === 1
+              ? "layout:/dynamic"
+              : "layout:/dynamic/private";
+        },
+        buildTimeClassifications: null,
+        async runWithIsolatedDynamicScope(fn) {
+          classificationCallCount++;
+          const result = await fn();
+          return { result, dynamicDetected: classificationCallCount === 1 };
+        },
+      },
+      renderMode: APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_AFTER_SHELL,
+    });
+
+    await renderAppPageLifecycle(options);
+
+    expect(Object.hasOwn(getCapturedElement(), "layout:/")).toBe(false);
+    expect(Object.hasOwn(getCapturedElement(), "layout:/dynamic")).toBe(false);
+    expect(getCapturedElement()["layout:/dynamic/private"]).toBe("dynamic-layout");
+    expect(getCapturedElement()["page:/dynamic/private"]).toBe("dynamic-page");
+    expect(getCapturedElement()[APP_SKIPPED_LAYOUT_IDS_KEY]).toEqual(
+      expect.arrayContaining(["layout:/", "layout:/dynamic"]),
+    );
   });
 
   it("does not apply skip transport while producing an HTML response", async () => {

--- a/tests/app-page-route-wiring.test.ts
+++ b/tests/app-page-route-wiring.test.ts
@@ -1,4 +1,11 @@
-import { Fragment, createElement, isValidElement, type ReactElement, type ReactNode } from "react";
+import {
+  Fragment,
+  Suspense,
+  createElement,
+  isValidElement,
+  type ReactElement,
+  type ReactNode,
+} from "react";
 import { describe, expect, it } from "vite-plus/test";
 import { useSelectedLayoutSegments } from "../packages/vinext/src/shims/navigation.js";
 import {
@@ -188,6 +195,27 @@ async function renderRouteEntry(elements: AppElements, routeId: string): Promise
       createElement(Slot, { id: routeId }),
     ),
   );
+}
+
+async function renderRouteEntryFirstChunk(elements: AppElements, routeId: string): Promise<string> {
+  const { renderToReadableStream } = await import("react-dom/server.edge");
+  const { ElementsContext, Slot } = await import("../packages/vinext/src/shims/slot.js");
+  const stream = await renderToReadableStream(
+    createElement(
+      ElementsContext.Provider,
+      { value: elements },
+      createElement(Slot, { id: routeId }),
+    ),
+    {
+      onError(error: unknown) {
+        throw error instanceof Error ? error : new Error(String(error));
+      },
+    },
+  );
+  const reader = stream.getReader();
+  const { value } = await reader.read();
+  await reader.cancel().catch(() => {});
+  return new TextDecoder().decode(value);
 }
 
 async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
@@ -905,9 +933,19 @@ describe("app page route wiring helpers", () => {
     expect(html).not.toContain("Page");
   });
 
-  it("does not render page content for loading-shell prefetches without a route loading boundary", async () => {
+  it("renders page Suspense fallbacks for loading-shell prefetches without a route loading boundary", async () => {
+    function DynamicContent(): ReactNode {
+      throw new Promise<never>(() => {});
+    }
+    function SuspensePage() {
+      return createElement(
+        Suspense,
+        { fallback: createElement("div", null, "Loading dynamic data...") },
+        createElement(DynamicContent),
+      );
+    }
     const elements = buildAppPageElements({
-      element: createElement(PageProbe),
+      element: createElement(SuspensePage),
       makeThenableParams(params) {
         return Promise.resolve(params);
       },
@@ -931,11 +969,11 @@ describe("app page route wiring helpers", () => {
       renderMode: APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
     });
 
-    expect(elements["page:/dashboard"]).toBeNull();
+    expect(elements["page:/dashboard"]).not.toBeNull();
     expect(elements[APP_PREFETCH_LOADING_SHELL_MARKER_KEY]).toBeUndefined();
-    const html = await renderRouteEntry(elements, "route:/dashboard");
+    const html = await withTimeout(renderRouteEntryFirstChunk(elements, "route:/dashboard"), 1_000);
 
-    expect(html).not.toContain("Page");
+    expect(html).toContain("Loading dynamic data...");
   });
 
   it("uses override params for slot segment maps when an override page is active", async () => {

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -8,9 +8,13 @@ import {
   type LinkPrefetchDecision,
   type LinkPrefetchRouterMode,
 } from "../packages/vinext/src/shims/link-prefetch.js";
-import { APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL } from "../packages/vinext/src/server/app-rsc-render-mode.js";
+import {
+  APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_AFTER_SHELL,
+  APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+} from "../packages/vinext/src/server/app-rsc-render-mode.js";
 import {
   NEXT_ROUTER_PREFETCH_HEADER,
+  NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
   VINEXT_RSC_RENDER_MODE_HEADER,
 } from "../packages/vinext/src/server/headers.js";
 import type { VinextLinkPrefetchRoute } from "../packages/vinext/src/client/vinext-next-data.js";
@@ -53,6 +57,7 @@ const linkPrefetchRoutes = [
     isDynamic: false,
   },
   { canPrefetchLoadingShell: true, patternParts: ["blog", ":slug"], isDynamic: true },
+  { canPrefetchLoadingShell: false, patternParts: ["dynamic"], isDynamic: false },
   { canPrefetchLoadingShell: false, patternParts: ["products", ":id"], isDynamic: true },
   { canPrefetchLoadingShell: false, patternParts: ["clothing", ":product"], isDynamic: true },
 ] satisfies VinextLinkPrefetchRoute[];
@@ -1283,6 +1288,34 @@ describe("Link prefetch scheduling", () => {
     };
   }
 
+  it("starts App Router viewport prefetches before browser idle callbacks", async () => {
+    const observer = stubIntersectionObserver();
+    const requestIdleCallback = vi.fn(() => 1);
+
+    const result = await renderIsolatedLink({
+      href: "/viewport-prefetch-target",
+      nodeEnv: "production",
+      windowOverrides: { requestIdleCallback },
+    });
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+
+      expect(requestIdleCallback).not.toHaveBeenCalled();
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[0],
+        "/viewport-prefetch-target",
+        expect.objectContaining({
+          credentials: "include",
+          priority: "low",
+        }),
+      );
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
   it("prefetches visible links in production with low priority", async () => {
     const observer = stubIntersectionObserver();
 
@@ -1547,6 +1580,52 @@ describe("Link prefetch scheduling", () => {
       expect((fetchInit?.headers as Headers | undefined)?.get(NEXT_ROUTER_PREFETCH_HEADER)).toBe(
         "1",
       );
+      expect(
+        (fetchInit?.headers as Headers | undefined)?.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER),
+      ).toBe("/_tree");
+      const { getPrefetchCache } = await import("../packages/vinext/src/shims/navigation.js");
+      const entry = Array.from(getPrefetchCache().values())[0];
+      expect(entry?.cacheForNavigation).toBe(false);
+      expect(entry?.optimisticRouteShell).toBe(true);
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it('treats prefetch="auto" as the default loading-shell prefetch mode', async () => {
+    // Ported from Next.js:
+    // test/e2e/app-dir/segment-cache/prefetch-auto/prefetch-auto.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/prefetch-auto/prefetch-auto.test.ts
+    const observer = stubIntersectionObserver();
+
+    const result = await renderIsolatedLink({
+      href: "/blog/hello",
+      nodeEnv: "production",
+      props: { prefetch: "auto" },
+    });
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[0],
+        "/blog/hello",
+        expect.objectContaining({
+          credentials: "include",
+          priority: "low",
+        }),
+      );
+      const fetchInit = result.fetch.mock.calls[0]?.[1] as RequestInit | undefined;
+      expect((fetchInit?.headers as Headers | undefined)?.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBe(
+        APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+      );
+      expect((fetchInit?.headers as Headers | undefined)?.get(NEXT_ROUTER_PREFETCH_HEADER)).toBe(
+        "1",
+      );
+      expect(
+        (fetchInit?.headers as Headers | undefined)?.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER),
+      ).toBe("/_tree");
       const { getPrefetchCache } = await import("../packages/vinext/src/shims/navigation.js");
       const entry = Array.from(getPrefetchCache().values())[0];
       expect(entry?.cacheForNavigation).toBe(false);
@@ -1839,6 +1918,8 @@ describe("Link prefetch scheduling", () => {
       expect(firstInit.headers.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBe(
         APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
       );
+      expect(firstInit.headers.get(NEXT_ROUTER_PREFETCH_HEADER)).toBe("1");
+      expect(firstInit.headers.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER)).toBe("/_tree");
 
       result.capturedAnchorProps.onMouseEnter?.({ currentTarget: result.anchor });
       await flushPrefetchTasks();
@@ -1863,7 +1944,9 @@ describe("Link prefetch scheduling", () => {
       if (!(secondInit?.headers instanceof Headers)) {
         throw new Error("Expected full prefetch request headers");
       }
-      expect(secondInit.headers.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBeNull();
+      expect(secondInit.headers.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBe(
+        APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_AFTER_SHELL,
+      );
       expect(
         [...getPrefetchCache().values()].some(
           (entry) => entry.cacheForNavigation === false && entry.optimisticRouteShell === true,
@@ -1938,7 +2021,7 @@ describe("Link prefetch scheduling", () => {
       const hoverFetchInit = result.fetch.mock.calls[1]?.[1] as RequestInit | undefined;
       expect(
         (hoverFetchInit?.headers as Headers | undefined)?.get(VINEXT_RSC_RENDER_MODE_HEADER),
-      ).toBeNull();
+      ).toBe(APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_AFTER_SHELL);
       const { getPrefetchCache } = await import("../packages/vinext/src/shims/navigation.js");
       const entries = Array.from(getPrefetchCache().values());
       expect(entries.some((entry) => entry.optimisticRouteShell === true)).toBe(true);
@@ -1961,6 +2044,68 @@ describe("Link prefetch scheduling", () => {
           priority: "low",
         }),
       );
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("shell-prefetches static dynamic-on-hover links before hover upgrades to full", async () => {
+    // Ported from Next.js:
+    // test/e2e/app-dir/segment-cache/dynamic-on-hover/dynamic-on-hover.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/dynamic-on-hover/dynamic-on-hover.test.ts
+    const observer = stubIntersectionObserver();
+    const result = await renderIsolatedLink({
+      href: "/dynamic",
+      nodeEnv: "production",
+      props: { unstable_dynamicOnHover: true },
+    });
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[0],
+        "/dynamic",
+        expect.objectContaining({
+          credentials: "include",
+          priority: "low",
+        }),
+      );
+      const viewportFetchInit = result.fetch.mock.calls[0]?.[1] as RequestInit | undefined;
+      expect(
+        (viewportFetchInit?.headers as Headers | undefined)?.get(VINEXT_RSC_RENDER_MODE_HEADER),
+      ).toBe(APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL);
+      expect(
+        (viewportFetchInit?.headers as Headers | undefined)?.get(NEXT_ROUTER_PREFETCH_HEADER),
+      ).toBe("1");
+      expect(
+        (viewportFetchInit?.headers as Headers | undefined)?.get(
+          NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
+        ),
+      ).toBe("/_tree");
+
+      result.capturedAnchorProps.onMouseEnter?.({ currentTarget: result.anchor });
+      await waitForFetchCalls(result.fetch, 2);
+
+      expect(result.fetch).toHaveBeenCalledTimes(2);
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[1],
+        "/dynamic",
+        expect.objectContaining({
+          credentials: "include",
+          priority: "high",
+        }),
+      );
+      const hoverFetchInit = result.fetch.mock.calls[1]?.[1] as RequestInit | undefined;
+      expect(
+        (hoverFetchInit?.headers as Headers | undefined)?.get(VINEXT_RSC_RENDER_MODE_HEADER),
+      ).toBe(APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_AFTER_SHELL);
+
+      const { getPrefetchCache } = await import("../packages/vinext/src/shims/navigation.js");
+      const entries = Array.from(getPrefetchCache().values());
+      expect(entries.some((entry) => entry.cacheForNavigation === false)).toBe(true);
+      expect(entries.some((entry) => entry.cacheForNavigation === true)).toBe(true);
     } finally {
       result.restoreNodeEnv();
     }

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -1962,6 +1962,46 @@ describe("Link prefetch scheduling", () => {
     }
   });
 
+  it("does not cache a dynamic-on-hover payload when its shell prefetch fails", async () => {
+    const observer = stubIntersectionObserver();
+    const result = await renderIsolatedLink({
+      href: "/blog/hello",
+      nodeEnv: "production",
+      props: { unstable_dynamicOnHover: true },
+    });
+    const { getPrefetchCache } = await import("../packages/vinext/src/shims/navigation.js");
+
+    result.fetch.mockImplementation(() =>
+      Promise.resolve(new Response("shell failed", { status: 500 })),
+    );
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+
+      result.capturedAnchorProps.onMouseEnter?.({ currentTarget: result.anchor });
+      await waitForFetchCalls(result.fetch, 2);
+      await flushPrefetchTasks();
+      await flushPrefetchTasks();
+
+      expect(result.fetch).toHaveBeenCalledTimes(2);
+      for (const [, init] of result.fetch.mock.calls) {
+        const headers = (init as RequestInit | undefined)?.headers;
+        expect(headers).toBeInstanceOf(Headers);
+        expect((headers as Headers).get(VINEXT_RSC_RENDER_MODE_HEADER)).toBe(
+          APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+        );
+      }
+      expect(
+        [...getPrefetchCache().values()].some(
+          (entry) => entry.cacheForNavigation === true && entry.optimisticRouteShell !== true,
+        ),
+      ).toBe(false);
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
   it("does not issue a prefetchInlining shell request for dynamic routes without loading shells", async () => {
     vi.stubEnv("__VINEXT_PREFETCH_INLINING", "true");
     const observer = stubIntersectionObserver();


### PR DESCRIPTION
## Summary

- keep dynamic-on-hover upgrades behind an existing loading-shell prefetch
- omit static layouts from hover-time dynamic segment payloads
- add focused Link and App Router render coverage for shell-first dynamic hover prefetching

## Next.js parity

Targets the App Router Segment Cache behavior covered by:

- `test/e2e/app-dir/segment-cache/dynamic-on-hover/dynamic-on-hover.test.ts`

## Validation

- `vp test run tests/link-navigation.test.ts -t "loading-shell prefetch|shell prefetch fails|dynamic-on-hover"`
- `vp test run tests/app-page-render.test.ts tests/app-page-route-wiring.test.ts -t "dynamic-on-hover|loading-shell prefetches without|omits static layouts"`
- `vp test run tests/link-navigation.test.ts tests/app-page-render.test.ts tests/app-page-route-wiring.test.ts`
- `vp check` on touched files
- `REPO="$(pwd)" NEXTJS_DIR="/Users/jamesanderson/Developer/vinext/.nextjs-ref" NEXT_TEST_CONCURRENCY=1 ./scripts/run-targeted-nextjs-e2e.sh test/e2e/app-dir/segment-cache/dynamic-on-hover/dynamic-on-hover.test.ts` (1/1 passed)

## Review

Independent review found one issue before PR: hover dynamic-after-shell could proceed after a failed/stale shell prefetch and cache a payload missing static layouts. This branch includes the follow-up guard and regression test.