### PR TITLE
fix(ci): harden perf publisher tree validation

### DIFF
--- a/benchmarks/perf/nextjs-input-fingerprint.mts
+++ b/benchmarks/perf/nextjs-input-fingerprint.mts
@@ -7,11 +7,38 @@ import { createHash } from "node:crypto";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const excludedPerfFiles = new Set([
+const includedExactInputPaths = [".github/workflows/perf.yml", "benchmarks/generate-app.mjs"];
+
+const includedInputPrefixes = ["benchmarks/nextjs/", "benchmarks/perf/"];
+
+const excludedInputPrefixes = ["benchmarks/nextjs/app/"];
+
+const excludedPerfInputPaths = [
+  "benchmarks/perf/README.md",
   "benchmarks/perf/format-pr-comment.mjs",
   "benchmarks/perf/upload-results.mjs",
   "benchmarks/perf/validate-results.mjs",
-]);
+];
+
+const excludedExactInputPaths = excludedPerfInputPaths;
+
+const includedInputPredicate = [
+  ...includedExactInputPaths.map((path) => `.path == ${JSON.stringify(path)}`),
+  ...includedInputPrefixes.map((prefix) => `(.path | startswith(${JSON.stringify(prefix)}))`),
+].join(" or ");
+
+const excludedInputPredicate = [
+  ...excludedInputPrefixes.map(
+    (prefix) => `((.path | startswith(${JSON.stringify(prefix)})) | not)`,
+  ),
+  ...excludedExactInputPaths.map((path) => `.path != ${JSON.stringify(path)}`),
+].join(" and ");
+
+export const nextjsBenchmarkInputTreeJq =
+  `{truncated, tree: [.tree[] | select(.type == "blob" and ` +
+  `(${includedInputPredicate}) and ${excludedInputPredicate}) | {path, sha, type}]}`;
+
+const excludedPerfFiles = new Set(excludedPerfInputPaths);
 
 export type GitTreeEntry = {
   path: string;
@@ -20,8 +47,7 @@ export type GitTreeEntry = {
 };
 
 export function isNextjsBenchmarkInput(path: string) {
-  if (path === ".github/workflows/perf.yml") return true;
-  if (path === "benchmarks/generate-app.mjs") return true;
+  if (includedExactInputPaths.includes(path)) return true;
   if (path.startsWith("benchmarks/nextjs/")) {
     return !path.startsWith("benchmarks/nextjs/app/");
   }

--- a/benchmarks/perf/validate-results.mjs
+++ b/benchmarks/perf/validate-results.mjs
@@ -5,7 +5,7 @@ import { lstat, readFile, realpath } from "node:fs/promises";
 import { dirname, isAbsolute, relative, resolve } from "node:path";
 import { promisify } from "node:util";
 import { gunzip } from "node:zlib";
-import { nextjsInputFingerprint } from "./nextjs-input-fingerprint.mts";
+import { nextjsBenchmarkInputTreeJq, nextjsInputFingerprint } from "./nextjs-input-fingerprint.mts";
 
 const inputPath = resolve(process.argv[2] ?? "performance-artifact/perf-results.json");
 const artifactRoot = dirname(inputPath);
@@ -36,12 +36,15 @@ function isSha(value) {
   return typeof value === "string" && /^[0-9a-f]{40}$/i.test(value);
 }
 
-function githubApi(path) {
+function githubApi(path, options = {}) {
   const token = requiredEnvironment("GITHUB_TOKEN");
+  const args = ["api", path];
+  if (options.jq) args.push("--jq", options.jq);
   return JSON.parse(
-    execFileSync("gh", ["api", path], {
+    execFileSync("gh", args, {
       encoding: "utf8",
       env: { ...process.env, GH_TOKEN: token },
+      maxBuffer: 8 * 1024 * 1024,
     }),
   );
 }
@@ -49,6 +52,7 @@ function githubApi(path) {
 function remoteNextjsInputFingerprint(repositoryName, ref) {
   const tree = githubApi(
     `repos/${repositoryName}/git/trees/${encodeURIComponent(ref)}?recursive=1`,
+    { jq: nextjsBenchmarkInputTreeJq },
   );
   assert(Array.isArray(tree.tree) && tree.truncated !== true, "Invalid repository tree");
   return nextjsInputFingerprint(tree.tree);

--- a/knip.ts
+++ b/knip.ts
@@ -125,6 +125,7 @@ export default {
     "taskkill",
     "eslint",
     "gh",
+    "jq",
   ],
   ignoreFiles: [
     "tests/e2e/app-router/nextjs-compat/playwright.nextjs-compat.config.ts",

--- a/tests/performance-benchmarks.test.ts
+++ b/tests/performance-benchmarks.test.ts
@@ -14,6 +14,7 @@ import { gzipSync } from "node:zlib";
 import { describe, expect, it } from "vitest";
 import {
   isNextjsBenchmarkInput,
+  nextjsBenchmarkInputTreeJq,
   nextjsInputFingerprint,
 } from "../benchmarks/perf/nextjs-input-fingerprint.mts";
 import { DEFAULT_PAIRED_ROUNDS, pairedRevisionOrder } from "../benchmarks/perf/pairing.mts";
@@ -236,6 +237,37 @@ describe("paired performance benchmarks", () => {
     }
     expect(isNextjsBenchmarkInput("benchmarks/perf/format-pr-comment.mjs")).toBe(false);
     expect(isNextjsBenchmarkInput("benchmarks/nextjs/app/page.tsx")).toBe(false);
+  });
+
+  const jqAvailable = spawnSync("jq", ["--version"], { encoding: "utf8" }).status === 0;
+  (jqAvailable ? it : it.skip)("keeps the remote tree jq predicate aligned with JS inputs", () => {
+    const entries = [
+      richGitTreeEntry(".github/workflows/perf.yml", "0"),
+      richGitTreeEntry("benchmarks/generate-app.mjs", "1"),
+      richGitTreeEntry("benchmarks/nextjs/package.json", "2"),
+      richGitTreeEntry("benchmarks/nextjs/app", "3"),
+      richGitTreeEntry("benchmarks/nextjs/app/page.tsx", "4"),
+      richGitTreeEntry("benchmarks/nextjs/appfoo/page.tsx", "5"),
+      richGitTreeEntry("benchmarks/perf/scenarios.json", "6"),
+      richGitTreeEntry("benchmarks/perf/README.md", "7"),
+      richGitTreeEntry("benchmarks/perf/format-pr-comment.mjs", "8"),
+      richGitTreeEntry("benchmarks/perf/upload-results.mjs", "9"),
+      richGitTreeEntry("benchmarks/perf/validate-results.mjs", "10"),
+      richGitTreeEntry("packages/vinext/src/index.ts", "11"),
+      { path: "benchmarks/perf/scenarios.json", sha: "tree", type: "tree", mode: "040000" },
+    ];
+
+    const jq = spawnSync("jq", [nextjsBenchmarkInputTreeJq], {
+      input: JSON.stringify(githubTree(entries)),
+      encoding: "utf8",
+    });
+
+    expect(jq.status, jq.stderr).toBe(0);
+    expect(JSON.parse(jq.stdout).tree).toEqual(
+      entries
+        .filter((entry) => entry.type === "blob" && isNextjsBenchmarkInput(entry.path))
+        .map((entry) => ({ path: entry.path, sha: entry.sha, type: entry.type })),
+    );
   });
 
   it("rejects symlinked bundle outputs", () => {
@@ -811,6 +843,67 @@ describe("paired performance benchmarks", () => {
     });
   });
 
+  it("filters remote tree responses before validating skipped Next.js inputs", () => {
+    const headSha = "a".repeat(40);
+    const baseSha = "b".repeat(40);
+    const mergeSha = "c".repeat(40);
+    const measuredAt = "2026-06-18T12:00:00.000Z";
+    const nextjsInputs = [
+      gitTreeEntry("benchmarks/nextjs/package.json", "1"),
+      gitTreeEntry("benchmarks/generate-app.mjs", "2"),
+      gitTreeEntry("benchmarks/perf/scenarios.json", "3"),
+    ];
+    const ignoredEntries = [
+      richGitTreeEntry("benchmarks/nextjs/app/page.tsx", "app"),
+      richGitTreeEntry("benchmarks/perf/README.md", "readme"),
+      richGitTreeEntry("benchmarks/perf/format-pr-comment.mjs", "formatter"),
+      { path: "benchmarks/perf", sha: "tree", type: "tree", mode: "040000" },
+      ...Array.from({ length: 5_000 }, (_, index) =>
+        richGitTreeEntry(`packages/vinext/src/generated-${index}.ts`, `${index}`),
+      ),
+    ];
+    const payload = performancePayload({
+      headSha,
+      baseSha,
+      measuredAt,
+      skippedImplementations: ["nextjs"],
+      benchmarks: [performanceBenchmark("vinext", true)],
+    });
+
+    const requests = validatePerformancePayload(payload, "pull_request", {
+      "repos/cloudflare/vinext/actions/runs/123": sourceRun("pull_request", headSha),
+      "repos/cloudflare/vinext/pulls/42": pullRequest(headSha, baseSha, mergeSha),
+      [`repos/cloudflare/vinext/contents/benchmarks/perf/scenarios.json?ref=${baseSha}`]:
+        githubFile(
+          JSON.stringify({
+            scenarios: [
+              performanceScenario([
+                { id: "nextjs", label: "Next.js", compareBase: true },
+                { id: "vinext", label: "vinext", compareBase: true },
+              ]),
+            ],
+          }),
+        ),
+      [`repos/cloudflare/vinext/git/trees/${baseSha}?recursive=1`]: githubTree([
+        ...nextjsInputs,
+        ...ignoredEntries,
+      ]),
+      [`repos/cloudflare/vinext/git/trees/${mergeSha}?recursive=1`]: githubTree([
+        ...nextjsInputs,
+        ...ignoredEntries,
+      ]),
+      [`repos/cloudflare/vinext/git/commits/${headSha}`]: commit(measuredAt),
+    });
+
+    const treeRequests = requests.filter((request) => request[1]?.includes("/git/trees/"));
+    expect(treeRequests).toHaveLength(2);
+    for (const request of treeRequests) {
+      const jqIndex = request.indexOf("--jq");
+      expect(jqIndex).toBeGreaterThan(-1);
+      expect(request[jqIndex + 1]).toBe(nextjsBenchmarkInputTreeJq);
+    }
+  });
+
   it("rejects skipped Next.js when a benchmark runtime input changed", () => {
     const workflowSha = "c".repeat(40);
     const headSha = "a".repeat(40);
@@ -906,6 +999,7 @@ function validatePerformancePayload(
   const directory = mkdtempSync(join(tmpdir(), "vinext-perf-validator-"));
   const payloadPath = join(directory, "results.json");
   const responsesPath = join(directory, "responses.json");
+  const requestsPath = join(directory, "requests.jsonl");
   const ghPath = join(directory, "gh");
   writeFileSync(payloadPath, JSON.stringify(payload));
   writeFileSync(responsesPath, JSON.stringify(githubResponses));
@@ -918,11 +1012,37 @@ function validatePerformancePayload(
   writeFileSync(
     ghPath,
     `#!/usr/bin/env node
-const responses = JSON.parse(require("node:fs").readFileSync(process.env.MOCK_GH_RESPONSES, "utf8"));
-const response = responses[process.argv[3]];
+const fs = require("node:fs");
+fs.appendFileSync(process.env.MOCK_GH_REQUESTS, JSON.stringify(process.argv.slice(2)) + "\\n");
+const responses = JSON.parse(fs.readFileSync(process.env.MOCK_GH_RESPONSES, "utf8"));
+let response = responses[process.argv[3]];
 if (response === undefined) {
   console.error("Unexpected gh api request:", process.argv[3]);
   process.exit(1);
+}
+const jqIndex = process.argv.indexOf("--jq");
+function isNextjsBenchmarkInput(path) {
+  if (path === ".github/workflows/perf.yml" || path === "benchmarks/generate-app.mjs") return true;
+  if (path.startsWith("benchmarks/nextjs/")) return !path.startsWith("benchmarks/nextjs/app/");
+  return (
+    path.startsWith("benchmarks/perf/") &&
+    path !== "benchmarks/perf/README.md" &&
+    path !== "benchmarks/perf/format-pr-comment.mjs" &&
+    path !== "benchmarks/perf/upload-results.mjs" &&
+    path !== "benchmarks/perf/validate-results.mjs"
+  );
+}
+if (
+  jqIndex !== -1 &&
+  process.argv[jqIndex + 1] === process.env.MOCK_TREE_JQ &&
+  Array.isArray(response.tree)
+) {
+  response = {
+    truncated: response.truncated,
+    tree: response.tree
+      .filter((entry) => entry.type === "blob" && isNextjsBenchmarkInput(entry.path))
+      .map((entry) => ({ path: entry.path, sha: entry.sha, type: entry.type })),
+  };
 }
 process.stdout.write(JSON.stringify(response));
 `,
@@ -943,6 +1063,8 @@ process.stdout.write(JSON.stringify(response));
         VINEXT_PERF_SOURCE_RUN_ID: "123",
         VINEXT_PERF_SOURCE_RUN_ATTEMPT: "1",
         MOCK_GH_RESPONSES: responsesPath,
+        MOCK_GH_REQUESTS: requestsPath,
+        MOCK_TREE_JQ: nextjsBenchmarkInputTreeJq,
       },
       encoding: "utf8",
     },
@@ -950,6 +1072,12 @@ process.stdout.write(JSON.stringify(response));
   if (validation.status !== 0) {
     throw new Error(validation.stderr || validation.stdout || "Performance validation failed");
   }
+  const requests = readFileSync(requestsPath, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as string[]);
+  return requests;
 }
 
 function performancePayload({
@@ -1137,7 +1265,11 @@ function gitTreeEntry(path: string, sha: string) {
   return { path, sha, type: "blob" };
 }
 
-function githubTree(tree: Array<ReturnType<typeof gitTreeEntry>>) {
+function richGitTreeEntry(path: string, sha: string) {
+  return { path, sha, type: "blob", mode: "100644", size: 123, url: "https://example.test" };
+}
+
+function githubTree(tree: Array<{ path: string; sha: string; type: string }>) {
   return { truncated: false, tree };
 }
 


### PR DESCRIPTION
## Summary

- filter remote GitHub tree responses in the perf publisher validator before fingerprinting skipped Next.js benchmark inputs
- share the fingerprint input rules with the `gh api --jq` projection so only relevant tree entries cross into Node
- keep a larger child-process buffer as a secondary guard for trusted GitHub API calls
- add regression coverage that records the validator's tree requests, verifies rich/non-blob/irrelevant entries are filtered out, and checks the generated jq predicate against real `jq` when available

## Validation

- `pnpm run fmt:check -- benchmarks/perf/nextjs-input-fingerprint.mts benchmarks/perf/validate-results.mjs tests/performance-benchmarks.test.ts knip.ts`
- `vp test run tests/performance-benchmarks.test.ts`