### PR TITLE
fix: fully elide inline type-only import specifiers

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2417,9 +2417,29 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           // continue to use `vite:oxc`'s default `lang` inference.
           //
           // Vite 7 uses `esbuild` for transforms, Vite 8+ uses `oxc`.
+          //
+          // `typescript.onlyRemoveTypeImports: false` matches Next.js (SWC)
+          // type-import elision: `import { type Metadata } from "next"` is
+          // removed entirely when every specifier is type-only. Without it,
+          // OXC/esbuild honour `"verbatimModuleSyntax": true` from the app's
+          // tsconfig (emitted stock by create-t3-app and other scaffolds) and
+          // keep a side-effect `import "next"` — which pulls the real Next.js
+          // server runtime into the RSC graph, and pulls server-only modules
+          // into the client bundle when a `"use client"` file imports only
+          // types from them.
           ...(viteMajorVersion >= 8
-            ? { oxc: { jsx: { runtime: "automatic" } } }
-            : { esbuild: { jsx: "automatic" } }),
+            ? {
+                oxc: {
+                  jsx: { runtime: "automatic" },
+                  typescript: { onlyRemoveTypeImports: false },
+                },
+              }
+            : {
+                esbuild: {
+                  jsx: "automatic",
+                  tsconfigRaw: { compilerOptions: { verbatimModuleSyntax: false } },
+                },
+              }),
           // Define env vars for client bundle
           define: defines,
           // Set base path if configured.

--- a/tests/fixtures/app-type-only-imports/app/client-widget.tsx
+++ b/tests/fixtures/app-type-only-imports/app/client-widget.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+// Mixed value + inline type specifiers: the value import must survive.
+import { useState, type FC } from "react";
+// Inline type-only specifier import of a server-only module. If elision
+// leaves a side-effect `import "./server-data"` behind, the server module
+// (and everything it imports) is pulled into the client bundle — the
+// create-t3-app failure mode where the tRPC server router shipped to the
+// browser.
+import { type ServerData } from "./server-data";
+
+const ClientWidget: FC = () => {
+  const [data] = useState<ServerData | null>(null);
+  return <p data-testid="client-widget">client widget {data ? data.secret : "empty"}</p>;
+};
+
+export default ClientWidget;

--- a/tests/fixtures/app-type-only-imports/app/layout.tsx
+++ b/tests/fixtures/app-type-only-imports/app/layout.tsx
@@ -1,0 +1,16 @@
+// Inline type-only specifier import (biome style). Popular scaffolds
+// (create-t3-app) emit this form; it must be fully elided even though this
+// fixture's tsconfig enables `verbatimModuleSyntax`.
+import { type Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Type-Only Imports Fixture",
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/tests/fixtures/app-type-only-imports/app/page.tsx
+++ b/tests/fixtures/app-type-only-imports/app/page.tsx
@@ -1,0 +1,10 @@
+import ClientWidget from "./client-widget";
+
+export default function HomePage() {
+  return (
+    <>
+      <h1 id="type-only-imports-home">Type Only Imports</h1>
+      <ClientWidget />
+    </>
+  );
+}

--- a/tests/fixtures/app-type-only-imports/app/server-data.ts
+++ b/tests/fixtures/app-type-only-imports/app/server-data.ts
@@ -1,0 +1,5 @@
+// Server-only module. Must never appear in the client module graph — it is
+// only ever imported via inline `type` specifiers from client code.
+export type ServerData = { secret: string };
+
+export const SERVER_DATA_SENTINEL = "server-data-sentinel";

--- a/tests/fixtures/app-type-only-imports/tsconfig.json
+++ b/tests/fixtures/app-type-only-imports/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "types": ["vite/client", "@vitejs/plugin-rsc/types"]
+  },
+  "include": ["app", "*.ts", "../../../packages/vinext/src/shims/next-shims.d.ts"]
+}

--- a/tests/type-only-imports.test.ts
+++ b/tests/type-only-imports.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Test: inline type-only import specifier elision
+ *
+ * Next.js (SWC) fully elides `import { type Metadata } from "next"` — the
+ * whole statement is removed because every specifier is type-only. esbuild
+ * and tsc (without `verbatimModuleSyntax`) behave the same way.
+ *
+ * Vite 8's OXC transform reads the project tsconfig; when it contains
+ * `"verbatimModuleSyntax": true` (emitted stock by create-t3-app and other
+ * scaffolds), OXC switches to `onlyRemoveTypeImports` semantics and leaves a
+ * side-effect `import "next"` behind. That pulls the real Next.js server
+ * runtime into the RSC graph (dev 500s, build failures) and — worse — pulls
+ * server-only modules into the client bundle when a `"use client"` file uses
+ * `import { type X } from "~/server/..."`.
+ *
+ * vinext forces `typescript.onlyRemoveTypeImports: false` so elision matches
+ * Next.js regardless of the app's tsconfig.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vite-plus/test";
+import type { ViteDevServer } from "vite-plus";
+import path from "node:path";
+import { startFixtureServer, fetchHtml } from "./helpers.js";
+
+const FIXTURE_DIR = path.resolve(import.meta.dirname, "./fixtures/app-type-only-imports");
+
+describe("inline type-only import elision (verbatimModuleSyntax tsconfig)", () => {
+  let server: ViteDevServer;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    ({ server, baseUrl } = await startFixtureServer(FIXTURE_DIR, {
+      appRouter: true,
+    }));
+    // Warm up
+    await fetch(`${baseUrl}/`).catch(() => {});
+  }, 60_000);
+
+  afterAll(async () => {
+    await server?.close();
+  });
+
+  it("should not leave a runtime import of 'next' when all specifiers are type-only", async () => {
+    const rsc = server.environments["rsc"];
+    expect(rsc).toBeDefined();
+    const result = await rsc!.transformRequest("/app/layout.tsx");
+    expect(result).not.toBeNull();
+    // A surviving side-effect `import "next"` resolves to the real Next.js
+    // package and drags its server runtime into the RSC graph. In the dev
+    // module runner the import is rewritten to a `__vite_ssr_import__` of
+    // the resolved `.../node_modules/next/dist/server/next.js` path, so
+    // assert no reference to the real package (or a bare "next" id) remains.
+    expect(result!.code).not.toMatch(/["'][^"']*\/next\/dist\//);
+    expect(result!.code).not.toMatch(/["']next["']/);
+  });
+
+  it("should keep value specifiers in mixed value + type imports", async () => {
+    const client = server.environments["client"];
+    expect(client).toBeDefined();
+    const result = await client!.transformRequest("/app/client-widget.tsx");
+    expect(result).not.toBeNull();
+    expect(result!.code).toContain("useState");
+  });
+
+  it("should not pull a server module into the client graph via a type-only import", async () => {
+    const client = server.environments["client"];
+    expect(client).toBeDefined();
+    const result = await client!.transformRequest("/app/client-widget.tsx");
+    expect(result).not.toBeNull();
+    expect(result!.code).not.toContain("server-data");
+  });
+
+  it("should serve the page successfully", async () => {
+    const { res, html } = await fetchHtml(baseUrl, "/");
+    expect(res.status).toBe(200);
+    expect(html).toContain("Type Only Imports");
+  });
+});


### PR DESCRIPTION
## Problem

When every specifier in an import is type-only in inline form — `import { type Metadata } from "next"` — vinext leaves a side-effect `import "next"` behind. Next.js (SWC), and esbuild/tsc without `verbatimModuleSyntax`, elide the whole statement.

This breaks popular scaffolds out of the box. create-t3-app emits both `"verbatimModuleSyntax": true` and the inline-type import style stock, so on vinext@0.2.0:

- `import { type Metadata } from "next"` in `app/layout.tsx` pulls the real Next.js server runtime into the RSC graph → `vinext dev` 500s every request (`require is not defined` in next's compiled CJS) and `vinext build` fails (`client-only cannot be imported in server build` via styled-jsx ← next-server).
- Worse: `import { type AppRouter } from "~/server/api/root"` in a `"use client"` file bundles the entire tRPC server router into the browser chunk — the build succeeds but hydration crashes in dev **and** prod, and server code ships to clients.
- Pages Router hits it too: `import { type GetStaticProps } from "next"` (stock in nextjs-notion-starter-kit) → dev 500, build fails resolving `critters`.

## Root cause

Vite 8's `vite:oxc` transform (and Vite 7's esbuild path) auto-discovers the app's tsconfig and maps `"verbatimModuleSyntax": true` → oxc `typescript.onlyRemoveTypeImports: true`. That's faithful TS semantics, but Next.js ignores the setting and always elides — so vinext must opt out to match.

## Fix

Force `typescript: { onlyRemoveTypeImports: false }` in the oxc transform options (Vite 8) and `verbatimModuleSyntax: false` via `tsconfigRaw` on the Vite 7 esbuild path. One config point; flows to all environments (rsc/ssr/client), dev and build.

## Testing

- New `tests/type-only-imports.test.ts` + fixture (tsconfig with `verbatimModuleSyntax: true`): (a) type-only import from `next` leaves no runtime reference in the RSC graph, (b) mixed `import { useState, type FC }` keeps the value import, (c) `"use client"` file importing only types from a server module doesn't pull it into the client graph. 3 of 4 fail before the fix, reproducing the exact t3 error.
- Existing suites green: `app-router-dev-server.test.ts` (171), `shims.test.ts` (1175), jsx-in-js family, `vp check`.
- E2E: fresh untouched `create-t3-app --CI --trpc --tailwind --appRouter` against a packed local build — `vinext dev` 200, `vinext build` succeeds, `vinext start` 200, built client chunks contain zero tRPC server code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
