### PR TITLE
chore(release): reclassify 9eed252 as feat

### DIFF
--- a/.changeset/9eed2527018ba4a9459b28edff0450bb8b689aa7.md
+++ b/.changeset/9eed2527018ba4a9459b28edff0450bb8b689aa7.md
@@ -1,0 +1,3 @@
+---
+"vinext": minor
+---


### PR DESCRIPTION
Reclassifies `9eed2527018ba4a9459b28edff0450bb8b689aa7` as a feature/minor change.

The SHA-named changeset intentionally contains only frontmatter so the original changelog entry remains unchanged.