### PR TITLE
perf:document only router runtime

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -38,6 +38,7 @@ export default {
         // Build-time entries referenced by path constant (Vite reads them
         // from disk via `fs`), so knip wouldn't otherwise trace them.
         "src/server/app-browser-entry.ts",
+        "src/server/app-browser-islands-entry.ts",
         "src/server/app-browser-server-action-client.ts",
         "src/server/app-ssr-entry.ts",
         // Forked as a child process by prerender-server-pool.ts via a path

--- a/packages/vinext/src/entries/app-browser-entry.ts
+++ b/packages/vinext/src/entries/app-browser-entry.ts
@@ -23,7 +23,13 @@ export function generateBrowserEntry(
     beforeFiles: [],
     fallback: [],
   },
+  hasClientRouterRuntime = true,
 ): string {
+  if (!hasClientRouterRuntime) {
+    const entryPath = resolveRuntimeEntryModule("app-browser-islands-entry");
+    return `import ${JSON.stringify(entryPath)};`;
+  }
+
   const entryPath = resolveRuntimeEntryModule("app-browser-entry");
   const navigationRuntimePath = resolveClientRuntimeModule("navigation-runtime");
   const prefetchRoutes: VinextLinkPrefetchRoute[] = routes.map((route) =>

--- a/packages/vinext/src/global.d.ts
+++ b/packages/vinext/src/global.d.ts
@@ -182,6 +182,13 @@ declare global {
     __VINEXT_RSC_BOOTSTRAP_STATE__: "starting" | "hydrated" | undefined;
 
     /**
+     * App Router document-only browser runtime marker. Set by the lightweight
+     * hydration entry when no client reference needs App Router navigation
+     * state or soft navigation APIs.
+     */
+    __VINEXT_DOCUMENT_ONLY_RSC_RUNTIME__: boolean | undefined;
+
+    /**
      * A Promise that resolves when the current in-flight popstate RSC navigation
      * finishes rendering.
      * Set by the popstate handler in the browser RSC entry; read by

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -6374,6 +6374,7 @@ export const loadServerActionClient = ${
       createRscClientReferenceLoadersPlugin({
         internalRoot: path.resolve(__dirname),
         routerRuntimeModuleIds: [
+          resolveShimModulePath(_shimsDir, "link"),
           resolveShimModulePath(_shimsDir, "navigation"),
           resolveShimModulePath(_shimsDir, "router"),
           resolveShimModulePath(_shimsDir, "form"),

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1331,6 +1331,22 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
     return Object.keys(pluginApi.manager.serverReferenceMetaMap).length > 0;
   }
 
+  let clientRouterRuntimeRequired: boolean | null = null;
+
+  async function resolveHasClientRouterRuntime(
+    config: Pick<ResolvedConfig, "command" | "plugins">,
+  ): Promise<boolean> {
+    if (
+      config.command !== "build" ||
+      hasPagesDir ||
+      instrumentationClientPath !== null ||
+      clientRouterRuntimeRequired !== false
+    ) {
+      return true;
+    }
+    return await resolveHasServerActions(config);
+  }
+
   const reactOptions = options.react && options.react !== true ? options.react : undefined;
 
   let reactPluginPromise: Promise<PluginOption[]> | null = null;
@@ -3346,6 +3362,9 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         }
         if (id === RESOLVED_APP_BROWSER_ENTRY && hasAppDir) {
           const graph = await appRouteGraph(appDir, nextConfig?.pageExtensions, fileMatcher);
+          const hasClientRouterRuntime = await resolveHasClientRouterRuntime(
+            this.environment.config,
+          );
           // In a hybrid build, the App browser entry also exposes the Pages
           // route manifest so a user who lands on an App page can still
           // see Pages ownership from a `<Link>` click.
@@ -3373,6 +3392,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             graph.routeManifest,
             pagesPrefetchRoutes,
             nextConfig.rewrites,
+            hasClientRouterRuntime,
           );
         }
         if (id === RESOLVED_APP_CAPABILITIES && hasAppDir) {
@@ -6216,7 +6236,35 @@ export const loadServerActionClient = ${
   if (rscPluginPromise) {
     plugins.push(rscPluginPromise);
     plugins.push(createRscReferenceValidationNormalizerPlugin());
-    plugins.push(createRscClientReferenceLoadersPlugin());
+    plugins.push(
+      createRscClientReferenceLoadersPlugin({
+        internalRoot: path.resolve(__dirname),
+        routerRuntimeModuleIds: [
+          resolveShimModulePath(_shimsDir, "navigation"),
+          resolveShimModulePath(_shimsDir, "router"),
+          resolveShimModulePath(_shimsDir, "form"),
+          resolveShimModulePath(_shimsDir, "navigation-state"),
+          resolveShimModulePath(_shimsDir, "router-state"),
+          resolveShimModulePath(_shimsDir, "internal/app-router-context"),
+        ],
+        routerRuntimeImportSpecifiers: [
+          "next/compat/router",
+          "next/form",
+          "next/link",
+          "next/navigation",
+          "next/navigation.js",
+          "next/router",
+          "next/dist/client/components/navigation",
+          "next/dist/shared/lib/app-router-context",
+          "next/dist/shared/lib/app-router-context.shared-runtime",
+          "vinext/navigation-state",
+          "vinext/router-state",
+        ],
+        onClientRouterRuntimeAnalysis(required) {
+          clientRouterRuntimeRequired = required;
+        },
+      }),
+    );
   }
 
   return plugins;

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1339,6 +1339,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
     if (
       config.command !== "build" ||
       hasPagesDir ||
+      nextConfig.i18n !== null ||
       instrumentationClientPath !== null ||
       clientRouterRuntimeRequired !== false
     ) {
@@ -6262,6 +6263,19 @@ export const loadServerActionClient = ${
         ],
         onClientRouterRuntimeAnalysis(required) {
           clientRouterRuntimeRequired = required;
+        },
+        rewriteClientReferenceImportId(importId, { hasServerActions }) {
+          if (
+            clientRouterRuntimeRequired === false &&
+            !hasPagesDir &&
+            nextConfig.i18n === null &&
+            instrumentationClientPath === null &&
+            !hasServerActions &&
+            importId === resolveShimModulePath(_shimsDir, "link")
+          ) {
+            return resolveShimModulePath(_shimsDir, "link-document");
+          }
+          return importId;
         },
       }),
     );

--- a/packages/vinext/src/plugins/rsc-client-reference-loaders.ts
+++ b/packages/vinext/src/plugins/rsc-client-reference-loaders.ts
@@ -145,6 +145,13 @@ function collectImportSpecifiers(code: string, id: string): string[] | null {
       } else if (node.type === "ImportExpression") {
         const source = getStaticString(node.source);
         if (source !== null) imports.add(source);
+      } else if (node.type === "CallExpression") {
+        const callee = isAstRecord(node.callee) ? node.callee : null;
+        if (callee?.type === "Identifier" && callee.name === "require") {
+          const firstArg = nodeArray(node.arguments)[0];
+          const source = getStaticString(firstArg);
+          if (source !== null) imports.add(source);
+        }
       }
       forEachAstChild(node, visit);
     };

--- a/packages/vinext/src/plugins/rsc-client-reference-loaders.ts
+++ b/packages/vinext/src/plugins/rsc-client-reference-loaders.ts
@@ -63,6 +63,7 @@ async function analyzeClientReferences(
 
   for (const clientReferenceId of options.clientReferenceIds) {
     const rootId = cleanModuleId(clientReferenceId);
+    if (routerRuntimeModuleIds.has(rootId)) return true;
     if (isWithinRoot(rootId, internalRoot)) continue;
 
     const pending = [clientReferenceId];
@@ -86,7 +87,12 @@ async function analyzeClientReferences(
         if (options.routerRuntimeImportSpecifiers.has(source)) return true;
         if (source.startsWith("node:")) continue;
 
-        const resolved = await options.resolveImport(source, cleanId);
+        let resolved: Awaited<ReturnType<typeof options.resolveImport>>;
+        try {
+          resolved = await options.resolveImport(source, cleanId);
+        } catch {
+          return true;
+        }
         if (resolved === null || resolved.external) return true;
         pending.push(resolved.id);
       }

--- a/packages/vinext/src/plugins/rsc-client-reference-loaders.ts
+++ b/packages/vinext/src/plugins/rsc-client-reference-loaders.ts
@@ -29,6 +29,10 @@ type ClientRouterRuntimeAnalysisOptions = {
 type RscClientReferenceLoadersPluginOptions = {
   internalRoot?: string;
   onClientRouterRuntimeAnalysis?: (required: boolean) => void;
+  rewriteClientReferenceImportId?: (
+    importId: string,
+    context: { hasServerActions: boolean },
+  ) => string;
   routerRuntimeImportSpecifiers?: readonly string[];
   routerRuntimeModuleIds?: readonly string[];
 };
@@ -184,12 +188,15 @@ function generateClientReferenceObject(meta: RscClientReferenceMeta): string {
   return exports ? `{\n${exports}\n    }` : "{}";
 }
 
-function generateDirectClientReferenceLoaders(metas: RscClientReferenceMeta[]): string {
+function generateDirectClientReferenceLoaders(
+  metas: RscClientReferenceMeta[],
+  resolveImportId: (importId: string) => string,
+): string {
   const entries = metas
     .slice()
     .sort((a, b) => a.referenceKey.localeCompare(b.referenceKey))
     .map((meta) => {
-      const importId = withResolvedIdProxy(meta.importId);
+      const importId = withResolvedIdProxy(resolveImportId(meta.importId));
       return [
         `  ${JSON.stringify(meta.referenceKey)}: async () => {`,
         `    const m = await import(${JSON.stringify(importId)});`,
@@ -242,7 +249,13 @@ export function createRscClientReferenceLoadersPlugin(
       }
 
       return {
-        code: generateDirectClientReferenceLoaders(metas),
+        code: generateDirectClientReferenceLoaders(metas, (importId) =>
+          options.rewriteClientReferenceImportId
+            ? options.rewriteClientReferenceImportId(importId, {
+                hasServerActions: Object.keys(manager.serverReferenceMetaMap).length > 0,
+              })
+            : importId,
+        ),
         map: null,
       };
     },

--- a/packages/vinext/src/plugins/rsc-client-reference-loaders.ts
+++ b/packages/vinext/src/plugins/rsc-client-reference-loaders.ts
@@ -1,5 +1,9 @@
-import type { Plugin } from "vite";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { parseAst, type Plugin } from "vite";
 import type { PluginApi } from "@vitejs/plugin-rsc";
+import { forEachAstChild, isAstRecord, nodeArray } from "./ast-utils.js";
+import { normalizePathSeparators } from "../utils/path.js";
 
 const CLIENT_REFERENCES_ID = "\0virtual:vite-rsc/client-references";
 const RESOLVED_ID_PROXY_PREFIX = "virtual:vite-rsc/resolved-id/";
@@ -9,6 +13,158 @@ type RscClientReferenceMeta = PluginApi["manager"]["clientReferenceMetaMap"][str
 type RscPluginWithApi = Plugin & {
   api?: PluginApi;
 };
+
+type ClientRouterRuntimeAnalysisOptions = {
+  clientReferenceIds: readonly string[];
+  readImportSpecifiers: (id: string) => Promise<readonly string[] | null>;
+  resolveImport: (
+    source: string,
+    importer: string,
+  ) => Promise<{ external?: boolean; id: string } | null>;
+  internalRoot: string;
+  routerRuntimeImportSpecifiers: ReadonlySet<string>;
+  routerRuntimeModuleIds: readonly string[];
+};
+
+type RscClientReferenceLoadersPluginOptions = {
+  internalRoot?: string;
+  onClientRouterRuntimeAnalysis?: (required: boolean) => void;
+  routerRuntimeImportSpecifiers?: readonly string[];
+  routerRuntimeModuleIds?: readonly string[];
+};
+
+function cleanModuleId(id: string): string {
+  return normalizePathSeparators(id.split("?", 1)[0]);
+}
+
+function isWithinRoot(id: string, root: string): boolean {
+  return id === root || id.startsWith(root + "/");
+}
+
+/**
+ * Return true unless the final client-reference graph proves that no user
+ * client component can reach an App Router state API.
+ */
+export function clientReferencesRequireRouterRuntime(
+  options: ClientRouterRuntimeAnalysisOptions,
+): Promise<boolean> {
+  return analyzeClientReferences(options);
+}
+
+async function analyzeClientReferences(
+  options: ClientRouterRuntimeAnalysisOptions,
+): Promise<boolean> {
+  const internalRoot = cleanModuleId(options.internalRoot).replace(/\/+$/, "");
+  const routerRuntimeModuleIds = new Set(options.routerRuntimeModuleIds.map(cleanModuleId));
+
+  for (const clientReferenceId of options.clientReferenceIds) {
+    const rootId = cleanModuleId(clientReferenceId);
+    if (isWithinRoot(rootId, internalRoot)) continue;
+
+    const pending = [clientReferenceId];
+    const visited = new Set<string>();
+    while (pending.length > 0) {
+      const id = pending.pop();
+      if (id === undefined) break;
+
+      const cleanId = cleanModuleId(id);
+      if (visited.has(cleanId)) continue;
+      visited.add(cleanId);
+
+      if (routerRuntimeModuleIds.has(cleanId)) return true;
+
+      const imports = await options.readImportSpecifiers(cleanId);
+      // An unreadable or unparsable JavaScript module means the scan cannot
+      // prove that this reference is router-independent.
+      if (imports === null) return true;
+
+      for (const source of imports) {
+        if (options.routerRuntimeImportSpecifiers.has(source)) return true;
+        if (source.startsWith("node:")) continue;
+
+        const resolved = await options.resolveImport(source, cleanId);
+        if (resolved === null || resolved.external) return true;
+        pending.push(resolved.id);
+      }
+    }
+  }
+
+  return false;
+}
+
+const NON_JAVASCRIPT_EXTENSIONS = new Set([
+  ".avif",
+  ".bmp",
+  ".css",
+  ".gif",
+  ".ico",
+  ".jpeg",
+  ".jpg",
+  ".json",
+  ".less",
+  ".png",
+  ".sass",
+  ".scss",
+  ".svg",
+  ".webp",
+]);
+
+function getStaticString(value: unknown): string | null {
+  if (!isAstRecord(value)) return null;
+  return typeof value.value === "string" ? value.value : null;
+}
+
+function collectImportSpecifiers(code: string, id: string): string[] | null {
+  const extension = path.extname(id).toLowerCase();
+  const lang =
+    extension === ".ts" || extension === ".mts" || extension === ".cts"
+      ? "ts"
+      : extension === ".tsx"
+        ? "tsx"
+        : extension === ".jsx"
+          ? "jsx"
+          : "js";
+  try {
+    const ast = parseAst(code, { lang });
+    const imports = new Set<string>();
+
+    const visit = (node: Parameters<typeof forEachAstChild>[0]) => {
+      if (
+        (node.type === "ImportDeclaration" ||
+          node.type === "ExportAllDeclaration" ||
+          node.type === "ExportNamedDeclaration") &&
+        node.importKind !== "type" &&
+        node.exportKind !== "type"
+      ) {
+        const source = getStaticString(node.source);
+        if (source !== null) imports.add(source);
+      } else if (node.type === "ImportExpression") {
+        const source = getStaticString(node.source);
+        if (source !== null) imports.add(source);
+      }
+      forEachAstChild(node, visit);
+    };
+
+    for (const statement of nodeArray(ast.body)) {
+      if (isAstRecord(statement)) visit(statement);
+    }
+    return [...imports];
+  } catch {
+    return null;
+  }
+}
+
+async function readImportSpecifiers(id: string): Promise<readonly string[] | null> {
+  if (id.startsWith("\0")) return null;
+  const cleanId = cleanModuleId(id);
+  if (NON_JAVASCRIPT_EXTENSIONS.has(path.extname(cleanId).toLowerCase())) return [];
+
+  try {
+    return collectImportSpecifiers(await fs.readFile(cleanId, "utf8"), cleanId);
+  } catch {
+    return null;
+  }
+}
 
 function withResolvedIdProxy(resolvedId: string): string {
   return resolvedId.startsWith("\0")
@@ -46,7 +202,9 @@ function generateDirectClientReferenceLoaders(metas: RscClientReferenceMeta[]): 
   return `export default {\n${entries}\n};\n`;
 }
 
-export function createRscClientReferenceLoadersPlugin(): Plugin {
+export function createRscClientReferenceLoadersPlugin(
+  options: RscClientReferenceLoadersPluginOptions = {},
+): Plugin {
   let rscApi: PluginApi | undefined;
 
   return {
@@ -87,6 +245,38 @@ export function createRscClientReferenceLoadersPlugin(): Plugin {
         code: generateDirectClientReferenceLoaders(metas),
         map: null,
       };
+    },
+    async generateBundle() {
+      const manager = rscApi?.manager;
+      if (
+        this.environment.name !== "rsc" ||
+        !manager?.isScanBuild ||
+        options.internalRoot === undefined ||
+        options.routerRuntimeImportSpecifiers === undefined ||
+        options.routerRuntimeModuleIds === undefined ||
+        options.onClientRouterRuntimeAnalysis === undefined
+      ) {
+        return;
+      }
+
+      options.onClientRouterRuntimeAnalysis(
+        await clientReferencesRequireRouterRuntime({
+          clientReferenceIds: Object.keys(manager.clientReferenceMetaMap),
+          readImportSpecifiers,
+          resolveImport: async (source, importer) => {
+            const resolved = await this.resolve(source, importer);
+            return resolved === null
+              ? null
+              : {
+                  id: resolved.id,
+                  external: resolved.external !== undefined && resolved.external !== false,
+                };
+          },
+          internalRoot: options.internalRoot,
+          routerRuntimeImportSpecifiers: new Set(options.routerRuntimeImportSpecifiers),
+          routerRuntimeModuleIds: options.routerRuntimeModuleIds,
+        }),
+      );
     },
   };
 }

--- a/packages/vinext/src/server/app-browser-islands-entry.ts
+++ b/packages/vinext/src/server/app-browser-islands-entry.ts
@@ -2,7 +2,7 @@
 
 import { createElement, startTransition, use, useEffect } from "react";
 import { createFromReadableStream } from "@vitejs/plugin-rsc/browser";
-import { hydrateRoot } from "react-dom/client";
+import { createRoot, hydrateRoot } from "react-dom/client";
 import "../client/instrumentation-client.js";
 import {
   chunksToReadableStream,
@@ -44,9 +44,20 @@ function readInitialRscStream(): ReadableStream<Uint8Array> {
   return createProgressiveRscStream();
 }
 
+function canonicalizeEmptySearchHref(): void {
+  if (!window.location.href.endsWith("?") || window.location.search !== "") return;
+  window.history.replaceState(
+    window.history.state,
+    "",
+    window.location.pathname + window.location.hash,
+  );
+}
+
 function main(): void {
   if (window.__VINEXT_RSC_ROOT__ || window.__VINEXT_RSC_BOOTSTRAP_STATE__) return;
+  window.__VINEXT_DOCUMENT_ONLY_RSC_RUNTIME__ = true;
   window.__VINEXT_RSC_BOOTSTRAP_STATE__ = "starting";
+  canonicalizeEmptySearchHref();
 
   const initialElements = decodeAppElementsPromise(
     createFromReadableStream<AppWireElements>(readInitialRscStream()),
@@ -54,7 +65,16 @@ function main(): void {
   const children = createElement(BrowserRoot, { initialElements });
 
   startTransition(() => {
-    window.__VINEXT_RSC_ROOT__ = hydrateRoot(document, children);
+    if (document.documentElement.id === "__next_error__") {
+      for (const style of document.querySelectorAll("style[data-vinext-error-shell-style]")) {
+        style.remove();
+      }
+      const root = createRoot(document);
+      root.render(children);
+      window.__VINEXT_RSC_ROOT__ = root;
+    } else {
+      window.__VINEXT_RSC_ROOT__ = hydrateRoot(document, children);
+    }
   });
   window.__VINEXT_RSC_BOOTSTRAP_STATE__ = "hydrated";
 }

--- a/packages/vinext/src/server/app-browser-islands-entry.ts
+++ b/packages/vinext/src/server/app-browser-islands-entry.ts
@@ -1,0 +1,65 @@
+/// <reference types="vite/client" />
+
+import { createElement, startTransition, use, useEffect } from "react";
+import { createFromReadableStream } from "@vitejs/plugin-rsc/browser";
+import { hydrateRoot } from "react-dom/client";
+import "../client/instrumentation-client.js";
+import {
+  chunksToReadableStream,
+  createProgressiveRscStream,
+  getVinextBrowserGlobal,
+} from "./app-browser-stream.js";
+import { AppElementsWire, type AppElements, type AppWireElements } from "./app-elements.js";
+import { ElementsContext, Slot } from "vinext/shims/slot";
+import { installWindowNext } from "../client/window-next.js";
+
+function decodeAppElementsPromise(payload: Promise<AppWireElements>): Promise<AppElements> {
+  return Promise.resolve(payload).then((elements) => AppElementsWire.decode(elements));
+}
+
+function BrowserRoot({ initialElements }: { initialElements: Promise<AppElements> }) {
+  const elements = use(initialElements);
+  const metadata = AppElementsWire.readMetadata(elements);
+
+  useEffect(() => {
+    const hydratedAt = performance.now();
+    window.__VINEXT_HYDRATED_AT = hydratedAt;
+    window.__NEXT_HYDRATED = true;
+    window.__NEXT_HYDRATED_AT = hydratedAt;
+    window.__NEXT_HYDRATED_CB?.();
+  }, []);
+
+  return createElement(
+    ElementsContext.Provider,
+    { value: elements },
+    createElement(Slot, { id: metadata.routeId }),
+  );
+}
+
+function readInitialRscStream(): ReadableStream<Uint8Array> {
+  const browserGlobal = getVinextBrowserGlobal();
+  if (browserGlobal.__VINEXT_RSC_DONE__) {
+    return chunksToReadableStream(browserGlobal.__VINEXT_RSC_CHUNKS__ ?? []);
+  }
+  return createProgressiveRscStream();
+}
+
+function main(): void {
+  if (window.__VINEXT_RSC_ROOT__ || window.__VINEXT_RSC_BOOTSTRAP_STATE__) return;
+  window.__VINEXT_RSC_BOOTSTRAP_STATE__ = "starting";
+
+  const initialElements = decodeAppElementsPromise(
+    createFromReadableStream<AppWireElements>(readInitialRscStream()),
+  );
+  const children = createElement(BrowserRoot, { initialElements });
+
+  startTransition(() => {
+    window.__VINEXT_RSC_ROOT__ = hydrateRoot(document, children);
+  });
+  window.__VINEXT_RSC_BOOTSTRAP_STATE__ = "hydrated";
+}
+
+if (typeof document !== "undefined") {
+  installWindowNext({ appDir: true });
+  main();
+}

--- a/packages/vinext/src/shims/link-document.tsx
+++ b/packages/vinext/src/shims/link-document.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import React, {
+  createContext,
+  forwardRef,
+  useContext,
+  type AnchorHTMLAttributes,
+  type MouseEvent,
+} from "react";
+import { appendSearchParamsToUrl, type UrlQuery, urlQueryToSearchParams } from "../utils/query.js";
+import {
+  isAbsoluteOrProtocolRelativeUrl,
+  normalizePathTrailingSlash,
+  withBasePath,
+} from "./url-utils.js";
+import { isDangerousScheme, reportBlockedDangerousNavigation } from "./url-safety.js";
+
+type NavigateEvent = {
+  url: URL;
+  preventDefault(): void;
+  defaultPrevented: boolean;
+};
+
+type LinkProps = {
+  href: string | { pathname?: string; query?: UrlQuery };
+  as?: string;
+  replace?: boolean;
+  prefetch?: boolean | "auto" | null;
+  unstable_dynamicOnHover?: boolean;
+  passHref?: boolean;
+  legacyBehavior?: boolean;
+  scroll?: boolean;
+  shallow?: boolean;
+  locale?: string | false;
+  onNavigate?: (event: NavigateEvent) => void;
+  children?: React.ReactNode;
+} & Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "href">;
+
+type LinkStatusContextValue = {
+  pending: boolean;
+};
+
+const LinkStatusContext = createContext<LinkStatusContextValue>({ pending: false });
+const IDLE_LINK_STATUS = { pending: false };
+const BASE_PATH: string = process.env.__NEXT_ROUTER_BASEPATH ?? "";
+const TRAILING_SLASH = process.env.__VINEXT_TRAILING_SLASH === "true";
+
+export function useLinkStatus(): LinkStatusContextValue {
+  return useContext(LinkStatusContext);
+}
+
+function resolveHref(href: LinkProps["href"]): string {
+  if (typeof href === "string") return href;
+  let url = href.pathname ?? "";
+  if (href.query) {
+    url = appendSearchParamsToUrl(url, urlQueryToSearchParams(href.query));
+  }
+  return url;
+}
+
+function normalizeRepeatedSlashes(url: string): string {
+  const [pathname = "", ...queryParts] = url.split("?");
+  const query = queryParts.join("?");
+  const normalized = pathname.replace(/\\/g, "/").replace(/\/\/+/g, "/");
+  return query ? `${normalized}?${query}` : normalized;
+}
+
+function resolveDocumentHref(href: LinkProps["href"], as: string | undefined): string {
+  const resolved = as ?? resolveHref(href);
+  if (isAbsoluteOrProtocolRelativeUrl(resolved)) return resolved;
+  return normalizePathTrailingSlash(
+    withBasePath(normalizeRepeatedSlashes(resolved), BASE_PATH),
+    TRAILING_SLASH,
+  );
+}
+
+function shouldHandleNavigation(event: MouseEvent<HTMLAnchorElement>): boolean {
+  return (
+    event.button === 0 &&
+    !event.metaKey &&
+    !event.ctrlKey &&
+    !event.shiftKey &&
+    !event.altKey &&
+    !event.currentTarget.hasAttribute("download") &&
+    (!event.currentTarget.target || event.currentTarget.target === "_self")
+  );
+}
+
+const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
+  {
+    href,
+    as,
+    replace = false,
+    prefetch: _prefetch,
+    unstable_dynamicOnHover: _unstableDynamicOnHover,
+    passHref = false,
+    legacyBehavior = false,
+    scroll: _scroll,
+    shallow: _shallow,
+    locale: _locale,
+    onNavigate,
+    children,
+    onClick,
+    ...anchorProps
+  },
+  forwardedRef,
+) {
+  const rawHref = as ?? resolveHref(href);
+  const dangerous = isDangerousScheme(rawHref);
+  const documentHref = dangerous ? undefined : resolveDocumentHref(href, as);
+
+  const handleClick = (event: MouseEvent<HTMLAnchorElement>): void => {
+    onClick?.(event);
+    if (event.defaultPrevented) return;
+    if (dangerous) {
+      event.preventDefault();
+      reportBlockedDangerousNavigation();
+      return;
+    }
+
+    if (!documentHref || !shouldHandleNavigation(event)) return;
+    if (onNavigate) {
+      let prevented = false;
+      onNavigate({
+        url: new URL(documentHref, window.location.href),
+        preventDefault() {
+          prevented = true;
+        },
+        get defaultPrevented() {
+          return prevented;
+        },
+      });
+      if (prevented) {
+        event.preventDefault();
+        return;
+      }
+    }
+
+    if (replace) {
+      event.preventDefault();
+      window.location.replace(documentHref);
+    }
+  };
+
+  if (legacyBehavior) {
+    const child = React.Children.only(children) as React.ReactElement<{
+      href?: string;
+      onClick?: (event: MouseEvent<HTMLAnchorElement>) => void;
+      ref?: React.Ref<HTMLAnchorElement>;
+    }>;
+    const childHasOwnHref = child.type === "a" && "href" in child.props;
+    const shouldForwardHref = passHref || (child.type === "a" && !childHasOwnHref);
+    const childOnClick = child.props.onClick;
+    const childRef = child.props.ref;
+    const setRefs = (node: HTMLAnchorElement | null): void => {
+      if (typeof childRef === "function") childRef(node);
+      else if (childRef) childRef.current = node;
+    };
+    return (
+      <LinkStatusContext.Provider value={IDLE_LINK_STATUS}>
+        {React.cloneElement(child, {
+          ...(shouldForwardHref ? { href: documentHref } : {}),
+          ref: setRefs,
+          onClick: (event: MouseEvent<HTMLAnchorElement>) => {
+            childOnClick?.(event);
+            if (!event.defaultPrevented) handleClick(event);
+          },
+        })}
+      </LinkStatusContext.Provider>
+    );
+  }
+
+  return (
+    <LinkStatusContext.Provider value={IDLE_LINK_STATUS}>
+      <a ref={forwardedRef} href={documentHref} onClick={handleClick} {...anchorProps}>
+        {children}
+      </a>
+    </LinkStatusContext.Provider>
+  );
+});
+
+export default Link;

--- a/packages/vinext/src/shims/link-document.tsx
+++ b/packages/vinext/src/shims/link-document.tsx
@@ -86,6 +86,11 @@ function shouldHandleNavigation(event: MouseEvent<HTMLAnchorElement>): boolean {
   );
 }
 
+function isExternalDocumentHref(href: string): boolean {
+  const url = new URL(href, window.location.href);
+  return url.origin !== window.location.origin;
+}
+
 const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
   {
     href,
@@ -119,10 +124,19 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
     }
 
     if (!documentHref || !shouldHandleNavigation(event)) return;
+    if (isExternalDocumentHref(documentHref)) {
+      if (replace) {
+        event.preventDefault();
+        window.location.replace(documentHref);
+      }
+      return;
+    }
+
     if (onNavigate) {
       let prevented = false;
+      const url = new URL(documentHref, window.location.href);
       onNavigate({
-        url: new URL(documentHref, window.location.href),
+        url,
         preventDefault() {
           prevented = true;
         },

--- a/tests/app-router-production-build.test.ts
+++ b/tests/app-router-production-build.test.ts
@@ -230,6 +230,59 @@ export default function Page() {
     }
   }, 30000);
 
+  it("keeps the full browser runtime when app client refs use router state", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-router-runtime-"));
+
+    try {
+      fs.symlinkSync(
+        path.resolve(import.meta.dirname, "../node_modules"),
+        path.join(tmpDir, "node_modules"),
+        "junction",
+      );
+      fs.mkdirSync(path.join(tmpDir, "app"), { recursive: true });
+      fs.writeFileSync(
+        path.join(tmpDir, "app", "layout.tsx"),
+        `export default function Root({ children }: { children: React.ReactNode }) {
+  return <html><body>{children}</body></html>;
+}
+`,
+      );
+      fs.writeFileSync(
+        path.join(tmpDir, "app", "client.tsx"),
+        `"use client";
+
+import { usePathname } from "next/navigation";
+
+export function ClientPathname() {
+  return <p>{usePathname()}</p>;
+}
+`,
+      );
+      fs.writeFileSync(
+        path.join(tmpDir, "app", "page.tsx"),
+        `import { ClientPathname } from "./client";
+
+export default function Page() {
+  return <ClientPathname />;
+}
+`,
+      );
+
+      const builder = await createBuilder({
+        root: tmpDir,
+        configFile: false,
+        plugins: [vinext({ appDir: tmpDir })],
+        logLevel: "silent",
+      });
+      await builder.buildApp();
+
+      const clientJs = readAllJs(path.join(tmpDir, "dist", "client"));
+      expect(clientJs).toContain("__VINEXT_LINK_PREFETCH_ROUTES__");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  }, 30000);
+
   it("adopts __VINEXT_SHARED_BUILD_ID so the runtime and BUILD_ID file agree", async () => {
     // The `vinext build` CLI resolves the build ID once and shares it via
     // __VINEXT_SHARED_BUILD_ID so that every plugin instance in a build (App

--- a/tests/app-router-production-build.test.ts
+++ b/tests/app-router-production-build.test.ts
@@ -192,11 +192,20 @@ describe("App Router Production build", () => {
 `,
       );
       fs.writeFileSync(
+        path.join(tmpDir, "app", "client.tsx"),
+        `"use client";
+
+export function ClientIsland() {
+  return <button type="button">island</button>;
+}
+`,
+      );
+      fs.writeFileSync(
         path.join(tmpDir, "app", "page.tsx"),
-        `import Link from "next/link";
+        `import { ClientIsland } from "./client";
 
 export default function Page() {
-  return <Link href="/about">about</Link>;
+  return <ClientIsland />;
 }
 `,
       );
@@ -225,6 +234,49 @@ export default function Page() {
       expect(clientJs).not.toContain("registerNavigationRuntimeBootstrap");
       expect(clientJs).not.toContain("registerNavigationRuntimeFunctions");
       expect(clientJs).not.toContain("__VINEXT_LINK_PREFETCH_ROUTES__");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  }, 30000);
+
+  it("keeps the full browser runtime when app routes render next/link", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-link-runtime-"));
+
+    try {
+      fs.symlinkSync(
+        path.resolve(import.meta.dirname, "../node_modules"),
+        path.join(tmpDir, "node_modules"),
+        "junction",
+      );
+      fs.mkdirSync(path.join(tmpDir, "app"), { recursive: true });
+      fs.writeFileSync(
+        path.join(tmpDir, "app", "layout.tsx"),
+        `export default function Root({ children }: { children: React.ReactNode }) {
+  return <html><body>{children}</body></html>;
+}
+`,
+      );
+      fs.writeFileSync(
+        path.join(tmpDir, "app", "page.tsx"),
+        `import Link from "next/link";
+
+export default function Page() {
+  return <Link href="/about">about</Link>;
+}
+`,
+      );
+
+      const builder = await createBuilder({
+        root: tmpDir,
+        configFile: false,
+        plugins: [vinext({ appDir: tmpDir })],
+        logLevel: "silent",
+      });
+      await builder.buildApp();
+
+      const clientJs = readAllJs(path.join(tmpDir, "dist", "client"));
+      expect(clientJs).toContain("vinext.navigationRuntime");
+      expect(clientJs).toContain("__VINEXT_LINK_PREFETCH_ROUTES__");
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/tests/app-router-production-build.test.ts
+++ b/tests/app-router-production-build.test.ts
@@ -174,6 +174,62 @@ describe("App Router Production build", () => {
     }
   }, 30000);
 
+  it("uses the document-only browser runtime when app client refs do not need router state", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-document-runtime-"));
+
+    try {
+      fs.symlinkSync(
+        path.resolve(import.meta.dirname, "../node_modules"),
+        path.join(tmpDir, "node_modules"),
+        "junction",
+      );
+      fs.mkdirSync(path.join(tmpDir, "app"), { recursive: true });
+      fs.writeFileSync(
+        path.join(tmpDir, "app", "layout.tsx"),
+        `export default function Root({ children }: { children: React.ReactNode }) {
+  return <html><body>{children}</body></html>;
+}
+`,
+      );
+      fs.writeFileSync(
+        path.join(tmpDir, "app", "page.tsx"),
+        `import Link from "next/link";
+
+export default function Page() {
+  return <Link href="/about">about</Link>;
+}
+`,
+      );
+
+      const builder = await createBuilder({
+        root: tmpDir,
+        configFile: false,
+        plugins: [vinext({ appDir: tmpDir })],
+        logLevel: "silent",
+      });
+      await builder.buildApp();
+
+      const clientDir = path.join(tmpDir, "dist", "client");
+      const manifest = JSON.parse(
+        fs.readFileSync(path.join(clientDir, ".vite", "manifest.json"), "utf-8"),
+      ) as Record<string, ClientManifestEntry>;
+      const manifestSources = Object.entries(manifest).map(([key, entry]) =>
+        (entry.src ?? key).replaceAll("\\", "/"),
+      );
+      expect(manifestSources.some((source) => /\/shims\/link\.(?:js|tsx)$/.test(source))).toBe(
+        false,
+      );
+
+      const clientJs = readAllJs(clientDir);
+      expect(clientJs).toContain("__VINEXT_RSC_BOOTSTRAP_STATE__");
+      expect(clientJs).not.toContain("registerNavigationRuntimeBootstrap");
+      expect(clientJs).not.toContain("registerNavigationRuntimeFunctions");
+      expect(clientJs).not.toContain("__VINEXT_LINK_PREFETCH_ROUTES__");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  }, 30000);
+
   it("adopts __VINEXT_SHARED_BUILD_ID so the runtime and BUILD_ID file agree", async () => {
     // The `vinext build` CLI resolves the build ID once and shares it via
     // __VINEXT_SHARED_BUILD_ID so that every plugin instance in a build (App

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -44,9 +44,10 @@ export async function waitForAppRouterHydration(page: Page): Promise<void> {
         runtime.functions !== null &&
         "navigate" in runtime.functions &&
         typeof runtime.functions.navigate === "function";
+      const hasDocumentOnlyRuntime = window.__VINEXT_DOCUMENT_ONLY_RSC_RUNTIME__ === true;
       const hydrated =
         Boolean(window.__VINEXT_RSC_ROOT__) &&
-        hasNavigate &&
+        (hasNavigate || hasDocumentOnlyRuntime) &&
         typeof window.__VINEXT_HYDRATED_AT === "number";
 
       if (!hydrated) {

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -135,6 +135,14 @@ describe("App Router generated manifest construction", () => {
     expect(code).toContain('"source":"/legacy","destination":"/about"');
   });
 
+  it("emits only the hydration entry when the client router runtime is unused", () => {
+    const code = generateBrowserEntry([], null, [], undefined, false);
+
+    expect(code).toContain("app-browser-islands-entry");
+    expect(code).not.toContain("registerNavigationRuntimeBootstrap");
+    expect(code).not.toContain("__VINEXT_LINK_PREFETCH_ROUTES__");
+  });
+
   it("embeds the Link auto-prefetch route manifest in the browser entry", () => {
     const code = generateBrowserEntry([
       ...minimalAppRoutes,

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -408,6 +408,126 @@ afterEach(() => {
   vi.resetModules();
 });
 
+describe("document-navigation Link onNavigate prop", () => {
+  async function renderDocumentLinkAndClick(args: {
+    href: string;
+    props?: Record<string, unknown>;
+    clickEvent?: Partial<CapturedClickEvent>;
+    locationOverrides?: Record<string, unknown>;
+  }) {
+    vi.resetModules();
+
+    let capturedAnchorProps: CapturedAnchorProps | undefined;
+    mockReactAnchorCaptureForLinkOnly_DO_NOT_REUSE({
+      captureAnchor(type, props) {
+        if (type === "a" && props !== null && typeof props === "object") {
+          capturedAnchorProps = props;
+        }
+      },
+    });
+
+    const locationReplace = vi.fn();
+    vi.stubGlobal("window", {
+      location: {
+        href: "https://example.com/current",
+        origin: "https://example.com",
+        replace: locationReplace,
+        ...args.locationOverrides,
+      },
+    });
+
+    const { default: IsolatedLink } = await import("../packages/vinext/src/shims/link-document.js");
+    const React = await vi.importActual<typeof import("react")>("react");
+
+    ReactDOMServer.renderToString(
+      React.createElement(IsolatedLink, { href: args.href, ...args.props }, "target"),
+    );
+
+    const onClickHandler = capturedAnchorProps?.onClick;
+    if (typeof onClickHandler !== "function") {
+      throw new Error("Expected rendered document Link anchor to expose an onClick handler");
+    }
+
+    const clickEvent = {
+      button: 0,
+      currentTarget: { hasAttribute: () => false, target: "" },
+      defaultPrevented: false,
+      preventDefault() {
+        this.defaultPrevented = true;
+      },
+      ...args.clickEvent,
+    };
+
+    await onClickHandler(clickEvent);
+
+    return {
+      clickEvent,
+      locationReplace,
+    };
+  }
+
+  it("fires onNavigate for local document navigations", async () => {
+    const onClick = vi.fn();
+    const onNavigate = vi.fn();
+
+    const result = await renderDocumentLinkAndClick({
+      href: "/subpage",
+      props: { onClick, onNavigate },
+    });
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onNavigate).toHaveBeenCalledTimes(1);
+    expect(result.clickEvent.defaultPrevented).toBe(false);
+    expect(result.locationReplace).not.toHaveBeenCalled();
+  });
+
+  it("cancels local document navigation when onNavigate prevents default", async () => {
+    const onNavigate = vi.fn((event: { preventDefault(): void }) => {
+      event.preventDefault();
+    });
+
+    const result = await renderDocumentLinkAndClick({
+      href: "/subpage",
+      props: { onNavigate },
+    });
+
+    expect(onNavigate).toHaveBeenCalledTimes(1);
+    expect(result.clickEvent.defaultPrevented).toBe(true);
+    expect(result.locationReplace).not.toHaveBeenCalled();
+  });
+
+  it("skips onNavigate for external document navigations", async () => {
+    const onClick = vi.fn();
+    const onNavigate = vi.fn();
+
+    const result = await renderDocumentLinkAndClick({
+      href: "https://example.org/about",
+      props: { onClick, onNavigate },
+    });
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onNavigate).not.toHaveBeenCalled();
+    expect(result.clickEvent.defaultPrevented).toBe(false);
+    expect(result.locationReplace).not.toHaveBeenCalled();
+  });
+
+  it("calls location.replace for external document navigations with replace", async () => {
+    const onClick = vi.fn();
+    const onNavigate = vi.fn();
+
+    const result = await renderDocumentLinkAndClick({
+      href: "https://example.org/about",
+      props: { onClick, onNavigate, replace: true },
+    });
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onNavigate).not.toHaveBeenCalled();
+    expect(result.clickEvent.defaultPrevented).toBe(true);
+    expect(result.locationReplace).toHaveBeenCalledTimes(1);
+    expect(result.locationReplace).toHaveBeenCalledWith("https://example.org/about");
+  });
+});
+
 describe("Link App Router navigation scheduling", () => {
   it.each([
     { locationMethod: "assign" as const, replace: false },

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -21,6 +21,7 @@ import Link, {
   resolveLinkPrefetchMode,
   useLinkStatus,
 } from "../packages/vinext/src/shims/link.js";
+import DocumentLink from "../packages/vinext/src/shims/link-document.js";
 import {
   navigatePagesRouterLink,
   navigatePagesRouterLinkWithFallback,
@@ -45,6 +46,46 @@ import {
   toSameOriginAppPath,
   toSameOriginPath,
 } from "../packages/vinext/src/shims/url-utils.js";
+
+describe("document-navigation Link rendering", () => {
+  it("renders string and object hrefs without router state", () => {
+    expect(
+      ReactDOMServer.renderToString(React.createElement(DocumentLink, { href: "/about" }, "About")),
+    ).toContain('href="/about"');
+    expect(
+      ReactDOMServer.renderToString(
+        React.createElement(
+          DocumentLink,
+          { href: { pathname: "/search", query: { q: "test" } } },
+          "Search",
+        ),
+      ),
+    ).toContain('href="/search?q=test"');
+  });
+
+  it("uses the as prop and preserves legacy anchor rendering", () => {
+    const child = React.createElement("a", { className: "legacy" }, "User");
+    const html = ReactDOMServer.renderToString(
+      React.createElement(
+        DocumentLink,
+        { href: "/user/[id]", as: "/user/42", legacyBehavior: true },
+        child,
+      ),
+    );
+
+    expect(html).toContain('href="/user/42"');
+    expect(html).toContain('class="legacy"');
+    expect(html.match(/<a/g)).toHaveLength(1);
+  });
+
+  it("renders dangerous schemes without an href", () => {
+    const html = ReactDOMServer.renderToString(
+      React.createElement(DocumentLink, { href: "javascript:alert(1)" }, "Blocked"),
+    );
+
+    expect(html).not.toContain("href=");
+  });
+});
 
 // ─── SSR rendering (mirrors Next.js test/unit/link-rendering.test.ts) ────
 

--- a/tests/rsc-client-reference-loaders.test.ts
+++ b/tests/rsc-client-reference-loaders.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vite-plus/test";
+import { clientReferencesRequireRouterRuntime } from "../packages/vinext/src/plugins/rsc-client-reference-loaders.js";
+
+function createSourceReader(entries: Record<string, string[] | null>) {
+  return async (id: string) => entries[id] ?? null;
+}
+
+function createResolver(entries: Record<string, string>) {
+  return async (source: string, importer: string) => {
+    const id = entries[`${importer}:${source}`];
+    return id === undefined ? null : { id };
+  };
+}
+
+describe("client reference router runtime analysis", () => {
+  const internalRoot = "/repo/packages/vinext/src";
+  const routerRuntimeImportSpecifiers = new Set(["next/navigation"]);
+  const routerRuntimeModuleIds = ["/repo/packages/vinext/src/shims/navigation.ts"];
+
+  it("ignores vinext-owned client references", async () => {
+    await expect(
+      clientReferencesRequireRouterRuntime({
+        clientReferenceIds: ["/repo/packages/vinext/src/shims/link.tsx"],
+        readImportSpecifiers: createSourceReader({}),
+        resolveImport: createResolver({}),
+        internalRoot,
+        routerRuntimeImportSpecifiers,
+        routerRuntimeModuleIds,
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it("detects transitive router imports from user client references", async () => {
+    await expect(
+      clientReferencesRequireRouterRuntime({
+        clientReferenceIds: ["/repo/app/counter.tsx"],
+        readImportSpecifiers: createSourceReader({
+          "/repo/app/counter.tsx": ["./use-navigation"],
+          "/repo/app/use-navigation.ts": ["next/navigation"],
+        }),
+        resolveImport: createResolver({
+          "/repo/app/counter.tsx:./use-navigation": "/repo/app/use-navigation.ts",
+        }),
+        internalRoot,
+        routerRuntimeImportSpecifiers,
+        routerRuntimeModuleIds,
+      }),
+    ).resolves.toBe(true);
+  });
+
+  it("allows router-independent user client references", async () => {
+    await expect(
+      clientReferencesRequireRouterRuntime({
+        clientReferenceIds: ["/repo/app/counter.tsx"],
+        readImportSpecifiers: createSourceReader({
+          "/repo/app/counter.tsx": ["react"],
+          "/repo/node_modules/react/index.js": [],
+        }),
+        resolveImport: createResolver({
+          "/repo/app/counter.tsx:react": "/repo/node_modules/react/index.js",
+        }),
+        internalRoot,
+        routerRuntimeImportSpecifiers,
+        routerRuntimeModuleIds,
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it("falls back to the full runtime when the graph is incomplete", async () => {
+    await expect(
+      clientReferencesRequireRouterRuntime({
+        clientReferenceIds: ["/repo/app/counter.tsx"],
+        readImportSpecifiers: createSourceReader({}),
+        resolveImport: createResolver({}),
+        internalRoot,
+        routerRuntimeImportSpecifiers,
+        routerRuntimeModuleIds,
+      }),
+    ).resolves.toBe(true);
+  });
+});

--- a/tests/rsc-client-reference-loaders.test.ts
+++ b/tests/rsc-client-reference-loaders.test.ts
@@ -22,9 +22,25 @@ function createResolver(entries: Record<string, string>) {
 describe("client reference router runtime analysis", () => {
   const internalRoot = "/repo/packages/vinext/src";
   const routerRuntimeImportSpecifiers = new Set(["next/navigation"]);
-  const routerRuntimeModuleIds = ["/repo/packages/vinext/src/shims/navigation.ts"];
+  const routerRuntimeModuleIds = [
+    "/repo/packages/vinext/src/shims/link.tsx",
+    "/repo/packages/vinext/src/shims/navigation.ts",
+  ];
 
-  it("ignores vinext-owned client references", async () => {
+  it("ignores vinext-owned client references that are not router runtime modules", async () => {
+    await expect(
+      clientReferencesRequireRouterRuntime({
+        clientReferenceIds: ["/repo/packages/vinext/src/shims/error-boundary.tsx"],
+        readImportSpecifiers: createSourceReader({}),
+        resolveImport: createResolver({}),
+        internalRoot,
+        routerRuntimeImportSpecifiers,
+        routerRuntimeModuleIds,
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it("keeps the full runtime for vinext-owned router client references", async () => {
     await expect(
       clientReferencesRequireRouterRuntime({
         clientReferenceIds: ["/repo/packages/vinext/src/shims/link.tsx"],
@@ -34,7 +50,7 @@ describe("client reference router runtime analysis", () => {
         routerRuntimeImportSpecifiers,
         routerRuntimeModuleIds,
       }),
-    ).resolves.toBe(false);
+    ).resolves.toBe(true);
   });
 
   it("detects transitive router imports from user client references", async () => {
@@ -130,6 +146,23 @@ describe("client reference router runtime analysis", () => {
           "/repo/app/counter.tsx": ["external-package"],
         }),
         resolveImport: async () => ({ id: "external-package", external: true }),
+        internalRoot,
+        routerRuntimeImportSpecifiers,
+        routerRuntimeModuleIds,
+      }),
+    ).resolves.toBe(true);
+  });
+
+  it("falls back to the full runtime when import resolution fails", async () => {
+    await expect(
+      clientReferencesRequireRouterRuntime({
+        clientReferenceIds: ["/repo/app/counter.tsx"],
+        readImportSpecifiers: createSourceReader({
+          "/repo/app/counter.tsx": ["my-differentiated-files/browser"],
+        }),
+        resolveImport: async () => {
+          throw new Error("No known conditions for ./browser specifier.");
+        },
         internalRoot,
         routerRuntimeImportSpecifiers,
         routerRuntimeModuleIds,

--- a/tests/rsc-client-reference-loaders.test.ts
+++ b/tests/rsc-client-reference-loaders.test.ts
@@ -1,5 +1,12 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vite-plus/test";
-import { clientReferencesRequireRouterRuntime } from "../packages/vinext/src/plugins/rsc-client-reference-loaders.js";
+import type { Plugin } from "vite";
+import {
+  clientReferencesRequireRouterRuntime,
+  createRscClientReferenceLoadersPlugin,
+} from "../packages/vinext/src/plugins/rsc-client-reference-loaders.js";
 
 function createSourceReader(entries: Record<string, string[] | null>) {
   return async (id: string) => entries[id] ?? null;
@@ -77,5 +84,94 @@ describe("client reference router runtime analysis", () => {
         routerRuntimeModuleIds,
       }),
     ).resolves.toBe(true);
+  });
+
+  it("detects direct router module ids even when Vite adds a query", async () => {
+    await expect(
+      clientReferencesRequireRouterRuntime({
+        clientReferenceIds: ["/repo/app/counter.tsx"],
+        readImportSpecifiers: createSourceReader({
+          "/repo/app/counter.tsx": ["./navigation"],
+        }),
+        resolveImport: createResolver({
+          "/repo/app/counter.tsx:./navigation": "/repo/packages/vinext/src/shims/navigation.ts?v=1",
+        }),
+        internalRoot,
+        routerRuntimeImportSpecifiers,
+        routerRuntimeModuleIds,
+      }),
+    ).resolves.toBe(true);
+  });
+
+  it("handles cycles in router-independent client reference graphs", async () => {
+    await expect(
+      clientReferencesRequireRouterRuntime({
+        clientReferenceIds: ["/repo/app/a.tsx"],
+        readImportSpecifiers: createSourceReader({
+          "/repo/app/a.tsx": ["./b"],
+          "/repo/app/b.tsx": ["./a"],
+        }),
+        resolveImport: createResolver({
+          "/repo/app/a.tsx:./b": "/repo/app/b.tsx",
+          "/repo/app/b.tsx:./a": "/repo/app/a.tsx",
+        }),
+        internalRoot,
+        routerRuntimeImportSpecifiers,
+        routerRuntimeModuleIds,
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it("falls back to the full runtime for external dependencies", async () => {
+    await expect(
+      clientReferencesRequireRouterRuntime({
+        clientReferenceIds: ["/repo/app/counter.tsx"],
+        readImportSpecifiers: createSourceReader({
+          "/repo/app/counter.tsx": ["external-package"],
+        }),
+        resolveImport: async () => ({ id: "external-package", external: true }),
+        internalRoot,
+        routerRuntimeImportSpecifiers,
+        routerRuntimeModuleIds,
+      }),
+    ).resolves.toBe(true);
+  });
+
+  it("detects static CommonJS router requires through the scan plugin", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-client-ref-scan-"));
+    try {
+      const clientReferenceId = path.join(root, "counter.js");
+      await fs.writeFile(
+        clientReferenceId,
+        `"use client";\nconst navigation = require("next/navigation");\nexport { navigation };\n`,
+      );
+
+      let required: boolean | undefined;
+      const plugin = createRscClientReferenceLoadersPlugin({
+        internalRoot,
+        routerRuntimeImportSpecifiers: ["next/navigation"],
+        routerRuntimeModuleIds,
+        onClientRouterRuntimeAnalysis(value) {
+          required = value;
+        },
+      }) as Plugin;
+      const manager = {
+        isScanBuild: true,
+        clientReferenceMetaMap: { [clientReferenceId]: {} },
+        serverReferenceMetaMap: {},
+      };
+
+      await (plugin.configResolved as Function).call(plugin, {
+        plugins: [{ name: "rsc:minimal", api: { manager } }],
+      });
+      await (plugin.generateBundle as Function).call({
+        environment: { name: "rsc" },
+        resolve: async () => null,
+      });
+
+      expect(required).toBe(true);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
This PR omits the heavy App Router client runtime in production builds when build-time client-reference analysis proves no user client component needs router state.

It rewrites `next/link` client references to a lightweight document-navigation shim in that case, while conservatively falling back to the full runtime for:

* pages,
* i18n,
* instrumentation,
* server actions,
* external/unknown graph edges,
* next/navigation usage

Note: This only helps apps with client islands that do not pull in next/link, next/form, router hooks, next/router, etc. So “static page plus isolated widgets” benefit from this change.