### PR TITLE
fix(app-router): keep built-in client refs valid in dev

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -8,6 +8,7 @@
  * Previously housed in server/app-dev-server.ts.
  */
 import { randomUUID } from "node:crypto";
+import { realpathSync } from "node:fs";
 import { buildAppRscManifestCode } from "./app-rsc-manifest.js";
 import { resolveEntryPath } from "./runtime-entry-module.js";
 import { normalizePathSeparators } from "../utils/path.js";
@@ -26,6 +27,15 @@ import { DEFAULT_DEVICE_SIZES, DEFAULT_IMAGE_SIZES } from "../server/image-optim
 
 const DEFAULT_EXPIRE_TIME = 31_536_000;
 const DEFAULT_REACT_MAX_HEADERS_LENGTH = 6000;
+
+function resolveRealEntryPath(rel: string, base: string): string {
+  const resolved = resolveEntryPath(rel, base);
+  try {
+    return normalizePathSeparators(realpathSync(resolved));
+  } catch {
+    return resolved;
+  }
+}
 
 // Pre-computed absolute paths for generated-code imports. The virtual RSC
 // entry can't use relative imports (it has no real file location), so we
@@ -111,6 +121,10 @@ const appHookWarningSuppressionPath = resolveEntryPath(
 );
 const serverGlobalsPath = resolveEntryPath("../server/server-globals.js", import.meta.url);
 const appPagesBridgePath = resolveEntryPath("../server/app-pages-bridge.js", import.meta.url);
+const defaultGlobalErrorShimPath = resolveRealEntryPath(
+  "../shims/default-global-error.js",
+  import.meta.url,
+);
 
 /**
  * Resolved config options relevant to App Router request handling.
@@ -314,6 +328,9 @@ import { ensureInstrumentationRegistered as __ensureInstrumentationRegistered } 
     : ""
 }
 import { createAppRscHandler } from "vinext/server/app-rsc-handler";
+// Ensure the built-in global error client component is registered with
+// plugin-rsc before SSR validates fallback error-boundary references.
+import __VinextDefaultGlobalError from ${JSON.stringify(defaultGlobalErrorShimPath)};
 import { registerConfiguredCacheAdapters as __registerConfiguredCacheAdapters } from "virtual:vinext-cache-adapters";
 import __pagesClientAssets from "virtual:vinext-pages-client-assets";
 import { setPagesClientAssets as __setPagesClientAssets } from "vinext/server/pages-client-assets";
@@ -332,6 +349,7 @@ ${
     ? `const __loadAppServerActionExecution = () => import(${JSON.stringify(appServerActionExecutionPath)});`
     : ""
 }
+void __VinextDefaultGlobalError;
 ${
   (metadataRoutes?.length ?? 0) > 0
     ? `const __loadMetadataRouteResponse = () => import(${JSON.stringify(metadataRouteResponsePath)});`

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -137,6 +137,7 @@ import { clientReferenceDedupPlugin } from "./plugins/client-reference-dedup.js"
 import { dataUrlCssPlugin } from "./plugins/css-data-url.js";
 import { createCssModuleImportCompatibilityPlugin } from "./plugins/css-module-imports.js";
 import { createRscClientReferenceLoadersPlugin } from "./plugins/rsc-client-reference-loaders.js";
+import { rscClientReferenceValidationPlugin } from "./plugins/rsc-client-reference-validation.js";
 import { createInstrumentationClientTransformPlugin } from "./plugins/instrumentation-client.js";
 import { createStyledJsxPlugin } from "./plugins/styled-jsx.js";
 import {
@@ -831,10 +832,6 @@ const _appBrowserServerActionClientPath = resolveShimModulePath(
 );
 const _appRscHandlerPath = resolveShimModulePath(_serverDir, "app-rsc-handler");
 const _pagesClientAssetsPath = resolveShimModulePath(_serverDir, "pages-client-assets");
-// Source checkouts resolve to TypeScript and must stay in Vite's graph so tests
-// do not execute a stale dist build. Published packages resolve to emitted JS,
-// which Node can load natively outside the RSC transform graph.
-const _canExternalizeAppRscHandler = _appRscHandlerPath.endsWith(".js");
 
 function isValidExportIdentifier(name: string): boolean {
   return /^[$A-Z_a-z][$\w]*$/.test(name);
@@ -2662,15 +2659,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                       external:
                         userSsrExternal === true
                           ? true
-                          : [
-                              "satori",
-                              "@resvg/resvg-js",
-                              "yoga-wasm-web",
-                              ...(env?.command === "serve" && _canExternalizeAppRscHandler
-                                ? ["vinext/server/app-rsc-handler"]
-                                : []),
-                              ...userSsrExternal,
-                            ],
+                          : ["satori", "@resvg/resvg-js", "yoga-wasm-web", ...userSsrExternal],
                       // Force all node_modules through Vite's transform pipeline
                       // so non-JS imports (CSS, images) don't hit Node's native
                       // ESM loader. Matches Next.js behavior of bundling everything.
@@ -3129,13 +3118,6 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           const cleanId = normalizePathSeparators(id.startsWith(VIRTUAL_PREFIX) ? id.slice(1) : id);
 
           if (cleanId === "vinext/server/app-rsc-handler") {
-            if (
-              _canExternalizeAppRscHandler &&
-              this.environment?.name === "rsc" &&
-              this.environment.config?.command === "serve"
-            ) {
-              return { id: _appRscHandlerPath, external: true };
-            }
             return _appRscHandlerPath;
           }
 
@@ -3655,6 +3637,7 @@ export const loadServerActionClient = ${
         return clientInjectModule;
       },
     },
+    rscClientReferenceValidationPlugin(),
     // Dedup client references from RSC proxy modules — see src/plugins/client-reference-dedup.ts
     ...(options.experimental?.clientReferenceDedup ? [clientReferenceDedupPlugin()] : []),
     // Proxy plugin for @mdx-js/rollup. The real MDX plugin is created lazily

--- a/packages/vinext/src/plugins/rsc-client-reference-validation.ts
+++ b/packages/vinext/src/plugins/rsc-client-reference-validation.ts
@@ -72,7 +72,8 @@ export function rscClientReferenceValidationPlugin(): Plugin {
     apply: "serve",
 
     load: {
-      filter: { id: /^\0virtual:vite-rsc\/reference-validation\?/ },
+      // oxlint-disable-next-line no-control-regex -- null byte prefix is intentional (Vite virtual module convention)
+      filter: { id: /^\u0000virtual:vite-rsc\/reference-validation\?/ },
       handler(id) {
         // Vite decodes `/@id/__x00__...` back to a NUL-prefixed id before
         // plugin-rsc validates it. Accept only the framework-owned client

--- a/packages/vinext/src/plugins/rsc-client-reference-validation.ts
+++ b/packages/vinext/src/plugins/rsc-client-reference-validation.ts
@@ -1,0 +1,85 @@
+import type { Plugin } from "vite";
+import { RSC_CLIENT_SHIM_SPECIFIERS } from "./rsc-client-shim-excludes.js";
+
+const REFERENCE_VALIDATION_PREFIX = "\0virtual:vite-rsc/reference-validation?";
+const CLIENT_PACKAGE_PROXY = "virtual:vite-rsc/client-package-proxy/";
+const CLIENT_IN_SERVER_PACKAGE_PROXY = "virtual:vite-rsc/client-in-server-package-proxy/";
+const REMOVE_DUPLICATE_SERVER_CSS_REFERENCE = "/@id/\0virtual:vite-rsc/remove-duplicate-server-css";
+const NEXT_CLIENT_SHIM_SPECIFIERS = new Set([
+  "next/form",
+  "next/image",
+  "next/link",
+  "next/script",
+]);
+const VINEXT_CLIENT_SHIM_NAMES = new Set(
+  RSC_CLIENT_SHIM_SPECIFIERS.map((specifier) => specifier.slice("vinext/shims/".length)),
+);
+
+function decodeProxyModuleId(referenceId: string): string | null {
+  const markerIndex = referenceId.indexOf(CLIENT_IN_SERVER_PACKAGE_PROXY);
+  if (markerIndex === -1) return null;
+
+  const encodedModuleId = referenceId.slice(markerIndex + CLIENT_IN_SERVER_PACKAGE_PROXY.length);
+  try {
+    return decodeURIComponent(encodedModuleId).replaceAll("\\", "/");
+  } catch {
+    return encodedModuleId.replaceAll("\\", "/");
+  }
+}
+
+function decodePackageProxySpecifier(referenceId: string): string | null {
+  const markerIndex = referenceId.indexOf(CLIENT_PACKAGE_PROXY);
+  if (markerIndex === -1) return null;
+  return referenceId.slice(markerIndex + CLIENT_PACKAGE_PROXY.length);
+}
+
+export function isVinextRscClientReferenceValidation(id: string): boolean {
+  if (!id.startsWith(REFERENCE_VALIDATION_PREFIX)) return false;
+
+  const queryIndex = id.indexOf("?");
+  if (queryIndex === -1) return false;
+
+  const params = new URLSearchParams(id.slice(queryIndex + 1));
+  if (params.get("type") !== "client") return false;
+
+  const referenceId = params.get("id") ?? "";
+  if (referenceId === REMOVE_DUPLICATE_SERVER_CSS_REFERENCE) return true;
+
+  const packageSpecifier = decodePackageProxySpecifier(referenceId);
+  if (
+    packageSpecifier &&
+    (NEXT_CLIENT_SHIM_SPECIFIERS.has(packageSpecifier) ||
+      RSC_CLIENT_SHIM_SPECIFIERS.includes(packageSpecifier))
+  ) {
+    return true;
+  }
+
+  const moduleId = decodeProxyModuleId(referenceId);
+  if (!moduleId) return false;
+
+  const match = moduleId.match(
+    /(?:^|\/)node_modules\/(?:\.pnpm\/[^/]+\/node_modules\/)?vinext\/dist\/shims\/([^/]+)\.js$/,
+  );
+  if (!match) return false;
+
+  return VINEXT_CLIENT_SHIM_NAMES.has(match[1]);
+}
+
+export function rscClientReferenceValidationPlugin(): Plugin {
+  return {
+    name: "vinext:rsc-client-reference-validation",
+    enforce: "pre",
+    apply: "serve",
+
+    load: {
+      filter: { id: /^\0virtual:vite-rsc\/reference-validation\?/ },
+      handler(id) {
+        // Vite decodes `/@id/__x00__...` back to a NUL-prefixed id before
+        // plugin-rsc validates it. Accept only the framework-owned client
+        // references whose metadata vinext intentionally wires into the graph.
+        if (!isVinextRscClientReferenceValidation(id)) return;
+        return "export {};";
+      },
+    },
+  };
+}

--- a/packages/vinext/src/plugins/rsc-client-shim-excludes.ts
+++ b/packages/vinext/src/plugins/rsc-client-shim-excludes.ts
@@ -1,13 +1,18 @@
-const RSC_CLIENT_SHIM_OPTIMIZE_DEPS_EXCLUDE = Object.freeze([
+export const RSC_CLIENT_SHIM_SPECIFIERS = Object.freeze([
   // @vitejs/plugin-rsc tracks package client references by the original
   // bare source. If Vite pre-bundles these known client shims, the generated
   // client-package proxy can lose the matching export metadata in dev.
+  "vinext/shims/app-router-scroll",
+  "vinext/shims/default-global-error",
+  "vinext/shims/dynamic-preload-chunks",
   "vinext/shims/error-boundary",
   "vinext/shims/form",
+  "vinext/shims/image",
   "vinext/shims/layout-segment-context",
   "vinext/shims/link",
   "vinext/shims/script",
   "vinext/shims/slot",
+  "vinext/shims/use-merged-ref",
   "vinext/shims/offline",
 ]);
 
@@ -18,7 +23,7 @@ export const VINEXT_OPTIMIZE_DEPS_EXCLUDE = Object.freeze([
   // shim). Not a real npm dep, so pre-bundling it would break HMR and cause
   // a "new dependencies optimized" reload on the first request.
   "private-next-instrumentation-client",
-  ...RSC_CLIENT_SHIM_OPTIMIZE_DEPS_EXCLUDE,
+  ...RSC_CLIENT_SHIM_SPECIFIERS,
 ]);
 
 // React entries that @vitejs/plugin-rsc adds to environments.ssr.optimizeDeps.include

--- a/tests/build-optimization.test.ts
+++ b/tests/build-optimization.test.ts
@@ -151,12 +151,17 @@ describe("clientManualChunks", () => {
 
 describe("optimizeDeps.exclude for vinext", () => {
   const rscClientShimExcludes = [
+    "vinext/shims/app-router-scroll",
+    "vinext/shims/default-global-error",
+    "vinext/shims/dynamic-preload-chunks",
     "vinext/shims/error-boundary",
     "vinext/shims/form",
+    "vinext/shims/image",
     "vinext/shims/layout-segment-context",
     "vinext/shims/link",
     "vinext/shims/script",
     "vinext/shims/slot",
+    "vinext/shims/use-merged-ref",
     "vinext/shims/offline",
   ];
 
@@ -336,7 +341,7 @@ describe("optimizeDeps.exclude for vinext", () => {
     }
   }, 15000);
 
-  it("does not externalize the built App Router request handler from a source checkout", async () => {
+  it("keeps the App Router request handler inside the RSC transform graph", async () => {
     const vinext = (await import("../packages/vinext/src/index.js")).default;
     const mainPlugin = vinext().find(
       (plugin: any) => plugin.name === "vinext:config" && typeof plugin.config === "function",
@@ -361,6 +366,10 @@ describe("optimizeDeps.exclude for vinext", () => {
         { root: tmpDir, build: {}, plugins: [] },
         { command: "serve" },
       );
+      // The handler imports vinext's built-in App Router client shims. Even
+      // from an installed package, externalizing it lets Node load those shims
+      // outside plugin-rsc's metadata pass and breaks client-reference
+      // validation for create-next-app projects.
       expect(devConfig.environments.rsc.resolve.external).not.toContain(
         "vinext/server/app-rsc-handler",
       );

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -849,8 +849,15 @@ describe("App Router entry templates", () => {
 
   it("generateRscEntry delegates App Router request handling to the typed helper", () => {
     const code = generateRscEntry("/tmp/test/app", minimalAppRoutes, null, [], null, "", false);
+    const defaultGlobalErrorShimPath = path
+      .resolve("packages/vinext/src/shims/default-global-error.js")
+      .replaceAll("\\", "/");
 
     expect(code).toContain('import { createAppRscHandler } from "vinext/server/app-rsc-handler";');
+    expect(code).toContain(
+      `import __VinextDefaultGlobalError from ${JSON.stringify(defaultGlobalErrorShimPath)};`,
+    );
+    expect(code).toContain("void __VinextDefaultGlobalError;");
     expect(code).toContain("export default createAppRscHandler({");
     expect(code).not.toContain("computeRscCacheBustingSearchParam(");
   });

--- a/tests/rsc-client-reference-validation.test.ts
+++ b/tests/rsc-client-reference-validation.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vite-plus/test";
+import { isVinextRscClientReferenceValidation } from "../packages/vinext/src/plugins/rsc-client-reference-validation.js";
+
+function validationId(referenceId: string, type = "client"): string {
+  return `\0virtual:vite-rsc/reference-validation?type=${type}&id=${encodeURIComponent(
+    referenceId,
+  )}&lang.js`;
+}
+
+function clientInServerPackageProxy(moduleId: string): string {
+  return `/@id/\0virtual:vite-rsc/client-in-server-package-proxy/${encodeURIComponent(moduleId)}`;
+}
+
+describe("rscClientReferenceValidationPlugin", () => {
+  it("accepts decoded validation ids for vinext's emitted client shims", () => {
+    const referenceId = clientInServerPackageProxy(
+      "/private/tmp/app/node_modules/.pnpm/vinext@file+pkg/node_modules/vinext/dist/shims/app-router-scroll.js",
+    );
+
+    expect(isVinextRscClientReferenceValidation(validationId(referenceId))).toBe(true);
+  });
+
+  it("accepts plugin-rsc's CSS dedupe virtual reference", () => {
+    expect(
+      isVinextRscClientReferenceValidation(
+        validationId("/@id/\0virtual:vite-rsc/remove-duplicate-server-css"),
+      ),
+    ).toBe(true);
+  });
+
+  it("accepts package-proxy validation ids for Next client shims vinext owns", () => {
+    expect(
+      isVinextRscClientReferenceValidation(
+        validationId("/@id/\0virtual:vite-rsc/client-package-proxy/next/image"),
+      ),
+    ).toBe(true);
+  });
+
+  it("accepts non-pnpm node_modules installs", () => {
+    const referenceId = clientInServerPackageProxy(
+      "C:/tmp/app/node_modules/vinext/dist/shims/error-boundary.js",
+    );
+
+    expect(isVinextRscClientReferenceValidation(validationId(referenceId))).toBe(true);
+  });
+
+  it("rejects non-client and non-vinext validation ids", () => {
+    const vinextReferenceId = clientInServerPackageProxy(
+      "/private/tmp/app/node_modules/vinext/dist/shims/default-global-error.js",
+    );
+    const appReferenceId = clientInServerPackageProxy("/private/tmp/app/app/global-error.tsx");
+
+    expect(isVinextRscClientReferenceValidation(validationId(vinextReferenceId, "server"))).toBe(
+      false,
+    );
+    expect(
+      isVinextRscClientReferenceValidation(
+        validationId("/@id/\0virtual:vite-rsc/client-package-proxy/some-package/client"),
+      ),
+    ).toBe(false);
+    expect(isVinextRscClientReferenceValidation(validationId(appReferenceId))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- keep vinext built-in client shims valid in installed-package dev projects by registering framework-owned RSC client references before plugin-rsc validation
- keep the App Router RSC handler inside the dev module graph so its shim imports participate in plugin-rsc metadata collection
- add coverage for the RSC client-reference allowlist, generated default global-error wiring, and dev externalization behavior

## Context

This is split out from #2478. It addresses the create-next-app dev-server smoke failure separately from the perf publisher ENOBUFS fix.

## Validation

- `vp check`
- `vp test run tests/rsc-client-reference-validation.test.ts tests/build-optimization.test.ts tests/entry-templates.test.ts`
- previously reproduced with a CI-shaped create-next-app smoke using a packed local vinext tarball, `vinext init --skip-check --platform=node`, `vite dev`, and HTTP 200 verification for `/`