### PR TITLE
fix(app-router): preserve client state on server-action revalidatePath under loading.tsx

### DIFF
--- a/packages/vinext/src/server/app-browser-navigation-controller.ts
+++ b/packages/vinext/src/server/app-browser-navigation-controller.ts
@@ -906,10 +906,29 @@ export function createAppBrowserNavigationController(
       }
 
       if (latestApproval.approvedCommit) {
-        dispatchSynchronousVisibleCommit(latestApproval.approvedCommit);
+        const approvedRevalidationCommit = latestApproval.approvedCommit;
+        // Commit the revalidation inside a transition, matching how ordinary
+        // client navigations commit (`dispatchApprovedVisibleCommit` in
+        // "transition" mode). This is defense-in-depth, not the fix for the
+        // loading.tsx remount bug — that fix is structural, in
+        // app-page-route-wiring.tsx (the loading Suspense boundary now stays in
+        // the tree for preserve-ui re-renders, so React reconciles in place).
+        // The transition matters because this code runs after the action's
+        // `await fetch`, outside React's event batch, so a plain setter would
+        // be an urgent update: if a future payload delivered through this path
+        // genuinely suspends inside the (now always-present) loading.tsx
+        // boundary, an urgent update would drop the subtree to its fallback,
+        // while a transition keeps the committed tree visible until the
+        // content resolves — Next.js's soft-refresh behavior. The HMR and
+        // history-traversal callers of dispatchSynchronousVisibleCommit are
+        // deliberately left non-transition (see the comment above
+        // dispatchApprovedVisibleCommit).
+        startTransition(() => {
+          dispatchSynchronousVisibleCommit(approvedRevalidationCommit);
+        });
         syncHistoryStatePreviousNextUrl(
-          latestApproval.approvedCommit.previousNextUrl,
-          latestApproval.approvedCommit.action.bfcacheIds,
+          approvedRevalidationCommit.previousNextUrl,
+          approvedRevalidationCommit.action.bfcacheIds,
         );
       } else {
         notifyDiscardedServerActionRevalidation(lifecycleOptions);

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -47,7 +47,6 @@ import { probeReactServerSubtree } from "./app-page-probe.js";
 import {
   APP_RSC_RENDER_MODE_NAVIGATION,
   APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
-  shouldSuppressLoadingBoundaries,
   type AppRscRenderMode,
 } from "./app-rsc-render-mode.js";
 import {
@@ -903,7 +902,7 @@ export function buildAppPageElements<
     }
 
     const slotLoadingComponent = getDefaultExport(slot.loading);
-    if (slotLoadingComponent && !shouldSuppressLoadingBoundaries(renderMode)) {
+    if (slotLoadingComponent) {
       const SlotLoadingComponent = slotLoadingComponent;
       slotElement = (
         <Suspense key={slotResetKey} fallback={<SlotLoadingComponent />}>
@@ -968,12 +967,26 @@ export function buildAppPageElements<
     // transitions rather than unmounting it.
     routeChildren = <RedirectBoundary>{routeChildren}</RedirectBoundary>;
 
-    if (routeLoadingComponent && !shouldSuppressLoadingBoundaries(renderMode)) {
+    if (routeLoadingComponent) {
       const RouteLoadingComponent = routeLoadingComponent;
       // Route-level wrappers cover the full page branch in vinext's flat element
       // transport, so their reset key includes the visible segment-state path.
       // Dynamic param changes reset the pending boundary, while search-only changes
       // preserve it.
+      //
+      // The loading boundary must stay in the tree for *every* render mode,
+      // including the "preserve-ui" refresh/server-action re-renders. It used to
+      // be omitted for those modes (`!shouldSuppressLoadingBoundaries(...)`), but
+      // the already-committed navigation tree always contains this <Suspense>, so
+      // dropping it on a re-render changed the element type at this position and
+      // made React unmount the boundary's subtree and mount a fresh one —
+      // destroying client `useState` on any route that defines loading.tsx (see
+      // the server-action revalidate remount bug). Keeping the boundary makes the
+      // re-render structurally identical to what is mounted, so React reconciles
+      // in place. Suppressing the *visible fallback* on these re-renders is
+      // instead handled by committing them inside a transition (see
+      // commitSameUrlNavigatePayload / the refresh navigation path), matching
+      // Next.js, which keeps loading boundaries mounted across refreshes.
       routeChildren = (
         <Suspense key={routeResetKey} fallback={<RouteLoadingComponent />}>
           {routeChildren}

--- a/tests/e2e/app-router/nextjs-compat/actions-revalidate.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/actions-revalidate.spec.ts
@@ -153,4 +153,56 @@ test.describe("Next.js compat: actions-revalidate (browser)", () => {
       expect(time2).not.toBe(time1);
     }).toPass({ timeout: 10_000 });
   });
+
+  // Ported from Next.js: test/e2e/app-dir/actions-revalidate-remount/actions-revalidate-remount.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/actions-revalidate-remount/actions-revalidate-remount.test.ts
+  //
+  // Regression: a server action that calls revalidatePath() must soft-refresh
+  // the current route (reconcile), not remount its client components. On a
+  // segment with loading.tsx, vinext used to omit the loading Suspense boundary
+  // from the "preserve-ui" re-render while the committed navigation tree still
+  // had it, so React unmounted and remounted the subtree — destroying client
+  // useState. This asserts the client counter survives the action.
+  test("revalidatePath from a server action preserves client state under loading.tsx", async ({
+    page,
+  }) => {
+    const loadingLogs: string[] = [];
+    page.on("console", (message) => {
+      if (message.text() === "Revalidate remount loading mounted") {
+        loadingLogs.push(message.text());
+      }
+    });
+
+    await page.goto(`${BASE}/nextjs-compat/action-revalidate-remount`);
+    await waitForAppRouterHydration(page);
+    loadingLogs.length = 0;
+
+    // Build up client-only state that only survives if the component is not
+    // remounted.
+    await page.click("#increment");
+    await page.click("#increment");
+    await page.click("#increment");
+    await expect(page.locator("#count")).toHaveText("3");
+
+    const serverRenderCount1 = await page.locator("#server-render-count").textContent();
+    expect(serverRenderCount1).toBeTruthy();
+
+    // Run the server action (revalidatePath on the current route).
+    await page.click("#run-action");
+
+    // The server re-rendered (revalidation took effect)...
+    await expect(async () => {
+      const serverRenderCount2 = await page.locator("#server-render-count").textContent();
+      expect(serverRenderCount2).toBeTruthy();
+      expect(serverRenderCount2).not.toBe(serverRenderCount1);
+    }).toPass({ timeout: 10_000 });
+
+    // ...yet the client component was reconciled in place, not remounted, so its
+    // useState is intact.
+    await expect(page.locator("#count")).toHaveText("3");
+
+    // And the loading boundary never became visible during the soft refresh.
+    expect(await page.locator("#revalidate-remount-loading").count()).toBe(0);
+    expect(loadingLogs).toEqual([]);
+  });
 });

--- a/tests/fixtures/app-basic/app/nextjs-compat/action-revalidate-remount/actions.ts
+++ b/tests/fixtures/app-basic/app/nextjs-compat/action-revalidate-remount/actions.ts
@@ -1,0 +1,10 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+export async function touchAction(): Promise<void> {
+  // Revalidating the current path re-renders the segment. The remount bug also
+  // fired for unrelated paths, but revalidating the current path is the common
+  // "mutate but stay on the page" case and re-renders deterministically.
+  revalidatePath("/nextjs-compat/action-revalidate-remount");
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/action-revalidate-remount/counter.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/action-revalidate-remount/counter.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useState } from "react";
+import { touchAction } from "./actions";
+
+declare global {
+  interface Window {
+    __VINEXT_REVALIDATE_REMOUNT_STARTED__?: boolean;
+  }
+}
+
+export function Counter() {
+  const [count, setCount] = useState(0);
+
+  function runAction() {
+    // Arm the loading.tsx sentinel: the fixture's Loading component only logs
+    // "Revalidate remount loading mounted" once this flag is set, so mounts
+    // during initial navigation/hydration are ignored and only a fallback
+    // mounted by the action's revalidation is reported.
+    window.__VINEXT_REVALIDATE_REMOUNT_STARTED__ = true;
+    touchAction();
+  }
+
+  return (
+    <>
+      <p id="count">{count}</p>
+      <button id="increment" type="button" onClick={() => setCount((value) => value + 1)}>
+        increment
+      </button>
+      <button id="run-action" type="button" onClick={runAction}>
+        run action
+      </button>
+    </>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/action-revalidate-remount/loading.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/action-revalidate-remount/loading.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { useEffect } from "react";
+
+declare global {
+  interface Window {
+    __VINEXT_REVALIDATE_REMOUNT_STARTED__?: boolean;
+  }
+}
+
+export default function Loading() {
+  useEffect(() => {
+    if (window.__VINEXT_REVALIDATE_REMOUNT_STARTED__ === true) {
+      console.log("Revalidate remount loading mounted");
+    }
+  }, []);
+
+  return <p id="revalidate-remount-loading">loading...</p>;
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/action-revalidate-remount/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/action-revalidate-remount/page.tsx
@@ -1,0 +1,16 @@
+import { Counter } from "./counter";
+import { nextServerRenderCount } from "./state";
+
+export const dynamic = "force-dynamic";
+
+export default function Page() {
+  const serverRenderCount = nextServerRenderCount();
+
+  return (
+    <main>
+      <h1>Action Revalidate Remount</h1>
+      <p id="server-render-count">{serverRenderCount}</p>
+      <Counter />
+    </main>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/action-revalidate-remount/state.ts
+++ b/tests/fixtures/app-basic/app/nextjs-compat/action-revalidate-remount/state.ts
@@ -1,0 +1,5 @@
+let serverRenderCount = 0;
+
+export function nextServerRenderCount(): number {
+  return ++serverRenderCount;
+}


### PR DESCRIPTION
Fixes #2505

## Problem

A Server Action calling `revalidatePath()` (and `router.refresh()` flows delivered through the same-URL action path) remounted the current route's Client Components — destroying their `useState` — whenever the segment defined a `loading.tsx`. In-progress form input, open dialogs, and optimistic UI were lost on every "mutate but stay on the page" flow. Next.js soft-refreshes instead: the segment reconciles in place and client state survives.

Segments **without** a `loading.tsx` were unaffected, which made the trigger easy to isolate (see the A/B in #2505).

## Root cause

The "preserve-ui" re-render modes (`action-rerender-preserve-ui`, `refresh-preserve-ui`) omitted the loading `<Suspense>` boundary from the payload (`shouldSuppressLoadingBoundaries` in `app-page-route-wiring.tsx`) — but the already-committed navigation tree always contains that boundary. Dropping it on the re-render changed the element type at the page position, so React unmounted the boundary's subtree and mounted a fresh one. The content was already resolved, so no fallback ever flashed — the remount was silent, which is why the suppression looked harmless.

Notably it was *not* a re-suspension problem: the fallback never rendered, and wrapping the commit in a transition alone did not fix it. The bug was purely structural.

## Fix

1. **`app-page-route-wiring.tsx`** — keep the loading Suspense boundary in the tree for every render mode (route-level and parallel-slot-level). The preserve-ui re-render is now structurally identical to the committed tree, so React reconciles in place and client state survives.
2. **`app-browser-navigation-controller.ts`** — commit same-URL server-action revalidations inside `startTransition`, matching how ordinary navigations commit (`dispatchApprovedVisibleCommit` in "transition" mode). This is defense-in-depth, not the fix itself: with the boundary now always present, a future payload that genuinely suspends would drop to the fallback under an urgent update, while a transition keeps the committed tree visible until content resolves — Next.js's soft-refresh behavior. The HMR and history-traversal callers of `dispatchSynchronousVisibleCommit` are deliberately untouched.

The original purpose of the suppression (no loading flash on refresh) is preserved — the existing `action-refresh-no-rerender` tests still pass, and the new test also asserts the fallback never mounts.

## Test

New fixture `tests/fixtures/app-basic/app/nextjs-compat/action-revalidate-remount/` (a client `useState` counter under a route with `loading.tsx`, plus a `revalidatePath` server action) and a regression test in `actions-revalidate.spec.ts` asserting, after the action:

- the server **did** re-render (render counter changed) — revalidation still works
- the client counter still shows its pre-action value — no remount
- the `loading.tsx` fallback never mounted (armed-sentinel console check, same pattern as `action-refresh-no-rerender`)

## Verification

- `pnpm run check` — clean (format, lint, types)
- `npx playwright test app-router/nextjs-compat/actions-revalidate.spec.ts --project=app-router` — 7/7 passing, including the two pre-existing "does not mount route loading" guards most at risk from this change
- Verified end-to-end in a browser against the minimal repro from #2505: with the fix, count survives the action (`3 → 3`) with no remount and no fallback flash, in dev; the same repro reproduced the bug on both `vinext dev` and production builds before the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
