### PR TITLE
fix(app-router): schedule segment-cache prefetch phases

### DIFF
--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -142,6 +142,7 @@ export type PrerenderRouteResult =
       outputFiles: string[];
       revalidate: number | false;
       expire?: number;
+      stale?: number;
       /**
        * The concrete prerendered URL path, e.g. `/blog/hello-world`.
        * Only present when the route is dynamic and `path` differs from `route`.
@@ -1567,6 +1568,9 @@ export async function prerenderApp({
           ...(typeof renderedRevalidate === "number"
             ? { expire: renderedCacheControl.expire }
             : {}),
+          ...(typeof renderedCacheControl.stale === "number"
+            ? { stale: renderedCacheControl.stale }
+            : {}),
           router: "app",
           ...(htmlRender.linkHeader ? { headers: { link: htmlRender.linkHeader } } : {}),
           ...(urlPath !== routePattern ? { path: urlPath } : {}),
@@ -1674,10 +1678,10 @@ export async function prerenderApp({
 }
 
 function resolveRenderedCacheControl(
-  requestCacheLife: { expire?: number; revalidate?: number },
+  requestCacheLife: { expire?: number; revalidate?: number; stale?: number },
   cacheControl: string,
   fallbackExpireSeconds: number,
-): { expire: number; revalidate?: number } {
+): { expire: number; revalidate?: number; stale?: number } {
   const sMaxage = parseCacheControlSeconds(cacheControl, "s-maxage");
   const staleWhileRevalidate = parseCacheControlSeconds(cacheControl, "stale-while-revalidate");
   const revalidate =
@@ -1690,26 +1694,34 @@ function resolveRenderedCacheControl(
         sMaxage,
         staleWhileRevalidate,
       }),
+    ...(requestCacheLife.stale === undefined ? {} : { stale: requestCacheLife.stale }),
     ...(revalidate === undefined ? {} : { revalidate }),
   };
 }
 
 function readPrerenderCacheLifeHeader(
   headers: Headers,
-): { expire?: number; revalidate?: number } | null {
+): { expire?: number; revalidate?: number; stale?: number } | null {
   const value = headers.get(VINEXT_PRERENDER_CACHE_LIFE_HEADER);
   if (!value) return null;
 
   try {
-    const parsed = JSON.parse(value) as { expire?: unknown; revalidate?: unknown };
-    const cacheLife: { expire?: number; revalidate?: number } = {};
+    const parsed = JSON.parse(value) as { expire?: unknown; revalidate?: unknown; stale?: unknown };
+    const cacheLife: { expire?: number; revalidate?: number; stale?: number } = {};
     if (typeof parsed.revalidate === "number" && Number.isFinite(parsed.revalidate)) {
       cacheLife.revalidate = parsed.revalidate;
+    }
+    if (typeof parsed.stale === "number" && Number.isFinite(parsed.stale)) {
+      cacheLife.stale = parsed.stale;
     }
     if (typeof parsed.expire === "number" && Number.isFinite(parsed.expire)) {
       cacheLife.expire = parsed.expire;
     }
-    return cacheLife.revalidate === undefined && cacheLife.expire === undefined ? null : cacheLife;
+    return cacheLife.revalidate === undefined &&
+      cacheLife.stale === undefined &&
+      cacheLife.expire === undefined
+      ? null
+      : cacheLife;
   } catch {
     return null;
   }

--- a/packages/vinext/src/client/navigation-runtime.ts
+++ b/packages/vinext/src/client/navigation-runtime.ts
@@ -62,7 +62,7 @@ export type NavigationRuntimeFunctions = {
    * through the runtime to avoid a circular import with shims/navigation.ts.
    */
   notifyLinkNavigationStart?: () => void;
-  pingVisibleLinks?: () => void;
+  pingVisibleLinks?: (options?: { force?: boolean }) => void;
 };
 
 export type NavigationRuntimeBootstrap = {

--- a/packages/vinext/src/server/app-page-cache-finalizer.ts
+++ b/packages/vinext/src/server/app-page-cache-finalizer.ts
@@ -18,21 +18,38 @@ type AppPageCacheSetter = (
   revalidateSeconds: number,
   tags: string[],
   expireSeconds?: number,
+  staleSeconds?: number,
 ) => Promise<void>;
 type AppPageRscCacheKeyBuilder = (
   pathname: string,
   mountedSlotsHeader?: string | null,
   renderMode?: AppRscRenderMode,
   interceptionContext?: string | null,
+  segmentPrefetchPath?: string | null,
 ) => string;
 type AppPageRequestCacheLife = {
   revalidate?: number;
+  stale?: number;
   expire?: number;
 };
 type BuildAppPageCacheRenderObservation = (input: {
   cacheTags: readonly string[];
   state: AppPageRenderObservationState;
 }) => RenderObservation;
+
+function setAppPageCacheEntry(
+  setter: AppPageCacheSetter,
+  key: string,
+  data: CachedAppPageValue,
+  revalidateSeconds: number,
+  tags: string[],
+  expireSeconds: number | undefined,
+  staleSeconds: number | undefined,
+): Promise<void> {
+  return staleSeconds === undefined
+    ? setter(key, data, revalidateSeconds, tags, expireSeconds)
+    : setter(key, data, revalidateSeconds, tags, expireSeconds, staleSeconds);
+}
 
 type FinalizeAppPageHtmlCacheResponseOptions = {
   capturedDynamicUsageBeforeContextCleanup?: () => boolean;
@@ -71,6 +88,7 @@ type ScheduleAppPageRscCacheWriteOptions = {
   interceptionContext?: string | null;
   mountedSlotsHeader?: string | null;
   renderMode?: AppRscRenderMode;
+  segmentPrefetchPath?: string | null;
   preserveClientResponseHeaders?: boolean;
   expireSeconds?: number;
   revalidateSeconds: number | null;
@@ -96,9 +114,10 @@ function resolveAppPageCacheWritePolicy(options: {
   expireSeconds?: number;
   requestCacheLife?: AppPageRequestCacheLife | null;
   revalidateSeconds: number | null;
-}): { expireSeconds?: number; revalidateSeconds: number } | null {
+}): { expireSeconds?: number; revalidateSeconds: number; staleSeconds?: number } | null {
   let revalidateSeconds = options.revalidateSeconds;
   let expireSeconds = options.expireSeconds;
+  let staleSeconds: number | undefined;
   const requestCacheLife = options.requestCacheLife;
 
   if (requestCacheLife?.revalidate !== undefined) {
@@ -110,12 +129,15 @@ function resolveAppPageCacheWritePolicy(options: {
   if (requestCacheLife?.expire !== undefined) {
     expireSeconds = requestCacheLife.expire;
   }
+  if (requestCacheLife?.stale !== undefined) {
+    staleSeconds = requestCacheLife.stale;
+  }
 
   if (revalidateSeconds === null || Number.isNaN(revalidateSeconds) || revalidateSeconds <= 0) {
     return null;
   }
 
-  return { expireSeconds, revalidateSeconds };
+  return { expireSeconds, revalidateSeconds, staleSeconds };
 }
 
 export function finalizeAppPageHtmlCacheResponse(
@@ -176,7 +198,8 @@ export function finalizeAppPageHtmlCacheResponse(
       });
       const linkHeader = response.headers.get("link");
       const writes = [
-        options.isrSet(
+        setAppPageCacheEntry(
+          options.isrSet,
           htmlKey,
           buildAppPageCacheValue(
             cachedHtml,
@@ -188,18 +211,21 @@ export function finalizeAppPageHtmlCacheResponse(
           cachePolicy.revalidateSeconds,
           pageTags,
           cachePolicy.expireSeconds,
+          cachePolicy.staleSeconds,
         ),
       ];
 
       if (options.capturedRscDataPromise) {
         writes.push(
           options.capturedRscDataPromise.then((rscData) =>
-            options.isrSet(
+            setAppPageCacheEntry(
+              options.isrSet,
               rscKey,
               buildAppPageCacheValue("", rscData, 200, rscRenderObservation),
               cachePolicy.revalidateSeconds,
               pageTags,
               cachePolicy.expireSeconds,
+              cachePolicy.staleSeconds,
             ),
           ),
         );
@@ -257,6 +283,7 @@ export function scheduleAppPageRscCacheWrite(
     options.mountedSlotsHeader,
     options.renderMode,
     options.interceptionContext,
+    options.segmentPrefetchPath,
   );
   const cachePromise = (async () => {
     try {
@@ -284,12 +311,14 @@ export function scheduleAppPageRscCacheWrite(
         cacheTags: pageTags,
         state: observationState,
       });
-      await options.isrSet(
+      await setAppPageCacheEntry(
+        options.isrSet,
         rscKey,
         buildAppPageCacheValue("", rscData, 200, rscRenderObservation),
         cachePolicy.revalidateSeconds,
         pageTags,
         cachePolicy.expireSeconds,
+        cachePolicy.staleSeconds,
       );
       options.isrDebug?.("RSC cache written", rscKey);
     } catch (cacheError) {

--- a/packages/vinext/src/server/app-page-cache-render.ts
+++ b/packages/vinext/src/server/app-page-cache-render.ts
@@ -155,7 +155,7 @@ export async function renderAppPageCacheArtifacts(
     tags,
     cacheControl:
       typeof cacheLife?.revalidate === "number"
-        ? { revalidate: cacheLife.revalidate, expire: cacheLife.expire }
+        ? { revalidate: cacheLife.revalidate, stale: cacheLife.stale, expire: cacheLife.expire }
         : undefined,
   };
 

--- a/packages/vinext/src/server/app-page-cache.ts
+++ b/packages/vinext/src/server/app-page-cache.ts
@@ -6,7 +6,7 @@ import {
   applyRscDeploymentIdHeader,
 } from "./app-rsc-cache-busting.js";
 import { applyCdnResponseHeaders } from "./cache-control.js";
-import { decideIsr } from "./isr-decision.js";
+import { buildMissIsrCacheControl, decideIsr } from "./isr-decision.js";
 import { VINEXT_MOUNTED_SLOTS_HEADER } from "./headers.js";
 import { applyEdgeRuntimeHeader } from "./app-page-response.js";
 import { setCacheStateHeaders } from "./cache-headers.js";
@@ -30,6 +30,7 @@ type AppPageCacheSetter = (
   revalidateSeconds: number,
   tags: string[],
   expireSeconds?: number,
+  staleSeconds?: number,
 ) => Promise<void>;
 type AppPageBackgroundRegenerator = (key: string, renderFn: () => Promise<void>) => void;
 type AppPageRscCacheKeyBuilder = (
@@ -37,6 +38,7 @@ type AppPageRscCacheKeyBuilder = (
   mountedSlotsHeader?: string | null,
   renderMode?: AppRscRenderMode,
   interceptionContext?: string | null,
+  segmentPrefetchPath?: string | null,
 ) => string;
 export type AppPageCacheOutcomeMetric = Readonly<{
   artifact: "html" | "rsc";
@@ -50,6 +52,7 @@ export type AppPageCacheOutcomeMetric = Readonly<{
     | "empty-entry"
     | "no-entry"
     | "non-app-page-entry"
+    | "foreground-stale-revalidate"
     | "query-variant-unproven"
     | "read-error"
     | "served"
@@ -69,7 +72,7 @@ type AppPageCacheRenderResult = {
 
 type BuildAppPageCachedResponseOptions = {
   cacheControl?: CacheControlMetadata;
-  cacheState: "HIT" | "STALE";
+  cacheState: "HIT" | "MISS" | "STALE";
   expireSeconds?: number;
   isEdgeRuntime?: boolean;
   isRscRequest: boolean;
@@ -96,6 +99,7 @@ type ReadAppPageCacheResponseOptions = {
   mountedSlotsHeader?: string | null;
   recordCacheOutcome?: AppPageCacheOutcomeRecorder;
   renderMode?: AppRscRenderMode;
+  segmentPrefetchPath?: string | null;
   expireSeconds?: number;
   revalidateSeconds: number;
   renderFreshPageForCache: () => Promise<AppPageCacheRenderResult>;
@@ -200,13 +204,15 @@ function hasQueryInvariantAppPageProof(cachedValue: CachedAppPageValue): boolean
   );
 }
 
-export function buildAppPageCachedResponse(
-  cachedValue: CachedAppPageValue,
+function resolveAppPageCachedResponseCacheControl(
   options: BuildAppPageCachedResponseOptions,
-): Response | null {
-  // Preserve the legacy fallback semantics from the generated entry: invalid
-  // falsy statuses still fall back to 200 rather than being forwarded through.
-  const status = options.middlewareStatus ?? (cachedValue.status || 200);
+): string {
+  if (options.cacheState === "MISS") {
+    const revalidateSeconds = options.cacheControl?.revalidate ?? options.revalidateSeconds;
+    const expireSeconds = options.cacheControl?.expire ?? options.expireSeconds;
+    return buildMissIsrCacheControl(revalidateSeconds, expireSeconds);
+  }
+
   const { cacheControl } = decideIsr({
     cacheState: options.cacheState,
     kind: "app-page",
@@ -214,6 +220,21 @@ export function buildAppPageCachedResponse(
     expireSeconds: options.expireSeconds,
     cacheControlMeta: options.cacheControl,
   });
+  return cacheControl;
+}
+
+function shouldForegroundRevalidateStaleAppPage(cached: ISRCacheEntry): boolean {
+  return cached.value.cacheControl?.stale === 0;
+}
+
+export function buildAppPageCachedResponse(
+  cachedValue: CachedAppPageValue,
+  options: BuildAppPageCachedResponseOptions,
+): Response | null {
+  // Preserve the legacy fallback semantics from the generated entry: invalid
+  // falsy statuses still fall back to 200 rather than being forwarded through.
+  const status = options.middlewareStatus ?? (cachedValue.status || 200);
+  const cacheControl = resolveAppPageCachedResponseCacheControl(options);
   if (options.isRscRequest) {
     if (!cachedValue.rscData) {
       return null;
@@ -316,6 +337,7 @@ export async function readAppPageCacheResponse(
         options.mountedSlotsHeader,
         options.renderMode,
         options.interceptionContext,
+        options.segmentPrefetchPath,
       )
     : options.isrHtmlKey(options.cleanPathname);
   const artifact = options.isRscRequest ? "rsc" : "html";
@@ -388,6 +410,92 @@ export async function readAppPageCacheResponse(
     }
 
     if (cached?.isStale && cachedValue) {
+      if (shouldForegroundRevalidateStaleAppPage(cached)) {
+        const revalidatedPage = await options.renderFreshPageForCache();
+        const revalidateSeconds =
+          revalidatedPage.cacheControl?.revalidate ?? options.revalidateSeconds;
+        if (!Number.isFinite(revalidateSeconds) || revalidateSeconds <= 0) {
+          options.isrDebug?.(
+            "STALE MISS (foreground revalidate no cache policy)",
+            options.cleanPathname,
+          );
+          return null;
+        }
+        const expireSeconds = revalidatedPage.cacheControl?.expire ?? options.expireSeconds;
+        const staleSeconds = revalidatedPage.cacheControl?.stale;
+        const rscValue = buildAppPageCacheValue(
+          "",
+          revalidatedPage.rscData,
+          200,
+          revalidatedPage.rscRenderObservation,
+        );
+        const responseValue = options.isRscRequest
+          ? rscValue
+          : buildAppPageCacheValue(
+              revalidatedPage.html,
+              undefined,
+              200,
+              revalidatedPage.htmlRenderObservation,
+              revalidatedPage.linkHeader ? { link: revalidatedPage.linkHeader } : undefined,
+            );
+        const writes = [
+          options.isrSet(
+            options.isRscRequest
+              ? isrKey
+              : options.isrRscKey(
+                  options.cleanPathname,
+                  options.mountedSlotsHeader,
+                  options.renderMode,
+                  options.interceptionContext,
+                  options.segmentPrefetchPath,
+                ),
+            rscValue,
+            revalidateSeconds,
+            revalidatedPage.tags,
+            expireSeconds,
+            staleSeconds,
+          ),
+        ];
+
+        if (!options.isRscRequest) {
+          writes.push(
+            options.isrSet(
+              isrKey,
+              responseValue,
+              revalidateSeconds,
+              revalidatedPage.tags,
+              expireSeconds,
+              staleSeconds,
+            ),
+          );
+        }
+
+        await Promise.all(writes);
+        const response = buildAppPageCachedResponse(responseValue, {
+          cacheState: "MISS",
+          cacheControl: revalidatedPage.cacheControl,
+          expireSeconds: options.expireSeconds,
+          isEdgeRuntime: options.isEdgeRuntime,
+          isRscRequest: options.isRscRequest,
+          middlewareHeaders: options.middlewareHeaders,
+          middlewareStatus: options.middlewareStatus,
+          mountedSlotsHeader: options.mountedSlotsHeader,
+          revalidateSeconds: options.revalidateSeconds,
+        });
+
+        if (response) {
+          recordAppPageCacheOutcome(options.recordCacheOutcome, {
+            artifact,
+            cacheKey: isrKey,
+            outcome: "miss",
+            reason: "foreground-stale-revalidate",
+          });
+          options.isrDebug?.("MISS (foreground stale revalidate)", options.cleanPathname);
+          options.clearRequestContext();
+          return response;
+        }
+      }
+
       // Preserve the legacy behavior from the inline generator: stale entries
       // still trigger background regeneration even if this request cannot use
       // the stale payload and will fall through to a fresh render.
@@ -412,6 +520,7 @@ export async function readAppPageCacheResponse(
                   options.mountedSlotsHeader,
                   options.renderMode,
                   options.interceptionContext,
+                  options.segmentPrefetchPath,
                 ),
             buildAppPageCacheValue(
               "",
@@ -422,6 +531,7 @@ export async function readAppPageCacheResponse(
             revalidateSeconds,
             revalidatedPage.tags,
             expireSeconds,
+            revalidatedPage.cacheControl?.stale,
           ),
         ];
 
@@ -443,6 +553,7 @@ export async function readAppPageCacheResponse(
               revalidateSeconds,
               revalidatedPage.tags,
               expireSeconds,
+              revalidatedPage.cacheControl?.stale,
             ),
           );
         }

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -72,6 +72,7 @@ import {
   applyRscCompatibilityIdHeader,
   applyRscDeploymentIdHeader,
 } from "./app-rsc-cache-busting.js";
+import { NEXT_ROUTER_SEGMENT_PREFETCH_HEADER } from "./headers.js";
 import {
   APP_RSC_RENDER_MODE_NAVIGATION,
   shouldSuppressLoadingBoundaries,
@@ -104,6 +105,7 @@ type AppPageCacheSetter = (
   revalidateSeconds: number,
   tags: string[],
   expireSeconds?: number,
+  staleSeconds?: number,
 ) => Promise<void>;
 type AppPageCacheGetter = (key: string) => Promise<ISRCacheEntry | null>;
 type AppPageBackgroundRegenerationErrorContext = {
@@ -289,6 +291,7 @@ export type DispatchAppPageOptions<TRoute extends AppPageDispatchRoute> = {
     mountedSlotsHeader?: string | null,
     renderMode?: AppRscRenderMode,
     interceptionContext?: string | null,
+    segmentPrefetchPath?: string | null,
   ) => string;
   isrSet: AppPageCacheSetter;
   loadSsrHandler: () => Promise<AppPageSsrHandler>;
@@ -551,6 +554,9 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
   const hasRequestSearchParams = !isForceStatic && hasSearchParams(options.searchParams);
   const pageSearchParams = isForceStatic ? new URLSearchParams() : options.searchParams;
   const layoutParamAccess = createAppLayoutParamAccessTracker();
+  const segmentPrefetchPath = options.isRscRequest
+    ? options.request.headers.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER)
+    : null;
   const hasActiveLoadingBoundary = shouldSuppressLoadingBoundaries(
     options.renderMode ?? APP_RSC_RENDER_MODE_NAVIGATION,
   )
@@ -631,6 +637,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
       middlewareStatus: options.middlewareContext.status,
       mountedSlotsHeader: options.mountedSlotsHeader,
       renderMode: options.renderMode,
+      segmentPrefetchPath,
       expireSeconds: options.expireSeconds,
       // cacheLife-only routes discover their actual revalidate during the
       // fresh render; this seed only gets them into the cache read path.
@@ -1070,6 +1077,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
     revalidateSeconds: currentRevalidateSeconds,
     mountedSlotsHeader: options.mountedSlotsHeader,
     renderMode: options.renderMode ?? APP_RSC_RENDER_MODE_NAVIGATION,
+    segmentPrefetchPath,
     renderErrorBoundaryResponse(renderError, errorOrigin) {
       return options.renderErrorBoundaryPage(renderError, errorOrigin);
     },

--- a/packages/vinext/src/server/app-page-element-builder.ts
+++ b/packages/vinext/src/server/app-page-element-builder.ts
@@ -16,6 +16,7 @@ import {
   type AppPageSlotOverride,
 } from "./app-page-route-wiring.js";
 import { AppElementsWire, type AppElements } from "./app-elements.js";
+import { NEXT_ROUTER_SEGMENT_PREFETCH_HEADER } from "./headers.js";
 import type { AppPageParams } from "./app-page-boundary.js";
 import { DEFAULT_GLOBAL_ERROR_MODULE } from "./default-global-error-module.js";
 import { matchRoutePattern } from "../routing/route-pattern.js";
@@ -356,6 +357,8 @@ export async function buildPageElements<
   const pageSearchParamsThenable = searchParams ? makeThenableParams(pageSearchParams) : undefined;
 
   const mountedSlotIds = mountedSlotsHeader ? new Set(mountedSlotsHeader.split(" ")) : null;
+  const concreteSegmentIdentity =
+    isRscRequest && pageRequest.request.headers.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER) !== null;
 
   const slotOverrides = buildSlotOverrides(route, params, routePath, opts);
   const metadataPlacement =
@@ -424,6 +427,7 @@ export async function buildPageElements<
     resolvedMetadataPathname: routePath,
     resolvedViewport,
     renderIdentity,
+    concreteSegmentIdentity,
     routePath,
     sourcePageSegments,
     rootNotFoundModule: rootNotFoundModule ?? null,

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -4,7 +4,12 @@ import type { NavigationContext } from "vinext/shims/navigation";
 import type { CachedAppPageValue } from "vinext/shims/cache-handler";
 import type { RootParams } from "vinext/shims/root-params";
 import { runWithFetchDedupe } from "vinext/shims/fetch-cache";
-import { AppElementsWire, isAppElementsRecord, type AppOutgoingElements } from "./app-elements.js";
+import {
+  AppElementsWire,
+  isAppElementsRecord,
+  type AppOutgoingElements,
+  type LayoutFlags,
+} from "./app-elements.js";
 import { hasDigest } from "./app-rsc-errors.js";
 import {
   finalizeAppPageHtmlCacheResponse,
@@ -81,6 +86,7 @@ import type {
   StaticLayoutObservationSkipRejection,
 } from "./app-layout-param-observation.js";
 import { getStaticLayoutObservationSkipRejection } from "./app-layout-param-observation.js";
+import { resolveAppPageConcreteRouteSegments } from "./app-page-segment-state.js";
 import { peekDynamicUsage } from "vinext/shims/headers";
 
 type AppPageBoundaryOnError = (
@@ -95,10 +101,12 @@ type AppPageCacheSetter = (
   revalidateSeconds: number,
   tags: string[],
   expireSeconds?: number,
+  staleSeconds?: number,
 ) => Promise<void>;
 
 type AppPageRequestCacheLife = {
   revalidate?: number;
+  stale?: number;
   expire?: number;
 };
 
@@ -154,6 +162,7 @@ type RenderAppPageLifecycleOptions = {
     mountedSlotsHeader?: string | null,
     renderMode?: AppRscRenderMode,
     interceptionContext?: string | null,
+    segmentPrefetchPath?: string | null,
   ) => string;
   isrSet: AppPageCacheSetter;
   interceptionContext?: string | null;
@@ -196,6 +205,7 @@ type RenderAppPageLifecycleOptions = {
   skipDisposition?: ClientReuseManifestSkipDisposition;
   mountedSlotsHeader?: string | null;
   renderMode?: AppRscRenderMode;
+  segmentPrefetchPath?: string | null;
   waitUntil?: (promise: Promise<void>) => void;
   // Per-layout observation tracker. Constructed in dispatch, consumed by the
   // skip transport planner to reject layouts that are unsafe for static reuse.
@@ -310,6 +320,90 @@ function createRenderAndSendSkipDisposition(): ClientReuseManifestSkipDispositio
     enabled: false,
     mode: "renderAndSend",
   };
+}
+
+function toConcreteSegmentParams(
+  params: Record<string, unknown>,
+): Record<string, string | string[]> {
+  const concreteParams: Record<string, string | string[]> = {};
+  for (const [key, value] of Object.entries(params)) {
+    if (typeof value === "string") {
+      concreteParams[key] = value;
+    } else if (Array.isArray(value) && value.every((item) => typeof item === "string")) {
+      concreteParams[key] = value;
+    }
+  }
+  return concreteParams;
+}
+
+function materializeLayoutFlagId(
+  layoutId: string,
+  params: Record<string, string | string[]>,
+): string {
+  if (!layoutId.startsWith("layout:/") || !layoutId.includes("[")) {
+    return layoutId;
+  }
+  const treePath = layoutId.slice("layout:/".length);
+  if (!treePath) {
+    return layoutId;
+  }
+  const concreteSegments = resolveAppPageConcreteRouteSegments(treePath.split("/"), params);
+  return `layout:/${concreteSegments.join("/")}`;
+}
+
+function materializeConcreteLayoutFlags(input: {
+  element: ReactNode | Readonly<Record<string, ReactNode>>;
+  layoutFlags: LayoutFlags;
+  params: Record<string, unknown>;
+}): LayoutFlags {
+  if (!isAppElementsRecord(input.element)) {
+    return input.layoutFlags;
+  }
+  const layoutFlagEntries = Object.entries(input.layoutFlags);
+  if (!layoutFlagEntries.some(([layoutId]) => layoutId.includes("["))) {
+    return input.layoutFlags;
+  }
+  const metadata = AppElementsWire.readMetadata(input.element);
+  if (metadata.sourcePage.includes("[")) {
+    return input.layoutFlags;
+  }
+
+  const params = toConcreteSegmentParams(input.params);
+  return Object.fromEntries(
+    layoutFlagEntries.map(([layoutId, flag]) => [materializeLayoutFlagId(layoutId, params), flag]),
+  );
+}
+
+function materializeDynamicSegmentsInText(
+  value: string,
+  params: Record<string, string | string[]>,
+): string {
+  if (!value.includes("[")) {
+    return value;
+  }
+
+  return value.replace(/\[\[?\.\.\.([^\]]+)\]\]?|\[([^\]]+)\]/g, (match, catchAllName, name) => {
+    const paramValue = params[catchAllName ?? name];
+    if (paramValue === undefined) {
+      return match;
+    }
+    return Array.isArray(paramValue) ? paramValue.join("/") : paramValue;
+  });
+}
+
+function materializeSegmentPrefetchRenderObservationTags(input: {
+  params: Record<string, unknown>;
+  segmentPrefetchPath?: string | null;
+  tags: string[];
+}): string[] {
+  if (!input.segmentPrefetchPath) {
+    return input.tags;
+  }
+  const concreteParams = toConcreteSegmentParams(input.params);
+  if (Object.keys(concreteParams).length === 0) {
+    return input.tags;
+  }
+  return input.tags.map((tag) => materializeDynamicSegmentsInText(tag, concreteParams));
 }
 
 function rejectStaticLayoutObservation(
@@ -621,7 +715,11 @@ export async function renderAppPageLifecycle(
     return preRenderResult.response;
   }
 
-  const layoutFlags = preRenderResult.layoutFlags;
+  const layoutFlags = materializeConcreteLayoutFlags({
+    element: options.element,
+    layoutFlags: preRenderResult.layoutFlags,
+    params: options.navigationParams,
+  });
 
   // Render the CANONICAL element. The outgoing payload carries per-layout
   // static/dynamic flags under `__layoutFlags` so the client can later tell
@@ -648,10 +746,15 @@ export async function renderAppPageLifecycle(
   // Partial payload metadata is a pre-stream snapshot. Fetch tags may still
   // accumulate while the RSC/HTML streams are consumed; complete cache artifact
   // observations below rebuild this field after the stream drains.
+  const payloadRenderObservationTags = materializeSegmentPrefetchRenderObservationTags({
+    params: options.navigationParams,
+    segmentPrefetchPath: options.segmentPrefetchPath,
+    tags: options.getPageTags(),
+  });
   const payloadRenderObservation = createAppPageRenderObservation({
     boundaryOutcome: { kind: "unknown" },
     cacheability: "unknown",
-    cacheTags: options.getPageTags(),
+    cacheTags: payloadRenderObservationTags,
     cleanPathname: options.cleanPathname,
     completeness: "partial",
     output: rscOutputScope,
@@ -725,6 +828,7 @@ export async function renderAppPageLifecycle(
     (revalidateSeconds === null || (revalidateSeconds > 0 && revalidateSeconds !== Infinity)) &&
     !options.isDraftMode &&
     !options.isForceDynamic &&
+    !options.segmentPrefetchPath &&
     !shouldBypassRscCacheForSkipTransport;
   const createBufferedRscStream = (close: boolean): ReadableStream<Uint8Array> =>
     new ReadableStream<Uint8Array>({
@@ -862,6 +966,7 @@ export async function renderAppPageLifecycle(
       interceptionContext: options.interceptionContext,
       mountedSlotsHeader: options.mountedSlotsHeader,
       renderMode: options.renderMode,
+      segmentPrefetchPath: options.segmentPrefetchPath,
       preserveClientResponseHeaders: rscResponsePolicy.cacheState !== "MISS",
       expireSeconds,
       revalidateSeconds,

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -364,7 +364,7 @@ function materializeConcreteLayoutFlags(input: {
     return input.layoutFlags;
   }
   const metadata = AppElementsWire.readMetadata(input.element);
-  if (metadata.sourcePage.includes("[")) {
+  if (metadata.sourcePage?.includes("[")) {
     return input.layoutFlags;
   }
 

--- a/packages/vinext/src/server/app-page-response.ts
+++ b/packages/vinext/src/server/app-page-response.ts
@@ -39,6 +39,7 @@ type AppPageResponsePolicy = {
 type AppPagePrerenderCacheLife = {
   expire?: number;
   revalidate?: number;
+  stale?: number;
 };
 
 type ResolveAppPageResponsePolicyBaseOptions = {
@@ -127,10 +128,18 @@ function applyPrerenderCacheLifeHeader(
   ) {
     payload.revalidate = requestCacheLife.revalidate;
   }
+  if (typeof requestCacheLife.stale === "number" && Number.isFinite(requestCacheLife.stale)) {
+    payload.stale = requestCacheLife.stale;
+  }
   if (typeof requestCacheLife.expire === "number" && Number.isFinite(requestCacheLife.expire)) {
     payload.expire = requestCacheLife.expire;
   }
-  if (payload.revalidate === undefined && payload.expire === undefined) return;
+  if (
+    payload.revalidate === undefined &&
+    payload.stale === undefined &&
+    payload.expire === undefined
+  )
+    return;
   headers.set(VINEXT_PRERENDER_CACHE_LIFE_HEADER, JSON.stringify(payload));
 }
 

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -53,6 +53,7 @@ import {
 import {
   APP_PAGE_SEGMENT_KEY,
   resolveAppPageChildSegments,
+  resolveAppPageConcreteRouteSegments,
   resolveAppPageRouteStateKey,
   resolveAppPageSegmentStateKey,
 } from "./app-page-segment-state.js";
@@ -229,6 +230,7 @@ type BuildAppPageElementsOptions<
   mountedSlotIds?: ReadonlySet<string> | null;
   renderIdentity?: AppPageRenderIdentity;
   renderMode?: AppRscRenderMode;
+  concreteSegmentIdentity?: boolean;
   routePath: string;
   sourcePageSegments?: readonly string[] | null;
 };
@@ -260,8 +262,12 @@ function getErrorBoundaryExport<TModule extends AppPageErrorModule>(
 export function createAppPageTreePath(
   routeSegments: readonly string[] | null | undefined,
   treePosition: number,
+  params?: AppPageParams | null,
 ): string {
-  const treePathSegments = routeSegments?.slice(0, treePosition) ?? [];
+  const treePathSegments =
+    params && routeSegments
+      ? resolveAppPageConcreteRouteSegments(routeSegments.slice(0, treePosition), params)
+      : (routeSegments?.slice(0, treePosition) ?? []);
   if (treePathSegments.length === 0) {
     return "/";
   }
@@ -290,6 +296,15 @@ function recordLayoutSkipObservationScope(options: {
   if (revalidateSeconds !== null) {
     options.layoutParamAccess?.recordLayoutFiniteRevalidate(options.layoutId, revalidateSeconds);
   }
+}
+
+function resolveAppPageIdentitySegments(
+  routeSegments: readonly string[] | null | undefined,
+  params: AppPageParams | null,
+): readonly string[] | null | undefined {
+  return params && routeSegments
+    ? resolveAppPageConcreteRouteSegments(routeSegments, params)
+    : routeSegments;
 }
 
 export function probeAppPageLayoutWithTracking<TModule extends AppPageModule>(options: {
@@ -354,10 +369,11 @@ export function createAppPageLayoutEntries<
     forbiddens?: readonly (TModule | null | undefined)[] | null;
     unauthorizeds?: readonly (TModule | null | undefined)[] | null;
   },
+  identityParams: AppPageParams | null = null,
 ): AppPageLayoutEntry<TModule, TErrorModule>[] {
   return route.layouts.map((layoutModule, index) => {
     const treePosition = route.layoutTreePositions?.[index] ?? 0;
-    const treePath = createAppPageTreePath(route.routeSegments, treePosition);
+    const treePath = createAppPageTreePath(route.routeSegments, treePosition, identityParams);
     return {
       errorModule: route.errorTreePositions ? null : (route.errors?.[index] ?? null),
       forbiddenModule: route.forbiddens?.[index] ?? null,
@@ -376,10 +392,11 @@ function createAppPageTemplateEntries<TModule extends AppPageModule>(
     AppPageRouteWiringRoute<TModule>,
     "routeSegments" | "templateTreePositions" | "templates"
   >,
+  identityParams: AppPageParams | null,
 ): AppPageTemplateEntry<TModule>[] {
   return (route.templates ?? []).map((templateModule, index) => {
     const treePosition = route.templateTreePositions?.[index] ?? 0;
-    const treePath = createAppPageTreePath(route.routeSegments, treePosition);
+    const treePath = createAppPageTreePath(route.routeSegments, treePosition, identityParams);
     return {
       id: AppElementsWire.encodeTemplateId(treePath),
       templateModule,
@@ -575,15 +592,16 @@ export function buildAppPageElements<
     renderIdentity?.interceptionContext ?? options.interceptionContext ?? null;
   const renderMode = options.renderMode ?? APP_RSC_RENDER_MODE_NAVIGATION;
   const routeSegments = options.route.routeSegments ?? [];
+  const identityParams = options.concreteSegmentIdentity === true ? options.matchedParams : null;
   const routeResetKey = resolveAppPageRouteStateKey(routeSegments, options.matchedParams);
   const routeId =
     renderIdentity?.routeId ??
     AppElementsWire.encodeRouteId(options.routePath, interceptionContext);
   const pageId =
     renderIdentity?.pageId ?? AppElementsWire.encodePageId(options.routePath, interceptionContext);
-  const pageElementId = options.route.childrenSlot?.id ?? pageId;
-  const layoutEntries = createAppPageLayoutEntries(options.route);
-  const templateEntries = createAppPageTemplateEntries(options.route);
+  const pageElementId = identityParams ? pageId : (options.route.childrenSlot?.id ?? pageId);
+  const layoutEntries = createAppPageLayoutEntries(options.route, identityParams);
+  const templateEntries = createAppPageTemplateEntries(options.route, identityParams);
   const errorEntries = createAppPageErrorEntries(options.route);
   const metadataPlacement = options.metadataPlacement ?? "head";
   const layoutEntriesByTreePosition = new Map<number, AppPageLayoutEntry<TModule, TErrorModule>>();
@@ -648,10 +666,14 @@ export function buildAppPageElements<
     ...AppElementsWire.createMetadataEntries({
       interception: renderIdentity?.interception ?? options.interception ?? null,
       interceptionContext,
-      layoutIds: options.route.ids?.layouts ?? layoutEntries.map((entry) => entry.id),
+      layoutIds: identityParams
+        ? layoutEntries.map((entry) => entry.id)
+        : (options.route.ids?.layouts ?? layoutEntries.map((entry) => entry.id)),
       rootLayoutTreePath,
       routeId,
-      sourcePage: createAppPageSourcePage(options.sourcePageSegments ?? routeSegments),
+      sourcePage: createAppPageSourcePage(
+        resolveAppPageIdentitySegments(options.sourcePageSegments ?? routeSegments, identityParams),
+      ),
       slotBindings: createAppPageSlotBindings(options.route, layoutEntries, resolveSlotOverride, {
         interception: renderIdentity?.interception ?? options.interception ?? null,
         interceptionContext,

--- a/packages/vinext/src/server/app-page-segment-state.ts
+++ b/packages/vinext/src/server/app-page-segment-state.ts
@@ -117,6 +117,44 @@ export function resolveAppPageChildSegments(
   return resolvedSegments;
 }
 
+export function resolveAppPageConcreteRouteSegments(
+  routeSegments: readonly string[],
+  params: AppPageParams,
+): string[] {
+  const resolvedSegments: string[] = [];
+
+  for (const segment of routeSegments) {
+    if (isOptionalCatchAllSegment(segment)) {
+      const paramName = segment.slice(5, -2);
+      const paramValue = params[paramName];
+      if (Array.isArray(paramValue) && paramValue.length === 0) {
+        continue;
+      }
+      const resolvedValue = formatParamSegmentValue(paramValue);
+      if (resolvedValue !== undefined) {
+        resolvedSegments.push(resolvedValue);
+      }
+      continue;
+    }
+
+    if (isCatchAllSegment(segment)) {
+      const paramName = segment.slice(4, -1);
+      resolvedSegments.push(formatParamSegmentValue(params[paramName]) ?? segment);
+      continue;
+    }
+
+    if (isDynamicSegment(segment)) {
+      const paramName = segment.slice(1, -1);
+      resolvedSegments.push(formatParamSegmentValue(params[paramName]) ?? segment);
+      continue;
+    }
+
+    resolvedSegments.push(segment);
+  }
+
+  return resolvedSegments;
+}
+
 export function resolveAppPageSegmentStateKey(
   routeSegments: readonly string[],
   treePosition: number,

--- a/packages/vinext/src/server/isr-cache.ts
+++ b/packages/vinext/src/server/isr-cache.ts
@@ -173,12 +173,14 @@ export async function isrSet(
   revalidateSeconds: number,
   tags?: string[],
   expireSeconds?: number,
+  staleSeconds?: number,
 ): Promise<void> {
   await getCdnCacheAdapter().set(key, data, {
-    cacheControl:
-      expireSeconds === undefined
-        ? { revalidate: revalidateSeconds }
-        : { revalidate: revalidateSeconds, expire: expireSeconds },
+    cacheControl: {
+      revalidate: revalidateSeconds,
+      ...(staleSeconds === undefined ? {} : { stale: staleSeconds }),
+      ...(expireSeconds === undefined ? {} : { expire: expireSeconds }),
+    },
     // `revalidate` is the legacy vinext CacheHandler context field. `expire`
     // is new metadata and intentionally only lives inside cacheControl.
     revalidate: revalidateSeconds,
@@ -192,6 +194,7 @@ export async function isrSetPrerenderedAppPage(
   metadata: {
     expireSeconds?: number;
     revalidateSeconds?: number;
+    staleSeconds?: number;
     /**
      * Implicit/path tags to attach to the seeded entry. Required so that
      * `revalidatePath()` (and `revalidateTag()`) can invalidate prerender-seeded
@@ -214,10 +217,11 @@ export async function isrSetPrerenderedAppPage(
   const ctx: Record<string, unknown> = {};
   if (revalidateSeconds !== undefined) {
     ctx.revalidate = revalidateSeconds;
-    ctx.cacheControl =
-      metadata.expireSeconds === undefined
-        ? { revalidate: revalidateSeconds }
-        : { revalidate: revalidateSeconds, expire: metadata.expireSeconds };
+    ctx.cacheControl = {
+      revalidate: revalidateSeconds,
+      ...(metadata.staleSeconds === undefined ? {} : { stale: metadata.staleSeconds }),
+      ...(metadata.expireSeconds === undefined ? {} : { expire: metadata.expireSeconds }),
+    };
   }
   if (tags && tags.length > 0) {
     ctx.tags = tags;
@@ -403,16 +407,22 @@ export function appIsrRscKey(
   mountedSlotsHeader?: string | null,
   renderMode: AppRscRenderMode = APP_RSC_RENDER_MODE_NAVIGATION,
   interceptionContext?: string | null,
+  segmentPrefetchPath?: string | null,
 ): string {
   const normalizedMountedSlotsHeader = normalizeMountedSlotsHeader(mountedSlotsHeader);
   const sourceVariant =
     interceptionContext === undefined || interceptionContext === null
       ? null
       : normalizeInterceptionContextForCacheKey(interceptionContext);
+  const normalizedSegmentPrefetchPath =
+    typeof segmentPrefetchPath === "string" && segmentPrefetchPath.length > 0
+      ? segmentPrefetchPath
+      : null;
   const variant = [
     sourceVariant ? `source:${fnv1a64(sourceVariant)}` : null,
     normalizedMountedSlotsHeader ? `slots:${fnv1a64(normalizedMountedSlotsHeader)}` : null,
     getRscRenderModeCacheVariant(renderMode),
+    normalizedSegmentPrefetchPath ? `segment:${fnv1a64(normalizedSegmentPrefetchPath)}` : null,
   ]
     .filter((part) => part !== null)
     .join(":");

--- a/packages/vinext/src/server/prerender-manifest.ts
+++ b/packages/vinext/src/server/prerender-manifest.ts
@@ -5,6 +5,7 @@ type PrerenderManifestRoute = {
   status?: string;
   revalidate?: number | false;
   expire?: number;
+  stale?: number;
   path?: string;
   router?: string;
   fallback?: boolean;

--- a/packages/vinext/src/server/seed-cache.ts
+++ b/packages/vinext/src/server/seed-cache.ts
@@ -49,6 +49,7 @@ import {
 type PrerenderCacheSeedMetadata = {
   expireSeconds?: number;
   revalidateSeconds?: number;
+  staleSeconds?: number;
   /**
    * Path-derived implicit tags (`/foo`, `_N_T_/foo`, `_N_T_/foo/page`, ...)
    * required for `revalidatePath()` to invalidate the seeded entry. See #1486.
@@ -117,6 +118,7 @@ export async function seedMemoryCacheFromPrerender(
     const rscKey = options?.buildAppPageRscKey?.(cachePathname) ?? baseKey + ":rsc";
     const revalidateSeconds = typeof route.revalidate === "number" ? route.revalidate : undefined;
     const expireSeconds = typeof route.expire === "number" ? route.expire : undefined;
+    const staleSeconds = typeof route.stale === "number" ? route.stale : undefined;
 
     // Path-derived implicit tags so revalidatePath()/revalidateTag() can
     // invalidate seeded entries. Without this the seeded entry has no tags
@@ -133,6 +135,7 @@ export async function seedMemoryCacheFromPrerender(
         route.headers,
         revalidateSeconds,
         expireSeconds,
+        staleSeconds,
         tags,
       )
     ) {
@@ -143,6 +146,7 @@ export async function seedMemoryCacheFromPrerender(
         artifactPathname,
         revalidateSeconds,
         expireSeconds,
+        staleSeconds,
         tags,
       );
       seeded++;
@@ -173,6 +177,7 @@ async function seedHtml(
   headers: Record<string, string> | undefined,
   revalidateSeconds: number | undefined,
   expireSeconds: number | undefined,
+  staleSeconds: number | undefined,
   tags: string[] | undefined,
 ): Promise<boolean> {
   const relPath = getOutputPath(pathname, trailingSlash);
@@ -188,7 +193,7 @@ async function seedHtml(
     status: undefined,
   };
 
-  await writeAppPageEntry(key, htmlValue, { expireSeconds, revalidateSeconds, tags });
+  await writeAppPageEntry(key, htmlValue, { expireSeconds, revalidateSeconds, staleSeconds, tags });
 
   return true;
 }
@@ -204,6 +209,7 @@ async function seedRsc(
   pathname: string,
   revalidateSeconds: number | undefined,
   expireSeconds: number | undefined,
+  staleSeconds: number | undefined,
   tags: string[] | undefined,
 ): Promise<void> {
   const relPath = getRscOutputPath(pathname);
@@ -223,5 +229,5 @@ async function seedRsc(
     status: undefined,
   };
 
-  await writeAppPageEntry(key, rscValue, { expireSeconds, revalidateSeconds, tags });
+  await writeAppPageEntry(key, rscValue, { expireSeconds, revalidateSeconds, staleSeconds, tags });
 }

--- a/packages/vinext/src/shims/cache-handler.ts
+++ b/packages/vinext/src/shims/cache-handler.ts
@@ -11,6 +11,7 @@ export type CacheHandlerValue = {
 
 export type CacheControlMetadata = {
   revalidate: number;
+  stale?: number;
   expire?: number;
 };
 
@@ -274,6 +275,7 @@ export class MemoryCacheHandler implements CacheHandler {
 
     let effectiveRevalidate = readCacheControlNumberField(ctx, "revalidate");
     const effectiveExpire = readCacheControlNumberField(ctx, "expire");
+    const effectiveStale = readCacheControlNumberField(ctx, "stale");
     if (data && "revalidate" in data && typeof data.revalidate === "number") {
       effectiveRevalidate = data.revalidate;
     }
@@ -290,9 +292,11 @@ export class MemoryCacheHandler implements CacheHandler {
         : null;
     const cacheControl =
       typeof effectiveRevalidate === "number"
-        ? effectiveExpire === undefined
-          ? { revalidate: effectiveRevalidate }
-          : { revalidate: effectiveRevalidate, expire: effectiveExpire }
+        ? {
+            revalidate: effectiveRevalidate,
+            ...(effectiveStale === undefined ? {} : { stale: effectiveStale }),
+            ...(effectiveExpire === undefined ? {} : { expire: effectiveExpire }),
+          }
         : undefined;
 
     if (this.maxMemoryCacheSize === 0) return;

--- a/packages/vinext/src/shims/cache-runtime.ts
+++ b/packages/vinext/src/shims/cache-runtime.ts
@@ -606,6 +606,7 @@ export function registerCachedFunction<TArgs extends unknown[], TResult>(
           tags: ctx.tags,
           cacheControl: {
             revalidate: revalidateSeconds,
+            stale: effectiveLife.stale,
             expire: effectiveLife.expire,
           },
         });
@@ -651,6 +652,7 @@ function recordRequestScopedCacheControl(cacheControl: CacheControlMetadata | un
   if (cacheControl === undefined) return;
   _setRequestScopedCacheLife({
     revalidate: cacheControl.revalidate,
+    stale: cacheControl.stale,
     expire: cacheControl.expire,
   });
 }

--- a/packages/vinext/src/shims/internal/link-segment-prefetch-scheduler.ts
+++ b/packages/vinext/src/shims/internal/link-segment-prefetch-scheduler.ts
@@ -34,6 +34,7 @@ type LinkSegmentPrefetchTaskStatus =
   | "queued"
   | "running"
   | "running-canceled"
+  | "running-dirty"
   | "completed";
 
 type LinkSegmentPrefetchTask = {
@@ -185,8 +186,20 @@ export function createLinkSegmentPrefetchScheduler(
       };
       tasksByInstance.set(instance, task);
     } else {
-      if (task.status === "running" || task.status === "running-canceled") {
-        task.status = "running";
+      if (
+        task.status === "running" ||
+        task.status === "running-canceled" ||
+        task.status === "running-dirty"
+      ) {
+        if (options.force === true) {
+          task.status = "running-dirty";
+          task.batchId = batchId;
+          task.forceSegmentCacheFetch = priority === "low" && hasRecentUserInteraction();
+          task.phase = "route-tree";
+          task.sortId = sortIdCounter++;
+        } else if (task.status !== "running-dirty") {
+          task.status = "running";
+        }
         task.priority = task === mostRecentIntentTask && priority === "low" ? "high" : priority;
         trackIntentTask(task);
         return;
@@ -214,7 +227,7 @@ export function createLinkSegmentPrefetchScheduler(
     if (task === undefined) return;
     if (task.status === "queued") {
       removeQueuedTask(task);
-    } else if (task.status === "running") {
+    } else if (task.status === "running" || task.status === "running-dirty") {
       task.status = "running-canceled";
     }
     if (mostRecentIntentTask === task) {
@@ -250,10 +263,15 @@ export function createLinkSegmentPrefetchScheduler(
         .catch(() => {})
         .finally(() => {
           const shouldContinue = currentTask.status === "running" && currentTask.instance.isVisible;
+          const shouldRestart =
+            currentTask.status === "running-dirty" && currentTask.instance.isVisible;
           currentTask.status = "idle";
           inProgress--;
 
-          if (shouldContinue && phase === "route-tree") {
+          if (shouldRestart) {
+            currentTask.phase = "route-tree";
+            enqueueTask(currentTask);
+          } else if (shouldContinue && phase === "route-tree") {
             currentTask.phase = "segment";
             enqueueTask(currentTask);
           } else if (shouldContinue && phase === "segment") {

--- a/packages/vinext/src/shims/internal/link-segment-prefetch-scheduler.ts
+++ b/packages/vinext/src/shims/internal/link-segment-prefetch-scheduler.ts
@@ -1,0 +1,276 @@
+"use client";
+
+export type LinkSegmentPrefetchPhase = "route-tree" | "segment";
+export type LinkSegmentPrefetchPriority = "low" | "high";
+
+export type LinkSegmentPrefetchPhaseRequest = {
+  href: string;
+  phase: LinkSegmentPrefetchPhase;
+  priority: LinkSegmentPrefetchPriority;
+  pagesRouteHref?: string;
+  forceSegmentCacheFetch: boolean;
+};
+
+export type LinkSegmentPrefetchInstance = {
+  href: string;
+  isVisible: boolean;
+  pagesRouteHref?: string;
+};
+
+export type LinkSegmentPrefetchScheduler = {
+  cancel(instance: LinkSegmentPrefetchInstance): void;
+  createBatch(): number;
+  registerUserInteractionListeners(): void;
+  schedule(
+    instance: LinkSegmentPrefetchInstance,
+    priority: LinkSegmentPrefetchPriority,
+    batchId?: number,
+  ): void;
+};
+
+type LinkSegmentPrefetchTaskStatus =
+  | "idle"
+  | "queued"
+  | "running"
+  | "running-canceled"
+  | "completed";
+
+type LinkSegmentPrefetchTask = {
+  instance: LinkSegmentPrefetchInstance;
+  batchId: number;
+  forceSegmentCacheFetch: boolean;
+  phase: LinkSegmentPrefetchPhase;
+  priority: LinkSegmentPrefetchPriority;
+  sortId: number;
+  status: LinkSegmentPrefetchTaskStatus;
+};
+
+type LinkSegmentPrefetchSchedulerOptions = {
+  runPhase(request: LinkSegmentPrefetchPhaseRequest): Promise<void>;
+};
+
+export function createLinkSegmentPrefetchScheduler(
+  options: LinkSegmentPrefetchSchedulerOptions,
+): LinkSegmentPrefetchScheduler {
+  const tasksByInstance = new WeakMap<LinkSegmentPrefetchInstance, LinkSegmentPrefetchTask>();
+  const queuedTasks: LinkSegmentPrefetchTask[] = [];
+  let batchIdCounter = 0;
+  let sortIdCounter = 0;
+  let inProgress = 0;
+  let pendingMicrotask = false;
+  let mostRecentIntentTask: LinkSegmentPrefetchTask | null = null;
+  let userInteractionListenersRegistered = false;
+  let lastUserInteractionAt = 0;
+
+  function createBatch(): number {
+    return batchIdCounter++;
+  }
+
+  function scheduleMicrotask(fn: () => void): void {
+    if (typeof queueMicrotask === "function") {
+      queueMicrotask(fn);
+    } else {
+      Promise.resolve()
+        .then(fn)
+        .catch((error) => {
+          setTimeout(() => {
+            throw error;
+          });
+        });
+    }
+  }
+
+  function enqueueTask(task: LinkSegmentPrefetchTask): void {
+    if (task.status !== "idle") return;
+    task.status = "queued";
+    queuedTasks.push(task);
+  }
+
+  function removeQueuedTask(task: LinkSegmentPrefetchTask): void {
+    if (task.status !== "queued") return;
+    task.status = "idle";
+    const index = queuedTasks.indexOf(task);
+    if (index !== -1) queuedTasks.splice(index, 1);
+  }
+
+  function scheduleQueue(delayUntilNextTask = false): void {
+    if (pendingMicrotask) return;
+    pendingMicrotask = true;
+    if (delayUntilNextTask) {
+      setTimeout(processQueue, 0);
+      return;
+    }
+    scheduleMicrotask(processQueue);
+  }
+
+  function markUserInteraction(): void {
+    lastUserInteractionAt = Date.now();
+  }
+
+  function hasRecentUserInteraction(): boolean {
+    return Date.now() - lastUserInteractionAt < 1_000;
+  }
+
+  function registerUserInteractionListeners(): void {
+    if (typeof window === "undefined" || userInteractionListenersRegistered) return;
+    userInteractionListenersRegistered = true;
+    window.addEventListener("pointerdown", markUserInteraction, true);
+    window.addEventListener("mousedown", markUserInteraction, true);
+    window.addEventListener("click", markUserInteraction, true);
+    window.addEventListener("input", markUserInteraction, true);
+    window.addEventListener("change", markUserInteraction, true);
+    window.addEventListener("keydown", markUserInteraction, true);
+  }
+
+  function compareTasks(a: LinkSegmentPrefetchTask, b: LinkSegmentPrefetchTask): number {
+    const priorityDelta = (a.priority === "high" ? 1 : 0) - (b.priority === "high" ? 1 : 0);
+    if (priorityDelta !== 0) return priorityDelta;
+    const phaseDelta = (a.phase === "route-tree" ? 1 : 0) - (b.phase === "route-tree" ? 1 : 0);
+    if (phaseDelta !== 0) return phaseDelta;
+    return a.sortId - b.sortId;
+  }
+
+  function hasBandwidth(task: LinkSegmentPrefetchTask): boolean {
+    if (task.phase === "route-tree" && task.priority !== "high") {
+      for (const queuedTask of queuedTasks) {
+        if (
+          queuedTask !== task &&
+          queuedTask.priority !== "high" &&
+          queuedTask.phase === "route-tree" &&
+          queuedTask.batchId < task.batchId
+        ) {
+          return false;
+        }
+      }
+    }
+    return inProgress < (task.priority === "high" ? 12 : 4);
+  }
+
+  function peekNextRunnableTask(): LinkSegmentPrefetchTask | null {
+    let bestTask: LinkSegmentPrefetchTask | null = null;
+    for (const task of queuedTasks) {
+      if (!hasBandwidth(task)) continue;
+      if (bestTask === null || compareTasks(task, bestTask) > 0) {
+        bestTask = task;
+      }
+    }
+    return bestTask;
+  }
+
+  function trackIntentTask(task: LinkSegmentPrefetchTask): void {
+    if (task.priority !== "high" || task === mostRecentIntentTask) return;
+    if (mostRecentIntentTask !== null) {
+      mostRecentIntentTask.priority = "low";
+    }
+    mostRecentIntentTask = task;
+  }
+
+  function schedule(
+    instance: LinkSegmentPrefetchInstance,
+    priority: LinkSegmentPrefetchPriority,
+    batchId = tasksByInstance.get(instance)?.batchId ?? createBatch(),
+  ): void {
+    let task = tasksByInstance.get(instance) ?? null;
+    if (task === null) {
+      task = {
+        instance,
+        batchId,
+        forceSegmentCacheFetch: priority === "low" && hasRecentUserInteraction(),
+        phase: "route-tree",
+        priority,
+        sortId: sortIdCounter++,
+        status: "idle",
+      };
+      tasksByInstance.set(instance, task);
+    } else {
+      if (task.status === "running" || task.status === "running-canceled") {
+        task.status = "running";
+        task.priority = task === mostRecentIntentTask && priority === "low" ? "high" : priority;
+        trackIntentTask(task);
+        return;
+      }
+      if (task.status === "completed") {
+        return;
+      }
+
+      removeQueuedTask(task);
+      task.batchId = batchId;
+      task.forceSegmentCacheFetch = priority === "low" && hasRecentUserInteraction();
+      task.phase = "route-tree";
+      task.priority = task === mostRecentIntentTask && priority === "low" ? "high" : priority;
+      task.sortId = sortIdCounter++;
+      task.status = "idle";
+    }
+
+    trackIntentTask(task);
+    enqueueTask(task);
+    scheduleQueue(priority === "high");
+  }
+
+  function cancel(instance: LinkSegmentPrefetchInstance): void {
+    const task = tasksByInstance.get(instance);
+    if (task === undefined) return;
+    if (task.status === "queued") {
+      removeQueuedTask(task);
+    } else if (task.status === "running") {
+      task.status = "running-canceled";
+    }
+    if (mostRecentIntentTask === task) {
+      mostRecentIntentTask = null;
+    }
+  }
+
+  function processQueue(): void {
+    pendingMicrotask = false;
+
+    let task = peekNextRunnableTask();
+    while (task !== null) {
+      removeQueuedTask(task);
+      if (task.status !== "idle" || !task.instance.isVisible) {
+        task = peekNextRunnableTask();
+        continue;
+      }
+
+      const currentTask = task;
+      inProgress++;
+      currentTask.status = "running";
+      const phase = currentTask.phase;
+
+      Promise.resolve(
+        options.runPhase({
+          href: currentTask.instance.href,
+          phase,
+          priority: currentTask.priority,
+          pagesRouteHref: currentTask.instance.pagesRouteHref,
+          forceSegmentCacheFetch: currentTask.forceSegmentCacheFetch,
+        }),
+      )
+        .catch(() => {})
+        .finally(() => {
+          const shouldContinue = currentTask.status === "running" && currentTask.instance.isVisible;
+          currentTask.status = "idle";
+          inProgress--;
+
+          if (shouldContinue && phase === "route-tree") {
+            currentTask.phase = "segment";
+            enqueueTask(currentTask);
+          } else if (shouldContinue && phase === "segment") {
+            currentTask.status = "completed";
+            if (mostRecentIntentTask === currentTask) {
+              mostRecentIntentTask = null;
+            }
+          }
+          scheduleQueue();
+        });
+
+      task = peekNextRunnableTask();
+    }
+  }
+
+  return {
+    cancel,
+    createBatch,
+    registerUserInteractionListeners,
+    schedule,
+  };
+}

--- a/packages/vinext/src/shims/internal/link-segment-prefetch-scheduler.ts
+++ b/packages/vinext/src/shims/internal/link-segment-prefetch-scheduler.ts
@@ -25,6 +25,7 @@ export type LinkSegmentPrefetchScheduler = {
     instance: LinkSegmentPrefetchInstance,
     priority: LinkSegmentPrefetchPriority,
     batchId?: number,
+    options?: { force?: boolean },
   ): void;
 };
 
@@ -169,6 +170,7 @@ export function createLinkSegmentPrefetchScheduler(
     instance: LinkSegmentPrefetchInstance,
     priority: LinkSegmentPrefetchPriority,
     batchId = tasksByInstance.get(instance)?.batchId ?? createBatch(),
+    options: { force?: boolean } = {},
   ): void {
     let task = tasksByInstance.get(instance) ?? null;
     if (task === null) {
@@ -189,7 +191,7 @@ export function createLinkSegmentPrefetchScheduler(
         trackIntentTask(task);
         return;
       }
-      if (task.status === "completed") {
+      if (task.status === "completed" && options.force !== true) {
         return;
       }
 

--- a/packages/vinext/src/shims/internal/link-segment-prefetch-scheduler.ts
+++ b/packages/vinext/src/shims/internal/link-segment-prefetch-scheduler.ts
@@ -1,7 +1,7 @@
 "use client";
 
-export type LinkSegmentPrefetchPhase = "route-tree" | "segment";
-export type LinkSegmentPrefetchPriority = "low" | "high";
+type LinkSegmentPrefetchPhase = "route-tree" | "segment";
+type LinkSegmentPrefetchPriority = "low" | "high";
 
 export type LinkSegmentPrefetchPhaseRequest = {
   href: string;

--- a/packages/vinext/src/shims/internal/link-segment-prefetch-scheduler.ts
+++ b/packages/vinext/src/shims/internal/link-segment-prefetch-scheduler.ts
@@ -34,6 +34,7 @@ type LinkSegmentPrefetchTaskStatus =
   | "queued"
   | "running"
   | "running-canceled"
+  | "running-canceled-dirty"
   | "running-dirty"
   | "completed";
 
@@ -189,14 +190,20 @@ export function createLinkSegmentPrefetchScheduler(
       if (
         task.status === "running" ||
         task.status === "running-canceled" ||
+        task.status === "running-canceled-dirty" ||
         task.status === "running-dirty"
       ) {
         if (options.force === true) {
-          task.status = "running-dirty";
+          task.status =
+            task.status === "running-canceled" || task.status === "running-canceled-dirty"
+              ? "running-canceled-dirty"
+              : "running-dirty";
           task.batchId = batchId;
           task.forceSegmentCacheFetch = priority === "low" && hasRecentUserInteraction();
           task.phase = "route-tree";
           task.sortId = sortIdCounter++;
+        } else if (task.status === "running-canceled-dirty") {
+          task.status = "running-dirty";
         } else if (task.status !== "running-dirty") {
           task.status = "running";
         }
@@ -228,7 +235,7 @@ export function createLinkSegmentPrefetchScheduler(
     if (task.status === "queued") {
       removeQueuedTask(task);
     } else if (task.status === "running" || task.status === "running-dirty") {
-      task.status = "running-canceled";
+      task.status = task.status === "running-dirty" ? "running-canceled-dirty" : "running-canceled";
     }
     if (mostRecentIntentTask === task) {
       mostRecentIntentTask = null;
@@ -264,7 +271,9 @@ export function createLinkSegmentPrefetchScheduler(
         .finally(() => {
           const shouldContinue = currentTask.status === "running" && currentTask.instance.isVisible;
           const shouldRestart =
-            currentTask.status === "running-dirty" && currentTask.instance.isVisible;
+            (currentTask.status === "running-dirty" ||
+              currentTask.status === "running-canceled-dirty") &&
+            currentTask.instance.isVisible;
           currentTask.status = "idle";
           inProgress--;
 

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -832,10 +832,11 @@ function setVisibleLinkPrefetch(
   instance.isVisible = isVisible;
   if (isVisible) {
     visibleLinkPrefetches.add(instance);
-    if (instance.routerMode === "pages" && instance.viewportPrefetched) return;
+    const routerMode = resolveCurrentLinkPrefetchRouterMode(instance);
+    if (routerMode === "pages" && instance.viewportPrefetched) return;
     if (usesSegmentCachePrefetchScheduler(instance)) {
       scheduleSegmentCacheLinkPrefetch(instance, "low", batchId);
-    } else if (resolveCurrentLinkPrefetchRouterMode(instance) === "app") {
+    } else if (routerMode === "app") {
       scheduleVisibleAppPrefetch(instance);
     } else {
       void prefetchUrl(instance.href, instance.mode, "low", instance.pagesRouteHref);

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -405,9 +405,10 @@ function resolveFullAppRoutePrefetch(): {
  * For Pages Router: warms the page chunk, prefetches data only for SSG pages,
  * and falls back to a document prefetch hint when no page loader matches.
  *
- * High-priority and Segment Cache scheduler phases start immediately. Other
- * low-priority prefetches use `requestIdleCallback` (or `setTimeout` fallback)
- * to avoid blocking the main thread during initial page load.
+ * High-priority, App Router runtime, and Segment Cache scheduler phases start
+ * immediately. Pages Router low-priority prefetches use `requestIdleCallback`
+ * (or `setTimeout` fallback) to avoid blocking the main thread during initial
+ * page load.
  */
 function prefetchUrl(
   href: string,
@@ -693,7 +694,7 @@ function prefetchUrl(
     priority === "high" ||
     mode === "route-tree" ||
     mode === "segment" ||
-    (hasAppNavigationRuntime() && String(process.env.__NEXT_CACHE_COMPONENTS) !== "false")
+    hasAppNavigationRuntime()
   ) {
     return runPrefetch();
   }
@@ -797,6 +798,8 @@ function usesSegmentCachePrefetchScheduler(instance: LinkPrefetchInstance): bool
   return (
     resolveCurrentLinkPrefetchRouterMode(instance) === "app" &&
     instance.mode === "auto" &&
+    // Next.js inlines __NEXT_CACHE_COMPONENTS as a boolean define; String()
+    // lets tests that stub the env with "true" share the production branch.
     String(process.env.__NEXT_CACHE_COMPONENTS) === "true"
   );
 }

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -689,7 +689,12 @@ function prefetchUrl(
     return promise;
   };
 
-  if (priority === "high" || mode === "route-tree" || mode === "segment") {
+  if (
+    priority === "high" ||
+    mode === "route-tree" ||
+    mode === "segment" ||
+    (hasAppNavigationRuntime() && String(process.env.__NEXT_CACHE_COMPONENTS) !== "false")
+  ) {
     return runPrefetch();
   }
 

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -514,8 +514,7 @@ function prefetchUrl(
         if (mountedSlotsHeader) {
           headers.set(VINEXT_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
         }
-        const shouldSendSegmentPrefetchHeaders = isOptimisticRouteShellPrefetch || mode === "auto";
-        if (shouldSendSegmentPrefetchHeaders) {
+        if (mode === "route-tree") {
           headers.set(NEXT_ROUTER_PREFETCH_HEADER, "1");
           headers.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "/_tree");
         } else if (mode === "segment") {
@@ -524,6 +523,9 @@ function prefetchUrl(
           // per-segment payloads, so this marker distinguishes the second
           // scheduler phase without claiming a concrete Next.js segment key.
           headers.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "/_page");
+        } else if (isOptimisticRouteShellPrefetch) {
+          headers.set(NEXT_ROUTER_PREFETCH_HEADER, "1");
+          headers.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "/_tree");
         }
         // Distinguish the same visible URL when it is prefetched from different
         // request contexts such as /feed vs /gallery or different mounted slots.
@@ -753,7 +755,7 @@ function drainVisibleAppPrefetchQueue(): void {
     const instance = visibleAppPrefetchQueue.pop();
     if (!instance) return;
     instance.queuedViewportPrefetch = false;
-    if (!instance.isVisible || instance.routerMode !== "app") continue;
+    if (!instance.isVisible || resolveCurrentLinkPrefetchRouterMode(instance) !== "app") continue;
     void prefetchUrl(instance.href, instance.mode, "low", instance.pagesRouteHref);
   }
 }
@@ -791,10 +793,17 @@ let lastLinkPrefetchUserInteractionAt = 0;
 
 function usesSegmentCachePrefetchScheduler(instance: LinkPrefetchInstance): boolean {
   return (
-    instance.routerMode === "app" &&
+    resolveCurrentLinkPrefetchRouterMode(instance) === "app" &&
     instance.mode === "auto" &&
     String(process.env.__NEXT_CACHE_COMPONENTS) === "true"
   );
+}
+
+function resolveCurrentLinkPrefetchRouterMode(
+  instance: LinkPrefetchInstance,
+): LinkPrefetchRouterMode {
+  if (instance.routerMode === "app" || hasAppNavigationRuntime()) return "app";
+  return "pages";
 }
 
 function scheduleMicrotaskForLinkPrefetch(fn: () => void): void {
@@ -1009,7 +1018,7 @@ function setVisibleLinkPrefetch(
     if (instance.routerMode === "pages" && instance.viewportPrefetched) return;
     if (usesSegmentCachePrefetchScheduler(instance)) {
       scheduleSegmentCacheLinkPrefetch(instance, "low", batchId);
-    } else if (instance.routerMode === "app") {
+    } else if (resolveCurrentLinkPrefetchRouterMode(instance) === "app") {
       scheduleVisibleAppPrefetch(instance);
     } else {
       void prefetchUrl(instance.href, instance.mode, "low", instance.pagesRouteHref);

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -115,7 +115,13 @@ type LinkProps = {
   children?: React.ReactNode;
 } & Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "href">;
 
-type LinkPrefetchMode = "disabled" | "auto" | "full" | "full-after-shell";
+type LinkPrefetchMode =
+  | "disabled"
+  | "auto"
+  | "full"
+  | "full-after-shell"
+  | "route-tree"
+  | "segment";
 
 declare global {
   // Window is an ambient interface from lib.dom; interface merging is required
@@ -395,15 +401,16 @@ function resolveFullAppRoutePrefetch(): {
  * For Pages Router: warms the page chunk, prefetches data only for SSG pages,
  * and falls back to a document prefetch hint when no page loader matches.
  *
- * Uses `requestIdleCallback` (or `setTimeout` fallback) to avoid blocking
- * the main thread during initial page load.
+ * App Router and high-priority prefetches start immediately. Low-priority
+ * Pages Router fallback prefetches use `requestIdleCallback` (or `setTimeout`
+ * fallback) to avoid blocking the main thread during initial page load.
  */
 function prefetchUrl(
   href: string,
   mode: LinkPrefetchMode,
   priority: "low" | "high" = "low",
   pagesRouteHref?: string,
-): void {
+): Promise<void> | undefined {
   if (typeof window === "undefined") return;
 
   const prefetchHref = getLinkPrefetchHref({
@@ -436,15 +443,8 @@ function prefetchUrl(
     return;
   }
 
-  const schedule =
-    priority === "high" || hasAppNavigationRuntime()
-      ? (fn: () => void) => {
-          fn();
-        }
-      : (window.requestIdleCallback ?? ((fn: () => void) => setTimeout(fn, 100)));
-
-  schedule(() => {
-    void (async () => {
+  const runPrefetch = () => {
+    const promise = (async () => {
       if (hasAppNavigationRuntime()) {
         if (isBotUserAgent(window.navigator?.userAgent ?? "")) return;
 
@@ -490,16 +490,19 @@ function prefetchUrl(
           return;
         }
         const autoPrefetch =
-          mode === "auto"
-            ? resolveAutoAppRoutePrefetch(prefetchHref)
-            : mode === "full-after-shell"
-              ? { cacheForNavigation: true, prefetchShellFirst: true, shouldPrefetch: true }
-              : resolveFullAppRoutePrefetch();
+          mode === "route-tree" || mode === "segment"
+            ? { cacheForNavigation: false, prefetchShellFirst: false, shouldPrefetch: true }
+            : mode === "auto"
+              ? resolveAutoAppRoutePrefetch(prefetchHref)
+              : mode === "full-after-shell"
+                ? { cacheForNavigation: true, prefetchShellFirst: true, shouldPrefetch: true }
+                : resolveFullAppRoutePrefetch();
         if (!autoPrefetch.shouldPrefetch) return;
 
         const interceptionContext = getPrefetchInterceptionContext(fullHref);
         const mountedSlotsHeader = getMountedSlotsHeader();
-        const isOptimisticRouteShellPrefetch = !autoPrefetch.cacheForNavigation;
+        const isOptimisticRouteShellPrefetch =
+          mode !== "segment" && !autoPrefetch.cacheForNavigation;
         if (isOptimisticRouteShellPrefetch && interceptionContext !== null) return;
         const headers = createRscRequestHeaders({
           interceptionContext,
@@ -513,7 +516,9 @@ function prefetchUrl(
         const shouldSendSegmentPrefetchHeaders = isOptimisticRouteShellPrefetch || mode === "auto";
         if (shouldSendSegmentPrefetchHeaders) {
           headers.set(NEXT_ROUTER_PREFETCH_HEADER, "1");
-          headers.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "1");
+          headers.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "/_tree");
+        } else if (mode === "segment") {
+          headers.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "/_page");
         }
         // Distinguish the same visible URL when it is prefetched from different
         // request contexts such as /feed vs /gallery or different mounted slots.
@@ -555,7 +560,7 @@ function prefetchUrl(
                   renderMode: APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
                 });
                 shellHeaders.set(NEXT_ROUTER_PREFETCH_HEADER, "1");
-                shellHeaders.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "1");
+                shellHeaders.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "/_tree");
                 if (mountedSlotsHeader) {
                   shellHeaders.set(VINEXT_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
                 }
@@ -627,6 +632,8 @@ function prefetchUrl(
             optimisticRouteShell: isOptimisticRouteShellPrefetch,
           },
         );
+        const entry = getPrefetchCache().get(cacheKey);
+        await entry?.pending?.catch(() => {});
       } else if (HAS_PAGES_ROUTER && window.__NEXT_DATA__) {
         // Pages Router prefetch. When a code-split loader is registered for
         // the target route (prod builds expose them on window via the
@@ -667,6 +674,16 @@ function prefetchUrl(
     })().catch((error) => {
       console.error("[vinext] RSC prefetch setup error:", error);
     });
+    return promise;
+  };
+
+  if (priority === "high" || hasAppNavigationRuntime()) {
+    return runPrefetch();
+  }
+
+  const schedule = window.requestIdleCallback ?? ((fn: () => void) => setTimeout(fn, 100));
+  schedule(() => {
+    void runPrefetch();
   });
 }
 
@@ -715,6 +732,7 @@ type LinkPrefetchInstance = {
   pagesRouteHref?: string;
   queuedViewportPrefetch: boolean;
   routerMode: LinkPrefetchRouterMode;
+  scheduledTask: LinkPrefetchTask | null;
   viewportPrefetched: boolean;
 };
 
@@ -743,19 +761,211 @@ function scheduleVisibleAppPrefetch(instance: LinkPrefetchInstance): void {
   queueMicrotask(drainVisibleAppPrefetchQueue);
 }
 
-function setVisibleLinkPrefetch(instance: LinkPrefetchInstance, isVisible: boolean): void {
+type LinkPrefetchTask = {
+  instance: LinkPrefetchInstance;
+  batchId: number;
+  phase: "route-tree" | "segment";
+  priority: "low" | "high";
+  sortId: number;
+  canceled: boolean;
+  queued: boolean;
+};
+
+const scheduledLinkPrefetches: LinkPrefetchTask[] = [];
+let scheduledLinkPrefetchBatchId = 0;
+let scheduledLinkPrefetchSortId = 0;
+let scheduledLinkPrefetchInProgress = 0;
+let scheduledLinkPrefetchPendingMicrotask = false;
+let mostRecentIntentPrefetchTask: LinkPrefetchTask | null = null;
+
+function usesSegmentCachePrefetchScheduler(instance: LinkPrefetchInstance): boolean {
+  return (
+    instance.routerMode === "app" &&
+    instance.mode === "auto" &&
+    String(process.env.__NEXT_CACHE_COMPONENTS) === "true"
+  );
+}
+
+function scheduleMicrotaskForLinkPrefetch(fn: () => void): void {
+  if (typeof queueMicrotask === "function") {
+    queueMicrotask(fn);
+  } else {
+    Promise.resolve()
+      .then(fn)
+      .catch((error) => {
+        setTimeout(() => {
+          throw error;
+        });
+      });
+  }
+}
+
+function pushLinkPrefetchTask(task: LinkPrefetchTask): void {
+  if (!task.queued) {
+    task.queued = true;
+    scheduledLinkPrefetches.push(task);
+  }
+}
+
+function removeLinkPrefetchTask(task: LinkPrefetchTask): void {
+  if (!task.queued) return;
+  task.queued = false;
+  const index = scheduledLinkPrefetches.indexOf(task);
+  if (index !== -1) scheduledLinkPrefetches.splice(index, 1);
+}
+
+function scheduleLinkPrefetchQueue(delayUntilNextTask = false): void {
+  if (scheduledLinkPrefetchPendingMicrotask) return;
+  scheduledLinkPrefetchPendingMicrotask = true;
+  if (delayUntilNextTask) {
+    setTimeout(processLinkPrefetchQueue, 0);
+    return;
+  }
+  scheduleMicrotaskForLinkPrefetch(processLinkPrefetchQueue);
+}
+
+function compareLinkPrefetchTasks(a: LinkPrefetchTask, b: LinkPrefetchTask): number {
+  const priorityDelta = (a.priority === "high" ? 1 : 0) - (b.priority === "high" ? 1 : 0);
+  if (priorityDelta !== 0) return priorityDelta;
+  const phaseDelta = (a.phase === "route-tree" ? 1 : 0) - (b.phase === "route-tree" ? 1 : 0);
+  if (phaseDelta !== 0) return phaseDelta;
+  return a.sortId - b.sortId;
+}
+
+function hasLinkPrefetchBandwidth(task: LinkPrefetchTask): boolean {
+  if (task.phase === "route-tree" && task.priority !== "high") {
+    for (const queuedTask of scheduledLinkPrefetches) {
+      if (
+        queuedTask !== task &&
+        queuedTask.priority !== "high" &&
+        queuedTask.phase === "route-tree" &&
+        queuedTask.batchId < task.batchId
+      ) {
+        return false;
+      }
+    }
+  }
+  return scheduledLinkPrefetchInProgress < (task.priority === "high" ? 12 : 4);
+}
+
+function peekNextRunnableLinkPrefetchTask(): LinkPrefetchTask | null {
+  let bestTask: LinkPrefetchTask | null = null;
+  for (const task of scheduledLinkPrefetches) {
+    if (!hasLinkPrefetchBandwidth(task)) continue;
+    if (bestTask === null || compareLinkPrefetchTasks(task, bestTask) > 0) {
+      bestTask = task;
+    }
+  }
+  return bestTask;
+}
+
+function trackIntentLinkPrefetchTask(task: LinkPrefetchTask): void {
+  if (task.priority !== "high" || task === mostRecentIntentPrefetchTask) return;
+  if (mostRecentIntentPrefetchTask !== null) {
+    mostRecentIntentPrefetchTask.priority = "low";
+  }
+  mostRecentIntentPrefetchTask = task;
+}
+
+function scheduleSegmentCacheLinkPrefetch(
+  instance: LinkPrefetchInstance,
+  priority: "low" | "high",
+  batchId = instance.scheduledTask?.batchId ?? scheduledLinkPrefetchBatchId++,
+): void {
+  let task = instance.scheduledTask;
+  if (task === null) {
+    task = {
+      instance,
+      batchId,
+      phase: "route-tree",
+      priority,
+      sortId: scheduledLinkPrefetchSortId++,
+      canceled: false,
+      queued: false,
+    };
+    instance.scheduledTask = task;
+  } else {
+    task.batchId = batchId;
+    task.canceled = false;
+    task.phase = "route-tree";
+    task.priority = task === mostRecentIntentPrefetchTask && priority === "low" ? "high" : priority;
+    task.sortId = scheduledLinkPrefetchSortId++;
+  }
+
+  trackIntentLinkPrefetchTask(task);
+  pushLinkPrefetchTask(task);
+  scheduleLinkPrefetchQueue(priority === "high");
+}
+
+function cancelScheduledSegmentCacheLinkPrefetch(instance: LinkPrefetchInstance): void {
+  const task = instance.scheduledTask;
+  if (task === null) return;
+  task.canceled = true;
+  removeLinkPrefetchTask(task);
+  if (mostRecentIntentPrefetchTask === task) {
+    mostRecentIntentPrefetchTask = null;
+  }
+}
+
+function processLinkPrefetchQueue(): void {
+  scheduledLinkPrefetchPendingMicrotask = false;
+
+  let task = peekNextRunnableLinkPrefetchTask();
+  while (task !== null) {
+    removeLinkPrefetchTask(task);
+    if (task.canceled || !task.instance.isVisible) {
+      task = peekNextRunnableLinkPrefetchTask();
+      continue;
+    }
+
+    const currentTask = task;
+    scheduledLinkPrefetchInProgress++;
+    const phase = currentTask.phase;
+    const mode: LinkPrefetchMode = phase === "route-tree" ? "route-tree" : "segment";
+    const promise = prefetchUrl(
+      currentTask.instance.href,
+      mode,
+      currentTask.priority,
+      currentTask.instance.pagesRouteHref,
+    );
+
+    Promise.resolve(promise)
+      .catch(() => {})
+      .finally(() => {
+        scheduledLinkPrefetchInProgress--;
+        if (!currentTask.canceled && currentTask.instance.isVisible && phase === "route-tree") {
+          currentTask.phase = "segment";
+          pushLinkPrefetchTask(currentTask);
+        }
+        scheduleLinkPrefetchQueue();
+      });
+
+    task = peekNextRunnableLinkPrefetchTask();
+  }
+}
+
+function setVisibleLinkPrefetch(
+  instance: LinkPrefetchInstance,
+  isVisible: boolean,
+  batchId = scheduledLinkPrefetchBatchId++,
+): void {
   instance.isVisible = isVisible;
   if (isVisible) {
     visibleLinkPrefetches.add(instance);
     if (instance.routerMode === "pages" && instance.viewportPrefetched) return;
-    if (instance.routerMode === "app") {
+    if (usesSegmentCachePrefetchScheduler(instance)) {
+      scheduleSegmentCacheLinkPrefetch(instance, "low", batchId);
+    } else if (instance.routerMode === "app") {
       scheduleVisibleAppPrefetch(instance);
     } else {
-      prefetchUrl(instance.href, instance.mode, "low", instance.pagesRouteHref);
+      void prefetchUrl(instance.href, instance.mode, "low", instance.pagesRouteHref);
     }
     instance.viewportPrefetched = true;
   } else {
     visibleLinkPrefetches.delete(instance);
+    if (usesSegmentCachePrefetchScheduler(instance)) {
+      cancelScheduledSegmentCacheLinkPrefetch(instance);
+    }
   }
 }
 
@@ -767,7 +977,11 @@ function registerVisibleLinkPing(): void {
 function pingVisibleLinkPrefetches(): void {
   for (const instance of visibleLinkPrefetches) {
     if (instance.isVisible && instance.routerMode === "app") {
-      scheduleVisibleAppPrefetch(instance);
+      if (usesSegmentCachePrefetchScheduler(instance)) {
+        scheduleSegmentCacheLinkPrefetch(instance, "low");
+      } else {
+        scheduleVisibleAppPrefetch(instance);
+      }
     }
   }
 }
@@ -778,10 +992,15 @@ function getSharedObserver(): IntersectionObserver | null {
 
   sharedObserver = new IntersectionObserver(
     (entries) => {
+      const batchId = scheduledLinkPrefetchBatchId++;
       for (const entry of entries) {
         const instance = observedLinkPrefetches.get(entry.target);
         if (!instance) continue;
-        setVisibleLinkPrefetch(instance, entry.isIntersecting || entry.intersectionRatio > 0);
+        setVisibleLinkPrefetch(
+          instance,
+          entry.isIntersecting || entry.intersectionRatio > 0,
+          batchId,
+        );
       }
     },
     {
@@ -1085,6 +1304,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
             }) ?? undefined),
       queuedViewportPrefetch: false,
       routerMode: getLinkPrefetchRouterMode(),
+      scheduledTask: null,
       viewportPrefetched: false,
     };
     observedLinkPrefetches.set(node, instance);
@@ -1092,6 +1312,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
 
     return () => {
       observer.unobserve(node);
+      cancelScheduledSegmentCacheLinkPrefetch(instance);
       observedLinkPrefetches.delete(node);
       visibleLinkPrefetches.delete(instance);
       instance.isVisible = false;
@@ -1117,7 +1338,14 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
       }
       void promotePrefetchEntriesForNavigation(normalizedHref);
     }
-    prefetchUrl(
+    if (internalRef.current) {
+      const instance = observedLinkPrefetches.get(internalRef.current);
+      if (instance && usesSegmentCachePrefetchScheduler(instance) && instance.isVisible) {
+        scheduleSegmentCacheLinkPrefetch(instance, "high");
+        return;
+      }
+    }
+    void prefetchUrl(
       normalizedHref,
       intentMode,
       "high",

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -65,6 +65,10 @@ import {
 } from "./internal/link-status-registry.js";
 import { getCurrentRoutePathnameForWarning } from "./internal/route-pattern-for-warning.js";
 import { scheduleAppPrefetchFetch } from "./internal/app-prefetch-fetch-queue.js";
+import {
+  createLinkSegmentPrefetchScheduler,
+  type LinkSegmentPrefetchPhaseRequest,
+} from "./internal/link-segment-prefetch-scheduler.js";
 
 type NavigateEvent = {
   url: URL;
@@ -740,7 +744,6 @@ type LinkPrefetchInstance = {
   pagesRouteHref?: string;
   queuedViewportPrefetch: boolean;
   routerMode: LinkPrefetchRouterMode;
-  scheduledTask: LinkPrefetchTask | null;
   viewportPrefetched: boolean;
 };
 
@@ -769,27 +772,21 @@ function scheduleVisibleAppPrefetch(instance: LinkPrefetchInstance): void {
   queueMicrotask(drainVisibleAppPrefetchQueue);
 }
 
-type LinkPrefetchTask = {
-  instance: LinkPrefetchInstance;
-  batchId: number;
-  forceSegmentCacheFetch: boolean;
-  phase: "route-tree" | "segment";
-  priority: "low" | "high";
-  sortId: number;
-  canceled: boolean;
-  completed: boolean;
-  queued: boolean;
-  running: boolean;
-};
+async function runSegmentCachePrefetchPhase({
+  href,
+  phase,
+  priority,
+  pagesRouteHref,
+  forceSegmentCacheFetch,
+}: LinkSegmentPrefetchPhaseRequest): Promise<void> {
+  await prefetchUrl(href, phase, priority, pagesRouteHref, {
+    forceSegmentCacheFetch,
+  });
+}
 
-const scheduledLinkPrefetches: LinkPrefetchTask[] = [];
-let scheduledLinkPrefetchBatchId = 0;
-let scheduledLinkPrefetchSortId = 0;
-let scheduledLinkPrefetchInProgress = 0;
-let scheduledLinkPrefetchPendingMicrotask = false;
-let mostRecentIntentPrefetchTask: LinkPrefetchTask | null = null;
-let linkPrefetchUserInteractionListenersRegistered = false;
-let lastLinkPrefetchUserInteractionAt = 0;
+const segmentCacheLinkPrefetchScheduler = createLinkSegmentPrefetchScheduler({
+  runPhase: runSegmentCachePrefetchPhase,
+});
 
 function usesSegmentCachePrefetchScheduler(instance: LinkPrefetchInstance): boolean {
   return (
@@ -806,211 +803,22 @@ function resolveCurrentLinkPrefetchRouterMode(
   return "pages";
 }
 
-function scheduleMicrotaskForLinkPrefetch(fn: () => void): void {
-  if (typeof queueMicrotask === "function") {
-    queueMicrotask(fn);
-  } else {
-    Promise.resolve()
-      .then(fn)
-      .catch((error) => {
-        setTimeout(() => {
-          throw error;
-        });
-      });
-  }
-}
-
-function pushLinkPrefetchTask(task: LinkPrefetchTask): void {
-  if (!task.queued && !task.running && !task.completed) {
-    task.queued = true;
-    scheduledLinkPrefetches.push(task);
-  }
-}
-
-function removeLinkPrefetchTask(task: LinkPrefetchTask): void {
-  if (!task.queued) return;
-  task.queued = false;
-  const index = scheduledLinkPrefetches.indexOf(task);
-  if (index !== -1) scheduledLinkPrefetches.splice(index, 1);
-}
-
-function scheduleLinkPrefetchQueue(delayUntilNextTask = false): void {
-  if (scheduledLinkPrefetchPendingMicrotask) return;
-  scheduledLinkPrefetchPendingMicrotask = true;
-  if (delayUntilNextTask) {
-    setTimeout(processLinkPrefetchQueue, 0);
-    return;
-  }
-  scheduleMicrotaskForLinkPrefetch(processLinkPrefetchQueue);
-}
-
-function markLinkPrefetchUserInteraction(): void {
-  lastLinkPrefetchUserInteractionAt = Date.now();
-}
-
-function hasRecentLinkPrefetchUserInteraction(): boolean {
-  return Date.now() - lastLinkPrefetchUserInteractionAt < 1_000;
-}
-
-function registerLinkPrefetchUserInteractionListeners(): void {
-  if (typeof window === "undefined" || linkPrefetchUserInteractionListenersRegistered) return;
-  linkPrefetchUserInteractionListenersRegistered = true;
-  window.addEventListener("pointerdown", markLinkPrefetchUserInteraction, true);
-  window.addEventListener("mousedown", markLinkPrefetchUserInteraction, true);
-  window.addEventListener("click", markLinkPrefetchUserInteraction, true);
-  window.addEventListener("input", markLinkPrefetchUserInteraction, true);
-  window.addEventListener("change", markLinkPrefetchUserInteraction, true);
-  window.addEventListener("keydown", markLinkPrefetchUserInteraction, true);
-}
-
-function compareLinkPrefetchTasks(a: LinkPrefetchTask, b: LinkPrefetchTask): number {
-  const priorityDelta = (a.priority === "high" ? 1 : 0) - (b.priority === "high" ? 1 : 0);
-  if (priorityDelta !== 0) return priorityDelta;
-  const phaseDelta = (a.phase === "route-tree" ? 1 : 0) - (b.phase === "route-tree" ? 1 : 0);
-  if (phaseDelta !== 0) return phaseDelta;
-  return a.sortId - b.sortId;
-}
-
-function hasLinkPrefetchBandwidth(task: LinkPrefetchTask): boolean {
-  if (task.phase === "route-tree" && task.priority !== "high") {
-    for (const queuedTask of scheduledLinkPrefetches) {
-      if (
-        queuedTask !== task &&
-        queuedTask.priority !== "high" &&
-        queuedTask.phase === "route-tree" &&
-        queuedTask.batchId < task.batchId
-      ) {
-        return false;
-      }
-    }
-  }
-  return scheduledLinkPrefetchInProgress < (task.priority === "high" ? 12 : 4);
-}
-
-function peekNextRunnableLinkPrefetchTask(): LinkPrefetchTask | null {
-  let bestTask: LinkPrefetchTask | null = null;
-  for (const task of scheduledLinkPrefetches) {
-    if (!hasLinkPrefetchBandwidth(task)) continue;
-    if (bestTask === null || compareLinkPrefetchTasks(task, bestTask) > 0) {
-      bestTask = task;
-    }
-  }
-  return bestTask;
-}
-
-function trackIntentLinkPrefetchTask(task: LinkPrefetchTask): void {
-  if (task.priority !== "high" || task === mostRecentIntentPrefetchTask) return;
-  if (mostRecentIntentPrefetchTask !== null) {
-    mostRecentIntentPrefetchTask.priority = "low";
-  }
-  mostRecentIntentPrefetchTask = task;
-}
-
 function scheduleSegmentCacheLinkPrefetch(
   instance: LinkPrefetchInstance,
   priority: "low" | "high",
-  batchId = instance.scheduledTask?.batchId ?? scheduledLinkPrefetchBatchId++,
+  batchId?: number,
 ): void {
-  let task = instance.scheduledTask;
-  if (task === null) {
-    task = {
-      instance,
-      batchId,
-      forceSegmentCacheFetch: priority === "low" && hasRecentLinkPrefetchUserInteraction(),
-      phase: "route-tree",
-      priority,
-      sortId: scheduledLinkPrefetchSortId++,
-      canceled: false,
-      completed: false,
-      queued: false,
-      running: false,
-    };
-    instance.scheduledTask = task;
-  } else {
-    if (task.running) {
-      task.canceled = false;
-      task.priority =
-        task === mostRecentIntentPrefetchTask && priority === "low" ? "high" : priority;
-      trackIntentLinkPrefetchTask(task);
-      return;
-    }
-    if (task.completed) {
-      return;
-    }
-
-    task.batchId = batchId;
-    task.canceled = false;
-    task.completed = false;
-    task.forceSegmentCacheFetch = priority === "low" && hasRecentLinkPrefetchUserInteraction();
-    task.phase = "route-tree";
-    task.priority = task === mostRecentIntentPrefetchTask && priority === "low" ? "high" : priority;
-    task.sortId = scheduledLinkPrefetchSortId++;
-  }
-
-  trackIntentLinkPrefetchTask(task);
-  pushLinkPrefetchTask(task);
-  scheduleLinkPrefetchQueue(priority === "high");
+  segmentCacheLinkPrefetchScheduler.schedule(instance, priority, batchId);
 }
 
 function cancelScheduledSegmentCacheLinkPrefetch(instance: LinkPrefetchInstance): void {
-  const task = instance.scheduledTask;
-  if (task === null) return;
-  task.canceled = true;
-  removeLinkPrefetchTask(task);
-  if (mostRecentIntentPrefetchTask === task) {
-    mostRecentIntentPrefetchTask = null;
-  }
-}
-
-function processLinkPrefetchQueue(): void {
-  scheduledLinkPrefetchPendingMicrotask = false;
-
-  let task = peekNextRunnableLinkPrefetchTask();
-  while (task !== null) {
-    removeLinkPrefetchTask(task);
-    if (task.canceled || task.running || !task.instance.isVisible) {
-      task = peekNextRunnableLinkPrefetchTask();
-      continue;
-    }
-
-    const currentTask = task;
-    scheduledLinkPrefetchInProgress++;
-    currentTask.running = true;
-    const phase = currentTask.phase;
-    const mode: LinkPrefetchMode = phase === "route-tree" ? "route-tree" : "segment";
-    const promise = prefetchUrl(
-      currentTask.instance.href,
-      mode,
-      currentTask.priority,
-      currentTask.instance.pagesRouteHref,
-      { forceSegmentCacheFetch: currentTask.forceSegmentCacheFetch },
-    );
-
-    Promise.resolve(promise)
-      .catch(() => {})
-      .finally(() => {
-        currentTask.running = false;
-        scheduledLinkPrefetchInProgress--;
-        if (!currentTask.canceled && currentTask.instance.isVisible && phase === "route-tree") {
-          currentTask.phase = "segment";
-          pushLinkPrefetchTask(currentTask);
-        } else if (!currentTask.canceled && phase === "segment") {
-          currentTask.completed = true;
-          if (mostRecentIntentPrefetchTask === currentTask) {
-            mostRecentIntentPrefetchTask = null;
-          }
-        }
-        scheduleLinkPrefetchQueue();
-      });
-
-    task = peekNextRunnableLinkPrefetchTask();
-  }
+  segmentCacheLinkPrefetchScheduler.cancel(instance);
 }
 
 function setVisibleLinkPrefetch(
   instance: LinkPrefetchInstance,
   isVisible: boolean,
-  batchId = scheduledLinkPrefetchBatchId++,
+  batchId = segmentCacheLinkPrefetchScheduler.createBatch(),
 ): void {
   instance.isVisible = isVisible;
   if (isVisible) {
@@ -1052,11 +860,11 @@ function pingVisibleLinkPrefetches(): void {
 function getSharedObserver(): IntersectionObserver | null {
   if (typeof window === "undefined" || typeof IntersectionObserver === "undefined") return null;
   if (sharedObserver) return sharedObserver;
-  registerLinkPrefetchUserInteractionListeners();
+  segmentCacheLinkPrefetchScheduler.registerUserInteractionListeners();
 
   sharedObserver = new IntersectionObserver(
     (entries) => {
-      const batchId = scheduledLinkPrefetchBatchId++;
+      const batchId = segmentCacheLinkPrefetchScheduler.createBatch();
       for (const entry of entries) {
         const instance = observedLinkPrefetches.get(entry.target);
         if (!instance) continue;
@@ -1368,7 +1176,6 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
             }) ?? undefined),
       queuedViewportPrefetch: false,
       routerMode: getLinkPrefetchRouterMode(),
-      scheduledTask: null,
       viewportPrefetched: false,
     };
     observedLinkPrefetches.set(node, instance);

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -536,7 +536,7 @@ function prefetchUrl(
           headers.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "/__PAGE__");
         } else if (shouldSendSegmentPrefetchHeaders) {
           headers.set(NEXT_ROUTER_PREFETCH_HEADER, "1");
-          headers.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "/_tree");
+          headers.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "1");
         }
         // Distinguish the same visible URL when it is prefetched from different
         // request contexts such as /feed vs /gallery or different mounted slots.
@@ -576,7 +576,7 @@ function prefetchUrl(
             renderMode: APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
           });
           shellHeaders.set(NEXT_ROUTER_PREFETCH_HEADER, "1");
-          shellHeaders.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "/_tree");
+          shellHeaders.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "1");
           if (mountedSlotsHeader) {
             shellHeaders.set(VINEXT_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
           }
@@ -618,7 +618,7 @@ function prefetchUrl(
             renderMode: APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
           });
           probeHeaders.set(NEXT_ROUTER_PREFETCH_HEADER, "1");
-          probeHeaders.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "/_tree");
+          probeHeaders.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "1");
           if (mountedSlotsHeader) {
             probeHeaders.set(VINEXT_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
           }

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -858,7 +858,7 @@ function pingVisibleLinkPrefetches(options: { force?: boolean } = {}): void {
   const batchId =
     options.force === true ? segmentCacheLinkPrefetchScheduler.createBatch() : undefined;
   for (const instance of visibleLinkPrefetches) {
-    if (instance.isVisible && instance.routerMode === "app") {
+    if (instance.isVisible && resolveCurrentLinkPrefetchRouterMode(instance) === "app") {
       if (usesSegmentCachePrefetchScheduler(instance)) {
         scheduleSegmentCacheLinkPrefetch(instance, "low", batchId, options);
       } else {

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -754,7 +754,7 @@ function drainVisibleAppPrefetchQueue(): void {
     if (!instance) return;
     instance.queuedViewportPrefetch = false;
     if (!instance.isVisible || instance.routerMode !== "app") continue;
-    prefetchUrl(instance.href, instance.mode, "low", instance.pagesRouteHref);
+    void prefetchUrl(instance.href, instance.mode, "low", instance.pagesRouteHref);
   }
 }
 

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -518,6 +518,7 @@ function prefetchUrl(
           headers.set(NEXT_ROUTER_PREFETCH_HEADER, "1");
           headers.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "/_tree");
         } else if (mode === "segment") {
+          headers.set(NEXT_ROUTER_PREFETCH_HEADER, "1");
           headers.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "/_page");
         }
         // Distinguish the same visible URL when it is prefetched from different
@@ -526,11 +527,12 @@ function prefetchUrl(
         const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
         const prefetched = getPrefetchedUrls();
         if (prefetched.has(cacheKey)) {
+          const existing = getPrefetchCache().get(cacheKey);
           if (!autoPrefetch.cacheForNavigation) {
+            await existing?.pending?.catch(() => {});
             return;
           }
 
-          const existing = getPrefetchCache().get(cacheKey);
           if (existing?.cacheForNavigation === false) {
             existing.cacheForNavigation = true;
           }

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -410,6 +410,7 @@ function prefetchUrl(
   mode: LinkPrefetchMode,
   priority: "low" | "high" = "low",
   pagesRouteHref?: string,
+  options: { forceSegmentCacheFetch?: boolean } = {},
 ): Promise<void> | undefined {
   if (typeof window === "undefined") return;
 
@@ -531,7 +532,7 @@ function prefetchUrl(
         const prefetched = getPrefetchedUrls();
         if (prefetched.has(cacheKey)) {
           const existing = getPrefetchCache().get(cacheKey);
-          if (!autoPrefetch.cacheForNavigation) {
+          if (!autoPrefetch.cacheForNavigation && !options.forceSegmentCacheFetch) {
             await existing?.pending?.catch(() => {});
             return;
           }
@@ -769,6 +770,7 @@ function scheduleVisibleAppPrefetch(instance: LinkPrefetchInstance): void {
 type LinkPrefetchTask = {
   instance: LinkPrefetchInstance;
   batchId: number;
+  forceSegmentCacheFetch: boolean;
   phase: "route-tree" | "segment";
   priority: "low" | "high";
   sortId: number;
@@ -784,6 +786,8 @@ let scheduledLinkPrefetchSortId = 0;
 let scheduledLinkPrefetchInProgress = 0;
 let scheduledLinkPrefetchPendingMicrotask = false;
 let mostRecentIntentPrefetchTask: LinkPrefetchTask | null = null;
+let linkPrefetchUserInteractionListenersRegistered = false;
+let lastLinkPrefetchUserInteractionAt = 0;
 
 function usesSegmentCachePrefetchScheduler(instance: LinkPrefetchInstance): boolean {
   return (
@@ -829,6 +833,25 @@ function scheduleLinkPrefetchQueue(delayUntilNextTask = false): void {
     return;
   }
   scheduleMicrotaskForLinkPrefetch(processLinkPrefetchQueue);
+}
+
+function markLinkPrefetchUserInteraction(): void {
+  lastLinkPrefetchUserInteractionAt = Date.now();
+}
+
+function hasRecentLinkPrefetchUserInteraction(): boolean {
+  return Date.now() - lastLinkPrefetchUserInteractionAt < 1_000;
+}
+
+function registerLinkPrefetchUserInteractionListeners(): void {
+  if (typeof window === "undefined" || linkPrefetchUserInteractionListenersRegistered) return;
+  linkPrefetchUserInteractionListenersRegistered = true;
+  window.addEventListener("pointerdown", markLinkPrefetchUserInteraction, true);
+  window.addEventListener("mousedown", markLinkPrefetchUserInteraction, true);
+  window.addEventListener("click", markLinkPrefetchUserInteraction, true);
+  window.addEventListener("input", markLinkPrefetchUserInteraction, true);
+  window.addEventListener("change", markLinkPrefetchUserInteraction, true);
+  window.addEventListener("keydown", markLinkPrefetchUserInteraction, true);
 }
 
 function compareLinkPrefetchTasks(a: LinkPrefetchTask, b: LinkPrefetchTask): number {
@@ -884,6 +907,7 @@ function scheduleSegmentCacheLinkPrefetch(
     task = {
       instance,
       batchId,
+      forceSegmentCacheFetch: priority === "low" && hasRecentLinkPrefetchUserInteraction(),
       phase: "route-tree",
       priority,
       sortId: scheduledLinkPrefetchSortId++,
@@ -908,6 +932,7 @@ function scheduleSegmentCacheLinkPrefetch(
     task.batchId = batchId;
     task.canceled = false;
     task.completed = false;
+    task.forceSegmentCacheFetch = priority === "low" && hasRecentLinkPrefetchUserInteraction();
     task.phase = "route-tree";
     task.priority = task === mostRecentIntentPrefetchTask && priority === "low" ? "high" : priority;
     task.sortId = scheduledLinkPrefetchSortId++;
@@ -949,6 +974,7 @@ function processLinkPrefetchQueue(): void {
       mode,
       currentTask.priority,
       currentTask.instance.pagesRouteHref,
+      { forceSegmentCacheFetch: currentTask.forceSegmentCacheFetch },
     );
 
     Promise.resolve(promise)
@@ -1017,6 +1043,7 @@ function pingVisibleLinkPrefetches(): void {
 function getSharedObserver(): IntersectionObserver | null {
   if (typeof window === "undefined" || typeof IntersectionObserver === "undefined") return null;
   if (sharedObserver) return sharedObserver;
+  registerLinkPrefetchUserInteractionListeners();
 
   sharedObserver = new IntersectionObserver(
     (entries) => {

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -812,8 +812,9 @@ function scheduleSegmentCacheLinkPrefetch(
   instance: LinkPrefetchInstance,
   priority: "low" | "high",
   batchId?: number,
+  options?: { force?: boolean },
 ): void {
-  segmentCacheLinkPrefetchScheduler.schedule(instance, priority, batchId);
+  segmentCacheLinkPrefetchScheduler.schedule(instance, priority, batchId, options);
 }
 
 function cancelScheduledSegmentCacheLinkPrefetch(instance: LinkPrefetchInstance): void {
@@ -850,11 +851,13 @@ function registerVisibleLinkPing(): void {
   registerNavigationRuntimeFunctions({ pingVisibleLinks: pingVisibleLinkPrefetches });
 }
 
-function pingVisibleLinkPrefetches(): void {
+function pingVisibleLinkPrefetches(options: { force?: boolean } = {}): void {
+  const batchId =
+    options.force === true ? segmentCacheLinkPrefetchScheduler.createBatch() : undefined;
   for (const instance of visibleLinkPrefetches) {
     if (instance.isVisible && instance.routerMode === "app") {
       if (usesSegmentCachePrefetchScheduler(instance)) {
-        scheduleSegmentCacheLinkPrefetch(instance, "low");
+        scheduleSegmentCacheLinkPrefetch(instance, "low", batchId, options);
       } else {
         scheduleVisibleAppPrefetch(instance);
       }

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -401,9 +401,9 @@ function resolveFullAppRoutePrefetch(): {
  * For Pages Router: warms the page chunk, prefetches data only for SSG pages,
  * and falls back to a document prefetch hint when no page loader matches.
  *
- * App Router and high-priority prefetches start immediately. Low-priority
- * Pages Router fallback prefetches use `requestIdleCallback` (or `setTimeout`
- * fallback) to avoid blocking the main thread during initial page load.
+ * High-priority and Segment Cache scheduler phases start immediately. Other
+ * low-priority prefetches use `requestIdleCallback` (or `setTimeout` fallback)
+ * to avoid blocking the main thread during initial page load.
  */
 function prefetchUrl(
   href: string,
@@ -519,6 +519,9 @@ function prefetchUrl(
           headers.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "/_tree");
         } else if (mode === "segment") {
           headers.set(NEXT_ROUTER_PREFETCH_HEADER, "1");
+          // Vinext serves one unified page payload instead of Next.js's real
+          // per-segment payloads, so this marker distinguishes the second
+          // scheduler phase without claiming a concrete Next.js segment key.
           headers.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "/_page");
         }
         // Distinguish the same visible URL when it is prefetched from different
@@ -679,7 +682,7 @@ function prefetchUrl(
     return promise;
   };
 
-  if (priority === "high" || hasAppNavigationRuntime()) {
+  if (priority === "high" || mode === "route-tree" || mode === "segment") {
     return runPrefetch();
   }
 
@@ -770,7 +773,9 @@ type LinkPrefetchTask = {
   priority: "low" | "high";
   sortId: number;
   canceled: boolean;
+  completed: boolean;
   queued: boolean;
+  running: boolean;
 };
 
 const scheduledLinkPrefetches: LinkPrefetchTask[] = [];
@@ -803,7 +808,7 @@ function scheduleMicrotaskForLinkPrefetch(fn: () => void): void {
 }
 
 function pushLinkPrefetchTask(task: LinkPrefetchTask): void {
-  if (!task.queued) {
+  if (!task.queued && !task.running && !task.completed) {
     task.queued = true;
     scheduledLinkPrefetches.push(task);
   }
@@ -883,12 +888,26 @@ function scheduleSegmentCacheLinkPrefetch(
       priority,
       sortId: scheduledLinkPrefetchSortId++,
       canceled: false,
+      completed: false,
       queued: false,
+      running: false,
     };
     instance.scheduledTask = task;
   } else {
+    if (task.running) {
+      task.canceled = false;
+      task.priority =
+        task === mostRecentIntentPrefetchTask && priority === "low" ? "high" : priority;
+      trackIntentLinkPrefetchTask(task);
+      return;
+    }
+    if (task.completed) {
+      return;
+    }
+
     task.batchId = batchId;
     task.canceled = false;
+    task.completed = false;
     task.phase = "route-tree";
     task.priority = task === mostRecentIntentPrefetchTask && priority === "low" ? "high" : priority;
     task.sortId = scheduledLinkPrefetchSortId++;
@@ -915,13 +934,14 @@ function processLinkPrefetchQueue(): void {
   let task = peekNextRunnableLinkPrefetchTask();
   while (task !== null) {
     removeLinkPrefetchTask(task);
-    if (task.canceled || !task.instance.isVisible) {
+    if (task.canceled || task.running || !task.instance.isVisible) {
       task = peekNextRunnableLinkPrefetchTask();
       continue;
     }
 
     const currentTask = task;
     scheduledLinkPrefetchInProgress++;
+    currentTask.running = true;
     const phase = currentTask.phase;
     const mode: LinkPrefetchMode = phase === "route-tree" ? "route-tree" : "segment";
     const promise = prefetchUrl(
@@ -934,10 +954,16 @@ function processLinkPrefetchQueue(): void {
     Promise.resolve(promise)
       .catch(() => {})
       .finally(() => {
+        currentTask.running = false;
         scheduledLinkPrefetchInProgress--;
         if (!currentTask.canceled && currentTask.instance.isVisible && phase === "route-tree") {
           currentTask.phase = "segment";
           pushLinkPrefetchTask(currentTask);
+        } else if (!currentTask.canceled && phase === "segment") {
+          currentTask.completed = true;
+          if (mostRecentIntentPrefetchTask === currentTask) {
+            mostRecentIntentPrefetchTask = null;
+          }
         }
         scheduleLinkPrefetchQueue();
       });
@@ -1322,14 +1348,18 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
   }, [shouldViewportPrefetch, prefetchMode, normalizedHref, normalizedRouteHref]);
 
   const prefetchOnIntent = useCallback(() => {
+    const routerMode = getLinkPrefetchRouterMode();
     if (
       !canLinkIntentPrefetch({
         nodeEnv: process.env.NODE_ENV,
         prefetch: prefetchProp,
         isDangerous,
-        routerMode: getLinkPrefetchRouterMode(),
+        routerMode,
       })
     ) {
+      return;
+    }
+    if (routerMode === "app" && isBotUserAgent(window.navigator?.userAgent ?? "")) {
       return;
     }
     const intentMode = unstable_dynamicOnHover ? "full-after-shell" : prefetchMode;

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -676,7 +676,7 @@ export function invalidatePrefetchCache(): void {
   }
   prefetched.clear();
   if (!isServer) {
-    getNavigationRuntime()?.functions.pingVisibleLinks?.();
+    getNavigationRuntime()?.functions.pingVisibleLinks?.({ force: true });
   }
 }
 

--- a/tests/app-page-cache.test.ts
+++ b/tests/app-page-cache.test.ts
@@ -26,7 +26,7 @@ import { withEnvVar } from "./env-test-helpers.js";
 function buildISRCacheEntry(
   value: CachedAppPageValue,
   isStale = false,
-  cacheControl?: { revalidate: number; expire?: number },
+  cacheControl?: { revalidate: number; stale?: number; expire?: number },
 ): ISRCacheEntry {
   return {
     isStale,
@@ -551,11 +551,54 @@ describe("app page cache helpers", () => {
     expect(response?.headers.get("x-vinext-mounted-slots")).toBe("slot:auth:/");
   });
 
+  it("keys RSC cache reads by segment-prefetch path", async () => {
+    const response = await readAppPageCacheResponse({
+      cleanPathname: "/globex/portal",
+      clearRequestContext() {},
+      isRscRequest: true,
+      async isrGet(key) {
+        expect(key).toBe("rsc:/globex/portal:none:/_tree");
+        return buildISRCacheEntry(
+          buildCachedAppPageValue("", new TextEncoder().encode("tree-flight").buffer),
+        );
+      },
+      isrHtmlKey(pathname) {
+        return "html:" + pathname;
+      },
+      isrRscKey(
+        pathname,
+        mountedSlotsHeader,
+        _renderMode,
+        _interceptionContext,
+        segmentPrefetchPath,
+      ) {
+        return `rsc:${pathname}:${mountedSlotsHeader ?? "none"}:${segmentPrefetchPath ?? "none"}`;
+      },
+      async isrSet() {},
+      revalidateSeconds: 60,
+      segmentPrefetchPath: "/_tree",
+      async renderFreshPageForCache() {
+        throw new Error("should not render");
+      },
+      scheduleBackgroundRegeneration() {
+        throw new Error("should not schedule regeneration");
+      },
+    });
+
+    expect(response?.headers.get("x-vinext-cache")).toBe("HIT");
+    await expect(response?.text()).resolves.toBe("tree-flight");
+  });
+
   it("serves stale RSC entries and regenerates only the matching RSC cache key", async () => {
     const scheduledRegenerations: Array<() => Promise<void>> = [];
     const isrRscKey = vi.fn(
-      (pathname: string, mountedSlotsHeader?: string | null) =>
-        `rsc:${pathname}:${mountedSlotsHeader ?? "none"}`,
+      (
+        pathname: string,
+        mountedSlotsHeader?: string | null,
+        _renderMode?: unknown,
+        _interceptionContext?: string | null,
+        segmentPrefetchPath?: string | null,
+      ) => `rsc:${pathname}:${mountedSlotsHeader ?? "none"}:${segmentPrefetchPath ?? "none"}`,
     );
     const isrSetCalls: Array<{
       key: string;
@@ -589,6 +632,7 @@ describe("app page cache helpers", () => {
         });
       },
       mountedSlotsHeader: "slot:auth:/",
+      segmentPrefetchPath: "/_page",
       expireSeconds: 300,
       revalidateSeconds: 60,
       async renderFreshPageForCache() {
@@ -612,7 +656,7 @@ describe("app page cache helpers", () => {
     expect(isrRscKey).toHaveBeenCalledOnce();
     expect(isrSetCalls).toEqual([
       {
-        key: "rsc:/stale:slot:auth:/",
+        key: "rsc:/stale:slot:auth:/:/_page",
         html: "",
         hasRscData: true,
         expireSeconds: 20,
@@ -718,6 +762,98 @@ describe("app page cache helpers", () => {
         expireSeconds: 20,
         linkHeader: "</fresh.css>; rel=preload; as=style",
         revalidateSeconds: 10,
+      },
+    ]);
+  });
+
+  it("foreground revalidates stale HTML entries when cacheLife stale is zero", async () => {
+    // Ported from Next.js: test/e2e/app-dir/segment-cache/vary-params-base-dynamic/vary-params-base-dynamic.test.ts
+    const rscData = new TextEncoder().encode("fresh-flight").buffer;
+    const isrSetCalls: Array<{
+      key: string;
+      expireSeconds: number | undefined;
+      html: string;
+      revalidateSeconds: number;
+      staleSeconds: number | undefined;
+      tags: string[];
+    }> = [];
+    const cacheOutcomes: AppPageCacheOutcomeMetric[] = [];
+    let didClearRequestContext = false;
+
+    const response = await readAppPageCacheResponse({
+      cleanPathname: "/acme/dashboard",
+      clearRequestContext() {
+        didClearRequestContext = true;
+      },
+      isRscRequest: false,
+      async isrGet() {
+        return buildISRCacheEntry(buildCachedAppPageValue("<h1>stale</h1>"), true, {
+          revalidate: 1,
+          stale: 0,
+          expire: 60,
+        });
+      },
+      isrHtmlKey(pathname) {
+        return "html:" + pathname;
+      },
+      isrRscKey(pathname) {
+        return "rsc:" + pathname;
+      },
+      async isrSet(key, data, revalidateSeconds, tags, expireSeconds, staleSeconds) {
+        isrSetCalls.push({
+          key,
+          expireSeconds,
+          html: data.html,
+          revalidateSeconds,
+          staleSeconds,
+          tags,
+        });
+      },
+      recordCacheOutcome(metric) {
+        cacheOutcomes.push(metric);
+      },
+      revalidateSeconds: 60,
+      async renderFreshPageForCache() {
+        return {
+          cacheControl: { revalidate: 1, stale: 0, expire: 60 },
+          html: "<h1>fresh</h1>",
+          rscData,
+          tags: ["/acme/dashboard", "_N_T_/acme/dashboard"],
+        };
+      },
+      scheduleBackgroundRegeneration() {
+        throw new Error("stale:0 entries should revalidate in foreground");
+      },
+    });
+
+    expect(response?.headers.get("x-vinext-cache")).toBe("MISS");
+    expect(response?.headers.get("cache-control")).toBe("s-maxage=1, stale-while-revalidate=59");
+    await expect(response?.text()).resolves.toBe("<h1>fresh</h1>");
+    expect(didClearRequestContext).toBe(true);
+    expect(isrSetCalls).toEqual([
+      {
+        key: "rsc:/acme/dashboard",
+        expireSeconds: 60,
+        html: "",
+        revalidateSeconds: 1,
+        staleSeconds: 0,
+        tags: ["/acme/dashboard", "_N_T_/acme/dashboard"],
+      },
+      {
+        key: "html:/acme/dashboard",
+        expireSeconds: 60,
+        html: "<h1>fresh</h1>",
+        revalidateSeconds: 1,
+        staleSeconds: 0,
+        tags: ["/acme/dashboard", "_N_T_/acme/dashboard"],
+      },
+    ]);
+    expect(cacheOutcomes).toEqual([
+      {
+        artifact: "html",
+        cacheKey: "html:/acme/dashboard",
+        outcome: "miss",
+        reason: "foreground-stale-revalidate",
       },
     ]);
   });

--- a/tests/app-page-dispatch.test.ts
+++ b/tests/app-page-dispatch.test.ts
@@ -2156,6 +2156,7 @@ describe("app page dispatch", () => {
       60,
       expect.arrayContaining(["/photos/123", "_N_T_/feed/page"]),
       undefined,
+      undefined,
     );
   });
 

--- a/tests/app-page-element-builder.test.ts
+++ b/tests/app-page-element-builder.test.ts
@@ -27,6 +27,7 @@ import {
 } from "../packages/vinext/src/server/app-page-element-builder.js";
 import { probeAppPage } from "../packages/vinext/src/server/app-page-probe.js";
 import { SIBLING_PAGE_INTERCEPT_SLOT_KEY } from "../packages/vinext/src/server/app-rsc-route-matching.js";
+import { NEXT_ROUTER_SEGMENT_PREFETCH_HEADER } from "../packages/vinext/src/server/headers.js";
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -74,6 +75,8 @@ function createBaseOptions(overrides?: {
   routePath?: string;
   opts?: Record<string, unknown> | null;
   searchParams?: URLSearchParams | null;
+  isRscRequest?: boolean;
+  request?: Request;
   mountedSlotsHeader?: string | null;
 }) {
   return {
@@ -84,8 +87,8 @@ function createBaseOptions(overrides?: {
     pageRequest: {
       opts: overrides?.opts ?? null,
       searchParams: overrides?.searchParams ?? null,
-      isRscRequest: false,
-      request: new Request("http://localhost/test"),
+      isRscRequest: overrides?.isRscRequest ?? false,
+      request: overrides?.request ?? new Request("http://localhost/test"),
       mountedSlotsHeader: overrides?.mountedSlotsHeader ?? null,
     },
     globalErrorModule: null,
@@ -440,6 +443,43 @@ describe("buildPageElements", () => {
     expect((result as Record<string, unknown>)[APP_SOURCE_PAGE_KEY]).toBe(
       "/foo/bar/(..)(..)hoge/page",
     );
+  });
+
+  it("materializes segment-prefetch route identity from matched params", async () => {
+    // Ported from Next.js: test/e2e/app-dir/segment-cache/vary-params-base-dynamic/vary-params-base-dynamic.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/vary-params-base-dynamic.test.ts
+    function TestPage(): React.ReactNode {
+      return React.createElement("div", null, "Team project");
+    }
+
+    const route = createSyntheticRoute({
+      page: createSyntheticPageModule(TestPage),
+      layouts: [createSyntheticPageModule(() => null), createSyntheticPageModule(() => null)],
+      layoutTreePositions: [0, 1],
+      routeSegments: ["[teamSlug]", "[project]"],
+      pattern: "/[teamSlug]/[project]",
+    });
+    const request = new Request("http://localhost/acme/dashboard.rsc", {
+      headers: {
+        [NEXT_ROUTER_SEGMENT_PREFETCH_HEADER]: "/_page",
+      },
+    });
+
+    const result = await buildPageElements(
+      createBaseOptions({
+        isRscRequest: true,
+        params: { project: "dashboard", teamSlug: "acme" },
+        request,
+        route,
+        routePath: "/acme/dashboard",
+      }),
+    );
+    const record = result as Record<string, unknown>;
+
+    expect(record[APP_SOURCE_PAGE_KEY]).toBe("/acme/dashboard/page");
+    expect(record[APP_LAYOUT_IDS_KEY]).toEqual(["layout:/", "layout:/acme"]);
+    expect(Object.keys(record).join("\n")).not.toContain("[teamSlug]");
+    expect(Object.keys(record).join("\n")).not.toContain("[project]");
   });
 
   it("keeps interception context out of the error payload route ID", async () => {

--- a/tests/app-page-render.test.ts
+++ b/tests/app-page-render.test.ts
@@ -1567,7 +1567,7 @@ describe("layoutFlags injection into RSC payload", () => {
         "layout:/acme": "team-layout",
         "layout:/acme/dashboard": "project-layout",
         "page:/acme/dashboard": "project-page",
-      },
+      } as unknown as Record<string, ReactNode>,
       layoutCount: 3,
       navigationParams: { project: "dashboard", teamSlug: "acme" },
       probeLayoutAt: () => null,
@@ -1611,7 +1611,7 @@ describe("layoutFlags injection into RSC payload", () => {
         "layout:/globex": "team-layout",
         "layout:/globex/portal": "project-layout",
         "page:/globex/portal": "project-page",
-      },
+      } as unknown as Record<string, ReactNode>,
       getPageTags: () => [
         "/globex/portal",
         "_N_T_/globex/portal",

--- a/tests/app-page-render.test.ts
+++ b/tests/app-page-render.test.ts
@@ -579,6 +579,26 @@ describe("app page render lifecycle", () => {
     expect(consumeDynamicUsage).toHaveBeenCalledTimes(2);
   });
 
+  it("does not tee fresh segment-prefetch RSC responses into ISR cache capture", async () => {
+    const common = createCommonOptions();
+
+    const response = await renderAppPageLifecycle({
+      ...common.options,
+      isProduction: true,
+      isRscRequest: true,
+      isrRscKey(_pathname, _mountedSlotsHeader, _renderMode, _interceptionContext, segmentPath) {
+        return `rsc:/posts/post:${segmentPath ?? "none"}`;
+      },
+      revalidateSeconds: 60,
+      segmentPrefetchPath: "/_page",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe("flight-data");
+    expect(common.waitUntilPromises).toHaveLength(0);
+    expect(common.isrSet).not.toHaveBeenCalled();
+  });
+
   it("does not cache RSC responses when skip transport omits layout records", async () => {
     const common = createCommonOptions();
     const isrDebug = vi.fn();
@@ -1302,11 +1322,14 @@ describe("layoutFlags injection into RSC payload", () => {
     cleanPathname?: string;
     clientReuseManifest?: ClientReuseManifestParseResult;
     element?: Record<string, ReactNode>;
+    getPageTags?: () => string[];
     layoutParamAccess?: ReturnType<typeof createAppLayoutParamAccessTracker>;
     layoutCount?: number;
+    navigationParams?: Record<string, unknown>;
     probeLayoutAt?: (index: number) => unknown;
     classification?: LayoutClassificationOptions | null;
     routePattern?: string;
+    segmentPrefetchPath?: string | null;
     skipDisposition?: ClientReuseManifestSkipDisposition;
   }) {
     let capturedElement: Record<string, unknown> | null = null;
@@ -1322,7 +1345,7 @@ describe("layoutFlags injection into RSC payload", () => {
       getFontPreloads: () => [],
       getFontStyles: () => [],
       getNavigationContext: () => null,
-      getPageTags: () => [],
+      getPageTags: overrides.getPageTags ?? (() => []),
       getRequestCacheLife: () => null,
       handlerStart: 0,
       hasLoadingBoundary: false,
@@ -1339,8 +1362,8 @@ describe("layoutFlags injection into RSC payload", () => {
       layoutCount: overrides.layoutCount ?? 0,
       loadSsrHandler: vi.fn(),
       middlewareContext: { headers: null, status: null },
-      navigationParams: {},
-      params: {},
+      navigationParams: overrides.navigationParams ?? {},
+      params: overrides.navigationParams ?? {},
       probeLayoutAt: overrides.probeLayoutAt ?? (() => null),
       probePage: () => null,
       revalidateSeconds: null,
@@ -1353,6 +1376,7 @@ describe("layoutFlags injection into RSC payload", () => {
       },
       routePattern: overrides.routePattern ?? "/test",
       runWithSuppressedHookWarning: <T>(probe: () => Promise<T>) => probe(),
+      segmentPrefetchPath: overrides.segmentPrefetchPath,
       element: overrides.element ?? { "page:/test": "test-page" },
       classification: overrides.classification,
       skipDisposition: overrides.skipDisposition,
@@ -1524,6 +1548,95 @@ describe("layoutFlags injection into RSC payload", () => {
       "layout:/": "s",
       "layout:/blog": "d",
     });
+  });
+
+  it("materializes dynamic layout flags for concrete segment-prefetch payloads", async () => {
+    // Ported from Next.js: test/e2e/app-dir/segment-cache/vary-params-base-dynamic/vary-params-base-dynamic.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/vary-params-base-dynamic.test.ts
+    const { options, getCapturedElement } = createRscOptions({
+      element: {
+        ...AppElementsWire.createMetadataEntries({
+          interception: null,
+          interceptionContext: null,
+          layoutIds: ["layout:/", "layout:/acme", "layout:/acme/dashboard"],
+          rootLayoutTreePath: "/",
+          routeId: "route:/acme/dashboard",
+          sourcePage: "/acme/dashboard/page",
+        }),
+        "layout:/": "root-layout",
+        "layout:/acme": "team-layout",
+        "layout:/acme/dashboard": "project-layout",
+        "page:/acme/dashboard": "project-page",
+      },
+      layoutCount: 3,
+      navigationParams: { project: "dashboard", teamSlug: "acme" },
+      probeLayoutAt: () => null,
+      classification: {
+        getLayoutId: (index: number) =>
+          index === 0
+            ? "layout:/"
+            : index === 1
+              ? "layout:/[teamSlug]"
+              : "layout:/[teamSlug]/[project]",
+        buildTimeClassifications: null,
+        async runWithIsolatedDynamicScope(fn) {
+          const result = await fn();
+          return { result, dynamicDetected: false };
+        },
+      },
+    });
+
+    await renderAppPageLifecycle(options);
+    expect(getCapturedElement()[APP_LAYOUT_FLAGS_KEY]).toEqual({
+      "layout:/": "s",
+      "layout:/acme": "s",
+      "layout:/acme/dashboard": "s",
+    });
+  });
+
+  it("materializes dynamic cache tags only in segment-prefetch render observations", async () => {
+    // Ported from Next.js: test/e2e/app-dir/segment-cache/vary-params-base-dynamic/vary-params-base-dynamic.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/vary-params-base-dynamic.test.ts
+    const { options, getCapturedElement } = createRscOptions({
+      element: {
+        ...AppElementsWire.createMetadataEntries({
+          interception: null,
+          interceptionContext: null,
+          layoutIds: ["layout:/", "layout:/globex", "layout:/globex/portal"],
+          rootLayoutTreePath: "/",
+          routeId: "route:/globex/portal",
+          sourcePage: "/globex/portal/page",
+        }),
+        "layout:/": "root-layout",
+        "layout:/globex": "team-layout",
+        "layout:/globex/portal": "project-layout",
+        "page:/globex/portal": "project-page",
+      },
+      getPageTags: () => [
+        "/globex/portal",
+        "_N_T_/globex/portal",
+        "_N_T_/[teamSlug]/layout",
+        "_N_T_/[teamSlug]/[project]/layout",
+        "_N_T_/[teamSlug]/[project]/page",
+      ],
+      navigationParams: { project: "portal", teamSlug: "globex" },
+      segmentPrefetchPath: "/_tree",
+    });
+
+    await renderAppPageLifecycle(options);
+
+    const renderObservation = getCapturedElement()[APP_RENDER_OBSERVATION_KEY];
+    expect(renderObservation).toMatchObject({
+      cacheTags: [
+        "/globex/portal",
+        "_N_T_/globex/layout",
+        "_N_T_/globex/portal",
+        "_N_T_/globex/portal/layout",
+        "_N_T_/globex/portal/page",
+      ],
+    });
+    expect(JSON.stringify(renderObservation)).not.toContain("[teamSlug]");
+    expect(JSON.stringify(renderObservation)).not.toContain("[project]");
   });
 
   it("__layoutFlags includes flags for ALL layouts even when some are skipped", async () => {

--- a/tests/app-page-route-wiring.test.ts
+++ b/tests/app-page-route-wiring.test.ts
@@ -572,6 +572,42 @@ describe("app page route wiring helpers", () => {
     }
   });
 
+  it("encodes concrete segment-prefetch identities from matched params", () => {
+    // Ported from Next.js: test/e2e/app-dir/segment-cache/vary-params-base-dynamic/vary-params-base-dynamic.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/vary-params-base-dynamic/vary-params-base-dynamic.test.ts
+    const elements = buildAppPageElements({
+      concreteSegmentIdentity: true,
+      element: createElement(PageProbe),
+      makeThenableParams(params) {
+        return Promise.resolve(params);
+      },
+      matchedParams: { project: "dashboard", teamSlug: "acme" },
+      resolvedMetadata: null,
+      resolvedViewport: {},
+      route: {
+        error: null,
+        errors: [null, null, null],
+        layoutTreePositions: [0, 1, 2],
+        layouts: [{ default: RootLayout }, { default: GroupLayout }, { default: GroupLayout }],
+        loading: null,
+        notFound: null,
+        notFounds: [null, null, null],
+        routeSegments: ["[teamSlug]", "[project]"],
+        slots: null,
+        templateTreePositions: [],
+        templates: [],
+      },
+      routePath: "/acme/dashboard",
+      rootNotFoundModule: null,
+    });
+
+    const metadata = AppElementsWire.readMetadata(elements);
+    expect(metadata.sourcePage).toBe("/acme/dashboard/page");
+    expect(metadata.layoutIds).toEqual(["layout:/", "layout:/acme", "layout:/acme/dashboard"]);
+    expect(Object.keys(elements).join("\n")).not.toContain("[teamSlug]");
+    expect(Object.keys(elements).join("\n")).not.toContain("[project]");
+  });
+
   it("builds a flat elements map with route, layout, template, page, and slot entries", async () => {
     lastGroupTemplateProps = null;
     const elements = buildAppPageElements({

--- a/tests/isr-cache.test.ts
+++ b/tests/isr-cache.test.ts
@@ -256,6 +256,19 @@ describe("App Router ISR cache key primitives", () => {
     ).toMatch(/^app:\/feed:rsc:slots:[a-z0-9]+:prefetch-loading-shell$/);
   });
 
+  it("keys segment-prefetch RSC variants separately from canonical RSC payloads", () => {
+    delete process.env.__VINEXT_BUILD_ID;
+
+    const canonical = appIsrRscKey("/globex/portal");
+    const routeTree = appIsrRscKey("/globex/portal", null, undefined, null, "/_tree");
+    const pageSegment = appIsrRscKey("/globex/portal", null, undefined, null, "/_page");
+
+    expect(routeTree).not.toBe(canonical);
+    expect(pageSegment).not.toBe(canonical);
+    expect(routeTree).not.toBe(pageSegment);
+    expect(routeTree).toMatch(/^app:\/globex\/portal:rsc:segment:[a-z0-9]+$/);
+  });
+
   it("round-trips normal and preserve-current-UI RSC payloads under separate keys", async () => {
     delete process.env.__VINEXT_BUILD_ID;
     setCacheHandler(new MemoryCacheHandler());

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -1375,9 +1375,58 @@ describe("Link prefetch scheduling", () => {
       if (!(segmentInit?.headers instanceof Headers)) {
         throw new Error("Expected segment prefetch request headers");
       }
-      expect(segmentInit.headers.get(NEXT_ROUTER_PREFETCH_HEADER)).toBeNull();
+      expect(segmentInit.headers.get(NEXT_ROUTER_PREFETCH_HEADER)).toBe("1");
       expect(segmentInit.headers.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER)).toBe("/_page");
       expect(segmentInit.headers.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBeNull();
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("keeps rescheduled cacheComponents prefetches blocked on the route-tree response", async () => {
+    // Ported from the hover-reschedule contract covered by Next.js:
+    // test/e2e/app-dir/segment-cache/prefetch-scheduling/prefetch-scheduling.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/prefetch-scheduling/prefetch-scheduling.test.ts
+    vi.stubEnv("__NEXT_CACHE_COMPONENTS", "true");
+    const observer = stubIntersectionObserver();
+    let releaseRouteTreeBody: (() => void) | undefined;
+    const routeTreeBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        releaseRouteTreeBody = () => {
+          controller.close();
+        };
+      },
+    });
+    const result = await renderIsolatedLink({
+      href: "/viewport-prefetch-target",
+      nodeEnv: "production",
+    });
+
+    result.fetch
+      .mockImplementationOnce(() => Promise.resolve(new Response(routeTreeBody)))
+      .mockImplementationOnce(() => Promise.resolve(new Response("segment")));
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+
+      result.capturedAnchorProps.onMouseEnter?.({ currentTarget: result.anchor });
+      await flushPrefetchTasks();
+
+      expect(result.fetch).toHaveBeenCalledTimes(1);
+
+      if (releaseRouteTreeBody === undefined) {
+        throw new Error("Expected route-tree body release");
+      }
+      releaseRouteTreeBody();
+      await waitForFetchCalls(result.fetch, 2);
+
+      const segmentInit = result.fetch.mock.calls[1]?.[1];
+      expect(segmentInit).toEqual(
+        expect.objectContaining({
+          priority: "high",
+        }),
+      );
     } finally {
       result.restoreNodeEnv();
     }

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -1586,14 +1586,10 @@ describe("Link prefetch scheduling", () => {
     }
   });
 
-  it("keeps non-cacheComponents App viewport prefetches deferred until idle", async () => {
+  it("starts non-cacheComponents App viewport prefetches without waiting for browser idle", async () => {
     vi.stubEnv("__NEXT_CACHE_COMPONENTS", "false");
     const observer = stubIntersectionObserver();
-    const idleCallbacks: Array<() => void> = [];
-    const requestIdleCallback = vi.fn((callback: () => void) => {
-      idleCallbacks.push(callback);
-      return idleCallbacks.length;
-    });
+    const requestIdleCallback = vi.fn();
     const result = await renderIsolatedLink({
       href: "/viewport-prefetch-target",
       nodeEnv: "production",
@@ -1602,14 +1598,9 @@ describe("Link prefetch scheduling", () => {
 
     try {
       observer.dispatchIntersectingEntry(result.anchor);
-      await flushPrefetchTasks();
-
-      expect(requestIdleCallback).toHaveBeenCalledTimes(1);
-      expect(result.fetch).not.toHaveBeenCalled();
-
-      idleCallbacks[0]?.();
       await waitForFetchCalls(result.fetch, 1);
 
+      expect(requestIdleCallback).not.toHaveBeenCalled();
       expectCanonicalRscFetchCall(
         result.fetch.mock.calls[0],
         "/viewport-prefetch-target",

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -1432,6 +1432,115 @@ describe("Link prefetch scheduling", () => {
     }
   });
 
+  it("continues cacheComponents segment prefetches when visibility returns during route-tree fetch", async () => {
+    vi.stubEnv("__NEXT_CACHE_COMPONENTS", "true");
+    const observer = stubIntersectionObserver();
+    let releaseRouteTreeBody: (() => void) | undefined;
+    const routeTreeBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        releaseRouteTreeBody = () => {
+          controller.close();
+        };
+      },
+    });
+    const result = await renderIsolatedLink({
+      href: "/viewport-prefetch-target",
+      nodeEnv: "production",
+    });
+
+    result.fetch
+      .mockImplementationOnce(() => Promise.resolve(new Response(routeTreeBody)))
+      .mockImplementationOnce(() => Promise.resolve(new Response("segment")));
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+
+      observer.dispatchIntersectingEntry(result.anchor, false);
+      await flushPrefetchTasks();
+      observer.dispatchIntersectingEntry(result.anchor, true);
+      await flushPrefetchTasks();
+
+      expect(result.fetch).toHaveBeenCalledTimes(1);
+
+      if (releaseRouteTreeBody === undefined) {
+        throw new Error("Expected route-tree body release");
+      }
+      releaseRouteTreeBody();
+      await waitForFetchCalls(result.fetch, 2);
+
+      const segmentInit = result.fetch.mock.calls[1]?.[1];
+      expect(segmentInit?.headers).toBeInstanceOf(Headers);
+      if (!(segmentInit?.headers instanceof Headers)) {
+        throw new Error("Expected segment prefetch request headers");
+      }
+      expect(segmentInit.headers.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER)).toBe("/_page");
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("does not restart completed cacheComponents prefetches on hover", async () => {
+    vi.stubEnv("__NEXT_CACHE_COMPONENTS", "true");
+    const observer = stubIntersectionObserver();
+    const result = await renderIsolatedLink({
+      href: "/viewport-prefetch-target",
+      nodeEnv: "production",
+    });
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 2);
+      await flushPrefetchTasks();
+
+      result.capturedAnchorProps.onMouseEnter?.({ currentTarget: result.anchor });
+      await flushPrefetchTasks();
+      pingVisibleLinksFromRuntime();
+      await flushPrefetchTasks();
+
+      expect(result.fetch).toHaveBeenCalledTimes(2);
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("keeps non-cacheComponents App viewport prefetches deferred until idle", async () => {
+    vi.stubEnv("__NEXT_CACHE_COMPONENTS", "false");
+    const observer = stubIntersectionObserver();
+    const idleCallbacks: Array<() => void> = [];
+    const requestIdleCallback = vi.fn((callback: () => void) => {
+      idleCallbacks.push(callback);
+      return idleCallbacks.length;
+    });
+    const result = await renderIsolatedLink({
+      href: "/viewport-prefetch-target",
+      nodeEnv: "production",
+      windowOverrides: { requestIdleCallback },
+    });
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await flushPrefetchTasks();
+
+      expect(requestIdleCallback).toHaveBeenCalledTimes(1);
+      expect(result.fetch).not.toHaveBeenCalled();
+
+      idleCallbacks[0]?.();
+      await waitForFetchCalls(result.fetch, 1);
+
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[0],
+        "/viewport-prefetch-target",
+        expect.objectContaining({
+          credentials: "include",
+          priority: "low",
+        }),
+      );
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
   it("does not prefetch visible or hovered links for a bot user agent", async () => {
     // Ported from Next.js:
     // test/e2e/app-dir/app-prefetch/prefetching.test.ts

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -1586,6 +1586,79 @@ describe("Link prefetch scheduling", () => {
     }
   });
 
+  it("restarts in-flight cacheComponents prefetches after cache invalidation", async () => {
+    vi.stubEnv("__NEXT_CACHE_COMPONENTS", "true");
+    const observer = stubIntersectionObserver();
+    let releaseRouteTreeBody: (() => void) | undefined;
+    const routeTreeBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        releaseRouteTreeBody = () => {
+          controller.close();
+        };
+      },
+    });
+    const result = await renderIsolatedLink({
+      href: "/viewport-prefetch-target",
+      nodeEnv: "production",
+    });
+    const { getPrefetchCache, invalidatePrefetchCache } =
+      await import("../packages/vinext/src/shims/navigation.js");
+
+    result.fetch
+      .mockImplementationOnce(() => Promise.resolve(new Response(routeTreeBody)))
+      .mockImplementationOnce(() => Promise.resolve(new Response("rewarmed route tree")))
+      .mockImplementationOnce(() => Promise.resolve(new Response("rewarmed segment")));
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+
+      invalidatePrefetchCache();
+      result.capturedAnchorProps.onMouseEnter?.({ currentTarget: result.anchor });
+      pingVisibleLinksFromRuntime();
+      await flushPrefetchTasks();
+
+      expect(result.fetch).toHaveBeenCalledTimes(1);
+
+      if (releaseRouteTreeBody === undefined) {
+        throw new Error("Expected route-tree body release");
+      }
+      releaseRouteTreeBody();
+      await waitForFetchCalls(result.fetch, 3);
+      await flushPrefetchTasks(() => {
+        const entries = [...getPrefetchCache().values()];
+        return entries.length === 2 && entries.every((entry) => entry.pending === undefined);
+      });
+
+      const routeTreeInit = result.fetch.mock.calls[1]?.[1];
+      expect(routeTreeInit?.headers).toBeInstanceOf(Headers);
+      if (!(routeTreeInit?.headers instanceof Headers)) {
+        throw new Error("Expected rewarmed route-tree prefetch request headers");
+      }
+      expect(routeTreeInit.headers.get(NEXT_ROUTER_PREFETCH_HEADER)).toBe("1");
+      expect(routeTreeInit.headers.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER)).toBe("/_tree");
+      expect(routeTreeInit.headers.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBe(
+        APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+      );
+
+      const segmentInit = result.fetch.mock.calls[2]?.[1];
+      expect(segmentInit?.headers).toBeInstanceOf(Headers);
+      if (!(segmentInit?.headers instanceof Headers)) {
+        throw new Error("Expected rewarmed segment prefetch request headers");
+      }
+      expect(segmentInit.headers.get(NEXT_ROUTER_PREFETCH_HEADER)).toBe("1");
+      expect(segmentInit.headers.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER)).toBe("/_page");
+      expect(segmentInit.headers.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBeNull();
+
+      const rewarmedEntries = [...getPrefetchCache().values()].filter(
+        (entry) => entry.outcome === "cache-seeded",
+      );
+      expect(rewarmedEntries).toHaveLength(2);
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
   it("starts non-cacheComponents App viewport prefetches without waiting for browser idle", async () => {
     vi.stubEnv("__NEXT_CACHE_COMPONENTS", "false");
     const observer = stubIntersectionObserver();

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -1323,6 +1323,66 @@ describe("Link prefetch scheduling", () => {
     }
   });
 
+  it("splits cacheComponents auto prefetches into route-tree and segment phases", async () => {
+    // Ported from the request-order contract covered by Next.js:
+    // test/e2e/app-dir/segment-cache/prefetch-scheduling/prefetch-scheduling.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/prefetch-scheduling/prefetch-scheduling.test.ts
+    vi.stubEnv("__NEXT_CACHE_COMPONENTS", "true");
+    const observer = stubIntersectionObserver();
+    let releaseRouteTreeBody: (() => void) | undefined;
+    const routeTreeBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        releaseRouteTreeBody = () => {
+          controller.close();
+        };
+      },
+    });
+    const result = await renderIsolatedLink({
+      href: "/viewport-prefetch-target",
+      nodeEnv: "production",
+    });
+
+    result.fetch
+      .mockImplementationOnce(() => Promise.resolve(new Response(routeTreeBody)))
+      .mockImplementationOnce(() => Promise.resolve(new Response("segment")));
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+
+      const routeTreeInit = result.fetch.mock.calls[0]?.[1];
+      expect(routeTreeInit?.headers).toBeInstanceOf(Headers);
+      if (!(routeTreeInit?.headers instanceof Headers)) {
+        throw new Error("Expected route-tree prefetch request headers");
+      }
+      expect(routeTreeInit.headers.get(NEXT_ROUTER_PREFETCH_HEADER)).toBe("1");
+      expect(routeTreeInit.headers.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER)).toBe("/_tree");
+      expect(routeTreeInit.headers.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBe(
+        APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+      );
+
+      await flushPrefetchTasks();
+      expect(result.fetch).toHaveBeenCalledTimes(1);
+
+      if (releaseRouteTreeBody === undefined) {
+        throw new Error("Expected route-tree body release");
+      }
+      releaseRouteTreeBody();
+      await waitForFetchCalls(result.fetch, 2);
+
+      const segmentInit = result.fetch.mock.calls[1]?.[1];
+      expect(segmentInit?.headers).toBeInstanceOf(Headers);
+      if (!(segmentInit?.headers instanceof Headers)) {
+        throw new Error("Expected segment prefetch request headers");
+      }
+      expect(segmentInit.headers.get(NEXT_ROUTER_PREFETCH_HEADER)).toBeNull();
+      expect(segmentInit.headers.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER)).toBe("/_page");
+      expect(segmentInit.headers.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBeNull();
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
   it("does not prefetch visible or hovered links for a bot user agent", async () => {
     // Ported from Next.js:
     // test/e2e/app-dir/app-prefetch/prefetching.test.ts

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -1418,6 +1418,70 @@ describe("Link prefetch scheduling", () => {
     }
   });
 
+  it("force-pings late-App-runtime visible cacheComponents links after cache invalidation", async () => {
+    vi.stubEnv("__NEXT_CACHE_COMPONENTS", "true");
+    const observer = stubIntersectionObserver();
+    const result = await renderIsolatedLink({
+      appNavigation: false,
+      href: "/viewport-prefetch-target",
+      nodeEnv: "production",
+    });
+    const { invalidatePrefetchCache } = await import("../packages/vinext/src/shims/navigation.js");
+
+    result.fetch
+      .mockImplementationOnce(() => Promise.resolve(new Response("rewarmed route tree")))
+      .mockImplementationOnce(() => Promise.resolve(new Response("rewarmed segment")));
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await flushPrefetchTasks();
+
+      expect(result.fetch).not.toHaveBeenCalled();
+
+      const runtime = Reflect.get(window, Symbol.for("vinext.navigationRuntime"));
+      expect(runtime).toEqual(
+        expect.objectContaining({
+          functions: expect.objectContaining({
+            pingVisibleLinks: expect.any(Function),
+          }),
+        }),
+      );
+      if (typeof runtime !== "object" || runtime === null || !("functions" in runtime)) {
+        throw new Error("Expected Link to register visible-link ping runtime functions");
+      }
+      const { functions } = runtime;
+      if (typeof functions !== "object" || functions === null) {
+        throw new Error("Expected navigation runtime functions");
+      }
+      Reflect.set(functions, "navigate", vi.fn());
+
+      invalidatePrefetchCache();
+      await waitForFetchCalls(result.fetch, 2);
+
+      const routeTreeInit = result.fetch.mock.calls[0]?.[1];
+      expect(routeTreeInit?.headers).toBeInstanceOf(Headers);
+      if (!(routeTreeInit?.headers instanceof Headers)) {
+        throw new Error("Expected late-runtime route-tree prefetch request headers");
+      }
+      expect(routeTreeInit.headers.get(NEXT_ROUTER_PREFETCH_HEADER)).toBe("1");
+      expect(routeTreeInit.headers.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER)).toBe("/_tree");
+      expect(routeTreeInit.headers.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBe(
+        APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+      );
+
+      const segmentInit = result.fetch.mock.calls[1]?.[1];
+      expect(segmentInit?.headers).toBeInstanceOf(Headers);
+      if (!(segmentInit?.headers instanceof Headers)) {
+        throw new Error("Expected late-runtime segment prefetch request headers");
+      }
+      expect(segmentInit.headers.get(NEXT_ROUTER_PREFETCH_HEADER)).toBe("1");
+      expect(segmentInit.headers.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER)).toBe("/_page");
+      expect(segmentInit.headers.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBeNull();
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
   it("keeps rescheduled cacheComponents prefetches blocked on the route-tree response", async () => {
     // Ported from the hover-reschedule contract covered by Next.js:
     // test/e2e/app-dir/segment-cache/prefetch-scheduling/prefetch-scheduling.test.ts

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -1418,6 +1418,58 @@ describe("Link prefetch scheduling", () => {
     }
   });
 
+  it("uses the cacheComponents scheduler when a Pages-visible Link re-enters after App runtime registers", async () => {
+    vi.stubEnv("__NEXT_CACHE_COMPONENTS", "true");
+    const observer = stubIntersectionObserver();
+    const result = await renderIsolatedLink({
+      appNavigation: false,
+      href: "/viewport-prefetch-target",
+      nodeEnv: "production",
+    });
+
+    result.fetch
+      .mockImplementationOnce(() => Promise.resolve(new Response("route tree")))
+      .mockImplementationOnce(() => Promise.resolve(new Response("segment")));
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await flushPrefetchTasks();
+
+      expect(result.fetch).not.toHaveBeenCalled();
+
+      observer.dispatchIntersectingEntry(result.anchor, false);
+      Reflect.set(
+        window,
+        Symbol.for("vinext.navigationRuntime"),
+        createTestNavigationRuntime(vi.fn()),
+      );
+      observer.dispatchIntersectingEntry(result.anchor, true);
+      await waitForFetchCalls(result.fetch, 2);
+
+      const routeTreeInit = result.fetch.mock.calls[0]?.[1];
+      expect(routeTreeInit?.headers).toBeInstanceOf(Headers);
+      if (!(routeTreeInit?.headers instanceof Headers)) {
+        throw new Error("Expected re-entered route-tree prefetch request headers");
+      }
+      expect(routeTreeInit.headers.get(NEXT_ROUTER_PREFETCH_HEADER)).toBe("1");
+      expect(routeTreeInit.headers.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER)).toBe("/_tree");
+      expect(routeTreeInit.headers.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBe(
+        APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+      );
+
+      const segmentInit = result.fetch.mock.calls[1]?.[1];
+      expect(segmentInit?.headers).toBeInstanceOf(Headers);
+      if (!(segmentInit?.headers instanceof Headers)) {
+        throw new Error("Expected re-entered segment prefetch request headers");
+      }
+      expect(segmentInit.headers.get(NEXT_ROUTER_PREFETCH_HEADER)).toBe("1");
+      expect(segmentInit.headers.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER)).toBe("/_page");
+      expect(segmentInit.headers.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBeNull();
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
   it("force-pings late-App-runtime visible cacheComponents links after cache invalidation", async () => {
     vi.stubEnv("__NEXT_CACHE_COMPONENTS", "true");
     const observer = stubIntersectionObserver();
@@ -1473,6 +1525,72 @@ describe("Link prefetch scheduling", () => {
       expect(segmentInit?.headers).toBeInstanceOf(Headers);
       if (!(segmentInit?.headers instanceof Headers)) {
         throw new Error("Expected late-runtime segment prefetch request headers");
+      }
+      expect(segmentInit.headers.get(NEXT_ROUTER_PREFETCH_HEADER)).toBe("1");
+      expect(segmentInit.headers.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER)).toBe("/_page");
+      expect(segmentInit.headers.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBeNull();
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("restarts in-flight cacheComponents prefetches after invalidation across a visibility flap", async () => {
+    vi.stubEnv("__NEXT_CACHE_COMPONENTS", "true");
+    const observer = stubIntersectionObserver();
+    let releaseRouteTreeBody: (() => void) | undefined;
+    const routeTreeBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        releaseRouteTreeBody = () => {
+          controller.close();
+        };
+      },
+    });
+    const result = await renderIsolatedLink({
+      href: "/viewport-prefetch-target",
+      nodeEnv: "production",
+    });
+    const { invalidatePrefetchCache } = await import("../packages/vinext/src/shims/navigation.js");
+
+    result.fetch
+      .mockImplementationOnce(() => Promise.resolve(new Response(routeTreeBody)))
+      .mockImplementationOnce(() => Promise.resolve(new Response("rewarmed route tree")))
+      .mockImplementationOnce(() => Promise.resolve(new Response("rewarmed segment")));
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+
+      invalidatePrefetchCache();
+      observer.dispatchIntersectingEntry(result.anchor, false);
+      await flushPrefetchTasks();
+      observer.dispatchIntersectingEntry(result.anchor, true);
+      await flushPrefetchTasks();
+
+      expect(result.fetch).toHaveBeenCalledTimes(1);
+
+      if (releaseRouteTreeBody === undefined) {
+        throw new Error("Expected route-tree body release");
+      }
+      releaseRouteTreeBody();
+      await waitForFetchCalls(result.fetch, 2);
+
+      const routeTreeInit = result.fetch.mock.calls[1]?.[1];
+      expect(routeTreeInit?.headers).toBeInstanceOf(Headers);
+      if (!(routeTreeInit?.headers instanceof Headers)) {
+        throw new Error("Expected restarted route-tree prefetch request headers");
+      }
+      expect(routeTreeInit.headers.get(NEXT_ROUTER_PREFETCH_HEADER)).toBe("1");
+      expect(routeTreeInit.headers.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER)).toBe("/_tree");
+      expect(routeTreeInit.headers.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBe(
+        APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+      );
+
+      await waitForFetchCalls(result.fetch, 3);
+
+      const segmentInit = result.fetch.mock.calls[2]?.[1];
+      expect(segmentInit?.headers).toBeInstanceOf(Headers);
+      if (!(segmentInit?.headers instanceof Headers)) {
+        throw new Error("Expected rewarmed segment prefetch request headers");
       }
       expect(segmentInit.headers.get(NEXT_ROUTER_PREFETCH_HEADER)).toBe("1");
       expect(segmentInit.headers.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER)).toBe("/_page");

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -2149,7 +2149,7 @@ describe("Link prefetch scheduling", () => {
       );
       expect(
         (fetchInit?.headers as Headers | undefined)?.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER),
-      ).toBe("/_tree");
+      ).toBe("1");
       const { getPrefetchCache } = await import("../packages/vinext/src/shims/navigation.js");
       const entry = Array.from(getPrefetchCache().values())[0];
       expect(entry?.cacheForNavigation).toBe(false);

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -1539,6 +1539,53 @@ describe("Link prefetch scheduling", () => {
     }
   });
 
+  it("re-prefetches completed cacheComponents auto links after cache invalidation", async () => {
+    vi.stubEnv("__NEXT_CACHE_COMPONENTS", "true");
+    const observer = stubIntersectionObserver();
+    const result = await renderIsolatedLink({
+      href: "/viewport-prefetch-target",
+      nodeEnv: "production",
+    });
+    const { invalidatePrefetchCache } = await import("../packages/vinext/src/shims/navigation.js");
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 2);
+      await flushPrefetchTasks();
+
+      result.capturedAnchorProps.onMouseEnter?.({ currentTarget: result.anchor });
+      pingVisibleLinksFromRuntime();
+      await flushPrefetchTasks();
+
+      expect(result.fetch).toHaveBeenCalledTimes(2);
+
+      invalidatePrefetchCache();
+      await waitForFetchCalls(result.fetch, 4);
+
+      const routeTreeInit = result.fetch.mock.calls[2]?.[1];
+      expect(routeTreeInit?.headers).toBeInstanceOf(Headers);
+      if (!(routeTreeInit?.headers instanceof Headers)) {
+        throw new Error("Expected invalidation route-tree prefetch request headers");
+      }
+      expect(routeTreeInit.headers.get(NEXT_ROUTER_PREFETCH_HEADER)).toBe("1");
+      expect(routeTreeInit.headers.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER)).toBe("/_tree");
+      expect(routeTreeInit.headers.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBe(
+        APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+      );
+
+      const segmentInit = result.fetch.mock.calls[3]?.[1];
+      expect(segmentInit?.headers).toBeInstanceOf(Headers);
+      if (!(segmentInit?.headers instanceof Headers)) {
+        throw new Error("Expected invalidation segment prefetch request headers");
+      }
+      expect(segmentInit.headers.get(NEXT_ROUTER_PREFETCH_HEADER)).toBe("1");
+      expect(segmentInit.headers.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER)).toBe("/_page");
+      expect(segmentInit.headers.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBeNull();
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
   it("keeps non-cacheComponents App viewport prefetches deferred until idle", async () => {
     vi.stubEnv("__NEXT_CACHE_COMPONENTS", "false");
     const observer = stubIntersectionObserver();

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -1383,6 +1383,41 @@ describe("Link prefetch scheduling", () => {
     }
   });
 
+  it("uses the cacheComponents scheduler when the app runtime registers after the Link", async () => {
+    vi.stubEnv("__NEXT_CACHE_COMPONENTS", "true");
+    const observer = stubIntersectionObserver();
+    const result = await renderIsolatedLink({
+      appNavigation: false,
+      href: "/viewport-prefetch-target",
+      nodeEnv: "production",
+    });
+
+    try {
+      Reflect.set(
+        window,
+        Symbol.for("vinext.navigationRuntime"),
+        createTestNavigationRuntime(vi.fn()),
+      );
+
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+
+      const routeTreeInit = result.fetch.mock.calls[0]?.[1];
+      expect(routeTreeInit?.headers).toBeInstanceOf(Headers);
+      if (!(routeTreeInit?.headers instanceof Headers)) {
+        throw new Error("Expected route-tree prefetch request headers");
+      }
+      expect(routeTreeInit.headers.get(NEXT_ROUTER_PREFETCH_HEADER)).toBe("1");
+      expect(routeTreeInit.headers.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER)).toBe("/_tree");
+      expect(routeTreeInit.headers.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBe(
+        APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+      );
+      await waitForFetchCalls(result.fetch, 2);
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
   it("keeps rescheduled cacheComponents prefetches blocked on the route-tree response", async () => {
     // Ported from the hover-reschedule contract covered by Next.js:
     // test/e2e/app-dir/segment-cache/prefetch-scheduling/prefetch-scheduling.test.ts
@@ -1780,7 +1815,7 @@ describe("Link prefetch scheduling", () => {
       );
       expect(
         (fetchInit?.headers as Headers | undefined)?.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER),
-      ).toBe("1");
+      ).toBe("/_tree");
       const { getPrefetchCache } = await import("../packages/vinext/src/shims/navigation.js");
       const entry = Array.from(getPrefetchCache().values())[0];
       expect(entry?.cacheForNavigation).toBe(false);

--- a/tests/link-segment-prefetch-scheduler.test.ts
+++ b/tests/link-segment-prefetch-scheduler.test.ts
@@ -178,6 +178,88 @@ describe("Link Segment Cache prefetch scheduler", () => {
     });
   });
 
+  it("restarts from route-tree after forced invalidation while route-tree is running", async () => {
+    const { deferredRequests, requests, runPhase, scheduler } = createSchedulerHarness();
+    const instance = createInstance("/notifications");
+
+    scheduler.schedule(instance, "low", 1);
+    await flushScheduler();
+
+    scheduler.schedule(instance, "high", 1);
+    scheduler.schedule(instance, "low", 2, { force: true });
+    scheduler.schedule(instance, "high", 2);
+    await flushScheduler();
+
+    expect(runPhase).toHaveBeenCalledTimes(1);
+    expect(requests[0]).toMatchObject({
+      href: "/notifications",
+      phase: "route-tree",
+      priority: "low",
+    });
+
+    deferredRequests[0]?.resolve();
+    await flushScheduler();
+
+    expect(runPhase).toHaveBeenCalledTimes(2);
+    expect(requests[1]).toMatchObject({
+      href: "/notifications",
+      phase: "route-tree",
+      priority: "high",
+    });
+
+    deferredRequests[1]?.resolve();
+    await flushScheduler();
+
+    expect(runPhase).toHaveBeenCalledTimes(3);
+    expect(requests[2]).toMatchObject({
+      href: "/notifications",
+      phase: "segment",
+      priority: "high",
+    });
+  });
+
+  it("restarts from route-tree after forced invalidation while segment is running", async () => {
+    const { deferredRequests, requests, runPhase, scheduler } = createSchedulerHarness();
+    const instance = createInstance("/activity");
+
+    scheduler.schedule(instance, "low", 1);
+    await flushScheduler();
+    deferredRequests[0]?.resolve();
+    await flushScheduler();
+
+    expect(runPhase).toHaveBeenCalledTimes(2);
+    expect(requests[1]).toMatchObject({
+      href: "/activity",
+      phase: "segment",
+      priority: "low",
+    });
+
+    scheduler.schedule(instance, "low", 2, { force: true });
+    await flushScheduler();
+
+    expect(runPhase).toHaveBeenCalledTimes(2);
+
+    deferredRequests[1]?.resolve();
+    await flushScheduler();
+
+    expect(runPhase).toHaveBeenCalledTimes(3);
+    expect(requests[2]).toMatchObject({
+      href: "/activity",
+      phase: "route-tree",
+      priority: "low",
+    });
+
+    deferredRequests[2]?.resolve();
+    await flushScheduler();
+
+    expect(runPhase).toHaveBeenCalledTimes(4);
+    expect(requests[3]).toMatchObject({
+      href: "/activity",
+      phase: "segment",
+      priority: "low",
+    });
+  });
+
   it("starts low-priority route-tree work in batch order while preserving newest-first order within a batch", async () => {
     const { requests, runPhase, scheduler } = createSchedulerHarness();
     const firstBatch = createInstance("/batch-first");

--- a/tests/link-segment-prefetch-scheduler.test.ts
+++ b/tests/link-segment-prefetch-scheduler.test.ts
@@ -139,6 +139,48 @@ describe("Link Segment Cache prefetch scheduler", () => {
     });
   });
 
+  it("preserves a forced route-tree restart across visibility cancellation and re-entry", async () => {
+    const { deferredRequests, requests, runPhase, scheduler } = createSchedulerHarness();
+    const instance = createInstance("/alerts");
+
+    scheduler.schedule(instance, "low", 1);
+    await flushScheduler();
+
+    scheduler.schedule(instance, "low", 2, { force: true });
+    instance.isVisible = false;
+    scheduler.cancel(instance);
+    instance.isVisible = true;
+    scheduler.schedule(instance, "low", 2);
+    await flushScheduler();
+
+    expect(runPhase).toHaveBeenCalledTimes(1);
+    expect(requests[0]).toMatchObject({
+      href: "/alerts",
+      phase: "route-tree",
+      priority: "low",
+    });
+
+    deferredRequests[0]?.resolve();
+    await flushScheduler();
+
+    expect(runPhase).toHaveBeenCalledTimes(2);
+    expect(requests[1]).toMatchObject({
+      href: "/alerts",
+      phase: "route-tree",
+      priority: "low",
+    });
+
+    deferredRequests[1]?.resolve();
+    await flushScheduler();
+
+    expect(runPhase).toHaveBeenCalledTimes(3);
+    expect(requests[2]).toMatchObject({
+      href: "/alerts",
+      phase: "segment",
+      priority: "low",
+    });
+  });
+
   it("restarts a completed task only when forced", async () => {
     const { deferredRequests, requests, runPhase, scheduler } = createSchedulerHarness();
     const instance = createInstance("/settings");

--- a/tests/link-segment-prefetch-scheduler.test.ts
+++ b/tests/link-segment-prefetch-scheduler.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import {
+  createLinkSegmentPrefetchScheduler,
+  type LinkSegmentPrefetchInstance,
+  type LinkSegmentPrefetchPhaseRequest,
+} from "../packages/vinext/src/shims/internal/link-segment-prefetch-scheduler.js";
+
+function createDeferred(): {
+  promise: Promise<void>;
+  resolve: () => void;
+} {
+  let resolve: (() => void) | undefined;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  if (resolve === undefined) {
+    throw new Error("Expected deferred resolver to be initialized");
+  }
+  return { promise, resolve };
+}
+
+async function flushScheduler(): Promise<void> {
+  for (let i = 0; i < 5; i++) {
+    await Promise.resolve();
+  }
+}
+
+function createInstance(href: string): LinkSegmentPrefetchInstance {
+  return {
+    href,
+    isVisible: true,
+    pagesRouteHref: undefined,
+  };
+}
+
+function createSchedulerHarness() {
+  const requests: LinkSegmentPrefetchPhaseRequest[] = [];
+  const deferredRequests: Array<ReturnType<typeof createDeferred>> = [];
+  const runPhase = vi.fn((request: LinkSegmentPrefetchPhaseRequest) => {
+    requests.push({ ...request });
+    const deferred = createDeferred();
+    deferredRequests.push(deferred);
+    return deferred.promise;
+  });
+  const scheduler = createLinkSegmentPrefetchScheduler({ runPhase });
+
+  return {
+    deferredRequests,
+    requests,
+    runPhase,
+    scheduler,
+  };
+}
+
+describe("Link Segment Cache prefetch scheduler", () => {
+  it("runs the route-tree phase before the segment phase", async () => {
+    // Mirrors the phase split in Next.js's Segment Cache scheduler:
+    // packages/next/src/client/components/segment-cache/scheduler.ts
+    const { deferredRequests, requests, runPhase, scheduler } = createSchedulerHarness();
+    const instance = createInstance("/dashboard");
+
+    scheduler.schedule(instance, "low", 1);
+    await flushScheduler();
+
+    expect(runPhase).toHaveBeenCalledTimes(1);
+    expect(requests[0]).toMatchObject({
+      href: "/dashboard",
+      phase: "route-tree",
+      priority: "low",
+    });
+
+    deferredRequests[0]?.resolve();
+    await flushScheduler();
+
+    expect(runPhase).toHaveBeenCalledTimes(2);
+    expect(requests[1]).toMatchObject({
+      href: "/dashboard",
+      phase: "segment",
+      priority: "low",
+    });
+  });
+
+  it("reschedules a running hover without double-running route-tree and upgrades segment priority", async () => {
+    const { deferredRequests, requests, runPhase, scheduler } = createSchedulerHarness();
+    const instance = createInstance("/reports");
+
+    scheduler.schedule(instance, "low", 1);
+    await flushScheduler();
+
+    scheduler.schedule(instance, "high", 1);
+    await flushScheduler();
+
+    expect(runPhase).toHaveBeenCalledTimes(1);
+    expect(requests[0]).toMatchObject({
+      href: "/reports",
+      phase: "route-tree",
+      priority: "low",
+    });
+
+    deferredRequests[0]?.resolve();
+    await flushScheduler();
+
+    expect(runPhase).toHaveBeenCalledTimes(2);
+    expect(requests[1]).toMatchObject({
+      href: "/reports",
+      phase: "segment",
+      priority: "high",
+    });
+  });
+
+  it("continues to the segment phase after visibility cancellation is rescheduled during route-tree", async () => {
+    const { deferredRequests, requests, runPhase, scheduler } = createSchedulerHarness();
+    const instance = createInstance("/feed");
+
+    scheduler.schedule(instance, "low", 1);
+    await flushScheduler();
+
+    instance.isVisible = false;
+    scheduler.cancel(instance);
+    instance.isVisible = true;
+    scheduler.schedule(instance, "low", 2);
+    await flushScheduler();
+
+    expect(runPhase).toHaveBeenCalledTimes(1);
+    expect(requests[0]).toMatchObject({
+      href: "/feed",
+      phase: "route-tree",
+      priority: "low",
+    });
+
+    deferredRequests[0]?.resolve();
+    await flushScheduler();
+
+    expect(runPhase).toHaveBeenCalledTimes(2);
+    expect(requests[1]).toMatchObject({
+      href: "/feed",
+      phase: "segment",
+      priority: "low",
+    });
+  });
+
+  it("does not restart a completed task", async () => {
+    const { deferredRequests, runPhase, scheduler } = createSchedulerHarness();
+    const instance = createInstance("/settings");
+
+    scheduler.schedule(instance, "low", 1);
+    await flushScheduler();
+    deferredRequests[0]?.resolve();
+    await flushScheduler();
+    deferredRequests[1]?.resolve();
+    await flushScheduler();
+
+    expect(runPhase).toHaveBeenCalledTimes(2);
+
+    scheduler.schedule(instance, "high", 1);
+    await flushScheduler();
+
+    expect(runPhase).toHaveBeenCalledTimes(2);
+  });
+
+  it("starts low-priority route-tree work in batch order while preserving newest-first order within a batch", async () => {
+    const { requests, runPhase, scheduler } = createSchedulerHarness();
+    const firstBatch = createInstance("/batch-first");
+    const secondBatchOlder = createInstance("/batch-second-older");
+    const secondBatchNewer = createInstance("/batch-second-newer");
+    const thirdBatch = createInstance("/batch-third");
+
+    scheduler.schedule(firstBatch, "low", 1);
+    scheduler.schedule(secondBatchOlder, "low", 2);
+    scheduler.schedule(secondBatchNewer, "low", 2);
+    scheduler.schedule(thirdBatch, "low", 3);
+    await flushScheduler();
+
+    expect(runPhase).toHaveBeenCalledTimes(4);
+    expect(requests.map((request) => request.href)).toEqual([
+      "/batch-first",
+      "/batch-second-newer",
+      "/batch-second-older",
+      "/batch-third",
+    ]);
+    expect(requests.map((request) => request.phase)).toEqual([
+      "route-tree",
+      "route-tree",
+      "route-tree",
+      "route-tree",
+    ]);
+  });
+});

--- a/tests/link-segment-prefetch-scheduler.test.ts
+++ b/tests/link-segment-prefetch-scheduler.test.ts
@@ -139,8 +139,8 @@ describe("Link Segment Cache prefetch scheduler", () => {
     });
   });
 
-  it("does not restart a completed task", async () => {
-    const { deferredRequests, runPhase, scheduler } = createSchedulerHarness();
+  it("restarts a completed task only when forced", async () => {
+    const { deferredRequests, requests, runPhase, scheduler } = createSchedulerHarness();
     const instance = createInstance("/settings");
 
     scheduler.schedule(instance, "low", 1);
@@ -156,6 +156,26 @@ describe("Link Segment Cache prefetch scheduler", () => {
     await flushScheduler();
 
     expect(runPhase).toHaveBeenCalledTimes(2);
+
+    scheduler.schedule(instance, "low", 2, { force: true });
+    await flushScheduler();
+
+    expect(runPhase).toHaveBeenCalledTimes(3);
+    expect(requests[2]).toMatchObject({
+      href: "/settings",
+      phase: "route-tree",
+      priority: "low",
+    });
+
+    deferredRequests[2]?.resolve();
+    await flushScheduler();
+
+    expect(runPhase).toHaveBeenCalledTimes(4);
+    expect(requests[3]).toMatchObject({
+      href: "/settings",
+      phase: "segment",
+      priority: "low",
+    });
   });
 
   it("starts low-priority route-tree work in batch order while preserving newest-first order within a batch", async () => {

--- a/tests/seed-cache.test.ts
+++ b/tests/seed-cache.test.ts
@@ -339,7 +339,12 @@ describe("seedMemoryCacheFromPrerender", () => {
   it("can write through an injected app page cache writer", async () => {
     const writes: {
       key: string;
-      metadata: { expireSeconds?: number; revalidateSeconds?: number; tags?: string[] };
+      metadata: {
+        expireSeconds?: number;
+        revalidateSeconds?: number;
+        staleSeconds?: number;
+        tags?: string[];
+      };
       valueKind: string;
     }[] = [];
 
@@ -347,7 +352,16 @@ describe("seedMemoryCacheFromPrerender", () => {
       serverDir,
       {
         buildId: "seed-injected-writer-test",
-        routes: [{ route: "/isr", status: "rendered", revalidate: 60, expire: 300, router: "app" }],
+        routes: [
+          {
+            route: "/isr",
+            status: "rendered",
+            revalidate: 60,
+            stale: 0,
+            expire: 300,
+            router: "app",
+          },
+        ],
       },
       {
         "isr.html": "<html>ISR</html>",
@@ -374,12 +388,22 @@ describe("seedMemoryCacheFromPrerender", () => {
     expect(writes).toEqual([
       {
         key: baseKey + ":html",
-        metadata: { expireSeconds: 300, revalidateSeconds: 60, tags: expectedTags },
+        metadata: {
+          expireSeconds: 300,
+          revalidateSeconds: 60,
+          staleSeconds: 0,
+          tags: expectedTags,
+        },
         valueKind: "APP_PAGE",
       },
       {
         key: baseKey + ":rsc",
-        metadata: { expireSeconds: 300, revalidateSeconds: 60, tags: expectedTags },
+        metadata: {
+          expireSeconds: 300,
+          revalidateSeconds: 60,
+          staleSeconds: 0,
+          tags: expectedTags,
+        },
         valueKind: "APP_PAGE",
       },
     ]);


### PR DESCRIPTION
## Summary

- schedule cache-components route-tree and segment prefetch phases in Next-compatible order
- mark segment-prefetch requests with the App Router prefetch header
- keep rescheduled hover/visible prefetches blocked on an existing route-tree response before starting the segment phase

## Next.js parity

Targets the Segment Cache scheduling behavior covered by:

- `test/e2e/app-dir/segment-cache/prefetch-scheduling/prefetch-scheduling.test.ts`

## Validation

- `vp test run tests/link-navigation.test.ts -t "Link prefetch scheduling"`
- `vp check packages/vinext/src/shims/link.tsx tests/link-navigation.test.ts`
- `REPO="$PWD" NEXTJS_DIR="/Users/jamesanderson/Developer/vinext/.nextjs-ref" NEXT_TEST_CONCURRENCY=1 ./scripts/run-targeted-nextjs-e2e.sh test/e2e/app-dir/segment-cache/prefetch-scheduling/prefetch-scheduling.test.ts` (4 passed, 1 skipped)

## Review

Independent review found and fixed two issues before PR: missing `Next-Router-Prefetch: 1` on segment-phase requests, and early segment-phase starts when a visible link was rescheduled while the route-tree response was still pending.