### PR TITLE
fix(cloudflare): respect TPR cache opt-outs

### DIFF
--- a/packages/cloudflare/src/tpr.ts
+++ b/packages/cloudflare/src/tpr.ts
@@ -523,6 +523,35 @@ const SERVER_STARTUP_TIMEOUT = 30_000;
 /** Max concurrent fetch requests during pre-rendering. */
 const FETCH_CONCURRENCY = 10;
 
+const NON_CACHEABLE_CACHE_CONTROL_RE = /\b(?:no-store|no-cache|private)\b/i;
+
+function getTprHeader(headers: Record<string, string>, name: string): string | undefined {
+  const normalizedName = name.toLowerCase();
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === normalizedName) return value;
+  }
+  return undefined;
+}
+
+function hasNonCacheableCacheControl(headers: Record<string, string>): boolean {
+  const cacheControl = getTprHeader(headers, "cache-control");
+  return cacheControl ? NON_CACHEABLE_CACHE_CONTROL_RE.test(cacheControl) : false;
+}
+
+function readTprRevalidateHeader(headers: Record<string, string>): number | undefined {
+  const revalidateHeader = getTprHeader(headers, VINEXT_REVALIDATE_HEADER);
+  if (revalidateHeader === undefined) return undefined;
+
+  return Number(revalidateHeader);
+}
+
+function isTprCacheable(headers: Record<string, string>): boolean {
+  if (hasNonCacheableCacheControl(headers)) return false;
+
+  const revalidate = readTprRevalidateHeader(headers);
+  return revalidate === undefined || (Number.isFinite(revalidate) && revalidate > 0);
+}
+
 /**
  * Start a local production server, fetch each route to produce HTML,
  * and return the results. Pages that fail to render are skipped.
@@ -562,9 +591,8 @@ async function prerenderRoutes(
             redirect: "manual", // Don't follow redirects — cache the redirect itself
           });
 
-          // Only cache successful responses (2xx and 3xx)
+          // Only cache successful, cacheable responses (2xx and 3xx)
           if (response.status < 400) {
-            const html = await response.text();
             const headers: Record<string, string> = {};
             response.headers.forEach((value, key) => {
               // Only keep relevant headers
@@ -577,6 +605,10 @@ async function prerenderRoutes(
                 headers[key] = value;
               }
             });
+
+            if (!isTprCacheable(headers)) return;
+
+            const html = await response.text();
             results.set(routePath, {
               html,
               status: response.status,
@@ -689,18 +721,15 @@ export function buildTprKVPairs(
   const pairs: Array<{ key: string; value: string; expiration_ttl: number }> = [];
 
   for (const [routePath, result] of entries) {
-    const revalidateHeader = result.headers[VINEXT_REVALIDATE_HEADER];
-    const revalidateSeconds =
-      revalidateHeader && !isNaN(Number(revalidateHeader))
-        ? Number(revalidateHeader)
-        : defaultRevalidateSeconds;
+    if (!isTprCacheable(result.headers)) continue;
 
-    const revalidateAt = revalidateSeconds > 0 ? now + revalidateSeconds * 1000 : null;
+    const revalidateSeconds = readTprRevalidateHeader(result.headers) ?? defaultRevalidateSeconds;
+    if (!Number.isFinite(revalidateSeconds) || revalidateSeconds <= 0) continue;
 
-    // For revalidating entries: 30-day TTL matches runtime KVCacheHandler.set().
-    // For non-revalidating entries: runtime uses no TTL (entries persist indefinitely),
-    // but TPR uses a 24h fallback so pre-warmed entries don't accumulate forever.
-    const kvTtl = revalidateSeconds > 0 ? MAX_KV_TTL_SECONDS : 24 * 3600;
+    const revalidateAt = now + revalidateSeconds * 1000;
+
+    // 30-day TTL matches runtime KVCacheHandler.set().
+    const kvTtl = MAX_KV_TTL_SECONDS;
 
     // Path-derived implicit tags so revalidatePath()/revalidateTag() can
     // invalidate TPR-seeded entries. Without this the seeded entry has no

--- a/tests/tpr-kv-keys.test.ts
+++ b/tests/tpr-kv-keys.test.ts
@@ -55,10 +55,84 @@ describe("TPR KV key format", () => {
     expect(pairs[0].expiration_ttl).toBe(30 * 24 * 3600);
   });
 
-  it("uses 24-hour fallback TTL when revalidation is disabled", () => {
+  it("skips responses that disable revalidation", () => {
     const pairs = buildTprKVPairs(entry("/archive", { "x-vinext-revalidate": "0" }), buildId, 60);
-    // revalidateSeconds === 0 means no revalidation — use 24h fallback TTL
-    expect(pairs[0].expiration_ttl).toBe(24 * 3600);
+    expect(pairs).toEqual([]);
+  });
+
+  it("skips responses with invalid revalidate metadata", () => {
+    const pairs = buildTprKVPairs(
+      new Map([
+        [
+          "/negative",
+          {
+            html: "<html>negative</html>",
+            status: 200,
+            headers: { "x-vinext-revalidate": "-1" },
+          },
+        ],
+        [
+          "/infinite",
+          {
+            html: "<html>infinite</html>",
+            status: 200,
+            headers: { "x-vinext-revalidate": "Infinity" },
+          },
+        ],
+        [
+          "/malformed",
+          {
+            html: "<html>malformed</html>",
+            status: 200,
+            headers: { "x-vinext-revalidate": "soon" },
+          },
+        ],
+      ]),
+      buildId,
+      60,
+    );
+
+    expect(pairs).toEqual([]);
+  });
+
+  it("skips entries when the default revalidate window is not cacheable", () => {
+    expect(buildTprKVPairs(entry("/default-zero"), buildId, 0)).toEqual([]);
+    expect(buildTprKVPairs(entry("/default-infinite"), buildId, Infinity)).toEqual([]);
+  });
+
+  it("skips responses with non-cacheable Cache-Control directives", () => {
+    const pairs = buildTprKVPairs(
+      new Map<string, { html: string; status: number; headers: Record<string, string> }>([
+        [
+          "/private",
+          {
+            html: "<html>private</html>",
+            status: 200,
+            headers: { "cache-control": "Private, No-Store" },
+          },
+        ],
+        [
+          "/no-cache",
+          {
+            html: "<html>no-cache</html>",
+            status: 200,
+            headers: { "Cache-Control": "public, max-age=0, no-cache" },
+          },
+        ],
+        [
+          "/public",
+          {
+            html: "<html>public</html>",
+            status: 200,
+            headers: { "cache-control": "public, s-maxage=60" },
+          },
+        ],
+      ]),
+      buildId,
+      60,
+    );
+
+    expect(pairs.map((pair) => pair.key)).toEqual([`cache:app:${buildId}:/public:html`]);
   });
 
   it("buildTprKVPairs accepts undefined buildId (documents key format; runTPR now fails fast if BUILD_ID is missing)", () => {


### PR DESCRIPTION
## Summary
- skip TPR KV seeding when prerendered responses opt out via `Cache-Control: private`, `no-store`, or `no-cache`
- reject non-positive, non-finite, or malformed `x-vinext-revalidate` metadata before writing KV pairs
- cover disabled revalidation, invalid metadata, bad default windows, and case-insensitive cache-control handling

## Validation
- `vp test run tests/tpr-kv-keys.test.ts`
- `vp check packages/cloudflare/src/tpr.ts tests/tpr-kv-keys.test.ts`
- `git diff --check`
- `vp run @vinext/cloudflare#build`

## Review
- Independent sub-agent review: no findings