### PR TITLE
fix(app-router): align app static ISR lifecycle

### DIFF
--- a/packages/cloudflare/src/cache/kv-data-adapter.runtime.ts
+++ b/packages/cloudflare/src/cache/kv-data-adapter.runtime.ts
@@ -127,6 +127,14 @@ function readStringArrayField(ctx: Record<string, unknown> | undefined, field: s
   return value.filter((item): item is string => typeof item === "string");
 }
 
+function readPositiveNumberField(
+  ctx: Record<string, unknown> | undefined,
+  field: string,
+): number | undefined {
+  const value = ctx?.[field];
+  return typeof value === "number" && value > 0 ? value : undefined;
+}
+
 function validUniqueTags(tags: string[]): string[] {
   const result: string[] = [];
   const seen = new Set<string>();
@@ -249,8 +257,16 @@ export class KVCacheHandler implements CacheHandler {
       return null;
     }
 
-    // Check time-based revalidation — return stale with cacheState
-    if (entry.revalidateAt !== null && Date.now() > entry.revalidateAt) {
+    // Check time-based revalidation — return stale with cacheState.
+    const now = Date.now();
+    const requestedRevalidate = readPositiveNumberField(_ctx, "revalidate");
+    const requestedRevalidateAt =
+      requestedRevalidate === undefined ? null : entry.lastModified + requestedRevalidate * 1000;
+    const isStale =
+      (entry.revalidateAt !== null && now > entry.revalidateAt) ||
+      (requestedRevalidateAt !== null && now > requestedRevalidateAt);
+
+    if (isStale) {
       return {
         lastModified: entry.lastModified,
         value: restoredValue,

--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -1440,7 +1440,7 @@ export async function prerenderApp({
             const cacheControl = response.headers.get("cache-control") ?? "";
             const linkHeader = response.headers.get("link");
             const responseCacheLife = readPrerenderCacheLifeHeader(response.headers);
-            if (!response.ok || (isSpeculative && cacheControl.includes("no-store"))) {
+            if (!response.ok || cacheControl.includes("no-store")) {
               await response.body?.cancel();
               return {
                 cacheControl,
@@ -1479,14 +1479,14 @@ export async function prerenderApp({
           };
         }
 
-        // Detect dynamic usage for speculative routes via Cache-Control header.
-        // When headers(), cookies(), connection(), or noStore() are called during
-        // render, the server sets Cache-Control: no-store. We treat this as a
-        // signal that the route is dynamic and should be skipped.
-        if (isSpeculative) {
-          if (htmlCacheControl.includes("no-store")) {
-            return { route: routePattern, status: "skipped", reason: "dynamic" };
-          }
+        // Detect dynamic usage via Cache-Control header. When headers(),
+        // cookies(), connection(), noStore(), or a no-store fetch are called
+        // during render, the server sets Cache-Control: no-store. Treat that
+        // as a dynamic skip even for concrete generateStaticParams paths: a
+        // generated param decides which URLs are admissible, not that the
+        // render output is reusable.
+        if (htmlCacheControl.includes("no-store")) {
+          return { route: routePattern, status: "skipped", reason: "dynamic" };
         }
 
         if (htmlRender.html === null) {

--- a/packages/vinext/src/server/app-page-cache.ts
+++ b/packages/vinext/src/server/app-page-cache.ts
@@ -199,6 +199,26 @@ function hasQueryInvariantAppPageProof(cachedValue: CachedAppPageValue): boolean
   );
 }
 
+function resolveRegeneratedAppPageCachePolicy(options: {
+  expireSeconds?: number;
+  renderCacheControl?: CacheControlMetadata;
+  routeRevalidateSeconds: number;
+}): { expireSeconds?: number; revalidateSeconds: number } {
+  let revalidateSeconds = options.routeRevalidateSeconds;
+  const renderRevalidateSeconds = options.renderCacheControl?.revalidate;
+  if (renderRevalidateSeconds !== undefined) {
+    revalidateSeconds =
+      revalidateSeconds > 0
+        ? Math.min(revalidateSeconds, renderRevalidateSeconds)
+        : renderRevalidateSeconds;
+  }
+
+  return {
+    expireSeconds: options.renderCacheControl?.expire ?? options.expireSeconds,
+    revalidateSeconds,
+  };
+}
+
 export function buildAppPageCachedResponse(
   cachedValue: CachedAppPageValue,
   options: BuildAppPageCachedResponseOptions,
@@ -395,9 +415,11 @@ export async function readAppPageCacheResponse(
       // reuse it instead of recomputing the hash.
       options.scheduleBackgroundRegeneration(isrKey, async () => {
         const revalidatedPage = await options.renderFreshPageForCache();
-        const revalidateSeconds =
-          revalidatedPage.cacheControl?.revalidate ?? options.revalidateSeconds;
-        const expireSeconds = revalidatedPage.cacheControl?.expire ?? options.expireSeconds;
+        const cachePolicy = resolveRegeneratedAppPageCachePolicy({
+          expireSeconds: options.expireSeconds,
+          renderCacheControl: revalidatedPage.cacheControl,
+          routeRevalidateSeconds: options.revalidateSeconds,
+        });
         const writes = [
           options.isrSet(
             // For an RSC request `isrKey` is already the RSC variant key, so
@@ -417,9 +439,9 @@ export async function readAppPageCacheResponse(
               200,
               revalidatedPage.rscRenderObservation,
             ),
-            revalidateSeconds,
+            cachePolicy.revalidateSeconds,
             revalidatedPage.tags,
-            expireSeconds,
+            cachePolicy.expireSeconds,
           ),
         ];
 
@@ -438,9 +460,9 @@ export async function readAppPageCacheResponse(
                 revalidatedPage.htmlRenderObservation,
                 revalidatedPage.linkHeader ? { link: revalidatedPage.linkHeader } : undefined,
               ),
-              revalidateSeconds,
+              cachePolicy.revalidateSeconds,
               revalidatedPage.tags,
-              expireSeconds,
+              cachePolicy.expireSeconds,
             ),
           );
         }

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -32,6 +32,7 @@ import {
   setCurrentFetchCacheMode,
   setCurrentForceDynamicFetchDefault,
   setCurrentFetchSoftTags,
+  setRefreshStaleFetchesInForeground,
 } from "vinext/shims/fetch-cache";
 import { AppElementsWire, type AppOutgoingElements } from "./app-elements.js";
 import type { AppPagePprFallbackCacheShell } from "./app-ppr-fallback-shell.js";
@@ -456,6 +457,20 @@ export function shouldReadAppPageCache(options: {
   );
 }
 
+function resolveAppPageCacheReadRevalidateSeconds(options: {
+  isDynamicError: boolean;
+  isForceStatic: boolean;
+  revalidateSeconds: number | null;
+}): number {
+  if (options.revalidateSeconds === null && (options.isForceStatic || options.isDynamicError)) {
+    return Infinity;
+  }
+
+  // cacheLife-only routes discover their actual revalidate during the fresh
+  // render; this seed only gets them into the cache read path.
+  return options.revalidateSeconds ?? 0;
+}
+
 export function hasSearchParams(searchParams: URLSearchParams | null | undefined): boolean {
   return searchParams !== null && searchParams !== undefined && searchParams.size > 0;
 }
@@ -497,6 +512,7 @@ async function runAppPageRevalidationContext<
 
   return runWithRequestContext(requestContext, async () => {
     ensureFetchPatch();
+    setRefreshStaleFetchesInForeground(process.env.VINEXT_PRERENDER === "1");
     setCurrentFetchSoftTags(buildAppPageTags(options.cleanPathname, [], options.routeSegments));
     options.setNavigationContext({
       pathname: options.displayPathname ?? options.cleanPathname,
@@ -631,9 +647,11 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
       mountedSlotsHeader: options.mountedSlotsHeader,
       renderMode: options.renderMode,
       expireSeconds: options.expireSeconds,
-      // cacheLife-only routes discover their actual revalidate during the
-      // fresh render; this seed only gets them into the cache read path.
-      revalidateSeconds: currentRevalidateSeconds ?? 0,
+      revalidateSeconds: resolveAppPageCacheReadRevalidateSeconds({
+        isDynamicError,
+        isForceStatic,
+        revalidateSeconds: currentRevalidateSeconds,
+      }),
       renderFreshPageForCache: async () => {
         const revalidationTarget = await resolveAppPageInterceptionRerenderTarget({
           cleanPathname: options.cleanPathname,

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -224,12 +224,32 @@ function buildResponseTiming(
 }
 
 function readRequestCacheLifeForPrerender(
-  options: Pick<RenderAppPageLifecycleOptions, "getRequestCacheLife" | "peekRequestCacheLife">,
+  options: Pick<
+    RenderAppPageLifecycleOptions,
+    "getRequestCacheLife" | "isEdgeRuntime" | "peekRequestCacheLife" | "revalidateSeconds"
+  >,
 ): AppPageRequestCacheLife | null {
+  if (options.isEdgeRuntime && options.revalidateSeconds === null) {
+    const requestCacheLife = options.peekRequestCacheLife?.() ?? options.getRequestCacheLife();
+    return requestCacheLife?.revalidate !== undefined ? { revalidate: 0 } : null;
+  }
   // Prefer the non-destructive reader so prerender.ts can consume metadata
   // after the handler returns. The consume fallback supports older entry glue
   // and is only safe because this path reads at most once per prerender.
   return options.peekRequestCacheLife?.() ?? options.getRequestCacheLife();
+}
+
+function readRequestCacheLifeForCachePolicy(
+  options: Pick<
+    RenderAppPageLifecycleOptions,
+    "getRequestCacheLife" | "isEdgeRuntime" | "revalidateSeconds"
+  >,
+): AppPageRequestCacheLife | null {
+  const requestCacheLife = options.getRequestCacheLife();
+  if (options.isEdgeRuntime && options.revalidateSeconds === null) {
+    return null;
+  }
+  return requestCacheLife;
 }
 
 function applyRequestCacheLife(options: {
@@ -254,6 +274,18 @@ function applyRequestCacheLife(options: {
   }
 
   return { expireSeconds, revalidateSeconds };
+}
+
+function resolveAppPageCacheWriteRevalidateSeconds(options: {
+  isDynamicError: boolean;
+  isForceStatic: boolean;
+  revalidateSeconds: number | null;
+}): number | null {
+  if (options.revalidateSeconds === null && (options.isForceStatic || options.isDynamicError)) {
+    return Infinity;
+  }
+
+  return options.revalidateSeconds;
 }
 
 function readRootBoundaryId(element: Readonly<Record<string, unknown>>): string | null {
@@ -854,7 +886,7 @@ export async function renderAppPageLifecycle(
         return options.getPageTags();
       },
       getRequestCacheLife() {
-        return options.getRequestCacheLife();
+        return readRequestCacheLifeForCachePolicy(options);
       },
       isrDebug: options.isrDebug,
       isrRscKey: options.isrRscKey,
@@ -864,7 +896,11 @@ export async function renderAppPageLifecycle(
       renderMode: options.renderMode,
       preserveClientResponseHeaders: rscResponsePolicy.cacheState !== "MISS",
       expireSeconds,
-      revalidateSeconds,
+      revalidateSeconds: resolveAppPageCacheWriteRevalidateSeconds({
+        isDynamicError: options.isDynamicError,
+        isForceStatic: options.isForceStatic,
+        revalidateSeconds,
+      }),
       waitUntil(promise) {
         options.waitUntil?.(promise);
       },
@@ -1054,6 +1090,7 @@ export async function renderAppPageLifecycle(
   const shouldSpeculativelyWriteCache =
     options.isProduction &&
     shouldCaptureRscForCacheMetadata &&
+    !options.isEdgeRuntime &&
     revalidateSeconds === null &&
     !options.isDynamicError &&
     !options.isForceStatic &&
@@ -1112,7 +1149,7 @@ export async function renderAppPageLifecycle(
         return options.getPageTags();
       },
       getRequestCacheLife() {
-        return options.getRequestCacheLife();
+        return readRequestCacheLifeForCachePolicy(options);
       },
       isrDebug: options.isrDebug,
       isrHtmlKey: options.isrHtmlKey,
@@ -1122,7 +1159,11 @@ export async function renderAppPageLifecycle(
       omitPendingDynamicCacheState: options.omitPendingDynamicCacheState,
       preserveClientResponseHeaders: !htmlResponsePolicy.shouldWriteToCache,
       expireSeconds,
-      revalidateSeconds,
+      revalidateSeconds: resolveAppPageCacheWriteRevalidateSeconds({
+        isDynamicError: options.isDynamicError,
+        isForceStatic: options.isForceStatic,
+        revalidateSeconds,
+      }),
       waitUntil(cachePromise) {
         options.waitUntil?.(cachePromise);
       },

--- a/packages/vinext/src/server/app-page-response.ts
+++ b/packages/vinext/src/server/app-page-response.ts
@@ -221,8 +221,8 @@ export function resolveAppPageHtmlResponsePolicy(
   if ((options.isForceStatic || options.isDynamicError) && options.revalidateSeconds === null) {
     return {
       cacheControl: STATIC_CACHE_CONTROL,
-      cacheState: "STATIC",
-      shouldWriteToCache: false,
+      cacheState: options.isProduction ? "MISS" : "STATIC",
+      shouldWriteToCache: options.isProduction,
     };
   }
 

--- a/packages/vinext/src/shims/cache-handler.ts
+++ b/packages/vinext/src/shims/cache-handler.ts
@@ -178,6 +178,14 @@ function readStringArrayField(ctx: Record<string, unknown> | undefined, field: s
   return value.filter((item): item is string => typeof item === "string");
 }
 
+function readPositiveNumberField(
+  ctx: Record<string, unknown> | undefined,
+  field: string,
+): number | undefined {
+  const value = ctx?.[field];
+  return typeof value === "number" && value > 0 ? value : undefined;
+}
+
 export class MemoryCacheHandler implements CacheHandler {
   private store = new Map<string, MemoryEntry>();
   private tagRevalidatedAt = new Map<string, number>();
@@ -242,7 +250,15 @@ export class MemoryCacheHandler implements CacheHandler {
 
     this.touchEntry(key, entry);
 
-    if (entry.revalidateAt !== null && Date.now() > entry.revalidateAt) {
+    const now = Date.now();
+    const requestedRevalidate = readPositiveNumberField(ctx, "revalidate");
+    const requestedRevalidateAt =
+      requestedRevalidate === undefined ? null : entry.lastModified + requestedRevalidate * 1000;
+    const isStale =
+      (entry.revalidateAt !== null && now > entry.revalidateAt) ||
+      (requestedRevalidateAt !== null && now > requestedRevalidateAt);
+
+    if (isStale) {
       return {
         lastModified: entry.lastModified,
         value: entry.value,

--- a/packages/vinext/src/shims/cache.ts
+++ b/packages/vinext/src/shims/cache.ts
@@ -32,6 +32,7 @@ import { makeHangingPromise } from "./internal/make-hanging-promise.js";
 import { encodeCacheTag, encodeCacheTags } from "../utils/encode-cache-tag.js";
 import { getCdnCacheAdapter } from "./cdn-cache.js";
 import { getDataCacheHandler, type CachedFetchValue } from "./cache-handler.js";
+import { addCollectedRequestTags } from "./fetch-cache.js";
 import {
   ACTION_DID_REVALIDATE_DYNAMIC_ONLY,
   ACTION_DID_REVALIDATE_STATIC_AND_DYNAMIC,
@@ -188,6 +189,9 @@ export function updateTag(tag: string): Promise<void> {
  * It's provided for API compatibility so apps importing it don't break.
  */
 export function unstable_noStore(): void {
+  if (isInsideUnstableCacheScope()) {
+    return;
+  }
   // Signal dynamic usage so ISR-configured routes bypass the cache
   _markDynamic();
 }
@@ -586,6 +590,7 @@ export function unstable_cache<T extends (...args: any[]) => Promise<any>>(
   const cachedFn = async (...args: Parameters<T>) => {
     const argsKey = JSON.stringify(args);
     const cacheKey = `unstable_cache:${baseKey}:${argsKey}`;
+    addCollectedRequestTags(tags);
     recordUnstableCacheObservation({
       kind: "unstable_cache",
       keyHash: fnv1a64(cacheKey),

--- a/packages/vinext/src/shims/fetch-cache.ts
+++ b/packages/vinext/src/shims/fetch-cache.ts
@@ -581,13 +581,14 @@ async function buildFetchCacheValue(
   response: Response,
   tags: string[],
   revalidateSeconds: number,
+  options?: { cloneForReturn?: boolean },
 ): Promise<CachedFetchValue | null> {
   if (response.status !== 200) return null;
 
-  const cloned = response.clone();
-  const body = await cloned.text();
+  const responseForCache = options?.cloneForReturn === false ? response : response.clone();
+  const body = await responseForCache.text();
   const headers: Record<string, string> = {};
-  cloned.headers.forEach((v, k) => {
+  responseForCache.headers.forEach((v, k) => {
     if (k.toLowerCase() === "set-cookie") return;
     headers[k] = v;
   });
@@ -598,7 +599,7 @@ async function buildFetchCacheValue(
       headers,
       body,
       url: response.url,
-      status: cloned.status,
+      status: responseForCache.status,
     },
     tags,
     revalidate: revalidateSeconds,
@@ -611,8 +612,9 @@ async function writeFetchCacheResponse(
   response: Response,
   tags: string[],
   revalidateSeconds: number,
+  options?: { cloneForReturn?: boolean },
 ): Promise<void> {
-  const cacheValue = await buildFetchCacheValue(response, tags, revalidateSeconds);
+  const cacheValue = await buildFetchCacheValue(response, tags, revalidateSeconds, options);
   if (!cacheValue) return;
 
   await handler.set(cacheKey, cacheValue, {
@@ -1162,7 +1164,12 @@ function createPatchedFetch(): typeof globalThis.fetch {
 
     // Try cache first
     try {
-      const cached = await handler.get(cacheKey, { kind: "FETCH", tags, softTags });
+      const cached = await handler.get(cacheKey, {
+        kind: "FETCH",
+        tags,
+        softTags,
+        revalidate: revalidateSeconds,
+      });
       if (cached?.value && cached.value.kind === "FETCH" && cached.cacheState !== "stale") {
         await lowerFetchCacheRevalidateIfNeeded(
           handler,
@@ -1192,7 +1199,9 @@ function createPatchedFetch(): typeof globalThis.fetch {
         if (!pendingRefetches.has(cacheKey)) {
           const refetchPromise = originalFetch(input, fetchInit)
             .then(async (freshResp) => {
-              await writeFetchCacheResponse(handler, cacheKey, freshResp, tags, revalidateSeconds);
+              await writeFetchCacheResponse(handler, cacheKey, freshResp, tags, revalidateSeconds, {
+                cloneForReturn: false,
+              });
             })
             .catch((err) => {
               const url =

--- a/packages/vinext/src/shims/fetch-cache.ts
+++ b/packages/vinext/src/shims/fetch-cache.ts
@@ -19,10 +19,11 @@
  *   await runWithFetchCache(async () => { ... render ... });
  */
 
-import { getDataCacheHandler, type CachedFetchValue } from "./cache-handler.js";
+import { getDataCacheHandler, type CachedFetchValue, type CacheHandler } from "./cache-handler.js";
 import { encodeCacheTags } from "../utils/encode-cache-tag.js";
 import { getOrCreateAls } from "./internal/als-registry.js";
 import { markDynamicUsage } from "./headers.js";
+import { _setRequestScopedCacheLife } from "./cache-request-state.js";
 import { getRequestExecutionContext } from "./request-context.js";
 import {
   isInsideUnifiedScope,
@@ -484,6 +485,7 @@ export type FetchCacheState = {
   currentFetchCacheMode: FetchCacheMode | null;
   currentForceDynamicFetchDefault: boolean;
   dynamicFetchUrls: Set<string>;
+  refreshStaleFetchesInForeground: boolean;
   isFetchDedupeActive: boolean;
   currentFetchDedupeEntries: Map<string, FetchDedupeEntry[]>;
 };
@@ -520,6 +522,7 @@ const _fallbackState = (_g[_FALLBACK_KEY] ??= {
   currentFetchCacheMode: null,
   currentForceDynamicFetchDefault: false,
   dynamicFetchUrls: new Set<string>(),
+  refreshStaleFetchesInForeground: false,
   isFetchDedupeActive: false,
   currentFetchDedupeEntries: new Map(),
 } satisfies FetchCacheState) as FetchCacheState;
@@ -542,6 +545,7 @@ function _resetFallbackState(isFetchDedupeActive: boolean): void {
   _fallbackState.currentFetchCacheMode = null;
   _fallbackState.currentForceDynamicFetchDefault = false;
   _fallbackState.dynamicFetchUrls = new Set<string>();
+  _fallbackState.refreshStaleFetchesInForeground = false;
   _fallbackState.isFetchDedupeActive = isFetchDedupeActive;
   _fallbackState.currentFetchDedupeEntries = new Map();
 }
@@ -561,6 +565,90 @@ function markUncachedFetchForPageOutput(input: string | URL | Request): void {
 
 function recordCacheableFetchObservation(input: string | URL | Request): void {
   _getState().cacheableFetchUrls.add(getFetchObservationUrl(input));
+}
+
+function recordFiniteFetchRevalidate(revalidateSeconds: number): void {
+  if (Number.isFinite(revalidateSeconds) && revalidateSeconds > 0) {
+    _setRequestScopedCacheLife({ revalidate: revalidateSeconds });
+  }
+}
+
+function shouldRefreshStaleFetchInForeground(): boolean {
+  return _getState().refreshStaleFetchesInForeground;
+}
+
+async function buildFetchCacheValue(
+  response: Response,
+  tags: string[],
+  revalidateSeconds: number,
+): Promise<CachedFetchValue | null> {
+  if (response.status !== 200) return null;
+
+  const cloned = response.clone();
+  const body = await cloned.text();
+  const headers: Record<string, string> = {};
+  cloned.headers.forEach((v, k) => {
+    if (k.toLowerCase() === "set-cookie") return;
+    headers[k] = v;
+  });
+
+  return {
+    kind: "FETCH",
+    data: {
+      headers,
+      body,
+      url: response.url,
+      status: cloned.status,
+    },
+    tags,
+    revalidate: revalidateSeconds,
+  };
+}
+
+async function writeFetchCacheResponse(
+  handler: CacheHandler,
+  cacheKey: string,
+  response: Response,
+  tags: string[],
+  revalidateSeconds: number,
+): Promise<void> {
+  const cacheValue = await buildFetchCacheValue(response, tags, revalidateSeconds);
+  if (!cacheValue) return;
+
+  await handler.set(cacheKey, cacheValue, {
+    fetchCache: true,
+    tags,
+    revalidate: revalidateSeconds,
+  });
+}
+
+async function lowerFetchCacheRevalidateIfNeeded(
+  handler: CacheHandler,
+  cacheKey: string,
+  cachedValue: CachedFetchValue,
+  tags: string[],
+  revalidateSeconds: number,
+): Promise<void> {
+  if (
+    !Number.isFinite(revalidateSeconds) ||
+    revalidateSeconds <= 0 ||
+    typeof cachedValue.revalidate !== "number" ||
+    cachedValue.revalidate <= revalidateSeconds
+  ) {
+    return;
+  }
+
+  const mergedTags = Array.from(new Set([...(cachedValue.tags ?? []), ...tags]));
+  const updatedValue: CachedFetchValue = {
+    ...cachedValue,
+    tags: mergedTags,
+    revalidate: revalidateSeconds,
+  };
+  await handler.set(cacheKey, updatedValue, {
+    fetchCache: true,
+    tags: mergedTags,
+    revalidate: revalidateSeconds,
+  });
 }
 
 export function peekCacheableFetchObservations(): string[] {
@@ -637,6 +725,10 @@ export function setCurrentFetchCacheMode(mode: FetchCacheMode | null): void {
 
 export function setCurrentForceDynamicFetchDefault(enabled: boolean): void {
   _getState().currentForceDynamicFetchDefault = enabled;
+}
+
+export function setRefreshStaleFetchesInForeground(enabled: boolean): void {
+  _getState().refreshStaleFetchesInForeground = enabled;
 }
 
 function isNoStoreFetch(
@@ -1031,6 +1123,7 @@ function createPatchedFetch(): typeof globalThis.fetch {
     // recording both cacheable and dynamic is conservative — a false "unsafe"
     // result costs performance, not correctness.
     recordCacheableFetchObservation(input);
+    recordFiniteFetchRevalidate(revalidateSeconds);
     const reqTags = _getState().currentRequestTags;
     const tags = encodeCacheTags(nextOpts?.tags ?? []);
     if (tags.length > 0) {
@@ -1071,6 +1164,13 @@ function createPatchedFetch(): typeof globalThis.fetch {
     try {
       const cached = await handler.get(cacheKey, { kind: "FETCH", tags, softTags });
       if (cached?.value && cached.value.kind === "FETCH" && cached.cacheState !== "stale") {
+        await lowerFetchCacheRevalidateIfNeeded(
+          handler,
+          cacheKey,
+          cached.value,
+          tags,
+          revalidateSeconds,
+        );
         const cachedData = cached.value.data;
         return buildCachedFetchResponse(cachedData, input);
       }
@@ -1079,6 +1179,12 @@ function createPatchedFetch(): typeof globalThis.fetch {
       // the simpler approach is to just re-fetch (the page-level ISR handles SWR).
       // However, if we have a stale entry, return it and trigger background refetch.
       if (cached?.value && cached.value.kind === "FETCH" && cached.cacheState === "stale") {
+        if (shouldRefreshStaleFetchInForeground()) {
+          const freshResponse = await dedupeFetch(input, fetchInit);
+          await writeFetchCacheResponse(handler, cacheKey, freshResponse, tags, revalidateSeconds);
+          return freshResponse;
+        }
+
         const staleData = cached.value.data;
 
         // Background refetch — deduped so only one in-flight refetch runs
@@ -1086,33 +1192,7 @@ function createPatchedFetch(): typeof globalThis.fetch {
         if (!pendingRefetches.has(cacheKey)) {
           const refetchPromise = originalFetch(input, fetchInit)
             .then(async (freshResp) => {
-              // Only cache 200 responses — a transient error or unexpected
-              // status must not overwrite previously-good cached data.
-              if (freshResp.status !== 200) return;
-
-              const freshBody = await freshResp.text();
-              const freshHeaders: Record<string, string> = {};
-              freshResp.headers.forEach((v, k) => {
-                if (k.toLowerCase() === "set-cookie") return;
-                freshHeaders[k] = v;
-              });
-
-              const freshValue: CachedFetchValue = {
-                kind: "FETCH",
-                data: {
-                  headers: freshHeaders,
-                  body: freshBody,
-                  url: freshResp.url,
-                  status: freshResp.status,
-                },
-                tags,
-                revalidate: revalidateSeconds,
-              };
-              await handler.set(cacheKey, freshValue, {
-                fetchCache: true,
-                tags,
-                revalidate: revalidateSeconds,
-              });
+              await writeFetchCacheResponse(handler, cacheKey, freshResp, tags, revalidateSeconds);
             })
             .catch((err) => {
               const url =
@@ -1160,32 +1240,8 @@ function createPatchedFetch(): typeof globalThis.fetch {
     // Cache miss — fetch from network
     const response = await dedupeFetch(input, fetchInit);
 
-    // Only cache 200 responses
-    if (response.status === 200) {
-      // Clone before reading body
-      const cloned = response.clone();
-      const body = await cloned.text();
-      const headers: Record<string, string> = {};
-      cloned.headers.forEach((v, k) => {
-        // Never cache Set-Cookie headers — they are per-user and must not
-        // be replayed to subsequent requests from different users.
-        if (k.toLowerCase() === "set-cookie") return;
-        headers[k] = v;
-      });
-
-      const cacheValue: CachedFetchValue = {
-        kind: "FETCH",
-        data: {
-          headers,
-          body,
-          url: response.url,
-          status: cloned.status,
-        },
-        tags,
-        revalidate: revalidateSeconds,
-      };
-
-      // Store in cache (fire-and-forget)
+    const cacheValue = await buildFetchCacheValue(response, tags, revalidateSeconds);
+    if (cacheValue) {
       handler
         .set(cacheKey, cacheValue, {
           fetchCache: true,
@@ -1278,6 +1334,7 @@ export async function runWithFetchCache<T>(fn: () => Promise<T>): Promise<T> {
       uCtx.currentRequestTags = [];
       uCtx.currentFetchSoftTags = [];
       uCtx.dynamicFetchUrls = new Set<string>();
+      uCtx.refreshStaleFetchesInForeground = false;
       uCtx.isFetchDedupeActive = true;
       uCtx.currentFetchDedupeEntries = new Map();
     }, fn);
@@ -1290,6 +1347,7 @@ export async function runWithFetchCache<T>(fn: () => Promise<T>): Promise<T> {
       currentFetchCacheMode: null,
       currentForceDynamicFetchDefault: false,
       dynamicFetchUrls: new Set<string>(),
+      refreshStaleFetchesInForeground: false,
       isFetchDedupeActive: true,
       currentFetchDedupeEntries: new Map(),
     },

--- a/packages/vinext/src/shims/unified-request-context.ts
+++ b/packages/vinext/src/shims/unified-request-context.ts
@@ -106,6 +106,7 @@ export function createRequestContext(opts?: Partial<UnifiedRequestContext>): Uni
     currentFetchCacheMode: null,
     currentForceDynamicFetchDefault: false,
     dynamicFetchUrls: new Set<string>(),
+    refreshStaleFetchesInForeground: false,
     isFetchDedupeActive: false,
     currentFetchDedupeEntries: new Map(),
     executionContext: _getInheritedExecutionContext(), // inherits from standalone ALS if present

--- a/tests/app-page-cache.test.ts
+++ b/tests/app-page-cache.test.ts
@@ -722,6 +722,66 @@ describe("app page cache helpers", () => {
     ]);
   });
 
+  it("preserves route-level revalidate when regenerated App page fetches live longer", async () => {
+    const scheduledRegenerations: Array<() => Promise<void>> = [];
+    const isrSetCalls: Array<{
+      key: string;
+      expireSeconds: number | undefined;
+      revalidateSeconds: number;
+    }> = [];
+    const rscData = new TextEncoder().encode("fresh-flight").buffer;
+
+    const response = await readAppPageCacheResponse({
+      cleanPathname: "/config-and-fetch-revalidate",
+      clearRequestContext() {},
+      isRscRequest: false,
+      async isrGet() {
+        return buildISRCacheEntry(buildCachedAppPageValue("<h1>stale</h1>"), true);
+      },
+      isrHtmlKey(pathname) {
+        return "html:" + pathname;
+      },
+      isrRscKey(pathname, mountedSlotsHeader) {
+        return `rsc:${pathname}:${mountedSlotsHeader ?? "none"}`;
+      },
+      async isrSet(key, _data, revalidateSeconds, _tags, expireSeconds) {
+        isrSetCalls.push({
+          key,
+          expireSeconds,
+          revalidateSeconds,
+        });
+      },
+      revalidateSeconds: 3,
+      async renderFreshPageForCache() {
+        return {
+          cacheControl: { revalidate: 9 },
+          html: "<h1>fresh</h1>",
+          rscData,
+          tags: ["/config-and-fetch-revalidate", "_N_T_/config-and-fetch-revalidate"],
+        };
+      },
+      scheduleBackgroundRegeneration(_key, renderFn) {
+        scheduledRegenerations.push(renderFn);
+      },
+    });
+
+    expect(response?.headers.get("x-vinext-cache")).toBe("STALE");
+    await scheduledRegenerations[0]();
+
+    expect(isrSetCalls).toEqual([
+      {
+        key: "rsc:/config-and-fetch-revalidate:none",
+        expireSeconds: undefined,
+        revalidateSeconds: 3,
+      },
+      {
+        key: "html:/config-and-fetch-revalidate",
+        expireSeconds: undefined,
+        revalidateSeconds: 3,
+      },
+    ]);
+  });
+
   it("serves stale static fallback shells without regenerating the shared shell key", async () => {
     const debugCalls: Array<[string, string]> = [];
 

--- a/tests/app-page-response.test.ts
+++ b/tests/app-page-response.test.ts
@@ -235,6 +235,42 @@ describe("app page response helpers", () => {
     });
   });
 
+  it("writes force-static HTML responses to cache in production", () => {
+    expect(
+      resolveAppPageHtmlResponsePolicy({
+        dynamicUsedDuringRender: false,
+        hasScriptNonce: false,
+        isDraftMode: false,
+        isDynamicError: false,
+        isForceDynamic: false,
+        isForceStatic: true,
+        isProduction: true,
+        revalidateSeconds: null,
+      }),
+    ).toEqual({
+      cacheControl: "s-maxage=31536000, stale-while-revalidate",
+      cacheState: "MISS",
+      shouldWriteToCache: true,
+    });
+
+    expect(
+      resolveAppPageHtmlResponsePolicy({
+        dynamicUsedDuringRender: false,
+        hasScriptNonce: false,
+        isDraftMode: false,
+        isDynamicError: false,
+        isForceDynamic: false,
+        isForceStatic: true,
+        isProduction: false,
+        revalidateSeconds: null,
+      }),
+    ).toEqual({
+      cacheControl: "s-maxage=31536000, stale-while-revalidate",
+      cacheState: "STATIC",
+      shouldWriteToCache: false,
+    });
+  });
+
   it("treats progressive action HTML responses as no-store", () => {
     expect(
       resolveAppPageHtmlResponsePolicy({

--- a/tests/app-router-production-server.test.ts
+++ b/tests/app-router-production-server.test.ts
@@ -109,12 +109,16 @@ type StartedTextSequenceTarget = {
   url: string;
 };
 
-async function startTextSequenceTarget(): Promise<StartedTextSequenceTarget> {
+async function startTextSequenceTarget(options?: {
+  prefix?: string;
+  recordRequest?: (req: http.IncomingMessage) => void;
+}): Promise<StartedTextSequenceTarget> {
   let responseCount = 0;
-  const upstream = http.createServer((_req, res) => {
+  const upstream = http.createServer((req, res) => {
     responseCount += 1;
+    options?.recordRequest?.(req);
     res.setHeader("content-type", "text/plain; charset=utf-8");
-    res.end(`random-${responseCount}`);
+    res.end(`${options?.prefix ?? "random"}-${responseCount}`);
   });
 
   await new Promise<void>((resolve, reject) => {
@@ -143,6 +147,48 @@ async function startTextSequenceTarget(): Promise<StartedTextSequenceTarget> {
   };
 }
 
+async function startDelayedJsonSequenceTarget(delayMs: number): Promise<StartedTextSequenceTarget> {
+  let responseCount = 0;
+  const upstream = http.createServer((req, res) => {
+    responseCount += 1;
+    const current = responseCount;
+    setTimeout(() => {
+      res.setHeader("content-type", "application/json");
+      res.end(
+        JSON.stringify({
+          count: current,
+          method: req.method,
+        }),
+      );
+    }, delayMs);
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    upstream.once("error", reject);
+    upstream.listen(0, "127.0.0.1", () => {
+      upstream.off("error", reject);
+      resolve();
+    });
+  });
+
+  const address = upstream.address();
+  if (!address || typeof address === "string") {
+    await new Promise<void>((resolve, reject) => {
+      upstream.close((error) => (error ? reject(error) : resolve()));
+    });
+    throw new Error("Delayed JSON target did not bind to a TCP port");
+  }
+
+  return {
+    url: `http://127.0.0.1:${address.port}/data`,
+    close() {
+      return new Promise<void>((resolve, reject) => {
+        upstream.close((error) => (error ? reject(error) : resolve()));
+      });
+    },
+  };
+}
+
 async function waitForCondition(
   condition: () => boolean | Promise<boolean>,
   options?: { intervalMs?: number; timeoutMs?: number },
@@ -162,6 +208,9 @@ describe("App Router Production server (startProdServer)", () => {
   const outDir = path.resolve(APP_FIXTURE_DIR, "dist");
   let server: import("node:http").Server | undefined;
   let baseUrl: string;
+  let appStaticDelayTarget: StartedTextSequenceTarget | undefined;
+  let appStaticDynamicTarget: StartedTextSequenceTarget | undefined;
+  let appStaticRevalidateTarget: StartedTextSequenceTarget | undefined;
   let revalidatePathFetchTarget: StartedTextSequenceTarget | undefined;
 
   function extractRequestId(html: string): string | undefined {
@@ -174,6 +223,10 @@ describe("App Router Production server (startProdServer)", () => {
 
   function extractRandomData(html: string): string | undefined {
     return html.match(/id="random-data"[^>]*>(?:<!--.*?-->)*([^<]+)/)?.[1];
+  }
+
+  function extractTextById(html: string, id: string): string | undefined {
+    return html.match(new RegExp(`id="${id}"[^>]*>(?:<!--.*?-->)*([^<]+)`))?.[1];
   }
 
   async function fetchRandomData(pathname: string, url = baseUrl): Promise<string> {
@@ -204,7 +257,13 @@ describe("App Router Production server (startProdServer)", () => {
   }
 
   beforeAll(async () => {
+    appStaticDelayTarget = await startDelayedJsonSequenceTarget(750);
+    appStaticDynamicTarget = await startTextSequenceTarget({ prefix: "dynamic" });
+    appStaticRevalidateTarget = await startTextSequenceTarget({ prefix: "revalidate" });
     revalidatePathFetchTarget = await startTextSequenceTarget();
+    process.env.TEST_APP_STATIC_DELAY_TARGET = appStaticDelayTarget.url;
+    process.env.TEST_APP_STATIC_DYNAMIC_TARGET = appStaticDynamicTarget.url;
+    process.env.TEST_APP_STATIC_REVALIDATE_TARGET = appStaticRevalidateTarget.url;
     process.env.TEST_REVALIDATE_PATH_REWRITES_TARGET = revalidatePathFetchTarget.url;
 
     try {
@@ -226,9 +285,18 @@ describe("App Router Production server (startProdServer)", () => {
     } catch (error) {
       server?.close();
       try {
-        await revalidatePathFetchTarget.close();
+        await appStaticDelayTarget?.close();
+        await appStaticDynamicTarget?.close();
+        await appStaticRevalidateTarget?.close();
+        await revalidatePathFetchTarget?.close();
       } finally {
+        appStaticDelayTarget = undefined;
+        appStaticDynamicTarget = undefined;
+        appStaticRevalidateTarget = undefined;
         revalidatePathFetchTarget = undefined;
+        delete process.env.TEST_APP_STATIC_DELAY_TARGET;
+        delete process.env.TEST_APP_STATIC_DYNAMIC_TARGET;
+        delete process.env.TEST_APP_STATIC_REVALIDATE_TARGET;
         delete process.env.TEST_REVALIDATE_PATH_REWRITES_TARGET;
       }
       throw error;
@@ -237,7 +305,13 @@ describe("App Router Production server (startProdServer)", () => {
 
   afterAll(async () => {
     server?.close();
+    await appStaticDelayTarget?.close();
+    await appStaticDynamicTarget?.close();
+    await appStaticRevalidateTarget?.close();
     await revalidatePathFetchTarget?.close();
+    delete process.env.TEST_APP_STATIC_DELAY_TARGET;
+    delete process.env.TEST_APP_STATIC_DYNAMIC_TARGET;
+    delete process.env.TEST_APP_STATIC_REVALIDATE_TARGET;
     delete process.env.TEST_REVALIDATE_PATH_REWRITES_TARGET;
     fs.rmSync(outDir, { recursive: true, force: true });
   });
@@ -293,6 +367,107 @@ describe("App Router Production server (startProdServer)", () => {
 
     const unknown = await fetch(`${baseUrl}/layout-segment-config/dynamic-error-false/unknown`);
     expect(unknown.status).toBe(404);
+  });
+
+  // Ported from Next.js: test/e2e/app-dir/app-static/app-static.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app-static/app-static.test.ts
+  it("revalidates static App pages that combine route config and fetch revalidate", async () => {
+    const initialRes = await fetch(`${baseUrl}/nextjs-compat/app-static-config-fetch-revalidate`);
+    expect(initialRes.status).toBe(200);
+    const initialHtml = await initialRes.text();
+    const initialDate = extractTextById(initialHtml, "date");
+    const initialData = extractTextById(initialHtml, "random-data");
+    expect(initialDate).toBeTruthy();
+    expect(initialData).toBeTruthy();
+
+    let firstFreshDate = "";
+    let firstFreshData = "";
+    await waitForCondition(
+      async () => {
+        const res = await fetch(`${baseUrl}/nextjs-compat/app-static-config-fetch-revalidate`);
+        expect(res.status).toBe(200);
+        const html = await res.text();
+        firstFreshDate = extractTextById(html, "date") ?? "";
+        firstFreshData = extractTextById(html, "random-data") ?? "";
+        return firstFreshDate !== initialDate && firstFreshData !== initialData;
+      },
+      { timeoutMs: 5000 },
+    );
+
+    await waitForCondition(
+      async () => {
+        const res = await fetch(`${baseUrl}/nextjs-compat/app-static-config-fetch-revalidate`);
+        expect(res.status).toBe(200);
+        const html = await res.text();
+        const nextDate = extractTextById(html, "date");
+        const nextData = extractTextById(html, "random-data");
+        return nextDate !== firstFreshDate && nextData !== firstFreshData;
+      },
+      { timeoutMs: 5000 },
+    );
+  });
+
+  // Ported from Next.js: test/e2e/app-dir/app-static/app-static.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app-static/app-static.test.ts
+  it("does not cache generated static params when the page uses dynamic fetch data", async () => {
+    const pathname = "/nextjs-compat/app-static-gen-params-dynamic/one";
+    const initialRes = await fetch(`${baseUrl}${pathname}`);
+    expect(initialRes.status).toBe(200);
+    const initialHtml = await initialRes.text();
+    expect(initialHtml).toContain("/nextjs-compat/app-static-gen-params-dynamic/[slug]");
+    expect(extractTextById(initialHtml, "slug")).toBe("one");
+    const initialData = extractTextById(initialHtml, "data");
+    expect(initialData).toBeTruthy();
+
+    for (let index = 0; index < 3; index++) {
+      const res = await fetch(`${baseUrl}${pathname}`);
+      expect(res.status).toBe(200);
+      const data = extractTextById(await res.text(), "data");
+      expect(data).toBeTruthy();
+      expect(data).not.toBe(initialData);
+    }
+  });
+
+  // Ported from Next.js: test/e2e/app-dir/app-static/app-static.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app-static/app-static.test.ts
+  it("caches lazy dynamic params for force-static App pages", async () => {
+    const pathname = "/nextjs-compat/app-static-force-static/lazy";
+    const first = await fetch(`${baseUrl}${pathname}`, {
+      headers: {
+        cookie: "app-static-dynamic=hidden",
+        "x-app-static": "hidden",
+      },
+    });
+    expect(first.status).toBe(200);
+    const firstHtml = await first.text();
+    expect(extractTextById(firstHtml, "id")).toBe("lazy");
+    expect(firstHtml).toContain('<p id="headers">[]</p>');
+    expect(firstHtml).toContain('<p id="cookies">[]</p>');
+    const firstNow = extractTextById(firstHtml, "now");
+    expect(firstNow).toBeTruthy();
+
+    const second = await fetch(`${baseUrl}${pathname}`);
+    expect(second.status).toBe(200);
+    expect(extractTextById(await second.text(), "now")).toBe(firstNow);
+  });
+
+  // Ported from Next.js: test/e2e/app-dir/app-static/app-static.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app-static/app-static.test.ts
+  it("serves stale edge App page responses without waiting for regeneration", async () => {
+    const pathname = "/nextjs-compat/app-static-stale-cache-serving-edge/app-page";
+    const prime = await fetch(`${baseUrl}${pathname}`);
+    expect(prime.status).toBe(200);
+    await prime.text();
+
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+    const started = Date.now();
+    const stale = await fetch(`${baseUrl}${pathname}`);
+    const html = await stale.text();
+    const duration = Date.now() - started;
+    expect(stale.status).toBe(200);
+    expect(duration).toBeLessThan(500);
+    const data = JSON.parse((extractTextById(html, "data") ?? "{}").replace(/&quot;/g, '"'));
+    expect(data.data.count).toBeGreaterThan(0);
   });
 
   // Ported from Next.js: test/e2e/app-dir/navigation/navigation.test.ts

--- a/tests/fetch-cache.test.ts
+++ b/tests/fetch-cache.test.ts
@@ -47,6 +47,7 @@ const {
   setCurrentFetchCacheMode,
   setCurrentForceDynamicFetchDefault,
   setCurrentFetchSoftTags,
+  setRefreshStaleFetchesInForeground,
   getOriginalFetch,
   _resetPendingRefetches,
   consumeDynamicFetchObservations,
@@ -851,6 +852,30 @@ describe("fetch cache shim", () => {
     // Wait for background refetch
     await new Promise((resolve) => setTimeout(resolve, 50));
     expect(fetchMock).toHaveBeenCalledTimes(2); // Original + background refetch
+  });
+
+  it("refreshes stale fetch entries when foreground fetch refresh is enabled", async () => {
+    const res1 = await fetch("https://api.example.com/foreground-stale", {
+      next: { revalidate: 1 },
+    });
+    expect((await res1.json()).count).toBe(1);
+
+    const handler = getCacheHandler() as InstanceType<typeof MemoryCacheHandler>;
+    const store = (handler as any).store as Map<string, any>;
+    for (const [, entry] of store) {
+      entry.revalidateAt = Date.now() - 1000;
+    }
+    startNewFetchCacheScope();
+
+    await runWithRequestContext(createRequestContext(), async () => {
+      setRefreshStaleFetchesInForeground(true);
+      const res2 = await fetch("https://api.example.com/foreground-stale", {
+        next: { revalidate: 1 },
+      });
+      expect((await res2.json()).count).toBe(2);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it("preserves Request bodies for stale background revalidation", async () => {

--- a/tests/fetch-cache.test.ts
+++ b/tests/fetch-cache.test.ts
@@ -878,6 +878,83 @@ describe("fetch cache shim", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it("foreground fetch refresh treats a shorter current revalidate as stale", async () => {
+    const res1 = await fetch("https://api.example.com/foreground-shorter-revalidate", {
+      next: { revalidate: 60 },
+    });
+    expect((await res1.json()).count).toBe(1);
+
+    const handler = getCacheHandler() as InstanceType<typeof MemoryCacheHandler>;
+    const store = (handler as any).store as Map<string, any>;
+    for (const [, entry] of store) {
+      entry.lastModified = Date.now() - 2_000;
+      entry.revalidateAt = Date.now() + 58_000;
+    }
+    startNewFetchCacheScope();
+
+    await runWithRequestContext(createRequestContext(), async () => {
+      setRefreshStaleFetchesInForeground(true);
+      const res2 = await fetch("https://api.example.com/foreground-shorter-revalidate", {
+        next: { revalidate: 1 },
+      });
+      expect((await res2.json()).count).toBe(2);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("refreshes in the background when a shorter current revalidate makes a fetch stale", async () => {
+    const res1 = await fetch("https://api.example.com/background-shorter-revalidate", {
+      next: { revalidate: 60 },
+    });
+    expect((await res1.json()).count).toBe(1);
+
+    const handler = getCacheHandler() as InstanceType<typeof MemoryCacheHandler>;
+    const store = (handler as any).store as Map<string, any>;
+    for (const [, entry] of store) {
+      entry.lastModified = Date.now() - 2_000;
+      entry.revalidateAt = Date.now() + 58_000;
+    }
+    startNewFetchCacheScope();
+
+    const res2 = await fetch("https://api.example.com/background-shorter-revalidate", {
+      next: { revalidate: 1 },
+    });
+    expect((await res2.json()).count).toBe(1);
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not clone the upstream response body for stale background revalidation", async () => {
+    const res1 = await fetch("https://api.example.com/background-no-returned-clone", {
+      next: { revalidate: 1 },
+    });
+    expect((await res1.json()).count).toBe(1);
+
+    const handler = getCacheHandler() as InstanceType<typeof MemoryCacheHandler>;
+    const store = (handler as any).store as Map<string, any>;
+    for (const [, entry] of store) {
+      entry.revalidateAt = Date.now() - 1000;
+    }
+    startNewFetchCacheScope();
+
+    const cloneSpy = vi.spyOn(Response.prototype, "clone");
+    try {
+      const res2 = await fetch("https://api.example.com/background-no-returned-clone", {
+        next: { revalidate: 1 },
+      });
+      expect((await res2.json()).count).toBe(1);
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(cloneSpy).not.toHaveBeenCalled();
+    } finally {
+      cloneSpy.mockRestore();
+    }
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it("preserves Request bodies for stale background revalidation", async () => {
     const seenBodies: string[] = [];
     fetchMock.mockImplementation(async (input: string | URL | Request, _init?: RequestInit) => {

--- a/tests/fixtures/app-basic/app/nextjs-compat/app-static-config-fetch-revalidate/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/app-static-config-fetch-revalidate/page.tsx
@@ -1,0 +1,19 @@
+export const revalidate = 1;
+
+export default async function Page() {
+  const target = process.env.TEST_APP_STATIC_REVALIDATE_TARGET;
+  if (!target) {
+    throw new Error("Missing TEST_APP_STATIC_REVALIDATE_TARGET");
+  }
+
+  const data = await fetch(target, {
+    next: { revalidate: 2 },
+  }).then((res) => res.text());
+
+  return (
+    <>
+      <p id="date">{Date.now()}</p>
+      <p id="random-data">{data}</p>
+    </>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/app-static-force-static/[id]/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/app-static-force-static/[id]/page.tsx
@@ -10,6 +10,7 @@ export default async function Page({ params }: { params: Promise<{ id: string }>
       <p id="id">{id}</p>
       <p id="headers">{JSON.stringify([...(await headers()).entries()])}</p>
       <p id="cookies">{JSON.stringify((await cookies()).getAll())}</p>
+      <p id="now">{Date.now()}</p>
     </main>
   );
 }

--- a/tests/fixtures/app-basic/app/nextjs-compat/app-static-gen-params-dynamic/[slug]/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/app-static-gen-params-dynamic/[slug]/page.tsx
@@ -1,0 +1,25 @@
+export async function generateStaticParams() {
+  return [{ slug: "one" }];
+}
+
+export default async function Page(props: { params: Promise<{ slug: string }> }) {
+  const { slug } = await props.params;
+  const target = process.env.TEST_APP_STATIC_DYNAMIC_TARGET;
+  if (!target) {
+    throw new Error("Missing TEST_APP_STATIC_DYNAMIC_TARGET");
+  }
+
+  const data = await fetch(target, {
+    method: "POST",
+    body: JSON.stringify({ hello: "world" }),
+    next: { revalidate: 0 },
+  }).then((res) => res.text());
+
+  return (
+    <>
+      <p id="page">/nextjs-compat/app-static-gen-params-dynamic/[slug]</p>
+      <p id="slug">{slug}</p>
+      <p id="data">{data}</p>
+    </>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/app-static-stale-cache-serving-edge/app-page/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/app-static-stale-cache-serving-edge/app-page/page.tsx
@@ -1,0 +1,24 @@
+export const runtime = "edge";
+
+export default async function Page() {
+  const target = process.env.TEST_APP_STATIC_DELAY_TARGET;
+  if (!target) {
+    throw new Error("Missing TEST_APP_STATIC_DELAY_TARGET");
+  }
+
+  const start = Date.now();
+  const data = await fetch(target, {
+    next: { revalidate: 1 },
+  }).then((res) => res.json());
+  const fetchDuration = Date.now() - start;
+
+  return (
+    <p id="data">
+      {JSON.stringify({
+        data,
+        fetchDuration,
+        start,
+      })}
+    </p>
+  );
+}

--- a/tests/kv-cache-handler.test.ts
+++ b/tests/kv-cache-handler.test.ts
@@ -468,6 +468,31 @@ describe("KVCacheHandler", () => {
       await expect(handler.get("expire-test")).resolves.toBeNull();
       expect(kv.delete).toHaveBeenCalledWith("cache:expire-test");
     });
+
+    it("serves stale when a shorter read-time revalidate has elapsed", async () => {
+      vi.useFakeTimers({ toFake: ["Date"] });
+      vi.setSystemTime(1_000);
+
+      await handler.set(
+        "shorter-read-revalidate",
+        {
+          kind: "FETCH",
+          data: { headers: {}, body: "cached", url: "https://example.com/data" },
+          tags: [],
+          revalidate: 60,
+        },
+        { revalidate: 60 },
+      );
+
+      vi.setSystemTime(3_500);
+      const stale = await handler.get("shorter-read-revalidate", { revalidate: 2 });
+
+      expect(stale?.cacheState).toBe("stale");
+      const value = stale?.value;
+      expect(value?.kind).toBe("FETCH");
+      if (value?.kind !== "FETCH") throw new Error("expected FETCH cache value");
+      expect(value.data.body).toBe("cached");
+    });
   });
 
   describe("tag invalidation", () => {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -5336,6 +5336,28 @@ describe("next/cache shim", () => {
     expect(() => noStore()).not.toThrow();
   });
 
+  it("unstable_noStore does not opt out when called inside unstable_cache", async () => {
+    const { unstable_cache, unstable_noStore } =
+      await import("../packages/vinext/src/shims/cache.js");
+    const { createRequestContext, runWithRequestContext, getRequestContext } =
+      await import("../packages/vinext/src/shims/unified-request-context.js");
+
+    await runWithRequestContext(createRequestContext(), async () => {
+      const cached = unstable_cache(
+        async () => {
+          unstable_noStore();
+          return "cached";
+        },
+        ["no-store-inside-cache"],
+        { tags: ["no-store-inside-cache"] },
+      );
+
+      await cached();
+      expect(getRequestContext().dynamicUsageDetected).toBe(false);
+      expect(getRequestContext().currentRequestTags).toContain("no-store-inside-cache");
+    });
+  });
+
   it("exports cacheLife with built-in profiles", async () => {
     const { cacheLife, cacheLifeProfiles } = await import("../packages/vinext/src/shims/cache.js");
     expect(typeof cacheLife).toBe("function");


### PR DESCRIPTION
## Summary
- skip App Router prerender artifacts when concrete static params render no-store output
- preserve route-level ISR policy during stale App page regeneration and foreground-refresh stale fetches during prerender regeneration
- cache force-static lazy App pages in production and keep edge stale App page responses non-blocking

## Validation
- `vp test run tests/app-page-cache.test.ts tests/app-page-response.test.ts tests/fetch-cache.test.ts tests/shims.test.ts -t "preserves route-level revalidate|writes force-static|foreground fetch refresh|unstable_noStore does not opt out"`
- `vp test run tests/app-router-production-server.test.ts -t "revalidates static App pages|does not cache generated static params|caches lazy dynamic params|serves stale edge App page" --maxWorkers=1`
- `vp check --fix`
- `REPO="$(pwd)" NEXTJS_DIR="/Users/jamesanderson/Developer/vinext/.nextjs-ref" NEXT_TEST_CONCURRENCY=1 ./scripts/run-targeted-nextjs-e2e.sh test/e2e/app-dir/app-static/app-static.test.ts` (passes target residual rows; remaining failures are the excluded useSearchParams Suspense server-response row and updateTag server-action row)
