### PR TITLE
fix(config): tsconfig paths — longest-prefix matching and stylesheet-scoped aliases

### DIFF
--- a/packages/vinext/src/config/tsconfig-paths.ts
+++ b/packages/vinext/src/config/tsconfig-paths.ts
@@ -193,7 +193,17 @@ export function loadTsconfigResolutionForRoot(projectRoot: string): TsconfigPath
   for (const name of TSCONFIG_FILES) {
     const candidate = path.join(projectRoot, name);
     if (!fs.existsSync(candidate)) continue;
-    return loadResolutionFromTsconfigFile(candidate, new Set());
+    const resolution = loadResolutionFromTsconfigFile(candidate, new Set());
+    return {
+      // TypeScript matches `paths` by longest prefix regardless of declaration
+      // order, while Vite's alias plugin picks the first matching entry. Order
+      // overlapping patterns (e.g. `@/*` + `@/public/*`) longest-first so the
+      // specific pattern is not shadowed by the general one.
+      aliases: Object.fromEntries(
+        Object.entries(resolution.aliases).sort((a, b) => b[0].length - a[0].length),
+      ),
+      baseUrl: resolution.baseUrl,
+    };
   }
   return emptyResolution();
 }

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -831,6 +831,19 @@ function suppressOptionalOptimizeDepsWarnings(logger: Logger): void {
 // transforms can see them via resolve.alias without re-reading config files per env.
 const _tsconfigAliasCache = new Map<string, Record<string, string>>();
 
+/**
+ * Order materialized tsconfig path aliases by descending prefix length.
+ *
+ * TypeScript (and Next.js) match `paths` patterns by longest matched prefix,
+ * regardless of declaration order, while Vite's alias plugin picks the first
+ * matching entry. Overlapping patterns like `@/*` + `@/public/*` must
+ * therefore be materialized longest-first or the general pattern shadows the
+ * specific one (`@/public/foo.svg` would resolve into `src/public/`).
+ */
+function sortTsconfigAliasesBySpecificity(aliases: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(Object.entries(aliases).sort((a, b) => b[0].length - a[0].length));
+}
+
 function resolveTsconfigAliases(projectRoot: string): Record<string, string> {
   if (_tsconfigAliasCache.has(projectRoot)) {
     return _tsconfigAliasCache.get(projectRoot)!;
@@ -840,7 +853,7 @@ function resolveTsconfigAliases(projectRoot: string): Record<string, string> {
   for (const name of TSCONFIG_FILES) {
     const candidate = path.join(projectRoot, name);
     if (!fs.existsSync(candidate)) continue;
-    aliases = loadTsconfigPathAliases(candidate, projectRoot);
+    aliases = sortTsconfigAliasesBySpecificity(loadTsconfigPathAliases(candidate, projectRoot));
     break;
   }
 

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1,14 +1,16 @@
 import type {
+  Alias,
   CSSModulesOptions,
   Logger,
   Plugin,
   PluginOption,
   ResolvedConfig,
+  ResolverFunction,
   SassPreprocessorOptions,
   UserConfig,
   ViteDevServer,
 } from "vite";
-import { loadEnv, parseAst, transformWithOxc } from "vite";
+import { createLogger, loadEnv, parseAst, transformWithOxc } from "vite";
 import {
   pagesRouter,
   apiRouter,
@@ -861,6 +863,96 @@ function resolveTsconfigAliases(projectRoot: string): Record<string, string> {
   return aliases;
 }
 
+/**
+ * Stylesheet importer contexts as seen by Vite's internal CSS resolvers.
+ *
+ * Vite resolves CSS `@import`/`composes`/`url()` specifiers through a
+ * dedicated resolver container that only runs the alias plugin plus Vite's
+ * own resolver — user plugins never participate. The importer is either the
+ * stylesheet's own path (sass, CSS modules `composes`, url() rewriting) or a
+ * synthetic `<basedir>/*` (postcss-import, less).
+ */
+const STYLESHEET_IMPORTER_RE = /\.(?:css|scss|sass|less|styl|stylus|pcss|sss)$/i;
+
+function isStylesheetImporter(importer: string | undefined): boolean {
+  if (!importer) return false;
+  if (importer.endsWith("/*") || importer.endsWith("\\*")) return true;
+  return STYLESHEET_IMPORTER_RE.test(stripViteModuleQuery(importer));
+}
+
+/**
+ * Alias resolver for tsconfig-derived path aliases that keeps them out of
+ * stylesheet resolution.
+ *
+ * TypeScript `paths` never apply to CSS in Next.js — `@import` specifiers in
+ * stylesheets use standard bundler resolution, including package.json
+ * `exports` maps. A blind prefix-replacement alias breaks that: with
+ * `"@scope/ui/*": ["../../packages/ui/src/*"]` in tsconfig, an
+ * `@import "@scope/ui/globals.css"` whose real target is `exports`-mapped
+ * gets rewritten to a nonexistent source path and fails with ENOENT.
+ *
+ * Returning `null` for stylesheet importers makes the alias plugin fall
+ * through, so Vite's own resolver handles the original specifier. JS/TS
+ * importers keep the default alias behavior (Next.js applies `paths` there,
+ * including for `import "@/styles/globals.css"` from a layout), and Vite's
+ * glob/dynamic-import transforms — which require blind prefix replacement
+ * because their patterns never exist on disk — keep working.
+ */
+// `ResolverFunction` is typed with rolldown's synchronous resolveId signature,
+// but the alias plugin awaits resolver results, so an async resolver is fine —
+// hence the cast.
+const tsconfigAliasCustomResolver = async function (
+  this: { resolve: ResolveFromImporter },
+  updatedId: string,
+  importer: string | undefined,
+  options?: { skipSelf?: boolean },
+) {
+  if (isStylesheetImporter(importer)) return null;
+  // Mirror the alias plugin's default resolution for every other importer.
+  const resolved = await this.resolve(updatedId, importer, { ...options, skipSelf: true });
+  return resolved ?? { id: updatedId };
+} as unknown as ResolverFunction;
+
+/**
+ * Convert the merged alias map into Vite alias entries, attaching the
+ * stylesheet-scoping resolver to entries that came from tsconfig `paths`.
+ * Array order preserves the map's first-match ordering.
+ */
+function buildResolveAliasEntries(
+  aliasMap: Record<string, string>,
+  tsconfigPathAliases: Record<string, string>,
+): Alias[] {
+  return Object.entries(aliasMap).map(([find, replacement]) =>
+    tsconfigPathAliases[find] === replacement
+      ? { find, replacement, customResolver: tsconfigAliasCustomResolver }
+      : { find, replacement },
+  );
+}
+
+// Vite 8 logs a deprecation warning when `resolve.alias` contains a
+// `customResolver`. vinext uses one deliberately (see
+// `tsconfigAliasCustomResolver`): the aliases must stay in `resolve.alias`
+// for Vite's glob/dynamic-import transforms and internal resolvers, but must
+// not apply inside stylesheet resolution — and only a `customResolver` can
+// observe the importer there. Filter the warning so every project with
+// tsconfig `paths` doesn't boot with it.
+const ALIAS_CUSTOM_RESOLVER_DEPRECATION_RE =
+  /`resolve\.alias` contains an alias with `customResolver` option/;
+const VINEXT_FILTERED_ALIAS_DEPRECATION_WARN = Symbol.for("vinext.filteredAliasDeprecationWarn");
+
+function suppressAliasCustomResolverDeprecationWarning(logger: Logger): Logger {
+  const marker = logger as Logger & { [VINEXT_FILTERED_ALIAS_DEPRECATION_WARN]?: true };
+  if (marker[VINEXT_FILTERED_ALIAS_DEPRECATION_WARN]) return logger;
+
+  const warn = logger.warn.bind(logger);
+  logger.warn = (msg, warnOptions) => {
+    if (ALIAS_CUSTOM_RESOLVER_DEPRECATION_RE.test(stripAnsi(msg))) return;
+    warn(msg, warnOptions);
+  };
+  marker[VINEXT_FILTERED_ALIAS_DEPRECATION_WARN] = true;
+  return logger;
+}
+
 // Virtual module IDs for Pages Router production build
 const VIRTUAL_WORKER_ENTRY = "virtual:vinext-worker-entry";
 const RESOLVED_WORKER_ENTRY = VIRTUAL_PREFIX + VIRTUAL_WORKER_ENTRY;
@@ -1677,6 +1769,18 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           viteMajorVersion >= 8 && userResolve?.tsconfigPaths === undefined;
         const tsconfigPathAliases = resolveTsconfigAliases(root);
         const swcHelpersAlias = resolveSwcHelpersAlias(root);
+
+        // tsconfig-derived alias entries carry a customResolver, which Vite 8
+        // reports as deprecated during config resolution. Filter that warning
+        // (see suppressAliasCustomResolverDeprecationWarning). Mutating
+        // config.customLogger (rather than returning it) keeps mergeConfig
+        // from deep-cloning the logger and flattening its hasWarned getter.
+        if (Object.keys(tsconfigPathAliases).length > 0) {
+          config.customLogger = suppressAliasCustomResolverDeprecationWarning(
+            config.customLogger ??
+              createLogger(config.logLevel, { allowClearScreen: config.clearScreen }),
+          );
+        }
 
         // Load .env files into process.env before anything else.
         // Next.js loads .env files before evaluating next.config.js, so
@@ -2499,13 +2603,18 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           resolve: {
             // Materialize simple tsconfig/jsconfig path aliases into resolve.alias
             // so Vite can transform import.meta.glob("@/...") and import(`@/...`).
-            alias: {
-              ...(swcHelpersAlias ? { "@swc/helpers/_": swcHelpersAlias } : {}),
-              ...tsconfigPathAliases,
-              ...nextConfig.aliases,
-              ...nextShimMap,
-              "vinext/server/pages-client-assets": _pagesClientAssetsPath,
-            },
+            // tsconfig-derived entries carry a customResolver that keeps them out
+            // of stylesheet resolution (see tsconfigAliasCustomResolver).
+            alias: buildResolveAliasEntries(
+              {
+                ...(swcHelpersAlias ? { "@swc/helpers/_": swcHelpersAlias } : {}),
+                ...tsconfigPathAliases,
+                ...nextConfig.aliases,
+                ...nextShimMap,
+                "vinext/server/pages-client-assets": _pagesClientAssetsPath,
+              },
+              tsconfigPathAliases,
+            ),
             // Dedupe React packages to prevent dual-instance errors.
             // When vinext is linked (npm link / bun link) or any dependency
             // brings its own React copy, multiple React instances can load,

--- a/tests/build-optimization.test.ts
+++ b/tests/build-optimization.test.ts
@@ -35,6 +35,7 @@ import { setPagesClientAssets } from "../packages/vinext/src/server/pages-client
 import { computeClientRuntimeMetadata } from "../packages/vinext/src/utils/client-runtime-metadata.js";
 import { manifestFileWithBase } from "../packages/vinext/src/utils/manifest-paths.js";
 import { asyncHooksStubPlugin as _asyncHooksStubPlugin } from "../packages/vinext/src/plugins/async-hooks-stub.js";
+import { aliasEntriesToRecord } from "./helpers.js";
 
 // `stripServerExports` returns `{ code, map }`; these tests assert on the
 // transformed source, so unwrap to the code string (null is preserved).
@@ -203,9 +204,9 @@ describe("optimizeDeps.exclude for vinext", () => {
       expect(new Set(result.optimizeDeps.exclude).size).toBe(result.optimizeDeps.exclude.length);
       expect(result.environments.ssr.resolve.external).toContain("typescript");
       expect(result.define?.["process.env.__VINEXT_HAS_PAGES_ROUTER"]).toBe('"true"');
-      expect(result.resolve.alias["vinext/server/pages-client-assets"]).toMatch(
-        /server\/pages-client-assets\.ts$/,
-      );
+      expect(
+        aliasEntriesToRecord(result.resolve.alias)["vinext/server/pages-client-assets"],
+      ).toMatch(/server\/pages-client-assets\.ts$/);
     } finally {
       await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
     }

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -113,6 +113,25 @@ export async function startFixtureServer(
   return { server, baseUrl };
 }
 
+// ── Config helpers ────────────────────────────────────────────
+
+/**
+ * Normalize a config-hook `resolve.alias` value to a find→replacement record.
+ * vinext emits alias entry arrays (so tsconfig-derived entries can carry a
+ * customResolver); tests assert on the object view.
+ */
+export function aliasEntriesToRecord(alias: unknown): Record<string, string> {
+  if (Array.isArray(alias)) {
+    return Object.fromEntries(
+      alias.map((entry: { find: string | RegExp; replacement: string }) => [
+        String(entry.find),
+        entry.replacement,
+      ]),
+    );
+  }
+  return (alias ?? {}) as Record<string, string>;
+}
+
 // ── Fetch helpers ─────────────────────────────────────────────
 
 /**

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vite-plus/test";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
-import { PAGES_FIXTURE_DIR } from "./helpers.js";
+import { PAGES_FIXTURE_DIR, aliasEntriesToRecord } from "./helpers.js";
 import { isExternalUrl, isHashOnlyChange } from "../packages/vinext/src/shims/router.js";
 import { extractVinextNextDataJson } from "../packages/vinext/src/client/vinext-next-data.js";
 import { isValidModulePath } from "../packages/vinext/src/client/validate-module-path.js";
@@ -23376,11 +23376,11 @@ describe("shim alias map .js variants", () => {
       { mode: "development", command: "serve" },
     );
 
-    const aliases = result?.resolve?.alias as Record<string, string> | undefined;
-    expect(aliases).toBeDefined();
+    const aliases = aliasEntriesToRecord(result?.resolve?.alias);
+    expect(Object.keys(aliases).length).toBeGreaterThan(0);
 
     // Collect top-level next/<name> keys (exclude next/dist/*, next/font/*, next/compat/*, next/legacy/*)
-    const topLevel = Object.keys(aliases!).filter((key) => {
+    const topLevel = Object.keys(aliases).filter((key) => {
       if (!key.startsWith("next/")) return false;
       if (key.endsWith(".js")) return false;
       const segment = key.slice("next/".length);
@@ -23393,7 +23393,7 @@ describe("shim alias map .js variants", () => {
 
     expect(topLevel.length).toBeGreaterThan(0);
 
-    const missing = topLevel.filter((key) => !(key + ".js" in aliases!));
+    const missing = topLevel.filter((key) => !(key + ".js" in aliases));
     expect(missing, `Missing .js aliases for: ${missing.join(", ")}`).toEqual([]);
   });
 

--- a/tests/tsconfig-path-alias-resolution.test.ts
+++ b/tests/tsconfig-path-alias-resolution.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Integration tests for tsconfig `paths` → Vite alias conversion.
+ *
+ * Covers two resolution bugs in the materialized `resolve.alias` entries:
+ *
+ * 1. Declaration-order shadowing: TypeScript (and Next.js) match `paths`
+ *    patterns by longest prefix, regardless of declaration order. Overlapping
+ *    patterns like `@/*` + `@/public/*` must resolve `@/public/...` through
+ *    the more specific pattern even when `@/*` is declared first.
+ *    (Seen on ixartz/Next-js-Boilerplate — every page 500'd.)
+ *
+ * 2. CSS `@import` hijacking: TypeScript `paths` never apply to CSS in
+ *    Next.js — `@import` specifiers in stylesheets use standard bundler
+ *    resolution (including package.json `exports`). A tsconfig alias like
+ *    `@scope/ui/*` must not rewrite `@import "@scope/ui/globals.css"` inside
+ *    a CSS file away from its `exports`-mapped target. JS/TS imports of CSS
+ *    files (e.g. `import "@/styles/globals.css"` from a layout) still go
+ *    through the alias. (Seen on create-better-t-stack scaffolds — dev 500'd
+ *    on every route and the build failed in the analyze step.)
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createBuilder } from "vite";
+import { afterAll, describe, expect, it } from "vite-plus/test";
+import vinext from "../packages/vinext/src/index.js";
+import { startFixtureServer, fetchHtml } from "./helpers.js";
+
+const tmpDirs: string[] = [];
+
+function writeFixtureFile(root: string, filePath: string, content: string) {
+  const absPath = path.join(root, filePath);
+  fs.mkdirSync(path.dirname(absPath), { recursive: true });
+  fs.writeFileSync(absPath, content);
+}
+
+function makeTmpDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+function linkRepoNodeModules(root: string) {
+  const repoNodeModules = path.resolve(import.meta.dirname, "../node_modules");
+  try {
+    fs.symlinkSync(repoNodeModules, path.join(root, "node_modules"), "dir");
+  } catch {
+    fs.symlinkSync(repoNodeModules, path.join(root, "node_modules"), "junction");
+  }
+}
+
+afterAll(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("overlapping tsconfig path aliases (longest prefix wins)", () => {
+  function writeOverlappingAliasFixture(root: string) {
+    linkRepoNodeModules(root);
+    writeFixtureFile(
+      root,
+      "package.json",
+      JSON.stringify({ name: "overlapping-alias-fixture", private: true, type: "module" }),
+    );
+    // `@/*` is intentionally declared BEFORE the more specific `@/public/*`
+    // (matching ixartz/Next-js-Boilerplate). TypeScript matches by longest
+    // prefix, not declaration order.
+    writeFixtureFile(
+      root,
+      "tsconfig.json",
+      JSON.stringify({
+        compilerOptions: {
+          jsx: "react-jsx",
+          paths: {
+            "@/*": ["./src/*"],
+            "@/public/*": ["./public/*"],
+          },
+        },
+      }),
+    );
+    writeFixtureFile(
+      root,
+      "public/assets/images/icon.svg",
+      `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"></svg>\n`,
+    );
+    writeFixtureFile(root, "src/styles/globals.css", `body { background: rgb(250, 250, 249); }\n`);
+    writeFixtureFile(
+      root,
+      "src/lib/greeting.ts",
+      `export const greeting = "greeting-through-alias";\n`,
+    );
+    writeFixtureFile(
+      root,
+      "src/app/layout.tsx",
+      `import "@/styles/globals.css";
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}
+`,
+    );
+    writeFixtureFile(
+      root,
+      "src/app/page.tsx",
+      `import icon from "@/public/assets/images/icon.svg";
+import { greeting } from "@/lib/greeting";
+
+export default function HomePage() {
+  return (
+    <main>
+      <h1>overlapping-alias-page</h1>
+      <p data-testid="greeting">{greeting}</p>
+      <img data-testid="icon" src={icon.src} alt="icon" />
+    </main>
+  );
+}
+`,
+    );
+  }
+
+  it("serves a page importing through the more specific @/public/* alias", async () => {
+    const root = makeTmpDir("vinext-overlapping-alias-");
+    writeOverlappingAliasFixture(root);
+
+    const { server, baseUrl } = await startFixtureServer(root, {
+      appDir: path.join(root, "src"),
+    });
+    try {
+      const { res, html } = await fetchHtml(baseUrl, "/");
+      expect(res.status).toBe(200);
+      expect(html).toContain("overlapping-alias-page");
+      // `@/lib/greeting` resolves through the general `@/*` alias.
+      expect(html).toContain("greeting-through-alias");
+      // `@/public/assets/images/icon.svg` must resolve through the more
+      // specific `@/public/*` alias to public/, not src/public/. Small SVGs
+      // may be inlined as data URIs, so assert the img rendered with a src.
+      expect(html).toMatch(/data-testid="icon" src="[^"]+"/);
+    } finally {
+      await server.close();
+    }
+  }, 60_000);
+});
+
+describe("tsconfig aliases and CSS @import resolution", () => {
+  function writeWorkspaceCssFixture(root: string): string {
+    // Monorepo-ish layout modeled on create-better-t-stack scaffolds:
+    //   packages/ui   — workspace package with exports-mapped CSS
+    //   apps/web      — Next.js app whose tsconfig aliases @test/ui/* to the
+    //                   package SOURCE dir (which does NOT contain globals.css
+    //                   at the aliased location; only `exports` maps it).
+    const appRoot = path.join(root, "apps", "web");
+    fs.mkdirSync(appRoot, { recursive: true });
+    linkRepoNodeModules(root);
+
+    writeFixtureFile(
+      root,
+      "packages/ui/package.json",
+      JSON.stringify({
+        name: "@test/ui",
+        version: "0.0.0",
+        private: true,
+        type: "module",
+        exports: {
+          "./globals.css": "./src/styles/globals.css",
+        },
+      }),
+    );
+    writeFixtureFile(
+      root,
+      "packages/ui/src/styles/globals.css",
+      `:root { --ui-token: 1; }\nbody { margin: 0; }\n`,
+    );
+    writeFixtureFile(
+      root,
+      "packages/ui/src/components/button.tsx",
+      `export function Button() {
+  return <button type="button">ui-button-through-alias</button>;
+}
+`,
+    );
+
+    writeFixtureFile(
+      appRoot,
+      "package.json",
+      JSON.stringify({ name: "workspace-css-web", private: true, type: "module" }),
+    );
+    // Simulate the workspace install: the app resolves @test/ui as a package.
+    fs.mkdirSync(path.join(appRoot, "node_modules", "@test"), { recursive: true });
+    fs.symlinkSync(
+      path.join(root, "packages", "ui"),
+      path.join(appRoot, "node_modules", "@test", "ui"),
+      "dir",
+    );
+    writeFixtureFile(
+      appRoot,
+      "tsconfig.json",
+      JSON.stringify({
+        compilerOptions: {
+          jsx: "react-jsx",
+          paths: {
+            "@/*": ["./src/*"],
+            "@test/ui/*": ["../../packages/ui/src/*"],
+          },
+        },
+      }),
+    );
+    // The CSS @import uses the bare package specifier. Next.js resolves it
+    // through the package `exports` map; the tsconfig alias must not rewrite
+    // it to packages/ui/src/globals.css (which does not exist).
+    writeFixtureFile(
+      appRoot,
+      "src/index.css",
+      `@import "@test/ui/globals.css";\n.web-local { color: red; }\n`,
+    );
+    writeFixtureFile(
+      appRoot,
+      "src/app/layout.tsx",
+      `import "../index.css";
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}
+`,
+    );
+    // JS/TS imports keep resolving through the tsconfig alias — including
+    // subpaths that the package `exports` map does not expose.
+    writeFixtureFile(
+      appRoot,
+      "src/app/page.tsx",
+      `import { Button } from "@test/ui/components/button";
+
+export default function HomePage() {
+  return (
+    <main>
+      <h1>workspace-css-page</h1>
+      <Button />
+    </main>
+  );
+}
+`,
+    );
+    return appRoot;
+  }
+
+  it("dev: resolves an exports-mapped CSS @import despite a conflicting alias", async () => {
+    const root = makeTmpDir("vinext-workspace-css-dev-");
+    const appRoot = writeWorkspaceCssFixture(root);
+
+    const { server, baseUrl } = await startFixtureServer(appRoot, {
+      appDir: path.join(appRoot, "src"),
+    });
+    try {
+      const { res, html } = await fetchHtml(baseUrl, "/");
+      expect(res.status).toBe(200);
+      expect(html).toContain("workspace-css-page");
+      expect(html).toContain("ui-button-through-alias");
+    } finally {
+      await server.close();
+    }
+  }, 60_000);
+
+  it("build: completes with an exports-mapped CSS @import and a conflicting alias", async () => {
+    const root = makeTmpDir("vinext-workspace-css-build-");
+    const appRoot = writeWorkspaceCssFixture(root);
+
+    const builder = await createBuilder({
+      root: appRoot,
+      configFile: false,
+      plugins: [vinext({ appDir: path.join(appRoot, "src") })],
+      logLevel: "silent",
+    });
+    await builder.buildApp();
+
+    expect(fs.existsSync(path.join(appRoot, "dist", "server", "index.js"))).toBe(true);
+  }, 120_000);
+});

--- a/tests/tsconfig-paths-config-loader.test.ts
+++ b/tests/tsconfig-paths-config-loader.test.ts
@@ -168,6 +168,29 @@ describe("loadTsconfigPathAliasesForRoot", () => {
     expect(aliases["@app"]).toBe(path.join(tmpDir, "src", "app.ts"));
   });
 
+  it("orders overlapping aliases longest-prefix-first regardless of declaration order", () => {
+    tmpDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(tmpDir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          paths: {
+            // General pattern declared first; TypeScript matches by longest
+            // prefix, so consumers applying first-match semantics (Vite's
+            // alias plugin) need `@/public` ordered before `@`.
+            "@/*": ["./src/*"],
+            "@/public/*": ["./public/*"],
+          },
+        },
+      }),
+    );
+
+    const aliases = loadTsconfigPathAliasesForRoot(tmpDir);
+    expect(Object.keys(aliases)).toEqual(["@/public", "@"]);
+    expect(aliases["@/public"]).toBe(path.join(tmpDir, "public"));
+    expect(aliases["@"]).toBe(path.join(tmpDir, "src"));
+  });
+
   it("returns empty object when tsconfig.json is missing", () => {
     tmpDir = makeTempDir();
     expect(loadTsconfigPathAliasesForRoot(tmpDir)).toEqual({});

--- a/tests/tsconfig-paths-vite8.test.ts
+++ b/tests/tsconfig-paths-vite8.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import type { Plugin, PluginOption } from "vite-plus";
 import vinext from "../packages/vinext/src/index.js";
+import { aliasEntriesToRecord } from "./helpers.js";
 
 const originalCwd = process.cwd();
 let createdRoot: string | undefined;
@@ -131,11 +132,64 @@ describe("Vite tsconfig paths support", () => {
       { command: "serve", mode: "development" },
     );
 
-    const alias = resolvedConfig?.resolve?.alias as Record<string, string>;
-    expect(alias).toBeDefined();
+    const alias = aliasEntriesToRecord(resolvedConfig?.resolve?.alias);
     expect(alias["@"]).toBeDefined();
     expect(path.isAbsolute(alias["@"])).toBe(true);
     expect(alias["@"].replace(/\\/g, "/")).toContain(root.replace(/\\/g, "/"));
+  });
+
+  it("orders overlapping tsconfig path aliases longest-prefix-first on Vite 8", async () => {
+    const root = setupProject({ name: "vite", version: "8.0.0" });
+    process.chdir(root);
+    fs.writeFileSync(
+      path.join(root, "tsconfig.json"),
+      JSON.stringify(
+        {
+          compilerOptions: {
+            paths: {
+              // Declaration order intentionally puts the general pattern
+              // first. TypeScript matches by longest prefix, so the
+              // materialized alias entries must order `@/public` before `@`.
+              "@/*": ["./src/*"],
+              "@/public/*": ["./public/*"],
+            },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const plugins = vinext({ appDir: root });
+    const configPlugin = (await findNamedPlugin(plugins, "vinext:config")) as {
+      config?: (
+        config: { root: string },
+        env: { command: "serve"; mode: string },
+      ) => Promise<{
+        resolve?: Record<string, unknown>;
+      }>;
+    };
+    const resolvedConfig = await configPlugin.config?.(
+      { root },
+      { command: "serve", mode: "development" },
+    );
+
+    const alias = resolvedConfig?.resolve?.alias as Array<{
+      find: string;
+      replacement: string;
+      customResolver?: unknown;
+    }>;
+    expect(Array.isArray(alias)).toBe(true);
+    const finds = alias.map((entry) => entry.find);
+    expect(finds.indexOf("@/public")).toBeGreaterThanOrEqual(0);
+    expect(finds.indexOf("@/public")).toBeLessThan(finds.indexOf("@"));
+
+    // tsconfig-derived entries carry the stylesheet-scoping customResolver.
+    const publicEntry = alias.find((entry) => entry.find === "@/public");
+    expect(typeof publicEntry?.customResolver).toBe("function");
+    // Non-tsconfig entries (the next/* shims) do not.
+    const shimEntry = alias.find((entry) => entry.find === "next/link");
+    expect(shimEntry?.customResolver).toBeUndefined();
   });
 
   it("materializes path aliases inherited via tsconfig extends on Vite 8", async () => {
@@ -182,7 +236,7 @@ describe("Vite tsconfig paths support", () => {
       { command: "serve", mode: "development" },
     );
 
-    expect(resolvedConfig?.resolve?.alias).toEqual(
+    expect(aliasEntriesToRecord(resolvedConfig?.resolve?.alias)).toEqual(
       expect.objectContaining({
         "@": "/src",
       }),


### PR DESCRIPTION
Two related bugs in how tsconfig `paths` are materialized into Vite `resolve.alias`, each capable of 500-ing every route in a real-world app. One commit per bug so they can be reviewed/reverted independently.

## Bug 1: overlapping paths matched by declaration order (539631f6)

With

```jsonc
"paths": { "@/*": ["./src/*"], "@/public/*": ["./public/*"] }
```

vinext emitted aliases in declaration order and Vite's alias plugin takes the first match, so `@/*` shadowed `@/public/*`: `import logo from '@/public/assets/logo.svg'` resolved to `src/public/...` → `Cannot find module` → every page 500s in dev, build fails. TypeScript and Next.js match by longest prefix regardless of order (ixartz/Next-js-Boilerplate ships exactly this config).

**Fix:** sort materialized aliases longest-prefix-first in `resolveTsconfigAliases` and the config-loader sibling.

## Bug 2: tsconfig aliases hijack CSS `@import` resolution (a95f0bb5)

In a workspace monorepo (create-better-t-stack scaffolds this shape):

- `apps/web/tsconfig.json`: `"@bts-app/ui/*": ["../../packages/ui/src/*"]`
- `apps/web/src/index.css`: `@import "@bts-app/ui/globals.css"`
- `packages/ui/package.json` exports: `"./globals.css": "./src/styles/globals.css"`

Vite resolves CSS `@import` through an internal container where only the alias plugin runs, so the tsconfig-derived alias blindly rewrote the import to `packages/ui/src/globals.css` (nonexistent) instead of letting the package exports map resolve it: `[postcss] ENOENT` on every route in dev, and build fails at "analyze client references". Next.js never applies tsconfig paths to CSS-from-CSS imports.

**Fix:** emit tsconfig-derived aliases as entry-array items with a `customResolver` that scopes by importer context — stylesheet importers (css/scss/sass/less/styl/pcss/sss, plus the synthetic `<basedir>/*` importer postcss-import/less use) fall through to standard resolution; JS/TS importers keep alias behavior, so `import '@/styles/globals.css'` from a layout still works (covered by a regression test).

**Caveat worth reviewer attention:** alias `customResolver` is deprecated in Vite 8 (removal planned in Vite 9), but the suggested resolveId-plugin replacement never participates in the CSS resolver container, so `customResolver` is currently the only importer-aware hook. This is the best vinext-side fix available today; the clean long-term fix needs upstream Vite to exclude tsconfig-derived aliases from CSS resolution natively. The one deprecation warning is filtered via a `customLogger` wrapper following the existing `suppressOptionalOptimizeDepsWarnings` pattern, applied only when tsconfig aliases exist. Side effect: with a customResolver present, bundled environments use the JS alias plugin rather than the native one (Vite's own gate); dev is unaffected.

## Testing

- New `tests/tsconfig-path-alias-resolution.test.ts` (all failing before the fix): overlapping-prefix fixture incl. `@/public/*` asset + aliased CSS import from TSX; monorepo fixture with exports-mapped CSS package (symlinked workspace dep) passing dev and build; JS subpath import through the alias.
- Unit coverage for ordering + resolver presence in `tests/tsconfig-paths-vite8.test.ts` and `tests/tsconfig-paths-config-loader.test.ts`; alias-shape assertions updated via a shared `aliasEntriesToRecord` helper.
- Green: tsconfig-path-alias-build, resolve-alias-build, node-modules-css, app-router-dev-server, shims, build-optimization, next-config (1,536+ tests); `vp check` clean.
- E2E: untouched `create-better-t-stack` scaffold (Next 16 App Router + tRPC monorepo) — previously postcss ENOENT on every route — now serves `/` 200 in dev with the ui package's CSS compiled in, builds, and runs under `vinext start`.
- Noted while testing: `features.test.ts` ".env vars" and one `pages-router.test.ts` CSS-order test fail on unmodified origin/main on this machine (pre-existing flakes, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)