### PR TITLE
fix(app-router): limit mounted slot cache variants

### DIFF
--- a/packages/vinext/src/server/app-page-cache-finalizer.ts
+++ b/packages/vinext/src/server/app-page-cache-finalizer.ts
@@ -251,13 +251,13 @@ export function scheduleAppPageRscCacheWrite(
   options: ScheduleAppPageRscCacheWriteOptions,
 ): boolean {
   const capturedRscDataPromise = options.capturedRscDataPromise;
-  if (!capturedRscDataPromise || options.dynamicUsedDuringBuild) {
+  if (!capturedRscDataPromise || options.dynamicUsedDuringBuild || options.mountedSlotsHeader) {
     return false;
   }
 
   const rscKey = options.isrRscKey(
     options.cleanPathname,
-    options.mountedSlotsHeader,
+    null,
     options.renderMode,
     options.interceptionContext,
   );

--- a/packages/vinext/src/server/app-page-cache.ts
+++ b/packages/vinext/src/server/app-page-cache.ts
@@ -330,10 +330,15 @@ async function serveAppPageCachedHtml(
 export async function readAppPageCacheResponse(
   options: ReadAppPageCacheResponseOptions,
 ): Promise<Response | null> {
+  if (options.isRscRequest && options.mountedSlotsHeader) {
+    options.isrDebug?.("MISS (mounted slots RSC variant)", options.cleanPathname);
+    return null;
+  }
+
   const isrKey = options.isRscRequest
     ? options.isrRscKey(
         options.cleanPathname,
-        options.mountedSlotsHeader,
+        null,
         options.renderMode,
         options.interceptionContext,
       )
@@ -431,7 +436,7 @@ export async function readAppPageCacheResponse(
               ? isrKey
               : options.isrRscKey(
                   options.cleanPathname,
-                  options.mountedSlotsHeader,
+                  null,
                   options.renderMode,
                   options.interceptionContext,
                 ),

--- a/tests/app-page-cache.test.ts
+++ b/tests/app-page-cache.test.ts
@@ -520,119 +520,86 @@ describe("app page cache helpers", () => {
     expect(didClearRequestContext).toBe(true);
   });
 
-  it("keys RSC cache reads by mounted-slot header and echoes the variant header", async () => {
+  it("bypasses persistent RSC cache reads for mounted-slot variants", async () => {
+    const debugCalls: Array<[string, string]> = [];
+    const isrGet = vi.fn();
+    const isrRscKey = vi.fn();
+
     const response = await readAppPageCacheResponse({
       cleanPathname: "/cached",
       clearRequestContext() {},
       isRscRequest: true,
-      async isrGet(key) {
-        expect(key).toBe("rsc:/cached:slot:auth:/");
-        return buildISRCacheEntry(
-          buildCachedAppPageValue("", new TextEncoder().encode("flight").buffer),
-        );
-      },
+      isrGet,
       isrHtmlKey(pathname) {
         return "html:" + pathname;
       },
-      isrRscKey(pathname, mountedSlotsHeader) {
-        return `rsc:${pathname}:${mountedSlotsHeader ?? "none"}`;
-      },
+      isrRscKey,
       async isrSet() {},
+      isrDebug(event, detail) {
+        debugCalls.push([event, detail]);
+      },
       mountedSlotsHeader: "slot:auth:/",
       revalidateSeconds: 60,
       async renderFreshPageForCache() {
-        throw new Error("should not render");
+        throw new Error("read helper should not render directly");
       },
       scheduleBackgroundRegeneration() {
         throw new Error("should not schedule regeneration");
       },
     });
 
-    expect(response?.headers.get("x-vinext-mounted-slots")).toBe("slot:auth:/");
+    expect(response).toBeNull();
+    expect(isrGet).not.toHaveBeenCalled();
+    expect(isrRscKey).not.toHaveBeenCalled();
+    expect(debugCalls).toEqual([["MISS (mounted slots RSC variant)", "/cached"]]);
   });
 
-  it("serves stale RSC entries and regenerates only the matching RSC cache key", async () => {
+  it("does not serve or regenerate stale mounted-slot RSC cache entries", async () => {
     const scheduledRegenerations: Array<() => Promise<void>> = [];
     const isrRscKey = vi.fn(
       (pathname: string, mountedSlotsHeader?: string | null) =>
         `rsc:${pathname}:${mountedSlotsHeader ?? "none"}`,
     );
-    const isrSetCalls: Array<{
-      key: string;
-      html: string;
-      hasRscData: boolean;
-      expireSeconds: number | undefined;
-      revalidateSeconds: number;
-      tags: string[];
-    }> = [];
-    const rscData = new TextEncoder().encode("fresh-flight").buffer;
+    const isrGet = vi.fn();
+    const isrSet = vi.fn();
 
     const response = await readAppPageCacheResponse({
       cleanPathname: "/stale",
       clearRequestContext() {},
       isRscRequest: true,
-      async isrGet() {
-        return buildISRCacheEntry(buildCachedAppPageValue("", rscData), true);
-      },
+      isrGet,
       isrHtmlKey(pathname) {
         return "html:" + pathname;
       },
       isrRscKey,
-      async isrSet(key, data, revalidateSeconds, tags, expireSeconds) {
-        isrSetCalls.push({
-          key,
-          html: data.html,
-          hasRscData: Boolean(data.rscData),
-          expireSeconds,
-          revalidateSeconds,
-          tags,
-        });
-      },
+      isrSet,
       mountedSlotsHeader: "slot:auth:/",
       expireSeconds: 300,
       revalidateSeconds: 60,
       async renderFreshPageForCache() {
-        return {
-          cacheControl: { revalidate: 10, expire: 20 },
-          html: "<h1>fresh</h1>",
-          rscData,
-          tags: ["/stale", "_N_T_/stale"],
-        };
+        throw new Error("read helper should not render directly");
       },
       scheduleBackgroundRegeneration(_key, renderFn) {
         scheduledRegenerations.push(renderFn);
       },
     });
 
-    expect(response?.headers.get("x-vinext-cache")).toBe("STALE");
-    expect(scheduledRegenerations).toHaveLength(1);
-
-    await scheduledRegenerations[0]();
-
-    expect(isrRscKey).toHaveBeenCalledOnce();
-    expect(isrSetCalls).toEqual([
-      {
-        key: "rsc:/stale:slot:auth:/",
-        html: "",
-        hasRscData: true,
-        expireSeconds: 20,
-        revalidateSeconds: 10,
-        tags: ["/stale", "_N_T_/stale"],
-      },
-    ]);
+    expect(response).toBeNull();
+    expect(isrGet).not.toHaveBeenCalled();
+    expect(isrRscKey).not.toHaveBeenCalled();
+    expect(isrSet).not.toHaveBeenCalled();
+    expect(scheduledRegenerations).toHaveLength(0);
   });
 
-  it("dedups stale RSC regeneration by the slot-specific cache key", async () => {
+  it("does not dedup mounted-slot RSC regeneration by a persistent cache key", async () => {
     const scheduledKeys: string[] = [];
-    const rscData = new TextEncoder().encode("stale-flight").buffer;
+    const isrGet = vi.fn();
 
-    await readAppPageCacheResponse({
+    const response = await readAppPageCacheResponse({
       cleanPathname: "/parallel",
       clearRequestContext() {},
       isRscRequest: true,
-      async isrGet() {
-        return buildISRCacheEntry(buildCachedAppPageValue("", rscData), true);
-      },
+      isrGet,
       isrHtmlKey(pathname) {
         return "html:" + pathname;
       },
@@ -643,18 +610,16 @@ describe("app page cache helpers", () => {
       mountedSlotsHeader: "slot:auth:/",
       revalidateSeconds: 60,
       async renderFreshPageForCache() {
-        return {
-          html: "<h1>fresh</h1>",
-          rscData,
-          tags: ["/parallel", "_N_T_/parallel"],
-        };
+        throw new Error("read helper should not render directly");
       },
       scheduleBackgroundRegeneration(key) {
         scheduledKeys.push(key);
       },
     });
 
-    expect(scheduledKeys).toEqual(["rsc:/parallel:slot:auth:/"]);
+    expect(response).toBeNull();
+    expect(isrGet).not.toHaveBeenCalled();
+    expect(scheduledKeys).toEqual([]);
   });
 
   it("serves stale HTML entries and regenerates HTML plus canonical RSC cache keys", async () => {
@@ -687,6 +652,7 @@ describe("app page cache helpers", () => {
           revalidateSeconds,
         });
       },
+      mountedSlotsHeader: "slot:forged:/",
       expireSeconds: 300,
       revalidateSeconds: 60,
       async renderFreshPageForCache() {
@@ -1251,6 +1217,36 @@ describe("app page cache helpers", () => {
       },
     ]);
     expect(debugCalls).toEqual([["RSC cache written", "rsc:/fresh-rsc"]]);
+  });
+
+  it("skips persistent RSC cache writes for mounted-slot variants", async () => {
+    const pendingCacheWrites: Promise<void>[] = [];
+    const isrRscKey = vi.fn();
+    const isrSet = vi.fn();
+
+    const didSchedule = scheduleAppPageRscCacheWrite({
+      capturedRscDataPromise: Promise.resolve(new TextEncoder().encode("flight").buffer),
+      cleanPathname: "/fresh-rsc",
+      consumeDynamicUsage() {
+        return false;
+      },
+      dynamicUsedDuringBuild: false,
+      getPageTags() {
+        return ["/fresh-rsc", "_N_T_/fresh-rsc"];
+      },
+      isrRscKey,
+      isrSet,
+      mountedSlotsHeader: "slot:auth:/",
+      revalidateSeconds: 60,
+      waitUntil(promise) {
+        pendingCacheWrites.push(promise);
+      },
+    });
+
+    expect(didSchedule).toBe(false);
+    expect(pendingCacheWrites).toEqual([]);
+    expect(isrRscKey).not.toHaveBeenCalled();
+    expect(isrSet).not.toHaveBeenCalled();
   });
 
   it("marks client-facing RSC cache MISS responses no-store until the stream dynamic check finishes", async () => {

--- a/tests/app-page-dispatch.test.ts
+++ b/tests/app-page-dispatch.test.ts
@@ -2089,7 +2089,7 @@ describe("app page dispatch", () => {
     });
   });
 
-  it("regenerates stale intercepted RSC cache entries from the source route", async () => {
+  it("fresh-renders mounted-slot intercepted RSC requests without persistent cache reuse", async () => {
     const sourceRoute = createRoute({ params: [], pattern: "/feed", routeSegments: ["feed"] });
     const currentRoute = createRoute({
       params: ["id"],
@@ -2172,20 +2172,15 @@ describe("app page dispatch", () => {
 
     const response = await dispatchAppPage(options);
 
-    expect(response.headers.get("x-vinext-cache")).toBe("STALE");
-    await expect(response.text()).resolves.toBe("stale-flight");
-    expect(typeof scheduledRender).toBe("function");
-    if (typeof scheduledRender !== "function") {
-      throw new Error("expected stale intercepted RSC response to schedule regeneration");
-    }
-
-    await scheduledRender();
+    expect(response.headers.get("x-vinext-cache")).toBeNull();
+    await expect(response.text()).resolves.toBe("flight");
+    expect(scheduledRender).toBeNull();
 
     const [routeArg, paramsArg, optsArg, searchParamsArg] = buildPageElement.mock.calls[0];
     expect(resolveRouteFetchCacheMode).toHaveBeenCalledWith(sourceRoute);
     expect(routeArg).toBe(sourceRoute);
     expect(paramsArg).toEqual({});
-    expect(searchParamsArg.toString()).toBe("");
+    expect(searchParamsArg.toString()).toBe("tab=popular");
     expect(optsArg).toMatchObject({
       interceptionContext: "/feed",
       interceptParams: { id: "123" },
@@ -2193,13 +2188,8 @@ describe("app page dispatch", () => {
       interceptSlotKey: "modal@app/feed/@modal",
       interceptSourceMatchedUrl: "/feed",
     });
-    expect(options.isrSet).toHaveBeenCalledWith(
-      "rsc:/photos/123:slot:modal:/feed:/feed",
-      expect.objectContaining({ kind: "APP_PAGE" }),
-      60,
-      expect.arrayContaining(["/photos/123", "_N_T_/feed/page"]),
-      undefined,
-    );
+    expect(options.isrGet).not.toHaveBeenCalled();
+    expect(options.isrSet).not.toHaveBeenCalled();
   });
 
   it("resolves the intercept source route's dynamic config for force-dynamic fetch defaults", async () => {
@@ -2777,14 +2767,9 @@ describe("app page dispatch", () => {
 
     const response = await dispatchAppPage(options);
 
-    expect(response.headers.get("x-vinext-cache")).toBe("STALE");
-    expect(typeof scheduledRender).toBe("function");
-    if (typeof scheduledRender !== "function") {
-      throw new Error("expected stale response to schedule regeneration");
-    }
-
-    await scheduledRender();
-
+    expect(response.headers.get("x-vinext-cache")).toBeNull();
+    await expect(response.text()).resolves.toBe("flight");
+    expect(scheduledRender).toBeNull();
     expect(resolveRouteDynamicConfig).toHaveBeenCalledWith(targetRoute);
     const [routeArg] = buildPageElement.mock.calls[0];
     expect(routeArg).toBe(targetRoute);


### PR DESCRIPTION
## Summary
- bypass persistent App Router RSC ISR cache reads and writes for mounted-slot variants
- keep HTML-triggered RSC regeneration on the canonical no-mounted-slots key
- keep mounted slots in the public RSC Vary/header-hash variant surface for Next.js-shaped CDN behavior
- preserve fresh mounted-slot RSC rendering semantics, including live request search params

## Tests
- vp test run tests/app-rsc-cache-busting.test.ts
- vp test run tests/app-page-cache.test.ts tests/app-page-dispatch.test.ts tests/app-rsc-cache-busting.test.ts tests/app-rsc-request-normalization.test.ts tests/isr-cache.test.ts
- vp check packages/vinext/src/server/app-page-cache.ts packages/vinext/src/server/app-page-cache-finalizer.ts packages/vinext/src/server/app-rsc-cache-busting.ts tests/app-page-cache.test.ts tests/app-page-dispatch.test.ts tests/app-rsc-cache-busting.test.ts

## Review
- independent review completed with no remaining findings
- Bonk review feedback addressed