### PR TITLE
fix(app-router): omit provisional RSC cache state for query renders

### DIFF
--- a/packages/vinext/src/server/app-page-cache-finalizer.ts
+++ b/packages/vinext/src/server/app-page-cache-finalizer.ts
@@ -70,6 +70,7 @@ type ScheduleAppPageRscCacheWriteOptions = {
   isrSet: AppPageCacheSetter;
   interceptionContext?: string | null;
   mountedSlotsHeader?: string | null;
+  omitPendingDynamicCacheState?: boolean;
   renderMode?: AppRscRenderMode;
   preserveClientResponseHeaders?: boolean;
   expireSeconds?: number;
@@ -235,7 +236,9 @@ export function finalizeAppPageRscCacheResponse(
   }
 
   const clientHeaders = new Headers(response.headers);
-  applyPendingDynamicCdnHeaders(clientHeaders, options.getPageTags());
+  applyPendingDynamicCdnHeaders(clientHeaders, options.getPageTags(), {
+    omitCacheState: options.omitPendingDynamicCacheState === true,
+  });
 
   return new Response(response.body, {
     status: response.status,

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -995,7 +995,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
     },
     handlerStart: options.handlerStart,
     hasLoadingBoundary: hasActiveLoadingBoundary,
-    omitPendingDynamicCacheState: !options.isRscRequest && hasRequestSearchParams,
+    omitPendingDynamicCacheState: hasRequestSearchParams,
     formState: options.formState ?? null,
     isProgressiveActionRender: options.isProgressiveActionRender === true,
     isDynamicError,

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -861,6 +861,7 @@ export async function renderAppPageLifecycle(
       isrSet: options.isrSet,
       interceptionContext: options.interceptionContext,
       mountedSlotsHeader: options.mountedSlotsHeader,
+      omitPendingDynamicCacheState: options.omitPendingDynamicCacheState,
       renderMode: options.renderMode,
       preserveClientResponseHeaders: rscResponsePolicy.cacheState !== "MISS",
       expireSeconds,

--- a/tests/app-page-cache.test.ts
+++ b/tests/app-page-cache.test.ts
@@ -1238,6 +1238,53 @@ describe("app page cache helpers", () => {
     expect(isrSetCalls).toEqual(["rsc:/fresh-rsc"]);
   });
 
+  it("omits provisional RSC cache state when pending dynamic usage may depend on query params", async () => {
+    const pendingCacheWrites: Promise<void>[] = [];
+    const isrSetCalls: string[] = [];
+
+    const response = finalizeAppPageRscCacheResponse(
+      new Response("flight", {
+        headers: {
+          "Content-Type": "text/x-component",
+          "Cache-Control": "s-maxage=60, stale-while-revalidate",
+          "X-Vinext-Cache": "MISS",
+        },
+      }),
+      {
+        capturedRscDataPromise: Promise.resolve(new TextEncoder().encode("flight").buffer),
+        cleanPathname: "/fresh-rsc",
+        consumeDynamicUsage() {
+          return false;
+        },
+        dynamicUsedDuringBuild: false,
+        getPageTags() {
+          return ["/fresh-rsc"];
+        },
+        isrRscKey(pathname) {
+          return "rsc:" + pathname;
+        },
+        async isrSet(key) {
+          isrSetCalls.push(key);
+        },
+        omitPendingDynamicCacheState: true,
+        revalidateSeconds: 60,
+        waitUntil(promise) {
+          pendingCacheWrites.push(promise);
+        },
+      },
+    );
+
+    expect(response.headers.get("Cache-Control")).toBe("no-store, must-revalidate");
+    expect(response.headers.get("X-Vinext-Cache")).toBeNull();
+    expect(response.headers.get("X-Nextjs-Cache")).toBeNull();
+    await expect(response.text()).resolves.toBe("flight");
+    expect(pendingCacheWrites).toHaveLength(1);
+
+    await pendingCacheWrites[0];
+
+    expect(isrSetCalls).toEqual(["rsc:/fresh-rsc"]);
+  });
+
   it("skips RSC cache writes when dynamic usage appears during stream rendering", async () => {
     const pendingCacheWrites: Promise<void>[] = [];
     const debugCalls: Array<[string, string]> = [];

--- a/tests/app-page-render.test.ts
+++ b/tests/app-page-render.test.ts
@@ -579,6 +579,50 @@ describe("app page render lifecycle", () => {
     expect(consumeDynamicUsage).toHaveBeenCalledTimes(2);
   });
 
+  it("omits RSC cache state and skips cache writes when stream-time searchParams usage is dynamic", async () => {
+    const common = createCommonOptions();
+    const streamGate = createDeferred();
+    let dynamicUsed = false;
+
+    const response = await renderAppPageLifecycle({
+      ...common.options,
+      consumeDynamicUsage() {
+        const value = dynamicUsed;
+        dynamicUsed = false;
+        return value;
+      },
+      isProduction: true,
+      isRscRequest: true,
+      omitPendingDynamicCacheState: true,
+      renderToReadableStream() {
+        let sent = false;
+        return new ReadableStream<Uint8Array>({
+          async pull(controller) {
+            if (sent) {
+              controller.close();
+              return;
+            }
+            sent = true;
+            await streamGate.promise;
+            dynamicUsed = true;
+            controller.enqueue(new TextEncoder().encode("flight-data"));
+          },
+        });
+      },
+      revalidateSeconds: 60,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store, must-revalidate");
+    expect(response.headers.get("x-vinext-cache")).toBeNull();
+    expect(common.waitUntilPromises).toHaveLength(1);
+
+    streamGate.resolve();
+    await expect(response.text()).resolves.toBe("flight-data");
+    await Promise.all(common.waitUntilPromises);
+    expect(common.isrSet).not.toHaveBeenCalled();
+  });
+
   it("does not cache RSC responses when skip transport omits layout records", async () => {
     const common = createCommonOptions();
     const isrDebug = vi.fn();


### PR DESCRIPTION
## Overview

| Field | Details |
| --- | --- |
| Goal | Avoid advertising provisional RSC cache state for query-bearing App Router RSC requests. |
| Core change | Thread `omitPendingDynamicCacheState` through RSC finalization and enable it whenever the request has search params. |
| Main boundary | Query-bearing RSC renders can discover `searchParams` usage only while the Flight stream is consumed, so the response should not expose a provisional cache state first. |
| Primary files | `packages/vinext/src/server/app-page-cache-finalizer.ts`, `packages/vinext/src/server/app-page-dispatch.ts`, `packages/vinext/src/server/app-page-render.ts` |
| Expected impact | Dynamic query renders avoid looking like shared-cache artifacts while their lazy RSC stream is still resolving cache safety. |

## Why

Cache headers should represent a completed cache decision, not a guess made before stream-time request API usage is known. Query-bearing raw RSC responses are especially sensitive because `searchParams` access may happen during lazy Flight consumption. This PR reuses the existing pending cache-state omission for RSC query requests so provisional state does not leak to the client.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| RSC cache state | A query render should not advertise shared-cache state before dynamic usage is settled. | Enables pending cache-state omission for requests with search params, including RSC. |
| Cache finalization | The finalizer owns response cache-state headers. | Adds an explicit finalizer option to omit pending cache state while keeping tag behavior. |
| Dispatch lifecycle | Request shape should decide whether provisional cache state is safe. | Passes the existing query detection through to render lifecycle for all render transports. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| Raw RSC request with query params | Could emit provisional pending dynamic cache state before lazy stream usage settled. | Omits the provisional cache-state marker while keeping other finalization behavior. |
| HTML request with query params | Already omitted pending dynamic cache state. | Still omits it. |
| Queryless RSC request | Existing cache-state behavior applies. | Unchanged. |

<details>
<summary>Maintainer review path</summary>

| File | Review focus |
| --- | --- |
| `packages/vinext/src/server/app-page-dispatch.ts` | Check the request-level decision that query-bearing requests set `omitPendingDynamicCacheState`. |
| `packages/vinext/src/server/app-page-render.ts` | Confirm the lifecycle passes that decision into RSC cache response finalization. |
| `packages/vinext/src/server/app-page-cache-finalizer.ts` | Verify pending dynamic CDN headers omit only cache state when requested. |
| `tests/app-page-cache.test.ts` | Review finalizer coverage for cache-state omission. |
| `tests/app-page-render.test.ts` | Review lifecycle coverage for query-bearing RSC responses. |

</details>

<details>
<summary>Validation</summary>

- `vp test run tests/app-page-cache.test.ts tests/app-page-render.test.ts`
- `vp check packages/vinext/src/server/app-page-cache-finalizer.ts packages/vinext/src/server/app-page-dispatch.ts packages/vinext/src/server/app-page-render.ts tests/app-page-cache.test.ts tests/app-page-render.test.ts`

</details>

<details>
<summary>Risk / compatibility</summary>

| Surface | Notes |
| --- | --- |
| Public API | No public API change. |
| Config | No config change. |
| Runtime | Narrow response-header behavior change for query-bearing App Router RSC requests. |
| Cache behavior | Avoids provisional cache-state exposure; does not change cache writes or cache keys. |
| Existing apps | Low risk. Queryless RSC and existing HTML query behavior are unchanged. |

</details>

<details>
<summary>Non-goals</summary>

- Does not change App Router cache key derivation.
- Does not change render observation semantics.
- Does not change RSC special-error or page-probe behavior.

</details>