### PR TITLE
fix(app-router): publish committed no-prefetch navigations

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -2169,7 +2169,7 @@ function bootstrapHydration(
               PREFETCH_CACHE_TTL,
               mountedSlotsHeader,
             );
-          } else if (committedState !== null && isCompleteAppPayloadMetadata(metadata)) {
+          } else if (committedState !== null) {
             const state = committedState as AppRouterState;
             const committedElements = {
               ...state.elements,
@@ -2178,6 +2178,9 @@ function bootstrapHydration(
               [AppElementsWire.keys.skippedLayoutIds]: [],
               [AppElementsWire.keys.slotBindings]: state.slotBindings,
             } satisfies AppElements;
+            const committedMetadata = AppElementsWire.readMetadata(committedElements);
+            if (!isCompleteAppPayloadMetadata(committedMetadata)) return;
+            // Complete committed payloads include parallel-slot data, so they are safe to replay.
             if (navigationCacheGeneration !== clientNavigationCacheGeneration) return;
             storeVisitedResponseSnapshot(
               rscUrl,

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -1516,25 +1516,15 @@ function bootstrapHydration(
             mountedSlotsHeader,
           );
         }
-        if (isCompleteAppPayloadMetadata(metadata)) {
-          return storeVisitedResponseSnapshot(
-            rscUrl,
-            metadata.interceptionContext,
-            snapshot,
-            initialParams,
-            fallbackTtlMs,
-            mountedSlotsHeader,
-            elements,
-          );
-        }
-        seedPrefetchResponseSnapshot(
+        return storeVisitedResponseSnapshot(
           rscUrl,
-          snapshot,
           metadata.interceptionContext,
-          mountedSlotsHeader,
+          snapshot,
+          initialParams,
           fallbackTtlMs,
+          mountedSlotsHeader,
+          elements,
         );
-        return () => deletePrefetchResponseSnapshot(rscUrl, snapshot, metadata.interceptionContext);
       });
     })
     .catch(() => {});

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -2178,9 +2178,10 @@ function bootstrapHydration(
               [AppElementsWire.keys.skippedLayoutIds]: [],
               [AppElementsWire.keys.slotBindings]: state.slotBindings,
             } satisfies AppElements;
-            const committedMetadata = AppElementsWire.readMetadata(committedElements);
-            if (!isCompleteAppPayloadMetadata(committedMetadata)) return;
-            // Complete committed payloads include parallel-slot data, so they are safe to replay.
+            // The committed router state is the post-merge tree, including named
+            // parallel-slot state. Skip-pruned wire payloads without a committed
+            // tree stay on the fallback path below and are not replayed as full
+            // visited responses.
             if (navigationCacheGeneration !== clientNavigationCacheGeneration) return;
             storeVisitedResponseSnapshot(
               rscUrl,

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -1516,6 +1516,17 @@ function bootstrapHydration(
             mountedSlotsHeader,
           );
         }
+        if (isCompleteAppPayloadMetadata(metadata)) {
+          return storeVisitedResponseSnapshot(
+            rscUrl,
+            metadata.interceptionContext,
+            snapshot,
+            initialParams,
+            fallbackTtlMs,
+            mountedSlotsHeader,
+            elements,
+          );
+        }
         seedPrefetchResponseSnapshot(
           rscUrl,
           snapshot,
@@ -2116,13 +2127,15 @@ function bootstrapHydration(
           detachedNavigationCommits ? "authoritative" : undefined,
         );
         if (renderOutcome !== "committed") return;
-        // Don't cache the response if this navigation was superseded during
-        // renderNavigationPayload's await — the elements were never dispatched.
-        if (!browserNavigationController.isCurrentNavigation(navId)) return;
         // Store the visited response only after renderNavigationPayload succeeds.
         // If we stored it before and renderNavigationPayload threw, a future
         // back/forward navigation could replay a snapshot from a navigation that
         // never actually rendered successfully.
+        //
+        // Once the payload has committed, a later navigation should not cancel
+        // publication. Next's segment cache learns from completed navigations
+        // even when the user immediately goes back; keep only the cache-generation
+        // guard below so refresh/action invalidations still win.
         try {
           const renderedElements = await rscPayload;
           if (navigationCacheGeneration !== clientNavigationCacheGeneration) return;
@@ -2166,10 +2179,7 @@ function bootstrapHydration(
               PREFETCH_CACHE_TTL,
               mountedSlotsHeader,
             );
-          } else if (
-            committedState !== null &&
-            getMountedSlotIdsHeader((committedState as AppRouterState).elements) === null
-          ) {
+          } else if (committedState !== null && isCompleteAppPayloadMetadata(metadata)) {
             const state = committedState as AppRouterState;
             const committedElements = {
               ...state.elements,

--- a/tests/e2e/app-router/nextjs-compat/client-cache.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/client-cache.spec.ts
@@ -23,6 +23,7 @@ type DelayedNavigationCachePublicationState = {
 
 type ClientCacheTestWindow = Window & {
   __VINEXT_DELAYED_NAVIGATION_CACHE_PUBLICATION__?: DelayedNavigationCachePublicationState;
+  __VINEXT_CLIENT_CACHE_TEE_COUNT__?: () => number;
   next?: {
     router?: {
       refresh(): void;
@@ -283,6 +284,7 @@ test.describe("Next.js compat: client cache", () => {
     const requests = trackRscRequests(page);
     await openHome(page);
     const initial = await navigateTo(page, "#client-cache-none", "2");
+    await expect(page.locator("#client-cache-breadcrumbs")).toHaveText('Catchall {"id":"2"}');
     await navigateHome(page);
 
     await page.evaluate(() => {
@@ -297,9 +299,31 @@ test.describe("Next.js compat: client cache", () => {
       state.releaseOldNavigationTail();
     });
 
+    await page.evaluate(() => {
+      const testWindow = window as ClientCacheTestWindow;
+      let teeCount = 0;
+      const originalTee = Reflect.get(
+        ReadableStream.prototype,
+        "tee",
+      ) as typeof ReadableStream.prototype.tee;
+      ReadableStream.prototype.tee = function (this: ReadableStream<unknown>) {
+        teeCount += 1;
+        return originalTee.call(this);
+      } as typeof ReadableStream.prototype.tee;
+      testWindow.__VINEXT_CLIENT_CACHE_TEE_COUNT__ = () => teeCount;
+    });
+
     requests.length = 0;
     expect(await navigateTo(page, "#client-cache-none", "2")).toBe(initial);
+    await expect(page.locator("#client-cache-breadcrumbs")).toHaveText('Catchall {"id":"2"}');
     expect(requestsFor(requests, `${ROOT}/2`)).toEqual([]);
+    expect(
+      await page.evaluate(() => {
+        const readTeeCount = (window as ClientCacheTestWindow).__VINEXT_CLIENT_CACHE_TEE_COUNT__;
+        if (readTeeCount === undefined) throw new Error("ReadableStream.tee counter missing");
+        return readTeeCount();
+      }),
+    ).toBe(0);
   });
 
   test("router refresh invalidates committed client cache payloads", async ({ page }) => {

--- a/tests/e2e/app-router/nextjs-compat/client-cache.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/client-cache.spec.ts
@@ -217,6 +217,91 @@ test.describe("Next.js compat: client cache", () => {
     expect(requestsFor(requests, `${ROOT}/2`)).toEqual([]);
   });
 
+  test("committed no-prefetch navigations publish cache snapshots after immediate back", async ({
+    page,
+  }) => {
+    // Ported from Next.js:
+    // test/e2e/app-dir/segment-cache/cached-navigations/cached-navigations.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/cached-navigations/cached-navigations.test.ts
+    await page.addInitScript((targetPath) => {
+      const testWindow = window as ClientCacheTestWindow;
+      const originalFetch = window.fetch.bind(window);
+      const state: DelayedNavigationCachePublicationState = {
+        releaseOldNavigationTail: null,
+      };
+      testWindow.__VINEXT_DELAYED_NAVIGATION_CACHE_PUBLICATION__ = state;
+
+      window.fetch = async (input, init) => {
+        const rawUrl =
+          typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+        const url = new URL(rawUrl, window.location.href);
+        const headers = new Headers(input instanceof Request ? input.headers : undefined);
+        if (init?.headers) {
+          new Headers(init.headers).forEach((value, key) => {
+            headers.set(key, value);
+          });
+        }
+
+        const response = await originalFetch(input, init);
+        if (
+          state.releaseOldNavigationTail !== null ||
+          url.pathname !== targetPath ||
+          !url.searchParams.has("_rsc") ||
+          headers.get("rsc") !== "1" ||
+          response.body === null
+        ) {
+          return response;
+        }
+
+        const targetBody = response.body;
+        const originalTee = targetBody.tee.bind(targetBody);
+        targetBody.tee = function () {
+          const [reactBranch, cacheBranch] = originalTee();
+          const cacheReader = cacheBranch.getReader();
+          const delayedCacheBranch = new ReadableStream<Uint8Array<ArrayBuffer>>({
+            async start(controller) {
+              while (true) {
+                const result = await cacheReader.read();
+                if (result.done) break;
+                controller.enqueue(result.value);
+              }
+              await new Promise<void>((resolve) => {
+                state.releaseOldNavigationTail = resolve;
+              });
+              controller.close();
+            },
+            cancel(reason) {
+              return cacheReader.cancel(reason);
+            },
+          });
+          return [reactBranch, delayedCacheBranch];
+        };
+        return response;
+      };
+    }, `${ROOT}/2`);
+
+    const requests = trackRscRequests(page);
+    await openHome(page);
+    const initial = await navigateTo(page, "#client-cache-none", "2");
+    await navigateHome(page);
+
+    await page.evaluate(() => {
+      const state = (window as ClientCacheTestWindow)
+        .__VINEXT_DELAYED_NAVIGATION_CACHE_PUBLICATION__;
+      if (
+        state?.releaseOldNavigationTail === null ||
+        state?.releaseOldNavigationTail === undefined
+      ) {
+        throw new Error("Old navigation tail was not delayed");
+      }
+      state.releaseOldNavigationTail();
+    });
+
+    requests.length = 0;
+    expect(await navigateTo(page, "#client-cache-none", "2")).toBe(initial);
+    expect(requestsFor(requests, `${ROOT}/2`)).toEqual([]);
+  });
+
   test("router refresh invalidates committed client cache payloads", async ({ page }) => {
     const requests = trackRscRequests(page);
     await openHome(page);


### PR DESCRIPTION
## Summary
- keep committed App Router navigation payloads eligible for visited-response publication even when the user immediately navigates back
- publish complete no-prefetch navigation snapshots into the visited-response cache instead of only seeding the Link prefetch cache
- add a Next.js-ported browser regression for the immediate-back cache publication path

## Validation
- `vp test run tests/app-visited-response-cache.test.ts tests/navigation-planner-prefetch-reuse.test.ts`
- `pnpm exec playwright test tests/e2e/app-router/nextjs-compat/client-cache.spec.ts --project=app-router-client-cache --workers=1 --retries=0`
- `vp check`
- `REPO="$(pwd)" NEXTJS_DIR="/Users/jamesanderson/Developer/vinext/.nextjs-ref" NEXT_TEST_CONCURRENCY=1 ./scripts/run-targeted-nextjs-e2e.sh test/e2e/app-dir/segment-cache/cached-navigations/cached-navigations.test.ts`

## Upstream target notes
The exact upstream target now passes `serves a fully static page without any requests on the second navigation`, which previously failed with an unexpected `/_rsc` request. Remaining assertions in that file still fail under the suite's `cacheComponents: true` / `use cache` segment staging behavior and are intentionally out of scope for this PR.
