### PR TITLE
fix(app-router): expose app rewrites to pages data clients

### DIFF
--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -805,6 +805,15 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     setRootParams(pickRootParams(preActionMatch.params, preActionMatch.route.rootParamNames));
   }
 
+  if (pagesDataRequest && didMiddlewareRewritePathname && preActionMatch) {
+    const headers = new Headers();
+    mergeMiddlewareResponseHeaders(headers, middlewareContext.headers);
+    headers.set("content-type", "application/json");
+    headers.set("x-nextjs-rewrite", resolvedUrl);
+    options.clearRequestContext();
+    return new Response("{}", { headers });
+  }
+
   if (!filesystemRouteEligible && isPostRequest && actionId) {
     options.clearRequestContext();
     return notFoundResponse();

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -2222,6 +2222,60 @@ describe("createAppRscHandler", () => {
     );
   });
 
+  it("exposes middleware rewrites from Pages data requests to App routes", async () => {
+    // Ported from Next.js: test/e2e/app-dir/app/index.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app/index.test.ts
+    // "rewrites should support rewrites on client-side navigation from pages to app with existing pages path"
+    const clearRequestContext = vi.fn();
+    const dispatchMatchedPage = vi.fn(async () => new Response("app"));
+    const renderPagesFallback = vi.fn(async () => new Response("pages"));
+    const handler = createHandler({
+      clearRequestContext,
+      configHeaders: [],
+      dispatchMatchedPage,
+      matchRoute: (pathname: string) =>
+        pathname === "/about"
+          ? {
+              params: {},
+              route: createPageRoute({ pattern: "/about", routeSegments: ["about"] }),
+            }
+          : null,
+      middlewareModule: {
+        default: (request: NextRequest) => {
+          if (request.nextUrl.pathname === "/exists-but-not-routed") {
+            return new Response(null, {
+              headers: {
+                "set-cookie": "probe=1; Path=/",
+                "x-test-header": "middleware",
+                "x-middleware-rewrite": new URL("/about", request.url).toString(),
+              },
+            });
+          }
+          return undefined;
+        },
+      },
+      renderPagesFallback,
+    });
+
+    const response = await handler(
+      new Request("https://example.test/docs/_next/data/build-id/exists-but-not-routed.json", {
+        headers: { "x-nextjs-data": "1" },
+      }),
+      null,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("application/json");
+    expect(response.headers.get("x-nextjs-rewrite")).toBe("/about");
+    expect(response.headers.get("x-test-header")).toBe("middleware");
+    expect(response.headers.get("set-cookie")).toBe("probe=1; Path=/");
+    expect(response.headers.get("x-middleware-rewrite")).toBeNull();
+    expect(await response.text()).toBe("{}");
+    expect(dispatchMatchedPage).not.toHaveBeenCalled();
+    expect(renderPagesFallback).not.toHaveBeenCalled();
+    expect(clearRequestContext).toHaveBeenCalled();
+  });
+
   it("uses the soft redirect protocol for URL-recognized Pages data requests", async () => {
     const handler = createHandler({
       configHeaders: [],

--- a/tests/e2e/app-router/pages-to-app-routing.spec.ts
+++ b/tests/e2e/app-router/pages-to-app-routing.spec.ts
@@ -76,4 +76,19 @@ test.describe("pages-to-app-routing: navigate from Pages Router to App Router vi
     await expect(page.locator("#app-page")).toHaveText("About");
     expect(page.url()).toContain("/exists-but-not-routed");
   });
+
+  test("clicking a static Pages link to an existing Pages path rewritten by middleware navigates to App Router", async ({
+    page,
+  }) => {
+    // Ported from Next.js: test/e2e/app-dir/app/index.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app/index.test.ts
+    // "rewrites should support rewrites on client-side navigation from pages to app with existing pages path"
+    await page.goto(`${BASE}/link-to-rewritten-path`);
+    await waitForHydration(page);
+
+    await page.click("#link-to-rewritten-path");
+    await waitForAppRouterHydration(page);
+    await expect(page.locator("#app-page")).toHaveText("About");
+    expect(page.url()).toContain("/exists-but-not-routed");
+  });
 });

--- a/tests/fixtures/app-basic/pages/link-to-rewritten-path.tsx
+++ b/tests/fixtures/app-basic/pages/link-to-rewritten-path.tsx
@@ -1,0 +1,9 @@
+import Link from "next/link";
+
+export default function LinkToRewrittenPathPage() {
+  return (
+    <Link href="/exists-but-not-routed" id="link-to-rewritten-path">
+      Exists but not routed
+    </Link>
+  );
+}


### PR DESCRIPTION
## Summary

- return the Pages client rewrite protocol when a Pages `/_next/data` request is rewritten by middleware into an App Router route
- preserve middleware response headers/cookies while stripping internal `x-middleware-*` headers
- add App Router fixture coverage for a static Pages link whose data request resolves through that rewrite path

## Validation

- `vp test run tests/app-rsc-handler.test.ts`
- `PLAYWRIGHT_PROJECT=app-router pnpm run test:e2e -- tests/e2e/app-router/pages-to-app-routing.spec.ts`
- `vp check packages/vinext/src/server/app-rsc-handler.ts tests/app-rsc-handler.test.ts tests/e2e/app-router/pages-to-app-routing.spec.ts tests/fixtures/app-basic/pages/link-to-rewritten-path.tsx`
- exact upstream wrapper: `REPO="$(pwd)" NEXTJS_DIR="/Users/jamesanderson/Developer/vinext/.nextjs-ref" NEXT_TEST_CONCURRENCY=1 ./scripts/run-targeted-nextjs-e2e.sh test/e2e/app-dir/app/index.test.ts` now passes the Pages-data rewrite navigation assertion this PR targets; the wrapper still exits non-zero for unrelated app/index failures tracked separately

## Review

- independently reviewed twice; second pass reported no findings after middleware header/cookie preservation was added
