### PR TITLE
fix(pages): align prerender functional parity

### DIFF
--- a/packages/vinext/src/client/vinext-next-data.ts
+++ b/packages/vinext/src/client/vinext-next-data.ts
@@ -43,6 +43,8 @@ export type VinextNextData = {
     hasMiddleware?: boolean;
     /** True when build-time rewrites can affect the initial Pages Router ready state. */
     hasRewrites?: boolean;
+    /** Server-resolved Pages route URL used to hydrate fallback shells behind rewrites. */
+    routeUrl?: string;
   };
 } & NEXT_DATA;
 

--- a/packages/vinext/src/entries/pages-client-entry.ts
+++ b/packages/vinext/src/entries/pages-client-entry.ts
@@ -295,9 +295,11 @@ async function hydrate() {
   window.__NEXT_HYDRATED_CB?.();
 
   if (nextData.isFallback) {
+    const currentUrl = window.location.pathname + window.location.search + window.location.hash;
+    const routeUrl = nextData.__vinext?.routeUrl;
     await Router.replace(
-      window.location.pathname + window.location.search + window.location.hash,
-      undefined,
+      routeUrl || currentUrl,
+      routeUrl ? currentUrl : undefined,
       { _h: 1, scroll: false },
     );
   }

--- a/packages/vinext/src/server/cache-control.ts
+++ b/packages/vinext/src/server/cache-control.ts
@@ -2,11 +2,23 @@ import { getCdnCacheAdapter, type CdnCacheableHeaderInput } from "vinext/shims/c
 
 export const NEVER_CACHE_CONTROL = "private, no-cache, no-store, max-age=0, must-revalidate";
 
+export const BROWSER_REVALIDATE_CACHE_CONTROL = "public, max-age=0, must-revalidate";
+
 export const STATIC_CACHE_CONTROL = "s-maxage=31536000, stale-while-revalidate";
 
 const STALE_REVALIDATE_CACHE_CONTROL = "s-maxage=0, stale-while-revalidate";
 
 export const NO_STORE_CACHE_CONTROL = "no-store, must-revalidate";
+
+const SHARED_CACHE_DIRECTIVE_RE = /(?:^|,)\s*s-maxage\s*=/i;
+
+export function shouldUseNextDeployCacheControl(): boolean {
+  return process.env.VINEXT_NEXT_DEPLOY_CACHE_CONTROL === "1";
+}
+
+function isSharedCacheControl(cacheControl: string): boolean {
+  return SHARED_CACHE_DIRECTIVE_RE.test(cacheControl);
+}
 
 /**
  * Route a cacheable response's headers through the active CDN cache adapter and
@@ -21,6 +33,11 @@ export const NO_STORE_CACHE_CONTROL = "no-store, must-revalidate";
  */
 export function applyCdnResponseHeaders(headers: Headers, input: CdnCacheableHeaderInput): void {
   headers.delete("Cache-Control");
+  if (shouldUseNextDeployCacheControl() && isSharedCacheControl(input.cacheControl)) {
+    headers.set("Cache-Control", BROWSER_REVALIDATE_CACHE_CONTROL);
+    return;
+  }
+
   const map = getCdnCacheAdapter().buildResponseHeaders(input);
   for (const [name, value] of Object.entries(map)) {
     if (value === null) {

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -82,7 +82,10 @@ import {
   loadDevAppInitialProps,
   loadPagesGetInitialProps,
 } from "./pages-get-initial-props.js";
-import { attachPagesRequestCookies } from "./pages-node-compat.js";
+import {
+  attachPagesRequestCookies,
+  getPagesPreviewDataFromCookieHeader,
+} from "./pages-node-compat.js";
 import { isBotUserAgent } from "../utils/html-limited-bots.js";
 import { isUnknownRecord } from "../utils/record.js";
 
@@ -795,6 +798,7 @@ export function createSSRHandler(
         // and `useRouter().isFallback === true`, matching Next.js render.tsx.
         let isFallbackRender = false;
         let shouldPersistFallbackData = false;
+        let staticPropsPreviewData: ReturnType<typeof getPagesPreviewDataFromCookieHeader> = false;
 
         // Handle getStaticPaths for dynamic routes: validate the path,
         // respect `fallback: false` (return 404 for unlisted paths), and
@@ -926,6 +930,15 @@ export function createSSRHandler(
           renderProps = { ...renderProps, __N_SSP: true };
           // Snapshot existing headers so we can detect what gSSP adds.
           const headersBeforeGSSP = new Set(Object.keys(res.getHeaders()));
+          const previewData = getPagesPreviewDataFromCookieHeader(req.headers.cookie);
+          const previewContext =
+            previewData === false
+              ? {}
+              : {
+                  draftMode: true as const,
+                  preview: true as const,
+                  previewData,
+                };
 
           const context = {
             params: userFacingParams,
@@ -936,6 +949,7 @@ export function createSSRHandler(
             locale: locale ?? currentDefaultLocale,
             locales: i18nConfig?.locales,
             defaultLocale: currentDefaultLocale,
+            ...previewContext,
           };
           const result = await pageModule.getServerSideProps(context);
           // If gSSP called res.end() directly (short-circuit pattern),
@@ -1077,6 +1091,18 @@ export function createSSRHandler(
           const isOnDemandRevalidate = isOnDemandRevalidateRequest(
             req.headers[PRERENDER_REVALIDATE_HEADER],
           );
+          const previewData = getPagesPreviewDataFromCookieHeader(req.headers.cookie, {
+            isOnDemandRevalidate,
+          });
+          staticPropsPreviewData = previewData;
+          const previewContext =
+            previewData === false
+              ? {}
+              : {
+                  draftMode: true as const,
+                  preview: true as const,
+                  previewData,
+                };
 
           if (
             !isOnDemandRevalidate &&
@@ -1085,7 +1111,8 @@ export function createSSRHandler(
             cached.value.value?.kind === "PAGES" &&
             !cached.value.value.generatedFromDataRequest &&
             !scriptNonce &&
-            !isDataReq
+            !isDataReq &&
+            previewData === false
           ) {
             // Fresh cache hit — serve directly
             const cachedPage = cached.value.value as CachedPagesValue;
@@ -1115,7 +1142,8 @@ export function createSSRHandler(
             cached.value.value?.kind === "PAGES" &&
             !cached.value.value.generatedFromDataRequest &&
             !scriptNonce &&
-            !isDataReq
+            !isDataReq &&
+            previewData === false
           ) {
             // Stale hit — serve stale immediately, trigger background regen
             const cachedPage = cached.value.value as CachedPagesValue;
@@ -1371,9 +1399,11 @@ export function createSSRHandler(
             revalidateReason: (isOnDemandRevalidate ? "on-demand" : "stale") as
               | "on-demand"
               | "stale",
+            ...previewContext,
           };
           const generatedPageData =
             !isOnDemandRevalidate &&
+            previewData === false &&
             cached?.isStale === false &&
             cached?.value.value?.kind === "PAGES" &&
             cached.value.value.generatedFromDataRequest &&
@@ -1437,9 +1467,14 @@ export function createSSRHandler(
           }
 
           // Extract revalidate period for ISR caching after render
-          if (typeof result?.revalidate === "number" && result.revalidate > 0) {
+          if (
+            previewData === false &&
+            typeof result?.revalidate === "number" &&
+            result.revalidate > 0
+          ) {
             isrRevalidateSeconds = result.revalidate;
           } else if (
+            previewData === false &&
             cached?.value.value?.kind === "PAGES" &&
             cached.value.value.generatedFromDataRequest
           ) {
@@ -1490,7 +1525,7 @@ export function createSSRHandler(
         // by getServerSideProps (cookies, status codes, etc.) are preserved
         // because we already let gSSP mutate `res` above.
         if (isDataReq) {
-          if (shouldPersistFallbackData) {
+          if (shouldPersistFallbackData && staticPropsPreviewData === false) {
             const cacheKey = pagesIsrCacheKey(url.split("?")[0]);
             const revalidateSeconds = isrRevalidateSeconds ?? 31_536_000;
             await isrSet(

--- a/packages/vinext/src/server/isr-cache.ts
+++ b/packages/vinext/src/server/isr-cache.ts
@@ -123,6 +123,11 @@ function safeEqual(a: string, b: string): boolean {
   return mismatch === 0;
 }
 
+export function isRevalidateSecret(value: string | null | undefined): boolean {
+  if (typeof value !== "string" || value.length === 0) return false;
+  return safeEqual(value, getRevalidateSecret());
+}
+
 /**
  * Authorize an incoming request as an on-demand revalidation trigger. Mirrors
  * Next.js's `checkIsOnDemandRevalidate`: the {@link PRERENDER_REVALIDATE_HEADER}
@@ -133,8 +138,8 @@ export function isOnDemandRevalidateRequest(
   headerValue: string | string[] | null | undefined,
 ): boolean {
   // Reject arrays (duplicate headers) and absent values outright.
-  if (typeof headerValue !== "string" || headerValue.length === 0) return false;
-  return safeEqual(headerValue, getRevalidateSecret());
+  if (typeof headerValue !== "string") return false;
+  return isRevalidateSecret(headerValue);
 }
 
 export type ISRCacheEntry = {

--- a/packages/vinext/src/server/pages-node-compat.ts
+++ b/packages/vinext/src/server/pages-node-compat.ts
@@ -5,7 +5,7 @@ import { readStreamAsTextWithLimit } from "../utils/text-stream.js";
 import { DEFAULT_PAGES_API_BODY_SIZE_LIMIT } from "./pages-body-parser-config.js";
 import { PagesBodyParseError, getMediaType, isJsonMediaType } from "./pages-media-type.js";
 import { performOnDemandRevalidate, type RevalidateOptions } from "./pages-revalidate.js";
-import { getRevalidateSecret } from "./isr-cache.js";
+import { getRevalidateSecret, isRevalidateSecret } from "./isr-cache.js";
 
 const MAX_PAGES_API_BODY_SIZE = DEFAULT_PAGES_API_BODY_SIZE_LIMIT;
 
@@ -214,7 +214,7 @@ export function getPagesPreviewDataFromCookieHeader(
   const bypass = cookies.__prerender_bypass;
   const payload = cookies.__next_preview_data;
   if (!bypass && !payload) return false;
-  if (bypass !== getRevalidateSecret()) return false;
+  if (!isRevalidateSecret(bypass)) return false;
   if (!payload) return {};
 
   // vinext writes preview data as base64url(JSON) instead of Next.js's signed

--- a/packages/vinext/src/server/pages-node-compat.ts
+++ b/packages/vinext/src/server/pages-node-compat.ts
@@ -5,6 +5,7 @@ import { readStreamAsTextWithLimit } from "../utils/text-stream.js";
 import { DEFAULT_PAGES_API_BODY_SIZE_LIMIT } from "./pages-body-parser-config.js";
 import { PagesBodyParseError, getMediaType, isJsonMediaType } from "./pages-media-type.js";
 import { performOnDemandRevalidate, type RevalidateOptions } from "./pages-revalidate.js";
+import { getRevalidateSecret } from "./isr-cache.js";
 
 const MAX_PAGES_API_BODY_SIZE = DEFAULT_PAGES_API_BODY_SIZE_LIMIT;
 
@@ -41,6 +42,10 @@ export type PagesReqResResponse = Writable & {
   redirect: (statusOrUrl: number | string, url?: string) => void;
   getHeaders: () => PagesReqResHeaders;
   revalidate: (urlPath: string, opts?: RevalidateOptions) => Promise<void>;
+  setPreviewData: (
+    data: object | string,
+    options?: { maxAge?: number; path?: string },
+  ) => PagesReqResResponse;
 };
 
 type PagesRequestCookiesCarrier = {
@@ -62,6 +67,8 @@ type CreatePagesReqResResult = {
   res: PagesReqResResponse;
   responsePromise: Promise<Response>;
 };
+
+export type PagesPreviewData = object | string;
 
 async function readPagesRequestBodyWithLimit(request: Request, maxBytes: number): Promise<string> {
   if (!request.body) {
@@ -163,6 +170,71 @@ function createRequestReadable(request: Request): Readable {
 
 function parsePagesRequestCookies(cookieHeader: string | string[] | null | undefined) {
   return parseCookieHeader(Array.isArray(cookieHeader) ? cookieHeader.join("; ") : cookieHeader);
+}
+
+function serializePreviewCookie(
+  name: "__prerender_bypass" | "__next_preview_data",
+  value: string,
+  options: { maxAge?: number; path?: string } = {},
+): string {
+  const parts = [
+    `${name}=${encodeURIComponent(value)}`,
+    "HttpOnly",
+    `Path=${options.path ?? "/"}`,
+    process.env.NODE_ENV !== "development" ? "SameSite=None" : "SameSite=Lax",
+  ];
+  if (process.env.NODE_ENV !== "development") {
+    parts.push("Secure");
+  }
+  if (options.maxAge !== undefined) {
+    parts.push(`Max-Age=${Math.trunc(options.maxAge)}`);
+  }
+  return parts.join("; ");
+}
+
+function decodePagesPreviewPayload(payload: string): PagesPreviewData | false {
+  try {
+    const decoded = Buffer.from(payload, "base64url").toString("utf8");
+    const value = JSON.parse(decoded);
+    return typeof value === "object" && value !== null ? value : String(value);
+  } catch {
+    return false;
+  }
+}
+
+export function getPagesPreviewDataFromCookieHeader(
+  cookieHeader: string | string[] | null | undefined,
+  options: { isOnDemandRevalidate?: boolean } = {},
+): PagesPreviewData | false {
+  // Next.js disables preview mode during on-demand revalidation so preview
+  // cookies cannot poison the regenerated ISR entry.
+  if (options.isOnDemandRevalidate) return false;
+
+  const cookies = parsePagesRequestCookies(cookieHeader);
+  const bypass = cookies.__prerender_bypass;
+  const payload = cookies.__next_preview_data;
+  if (!bypass && !payload) return false;
+  if (bypass !== getRevalidateSecret()) return false;
+  if (!payload) return {};
+
+  // vinext writes preview data as base64url(JSON) instead of Next.js's signed
+  // encrypted JWT. The writer and reader are intentionally paired internally.
+  return decodePagesPreviewPayload(payload);
+}
+
+export function getPagesPreviewData(
+  request: Request,
+  options: { isOnDemandRevalidate?: boolean } = {},
+): PagesPreviewData | false {
+  return getPagesPreviewDataFromCookieHeader(request.headers.get("cookie"), options);
+}
+
+function normalizeSetCookieHeader(
+  value: string | number | boolean | string[] | undefined,
+): string[] {
+  if (value === undefined) return [];
+  if (Array.isArray(value)) return value.map(String);
+  return [String(value)];
 }
 
 export function attachPagesRequestCookies(req: PagesRequestCookiesCarrier): void {
@@ -300,6 +372,25 @@ class PagesResponseStream extends Writable {
 
   async revalidate(urlPath: string, opts?: RevalidateOptions): Promise<void> {
     await performOnDemandRevalidate(this.requestHeaders, urlPath, opts);
+  }
+
+  setPreviewData(
+    data: object | string,
+    options: { maxAge?: number; path?: string } = {},
+  ): PagesReqResResponse {
+    const payload = Buffer.from(JSON.stringify(data)).toString("base64url");
+    if (payload.length > 2048) {
+      throw new Error(
+        "Preview data is limited to 2KB currently, reduce how much data you are storing as preview data to continue",
+      );
+    }
+
+    this.setHeader("Set-Cookie", [
+      ...normalizeSetCookieHeader(this.getHeader("Set-Cookie")),
+      serializePreviewCookie("__prerender_bypass", getRevalidateSecret(), options),
+      serializePreviewCookie("__next_preview_data", payload, options),
+    ]);
+    return this as PagesReqResResponse;
   }
 
   override _write(

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -7,6 +7,7 @@ import { applyCdnResponseHeaders } from "./cache-control.js";
 import { decideIsr } from "./isr-decision.js";
 import { buildCacheStateHeaders } from "./cache-headers.js";
 import { buildPagesCacheValue, type ISRCacheEntry } from "./isr-cache.js";
+import type { PagesPreviewData } from "./pages-node-compat.js";
 import {
   buildPagesNextDataScript,
   etagMatches,
@@ -100,12 +101,18 @@ export type PagesPageModule = {
     locale?: string;
     locales?: string[];
     defaultLocale?: string;
+    draftMode?: true;
+    preview?: true;
+    previewData?: PagesPreviewData;
   }) => Promise<PagesPagePropsResult> | PagesPagePropsResult;
   getStaticProps?: (context: {
     params: Record<string, unknown> | null;
     locale?: string;
     locales?: string[];
     defaultLocale?: string;
+    draftMode?: true;
+    preview?: true;
+    previewData?: PagesPreviewData;
     /**
      * Indicates why `getStaticProps` was invoked.
      *
@@ -173,6 +180,7 @@ export type ResolvePagesPageDataOptions = {
    * `.nextjs-ref/packages/next/src/server/render.tsx`.
    */
   isBuildTimePrerendering?: boolean;
+  validatePropsSerialization?: boolean;
   /**
    * When true, this dispatch was triggered by an on-demand revalidation
    * request (e.g. `res.revalidate()` in a Pages Router API route, or an
@@ -189,6 +197,7 @@ export type ResolvePagesPageDataOptions = {
    * presence — see the security note in `isr-cache.ts`.
    */
   isOnDemandRevalidate?: boolean;
+  previewData?: PagesPreviewData | false;
   /**
    * The deployment ID used for deployment-skew protection. When set, it is
    * included as `x-nextjs-deployment-id` on all `_next/data` responses
@@ -710,6 +719,15 @@ export async function resolvePagesPageData(
 
   let pageProps: Record<string, unknown> = {};
   let gsspRes: PagesMutableGsspResponse | null = null;
+  const previewData = options.isOnDemandRevalidate ? false : (options.previewData ?? false);
+  const previewContext =
+    previewData === false
+      ? {}
+      : {
+          draftMode: true as const,
+          preview: true as const,
+          previewData,
+        };
 
   let sharedReqRes: PagesGsspContextResponse | null = null;
   function getSharedReqRes(): PagesGsspContextResponse {
@@ -768,6 +786,7 @@ export async function resolvePagesPageData(
       locale: options.i18n.locale,
       locales: options.i18n.locales,
       defaultLocale: options.i18n.defaultLocale,
+      ...previewContext,
     });
 
     if (isResponseSent(res)) {
@@ -808,7 +827,7 @@ export async function resolvePagesPageData(
     // .nextjs-ref/packages/next/src/server/render.tsx (~line 1200) and
     // .nextjs-ref/packages/next/src/lib/is-serializable-props.ts. Tracked in
     // vinext#1478.
-    if (result?.props !== undefined) {
+    if (result?.props !== undefined && options.validatePropsSerialization !== false) {
       isSerializableProps(options.routePattern, "getServerSideProps", pageProps);
     }
 
@@ -836,7 +855,8 @@ export async function resolvePagesPageData(
       cached &&
       !cached.isStale &&
       !options.scriptNonce &&
-      !options.isDataReq
+      !options.isDataReq &&
+      previewData === false
     ) {
       const hitResponse = buildPagesCacheResponse(
         cachedValue.html,
@@ -866,7 +886,8 @@ export async function resolvePagesPageData(
       cached &&
       cached.isStale &&
       !options.scriptNonce &&
-      !options.isDataReq
+      !options.isDataReq &&
+      previewData === false
     ) {
       options.triggerBackgroundRegeneration(
         cacheKey,
@@ -964,6 +985,7 @@ export async function resolvePagesPageData(
 
     const generatedPageData =
       !options.isOnDemandRevalidate &&
+      previewData === false &&
       cached?.isStale === false &&
       cachedValue?.kind === "PAGES" &&
       cachedValue.generatedFromDataRequest &&
@@ -981,6 +1003,7 @@ export async function resolvePagesPageData(
           locale: options.i18n.locale,
           locales: options.i18n.locales,
           defaultLocale: options.i18n.defaultLocale,
+          ...previewContext,
           revalidateReason: options.isOnDemandRevalidate
             ? "on-demand"
             : options.isBuildTimePrerendering
@@ -1017,17 +1040,21 @@ export async function resolvePagesPageData(
     // .nextjs-ref/packages/next/src/server/render.tsx (~line 982) and
     // .nextjs-ref/packages/next/src/lib/is-serializable-props.ts. Tracked in
     // vinext#1478.
-    if (result?.props !== undefined) {
+    if (result?.props !== undefined && options.validatePropsSerialization !== false) {
       isSerializableProps(options.routePattern, "getStaticProps", pageProps);
     }
 
-    if (typeof result?.revalidate === "number" && result.revalidate > 0) {
+    if (previewData === false && typeof result?.revalidate === "number" && result.revalidate > 0) {
       isrRevalidateSeconds = result.revalidate;
-    } else if (cachedValue?.kind === "PAGES" && cachedValue.generatedFromDataRequest) {
+    } else if (
+      previewData === false &&
+      cachedValue?.kind === "PAGES" &&
+      cachedValue.generatedFromDataRequest
+    ) {
       isrRevalidateSeconds = cached?.value.cacheControl?.revalidate ?? 31_536_000;
     }
 
-    if (shouldPersistFallbackData) {
+    if (shouldPersistFallbackData && previewData === false) {
       const revalidateSeconds = isrRevalidateSeconds ?? 31_536_000;
       await options.isrSet(
         cacheKey,

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -16,7 +16,7 @@ import type { ComponentType, ReactNode } from "react";
 import { mergeRouteParamsIntoQuery, parseQueryString as parseQuery } from "../utils/query.js";
 import { patternToNextFormat } from "../routing/route-validation.js";
 import { resolvePagesI18nRequest } from "./pages-i18n.js";
-import { createPagesReqRes } from "./pages-node-compat.js";
+import { createPagesReqRes, getPagesPreviewData } from "./pages-node-compat.js";
 import { resolvePagesPageData } from "./pages-page-data.js";
 import type { PagesPageModule } from "./pages-page-data.js";
 import { resolvePagesPageMethodResponse } from "./pages-page-method.js";
@@ -24,6 +24,11 @@ import { renderPagesPageResponse } from "./pages-page-response.js";
 import { buildPagesReadinessNextData } from "./pages-readiness.js";
 import type { PagesI18nRenderContext } from "./pages-page-response.js";
 import type { RenderPageEnhancers } from "./pages-document-initial-props.js";
+import {
+  BROWSER_REVALIDATE_CACHE_CONTROL,
+  shouldUseNextDeployCacheControl,
+  applyCdnResponseHeaders,
+} from "./cache-control.js";
 import {
   buildNextDataPropsJsonResponse,
   buildNextDataNotFoundResponse,
@@ -46,7 +51,7 @@ import { getRequestExecutionContext } from "vinext/shims/request-context";
 import { ensureFetchPatch } from "vinext/shims/fetch-cache";
 import { collectAssetTags, resolveClientModuleUrl } from "./pages-asset-tags.js";
 import { NEXTJS_DEPLOYMENT_ID_HEADER } from "./headers.js";
-import { ISR_NEVER_CACHE_CONTROL } from "./isr-decision.js";
+import { buildMissIsrCacheControl, ISR_NEVER_CACHE_CONTROL } from "./isr-decision.js";
 import { appendAssetDeploymentIdQuery } from "../utils/deployment-id.js";
 import { hasPagesGetInitialProps } from "./pages-get-initial-props.js";
 
@@ -435,6 +440,7 @@ export function createPagesPageHandler(
         // the configured-rewrites flag decide the initial `router.isReady` value,
         // mirroring Next.js's Pages adapter. See server/render.tsx readiness rule.
         const pageModule = route.module;
+        const isStaticPropsRoute = typeof pageModule.getStaticProps === "function";
         const pagesNextData = buildPagesReadinessNextData({
           pageModule,
           appComponent: AppComponent as { getInitialProps?: unknown } | null,
@@ -519,6 +525,7 @@ export function createPagesPageHandler(
             pageModuleUrl,
             appModuleUrl,
             hasMiddleware,
+            routeUrl,
           },
         };
         const scriptNonce = getScriptNonceFromHeaderSources(request.headers, middlewareHeaders);
@@ -554,6 +561,9 @@ export function createPagesPageHandler(
             url: originalRequestPathAndSearch,
           });
 
+        const isOnDemandRevalidate = isOnDemandRevalidateRequest(
+          request.headers.get(PRERENDER_REVALIDATE_HEADER),
+        );
         const pageDataResult = await resolvePagesPageData({
           isDataReq,
           err: err instanceof Error ? err : undefined,
@@ -578,6 +588,8 @@ export function createPagesPageHandler(
           expireSeconds: vinextConfig.expireTime,
           isBuildTimePrerendering:
             typeof process !== "undefined" && process.env && process.env.VINEXT_PRERENDER === "1",
+          validatePropsSerialization:
+            process.env.NODE_ENV !== "production" || process.env.VINEXT_PRERENDER === "1",
           // `res.revalidate()` issues an internal request carrying the
           // `x-prerender-revalidate` header set to the process revalidate
           // secret; treat it as an on-demand revalidation so getStaticProps
@@ -587,9 +599,8 @@ export function createPagesPageHandler(
           // mirrors Next.js's `checkIsOnDemandRevalidate`, preventing an
           // external client from forcing synchronous regeneration via an
           // arbitrary header value (cache-stampede/DoS vector).
-          isOnDemandRevalidate: isOnDemandRevalidateRequest(
-            request.headers.get(PRERENDER_REVALIDATE_HEADER),
-          ),
+          isOnDemandRevalidate,
+          previewData: getPagesPreviewData(request, { isOnDemandRevalidate }),
           pageModule,
           AppComponent,
           params,
@@ -694,6 +705,21 @@ export function createPagesPageHandler(
             if (!hasUserCacheControl) {
               init.headers["Cache-Control"] = ISR_NEVER_CACHE_CONTROL;
             }
+          } else if (isStaticPropsRoute) {
+            if (isrRevalidateSeconds) {
+              const headers = new Headers(init.headers);
+              applyCdnResponseHeaders(headers, {
+                cacheControl: buildMissIsrCacheControl(
+                  isrRevalidateSeconds,
+                  vinextConfig.expireTime,
+                ),
+              });
+              for (const [key, value] of headers) {
+                init.headers[key] = value;
+              }
+            } else if (shouldUseNextDeployCacheControl()) {
+              init.headers["Cache-Control"] = BROWSER_REVALIDATE_CACHE_CONTROL;
+            }
           }
           // Mirror Next.js pages-handler.ts: set x-nextjs-deployment-id on
           // every _next/data response so the client router can detect a new
@@ -757,6 +783,7 @@ export function createPagesPageHandler(
           isrCacheKey: pageIsrCacheKey,
           expireSeconds: vinextConfig.expireTime,
           isrRevalidateSeconds,
+          isStaticPropsRoute,
           isrSet,
           i18n: buildI18nRenderContext(i18nConfig, locale, currentDefaultLocale, domainLocales),
           isFallback: isFallbackRender,

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -3,7 +3,11 @@ import type { VinextNextData } from "../client/vinext-next-data.js";
 import type { CachedPagesValue } from "vinext/shims/cache-handler";
 import { withScriptNonce } from "vinext/shims/script-nonce-context";
 import { getRequestExecutionContext } from "vinext/shims/request-context";
-import { applyCdnResponseHeaders } from "./cache-control.js";
+import {
+  applyCdnResponseHeaders,
+  BROWSER_REVALIDATE_CACHE_CONTROL,
+  shouldUseNextDeployCacheControl,
+} from "./cache-control.js";
 import {
   buildMissIsrCacheControl,
   ISR_NEVER_CACHE_CONTROL,
@@ -176,6 +180,7 @@ type RenderPagesPageResponseOptions = {
   isrCacheKey: (router: string, pathname: string) => string;
   expireSeconds?: number;
   isrRevalidateSeconds: number | null;
+  isStaticPropsRoute?: boolean;
   isrSet: (
     key: string,
     data: CachedPagesValue,
@@ -663,6 +668,8 @@ export async function renderPagesPageResponse(
       tags: [encodeCacheTag(`_N_T_${stem || "/"}`)],
     });
     setCacheStateHeaders(responseHeaders, "MISS");
+  } else if (options.isStaticPropsRoute && shouldUseNextDeployCacheControl()) {
+    responseHeaders.set("Cache-Control", BROWSER_REVALIDATE_CACHE_CONTROL);
   } else if (options.gsspRes && !userSetCacheControl) {
     // Default for getServerSideProps responses, matching Next.js
     // pages-handler.ts (revalidate: 0 → getCacheControlHeader). Without this,

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -1452,6 +1452,7 @@ function scheduleHardNavigationAndThrow(url: string, message: string): never {
 
 type NavigateClientOptions = {
   allowNotFoundResponse?: boolean;
+  isHydrationQueryUpdate?: boolean;
   /**
    * The history mode of the originating navigation. Used when a gSSP/gSP data
    * response carries a `__N_REDIRECT` marker so the re-entrant navigation to
@@ -2169,6 +2170,9 @@ async function navigateClientData(
   }
 
   if (!res.ok) {
+    if (options.isHydrationQueryUpdate) {
+      return;
+    }
     // 404 here is the deploy-skew signal (server buildId rotated) — hard
     // reload to land on the new build's HTML. Any other non-OK status is
     // treated the same way per the user-configured "always hard reload"
@@ -2191,6 +2195,9 @@ async function navigateClientData(
   try {
     body = (await res.json()) as PagesDataResponse;
   } catch {
+    if (options.isHydrationQueryUpdate) {
+      return;
+    }
     scheduleHardNavigationAndThrow(url, "Data navigation failed: invalid JSON response");
   }
   assertStillCurrent();
@@ -2973,8 +2980,13 @@ async function performNavigation(
   // scroll after completion.
   const scrollTarget = doScroll ? { x: 0, y: 0 } : null;
   const navigateOptions: NavigateClientOptions = errorRouteHtmlFetchUrl
-    ? { allowNotFoundResponse: true, mode, scroll: scrollTarget }
-    : { mode, scroll: scrollTarget };
+    ? {
+        allowNotFoundResponse: true,
+        mode,
+        scroll: scrollTarget,
+        isHydrationQueryUpdate: options?._h === 1,
+      }
+    : { mode, scroll: scrollTarget, isHydrationQueryUpdate: options?._h === 1 };
 
   // Next.js push→replace coercion (narrowed): when the display URL (asPath)
   // doesn't change AND the route URL DOES change AND the locale doesn't

--- a/tests/cache-control.test.ts
+++ b/tests/cache-control.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it, afterEach } from "vite-plus/test";
 import {
   applyCdnResponseHeaders,
+  BROWSER_REVALIDATE_CACHE_CONTROL,
   buildCachedRevalidateCacheControl,
   buildRevalidateCacheControl,
+  shouldUseNextDeployCacheControl,
 } from "../packages/vinext/src/server/cache-control.js";
 import {
   setCdnCacheAdapter,
@@ -55,14 +57,31 @@ describe("cache-control helpers", () => {
 
 describe("applyCdnResponseHeaders", () => {
   const CDN_KEY = Symbol.for("vinext.cdnCacheAdapter");
+  const originalNextDeployCacheControl = process.env.VINEXT_NEXT_DEPLOY_CACHE_CONTROL;
   afterEach(() => {
     delete (globalThis as Record<PropertyKey, unknown>)[CDN_KEY];
+    if (originalNextDeployCacheControl === undefined) {
+      delete process.env.VINEXT_NEXT_DEPLOY_CACHE_CONTROL;
+    } else {
+      process.env.VINEXT_NEXT_DEPLOY_CACHE_CONTROL = originalNextDeployCacheControl;
+    }
   });
 
   it("default adapter sets a single Cache-Control identical to the input", () => {
     const headers = new Headers();
     applyCdnResponseHeaders(headers, { cacheControl: "s-maxage=60, stale-while-revalidate" });
     expect(headers.get("Cache-Control")).toBe("s-maxage=60, stale-while-revalidate");
+    expect(headers.get("CDN-Cache-Control")).toBeNull();
+  });
+
+  it("uses browser revalidation Cache-Control for shared cache policies in Next deploy mode", () => {
+    process.env.VINEXT_NEXT_DEPLOY_CACHE_CONTROL = "1";
+    const headers = new Headers();
+
+    applyCdnResponseHeaders(headers, { cacheControl: "s-maxage=60, stale-while-revalidate" });
+
+    expect(shouldUseNextDeployCacheControl()).toBe(true);
+    expect(headers.get("Cache-Control")).toBe(BROWSER_REVALIDATE_CACHE_CONTROL);
     expect(headers.get("CDN-Cache-Control")).toBeNull();
   });
 

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -1303,7 +1303,10 @@ describe("Pages Router entry template", () => {
       expect(code).toContain("element = wrapWithRouterContext(element, resolveHydrationCommit);");
       expect(code).toContain("await hydrationCommitted;");
       expect(code).toContain("if (nextData.isFallback) {");
+      expect(code).toContain("const routeUrl = nextData.__vinext?.routeUrl;");
       expect(code).toContain("await Router.replace(");
+      expect(code).toContain("routeUrl || currentUrl,");
+      expect(code).toContain("routeUrl ? currentUrl : undefined,");
       expect(code).toContain("{ _h: 1, scroll: false },");
       expect(code).not.toContain("function VinextHydrationMarker");
       expect(code).not.toContain("React.createElement(VinextHydrationMarker");

--- a/tests/pages-node-compat.test.ts
+++ b/tests/pages-node-compat.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  createPagesReqRes,
+  getPagesPreviewData,
+} from "../packages/vinext/src/server/pages-node-compat.js";
+
+describe("Pages Node compat response", () => {
+  it("setPreviewData appends both preview cookies while preserving existing cookies", () => {
+    const { res } = createPagesReqRes({
+      body: undefined,
+      query: {},
+      request: new Request("https://example.test/api/enable"),
+      url: "/api/enable",
+    });
+
+    res.setHeader("Set-Cookie", "existing=1; Path=/");
+    res.setPreviewData({ hello: "world" });
+
+    const cookies = res.getHeader("Set-Cookie");
+    if (!Array.isArray(cookies)) throw new Error("expected Set-Cookie array");
+    expect(cookies).toHaveLength(3);
+    expect(cookies).toEqual(
+      expect.arrayContaining([
+        "existing=1; Path=/",
+        expect.stringMatching(/^__prerender_bypass=/),
+        expect.stringMatching(/^__next_preview_data=/),
+      ]),
+    );
+  });
+
+  it("reads preview data from cookies emitted by setPreviewData", () => {
+    const { res } = createPagesReqRes({
+      body: undefined,
+      query: {},
+      request: new Request("https://example.test/api/enable"),
+      url: "/api/enable",
+    });
+
+    res.setPreviewData({ hello: "world" });
+
+    const cookies = res.getHeader("Set-Cookie");
+    if (!Array.isArray(cookies)) throw new Error("expected Set-Cookie array");
+    const cookieHeader = cookies.map((value) => value.split(";", 1)[0]).join("; ");
+
+    const request = new Request("https://example.test/preview", {
+      headers: { cookie: cookieHeader },
+    });
+    expect(getPagesPreviewData(request)).toEqual({ hello: "world" });
+    expect(getPagesPreviewData(request, { isOnDemandRevalidate: true })).toBe(false);
+  });
+});

--- a/tests/pages-node-compat.test.ts
+++ b/tests/pages-node-compat.test.ts
@@ -48,4 +48,29 @@ describe("Pages Node compat response", () => {
     expect(getPagesPreviewData(request)).toEqual({ hello: "world" });
     expect(getPagesPreviewData(request, { isOnDemandRevalidate: true })).toBe(false);
   });
+
+  it("rejects preview data when the bypass cookie secret is wrong", () => {
+    const { res } = createPagesReqRes({
+      body: undefined,
+      query: {},
+      request: new Request("https://example.test/api/enable"),
+      url: "/api/enable",
+    });
+
+    res.setPreviewData({ hello: "world" });
+
+    const cookies = res.getHeader("Set-Cookie");
+    if (!Array.isArray(cookies)) throw new Error("expected Set-Cookie array");
+    const cookieHeader = cookies
+      .map((value) => value.split(";", 1)[0])
+      .map((value) =>
+        value.startsWith("__prerender_bypass=") ? "__prerender_bypass=wrong-secret" : value,
+      )
+      .join("; ");
+
+    const request = new Request("https://example.test/preview", {
+      headers: { cookie: cookieHeader },
+    });
+    expect(getPagesPreviewData(request)).toBe(false);
+  });
 });

--- a/tests/pages-page-data.test.ts
+++ b/tests/pages-page-data.test.ts
@@ -1316,6 +1316,102 @@ describe("pages page data", () => {
     expect(received).toBe("on-demand");
   });
 
+  it("passes preview context to getStaticProps and bypasses fresh ISR hits", async () => {
+    let received: unknown = "untouched";
+    const getStaticProps = vi.fn(async (context) => {
+      received = {
+        draftMode: context.draftMode,
+        preview: context.preview,
+        previewData: context.previewData,
+      };
+      return { props: { fromPreview: true } };
+    });
+
+    const result = await resolvePagesPageData(
+      createOptions({
+        isrGet: vi.fn().mockResolvedValue({
+          isStale: false,
+          value: {
+            lastModified: 1,
+            cacheState: "hit",
+            value: {
+              kind: "PAGES",
+              html: "<html>cached</html>",
+              pageData: { pageProps: { cached: true } },
+              headers: undefined,
+              status: undefined,
+            },
+          },
+        }),
+        pageModule: { getStaticProps },
+        previewData: { hello: "world" },
+      }),
+    );
+
+    expect(getStaticProps).toHaveBeenCalledOnce();
+    expect(received).toEqual({
+      draftMode: true,
+      preview: true,
+      previewData: { hello: "world" },
+    });
+    expect(result.kind).toBe("render");
+    if (result.kind !== "render") throw new Error("expected render");
+    expect(result.pageProps).toEqual({ fromPreview: true });
+  });
+
+  it("disables preview context for on-demand getStaticProps regeneration", async () => {
+    let received: unknown = "untouched";
+    await resolvePagesPageData(
+      createOptions({
+        isOnDemandRevalidate: true,
+        pageModule: {
+          async getStaticProps(context) {
+            received = {
+              draftMode: context.draftMode,
+              preview: context.preview,
+              previewData: context.previewData,
+              revalidateReason: context.revalidateReason,
+            };
+            return { props: {} };
+          },
+        },
+        previewData: { hello: "world" },
+      }),
+    );
+
+    expect(received).toEqual({
+      draftMode: undefined,
+      preview: undefined,
+      previewData: undefined,
+      revalidateReason: "on-demand",
+    });
+  });
+
+  it("passes preview context to getServerSideProps", async () => {
+    let received: unknown = "untouched";
+    await resolvePagesPageData(
+      createOptions({
+        pageModule: {
+          async getServerSideProps(context) {
+            received = {
+              draftMode: context.draftMode,
+              preview: context.preview,
+              previewData: context.previewData,
+            };
+            return { props: {} };
+          },
+        },
+        previewData: "draft",
+      }),
+    );
+
+    expect(received).toEqual({
+      draftMode: true,
+      preview: true,
+      previewData: "draft",
+    });
+  });
+
   it("passes revalidateReason: 'stale' to getStaticProps for runtime cache-miss requests", async () => {
     let received: unknown = "untouched";
     await resolvePagesPageData(
@@ -1403,6 +1499,25 @@ describe("pages page data", () => {
     ).rejects.toThrow(
       /Error serializing `\.date` returned from `getStaticProps` in "\/non-json"\.\s*Reason: `object` \("\[object Date\]"\) cannot be serialized as JSON/,
     );
+  });
+
+  it("allows non-serializable getStaticProps props when production SSR validation is disabled", async () => {
+    const result = await resolvePagesPageData(
+      createOptions({
+        pageModule: {
+          async getStaticProps() {
+            return { props: { date: new Date(0) } };
+          },
+        },
+        routePattern: "/non-json",
+        routeUrl: "/non-json",
+        validatePropsSerialization: false,
+      }),
+    );
+
+    expect(result.kind).toBe("render");
+    if (result.kind !== "render") throw new Error("expected render");
+    expect(result.pageProps.date).toBeInstanceOf(Date);
   });
 
   it("throws a Next.js-style error when getServerSideProps returns non-serializable props", async () => {

--- a/tests/pages-page-response.test.ts
+++ b/tests/pages-page-response.test.ts
@@ -460,6 +460,29 @@ describe("pages page response", () => {
     expect(response.headers.get("cache-control")).toBeNull();
   });
 
+  it("sets browser revalidation Cache-Control for static Pages responses in Next deploy mode", async () => {
+    const oldValue = process.env.VINEXT_NEXT_DEPLOY_CACHE_CONTROL;
+    process.env.VINEXT_NEXT_DEPLOY_CACHE_CONTROL = "1";
+    try {
+      const common = createCommonOptions();
+
+      const response = await renderPagesPageResponse({
+        ...common.options,
+        gsspRes: null,
+        isStaticPropsRoute: true,
+        isrRevalidateSeconds: null,
+      });
+
+      expect(response.headers.get("cache-control")).toBe("public, max-age=0, must-revalidate");
+    } finally {
+      if (oldValue === undefined) {
+        delete process.env.VINEXT_NEXT_DEPLOY_CACHE_CONTROL;
+      } else {
+        process.env.VINEXT_NEXT_DEPLOY_CACHE_CONTROL = oldValue;
+      }
+    }
+  });
+
   it("disables pages ISR caching when a script nonce is present", async () => {
     const common = createCommonOptions();
 


### PR DESCRIPTION
## Summary
- match Next deploy browser Cache-Control for Pages SSG/ISR HTML and `_next/data` responses
- hydrate fallback shells through the server-resolved Pages route URL and avoid hard reloads for failed internal `_h` hydration data updates
- gate Pages props serializability validation like Next.js production SSR, and add Pages API `res.setPreviewData()` cookies

## Failure mapping
- Covered here: `test/e2e/prerender.test.ts` cache header rows for revalidate/fallback/no-revalidate pages, fallback dynamic SSG rewrite, invalid JSON from `getStaticProps` on SSR/CST, on-demand revalidate with preview cookie, and no prerender data fetch on mount.
- Covered by #2218: `should not supply query values to params or useRouter non-dynamic page SSR`. Existing coverage comments are already present there.
- Covered by #2027: `should not revalidate when set to false`. Added a coverage note: https://github.com/cloudflare/vinext/pull/2027#issuecomment-4852233578

## Validation
- `vp test run tests/cache-control.test.ts tests/pages-page-response.test.ts tests/pages-page-data.test.ts tests/pages-node-compat.test.ts tests/entry-templates.test.ts`
- `vp check tests/cache-control.test.ts tests/pages-page-response.test.ts tests/pages-page-data.test.ts tests/pages-node-compat.test.ts tests/entry-templates.test.ts`
- `REPO="$(pwd)" NEXTJS_DIR="/Users/jamesanderson/Developer/vinext/.nextjs-ref" NEXT_TEST_CONCURRENCY=1 ./scripts/run-targeted-nextjs-e2e.sh test/e2e/prerender.test.ts`
  - Result: 61 passed, 2 failed; the remaining failures are the rows mapped to #2218 and #2027 above.

Artifacts from the local E2E/build run were removed after validation.