### PR TITLE
fix(app-router): normalize rsc reference validation ids

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -137,6 +137,7 @@ import { clientReferenceDedupPlugin } from "./plugins/client-reference-dedup.js"
 import { dataUrlCssPlugin } from "./plugins/css-data-url.js";
 import { createCssModuleImportCompatibilityPlugin } from "./plugins/css-module-imports.js";
 import { createRscClientReferenceLoadersPlugin } from "./plugins/rsc-client-reference-loaders.js";
+import { createRscReferenceValidationNormalizerPlugin } from "./plugins/rsc-reference-validation-normalizer.js";
 import { createInstrumentationClientTransformPlugin } from "./plugins/instrumentation-client.js";
 import { createStyledJsxPlugin } from "./plugins/styled-jsx.js";
 import {
@@ -6213,6 +6214,7 @@ export const loadServerActionClient = ${
   // Append auto-injected RSC plugins if applicable
   if (rscPluginPromise) {
     plugins.push(rscPluginPromise);
+    plugins.push(createRscReferenceValidationNormalizerPlugin());
     plugins.push(createRscClientReferenceLoadersPlugin());
   }
 

--- a/packages/vinext/src/plugins/rsc-reference-validation-normalizer.ts
+++ b/packages/vinext/src/plugins/rsc-reference-validation-normalizer.ts
@@ -45,7 +45,9 @@ export function createRscReferenceValidationNormalizerPlugin(): Plugin {
   return {
     name: "vinext:rsc-reference-validation-normalizer",
     enforce: "pre",
-    apply: "serve",
+    apply(_config, env) {
+      return env.command === "serve" && env.isPreview !== true;
+    },
     configResolved(config) {
       rscApi = (
         config.plugins.find((plugin) => plugin.name === "rsc:minimal") as

--- a/packages/vinext/src/plugins/rsc-reference-validation-normalizer.ts
+++ b/packages/vinext/src/plugins/rsc-reference-validation-normalizer.ts
@@ -1,0 +1,78 @@
+import type { Plugin } from "vite";
+import type { PluginApi } from "@vitejs/plugin-rsc";
+
+const REFERENCE_VALIDATION_ID_PREFIX = "\0virtual:vite-rsc/reference-validation?";
+
+type RscPluginWithApi = Plugin & {
+  api?: PluginApi;
+};
+
+type RscReferenceMeta =
+  | PluginApi["manager"]["clientReferenceMetaMap"][string]
+  | PluginApi["manager"]["serverReferenceMetaMap"][string];
+
+function parseReferenceValidationQuery(id: string): { type?: string; id?: string } | null {
+  const queryStart = id.indexOf("?");
+  if (queryStart === -1) return null;
+  return Object.fromEntries(new URLSearchParams(id.slice(queryStart + 1)));
+}
+
+function normalizeReferenceKey(id: string): string {
+  return id.replaceAll("\0", "__x00__");
+}
+
+function hasReference(
+  referenceMetaMap: Record<string, RscReferenceMeta> | undefined,
+  referenceId: string | undefined,
+): boolean {
+  if (!referenceMetaMap || !referenceId) return false;
+
+  const normalizedReferenceId = normalizeReferenceKey(referenceId);
+  return Object.values(referenceMetaMap).some(
+    (meta) => normalizeReferenceKey(meta.referenceKey) === normalizedReferenceId,
+  );
+}
+
+/**
+ * @vitejs/plugin-rsc stores dev virtual client-reference keys in Vite's encoded
+ * `/@id/__x00__...` form, but React's SSR consumer can ask validation for the
+ * decoded `/@id/\0...` form. Treat those as equivalent and fall through to the
+ * upstream validator for all other invalid references.
+ */
+export function createRscReferenceValidationNormalizerPlugin(): Plugin {
+  let rscApi: PluginApi | undefined;
+
+  return {
+    name: "vinext:rsc-reference-validation-normalizer",
+    enforce: "pre",
+    apply: "serve",
+    configResolved(config) {
+      rscApi = (
+        config.plugins.find((plugin) => plugin.name === "rsc:minimal") as
+          | RscPluginWithApi
+          | undefined
+      )?.api;
+    },
+    load: {
+      // oxlint-disable-next-line no-control-regex -- null byte prefix is intentional (Vite virtual module convention)
+      filter: { id: /^\u0000virtual:vite-rsc\/reference-validation\?/ },
+      handler(id) {
+        if (!id.startsWith(REFERENCE_VALIDATION_ID_PREFIX)) return null;
+
+        const query = parseReferenceValidationQuery(id);
+        if (!query) return null;
+
+        const manager = rscApi?.manager;
+        if (query.type === "client" && hasReference(manager?.clientReferenceMetaMap, query.id)) {
+          return "export {}";
+        }
+
+        if (query.type === "server" && hasReference(manager?.serverReferenceMetaMap, query.id)) {
+          return "export {}";
+        }
+
+        return null;
+      },
+    },
+  };
+}

--- a/tests/rsc-reference-validation-normalizer.test.ts
+++ b/tests/rsc-reference-validation-normalizer.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import type { Plugin } from "vite";
+import { createRscReferenceValidationNormalizerPlugin } from "../packages/vinext/src/plugins/rsc-reference-validation-normalizer.js";
+
+function validationId(type: "client" | "server", id: string) {
+  return `\0virtual:vite-rsc/reference-validation?type=${type}&id=${encodeURIComponent(id)}&lang.js`;
+}
+
+async function configurePlugin(manager: unknown): Promise<Plugin> {
+  const plugin = createRscReferenceValidationNormalizerPlugin();
+  if (typeof plugin.configResolved !== "function") {
+    throw new Error("Expected function configResolved hook");
+  }
+  await plugin.configResolved.call(
+    {} as never,
+    {
+      plugins: [
+        {
+          name: "rsc:minimal",
+          api: { manager },
+        },
+      ],
+    } as never,
+  );
+  return plugin;
+}
+
+async function load(plugin: Plugin, id: string): Promise<unknown> {
+  const hook = typeof plugin.load === "function" ? plugin.load : plugin.load?.handler;
+  if (typeof hook !== "function") throw new Error("Expected function load hook");
+  return await hook.call({} as never, id);
+}
+
+describe("rsc reference validation normalizer", () => {
+  it("accepts decoded client reference ids when plugin-rsc has encoded metadata", async () => {
+    const encodedReference =
+      "/@id/__x00__virtual:vite-rsc/client-in-server-package-proxy/%2Fapp%2Fnode_modules%2Fvinext%2Fdist%2Fshims%2Fdefault-global-error.js";
+    const decodedReference = encodedReference.replace("__x00__", "\0");
+    const plugin = await configurePlugin({
+      clientReferenceMetaMap: {
+        "/@id/__x00__virtual:vite-rsc/client-in-server-package-proxy/test": {
+          referenceKey: encodedReference,
+        },
+      },
+    });
+
+    await expect(load(plugin, validationId("client", decodedReference))).resolves.toBe("export {}");
+  });
+
+  it("accepts server reference ids when plugin-rsc has matching metadata", async () => {
+    const plugin = await configurePlugin({
+      serverReferenceMetaMap: {
+        "/app/actions.ts": {
+          referenceKey: "/app/actions.ts",
+        },
+      },
+    });
+
+    await expect(load(plugin, validationId("server", "/app/actions.ts"))).resolves.toBe(
+      "export {}",
+    );
+  });
+
+  it("falls through to plugin-rsc validation when metadata does not match", async () => {
+    const plugin = await configurePlugin({
+      clientReferenceMetaMap: {
+        "/app/known.tsx": {
+          referenceKey: "/app/known.tsx",
+        },
+      },
+      serverReferenceMetaMap: {
+        "/app/action.ts": {
+          referenceKey: "/app/action.ts",
+        },
+      },
+    });
+
+    await expect(load(plugin, validationId("client", "/app/unknown.tsx"))).resolves.toBeNull();
+    await expect(load(plugin, validationId("server", "/app/known.tsx"))).resolves.toBeNull();
+  });
+
+  it("falls through when plugin-rsc metadata is unavailable", async () => {
+    const plugin = createRscReferenceValidationNormalizerPlugin();
+
+    await expect(load(plugin, validationId("client", "/app/client.tsx"))).resolves.toBeNull();
+  });
+});

--- a/tests/rsc-reference-validation-normalizer.test.ts
+++ b/tests/rsc-reference-validation-normalizer.test.ts
@@ -32,6 +32,42 @@ async function load(plugin: Plugin, id: string): Promise<unknown> {
 }
 
 describe("rsc reference validation normalizer", () => {
+  it("only applies to the dev server, not build or preview", () => {
+    const plugin = createRscReferenceValidationNormalizerPlugin();
+    if (typeof plugin.apply !== "function") throw new Error("Expected function apply hook");
+
+    expect(
+      plugin.apply(
+        {},
+        {
+          command: "serve",
+          mode: "development",
+          isPreview: false,
+        },
+      ),
+    ).toBe(true);
+    expect(
+      plugin.apply(
+        {},
+        {
+          command: "serve",
+          mode: "production",
+          isPreview: true,
+        },
+      ),
+    ).toBe(false);
+    expect(
+      plugin.apply(
+        {},
+        {
+          command: "build",
+          mode: "production",
+          isPreview: false,
+        },
+      ),
+    ).toBe(false);
+  });
+
   it("accepts decoded client reference ids when plugin-rsc has encoded metadata", async () => {
     const encodedReference =
       "/@id/__x00__virtual:vite-rsc/client-in-server-package-proxy/%2Fapp%2Fnode_modules%2Fvinext%2Fdist%2Fshims%2Fdefault-global-error.js";


### PR DESCRIPTION
## Summary

- add a dev-only RSC reference-validation normalizer that treats plugin-rsc encoded `__x00__` reference keys and decoded `\0` validation ids as equivalent
- only short-circuit validation when the upstream plugin-rsc metadata map already contains the matching client/server reference
- add unit coverage for decoded client references, cached server references, unmatched references, and missing plugin-rsc metadata

## Context

This is the narrower alternative to #2479. It fixes the create-next-app dev-server client-reference validation shape without adding a vinext framework allowlist or changing App Router handler externalization.

## Validation

- `vp check`
- `vp test run tests/rsc-reference-validation-normalizer.test.ts`
- CI-shaped create-next-app smoke on the normalizer-only production code: packed local vinext, scaffolded `create-next-app@16.2.7`, ran `vinext init --skip-check --platform=node`, started `vite dev`, and verified `/` returned HTTP 200 on attempt 2