### PR TITLE
fix(init): default to Workers Cache on Cloudflare

### DIFF
--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -984,6 +984,8 @@ function printHelp(cmd?: string) {
     --platform <target>  Deployment target: cloudflare or node
     --prerender          Configure vinext build to pre-render all static routes
                          (default: prompt, with No selected by default)
+    --cdn-cache <type>   Cloudflare CDN cache: workers-cache or data-cache
+                         (default: workers-cache)
     --data-cache <type>  Cloudflare data cache: kv or none (default: kv)
     --image-optimization <type>
                          Cloudflare image optimization: cloudflare-images or none
@@ -992,6 +994,8 @@ function printHelp(cmd?: string) {
   Examples:
     vinext init                   Prompt for a deployment platform
     vinext init --platform=cloudflare  Configure Cloudflare Workers (default)
+    vinext init --platform=cloudflare --cdn-cache=data-cache
+                                Fall through CDN caching to the data cache
     vinext init --platform=cloudflare --data-cache=kv
                                 Configure the default Cloudflare cache handlers
     vinext init --platform=cloudflare --image-optimization=none

--- a/packages/vinext/src/init-cloudflare.ts
+++ b/packages/vinext/src/init-cloudflare.ts
@@ -17,7 +17,7 @@ export type CloudflareProjectInfo = {
 
 const DEFAULT_CLOUDFLARE_INIT_OPTIONS: CloudflareInitOptions = {
   dataCache: "kv",
-  cdnCache: "data-cache",
+  cdnCache: "workers-cache",
   imageOptimization: "cloudflare-images",
 };
 

--- a/packages/vinext/src/init-cloudflare.ts
+++ b/packages/vinext/src/init-cloudflare.ts
@@ -1319,7 +1319,7 @@ export function updateViteConfigForCloudflare(
   const program = parseViteConfig(filePath, code);
   const cacheOptions = options.cache ?? {
     dataCache: "none",
-    cdnCache: "data-cache",
+    cdnCache: "workers-cache",
     imageOptimization: "cloudflare-images",
   };
   const config = findConfigObject(program);

--- a/packages/vinext/src/init-platform.ts
+++ b/packages/vinext/src/init-platform.ts
@@ -219,10 +219,10 @@ export async function resolveCloudflareInitOptions(
   const explicitDataCache = parseDataCacheArg(args);
   const explicitCdnCache = parseCdnCacheArg(args);
   const explicitImageOptimization = parseImageOptimizationArg(args);
-  if (explicitDataCache && explicitImageOptimization) {
+  if (explicitCdnCache && explicitDataCache && explicitImageOptimization) {
     return {
       dataCache: explicitDataCache,
-      cdnCache: explicitCdnCache ?? "workers-cache",
+      cdnCache: explicitCdnCache,
       imageOptimization: explicitImageOptimization,
     };
   }

--- a/packages/vinext/src/init-platform.ts
+++ b/packages/vinext/src/init-platform.ts
@@ -98,7 +98,7 @@ export function parseDataCacheArg(args: string[]): InitDataCache | undefined {
 }
 
 export function parseCdnCacheArg(args: string[]): InitCdnCache | undefined {
-  return parseChoiceArg(args, "--cdn-cache", ["data-cache", "workers-cache"], ["data-cache"]);
+  return parseChoiceArg(args, "--cdn-cache", ["workers-cache", "data-cache"]);
 }
 
 export function parseImageOptimizationArg(args: string[]): InitImageOptimization | undefined {
@@ -230,7 +230,7 @@ export async function resolveCloudflareInitOptions(
   const env = options.env ?? process.env;
   if (isAgentEnvironment(env)) {
     throw new Error(
-      "vinext init needs Cloudflare cache and image choices. Ask the user which data cache (kv or none) and image optimization (cloudflare-images or none) they want, then re-run with --data-cache=... and --image-optimization=....",
+      "vinext init needs Cloudflare cache and image choices. Ask the user which CDN cache (workers-cache or data-cache), data cache (kv or none), and image optimization (cloudflare-images or none) they want, then re-run with --cdn-cache=..., --data-cache=..., and --image-optimization=....",
     );
   }
 
@@ -272,6 +272,20 @@ export async function resolveCloudflareInitOptions(
       }
     };
 
+    const cdnCache = await promptChoice(
+      explicitCdnCache,
+      "  Choose a CDN cache:\n    1. Workers Cache (default)\n    2. Data cache\n  CDN cache [1]: ",
+      {
+        "1": "workers-cache",
+        "workers-cache": "workers-cache",
+        workers: "workers-cache",
+        "2": "data-cache",
+        "data-cache": "data-cache",
+        data: "data-cache",
+      },
+      "workers-cache",
+      "Please choose Workers Cache (1) or Data cache (2).",
+    );
     const dataCache = await promptChoice(
       explicitDataCache,
       "  Choose a data cache:\n    1. Cloudflare KV (default)\n    2. None\n  Data cache [1]: ",
@@ -279,7 +293,6 @@ export async function resolveCloudflareInitOptions(
       "kv",
       "Please choose Cloudflare KV (1) or None (2).",
     );
-    const cdnCache = explicitCdnCache ?? "workers-cache";
     const imageOptimization = await promptChoice(
       explicitImageOptimization,
       "  Choose image optimization:\n    1. Cloudflare Images (default)\n    2. None\n  Image optimization [1]: ",

--- a/packages/vinext/src/init-platform.ts
+++ b/packages/vinext/src/init-platform.ts
@@ -222,7 +222,7 @@ export async function resolveCloudflareInitOptions(
   if (explicitDataCache && explicitImageOptimization) {
     return {
       dataCache: explicitDataCache,
-      cdnCache: explicitCdnCache ?? "data-cache",
+      cdnCache: explicitCdnCache ?? "workers-cache",
       imageOptimization: explicitImageOptimization,
     };
   }
@@ -241,7 +241,7 @@ export async function resolveCloudflareInitOptions(
   if (!isInteractive) {
     return {
       dataCache: explicitDataCache ?? "kv",
-      cdnCache: explicitCdnCache ?? "data-cache",
+      cdnCache: explicitCdnCache ?? "workers-cache",
       imageOptimization: explicitImageOptimization ?? "cloudflare-images",
     };
   }
@@ -279,7 +279,7 @@ export async function resolveCloudflareInitOptions(
       "kv",
       "Please choose Cloudflare KV (1) or None (2).",
     );
-    const cdnCache = explicitCdnCache ?? "data-cache";
+    const cdnCache = explicitCdnCache ?? "workers-cache";
     const imageOptimization = await promptChoice(
       explicitImageOptimization,
       "  Choose image optimization:\n    1. Cloudflare Images (default)\n    2. None\n  Image optimization [1]: ",

--- a/packages/vinext/src/init.ts
+++ b/packages/vinext/src/init.ts
@@ -153,7 +153,7 @@ export default defineConfig({
  * Add vinext scripts to package.json without overwriting existing scripts.
  * Returns the list of script names that were added.
  */
-export function addScripts(root: string, port: number): string[] {
+export function addScripts(root: string, port: number, platform: InitPlatform = "node"): string[] {
   const pkgPath = path.join(root, "package.json");
   if (!fs.existsSync(pkgPath)) return [];
 
@@ -180,6 +180,11 @@ export function addScripts(root: string, port: number): string[] {
     if (!pkg.scripts["start:vinext"]) {
       pkg.scripts["start:vinext"] = "vinext start";
       added.push("start:vinext");
+    }
+
+    if (platform === "cloudflare" && !pkg.scripts["deploy:vinext"]) {
+      pkg.scripts["deploy:vinext"] = "vinext-cloudflare deploy";
+      added.push("deploy:vinext");
     }
 
     if (added.length > 0) {
@@ -462,7 +467,7 @@ export async function init(options: InitOptions): Promise<InitResult> {
 
   // ── Step 3: Add scripts ────────────────────────────────────────────────
 
-  const addedScripts = addScripts(root, port);
+  const addedScripts = addScripts(root, port, platform);
 
   // ── Step 4: Generate vite.config.ts ────────────────────────────────────
 
@@ -595,6 +600,10 @@ export async function init(options: InitOptions): Promise<InitResult> {
       "   pnpm install",
     );
   }
+  const deployCommandStep =
+    platform === "cloudflare"
+      ? `    ${pmName} run deploy:vinext Deploy to Cloudflare Workers\n`
+      : "";
 
   console.log(`
   ${terminalStyle.cyan(terminalStyle.bold("Next steps:"))}
@@ -602,7 +611,7 @@ ${nextSteps.map((step) => `    ${step}`).join("\n")}${nextSteps.length > 0 ? "\n
     ${pmName} run dev:vinext    Start the vinext dev server
     ${pmName} run build:vinext  Build production output
     ${pmName} run start:vinext  Start vinext production server
-    ${pmName} run dev           Start Next.js (still works as before)
+${deployCommandStep}    ${pmName} run dev           Start Next.js (still works as before)
 `);
 
   return {

--- a/tests/__snapshots__/init.test.ts.snap
+++ b/tests/__snapshots__/init.test.ts.snap
@@ -25,7 +25,8 @@ export default function Home() { return <div>hi</div> }
   "scripts": {
     "dev:vinext": "vinext dev --port 3001",
     "build:vinext": "vinext build",
-    "start:vinext": "vinext start"
+    "start:vinext": "vinext start",
+    "deploy:vinext": "vinext-cloudflare deploy"
   }
 }
 
@@ -140,7 +141,8 @@ export default function Home() { return <div>hi</div> }
   "scripts": {
     "dev:vinext": "vinext dev --port 3001",
     "build:vinext": "vinext build",
-    "start:vinext": "vinext start"
+    "start:vinext": "vinext start",
+    "deploy:vinext": "vinext-cloudflare deploy"
   }
 }
 

--- a/tests/__snapshots__/init.test.ts.snap
+++ b/tests/__snapshots__/init.test.ts.snap
@@ -34,12 +34,13 @@ import { defineConfig } from "vite";
 import vinext from "vinext";
 import { cloudflare } from "@cloudflare/vite-plugin";
 import { kvDataAdapter } from "@vinext/cloudflare/cache/kv-data-adapter";
+import { cdnAdapter } from "@vinext/cloudflare/cache/cdn-adapter";
 import { imagesOptimizer } from "@vinext/cloudflare/images/images-optimizer";
 
 export default defineConfig({
   plugins: [
     vinext({
-      cache: { data: kvDataAdapter() },
+      cache: { data: kvDataAdapter(), cdn: cdnAdapter() },
       images: { optimizer: imagesOptimizer() },
     }),
     cloudflare({
@@ -64,6 +65,9 @@ export default defineConfig({
     "directory": "dist/client",
     "not_found_handling": "none",
     "binding": "ASSETS"
+  },
+  "cache": {
+    "enabled": true
   },
   "images": {
     "binding": "IMAGES"
@@ -145,6 +149,7 @@ import { defineConfig } from "vite";
 import vinext from "vinext";
 import custom from "./custom.js";
 import { kvDataAdapter } from "@vinext/cloudflare/cache/kv-data-adapter";
+import { cdnAdapter } from "@vinext/cloudflare/cache/cdn-adapter";
 import { imagesOptimizer } from "@vinext/cloudflare/images/images-optimizer";
 import { cloudflare } from "@cloudflare/vite-plugin";
 
@@ -152,7 +157,7 @@ export default defineConfig({
   plugins: [
     custom(),
     vinext({
-      cache: { data: kvDataAdapter() },
+      cache: { data: kvDataAdapter(), cdn: cdnAdapter() },
       images: { optimizer: imagesOptimizer() },
     }),
     cloudflare({
@@ -178,6 +183,9 @@ export default defineConfig({
     "directory": "dist/client",
     "not_found_handling": "none",
     "binding": "ASSETS"
+  },
+  "cache": {
+    "enabled": true
   },
   "images": {
     "binding": "IMAGES"

--- a/tests/init-platform.test.ts
+++ b/tests/init-platform.test.ts
@@ -32,12 +32,12 @@ describe("Cloudflare init choices", () => {
     expect(parseImageOptimizationArg(["--image-optimization=none"])).toBe("none");
   });
 
-  it("defaults to KV data, data-cache CDN fallback, and Cloudflare Images", async () => {
+  it("defaults to KV data, Workers Cache CDN, and Cloudflare Images", async () => {
     await expect(
       resolveCloudflareInitOptions([], { env: {}, isInteractive: false }),
     ).resolves.toEqual({
       dataCache: "kv",
-      cdnCache: "data-cache",
+      cdnCache: "workers-cache",
       imageOptimization: "cloudflare-images",
     });
   });
@@ -55,7 +55,7 @@ describe("Cloudflare init choices", () => {
       }),
     ).resolves.toEqual({
       dataCache: "kv",
-      cdnCache: "data-cache",
+      cdnCache: "workers-cache",
       imageOptimization: "none",
     });
   });
@@ -81,7 +81,7 @@ describe("Cloudflare init choices", () => {
       }),
     ).resolves.toEqual({
       dataCache: "none",
-      cdnCache: "data-cache",
+      cdnCache: "workers-cache",
       imageOptimization: "none",
     });
     expect(prompts).toEqual([

--- a/tests/init-platform.test.ts
+++ b/tests/init-platform.test.ts
@@ -48,16 +48,27 @@ describe("Cloudflare init choices", () => {
     ).rejects.toThrow("--cdn-cache=..., --data-cache=..., and --image-optimization=...");
   });
 
-  it("lets agents omit the default CDN cache flag", async () => {
+  it("uses explicit Cloudflare choices in agent environments", async () => {
     await expect(
-      resolveCloudflareInitOptions(["--data-cache=kv", "--image-optimization=none"], {
-        env: { CODEX_THREAD_ID: "test" },
-      }),
+      resolveCloudflareInitOptions(
+        ["--cdn-cache=workers-cache", "--data-cache=kv", "--image-optimization=none"],
+        {
+          env: { CODEX_THREAD_ID: "test" },
+        },
+      ),
     ).resolves.toEqual({
       dataCache: "kv",
       cdnCache: "workers-cache",
       imageOptimization: "none",
     });
+  });
+
+  it("requires agents to pass the CDN cache choice with other Cloudflare choices", async () => {
+    await expect(
+      resolveCloudflareInitOptions(["--data-cache=kv", "--image-optimization=none"], {
+        env: { CODEX_THREAD_ID: "test" },
+      }),
+    ).rejects.toThrow("--cdn-cache=..., --data-cache=..., and --image-optimization=...");
   });
 
   it("rejects legacy CDN cache choices", () => {
@@ -109,6 +120,30 @@ describe("Cloudflare init choices", () => {
       cdnCache: "data-cache",
       imageOptimization: "none",
     });
+  });
+
+  it("prompts interactively for a missing CDN cache choice before honoring other flags", async () => {
+    const prompts: string[] = [];
+    const output = new PassThrough();
+    await expect(
+      resolveCloudflareInitOptions(["--data-cache=kv", "--image-optimization=none"], {
+        env: {},
+        isInteractive: true,
+        output,
+        question: async (prompt) => {
+          prompts.push(prompt);
+          return "2";
+        },
+      }),
+    ).resolves.toEqual({
+      dataCache: "kv",
+      cdnCache: "data-cache",
+      imageOptimization: "none",
+    });
+    expect(prompts).toEqual([
+      "  Choose a CDN cache:\n    1. Workers Cache (default)\n    2. Data cache\n  CDN cache [1]: ",
+    ]);
+    expect(output.read()?.toString()).toBe("\n");
   });
 
   it("does not add a section break when repeating an invalid choice", async () => {

--- a/tests/init-platform.test.ts
+++ b/tests/init-platform.test.ts
@@ -45,7 +45,7 @@ describe("Cloudflare init choices", () => {
   it("tells agents to ask and rerun with public Cloudflare flags", async () => {
     await expect(
       resolveCloudflareInitOptions([], { env: { CODEX_THREAD_ID: "test" } }),
-    ).rejects.toThrow("--data-cache=... and --image-optimization=...");
+    ).rejects.toThrow("--cdn-cache=..., --data-cache=..., and --image-optimization=...");
   });
 
   it("lets agents omit the default CDN cache flag", async () => {
@@ -61,13 +61,17 @@ describe("Cloudflare init choices", () => {
   });
 
   it("rejects legacy CDN cache choices", () => {
-    expect(() => parseCdnCacheArg(["--cdn-cache=kv"])).toThrow("Expected data-cache");
-    expect(() => parseCdnCacheArg(["--cdn-cache=none"])).toThrow("Expected data-cache");
+    expect(() => parseCdnCacheArg(["--cdn-cache=kv"])).toThrow(
+      "Expected workers-cache or data-cache",
+    );
+    expect(() => parseCdnCacheArg(["--cdn-cache=none"])).toThrow(
+      "Expected workers-cache or data-cache",
+    );
   });
 
-  it("prompts only for public Cloudflare choices", async () => {
+  it("prompts for CDN cache before the other Cloudflare choices", async () => {
     const prompts: string[] = [];
-    const answers = ["2", "2"];
+    const answers = ["2", "2", "2"];
     const output = new PassThrough();
     await expect(
       resolveCloudflareInitOptions([], {
@@ -81,36 +85,35 @@ describe("Cloudflare init choices", () => {
       }),
     ).resolves.toEqual({
       dataCache: "none",
-      cdnCache: "workers-cache",
+      cdnCache: "data-cache",
       imageOptimization: "none",
     });
     expect(prompts).toEqual([
+      "  Choose a CDN cache:\n    1. Workers Cache (default)\n    2. Data cache\n  CDN cache [1]: ",
       "  Choose a data cache:\n    1. Cloudflare KV (default)\n    2. None\n  Data cache [1]: ",
       "  Choose image optimization:\n    1. Cloudflare Images (default)\n    2. None\n  Image optimization [1]: ",
     ]);
-    expect(output.read()?.toString()).toBe("\n\n");
-    expect(prompts.join("\n")).not.toContain("Workers Cache");
-    expect(prompts.join("\n")).not.toContain("CDN");
+    expect(output.read()?.toString()).toBe("\n\n\n");
   });
 
-  it("preserves the hidden Workers Cache flag during interactive setup", async () => {
+  it("preserves an explicit CDN cache flag during interactive setup", async () => {
     const answers = ["2", "2"];
     await expect(
-      resolveCloudflareInitOptions(["--cdn-cache=workers-cache"], {
+      resolveCloudflareInitOptions(["--cdn-cache=data-cache"], {
         env: {},
         isInteractive: true,
         question: async () => answers.shift() ?? "",
       }),
     ).resolves.toEqual({
       dataCache: "none",
-      cdnCache: "workers-cache",
+      cdnCache: "data-cache",
       imageOptimization: "none",
     });
   });
 
   it("does not add a section break when repeating an invalid choice", async () => {
     const prompts: string[] = [];
-    const answers = ["invalid", "2", "2"];
+    const answers = ["invalid", "2", "2", "2"];
     const output = new PassThrough();
     await resolveCloudflareInitOptions([], {
       env: {},
@@ -122,10 +125,13 @@ describe("Cloudflare init choices", () => {
       },
     });
 
-    expect(prompts[0]).toMatch(/^  Choose a data cache:/);
-    expect(prompts[1]).toMatch(/^  Choose a data cache:/);
-    expect(prompts[2]).toMatch(/^  Choose image optimization:/);
-    expect(output.read()?.toString()).toBe("  Please choose Cloudflare KV (1) or None (2).\n\n\n");
+    expect(prompts[0]).toMatch(/^  Choose a CDN cache:/);
+    expect(prompts[1]).toMatch(/^  Choose a CDN cache:/);
+    expect(prompts[2]).toMatch(/^  Choose a data cache:/);
+    expect(prompts[3]).toMatch(/^  Choose image optimization:/);
+    expect(output.read()?.toString()).toBe(
+      "  Please choose Workers Cache (1) or Data cache (2).\n\n\n\n",
+    );
   });
 });
 

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -277,6 +277,17 @@ describe("addScripts", () => {
     expect(pkg.scripts["dev:vinext"]).toBe("vinext dev --port 3001");
     expect(pkg.scripts["build:vinext"]).toBe("vinext build");
     expect(pkg.scripts["start:vinext"]).toBe("vinext start");
+    expect(pkg.scripts["deploy:vinext"]).toBeUndefined();
+  });
+
+  it("adds deploy:vinext for Cloudflare projects", () => {
+    setupProject(tmpDir, { router: "app" });
+
+    const added = addScripts(tmpDir, 3001, "cloudflare");
+
+    expect(added).toContain("deploy:vinext");
+    const pkg = readPkg(tmpDir) as { scripts: Record<string, string> };
+    expect(pkg.scripts["deploy:vinext"]).toBe("vinext-cloudflare deploy");
   });
 
   it("uses custom port", () => {
@@ -291,17 +302,24 @@ describe("addScripts", () => {
   it("does not overwrite existing scripts", () => {
     setupProject(tmpDir, {
       router: "app",
-      extraPkg: { scripts: { "dev:vinext": "custom-command" } },
+      extraPkg: {
+        scripts: {
+          "dev:vinext": "custom-command",
+          "deploy:vinext": "custom-deploy",
+        },
+      },
     });
 
-    const added = addScripts(tmpDir, 3001);
+    const added = addScripts(tmpDir, 3001, "cloudflare");
 
     expect(added).not.toContain("dev:vinext");
+    expect(added).not.toContain("deploy:vinext");
     expect(added).toContain("build:vinext");
     expect(added).toContain("start:vinext");
 
     const pkg = readPkg(tmpDir) as { scripts: Record<string, string> };
     expect(pkg.scripts["dev:vinext"]).toBe("custom-command");
+    expect(pkg.scripts["deploy:vinext"]).toBe("custom-deploy");
   });
 
   it("creates scripts object if missing", () => {
@@ -796,7 +814,7 @@ export default { plugins: [vinext({ cache: { data: customData() } })] };
     expect(result.addedTypeModule).toBe(false);
   });
 
-  it("adds dev:vinext, build:vinext, and start:vinext scripts", async () => {
+  it("adds dev:vinext, build:vinext, start:vinext, and deploy:vinext scripts", async () => {
     setupProject(tmpDir, { router: "app" });
 
     const { result } = await runInit(tmpDir);
@@ -804,11 +822,23 @@ export default { plugins: [vinext({ cache: { data: customData() } })] };
     expect(result.addedScripts).toContain("dev:vinext");
     expect(result.addedScripts).toContain("build:vinext");
     expect(result.addedScripts).toContain("start:vinext");
+    expect(result.addedScripts).toContain("deploy:vinext");
 
     const pkg = readPkg(tmpDir) as { scripts: Record<string, string> };
     expect(pkg.scripts["dev:vinext"]).toBe("vinext dev --port 3001");
     expect(pkg.scripts["build:vinext"]).toBe("vinext build");
     expect(pkg.scripts["start:vinext"]).toBe("vinext start");
+    expect(pkg.scripts["deploy:vinext"]).toBe("vinext-cloudflare deploy");
+  });
+
+  it("does not add deploy:vinext for Node init", async () => {
+    setupProject(tmpDir, { router: "app" });
+
+    const { result } = await runInit(tmpDir, { platform: "node" });
+
+    expect(result.addedScripts).not.toContain("deploy:vinext");
+    const pkg = readPkg(tmpDir) as { scripts: Record<string, string> };
+    expect(pkg.scripts["deploy:vinext"]).toBeUndefined();
   });
 
   it("uses custom port in dev:vinext script", async () => {
@@ -944,6 +974,7 @@ describe("init — dependency installation", () => {
         "dev:vinext": "vinext dev --port 3001",
         "build:vinext": "vinext build",
         "start:vinext": "vinext start",
+        "deploy:vinext": "vinext-cloudflare deploy",
       });
       expect(setup.viteConfigExists).toBe(true);
       expect(setup.wranglerConfigExists).toBe(true);
@@ -970,6 +1001,7 @@ describe("init — dependency installation", () => {
         "dev:vinext": "vinext dev --port 3001",
         "build:vinext": "vinext build",
         "start:vinext": "vinext start",
+        "deploy:vinext": "vinext-cloudflare deploy",
       },
     });
     expect(fs.existsSync(path.join(tmpDir, "vite.config.ts"))).toBe(true);
@@ -1290,6 +1322,7 @@ describe("init — guard rails", () => {
     expect(result.addedScripts).toContain("dev:vinext");
     expect(result.addedScripts).toContain("build:vinext");
     expect(result.addedScripts).toContain("start:vinext");
+    expect(result.addedScripts).not.toContain("deploy:vinext");
     // But vite config should be skipped
     expect(result.generatedViteConfig).toBe(false);
     expect(result.skippedViteConfig).toBe(true);

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -172,7 +172,7 @@ async function runInit(
       platform: "cloudflare",
       cloudflare: {
         dataCache: "kv",
-        cdnCache: "data-cache",
+        cdnCache: "workers-cache",
         imageOptimization: "cloudflare-images",
       },
       ...opts,
@@ -205,7 +205,7 @@ async function runInitExpectExit(dir: string, opts: Partial<InitOptions> = {}): 
       platform: "cloudflare",
       cloudflare: {
         dataCache: "kv",
-        cdnCache: "data-cache",
+        cdnCache: "workers-cache",
         imageOptimization: "cloudflare-images",
       },
       ...opts,
@@ -472,7 +472,7 @@ describe("init — basic functionality", () => {
     const config = readFile(tmpDir, "vite.config.ts");
     expect(config).toContain("vinext({");
     expect(config).toContain("data: kvDataAdapter()");
-    expect(config).not.toContain("cdn:");
+    expect(config).toContain("cdn: cdnAdapter()");
     expect(config).not.toContain("plugin-rsc");
   });
 
@@ -485,9 +485,10 @@ describe("init — basic functionality", () => {
     expect(result.generatedPlatformFiles).toEqual(["wrangler.jsonc"]);
     expect(readFile(tmpDir, "vite.config.ts")).toContain("@cloudflare/vite-plugin");
     expect(readFile(tmpDir, "vite.config.ts")).toContain("data: kvDataAdapter()");
-    expect(readFile(tmpDir, "vite.config.ts")).not.toContain("cdn:");
+    expect(readFile(tmpDir, "vite.config.ts")).toContain("cdn: cdnAdapter()");
     expect(fs.existsSync(path.join(tmpDir, "worker", "index.ts"))).toBe(false);
     expect(JSON.parse(readFile(tmpDir, "wrangler.jsonc"))).toMatchObject({
+      cache: { enabled: true },
       main: "vinext/server/fetch-handler",
     });
   });
@@ -528,6 +529,7 @@ describe("init — basic functionality", () => {
     const config = readFile(tmpDir, "vite.config.ts");
     expect(config).toContain('prerender: { routes: "*" }');
     expect(config).toContain("data: kvDataAdapter()");
+    expect(config).toContain("cdn: cdnAdapter()");
     expect(config).toContain("images: { optimizer: imagesOptimizer() }");
   });
 


### PR DESCRIPTION
## Summary
- default Cloudflare init CDN cache selection back to Workers Cache
- show CDN cache as a first-class Cloudflare init prompt before the data cache prompt
- document --cdn-cache in CLI help while preserving the data-cache opt-out
- add deploy:vinext for Cloudflare init projects using vinext-cloudflare deploy
- update generated init snapshots to include cdnAdapter(), Wrangler cache.enabled, and the Cloudflare deploy script

## Tests
- vp test run tests/init.test.ts -u
- vp test run tests/init-platform.test.ts tests/init-cloudflare.test.ts tests/init.test.ts tests/cli-args.test.ts
- vp check packages/vinext/src/init.ts packages/vinext/src/init-platform.ts packages/vinext/src/init-cloudflare.ts packages/vinext/src/cli.ts tests/init-platform.test.ts tests/init.test.ts