### PR TITLE
fix(app-router): vary segment prefetches by accessed params

### DIFF
--- a/packages/vinext/src/client/vinext-next-data.ts
+++ b/packages/vinext/src/client/vinext-next-data.ts
@@ -8,12 +8,26 @@
 import type { NEXT_DATA } from "vinext/shims/internal/utils";
 import { isUnknownRecord } from "../utils/record.js";
 
+export type VinextRuntimePrefetchLoadingFallback = {
+  attributes: Record<string, string>;
+  tagName: string;
+  text: string;
+};
+
 export type VinextLinkPrefetchRoute = {
   canPrefetchLoadingShell: boolean;
+  canPrefetchRuntimeShell?: boolean;
+  canPrefetchStaticRoute?: boolean;
   documentOnly?: boolean;
   isDynamic: boolean;
+  loadingShellVaryParamNames?: string[];
   patternParts: string[];
+  prefetchVaryParamNames?: string[];
+  prefetchVarySearchParams?: boolean;
   requiresDynamicNavigationRequest?: boolean;
+  runtimePrefetchLoadingFallback?: VinextRuntimePrefetchLoadingFallback;
+  runtimePrefetchVaryParamNames?: string[];
+  runtimePrefetchVarySearchParams?: boolean;
 };
 
 /**

--- a/packages/vinext/src/entries/app-browser-entry.ts
+++ b/packages/vinext/src/entries/app-browser-entry.ts
@@ -137,9 +137,76 @@ function serverPrefetchSource(source: string): string {
   return sourceHasUseClientDirective(source) ? "" : source;
 }
 
+function readIdentifier(source: string, index: number): string | null {
+  const match = /[A-Za-z_$][\w$]*/.exec(source.slice(index));
+  return match?.index === 0 ? match[0] : null;
+}
+
+function skipsQuotedSource(source: string, index: number): number {
+  const quote = source[index];
+  let cursor = index + 1;
+  while (cursor < source.length) {
+    const char = source[cursor];
+    if (char === "\\") {
+      cursor += 2;
+      continue;
+    }
+    if (char === quote) return cursor + 1;
+    cursor++;
+  }
+  return source.length;
+}
+
+function nextNonWhitespaceIndex(source: string, index: number): number {
+  let cursor = index;
+  while (cursor < source.length && /\s/.test(source[cursor] ?? "")) {
+    cursor++;
+  }
+  return cursor;
+}
+
+function findConnectionCallIndex(source: string): number | null {
+  const allowedPreviousIdentifiers = new Set(["await", "return", "void", "yield"]);
+  const allowedPreviousPunctuation = new Set(["", "(", "{", "[", "=", ":", ",", ";", "?", "!"]);
+  let previousToken = "";
+  let index = 0;
+
+  while (index < source.length) {
+    const char = source[index];
+    if (char === '"' || char === "'" || char === "`") {
+      index = skipsQuotedSource(source, index);
+      continue;
+    }
+
+    const identifier = readIdentifier(source, index);
+    if (identifier !== null) {
+      if (identifier === "connection") {
+        const nextIndex = nextNonWhitespaceIndex(source, index + identifier.length);
+        if (
+          source[nextIndex] === "(" &&
+          (allowedPreviousIdentifiers.has(previousToken) ||
+            allowedPreviousPunctuation.has(previousToken))
+        ) {
+          return index;
+        }
+      }
+      previousToken = identifier;
+      index += identifier.length;
+      continue;
+    }
+
+    if (!/\s/.test(char ?? "")) {
+      previousToken = char ?? "";
+    }
+    index++;
+  }
+
+  return null;
+}
+
 function staticPrefetchRegion(source: string): string {
-  const connectionMatch = /\bconnection\s*\(/.exec(source);
-  return connectionMatch?.index === undefined ? source : source.slice(0, connectionMatch.index);
+  const connectionIndex = findConnectionCallIndex(source);
+  return connectionIndex === null ? source : source.slice(0, connectionIndex);
 }
 
 function findExportedFunctionBodyStart(source: string, functionName: string): number | null {
@@ -231,15 +298,44 @@ function sourcePattern(
   return `(?:${patterns.join("|")})`;
 }
 
+function collectSourceAliases(
+  source: string,
+  identifiers: readonly string[],
+  memberPropName: string,
+): string[] {
+  const aliases: string[] = [];
+  const seen = new Set(identifiers);
+
+  for (;;) {
+    const sourceExpressionPattern = sourcePattern(Array.from(seen), memberPropName, source);
+    const discovered = Array.from(
+      source.matchAll(
+        new RegExp(
+          String.raw`\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*${sourceExpressionPattern}\b`,
+          "g",
+        ),
+      ),
+      (match) => match[1],
+    ).filter((alias) => !seen.has(alias));
+
+    if (discovered.length === 0) return aliases;
+    for (const alias of discovered) {
+      seen.add(alias);
+      aliases.push(alias);
+    }
+  }
+}
+
 function collectParamAccesses(source: string, paramNames: readonly string[]): Set<string> {
   const region = staticPrefetchRegion(source);
   const accessed = new Set<string>();
   const paramPropAliases = collectPropAliases(region, "params");
-  const paramPromiseSourcePattern = sourcePattern(
-    ["params", ...paramPropAliases],
+  const paramPromiseIdentifiers = [
     "params",
-    region,
-  );
+    ...paramPropAliases,
+    ...collectSourceAliases(region, ["params", ...paramPropAliases], "params"),
+  ];
+  const paramPromiseSourcePattern = sourcePattern(paramPromiseIdentifiers, "params", region);
   const awaitedParamAliases = Array.from(
     region.matchAll(
       new RegExp(
@@ -250,7 +346,7 @@ function collectParamAccesses(source: string, paramNames: readonly string[]): Se
     (match) => match[1],
   );
   const paramSourcePattern = sourcePattern(
-    ["params", ...paramPropAliases, ...awaitedParamAliases],
+    [...paramPromiseIdentifiers, ...awaitedParamAliases],
     "params",
     region,
   );
@@ -324,8 +420,13 @@ function mergeAccesses(target: Set<string>, source: Set<string>): void {
 function sourceAccessesSearchParams(source: string): boolean {
   const region = staticPrefetchRegion(source);
   const searchParamPropAliases = collectPropAliases(region, "searchParams");
+  const searchParamPromiseIdentifiers = [
+    "searchParams",
+    ...searchParamPropAliases,
+    ...collectSourceAliases(region, ["searchParams", ...searchParamPropAliases], "searchParams"),
+  ];
   const searchParamPromiseSourcePattern = sourcePattern(
-    ["searchParams", ...searchParamPropAliases],
+    searchParamPromiseIdentifiers,
     "searchParams",
     region,
   );
@@ -339,7 +440,7 @@ function sourceAccessesSearchParams(source: string): boolean {
     (match) => match[1],
   );
   const searchParamSourcePattern = sourcePattern(
-    ["searchParams", ...searchParamPropAliases, ...awaitedSearchParamAliases],
+    [...searchParamPromiseIdentifiers, ...awaitedSearchParamAliases],
     "searchParams",
     region,
   );
@@ -374,7 +475,7 @@ function sourceHasGenerateStaticParams(source: string): boolean {
 }
 
 function sourceHasConnectionCall(source: string): boolean {
-  return /\bconnection\s*\(/.test(source);
+  return findConnectionCallIndex(source) !== null;
 }
 
 function sourceHasSuspenseFallback(source: string): boolean {

--- a/packages/vinext/src/entries/app-browser-entry.ts
+++ b/packages/vinext/src/entries/app-browser-entry.ts
@@ -1,11 +1,14 @@
 import { resolveClientRuntimeModule, resolveRuntimeEntryModule } from "./runtime-entry-module.js";
+import fs from "node:fs";
 import type {
   VinextLinkPrefetchRoute,
   VinextPagesLinkPrefetchRoute,
+  VinextRuntimePrefetchLoadingFallback,
 } from "../client/vinext-next-data.js";
 import type { AppRoute } from "../routing/app-router.js";
 import type { RouteManifest } from "../routing/app-route-graph.js";
 import type { NextRewrite } from "../config/next-config.js";
+import { escapeRegExp } from "../utils/regex.js";
 
 /**
  * Generate the virtual browser entry module.
@@ -65,17 +68,413 @@ export function toDocumentOnlyAppRoute(route: AppRoute): VinextLinkPrefetchRoute
   };
 }
 
-function requiresDynamicNavigationRequest(route: AppRoute): boolean {
-  return route.isDynamic && route.parallelSlots.length > 0;
+function requiresDynamicNavigationRequest(route: AppRoute, vary: PrefetchVaryAnalysis): boolean {
+  return (
+    (route.isDynamic && route.parallelSlots.length > 0) || vary.requiresDynamicNavigationRequest
+  );
 }
 
 /** Project an `AppRoute` down to the public `VinextLinkPrefetchRoute` shape. */
 export function toLinkPrefetchRoute(route: AppRoute): VinextLinkPrefetchRoute {
+  const vary = analyzePrefetchVary(route);
   return {
     canPrefetchLoadingShell: route.loadingPath !== null,
+    ...(vary.canPrefetchRuntimeShell ? { canPrefetchRuntimeShell: true } : {}),
+    ...(vary.canPrefetchStaticRoute || !route.isDynamic ? { canPrefetchStaticRoute: true } : {}),
+    ...((route.loadingPath !== null || vary.canPrefetchRuntimeShell) &&
+    vary.loadingShellParamNames.length > 0
+      ? { loadingShellVaryParamNames: vary.loadingShellParamNames }
+      : {}),
     patternParts: [...route.patternParts],
+    ...(vary.prefetchParamNames.length > 0
+      ? { prefetchVaryParamNames: vary.prefetchParamNames }
+      : {}),
+    ...(vary.prefetchVarySearchParams ? { prefetchVarySearchParams: true } : {}),
+    ...(vary.runtimePrefetchParamNames.length > 0
+      ? { runtimePrefetchVaryParamNames: vary.runtimePrefetchParamNames }
+      : {}),
+    ...(vary.runtimePrefetchLoadingFallback
+      ? { runtimePrefetchLoadingFallback: vary.runtimePrefetchLoadingFallback }
+      : {}),
+    ...(vary.runtimePrefetchVarySearchParams ? { runtimePrefetchVarySearchParams: true } : {}),
     isDynamic: route.isDynamic,
-    ...(requiresDynamicNavigationRequest(route) ? { requiresDynamicNavigationRequest: true } : {}),
+    ...(requiresDynamicNavigationRequest(route, vary)
+      ? { requiresDynamicNavigationRequest: true }
+      : {}),
+  };
+}
+
+type PrefetchVaryAnalysis = {
+  canPrefetchRuntimeShell: boolean;
+  canPrefetchStaticRoute: boolean;
+  loadingShellParamNames: string[];
+  prefetchParamNames: string[];
+  prefetchVarySearchParams: boolean;
+  runtimePrefetchLoadingFallback: VinextRuntimePrefetchLoadingFallback | null;
+  runtimePrefetchParamNames: string[];
+  runtimePrefetchVarySearchParams: boolean;
+  requiresDynamicNavigationRequest: boolean;
+};
+
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/.*$/gm, "$1");
+}
+
+function readSource(filePath: string | null | undefined): string {
+  if (!filePath) return "";
+  try {
+    return stripComments(fs.readFileSync(filePath, "utf8"));
+  } catch {
+    return "";
+  }
+}
+
+function sourceHasUseClientDirective(source: string): boolean {
+  return /^["']use client["']\s*;?/.test(source.trimStart());
+}
+
+function serverPrefetchSource(source: string): string {
+  return sourceHasUseClientDirective(source) ? "" : source;
+}
+
+function staticPrefetchRegion(source: string): string {
+  const connectionMatch = /\bconnection\s*\(/.exec(source);
+  return connectionMatch?.index === undefined ? source : source.slice(0, connectionMatch.index);
+}
+
+function findExportedFunctionBodyStart(source: string, functionName: string): number | null {
+  const startMatch = new RegExp(
+    String.raw`\bexport\s+(?:async\s+)?function\s+${escapeRegExp(functionName)}\b`,
+  ).exec(source);
+  if (!startMatch || startMatch.index === undefined) return null;
+
+  const paramsStart = source.indexOf("(", startMatch.index);
+  if (paramsStart === -1) return null;
+
+  let parenDepth = 0;
+  for (let index = paramsStart; index < source.length; index++) {
+    const char = source[index];
+    if (char === "(") {
+      parenDepth++;
+    } else if (char === ")") {
+      parenDepth--;
+      if (parenDepth === 0) {
+        const bodyStart = source.indexOf("{", index);
+        return bodyStart === -1 ? null : bodyStart;
+      }
+    }
+  }
+  return null;
+}
+
+function findExportedFunctionBodyEnd(source: string, functionName: string): number | null {
+  const bodyStart = findExportedFunctionBodyStart(source, functionName);
+  if (bodyStart === null) return null;
+
+  let depth = 0;
+  for (let index = bodyStart; index < source.length; index++) {
+    const char = source[index];
+    if (char === "{") {
+      depth++;
+    } else if (char === "}") {
+      depth--;
+      if (depth === 0) return index + 1;
+    }
+  }
+  return null;
+}
+
+function extractExportedFunction(source: string, functionName: string): string {
+  const startMatch = new RegExp(
+    String.raw`\bexport\s+(?:async\s+)?function\s+${escapeRegExp(functionName)}\b`,
+  ).exec(source);
+  if (!startMatch || startMatch.index === undefined) return "";
+  const end = findExportedFunctionBodyEnd(source, functionName);
+  return end === null ? "" : source.slice(startMatch.index, end);
+}
+
+function removeExportedFunction(source: string, functionName: string): string {
+  const startMatch = new RegExp(
+    String.raw`\bexport\s+(?:async\s+)?function\s+${escapeRegExp(functionName)}\b`,
+  ).exec(source);
+  if (!startMatch || startMatch.index === undefined) return source;
+  const end = findExportedFunctionBodyEnd(source, functionName);
+  return end === null ? source : `${source.slice(0, startMatch.index)}\n${source.slice(end)}`;
+}
+
+function collectPropAliases(source: string, propName: string): string[] {
+  return Array.from(
+    source.matchAll(
+      new RegExp(String.raw`\{[^}]*\b${escapeRegExp(propName)}\s*:\s*([A-Za-z_$][\w$]*)`, "g"),
+    ),
+    (match) => match[1],
+  );
+}
+
+function collectParamAccesses(source: string, paramNames: readonly string[]): Set<string> {
+  const region = staticPrefetchRegion(source);
+  const accessed = new Set<string>();
+  const paramPropAliases = collectPropAliases(region, "params");
+  const paramPromiseSources = ["params", ...paramPropAliases].map(escapeRegExp);
+  const paramPromiseSourcePattern = `(?:${paramPromiseSources.join("|")})`;
+  const awaitedParamAliases = Array.from(
+    region.matchAll(
+      new RegExp(
+        String.raw`\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*await\s+${paramPromiseSourcePattern}\b`,
+        "g",
+      ),
+    ),
+    (match) => match[1],
+  );
+  const paramSources = ["params", ...paramPropAliases, ...awaitedParamAliases].map(escapeRegExp);
+  const paramSourcePattern = `(?:${paramSources.join("|")})`;
+  const enumeratesParams = new RegExp(
+    String.raw`(?:\{\s*\.\.\.\s*${paramSourcePattern}\s*\}|\bObject\.(?:keys|values|entries|assign)\s*\(\s*${paramSourcePattern}\b)`,
+  ).test(region);
+  const computedParamAccess = new RegExp(
+    String.raw`(?:\b${paramSourcePattern}\s*\[|\bReflect\.get\s*\(\s*${paramSourcePattern}\b)`,
+  ).test(region);
+  const passesParamsToHelper = new RegExp(
+    String.raw`\b[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)?\(\s*(?:await\s+params|${paramSourcePattern})\b`,
+  ).test(region);
+
+  // Unknown computed or helper reads must over-vary instead of sharing the wrong segment.
+  if (enumeratesParams || computedParamAccess || passesParamsToHelper) {
+    for (const name of paramNames) {
+      accessed.add(name);
+    }
+  }
+
+  for (const name of paramNames) {
+    const escaped = escapeRegExp(name);
+    if (
+      new RegExp(
+        String.raw`\{[^}]*\b${escaped}\b[^}]*\}\s*=\s*await\s+${paramPromiseSourcePattern}\b`,
+      ).test(region)
+    ) {
+      accessed.add(name);
+      continue;
+    }
+    if (new RegExp(String.raw`\b${paramSourcePattern}\s*\.\s*${escaped}\b`).test(region)) {
+      accessed.add(name);
+      continue;
+    }
+    if (new RegExp(String.raw`["']${escaped}["']\s+in\s*${paramSourcePattern}\b`).test(region)) {
+      accessed.add(name);
+      continue;
+    }
+    if (
+      awaitedParamAliases.some((alias) =>
+        new RegExp(String.raw`\b${escapeRegExp(alias)}\s*\.\s*${escaped}\b`).test(region),
+      )
+    ) {
+      accessed.add(name);
+      continue;
+    }
+  }
+
+  return accessed;
+}
+
+function collectRootParamAccesses(source: string, paramNames: readonly string[]): Set<string> {
+  if (!/\bfrom\s+["']next\/root-params["']/.test(source)) return new Set();
+
+  const region = staticPrefetchRegion(source);
+  const accessed = new Set<string>();
+  for (const name of paramNames) {
+    if (new RegExp(String.raw`\b${escapeRegExp(name)}\s*\(`).test(region)) {
+      accessed.add(name);
+    }
+  }
+  return accessed;
+}
+
+function mergeAccesses(target: Set<string>, source: Set<string>): void {
+  for (const name of source) {
+    target.add(name);
+  }
+}
+
+function sourceAccessesSearchParams(source: string): boolean {
+  const region = staticPrefetchRegion(source);
+  const searchParamPropAliases = collectPropAliases(region, "searchParams");
+  const searchParamPromiseSources = ["searchParams", ...searchParamPropAliases].map(escapeRegExp);
+  const searchParamPromiseSourcePattern = `(?:${searchParamPromiseSources.join("|")})`;
+  const awaitedSearchParamAliases = Array.from(
+    region.matchAll(
+      new RegExp(
+        String.raw`\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*await\s+${searchParamPromiseSourcePattern}\b`,
+        "g",
+      ),
+    ),
+    (match) => match[1],
+  );
+  const searchParamSources = [
+    "searchParams",
+    ...searchParamPropAliases,
+    ...awaitedSearchParamAliases,
+  ].map(escapeRegExp);
+  const searchParamSourcePattern = `(?:${searchParamSources.join("|")})`;
+  return (
+    new RegExp(String.raw`\bawait\s+${searchParamPromiseSourcePattern}\b`).test(region) ||
+    new RegExp(String.raw`\b${searchParamSourcePattern}\s*(?:\.|\[)`).test(region) ||
+    new RegExp(
+      String.raw`\bObject\.(?:keys|values|entries|assign)\s*\(\s*(?:await\s+)?${searchParamSourcePattern}\b`,
+    ).test(region) ||
+    new RegExp(String.raw`\{\s*\.\.\.\s*(?:await\s+)?${searchParamSourcePattern}\s*\}`).test(
+      region,
+    ) ||
+    new RegExp(String.raw`\bReflect\.get\s*\(\s*${searchParamSourcePattern}\b`).test(region) ||
+    new RegExp(
+      String.raw`\b[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)?\(\s*(?:await\s+${searchParamPromiseSourcePattern}|${searchParamSourcePattern})\b`,
+    ).test(region)
+  );
+}
+
+function sourceAllowsRuntimePrefetch(source: string): boolean {
+  return (
+    /\bexport\s+const\s+prefetch\s*=\s*["']allow-runtime["']/.test(source) ||
+    /\bexport\s+const\s+unstable_instant\b[\s\S]*?\bprefetch\s*:\s*["']runtime["']/.test(source)
+  );
+}
+
+function sourceHasGenerateStaticParams(source: string): boolean {
+  return /\bexport\s+(?:async\s+)?function\s+generateStaticParams\b/.test(source);
+}
+
+function sourceHasConnectionCall(source: string): boolean {
+  return /\bconnection\s*\(/.test(source);
+}
+
+function sourceHasSuspenseFallback(source: string): boolean {
+  return /<\s*Suspense\b/.test(source);
+}
+
+function decodeSimpleJsxText(value: string): string {
+  // Decode only one entity layer so `&amp;lt;` remains `&lt;`, matching JSX text semantics.
+  return value.replace(/&(quot|#39|amp|lt|gt);/g, (match, entity: string) => {
+    switch (entity) {
+      case "quot":
+        return '"';
+      case "#39":
+        return "'";
+      case "amp":
+        return "&";
+      case "lt":
+        return "<";
+      case "gt":
+        return ">";
+      default:
+        return match;
+    }
+  });
+}
+
+function parseSimpleJsxAttributes(source: string): Record<string, string> {
+  const attributes: Record<string, string> = {};
+  const attributePattern =
+    /\s([A-Za-z_:][\w:.-]*)(?:=(?:"([^"]*)"|'([^']*)'|\{\s*["']([^"']*)["']\s*\}))?/g;
+  for (const match of source.matchAll(attributePattern)) {
+    attributes[match[1]] = decodeSimpleJsxText(match[2] ?? match[3] ?? match[4] ?? "true");
+  }
+  return attributes;
+}
+
+function extractRuntimePrefetchLoadingFallback(
+  source: string,
+): VinextRuntimePrefetchLoadingFallback | null {
+  const fallbackPattern = /fallback=\{\s*<([a-z][\w-]*)([^>]*)>\s*([^<{}]+?)\s*<\/\1>\s*\}/g;
+  const fallbacks: VinextRuntimePrefetchLoadingFallback[] = [];
+  for (const match of source.matchAll(fallbackPattern)) {
+    fallbacks.push({
+      attributes: parseSimpleJsxAttributes(match[2] ?? ""),
+      tagName: match[1],
+      text: decodeSimpleJsxText((match[3] ?? "").replace(/\s+/g, " ").trim()),
+    });
+  }
+  return (
+    fallbacks.find((fallback) => Object.hasOwn(fallback.attributes, "data-loading")) ??
+    fallbacks[0] ??
+    null
+  );
+}
+
+function sortedKnownParams(input: Set<string>, route: AppRoute): string[] {
+  return route.params.filter((name) => input.has(name));
+}
+
+function analyzePrefetchVary(route: AppRoute): PrefetchVaryAnalysis {
+  const layoutSources = route.layouts.map((layoutPath) =>
+    serverPrefetchSource(readSource(layoutPath)),
+  );
+  const pageSource = serverPrefetchSource(readSource(route.pagePath));
+  const metadataSource = extractExportedFunction(pageSource, "generateMetadata");
+  const pageBodySource = removeExportedFunction(pageSource, "generateMetadata");
+  const pageDir = route.pagePath ? route.pagePath.replace(/[/\\][^/\\]+$/, "") : null;
+  let terminalLayoutSource = "";
+  if (pageDir !== null) {
+    for (let index = route.layouts.length - 1; index >= 0; index--) {
+      const layoutPath = route.layouts[index];
+      if (layoutPath?.replace(/[/\\][^/\\]+$/, "") === pageDir) {
+        terminalLayoutSource = layoutSources[index] ?? "";
+        break;
+      }
+    }
+  }
+  const canPrefetchRuntimeShell =
+    sourceAllowsRuntimePrefetch(pageSource) ||
+    (route.loadingPath === null && sourceHasSuspenseFallback(pageSource));
+  const canPrefetchStaticRoute =
+    sourceHasGenerateStaticParams(pageSource) ||
+    sourceHasGenerateStaticParams(terminalLayoutSource);
+  const requiresDynamicNavigationRequest =
+    route.isDynamic && canPrefetchStaticRoute && sourceHasConnectionCall(pageBodySource);
+  const layoutParamAccesses = new Set<string>();
+  const metadataParamAccesses = new Set<string>();
+  const pageParamAccesses = new Set<string>();
+
+  for (const source of layoutSources) {
+    mergeAccesses(layoutParamAccesses, collectParamAccesses(source, route.params));
+    mergeAccesses(layoutParamAccesses, collectRootParamAccesses(source, route.params));
+  }
+  mergeAccesses(metadataParamAccesses, collectParamAccesses(metadataSource, route.params));
+  mergeAccesses(metadataParamAccesses, collectRootParamAccesses(metadataSource, route.params));
+
+  if (
+    !(
+      route.loadingPath === null &&
+      sourceHasSuspenseFallback(pageSource) &&
+      !sourceAllowsRuntimePrefetch(pageSource)
+    )
+  ) {
+    mergeAccesses(pageParamAccesses, collectParamAccesses(pageBodySource, route.params));
+    mergeAccesses(pageParamAccesses, collectRootParamAccesses(pageBodySource, route.params));
+  }
+
+  const loadingShellParamAccesses = new Set(layoutParamAccesses);
+  mergeAccesses(loadingShellParamAccesses, metadataParamAccesses);
+  const runtimeParamAccesses = new Set(pageParamAccesses);
+  mergeAccesses(runtimeParamAccesses, metadataParamAccesses);
+
+  return {
+    canPrefetchRuntimeShell,
+    canPrefetchStaticRoute,
+    loadingShellParamNames: sortedKnownParams(loadingShellParamAccesses, route),
+    prefetchParamNames: sortedKnownParams(
+      canPrefetchRuntimeShell ? runtimeParamAccesses : pageParamAccesses,
+      route,
+    ),
+    prefetchVarySearchParams:
+      sourceAccessesSearchParams(pageBodySource) || layoutSources.some(sourceAccessesSearchParams),
+    runtimePrefetchLoadingFallback: canPrefetchRuntimeShell
+      ? extractRuntimePrefetchLoadingFallback(pageBodySource)
+      : null,
+    runtimePrefetchParamNames: sortedKnownParams(runtimeParamAccesses, route),
+    runtimePrefetchVarySearchParams:
+      sourceAccessesSearchParams(pageBodySource) ||
+      sourceAccessesSearchParams(metadataSource) ||
+      layoutSources.some(sourceAccessesSearchParams),
+    requiresDynamicNavigationRequest,
   };
 }
 

--- a/packages/vinext/src/entries/app-browser-entry.ts
+++ b/packages/vinext/src/entries/app-browser-entry.ts
@@ -211,31 +211,57 @@ function collectPropAliases(source: string, propName: string): string[] {
   );
 }
 
+function propMemberSourcePattern(propName: string): string {
+  return String.raw`\b[A-Za-z_$][\w$]*(?:\s*\.\s*[A-Za-z_$][\w$]*)*\s*\.\s*${escapeRegExp(propName)}\b`;
+}
+
+function hasPropMemberSource(source: string, propName: string): boolean {
+  return new RegExp(propMemberSourcePattern(propName)).test(source);
+}
+
+function sourcePattern(
+  identifiers: readonly string[],
+  memberPropName: string,
+  source: string,
+): string {
+  const patterns = identifiers.map((name) => String.raw`\b${escapeRegExp(name)}\b`);
+  if (hasPropMemberSource(source, memberPropName)) {
+    patterns.push(propMemberSourcePattern(memberPropName));
+  }
+  return `(?:${patterns.join("|")})`;
+}
+
 function collectParamAccesses(source: string, paramNames: readonly string[]): Set<string> {
   const region = staticPrefetchRegion(source);
   const accessed = new Set<string>();
   const paramPropAliases = collectPropAliases(region, "params");
-  const paramPromiseSources = ["params", ...paramPropAliases].map(escapeRegExp);
-  const paramPromiseSourcePattern = `(?:${paramPromiseSources.join("|")})`;
+  const paramPromiseSourcePattern = sourcePattern(
+    ["params", ...paramPropAliases],
+    "params",
+    region,
+  );
   const awaitedParamAliases = Array.from(
     region.matchAll(
       new RegExp(
-        String.raw`\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*await\s+${paramPromiseSourcePattern}\b`,
+        String.raw`\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*await\s+${paramPromiseSourcePattern}`,
         "g",
       ),
     ),
     (match) => match[1],
   );
-  const paramSources = ["params", ...paramPropAliases, ...awaitedParamAliases].map(escapeRegExp);
-  const paramSourcePattern = `(?:${paramSources.join("|")})`;
+  const paramSourcePattern = sourcePattern(
+    ["params", ...paramPropAliases, ...awaitedParamAliases],
+    "params",
+    region,
+  );
   const enumeratesParams = new RegExp(
-    String.raw`(?:\{\s*\.\.\.\s*${paramSourcePattern}\s*\}|\bObject\.(?:keys|values|entries|assign)\s*\(\s*${paramSourcePattern}\b)`,
+    String.raw`(?:\{\s*\.\.\.\s*${paramSourcePattern}\s*\}|\bObject\.(?:keys|values|entries)\s*\(\s*(?:await\s+)?${paramSourcePattern}|\bObject\.assign\s*\([^)]*(?:await\s+)?${paramSourcePattern})`,
   ).test(region);
   const computedParamAccess = new RegExp(
     String.raw`(?:\b${paramSourcePattern}\s*\[|\bReflect\.get\s*\(\s*${paramSourcePattern}\b)`,
   ).test(region);
   const passesParamsToHelper = new RegExp(
-    String.raw`\b[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)?\(\s*(?:await\s+params|${paramSourcePattern})\b`,
+    String.raw`\b[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)?\(\s*(?:await\s+${paramPromiseSourcePattern}|${paramSourcePattern})`,
   ).test(region);
 
   // Unknown computed or helper reads must over-vary instead of sharing the wrong segment.
@@ -298,29 +324,34 @@ function mergeAccesses(target: Set<string>, source: Set<string>): void {
 function sourceAccessesSearchParams(source: string): boolean {
   const region = staticPrefetchRegion(source);
   const searchParamPropAliases = collectPropAliases(region, "searchParams");
-  const searchParamPromiseSources = ["searchParams", ...searchParamPropAliases].map(escapeRegExp);
-  const searchParamPromiseSourcePattern = `(?:${searchParamPromiseSources.join("|")})`;
+  const searchParamPromiseSourcePattern = sourcePattern(
+    ["searchParams", ...searchParamPropAliases],
+    "searchParams",
+    region,
+  );
   const awaitedSearchParamAliases = Array.from(
     region.matchAll(
       new RegExp(
-        String.raw`\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*await\s+${searchParamPromiseSourcePattern}\b`,
+        String.raw`\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*await\s+${searchParamPromiseSourcePattern}`,
         "g",
       ),
     ),
     (match) => match[1],
   );
-  const searchParamSources = [
+  const searchParamSourcePattern = sourcePattern(
+    ["searchParams", ...searchParamPropAliases, ...awaitedSearchParamAliases],
     "searchParams",
-    ...searchParamPropAliases,
-    ...awaitedSearchParamAliases,
-  ].map(escapeRegExp);
-  const searchParamSourcePattern = `(?:${searchParamSources.join("|")})`;
+    region,
+  );
   return (
-    new RegExp(String.raw`\bawait\s+${searchParamPromiseSourcePattern}\b`).test(region) ||
+    new RegExp(String.raw`\bawait\s+${searchParamPromiseSourcePattern}`).test(region) ||
     new RegExp(String.raw`\b${searchParamSourcePattern}\s*(?:\.|\[)`).test(region) ||
     new RegExp(
-      String.raw`\bObject\.(?:keys|values|entries|assign)\s*\(\s*(?:await\s+)?${searchParamSourcePattern}\b`,
+      String.raw`\bObject\.(?:keys|values|entries)\s*\(\s*(?:await\s+)?${searchParamSourcePattern}`,
     ).test(region) ||
+    new RegExp(String.raw`\bObject\.assign\s*\([^)]*(?:await\s+)?${searchParamSourcePattern}`).test(
+      region,
+    ) ||
     new RegExp(String.raw`\{\s*\.\.\.\s*(?:await\s+)?${searchParamSourcePattern}\s*\}`).test(
       region,
     ) ||

--- a/packages/vinext/src/entries/app-browser-entry.ts
+++ b/packages/vinext/src/entries/app-browser-entry.ts
@@ -165,7 +165,26 @@ function nextNonWhitespaceIndex(source: string, index: number): number {
   return cursor;
 }
 
+function collectNextServerConnectionIdentifiers(source: string): Set<string> {
+  const identifiers = new Set<string>();
+  const importPattern = /\bimport\s*\{([^}]+)\}\s*from\s*["']next\/server(?:\.js)?["']/g;
+
+  for (const match of source.matchAll(importPattern)) {
+    for (const specifier of (match[1] ?? "").split(",")) {
+      const importName = specifier.trim().match(/^connection(?:\s+as\s+([A-Za-z_$][\w$]*))?$/);
+      if (importName) {
+        identifiers.add(importName[1] ?? "connection");
+      }
+    }
+  }
+
+  return identifiers;
+}
+
 function findConnectionCallIndex(source: string): number | null {
+  const connectionIdentifiers = collectNextServerConnectionIdentifiers(source);
+  if (connectionIdentifiers.size === 0) return null;
+
   const allowedPreviousIdentifiers = new Set(["await", "return", "void", "yield"]);
   const allowedPreviousPunctuation = new Set(["", "(", "{", "[", "=", ":", ",", ";", "?", "!"]);
   let previousToken = "";
@@ -180,7 +199,7 @@ function findConnectionCallIndex(source: string): number | null {
 
     const identifier = readIdentifier(source, index);
     if (identifier !== null) {
-      if (identifier === "connection") {
+      if (connectionIdentifiers.has(identifier)) {
         const nextIndex = nextNonWhitespaceIndex(source, index + identifier.length);
         if (
           source[nextIndex] === "(" &&
@@ -372,6 +391,22 @@ function collectParamAccesses(source: string, paramNames: readonly string[]): Se
     if (
       new RegExp(
         String.raw`\{[^}]*\b${escaped}\b[^}]*\}\s*=\s*await\s+${paramPromiseSourcePattern}\b`,
+      ).test(region)
+    ) {
+      accessed.add(name);
+      continue;
+    }
+    if (
+      new RegExp(String.raw`\{[^}]*\b${escaped}\b[^}]*\}\s*=\s*${paramSourcePattern}\b`).test(
+        region,
+      )
+    ) {
+      accessed.add(name);
+      continue;
+    }
+    if (
+      new RegExp(
+        String.raw`\(\s*await\s+${paramPromiseSourcePattern}\s*\)\s*\.\s*${escaped}\b`,
       ).test(region)
     ) {
       accessed.add(name);

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -137,6 +137,7 @@ import { clientReferenceDedupPlugin } from "./plugins/client-reference-dedup.js"
 import { dataUrlCssPlugin } from "./plugins/css-data-url.js";
 import { createCssModuleImportCompatibilityPlugin } from "./plugins/css-module-imports.js";
 import { createRscClientReferenceLoadersPlugin } from "./plugins/rsc-client-reference-loaders.js";
+import { createRscReferenceValidationCompatPlugin } from "./plugins/rsc-reference-validation-compat.js";
 import { createInstrumentationClientTransformPlugin } from "./plugins/instrumentation-client.js";
 import { createStyledJsxPlugin } from "./plugins/styled-jsx.js";
 import {
@@ -6213,6 +6214,7 @@ export const loadServerActionClient = ${
   // Append auto-injected RSC plugins if applicable
   if (rscPluginPromise) {
     plugins.push(rscPluginPromise);
+    plugins.push(createRscReferenceValidationCompatPlugin());
     plugins.push(createRscClientReferenceLoadersPlugin());
   }
 

--- a/packages/vinext/src/plugins/rsc-reference-validation-compat.ts
+++ b/packages/vinext/src/plugins/rsc-reference-validation-compat.ts
@@ -1,0 +1,91 @@
+import type { Plugin } from "vite";
+import type { PluginApi } from "@vitejs/plugin-rsc";
+
+const REFERENCE_VALIDATION_PREFIX = "\0virtual:vite-rsc/reference-validation?";
+// oxlint-disable-next-line no-control-regex -- null byte prefix is intentional (Vite virtual module convention)
+const REFERENCE_VALIDATION_FILTER = /^\0virtual:vite-rsc\/reference-validation\?/;
+const DECODED_RSC_VIRTUAL_PREFIX = "/@id/\0virtual:vite-rsc/";
+const ENCODED_RSC_VIRTUAL_PREFIX = "/@id/__x00__virtual:vite-rsc/";
+
+type RscPluginWithApi = Plugin & {
+  api?: PluginApi;
+};
+
+type ClientReferenceMetaLike = {
+  referenceKey: string;
+};
+
+type ReferenceValidationRequest = {
+  type: string;
+  id: string;
+};
+
+function parseReferenceValidationRequest(id: string): ReferenceValidationRequest | null {
+  if (!id.startsWith(REFERENCE_VALIDATION_PREFIX)) return null;
+  const queryIndex = id.indexOf("?");
+  if (queryIndex === -1) return null;
+
+  const query = new URLSearchParams(id.slice(queryIndex + 1));
+  const type = query.get("type");
+  const referenceId = query.get("id");
+  return type && referenceId ? { type, id: referenceId } : null;
+}
+
+function toEncodedViteRscVirtualReferenceKey(referenceId: string): string | null {
+  return referenceId.startsWith(DECODED_RSC_VIRTUAL_PREFIX)
+    ? ENCODED_RSC_VIRTUAL_PREFIX + referenceId.slice(DECODED_RSC_VIRTUAL_PREFIX.length)
+    : null;
+}
+
+export function shouldAcceptDecodedViteRscReferenceValidation(
+  referenceId: string,
+  clientReferenceMetas: Iterable<ClientReferenceMetaLike>,
+): boolean {
+  const encodedReferenceKey = toEncodedViteRscVirtualReferenceKey(referenceId);
+  if (encodedReferenceKey === null) return false;
+
+  return Array.from(clientReferenceMetas).some((meta) => meta.referenceKey === encodedReferenceKey);
+}
+
+export function createRscReferenceValidationCompatPlugin(): Plugin {
+  let rscApi: PluginApi | undefined;
+
+  return {
+    name: "vinext:rsc-reference-validation-compat",
+    enforce: "pre",
+    apply: "serve",
+    configResolved(config) {
+      rscApi = (
+        config.plugins.find((plugin) => plugin.name === "rsc:minimal") as
+          | RscPluginWithApi
+          | undefined
+      )?.api;
+    },
+    load: {
+      filter: { id: REFERENCE_VALIDATION_FILTER },
+      handler(id) {
+        const request = parseReferenceValidationRequest(id);
+        if (request?.type !== "client") return null;
+
+        const manager = rscApi?.manager;
+        if (!manager) return null;
+
+        // @vitejs/plugin-rsc records dev virtual reference keys after Vite
+        // import-analysis escapes the null byte as `__x00__`, while React's
+        // SSR validation request can arrive with the decoded null byte. Accept
+        // only when the normalized key is already present in plugin-rsc's
+        // metadata, preserving the validator's allowlist semantics.
+        if (
+          shouldAcceptDecodedViteRscReferenceValidation(
+            request.id,
+            Object.values(manager.clientReferenceMetaMap),
+          )
+        ) {
+          return "export {};";
+        }
+
+        return null;
+      },
+    },
+  };
+}

--- a/packages/vinext/src/plugins/rsc-reference-validation-compat.ts
+++ b/packages/vinext/src/plugins/rsc-reference-validation-compat.ts
@@ -1,35 +1,9 @@
-import type { Plugin } from "vite";
-import type { PluginApi } from "@vitejs/plugin-rsc";
-
-const REFERENCE_VALIDATION_PREFIX = "\0virtual:vite-rsc/reference-validation?";
-// oxlint-disable-next-line no-control-regex -- null byte prefix is intentional (Vite virtual module convention)
-const REFERENCE_VALIDATION_FILTER = /^\0virtual:vite-rsc\/reference-validation\?/;
 const DECODED_RSC_VIRTUAL_PREFIX = "/@id/\0virtual:vite-rsc/";
 const ENCODED_RSC_VIRTUAL_PREFIX = "/@id/__x00__virtual:vite-rsc/";
-
-type RscPluginWithApi = Plugin & {
-  api?: PluginApi;
-};
 
 type ClientReferenceMetaLike = {
   referenceKey: string;
 };
-
-type ReferenceValidationRequest = {
-  type: string;
-  id: string;
-};
-
-function parseReferenceValidationRequest(id: string): ReferenceValidationRequest | null {
-  if (!id.startsWith(REFERENCE_VALIDATION_PREFIX)) return null;
-  const queryIndex = id.indexOf("?");
-  if (queryIndex === -1) return null;
-
-  const query = new URLSearchParams(id.slice(queryIndex + 1));
-  const type = query.get("type");
-  const referenceId = query.get("id");
-  return type && referenceId ? { type, id: referenceId } : null;
-}
 
 function toEncodedViteRscVirtualReferenceKey(referenceId: string): string | null {
   return referenceId.startsWith(DECODED_RSC_VIRTUAL_PREFIX)
@@ -45,47 +19,4 @@ export function shouldAcceptDecodedViteRscReferenceValidation(
   if (encodedReferenceKey === null) return false;
 
   return Array.from(clientReferenceMetas).some((meta) => meta.referenceKey === encodedReferenceKey);
-}
-
-export function createRscReferenceValidationCompatPlugin(): Plugin {
-  let rscApi: PluginApi | undefined;
-
-  return {
-    name: "vinext:rsc-reference-validation-compat",
-    enforce: "pre",
-    apply: "serve",
-    configResolved(config) {
-      rscApi = (
-        config.plugins.find((plugin) => plugin.name === "rsc:minimal") as
-          | RscPluginWithApi
-          | undefined
-      )?.api;
-    },
-    load: {
-      filter: { id: REFERENCE_VALIDATION_FILTER },
-      handler(id) {
-        const request = parseReferenceValidationRequest(id);
-        if (request?.type !== "client") return null;
-
-        const manager = rscApi?.manager;
-        if (!manager) return null;
-
-        // @vitejs/plugin-rsc records dev virtual reference keys after Vite
-        // import-analysis escapes the null byte as `__x00__`, while React's
-        // SSR validation request can arrive with the decoded null byte. Accept
-        // only when the normalized key is already present in plugin-rsc's
-        // metadata, preserving the validator's allowlist semantics.
-        if (
-          shouldAcceptDecodedViteRscReferenceValidation(
-            request.id,
-            Object.values(manager.clientReferenceMetaMap),
-          )
-        ) {
-          return "export {};";
-        }
-
-        return null;
-      },
-    },
-  };
 }

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -40,6 +40,7 @@ import {
   pushHistoryStateWithoutNotify,
   replaceClientParamsWithoutNotify,
   replaceHistoryStateWithoutNotify,
+  resolveAppPrefetchSharedCacheKey,
   resolvePrefetchCacheEntryMountedSlotsHeader,
   restoreRscResponse,
   saveScrollPosition,
@@ -132,11 +133,11 @@ import {
   restoreSynchronousPopstateScrollPosition,
 } from "./app-browser-popstate.js";
 import {
+  DefaultGlobalError,
   DevRecoveryBoundary,
   GlobalErrorBoundary,
   RedirectBoundary,
 } from "vinext/shims/error-boundary";
-import DefaultGlobalError from "vinext/shims/default-global-error";
 import { AppRouterContext } from "vinext/shims/internal/app-router-context";
 import { BfcacheStateKeyMapContext, ElementsContext, Slot } from "vinext/shims/slot";
 import type { RouteManifest } from "../routing/app-route-graph.js";
@@ -464,6 +465,11 @@ async function learnOptimisticRouteTemplateFromPrefetch(options: {
   const elements = await decodeAppElementsPromise(
     createFromFetch<AppWireElements>(Promise.resolve(restoreRscResponse(options.entry.snapshot))),
   );
+  const preservePageElements =
+    options.entry.cacheForNavigation === false && options.entry.optimisticRouteShell !== true;
+  const variantKey = preservePageElements
+    ? (options.entry.runtimeTemplateVariantKey ?? options.entry.sharedCacheKey ?? null)
+    : null;
   const template = createOptimisticRouteTemplate({
     allowLoadingShell: options.entry.optimisticRouteShell === true,
     basePath: __basePath,
@@ -471,7 +477,10 @@ async function learnOptimisticRouteTemplateFromPrefetch(options: {
     href: options.entry.snapshot.url || source.rscUrl,
     interceptionContext: options.interceptionContext,
     mountedSlotsHeader: options.mountedSlotsHeader,
+    preservePageElements,
     routeManifest: options.routeManifest,
+    runtimeLoadingFallback: preservePageElements ? options.entry.runtimeLoadingFallback : null,
+    variantKey,
   });
   if (template === null) return false;
 
@@ -480,6 +489,7 @@ async function learnOptimisticRouteTemplateFromPrefetch(options: {
       interceptionContext: options.interceptionContext,
       mountedSlotsHeader: options.mountedSlotsHeader,
       routeId: template.routeId,
+      variantKey: template.variantKey,
     }),
     template,
   );
@@ -1760,6 +1770,13 @@ function bootstrapHydration(
           navigationKind,
           visitedResponse,
         });
+        const sharedPrefetchCacheKey = resolveAppPrefetchSharedCacheKey(url.href, "navigation");
+        const runtimeTemplateVariantKey =
+          sharedPrefetchCacheKey === null
+            ? null
+            : `${sharedPrefetchCacheKey}\0${
+                resolveAppPrefetchSharedCacheKey(url.href, "loading-shell") ?? ""
+              }`;
         let routeManifest = navigationKind === "navigate" ? getBrowserRouteManifest() : null;
         const hasPrefetchCandidate =
           prefetchProbeDecision.kind === "probe" &&
@@ -1767,7 +1784,7 @@ function bootstrapHydration(
             rscUrl,
             requestInterceptionContext,
             mountedSlotsHeader,
-            { notifyInvalidation: false },
+            { notifyInvalidation: false, sharedCacheKey: sharedPrefetchCacheKey },
           );
         const reuseDecision = navigationPlanner.classifyNavigationReuse({
           bypassNavigationCache: shouldBypassNavigationCache,
@@ -1882,6 +1899,7 @@ function bootstrapHydration(
             mountedSlotsHeader,
             {
               shouldConsume: () => browserNavigationController.isCurrentNavigation(navId),
+              sharedCacheKey: sharedPrefetchCacheKey,
             },
           );
           if (!browserNavigationController.isCurrentNavigation(navId)) return;
@@ -1928,8 +1946,8 @@ function bootstrapHydration(
               mountedSlotsHeader,
               routeManifest,
               templates: optimisticRouteTemplates,
+              variantKey: runtimeTemplateVariantKey,
             });
-
             if (optimisticPayload !== null) {
               detachedNavigationCommits = true;
               const optimisticNavigationSnapshot = createClientNavigationRenderSnapshot(

--- a/packages/vinext/src/server/app-optimistic-routing.ts
+++ b/packages/vinext/src/server/app-optimistic-routing.ts
@@ -1,4 +1,11 @@
-import { createElement, isValidElement, Suspense } from "react";
+import {
+  cloneElement,
+  createElement,
+  isValidElement,
+  Suspense,
+  type ReactElement,
+  type ReactNode,
+} from "react";
 import { isUnknownRecord } from "../utils/record.js";
 import { stripBasePath } from "../utils/base-path.js";
 import { buildParams, decodeMatchedParams, splitPathnameForRouteMatch } from "../routing/utils.js";
@@ -11,6 +18,7 @@ import {
   type AppElementValue,
   type AppElements,
 } from "./app-elements.js";
+import type { VinextRuntimePrefetchLoadingFallback } from "../client/vinext-next-data.js";
 
 type OptimisticRouteTrieNode = {
   catchAllChild: { paramName: string; route: RouteManifestRoute } | null;
@@ -29,13 +37,22 @@ export type OptimisticRouteTemplate = {
   elements: AppElements;
   mountedSlotsHeader: string | null;
   pageElementIds: readonly string[];
+  preservePageElements?: boolean;
   routeId: string;
+  runtimeLoadingFallback?: VinextRuntimePrefetchLoadingFallback | null;
+  variantKey?: string | null;
 };
 
 type OptimisticNavigationPayload = {
   elements: AppElements;
   params: Record<string, string | string[]>;
   template: OptimisticRouteTemplate;
+};
+
+type SuspenseReplacementResult = {
+  containsSuspense: boolean;
+  replaced: boolean;
+  value: AppElementValue;
 };
 
 const routeTrieCache = new WeakMap<RouteManifest, OptimisticRouteTrieNode>();
@@ -47,8 +64,9 @@ export function getOptimisticRouteTemplateKey(options: {
   interceptionContext: string | null;
   mountedSlotsHeader: string | null;
   routeId: string;
+  variantKey?: string | null;
 }): string {
-  return `${options.routeId}\0${options.interceptionContext ?? ""}\0${options.mountedSlotsHeader ?? ""}`;
+  return `${options.routeId}\0${options.interceptionContext ?? ""}\0${options.mountedSlotsHeader ?? ""}\0${options.variantKey ?? ""}`;
 }
 
 export function getOptimisticPrefetchSourceKey(options: {
@@ -300,6 +318,100 @@ function OptimisticRouteSegment(): null {
   throw OPTIMISTIC_ROUTE_SEGMENT_SUSPENSE_TRIGGER;
 }
 
+function createRuntimeLoadingFallbackElement(
+  fallback: VinextRuntimePrefetchLoadingFallback | null | undefined,
+): AppElementValue | null {
+  if (!fallback) return null;
+  return createElement(fallback.tagName, fallback.attributes, fallback.text);
+}
+
+function appendRuntimeLoadingFallback(
+  value: AppElementValue,
+  fallback: VinextRuntimePrefetchLoadingFallback | null | undefined,
+): AppElementValue {
+  const fallbackElement = createRuntimeLoadingFallbackElement(fallback);
+  if (fallbackElement === null) return value;
+
+  if (!isValidElement(value)) {
+    return [value as ReactNode, fallbackElement] as unknown as AppElementValue;
+  }
+
+  const props = Reflect.get(value, "props");
+  if (!isUnknownRecord(props)) return value;
+
+  const children = Reflect.get(props, "children");
+  const nextChildren =
+    children === undefined
+      ? fallbackElement
+      : Array.isArray(children)
+        ? [...children, fallbackElement]
+        : [children, fallbackElement];
+  return cloneElement<{ children?: ReactNode }>(
+    value as ReactElement<{ children?: ReactNode }>,
+    undefined,
+    nextChildren as ReactNode,
+  ) as AppElementValue;
+}
+
+function replaceInnermostSuspenseChildren(
+  value: AppElementValue,
+  depth = 0,
+): SuspenseReplacementResult {
+  // Keep malformed or unexpectedly deep decoded trees from recursing forever.
+  if (depth > 100) return { containsSuspense: false, replaced: false, value };
+
+  if (Array.isArray(value)) {
+    let containsSuspense = false;
+    let replaced = false;
+    const nextValue = value.map((entry) => {
+      const result = replaceInnermostSuspenseChildren(entry, depth + 1);
+      containsSuspense ||= result.containsSuspense;
+      replaced ||= result.replaced;
+      return result.value;
+    });
+    return {
+      containsSuspense,
+      replaced,
+      value: replaced ? nextValue : value,
+    };
+  }
+
+  if (!isValidElement(value)) return { containsSuspense: false, replaced: false, value };
+
+  const props = Reflect.get(value, "props");
+  if (!isUnknownRecord(props)) return { containsSuspense: false, replaced: false, value };
+
+  const children = Reflect.get(props, "children") as AppElementValue;
+  const childResult =
+    children === undefined
+      ? { containsSuspense: false, replaced: false, value: children as AppElementValue }
+      : replaceInnermostSuspenseChildren(children, depth + 1);
+  const isSuspense = value.type === Suspense;
+  const containsSuspense = isSuspense || childResult.containsSuspense;
+
+  if (isSuspense && !childResult.containsSuspense) {
+    return {
+      containsSuspense: true,
+      replaced: true,
+      value: cloneElement(value as ReactElement, undefined, createElement(OptimisticRouteSegment)),
+    };
+  }
+
+  if (childResult.replaced) {
+    return {
+      containsSuspense,
+      replaced: true,
+      value: cloneElement<{ children?: ReactNode }>(
+        value as ReactElement<{ children?: ReactNode }>,
+        undefined,
+        childResult.value as ReactNode,
+      ) as AppElementValue,
+    };
+  }
+
+  return { containsSuspense, replaced: false, value };
+}
+
 export function createOptimisticRouteTemplate(options: {
   allowLoadingShell?: boolean;
   basePath: string;
@@ -307,14 +419,21 @@ export function createOptimisticRouteTemplate(options: {
   href: string;
   interceptionContext: string | null;
   mountedSlotsHeader: string | null;
+  preservePageElements?: boolean;
   routeManifest: RouteManifest;
+  runtimeLoadingFallback?: VinextRuntimePrefetchLoadingFallback | null;
+  variantKey?: string | null;
 }): OptimisticRouteTemplate | null {
   const match = matchOptimisticRouteManifestRoute({
     basePath: options.basePath,
     href: options.href,
     routeManifest: options.routeManifest,
   });
-  if (match === null || (!options.allowLoadingShell && !match.route.isDynamic)) return null;
+  if (
+    match === null ||
+    (!options.preservePageElements && !options.allowLoadingShell && !match.route.isDynamic)
+  )
+    return null;
   if (options.interceptionContext !== null) return null;
 
   const metadata = AppElementsWire.readMetadata(options.elements);
@@ -325,7 +444,12 @@ export function createOptimisticRouteTemplate(options: {
   // are accepted only when the serialized route subtree still contains a
   // Suspense fallback. Authoritative loading-shell prefetches use the marker
   // check below instead.
-  if (!options.allowLoadingShell && !elementHasSuspenseFallback(routeElement)) return null;
+  if (
+    !options.preservePageElements &&
+    !options.allowLoadingShell &&
+    !elementHasSuspenseFallback(routeElement)
+  )
+    return null;
   if (
     options.allowLoadingShell &&
     options.elements[APP_PREFETCH_LOADING_SHELL_MARKER_KEY] !== "LoadingBoundary"
@@ -344,14 +468,29 @@ export function createOptimisticRouteTemplate(options: {
     elements: options.elements,
     mountedSlotsHeader: options.mountedSlotsHeader,
     pageElementIds,
+    ...(options.preservePageElements ? { preservePageElements: true } : {}),
     routeId: match.route.id,
+    ...(options.runtimeLoadingFallback
+      ? { runtimeLoadingFallback: options.runtimeLoadingFallback }
+      : {}),
+    ...(options.variantKey != null ? { variantKey: options.variantKey } : {}),
   };
 }
 
 export function createOptimisticRouteElements(template: OptimisticRouteTemplate): AppElements {
   const elements: Record<string, AppElementValue> = { ...template.elements };
   for (const pageElementId of template.pageElementIds) {
-    elements[pageElementId] = createElement(OptimisticRouteSegment);
+    if (template.preservePageElements === true) {
+      const preserved = elements[pageElementId];
+      if (preserved !== undefined) {
+        const result = replaceInnermostSuspenseChildren(preserved);
+        elements[pageElementId] = result.replaced
+          ? result.value
+          : appendRuntimeLoadingFallback(result.value, template.runtimeLoadingFallback);
+      }
+    } else {
+      elements[pageElementId] = createElement(OptimisticRouteSegment);
+    }
   }
   return elements;
 }
@@ -363,6 +502,7 @@ export function resolveOptimisticNavigationPayload(options: {
   mountedSlotsHeader: string | null;
   routeManifest: RouteManifest;
   templates: ReadonlyMap<string, OptimisticRouteTemplate>;
+  variantKey?: string | null;
 }): OptimisticNavigationPayload | null {
   if (options.interceptionContext !== null) return null;
 
@@ -376,13 +516,26 @@ export function resolveOptimisticNavigationPayload(options: {
   });
   if (match === null) return null;
 
-  const template = options.templates.get(
-    getOptimisticRouteTemplateKey({
-      interceptionContext: options.interceptionContext,
-      mountedSlotsHeader: options.mountedSlotsHeader,
-      routeId: match.route.id,
-    }),
-  );
+  const variantTemplate =
+    options.variantKey == null
+      ? undefined
+      : options.templates.get(
+          getOptimisticRouteTemplateKey({
+            interceptionContext: options.interceptionContext,
+            mountedSlotsHeader: options.mountedSlotsHeader,
+            routeId: match.route.id,
+            variantKey: options.variantKey,
+          }),
+        );
+  const template =
+    variantTemplate ??
+    options.templates.get(
+      getOptimisticRouteTemplateKey({
+        interceptionContext: options.interceptionContext,
+        mountedSlotsHeader: options.mountedSlotsHeader,
+        routeId: match.route.id,
+      }),
+    );
   if (template === undefined) return null;
   if (template.mountedSlotsHeader !== options.mountedSlotsHeader) return null;
 

--- a/packages/vinext/src/server/app-page-boundary-render.ts
+++ b/packages/vinext/src/server/app-page-boundary-render.ts
@@ -1,7 +1,7 @@
 import { Fragment, createElement, type ComponentType, type ReactNode } from "react";
 import { buildClientHookErrorMessage } from "vinext/shims/client-hook-error";
-import DefaultGlobalError from "vinext/shims/default-global-error";
 import {
+  DefaultGlobalError,
   ErrorBoundary,
   GlobalErrorBoundary,
   SerializedErrorBoundary,

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -15,9 +15,9 @@ import {
   NotFoundBoundary,
   RedirectBoundary,
   UnauthorizedBoundary,
+  DefaultGlobalError,
 } from "vinext/shims/error-boundary";
 import { AppRouterScrollTarget } from "vinext/shims/app-router-scroll";
-import DefaultGlobalError from "vinext/shims/default-global-error";
 import type { AppRouteSemanticIds } from "../routing/app-route-graph.js";
 import { LayoutSegmentProvider } from "vinext/shims/layout-segment-context";
 import {

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -52,7 +52,7 @@ import { AppRouterContext } from "vinext/shims/internal/app-router-context";
 import { createClientReferencePreloader } from "./app-client-reference-preloader.js";
 import { RSC_FORM_STATE_GLOBAL } from "./app-browser-hydration.js";
 import { isPprFallbackShellAbortError } from "vinext/shims/ppr-fallback-shell";
-import DefaultGlobalError from "vinext/shims/default-global-error";
+import { DefaultGlobalErrorDocument } from "./default-global-error-document.js";
 import { appendAssetDeploymentIdQuery } from "../utils/deployment-id.js";
 import { ssrAppRouterInstance } from "./app-ssr-router-instance.js";
 // @ts-expect-error — resolved by the vinext build plugin in SSR environments.
@@ -180,7 +180,7 @@ function renderSsrErrorDocumentShell(
   nonce?: string,
 ): ReadableStream<Uint8Array> {
   const html = renderToStaticMarkup(
-    createReactElement(DefaultGlobalError, {
+    createReactElement(DefaultGlobalErrorDocument, {
       error: null,
     }),
   ).replace("<style>", '<style data-vinext-error-shell-style="">');

--- a/packages/vinext/src/server/default-global-error-document.tsx
+++ b/packages/vinext/src/server/default-global-error-document.tsx
@@ -1,0 +1,182 @@
+import React from "react";
+
+/**
+ * SSR-only mirror of the built-in default global error document.
+ *
+ * The interactive client fallback lives in `shims/default-global-error.tsx`.
+ * `app-ssr-entry` only needs static HTML for shell-error recovery, so using a
+ * server component here avoids creating a plugin-rsc client reference from the
+ * SSR environment while preserving the emitted document markup.
+ */
+
+type DefaultGlobalErrorDocumentProps = {
+  error: { digest?: string } | null | undefined;
+};
+
+const errorStyles = {
+  container: {
+    fontFamily:
+      'system-ui,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji"',
+    height: "100vh",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  card: {
+    marginTop: "-32px",
+    maxWidth: "325px",
+    padding: "32px 28px",
+    textAlign: "left" as const,
+  },
+  icon: {
+    marginBottom: "24px",
+  },
+  title: {
+    fontSize: "24px",
+    fontWeight: 500,
+    letterSpacing: "-0.02em",
+    lineHeight: "32px",
+    margin: "0 0 12px 0",
+    color: "var(--next-error-title)",
+  },
+  message: {
+    fontSize: "14px",
+    fontWeight: 400,
+    lineHeight: "21px",
+    margin: "0 0 20px 0",
+    color: "var(--next-error-message)",
+  },
+  form: {
+    margin: 0,
+  },
+  buttonGroup: {
+    display: "flex",
+    gap: "8px",
+    alignItems: "center",
+  },
+  button: {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    height: "32px",
+    padding: "0 12px",
+    fontSize: "14px",
+    fontWeight: 500,
+    lineHeight: "20px",
+    borderRadius: "6px",
+    cursor: "pointer",
+    color: "var(--next-error-btn-text)",
+    background: "var(--next-error-btn-bg)",
+    border: "var(--next-error-btn-border)",
+  },
+  buttonSecondary: {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    height: "32px",
+    padding: "0 12px",
+    fontSize: "14px",
+    fontWeight: 500,
+    lineHeight: "20px",
+    borderRadius: "6px",
+    cursor: "pointer",
+    color: "var(--next-error-btn-secondary-text)",
+    background: "var(--next-error-btn-secondary-bg)",
+    border: "var(--next-error-btn-secondary-border)",
+  },
+  digestFooter: {
+    position: "fixed" as const,
+    bottom: "32px",
+    left: "0",
+    right: "0",
+    textAlign: "center" as const,
+    fontFamily: 'ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,monospace',
+    fontSize: "12px",
+    lineHeight: "18px",
+    fontWeight: 400,
+    margin: "0",
+    color: "var(--next-error-digest)",
+  },
+} as const;
+
+const errorThemeCss = `
+:root {
+  --next-error-bg: #fff;
+  --next-error-text: #171717;
+  --next-error-title: #171717;
+  --next-error-message: #171717;
+  --next-error-digest: #666666;
+  --next-error-btn-text: #fff;
+  --next-error-btn-bg: #171717;
+  --next-error-btn-border: none;
+  --next-error-btn-secondary-text: #171717;
+  --next-error-btn-secondary-bg: transparent;
+  --next-error-btn-secondary-border: 1px solid rgba(0,0,0,0.08);
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --next-error-bg: #0a0a0a;
+    --next-error-text: #ededed;
+    --next-error-title: #ededed;
+    --next-error-message: #ededed;
+    --next-error-digest: #a0a0a0;
+    --next-error-btn-text: #0a0a0a;
+    --next-error-btn-bg: #ededed;
+    --next-error-btn-border: none;
+    --next-error-btn-secondary-text: #ededed;
+    --next-error-btn-secondary-bg: transparent;
+    --next-error-btn-secondary-border: 1px solid rgba(255,255,255,0.14);
+  }
+}
+body { margin: 0; color: var(--next-error-text); background: var(--next-error-bg); }
+`.replace(/\n\s*/g, "");
+
+function WarningIcon() {
+  return (
+    <svg width="32" height="32" viewBox="-0.2 -1.5 32 32" fill="none" style={errorStyles.icon}>
+      <path
+        d="M16.9328 0C18.0839 0.000116771 19.1334 0.658832 19.634 1.69531L31.4299 26.1309C32.0708 27.4588 31.1036 28.9999 29.6291 29H2.00215C0.527541 29 -0.439628 27.4588 0.201371 26.1309L11.9973 1.69531C12.4979 0.658823 13.5474 7.75066e-05 14.6984 0H16.9328ZM3.59493 26H28.0363L16.9328 3H14.6984L3.59493 26ZM15.8156 19C16.9202 19.0001 17.8156 19.8955 17.8156 21C17.8156 22.1045 16.9202 22.9999 15.8156 23C14.7111 23 13.8156 22.1046 13.8156 21C13.8156 19.8954 14.7111 19 15.8156 19ZM17.3156 16.5H14.3156V8.5H17.3156V16.5Z"
+        fill="var(--next-error-title)"
+      />
+    </svg>
+  );
+}
+
+export function DefaultGlobalErrorDocument({ error }: DefaultGlobalErrorDocumentProps) {
+  const digest: string | undefined = error?.digest;
+  const isServerError = !!digest;
+
+  const message = isServerError
+    ? "A server error occurred. Reload to try again."
+    : "Reload to try again, or go back.";
+
+  return (
+    <html id="__next_error__">
+      <head>
+        <style dangerouslySetInnerHTML={{ __html: errorThemeCss }} />
+      </head>
+      <body>
+        <div style={errorStyles.container}>
+          <div style={errorStyles.card}>
+            <WarningIcon />
+            <h1 style={errorStyles.title}>This page couldn&#x2019;t load</h1>
+            <p style={errorStyles.message}>{message}</p>
+            <div style={errorStyles.buttonGroup}>
+              <form style={errorStyles.form}>
+                <button type="submit" style={errorStyles.button}>
+                  Reload
+                </button>
+              </form>
+              {!isServerError && (
+                <button type="button" style={errorStyles.buttonSecondary}>
+                  Back
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+        {digest && <p style={errorStyles.digestFooter}>ERROR {digest}</p>}
+      </body>
+    </html>
+  );
+}

--- a/packages/vinext/src/server/default-global-error-module.ts
+++ b/packages/vinext/src/server/default-global-error-module.ts
@@ -1,4 +1,4 @@
-import DefaultGlobalError from "vinext/shims/default-global-error";
+import { DefaultGlobalError } from "vinext/shims/error-boundary";
 
 /**
  * Module-shaped wrapper around vinext's built-in default global error

--- a/packages/vinext/src/shims/error-boundary.tsx
+++ b/packages/vinext/src/shims/error-boundary.tsx
@@ -3,10 +3,16 @@
 import React from "react";
 import { decodeRedirectError, isRedirectError } from "./navigation-server.js";
 import { useErrorBoundaryPathname, useErrorBoundaryRouter } from "./error-boundary-navigation.js";
-import DefaultGlobalError from "./default-global-error.js";
+import DefaultGlobalErrorImpl from "./default-global-error.js";
 import { handleAppNavigationFailure } from "../client/app-nav-failure-handler.js";
 import { VINEXT_DEV_ERROR_RECOVERY_EVENT } from "../utils/dev-error-recovery-event.js";
 import { isNavigationSignalError } from "../utils/navigation-signal.js";
+
+type DefaultGlobalErrorProps = React.ComponentProps<typeof DefaultGlobalErrorImpl>;
+
+export function DefaultGlobalError(props: DefaultGlobalErrorProps) {
+  return <DefaultGlobalErrorImpl {...props} />;
+}
 
 export type ErrorBoundaryProps = {
   fallback: React.ComponentType<{ error: unknown; reset: () => void }>;

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -764,9 +764,7 @@ function prefetchUrl(
           __prefetchInlining && mode === "auto" && autoPrefetch.prefetchShellFirst;
         const gateViaLoadingShell = mode === "full-after-shell" && autoPrefetch.prefetchShellFirst;
         const fetchPromise =
-          cacheForNavigation &&
-          !renderLoadingShell &&
-          (gateViaRouteTree || gateViaLoadingShell)
+          cacheForNavigation && !renderLoadingShell && (gateViaRouteTree || gateViaLoadingShell)
             ? (async () => {
                 if (gateViaLoadingShell) {
                   await fetchLoadingShellForReuse();

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -314,17 +314,34 @@ function getLinkPrefetchRouterMode(): LinkPrefetchRouterMode {
 
 function resolveMatchedAutoAppRoutePrefetch(route: VinextLinkPrefetchRoute): {
   cacheForNavigation: boolean;
-  prefetchShellFirst: boolean;
+  renderLoadingShell: boolean;
+  runtimeLoadingFallback?: VinextLinkPrefetchRoute["runtimePrefetchLoadingFallback"];
   shouldPrefetch: boolean;
 } {
+  if (route.canPrefetchRuntimeShell) {
+    return {
+      cacheForNavigation: false,
+      renderLoadingShell: false,
+      runtimeLoadingFallback: route.runtimePrefetchLoadingFallback,
+      shouldPrefetch: true,
+    };
+  }
+  if (route.canPrefetchStaticRoute) {
+    return {
+      cacheForNavigation: route.requiresDynamicNavigationRequest !== true,
+      renderLoadingShell: route.requiresDynamicNavigationRequest === true,
+      shouldPrefetch: true,
+    };
+  }
   const hasLoadingShell = route.canPrefetchLoadingShell;
+  const requiresDynamicNavigationRequest = route.requiresDynamicNavigationRequest === true;
   return {
     // Automatic prefetches are only unsafe as authoritative navigation
     // payloads for dynamic routes whose active parallel branches must be
     // derived from the click-time target tree. Other concrete dynamic URLs can
     // match Next.js's full-prefetch behavior, including client-param routes.
-    cacheForNavigation: !hasLoadingShell && route.requiresDynamicNavigationRequest !== true,
-    prefetchShellFirst: !route.isDynamic,
+    cacheForNavigation: !hasLoadingShell && !requiresDynamicNavigationRequest,
+    renderLoadingShell: hasLoadingShell || requiresDynamicNavigationRequest,
     shouldPrefetch: true,
   };
 }
@@ -346,26 +363,27 @@ export function canAutoPrefetchFullAppRoute(href: string): boolean {
 
 export function resolveAutoAppRoutePrefetch(href: string): {
   cacheForNavigation: boolean;
-  prefetchShellFirst: boolean;
+  renderLoadingShell: boolean;
+  runtimeLoadingFallback?: VinextLinkPrefetchRoute["runtimePrefetchLoadingFallback"];
   shouldPrefetch: boolean;
 } {
   if (typeof window === "undefined") {
-    return { cacheForNavigation: false, prefetchShellFirst: false, shouldPrefetch: false };
+    return { cacheForNavigation: false, renderLoadingShell: false, shouldPrefetch: false };
   }
 
   const routes = window.__VINEXT_LINK_PREFETCH_ROUTES__;
   if (!routes) {
-    return { cacheForNavigation: false, prefetchShellFirst: false, shouldPrefetch: false };
+    return { cacheForNavigation: false, renderLoadingShell: false, shouldPrefetch: false };
   }
 
   const routeHref = toSameOriginRouteHref(href);
   if (routeHref === null) {
-    return { cacheForNavigation: false, prefetchShellFirst: false, shouldPrefetch: false };
+    return { cacheForNavigation: false, renderLoadingShell: false, shouldPrefetch: false };
   }
 
   const match = matchRouteWithTrie(routeHref, routes, linkPrefetchRouteTrieCache);
   if (!match) {
-    return { cacheForNavigation: false, prefetchShellFirst: false, shouldPrefetch: false };
+    return { cacheForNavigation: false, renderLoadingShell: false, shouldPrefetch: false };
   }
 
   return resolveMatchedAutoAppRoutePrefetch(match.route);
@@ -373,12 +391,12 @@ export function resolveAutoAppRoutePrefetch(href: string): {
 
 function resolveFullAppRoutePrefetch(): {
   cacheForNavigation: true;
-  prefetchShellFirst: boolean;
+  renderLoadingShell: boolean;
   shouldPrefetch: true;
 } {
   return {
     cacheForNavigation: true,
-    prefetchShellFirst: true,
+    renderLoadingShell: false,
     shouldPrefetch: true,
   };
 }
@@ -471,6 +489,7 @@ function prefetchUrl(
           hasPrefetchCacheEntryForNavigation,
           prefetchRscResponse,
           PREFETCH_CACHE_TTL,
+          resolveAppPrefetchSharedCacheKey,
         } = navigation;
         const { createRscRequestHeaders, createRscRequestUrl } = rscCacheBusting;
         const {
@@ -493,35 +512,83 @@ function prefetchUrl(
           mode === "auto"
             ? resolveAutoAppRoutePrefetch(prefetchHref)
             : mode === "full-after-shell"
-              ? { cacheForNavigation: true, prefetchShellFirst: true, shouldPrefetch: true }
+              ? { cacheForNavigation: true, renderLoadingShell: false, shouldPrefetch: true }
               : resolveFullAppRoutePrefetch();
         if (!autoPrefetch.shouldPrefetch) return;
 
         const interceptionContext = getPrefetchInterceptionContext(fullHref);
         const mountedSlotsHeader = getMountedSlotsHeader();
-        const isOptimisticRouteShellPrefetch = !autoPrefetch.cacheForNavigation;
-        if (isOptimisticRouteShellPrefetch && interceptionContext !== null) return;
-        const headers = createRscRequestHeaders({
+        let cacheForNavigation = autoPrefetch.cacheForNavigation;
+        let renderLoadingShell = autoPrefetch.renderLoadingShell;
+        let shouldLearnOptimisticRouteShell = !cacheForNavigation;
+        if (shouldLearnOptimisticRouteShell && interceptionContext !== null) return;
+        let sharedCacheKey = resolveAppPrefetchSharedCacheKey(
+          fullHref,
+          renderLoadingShell ? "loading-shell" : "navigation",
+        );
+        let headers = createRscRequestHeaders({
           interceptionContext,
-          renderMode: isOptimisticRouteShellPrefetch
-            ? APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL
-            : undefined,
+          renderMode: renderLoadingShell ? APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL : undefined,
         });
         if (mountedSlotsHeader) {
           headers.set(VINEXT_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
         }
-        const shouldSendSegmentPrefetchHeaders = isOptimisticRouteShellPrefetch || mode === "auto";
+        const shouldSendSegmentPrefetchHeaders = shouldLearnOptimisticRouteShell || mode === "auto";
         if (shouldSendSegmentPrefetchHeaders) {
           headers.set(NEXT_ROUTER_PREFETCH_HEADER, "1");
           headers.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "1");
         }
         // Distinguish the same visible URL when it is prefetched from different
         // request contexts such as /feed vs /gallery or different mounted slots.
-        const rscUrl = await createRscRequestUrl(fullHref, headers);
-        const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
+        let rscUrl = await createRscRequestUrl(fullHref, headers);
+        let cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
         const prefetched = getPrefetchedUrls();
+        if (cacheForNavigation && !renderLoadingShell) {
+          const loadingShellSharedCacheKey = resolveAppPrefetchSharedCacheKey(
+            fullHref,
+            "loading-shell",
+          );
+          if (
+            loadingShellSharedCacheKey !== null &&
+            loadingShellSharedCacheKey !== sharedCacheKey &&
+            hasPrefetchCacheEntryForNavigation(rscUrl, interceptionContext, mountedSlotsHeader, {
+              sharedCacheKey,
+            })
+          ) {
+            const shellHeaders = createRscRequestHeaders({
+              interceptionContext,
+              renderMode: APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+            });
+            shellHeaders.set(NEXT_ROUTER_PREFETCH_HEADER, "1");
+            shellHeaders.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "1");
+            if (mountedSlotsHeader) {
+              shellHeaders.set(VINEXT_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
+            }
+            const shellRscUrl = await createRscRequestUrl(fullHref, shellHeaders);
+            if (
+              hasPrefetchCacheEntryForNavigation(
+                shellRscUrl,
+                interceptionContext,
+                mountedSlotsHeader,
+                {
+                  includeNonNavigation: true,
+                  sharedCacheKey: loadingShellSharedCacheKey,
+                },
+              )
+            ) {
+              return;
+            }
+            cacheForNavigation = false;
+            renderLoadingShell = true;
+            shouldLearnOptimisticRouteShell = true;
+            sharedCacheKey = loadingShellSharedCacheKey;
+            headers = shellHeaders;
+            rscUrl = shellRscUrl;
+            cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
+          }
+        }
         if (prefetched.has(cacheKey)) {
-          if (!autoPrefetch.cacheForNavigation) {
+          if (!cacheForNavigation) {
             return;
           }
 
@@ -534,8 +601,10 @@ function prefetchUrl(
         // an equivalent `_rsc` variant; the helper also deletes any stale exact
         // entry, so a stale `prefetched` member is harmlessly re-added below.
         if (
-          autoPrefetch.cacheForNavigation &&
-          hasPrefetchCacheEntryForNavigation(rscUrl, interceptionContext, mountedSlotsHeader)
+          hasPrefetchCacheEntryForNavigation(rscUrl, interceptionContext, mountedSlotsHeader, {
+            includeNonNavigation: shouldLearnOptimisticRouteShell,
+            sharedCacheKey,
+          })
         ) {
           return;
         }
@@ -546,8 +615,8 @@ function prefetchUrl(
         // request to preserve the same pending/dedup observable contract.
         const fetchPromise =
           (mode === "full" || mode === "full-after-shell" || __prefetchInlining) &&
-          autoPrefetch.cacheForNavigation &&
-          autoPrefetch.prefetchShellFirst &&
+          cacheForNavigation &&
+          !renderLoadingShell &&
           (mode !== "full" || mountedSlotsHeader === null)
             ? (async () => {
                 const shellHeaders = createRscRequestHeaders({
@@ -587,6 +656,7 @@ function prefetchUrl(
                     {
                       cacheForNavigation: false,
                       optimisticRouteShell: true,
+                      sharedCacheKey,
                     },
                   );
                   shellEntry = shellCache.get(shellCacheKey);
@@ -622,9 +692,17 @@ function prefetchUrl(
           mountedSlotsHeader,
           undefined,
           {
-            cacheForNavigation: autoPrefetch.cacheForNavigation,
+            cacheForNavigation,
             fallbackTtlMs: PREFETCH_CACHE_TTL,
-            optimisticRouteShell: isOptimisticRouteShellPrefetch,
+            optimisticRouteShell: shouldLearnOptimisticRouteShell && renderLoadingShell,
+            runtimeLoadingFallback: autoPrefetch.runtimeLoadingFallback ?? null,
+            runtimeTemplateVariantKey:
+              shouldLearnOptimisticRouteShell && !renderLoadingShell && sharedCacheKey !== null
+                ? `${sharedCacheKey}\0${
+                    resolveAppPrefetchSharedCacheKey(fullHref, "loading-shell") ?? ""
+                  }`
+                : null,
+            sharedCacheKey,
           },
         );
       } else if (HAS_PAGES_ROUTER && window.__NEXT_DATA__) {

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -16,6 +16,10 @@ import {
   hasAppNavigationRuntime,
   type NavigationRuntimeVisibleCommitMode,
 } from "../client/navigation-runtime.js";
+import type {
+  VinextLinkPrefetchRoute,
+  VinextRuntimePrefetchLoadingFallback,
+} from "../client/vinext-next-data.js";
 import { notifyAppRouterTransitionStart } from "../client/instrumentation-client-state.js";
 import {
   clearAppNavigationFailureTarget,
@@ -48,6 +52,7 @@ import {
   withBasePath,
 } from "./url-utils.js";
 import { navigationPlanner } from "../server/navigation-planner.js";
+import { createRouteTrieCache, matchRouteWithTrie } from "../routing/route-matching.js";
 import { stripBasePath } from "../utils/base-path.js";
 import { isBotUserAgent } from "../utils/html-limited-bots.js";
 import { ReadonlyURLSearchParams } from "./readonly-url-search-params.js";
@@ -263,9 +268,14 @@ export type PrefetchCacheEntry = {
   outcome: "pending" | "cache-seeded";
   snapshot?: CachedRscResponse;
   pending?: Promise<void>;
+  runtimeLoadingFallback?: VinextRuntimePrefetchLoadingFallback | null;
+  runtimeTemplateVariantKey?: string | null;
+  sharedCacheKey?: string | null;
   size?: number;
   timestamp: number;
 };
+
+const appPrefetchRouteTrieCache = createRouteTrieCache<VinextLinkPrefetchRoute>();
 
 export function getCurrentInterceptionContext(): string | null {
   if (isServer) {
@@ -416,6 +426,53 @@ function parsePrefetchCacheKey(cacheKey: string): {
   };
 }
 
+function encodePrefetchParamValue(value: string | string[] | undefined): string {
+  if (Array.isArray(value)) return value.map(encodeURIComponent).join("/");
+  return encodeURIComponent(value ?? "");
+}
+
+export function resolveAppPrefetchSharedCacheKey(
+  href: string,
+  kind: "navigation" | "loading-shell" | "runtime",
+): string | null {
+  if (isServer) return null;
+  const routes = window.__VINEXT_LINK_PREFETCH_ROUTES__;
+  if (!routes) return null;
+
+  let url: URL;
+  try {
+    url = new URL(href, window.location.href);
+  } catch {
+    return null;
+  }
+  if (url.origin !== window.location.origin) return null;
+
+  const routeHref = `${stripBasePath(url.pathname, __basePath)}${url.search}`;
+  const match = matchRouteWithTrie(routeHref, routes, appPrefetchRouteTrieCache);
+  if (!match) return null;
+
+  const route = match.route;
+  const varyParamNames =
+    kind === "loading-shell"
+      ? route.loadingShellVaryParamNames
+      : kind === "runtime"
+        ? route.runtimePrefetchVaryParamNames
+        : route.prefetchVaryParamNames;
+  const varyParams = new Set(varyParamNames ?? []);
+  const keyParts = route.patternParts.map((part) => {
+    if (!part.startsWith(":")) return part;
+    const name = part.replace(/^:/, "").replace(/[+*]$/, "");
+    return varyParams.has(name) ? encodePrefetchParamValue(match.params[name]) : `:${name}`;
+  });
+  const search =
+    kind === "runtime" && route.runtimePrefetchVarySearchParams === true
+      ? url.search
+      : kind === "navigation" && route.prefetchVarySearchParams === true
+        ? url.search
+        : "";
+  return `${route.patternParts.join("/")}\0${keyParts.join("/")}${search}`;
+}
+
 function isPrefetchCacheEntryCompatibleWithMountedSlots(
   entry: PrefetchCacheEntry,
   mountedSlotsHeader: string | null,
@@ -437,13 +494,14 @@ function findPrefetchCacheEntryForNavigation(
   rscUrl: string,
   interceptionContext: string | null,
   mountedSlotsHeader: string | null,
+  options: { includeNonNavigation?: boolean; sharedCacheKey?: string | null } = {},
 ): { cacheKey: string; entry: PrefetchCacheEntry } | null {
   const exactCacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
   const cache = getPrefetchCache();
   const exactEntry = cache.get(exactCacheKey);
   if (
     exactEntry &&
-    exactEntry.cacheForNavigation !== false &&
+    (options.includeNonNavigation === true || exactEntry.cacheForNavigation !== false) &&
     isPrefetchCacheEntryCompatibleWithMountedSlots(exactEntry, mountedSlotsHeader)
   ) {
     return { cacheKey: exactCacheKey, entry: exactEntry };
@@ -454,11 +512,18 @@ function findPrefetchCacheEntryForNavigation(
 
   for (const [cacheKey, entry] of cache) {
     if (cacheKey === exactCacheKey) continue;
-    if (entry.cacheForNavigation === false) continue;
+    if (options.includeNonNavigation !== true && entry.cacheForNavigation === false) continue;
 
     const source = parsePrefetchCacheKey(cacheKey);
     if (source.interceptionContext !== interceptionContext) continue;
-    if (normalizeRscCacheLookupUrl(source.rscUrl) !== normalizedTarget) continue;
+    if (
+      normalizeRscCacheLookupUrl(source.rscUrl) !== normalizedTarget &&
+      (options.sharedCacheKey === null ||
+        options.sharedCacheKey === undefined ||
+        entry.sharedCacheKey !== options.sharedCacheKey)
+    ) {
+      continue;
+    }
     if (!isPrefetchCacheEntryCompatibleWithMountedSlots(entry, mountedSlotsHeader)) continue;
 
     return { cacheKey, entry };
@@ -471,12 +536,17 @@ export function hasPrefetchCacheEntryForNavigation(
   rscUrl: string,
   interceptionContext: string | null = null,
   mountedSlotsHeader: string | null = null,
-  options: { notifyInvalidation?: boolean } = {},
+  options: {
+    includeNonNavigation?: boolean;
+    notifyInvalidation?: boolean;
+    sharedCacheKey?: string | null;
+  } = {},
 ): boolean {
   const match = findPrefetchCacheEntryForNavigation(
     rscUrl,
     interceptionContext,
     mountedSlotsHeader,
+    options,
   );
   if (match === null) return false;
 
@@ -870,6 +940,9 @@ export function prefetchRscResponse(
     cacheForNavigation?: boolean;
     fallbackTtlMs?: number;
     optimisticRouteShell?: boolean;
+    runtimeLoadingFallback?: VinextRuntimePrefetchLoadingFallback | null;
+    runtimeTemplateVariantKey?: string | null;
+    sharedCacheKey?: string | null;
   } = {},
 ): void {
   const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
@@ -886,6 +959,9 @@ export function prefetchRscResponse(
     mountedSlotsHeader,
     optimisticRouteShell: behavior.optimisticRouteShell === true,
     outcome: "pending",
+    runtimeLoadingFallback: behavior.runtimeLoadingFallback ?? null,
+    runtimeTemplateVariantKey: behavior.runtimeTemplateVariantKey ?? null,
+    sharedCacheKey: behavior.sharedCacheKey ?? null,
     timestamp: now,
   };
   addPrefetchInvalidationCallback(entry, options?.onInvalidate);
@@ -938,6 +1014,7 @@ export function consumePrefetchResponse(
   rscUrl: string,
   interceptionContext: string | null = null,
   mountedSlotsHeader: string | null = null,
+  options: { sharedCacheKey?: string | null } = {},
 ): CachedRscResponse | null {
   const cache = getPrefetchCache();
   const exactCacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
@@ -954,6 +1031,7 @@ export function consumePrefetchResponse(
     rscUrl,
     interceptionContext,
     mountedSlotsHeader,
+    { sharedCacheKey: options.sharedCacheKey },
   );
   if (!match) return null;
   const { cacheKey, entry } = match;
@@ -1005,13 +1083,14 @@ export async function consumePrefetchResponseForNavigation(
   rscUrl: string,
   interceptionContext: string | null = null,
   mountedSlotsHeader: string | null = null,
-  options?: ConsumePrefetchResponseForNavigationOptions,
+  options?: ConsumePrefetchResponseForNavigationOptions & { sharedCacheKey?: string | null },
 ): Promise<CachedRscResponse | null> {
   const cache = getPrefetchCache();
   const match = findPrefetchCacheEntryForNavigation(
     rscUrl,
     interceptionContext,
     mountedSlotsHeader,
+    { sharedCacheKey: options?.sharedCacheKey },
   );
   if (!match) return null;
   const { cacheKey, entry } = match;
@@ -1023,7 +1102,9 @@ export async function consumePrefetchResponseForNavigation(
 
   if (options?.shouldConsume?.() === false) return null;
 
-  return consumePrefetchResponse(rscUrl, interceptionContext, mountedSlotsHeader);
+  return consumePrefetchResponse(rscUrl, interceptionContext, mountedSlotsHeader, {
+    sharedCacheKey: options?.sharedCacheKey,
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/app-optimistic-routing.test.ts
+++ b/tests/app-optimistic-routing.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vite-plus/test";
-import { createElement, Suspense } from "react";
+import { createElement, isValidElement, Suspense } from "react";
 import {
   AppElementsWire,
   APP_PREFETCH_LOADING_SHELL_MARKER_KEY,
@@ -281,6 +281,130 @@ describe("App Router optimistic routing", () => {
 
     expect(navigationPayload?.params).toEqual({ slug: "post-2" });
     expect(navigationPayload?.elements[pageId]).not.toBe(elements[pageId]);
+  });
+
+  it("preserves runtime-prefetch page content while suspending innermost page suspense", () => {
+    const routeManifest = manifest([
+      route({
+        id: "route:/runtime/:itemId",
+        isDynamic: true,
+        paramNames: ["itemId"],
+        pattern: "/runtime/:itemId",
+        patternParts: ["runtime", ":itemId"],
+      }),
+    ]);
+    const layoutId = AppElementsWire.encodeLayoutId("/");
+    const routeId = AppElementsWire.encodeRouteId("/runtime/phone", null);
+    const pageId = AppElementsWire.encodePageId("/runtime/phone", null);
+    const layout = createElement(
+      Suspense,
+      { fallback: createElement("p", { id: "layout-loading" }, "Loading layout") },
+      createElement("div", { "data-layout": true }, "Cached layout"),
+    );
+    const staticContent = createElement("div", { "data-static": true }, "Static content");
+    const innerSuspense = createElement(
+      Suspense,
+      { fallback: createElement("p", { id: "page-loading" }, "Loading item details") },
+      createElement("div", { "data-dynamic": true }, "Stale item"),
+    );
+    const elements: AppElements = {
+      ...AppElementsWire.createMetadataEntries({
+        interceptionContext: null,
+        layoutIds: [layoutId],
+        rootLayoutTreePath: "/",
+        routeId,
+      }),
+      [layoutId]: layout,
+      [pageId]: createElement("section", null, staticContent, innerSuspense),
+      [routeId]: createElement("main", null, "Route"),
+    };
+
+    const template = createOptimisticRouteTemplate({
+      basePath: "",
+      elements,
+      href: "/runtime/phone.rsc",
+      interceptionContext: null,
+      mountedSlotsHeader: null,
+      preservePageElements: true,
+      routeManifest,
+      variantKey: "runtime:phone",
+    });
+
+    expect(template?.pageElementIds).toEqual([pageId]);
+
+    const optimisticElements = createOptimisticRouteElements(template!);
+    expect(optimisticElements[layoutId]).toBe(layout);
+    expect(optimisticElements[pageId]).not.toBe(elements[pageId]);
+
+    const pageElement = optimisticElements[pageId];
+    expect(isValidElement(pageElement)).toBe(true);
+    if (!isValidElement(pageElement)) return;
+
+    const children = (pageElement.props as { children: unknown }).children;
+    expect(Array.isArray(children)).toBe(true);
+    if (!Array.isArray(children)) return;
+    expect(children[0]).toBe(staticContent);
+    expect(children[1]).not.toBe(innerSuspense);
+    const suspense = children[1];
+    expect(isValidElement(suspense)).toBe(true);
+    if (!isValidElement(suspense)) return;
+    expect((suspense.props as { fallback: unknown }).fallback).toBe(
+      (innerSuspense.props as { fallback: unknown }).fallback,
+    );
+  });
+
+  it("appends runtime-prefetch fallback when decoded page content has no suspense", () => {
+    const routeManifest = manifest([
+      route({
+        id: "route:/runtime/:itemId",
+        isDynamic: true,
+        paramNames: ["itemId"],
+        pattern: "/runtime/:itemId",
+        patternParts: ["runtime", ":itemId"],
+      }),
+    ]);
+    const routeId = AppElementsWire.encodeRouteId("/runtime/phone", null);
+    const pageId = AppElementsWire.encodePageId("/runtime/phone", null);
+    const staticContent = createElement("div", { "data-static": true }, "Static content");
+    const elements: AppElements = {
+      ...AppElementsWire.createMetadataEntries({
+        interceptionContext: null,
+        layoutIds: ["layout:/"],
+        rootLayoutTreePath: "/",
+        routeId,
+      }),
+      [pageId]: createElement("section", null, staticContent),
+      [routeId]: createElement("main", null, "Route"),
+    };
+
+    const template = createOptimisticRouteTemplate({
+      basePath: "",
+      elements,
+      href: "/runtime/phone.rsc",
+      interceptionContext: null,
+      mountedSlotsHeader: null,
+      preservePageElements: true,
+      routeManifest,
+      runtimeLoadingFallback: {
+        attributes: { "data-loading": "true" },
+        tagName: "div",
+        text: "Loading item details...",
+      },
+    });
+
+    const optimisticPage = createOptimisticRouteElements(template!)[pageId];
+    expect(isValidElement(optimisticPage)).toBe(true);
+    if (!isValidElement(optimisticPage)) return;
+
+    const children = (optimisticPage.props as { children: unknown }).children;
+    expect(Array.isArray(children)).toBe(true);
+    if (!Array.isArray(children)) return;
+    expect(children[0]).toBe(staticContent);
+    const fallback = children[1];
+    expect(isValidElement(fallback)).toBe(true);
+    if (!isValidElement(fallback)) return;
+    expect((fallback.props as { "data-loading": unknown })["data-loading"]).toBe("true");
+    expect((fallback.props as { children: unknown }).children).toBe("Loading item details...");
   });
 
   it("includes active parallel slot params in optimistic navigation payloads", () => {

--- a/tests/app-prefetch-vary-analysis.test.ts
+++ b/tests/app-prefetch-vary-analysis.test.ts
@@ -1,0 +1,395 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { toLinkPrefetchRoute } from "../packages/vinext/src/entries/app-browser-entry.js";
+import type { AppRoute } from "../packages/vinext/src/routing/app-router.js";
+
+const tmpDirs: string[] = [];
+
+function writeSource(name: string, source: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-prefetch-vary-"));
+  tmpDirs.push(dir);
+  const filePath = path.join(dir, name);
+  fs.writeFileSync(filePath, source);
+  return filePath;
+}
+
+function createRoute(overrides: Partial<AppRoute> = {}): AppRoute {
+  return {
+    errorPath: null,
+    forbiddenPath: null,
+    forbiddenPaths: [],
+    isDynamic: true,
+    layoutErrorPaths: [],
+    layouts: [],
+    layoutTreePositions: [],
+    loadingPath: null,
+    notFoundPath: null,
+    notFoundPaths: [],
+    pagePath: null,
+    parallelSlots: [],
+    params: ["category", "itemId"],
+    pattern: "/items/:category/:itemId",
+    patternParts: ["items", ":category", ":itemId"],
+    routePath: null,
+    routeSegments: ["items", "[category]", "[itemId]"],
+    siblingIntercepts: [],
+    templates: [],
+    unauthorizedPath: null,
+    unauthorizedPaths: [],
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  while (tmpDirs.length > 0) {
+    fs.rmSync(tmpDirs.pop()!, { force: true, recursive: true });
+  }
+});
+
+describe("App Router prefetch vary analysis", () => {
+  it("does not treat JSX text as a searchParams access", () => {
+    const pagePath = writeSource(
+      "page.tsx",
+      `export default function Page() {
+        return <div>Static target content - no searchParams access</div>;
+      }`,
+    );
+
+    const route = toLinkPrefetchRoute(
+      createRoute({ pagePath, params: [], patternParts: ["static"] }),
+    );
+
+    expect(route.prefetchVarySearchParams).toBeUndefined();
+  });
+
+  it("marks routes that await searchParams as varying by query", () => {
+    const pagePath = writeSource(
+      "page.tsx",
+      `export default async function Page({ searchParams }: { searchParams: Promise<{ foo?: string }> }) {
+        const { foo } = await searchParams;
+        return <div>{foo}</div>;
+      }`,
+    );
+
+    const route = toLinkPrefetchRoute(
+      createRoute({ pagePath, params: [], patternParts: ["target"] }),
+    );
+
+    expect(route.prefetchVarySearchParams).toBe(true);
+  });
+
+  it("marks helper searchParams reads as varying by query", () => {
+    const pagePath = writeSource(
+      "page.tsx",
+      `export default function Page({ searchParams }: { searchParams: Promise<{ foo?: string }> }) {
+        return <div>{readQuery(searchParams)}</div>;
+      }
+
+      async function readQuery(input: Promise<{ foo?: string }>) {
+        return (await input).foo;
+      }`,
+    );
+
+    const route = toLinkPrefetchRoute(
+      createRoute({ pagePath, params: [], patternParts: ["target"] }),
+    );
+
+    expect(route.prefetchVarySearchParams).toBe(true);
+  });
+
+  it("marks prop-renamed searchParams reads as varying by query", () => {
+    const pagePath = writeSource(
+      "page.tsx",
+      `export default async function Page({ searchParams: query }: { searchParams: Promise<{ foo?: string }> }) {
+        const resolved = await query;
+        return <div>{resolved.foo}</div>;
+      }`,
+    );
+
+    const route = toLinkPrefetchRoute(
+      createRoute({ pagePath, params: [], patternParts: ["target"] }),
+    );
+
+    expect(route.prefetchVarySearchParams).toBe(true);
+  });
+
+  it("does not treat client module param reads as server segment variation", () => {
+    const layoutPath = writeSource(
+      "layout.tsx",
+      `"use client";
+
+      import { use } from "react";
+
+      export default function Layout({ params, children }: { params: Promise<{ category: string }>; children: React.ReactNode }) {
+        const { category } = use(params);
+        return <section data-category={category}>{children}</section>;
+      }`,
+    );
+    const pagePath = writeSource(
+      "page.tsx",
+      `"use client";
+
+      import { use } from "react";
+
+      export default function Page({ params, searchParams }: { params: Promise<{ itemId: string }>; searchParams: Promise<Record<string, string>> }) {
+        const { itemId } = use(params);
+        const query = use(searchParams);
+        return <div>{itemId}:{query.q}</div>;
+      }`,
+    );
+
+    const route = toLinkPrefetchRoute(createRoute({ layouts: [layoutPath], pagePath }));
+
+    expect(route.loadingShellVaryParamNames).toBeUndefined();
+    expect(route.prefetchVaryParamNames).toBeUndefined();
+    expect(route.prefetchVarySearchParams).toBeUndefined();
+  });
+
+  it("tracks only params accessed before connection for runtime-prefetch sharing", () => {
+    const layoutPath = writeSource(
+      "layout.tsx",
+      `export default async function Layout({ children, params }: { children: React.ReactNode; params: Promise<{ category: string; itemId: string }> }) {
+        const { category } = await params;
+        return <section data-category={category}>{children}</section>;
+      }`,
+    );
+    const pagePath = writeSource(
+      "page.tsx",
+      `import { connection } from "next/server";
+
+      export default async function Page({ params }: { params: Promise<{ category: string; itemId: string }> }) {
+        const { category } = await params;
+        await connection();
+        const { itemId } = await params;
+        return <div>{category}:{itemId}</div>;
+      }`,
+    );
+
+    const route = toLinkPrefetchRoute(
+      createRoute({
+        layouts: [layoutPath],
+        loadingPath: writeSource(
+          "loading.tsx",
+          "export default function Loading() { return null; }",
+        ),
+        pagePath,
+      }),
+    );
+
+    expect(route.loadingShellVaryParamNames).toEqual(["category"]);
+    expect(route.prefetchVaryParamNames).toEqual(["category"]);
+  });
+
+  it("marks static-param pages that call connection as requiring fresh navigation", () => {
+    const pagePath = writeSource(
+      "page.tsx",
+      `import { connection } from "next/server";
+
+      export function generateStaticParams() {
+        return [{ category: "books" }];
+      }
+
+      export default async function Page({ params }: { params: Promise<{ category: string }> }) {
+        await connection();
+        const { category } = await params;
+        return <div>{category}</div>;
+      }`,
+    );
+
+    const route = toLinkPrefetchRoute(
+      createRoute({
+        loadingPath: writeSource(
+          "loading.tsx",
+          "export default function Loading() { return null; }",
+        ),
+        pagePath,
+        params: ["category"],
+        patternParts: ["items", ":category"],
+      }),
+    );
+
+    expect(route.canPrefetchStaticRoute).toBe(true);
+    expect(route.requiresDynamicNavigationRequest).toBe(true);
+  });
+
+  it("does not truncate static analysis on connection substrings", () => {
+    const pagePath = writeSource(
+      "page.tsx",
+      `function myConnection() {
+        return "not next/server connection";
+      }
+
+      export default async function Page({ params }: { params: Promise<{ category: string; itemId: string }> }) {
+        myConnection();
+        const { itemId } = await params;
+        return <div>{itemId}</div>;
+      }`,
+    );
+
+    const route = toLinkPrefetchRoute(createRoute({ pagePath }));
+
+    expect(route.prefetchVaryParamNames).toEqual(["itemId"]);
+  });
+
+  it("marks computed param reads as varying by all known params", () => {
+    const pagePath = writeSource(
+      "page.tsx",
+      `export default async function Page({ params }: { params: Promise<{ category: string; itemId: string }> }) {
+        const key = "category";
+        const resolved = await params;
+        return <div>{resolved[key]}</div>;
+      }`,
+    );
+
+    const route = toLinkPrefetchRoute(createRoute({ pagePath }));
+
+    expect(route.prefetchVaryParamNames).toEqual(["category", "itemId"]);
+  });
+
+  it("marks helper param reads as varying by all known params", () => {
+    const pagePath = writeSource(
+      "page.tsx",
+      `export default async function Page({ params }: { params: Promise<{ category: string; itemId: string }> }) {
+        return <div>{readItem(await params)}</div>;
+      }
+
+      function readItem(input: { category: string; itemId: string }) {
+        return input.itemId;
+      }`,
+    );
+
+    const route = toLinkPrefetchRoute(createRoute({ pagePath }));
+
+    expect(route.prefetchVaryParamNames).toEqual(["category", "itemId"]);
+  });
+
+  it("tracks prop-renamed param reads", () => {
+    const pagePath = writeSource(
+      "page.tsx",
+      `export default async function Page({ params: routeParams }: { params: Promise<{ category: string; itemId: string }> }) {
+        const resolved = await routeParams;
+        return <div>{resolved.itemId}</div>;
+      }`,
+    );
+
+    const route = toLinkPrefetchRoute(createRoute({ pagePath }));
+
+    expect(route.prefetchVaryParamNames).toEqual(["itemId"]);
+  });
+
+  it("extracts runtime-prefetch loading fallback metadata", () => {
+    const pagePath = writeSource(
+      "page.tsx",
+      `import { Suspense } from "react";
+      import { connection } from "next/server";
+
+      export const unstable_instant = { prefetch: "runtime", samples: [] };
+
+      export default async function Page({ params }: { params: Promise<{ category: string; itemId: string }> }) {
+        const { category } = await params;
+        return <section>
+          <div>{category}</div>
+          <Suspense fallback={<div>Loading page...</div>}>
+            <StaticContent />
+          </Suspense>
+          <Suspense fallback={<div data-loading="true">Loading item details...</div>}>
+            <DynamicContent />
+          </Suspense>
+        </section>;
+      }
+
+      async function StaticContent() {
+        return <div>Static</div>;
+      }
+
+      async function DynamicContent() {
+        await connection();
+        return <div>Dynamic</div>;
+      }`,
+    );
+
+    const route = toLinkPrefetchRoute(createRoute({ pagePath }));
+
+    expect(route.runtimePrefetchLoadingFallback).toEqual({
+      attributes: { "data-loading": "true" },
+      tagName: "div",
+      text: "Loading item details...",
+    });
+  });
+
+  it("decodes runtime-prefetch fallback entities without double-decoding", () => {
+    const pagePath = writeSource(
+      "page.tsx",
+      `import { Suspense } from "react";
+
+      export const prefetch = "allow-runtime";
+
+      export default function Page() {
+        return <Suspense fallback={<div data-loading="true" data-label="&amp;lt;">Loading &amp;lt;item&amp;gt;</div>}>
+          <DynamicContent />
+        </Suspense>;
+      }`,
+    );
+
+    const route = toLinkPrefetchRoute(createRoute({ pagePath }));
+
+    expect(route.runtimePrefetchLoadingFallback).toEqual({
+      attributes: { "data-label": "&lt;", "data-loading": "true" },
+      tagName: "div",
+      text: "Loading &lt;item&gt;",
+    });
+  });
+
+  it("recognizes optional catch-all direct, enumeration, and in-operator param accesses", () => {
+    const directRoute = toLinkPrefetchRoute(
+      createRoute({
+        pagePath: writeSource(
+          "direct.tsx",
+          `export default async function Page({ params }: { params: Promise<{ slug?: string[] }> }) {
+            const { slug } = await params;
+            return <div>{slug?.join("/")}</div>;
+          }`,
+        ),
+        params: ["slug"],
+        pattern: "/:slug*",
+        patternParts: [":slug*"],
+      }),
+    );
+    const enumerationRoute = toLinkPrefetchRoute(
+      createRoute({
+        pagePath: writeSource(
+          "enumeration.tsx",
+          `export default async function Page({ params }: { params: Promise<{ slug?: string[] }> }) {
+            const resolved = await params;
+            const copy = { ...resolved };
+            return <div>{copy.slug?.join("/")}</div>;
+          }`,
+        ),
+        params: ["slug"],
+        pattern: "/:slug*",
+        patternParts: [":slug*"],
+      }),
+    );
+    const inOperatorRoute = toLinkPrefetchRoute(
+      createRoute({
+        pagePath: writeSource(
+          "in-operator.tsx",
+          `export default async function Page({ params }: { params: Promise<{ slug?: string[] }> }) {
+            const resolved = await params;
+            const hasSlug = "slug" in resolved;
+            return <div>{String(hasSlug)}</div>;
+          }`,
+        ),
+        params: ["slug"],
+        pattern: "/:slug*",
+        patternParts: [":slug*"],
+      }),
+    );
+
+    expect(directRoute.prefetchVaryParamNames).toEqual(["slug"]);
+    expect(enumerationRoute.prefetchVaryParamNames).toEqual(["slug"]);
+    expect(inOperatorRoute.prefetchVaryParamNames).toEqual(["slug"]);
+  });
+});

--- a/tests/app-prefetch-vary-analysis.test.ts
+++ b/tests/app-prefetch-vary-analysis.test.ts
@@ -162,6 +162,27 @@ describe("App Router prefetch vary analysis", () => {
     expect(route.prefetchVarySearchParams).toBe(true);
   });
 
+  it("tracks object props params and searchParams promise aliases", () => {
+    const pagePath = writeSource(
+      "page.tsx",
+      `export default async function Page(props: {
+        params: Promise<{ category: string; itemId: string }>;
+        searchParams: Promise<{ foo?: string }>;
+      }) {
+        const routeParams = props.params;
+        const queryPromise = props.searchParams;
+        const { itemId } = await routeParams;
+        const query = await queryPromise;
+        return <div>{itemId}:{query.foo}</div>;
+      }`,
+    );
+
+    const route = toLinkPrefetchRoute(createRoute({ pagePath }));
+
+    expect(route.prefetchVaryParamNames).toEqual(["itemId"]);
+    expect(route.prefetchVarySearchParams).toBe(true);
+  });
+
   it("marks Object.assign param and searchParam copies as varying", () => {
     const pagePath = writeSource(
       "page.tsx",
@@ -294,6 +315,21 @@ describe("App Router prefetch vary analysis", () => {
         myConnection();
         const { itemId } = await params;
         return <div>{itemId}</div>;
+      }`,
+    );
+
+    const route = toLinkPrefetchRoute(createRoute({ pagePath }));
+
+    expect(route.prefetchVaryParamNames).toEqual(["itemId"]);
+  });
+
+  it("does not truncate static analysis on connection text", () => {
+    const pagePath = writeSource(
+      "page.tsx",
+      `export default async function Page({ params }: { params: Promise<{ category: string; itemId: string }> }) {
+        const docs = "Call connection() to opt into dynamic rendering";
+        const { itemId } = await params;
+        return <div>{docs}<code>connection()</code>{itemId}</div>;
       }`,
     );
 

--- a/tests/app-prefetch-vary-analysis.test.ts
+++ b/tests/app-prefetch-vary-analysis.test.ts
@@ -115,6 +115,75 @@ describe("App Router prefetch vary analysis", () => {
     expect(route.prefetchVarySearchParams).toBe(true);
   });
 
+  it("tracks params read from an object props argument", () => {
+    const pagePath = writeSource(
+      "page.tsx",
+      `export default async function Page(props: { params: Promise<{ category: string; itemId: string }> }) {
+        const { itemId } = await props.params;
+        return <div>{itemId}</div>;
+      }`,
+    );
+
+    const route = toLinkPrefetchRoute(createRoute({ pagePath }));
+
+    expect(route.prefetchVaryParamNames).toEqual(["itemId"]);
+  });
+
+  it("marks helper-passed object props params as varying by all known params", () => {
+    const pagePath = writeSource(
+      "page.tsx",
+      `export default function Page(props: { params: Promise<{ category: string; itemId: string }> }) {
+        return <div>{readItem(props.params)}</div>;
+      }
+
+      async function readItem(input: Promise<{ category: string; itemId: string }>) {
+        return (await input).itemId;
+      }`,
+    );
+
+    const route = toLinkPrefetchRoute(createRoute({ pagePath }));
+
+    expect(route.prefetchVaryParamNames).toEqual(["category", "itemId"]);
+  });
+
+  it("marks object props searchParams reads as varying by query", () => {
+    const pagePath = writeSource(
+      "page.tsx",
+      `export default async function Page(props: { searchParams: Promise<{ foo?: string }> }) {
+        const query = await props.searchParams;
+        return <div>{query.foo}</div>;
+      }`,
+    );
+
+    const route = toLinkPrefetchRoute(
+      createRoute({ pagePath, params: [], patternParts: ["target"] }),
+    );
+
+    expect(route.prefetchVarySearchParams).toBe(true);
+  });
+
+  it("marks Object.assign param and searchParam copies as varying", () => {
+    const pagePath = writeSource(
+      "page.tsx",
+      `export default async function Page({
+        params,
+        searchParams,
+      }: {
+        params: Promise<{ category: string; itemId: string }>;
+        searchParams: Promise<{ foo?: string }>;
+      }) {
+        const paramCopy = Object.assign({}, await params);
+        const queryCopy = Object.assign({}, await searchParams);
+        return <div>{paramCopy.itemId}:{queryCopy.foo}</div>;
+      }`,
+    );
+
+    const route = toLinkPrefetchRoute(createRoute({ pagePath }));
+
+    expect(route.prefetchVaryParamNames).toEqual(["category", "itemId"]);
+    expect(route.prefetchVarySearchParams).toBe(true);
+  });
+
   it("does not treat client module param reads as server segment variation", () => {
     const layoutPath = writeSource(
       "layout.tsx",

--- a/tests/app-prefetch-vary-analysis.test.ts
+++ b/tests/app-prefetch-vary-analysis.test.ts
@@ -183,6 +183,35 @@ describe("App Router prefetch vary analysis", () => {
     expect(route.prefetchVarySearchParams).toBe(true);
   });
 
+  it("tracks params read from awaited member expressions", () => {
+    const pagePath = writeSource(
+      "page.tsx",
+      `export default async function Page({ params }: { params: Promise<{ category: string; itemId: string }> }) {
+        const itemId = (await params).itemId;
+        return <div>{itemId}</div>;
+      }`,
+    );
+
+    const route = toLinkPrefetchRoute(createRoute({ pagePath }));
+
+    expect(route.prefetchVaryParamNames).toEqual(["itemId"]);
+  });
+
+  it("tracks params destructured from awaited aliases", () => {
+    const pagePath = writeSource(
+      "page.tsx",
+      `export default async function Page({ params }: { params: Promise<{ category: string; itemId: string }> }) {
+        const resolved = await params;
+        const { itemId } = resolved;
+        return <div>{itemId}</div>;
+      }`,
+    );
+
+    const route = toLinkPrefetchRoute(createRoute({ pagePath }));
+
+    expect(route.prefetchVaryParamNames).toEqual(["itemId"]);
+  });
+
   it("marks Object.assign param and searchParam copies as varying", () => {
     const pagePath = writeSource(
       "page.tsx",
@@ -301,6 +330,75 @@ describe("App Router prefetch vary analysis", () => {
     );
 
     expect(route.canPrefetchStaticRoute).toBe(true);
+    expect(route.requiresDynamicNavigationRequest).toBe(true);
+  });
+
+  it("does not truncate static analysis on local connection helpers", () => {
+    const pagePath = writeSource(
+      "page.tsx",
+      `function connection() {
+        return Promise.resolve();
+      }
+
+      export function generateStaticParams() {
+        return [{ category: "books" }];
+      }
+
+      export default async function Page({ params }: { params: Promise<{ category: string; itemId: string }> }) {
+        await connection();
+        const { itemId } = await params;
+        return <div>{itemId}</div>;
+      }`,
+    );
+
+    const route = toLinkPrefetchRoute(createRoute({ pagePath }));
+
+    expect(route.prefetchVaryParamNames).toEqual(["itemId"]);
+    expect(route.requiresDynamicNavigationRequest).toBeUndefined();
+  });
+
+  it("does not truncate static analysis on non-Next connection imports", () => {
+    const pagePath = writeSource(
+      "page.tsx",
+      `import { connection } from "./db";
+
+      export function generateStaticParams() {
+        return [{ category: "books" }];
+      }
+
+      export default async function Page({ params }: { params: Promise<{ category: string; itemId: string }> }) {
+        await connection();
+        const { itemId } = await params;
+        return <div>{itemId}</div>;
+      }`,
+    );
+
+    const route = toLinkPrefetchRoute(createRoute({ pagePath }));
+
+    expect(route.prefetchVaryParamNames).toEqual(["itemId"]);
+    expect(route.requiresDynamicNavigationRequest).toBeUndefined();
+  });
+
+  it("uses aliased next/server.js connection imports as the static analysis cutoff", () => {
+    const pagePath = writeSource(
+      "page.tsx",
+      `import { connection as waitForRequest } from "next/server.js";
+
+      export function generateStaticParams() {
+        return [{ category: "books" }];
+      }
+
+      export default async function Page({ params }: { params: Promise<{ category: string; itemId: string }> }) {
+        const { category } = await params;
+        await waitForRequest();
+        const { itemId } = await params;
+        return <div>{category}:{itemId}</div>;
+      }`,
+    );
+
+    const route = toLinkPrefetchRoute(createRoute({ pagePath }));
+
+    expect(route.prefetchVaryParamNames).toEqual(["category"]);
     expect(route.requiresDynamicNavigationRequest).toBe(true);
   });
 

--- a/tests/e2e/app-router/nextjs-compat/vary-params.browser.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/vary-params.browser.spec.ts
@@ -1,0 +1,269 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { expect, test, type Page, type Request } from "@playwright/test";
+import { waitForAppRouterHydration } from "../../helpers";
+import {
+  startChildProductionServer,
+  stopChildProductionServer,
+  type ChildProductionServer,
+} from "../../production-server";
+
+const ROOT = "/nextjs-compat/segment-cache-vary-params/search-params";
+
+type RscRequest = {
+  pathname: string;
+  search: string;
+};
+
+type ProductionApp = {
+  baseUrl: string;
+  fixtureRoot: string;
+  server: ChildProductionServer;
+};
+
+async function linkFixtureNodeModules(fixtureRoot: string): Promise<void> {
+  const sourceNodeModules = path.resolve(process.cwd(), "tests/fixtures/app-basic/node_modules");
+  const targetNodeModules = path.join(fixtureRoot, "node_modules");
+
+  await fs.mkdir(targetNodeModules, { recursive: true });
+  for (const entry of await fs.readdir(sourceNodeModules, { withFileTypes: true })) {
+    if (entry.name === ".vite" || entry.name === ".vite-temp") continue;
+
+    await fs.symlink(
+      path.join(sourceNodeModules, entry.name),
+      path.join(targetNodeModules, entry.name),
+      entry.isDirectory() ? "junction" : "file",
+    );
+  }
+}
+
+async function writeVaryParamsFixture(fixtureRoot: string): Promise<void> {
+  const appDir = path.join(fixtureRoot, "app");
+  const routeRoot = path.join(appDir, "nextjs-compat", "segment-cache-vary-params");
+  const searchParamsDir = path.join(routeRoot, "search-params");
+  await fs.mkdir(path.join(searchParamsDir, "static-target"), { recursive: true });
+  await fs.mkdir(path.join(searchParamsDir, "target-page"), { recursive: true });
+  await linkFixtureNodeModules(fixtureRoot);
+
+  await fs.writeFile(
+    path.join(fixtureRoot, "package.json"),
+    `${JSON.stringify({ type: "module", dependencies: {} }, null, 2)}\n`,
+  );
+  await fs.writeFile(
+    path.join(appDir, "layout.tsx"),
+    `import type { ReactNode } from "react";
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return <html><body>{children}</body></html>;
+}
+`,
+  );
+  await fs.writeFile(
+    path.join(routeRoot, "link-accordion.tsx"),
+    `"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+
+export function LinkAccordion({ href, children }: { href: string; children: React.ReactNode }) {
+  const [isVisible, setIsVisible] = useState(false);
+
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+      />
+      {isVisible ? <Link href={href}>{children}</Link> : <>{children} (link is hidden)</>}
+    </>
+  );
+}
+`,
+  );
+  await fs.writeFile(
+    path.join(searchParamsDir, "page.tsx"),
+    `import { LinkAccordion } from "../link-accordion";
+
+export default function SearchParamsIndexPage() {
+  return (
+    <div id="segment-cache-vary-search-params-index">
+      <h1>Segment Cache Vary Params</h1>
+      <ul>
+        <li>
+          <LinkAccordion href="${ROOT}/static-target?foo=1">Static target with foo=1</LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="${ROOT}/static-target?foo=2">Static target with foo=2</LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="${ROOT}/target-page?foo=1">Target with foo=1</LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="${ROOT}/target-page?foo=2">Target with foo=2</LinkAccordion>
+        </li>
+      </ul>
+    </div>
+  );
+}
+`,
+  );
+  await fs.writeFile(
+    path.join(searchParamsDir, "static-target", "page.tsx"),
+    `export default function StaticTargetPage() {
+  return (
+    <div id="segment-cache-vary-static-target-page">
+      <div data-static-target-content="true">Static target content - no searchParams access</div>
+    </div>
+  );
+}
+`,
+  );
+  await fs.writeFile(
+    path.join(searchParamsDir, "target-page", "page.tsx"),
+    `type SearchParams = { foo?: string };
+
+export default async function SearchParamsTargetPage({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>;
+}) {
+  const { foo } = await searchParams;
+
+  return (
+    <div id="segment-cache-vary-search-params-target-page">
+      <div data-search-params-content="true">
+        {\`Search params target - foo: \${foo ?? "undefined"}\`}
+      </div>
+    </div>
+  );
+}
+`,
+  );
+
+  const vinextSource = path.resolve(process.cwd(), "packages/vinext/src/index.ts");
+  await fs.writeFile(
+    path.join(fixtureRoot, "vite.config.ts"),
+    `import { defineConfig } from "vite";
+import vinext from ${JSON.stringify(pathToFileURL(vinextSource).href)};
+
+export default defineConfig({
+  plugins: [vinext({ appDir: import.meta.dirname })],
+});
+`,
+  );
+}
+
+async function buildAndServeVaryParamsFixture(): Promise<ProductionApp> {
+  const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-vary-params-"));
+  await writeVaryParamsFixture(fixtureRoot);
+
+  const { createBuilder } = await import("vite");
+  const builder = await createBuilder({
+    root: fixtureRoot,
+    configFile: path.join(fixtureRoot, "vite.config.ts"),
+    logLevel: "silent",
+  });
+  await builder.buildApp();
+
+  const { runPrerender } = await import(
+    pathToFileURL(path.resolve(process.cwd(), "packages/vinext/dist/build/run-prerender.js")).href
+  );
+  await runPrerender({ root: fixtureRoot });
+
+  const started = await startChildProductionServer(fixtureRoot);
+
+  return {
+    baseUrl: `http://127.0.0.1:${started.port}`,
+    fixtureRoot,
+    server: started,
+  };
+}
+
+function trackRscRequests(page: Page): RscRequest[] {
+  const requests: RscRequest[] = [];
+  page.on("request", (request: Request) => {
+    const url = new URL(request.url());
+    if (!url.searchParams.has("_rsc") || request.headers()["rsc"] !== "1") return;
+    requests.push({ pathname: url.pathname, search: url.search });
+  });
+  return requests;
+}
+
+async function revealLink(page: Page, href: string): Promise<void> {
+  await page.locator(`input[data-link-accordion="${href}"]`).click();
+  const link = page.locator(`a[href="${href}"]`);
+  await expect(link).toBeVisible();
+  await link.hover();
+}
+
+function requestsFor(requests: readonly RscRequest[], pathname: string): RscRequest[] {
+  return requests.filter((request) => request.pathname === pathname);
+}
+
+function requireStartedApp(app: ProductionApp | undefined): ProductionApp {
+  if (!app) throw new Error("Vary params fixture was not started");
+  return app;
+}
+
+test.describe("Next.js compat: segment cache vary params", () => {
+  let app: ProductionApp | undefined;
+
+  test.setTimeout(90_000);
+
+  test.beforeAll(async () => {
+    app = await buildAndServeVaryParamsFixture();
+  });
+
+  test.afterAll(async () => {
+    if (!app) return;
+    try {
+      await stopChildProductionServer(app.server);
+    } finally {
+      await fs.rm(app.fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  // Ported from Next.js: test/e2e/app-dir/segment-cache/vary-params/vary-params.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/vary-params/vary-params.test.ts
+  test("reuses prefetched static page segment across search params when searchParams are not accessed", async ({
+    page,
+  }) => {
+    const currentApp = requireStartedApp(app);
+    const requests = trackRscRequests(page);
+    const target = `${ROOT}/static-target`;
+
+    await page.goto(`${currentApp.baseUrl}${ROOT}`);
+    await waitForAppRouterHydration(page);
+    await revealLink(page, `${target}?foo=1`);
+    await expect.poll(() => requestsFor(requests, target).length).toBe(1);
+
+    requests.length = 0;
+    await revealLink(page, `${target}?foo=2`);
+    await page.waitForTimeout(500);
+
+    expect(requestsFor(requests, target)).toEqual([]);
+  });
+
+  // Ported from Next.js: test/e2e/app-dir/segment-cache/vary-params/vary-params.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/vary-params/vary-params.test.ts
+  test("does not reuse prefetched page segment when searchParams are accessed", async ({
+    page,
+  }) => {
+    const currentApp = requireStartedApp(app);
+    const requests = trackRscRequests(page);
+    const target = `${ROOT}/target-page`;
+
+    await page.goto(`${currentApp.baseUrl}${ROOT}`);
+    await waitForAppRouterHydration(page);
+    await revealLink(page, `${target}?foo=1`);
+    await expect.poll(() => requestsFor(requests, target).length).toBe(1);
+
+    requests.length = 0;
+    await revealLink(page, `${target}?foo=2`);
+    await expect.poll(() => requestsFor(requests, target).length).toBe(1);
+  });
+});

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -258,7 +258,7 @@ describe("App Router generated manifest construction", () => {
     expect(code).toContain("registerNavigationRuntimeBootstrap({");
     expect(code).toContain("routeManifest: null");
     expect(code).toContain(
-      '{"canPrefetchLoadingShell":false,"patternParts":["about"],"isDynamic":false}',
+      '{"canPrefetchLoadingShell":false,"canPrefetchStaticRoute":true,"patternParts":["about"],"isDynamic":false}',
     );
     expect(code).toContain(
       '{"canPrefetchLoadingShell":false,"patternParts":["blog",":slug"],"isDynamic":true}',
@@ -270,7 +270,7 @@ describe("App Router generated manifest construction", () => {
       '{"canPrefetchLoadingShell":false,"patternParts":["teams",":team","dashboard"],"isDynamic":true,"requiresDynamicNavigationRequest":true}',
     );
     expect(code).toContain(
-      '{"canPrefetchLoadingShell":false,"patternParts":["modal-host"],"isDynamic":false}',
+      '{"canPrefetchLoadingShell":false,"canPrefetchStaticRoute":true,"patternParts":["modal-host"],"isDynamic":false}',
     );
     expect(code).not.toContain(
       '{"canPrefetchLoadingShell":false,"patternParts":["api"],"isDynamic":false}',

--- a/tests/fixtures/app-basic/app/nextjs-compat/segment-cache-vary-params/link-accordion.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/segment-cache-vary-params/link-accordion.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+
+export function LinkAccordion({ href, children }: { href: string; children: React.ReactNode }) {
+  const [isVisible, setIsVisible] = useState(false);
+
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+      />
+      {isVisible ? <Link href={href}>{children}</Link> : <>{children} (link is hidden)</>}
+    </>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/segment-cache-vary-params/search-params/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/segment-cache-vary-params/search-params/page.tsx
@@ -1,0 +1,33 @@
+import { LinkAccordion } from "../link-accordion";
+
+// Ported from Next.js: test/e2e/app-dir/segment-cache/vary-params/app/(main)/search-params/page.tsx
+// https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/vary-params/app/(main)/search-params/page.tsx
+export default function SearchParamsIndexPage() {
+  return (
+    <div id="segment-cache-vary-search-params-index">
+      <h1>Segment Cache Vary Params</h1>
+      <ul>
+        <li>
+          <LinkAccordion href="/nextjs-compat/segment-cache-vary-params/search-params/static-target?foo=1">
+            Static target with foo=1
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/nextjs-compat/segment-cache-vary-params/search-params/static-target?foo=2">
+            Static target with foo=2
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/nextjs-compat/segment-cache-vary-params/search-params/target-page?foo=1">
+            Target with foo=1
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/nextjs-compat/segment-cache-vary-params/search-params/target-page?foo=2">
+            Target with foo=2
+          </LinkAccordion>
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/segment-cache-vary-params/search-params/static-target/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/segment-cache-vary-params/search-params/static-target/page.tsx
@@ -1,0 +1,9 @@
+// Ported from Next.js: test/e2e/app-dir/segment-cache/vary-params/app/(main)/search-params/static-target/page.tsx
+// https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/vary-params/app/(main)/search-params/static-target/page.tsx
+export default function StaticTargetPage() {
+  return (
+    <div id="segment-cache-vary-static-target-page">
+      <div data-static-target-content="true">Static target content - no searchParams access</div>
+    </div>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/segment-cache-vary-params/search-params/target-page/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/segment-cache-vary-params/search-params/target-page/page.tsx
@@ -1,0 +1,19 @@
+type SearchParams = { foo?: string };
+
+// Ported from Next.js: test/e2e/app-dir/segment-cache/vary-params/app/(main)/search-params/target-page/page.tsx
+// https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/vary-params/app/(main)/search-params/target-page/page.tsx
+export default async function SearchParamsTargetPage({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>;
+}) {
+  const { foo } = await searchParams;
+
+  return (
+    <div id="segment-cache-vary-search-params-target-page">
+      <div data-search-params-content="true">
+        {`Search params target - foo: ${foo ?? "undefined"}`}
+      </div>
+    </div>
+  );
+}

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -291,7 +291,12 @@ describe("Link App Router prefetch mode", () => {
           isDynamic: true,
           requiresDynamicNavigationRequest: true,
         },
-        { canPrefetchLoadingShell: true, patternParts: ["settings"], isDynamic: false },
+        {
+          canPrefetchLoadingShell: true,
+          canPrefetchStaticRoute: true,
+          patternParts: ["settings"],
+          isDynamic: false,
+        },
       ],
     };
 
@@ -301,7 +306,7 @@ describe("Link App Router prefetch mode", () => {
       expect(canAutoPrefetchFullAppRoute("/docs/a/b")).toBe(false);
       expect(canAutoPrefetchFullAppRoute("/products/1")).toBe(true);
       expect(canAutoPrefetchFullAppRoute("/teams/vercel/dashboard")).toBe(false);
-      expect(canAutoPrefetchFullAppRoute("/settings")).toBe(false);
+      expect(canAutoPrefetchFullAppRoute("/settings")).toBe(true);
       expect(canAutoPrefetchFullAppRoute("/missing")).toBe(false);
     } finally {
       if (originalWindow === undefined) {
@@ -337,22 +342,22 @@ describe("Link App Router prefetch mode", () => {
     try {
       expect(resolveAutoAppRoutePrefetch("/about")).toEqual({
         cacheForNavigation: true,
-        prefetchShellFirst: true,
+        renderLoadingShell: false,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/blog/hello-world")).toEqual({
         cacheForNavigation: false,
-        prefetchShellFirst: false,
+        renderLoadingShell: true,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/settings")).toEqual({
         cacheForNavigation: false,
-        prefetchShellFirst: true,
+        renderLoadingShell: true,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/products/1")).toEqual({
         cacheForNavigation: true,
-        prefetchShellFirst: false,
+        renderLoadingShell: false,
         shouldPrefetch: true,
       });
       // Ported from Next.js:
@@ -360,17 +365,17 @@ describe("Link App Router prefetch mode", () => {
       // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/segment-cache/client-params/client-params.test.ts
       expect(resolveAutoAppRoutePrefetch("/clothing/1")).toEqual({
         cacheForNavigation: true,
-        prefetchShellFirst: false,
+        renderLoadingShell: false,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/teams/vercel/dashboard")).toEqual({
         cacheForNavigation: false,
-        prefetchShellFirst: false,
+        renderLoadingShell: true,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/missing")).toEqual({
         cacheForNavigation: false,
-        prefetchShellFirst: false,
+        renderLoadingShell: false,
         shouldPrefetch: false,
       });
     } finally {

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -342,21 +342,25 @@ describe("Link App Router prefetch mode", () => {
     try {
       expect(resolveAutoAppRoutePrefetch("/about")).toEqual({
         cacheForNavigation: true,
+        prefetchShellFirst: true,
         renderLoadingShell: false,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/blog/hello-world")).toEqual({
         cacheForNavigation: false,
+        prefetchShellFirst: false,
         renderLoadingShell: true,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/settings")).toEqual({
         cacheForNavigation: false,
+        prefetchShellFirst: true,
         renderLoadingShell: true,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/products/1")).toEqual({
         cacheForNavigation: true,
+        prefetchShellFirst: false,
         renderLoadingShell: false,
         shouldPrefetch: true,
       });
@@ -365,16 +369,19 @@ describe("Link App Router prefetch mode", () => {
       // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/segment-cache/client-params/client-params.test.ts
       expect(resolveAutoAppRoutePrefetch("/clothing/1")).toEqual({
         cacheForNavigation: true,
+        prefetchShellFirst: false,
         renderLoadingShell: false,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/teams/vercel/dashboard")).toEqual({
         cacheForNavigation: false,
+        prefetchShellFirst: false,
         renderLoadingShell: true,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/missing")).toEqual({
         cacheForNavigation: false,
+        prefetchShellFirst: false,
         renderLoadingShell: false,
         shouldPrefetch: false,
       });

--- a/tests/rsc-reference-validation-compat.test.ts
+++ b/tests/rsc-reference-validation-compat.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { shouldAcceptDecodedViteRscReferenceValidation } from "../packages/vinext/src/plugins/rsc-reference-validation-compat.js";
+
+function decodedViteRscReference(path: string): string {
+  return `/@id/\0virtual:vite-rsc/${path}`;
+}
+
+function encodedViteRscReferenceKey(path: string): string {
+  return `/@id/__x00__virtual:vite-rsc/${path}`;
+}
+
+describe("RSC reference validation compatibility", () => {
+  it("accepts decoded plugin-rsc framework virtual references with matching metadata", () => {
+    expect(
+      shouldAcceptDecodedViteRscReferenceValidation(
+        decodedViteRscReference("remove-duplicate-server-css"),
+        [{ referenceKey: encodedViteRscReferenceKey("remove-duplicate-server-css") }],
+      ),
+    ).toBe(true);
+  });
+
+  it("accepts decoded client package proxy references with matching metadata", () => {
+    expect(
+      shouldAcceptDecodedViteRscReferenceValidation(
+        decodedViteRscReference("client-package-proxy/next/image"),
+        [{ referenceKey: encodedViteRscReferenceKey("client-package-proxy/next/image") }],
+      ),
+    ).toBe(true);
+  });
+
+  it("accepts decoded client-in-server package proxy references with matching metadata", () => {
+    const source = encodeURIComponent(
+      "/project/node_modules/vinext/dist/shims/app-router-scroll.js",
+    );
+    const proxyPath = `client-in-server-package-proxy/${source}`;
+
+    expect(
+      shouldAcceptDecodedViteRscReferenceValidation(decodedViteRscReference(proxyPath), [
+        { referenceKey: encodedViteRscReferenceKey(proxyPath) },
+      ]),
+    ).toBe(true);
+  });
+
+  it("does not accept decoded virtual references that plugin-rsc has not recorded", () => {
+    expect(
+      shouldAcceptDecodedViteRscReferenceValidation(
+        decodedViteRscReference("client-package-proxy/next/image"),
+        [],
+      ),
+    ).toBe(false);
+  });
+
+  it("does not accept non-plugin-rsc reference IDs", () => {
+    expect(
+      shouldAcceptDecodedViteRscReferenceValidation("/app/client.tsx", [
+        { referenceKey: "/app/client.tsx" },
+      ]),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- add App Router prefetch metadata for params/searchParams that are accessed before runtime boundaries
- key navigation/loading/runtime prefetch reuse by the tracked vary params, including runtime-prefetch shells
- preserve runtime-prefetch optimistic page content while suspending or appending the recorded loading fallback
- add focused unit coverage plus a small Next.js-ported browser fixture for searchParams segment-cache reuse

Covers GitHub Actions run 28478866791, job 84413308650 for `test/e2e/app-dir/segment-cache/vary-params/vary-params.test.ts`.

## Original failing rows

- renders cached loading state instantly during navigation
- renders cached loading state instantly with runtime prefetching
- does not reuse prefetched segment when page accesses searchParams
- reuses prefetched segment when page does not access searchParams
- tracks param access in generateMetadata
- caches head segment when generateMetadata does not access params
- reuses page segment when layout varies but page does not
- does not reuse cached segment for optional catch-all when page accesses slug
- does not reuse cached segment for optional catch-all when page enumerates params
- does not reuse cached segment for optional catch-all when page checks slug with in operator
- shares cached segment across all params when none accessed statically (runtime prefetch)
- does not share cached segment when all params accessed statically (runtime prefetch)
- shares cached segment across search params when not accessed (runtime prefetch)
- tracks metadata param access separately from body (runtime prefetch)
- tracks vary params per-segment with layout/page split (runtime prefetch)
- tracks root param access via rootParams API

## Validation

- `vp fmt --check packages/vinext/src/client/vinext-next-data.ts packages/vinext/src/entries/app-browser-entry.ts packages/vinext/src/server/app-browser-entry.ts packages/vinext/src/server/app-optimistic-routing.ts packages/vinext/src/shims/link.tsx packages/vinext/src/shims/navigation.ts tests/app-optimistic-routing.test.ts tests/app-prefetch-vary-analysis.test.ts tests/e2e/app-router/nextjs-compat/vary-params.browser.spec.ts tests/fixtures/app-basic/app/nextjs-compat/segment-cache-vary-params`
- `vp test run tests/app-optimistic-routing.test.ts tests/app-prefetch-vary-analysis.test.ts`
- `vp check tests/app-optimistic-routing.test.ts tests/app-prefetch-vary-analysis.test.ts`
- `REPO="$(pwd)" NEXTJS_DIR="/Users/jamesanderson/Developer/vinext/.nextjs-ref" NEXT_TEST_CONCURRENCY=1 ./scripts/run-targeted-nextjs-e2e.sh test/e2e/app-dir/segment-cache/vary-params/vary-params.test.ts` (16/16 passed)
