### PR TITLE
fix(benchmark): render fork benchmark comments without dashboard uploads

### DIFF
--- a/benchmarks/perf/format-pr-comment.mjs
+++ b/benchmarks/perf/format-pr-comment.mjs
@@ -13,26 +13,28 @@ if (results.run.kind !== "pull_request") {
   process.exit(0);
 }
 
-const response = JSON.parse(await readFile(responsePath, "utf8"));
-const uploadedComparison = response.comparison;
-if (!uploadedComparison)
-  throw new Error("Performance upload response did not include a comparison");
-
 const resultBenchmarks = Array.isArray(results.benchmarks) ? results.benchmarks : [];
 const resultsByBenchmark = new Map(
   resultBenchmarks.map((benchmark) => [benchmark.benchmarkId, benchmark]),
 );
+const response = await readUploadResponse(responsePath);
+const uploadedComparison = response.comparison;
+if (!uploadedComparison && resultBenchmarks.length === 0) {
+  await writeFile(outputPath, "");
+  process.exit(0);
+}
 const hasPairedBaseline = resultBenchmarks.some((benchmark) => benchmark.baselineSamples);
+const comparisonSource = uploadedComparison ?? localComparison(resultBenchmarks);
 const comparison = {
-  ...uploadedComparison,
+  ...comparisonSource,
   baseline: hasPairedBaseline
     ? {
         sha: results.run.baseSha,
-        shortSha: results.run.baseSha.slice(0, 7),
+        shortSha: shortSha(results.run.baseSha),
         measuredAt: results.run.measuredAt,
       }
-    : uploadedComparison.baseline,
-  measurements: uploadedComparison.measurements.map((measurement) => {
+    : comparisonSource.baseline,
+  measurements: comparisonSource.measurements.map((measurement) => {
     const benchmark = resultsByBenchmark.get(measurement.benchmarkId);
     return benchmark?.baselineSamples
       ? {
@@ -62,6 +64,46 @@ function formatValue(value, unit) {
     return `${(value / (1024 * 1024)).toFixed(2)} MB`;
   }
   return `${Number(value.toFixed(2))} ${unit}`;
+}
+
+function shortSha(sha) {
+  return typeof sha === "string" && sha.length > 0 ? sha.slice(0, 7) : "unknown";
+}
+
+async function readUploadResponse(path) {
+  try {
+    return JSON.parse(await readFile(path, "utf8"));
+  } catch (error) {
+    if (error?.code === "ENOENT") return { uploaded: false, reason: "missing_response" };
+    throw error;
+  }
+}
+
+function localComparison(benchmarks) {
+  return {
+    uploaded: false,
+    head: {
+      sha: results.run.commitSha,
+      shortSha: shortSha(results.run.commitSha),
+      measuredAt: results.run.measuredAt,
+    },
+    baseline: results.run.baseSha
+      ? {
+          sha: results.run.baseSha,
+          shortSha: shortSha(results.run.baseSha),
+          measuredAt: results.run.measuredAt,
+        }
+      : null,
+    measurements: benchmarks.map((benchmark) => ({
+      benchmarkId: benchmark.benchmarkId,
+      label: benchmark.label,
+      implementationLabel: benchmark.implementationLabel,
+      unit: benchmark.unit,
+      lowerIsBetter: benchmark.lowerIsBetter,
+      baseline: benchmark.baselineSamples,
+      current: benchmark.samples,
+    })),
+  };
 }
 
 function measurementChange(measurement) {
@@ -115,7 +157,9 @@ const hasCurrentOnlyMeasurement = comparison.measurements.some(
   (measurement) =>
     !measurement.baseline && !resultsByBenchmark.get(measurement.benchmarkId)?.baselineSamples,
 );
-const dashboardUrl = `https://vinext.dev/benchmarks/pull/${results.run.pullRequest}`;
+const dashboardUrl = uploadedComparison
+  ? `https://vinext.dev/benchmarks/pull/${results.run.pullRequest}`
+  : null;
 const rows = measurements.map((measurement) =>
   [
     escapeCell(measurement.label),
@@ -140,7 +184,7 @@ const body = [
             : `Compared \`${comparison.head.shortSha}\` against base \`${comparison.baseline.shortSha}\`. Paired benchmarks use alternating same-runner rounds; unpaired benchmarks have no baseline.${skippedNextjs ? " Next.js was unchanged and skipped." : ""}`
         : `Compared \`${comparison.head.shortSha}\` against base \`${comparison.baseline.shortSha}\` using alternating same-runner rounds.${skippedNextjs ? " Next.js was unchanged and skipped." : ""}`
       : `Compared \`${comparison.head.shortSha}\` against base \`${comparison.baseline.shortSha}\`.`
-    : `Measured \`${comparison.head.shortSha}\`. No benchmark run is available for base \`${results.run.baseSha.slice(0, 7)}\`.`,
+    : `Measured \`${comparison.head.shortSha}\`. No benchmark run is available for base \`${shortSha(results.run.baseSha)}\`.`,
   "",
   comparison.baseline
     ? `**${improvements} improved · ${regressions} regressed · ${neutral} within ±1.5%**`
@@ -150,7 +194,9 @@ const body = [
   "|---|---|---:|---:|---:|",
   ...rows.map((row) => `| ${row} |`),
   "",
-  `[View detailed results and traces](${dashboardUrl})`,
+  dashboardUrl
+    ? `[View detailed results and traces](${dashboardUrl})`
+    : "Dashboard upload was unavailable for this run.",
   "",
   `<sub>🟢 improvement · 🔴 regression · ⚫ change below 1.5%${
     hasPairedBaseline

--- a/benchmarks/perf/format-pr-comment.mjs
+++ b/benchmarks/perf/format-pr-comment.mjs
@@ -31,7 +31,7 @@ const comparison = {
     ? {
         sha: results.run.baseSha,
         shortSha: shortSha(results.run.baseSha),
-        measuredAt: results.run.measuredAt,
+        measuredAt: comparisonSource.baseline?.measuredAt ?? null,
       }
     : comparisonSource.baseline,
   measurements: comparisonSource.measurements.map((measurement) => {
@@ -74,12 +74,17 @@ async function readUploadResponse(path) {
   try {
     return JSON.parse(await readFile(path, "utf8"));
   } catch (error) {
+    // The skipped-upload fields are diagnostic metadata; comment formatting is
+    // gated by the presence of a dashboard comparison.
     if (error?.code === "ENOENT") return { uploaded: false, reason: "missing_response" };
     throw error;
   }
 }
 
 function localComparison(benchmarks) {
+  const hasLocalBaseline =
+    results.run.baseSha && benchmarks.some((benchmark) => benchmark.baselineSamples);
+
   return {
     uploaded: false,
     head: {
@@ -87,11 +92,11 @@ function localComparison(benchmarks) {
       shortSha: shortSha(results.run.commitSha),
       measuredAt: results.run.measuredAt,
     },
-    baseline: results.run.baseSha
+    baseline: hasLocalBaseline
       ? {
           sha: results.run.baseSha,
           shortSha: shortSha(results.run.baseSha),
-          measuredAt: results.run.measuredAt,
+          measuredAt: null,
         }
       : null,
     measurements: benchmarks.map((benchmark) => ({

--- a/benchmarks/perf/upload-results.mjs
+++ b/benchmarks/perf/upload-results.mjs
@@ -11,8 +11,17 @@ const secret = process.env.COMPAT_INGEST_SECRET;
 const artifactRoot = process.env.VINEXT_PERF_ARTIFACT_ROOT
   ? resolve(process.env.VINEXT_PERF_ARTIFACT_ROOT)
   : null;
+const uploadResponsePath = process.env.VINEXT_PERF_UPLOAD_RESPONSE_PATH
+  ? resolve(process.env.VINEXT_PERF_UPLOAD_RESPONSE_PATH)
+  : null;
 
 if (!secret) {
+  if (uploadResponsePath) {
+    await writeFile(
+      uploadResponsePath,
+      `${JSON.stringify({ uploaded: false, reason: "missing_secret" })}\n`,
+    );
+  }
   console.log("COMPAT_INGEST_SECRET is not configured; skipping performance upload.");
   process.exit(0);
 }
@@ -116,8 +125,8 @@ try {
   const responseBody = await uploadMetadata();
   metadataCommitted = true;
 
-  if (process.env.VINEXT_PERF_UPLOAD_RESPONSE_PATH) {
-    await writeFile(resolve(process.env.VINEXT_PERF_UPLOAD_RESPONSE_PATH), `${responseBody}\n`);
+  if (uploadResponsePath) {
+    await writeFile(uploadResponsePath, `${responseBody}\n`);
   }
   console.log(responseBody);
 } catch (error) {

--- a/tests/performance-benchmarks.test.ts
+++ b/tests/performance-benchmarks.test.ts
@@ -649,7 +649,7 @@ describe("paired performance benchmarks", () => {
     });
   });
 
-  it("renders paired PR comments without a dashboard upload response", () => {
+  it("renders paired PR comments when the dashboard upload response is missing", () => {
     const directory = mkdtempSync(join(tmpdir(), "vinext-perf-local-comment-"));
     const resultsPath = join(directory, "results.json");
     const responsePath = join(directory, "response.json");
@@ -677,7 +677,6 @@ describe("paired performance benchmarks", () => {
         ],
       }),
     );
-    writeFileSync(responsePath, JSON.stringify({ uploaded: false, reason: "missing_secret" }));
 
     execFileSync(
       process.execPath,

--- a/tests/performance-benchmarks.test.ts
+++ b/tests/performance-benchmarks.test.ts
@@ -692,6 +692,49 @@ describe("paired performance benchmarks", () => {
     expect(comment).not.toContain("View detailed results and traces");
   });
 
+  it("does not summarize unpaired local PR comments as baseline comparisons", () => {
+    const directory = mkdtempSync(join(tmpdir(), "vinext-perf-unpaired-local-comment-"));
+    const resultsPath = join(directory, "results.json");
+    const responsePath = join(directory, "response.json");
+    const outputPath = join(directory, "comment.md");
+    writeFileSync(
+      resultsPath,
+      JSON.stringify({
+        run: {
+          kind: "pull_request",
+          pullRequest: 42,
+          commitSha: "a".repeat(40),
+          baseSha: "b".repeat(40),
+          measuredAt: "2026-01-01T00:00:00.000Z",
+        },
+        benchmarks: [
+          {
+            benchmarkId: "vinext-production-build",
+            label: "Production build time",
+            implementationLabel: "vinext",
+            unit: "ms",
+            lowerIsBetter: true,
+            samples: { median: 90 },
+          },
+        ],
+      }),
+    );
+
+    execFileSync(
+      process.execPath,
+      ["benchmarks/perf/format-pr-comment.mjs", resultsPath, responsePath, outputPath],
+      { cwd: join(import.meta.dirname, "..") },
+    );
+
+    const comment = readFileSync(outputPath, "utf8");
+    expect(comment).toContain(
+      "Measured `aaaaaaa`. No benchmark run is available for base `bbbbbbb`.",
+    );
+    expect(comment).toContain("1 measurements recorded · baseline unavailable");
+    expect(comment).toContain("| Production build time | vinext | — | 90 ms | New |");
+    expect(comment).not.toContain("0 improved · 0 regressed · 0 within ±1.5%");
+  });
+
   it("labels mixed paired and historical PR comment baselines", () => {
     const directory = mkdtempSync(join(tmpdir(), "vinext-perf-mixed-comment-"));
     const resultsPath = join(directory, "results.json");

--- a/tests/performance-benchmarks.test.ts
+++ b/tests/performance-benchmarks.test.ts
@@ -628,6 +628,71 @@ describe("paired performance benchmarks", () => {
     expect(comment).not.toContain("Next.js |");
   });
 
+  it("writes a skipped upload response when the dashboard secret is unavailable", () => {
+    const directory = mkdtempSync(join(tmpdir(), "vinext-perf-upload-skip-"));
+    const resultsPath = join(directory, "results.json");
+    const responsePath = join(directory, "response.json");
+    writeFileSync(resultsPath, JSON.stringify({ benchmarks: [] }));
+
+    execFileSync(process.execPath, ["benchmarks/perf/upload-results.mjs", resultsPath], {
+      cwd: join(import.meta.dirname, ".."),
+      env: {
+        ...process.env,
+        COMPAT_INGEST_SECRET: "",
+        VINEXT_PERF_UPLOAD_RESPONSE_PATH: responsePath,
+      },
+    });
+
+    expect(JSON.parse(readFileSync(responsePath, "utf8"))).toEqual({
+      uploaded: false,
+      reason: "missing_secret",
+    });
+  });
+
+  it("renders paired PR comments without a dashboard upload response", () => {
+    const directory = mkdtempSync(join(tmpdir(), "vinext-perf-local-comment-"));
+    const resultsPath = join(directory, "results.json");
+    const responsePath = join(directory, "response.json");
+    const outputPath = join(directory, "comment.md");
+    writeFileSync(
+      resultsPath,
+      JSON.stringify({
+        run: {
+          kind: "pull_request",
+          pullRequest: 42,
+          commitSha: "a".repeat(40),
+          baseSha: "b".repeat(40),
+          measuredAt: "2026-01-01T00:00:00.000Z",
+        },
+        benchmarks: [
+          {
+            benchmarkId: "vinext-production-build",
+            label: "Production build time",
+            implementationLabel: "vinext",
+            unit: "ms",
+            lowerIsBetter: true,
+            samples: { median: 90 },
+            baselineSamples: { median: 100 },
+          },
+        ],
+      }),
+    );
+    writeFileSync(responsePath, JSON.stringify({ uploaded: false, reason: "missing_secret" }));
+
+    execFileSync(
+      process.execPath,
+      ["benchmarks/perf/format-pr-comment.mjs", resultsPath, responsePath, outputPath],
+      { cwd: join(import.meta.dirname, "..") },
+    );
+
+    const comment = readFileSync(outputPath, "utf8");
+    expect(comment).toContain("Compared `aaaaaaa` against base `bbbbbbb`");
+    expect(comment).toContain("1 improved · 0 regressed · 0 within ±1.5%");
+    expect(comment).toContain("| Production build time | vinext | 100 ms | 90 ms |");
+    expect(comment).toContain("Dashboard upload was unavailable for this run.");
+    expect(comment).not.toContain("View detailed results and traces");
+  });
+
   it("labels mixed paired and historical PR comment baselines", () => {
     const directory = mkdtempSync(join(tmpdir(), "vinext-perf-mixed-comment-"));
     const resultsPath = join(directory, "results.json");


### PR DESCRIPTION
## Overview

| Area | Details |
|---|---|
| Goal | Let fork PR benchmark publisher runs produce GitHub comments without requiring the private dashboard ingest secret. |
| Core change | Missing dashboard uploads now produce an explicit skipped-upload response, and the formatter can render paired PR comparisons directly from `perf-results.json`. |
| Primary files | `benchmarks/perf/upload-results.mjs`, `benchmarks/perf/format-pr-comment.mjs`, `tests/performance-benchmarks.test.ts` |
| Expected impact | Upstream dashboard-backed comments keep the existing path. Fork PR publisher runs can still generate local comparison comments when dashboard upload is unavailable. |

## Why

The trusted publisher validates benchmark artifacts before publishing, but fork repositories do not have `COMPAT_INGEST_SECRET`. That missing secret is a valid capability boundary, not a benchmark failure. The publisher should skip dashboard upload while still using the paired samples already present in the validated PR artifact.

| Area | Principle / invariant | What this PR changes |
|---|---|---|
| Dashboard upload | Writing to the shared benchmark dashboard requires the ingest secret. | The uploader records `{ "uploaded": false, "reason": "missing_secret" }` instead of silently omitting the response file. |
| PR comments | Comment rendering should depend on validated benchmark data, not on private dashboard access. | The formatter derives paired rows from `baselineSamples` and `samples` when no dashboard comparison is available. |
| Existing upstream path | Dashboard-backed upstream comments should remain unchanged. | If the upload response includes `comparison`, the existing dashboard comparison and link are still used. |

## What changed

| Scenario | Before | After |
|---|---|---|
| Fork PR without `COMPAT_INGEST_SECRET` | Upload skipped, `performance-upload.json` was absent, and `format-pr-comment.mjs` failed with `ENOENT`. | Upload skip is explicit, and the formatter can render from the local paired artifact. |
| Missing upload response file | The formatter crashed while reading the response. | The formatter treats `ENOENT` as a skipped upload and falls back to local paired comparison data. |
| Dashboard upload succeeds | Formatter used uploaded comparison data and linked detailed traces. | Same behavior. |

## Validation

- `vp test run --project unit tests/performance-benchmarks.test.ts`
- `vp check tests/performance-benchmarks.test.ts benchmarks/perf/format-pr-comment.mjs benchmarks/perf/upload-results.mjs`
- `git diff --check`

## References

| Link | Why it matters |
|---|---|
| https://github.com/NathanDrake2406/vinext/actions/runs/28583352418 | Original fork publisher failure: validation passed, dashboard upload skipped, comment formatter failed on missing `performance-upload.json`. |
| https://github.com/NathanDrake2406/vinext/actions/runs/28584440974/job/84752398100 | Confirms workflow_run publisher checks out the fork default branch, so branch-only fork PRs cannot test the trusted publisher fix before it lands on `main`. |
