### PR TITLE
fix(pages): normalize data routes for trailing slash middleware

### DIFF
--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -242,7 +242,7 @@ export function normalizeDataRequest(request) {
     request,
     buildId,
     vinextConfig.basePath,
-    vinextConfig.trailingSlash,
+    hasMiddleware && vinextConfig.trailingSlash,
   );
 }
 export const hasMiddleware = ${JSON.stringify(Boolean(middlewarePath))};

--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -238,7 +238,12 @@ const i18nConfig = ${i18nConfigJson};
 // to load next.config.js at runtime.
 export const buildId = ${buildIdJson};
 export function normalizeDataRequest(request) {
-  return __normalizePagesDataRequest(request, buildId);
+  return __normalizePagesDataRequest(
+    request,
+    buildId,
+    vinextConfig.basePath,
+    vinextConfig.trailingSlash,
+  );
 }
 export const hasMiddleware = ${JSON.stringify(Boolean(middlewarePath))};
 

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -4467,6 +4467,8 @@ export const loadServerActionClient = ${
                 url = pathname + qs;
               }
 
+              const capturedMiddlewarePath = middlewarePath;
+
               // Strip basePath prefix from URL for route matching.
               // All internal routing uses basePath-free paths.
               //
@@ -4533,7 +4535,7 @@ export const loadServerActionClient = ${
                   const qs = url.includes("?") ? url.slice(url.indexOf("?")) : "";
                   const pagePathname = normalizeNextDataPagePathname(
                     dataMatch.pagePathname,
-                    nextConfig?.trailingSlash,
+                    capturedMiddlewarePath !== null && nextConfig?.trailingSlash === true,
                   );
                   url = pagePathname + qs;
                   pathname = pagePathname;
@@ -4655,7 +4657,6 @@ export const loadServerActionClient = ${
               // returns a MiddlewareResult. Side-effects needed by App Router
               // hybrid mode (VINEXT_MW_CTX_HEADER) are applied here as a
               // side effect so the RSC entry sees them before rendering.
-              const capturedMiddlewarePath = middlewarePath;
               const devRunMiddlewareAdapter: PagesPipelineDeps["runMiddleware"] =
                 capturedMiddlewarePath
                   ? async (_request, _ctx, opts) => {

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -80,7 +80,11 @@ import {
 import { mergeServerExternalPackages } from "./config/server-external-packages.js";
 
 import { findMiddlewareFile, isProxyFile, runMiddleware } from "./server/middleware.js";
-import { isNextDataPathname, parseNextDataPathname } from "./server/pages-data-route.js";
+import {
+  isNextDataPathname,
+  normalizeNextDataPagePathname,
+  parseNextDataPathname,
+} from "./server/pages-data-route.js";
 import { resolvePagesI18nRequest, stripI18nLocaleForApiRoute } from "./server/pages-i18n.js";
 import {
   MIDDLEWARE_NEXT_HEADER,
@@ -4527,8 +4531,12 @@ export const loadServerActionClient = ${
                 if (dataMatch) {
                   isDataReq = true;
                   const qs = url.includes("?") ? url.slice(url.indexOf("?")) : "";
-                  url = dataMatch.pagePathname + qs;
-                  pathname = dataMatch.pagePathname;
+                  const pagePathname = normalizeNextDataPagePathname(
+                    dataMatch.pagePathname,
+                    nextConfig?.trailingSlash,
+                  );
+                  url = pagePathname + qs;
+                  pathname = pagePathname;
                   // Rewrite req.url so downstream middleware sees the page
                   // path, not the raw _next/data URL.
                   req.url = url;

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -1244,7 +1244,7 @@ export function createAppRscHandler<TRoute extends AppRscHandlerRoute>(
       : null;
     const pagesDataNormalization =
       options.renderPagesFallback && pagesDataCandidate
-        ? normalizePagesDataRequest(pagesDataCandidate, options.buildId)
+        ? normalizePagesDataRequest(pagesDataCandidate, options.buildId, "", options.trailingSlash)
         : null;
     if (pagesDataNormalization?.notFoundResponse) {
       return pagesDataNormalization.notFoundResponse;

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -1244,7 +1244,12 @@ export function createAppRscHandler<TRoute extends AppRscHandlerRoute>(
       : null;
     const pagesDataNormalization =
       options.renderPagesFallback && pagesDataCandidate
-        ? normalizePagesDataRequest(pagesDataCandidate, options.buildId, "", options.trailingSlash)
+        ? normalizePagesDataRequest(
+            pagesDataCandidate,
+            options.buildId,
+            "",
+            typeof options.runMiddleware === "function" && options.trailingSlash,
+          )
         : null;
     if (pagesDataNormalization?.notFoundResponse) {
       return pagesDataNormalization.notFoundResponse;

--- a/packages/vinext/src/server/pages-data-route.ts
+++ b/packages/vinext/src/server/pages-data-route.ts
@@ -88,6 +88,11 @@ export function parseNextDataPathname(pathname: string, buildId: string): NextDa
   return { pagePathname: `/${rest}` };
 }
 
+export function normalizeNextDataPagePathname(pagePathname: string, trailingSlash = false): string {
+  if (!trailingSlash || pagePathname === "/" || pagePathname.endsWith("/")) return pagePathname;
+  return `${pagePathname}/`;
+}
+
 /**
  * Build the JSON envelope returned by `/_next/data/<buildId>/<page>.json`.
  * Mirrors Next.js' `RenderResult(JSON.stringify(props))` path in
@@ -199,6 +204,7 @@ export function normalizePagesDataRequest(
   request: Request,
   buildId: string | null,
   basePath = "",
+  trailingSlash = false,
 ): NormalizePagesDataRequestResult {
   const reqUrl = new URL(request.url);
   const hadBasePath = !!basePath && hasBasePath(reqUrl.pathname, basePath);
@@ -222,14 +228,15 @@ export function normalizePagesDataRequest(
       notFoundResponse: buildNextDataNotFoundResponse(),
     };
   }
+  const pagePathname = normalizeNextDataPagePathname(dataMatch.pagePathname, trailingSlash);
   const normalizedUrl = new URL(reqUrl);
   normalizedUrl.pathname = hadBasePath
-    ? addBasePathToPathname(dataMatch.pagePathname, basePath)
-    : dataMatch.pagePathname;
+    ? addBasePathToPathname(pagePathname, basePath)
+    : pagePathname;
   return {
     isDataReq: true,
     request: new Request(normalizedUrl, request),
-    normalizedPathname: dataMatch.pagePathname,
+    normalizedPathname: pagePathname,
     search: reqUrl.search,
     notFoundResponse: null,
   };

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -310,7 +310,12 @@ export function createPagesPageHandler(
     const originalRequestPathAndSearch = originalRequestUrl.pathname + originalRequestUrl.search;
     let dataRequestPathname: string | null = null;
     let dataRequestSearch = "";
-    const initialDataNorm = normalizePagesDataRequest(request, buildId);
+    const initialDataNorm = normalizePagesDataRequest(
+      request,
+      buildId,
+      vinextConfig.basePath,
+      vinextConfig.trailingSlash,
+    );
 
     // Auto-detect /_next/data/... requests by inspecting the incoming URL.
     // When the worker pipeline forwards an unrewritten data URL as the `url`

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -314,7 +314,7 @@ export function createPagesPageHandler(
       request,
       buildId,
       vinextConfig.basePath,
-      vinextConfig.trailingSlash,
+      hasMiddleware && vinextConfig.trailingSlash,
     );
 
     // Auto-detect /_next/data/... requests by inspecting the incoming URL.

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -1789,7 +1789,10 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
         }
         isDataReq = true;
         const qs = url.includes("?") ? url.slice(url.indexOf("?")) : "";
-        const pagePathname = normalizeNextDataPagePathname(dataMatch.pagePathname, trailingSlash);
+        const pagePathname = normalizeNextDataPagePathname(
+          dataMatch.pagePathname,
+          hasMiddleware && trailingSlash,
+        );
         url = pagePathname + qs;
         pathname = pagePathname;
       }

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -45,6 +45,7 @@ import {
 } from "./pages-request-pipeline.js";
 import { mergeHeaders } from "./worker-utils.js";
 import {
+  normalizeNextDataPagePathname,
   isNextDataPathname,
   parseNextDataPathname,
   buildNextDataNotFoundResponse,
@@ -1788,8 +1789,9 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
         }
         isDataReq = true;
         const qs = url.includes("?") ? url.slice(url.indexOf("?")) : "";
-        url = dataMatch.pagePathname + qs;
-        pathname = dataMatch.pagePathname;
+        const pagePathname = normalizeNextDataPagePathname(dataMatch.pagePathname, trailingSlash);
+        url = pagePathname + qs;
+        pathname = pagePathname;
       }
 
       // Convert Node.js req to Web Request for the server entry

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -1061,7 +1061,7 @@ describe("Pages Router entry template", () => {
       );
 
       expect(code).toContain("export function normalizeDataRequest(request)");
-      expect(code).toContain("return __normalizePagesDataRequest(request, buildId)");
+      expect(code).toContain("vinextConfig.basePath,\n    vinextConfig.trailingSlash");
       expect(code).toContain("export const hasMiddleware = true");
       expect(code).not.toContain('request.headers.get("x-nextjs-data")');
     } finally {

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -1061,7 +1061,9 @@ describe("Pages Router entry template", () => {
       );
 
       expect(code).toContain("export function normalizeDataRequest(request)");
-      expect(code).toContain("vinextConfig.basePath,\n    vinextConfig.trailingSlash");
+      expect(code).toContain(
+        "vinextConfig.basePath,\n    hasMiddleware && vinextConfig.trailingSlash",
+      );
       expect(code).toContain("export const hasMiddleware = true");
       expect(code).not.toContain('request.headers.get("x-nextjs-data")');
     } finally {

--- a/tests/pages-data-route.test.ts
+++ b/tests/pages-data-route.test.ts
@@ -5,6 +5,7 @@ import {
   buildNextDataJsonResponse,
   buildNextDataNotFoundResponse,
   normalizePagesDataRequest,
+  normalizeNextDataPagePathname,
 } from "../packages/vinext/src/server/pages-data-route.js";
 
 // Helper mirroring vinext/html safeJsonStringify behavior for tests.
@@ -91,6 +92,22 @@ describe("pages-data-route", () => {
   });
 
   describe("normalizePagesDataRequest", () => {
+    it("applies trailingSlash to the page URL before middleware sees data requests", () => {
+      // Mirrors Next.js middleware-trailing-slash data-request coverage:
+      // test/e2e/middleware-trailing-slash/test/index.test.ts.
+      const buildId = "abc123";
+      const req = new Request(`http://localhost/_next/data/${buildId}/ssr-page.json?x=1`);
+      const result = normalizePagesDataRequest(req, buildId, "", true);
+
+      expect(result.isDataReq).toBe(true);
+      expect(result.normalizedPathname).toBe("/ssr-page/");
+      expect(result.request.url).toBe("http://localhost/ssr-page/?x=1");
+    });
+
+    it("preserves the root pathname when trailingSlash is enabled", () => {
+      expect(normalizeNextDataPagePathname("/", true)).toBe("/");
+    });
+
     it("recognizes a data URL under basePath while preserving basePath for middleware", () => {
       const buildId = "abc123";
       const req = new Request(`http://localhost/root/_next/data/${buildId}/about.json?x=1`);
@@ -101,6 +118,16 @@ describe("pages-data-route", () => {
       expect(result.search).toBe("?x=1");
       expect(result.request.url).toBe("http://localhost/root/about?x=1");
       expect(result.notFoundResponse).toBeNull();
+    });
+
+    it("applies trailingSlash after preserving basePath for middleware", () => {
+      const buildId = "abc123";
+      const req = new Request(`http://localhost/root/_next/data/${buildId}/about.json?x=1`);
+      const result = normalizePagesDataRequest(req, buildId, "/root", true);
+
+      expect(result.isDataReq).toBe(true);
+      expect(result.normalizedPathname).toBe("/about/");
+      expect(result.request.url).toBe("http://localhost/root/about/?x=1");
     });
 
     it("preserves an absolute data URL outside the configured basePath", () => {

--- a/tests/pages-page-handler.test.ts
+++ b/tests/pages-page-handler.test.ts
@@ -208,6 +208,45 @@ describe("createPagesPageHandler — _next/data", () => {
     const ct = res.headers.get("content-type");
     expect(ct).toContain("application/json");
   });
+
+  it("preserves no-middleware trailingSlash data request resolvedUrl and asPath", async () => {
+    // Next.js derives Pages data resolvedUrl/asPath from the parsed data
+    // pathname. The trailingSlash data-path adjustment is middleware-only.
+    const setSSRContext = vi.fn();
+    const routes = [
+      makeRoute(
+        "/about",
+        makePageModule({
+          getServerSideProps: async ({ resolvedUrl }: { resolvedUrl: string }) => ({
+            props: { resolvedUrl },
+          }),
+        }),
+      ),
+    ];
+    const handler = createPagesPageHandler(
+      makeOpts({
+        pageRoutes: routes,
+        setSSRContext,
+        vinextConfig: {
+          basePath: "",
+          assetPrefix: "",
+          trailingSlash: true,
+          disableOptimizedLoading: true,
+        },
+      }),
+    );
+
+    const dataUrl = "/_next/data/test-build-id/about.json?x=1";
+    const res = await handler(makeRequest(dataUrl), dataUrl, null, null, null);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { pageProps: { resolvedUrl: string } };
+    expect(body.pageProps.resolvedUrl).toBe("/about?x=1");
+
+    const context = setSSRContext.mock.calls.find((call) => call[0] !== null)?.[0] as
+      | { asPath?: string }
+      | undefined;
+    expect(context?.asPath).toBe("/about?x=1");
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- normalize Pages `/_next/data` requests back to trailing-slash page paths before middleware and route matching see them
- thread `basePath` and `trailingSlash` into Pages data normalization across generated Pages entries, worker/page handlers, prod server, and App Router Pages fallback
- add focused regression coverage for trailing-slash Pages data normalization, including basePath preservation

## Next.js parity

Next.js rebuilds `/_next/data/<buildId>/*.json` requests into page pathnames and, when middleware is present, applies `nextConfig.trailingSlash` before continuing request handling. This fixes the Pages middleware trailing-slash data-request rows from deploy-suite run `28478866791` / job `84413308650` without duplicating the rewrite-query/navigation/cache fixes already covered by sibling PRs.

## Run 28478866791 mapping

- Covered elsewhere: #2216 covers middleware rewrite query/cache/static request-shape failures; #2454 covers rewrite navigation/shallow-linking state; #2451 covers middleware-rewrites prefetch caching rows.
- This PR covers the remaining trailing-slash data-path normalization rows: `should trigger middleware for data requests`, `should add a rewrite header on data requests for rewrites`, plus the dynamic/chained rewrite rows that were failing because data requests were normalized without the configured slash.

## Validation

- `vp test run tests/pages-data-route.test.ts tests/entry-templates.test.ts` — 64 passed
- `vp check packages/vinext/src/server/pages-data-route.ts packages/vinext/src/server/pages-page-handler.ts packages/vinext/src/server/prod-server.ts packages/vinext/src/server/app-rsc-handler.ts packages/vinext/src/entries/pages-server-entry.ts packages/vinext/src/index.ts tests/pages-data-route.test.ts tests/entry-templates.test.ts` — pass
- `REPO="$(pwd)" NEXTJS_DIR="/Users/jamesanderson/Developer/vinext/.nextjs-ref" NEXT_TEST_CONCURRENCY=1 ./scripts/run-targeted-nextjs-e2e.sh test/e2e/middleware-general/test/index.test.ts` — 60 passed, 6 failed; remaining rows mapped to #2216/#2454
- `REPO="$(pwd)" NEXTJS_DIR="/Users/jamesanderson/Developer/vinext/.nextjs-ref" NEXT_TEST_CONCURRENCY=1 ./scripts/run-targeted-nextjs-e2e.sh test/e2e/middleware-general/test/node-runtime.test.ts` — 62 passed, 6 failed; remaining rows mapped to #2216/#2454
- `REPO="$(pwd)" NEXTJS_DIR="/Users/jamesanderson/Developer/vinext/.nextjs-ref" NEXT_TEST_CONCURRENCY=1 ./scripts/run-targeted-nextjs-e2e.sh test/e2e/middleware-rewrites/test/index.test.ts` — 52 passed, 4 failed, 2 skipped; remaining rows mapped to #2216/#2451/#2454
- `REPO="$(pwd)" NEXTJS_DIR="/Users/jamesanderson/Developer/vinext/.nextjs-ref" NEXT_TEST_CONCURRENCY=1 ./scripts/run-targeted-nextjs-e2e.sh test/e2e/middleware-trailing-slash/test/index.test.ts` — 20 passed, 3 failed; remaining rows mapped to #2216/#2454

Artifacts from local deploy-suite runs were cleaned after validation.
