### PR TITLE
perf(config): avoid loading font plugin for tsconfig paths

### DIFF
--- a/packages/vinext/src/config/tsconfig-paths.ts
+++ b/packages/vinext/src/config/tsconfig-paths.ts
@@ -25,8 +25,8 @@
 import fs from "node:fs";
 import path from "node:path";
 import { createRequire } from "node:module";
-import { parseStaticObjectLiteral } from "../plugins/fonts.js";
 import { isUnknownRecord as isRecord } from "../utils/record.js";
+import { parseStaticObjectLiteral } from "../utils/static-object-literal.js";
 
 const TSCONFIG_FILES = ["tsconfig.json", "jsconfig.json"];
 

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -165,11 +165,11 @@ import { createServerExternalsManifestPlugin } from "./plugins/server-externals-
 import {
   VIRTUAL_GOOGLE_FONTS,
   RESOLVED_VIRTUAL_GOOGLE_FONTS,
-  parseStaticObjectLiteral,
   generateGoogleFontsVirtualModule,
   createGoogleFontsPlugin,
   createLocalFontsPlugin,
 } from "./plugins/fonts.js";
+import { parseStaticObjectLiteral } from "./utils/static-object-literal.js";
 import { computeClientRuntimeMetadata } from "./utils/client-runtime-metadata.js";
 import {
   VINEXT_CLIENT_ENTRY_MANIFEST,

--- a/packages/vinext/src/plugins/fonts.ts
+++ b/packages/vinext/src/plugins/fonts.ts
@@ -25,7 +25,6 @@
  */
 
 import type { Plugin } from "vite";
-import { parseAst } from "vite";
 import path from "node:path";
 import fs from "node:fs";
 import { escapeRegExp } from "../utils/regex.js";
@@ -41,6 +40,7 @@ import { buildGoogleFontsUrl } from "../build/google-fonts/build-url.js";
 import { findFontFilesInCss } from "../build/google-fonts/find-font-files-in-css.js";
 import { CONTENT_TYPES } from "../server/static-file-cache.js";
 import { ASSET_PREFIX_URL_DIR } from "../utils/asset-prefix.js";
+import { parseStaticObjectLiteral } from "../utils/static-object-literal.js";
 
 /**
  * Thrown when Google Fonts returns a non-2xx response. Distinct from a raw
@@ -163,103 +163,6 @@ type GoogleFontNamedSpecifier = {
   isType: boolean;
   raw: string;
 };
-
-// ── Helpers shared with index.ts ──────────────────────────────────────────────
-
-/**
- * Safely parse a static JS object literal string into a plain object.
- * Uses Vite's parseAst (Rollup/acorn) so no code is ever evaluated.
- * Returns null if the expression contains anything dynamic (function calls,
- * template literals, identifiers, computed properties, etc.).
- *
- * Supports: string literals, numeric literals, boolean literals,
- * arrays of the above, and nested object literals.
- */
-export function parseStaticObjectLiteral(objectStr: string): Record<string, unknown> | null {
-  let ast: ReturnType<typeof parseAst>;
-  try {
-    // Wrap in parens so the parser treats `{…}` as an expression, not a block
-    ast = parseAst(`(${objectStr})`);
-  } catch {
-    return null;
-  }
-
-  // The AST should be: Program > ExpressionStatement > ObjectExpression
-  const body = ast.body;
-  if (body.length !== 1 || body[0].type !== "ExpressionStatement") return null;
-
-  const expr = body[0].expression;
-  if (expr.type !== "ObjectExpression") return null;
-
-  const result = extractStaticValue(expr);
-  return result === undefined ? null : (result as Record<string, unknown>);
-}
-
-/**
- * Recursively extract a static value from an ESTree AST node.
- * Returns undefined (not null) if the node contains any dynamic expression.
- *
- * Uses `any` for the node parameter because Rollup's internal ESTree types
- * (estree.Expression, estree.ObjectExpression, etc.) aren't re-exported by Vite,
- * and the recursive traversal touches many different node shapes.
- */
-// oxlint-disable-next-line @typescript-eslint/no-explicit-any
-function extractStaticValue(node: any): unknown {
-  switch (node.type) {
-    case "Literal":
-      // String, number, boolean, null
-      return node.value;
-
-    case "UnaryExpression":
-      // Handle negative numbers: -1, -3.14
-      if (
-        node.operator === "-" &&
-        node.argument?.type === "Literal" &&
-        typeof node.argument.value === "number"
-      ) {
-        return -node.argument.value;
-      }
-      return undefined;
-
-    case "ArrayExpression": {
-      const arr: unknown[] = [];
-      for (const elem of node.elements) {
-        if (!elem) return undefined; // sparse array
-        const val = extractStaticValue(elem);
-        if (val === undefined) return undefined;
-        arr.push(val);
-      }
-      return arr;
-    }
-
-    case "ObjectExpression": {
-      const obj: Record<string, unknown> = {};
-      for (const prop of node.properties) {
-        if (prop.type !== "Property") return undefined; // SpreadElement etc.
-        if (prop.computed) return undefined; // [expr]: val
-
-        // Key can be Identifier (unquoted) or Literal (quoted)
-        let key: string;
-        if (prop.key.type === "Identifier") {
-          key = prop.key.name;
-        } else if (prop.key.type === "Literal" && typeof prop.key.value === "string") {
-          key = prop.key.value;
-        } else {
-          return undefined;
-        }
-
-        const val = extractStaticValue(prop.value);
-        if (val === undefined) return undefined;
-        obj[key] = val;
-      }
-      return obj;
-    }
-
-    default:
-      // TemplateLiteral, CallExpression, Identifier, etc. — reject
-      return undefined;
-  }
-}
 
 // ── Virtual module encoding/decoding ─────────────────────────────────────────
 
@@ -840,7 +743,7 @@ export function createGoogleFontsPlugin(fontGoogleShimPath: string, shimsDir: st
           family: string,
           calleeSource: string,
         ) {
-          // Parse options safely via AST — no eval/new Function
+          // Parse options safely without eval/new Function.
           // oxlint-disable-next-line @typescript-eslint/no-explicit-any
           let options: Record<string, any> = {};
           try {

--- a/packages/vinext/src/utils/static-object-literal.ts
+++ b/packages/vinext/src/utils/static-object-literal.ts
@@ -1,0 +1,362 @@
+const INVALID = Symbol("invalid-static-literal");
+
+type InvalidStaticLiteral = typeof INVALID;
+type StaticObject = { [key: string]: StaticValue };
+type StaticValue = string | number | boolean | null | StaticValue[] | StaticObject;
+type ParseResult = StaticValue | InvalidStaticLiteral;
+
+function isStaticObject(value: StaticValue): value is StaticObject {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isIdentifierStart(char: string | undefined): boolean {
+  return char !== undefined && /[A-Za-z_$]/.test(char);
+}
+
+function isIdentifierPart(char: string | undefined): boolean {
+  return char !== undefined && /[A-Za-z0-9_$]/.test(char);
+}
+
+function isDigit(char: string | undefined): boolean {
+  return char !== undefined && char >= "0" && char <= "9";
+}
+
+function isHexDigit(char: string | undefined): boolean {
+  return char !== undefined && /[0-9A-Fa-f]/.test(char);
+}
+
+function isWhitespace(char: string | undefined): boolean {
+  return (
+    char === " " ||
+    char === "\t" ||
+    char === "\n" ||
+    char === "\r" ||
+    char === "\v" ||
+    char === "\f" ||
+    char === "\u00a0" ||
+    char === "\ufeff"
+  );
+}
+
+class StaticObjectLiteralParser {
+  private index = 0;
+  private failed = false;
+
+  constructor(private readonly source: string) {}
+
+  parse(): ParseResult {
+    const value = this.parseValue();
+    if (value === INVALID) return INVALID;
+    this.skipTrivia();
+    if (this.failed || this.index !== this.source.length) return INVALID;
+    return value;
+  }
+
+  private current(): string | undefined {
+    return this.source[this.index];
+  }
+
+  private next(): string | undefined {
+    return this.source[this.index + 1];
+  }
+
+  private consume(expected: string): boolean {
+    if (this.current() !== expected) return false;
+    this.index++;
+    return true;
+  }
+
+  private skipTrivia(): void {
+    while (this.index < this.source.length) {
+      const char = this.current();
+      if (isWhitespace(char)) {
+        this.index++;
+        continue;
+      }
+
+      if (char === "/" && this.next() === "/") {
+        this.index += 2;
+        while (this.index < this.source.length) {
+          const commentChar = this.current();
+          if (commentChar === "\n" || commentChar === "\r") break;
+          this.index++;
+        }
+        continue;
+      }
+
+      if (char === "/" && this.next() === "*") {
+        const end = this.source.indexOf("*/", this.index + 2);
+        if (end === -1) {
+          this.failed = true;
+          this.index = this.source.length;
+          return;
+        }
+        this.index = end + 2;
+        continue;
+      }
+
+      return;
+    }
+  }
+
+  private parseValue(): ParseResult {
+    this.skipTrivia();
+    if (this.failed) return INVALID;
+
+    const char = this.current();
+    if (char === "{") return this.parseObject();
+    if (char === "[") return this.parseArray();
+    if (char === '"' || char === "'") return this.parseString();
+    if (char === "-" || char === "." || isDigit(char)) return this.parseNumber();
+    if (this.consumeWord("true")) return true;
+    if (this.consumeWord("false")) return false;
+    if (this.consumeWord("null")) return null;
+    return INVALID;
+  }
+
+  private parseObject(): ParseResult {
+    if (!this.consume("{")) return INVALID;
+
+    const object: StaticObject = {};
+    this.skipTrivia();
+    if (this.failed) return INVALID;
+    if (this.consume("}")) return object;
+
+    while (this.index < this.source.length) {
+      const key = this.parseObjectKey();
+      if (key === INVALID) return INVALID;
+
+      this.skipTrivia();
+      if (this.failed || !this.consume(":")) return INVALID;
+
+      const value = this.parseValue();
+      if (value === INVALID) return INVALID;
+      object[key] = value;
+
+      this.skipTrivia();
+      if (this.failed) return INVALID;
+      if (this.consume("}")) return object;
+      if (!this.consume(",")) return INVALID;
+
+      this.skipTrivia();
+      if (this.failed) return INVALID;
+      if (this.consume("}")) return object;
+    }
+
+    return INVALID;
+  }
+
+  private parseArray(): ParseResult {
+    if (!this.consume("[")) return INVALID;
+
+    const array: StaticValue[] = [];
+    this.skipTrivia();
+    if (this.failed) return INVALID;
+    if (this.consume("]")) return array;
+
+    while (this.index < this.source.length) {
+      const value = this.parseValue();
+      if (value === INVALID) return INVALID;
+      array.push(value);
+
+      this.skipTrivia();
+      if (this.failed) return INVALID;
+      if (this.consume("]")) return array;
+      if (!this.consume(",")) return INVALID;
+
+      this.skipTrivia();
+      if (this.failed) return INVALID;
+      if (this.consume("]")) return array;
+    }
+
+    return INVALID;
+  }
+
+  private parseObjectKey(): string | InvalidStaticLiteral {
+    this.skipTrivia();
+    if (this.failed) return INVALID;
+
+    const char = this.current();
+    if (char === '"' || char === "'") {
+      const key = this.parseString();
+      return typeof key === "string" ? key : INVALID;
+    }
+    if (!isIdentifierStart(char)) return INVALID;
+
+    const start = this.index;
+    this.index++;
+    while (isIdentifierPart(this.current())) this.index++;
+    return this.source.slice(start, this.index);
+  }
+
+  private parseString(): string | InvalidStaticLiteral {
+    const quote = this.current();
+    if (quote !== '"' && quote !== "'") return INVALID;
+    this.index++;
+
+    let value = "";
+    while (this.index < this.source.length) {
+      const char = this.current();
+      if (char === quote) {
+        this.index++;
+        return value;
+      }
+      if (char === "\n" || char === "\r" || char === undefined) return INVALID;
+      if (char !== "\\") {
+        value += char;
+        this.index++;
+        continue;
+      }
+
+      this.index++;
+      const escaped = this.current();
+      if (escaped === undefined) return INVALID;
+      const parsedEscape = this.parseEscapeSequence(escaped);
+      if (parsedEscape === INVALID) return INVALID;
+      value += parsedEscape;
+    }
+
+    return INVALID;
+  }
+
+  private parseEscapeSequence(escaped: string): string | InvalidStaticLiteral {
+    this.index++;
+
+    switch (escaped) {
+      case '"':
+      case "'":
+      case "\\":
+        return escaped;
+      case "b":
+        return "\b";
+      case "f":
+        return "\f";
+      case "n":
+        return "\n";
+      case "r":
+        return "\r";
+      case "t":
+        return "\t";
+      case "v":
+        return "\v";
+      case "0":
+        if (isDigit(this.current())) return INVALID;
+        return "\0";
+      case "\n":
+        return "";
+      case "\r":
+        if (this.current() === "\n") this.index++;
+        return "";
+      case "x":
+        return this.parseFixedHexEscape(2);
+      case "u":
+        return this.parseUnicodeEscape();
+      default:
+        return escaped;
+    }
+  }
+
+  private parseFixedHexEscape(length: number): string | InvalidStaticLiteral {
+    const start = this.index;
+    for (let offset = 0; offset < length; offset++) {
+      if (!isHexDigit(this.source[start + offset])) return INVALID;
+    }
+    this.index += length;
+    return String.fromCharCode(Number.parseInt(this.source.slice(start, start + length), 16));
+  }
+
+  private parseUnicodeEscape(): string | InvalidStaticLiteral {
+    if (this.consume("{")) {
+      const start = this.index;
+      while (isHexDigit(this.current())) this.index++;
+      if (this.index === start || !this.consume("}")) return INVALID;
+
+      const codePoint = Number.parseInt(this.source.slice(start, this.index - 1), 16);
+      if (!Number.isInteger(codePoint) || codePoint > 0x10ffff) return INVALID;
+      return String.fromCodePoint(codePoint);
+    }
+
+    return this.parseFixedHexEscape(4);
+  }
+
+  private parseNumber(): number | InvalidStaticLiteral {
+    const negative = this.consume("-");
+
+    if (this.current() === "0") {
+      const radixPrefix = this.next();
+      if (radixPrefix === "x" || radixPrefix === "X") return this.parseRadixNumber(16, negative);
+      if (radixPrefix === "b" || radixPrefix === "B") return this.parseRadixNumber(2, negative);
+      if (radixPrefix === "o" || radixPrefix === "O") return this.parseRadixNumber(8, negative);
+    }
+
+    const start = this.index;
+    let hasDigits = false;
+    if (this.current() === "0") {
+      this.index++;
+      hasDigits = true;
+      if (isDigit(this.current())) return INVALID;
+    } else {
+      while (isDigit(this.current())) {
+        this.index++;
+        hasDigits = true;
+      }
+    }
+
+    if (this.consume(".")) {
+      while (isDigit(this.current())) {
+        this.index++;
+        hasDigits = true;
+      }
+    }
+    if (!hasDigits) return INVALID;
+
+    const exponent = this.current();
+    if (exponent === "e" || exponent === "E") {
+      this.index++;
+      const sign = this.current();
+      if (sign === "+" || sign === "-") this.index++;
+      if (!isDigit(this.current())) return INVALID;
+      while (isDigit(this.current())) this.index++;
+    }
+
+    const raw = `${negative ? "-" : ""}${this.source.slice(start, this.index)}`;
+    const value = Number(raw);
+    return Number.isFinite(value) ? value : INVALID;
+  }
+
+  private parseRadixNumber(radix: 2 | 8 | 16, negative: boolean): number | InvalidStaticLiteral {
+    this.index += 2;
+    const start = this.index;
+    while (this.isRadixDigit(this.current(), radix)) this.index++;
+    if (this.index === start) return INVALID;
+
+    const value = Number.parseInt(this.source.slice(start, this.index), radix);
+    return Number.isFinite(value) ? (negative ? -value : value) : INVALID;
+  }
+
+  private isRadixDigit(char: string | undefined, radix: 2 | 8 | 16): boolean {
+    if (radix === 2) return char === "0" || char === "1";
+    if (radix === 8) return char !== undefined && char >= "0" && char <= "7";
+    return isHexDigit(char);
+  }
+
+  private consumeWord(word: string): boolean {
+    if (!this.source.startsWith(word, this.index)) return false;
+    const next = this.source[this.index + word.length];
+    if (isIdentifierPart(next)) return false;
+    this.index += word.length;
+    return true;
+  }
+}
+
+/**
+ * Safely parse a static JS object literal string into a plain object.
+ * Returns null if the expression contains anything dynamic.
+ *
+ * Supports string, number, boolean, and null literals; arrays of those values;
+ * nested object literals; comments; and trailing commas.
+ */
+export function parseStaticObjectLiteral(objectStr: string): Record<string, unknown> | null {
+  const parsed = new StaticObjectLiteralParser(objectStr).parse();
+  return parsed !== INVALID && isStaticObject(parsed) ? parsed : null;
+}

--- a/tests/font-google.test.ts
+++ b/tests/font-google.test.ts
@@ -5,7 +5,6 @@ import { http, HttpResponse } from "msw";
 import { server } from "./_msw/server.js";
 import vinext from "../packages/vinext/src/index.js";
 import {
-  parseStaticObjectLiteral,
   _findBalancedObject as findBalancedObject,
   _findCallEnd as findCallEnd,
   _rewriteCachedFontCssToServedUrls as rewriteCachedFontCssToServedUrls,
@@ -1547,109 +1546,6 @@ describe("_rewriteCachedFontCssToServedUrls", () => {
 
     expect(out).toBe("src: url(/_next/static/_vinext_fonts/geist/a.woff2);");
     expect(out).not.toContain("//_vinext_fonts");
-  });
-});
-
-// ── parseStaticObjectLiteral security tests ───────────────────
-
-describe("parseStaticObjectLiteral", () => {
-  it("parses simple object with string values", () => {
-    const result = parseStaticObjectLiteral(`{ weight: '400', display: 'swap' }`);
-    expect(result).toEqual({ weight: "400", display: "swap" });
-  });
-
-  it("parses object with array of strings", () => {
-    const result = parseStaticObjectLiteral(`{ weight: ['400', '700'], subsets: ['latin'] }`);
-    expect(result).toEqual({ weight: ["400", "700"], subsets: ["latin"] });
-  });
-
-  it("parses object with double-quoted strings", () => {
-    const result = parseStaticObjectLiteral(`{ weight: "400" }`);
-    expect(result).toEqual({ weight: "400" });
-  });
-
-  it("parses object with trailing comma", () => {
-    const result = parseStaticObjectLiteral(`{ weight: '400', }`);
-    expect(result).toEqual({ weight: "400" });
-  });
-
-  it("parses object with numeric values", () => {
-    const result = parseStaticObjectLiteral(`{ size: 16 }`);
-    expect(result).toEqual({ size: 16 });
-  });
-
-  it("parses object with boolean values", () => {
-    const result = parseStaticObjectLiteral(`{ preload: true }`);
-    expect(result).toEqual({ preload: true });
-  });
-
-  it("parses object with quoted keys", () => {
-    const result = parseStaticObjectLiteral(`{ 'weight': '400' }`);
-    expect(result).toEqual({ weight: "400" });
-  });
-
-  it("parses empty object", () => {
-    const result = parseStaticObjectLiteral(`{}`);
-    expect(result).toEqual({});
-  });
-
-  it("parses nested objects", () => {
-    const result = parseStaticObjectLiteral(`{ axes: { wght: 400 } }`);
-    expect(result).toEqual({ axes: { wght: 400 } });
-  });
-
-  // ── Security: these must all return null ──
-
-  it("rejects function calls (code execution)", () => {
-    const result = parseStaticObjectLiteral(
-      `{ weight: require('child_process').execSync('whoami') }`,
-    );
-    expect(result).toBeNull();
-  });
-
-  it("rejects template literals", () => {
-    const result = parseStaticObjectLiteral("{ weight: `${process.env.HOME}` }");
-    expect(result).toBeNull();
-  });
-
-  it("rejects identifier references", () => {
-    const result = parseStaticObjectLiteral(`{ weight: myVar }`);
-    expect(result).toBeNull();
-  });
-
-  it("rejects computed property keys", () => {
-    const result = parseStaticObjectLiteral(`{ [Symbol.toPrimitive]: '400' }`);
-    expect(result).toBeNull();
-  });
-
-  it("rejects spread elements", () => {
-    const result = parseStaticObjectLiteral(`{ ...evil }`);
-    expect(result).toBeNull();
-  });
-
-  it("rejects new expressions", () => {
-    const result = parseStaticObjectLiteral(`{ weight: new Function('return 1')() }`);
-    expect(result).toBeNull();
-  });
-
-  it("rejects IIFE in values", () => {
-    const result = parseStaticObjectLiteral(`{ weight: (() => { process.exit(1) })() }`);
-    expect(result).toBeNull();
-  });
-
-  it("rejects import() expressions", () => {
-    const result = parseStaticObjectLiteral(`{ weight: import('fs') }`);
-    expect(result).toBeNull();
-  });
-
-  it("returns null for invalid syntax", () => {
-    const result = parseStaticObjectLiteral(`{ not valid javascript `);
-    expect(result).toBeNull();
-  });
-
-  it("returns null for non-object expressions", () => {
-    const result = parseStaticObjectLiteral(`"just a string"`);
-    expect(result).toBeNull();
   });
 });
 

--- a/tests/static-object-literal.test.ts
+++ b/tests/static-object-literal.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vite-plus/test";
+import { parseStaticObjectLiteral } from "../packages/vinext/src/utils/static-object-literal.js";
+
+describe("parseStaticObjectLiteral", () => {
+  it("parses simple object with string values", () => {
+    const result = parseStaticObjectLiteral(`{ weight: '400', display: 'swap' }`);
+    expect(result).toEqual({ weight: "400", display: "swap" });
+  });
+
+  it("parses object with array of strings", () => {
+    const result = parseStaticObjectLiteral(`{ weight: ['400', '700'], subsets: ['latin'] }`);
+    expect(result).toEqual({ weight: ["400", "700"], subsets: ["latin"] });
+  });
+
+  it("parses object with double-quoted strings", () => {
+    const result = parseStaticObjectLiteral(`{ weight: "400" }`);
+    expect(result).toEqual({ weight: "400" });
+  });
+
+  it("parses object with trailing comma", () => {
+    const result = parseStaticObjectLiteral(`{ weight: '400', }`);
+    expect(result).toEqual({ weight: "400" });
+  });
+
+  it("parses object with comments", () => {
+    const result = parseStaticObjectLiteral(`
+      {
+        // tsconfig-style line comment
+        compilerOptions: {
+          baseUrl: ".",
+          paths: {
+            "@/*": ["src/*"], /* trailing block comment */
+          },
+        },
+      }
+    `);
+    expect(result).toEqual({
+      compilerOptions: {
+        baseUrl: ".",
+        paths: {
+          "@/*": ["src/*"],
+        },
+      },
+    });
+  });
+
+  it("treats a leading BOM as whitespace", () => {
+    const result = parseStaticObjectLiteral(`\ufeff{ weight: '400' }`);
+    expect(result).toEqual({ weight: "400" });
+  });
+
+  it("parses object with numeric values", () => {
+    const result = parseStaticObjectLiteral(
+      `{ size: 16, offset: -1, ratio: 1.5e2, half: .5, mask: 0xff }`,
+    );
+    expect(result).toEqual({ size: 16, offset: -1, ratio: 150, half: 0.5, mask: 255 });
+  });
+
+  it("parses object with boolean and null values", () => {
+    const result = parseStaticObjectLiteral(`{ preload: true, fallback: null }`);
+    expect(result).toEqual({ preload: true, fallback: null });
+  });
+
+  it("parses quoted keys", () => {
+    const result = parseStaticObjectLiteral(`{ 'weight': '400' }`);
+    expect(result).toEqual({ weight: "400" });
+  });
+
+  it("parses escaped string values", () => {
+    const result = parseStaticObjectLiteral(`{ family: "A\\nB", axis: "\\u0077ght" }`);
+    expect(result).toEqual({ family: "A\nB", axis: "wght" });
+  });
+
+  it("parses empty object", () => {
+    const result = parseStaticObjectLiteral(`{}`);
+    expect(result).toEqual({});
+  });
+
+  it("parses nested objects", () => {
+    const result = parseStaticObjectLiteral(`{ axes: { wght: 400 } }`);
+    expect(result).toEqual({ axes: { wght: 400 } });
+  });
+
+  it("rejects function calls (code execution)", () => {
+    const result = parseStaticObjectLiteral(
+      `{ weight: require('child_process').execSync('whoami') }`,
+    );
+    expect(result).toBeNull();
+  });
+
+  it("rejects template literals", () => {
+    const result = parseStaticObjectLiteral("{ weight: `${process.env.HOME}` }");
+    expect(result).toBeNull();
+  });
+
+  it("rejects identifier references", () => {
+    const result = parseStaticObjectLiteral(`{ weight: myVar }`);
+    expect(result).toBeNull();
+  });
+
+  it("rejects computed property keys", () => {
+    const result = parseStaticObjectLiteral(`{ [Symbol.toPrimitive]: '400' }`);
+    expect(result).toBeNull();
+  });
+
+  it("rejects spread elements", () => {
+    const result = parseStaticObjectLiteral(`{ ...evil }`);
+    expect(result).toBeNull();
+  });
+
+  it("rejects sparse arrays", () => {
+    const result = parseStaticObjectLiteral(`{ weight: ['400', , '700'] }`);
+    expect(result).toBeNull();
+  });
+
+  it("rejects new expressions", () => {
+    const result = parseStaticObjectLiteral(`{ weight: new Function('return 1')() }`);
+    expect(result).toBeNull();
+  });
+
+  it("rejects IIFE in values", () => {
+    const result = parseStaticObjectLiteral(`{ weight: (() => { process.exit(1) })() }`);
+    expect(result).toBeNull();
+  });
+
+  it("rejects import() expressions", () => {
+    const result = parseStaticObjectLiteral(`{ weight: import('fs') }`);
+    expect(result).toBeNull();
+  });
+
+  it("returns null for invalid syntax", () => {
+    const result = parseStaticObjectLiteral(`{ not valid javascript `);
+    expect(result).toBeNull();
+  });
+
+  it("returns null for non-object expressions", () => {
+    const result = parseStaticObjectLiteral(`"just a string"`);
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Overview

| Field | Details |
| --- | --- |
| Goal | Keep config-only tsconfig path loading out of the Google Fonts plugin dependency graph. |
| Core change | Move static object literal parsing into a dependency-free utils parser and import it from config, fonts, and index. |
| Main boundary | `config/tsconfig-paths` now depends on `utils/static-object-literal`, not `plugins/fonts`. |
| Expected impact | Cold import of built `dist/config/tsconfig-paths.js` dropped from 96.3ms mean to 34.1ms mean locally under `hyperfine`; in-process module import is about 3ms. |

## Why

Config loading should only pay for config dependencies. `tsconfig-paths` needs a static literal parser for JSONC-shaped config files, but importing it from `plugins/fonts` pulls the whole font plugin and Vite parser into Node contexts that only need aliases.

## What Changed

| Surface | Before | After |
| --- | --- | --- |
| `config/tsconfig-paths` | Imported `parseStaticObjectLiteral` from `plugins/fonts` | Imports it from `utils/static-object-literal` |
| Font plugin | Owned the parser and imported Vite `parseAst` for that helper | Uses the shared dependency-free parser |
| Tests | Parser tests lived in the Google Fonts suite | Parser contract has focused tests for comments, trailing commas, literals, BOM, numeric forms, and dynamic rejection |

<details>
<summary>Validation</summary>

- `vp check`
- `vp test run tests/static-object-literal.test.ts tests/tsconfig-paths-config-loader.test.ts tests/font-google.test.ts tests/next-config.test.ts tests/next-config-runtime-shapes.test.ts`
- `vp run vinext#build`
- `hyperfine --warmup 3 --runs 20 'node -e '\''await import("./packages/vinext/dist/config/tsconfig-paths.js")'\'''`
  - before: 96.3 ms mean
  - after: 34.1 ms mean
- `rg -n "plugins/fonts|from \"vite\"|parseAst" packages/vinext/dist/config/tsconfig-paths.js packages/vinext/dist/utils/static-object-literal.js` returned no matches.

</details>

<details>
<summary>Risk and Compatibility</summary>

- The parser remains intentionally static only. Dynamic expressions, computed keys, spreads, calls, imports, and sparse arrays return `null`.
- This does not change public package exports.
- Main compatibility risk is divergence from Vite's parser on obscure JavaScript literal syntax. Tests cover the tsconfig JSONC and font option shapes vinext uses.

</details>
