### PR TITLE
fix(check): mark cache components partially supported

### DIFF
--- a/packages/vinext/src/check.ts
+++ b/packages/vinext/src/check.ts
@@ -204,8 +204,8 @@ const CONFIG_SUPPORT: Record<string, { status: Status; detail?: string }> = {
     detail: "sourcemap-resolved stack traces during prerender",
   },
   cacheComponents: {
-    status: "unsupported",
-    detail: "Cache Components are not yet supported",
+    status: "partial",
+    detail: "experimental support; behavior is incomplete",
   },
   "experimental.ppr": { status: "unsupported", detail: "partial prerendering not yet implemented" },
   "experimental.typedRoutes": { status: "unsupported", detail: "typed routes not implemented" },

--- a/packages/vinext/src/check.ts
+++ b/packages/vinext/src/check.ts
@@ -203,6 +203,10 @@ const CONFIG_SUPPORT: Record<string, { status: Status; detail?: string }> = {
     status: "supported",
     detail: "sourcemap-resolved stack traces during prerender",
   },
+  cacheComponents: {
+    status: "unsupported",
+    detail: "Cache Components are not yet supported",
+  },
   "experimental.ppr": { status: "unsupported", detail: "partial prerendering not yet implemented" },
   "experimental.typedRoutes": { status: "unsupported", detail: "typed routes not implemented" },
   "experimental.serverActions": {
@@ -916,6 +920,7 @@ export function analyzeConfig(root: string): CheckItem[] {
     "output",
     "transpilePackages",
     "webpack",
+    "cacheComponents",
     "reactStrictMode",
     "poweredByHeader",
     "skipMiddlewareUrlNormalize",

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -310,7 +310,7 @@ describe("analyzeConfig", () => {
     expect(webpackItem?.detail).toContain("Vite replaces webpack");
   });
 
-  it("detects cacheComponents as unsupported", () => {
+  it("detects cacheComponents as partially supported", () => {
     writeFile(
       "next.config.mjs",
       `export default {
@@ -320,8 +320,8 @@ describe("analyzeConfig", () => {
 
     const items = analyzeConfig(tmpDir);
     const cacheComponentsItem = items.find((i) => i.name === "cacheComponents");
-    expect(cacheComponentsItem?.status).toBe("unsupported");
-    expect(cacheComponentsItem?.detail).toContain("not yet supported");
+    expect(cacheComponentsItem?.status).toBe("partial");
+    expect(cacheComponentsItem?.detail).toContain("experimental support");
   });
 
   it("does not flag webpack when it only appears in a comment", () => {

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -310,6 +310,20 @@ describe("analyzeConfig", () => {
     expect(webpackItem?.detail).toContain("Vite replaces webpack");
   });
 
+  it("detects cacheComponents as unsupported", () => {
+    writeFile(
+      "next.config.mjs",
+      `export default {
+        cacheComponents: true,
+      };`,
+    );
+
+    const items = analyzeConfig(tmpDir);
+    const cacheComponentsItem = items.find((i) => i.name === "cacheComponents");
+    expect(cacheComponentsItem?.status).toBe("unsupported");
+    expect(cacheComponentsItem?.detail).toContain("not yet supported");
+  });
+
   it("does not flag webpack when it only appears in a comment", () => {
     writeFile(
       "next.config.js",


### PR DESCRIPTION
## Summary

- report `cacheComponents` as partially supported in `vinext check`
- identify the current implementation as experimental and incomplete
- add focused compatibility scanner coverage

## Validation

- `vp test run tests/check.test.ts`
- `vp check packages/vinext/src/check.ts tests/check.test.ts`
- `git diff --check`
