### PR TITLE
fix(release): support beta prereleases

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -19,6 +19,19 @@ Commits** by `scripts/create-changeset.mts` during CI (see
 committed to `main`** — they exist just long enough for `changesets/action` to
 consume them into the rolling "Version Packages" PR.
 
+## Prerelease mode
+
+The repository is currently in Changesets prerelease mode with the `beta` tag.
+The initial Version Packages PR will release `vinext`, `@vinext/cloudflare`, and
+`create-vinext-app` as `1.0.0-beta.0`. Later Version PRs will increment the beta
+number, and `changeset publish` publishes them to npm's `beta` dist-tag. For
+example, install a vinext prerelease with `npm install vinext@beta`.
+
+When the beta is ready to become stable, run `vp exec changeset pre exit` and
+commit the resulting `.changeset/pre.json` update. The next Version Packages PR
+will remove the prerelease suffix, and its release will publish to npm's
+`latest` dist-tag.
+
 You can still author changesets by hand. A human-committed `.changeset/*.md` on
 `main` is honored exactly like normal: it is consumed alongside the
 auto-generated ones when the Version PR is built. Add one with `pnpm changeset`

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,6 +7,7 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
+  "bumpVersionsWithWorkspaceProtocolOnly": true,
   "ignore": [],
   "privatePackages": { "version": false, "tag": false },
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {

--- a/.changeset/enter-v1-beta.md
+++ b/.changeset/enter-v1-beta.md
@@ -1,0 +1,7 @@
+---
+"@vinext/cloudflare": major
+"create-vinext-app": major
+"vinext": major
+---
+
+Release the first vinext 1.0 beta.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,10 @@
+{
+  "mode": "pre",
+  "tag": "beta",
+  "initialVersions": {
+    "@vinext/cloudflare": "0.2.1",
+    "create-vinext-app": "0.2.0",
+    "vinext": "0.2.1"
+  },
+  "changesets": []
+}

--- a/scripts/create-changeset.mts
+++ b/scripts/create-changeset.mts
@@ -108,15 +108,55 @@ export function affectedPackages(
   return [...affected].sort();
 }
 
-/** Compare semver-ish strings (major.minor.patch, ignores prerelease). */
+type ParsedVersion = {
+  core: [number, number, number];
+  prerelease: string[];
+};
+
+function parseVersion(version: string): ParsedVersion {
+  const value = String(version);
+  const buildIndex = value.indexOf("+");
+  const withoutBuild = buildIndex === -1 ? value : value.slice(0, buildIndex);
+  const prereleaseIndex = withoutBuild.indexOf("-");
+  const corePart = prereleaseIndex === -1 ? withoutBuild : withoutBuild.slice(0, prereleaseIndex);
+  const prereleasePart = prereleaseIndex === -1 ? "" : withoutBuild.slice(prereleaseIndex + 1);
+  const core = corePart.split(".").map((part) => Number.parseInt(part, 10) || 0);
+  return {
+    core: [core[0] ?? 0, core[1] ?? 0, core[2] ?? 0],
+    prerelease: prereleasePart ? prereleasePart.split(".") : [],
+  };
+}
+
+/** Compare SemVer versions, including prerelease precedence and build metadata. */
 export function compareVersions(a: string, b: string): -1 | 0 | 1 {
-  const parse = (v: string) => v.split(/[.+-]/).map((n) => Number.parseInt(n, 10) || 0);
-  const pa = parse(String(a));
-  const pb = parse(String(b));
+  const pa = parseVersion(a);
+  const pb = parseVersion(b);
   for (let i = 0; i < 3; i++) {
-    const x = pa[i] ?? 0;
-    const y = pb[i] ?? 0;
+    const x = pa.core[i];
+    const y = pb.core[i];
     if (x !== y) return x > y ? 1 : -1;
+  }
+
+  if (pa.prerelease.length === 0 || pb.prerelease.length === 0) {
+    if (pa.prerelease.length === pb.prerelease.length) return 0;
+    return pa.prerelease.length === 0 ? 1 : -1;
+  }
+
+  const length = Math.max(pa.prerelease.length, pb.prerelease.length);
+  for (let i = 0; i < length; i++) {
+    const x = pa.prerelease[i];
+    const y = pb.prerelease[i];
+    if (x === undefined || y === undefined) return x === undefined ? -1 : 1;
+    if (x === y) continue;
+
+    const xNumeric = /^\d+$/.test(x);
+    const yNumeric = /^\d+$/.test(y);
+    if (xNumeric && yNumeric) {
+      if (x.length !== y.length) return x.length > y.length ? 1 : -1;
+      return x > y ? 1 : -1;
+    }
+    if (xNumeric !== yNumeric) return xNumeric ? -1 : 1;
+    return x > y ? 1 : -1;
   }
   return 0;
 }

--- a/scripts/create-changeset.test.ts
+++ b/scripts/create-changeset.test.ts
@@ -127,11 +127,23 @@ describe("affectedPackages", () => {
 });
 
 describe("compareVersions", () => {
-  it("orders semver-ish strings", () => {
+  it("orders stable versions", () => {
     expect(compareVersions("0.0.55", "0.0.5")).toBe(1);
     expect(compareVersions("0.0.5", "0.0.55")).toBe(-1);
     expect(compareVersions("1.2.3", "1.2.3")).toBe(0);
     expect(compareVersions("1.0.0", "0.9.9")).toBe(1);
+  });
+
+  it("orders prerelease versions using SemVer precedence", () => {
+    expect(compareVersions("0.3.0-beta.1", "0.3.0-beta.0")).toBe(1);
+    expect(compareVersions("0.3.0-beta.10", "0.3.0-beta.2")).toBe(1);
+    expect(compareVersions("0.3.0-beta.0", "0.3.0-beta.0")).toBe(0);
+    expect(compareVersions("0.3.0", "0.3.0-beta.1")).toBe(1);
+    expect(compareVersions("0.3.0-beta.1", "0.3.0")).toBe(-1);
+    expect(compareVersions("1.0.0-beta", "1.0.0-alpha.1")).toBe(1);
+    expect(compareVersions("1.0.0-alpha.1", "1.0.0-alpha.beta")).toBe(-1);
+    expect(compareVersions("1.0.0-beta-feature.1", "1.0.0-beta-feature.0")).toBe(1);
+    expect(compareVersions("1.0.0+build.2", "1.0.0+build.1")).toBe(0);
   });
 });
 
@@ -140,8 +152,16 @@ describe("decideGeneration (THE CORRECTNESS RULE)", () => {
     expect(decideGeneration("0.1.0", "0.0.55").action).toBe("skip");
   });
 
+  it("skips when a new prerelease version is awaiting publish", () => {
+    expect(decideGeneration("0.3.0-beta.1", "0.3.0-beta.0").action).toBe("skip");
+  });
+
   it("generates when package.json version == tag version (normal accumulation)", () => {
     expect(decideGeneration("0.0.55", "0.0.55").action).toBe("generate");
+  });
+
+  it("generates after the matching prerelease tag is published", () => {
+    expect(decideGeneration("0.3.0-beta.1", "0.3.0-beta.1").action).toBe("generate");
   });
 
   it("generates when there is no tag yet", () => {
@@ -166,6 +186,24 @@ describe("latestTagVersionFromTags (release range source)", () => {
 
   it("picks the highest scoped tag for a package with the `<name>@<version>` scheme", () => {
     expect(latestTagVersionFromTags(tags, "@vinext/cloudflare")).toBe("1.1.0");
+  });
+
+  it("picks the latest prerelease tag using SemVer precedence", () => {
+    expect(
+      latestTagVersionFromTags(
+        ["vinext@0.3.0-beta.2", "vinext@0.3.0-beta.10", "vinext@0.3.0-beta.1"],
+        "vinext",
+      ),
+    ).toBe("0.3.0-beta.10");
+  });
+
+  it("prefers a stable tag over prereleases of the same version", () => {
+    expect(
+      latestTagVersionFromTags(
+        ["vinext@0.3.0-beta.1", "vinext@0.3.0", "vinext@0.3.0-beta.2"],
+        "vinext",
+      ),
+    ).toBe("0.3.0");
   });
 
   it("falls back to the legacy global `v<version>` tag for the root package", () => {


### PR DESCRIPTION
## Summary

- enter Changesets prerelease mode with the `beta` tag
- release all three public packages as `1.0.0-beta.0`
- compare release tags using full SemVer prerelease precedence
- restrict prerelease dependency bumps to explicit workspace ranges
- document the beta install and exit flow

## Verified release plan

Both the committed changesets and the CI-generated changeset flow resolve to:

- `vinext`: `0.2.1` → `1.0.0-beta.0`
- `@vinext/cloudflare`: `0.2.1` → `1.0.0-beta.0`
- `create-vinext-app`: `0.2.0` → `1.0.0-beta.0`

`.changeset/pre.json` contains exactly those three publishable packages.

## Validation

- `vp test run scripts/create-changeset.test.ts scripts/version.test.ts`
- `vp check .changeset/config.json .changeset/README.md .changeset/pre.json .changeset/enter-v1-beta.md scripts/create-changeset.mts scripts/create-changeset.test.ts`
- `node scripts/create-changeset.mts`
- `vp exec changeset status --output /tmp/vinext-v1-beta-ci-plan.json`
- `git diff --check`
