### PR TITLE
fix(app-router): evict segment prefetches under memory pressure

### DIFF
--- a/packages/vinext/src/shims/internal/app-prefetch-fetch-queue.ts
+++ b/packages/vinext/src/shims/internal/app-prefetch-fetch-queue.ts
@@ -1,0 +1,81 @@
+"use client";
+
+const APP_PREFETCH_FETCH_SLOT_RELEASE_KEY = Symbol.for("vinext.appPrefetchFetchSlotRelease");
+
+const MAX_DEFAULT_APP_PREFETCH_REQUESTS = 4;
+const defaultAppPrefetchQueue: Array<() => void> = [];
+let activeDefaultAppPrefetchRequests = 0;
+let defaultAppPrefetchDrainScheduled = false;
+
+function drainDefaultAppPrefetchQueue(): void {
+  defaultAppPrefetchDrainScheduled = false;
+  while (activeDefaultAppPrefetchRequests < MAX_DEFAULT_APP_PREFETCH_REQUESTS) {
+    const run = defaultAppPrefetchQueue.shift();
+    if (!run) return;
+    activeDefaultAppPrefetchRequests += 1;
+    run();
+  }
+}
+
+function scheduleDefaultAppPrefetchDrain(): void {
+  if (defaultAppPrefetchDrainScheduled) return;
+  defaultAppPrefetchDrainScheduled = true;
+  queueMicrotask(drainDefaultAppPrefetchQueue);
+}
+
+export function releaseAppPrefetchFetchSlot(response: Response): void {
+  const release = (response as Response & Record<symbol, (() => void) | undefined>)[
+    APP_PREFETCH_FETCH_SLOT_RELEASE_KEY
+  ];
+  if (release === undefined) return;
+
+  (response as Response & Record<symbol, (() => void) | undefined>)[
+    APP_PREFETCH_FETCH_SLOT_RELEASE_KEY
+  ] = undefined;
+  release();
+}
+
+/**
+ * Low-priority App Router prefetches share a small request queue. The consumer
+ * must either snapshot the returned Response with snapshotRscResponse() or call
+ * releaseAppPrefetchFetchSlot() when it drops the response without consuming it.
+ */
+export function scheduleAppPrefetchFetch(
+  fetcher: () => Promise<Response>,
+  priority: "low" | "high",
+): Promise<Response> {
+  if (priority === "high") {
+    return fetcher();
+  }
+
+  return new Promise<Response>((resolve, reject) => {
+    defaultAppPrefetchQueue.push(() => {
+      let didRelease = false;
+      const release = () => {
+        if (didRelease) return;
+        didRelease = true;
+        activeDefaultAppPrefetchRequests -= 1;
+        drainDefaultAppPrefetchQueue();
+      };
+
+      try {
+        fetcher().then(
+          (response) => {
+            (response as Response & Record<symbol, (() => void) | undefined>)[
+              APP_PREFETCH_FETCH_SLOT_RELEASE_KEY
+            ] = release;
+            resolve(response);
+          },
+          (error: unknown) => {
+            release();
+            reject(error);
+          },
+        );
+      } catch (error) {
+        release();
+        reject(error);
+      }
+    });
+    scheduleDefaultAppPrefetchDrain();
+  });
+}

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -437,7 +437,7 @@ function prefetchUrl(
   }
 
   const schedule =
-    priority === "high"
+    priority === "high" || hasAppNavigationRuntime()
       ? (fn: () => void) => {
           fn();
         }
@@ -473,7 +473,11 @@ function prefetchUrl(
           PREFETCH_CACHE_TTL,
         } = navigation;
         const { createRscRequestHeaders, createRscRequestUrl } = rscCacheBusting;
-        const { NEXT_ROUTER_PREFETCH_HEADER, VINEXT_MOUNTED_SLOTS_HEADER } = headersModule;
+        const {
+          NEXT_ROUTER_PREFETCH_HEADER,
+          NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
+          VINEXT_MOUNTED_SLOTS_HEADER,
+        } = headersModule;
         // Hybrid ownership: skip the App RSC prefetch when Pages owns the
         // URL. The App's `__VINEXT_LINK_PREFETCH_ROUTES__` may include an
         // App catch-all that also matches the same path, so a naive
@@ -506,8 +510,10 @@ function prefetchUrl(
         if (mountedSlotsHeader) {
           headers.set(VINEXT_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
         }
-        if (isOptimisticRouteShellPrefetch) {
+        const shouldSendSegmentPrefetchHeaders = isOptimisticRouteShellPrefetch || mode === "auto";
+        if (shouldSendSegmentPrefetchHeaders) {
           headers.set(NEXT_ROUTER_PREFETCH_HEADER, "1");
+          headers.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "1");
         }
         // Distinguish the same visible URL when it is prefetched from different
         // request contexts such as /feed vs /gallery or different mounted slots.
@@ -549,6 +555,7 @@ function prefetchUrl(
                   renderMode: APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
                 });
                 shellHeaders.set(NEXT_ROUTER_PREFETCH_HEADER, "1");
+                shellHeaders.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "1");
                 if (mountedSlotsHeader) {
                   shellHeaders.set(VINEXT_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
                 }
@@ -563,14 +570,16 @@ function prefetchUrl(
                   getPrefetchedUrls().add(shellCacheKey);
                   prefetchRscResponse(
                     shellRscUrl,
-                    Promise.resolve().then(() =>
-                      fetch(shellRscUrl, {
-                        headers: shellHeaders,
-                        credentials: "include",
-                        priority,
-                        // @ts-expect-error — purpose is a valid fetch option in some browsers
-                        purpose: "prefetch",
-                      }),
+                    scheduleAppPrefetchFetch(
+                      () =>
+                        fetch(shellRscUrl, {
+                          headers: shellHeaders,
+                          credentials: "include",
+                          priority,
+                          // @ts-expect-error — purpose is a valid fetch option in some browsers
+                          purpose: "prefetch",
+                        }),
+                      priority,
                     ),
                     interceptionContext,
                     mountedSlotsHeader,
@@ -583,21 +592,29 @@ function prefetchUrl(
                   shellEntry = shellCache.get(shellCacheKey);
                 }
                 await shellEntry?.pending?.catch(() => {});
-                return fetch(rscUrl, {
-                  headers,
-                  credentials: "include",
+                return scheduleAppPrefetchFetch(
+                  () =>
+                    fetch(rscUrl, {
+                      headers,
+                      credentials: "include",
+                      priority,
+                      // @ts-expect-error — purpose is a valid fetch option in some browsers
+                      purpose: "prefetch",
+                    }),
                   priority,
-                  // @ts-expect-error — purpose is a valid fetch option in some browsers
-                  purpose: "prefetch",
-                });
+                );
               })()
-            : fetch(rscUrl, {
-                headers,
-                credentials: "include",
+            : scheduleAppPrefetchFetch(
+                () =>
+                  fetch(rscUrl, {
+                    headers,
+                    credentials: "include",
+                    priority,
+                    // @ts-expect-error — purpose is a valid fetch option in some browsers
+                    purpose: "prefetch",
+                  }),
                 priority,
-                // @ts-expect-error — purpose is a valid fetch option in some browsers
-                purpose: "prefetch",
-              });
+              );
         prefetchRscResponse(
           rscUrl,
           fetchPromise,
@@ -696,19 +713,88 @@ type LinkPrefetchInstance = {
   isVisible: boolean;
   mode: LinkPrefetchMode;
   pagesRouteHref?: string;
+  queuedViewportPrefetch: boolean;
   routerMode: LinkPrefetchRouterMode;
   viewportPrefetched: boolean;
 };
 
 const observedLinkPrefetches = new WeakMap<Element, LinkPrefetchInstance>();
 const visibleLinkPrefetches = new Set<LinkPrefetchInstance>();
+const visibleAppPrefetchQueue: LinkPrefetchInstance[] = [];
+let visibleAppPrefetchDrainScheduled = false;
+
+const MAX_DEFAULT_APP_PREFETCH_REQUESTS = 4;
+const defaultAppPrefetchQueue: Array<() => void> = [];
+let activeDefaultAppPrefetchRequests = 0;
+let defaultAppPrefetchDrainScheduled = false;
+
+function drainDefaultAppPrefetchQueue(): void {
+  defaultAppPrefetchDrainScheduled = false;
+  while (activeDefaultAppPrefetchRequests < MAX_DEFAULT_APP_PREFETCH_REQUESTS) {
+    const run = defaultAppPrefetchQueue.pop();
+    if (!run) return;
+    activeDefaultAppPrefetchRequests += 1;
+    run();
+  }
+}
+
+function scheduleDefaultAppPrefetchDrain(): void {
+  if (defaultAppPrefetchDrainScheduled) return;
+  defaultAppPrefetchDrainScheduled = true;
+  queueMicrotask(drainDefaultAppPrefetchQueue);
+}
+
+function scheduleAppPrefetchFetch(
+  fetcher: () => Promise<Response>,
+  priority: "low" | "high",
+): Promise<Response> {
+  if (priority === "high") {
+    return fetcher();
+  }
+
+  return new Promise<Response>((resolve, reject) => {
+    defaultAppPrefetchQueue.push(() => {
+      fetcher()
+        .then(resolve, reject)
+        .finally(() => {
+          activeDefaultAppPrefetchRequests -= 1;
+          drainDefaultAppPrefetchQueue();
+        });
+    });
+    scheduleDefaultAppPrefetchDrain();
+  });
+}
+
+function drainVisibleAppPrefetchQueue(): void {
+  visibleAppPrefetchDrainScheduled = false;
+  while (true) {
+    const instance = visibleAppPrefetchQueue.pop();
+    if (!instance) return;
+    instance.queuedViewportPrefetch = false;
+    if (!instance.isVisible || instance.routerMode !== "app") continue;
+    prefetchUrl(instance.href, instance.mode, "low", instance.pagesRouteHref);
+  }
+}
+
+function scheduleVisibleAppPrefetch(instance: LinkPrefetchInstance): void {
+  if (instance.queuedViewportPrefetch) return;
+  instance.queuedViewportPrefetch = true;
+  visibleAppPrefetchQueue.push(instance);
+  if (visibleAppPrefetchDrainScheduled) return;
+  visibleAppPrefetchDrainScheduled = true;
+  queueMicrotask(drainVisibleAppPrefetchQueue);
+}
 
 function setVisibleLinkPrefetch(instance: LinkPrefetchInstance, isVisible: boolean): void {
   instance.isVisible = isVisible;
   if (isVisible) {
     visibleLinkPrefetches.add(instance);
     if (instance.routerMode === "pages" && instance.viewportPrefetched) return;
-    prefetchUrl(instance.href, instance.mode, "low", instance.pagesRouteHref);
+    if (instance.routerMode === "app") {
+      scheduleVisibleAppPrefetch(instance);
+    } else {
+      prefetchUrl(instance.href, instance.mode, "low", instance.pagesRouteHref);
+    }
     instance.viewportPrefetched = true;
   } else {
     visibleLinkPrefetches.delete(instance);
@@ -723,7 +809,7 @@ function registerVisibleLinkPing(): void {
 function pingVisibleLinkPrefetches(): void {
   for (const instance of visibleLinkPrefetches) {
     if (instance.isVisible && instance.routerMode === "app") {
-      prefetchUrl(instance.href, instance.mode, "low", instance.pagesRouteHref);
+      scheduleVisibleAppPrefetch(instance);
     }
   }
 }
@@ -1039,6 +1125,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
               basePath: __basePath,
               currentOrigin: window.location.origin,
             }) ?? undefined),
+      queuedViewportPrefetch: false,
       routerMode: getLinkPrefetchRouterMode(),
       viewportPrefetched: false,
     };
@@ -1049,6 +1136,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
       observer.unobserve(node);
       observedLinkPrefetches.delete(node);
       visibleLinkPrefetches.delete(instance);
+      instance.isVisible = false;
     };
   }, [shouldViewportPrefetch, prefetchMode, normalizedHref, normalizedRouteHref]);
 

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -64,6 +64,7 @@ import {
   type PendingLinkSetter,
 } from "./internal/link-status-registry.js";
 import { getCurrentRoutePathnameForWarning } from "./internal/route-pattern-for-warning.js";
+import { scheduleAppPrefetchFetch } from "./internal/app-prefetch-fetch-queue.js";
 
 type NavigateEvent = {
   url: URL;
@@ -722,48 +723,6 @@ const observedLinkPrefetches = new WeakMap<Element, LinkPrefetchInstance>();
 const visibleLinkPrefetches = new Set<LinkPrefetchInstance>();
 const visibleAppPrefetchQueue: LinkPrefetchInstance[] = [];
 let visibleAppPrefetchDrainScheduled = false;
-
-const MAX_DEFAULT_APP_PREFETCH_REQUESTS = 4;
-const defaultAppPrefetchQueue: Array<() => void> = [];
-let activeDefaultAppPrefetchRequests = 0;
-let defaultAppPrefetchDrainScheduled = false;
-
-function drainDefaultAppPrefetchQueue(): void {
-  defaultAppPrefetchDrainScheduled = false;
-  while (activeDefaultAppPrefetchRequests < MAX_DEFAULT_APP_PREFETCH_REQUESTS) {
-    const run = defaultAppPrefetchQueue.pop();
-    if (!run) return;
-    activeDefaultAppPrefetchRequests += 1;
-    run();
-  }
-}
-
-function scheduleDefaultAppPrefetchDrain(): void {
-  if (defaultAppPrefetchDrainScheduled) return;
-  defaultAppPrefetchDrainScheduled = true;
-  queueMicrotask(drainDefaultAppPrefetchQueue);
-}
-
-function scheduleAppPrefetchFetch(
-  fetcher: () => Promise<Response>,
-  priority: "low" | "high",
-): Promise<Response> {
-  if (priority === "high") {
-    return fetcher();
-  }
-
-  return new Promise<Response>((resolve, reject) => {
-    defaultAppPrefetchQueue.push(() => {
-      fetcher()
-        .then(resolve, reject)
-        .finally(() => {
-          activeDefaultAppPrefetchRequests -= 1;
-          drainDefaultAppPrefetchQueue();
-        });
-    });
-    scheduleDefaultAppPrefetchDrain();
-  });
-}
 
 function drainVisibleAppPrefetchQueue(): void {
   visibleAppPrefetchDrainScheduled = false;

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -73,6 +73,10 @@ import {
   registerServerInsertedHTMLCallback,
   type NavigationContext,
 } from "./navigation-context-state.js";
+import {
+  releaseAppPrefetchFetchSlot,
+  scheduleAppPrefetchFetch,
+} from "./internal/app-prefetch-fetch-queue.js";
 
 export {
   type NavigationContext,
@@ -499,12 +503,26 @@ function getPrefetchCacheEntrySize(entry: PrefetchCacheEntry): number {
   return entry.snapshot?.buffer.byteLength ?? entry.size ?? 0;
 }
 
+let trackedPrefetchCache: Map<string, PrefetchCacheEntry> | null = null;
+let trackedPrefetchCacheByteSize = 0;
+
 function getPrefetchCacheByteSize(cache: Map<string, PrefetchCacheEntry>): number {
+  if (trackedPrefetchCache === cache) {
+    return trackedPrefetchCacheByteSize;
+  }
+
   let total = 0;
   for (const entry of cache.values()) {
     total += getPrefetchCacheEntrySize(entry);
   }
+  trackedPrefetchCache = cache;
+  trackedPrefetchCacheByteSize = total;
   return total;
+}
+
+function adjustPrefetchCacheByteSize(cache: Map<string, PrefetchCacheEntry>, delta: number): void {
+  if (trackedPrefetchCache !== cache) return;
+  trackedPrefetchCacheByteSize = Math.max(0, trackedPrefetchCacheByteSize + delta);
 }
 
 function touchPrefetchCacheEntry(
@@ -519,10 +537,14 @@ function touchPrefetchCacheEntry(
 
 /**
  * Evict prefetch cache entries if buffered payloads exceed the byte budget.
- * First sweeps expired entries, then evicts least-recently-used entries.
+ * Sweeps expired entries only after the cheap byte-budget check says cleanup is
+ * needed, then evicts least-recently-used entries down to the target size.
  */
 function evictPrefetchCacheIfNeeded(): void {
   const cache = getPrefetchCache();
+  let totalSize = getPrefetchCacheByteSize(cache);
+  if (totalSize <= MAX_PREFETCH_CACHE_SIZE) return;
+
   const now = Date.now();
   const prefetched = getPrefetchedUrls();
 
@@ -532,19 +554,28 @@ function evictPrefetchCacheIfNeeded(): void {
     }
   }
 
-  let totalSize = getPrefetchCacheByteSize(cache);
+  totalSize = getPrefetchCacheByteSize(cache);
   if (totalSize <= MAX_PREFETCH_CACHE_SIZE) return;
 
-  while (totalSize > PREFETCH_CACHE_EVICTION_TARGET_SIZE) {
+  let inspectedEntries = 0;
+  while (totalSize > PREFETCH_CACHE_EVICTION_TARGET_SIZE && inspectedEntries < cache.size) {
     const oldest = cache.keys().next().value;
     if (oldest !== undefined) {
       const entry = cache.get(oldest);
       if (entry) {
-        totalSize -= getPrefetchCacheEntrySize(entry);
+        const entrySize = getPrefetchCacheEntrySize(entry);
+        if (entry.pending !== undefined && entrySize === 0) {
+          touchPrefetchCacheEntry(cache, oldest, entry);
+          inspectedEntries += 1;
+          continue;
+        }
+        totalSize -= entrySize;
         deletePrefetchCacheEntry(cache, prefetched, oldest, entry, true);
+        inspectedEntries = 0;
       } else {
         cache.delete(oldest);
         prefetched.delete(oldest);
+        inspectedEntries += 1;
       }
     } else {
       break;
@@ -585,6 +616,7 @@ function deletePrefetchCacheEntry(
   entry: PrefetchCacheEntry,
   notify: boolean,
 ): void {
+  adjustPrefetchCacheByteSize(cache, -getPrefetchCacheEntrySize(entry));
   cache.delete(cacheKey);
   prefetched.delete(cacheKey);
   if (notify) {
@@ -672,6 +704,7 @@ export function seedPrefetchResponseSnapshot(
     timestamp,
   };
   cache.set(cacheKey, entry);
+  adjustPrefetchCacheByteSize(cache, snapshot.buffer.byteLength);
   getPrefetchedUrls().add(cacheKey);
   schedulePrefetchInvalidation(cacheKey, entry);
   evictPrefetchCacheIfNeeded();
@@ -712,6 +745,12 @@ export function storePrefetchResponse(
   options?: PrefetchOptions,
 ): void {
   const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
+  const cache = getPrefetchCache();
+  const prefetched = getPrefetchedUrls();
+  const existing = cache.get(cacheKey);
+  if (existing) {
+    deletePrefetchCacheEntry(cache, prefetched, cacheKey, existing, false);
+  }
   const entry: PrefetchCacheEntry = {
     mountedSlotsHeader: null,
     outcome: "pending",
@@ -720,10 +759,12 @@ export function storePrefetchResponse(
   addPrefetchInvalidationCallback(entry, options?.onInvalidate);
   entry.pending = snapshotRscResponse(response)
     .then((snapshot) => {
-      if (getPrefetchCache().get(cacheKey) !== entry) return;
+      if (cache.get(cacheKey) !== entry) return;
+      const previousSize = getPrefetchCacheEntrySize(entry);
       entry.mountedSlotsHeader = snapshot.mountedSlotsHeader ?? null;
       entry.snapshot = snapshot;
       entry.size = snapshot.buffer.byteLength;
+      adjustPrefetchCacheByteSize(cache, entry.size - previousSize);
       entry.expiresAt = resolveCachedRscResponseExpiresAt(
         entry.timestamp,
         snapshot,
@@ -732,17 +773,17 @@ export function storePrefetchResponse(
       evictPrefetchCacheIfNeeded();
     })
     .catch(() => {
-      deletePrefetchCacheEntry(getPrefetchCache(), getPrefetchedUrls(), cacheKey, entry, false);
+      deletePrefetchCacheEntry(cache, prefetched, cacheKey, entry, false);
     })
     .finally(() => {
-      if (getPrefetchCache().get(cacheKey) !== entry) return;
+      if (cache.get(cacheKey) !== entry) return;
       entry.pending = undefined;
       if (entry.snapshot) {
         entry.outcome = "cache-seeded";
         schedulePrefetchInvalidation(cacheKey, entry);
       }
     });
-  getPrefetchCache().set(cacheKey, entry);
+  cache.set(cacheKey, entry);
 }
 
 export function createCachedRscResponseSnapshot(
@@ -769,7 +810,11 @@ export function createCachedRscResponseSnapshot(
  * Consumes the response body and stores it with content-type and URL metadata.
  */
 export async function snapshotRscResponse(response: Response): Promise<CachedRscResponse> {
-  return createCachedRscResponseSnapshot(response, await response.arrayBuffer());
+  try {
+    return createCachedRscResponseSnapshot(response, await response.arrayBuffer());
+  } finally {
+    releaseAppPrefetchFetchSlot(response);
+  }
 }
 
 /**
@@ -831,6 +876,10 @@ export function prefetchRscResponse(
   const cache = getPrefetchCache();
   const prefetched = getPrefetchedUrls();
   const now = Date.now();
+  const existing = cache.get(cacheKey);
+  if (existing) {
+    deletePrefetchCacheEntry(cache, prefetched, cacheKey, existing, false);
+  }
 
   const entry: PrefetchCacheEntry = {
     cacheForNavigation: behavior.cacheForNavigation ?? true,
@@ -846,8 +895,10 @@ export function prefetchRscResponse(
       if (response.ok) {
         const snapshot = await snapshotRscResponse(response);
         if (cache.get(cacheKey) !== entry) return;
+        const previousSize = getPrefetchCacheEntrySize(entry);
         entry.snapshot = snapshot;
         entry.size = snapshot.buffer.byteLength;
+        adjustPrefetchCacheByteSize(cache, entry.size - previousSize);
         entry.expiresAt = resolvePrefetchedRscResponseExpiresAt(
           entry.timestamp,
           entry.snapshot,
@@ -855,6 +906,7 @@ export function prefetchRscResponse(
         );
         evictPrefetchCacheIfNeeded();
       } else {
+        releaseAppPrefetchFetchSlot(response);
         deletePrefetchCacheEntry(cache, prefetched, cacheKey, entry, false);
       }
     })
@@ -2015,11 +2067,15 @@ const _appRouter: AppRouterInstance = {
       prefetched.add(cacheKey);
       prefetchRscResponse(
         rscUrl,
-        fetch(rscUrl, {
-          headers,
-          credentials: "include",
-          priority: "low" as RequestInit["priority"],
-        }),
+        scheduleAppPrefetchFetch(
+          () =>
+            fetch(rscUrl, {
+              headers,
+              credentials: "include",
+              priority: "low" as RequestInit["priority"],
+            }),
+          "low",
+        ),
         interceptionContext,
         mountedSlotsHeader,
         options,

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -197,8 +197,9 @@ export const __basePath: string = process.env.__NEXT_ROUTER_BASEPATH ?? "";
 // RSC prefetch cache utilities (shared between link.tsx and browser entry)
 // ---------------------------------------------------------------------------
 
-/** Maximum number of entries in the RSC prefetch cache. */
-export const MAX_PREFETCH_CACHE_SIZE = 50;
+/** Maximum buffered bytes in the RSC prefetch cache. Mirrors Next.js' 50 MB LRU. */
+export const MAX_PREFETCH_CACHE_SIZE = 50 * 1024 * 1024;
+const PREFETCH_CACHE_EVICTION_TARGET_SIZE = MAX_PREFETCH_CACHE_SIZE * 0.9;
 
 /**
  * TTL for prefetch cache entries in ms.
@@ -258,6 +259,7 @@ export type PrefetchCacheEntry = {
   outcome: "pending" | "cache-seeded";
   snapshot?: CachedRscResponse;
   pending?: Promise<void>;
+  size?: number;
   timestamp: number;
 };
 
@@ -474,8 +476,14 @@ export function hasPrefetchCacheEntryForNavigation(
   );
   if (match === null) return false;
 
-  if (match.entry.pending !== undefined) return true;
-  if (resolvePrefetchCacheEntryExpiresAt(match.entry) > Date.now()) return true;
+  if (match.entry.pending !== undefined) {
+    touchPrefetchCacheEntry(getPrefetchCache(), match.cacheKey, match.entry);
+    return true;
+  }
+  if (resolvePrefetchCacheEntryExpiresAt(match.entry) > Date.now()) {
+    touchPrefetchCacheEntry(getPrefetchCache(), match.cacheKey, match.entry);
+    return true;
+  }
 
   deletePrefetchCacheEntry(
     getPrefetchCache(),
@@ -487,14 +495,34 @@ export function hasPrefetchCacheEntryForNavigation(
   return false;
 }
 
+function getPrefetchCacheEntrySize(entry: PrefetchCacheEntry): number {
+  return entry.snapshot?.buffer.byteLength ?? entry.size ?? 0;
+}
+
+function getPrefetchCacheByteSize(cache: Map<string, PrefetchCacheEntry>): number {
+  let total = 0;
+  for (const entry of cache.values()) {
+    total += getPrefetchCacheEntrySize(entry);
+  }
+  return total;
+}
+
+function touchPrefetchCacheEntry(
+  cache: Map<string, PrefetchCacheEntry>,
+  cacheKey: string,
+  entry: PrefetchCacheEntry,
+): void {
+  if (cache.get(cacheKey) !== entry) return;
+  cache.delete(cacheKey);
+  cache.set(cacheKey, entry);
+}
+
 /**
- * Evict prefetch cache entries if at capacity.
- * First sweeps expired entries, then falls back to FIFO eviction.
+ * Evict prefetch cache entries if buffered payloads exceed the byte budget.
+ * First sweeps expired entries, then evicts least-recently-used entries.
  */
 function evictPrefetchCacheIfNeeded(): void {
   const cache = getPrefetchCache();
-  if (cache.size < MAX_PREFETCH_CACHE_SIZE) return;
-
   const now = Date.now();
   const prefetched = getPrefetchedUrls();
 
@@ -504,11 +532,15 @@ function evictPrefetchCacheIfNeeded(): void {
     }
   }
 
-  while (cache.size >= MAX_PREFETCH_CACHE_SIZE) {
+  let totalSize = getPrefetchCacheByteSize(cache);
+  if (totalSize <= MAX_PREFETCH_CACHE_SIZE) return;
+
+  while (totalSize > PREFETCH_CACHE_EVICTION_TARGET_SIZE) {
     const oldest = cache.keys().next().value;
     if (oldest !== undefined) {
       const entry = cache.get(oldest);
       if (entry) {
+        totalSize -= getPrefetchCacheEntrySize(entry);
         deletePrefetchCacheEntry(cache, prefetched, oldest, entry, true);
       } else {
         cache.delete(oldest);
@@ -629,19 +661,20 @@ export function seedPrefetchResponseSnapshot(
   if (existing) {
     deletePrefetchCacheEntry(cache, getPrefetchedUrls(), cacheKey, existing, false);
   }
-  evictPrefetchCacheIfNeeded();
   const timestamp = Date.now();
   const entry: PrefetchCacheEntry = {
     cacheForNavigation: true,
     expiresAt: resolveCachedRscResponseExpiresAt(timestamp, snapshot, fallbackTtlMs),
     mountedSlotsHeader,
     outcome: "cache-seeded",
+    size: snapshot.buffer.byteLength,
     snapshot,
     timestamp,
   };
   cache.set(cacheKey, entry);
   getPrefetchedUrls().add(cacheKey);
   schedulePrefetchInvalidation(cacheKey, entry);
+  evictPrefetchCacheIfNeeded();
 }
 
 export function deletePrefetchResponseSnapshot(
@@ -679,7 +712,6 @@ export function storePrefetchResponse(
   options?: PrefetchOptions,
 ): void {
   const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
-  evictPrefetchCacheIfNeeded();
   const entry: PrefetchCacheEntry = {
     mountedSlotsHeader: null,
     outcome: "pending",
@@ -688,18 +720,22 @@ export function storePrefetchResponse(
   addPrefetchInvalidationCallback(entry, options?.onInvalidate);
   entry.pending = snapshotRscResponse(response)
     .then((snapshot) => {
+      if (getPrefetchCache().get(cacheKey) !== entry) return;
       entry.mountedSlotsHeader = snapshot.mountedSlotsHeader ?? null;
       entry.snapshot = snapshot;
+      entry.size = snapshot.buffer.byteLength;
       entry.expiresAt = resolveCachedRscResponseExpiresAt(
         entry.timestamp,
         snapshot,
         PREFETCH_CACHE_TTL,
       );
+      evictPrefetchCacheIfNeeded();
     })
     .catch(() => {
       deletePrefetchCacheEntry(getPrefetchCache(), getPrefetchedUrls(), cacheKey, entry, false);
     })
     .finally(() => {
+      if (getPrefetchCache().get(cacheKey) !== entry) return;
       entry.pending = undefined;
       if (entry.snapshot) {
         entry.outcome = "cache-seeded";
@@ -808,12 +844,16 @@ export function prefetchRscResponse(
   entry.pending = fetchPromise
     .then(async (response) => {
       if (response.ok) {
-        entry.snapshot = await snapshotRscResponse(response);
+        const snapshot = await snapshotRscResponse(response);
+        if (cache.get(cacheKey) !== entry) return;
+        entry.snapshot = snapshot;
+        entry.size = snapshot.buffer.byteLength;
         entry.expiresAt = resolvePrefetchedRscResponseExpiresAt(
           entry.timestamp,
           entry.snapshot,
           behavior.fallbackTtlMs ?? PREFETCH_CACHE_TTL,
         );
+        evictPrefetchCacheIfNeeded();
       } else {
         deletePrefetchCacheEntry(cache, prefetched, cacheKey, entry, false);
       }
@@ -822,6 +862,7 @@ export function prefetchRscResponse(
       deletePrefetchCacheEntry(cache, prefetched, cacheKey, entry, false);
     })
     .finally(() => {
+      if (cache.get(cacheKey) !== entry) return;
       entry.pending = undefined;
       if (entry.snapshot) {
         entry.outcome = "cache-seeded";

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -11,6 +11,7 @@ import {
 import { APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL } from "../packages/vinext/src/server/app-rsc-render-mode.js";
 import {
   NEXT_ROUTER_PREFETCH_HEADER,
+  NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
   VINEXT_RSC_RENDER_MODE_HEADER,
 } from "../packages/vinext/src/server/headers.js";
 import type { VinextLinkPrefetchRoute } from "../packages/vinext/src/client/vinext-next-data.js";
@@ -180,9 +181,12 @@ function mockReactAnchorCaptureForLinkOnly_DO_NOT_REUSE(
 async function flushPrefetchTasks(): Promise<void> {
   // requestIdleCallback is mocked as sync, then prefetchUrl enters an async
   // IIFE that may resolve lazy runtime modules before hashing headers and
-  // writing caches. Dynamic imports can cross a macrotask boundary, so drain
-  // one event-loop turn rather than relying on a fixed microtask depth.
-  await new Promise((resolve) => setTimeout(resolve, 0));
+  // writing caches. Low-priority App Router fetches then drain from a
+  // microtask-backed queue, so drain a few event-loop turns rather than
+  // relying on a fixed microtask depth.
+  for (let i = 0; i < 3; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
 }
 
 async function waitForFetchCalls(
@@ -1547,10 +1551,41 @@ describe("Link prefetch scheduling", () => {
       expect((fetchInit?.headers as Headers | undefined)?.get(NEXT_ROUTER_PREFETCH_HEADER)).toBe(
         "1",
       );
+      expect(
+        (fetchInit?.headers as Headers | undefined)?.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER),
+      ).toBe("1");
       const { getPrefetchCache } = await import("../packages/vinext/src/shims/navigation.js");
       const entry = Array.from(getPrefetchCache().values())[0];
       expect(entry?.cacheForNavigation).toBe(false);
       expect(entry?.optimisticRouteShell).toBe(true);
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("starts App Router viewport prefetches without waiting for browser idle", async () => {
+    const observer = stubIntersectionObserver();
+    const requestIdleCallback = vi.fn();
+
+    const result = await renderIsolatedLink({
+      href: "/viewport-prefetch-target",
+      nodeEnv: "production",
+      windowOverrides: { requestIdleCallback },
+    });
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+
+      expect(requestIdleCallback).not.toHaveBeenCalled();
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[0],
+        "/viewport-prefetch-target",
+        expect.objectContaining({
+          credentials: "include",
+          priority: "low",
+        }),
+      );
     } finally {
       result.restoreNodeEnv();
     }

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -178,28 +178,31 @@ function mockReactAnchorCaptureForLinkOnly_DO_NOT_REUSE(
   });
 }
 
-async function flushPrefetchTasks(): Promise<void> {
+async function flushPrefetchTasks(until?: () => boolean): Promise<void> {
   // requestIdleCallback is mocked as sync, then prefetchUrl enters an async
   // IIFE that may resolve lazy runtime modules before hashing headers and
   // writing caches. Low-priority App Router fetches then drain from a
-  // microtask-backed queue, so drain a few event-loop turns rather than
-  // relying on a fixed microtask depth.
-  for (let i = 0; i < 3; i++) {
+  // microtask-backed queue. Without an explicit condition, settle dynamic
+  // imports first, then yield one event-loop turn for the queue drain.
+  if (until === undefined) {
+    await vi.dynamicImportSettled();
     await new Promise((resolve) => setTimeout(resolve, 0));
+    await vi.dynamicImportSettled();
+    return;
   }
+
+  const deadline = Date.now() + 1_000;
+  do {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    if (until()) return;
+  } while (Date.now() < deadline);
 }
 
 async function waitForFetchCalls(
   fetch: { mock: { calls: unknown[] } },
   expectedCalls: number,
 ): Promise<void> {
-  for (let attempt = 0; attempt < 100; attempt++) {
-    await flushPrefetchTasks();
-    if (fetch.mock.calls.length >= expectedCalls) {
-      return;
-    }
-    await new Promise((resolve) => setTimeout(resolve, 0));
-  }
+  await flushPrefetchTasks(() => fetch.mock.calls.length >= expectedCalls);
 }
 
 function expectCanonicalRscFetchCall(

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -79,13 +79,17 @@ afterEach(() => {
 });
 
 /** Helper: fill cache with `count` entries at a given timestamp. */
-function fillCache(count: number, timestamp: number, keyPrefix = "/page-"): void {
+function fillCache(
+  count: number,
+  timestamp: number,
+  keyPrefix = "/page-",
+  bytesPerEntry = 1,
+): void {
   const cache = getPrefetchCache();
   const prefetched = getPrefetchedUrls();
   for (let i = 0; i < count; i++) {
     const key = `${keyPrefix}${i}.rsc`;
-    const body = `body-${i}`;
-    const buffer = new TextEncoder().encode(body).buffer;
+    const buffer = new ArrayBuffer(bytesPerEntry);
     cache.set(key, {
       snapshot: {
         buffer,
@@ -562,80 +566,85 @@ describe("prefetch cache eviction", () => {
     expect(getPrefetchedUrls().has(rscUrl)).toBe(false);
   });
 
-  it("sweeps all expired entries before FIFO", () => {
+  it("sweeps expired entries before applying the byte LRU", () => {
     // Use fixed arbitrary values to avoid any dependency on the real wall clock
     const now = 1_000_000;
     const expired = now - PREFETCH_CACHE_TTL - 1_000; // 31s before `now`
 
-    fillCache(MAX_PREFETCH_CACHE_SIZE, expired);
-    expect(getPrefetchCache().size).toBe(MAX_PREFETCH_CACHE_SIZE);
-    expect(getPrefetchedUrls().size).toBe(MAX_PREFETCH_CACHE_SIZE);
+    fillCache(2, expired, "/expired-", MAX_PREFETCH_CACHE_SIZE / 2);
+    expect(getPrefetchCache().size).toBe(2);
+    expect(getPrefetchedUrls().size).toBe(2);
 
     vi.spyOn(Date, "now").mockReturnValue(now);
-    storePrefetchResponse("/new.rsc", new Response("new"));
+    seedPrefetchResponseSnapshot("/new.rsc", {
+      buffer: new TextEncoder().encode("new").buffer,
+      contentType: "text/x-component",
+      mountedSlotsHeader: null,
+      paramsHeader: null,
+      url: "/new.rsc",
+    });
 
     const cache = getPrefetchCache();
     expect(cache.size).toBe(1);
     expect(cache.has("/new.rsc")).toBe(true);
-    // All evicted entries should be removed from prefetched URL set
-    expect(getPrefetchedUrls().size).toBe(0);
+    // Evicted entries should be removed; the newly seeded entry remains.
+    expect(getPrefetchedUrls().size).toBe(1);
   });
 
-  it("falls back to FIFO when all entries are fresh", () => {
+  it("evicts least-recently-used prefetched payloads by buffered byte size", () => {
+    // Ported from Next.js:
+    // test/e2e/app-dir/segment-cache/memory-pressure/segment-cache-memory-pressure.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/memory-pressure/segment-cache-memory-pressure.test.ts
     // Use fixed arbitrary values to avoid any dependency on the real wall clock
     const now = 1_000_000;
 
-    fillCache(MAX_PREFETCH_CACHE_SIZE, now);
-    expect(getPrefetchCache().size).toBe(MAX_PREFETCH_CACHE_SIZE);
-    expect(getPrefetchedUrls().size).toBe(MAX_PREFETCH_CACHE_SIZE);
+    const oneMiB = 1024 * 1024;
+    fillCache(51, now, "/page-", oneMiB);
+    expect(getPrefetchCache().size).toBe(51);
+    expect(getPrefetchedUrls().size).toBe(51);
 
     vi.spyOn(Date, "now").mockReturnValue(now);
-    storePrefetchResponse("/new.rsc", new Response("new"));
+    seedPrefetchResponseSnapshot("/new.rsc", {
+      buffer: new ArrayBuffer(oneMiB),
+      contentType: "text/x-component",
+      mountedSlotsHeader: null,
+      paramsHeader: null,
+      url: "/new.rsc",
+    });
 
     const cache = getPrefetchCache();
-    // FIFO evicted one, new one added → still at capacity
-    expect(cache.size).toBe(MAX_PREFETCH_CACHE_SIZE);
+    // 52 MiB exceeds the 50 MiB limit, so cleanup trims back to 90% capacity.
+    expect(cache.size).toBe(45);
     expect(cache.has("/new.rsc")).toBe(true);
-    // First inserted entry should be evicted
     expect(cache.has("/page-0.rsc")).toBe(false);
-    // Second entry should survive
-    expect(cache.has("/page-1.rsc")).toBe(true);
-    // FIFO-evicted entry should be removed from prefetched URL set
-    expect(getPrefetchedUrls().size).toBe(MAX_PREFETCH_CACHE_SIZE - 1);
+    expect(cache.has("/page-6.rsc")).toBe(false);
+    expect(cache.has("/page-7.rsc")).toBe(true);
     expect(getPrefetchedUrls().has("/page-0.rsc")).toBe(false);
   });
 
-  it("sweeps only expired entries when cache has a mix", () => {
+  it("keeps recently touched entries during byte LRU cleanup", () => {
     // Use fixed arbitrary values to avoid any dependency on the real wall clock
     const now = 1_000_000;
-    const expired = now - PREFETCH_CACHE_TTL - 1_000;
+    const oneMiB = 1024 * 1024;
 
-    const half = Math.floor(MAX_PREFETCH_CACHE_SIZE / 2);
-    const rest = MAX_PREFETCH_CACHE_SIZE - half;
-
-    fillCache(half, expired, "/expired-");
-    fillCache(rest, now, "/fresh-");
-    expect(getPrefetchCache().size).toBe(MAX_PREFETCH_CACHE_SIZE);
-    expect(getPrefetchedUrls().size).toBe(MAX_PREFETCH_CACHE_SIZE);
+    fillCache(51, now, "/page-", oneMiB);
+    expect(getPrefetchCache().size).toBe(51);
 
     vi.spyOn(Date, "now").mockReturnValue(now);
-    storePrefetchResponse("/new.rsc", new Response("new"));
+    expect(hasPrefetchCacheEntryForNavigation("/page-1.rsc")).toBe(true);
+    seedPrefetchResponseSnapshot("/new.rsc", {
+      buffer: new ArrayBuffer(oneMiB),
+      contentType: "text/x-component",
+      mountedSlotsHeader: null,
+      paramsHeader: null,
+      url: "/new.rsc",
+    });
 
     const cache = getPrefetchCache();
-    // expired swept, fresh kept, 1 new added
-    expect(cache.size).toBe(rest + 1);
-    expect(cache.has("/new.rsc")).toBe(true);
-
-    // All expired entries should be gone
-    for (let i = 0; i < half; i++) {
-      expect(cache.has(`/expired-${i}.rsc`)).toBe(false);
-    }
-    // All fresh entries should survive
-    for (let i = 0; i < rest; i++) {
-      expect(cache.has(`/fresh-${i}.rsc`)).toBe(true);
-    }
-    // Only fresh entries remain in prefetched URL set
-    expect(getPrefetchedUrls().size).toBe(rest);
+    expect(cache.has("/page-0.rsc")).toBe(false);
+    expect(cache.has("/page-1.rsc")).toBe(true);
+    expect(getPrefetchedUrls().has("/page-0.rsc")).toBe(false);
+    expect(getPrefetchedUrls().has("/page-1.rsc")).toBe(true);
   });
 
   // Regression for issue #1490: experimental.staleTimes.static should be
@@ -884,24 +893,26 @@ describe("prefetch cache eviction", () => {
     expect(consumePrefetchResponse(rscUrl, null, snapshot.mountedSlotsHeader)).toBeNull();
   });
 
-  it("does not sweep when cache is below capacity", () => {
+  it("sweeps expired entries even when cache is below byte capacity", () => {
     // Use fixed arbitrary values to avoid any dependency on the real wall clock
     const now = 1_000_000;
     const expired = now - PREFETCH_CACHE_TTL - 1_000;
 
-    const belowCapacity = MAX_PREFETCH_CACHE_SIZE - 1;
-    fillCache(belowCapacity, expired);
+    const belowCapacity = 2;
+    fillCache(belowCapacity, expired, "/expired-small-");
 
     vi.spyOn(Date, "now").mockReturnValue(now);
-    storePrefetchResponse("/new.rsc", new Response("new"));
+    seedPrefetchResponseSnapshot("/new.rsc", {
+      buffer: new TextEncoder().encode("new").buffer,
+      contentType: "text/x-component",
+      mountedSlotsHeader: null,
+      paramsHeader: null,
+      url: "/new.rsc",
+    });
 
     const cache = getPrefetchCache();
-    // Below capacity — no eviction, all entries kept + 1 new
-    expect(cache.size).toBe(belowCapacity + 1);
-    // storePrefetchResponse only manages the prefetch cache — the caller
-    // (router.prefetch()) is responsible for adding to prefetchedUrls. So
-    // the new entry (/new.rsc) is NOT in prefetchedUrls here, and the count
-    // stays at belowCapacity (no evictions triggered).
-    expect(getPrefetchedUrls().size).toBe(belowCapacity);
+    expect(cache.size).toBe(1);
+    expect(cache.has("/new.rsc")).toBe(true);
+    expect(getPrefetchedUrls().size).toBe(1);
   });
 });

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -383,6 +383,33 @@ describe("prefetch cache eviction", () => {
     await expect(restored.text()).resolves.toBe("flight");
   });
 
+  it("releases queued App prefetch fetch slots after consuming the response body", async () => {
+    let closeBody!: () => void;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("flight"));
+        closeBody = () => controller.close();
+      },
+    });
+    const response = new Response(body, {
+      headers: { "content-type": "text/x-component" },
+    });
+    const release = vi.fn();
+    (response as Response & Record<symbol, (() => void) | undefined>)[
+      Symbol.for("vinext.appPrefetchFetchSlotRelease")
+    ] = release;
+
+    const snapshotPromise = snapshotRscResponse(response);
+    await Promise.resolve();
+    expect(release).not.toHaveBeenCalled();
+
+    closeBody();
+    await expect(
+      snapshotPromise.then((snapshot) => restoreRscResponse(snapshot).text()),
+    ).resolves.toBe("flight");
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
   it("settles router.prefetch as a consumable cache-seeded response without visible navigation", async () => {
     let resolveResponse!: (response: Response) => void;
     const fetchPromise = new Promise<Response>((resolve) => {
@@ -438,6 +465,40 @@ describe("prefetch cache eviction", () => {
     expect(getPrefetchCache().has(cacheKey)).toBe(false);
     expect(getPrefetchedUrls().has(cacheKey)).toBe(false);
     expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("limits low-priority router.prefetch requests until queued responses are snapshotted", async () => {
+    const deferredResponses: Array<{
+      resolve: (response: Response) => void;
+      promise: Promise<Response>;
+    }> = [];
+    const fetch = vi.fn(() => {
+      let resolve!: (response: Response) => void;
+      const promise = new Promise<Response>((resolveInner) => {
+        resolve = resolveInner;
+      });
+      deferredResponses.push({ promise, resolve });
+      return promise;
+    });
+    (globalThis as any).fetch = fetch;
+
+    for (let i = 0; i < 5; i++) {
+      appRouterInstance.prefetch(`/dashboard-${i}`);
+    }
+
+    await waitForPrefetchSetup(() => fetch.mock.calls.length === 4);
+    expect(fetch).toHaveBeenCalledTimes(4);
+
+    deferredResponses[0].resolve(
+      new Response("flight", { headers: { "content-type": "text/x-component" } }),
+    );
+
+    await waitForPrefetchSetup(() => fetch.mock.calls.length === 5);
+    expect(fetch).toHaveBeenCalledTimes(5);
+
+    for (const deferred of deferredResponses.slice(1)) {
+      deferred.resolve(new Response("flight", { headers: { "content-type": "text/x-component" } }));
+    }
   });
 
   it("awaits an in-flight prefetch instead of missing the navigation cache", async () => {
@@ -645,6 +706,65 @@ describe("prefetch cache eviction", () => {
     expect(cache.has("/page-1.rsc")).toBe(true);
     expect(getPrefetchedUrls().has("/page-0.rsc")).toBe(false);
     expect(getPrefetchedUrls().has("/page-1.rsc")).toBe(true);
+  });
+
+  it("skips pending prefetches when byte LRU cleanup needs to free memory", async () => {
+    const now = 1_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const pendingRscUrl = "/pending.rsc";
+    const largeRscUrl = "/large.rsc";
+    const pending = createDeferredResponse();
+
+    prefetchRscResponse(pendingRscUrl, pending.promise, null, null);
+    expect(getPrefetchCache().get(pendingRscUrl)?.outcome).toBe("pending");
+
+    seedPrefetchResponseSnapshot(largeRscUrl, {
+      buffer: new ArrayBuffer(MAX_PREFETCH_CACHE_SIZE + 1024 * 1024),
+      contentType: "text/x-component",
+      mountedSlotsHeader: null,
+      paramsHeader: null,
+      url: largeRscUrl,
+    });
+
+    expect(getPrefetchCache().get(pendingRscUrl)?.outcome).toBe("pending");
+    expect(getPrefetchCache().has(largeRscUrl)).toBe(false);
+
+    pending.resolve(new Response("flight", { headers: { "content-type": "text/x-component" } }));
+    await waitForPrefetchSetup(
+      () => getPrefetchCache().get(pendingRscUrl)?.outcome === "cache-seeded",
+    );
+  });
+
+  it("subtracts overwritten prefetch entries before applying the byte LRU", async () => {
+    const now = 1_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const largeRscUrl = "/large.rsc";
+
+    seedPrefetchResponseSnapshot(largeRscUrl, {
+      buffer: new ArrayBuffer(MAX_PREFETCH_CACHE_SIZE - 1024 * 1024),
+      contentType: "text/x-component",
+      mountedSlotsHeader: null,
+      paramsHeader: null,
+      url: largeRscUrl,
+    });
+
+    storePrefetchResponse(largeRscUrl, new Response("x"));
+    await waitForPrefetchSetup(
+      () =>
+        getPrefetchCache().get(largeRscUrl)?.outcome === "cache-seeded" &&
+        getPrefetchCache().get(largeRscUrl)?.pending === undefined,
+    );
+
+    seedPrefetchResponseSnapshot("/small.rsc", {
+      buffer: new ArrayBuffer(2 * 1024 * 1024),
+      contentType: "text/x-component",
+      mountedSlotsHeader: null,
+      paramsHeader: null,
+      url: "/small.rsc",
+    });
+
+    expect(getPrefetchCache().has(largeRscUrl)).toBe(true);
+    expect(getPrefetchCache().has("/small.rsc")).toBe(true);
   });
 
   // Regression for issue #1490: experimental.staleTimes.static should be
@@ -893,7 +1013,7 @@ describe("prefetch cache eviction", () => {
     expect(consumePrefetchResponse(rscUrl, null, snapshot.mountedSlotsHeader)).toBeNull();
   });
 
-  it("sweeps expired entries even when cache is below byte capacity", () => {
+  it("does not sweep expired entries on under-budget cache writes", () => {
     // Use fixed arbitrary values to avoid any dependency on the real wall clock
     const now = 1_000_000;
     const expired = now - PREFETCH_CACHE_TTL - 1_000;
@@ -911,8 +1031,10 @@ describe("prefetch cache eviction", () => {
     });
 
     const cache = getPrefetchCache();
-    expect(cache.size).toBe(1);
+    expect(cache.size).toBe(3);
+    expect(cache.has("/expired-small-0.rsc")).toBe(true);
+    expect(cache.has("/expired-small-1.rsc")).toBe(true);
     expect(cache.has("/new.rsc")).toBe(true);
-    expect(getPrefetchedUrls().size).toBe(1);
+    expect(getPrefetchedUrls().size).toBe(3);
   });
 });


### PR DESCRIPTION
## Summary
- bound the App Router segment prefetch cache under memory pressure
- keep low-priority prefetch queue slots occupied until RSC bodies are consumed
- add focused regression coverage for cache eviction and queue-slot release

## Validation
- vp test run tests/link-navigation.test.ts tests/prefetch-cache.test.ts
- vp check --fix packages/vinext/src/shims/link.tsx packages/vinext/src/shims/navigation.ts tests/link-navigation.test.ts tests/prefetch-cache.test.ts
- REPO="$(pwd)" NEXTJS_DIR="/Users/jamesanderson/Developer/vinext/.nextjs-ref" NEXT_TEST_CONCURRENCY=1 ./scripts/run-targeted-nextjs-e2e.sh test/e2e/app-dir/segment-cache/memory-pressure/segment-cache-memory-pressure.test.ts