### PR TITLE
refactor: migrate the CLI cluster path handling to pathslash

### DIFF
--- a/packages/vinext/package.json
+++ b/packages/vinext/package.json
@@ -141,6 +141,7 @@
     "image-size": "catalog:",
     "ipaddr.js": "catalog:",
     "magic-string": "catalog:",
+    "pathslash": "catalog:",
     "vite-plugin-commonjs": "catalog:",
     "web-vitals": "catalog:"
   },

--- a/packages/vinext/src/check.ts
+++ b/packages/vinext/src/check.ts
@@ -6,10 +6,9 @@
  */
 
 import { detectPackageManager, findDir } from "./utils/project.js";
-import { normalizePathSeparators } from "./utils/path.js";
 import { parseAst, type ESTree } from "vite";
 import fs from "node:fs";
-import path from "node:path";
+import path from "pathslash";
 
 // ── Support status definitions ─────────────────────────────────────────────
 
@@ -348,11 +347,6 @@ const LIBRARY_SUPPORT: Record<string, { status: Status; detail?: string }> = {
 
 /**
  * Recursively find all source files in a directory.
- *
- * `dir` must be forward-slash, and the returned paths are forward-slash too:
- * each entry is joined with `path.posix.join`, which only stays canonical when
- * the base already is. This keeps downstream substring checks (e.g.
- * `f.includes("/api/")`) and reported paths consistent across platforms.
  */
 function findSourceFiles(
   dir: string,
@@ -363,7 +357,7 @@ function findSourceFiles(
 
   const entries = fs.readdirSync(dir, { withFileTypes: true });
   for (const entry of entries) {
-    const fullPath = path.posix.join(dir, entry.name);
+    const fullPath = path.join(dir, entry.name);
     if (entry.isDirectory()) {
       if (
         entry.name === "node_modules" ||
@@ -610,9 +604,6 @@ export function hasFreeCjsGlobal(content: string): boolean {
 
 /**
  * Scan source files for `import ... from 'next/...'` statements.
- *
- * `root` must be forward-slash: it is passed to `findSourceFiles`, which
- * requires it.
  */
 export function scanImports(root: string): CheckItem[] {
   const files = findSourceFiles(root);
@@ -641,7 +632,7 @@ export function scanImports(root: string): CheckItem[] {
         // Normalize: next/font/google -> next/font/google
         const normalized = mod === "next" ? "next" : mod;
         if (!importUsage.has(normalized)) importUsage.set(normalized, []);
-        const relFile = normalizePathSeparators(path.relative(root, file));
+        const relFile = path.relative(root, file);
         const usedInFiles = importUsage.get(normalized) ?? [];
         if (!usedInFiles.includes(relFile)) {
           usedInFiles.push(relFile);
@@ -862,9 +853,6 @@ function collectConfigKeys(source: string): ConfigKeys {
 
 /**
  * Analyze next.config.js/mjs/ts for supported and unsupported options.
- *
- * `root` must be forward-slash — joined with `path.posix.join`. Only called
- * from `runCheck`, which normalizes it.
  */
 export function analyzeConfig(root: string): CheckItem[] {
   // Mirror the Next.js-compatible set in shims/constants.ts. Accepts both
@@ -879,7 +867,7 @@ export function analyzeConfig(root: string): CheckItem[] {
   ];
   let configPath: string | null = null;
   for (const f of configFiles) {
-    const p = path.posix.join(root, f);
+    const p = path.join(root, f);
     if (fs.existsSync(p)) {
       configPath = p;
       break;
@@ -950,12 +938,9 @@ export function analyzeConfig(root: string): CheckItem[] {
 
 /**
  * Check package.json dependencies for known libraries.
- *
- * `root` must be forward-slash — joined with `path.posix.join`. Only called
- * from `runCheck`, which normalizes it.
  */
 export function checkLibraries(root: string): CheckItem[] {
-  const pkgPath = path.posix.join(root, "package.json");
+  const pkgPath = path.join(root, "package.json");
   if (!fs.existsSync(pkgPath)) return [];
 
   const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8"));
@@ -980,9 +965,6 @@ export function checkLibraries(root: string): CheckItem[] {
 
 /**
  * Check file conventions (pages, app directory, middleware, etc.)
- *
- * `root` must be forward-slash — joined with `path.posix.join` and passed to
- * `findDir`. Only called from `runCheck`, which normalizes it.
  */
 export function checkConventions(root: string): CheckItem[] {
   const items: CheckItem[] = [];
@@ -992,11 +974,10 @@ export function checkConventions(root: string): CheckItem[] {
   const appDirPath = findDir(root, "app", "src/app");
 
   const hasProxy =
-    fs.existsSync(path.posix.join(root, "proxy.ts")) ||
-    fs.existsSync(path.posix.join(root, "proxy.js"));
+    fs.existsSync(path.join(root, "proxy.ts")) || fs.existsSync(path.join(root, "proxy.js"));
   const hasMiddleware =
-    fs.existsSync(path.posix.join(root, "middleware.ts")) ||
-    fs.existsSync(path.posix.join(root, "middleware.js"));
+    fs.existsSync(path.join(root, "middleware.ts")) ||
+    fs.existsSync(path.join(root, "middleware.js"));
 
   if (pagesDir !== null) {
     const isSrc = pagesDir.includes("src/pages");
@@ -1073,7 +1054,7 @@ export function checkConventions(root: string): CheckItem[] {
   }
 
   // Check for "type": "module" in package.json
-  const pkgPath = path.posix.join(root, "package.json");
+  const pkgPath = path.join(root, "package.json");
   if (fs.existsSync(pkgPath)) {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8"));
     if (pkg.type !== "module") {
@@ -1098,7 +1079,7 @@ export function checkConventions(root: string): CheckItem[] {
   const cjsGlobalFiles: string[] = [];
   for (const file of allSourceFiles) {
     const content = fs.readFileSync(file, "utf-8");
-    const rel = normalizePathSeparators(path.relative(root, file));
+    const rel = path.relative(root, file);
 
     if (viewTransitionRegex.test(content)) {
       viewTransitionFiles.push(rel);
@@ -1121,7 +1102,7 @@ export function checkConventions(root: string): CheckItem[] {
   // Check PostCSS config for string-form plugins
   const postcssConfigs = ["postcss.config.mjs", "postcss.config.js", "postcss.config.cjs"];
   for (const configFile of postcssConfigs) {
-    const configPath = path.posix.join(root, configFile);
+    const configPath = path.join(root, configFile);
     if (fs.existsSync(configPath)) {
       const content = fs.readFileSync(configPath, "utf-8");
       // Detect string-form plugins where the first array element is a bare string
@@ -1166,10 +1147,6 @@ export function checkConventions(root: string): CheckItem[] {
 
 /**
  * Run the full compatibility check.
- *
- * `root` must be forward-slash — callers normalize it at the CLI entry, and it
- * is forwarded to `scanImports` / `checkConventions` / `findDir`, which build
- * paths with `path.posix.*`.
  */
 export function runCheck(root: string): CheckResult {
   const imports = scanImports(root);

--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -16,7 +16,7 @@
 
 import vinext from "./index.js";
 import { runPrerender } from "./build/run-prerender.js";
-import path from "node:path";
+import path, { toSlash } from "pathslash";
 import fs from "node:fs";
 import { pathToFileURL } from "node:url";
 import { createRequire } from "node:module";
@@ -51,7 +51,6 @@ import {
   tryAcquireLockfile,
 } from "./server/dev-lockfile.js";
 import { generateRouteTypes } from "./typegen.js";
-import { normalizePathSeparators } from "./utils/path.js";
 import { createDevServerConfigPlugin, normalizeDevServerHostname } from "./cli-dev-config.js";
 import {
   findVinextPrerenderConfigInPlugins,
@@ -480,8 +479,8 @@ async function buildApp() {
 
   console.log(`\n  vinext build  (Vite ${getViteVersion()})\n`);
 
-  const root = process.cwd();
-  const isApp = hasAppDir(normalizePathSeparators(root));
+  const root = toSlash(process.cwd());
+  const isApp = hasAppDir(root);
   const resolvedNextConfig = await resolveNextConfig(
     await loadNextConfig(root, PHASE_PRODUCTION_BUILD),
     root,
@@ -691,7 +690,7 @@ async function buildApp() {
     process.stdout.write("\x1b[0m");
     console.log(`  ${formatVinextPrerenderLabel(prerenderDecision)}`);
     prerenderResult = await runPrerender({
-      root: normalizePathSeparators(process.cwd()),
+      root,
       concurrency: parsed.prerenderConcurrency,
     });
   }
@@ -702,7 +701,7 @@ async function buildApp() {
   process.stdout.write("\x1b[0m");
   const { printBuildReport } = await import("./build/report.js");
   await printBuildReport({
-    root: normalizePathSeparators(process.cwd()),
+    root,
     pageExtensions: resolvedNextConfig.pageExtensions,
     prerenderResult: prerenderResult ?? undefined,
   });
@@ -838,7 +837,7 @@ async function check() {
   console.log(`\n  vinext check\n`);
   console.log("  Scanning project...\n");
 
-  const result = runCheck(normalizePathSeparators(process.cwd()));
+  const result = runCheck(toSlash(process.cwd()));
   console.log(formatReport(result));
 }
 

--- a/packages/vinext/src/init-cloudflare.ts
+++ b/packages/vinext/src/init-cloudflare.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs";
-import path from "node:path";
+import path from "pathslash";
 import MagicString from "magic-string";
 import { parseSync } from "vite";
 import type { ESTree } from "vite";

--- a/packages/vinext/src/init.ts
+++ b/packages/vinext/src/init.ts
@@ -17,7 +17,7 @@
  */
 
 import fs from "node:fs";
-import path from "node:path";
+import path from "pathslash";
 import { spawn, spawnSync } from "node:child_process";
 import { runCheck, formatReport } from "./check.js";
 import {

--- a/packages/vinext/src/typegen.ts
+++ b/packages/vinext/src/typegen.ts
@@ -1,12 +1,11 @@
 import fs from "node:fs/promises";
-import path from "node:path";
+import path from "pathslash";
 import { isInvisibleSegment } from "./routing/app-route-graph.js";
 import { appRouteGraph } from "./routing/app-router.js";
 import { patternToNextFormat } from "./routing/route-validation.js";
 import { decodeRouteSegment } from "./routing/utils.js";
 import { compareStrings } from "./utils/compare.js";
 import { findDir } from "./utils/project.js";
-import { normalizePathSeparators } from "./utils/path.js";
 
 type GenerateRouteTypesOptions = {
   root: string;
@@ -25,24 +24,22 @@ import "./.next/types/routes.d.ts";
 `;
 
 export async function generateRouteTypes(options: GenerateRouteTypesOptions): Promise<string> {
-  const root = normalizePathSeparators(path.resolve(options.root));
-  const appDir = options.appDir
-    ? normalizePathSeparators(path.resolve(options.appDir))
-    : findDir(root, "app", "src/app");
-  const outPath = path.posix.join(root, ".next", "types", "routes.d.ts");
+  const root = path.resolve(options.root);
+  const appDir = options.appDir ? path.resolve(options.appDir) : findDir(root, "app", "src/app");
+  const outPath = path.join(root, ".next", "types", "routes.d.ts");
 
   const content = appDir
     ? renderRouteTypes(await collectRouteTypeModel(appDir, options.pageExtensions))
     : renderRouteTypes(emptyRouteTypeModel());
 
-  await fs.mkdir(path.posix.dirname(outPath), { recursive: true });
+  await fs.mkdir(path.dirname(outPath), { recursive: true });
   await fs.writeFile(outPath, content, "utf-8");
   await ensureNextEnvFile(root);
   return outPath;
 }
 
 async function ensureNextEnvFile(root: string): Promise<void> {
-  const envPath = path.posix.join(root, "next-env.d.ts");
+  const envPath = path.join(root, "next-env.d.ts");
   try {
     await fs.writeFile(envPath, NEXT_ENV_FILE_CONTENT, { encoding: "utf-8", flag: "wx" });
   } catch (error) {

--- a/packages/vinext/src/utils/project.ts
+++ b/packages/vinext/src/utils/project.ts
@@ -7,7 +7,7 @@
  */
 
 import fs from "node:fs";
-import path from "node:path";
+import path from "pathslash";
 import { createRequire } from "node:module";
 
 // ─── CJS Config Handling ─────────────────────────────────────────────────────
@@ -601,14 +601,10 @@ export function getMissingDeps(
  * Return the first candidate directory (resolved against `root`) that exists,
  * or null. Used to locate conventional `app`/`pages` directories that may live
  * at the root or under `src/`.
- *
- * `root` and `candidates` must be forward-slash, and the returned path is
- * forward-slash too: the candidate is joined with `path.posix.join`, which only
- * stays canonical when its inputs already are.
  */
 export function findDir(root: string, ...candidates: string[]): string | null {
   for (const candidate of candidates) {
-    const full = path.posix.join(root, candidate);
+    const full = path.join(root, candidate);
     try {
       if (fs.statSync(full).isDirectory()) return full;
     } catch {
@@ -620,8 +616,6 @@ export function findDir(root: string, ...candidates: string[]): string | null {
 
 /**
  * Check if the project uses App Router (has an app/ directory).
- *
- * `root` must be forward-slash — it is passed straight to `findDir`.
  */
 export function hasAppDir(root: string): boolean {
   return findDir(root, "app", "src/app") !== null;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,9 @@ catalogs:
     nuqs:
       specifier: ^2.8.8
       version: 2.8.8
+    pathslash:
+      specifier: ^0.1.0
+      version: 0.1.0
     playwright:
       specifier: ^1.60.0
       version: 1.60.0
@@ -1002,6 +1005,9 @@ importers:
       magic-string:
         specifier: 'catalog:'
         version: 0.30.21
+      pathslash:
+        specifier: 'catalog:'
+        version: 0.1.0
       vite:
         specifier: npm:@voidzero-dev/vite-plus-core@0.2.1
         version: '@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0)'
@@ -7004,6 +7010,10 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pathslash@0.1.0:
+    resolution: {integrity: sha512-mJSfhMv8Ra0gN4xGqzRQ7IpUSc4v6rV+r3X5FY9HrxC9Te2ZvtZe6RPS6UDmgOVUI5DKGDHuPXRuNzhffawG2Q==}
+    engines: {node: '>=22'}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -12760,6 +12770,8 @@ snapshots:
   path-type@4.0.0: {}
 
   pathe@2.0.3: {}
+
+  pathslash@0.1.0: {}
 
   picocolors@1.1.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,8 @@ preferFrozenLockfile: true
 saveExact: true
 blockExoticSubdeps: true
 minimumReleaseAge: 1440
+minimumReleaseAgeExclude:
+  - pathslash
 
 packages:
   - apps/*
@@ -73,6 +75,7 @@ catalog:
   next-view-transitions: ^0.3.5
   nitro: npm:nitro-nightly@latest
   nuqs: ^2.8.8
+  pathslash: ^0.1.0
   playwright: ^1.60.0
   postcss: 8.5.10
   react: ^19.2.7

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -44,6 +44,7 @@ import { readPagesRouterEntrySource } from "./worker-entry-source.js";
 import { scanPublicFileRoutes } from "../packages/vinext/src/utils/public-routes.js";
 import { isUnknownRecord } from "../packages/vinext/src/utils/record.js";
 import { computeClientRuntimeMetadata } from "../packages/vinext/src/utils/client-runtime-metadata.js";
+import { normalizePathSeparators } from "../packages/vinext/src/utils/path.js";
 import {
   buildPagesClientAssetsModule,
   writePagesClientAssetsModuleIfMissing,
@@ -2608,13 +2609,17 @@ describe("findInNodeModules", () => {
   it("finds a package in the immediate node_modules", () => {
     mkdir(tmpDir, "node_modules/@cloudflare/vite-plugin");
     const result = findInNodeModules(tmpDir, "@cloudflare/vite-plugin");
-    expect(result).toBe(path.join(tmpDir, "node_modules", "@cloudflare", "vite-plugin"));
+    expect(result).toBe(
+      normalizePathSeparators(path.join(tmpDir, "node_modules", "@cloudflare", "vite-plugin")),
+    );
   });
 
   it("finds a binary in node_modules/.bin", () => {
     writeFile(tmpDir, "node_modules/.bin/wrangler", "#!/usr/bin/env node");
     const result = findInNodeModules(tmpDir, ".bin/wrangler");
-    expect(result).toBe(path.join(tmpDir, "node_modules", ".bin", "wrangler"));
+    expect(result).toBe(
+      normalizePathSeparators(path.join(tmpDir, "node_modules", ".bin", "wrangler")),
+    );
   });
 
   it("returns null when not found anywhere", () => {
@@ -2627,7 +2632,9 @@ describe("findInNodeModules", () => {
     fs.mkdirSync(appDir, { recursive: true });
 
     const result = findInNodeModules(appDir, ".bin/wrangler");
-    expect(result).toBe(path.join(tmpDir, "node_modules", ".bin", "wrangler"));
+    expect(result).toBe(
+      normalizePathSeparators(path.join(tmpDir, "node_modules", ".bin", "wrangler")),
+    );
   });
 
   it("prefers the closest node_modules when both app and root have the package", () => {
@@ -2636,7 +2643,9 @@ describe("findInNodeModules", () => {
     mkdir(appDir, "node_modules/@cloudflare/vite-plugin");
 
     const result = findInNodeModules(appDir, "@cloudflare/vite-plugin");
-    expect(result).toBe(path.join(appDir, "node_modules", "@cloudflare", "vite-plugin"));
+    expect(result).toBe(
+      normalizePathSeparators(path.join(appDir, "node_modules", "@cloudflare", "vite-plugin")),
+    );
   });
 });
 

--- a/tests/typegen.test.ts
+++ b/tests/typegen.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import vinext from "../packages/vinext/src/index.js";
 import { generateRouteTypes } from "../packages/vinext/src/typegen.js";
+import { normalizePathSeparators } from "../packages/vinext/src/utils/path.js";
 
 const EMPTY_PAGE = "export default function Page() { return null; }\n";
 const EMPTY_LAYOUT = "export default function Layout({ children }: any) { return children; }\n";
@@ -60,7 +61,7 @@ describe("generateRouteTypes", () => {
       const outputPath = await generateRouteTypes({ root });
       const generated = await readFile(outputPath, "utf-8");
 
-      expect(outputPath).toBe(path.join(root, ".next/types/routes.d.ts"));
+      expect(outputPath).toBe(normalizePathSeparators(path.join(root, ".next/types/routes.d.ts")));
       expect(generated).toContain("declare namespace VinextRouteTypes");
       expect(generated).toContain(
         'type PageRoute = "/" | "/[slug]" | "/_sites" | "/blog/[slug]" | "/dashboard" | "/docs/[...slug]" | "/shop/[[...slug]]";',


### PR DESCRIPTION
## What

First batch of the `node:path` → [`pathslash`](https://github.com/shulaoda/pathslash) migration. Introduces the dependency and migrates the self-contained CLI cluster:

- `packages/vinext/src/typegen.ts`
- `packages/vinext/src/check.ts`
- `packages/vinext/src/cli.ts`
- `packages/vinext/src/init.ts`
- `packages/vinext/src/init-cloudflare.ts`
- `packages/vinext/src/utils/project.ts`

## Why

The forward-slash invariant currently lives in JSDoc prose ("`root` must be forward-slash — callers normalize it at the CLI entry…") and has to be restated and hand-maintained at every hop, which produced a five-week, 50+-commit whack-a-mole campaign. `pathslash` turns that convention into an API guarantee: it delegates every operation to the real `node:path` (drive letters, per-drive cwd, case-insensitive `relative` all keep native semantics) and only converts Windows output separators to `/`. Once a module imports it, every `join`/`resolve`/`relative`/`dirname` result is canonical forward-slash by construction, so the per-function contracts, the `path.posix.*` rewrites, and the `normalizePathSeparators(...)` wrappers all become unnecessary in migrated code.

Notably, `pathslash.relative` bakes in the rule this repo learned the hard way in #2308: relativize natively, then normalize the output (`E:/...` paths are not POSIX-absolute, so `path.posix.relative` was a dead end).

## How

- `import path from "node:path"` → `import path from "pathslash"` in the six files.
- `path.posix.join/dirname` → `path.join/dirname`; `normalizePathSeparators(path.resolve/relative(...))` → bare `path.resolve/relative(...)`.
- Raw `process.cwd()` reads that never pass through a path API are normalized once at the entry with `toSlash` (build command root, `check` root); `runPrerender`/`printBuildReport` now reuse the already-canonical `root` instead of re-reading and re-normalizing `process.cwd()`.
- Obsolete "must be forward-slash" JSDoc contracts removed outright — the guarantee now lives in the `pathslash` import, not in per-function prose. Contracts on unmigrated files stay until their batch migrates them.
- `init-cloudflare.ts` still emits `import path from "node:path"` literals into _generated user configs_ — those are intentionally untouched.
- `utils/path.ts` (`normalizePathSeparators`) stays: unmigrated files and tests still consume it; it is deleted in the final batch.
- Workspace: `pathslash@^0.1.0` added via catalog; `minimumReleaseAgeExclude` added since it is our own package and the release-age quarantine only delays dogfooding fresh releases.
- Tests keep building inputs with native `node:path` and pin the new output contract by wrapping expectations in `normalizePathSeparators` (5 expectations in `tests/deploy.test.ts` / `tests/typegen.test.ts` — `findInNodeModules` and the typegen `outPath` now return forward-slash on Windows). Keeping tests on `node:path` is deliberate: on a Windows machine the inputs stay backslash, so a source regression that stops normalizing still fails.

## Testing

- `vp check` green (format + lint + types, 1063 files).
- `tests/{check,typegen,init,deploy}.test.ts`: 522/522 pass on Windows.
- Full unit suite compared against a clean `HEAD` baseline worktree on the same Windows machine: identical failure sets (61 pre-existing Windows long-tail failures in unmigrated areas — routing/app-route-graph/scss/build — with a ±4 flaky churn between runs that also flips within the same tree). Zero new failures attributable to this change.
- Adversarial multi-agent review over the diff (call-site equivalence, downstream consumers, test masking, Windows edge cases): no semantic issues; two minor **pre-existing** coverage gaps noted for follow-up — CI runs vitest on ubuntu only, and `cli.ts` root normalization has no direct test (extending the windows-latest smoke job with `vinext check` would close both cheaply).
