### PR TITLE
feat(build): require Vite 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Use `--env <name>` to target `wrangler.jsonc` `env.<name>`. `--preview` is short
 The init command also auto-detects and fixes common migration issues:
 
 - Adds `"type": "module"` to package.json if missing
-- Resolves tsconfig.json path aliases automatically (via `vite-tsconfig-paths`)
+- Resolves tsconfig.json path aliases automatically with Vite's native resolver
 - Detects MDX usage and configures `@mdx-js/rollup`
 - Renames CJS config files (postcss.config.js, etc.) to `.cjs` when needed
 - Detects native Node.js modules (sharp, resvg, satori, lightningcss, @napi-rs/canvas) and auto-stubs them for Workers. If you encounter others that need stubbing, PRs are welcome.
@@ -619,7 +619,6 @@ These are gaps we'd like to close — distinct from the [intentional exclusions]
 - **Route segment config** — `runtime` and `preferredRegion` are ignored (everything runs in the same environment).
 - **Node.js production server (`vinext start`)** works for testing but is less complete than Workers deployment. Cloudflare Workers is the primary target.
 - **Native Node modules (sharp, resvg, satori, lightningcss, @napi-rs/canvas)** crash Vite's RSC dev environment. Dynamic OG image/icon routes using these work in production builds but not in dev mode. These are auto-stubbed during `@vinext/cloudflare deploy`.
-- **`next.config.ts` `baseUrl` bare imports require Vite 8.** A `next.config.ts` that imports a bare specifier resolved through `tsconfig.json`'s `compilerOptions.baseUrl` (e.g. `import { bar } from "bar"` resolving to a local `bar.ts`) relies on Vite 8's native `resolve.tsconfigPaths` (Rolldown/oxc-resolver). On Vite 7 there is no native equivalent, so these imports are not resolved. `compilerOptions.paths` aliases (e.g. `@/foo`) work on both Vite 7 and 8. Note that if a bare import matches both a `baseUrl`-local file and an installed package of the same name, the installed package wins (vinext keeps packages externalized so CJS config plugins like `@next/mdx` keep working).
 
 ## Benchmarks
 
@@ -642,7 +641,7 @@ Benchmarks run on GitHub CI runners (2-core Ubuntu) on every merge to `main`. Se
 
 Analysis of the build output shows two main factors:
 
-1. **Tree-shaking**: Vite/Rollup produces a smaller React+ReactDOM bundle than Next.js/Turbopack. Rollup's more aggressive dead-code elimination accounts for roughly half the overall difference.
+1. **Tree-shaking**: Vite/Rolldown produces a smaller React+ReactDOM bundle than Next.js/Turbopack. Rolldown's more aggressive dead-code elimination accounts for roughly half the overall difference.
 2. **Framework overhead**: Next.js ships more client-side infrastructure (router, Turbopack runtime loader, prefetching, error handling) than vinext's lighter client runtime.
 
 Both frameworks ship the same app code and the same RSC client runtime (`react-server-dom-webpack`). The difference is in how much of React's internals survive tree-shaking and how much framework plumbing each tool adds.
@@ -769,7 +768,7 @@ Or add it to your `package.json` as a file dependency:
 }
 ```
 
-vinext has peer dependencies on `react ^19.2.6`, `react-dom ^19.2.6`, `react-server-dom-webpack ^19.2.6`, and `vite ^7.0.0 || ^8.0.0`. Then replace `next` with `vinext` in your scripts and run as normal.
+vinext has peer dependencies on `react ^19.2.6`, `react-dom ^19.2.6`, `react-server-dom-webpack ^19.2.6`, and `vite ^8.0.0`. Then replace `next` with `vinext` in your scripts and run as normal.
 
 ## Contributing
 

--- a/packages/vinext/package.json
+++ b/packages/vinext/package.json
@@ -154,8 +154,7 @@
     "am-i-vibing": "catalog:",
     "react-server-dom-webpack": "catalog:",
     "vite": "catalog:",
-    "vite-plus": "catalog:",
-    "vite-tsconfig-paths": "catalog:"
+    "vite-plus": "catalog:"
   },
   "peerDependencies": {
     "@mdx-js/rollup": "^3.0.0",
@@ -164,8 +163,7 @@
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-server-dom-webpack": "^19.2.6",
-    "vite": "^7.0.0 || ^8.0.0",
-    "vite-tsconfig-paths": "^6.1.1"
+    "vite": "^8.0.0"
   },
   "peerDependenciesMeta": {
     "@mdx-js/rollup": {
@@ -175,9 +173,6 @@
       "optional": true
     },
     "react-server-dom-webpack": {
-      "optional": true
-    },
-    "vite-tsconfig-paths": {
       "optional": true
     }
   },

--- a/packages/vinext/src/build/client-build-config.ts
+++ b/packages/vinext/src/build/client-build-config.ts
@@ -7,15 +7,6 @@ type ClientAssetFileNameInfo = {
   readonly originalFileNames?: readonly string[];
 };
 
-type RscFrameworkModuleInfo = {
-  importers: string[];
-  isEntry: boolean;
-};
-
-type RscFrameworkManualChunksMeta = {
-  getModuleInfo(id: string): RscFrameworkModuleInfo | null;
-};
-
 const ROUTE_OWNED_CLIENT_SHIMS = new Set([
   "compat-router",
   "dynamic",
@@ -112,7 +103,7 @@ function getPackageName(id: string): string | null {
  *   mobile devices.
  * - No major Vite-based framework (Remix, SvelteKit, Astro, TanStack)
  *   uses per-package splitting. Next.js only isolates packages >160KB.
- * - Rollup's graph-based splitting already handles the common case
+ * - The bundler's graph-based splitting already handles the common case
  *   well: shared dependencies between routes get their own chunks,
  *   and route-specific code stays in route chunks.
  */
@@ -128,7 +119,7 @@ export function createClientManualChunks(shimsDir: string, preserveRouteBoundari
       if (pkg === "react" || pkg === "react-dom" || pkg === "scheduler") {
         return "framework";
       }
-      // Let Rollup handle all other vendor code via its default
+      // Let the bundler handle all other vendor code via its default
       // graph-based splitting. This produces a reasonable number of
       // shared chunks (typically 5-15) based on actual import patterns,
       // with good compression efficiency.
@@ -149,32 +140,11 @@ export function createClientManualChunks(shimsDir: string, preserveRouteBoundari
   };
 }
 
-/**
- * Rollup output config with manualChunks for client code-splitting.
- * Used by both CLI builds and multi-environment builds.
- *
- * experimentalMinChunkSize merges tiny shared chunks (< 10KB) back into
- * their importers. This reduces HTTP request count and improves gzip
- * compression efficiency — small files restart the compression dictionary,
- * adding ~5-15% wire overhead vs fewer larger chunks.
- */
 export function createClientFileNameConfig(assetsDir: string) {
   const chunksDir = `${assetsDir}/chunks`;
   return {
     entryFileNames: `${chunksDir}/[name]-[hash].js`,
     chunkFileNames: `${chunksDir}/[name]-[hash].js`,
-  };
-}
-
-export function createClientOutputConfig(
-  clientManualChunks: (id: string) => string | undefined,
-  assetsDir: string,
-) {
-  return {
-    ...createClientFileNameConfig(assetsDir),
-    assetFileNames: createClientAssetFileNames(assetsDir),
-    manualChunks: clientManualChunks,
-    experimentalMinChunkSize: 10_000,
   };
 }
 
@@ -234,142 +204,54 @@ export function isRscFrameworkModule(id: string): boolean {
   return pkg !== null && (FRAMEWORK_PACKAGES as readonly string[]).includes(pkg);
 }
 
-function isStaticallyReachableFromEntry(
-  id: string,
-  meta: RscFrameworkManualChunksMeta,
-  visited = new Set<string>(),
-): boolean {
-  if (visited.has(id)) return false;
-  visited.add(id);
-
-  const moduleInfo = meta.getModuleInfo(id);
-  if (!moduleInfo) return false;
-  if (moduleInfo.isEntry) return true;
-  return moduleInfo.importers.some((importer) =>
-    isStaticallyReachableFromEntry(importer, meta, visited),
-  );
-}
-
 /**
  * Output config that isolates React (and the RSC flight runtime) into a
- * dedicated "framework" chunk in the RSC server build. Returns the bundler-
- * appropriate shape: rolldown's `codeSplitting` for Vite 8+, Rollup's
- * `manualChunks` for Vite 7. See {@link RSC_FRAMEWORK_CHUNK_TEST} for the
- * motivation (issue #1549). Framework modules that are only reachable through
- * dynamic imports must stay out of the eager framework chunk (issue #2073).
+ * dedicated "framework" chunk in the RSC server build. See
+ * {@link RSC_FRAMEWORK_CHUNK_TEST} for the motivation (issue #1549). Framework
+ * modules that are only reachable through dynamic imports must stay out of the
+ * eager framework chunk (issue #2073).
  */
-export function createRscFrameworkChunkOutputConfig(viteMajorVersion: number) {
-  if (viteMajorVersion >= 8) {
-    return {
-      codeSplitting: {
-        groups: [
-          {
-            name: "framework",
-            test: RSC_FRAMEWORK_CHUNK_TEST,
-            // Split by the entries that use each module so lazy framework
-            // imports cannot become eager Worker-startup dependencies (#2073).
-            entriesAware: true,
-          },
-        ],
-      },
-    };
-  }
+export function createRscFrameworkChunkOutputConfig() {
   return {
-    manualChunks(id: string, meta: RscFrameworkManualChunksMeta): string | undefined {
-      return isRscFrameworkModule(id) && isStaticallyReachableFromEntry(id, meta)
-        ? "framework"
-        : undefined;
+    codeSplitting: {
+      groups: [
+        {
+          name: "framework",
+          test: RSC_FRAMEWORK_CHUNK_TEST,
+          // Split by the entries that use each module so lazy framework
+          // imports cannot become eager Worker-startup dependencies (#2073).
+          entriesAware: true,
+        },
+      ],
     },
   };
 }
 
 /**
- * Rollup treeshake configuration for production client builds.
- *
- * Uses the 'recommended' preset as a safe base, then overrides
- * moduleSideEffects to strip unused re-exports from npm packages.
- *
- * The 'no-external' value for moduleSideEffects means:
- * - Local project modules: preserve side effects (CSS imports, polyfills)
- * - node_modules packages: treat as side-effect-free unless exports are used
- *
- * This is the single highest-impact optimization for large barrel-exporting
- * libraries like mermaid, @mui/material, lucide-react, etc. These libraries
- * re-export hundreds of sub-modules through barrel files. Without this,
- * Rollup preserves every sub-module even when only a few exports are consumed.
- *
- * Why 'no-external' instead of false (global side-effect-free)?
- * - User code may rely on import-time side effects (e.g., `import './global.css'`)
- * - 'no-external' is safe for app code while still enabling aggressive DCE for deps
- *
- * Why not the 'smallest' preset?
- * - 'smallest' also sets propertyReadSideEffects: false and
- *   tryCatchDeoptimization: false, which can break specific libraries
- *   that rely on property access side effects or try/catch for feature detection
- * - 'recommended' + 'no-external' gives most of the benefit with less risk
- *
- * @deprecated Use getClientTreeshakeConfigForVite(viteMajorVersion) instead
- * for Vite version compatibility. Kept for backward compatibility.
- */
-export const clientTreeshakeConfig = {
-  preset: "recommended" as const,
-  moduleSideEffects: "no-external" as const,
-};
-
-/**
- * Returns treeshake configuration appropriate for the Vite version.
- *
- * Rollup (Vite 7) supports presets like "recommended" which set multiple
- * treeshake options at once. Rolldown (Vite 8+) doesn't support presets,
- * so we only return moduleSideEffects for Vite 8+.
- *
- * The Rollup "recommended" preset sets:
- * - annotations: true (Rolldown default is also true)
- * - manualPureFunctions: [] (Rolldown default is also [])
- * - propertyReadSideEffects: true (Rolldown equivalent is 'always', the default)
- * - unknownGlobalSideEffects: false (Rolldown default is true — this is a known acceptable
- *   divergence. Slightly less aggressive DCE on unknown globals, acceptable for client bundles)
- * - correctVarValueBeforeDeclaration and tryCatchDeoptimization (Rolldown handles these differently)
+ * Returns Rolldown treeshake configuration for production client builds.
  *
  * The key optimization is moduleSideEffects: "no-external", which is supported
- * by both bundlers and provides the DCE benefits for barrel-exporting libraries.
- * It treats node_modules as side-effect-free (enabling aggressive DCE) while
- * preserving side effects in local code.
+ * by Rolldown and provides the DCE benefits for barrel-exporting libraries. It
+ * treats node_modules as side-effect-free while preserving side effects in
+ * local code.
  */
-export function getClientTreeshakeConfigForVite(viteMajorVersion: number) {
-  if (viteMajorVersion >= 8) {
-    // Rolldown (Vite 8+) - no preset support, only specific options.
-    // Rolldown's built-in defaults already cover what Rollup's 'recommended'
-    // preset provides (annotations, correctContext, tryCatchDeoptimization).
-    return {
-      moduleSideEffects: "no-external" as const,
-    };
-  }
-  // Rollup (Vite 7) - supports presets for convenient option grouping
+export function getClientTreeshakeConfig() {
   return {
-    preset: "recommended" as const,
     moduleSideEffects: "no-external" as const,
   };
 }
 
 type VinextBuildConfig = NonNullable<UserConfig["build"]>;
 type VinextBuildBundlerOptions = NonNullable<VinextBuildConfig["rolldownOptions"]>;
-type VinextBuildConfigWithLegacy = VinextBuildConfig & {
-  rollupOptions?: VinextBuildBundlerOptions;
-};
 
 export function getBuildBundlerOptions(
   build: UserConfig["build"] | undefined,
 ): VinextBuildBundlerOptions | undefined {
-  const buildConfig = build as VinextBuildConfigWithLegacy | undefined;
-  return buildConfig?.rolldownOptions ?? buildConfig?.rollupOptions;
+  return build?.rolldownOptions;
 }
 
 export function withBuildBundlerOptions(
-  viteMajorVersion: number,
   bundlerOptions: VinextBuildBundlerOptions,
-): Partial<VinextBuildConfigWithLegacy> {
-  return viteMajorVersion >= 8
-    ? { rolldownOptions: bundlerOptions }
-    : { rollupOptions: bundlerOptions };
+): Partial<VinextBuildConfig> {
+  return { rolldownOptions: bundlerOptions };
 }

--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -473,10 +473,10 @@ async function buildApp() {
   applyViteConfigCompatibility(process.cwd());
 
   const vite = await loadVite();
-  const viteMajorVersion = Number.parseInt(vite.version, 10) || 7;
 
-  const withBuildBundlerOptions = (bundlerOptions: Record<string, unknown>) =>
-    viteMajorVersion >= 8 ? { rolldownOptions: bundlerOptions } : { rollupOptions: bundlerOptions };
+  const withBuildBundlerOptions = (bundlerOptions: Record<string, unknown>) => ({
+    rolldownOptions: bundlerOptions,
+  });
 
   console.log(`\n  vinext build  (Vite ${getViteVersion()})\n`);
 
@@ -622,8 +622,6 @@ async function buildApp() {
               // @vitejs/plugin-rsc and its sub-plugins — App Router only
               !p.name.startsWith("rsc:") &&
               p.name !== "vite-rsc-load-module-dev-proxy" &&
-              // vite-tsconfig-paths — auto-registered by vinext
-              p.name !== "vite-tsconfig-paths" &&
               // cloudflare() — injects multi-env environments block which
               // conflicts with the plain SSR build config below
               !p.name.startsWith("vite-plugin-cloudflare"),

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -16,7 +16,6 @@ import { getHtmlLimitedBotRegex } from "../utils/html-limited-bots.js";
 import { isUnknownRecord } from "../utils/record.js";
 import { applyLocaleToRoutes, isExternalUrl } from "./config-matchers.js";
 import { loadTsconfigResolutionForRoot } from "./tsconfig-paths.js";
-import { getViteMajorVersion } from "../utils/vite-version.js";
 import { loadCommonJsModule, shouldRetryAsCommonJs } from "../utils/commonjs-loader.js";
 
 /**
@@ -965,16 +964,14 @@ export async function loadNextConfig(
   const tsconfigBaseUrl = isTypeScriptConfig ? tsconfigResolution.baseUrl : null;
 
   // Vite 8 (Rolldown) resolves tsconfig `baseUrl` bare imports natively via
-  // `resolve.tsconfigPaths` (oxc-resolver). Vite 7 has no equivalent option,
-  // so baseUrl-based imports in `next.config.ts` are a documented Vite 7/8
-  // capability gap (see docs). `paths` aliases still work on both via
-  // `resolve.alias`. Mirrors the Vite-major gate used in index.ts.
+  // `resolve.tsconfigPaths` (oxc-resolver). `paths` aliases are materialized
+  // into `resolve.alias` so import.meta.glob and dynamic imports can see them.
   //
   // Note: installed packages stay externalized (so CJS config plugins like
   // `@next/mdx` that call `require`/`require.resolve` at runtime keep working).
   // baseUrl resolves bare imports that have no installed package of the same
   // name; it does not shadow an installed package with a baseUrl-local file.
-  const useNativeTsconfigPaths = !!tsconfigBaseUrl && getViteMajorVersion() >= 8;
+  const useNativeTsconfigPaths = !!tsconfigBaseUrl;
 
   // Symlink-resolved config path, used by the `commonjs()` filter below to
   // exclude the config file itself. macOS uses /private/var symlinks, so
@@ -995,9 +992,7 @@ export async function loadNextConfig(
         // handling: it follows `extends` and resolves baseUrl-local bare imports
         // via per-importer tsconfig discovery. Installed packages stay
         // externalized, so a baseUrl-local file does not shadow a package of the
-        // same name. Vite 7 has no native equivalent, so baseUrl bare imports in
-        // next.config.ts are unsupported there (documented gap); `resolve.alias`
-        // still covers `paths` aliases on both.
+        // same name.
         ...(useNativeTsconfigPaths ? { tsconfigPaths: true } : {}),
         // Include `.cjs` and `.cts` so `vite-plugin-commonjs` recognises
         // those extensions (the plugin keys off `config.resolve.extensions`,

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -186,11 +186,10 @@ import {
 import {
   createClientFileNameConfig,
   createClientManualChunks,
-  createClientOutputConfig,
   createClientCodeSplittingConfig,
   createClientAssetFileNames,
   createRscFrameworkChunkOutputConfig,
-  getClientTreeshakeConfigForVite,
+  getClientTreeshakeConfig,
   getBuildBundlerOptions,
   withBuildBundlerOptions,
 } from "./build/client-build-config.js";
@@ -229,8 +228,8 @@ import { createIgnoreDynamicRequestsPlugin } from "./plugins/ignore-dynamic-requ
 import { normalizePathSeparators, stripJsExtension, stripViteModuleQuery } from "./utils/path.js";
 import { escapeRegExp } from "./utils/regex.js";
 import {
+  assertSupportedViteVersion,
   getDepOptimizeNodeEnvOptions,
-  getViteMajorVersion,
   serializeViteDefine,
 } from "./utils/vite-version.js";
 import {
@@ -335,7 +334,6 @@ function hasServerOnlyMarkerImport(code: string): boolean {
 
 const __dirname = import.meta.dirname;
 type VitePluginReactModule = typeof import("@vitejs/plugin-react");
-type ViteTsconfigPathsModule = typeof import("vite-tsconfig-paths");
 
 function resolveOptionalDependency(projectRoot: string, specifier: string): string | null {
   try {
@@ -349,19 +347,6 @@ function resolveOptionalDependency(projectRoot: string, specifier: string): stri
   } catch {}
 
   return null;
-}
-
-async function loadVite7TsconfigPathsPlugin(projectRoot: string): Promise<Plugin> {
-  const resolvedPath = resolveOptionalDependency(projectRoot, "vite-tsconfig-paths");
-  if (!resolvedPath) {
-    throw new Error(
-      "[vinext] Vite 7 requires the optional peer dependency vite-tsconfig-paths " +
-        "for tsconfig path alias support. Install vite-tsconfig-paths or upgrade to Vite 8.",
-    );
-  }
-
-  const module = (await import(pathToFileURL(resolvedPath).href)) as ViteTsconfigPathsModule;
-  return module.default();
 }
 
 function resolveShimModulePath(shimsDir: string, moduleName: string): string {
@@ -946,22 +931,15 @@ const clientCodeSplittingConfig = createClientCodeSplittingConfig(clientManualCh
 const appClientManualChunks = createClientManualChunks(_shimsDir, true);
 const appClientCodeSplittingConfig = createClientCodeSplittingConfig(appClientManualChunks);
 
-function getClientOutputConfigForVite(
-  viteMajorVersion: number,
-  assetsDir: string,
-  preserveAppRouteBoundaries = false,
-) {
-  const manualChunks = preserveAppRouteBoundaries ? appClientManualChunks : clientManualChunks;
+function getClientOutputConfig(assetsDir: string, preserveAppRouteBoundaries = false) {
   const codeSplitting = preserveAppRouteBoundaries
     ? appClientCodeSplittingConfig
     : clientCodeSplittingConfig;
-  return viteMajorVersion >= 8
-    ? {
-        ...createClientFileNameConfig(assetsDir),
-        assetFileNames: createClientAssetFileNames(assetsDir),
-        codeSplitting,
-      }
-    : createClientOutputConfig(manualChunks, assetsDir);
+  return {
+    ...createClientFileNameConfig(assetsDir),
+    assetFileNames: createClientAssetFileNames(assetsDir),
+    codeSplitting,
+  };
 }
 
 export type VinextOptions = {
@@ -1112,8 +1090,8 @@ type NitroSetupContext = {
 };
 
 export default function vinext(options: VinextOptions = {}): PluginOption[] {
+  assertSupportedViteVersion();
   const prerenderConfig = normalizeVinextPrerenderConfig(options.prerender);
-  const viteMajorVersion = getViteMajorVersion();
   let root: string;
   let pagesDir: string;
   let canonicalPagesDir: string;
@@ -1426,7 +1404,6 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
     // Resolve tsconfig paths/baseUrl aliases so real-world Next.js repos
     // that use @/*, #/*, or baseUrl imports work out of the box.
     // Vite 8+ supports this natively via resolve.tsconfigPaths.
-    ...(viteMajorVersion >= 8 ? [] : [loadVite7TsconfigPathsPlugin(earlyBaseDir)]),
     createStyledJsxPlugin(earlyBaseDir),
     // React Fast Refresh + JSX transform for client components.
     reactPluginPromise,
@@ -1482,50 +1459,46 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
     //   1. avoid re-parsing every `.js` in `node_modules` (build perf), and
     //   2. avoid forcibly applying `lang: "jsx"` to library code that may use
     //      syntax incompatible with the JSX-enabled OXC parser.
-    ...(viteMajorVersion >= 8
-      ? [
-          {
-            name: "vinext:jsx-in-js",
-            enforce: "pre" as const,
-            transform: {
-              filter: { id: /\.m?js(?:\?.*)?$/ },
-              async handler(code: string, id: string) {
-                const cleanId = id.split("?")[0];
+    {
+      name: "vinext:jsx-in-js",
+      enforce: "pre" as const,
+      transform: {
+        filter: { id: /\.m?js(?:\?.*)?$/ },
+        async handler(code: string, id: string) {
+          const cleanId = id.split("?")[0];
 
-                // vinext's published runtime is already compiled by tsdown.
-                // Workspace symlinks resolve these files outside node_modules,
-                // so skip them explicitly instead of parsing the whole runtime
-                // again as possible JSX on every cold request.
-                if (isInsideDirectory(__dirname, cleanId)) return;
+          // vinext's published runtime is already compiled by tsdown. Workspace
+          // symlinks resolve these files outside node_modules, so skip them
+          // explicitly instead of parsing the whole runtime again as possible
+          // JSX on every cold request.
+          if (isInsideDirectory(__dirname, cleanId)) return;
 
-                // Inside node_modules, restrict the JSX transform to files that
-                // carry a React directive. `@vitejs/plugin-rsc` only parses
-                // such modules (and only those failures have been observed in
-                // the wild). The cheap `includes` check avoids any work for the
-                // vast majority of `.js` files in `node_modules`.
-                if (cleanId.includes("/node_modules/")) {
-                  if (!code.includes("use client") && !code.includes("use server")) {
-                    return;
-                  }
-                  if (!hasReactDirective(code)) {
-                    return;
-                  }
-                }
+          // Inside node_modules, restrict the JSX transform to files that carry
+          // a React directive. `@vitejs/plugin-rsc` only parses such modules
+          // (and only those failures have been observed in the wild). The cheap
+          // `includes` check avoids any work for the vast majority of `.js`
+          // files in `node_modules`.
+          if (cleanId.includes("/node_modules/")) {
+            if (!code.includes("use client") && !code.includes("use server")) {
+              return;
+            }
+            if (!hasReactDirective(code)) {
+              return;
+            }
+          }
 
-                const result = await transformWithOxc(code, id, {
-                  lang: "jsx",
-                  jsx: { runtime: "automatic" as const },
-                  sourcemap: true,
-                });
-                return {
-                  code: result.code,
-                  map: result.map,
-                };
-              },
-            },
-          } satisfies Plugin,
-        ]
-      : []),
+          const result = await transformWithOxc(code, id, {
+            lang: "jsx",
+            jsx: { runtime: "automatic" as const },
+            sourcemap: true,
+          });
+          return {
+            code: result.code,
+            map: result.map,
+          };
+        },
+      },
+    } satisfies Plugin,
     // Allow `import 'server-only'` from middleware (and any module reachable
     // from it) in non-RSC environments. Registered before `vinext:config` so
     // its `enforce: "pre"` resolveId runs ahead of @vitejs/plugin-rsc's
@@ -1563,8 +1536,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         isServeCommand = env.command === "serve";
         root = normalizePathSeparators(config.root ?? process.cwd());
         const userResolve = config.resolve as UserResolveConfigWithTsconfigPaths | undefined;
-        const shouldEnableNativeTsconfigPaths =
-          viteMajorVersion >= 8 && userResolve?.tsconfigPaths === undefined;
+        const shouldEnableNativeTsconfigPaths = userResolve?.tsconfigPaths === undefined;
         const tsconfigPathAliases = resolveTsconfigAliases(root);
         const swcHelpersAlias = resolveSwcHelpersAlias(root);
 
@@ -2256,7 +2228,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             ...(!isSSR && !hasClientBuildEnvironment
               ? { assetsInlineLimit: clientAssetsInlineLimit }
               : {}),
-            ...withBuildBundlerOptions(viteMajorVersion, {
+            ...withBuildBundlerOptions({
               // Suppress "Module level directives cause errors when bundled"
               // warnings for "use client" / "use server" directives. Our shims
               // and third-party libraries legitimately use these directives;
@@ -2309,7 +2281,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 };
               })(),
               // Enable aggressive tree-shaking for client builds.
-              // See getClientTreeshakeConfigForVite JSDoc for rationale.
+              // See getClientTreeshakeConfig JSDoc for rationale.
               // Only apply globally for standalone client builds (Pages Router
               // CLI). For multi-environment builds (App Router, Cloudflare),
               // treeshake is set per-environment on the client env below to
@@ -2318,7 +2290,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               // that rely on module-level side effects.
               ...(!isSSR && !isMultiEnv
                 ? {
-                    treeshake: getClientTreeshakeConfigForVite(viteMajorVersion),
+                    treeshake: getClientTreeshakeConfig(),
                   }
                 : {}),
               // Code-split client bundles: separate framework (React/ReactDOM),
@@ -2328,9 +2300,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               // Router). For multi-environment builds (App Router, Cloudflare),
               // manualChunks is set per-environment on the client env below
               // to avoid leaking into RSC/SSR environments.
-              ...(!isSSR && !isMultiEnv
-                ? { output: getClientOutputConfigForVite(viteMajorVersion, clientAssetsDir) }
-                : {}),
+              ...(!isSSR && !isMultiEnv ? { output: getClientOutputConfig(clientAssetsDir) } : {}),
             }),
           },
           // Let OPTIONS requests pass through Vite's CORS middleware to our
@@ -2416,10 +2386,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           // so JSX syntax is parsed correctly, while TypeScript files
           // continue to use `vite:oxc`'s default `lang` inference.
           //
-          // Vite 7 uses `esbuild` for transforms, Vite 8+ uses `oxc`.
-          ...(viteMajorVersion >= 8
-            ? { oxc: { jsx: { runtime: "automatic" } } }
-            : { esbuild: { jsx: "automatic" } }),
+          oxc: { jsx: { runtime: "automatic" } },
           // Define env vars for client bundle
           define: defines,
           // Set base path if configured.
@@ -2599,10 +2566,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             }
           },
         };
-        const depOptimizeNodeEnvOptions = getDepOptimizeNodeEnvOptions(
-          viteMajorVersion,
-          nodeEnvDefine,
-        );
+        const depOptimizeNodeEnvOptions = getDepOptimizeNodeEnvOptions(nodeEnvDefine);
         // Apply the define to the default optimizer and explicitly to server
         // environments, where Vite's keepProcessEnv default prevents replacement.
         viteConfig.optimizeDeps = {
@@ -2693,7 +2657,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               },
               build: {
                 outDir: options.rscOutDir ?? "dist/server",
-                ...withBuildBundlerOptions(viteMajorVersion, {
+                ...withBuildBundlerOptions({
                   input: { index: VIRTUAL_RSC_ENTRY },
                   // Split React (and the RSC flight runtime) into a dedicated
                   // CSS-free "framework" chunk so `app/global-not-found.tsx`
@@ -2702,7 +2666,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                   // this, global-not-found inherits the layout's stylesheet and
                   // the route-miss 404 document resolves the cascade to the
                   // layout's rules instead of global-not-found's (issue #1549).
-                  output: createRscFrameworkChunkOutputConfig(viteMajorVersion),
+                  output: createRscFrameworkChunkOutputConfig(),
                 }),
               },
             },
@@ -2764,7 +2728,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               },
               build: {
                 outDir: options.ssrOutDir ?? "dist/server/ssr",
-                ...withBuildBundlerOptions(viteMajorVersion, {
+                ...withBuildBundlerOptions({
                   input: { index: VIRTUAL_APP_SSR_ENTRY },
                 }),
               },
@@ -2823,10 +2787,10 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 // Client-scoped so RSC/SSR keep their normal asset handling
                 // unless the user configured Vite globally.
                 assetsInlineLimit: clientAssetsInlineLimit,
-                ...withBuildBundlerOptions(viteMajorVersion, {
+                ...withBuildBundlerOptions({
                   input: appClientInput,
-                  output: getClientOutputConfigForVite(viteMajorVersion, clientAssetsDir, true),
-                  treeshake: getClientTreeshakeConfigForVite(viteMajorVersion),
+                  output: getClientOutputConfig(clientAssetsDir, true),
+                  treeshake: getClientTreeshakeConfig(),
                 }),
               },
             },
@@ -2847,10 +2811,10 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 manifest: true,
                 ssrManifest: true,
                 assetsInlineLimit: clientAssetsInlineLimit,
-                ...withBuildBundlerOptions(viteMajorVersion, {
+                ...withBuildBundlerOptions({
                   input: { index: VIRTUAL_CLIENT_ENTRY },
-                  output: getClientOutputConfigForVite(viteMajorVersion, clientAssetsDir),
-                  treeshake: getClientTreeshakeConfigForVite(viteMajorVersion),
+                  output: getClientOutputConfig(clientAssetsDir),
+                  treeshake: getClientTreeshakeConfig(),
                 }),
               },
             },
@@ -2876,10 +2840,10 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 manifest: true,
                 ssrManifest: true,
                 assetsInlineLimit: clientAssetsInlineLimit,
-                ...withBuildBundlerOptions(viteMajorVersion, {
+                ...withBuildBundlerOptions({
                   input: { index: VIRTUAL_CLIENT_ENTRY },
-                  output: getClientOutputConfigForVite(viteMajorVersion, clientAssetsDir),
-                  treeshake: getClientTreeshakeConfigForVite(viteMajorVersion),
+                  output: getClientOutputConfig(clientAssetsDir),
+                  treeshake: getClientTreeshakeConfig(),
                 }),
               },
             },
@@ -2906,7 +2870,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               },
               build: {
                 outDir: "dist/server",
-                ...withBuildBundlerOptions(viteMajorVersion, {
+                ...withBuildBundlerOptions({
                   input: { index: VIRTUAL_SERVER_ENTRY },
                   output: {
                     entryFileNames: "entry.js",
@@ -3562,7 +3526,7 @@ export const loadServerActionClient = ${
         );
         return {
           build: {
-            ...withBuildBundlerOptions(viteMajorVersion, {
+            ...withBuildBundlerOptions({
               output: { assetFileNames },
             }),
           },

--- a/packages/vinext/src/init-cloudflare.ts
+++ b/packages/vinext/src/init-cloudflare.ts
@@ -507,7 +507,7 @@ export function generateAppRouterViteConfig(
     }),`);
 
   // Build resolve.alias for native module stubs (tsconfig paths are handled
-  // by the vinext plugin's Vite 8 native support / Vite 7 fallback).
+  // by the vinext plugin's native Vite support).
   let resolveBlock = "";
   const aliases: string[] = [];
 
@@ -550,7 +550,7 @@ export function generatePagesRouterViteConfig(
   }
 
   // Build resolve.alias for native module stubs (tsconfig paths are handled
-  // by the vinext plugin's Vite 8 native support / Vite 7 fallback).
+  // by the vinext plugin's native Vite support).
   let resolveBlock = "";
   const aliases: string[] = [];
 

--- a/packages/vinext/src/server/dev-module-runner.ts
+++ b/packages/vinext/src/server/dev-module-runner.ts
@@ -6,7 +6,7 @@
  *
  * ## Why this exists
  *
- * Vite 7's `server.ssrLoadModule()` and the lazy `RunnableDevEnvironment.runner`
+ * Vite's `server.ssrLoadModule()` and the lazy `RunnableDevEnvironment.runner`
  * getter both use `SSRCompatModuleRunner`, which constructs a
  * `createServerModuleRunnerTransport` synchronously. That transport calls
  * `connect()` immediately, which reads `environment.hot.api.outsideEmitter` —

--- a/packages/vinext/src/server/dev-origin-check.ts
+++ b/packages/vinext/src/server/dev-origin-check.ts
@@ -4,8 +4,8 @@
  * Prevents external websites from making cross-origin requests to the
  * local dev server and reading the responses (data exfiltration).
  *
- * Vite 7 provides built-in CORS and WebSocket origin protection, but
- * vinext overrides Vite's CORS config to allow OPTIONS passthrough.
+ * Vite provides built-in CORS and WebSocket origin protection, but vinext
+ * overrides Vite's CORS config to allow OPTIONS passthrough.
  * This module adds origin verification to vinext's own request handlers.
  */
 

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -115,10 +115,9 @@ function resolveCanonicalServerEntry(entryPath: string): { href: string; mtime: 
  *
  * The first import of a given path uses the plain file:// URL with NO query
  * string. This is load-bearing: code-split builds emit lazy chunks that
- * import the entry back by bare specifier (default Vite builds on both
- * supported majors — Rollup on Vite 7 and Rolldown on Vite 8 — hoist modules
- * shared between the entry's static graph and lazy route chunks into the
- * entry chunk, which the chunks then import as e.g. "../../index.js").
+ * import the entry back by bare specifier (default Vite/Rolldown builds hoist
+ * modules shared between the entry's static graph and lazy route chunks into
+ * the entry chunk, which the chunks then import as e.g. "../../index.js").
  * Node keys its ESM cache on the full URL including the query string, so if
  * the server imported the entry as `index.js?t=<mtime>`, a chunk's bare
  * back-import would evaluate the entire server bundle a second time and

--- a/packages/vinext/src/utils/vite-version.ts
+++ b/packages/vinext/src/utils/vite-version.ts
@@ -1,10 +1,8 @@
 /**
  * Vite major-version detection.
  *
- * Several vinext behaviors depend on whether the host project is running Vite 8
- * (Rolldown-based, with native `resolve.tsconfigPaths`, `oxc` transforms, and
- * `rolldownOptions`) or Vite 7 (Rollup/esbuild). This helper centralizes the
- * detection so the Vite-major gate is computed the same way everywhere.
+ * vinext requires Vite 8 or newer so it can rely on Rolldown-based build
+ * options, native `resolve.tsconfigPaths`, and OXC transforms.
  */
 import path from "node:path";
 import { createRequire } from "node:module";
@@ -16,19 +14,12 @@ export function serializeViteDefine(value: unknown): string {
   return JSON.stringify(value) ?? "undefined";
 }
 
-export function getDepOptimizeNodeEnvOptions(
-  viteMajorVersion: number,
-  nodeEnvDefine: string,
-): {
+export function getDepOptimizeNodeEnvOptions(nodeEnvDefine: string): {
   rolldownOptions?: {
     transform: {
       define: Record<string, string>;
     };
     moduleTypes?: Record<string, "jsx">;
-  };
-  esbuildOptions?: {
-    define: Record<string, string>;
-    loader?: Record<string, "jsx">;
   };
 } {
   // Vite defaults keepProcessEnv to true for server-consumer environments,
@@ -38,7 +29,7 @@ export function getDepOptimizeNodeEnvOptions(
     "process.env.NODE_ENV": nodeEnvDefine,
   };
 
-  // The dep optimizer scanner and pre-bundler run their own Rolldown/esbuild
+  // The dep optimizer scanner and pre-bundler run their own Rolldown
   // pipeline that does NOT go through the `vinext:jsx-in-js` transform plugin
   // (which only runs in the Vite plugin pipeline). Next.js allows JSX in plain
   // `.js`/`.mjs` files, and the scanner crawls the app's source entries to
@@ -55,48 +46,63 @@ export function getDepOptimizeNodeEnvOptions(
   // what this option is verified to address; this only keeps the scan from
   // aborting on JSX-in-`.js`/`.mjs`.
   const jsxModuleTypes = { ".js": "jsx", ".mjs": "jsx" } as const;
-  return viteMajorVersion >= 8
-    ? {
-        rolldownOptions: {
-          transform: { define },
-          moduleTypes: jsxModuleTypes,
-        },
-      }
-    : {
-        esbuildOptions: { define, loader: jsxModuleTypes },
-      };
+  return {
+    rolldownOptions: {
+      transform: { define },
+      moduleTypes: jsxModuleTypes,
+    },
+  };
 }
 
 /**
- * Detect Vite major version at runtime by resolving from cwd.
- * The plugin may be installed in a workspace root with Vite 7 but used
- * by a project that has Vite 8 — so we resolve from cwd, not from
- * the plugin's own location.
+ * Detect Vite major version at runtime. Prefer the project cwd, then fall back
+ * to vinext's own dependency graph for tests and linked source checkouts.
  */
 export function getViteMajorVersion(): number {
   try {
-    const require = createRequire(path.join(process.cwd(), "package.json"));
-    const vitePkg = require("vite/package.json");
-
-    const viteMajor = parseInt(vitePkg?.version, 10);
-    if (vitePkg?.name === "vite" && Number.isFinite(viteMajor)) {
-      return viteMajor;
+    return getViteMajorVersionFromRequire(createRequire(path.join(process.cwd(), "package.json")));
+  } catch (error) {
+    if (!isModuleNotFoundError(error)) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`[vinext] Vite 8 or newer is required, but ${message}`);
     }
+  }
 
-    const bundledViteMajor = parseInt(vitePkg?.bundledVersions?.vite, 10);
-    if (Number.isFinite(bundledViteMajor)) {
-      return bundledViteMajor;
-    }
-
-    // npm aliases like `vite: npm:@voidzero-dev/vite-plus-core@...` expose the
-    // aliased package.json, whose own version is not Vite's version.
-    console.warn(
-      `[vinext] Could not determine Vite major version from ${vitePkg?.name ?? "vite/package.json"}; assuming Vite 7`,
-    );
-    return 7;
+  try {
+    return getViteMajorVersionFromRequire(createRequire(import.meta.url));
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    console.warn(`[vinext] Failed to resolve vite/package.json (${message}); assuming Vite 7`);
-    return 7;
+    throw new Error(
+      `[vinext] Vite 8 or newer is required, but vinext could not resolve vite/package.json (${message})`,
+    );
   }
+}
+
+function getViteMajorVersionFromRequire(require: NodeRequire): number {
+  const vitePkg = require("vite/package.json");
+  const viteMajor = parseInt(vitePkg?.version, 10);
+  if (vitePkg?.name === "vite" && Number.isFinite(viteMajor)) {
+    return viteMajor;
+  }
+
+  const bundledViteMajor = parseInt(vitePkg?.bundledVersions?.vite, 10);
+  if (Number.isFinite(bundledViteMajor)) {
+    return bundledViteMajor;
+  }
+
+  throw new Error(`could not determine Vite version from ${vitePkg?.name ?? "vite/package.json"}`);
+}
+
+function isModuleNotFoundError(error: unknown): boolean {
+  return (
+    !!error && typeof error === "object" && "code" in error && error.code === "MODULE_NOT_FOUND"
+  );
+}
+
+export function assertSupportedViteVersion(): number {
+  const viteMajorVersion = getViteMajorVersion();
+  if (viteMajorVersion < 8) {
+    throw new Error(`[vinext] Vite 8 or newer is required. Detected Vite ${viteMajorVersion}.`);
+  }
+  return viteMajorVersion;
 }

--- a/packages/vinext/src/utils/vite-version.ts
+++ b/packages/vinext/src/utils/vite-version.ts
@@ -58,7 +58,7 @@ export function getDepOptimizeNodeEnvOptions(nodeEnvDefine: string): {
  * Detect Vite major version at runtime. Prefer the project cwd, then fall back
  * to vinext's own dependency graph for tests and linked source checkouts.
  */
-export function getViteMajorVersion(): number {
+function getViteMajorVersion(): number {
   try {
     return getViteMajorVersionFromRequire(createRequire(path.join(process.cwd(), "package.json")));
   } catch (error) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,9 +231,6 @@ catalogs:
     vite-plus:
       specifier: 0.2.1
       version: 0.2.1
-    vite-tsconfig-paths:
-      specifier: ^6.1.1
-      version: 6.1.1
     web-vitals:
       specifier: ^4.2.4
       version: 4.2.4
@@ -1039,9 +1036,6 @@ importers:
       vite-plus:
         specifier: 'catalog:'
         version: 0.2.1(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-istanbul@4.1.9(vitest@4.1.9))(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0))(esbuild@0.27.3)(jiti@2.7.0)(msw@2.14.6(@types/node@25.9.2)(typescript@5.9.3))(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0)
-      vite-tsconfig-paths:
-        specifier: 'catalog:'
-        version: 6.1.1(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0))(typescript@5.9.3)
 
   tests/fixtures/app-basic:
     dependencies:
@@ -7781,11 +7775,6 @@ packages:
       '@vitest/browser-webdriverio':
         optional: true
 
-  vite-tsconfig-paths@6.1.1:
-    resolution: {integrity: sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==}
-    peerDependencies:
-      vite: '*'
-
   vitefu@1.1.3:
     resolution: {integrity: sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==}
     peerDependencies:
@@ -13623,16 +13612,6 @@ snapshots:
       - utf-8-validate
       - vite
       - yaml
-
-  vite-tsconfig-paths@6.1.1(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0))(typescript@5.9.3):
-    dependencies:
-      debug: 4.4.3
-      globrex: 0.1.2
-      tsconfck: 3.1.6(typescript@5.9.3)
-      vite: '@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0)'
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
 
   vitefu@1.1.3(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@5.9.3)(yaml@2.9.0)):
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -90,7 +90,6 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@0.2.1
   vite-plugin-commonjs: ^0.10.4
   vite-plus: 0.2.1
-  vite-tsconfig-paths: ^6.1.1
   vitest: 4.1.9
   web-vitals: ^4.2.4
   wrangler: ^4.80.0

--- a/tests/app-router-dev-server.test.ts
+++ b/tests/app-router-dev-server.test.ts
@@ -1979,7 +1979,7 @@ describe("App Router integration", () => {
   });
 
   it("sets optimizeDeps.entries for rsc, ssr, and client environments so deps are discovered at startup", () => {
-    // Without optimizeDeps.entries, Vite only crawls build.rollupOptions.input
+    // Without optimizeDeps.entries, Vite only crawls build.rolldownOptions.input
     // for dependency discovery — but those are virtual modules that don't
     // import user dependencies. This causes lazy discovery, re-optimisation
     // cascades, and "Invalid hook call" errors on first load.

--- a/tests/app-router-production-server.test.ts
+++ b/tests/app-router-production-server.test.ts
@@ -1633,9 +1633,9 @@ describe("App Router Production server (startProdServer)", () => {
 describe("App Router production server entry module identity", () => {
   // Regression test for cloudflare/vinext#1923.
   //
-  // Chunks emitted by default Vite builds — Rollup on Vite 7 and Rolldown on
-  // Vite 8 — import the server entry back by its bare path: modules shared
-  // between the entry's static graph (middleware, instrumentation) and lazy
+  // Chunks emitted by default Vite/Rolldown builds import the server entry
+  // back by its bare path: modules shared between the entry's static graph
+  // (middleware, instrumentation) and lazy
   // route chunks are hoisted into the entry chunk, and the lazy chunks then
   // import them via "../../index.js" (e.g. a plain `vite@8.0.16` SSR build
   // of an entry-shared module emits `import { t as shared } from

--- a/tests/asset-prefix.test.ts
+++ b/tests/asset-prefix.test.ts
@@ -749,7 +749,7 @@ export default function middleware(request: Request) {
       build: {
         outDir: path.join(outDir, "server"),
         ssr: "virtual:vinext-server-entry",
-        rollupOptions: { output: { entryFileNames: "entry.js" } },
+        rolldownOptions: { output: { entryFileNames: "entry.js" } },
       },
     });
     await build({
@@ -761,7 +761,7 @@ export default function middleware(request: Request) {
         outDir: path.join(outDir, "client"),
         manifest: true,
         ssrManifest: true,
-        rollupOptions: { input: "virtual:vinext-client-entry" },
+        rolldownOptions: { input: "virtual:vinext-client-entry" },
       },
     });
 

--- a/tests/build-optimization.test.ts
+++ b/tests/build-optimization.test.ts
@@ -19,8 +19,7 @@ import {
 } from "../packages/vinext/src/plugins/strip-server-exports.js";
 import {
   createClientManualChunks,
-  clientTreeshakeConfig,
-  getClientTreeshakeConfigForVite,
+  getClientTreeshakeConfig,
   createRscFrameworkChunkOutputConfig,
   RSC_FRAMEWORK_CHUNK_TEST,
   isRscFrameworkModule,
@@ -70,27 +69,12 @@ afterEach(() => {
 });
 
 function getBuildBundlerOptions(result: any) {
-  return result.build?.rolldownOptions ?? result.build?.rollupOptions;
+  return result.build?.rolldownOptions;
 }
 
 function getEnvBuildBundlerOptions(env: any) {
-  return env?.build?.rolldownOptions ?? env?.build?.rollupOptions;
+  return env?.build?.rolldownOptions;
 }
-
-// ─── clientTreeshakeConfig ────────────────────────────────────────────────────
-
-describe("clientTreeshakeConfig", () => {
-  it("uses 'recommended' preset for safe defaults", () => {
-    expect(clientTreeshakeConfig.preset).toBe("recommended");
-  });
-
-  it("sets moduleSideEffects to 'no-external' for aggressive vendor DCE", () => {
-    // 'no-external' marks node_modules as side-effect-free (enabling DCE for
-    // barrel-heavy libraries) while preserving side effects for local modules
-    // (CSS imports, polyfills).
-    expect(clientTreeshakeConfig.moduleSideEffects).toBe("no-external");
-  });
-});
 
 // ─── clientManualChunks ───────────────────────────────────────────────────────
 
@@ -107,7 +91,7 @@ describe("clientManualChunks", () => {
     expect(clientManualChunks("/node_modules/scheduler/index.js")).toBe("framework");
   });
 
-  it("returns undefined for other node_modules (Rollup default splitting)", () => {
+  it("returns undefined for other node_modules (default graph splitting)", () => {
     expect(clientManualChunks("/node_modules/mermaid/dist/mermaid.js")).toBeUndefined();
     expect(clientManualChunks("/node_modules/lodash-es/lodash.js")).toBeUndefined();
     expect(clientManualChunks("/node_modules/@mui/material/index.js")).toBeUndefined();
@@ -3502,32 +3486,12 @@ export const getStaticPaths = () => [
   });
 });
 
-// ─── getClientTreeshakeConfigForVite ──────────────────────────────────────────
+// ─── getClientTreeshakeConfig ─────────────────────────────────────────────────
 
-describe("getClientTreeshakeConfigForVite", () => {
-  it("returns preset for Vite 7 (Rollup compatibility)", () => {
-    const config = getClientTreeshakeConfigForVite(7);
+describe("getClientTreeshakeConfig", () => {
+  it("returns Rolldown treeshake config without a Rollup preset", () => {
+    const config = getClientTreeshakeConfig();
     expect(config).toEqual({
-      preset: "recommended",
-      moduleSideEffects: "no-external",
-    });
-  });
-
-  it("returns config without preset for Vite 8 (Rolldown compatibility)", () => {
-    const config = getClientTreeshakeConfigForVite(8);
-    expect(config).toEqual({
-      moduleSideEffects: "no-external",
-    });
-  });
-
-  it("returns config without preset for Vite 9+", () => {
-    const config9 = getClientTreeshakeConfigForVite(9);
-    expect(config9).toEqual({
-      moduleSideEffects: "no-external",
-    });
-
-    const config10 = getClientTreeshakeConfigForVite(10);
-    expect(config10).toEqual({
       moduleSideEffects: "no-external",
     });
   });
@@ -3536,68 +3500,11 @@ describe("getClientTreeshakeConfigForVite", () => {
 // ─── createRscFrameworkChunkOutputConfig ──────────────────────────────────────
 
 describe("createRscFrameworkChunkOutputConfig", () => {
-  it("returns manualChunks for Vite 7 (Rollup) routing framework modules to 'framework'", () => {
-    const config = createRscFrameworkChunkOutputConfig(7);
-    expect(config).not.toHaveProperty("codeSplitting");
-    expect(config).toHaveProperty("manualChunks");
-    const manualChunks = (
-      config as {
-        manualChunks: (
-          id: string,
-          meta: {
-            getModuleInfo(id: string): { importers: string[]; isEntry: boolean } | null;
-          },
-        ) => string | undefined;
-      }
-    ).manualChunks;
-    const moduleInfo = new Map([
-      ["/app/src/entry.js", { importers: [], isEntry: true }],
-      ["/app/src/middleman.js", { importers: ["/app/src/entry.js"], isEntry: false }],
-      ["/app/src/lazy.js", { importers: [], isEntry: false }],
-      [
-        "/app/node_modules/react/index.js",
-        { importers: ["/app/src/middleman.js"], isEntry: false },
-      ],
-      [
-        "/app/node_modules/react-server-dom-webpack/client.js",
-        { importers: ["/app/src/entry.js"], isEntry: false },
-      ],
-      [
-        "/app/node_modules/react-dom/server.react-server.js",
-        { importers: ["/app/src/lazy.js"], isEntry: false },
-      ],
-    ]);
-    const meta = { getModuleInfo: (id: string) => moduleInfo.get(id) ?? null };
-    expect(manualChunks("/app/node_modules/react/index.js", meta)).toBe("framework");
-    expect(manualChunks("/app/node_modules/react-server-dom-webpack/client.js", meta)).toBe(
-      "framework",
-    );
-    expect(
-      manualChunks("/app/node_modules/react-dom/server.react-server.js", meta),
-    ).toBeUndefined();
-    // Non-framework node_modules and local files are left to the default algo.
-    expect(manualChunks("/app/node_modules/react-icons/lib/index.js", meta)).toBeUndefined();
-    expect(manualChunks("/app/src/page.tsx", meta)).toBeUndefined();
-  });
-
-  it("returns codeSplitting for Vite 8+ (Rolldown), not the deprecated advancedChunks", () => {
-    const config = createRscFrameworkChunkOutputConfig(8);
+  it("returns Rolldown codeSplitting, not the deprecated advancedChunks", () => {
+    const config = createRscFrameworkChunkOutputConfig();
     expect(config).not.toHaveProperty("advancedChunks");
     expect(config).not.toHaveProperty("manualChunks");
     expect(config).toEqual({
-      codeSplitting: {
-        groups: [
-          {
-            name: "framework",
-            test: RSC_FRAMEWORK_CHUNK_TEST,
-            entriesAware: true,
-          },
-        ],
-      },
-    });
-
-    // Vite 9+ uses the same Rolldown shape.
-    expect(createRscFrameworkChunkOutputConfig(9)).toEqual({
       codeSplitting: {
         groups: [
           {
@@ -3621,7 +3528,7 @@ describe("RSC framework package matching", () => {
     "/app/node_modules/react-server-dom-webpack/client.js",
     // pnpm-style nested path.
     "/app/node_modules/.pnpm/react@19.0.0/node_modules/react/index.js",
-    // Windows-style path used by the Vite 7 getPackageName predicate.
+    // Windows-style path used by the shared package-name predicate.
     "C:\\app\\node_modules\\react-dom\\server.js",
   ];
   const notMatching = [

--- a/tests/css-media-query-target.test.ts
+++ b/tests/css-media-query-target.test.ts
@@ -81,7 +81,7 @@ describe("CSS media-query syntax preservation in production build", () => {
           outDir: path.join(outDir, "client"),
           manifest: true,
           ssrManifest: true,
-          rollupOptions: { input: "virtual:vinext-client-entry" },
+          rolldownOptions: { input: "virtual:vinext-client-entry" },
         },
       });
 

--- a/tests/css-modules-data-urls.test.ts
+++ b/tests/css-modules-data-urls.test.ts
@@ -105,7 +105,7 @@ describe("CSS data URL imports", () => {
           outDir: path.join(outDir, "client"),
           manifest: true,
           ssrManifest: true,
-          rollupOptions: { input: "virtual:vinext-client-entry" },
+          rolldownOptions: { input: "virtual:vinext-client-entry" },
         },
       });
 
@@ -175,7 +175,7 @@ describe("CSS data URL imports", () => {
           outDir: path.join(outDir, "client"),
           manifest: true,
           ssrManifest: true,
-          rollupOptions: { input: "virtual:vinext-client-entry" },
+          rolldownOptions: { input: "virtual:vinext-client-entry" },
         },
       });
 

--- a/tests/css-url-assets.test.ts
+++ b/tests/css-url-assets.test.ts
@@ -206,7 +206,7 @@ describe("Pages Router CSS url() asset emission", () => {
       build: {
         outDir: path.join(outDir, "server"),
         ssr: "virtual:vinext-server-entry",
-        rollupOptions: { output: { entryFileNames: "entry.js" } },
+        rolldownOptions: { output: { entryFileNames: "entry.js" } },
       },
     });
     await build({
@@ -218,7 +218,7 @@ describe("Pages Router CSS url() asset emission", () => {
         outDir: path.join(outDir, "client"),
         manifest: true,
         ssrManifest: true,
-        rollupOptions: { input: "virtual:vinext-client-entry" },
+        rolldownOptions: { input: "virtual:vinext-client-entry" },
       },
     });
 

--- a/tests/fixture-dev-server.test.ts
+++ b/tests/fixture-dev-server.test.ts
@@ -35,7 +35,7 @@ describe("fixture dev server helper", () => {
           fixtureProcess = proc;
         },
       }),
-    ).rejects.toThrow(/Fixture "never-ready" did not start within 100ms: .*never listened/s);
+    ).rejects.toThrow(/Fixture "never-ready" did not start within 100ms/);
 
     expect(fixtureProcess).toBeDefined();
     // Wait until the child has actually exited. `killed` only means a signal was

--- a/tests/fixtures/pages-basic/instrumentation.ts
+++ b/tests/fixtures/pages-basic/instrumentation.ts
@@ -3,8 +3,7 @@
  *
  * This file exercises the instrumentation.ts support for Pages Router apps.
  * The key regression it covers: calling server.ssrLoadModule() during
- * configureServer() (at startup, before the server is listening) crashes in
- * Vite 7 with:
+ * configureServer() (at startup, before the server is listening) can crash with:
  *
  *   TypeError: Cannot read properties of undefined (reading 'outsideEmitter')
  *

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -242,7 +242,7 @@ export async function buildPagesFixture(fixtureDir: string): Promise<string> {
       outDir: serverOutDir,
       emptyOutDir: true,
       ssr: "virtual:vinext-server-entry",
-      rollupOptions: {
+      rolldownOptions: {
         output: { entryFileNames: "entry.js" },
       },
     },

--- a/tests/invalid-static-asset-404.test.ts
+++ b/tests/invalid-static-asset-404.test.ts
@@ -238,7 +238,7 @@ async function buildPagesFixture(tmpDir: string, outDir: string): Promise<void> 
     build: {
       outDir: path.join(outDir, "server"),
       ssr: "virtual:vinext-server-entry",
-      rollupOptions: { output: { entryFileNames: "entry.js" } },
+      rolldownOptions: { output: { entryFileNames: "entry.js" } },
     },
   });
   await build({
@@ -250,7 +250,7 @@ async function buildPagesFixture(tmpDir: string, outDir: string): Promise<void> 
       outDir: path.join(outDir, "client"),
       manifest: true,
       ssrManifest: true,
-      rollupOptions: { input: "virtual:vinext-client-entry" },
+      rolldownOptions: { input: "virtual:vinext-client-entry" },
     },
   });
 }

--- a/tests/lightning-css-features.test.ts
+++ b/tests/lightning-css-features.test.ts
@@ -91,7 +91,7 @@ describe("experimental.lightningCssFeatures", () => {
           outDir: path.join(outDir, "client"),
           manifest: true,
           ssrManifest: true,
-          rollupOptions: { input: "virtual:vinext-client-entry" },
+          rolldownOptions: { input: "virtual:vinext-client-entry" },
         },
       });
 
@@ -133,7 +133,7 @@ describe("experimental.lightningCssFeatures", () => {
           outDir: path.join(outDir, "client"),
           manifest: true,
           ssrManifest: true,
-          rollupOptions: { input: "virtual:vinext-client-entry" },
+          rolldownOptions: { input: "virtual:vinext-client-entry" },
         },
       });
 

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -2360,10 +2360,16 @@ describe("Link prefetch scheduling", () => {
 
     try {
       result.capturedAnchorProps.onMouseEnter?.({ currentTarget: result.anchor });
-      await flushPrefetchTasks();
+      const rscCall = await waitForFetchCall(result.fetch, (call) => {
+        const input = call[0];
+        if (typeof input !== "string") return false;
+        return (
+          new URL(input, "https://example.com").pathname === "/same-origin-intent-prefetch-target"
+        );
+      });
 
       expectCanonicalRscFetchCall(
-        result.fetch.mock.calls[0],
+        rscCall,
         "/same-origin-intent-prefetch-target",
         expect.objectContaining({
           credentials: "include",

--- a/tests/og-inline.test.ts
+++ b/tests/og-inline.test.ts
@@ -342,7 +342,7 @@ describe("vinext:og-inline-fetch-assets plugin", () => {
       plugins: [createOgInlinePlugin("build", projectRoot)],
       build: {
         outDir: "dist",
-        rollupOptions: {
+        rolldownOptions: {
           input: path.join(projectRoot, "index.js"),
           output: { entryFileNames: "bundle.js" },
         },
@@ -378,7 +378,7 @@ describe("vinext:og-inline-fetch-assets plugin", () => {
       plugins: [createOgInlinePlugin("build", projectRoot)],
       build: {
         outDir: "dist",
-        rollupOptions: {
+        rolldownOptions: {
           input: path.join(projectRoot, "index.js"),
           output: { entryFileNames: "bundle.js" },
         },
@@ -420,7 +420,7 @@ describe("vinext:og-inline-fetch-assets plugin", () => {
       plugins: [createOgInlinePlugin("build", projectRoot)],
       build: {
         outDir: "dist",
-        rollupOptions: {
+        rolldownOptions: {
           input: path.join(projectRoot, "index.js"),
           output: { entryFileNames: "bundle.js" },
         },

--- a/tests/optimize-deps-jsx-in-js.test.ts
+++ b/tests/optimize-deps-jsx-in-js.test.ts
@@ -11,9 +11,9 @@
  * pre-bundling.
  *
  * Fix: vinext configures the dep optimizer to treat `.js`/`.mjs` as JSX via
- * an optimizer-wide extension mapping (`optimizeDeps.rolldownOptions.moduleTypes`
- * on Vite 8, `optimizeDeps.esbuildOptions.loader` on Vite 7). This is broader
- * than `vinext:jsx-in-js` because it can also apply to optimized dependencies.
+ * an optimizer-wide extension mapping (`optimizeDeps.rolldownOptions.moduleTypes`).
+ * This is broader than `vinext:jsx-in-js` because it can also apply to optimized
+ * dependencies.
  *
  * The motivating real-world symptom (issue #5) is that, once the scan aborts,
  * pre-bundling is skipped and UMD/CJS deps can fail to interop under SSR
@@ -28,7 +28,6 @@ import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import vinext from "../packages/vinext/src/index.js";
-import { getViteMajorVersion } from "../packages/vinext/src/utils/vite-version.js";
 
 type VinextPlugin = {
   name: string;
@@ -37,7 +36,6 @@ type VinextPlugin = {
 
 type OptimizerConfig = {
   rolldownOptions?: { moduleTypes?: Record<string, string> };
-  esbuildOptions?: { loader?: Record<string, string> };
 };
 
 type VinextConfigResult = {
@@ -154,19 +152,12 @@ async function expectDevScanAllowsJsxInJs(tmpDir: string, expectedTexts: string[
   }
 }
 
-function expectJsxDotJs(optimizeDeps: OptimizerConfig, viteMajor: number) {
-  if (viteMajor >= 8) {
-    expect(optimizeDeps.rolldownOptions?.moduleTypes?.[".js"]).toBe("jsx");
-    expect(optimizeDeps.rolldownOptions?.moduleTypes?.[".mjs"]).toBe("jsx");
-  } else {
-    expect(optimizeDeps.esbuildOptions?.loader?.[".js"]).toBe("jsx");
-    expect(optimizeDeps.esbuildOptions?.loader?.[".mjs"]).toBe("jsx");
-  }
+function expectJsxDotJs(optimizeDeps: OptimizerConfig) {
+  expect(optimizeDeps.rolldownOptions?.moduleTypes?.[".js"]).toBe("jsx");
+  expect(optimizeDeps.rolldownOptions?.moduleTypes?.[".mjs"]).toBe("jsx");
 }
 
 describe("optimizeDeps: JSX in plain .js files", () => {
-  const viteMajor = getViteMajorVersion();
-
   it("configures the dep optimizer to treat .js as JSX in every environment", async () => {
     const tmpDir = await setupAppProject();
     try {
@@ -183,13 +174,13 @@ describe("optimizeDeps: JSX in plain .js files", () => {
 
       // Top-level optimizeDeps (Pages Router default + client inheritance).
       expect(result.optimizeDeps).toBeDefined();
-      expectJsxDotJs(result.optimizeDeps!, viteMajor);
+      expectJsxDotJs(result.optimizeDeps!);
 
       // App Router environments each run their own scanner over app/ sources.
       for (const envName of ["rsc", "ssr", "client"] as const) {
         const envOptimizeDeps = result.environments?.[envName]?.optimizeDeps;
         expect(envOptimizeDeps, `${envName} optimizeDeps`).toBeDefined();
-        expectJsxDotJs(envOptimizeDeps!, viteMajor);
+        expectJsxDotJs(envOptimizeDeps!);
       }
     } finally {
       await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
@@ -219,7 +210,7 @@ describe("optimizeDeps: JSX in plain .js files", () => {
         const clientOptimizeDeps = config.environments?.client?.optimizeDeps;
         expect(clientOptimizeDeps, `${label} client optimizeDeps`).toBeDefined();
         expect(clientOptimizeDeps?.entries).toContain("pages/**/*.{tsx,ts,jsx,js}");
-        expectJsxDotJs(clientOptimizeDeps!, viteMajor);
+        expectJsxDotJs(clientOptimizeDeps!);
       }
     } finally {
       await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});

--- a/tests/pages-api-with-middleware.test.ts
+++ b/tests/pages-api-with-middleware.test.ts
@@ -46,7 +46,7 @@ async function buildFixture(rootDir: string, outDir: string): Promise<void> {
     build: {
       outDir: path.join(outDir, "server"),
       ssr: "virtual:vinext-server-entry",
-      rollupOptions: { output: { entryFileNames: "entry.js" } },
+      rolldownOptions: { output: { entryFileNames: "entry.js" } },
     },
   });
 
@@ -59,7 +59,7 @@ async function buildFixture(rootDir: string, outDir: string): Promise<void> {
       outDir: path.join(outDir, "client"),
       manifest: true,
       ssrManifest: true,
-      rollupOptions: { input: "virtual:vinext-client-entry" },
+      rolldownOptions: { input: "virtual:vinext-client-entry" },
     },
   });
 }

--- a/tests/pages-css-url-encoding.test.ts
+++ b/tests/pages-css-url-encoding.test.ts
@@ -62,7 +62,7 @@ async function buildPagesFixture(tmpDir: string, outDir: string): Promise<void> 
     build: {
       outDir: path.join(outDir, "server"),
       ssr: "virtual:vinext-server-entry",
-      rollupOptions: { output: { entryFileNames: "entry.js" } },
+      rolldownOptions: { output: { entryFileNames: "entry.js" } },
     },
   });
   await build({
@@ -74,7 +74,7 @@ async function buildPagesFixture(tmpDir: string, outDir: string): Promise<void> 
       outDir: path.join(outDir, "client"),
       manifest: true,
       ssrManifest: true,
-      rollupOptions: { input: "virtual:vinext-client-entry" },
+      rolldownOptions: { input: "virtual:vinext-client-entry" },
     },
   });
 }

--- a/tests/pages-i18n-prod.test.ts
+++ b/tests/pages-i18n-prod.test.ts
@@ -31,7 +31,7 @@ async function startProdFixture(
     build: {
       outDir: path.join(outDir, "server"),
       ssr: "virtual:vinext-server-entry",
-      rollupOptions: { output: { entryFileNames: "entry.js" } },
+      rolldownOptions: { output: { entryFileNames: "entry.js" } },
     },
   });
   await build({
@@ -43,7 +43,7 @@ async function startProdFixture(
       outDir: path.join(outDir, "client"),
       manifest: true,
       ssrManifest: true,
-      rollupOptions: { input: "virtual:vinext-client-entry" },
+      rolldownOptions: { input: "virtual:vinext-client-entry" },
     },
   });
 

--- a/tests/pages-i18n-public-rewrite.test.ts
+++ b/tests/pages-i18n-public-rewrite.test.ts
@@ -25,7 +25,7 @@ async function startProdFixture(): Promise<{
     build: {
       outDir: path.join(outDir, "server"),
       ssr: "virtual:vinext-server-entry",
-      rollupOptions: { output: { entryFileNames: "entry.js" } },
+      rolldownOptions: { output: { entryFileNames: "entry.js" } },
     },
   });
   await build({
@@ -37,7 +37,7 @@ async function startProdFixture(): Promise<{
       outDir: path.join(outDir, "client"),
       manifest: true,
       ssrManifest: true,
-      rollupOptions: { input: "virtual:vinext-client-entry" },
+      rolldownOptions: { input: "virtual:vinext-client-entry" },
     },
   });
 

--- a/tests/pages-router-concurrency.test.ts
+++ b/tests/pages-router-concurrency.test.ts
@@ -107,7 +107,7 @@ describe("Pages Router prod concurrency isolation", () => {
       build: {
         outDir: path.join(outDir, "server"),
         ssr: "virtual:vinext-server-entry",
-        rollupOptions: { output: { entryFileNames: "entry.js" } },
+        rolldownOptions: { output: { entryFileNames: "entry.js" } },
       },
     });
 
@@ -120,7 +120,7 @@ describe("Pages Router prod concurrency isolation", () => {
         outDir: path.join(outDir, "client"),
         manifest: true,
         ssrManifest: true,
-        rollupOptions: { input: "virtual:vinext-client-entry" },
+        rolldownOptions: { input: "virtual:vinext-client-entry" },
       },
     });
 

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -28,7 +28,7 @@ type ClientBuildManifestEntry = {
 };
 
 function getBuildBundlerOptions(result: any) {
-  return result.build?.rolldownOptions ?? result.build?.rollupOptions;
+  return result.build?.rolldownOptions;
 }
 
 /**
@@ -512,7 +512,7 @@ async function buildPagesFixtureToOutDir(rootDir: string, outDir: string): Promi
     build: {
       outDir: path.join(outDir, "server"),
       ssr: "virtual:vinext-server-entry",
-      rollupOptions: { output: { entryFileNames: "entry.js" } },
+      rolldownOptions: { output: { entryFileNames: "entry.js" } },
     },
   });
 
@@ -525,7 +525,7 @@ async function buildPagesFixtureToOutDir(rootDir: string, outDir: string): Promi
       outDir: path.join(outDir, "client"),
       manifest: true,
       ssrManifest: true,
-      rollupOptions: { input: "virtual:vinext-client-entry" },
+      rolldownOptions: { input: "virtual:vinext-client-entry" },
     },
   });
 }
@@ -3695,7 +3695,7 @@ describe("Plugin config", () => {
     expect(result.resolve.dedupe).toContain("react/jsx-dev-runtime");
   });
 
-  it("suppresses MODULE_LEVEL_DIRECTIVE warnings from Rollup", async () => {
+  it("suppresses MODULE_LEVEL_DIRECTIVE warnings from the bundler", async () => {
     const plugins = vinext() as any[];
     const configPlugin = plugins.find((p) => p.name === "vinext:config");
     expect(configPlugin).toBeDefined();
@@ -3819,7 +3819,7 @@ describe("Plugin config", () => {
     expect(defaultHandler).toHaveBeenCalledTimes(2);
   });
 
-  it("preserves user-supplied build.rollupOptions.onwarn", async () => {
+  it("preserves user-supplied build.rolldownOptions.onwarn", async () => {
     const plugins = vinext() as any[];
     const configPlugin = plugins.find((p) => p.name === "vinext:config");
     expect(configPlugin).toBeDefined();
@@ -3829,7 +3829,7 @@ describe("Plugin config", () => {
       {
         root: FIXTURE_DIR,
         plugins: [],
-        build: { rollupOptions: { onwarn: userOnwarn } },
+        build: { rolldownOptions: { onwarn: userOnwarn } },
       },
       { command: "build", mode: "production" },
     );
@@ -3990,7 +3990,7 @@ describe("Production build", () => {
       build: {
         outDir: path.join(outDir, "server"),
         ssr: "virtual:vinext-server-entry",
-        rollupOptions: {
+        rolldownOptions: {
           output: {
             entryFileNames: "entry.js",
           },
@@ -4111,7 +4111,7 @@ export const config = { matcher: ["/protected"] };
         build: {
           outDir: path.join(fixtureOutDir, "server"),
           ssr: "virtual:vinext-server-entry",
-          rollupOptions: {
+          rolldownOptions: {
             output: {
               entryFileNames: "entry.js",
             },
@@ -4181,7 +4181,7 @@ export const config = { matcher: ["/protected"] };
         build: {
           outDir: path.join(fixtureOutDir, "server"),
           ssr: "virtual:vinext-server-entry",
-          rollupOptions: {
+          rolldownOptions: {
             output: {
               entryFileNames: "entry.js",
             },
@@ -4224,7 +4224,7 @@ export const config = { matcher: ["/protected"] };
           build: {
             outDir: path.join(fixtureOutDir, "server"),
             ssr: "virtual:vinext-server-entry",
-            rollupOptions: {
+            rolldownOptions: {
               output: { entryFileNames: "entry.js" },
             },
           },
@@ -4248,7 +4248,7 @@ export const config = { matcher: ["/protected"] };
         outDir: path.join(outDir, "client"),
         manifest: true,
         ssrManifest: true,
-        rollupOptions: {
+        rolldownOptions: {
           input: "virtual:vinext-client-entry",
         },
       },
@@ -4348,7 +4348,7 @@ export default function CounterPage() {
         build: {
           outDir: path.join(fixtureOutDir, "server"),
           ssr: "virtual:vinext-server-entry",
-          rollupOptions: { output: { entryFileNames: "entry.js" } },
+          rolldownOptions: { output: { entryFileNames: "entry.js" } },
         },
       });
 
@@ -4361,7 +4361,7 @@ export default function CounterPage() {
           outDir: path.join(fixtureOutDir, "client"),
           manifest: true,
           ssrManifest: true,
-          rollupOptions: { input: "virtual:vinext-client-entry" },
+          rolldownOptions: { input: "virtual:vinext-client-entry" },
         },
       });
 
@@ -4492,7 +4492,7 @@ export default function CounterPage() {
         build: {
           outDir: path.join(fixtureOutDir, "server"),
           ssr: "virtual:vinext-server-entry",
-          rollupOptions: { output: { entryFileNames: "entry.js" } },
+          rolldownOptions: { output: { entryFileNames: "entry.js" } },
         },
       });
       await build({
@@ -4504,7 +4504,7 @@ export default function CounterPage() {
           outDir: path.join(fixtureOutDir, "client"),
           manifest: true,
           ssrManifest: true,
-          rollupOptions: { input: "virtual:vinext-client-entry" },
+          rolldownOptions: { input: "virtual:vinext-client-entry" },
         },
       });
 
@@ -5088,7 +5088,7 @@ export default function CounterPage() {
         build: {
           outDir: path.join(fixtureOutDir, "server"),
           ssr: "virtual:vinext-server-entry",
-          rollupOptions: { output: { entryFileNames: "entry.js" } },
+          rolldownOptions: { output: { entryFileNames: "entry.js" } },
         },
       });
 
@@ -5101,7 +5101,7 @@ export default function CounterPage() {
           outDir: path.join(fixtureOutDir, "client"),
           manifest: true,
           ssrManifest: true,
-          rollupOptions: { input: "virtual:vinext-client-entry" },
+          rolldownOptions: { input: "virtual:vinext-client-entry" },
         },
       });
 
@@ -5184,7 +5184,7 @@ export default function CounterPage() {
         build: {
           outDir: path.join(outDir, "server"),
           ssr: "virtual:vinext-server-entry",
-          rollupOptions: { output: { entryFileNames: "entry.js" } },
+          rolldownOptions: { output: { entryFileNames: "entry.js" } },
         },
       });
       await build({
@@ -5196,7 +5196,7 @@ export default function CounterPage() {
           outDir: path.join(outDir, "client"),
           manifest: true,
           ssrManifest: true,
-          rollupOptions: { input: "virtual:vinext-client-entry" },
+          rolldownOptions: { input: "virtual:vinext-client-entry" },
         },
       });
     }
@@ -5499,7 +5499,7 @@ export default function CounterPage() {
         build: {
           outDir: path.join(outDir, "server"),
           ssr: "virtual:vinext-server-entry",
-          rollupOptions: {
+          rolldownOptions: {
             output: {
               entryFileNames: "entry.js",
             },
@@ -5596,7 +5596,7 @@ describe("Production server middleware (Pages Router)", () => {
         build: {
           outDir: path.join(outDir, "server"),
           ssr: "virtual:vinext-server-entry",
-          rollupOptions: { output: { entryFileNames: "entry.js" } },
+          rolldownOptions: { output: { entryFileNames: "entry.js" } },
         },
       });
       await build({
@@ -5608,7 +5608,7 @@ describe("Production server middleware (Pages Router)", () => {
           outDir: path.join(outDir, "client"),
           manifest: true,
           ssrManifest: true,
-          rollupOptions: { input: "virtual:vinext-client-entry" },
+          rolldownOptions: { input: "virtual:vinext-client-entry" },
         },
       });
     }
@@ -5691,7 +5691,7 @@ describe("Production server middleware (Pages Router)", () => {
         build: {
           outDir: path.join(tmpDir, "dist", "server"),
           ssr: "virtual:vinext-server-entry",
-          rollupOptions: { output: { entryFileNames: "entry.js" } },
+          rolldownOptions: { output: { entryFileNames: "entry.js" } },
         },
       });
       await build({
@@ -5703,7 +5703,7 @@ describe("Production server middleware (Pages Router)", () => {
           outDir: path.join(tmpDir, "dist", "client"),
           manifest: true,
           ssrManifest: true,
-          rollupOptions: { input: "virtual:vinext-client-entry" },
+          rolldownOptions: { input: "virtual:vinext-client-entry" },
         },
       });
 
@@ -5766,7 +5766,7 @@ describe("Production server middleware (Pages Router)", () => {
         build: {
           outDir: path.join(tmpDir, "dist", "server"),
           ssr: "virtual:vinext-server-entry",
-          rollupOptions: { output: { entryFileNames: "entry.js" } },
+          rolldownOptions: { output: { entryFileNames: "entry.js" } },
         },
       });
       await build({
@@ -5778,7 +5778,7 @@ describe("Production server middleware (Pages Router)", () => {
           outDir: path.join(tmpDir, "dist", "client"),
           manifest: true,
           ssrManifest: true,
-          rollupOptions: { input: "virtual:vinext-client-entry" },
+          rolldownOptions: { input: "virtual:vinext-client-entry" },
         },
       });
 
@@ -7105,7 +7105,7 @@ describe("Production server next.config.js features (Pages Router)", () => {
         build: {
           outDir: path.join(outDir, "server"),
           ssr: "virtual:vinext-server-entry",
-          rollupOptions: { output: { entryFileNames: "entry.js" } },
+          rolldownOptions: { output: { entryFileNames: "entry.js" } },
         },
       });
       await build({
@@ -7117,7 +7117,7 @@ describe("Production server next.config.js features (Pages Router)", () => {
           outDir: path.join(outDir, "client"),
           manifest: true,
           ssrManifest: true,
-          rollupOptions: { input: "virtual:vinext-client-entry" },
+          rolldownOptions: { input: "virtual:vinext-client-entry" },
         },
       });
     }
@@ -7490,7 +7490,7 @@ export function middleware(request) {
         build: {
           outDir: path.join(outDir, "server"),
           ssr: "virtual:vinext-server-entry",
-          rollupOptions: { output: { entryFileNames: "entry.js" } },
+          rolldownOptions: { output: { entryFileNames: "entry.js" } },
         },
       });
       await build({
@@ -7502,7 +7502,7 @@ export function middleware(request) {
           outDir: path.join(outDir, "client"),
           manifest: true,
           ssrManifest: true,
-          rollupOptions: { input: "virtual:vinext-client-entry" },
+          rolldownOptions: { input: "virtual:vinext-client-entry" },
         },
       });
 

--- a/tests/prod-server-entry-import.test.ts
+++ b/tests/prod-server-entry-import.test.ts
@@ -16,8 +16,8 @@ import {
  *
  * 1. The first import of a built entry must use the bare (query-less)
  *    canonical file:// URL, so emitted chunks that import the entry back by
- *    bare specifier (Rollup-based Vite 7 builds) or via realpath-derived
- *    URLs resolve to the SAME module instance. The previous unconditional
+ *    bare specifier or via realpath-derived URLs resolve to the SAME module
+ *    instance. The previous unconditional
  *    `?t=<mtime>` query created a second instance of the whole server bundle
  *    and module-level singletons diverged.
  *

--- a/tests/resolve-alias-build.test.ts
+++ b/tests/resolve-alias-build.test.ts
@@ -62,7 +62,7 @@ export default function Home() {
     build: {
       outDir: path.join(tmpDir, "dist", "server"),
       ssr: "virtual:vinext-server-entry",
-      rollupOptions: { output: { entryFileNames: "entry.js" } },
+      rolldownOptions: { output: { entryFileNames: "entry.js" } },
     },
   });
 }

--- a/tests/scss-composes.test.ts
+++ b/tests/scss-composes.test.ts
@@ -85,7 +85,7 @@ async function buildAndCollect(tmpDir: string): Promise<{ css: string; js: strin
         outDir: path.join(outDir, "client"),
         manifest: true,
         ssrManifest: true,
-        rollupOptions: { input: "virtual:vinext-client-entry" },
+        rolldownOptions: { input: "virtual:vinext-client-entry" },
       },
     });
 

--- a/tests/scss.test.ts
+++ b/tests/scss.test.ts
@@ -160,7 +160,7 @@ describe("SCSS preprocessing (Pages Router)", () => {
         build: {
           outDir: path.join(outDir, "server"),
           ssr: "virtual:vinext-server-entry",
-          rollupOptions: { output: { entryFileNames: "entry.js" } },
+          rolldownOptions: { output: { entryFileNames: "entry.js" } },
         },
       });
 
@@ -173,7 +173,7 @@ describe("SCSS preprocessing (Pages Router)", () => {
           outDir: path.join(outDir, "client"),
           manifest: true,
           ssrManifest: true,
-          rollupOptions: { input: "virtual:vinext-client-entry" },
+          rolldownOptions: { input: "virtual:vinext-client-entry" },
         },
       });
 

--- a/tests/tsconfig-paths-vite8.test.ts
+++ b/tests/tsconfig-paths-vite8.test.ts
@@ -65,22 +65,20 @@ afterEach(() => {
 });
 
 describe("Vite tsconfig paths support", () => {
-  it("keeps vite-tsconfig-paths on Vite 7", async () => {
+  it("rejects Vite 7", () => {
     const root = setupProject({ name: "vite", version: "7.3.1" });
     process.chdir(root);
 
-    const plugins = vinext({ appDir: root });
-
-    expect(await findNamedPlugin(plugins, "vite-tsconfig-paths")).toBeDefined();
+    expect(() => vinext({ appDir: root })).toThrow(
+      "[vinext] Vite 8 or newer is required. Detected Vite 7.",
+    );
   });
 
-  it("uses resolve.tsconfigPaths on Vite 8 instead of vite-tsconfig-paths", async () => {
+  it("uses resolve.tsconfigPaths on Vite 8", async () => {
     const root = setupProject({ name: "vite", version: "8.0.0" });
     process.chdir(root);
 
     const plugins = vinext({ appDir: root });
-
-    expect(await findNamedPlugin(plugins, "vite-tsconfig-paths")).toBeUndefined();
 
     const configPlugin = (await findNamedPlugin(plugins, "vinext:config")) as {
       config?: (
@@ -220,8 +218,6 @@ describe("Vite tsconfig paths support", () => {
 
     const plugins = vinext({ appDir: root });
 
-    expect(await findNamedPlugin(plugins, "vite-tsconfig-paths")).toBeUndefined();
-
     const configPlugin = (await findNamedPlugin(plugins, "vinext:config")) as {
       config?: (
         config: { root: string },
@@ -238,20 +234,15 @@ describe("Vite tsconfig paths support", () => {
     expect(resolvedConfig?.resolve?.tsconfigPaths).toBe(true);
   });
 
-  it("falls back to Vite 7 for npm alias packages without bundled versions", async () => {
+  it("rejects npm alias packages without bundled Vite versions", () => {
     const root = setupProject({
       name: "@voidzero-dev/vite-plus-core",
       version: "0.1.11",
     });
     process.chdir(root);
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-    const plugins = vinext({ appDir: root });
-
-    expect(await findNamedPlugin(plugins, "vite-tsconfig-paths")).toBeDefined();
-    expect(warn).toHaveBeenCalledOnce();
-    expect(warn).toHaveBeenCalledWith(
-      "[vinext] Could not determine Vite major version from @voidzero-dev/vite-plus-core; assuming Vite 7",
+    expect(() => vinext({ appDir: root })).toThrow(
+      "[vinext] Vite 8 or newer is required, but could not determine Vite version from @voidzero-dev/vite-plus-core",
     );
   });
 });


### PR DESCRIPTION
## Summary
- raise vinext's Vite peer requirement to Vite 8 and remove the optional vite-tsconfig-paths fallback
- collapse Vite-version branches to Vite 8/Rolldown config shapes
- update tests and docs to use rolldownOptions and assert Vite 7 is rejected

## Validation
- vp install
- vp test run tests/build-optimization.test.ts tests/tsconfig-paths-vite8.test.ts tests/optimize-deps-jsx-in-js.test.ts
- vp test run tests/pages-router.test.ts -t "MODULE_LEVEL_DIRECTIVE|preserves user-supplied"
- vp check $(git diff --name-only | tr '\n' ' ')
