### PR TITLE
fix(app-router): cache segment prefetches by rendered search params

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -749,6 +749,7 @@ export default createAppRscHandler({
     staticParamsValidationParams,
     rootParams,
     request,
+    renderedPathAndSearch,
     route,
     scriptNonce,
     searchParams,
@@ -915,6 +916,7 @@ export default createAppRscHandler({
       prerenderToReadableStream,
       request,
       revalidateSeconds: __segmentConfig.revalidateSeconds,
+      renderedPathAndSearch,
       resolveRouteFetchCacheMode(targetRoute) {
         return __resolveRouteFetchCacheMode(targetRoute);
       },

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -1535,6 +1535,7 @@ function bootstrapHydration(
           : {}),
         mountedSlotsHeader,
         paramsHeader: encodeURIComponent(JSON.stringify(initialParams)),
+        renderedPathAndSearch: null,
         url: rscUrl,
       } satisfies CachedRscResponse;
       const fallbackTtlMs =

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -74,6 +74,7 @@ import {
   applyRscDeploymentIdHeader,
 } from "./app-rsc-cache-busting.js";
 import {
+  APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_SHELL,
   APP_RSC_RENDER_MODE_NAVIGATION,
   shouldSuppressLoadingBoundaries,
   type AppRscRenderMode,
@@ -341,6 +342,7 @@ export type DispatchAppPageOptions<TRoute extends AppPageDispatchRoute> = {
   ) => Promise<{ prelude: ReadableStream<Uint8Array> }>;
   request: Request;
   revalidateSeconds: number | null;
+  renderedPathAndSearch?: string | null;
   resolveRouteFetchCacheMode?: (route: TRoute) => FetchCacheMode | null;
   resolveRouteDynamicConfig?: (route: TRoute) => string | null | undefined;
   rootForbiddenModule?: AppPageModule | null;
@@ -563,10 +565,15 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
   const isForceStatic = dynamicConfig === "force-static";
   const isDynamicError = dynamicConfig === "error";
   const isForceDynamic = dynamicConfig === "force-dynamic";
+  const isPrefetchDynamicShell = options.renderMode === APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_SHELL;
   const isDraftMode = isDraftModeRequest(options.request, options.draftModeSecret);
   const requestHeadersContext = getHeadersContext();
-  const hasRequestSearchParams = !isForceStatic && hasSearchParams(options.searchParams);
-  const pageSearchParams = isForceStatic ? new URLSearchParams() : options.searchParams;
+  const shouldUseEmptySearchParams = isForceStatic || isPrefetchDynamicShell;
+  const hasRequestSearchParams =
+    !shouldUseEmptySearchParams && hasSearchParams(options.searchParams);
+  const pageSearchParams = shouldUseEmptySearchParams
+    ? new URLSearchParams()
+    : options.searchParams;
   const layoutParamAccess = createAppLayoutParamAccessTracker();
   const hasActiveLoadingBoundary = shouldSuppressLoadingBoundaries(
     options.renderMode ?? APP_RSC_RENDER_MODE_NAVIGATION,
@@ -1042,6 +1049,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
     params: options.params,
     pprFallbackShellSignal,
     pprFallbackShellReactSignal,
+    renderedPathAndSearch: options.renderedPathAndSearch,
     abortPprFallbackShell: activeFallbackShellState
       ? () => {
           options.pprRuntime!.beginFinalRender(activeFallbackShellState);

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -196,6 +196,7 @@ type RenderAppPageLifecycleOptions = {
   clientReuseManifest?: ClientReuseManifestParseResult;
   skipDisposition?: ClientReuseManifestSkipDisposition;
   mountedSlotsHeader?: string | null;
+  renderedPathAndSearch?: string | null;
   renderMode?: AppRscRenderMode;
   waitUntil?: (promise: Promise<void>) => void;
   // Per-layout observation tracker. Constructed in dispatch, consumed by the
@@ -843,6 +844,7 @@ export async function renderAppPageLifecycle(
       mountedSlotsHeader: options.mountedSlotsHeader,
       params: options.navigationParams,
       policy: rscResponsePolicy,
+      renderedPathAndSearch: options.renderedPathAndSearch,
       requestCacheLife: requestCacheLifeForPrerender,
       timing: buildResponseTiming({
         compileEnd,

--- a/packages/vinext/src/server/app-page-response.ts
+++ b/packages/vinext/src/server/app-page-response.ts
@@ -299,12 +299,6 @@ export function buildAppPageRscResponse(
   if (options.mountedSlotsHeader) {
     headers.set(VINEXT_MOUNTED_SLOTS_HEADER, options.mountedSlotsHeader);
   }
-  if (options.renderedPathAndSearch) {
-    headers.set(
-      VINEXT_RENDERED_PATH_AND_SEARCH_HEADER,
-      encodeURIComponent(options.renderedPathAndSearch),
-    );
-  }
   applyDynamicStaleTimeHeader(headers, options.dynamicStaleTimeSeconds);
   if (options.policy.cacheControl) {
     headers.set("Cache-Control", options.policy.cacheControl);
@@ -313,6 +307,12 @@ export function buildAppPageRscResponse(
     setCacheStateHeaders(headers, options.policy.cacheState);
   }
   mergeMiddlewareResponseHeaders(headers, options.middlewareContext.headers);
+  if (options.renderedPathAndSearch) {
+    headers.set(
+      VINEXT_RENDERED_PATH_AND_SEARCH_HEADER,
+      encodeURIComponent(options.renderedPathAndSearch),
+    );
+  }
   applyRscCompatibilityIdHeader(headers);
   applyRscDeploymentIdHeader(headers);
   applyPrerenderCacheLifeHeader(headers, options.requestCacheLife);

--- a/packages/vinext/src/server/app-page-response.ts
+++ b/packages/vinext/src/server/app-page-response.ts
@@ -8,6 +8,7 @@ import {
   VINEXT_MOUNTED_SLOTS_HEADER,
   VINEXT_PARAMS_HEADER,
   VINEXT_PRERENDER_CACHE_LIFE_HEADER,
+  VINEXT_RENDERED_PATH_AND_SEARCH_HEADER,
   VINEXT_TIMING_HEADER,
 } from "./headers.js";
 import { setCacheStateHeaders } from "./cache-headers.js";
@@ -72,6 +73,7 @@ type BuildAppPageRscResponseOptions = {
   mountedSlotsHeader?: string | null;
   params?: Record<string, unknown>;
   policy: AppPageResponsePolicy;
+  renderedPathAndSearch?: string | null;
   requestCacheLife?: AppPagePrerenderCacheLife | null;
   timing?: AppPageResponseTiming;
 };
@@ -296,6 +298,12 @@ export function buildAppPageRscResponse(
   }
   if (options.mountedSlotsHeader) {
     headers.set(VINEXT_MOUNTED_SLOTS_HEADER, options.mountedSlotsHeader);
+  }
+  if (options.renderedPathAndSearch) {
+    headers.set(
+      VINEXT_RENDERED_PATH_AND_SEARCH_HEADER,
+      encodeURIComponent(options.renderedPathAndSearch),
+    );
   }
   applyDynamicStaleTimeHeader(headers, options.dynamicStaleTimeSeconds);
   if (options.policy.cacheControl) {

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -181,6 +181,7 @@ type DispatchMatchedPageOptions<TRoute> = {
   staticParamsValidationParams?: AppPageParams;
   rootParams?: RootParams;
   request: Request;
+  renderedPathAndSearch?: string | null;
   route: TRoute;
   scriptNonce?: string;
   searchParams: URLSearchParams;
@@ -1165,6 +1166,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
       prerenderRouteParams === null || isPrerenderFallbackShell ? undefined : params,
     rootParams,
     request,
+    renderedPathAndSearch: resolvedUrl,
     route,
     scriptNonce,
     searchParams: resolvedSearchParams,

--- a/packages/vinext/src/server/app-rsc-render-mode.ts
+++ b/packages/vinext/src/server/app-rsc-render-mode.ts
@@ -1,10 +1,13 @@
 export type AppRscRenderMode =
   | "navigation"
+  | "prefetch-dynamic-shell"
   | "prefetch-loading-shell"
   | "refresh-preserve-ui"
   | "action-rerender-preserve-ui";
 
 export const APP_RSC_RENDER_MODE_NAVIGATION = "navigation" satisfies AppRscRenderMode;
+export const APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_SHELL =
+  "prefetch-dynamic-shell" satisfies AppRscRenderMode;
 export const APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL =
   "prefetch-loading-shell" satisfies AppRscRenderMode;
 export const APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI =
@@ -24,6 +27,10 @@ function shouldUsePreserveUiCacheVariant(mode: AppRscRenderMode): boolean {
 }
 
 export function getRscRenderModeCacheVariant(mode: AppRscRenderMode): string | null {
+  if (mode === APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_SHELL) {
+    return "prefetch-dynamic-shell";
+  }
+
   if (mode === APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL) {
     return "prefetch-loading-shell";
   }
@@ -33,6 +40,8 @@ export function getRscRenderModeCacheVariant(mode: AppRscRenderMode): string | n
 
 export function parseAppRscRenderMode(value: string | null): AppRscRenderMode {
   switch (value) {
+    case APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_SHELL:
+      return APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_SHELL;
     case APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL:
       return APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL;
     case APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI:

--- a/packages/vinext/src/server/headers.ts
+++ b/packages/vinext/src/server/headers.ts
@@ -60,6 +60,9 @@ export const VINEXT_MOUNTED_SLOTS_HEADER = "X-Vinext-Mounted-Slots";
 /** Per-page dynamic stale time in seconds for App Router RSC responses. */
 export const VINEXT_DYNAMIC_STALE_TIME_HEADER = "X-Vinext-Dynamic-Stale-Time";
 
+/** URL-encoded rendered path and search after middleware/config rewrites. */
+export const VINEXT_RENDERED_PATH_AND_SEARCH_HEADER = "X-Vinext-Rendered-Path-And-Search";
+
 /** Prerender-only JSON side channel carrying request cacheLife metadata. */
 export const VINEXT_PRERENDER_CACHE_LIFE_HEADER = "x-vinext-prerender-cache-life";
 

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -341,7 +341,7 @@ export function canAutoPrefetchFullAppRoute(href: string): boolean {
   const match = matchRouteWithTrie(routeHref, routes, linkPrefetchRouteTrieCache);
   if (!match) return false;
 
-  return resolveMatchedAutoAppRoutePrefetch(match.route).cacheForNavigation;
+  return resolveAutoAppRoutePrefetch(href).cacheForNavigation;
 }
 
 export function resolveAutoAppRoutePrefetch(href: string): {
@@ -368,7 +368,17 @@ export function resolveAutoAppRoutePrefetch(href: string): {
     return { cacheForNavigation: false, prefetchShellFirst: false, shouldPrefetch: false };
   }
 
-  return resolveMatchedAutoAppRoutePrefetch(match.route);
+  const prefetch = resolveMatchedAutoAppRoutePrefetch(match.route);
+  const url = new URL(routeHref, "http://vinext.local");
+  if (url.search !== "") {
+    return {
+      ...prefetch,
+      cacheForNavigation: false,
+      prefetchShellFirst: true,
+    };
+  }
+
+  return prefetch;
 }
 
 function resolveFullAppRoutePrefetch(): {
@@ -446,7 +456,10 @@ function prefetchUrl(
           navigation,
           { AppElementsWire },
           rscCacheBusting,
-          { APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL },
+          {
+            APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_SHELL,
+            APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+          },
           headersModule,
           { resolveHybridClientRewriteHref, resolveHybridClientRouteOwner },
         ] = await Promise.all([
@@ -462,8 +475,11 @@ function prefetchUrl(
           getPrefetchCache,
           getPrefetchedUrls,
           getMountedSlotsHeader,
+          hasSearchAgnosticPrefetchShellForRoute,
           hasPrefetchCacheEntryForNavigation,
+          peekPrefetchResponseForNavigation,
           prefetchRscResponse,
+          restoreRscResponse,
           PREFETCH_CACHE_TTL,
         } = navigation;
         const { createRscRequestHeaders, createRscRequestUrl } = rscCacheBusting;
@@ -496,11 +512,26 @@ function prefetchUrl(
         const interceptionContext = getPrefetchInterceptionContext(fullHref);
         const mountedSlotsHeader = getMountedSlotsHeader();
         const isOptimisticRouteShellPrefetch = !autoPrefetch.cacheForNavigation;
+        const isAutomaticSearchParamShell =
+          mode === "auto" &&
+          isOptimisticRouteShellPrefetch &&
+          new URL(fullHref, window.location.href).search !== "";
         if (isOptimisticRouteShellPrefetch && interceptionContext !== null) return;
+        const hasSearchAgnosticShell =
+          isAutomaticSearchParamShell &&
+          hasSearchAgnosticPrefetchShellForRoute(
+            await createRscRequestUrl(fullHref, new Headers()),
+            interceptionContext,
+            mountedSlotsHeader,
+          );
         const headers = createRscRequestHeaders({
           interceptionContext,
           renderMode: isOptimisticRouteShellPrefetch
-            ? APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL
+            ? hasSearchAgnosticShell
+              ? APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL
+              : isAutomaticSearchParamShell
+                ? APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_SHELL
+                : APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL
             : undefined,
         });
         if (mountedSlotsHeader) {
@@ -693,7 +724,29 @@ function prefetchUrl(
                   shellEntry = shellCache.get(shellCacheKey);
                 }
                 await shellEntry?.pending?.catch(() => {});
-                return fetchFullRscPayload();
+                const renderedPathAndSearch = shellEntry?.snapshot?.renderedPathAndSearch;
+                if (renderedPathAndSearch) {
+                  const renderedRscUrl = await createRscRequestUrl(renderedPathAndSearch, headers);
+                  const cachedRenderedResponse = peekPrefetchResponseForNavigation(
+                    renderedRscUrl,
+                    interceptionContext,
+                    mountedSlotsHeader,
+                  );
+                  if (cachedRenderedResponse) {
+                    return restoreRscResponse(cachedRenderedResponse);
+                  }
+                }
+                return scheduleAppPrefetchFetch(
+                  () =>
+                    fetch(rscUrl, {
+                      headers,
+                      credentials: "include",
+                      priority,
+                      // @ts-expect-error — purpose is a valid fetch option in some browsers
+                      purpose: "prefetch",
+                    }),
+                  priority,
+                );
               })()
             : fetchFullRscPayload();
         if (
@@ -715,6 +768,7 @@ function prefetchUrl(
             fallbackTtlMs: PREFETCH_CACHE_TTL,
             optimisticRouteShell: isOptimisticRouteShellPrefetch,
             prefetchKind: isOptimisticRouteShellPrefetch ? "loading-shell" : "navigation",
+            searchAgnosticShell: isAutomaticSearchParamShell && !hasSearchAgnosticShell,
           },
         );
       } else if (HAS_PAGES_ROUTER && window.__NEXT_DATA__) {

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -512,10 +512,9 @@ function prefetchUrl(
         const interceptionContext = getPrefetchInterceptionContext(fullHref);
         const mountedSlotsHeader = getMountedSlotsHeader();
         const isOptimisticRouteShellPrefetch = !autoPrefetch.cacheForNavigation;
+        const hasSearchParams = new URL(fullHref, window.location.href).search !== "";
         const isAutomaticSearchParamShell =
-          mode === "auto" &&
-          isOptimisticRouteShellPrefetch &&
-          new URL(fullHref, window.location.href).search !== "";
+          mode === "auto" && isOptimisticRouteShellPrefetch && hasSearchParams;
         if (isOptimisticRouteShellPrefetch && interceptionContext !== null) return;
         const hasSearchAgnosticShell =
           isAutomaticSearchParamShell &&
@@ -673,7 +672,14 @@ function prefetchUrl(
         // pending while tests/userland can still observe the later data fetch.
         const gateViaRouteTree =
           __prefetchInlining && mode === "auto" && autoPrefetch.prefetchShellFirst;
-        const gateViaLoadingShell = mode === "full-after-shell" && autoPrefetch.prefetchShellFirst;
+        const gateViaExplicitSearchShell =
+          mode === "full" &&
+          hasSearchParams &&
+          autoPrefetch.prefetchShellFirst &&
+          mountedSlotsHeader === null;
+        const gateViaLoadingShell =
+          (mode === "full-after-shell" || gateViaExplicitSearchShell) &&
+          autoPrefetch.prefetchShellFirst;
         const fetchPromise =
           autoPrefetch.cacheForNavigation && (gateViaRouteTree || gateViaLoadingShell)
             ? (async () => {
@@ -753,7 +759,8 @@ function prefetchUrl(
           mode === "full" &&
           autoPrefetch.cacheForNavigation &&
           autoPrefetch.prefetchShellFirst &&
-          mountedSlotsHeader === null
+          mountedSlotsHeader === null &&
+          !gateViaExplicitSearchShell
         ) {
           void fetchLoadingShellForReuse();
         }

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -32,6 +32,7 @@ import {
   createRscRequestHeaders,
   createRscRequestUrl,
   stripRscCacheBustingSearchParam,
+  stripRscSuffix,
   VINEXT_RSC_COMPATIBILITY_ID_HEADER,
   VINEXT_RSC_CONTENT_TYPE,
 } from "../server/app-rsc-cache-busting.js";
@@ -40,6 +41,7 @@ import {
   VINEXT_DYNAMIC_STALE_TIME_HEADER,
   VINEXT_MOUNTED_SLOTS_HEADER,
   VINEXT_PARAMS_HEADER,
+  VINEXT_RENDERED_PATH_AND_SEARCH_HEADER,
 } from "../server/headers.js";
 import {
   isAbsoluteOrProtocolRelativeUrl,
@@ -245,6 +247,7 @@ export type CachedRscResponse = {
   expiresAt?: number;
   mountedSlotsHeader?: string | null;
   paramsHeader: string | null;
+  renderedPathAndSearch: string | null;
   url: string;
 };
 
@@ -264,8 +267,10 @@ export type PrefetchCacheEntry = {
   optimisticRouteShell?: boolean;
   outcome: "pending" | "cache-seeded";
   snapshot?: CachedRscResponse;
+  cacheKeys?: Set<string>;
   pending?: Promise<void>;
   prefetchKind?: PrefetchCacheKind;
+  searchAgnosticShell?: boolean;
   size?: number;
   timestamp: number;
 };
@@ -405,6 +410,15 @@ function normalizeRscCacheLookupUrl(rscUrl: string): string | null {
   }
 }
 
+function normalizeRscCacheLookupPathname(rscUrl: string): string | null {
+  try {
+    const url = new URL(rscUrl, "http://vinext.local");
+    return stripRscSuffix(url.pathname);
+  } catch {
+    return null;
+  }
+}
+
 function parsePrefetchCacheKey(cacheKey: string): {
   interceptionContext: string | null;
   rscUrl: string;
@@ -512,6 +526,32 @@ export function hasPrefetchCacheEntryForNavigation(
   return false;
 }
 
+export function hasSearchAgnosticPrefetchShellForRoute(
+  rscUrl: string,
+  interceptionContext: string | null = null,
+  mountedSlotsHeader: string | null = null,
+): boolean {
+  const normalizedTargetPathname = normalizeRscCacheLookupPathname(rscUrl);
+  if (normalizedTargetPathname === null) return false;
+
+  const cache = getPrefetchCache();
+  for (const [cacheKey, entry] of cache) {
+    if (entry.searchAgnosticShell !== true) continue;
+
+    const source = parsePrefetchCacheKey(cacheKey);
+    if (source.interceptionContext !== interceptionContext) continue;
+    if (normalizeRscCacheLookupPathname(source.rscUrl) !== normalizedTargetPathname) continue;
+    if (!isPrefetchCacheEntryCompatibleWithMountedSlots(entry, mountedSlotsHeader)) continue;
+
+    if (entry.pending !== undefined) return true;
+    if (resolvePrefetchCacheEntryExpiresAt(entry) > Date.now()) return true;
+
+    deletePrefetchCacheEntry(cache, getPrefetchedUrls(), cacheKey, entry, true);
+  }
+
+  return false;
+}
+
 function getPrefetchCacheEntrySize(entry: PrefetchCacheEntry): number {
   return entry.snapshot?.buffer.byteLength ?? entry.size ?? 0;
 }
@@ -525,7 +565,10 @@ function getPrefetchCacheByteSize(cache: Map<string, PrefetchCacheEntry>): numbe
   }
 
   let total = 0;
+  const seen = new Set<PrefetchCacheEntry>();
   for (const entry of cache.values()) {
+    if (seen.has(entry)) continue;
+    seen.add(entry);
     total += getPrefetchCacheEntrySize(entry);
   }
   trackedPrefetchCache = cache;
@@ -546,6 +589,11 @@ function touchPrefetchCacheEntry(
   if (cache.get(cacheKey) !== entry) return;
   cache.delete(cacheKey);
   cache.set(cacheKey, entry);
+  for (const key of entry.cacheKeys ?? []) {
+    if (key === cacheKey || cache.get(key) !== entry) continue;
+    cache.delete(key);
+    cache.set(key, entry);
+  }
 }
 
 /**
@@ -630,8 +678,14 @@ function deletePrefetchCacheEntry(
   notify: boolean,
 ): void {
   adjustPrefetchCacheByteSize(cache, -getPrefetchCacheEntrySize(entry));
-  cache.delete(cacheKey);
-  prefetched.delete(cacheKey);
+  const cacheKeys = entry.cacheKeys ?? new Set([cacheKey]);
+  for (const key of cacheKeys) {
+    if (cache.get(key) === entry) {
+      cache.delete(key);
+    }
+    prefetched.delete(key);
+  }
+  entry.cacheKeys = undefined;
   if (notify) {
     notifyPrefetchInvalidated(entry);
   } else {
@@ -709,6 +763,7 @@ export function seedPrefetchResponseSnapshot(
   const timestamp = Date.now();
   const entry: PrefetchCacheEntry = {
     cacheForNavigation: true,
+    cacheKeys: new Set([cacheKey]),
     expiresAt: resolveCachedRscResponseExpiresAt(timestamp, snapshot, fallbackTtlMs),
     mountedSlotsHeader,
     outcome: "cache-seeded",
@@ -765,6 +820,7 @@ export function storePrefetchResponse(
     deletePrefetchCacheEntry(cache, prefetched, cacheKey, existing, false);
   }
   const entry: PrefetchCacheEntry = {
+    cacheKeys: new Set([cacheKey]),
     mountedSlotsHeader: null,
     outcome: "pending",
     timestamp: Date.now(),
@@ -814,8 +870,21 @@ export function createCachedRscResponseSnapshot(
     ...(dynamicStaleTimeSeconds !== undefined ? { dynamicStaleTimeSeconds } : {}),
     mountedSlotsHeader: response.headers.get(VINEXT_MOUNTED_SLOTS_HEADER),
     paramsHeader: response.headers.get(VINEXT_PARAMS_HEADER),
+    renderedPathAndSearch: parseRenderedPathAndSearchHeader(
+      response.headers.get(VINEXT_RENDERED_PATH_AND_SEARCH_HEADER),
+    ),
     url: responseUrl ?? response.url,
   };
+}
+
+function parseRenderedPathAndSearchHeader(value: string | null): string | null {
+  if (value === null || value === "") return null;
+  try {
+    const decoded = decodeURIComponent(value);
+    return decoded.startsWith("/") ? decoded : null;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -859,6 +928,12 @@ export function restoreRscResponse(cached: CachedRscResponse, copy = true): Resp
   if (cached.paramsHeader != null) {
     headers.set(VINEXT_PARAMS_HEADER, cached.paramsHeader);
   }
+  if (cached.renderedPathAndSearch != null) {
+    headers.set(
+      VINEXT_RENDERED_PATH_AND_SEARCH_HEADER,
+      encodeURIComponent(cached.renderedPathAndSearch),
+    );
+  }
 
   return new Response(copy ? cached.buffer.slice(0) : cached.buffer, {
     status: 200,
@@ -884,6 +959,7 @@ export function prefetchRscResponse(
     fallbackTtlMs?: number;
     optimisticRouteShell?: boolean;
     prefetchKind?: PrefetchCacheKind;
+    searchAgnosticShell?: boolean;
   } = {},
 ): void {
   const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
@@ -897,12 +973,14 @@ export function prefetchRscResponse(
 
   const entry: PrefetchCacheEntry = {
     cacheForNavigation: behavior.cacheForNavigation ?? true,
+    cacheKeys: new Set([cacheKey]),
     mountedSlotsHeader,
     optimisticRouteShell: behavior.optimisticRouteShell === true,
     outcome: "pending",
     prefetchKind:
       behavior.prefetchKind ??
       (behavior.optimisticRouteShell === true ? "loading-shell" : "navigation"),
+    searchAgnosticShell: behavior.searchAgnosticShell === true,
     timestamp: now,
   };
   addPrefetchInvalidationCallback(entry, options?.onInvalidate);
@@ -921,6 +999,7 @@ export function prefetchRscResponse(
           entry.snapshot,
           behavior.fallbackTtlMs ?? PREFETCH_CACHE_TTL,
         );
+        addRenderedPathAndSearchPrefetchAlias(cache, prefetched, cacheKey, entry);
         evictPrefetchCacheIfNeeded();
       } else {
         releaseAppPrefetchFetchSlot(response);
@@ -944,6 +1023,62 @@ export function prefetchRscResponse(
   // entries inserted before it are candidates for removal.
   cache.set(cacheKey, entry);
   evictPrefetchCacheIfNeeded();
+}
+
+function addRenderedPathAndSearchPrefetchAlias(
+  cache: Map<string, PrefetchCacheEntry>,
+  prefetched: Set<string>,
+  primaryCacheKey: string,
+  entry: PrefetchCacheEntry,
+): void {
+  if (entry.cacheForNavigation === false) return;
+  const renderedPathAndSearch = entry.snapshot?.renderedPathAndSearch;
+  if (!renderedPathAndSearch) return;
+
+  const source = parsePrefetchCacheKey(primaryCacheKey);
+  const aliasCacheKey = AppElementsWire.encodeCacheKey(
+    renderedPathAndSearch,
+    source.interceptionContext,
+  );
+  if (aliasCacheKey === primaryCacheKey) return;
+
+  const existing = cache.get(aliasCacheKey);
+  if (existing && existing !== entry) {
+    deletePrefetchCacheEntry(cache, prefetched, aliasCacheKey, existing, false);
+  }
+
+  entry.cacheKeys ??= new Set([primaryCacheKey]);
+  entry.cacheKeys.add(aliasCacheKey);
+  cache.set(aliasCacheKey, entry);
+  prefetched.add(aliasCacheKey);
+}
+
+export function peekPrefetchResponseForNavigation(
+  rscUrl: string,
+  interceptionContext: string | null = null,
+  mountedSlotsHeader: string | null = null,
+): CachedRscResponse | null {
+  const match = findPrefetchCacheEntryForNavigation(
+    rscUrl,
+    interceptionContext,
+    mountedSlotsHeader,
+  );
+  if (!match) return null;
+
+  const { cacheKey, entry } = match;
+  if (entry.pending || entry.outcome !== "cache-seeded") return null;
+  if (entry.cacheForNavigation === false || !entry.snapshot) return null;
+  if (resolvePrefetchCacheEntryExpiresAt(entry) <= Date.now()) {
+    deletePrefetchCacheEntry(getPrefetchCache(), getPrefetchedUrls(), cacheKey, entry, true);
+    return null;
+  }
+  if (entry.expiresAt !== undefined || entry.snapshot.expiresAt !== undefined) {
+    return {
+      ...entry.snapshot,
+      expiresAt: resolvePrefetchCacheEntryExpiresAt(entry),
+    };
+  }
+  return entry.snapshot;
 }
 
 /**

--- a/packages/vinext/src/shims/next-shims.d.ts
+++ b/packages/vinext/src/shims/next-shims.d.ts
@@ -238,6 +238,7 @@ declare module "next/navigation" {
     expiresAt?: number;
     mountedSlotsHeader?: string | null;
     paramsHeader: string | null;
+    renderedPathAndSearch: string | null;
     url: string;
   };
   export type PrefetchCacheEntry = {
@@ -249,8 +250,10 @@ declare module "next/navigation" {
     optimisticRouteShell?: boolean;
     outcome: "pending" | "cache-seeded";
     snapshot?: CachedRscResponse;
+    cacheKeys?: Set<string>;
     pending?: Promise<void>;
     prefetchKind?: "loading-shell" | "navigation" | "route-tree";
+    searchAgnosticShell?: boolean;
     timestamp: number;
   };
   export const MAX_PREFETCH_CACHE_SIZE: number;
@@ -269,6 +272,16 @@ declare module "next/navigation" {
     mountedSlotsHeader?: string | null,
     options?: { notifyInvalidation?: boolean },
   ): boolean;
+  export function hasSearchAgnosticPrefetchShellForRoute(
+    rscUrl: string,
+    interceptionContext?: string | null,
+    mountedSlotsHeader?: string | null,
+  ): boolean;
+  export function peekPrefetchResponseForNavigation(
+    rscUrl: string,
+    interceptionContext?: string | null,
+    mountedSlotsHeader?: string | null,
+  ): CachedRscResponse | null;
   export function storePrefetchResponse(
     rscUrl: string,
     response: Response,

--- a/tests/app-page-dispatch.test.ts
+++ b/tests/app-page-dispatch.test.ts
@@ -31,6 +31,7 @@ import {
   buildRenderRequestApiObservations,
   type RenderObservation,
 } from "../packages/vinext/src/server/cache-proof.js";
+import { APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_SHELL } from "../packages/vinext/src/server/app-rsc-render-mode.js";
 import { makeThenableParams } from "../packages/vinext/src/shims/thenable-params.js";
 import { connection } from "../packages/vinext/src/shims/server.js";
 import type { AppPageMiddlewareContext } from "../packages/vinext/src/server/app-page-response.js";
@@ -296,6 +297,7 @@ type CreateDispatchOptionsOverrides = {
   probeLayoutAt?: DispatchOptions["probeLayoutAt"];
   probePage?: DispatchOptions["probePage"];
   renderedConcreteUrlPaths?: DispatchOptions["renderedConcreteUrlPaths"];
+  renderMode?: DispatchOptions["renderMode"];
   renderToReadableStream?: DispatchOptions["renderToReadableStream"];
   request?: Request;
   revalidateSeconds?: number | null;
@@ -388,6 +390,7 @@ function createDispatchOptions(overrides: CreateDispatchOptionsOverrides = {}) {
     probeLayoutAt: overrides.probeLayoutAt ?? createLayoutParamProbe(route, params, []),
     probePage: overrides.probePage ?? (() => null),
     renderedConcreteUrlPaths: overrides.renderedConcreteUrlPaths,
+    renderMode: overrides.renderMode,
     renderErrorBoundaryPage: vi.fn(async () => null),
     renderHttpAccessFallbackPage: vi.fn(async () => null),
     renderToReadableStream,
@@ -1196,6 +1199,46 @@ describe("app page dispatch", () => {
     expect(isrGet).toHaveBeenCalled();
     expect(response.headers.get("x-vinext-cache")).toBe("HIT");
     await expect(response.text()).resolves.toBe("<html>cached force static</html>");
+  });
+
+  it("renders prefetch dynamic shells with empty page searchParams", async () => {
+    // Ported from Next.js:
+    // test/e2e/app-dir/segment-cache/search-params/segment-cache-search-params.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/search-params/segment-cache-search-params.test.ts
+    const buildQueries: string[] = [];
+    const probeQueries: string[] = [];
+    const setNavigationContext = vi.fn<DispatchOptions["setNavigationContext"]>();
+    const buildPageElement = vi.fn<DispatchOptions["buildPageElement"]>(
+      async (_route, _params, _opts, searchParams) => {
+        buildQueries.push(searchParams.toString());
+        return searchParams.get("searchParam") ?? "empty";
+      },
+    );
+    const { options } = createDispatchOptions({
+      buildPageElement,
+      isRscRequest: true,
+      probePage(searchParams) {
+        probeQueries.push(searchParams?.get("searchParam") ?? "empty");
+        return null;
+      },
+      renderMode: APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_SHELL,
+      renderToReadableStream(element) {
+        if (typeof element !== "string") {
+          throw new Error("Expected string dynamic shell test element");
+        }
+        return createStream([element]);
+      },
+      searchParams: new URLSearchParams("searchParam=a_PPR"),
+      setNavigationContext,
+    });
+
+    const response = await dispatchAppPage(options);
+
+    await expect(response.text()).resolves.toBe("empty");
+    expect(buildQueries).toEqual([""]);
+    expect(probeQueries).toEqual(["empty"]);
+    const navigationContext = setNavigationContext.mock.calls.at(-1)?.[0];
+    expect(navigationContext?.searchParams.toString()).toBe("");
   });
 
   it.each([

--- a/tests/app-page-response.test.ts
+++ b/tests/app-page-response.test.ts
@@ -10,7 +10,10 @@ import {
   VINEXT_RSC_COMPATIBILITY_ID_HEADER,
   VINEXT_RSC_VARY_HEADER,
 } from "../packages/vinext/src/server/app-rsc-cache-busting.js";
-import { VINEXT_DYNAMIC_STALE_TIME_HEADER } from "../packages/vinext/src/server/headers.js";
+import {
+  VINEXT_DYNAMIC_STALE_TIME_HEADER,
+  VINEXT_RENDERED_PATH_AND_SEARCH_HEADER,
+} from "../packages/vinext/src/server/headers.js";
 import { withEnvVar } from "./env-test-helpers.js";
 
 function createBody(text: string): ReadableStream {
@@ -486,6 +489,22 @@ describe("app page response helpers", () => {
     });
 
     expect(response.headers.get(VINEXT_DYNAMIC_STALE_TIME_HEADER)).toBe("60");
+  });
+
+  it("keeps the framework rendered path when middleware sets the internal alias header", () => {
+    const middlewareHeaders = new Headers({
+      [VINEXT_RENDERED_PATH_AND_SEARCH_HEADER]: encodeURIComponent("/spoofed?searchParam=wrong"),
+    });
+
+    const response = buildAppPageRscResponse(createBody("flight"), {
+      middlewareContext: { headers: middlewareHeaders, status: null },
+      policy: {},
+      renderedPathAndSearch: "/search-params/target-page?searchParam=rewrittenSearchParam",
+    });
+
+    expect(response.headers.get(VINEXT_RENDERED_PATH_AND_SEARCH_HEADER)).toBe(
+      encodeURIComponent("/search-params/target-page?searchParam=rewrittenSearchParam"),
+    );
   });
 
   it("keeps the framework compatibility ID when middleware sets the internal header", () => {

--- a/tests/app-visited-response-cache.test.ts
+++ b/tests/app-visited-response-cache.test.ts
@@ -13,6 +13,7 @@ function createCachedResponse(overrides: Partial<CachedRscResponse> = {}): Cache
     buffer: new TextEncoder().encode("flight").buffer,
     contentType: "text/x-component",
     paramsHeader: null,
+    renderedPathAndSearch: null,
     url: "/dynamic.rsc",
     ...overrides,
   };

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -8,7 +8,10 @@ import {
   type LinkPrefetchDecision,
   type LinkPrefetchRouterMode,
 } from "../packages/vinext/src/shims/link-prefetch.js";
-import { APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL } from "../packages/vinext/src/server/app-rsc-render-mode.js";
+import {
+  APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_SHELL,
+  APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+} from "../packages/vinext/src/server/app-rsc-render-mode.js";
 import {
   NEXT_ROUTER_PREFETCH_HEADER,
   NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
@@ -1641,6 +1644,105 @@ describe("Link prefetch scheduling", () => {
     }
   });
 
+  it("prefetches visible links with search params as non-consumable shells", async () => {
+    const observer = stubIntersectionObserver();
+
+    const result = await renderIsolatedLink({
+      href: "/viewport-prefetch-target?searchParam=a_PPR",
+      nodeEnv: "production",
+    });
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+
+      // Ported from Next.js:
+      // test/e2e/app-dir/segment-cache/search-params/segment-cache-search-params.test.ts
+      // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/search-params/segment-cache-search-params.test.ts
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[0],
+        "/viewport-prefetch-target",
+        expect.objectContaining({
+          credentials: "include",
+          priority: "low",
+        }),
+      );
+      const fetchedInput = result.fetch.mock.calls[0]?.[0];
+      expect(typeof fetchedInput).toBe("string");
+      const fetchedUrl = new URL(fetchedInput as string, "https://example.com");
+      expect(fetchedUrl.searchParams.get("searchParam")).toBe("a_PPR");
+      const fetchInit = result.fetch.mock.calls[0]?.[1] as RequestInit | undefined;
+      expect((fetchInit?.headers as Headers | undefined)?.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBe(
+        APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_SHELL,
+      );
+      expect((fetchInit?.headers as Headers | undefined)?.get(NEXT_ROUTER_PREFETCH_HEADER)).toBe(
+        "1",
+      );
+      const { getPrefetchCache } = await import("../packages/vinext/src/shims/navigation.js");
+      const entry = Array.from(getPrefetchCache().values())[0];
+      expect(entry?.cacheForNavigation).toBe(false);
+      expect(entry?.optimisticRouteShell).toBe(true);
+      expect(entry?.searchAgnosticShell).toBe(true);
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("prefetches a loading shell when a search-agnostic shell already covers another query", async () => {
+    const observer = stubIntersectionObserver();
+
+    const result = await renderIsolatedLink({
+      href: "/viewport-prefetch-target?searchParam=c_PPR",
+      nodeEnv: "production",
+    });
+
+    try {
+      const { getPrefetchCache, prefetchRscResponse } =
+        await import("../packages/vinext/src/shims/navigation.js");
+      prefetchRscResponse(
+        "/viewport-prefetch-target?searchParam=a_PPR&_rsc=first",
+        Promise.resolve(new Response("target-page-with-search-param")),
+        null,
+        null,
+        undefined,
+        {
+          cacheForNavigation: false,
+          optimisticRouteShell: true,
+          searchAgnosticShell: true,
+        },
+      );
+      await Array.from(getPrefetchCache().values())[0]?.pending;
+
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+
+      // Ported from Next.js:
+      // test/e2e/app-dir/segment-cache/search-params/segment-cache-search-params.test.ts
+      // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/search-params/segment-cache-search-params.test.ts
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[0],
+        "/viewport-prefetch-target",
+        expect.objectContaining({
+          credentials: "include",
+          priority: "low",
+        }),
+      );
+      const fetchedInput = result.fetch.mock.calls[0]?.[0];
+      expect(typeof fetchedInput).toBe("string");
+      const fetchedUrl = new URL(fetchedInput as string, "https://example.com");
+      expect(fetchedUrl.searchParams.get("searchParam")).toBe("c_PPR");
+      const fetchInit = result.fetch.mock.calls[0]?.[1] as RequestInit | undefined;
+      expect((fetchInit?.headers as Headers | undefined)?.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBe(
+        APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+      );
+      const entries = Array.from(getPrefetchCache().values());
+      expect(entries.some((entry) => entry.searchAgnosticShell === true)).toBe(true);
+      expect(entries.at(-1)?.searchAgnosticShell).not.toBe(true);
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
   it("starts App Router viewport prefetches without waiting for browser idle", async () => {
     const observer = stubIntersectionObserver();
     const requestIdleCallback = vi.fn();
@@ -1744,6 +1846,53 @@ describe("Link prefetch scheduling", () => {
       expect(
         (shellFetchInit?.headers as Headers | undefined)?.get(VINEXT_RSC_RENDER_MODE_HEADER),
       ).toBe(APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL);
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("uses a loading shell before full-prefetching explicit links with search params", async () => {
+    const observer = stubIntersectionObserver();
+
+    const result = await renderIsolatedLink({
+      href: "/blog/hello?searchParam=b_full",
+      nodeEnv: "production",
+      props: { prefetch: true },
+    });
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 2);
+
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[0],
+        "/blog/hello",
+        expect.objectContaining({
+          credentials: "include",
+          priority: "low",
+        }),
+      );
+      const shellUrl = new URL(result.fetch.mock.calls[0]?.[0] as string, "https://example.com");
+      expect(shellUrl.searchParams.get("searchParam")).toBe("b_full");
+      const shellFetchInit = result.fetch.mock.calls[0]?.[1] as RequestInit | undefined;
+      expect(
+        (shellFetchInit?.headers as Headers | undefined)?.get(VINEXT_RSC_RENDER_MODE_HEADER),
+      ).toBe(APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL);
+
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[1],
+        "/blog/hello",
+        expect.objectContaining({
+          credentials: "include",
+          priority: "low",
+        }),
+      );
+      const fullUrl = new URL(result.fetch.mock.calls[1]?.[0] as string, "https://example.com");
+      expect(fullUrl.searchParams.get("searchParam")).toBe("b_full");
+      const fullFetchInit = result.fetch.mock.calls[1]?.[1] as RequestInit | undefined;
+      expect(
+        (fullFetchInit?.headers as Headers | undefined)?.get(VINEXT_RSC_RENDER_MODE_HEADER),
+      ).toBeNull();
     } finally {
       result.restoreNodeEnv();
     }
@@ -1861,6 +2010,7 @@ describe("Link prefetch scheduling", () => {
       contentType: "text/x-component",
       mountedSlotsHeader: null,
       paramsHeader: null,
+      renderedPathAndSearch: null,
       url: rscUrl,
     };
 

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -15,6 +15,7 @@ import { VINEXT_RSC_COMPATIBILITY_ID_HEADER } from "../packages/vinext/src/serve
 import {
   VINEXT_DYNAMIC_STALE_TIME_HEADER,
   VINEXT_MOUNTED_SLOTS_HEADER,
+  VINEXT_RENDERED_PATH_AND_SEARCH_HEADER,
 } from "../packages/vinext/src/server/headers.js";
 
 type Navigation = typeof import("../packages/vinext/src/shims/navigation.js");
@@ -31,6 +32,8 @@ let restoreRscResponse: Navigation["restoreRscResponse"];
 let prefetchRscResponse: Navigation["prefetchRscResponse"];
 let invalidatePrefetchCache: Navigation["invalidatePrefetchCache"];
 let hasPrefetchCacheEntryForNavigation: Navigation["hasPrefetchCacheEntryForNavigation"];
+let hasSearchAgnosticPrefetchShellForRoute: Navigation["hasSearchAgnosticPrefetchShellForRoute"];
+let peekPrefetchResponseForNavigation: Navigation["peekPrefetchResponseForNavigation"];
 let appRouterInstance: Navigation["appRouterInstance"];
 let consumePrefetchResponseForNavigation: Navigation["consumePrefetchResponseForNavigation"];
 let seedPrefetchResponseSnapshot: Navigation["seedPrefetchResponseSnapshot"];
@@ -67,6 +70,8 @@ beforeEach(async () => {
   prefetchRscResponse = nav.prefetchRscResponse;
   invalidatePrefetchCache = nav.invalidatePrefetchCache;
   hasPrefetchCacheEntryForNavigation = nav.hasPrefetchCacheEntryForNavigation;
+  hasSearchAgnosticPrefetchShellForRoute = nav.hasSearchAgnosticPrefetchShellForRoute;
+  peekPrefetchResponseForNavigation = nav.peekPrefetchResponseForNavigation;
   appRouterInstance = nav.appRouterInstance;
   consumePrefetchResponseForNavigation = nav.consumePrefetchResponseForNavigation;
   seedPrefetchResponseSnapshot = nav.seedPrefetchResponseSnapshot;
@@ -95,6 +100,7 @@ function fillCache(
         buffer,
         contentType: "text/x-component",
         paramsHeader: null,
+        renderedPathAndSearch: null,
         url: key,
       },
       outcome: "cache-seeded",
@@ -228,6 +234,7 @@ describe("prefetch cache eviction", () => {
       contentType: "text/x-component",
       mountedSlotsHeader: "slot:auth:/",
       paramsHeader: null,
+      renderedPathAndSearch: null,
       url: rscUrl,
     };
 
@@ -251,6 +258,7 @@ describe("prefetch cache eviction", () => {
         contentType: "text/x-component",
         mountedSlotsHeader: "slot:auth:/",
         paramsHeader: null,
+        renderedPathAndSearch: null,
         url: rscUrl,
       },
       timestamp: Date.now(),
@@ -300,6 +308,7 @@ describe("prefetch cache eviction", () => {
       contentType: "text/x-component",
       mountedSlotsHeader,
       paramsHeader: null,
+      renderedPathAndSearch: null,
       url: originalRscUrl,
     };
 
@@ -334,6 +343,7 @@ describe("prefetch cache eviction", () => {
         contentType: "text/x-component",
         mountedSlotsHeader: null,
         paramsHeader: null,
+        renderedPathAndSearch: null,
         url: rscUrl,
       },
       timestamp: Date.now(),
@@ -666,6 +676,7 @@ describe("prefetch cache eviction", () => {
       contentType: "text/x-component",
       mountedSlotsHeader: null,
       paramsHeader: null,
+      renderedPathAndSearch: null,
       url: "/new.rsc",
     });
 
@@ -694,6 +705,7 @@ describe("prefetch cache eviction", () => {
       contentType: "text/x-component",
       mountedSlotsHeader: null,
       paramsHeader: null,
+      renderedPathAndSearch: null,
       url: "/new.rsc",
     });
 
@@ -722,6 +734,7 @@ describe("prefetch cache eviction", () => {
       contentType: "text/x-component",
       mountedSlotsHeader: null,
       paramsHeader: null,
+      renderedPathAndSearch: null,
       url: "/new.rsc",
     });
 
@@ -747,6 +760,7 @@ describe("prefetch cache eviction", () => {
       contentType: "text/x-component",
       mountedSlotsHeader: null,
       paramsHeader: null,
+      renderedPathAndSearch: null,
       url: largeRscUrl,
     });
 
@@ -769,6 +783,7 @@ describe("prefetch cache eviction", () => {
       contentType: "text/x-component",
       mountedSlotsHeader: null,
       paramsHeader: null,
+      renderedPathAndSearch: null,
       url: largeRscUrl,
     });
 
@@ -784,6 +799,7 @@ describe("prefetch cache eviction", () => {
       contentType: "text/x-component",
       mountedSlotsHeader: null,
       paramsHeader: null,
+      renderedPathAndSearch: null,
       url: "/small.rsc",
     });
 
@@ -850,6 +866,7 @@ describe("prefetch cache eviction", () => {
         contentType: "text/x-component",
         mountedSlotsHeader: null,
         paramsHeader: null,
+        renderedPathAndSearch: null,
         url: rscUrl,
       };
 
@@ -875,6 +892,7 @@ describe("prefetch cache eviction", () => {
         contentType: "text/x-component",
         mountedSlotsHeader: null,
         paramsHeader: null,
+        renderedPathAndSearch: null,
         url: rscUrl,
       };
 
@@ -887,6 +905,74 @@ describe("prefetch cache eviction", () => {
     });
   });
 
+  it("matches only search-agnostic optimistic shells across page search params", () => {
+    // Ported from Next.js:
+    // test/e2e/app-dir/segment-cache/search-params/segment-cache-search-params.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/search-params/segment-cache-search-params.test.ts
+    const cache = getPrefetchCache();
+    const firstRscUrl = "/search-params/target-page?searchParam=a_PPR&_rsc=first";
+    const secondRscUrl = "/search-params/target-page?searchParam=c_PPR&_rsc=second";
+    const ordinaryShellRscUrl = "/search-params/target-page?searchParam=b_full&_rsc=full";
+
+    cache.set(AppElementsWire.encodeCacheKey(ordinaryShellRscUrl, null), {
+      cacheForNavigation: false,
+      mountedSlotsHeader: null,
+      optimisticRouteShell: true,
+      outcome: "pending",
+      pending: Promise.resolve(),
+      timestamp: Date.now(),
+    });
+    expect(hasSearchAgnosticPrefetchShellForRoute(secondRscUrl, null, null)).toBe(false);
+
+    cache.set(AppElementsWire.encodeCacheKey(firstRscUrl, null), {
+      cacheForNavigation: false,
+      mountedSlotsHeader: null,
+      optimisticRouteShell: true,
+      outcome: "pending",
+      pending: Promise.resolve(),
+      searchAgnosticShell: true,
+      timestamp: Date.now(),
+    });
+
+    expect(hasSearchAgnosticPrefetchShellForRoute(secondRscUrl, null, null)).toBe(true);
+    expect(hasPrefetchCacheEntryForNavigation(secondRscUrl, null, null)).toBe(false);
+  });
+
+  it("aliases full prefetch responses by their server-rendered path and search", async () => {
+    // Ported from Next.js:
+    // test/e2e/app-dir/segment-cache/search-params/segment-cache-search-params.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/search-params/segment-cache-search-params.test.ts
+    const originalRscUrl =
+      "/search-params/target-page?searchParam=rewritesToANewSearchParam&_rsc=first";
+    const renderedPathAndSearch = "/search-params/target-page?searchParam=rewrittenSearchParam";
+    const renderedRscUrl = `${renderedPathAndSearch}&_rsc=second`;
+
+    prefetchRscResponse(
+      originalRscUrl,
+      Promise.resolve(
+        new Response("flight", {
+          headers: {
+            "content-type": "text/x-component",
+            [VINEXT_RENDERED_PATH_AND_SEARCH_HEADER]: encodeURIComponent(renderedPathAndSearch),
+          },
+        }),
+      ),
+      null,
+      null,
+    );
+    await getPrefetchCache().get(originalRscUrl)?.pending;
+
+    expect(hasPrefetchCacheEntryForNavigation(renderedRscUrl, null, null)).toBe(true);
+    const peeked = peekPrefetchResponseForNavigation(renderedRscUrl, null, null);
+    expect(peeked?.renderedPathAndSearch).toBe(renderedPathAndSearch);
+    expect(await restoreRscResponse(peeked!).text()).toBe("flight");
+
+    const consumed = consumePrefetchResponse(renderedRscUrl, null, null);
+    expect(consumed?.renderedPathAndSearch).toBe(renderedPathAndSearch);
+    expect(getPrefetchCache().has(originalRscUrl)).toBe(false);
+    expect(getPrefetchCache().has(renderedPathAndSearch)).toBe(false);
+  });
+
   it("seeds a committed navigation snapshot with the dynamic stale window", () => {
     const now = 1_000_000;
     vi.spyOn(Date, "now").mockReturnValue(now);
@@ -896,6 +982,7 @@ describe("prefetch cache eviction", () => {
       contentType: "text/x-component",
       mountedSlotsHeader: null,
       paramsHeader: null,
+      renderedPathAndSearch: null,
       url: rscUrl,
     };
 
@@ -922,6 +1009,7 @@ describe("prefetch cache eviction", () => {
       dynamicStaleTimeSeconds: 60,
       mountedSlotsHeader: null,
       paramsHeader: null,
+      renderedPathAndSearch: null,
       url: "/dynamic-stale-60.rsc",
     };
     const snapshot10 = {
@@ -930,6 +1018,7 @@ describe("prefetch cache eviction", () => {
       dynamicStaleTimeSeconds: 10,
       mountedSlotsHeader: null,
       paramsHeader: null,
+      renderedPathAndSearch: null,
       url: "/dynamic-stale-10.rsc",
     };
 
@@ -957,6 +1046,7 @@ describe("prefetch cache eviction", () => {
         dynamicStaleTimeSeconds: 10,
         mountedSlotsHeader: null,
         paramsHeader: null,
+        renderedPathAndSearch: null,
         url: rscUrl,
       },
       timestamp: now,
@@ -985,6 +1075,7 @@ describe("prefetch cache eviction", () => {
         dynamicStaleTimeSeconds: 10,
         mountedSlotsHeader: null,
         paramsHeader: null,
+        renderedPathAndSearch: null,
         url: rscUrl,
       },
       timestamp: now,
@@ -1054,6 +1145,7 @@ describe("prefetch cache eviction", () => {
       dynamicStaleTimeSeconds: 15,
       mountedSlotsHeader: "slot:slotA:/parallel-slots slot:slotB:/parallel-slots",
       paramsHeader: null,
+      renderedPathAndSearch: null,
       url: rscUrl,
     };
 
@@ -1092,6 +1184,7 @@ describe("prefetch cache eviction", () => {
       contentType: "text/x-component",
       mountedSlotsHeader: null,
       paramsHeader: null,
+      renderedPathAndSearch: null,
       url: "/new.rsc",
     });
 

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -1104,6 +1104,7 @@ describe("prefetch cache eviction", () => {
       contentType: "text/x-component",
       mountedSlotsHeader: null,
       paramsHeader: null,
+      renderedPathAndSearch: null,
       url: sourceRscUrl,
     };
 


### PR DESCRIPTION
## Summary

- accept framework-owned RSC dev client references from packed vinext installs so the create-next-app smoke can render the default app
- render automatic search-param segment prefetch shells without page searchParams so the shell can be reused across query values
- alias full prefetch cache entries by the server-rendered path/search returned after rewrites
- keep a router-visible loading-shell request when a search-agnostic shell is already cached, matching the upstream segment-cache search params contract

## Validation

- vp check tests/rsc-reference-validation-compat.test.ts packages/vinext/src/plugins/rsc-reference-validation-compat.ts packages/vinext/src/index.ts
- vp test run tests/rsc-reference-validation-compat.test.ts
- packed create-next-app@16.2.7 replay matching CI create-next-app job -> GET / 200 on attempt 2
- vp check tests/app-page-dispatch.test.ts tests/prefetch-cache.test.ts tests/link-navigation.test.ts packages/vinext/src/server/app-page-dispatch.ts packages/vinext/src/shims/navigation.ts packages/vinext/src/shims/link.tsx packages/vinext/src/server/app-rsc-render-mode.ts packages/vinext/src/server/app-rsc-handler.ts packages/vinext/src/server/app-page-response.ts packages/vinext/src/server/app-page-render.ts
- vp test run tests/app-page-dispatch.test.ts tests/prefetch-cache.test.ts tests/link-navigation.test.ts
- REPO="$(pwd)" NEXTJS_DIR="/Users/jamesanderson/Developer/vinext/.nextjs-ref" NEXT_TEST_CONCURRENCY=1 ./scripts/run-targeted-nextjs-e2e.sh test/e2e/app-dir/segment-cache/search-params/segment-cache-search-params.test.ts
