### PR TITLE
perf(app-router): cache route-handler dispatch import

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -330,7 +330,13 @@ ${
 } from ${JSON.stringify(appRouteHandlerResponsePath)};`
     : ""
 }
-const __loadAppRouteHandlerDispatch = () => import(${JSON.stringify(appRouteHandlerDispatchPath)});
+let __dispatchAppRouteHandlerFn;
+const __loadAppRouteHandlerDispatch = async () => {
+  if (__dispatchAppRouteHandlerFn) return __dispatchAppRouteHandlerFn;
+  const { dispatchAppRouteHandler } = await import(${JSON.stringify(appRouteHandlerDispatchPath)});
+  __dispatchAppRouteHandlerFn = dispatchAppRouteHandler;
+  return __dispatchAppRouteHandlerFn;
+};
 ${
   hasServerActions
     ? `const __loadAppServerActionExecution = () => import(${JSON.stringify(appServerActionExecutionPath)});`
@@ -947,8 +953,8 @@ export default createAppRscHandler({
     route,
     searchParams,
   }) {
-    const { dispatchAppRouteHandler: __dispatchAppRouteHandler } =
-      await __loadAppRouteHandlerDispatch();
+    const __dispatchAppRouteHandler =
+      __dispatchAppRouteHandlerFn ?? (await __loadAppRouteHandlerDispatch());
     return __dispatchAppRouteHandler({
       basePath: __basePath,
       cleanPathname,

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -962,9 +962,13 @@ describe("App Router entry templates", () => {
   it("generateRscEntry defers route-handler and server-action runtimes", () => {
     const code = generateRscEntry("/tmp/test/app", minimalAppRoutes, null, [], null, "", false);
 
-    expect(code).toContain('const __loadAppRouteHandlerDispatch = () => import("');
+    expect(code).toContain("let __dispatchAppRouteHandlerFn;");
+    expect(code).toContain("const __loadAppRouteHandlerDispatch = async () => {");
+    expect(code).toContain('const { dispatchAppRouteHandler } = await import("');
     expect(code).toContain('const __loadAppServerActionExecution = () => import("');
-    expect(code).toContain("await __loadAppRouteHandlerDispatch()");
+    expect(code).toContain(
+      "__dispatchAppRouteHandlerFn ?? (await __loadAppRouteHandlerDispatch())",
+    );
     expect(code).toContain("await __loadAppServerActionExecution()");
     expect(code).not.toMatch(/import \{\s*dispatchAppRouteHandler as __dispatchAppRouteHandler,/);
     expect(code).not.toMatch(


### PR DESCRIPTION
## Overview

| Item | Detail |
| --- | --- |
| Goal | Reduce steady-state Worker overhead for App Router route handlers. |
| Core change | Cache the resolved `dispatchAppRouteHandler` function after the generated RSC entry's first lazy import. |
| Boundary | Route-handler dispatch stays lazy and split from the main Worker entry. |
| Primary files | `packages/vinext/src/entries/app-rsc-entry.ts`, `tests/entry-templates.test.ts` |
| Benchmark signal | `/api/hello` median avg `2.5881ms` -> `2.4354ms` (`-0.1527ms/request`, about `-5.9%`); p90 avg `3.4362ms` -> `2.9384ms`. |
| Bundle impact | Main Worker entry remains `180,972` bytes (`52,281` gzip) and route dispatch remains a `13,716` byte split chunk. |

## Why This Is Still A Win

Route handlers are steady-state Worker hot-path requests. The first-principles target is simple: keep cold or optional route-handler runtime out of the main Worker entry, but do not keep paying route-handler module-resolution work after the isolate already loaded that module.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Per-request work | Work paid on every request compounds directly into route latency. | Later requests reuse the already resolved dispatch function instead of re-entering the dynamic import loader path. |
| Per-isolate work | Work that is only needed for route handlers can be paid once when the isolate first handles a route. | The first route request still imports `app-route-handler-dispatch`; the cache only applies after that. |
| Main Worker bundle | A Workers perf win should not buy a tiny route gain by making every entry request load more JS. | The dispatch runtime remains split out instead of becoming a static import. |
| App Router semantics | The generated entry should not duplicate route dispatch behavior. | Dispatch still executes through `app-route-handler-dispatch`; this only changes how the generated entry reaches it after first load. |

This matters even though the median delta is small. The static-import experiment made the route path faster, but it moved dispatch code into the main entry (`222.63 kB`, `64.90 kB` gzip), which makes unrelated Worker traffic pay for route-handler runtime. This version keeps the main entry at `180,972` bytes (`52,281` gzip) and removes repeat steady-state overhead only for isolates that actually serve route handlers.

## Worker Benchmark

Same fixture and local Worker runtime as the investigation path: `tests/fixtures/cf-app-basic`, Wrangler local workerd, `/api/hello`, 300 warmup requests, 2000 measured requests, 4 rounds.

| Metric | Same-session baseline | This PR | Delta |
| --- | ---: | ---: | ---: |
| Median avg | `2.5881ms` | `2.4354ms` | `-0.1527ms/request` (`-5.9%`) |
| p90 avg | `3.4362ms` | `2.9384ms` | `-0.4978ms/request` |
| Median rounds | `2.5727`, `2.4550`, `2.6480`, `2.6766` | `2.5379`, `2.3263`, `2.4365`, `2.4407` | Lower in all paired rounds. |
| p90 rounds | `3.9219`, `3.0033`, `3.4633`, `3.3562` | `3.2933`, `2.7144`, `2.9570`, `2.7887` | Lower in all paired rounds. |

Bundle shape after the change:

| Build artifact | Size |
| --- | ---: |
| `dist/server/index.js` | `180,972` bytes |
| gzipped `dist/server/index.js` | `52,281` bytes |
| route dispatch chunk | `13,716` bytes |

## What Changed

| Scenario | Before | After |
| --- | --- | --- |
| First route-handler request in an isolate | Dynamically imports `app-route-handler-dispatch`. | Still dynamically imports `app-route-handler-dispatch`. |
| Later route-handler requests in the same isolate | Awaits the loader path again. | Reuses the cached dispatch function directly. |
| Page and server-action paths | Route-handler runtime stays deferred. | Same. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/entries/app-rsc-entry.ts`
   - Review the generated loader shape.
   - Confirm it still uses dynamic `import()` and only caches the resolved function.

2. `tests/entry-templates.test.ts`
   - Confirms the route-handler runtime is still deferred.
   - Confirms no static `dispatchAppRouteHandler` import is emitted.

</details>

<details>
<summary>Validation</summary>

Checks run:

```bash
vp test run tests/entry-templates.test.ts tests/app-router-isr-codegen.test.ts tests/app-router-next-config-codegen.test.ts tests/app-rsc-handler.test.ts tests/app-route-handler-dispatch.test.ts tests/app-route-handler-execution.test.ts tests/after-deploy.test.ts
vp check packages/vinext/src/entries/app-rsc-entry.ts tests/entry-templates.test.ts
vp run vinext#build
cd tests/fixtures/cf-app-basic && vp build
```

Worker benchmark:

```bash
cd tests/fixtures/cf-app-basic
./node_modules/.bin/wrangler dev --config dist/server/wrangler.json --port 4192 --log-level error
```

Then `/api/hello`, 300 warmup, 2000 measured requests, 4 rounds.

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: no public API change.
- Runtime behavior: route dispatch still executes through the existing dispatch helper.
- Build output: route dispatch remains lazy and split.
- Worker impact: small steady-state route-handler improvement without the large main-bundle regression seen with a static import.
- Existing apps: first request in an isolate still pays the dynamic import as before.

</details>

<details>
<summary>Non-goals</summary>

- This does not implement a route-handler-specific request-state fast path.
- This does not change cookies, headers, middleware, fetch cache, ISR, route matching, or response finalisation.
- This does not optimise server-action dispatch.

</details>
