### PR TITLE
fix(app-router): preserve client state during action revalidation

### DIFF
--- a/examples/app-router-cloudflare/app/action-revalidate/actions.ts
+++ b/examples/app-router-cloudflare/app/action-revalidate/actions.ts
@@ -1,0 +1,7 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+export async function revalidateAction() {
+  revalidatePath("/action-revalidate");
+}

--- a/examples/app-router-cloudflare/app/action-revalidate/loading.tsx
+++ b/examples/app-router-cloudflare/app/action-revalidate/loading.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function Loading() {
+  useEffect(() => {
+    console.log("Action revalidate loading mounted");
+  }, []);
+
+  return <p data-testid="action-revalidate-loading">Loading...</p>;
+}

--- a/examples/app-router-cloudflare/app/action-revalidate/page.tsx
+++ b/examples/app-router-cloudflare/app/action-revalidate/page.tsx
@@ -1,0 +1,18 @@
+import { RevalidateForm } from "./revalidate-form";
+
+export default async function ActionRevalidatePage() {
+  await new Promise((resolve) => setTimeout(resolve, 200));
+
+  return (
+    <main>
+      <h1>Action revalidation</h1>
+      <p>
+        Increment the client count, then revalidate the path. The timestamp should change without
+        resetting the client count or mounting the loading fallback.
+      </p>
+      <p data-testid="action-revalidate-time">Rendered at: {Date.now()}</p>
+      <RevalidateForm />
+      <a href="/">Back to home</a>
+    </main>
+  );
+}

--- a/examples/app-router-cloudflare/app/action-revalidate/revalidate-form.tsx
+++ b/examples/app-router-cloudflare/app/action-revalidate/revalidate-form.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useState } from "react";
+import { revalidateAction } from "./actions";
+
+export function RevalidateForm() {
+  const [count, setCount] = useState(0);
+
+  return (
+    <>
+      <p data-testid="action-revalidate-client-count">Client count: {count}</p>
+      <button
+        data-testid="action-revalidate-increment"
+        type="button"
+        onClick={() => setCount((value) => value + 1)}
+      >
+        Increment client count
+      </button>
+      <form action={revalidateAction}>
+        <button data-testid="action-revalidate-submit" type="submit">
+          Revalidate path
+        </button>
+      </form>
+    </>
+  );
+}

--- a/examples/app-router-cloudflare/app/page.tsx
+++ b/examples/app-router-cloudflare/app/page.tsx
@@ -10,6 +10,7 @@ export default function HomePage() {
       <nav>
         <ul>
           <li><a href="/about">About</a></li>
+          <li><a href="/action-revalidate">Action revalidation</a></li>
           <li><a href="/api/hello">API Route</a></li>
         </ul>
       </nav>

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -165,7 +165,6 @@ import {
   VINEXT_RSC_COMPATIBILITY_ID_HEADER,
   VINEXT_RSC_CONTENT_TYPE,
 } from "./app-rsc-cache-busting.js";
-import { APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI } from "./app-rsc-render-mode.js";
 import { blockDangerousStreamedRscRedirect } from "./app-browser-rsc-redirect.js";
 import {
   createOptimisticRouteTemplate,
@@ -1766,8 +1765,6 @@ function bootstrapHydration(
         const requestHeaders = createRscRequestHeaders({
           interceptionContext: requestInterceptionContext,
           mountedSlotsHeader,
-          renderMode:
-            navigationKind === "refresh" ? APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI : undefined,
         });
         const rscUrl = await createRscRequestUrl(url.pathname + url.search, requestHeaders);
         const rewrittenNavigationHref =

--- a/packages/vinext/src/server/app-browser-navigation-controller.ts
+++ b/packages/vinext/src/server/app-browser-navigation-controller.ts
@@ -906,10 +906,13 @@ export function createAppBrowserNavigationController(
       }
 
       if (latestApproval.approvedCommit) {
-        dispatchSynchronousVisibleCommit(latestApproval.approvedCommit);
+        const approvedRevalidationCommit = latestApproval.approvedCommit;
+        startTransition(() => {
+          dispatchSynchronousVisibleCommit(approvedRevalidationCommit);
+        });
         syncHistoryStatePreviousNextUrl(
-          latestApproval.approvedCommit.previousNextUrl,
-          latestApproval.approvedCommit.action.bfcacheIds,
+          approvedRevalidationCommit.previousNextUrl,
+          approvedRevalidationCommit.action.bfcacheIds,
         );
       } else {
         notifyDiscardedServerActionRevalidation(lifecycleOptions);

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -76,7 +76,6 @@ import {
 import {
   APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_SHELL,
   APP_RSC_RENDER_MODE_NAVIGATION,
-  shouldSuppressLoadingBoundaries,
   type AppRscRenderMode,
 } from "./app-rsc-render-mode.js";
 import { shouldServeStreamingMetadata } from "./streaming-metadata.js";
@@ -575,11 +574,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
     ? new URLSearchParams()
     : options.searchParams;
   const layoutParamAccess = createAppLayoutParamAccessTracker();
-  const hasActiveLoadingBoundary = shouldSuppressLoadingBoundaries(
-    options.renderMode ?? APP_RSC_RENDER_MODE_NAVIGATION,
-  )
-    ? false
-    : Boolean(route.loading?.default);
+  const hasActiveLoadingBoundary = Boolean(route.loading?.default);
 
   setCurrentFetchSoftTags(buildAppPageTags(options.cleanPathname, [], route.routeSegments));
   setCurrentFetchCacheMode(options.fetchCache ?? null);
@@ -927,10 +922,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
         );
       },
       async probePageSpecialError() {
-        if (
-          !shouldSuppressLoadingBoundaries(options.renderMode ?? APP_RSC_RENDER_MODE_NAVIGATION) &&
-          route.loading?.default
-        ) {
+        if (route.loading?.default) {
           return null;
         }
         const pageError = await probeAppPageThrownError({

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -47,7 +47,6 @@ import { probeReactServerSubtree } from "./app-page-probe.js";
 import {
   APP_RSC_RENDER_MODE_NAVIGATION,
   APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
-  shouldSuppressLoadingBoundaries,
   type AppRscRenderMode,
 } from "./app-rsc-render-mode.js";
 import {
@@ -903,7 +902,7 @@ export function buildAppPageElements<
     }
 
     const slotLoadingComponent = getDefaultExport(slot.loading);
-    if (slotLoadingComponent && !shouldSuppressLoadingBoundaries(renderMode)) {
+    if (slotLoadingComponent) {
       const SlotLoadingComponent = slotLoadingComponent;
       slotElement = (
         <Suspense key={slotResetKey} fallback={<SlotLoadingComponent />}>
@@ -968,7 +967,7 @@ export function buildAppPageElements<
     // transitions rather than unmounting it.
     routeChildren = <RedirectBoundary>{routeChildren}</RedirectBoundary>;
 
-    if (routeLoadingComponent && !shouldSuppressLoadingBoundaries(renderMode)) {
+    if (routeLoadingComponent) {
       const RouteLoadingComponent = routeLoadingComponent;
       // Route-level wrappers cover the full page branch in vinext's flat element
       // transport, so their reset key includes the visible segment-state path.

--- a/packages/vinext/src/server/app-rsc-render-mode.ts
+++ b/packages/vinext/src/server/app-rsc-render-mode.ts
@@ -1,30 +1,10 @@
-export type AppRscRenderMode =
-  | "navigation"
-  | "prefetch-dynamic-shell"
-  | "prefetch-loading-shell"
-  | "refresh-preserve-ui"
-  | "action-rerender-preserve-ui";
+export type AppRscRenderMode = "navigation" | "prefetch-dynamic-shell" | "prefetch-loading-shell";
 
 export const APP_RSC_RENDER_MODE_NAVIGATION = "navigation" satisfies AppRscRenderMode;
 export const APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_SHELL =
   "prefetch-dynamic-shell" satisfies AppRscRenderMode;
 export const APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL =
   "prefetch-loading-shell" satisfies AppRscRenderMode;
-export const APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI =
-  "refresh-preserve-ui" satisfies AppRscRenderMode;
-export const APP_RSC_RENDER_MODE_ACTION_RERENDER_PRESERVE_UI =
-  "action-rerender-preserve-ui" satisfies AppRscRenderMode;
-
-export function shouldSuppressLoadingBoundaries(mode: AppRscRenderMode): boolean {
-  return (
-    mode === APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI ||
-    mode === APP_RSC_RENDER_MODE_ACTION_RERENDER_PRESERVE_UI
-  );
-}
-
-function shouldUsePreserveUiCacheVariant(mode: AppRscRenderMode): boolean {
-  return shouldSuppressLoadingBoundaries(mode);
-}
 
 export function getRscRenderModeCacheVariant(mode: AppRscRenderMode): string | null {
   if (mode === APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_SHELL) {
@@ -35,7 +15,7 @@ export function getRscRenderModeCacheVariant(mode: AppRscRenderMode): string | n
     return "prefetch-loading-shell";
   }
 
-  return shouldUsePreserveUiCacheVariant(mode) ? "preserve-ui" : null;
+  return null;
 }
 
 export function parseAppRscRenderMode(value: string | null): AppRscRenderMode {
@@ -44,10 +24,6 @@ export function parseAppRscRenderMode(value: string | null): AppRscRenderMode {
       return APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_SHELL;
     case APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL:
       return APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL;
-    case APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI:
-      return APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI;
-    case APP_RSC_RENDER_MODE_ACTION_RERENDER_PRESERVE_UI:
-      return APP_RSC_RENDER_MODE_ACTION_RERENDER_PRESERVE_UI;
     case null:
     default:
       return APP_RSC_RENDER_MODE_NAVIGATION;

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -43,10 +43,7 @@ import { deferUntilStreamConsumed } from "./app-page-stream.js";
 import { buildAppPageTags } from "./implicit-tags.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
 import { getSetCookieName } from "./cookie-utils.js";
-import {
-  APP_RSC_RENDER_MODE_ACTION_RERENDER_PRESERVE_UI,
-  type AppRscRenderMode,
-} from "./app-rsc-render-mode.js";
+import { APP_RSC_RENDER_MODE_NAVIGATION, type AppRscRenderMode } from "./app-rsc-render-mode.js";
 import {
   getNextErrorDigest,
   parseNextHttpErrorDigest,
@@ -1337,7 +1334,7 @@ export async function handleServerActionRscRequest<
               request: redirectRenderRequest,
               route: targetMatch.route,
               searchParams: redirectSearchParams,
-              renderMode: APP_RSC_RENDER_MODE_ACTION_RERENDER_PRESERVE_UI,
+              renderMode: APP_RSC_RENDER_MODE_NAVIGATION,
               observeMetadataSearchParamsAccess: redirectDynamicConfig !== "force-static",
               observePageSearchParamsAccess: redirectDynamicConfig !== "force-static",
             });
@@ -1484,7 +1481,7 @@ export async function handleServerActionRscRequest<
           request: options.request,
           route: actionRerenderTarget.route,
           searchParams: actionRerenderSearchParams,
-          renderMode: APP_RSC_RENDER_MODE_ACTION_RERENDER_PRESERVE_UI,
+          renderMode: APP_RSC_RENDER_MODE_NAVIGATION,
           observeMetadataSearchParamsAccess: actionRerenderDynamicConfig !== "force-static",
           observePageSearchParamsAccess: actionRerenderDynamicConfig !== "force-static",
         });

--- a/packages/vinext/src/server/isr-cache.ts
+++ b/packages/vinext/src/server/isr-cache.ts
@@ -398,7 +398,7 @@ function normalizeInterceptionContextForCacheKey(interceptionContext: string): s
  *
  * Variants are sequenced in order: `source:<hash>` (intercepted source context,
  * only when an interception context is present), `slots:<hash>` (mounted parallel
- * route slots), and optionally `<render-mode-variant>` (e.g. `preserve-ui` or
+ * route slots), and optionally `<render-mode-variant>` (for example,
  * `prefetch-loading-shell`). Existing cached entries under the old format will
  * become unreachable after deployment. This is acceptable because ISR entries
  * have TTLs and will be regenerated on the next request.

--- a/tests/app-page-route-wiring.test.ts
+++ b/tests/app-page-route-wiring.test.ts
@@ -21,10 +21,7 @@ import {
   resolveAppPageChildSegments,
 } from "../packages/vinext/src/server/app-page-route-wiring.js";
 import { createAppLayoutParamAccessTracker } from "../packages/vinext/src/server/app-layout-param-observation.js";
-import {
-  APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
-  APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI,
-} from "../packages/vinext/src/server/app-rsc-render-mode.js";
+import { APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL } from "../packages/vinext/src/server/app-rsc-render-mode.js";
 import { makeThenableParams } from "../packages/vinext/src/shims/thenable-params.js";
 import {
   createRequestContext,
@@ -829,7 +826,7 @@ describe("app page route wiring helpers", () => {
     expect(html.indexOf('data-slot-layout="nested"')).toBeLessThan(html.indexOf("data-slot-page"));
   });
 
-  it("suppresses route and slot loading boundaries for refresh payloads", () => {
+  it("keeps route loading boundaries in the rendered tree", () => {
     const elements = buildAppPageElements({
       element: createElement(PageProbe),
       makeThenableParams(params) {
@@ -847,16 +844,45 @@ describe("app page route wiring helpers", () => {
         notFound: null,
         notFounds: [null],
         routeSegments: ["dashboard"],
+        slots: {},
+        templateTreePositions: [],
+        templates: [],
+      },
+      routePath: "/dashboard",
+      rootNotFoundModule: null,
+    });
+
+    expect(containsElementType(elements["route:/dashboard"], RouteLoadingProbe)).toBe(true);
+  });
+
+  it("keeps slot loading boundaries in the rendered tree", () => {
+    const elements = buildAppPageElements({
+      element: createElement(PageProbe),
+      makeThenableParams(params) {
+        return Promise.resolve(params);
+      },
+      matchedParams: {},
+      resolvedMetadata: null,
+      resolvedViewport: {},
+      route: {
+        error: null,
+        errors: [],
+        layoutTreePositions: [],
+        layouts: [],
+        loading: null,
+        notFound: null,
+        notFounds: [],
+        routeSegments: ["dashboard"],
         slots: {
           sidebar: {
             default: null,
             error: null,
             layout: null,
-            layoutIndex: 0,
+            layoutIndex: -1,
             loading: { default: SlotLoadingProbe },
             name: "sidebar",
             page: { default: SlotPage },
-            routeSegments: [],
+            routeSegments: ["members"],
           },
         },
         templateTreePositions: [],
@@ -864,11 +890,11 @@ describe("app page route wiring helpers", () => {
       },
       routePath: "/dashboard",
       rootNotFoundModule: null,
-      renderMode: APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI,
     });
 
-    expect(containsElementType(elements["route:/dashboard"], RouteLoadingProbe)).toBe(false);
-    expect(containsElementType(elements["slot:sidebar:/"], SlotLoadingProbe)).toBe(false);
+    expect(
+      Object.values(elements).some((element) => containsElementType(element, SlotLoadingProbe)),
+    ).toBe(true);
   });
 
   it("serializes route loading UI instead of page content for loading-shell prefetches", async () => {

--- a/tests/app-page-route-wiring.test.ts
+++ b/tests/app-page-route-wiring.test.ts
@@ -892,9 +892,7 @@ describe("app page route wiring helpers", () => {
       rootNotFoundModule: null,
     });
 
-    expect(
-      Object.values(elements).some((element) => containsElementType(element, SlotLoadingProbe)),
-    ).toBe(true);
+    expect(containsElementType(elements["slot:sidebar:/"], SlotLoadingProbe)).toBe(true);
   });
 
   it("serializes route loading UI instead of page content for loading-shell prefetches", async () => {

--- a/tests/app-rsc-cache-busting.test.ts
+++ b/tests/app-rsc-cache-busting.test.ts
@@ -15,10 +15,7 @@ import {
   VINEXT_RSC_RENDER_MODE_HEADER,
   VINEXT_RSC_VARY_HEADER,
 } from "../packages/vinext/src/server/app-rsc-cache-busting.js";
-import {
-  APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
-  APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI,
-} from "../packages/vinext/src/server/app-rsc-render-mode.js";
+import { APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL } from "../packages/vinext/src/server/app-rsc-render-mode.js";
 import { VINEXT_CLIENT_REUSE_MANIFEST_HEADER } from "../packages/vinext/src/server/headers.js";
 import { fnv1a64 } from "../packages/vinext/src/utils/hash.js";
 import { withEnvVar } from "./env-test-helpers.js";
@@ -109,16 +106,6 @@ describe("App Router RSC cache-busting", () => {
     );
 
     expect(feedHash).not.toBe(galleryHash);
-  });
-
-  it("varies preserve-current-UI refresh payloads from normal navigations", async () => {
-    const navigationHash = await computeRscCacheBustingSearchParam(createRscRequestHeaders());
-    const refreshHash = await computeRscCacheBustingSearchParam(
-      createRscRequestHeaders({ renderMode: APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI }),
-    );
-
-    expect(navigationHash).toBe("");
-    expect(refreshHash).not.toBe("");
   });
 
   it("varies loading-shell prefetch payloads from normal navigations", async () => {
@@ -267,42 +254,6 @@ describe("App Router RSC cache-busting", () => {
     await expect(
       resolveInvalidRscCacheBustingRequest({ isRscRequest: true, request }),
     ).resolves.toBeNull();
-  });
-
-  it("does not accept a bare previous hash for preserve-current-UI payloads", async () => {
-    const headers = createRscRequestHeaders({
-      renderMode: APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI,
-    });
-    const request = new Request("https://example.com/photos/42.rsc?_rsc", { headers });
-    const hash = await computeRscCacheBustingSearchParam(headers);
-
-    const response = await resolveInvalidRscCacheBustingRequest({
-      isRscRequest: true,
-      request,
-    });
-
-    expect(response?.status).toBe(307);
-    expect(response?.headers.get("Location")).toBe(`/photos/42.rsc?_rsc=${hash}`);
-  });
-
-  it("does not accept previous mounted-slot hashes for preserve-current-UI payloads", async () => {
-    const headers = createRscRequestHeaders({
-      mountedSlotsHeader: "slot:modal:/",
-      renderMode: APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI,
-    });
-    const previousHash = await sha256CacheBustingHash("0,0,0,0,0,slot:modal:/");
-    const currentHash = await computeRscCacheBustingSearchParam(headers);
-    const request = new Request(`https://example.com/photos/42.rsc?_rsc=${previousHash}`, {
-      headers,
-    });
-
-    const response = await resolveInvalidRscCacheBustingRequest({
-      isRscRequest: true,
-      request,
-    });
-
-    expect(response?.status).toBe(307);
-    expect(response?.headers.get("Location")).toBe(`/photos/42.rsc?_rsc=${currentHash}`);
   });
 
   it("ignores non-RSC and mutating requests", async () => {

--- a/tests/app-rsc-request-normalization.test.ts
+++ b/tests/app-rsc-request-normalization.test.ts
@@ -24,7 +24,6 @@ import {
 import {
   APP_RSC_RENDER_MODE_NAVIGATION,
   APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
-  APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI,
 } from "../packages/vinext/src/server/app-rsc-render-mode.js";
 import {
   createClientReuseManifest,
@@ -445,14 +444,6 @@ describe("normalizeRscRequest — mounted slots normalization", () => {
   });
 
   it("normalizes the semantic render mode marker", () => {
-    const refresh = normalized(
-      normalizeRscRequest(
-        req("/page.rsc", {
-          [VINEXT_RSC_RENDER_MODE_HEADER]: APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI,
-        }),
-        "",
-      ),
-    );
     const normal = normalized(
       normalizeRscRequest(req("/page.rsc", { [VINEXT_RSC_RENDER_MODE_HEADER]: "true" }), ""),
     );
@@ -466,12 +457,13 @@ describe("normalizeRscRequest — mounted slots normalization", () => {
     );
     const html = normalized(
       normalizeRscRequest(
-        req("/page", { [VINEXT_RSC_RENDER_MODE_HEADER]: APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI }),
+        req("/page", {
+          [VINEXT_RSC_RENDER_MODE_HEADER]: APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+        }),
         "",
       ),
     );
 
-    expect(refresh.renderMode).toBe(APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI);
     expect(prefetchShell.renderMode).toBe(APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL);
     expect(normal.renderMode).toBe(APP_RSC_RENDER_MODE_NAVIGATION);
     expect(html.renderMode).toBe(APP_RSC_RENDER_MODE_NAVIGATION);
@@ -482,14 +474,14 @@ describe("normalizeRscRequest — mounted slots normalization", () => {
       normalizeRscRequest(
         req(`/page?${VINEXT_RSC_CACHE_BUSTING_SEARCH_PARAM}`, {
           [RSC_HEADER]: "1",
-          [VINEXT_RSC_RENDER_MODE_HEADER]: APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI,
+          [VINEXT_RSC_RENDER_MODE_HEADER]: APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
         }),
         "",
       ),
     );
 
     expect(result.isRscRequest).toBe(true);
-    expect(result.renderMode).toBe(APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI);
+    expect(result.renderMode).toBe(APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL);
   });
 });
 

--- a/tests/e2e/app-router/nextjs-compat/actions-revalidate.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/actions-revalidate.spec.ts
@@ -103,22 +103,31 @@ test.describe("Next.js compat: actions-revalidate (browser)", () => {
     });
   });
 
-  // Next.js: 'should not remount the page + loading component when revalidating'
-  // Adapted: Verify that clicking revalidate button updates the timestamp
-  test("revalidating server actions update page and layout output", async ({ page }) => {
+  // Ported from Next.js: test/e2e/app-dir/actions-revalidate-remount/actions-revalidate-remount.test.ts
+  test("revalidating server actions preserve client state under loading.tsx", async ({ page }) => {
+    const loadingLogs: string[] = [];
+    page.on("console", (message) => {
+      if (message.text() === "Action revalidate loading mounted") {
+        loadingLogs.push(message.text());
+      }
+    });
+
     await page.goto(`${BASE}/nextjs-compat/action-revalidate`);
     await waitForAppRouterHydration(page);
+    loadingLogs.length = 0;
 
-    // Read initial timestamp
+    await page.click("#action-revalidate-increment");
+    await page.click("#action-revalidate-increment");
+    await page.click("#action-revalidate-increment");
+    await expect(page.locator("#action-revalidate-client-count")).toHaveText("3");
+
     const time1 = await page.locator("#time").textContent();
     const layoutVersion1 = await page.locator("#layout-version").textContent();
     expect(time1).toBeTruthy();
     expect(layoutVersion1).toBeTruthy();
 
-    // Click revalidate button (triggers server action with revalidatePath)
     await page.click("#revalidate");
 
-    // Wait for timestamp to change (page should re-render with fresh data)
     await expect(async () => {
       const time2 = await page.locator("#time").textContent();
       expect(time2).toBeTruthy();
@@ -129,6 +138,9 @@ test.describe("Next.js compat: actions-revalidate (browser)", () => {
 
     const layoutVersion2 = await page.locator("#layout-version").textContent();
     expect(layoutVersion2).toBeTruthy();
+    await expect(page.locator("#action-revalidate-client-count")).toHaveText("3");
+    expect(await page.locator("#action-revalidate-loading").count()).toBe(0);
+    expect(loadingLogs).toEqual([]);
 
     await page.click("#revalidate-tag");
     await expect(page.locator("#layout-version")).not.toHaveText(layoutVersion2!);

--- a/tests/e2e/cloudflare-workers/action-revalidate.spec.ts
+++ b/tests/e2e/cloudflare-workers/action-revalidate.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from "../fixtures";
+
+const BASE = "http://localhost:4176";
+
+// Ported from Next.js: test/e2e/app-dir/actions-revalidate-remount/actions-revalidate-remount.test.ts
+// https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/actions-revalidate-remount/actions-revalidate-remount.test.ts
+test("server action revalidation preserves client state under loading.tsx", async ({
+  page,
+  consoleErrors,
+}) => {
+  const loadingLogs: string[] = [];
+  page.on("console", (message) => {
+    if (message.text() === "Action revalidate loading mounted") {
+      loadingLogs.push(message.text());
+    }
+  });
+
+  await page.goto(`${BASE}/action-revalidate`);
+  await expect(page.getByTestId("action-revalidate-client-count")).toHaveText("Client count: 0");
+  loadingLogs.length = 0;
+
+  await page.getByTestId("action-revalidate-increment").click();
+  await page.getByTestId("action-revalidate-increment").click();
+  await page.getByTestId("action-revalidate-increment").click();
+  await expect(page.getByTestId("action-revalidate-client-count")).toHaveText("Client count: 3");
+
+  const initialTime = await page.getByTestId("action-revalidate-time").textContent();
+  expect(initialTime).toBeTruthy();
+
+  await page.getByTestId("action-revalidate-submit").click();
+
+  await expect(page.getByTestId("action-revalidate-time")).not.toHaveText(initialTime!);
+  await expect(page.getByTestId("action-revalidate-client-count")).toHaveText("Client count: 3");
+  await expect(page.getByTestId("action-revalidate-loading")).toHaveCount(0);
+  expect(loadingLogs).toEqual([]);
+
+  void consoleErrors;
+});

--- a/tests/fixtures/app-basic/app/nextjs-compat/action-revalidate/loading.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/action-revalidate/loading.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function Loading() {
+  useEffect(() => {
+    console.log("Action revalidate loading mounted");
+  }, []);
+
+  return <p id="action-revalidate-loading">Loading...</p>;
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/action-revalidate/revalidate-form.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/action-revalidate/revalidate-form.tsx
@@ -1,10 +1,21 @@
 "use client";
 
+import { useState } from "react";
 import { revalidateAction, revalidateTagAction } from "./actions";
 
 export function RevalidateForm() {
+  const [count, setCount] = useState(0);
+
   return (
     <>
+      <p id="action-revalidate-client-count">{count}</p>
+      <button
+        id="action-revalidate-increment"
+        type="button"
+        onClick={() => setCount((value) => value + 1)}
+      >
+        Increment
+      </button>
       <form action={revalidateAction}>
         <button type="submit" id="revalidate">
           Revalidate path

--- a/tests/isr-cache.test.ts
+++ b/tests/isr-cache.test.ts
@@ -23,10 +23,7 @@ import {
   getRevalidateDuration,
   triggerBackgroundRegeneration,
 } from "../packages/vinext/src/server/isr-cache.js";
-import {
-  APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
-  APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI,
-} from "../packages/vinext/src/server/app-rsc-render-mode.js";
+import { APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL } from "../packages/vinext/src/server/app-rsc-render-mode.js";
 import { fnv1a64 } from "../packages/vinext/src/utils/hash.js";
 import { buildPageCacheTags } from "../packages/vinext/src/server/implicit-tags.js";
 import { runWithExecutionContext } from "../packages/vinext/src/shims/request-context.js";
@@ -234,17 +231,6 @@ describe("App Router ISR cache key primitives", () => {
     expect(invalidSource).toBe(direct);
   });
 
-  it("keys RSC refresh variants separately from normal navigation variants", () => {
-    delete process.env.__VINEXT_BUILD_ID;
-
-    expect(appIsrRscKey("/feed", null, APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI)).toBe(
-      "app:/feed:rsc:preserve-ui",
-    );
-    expect(appIsrRscKey("/feed", "slot:modal:/", APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI)).toMatch(
-      /^app:\/feed:rsc:slots:[a-z0-9]+:preserve-ui$/,
-    );
-  });
-
   it("keys RSC loading-shell prefetch variants separately from normal navigation variants", () => {
     delete process.env.__VINEXT_BUILD_ID;
 
@@ -254,34 +240,6 @@ describe("App Router ISR cache key primitives", () => {
     expect(
       appIsrRscKey("/feed", "slot:modal:/", APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL),
     ).toMatch(/^app:\/feed:rsc:slots:[a-z0-9]+:prefetch-loading-shell$/);
-  });
-
-  it("round-trips normal and preserve-current-UI RSC payloads under separate keys", async () => {
-    delete process.env.__VINEXT_BUILD_ID;
-    setCacheHandler(new MemoryCacheHandler());
-
-    const normalKey = appIsrRscKey("/feed");
-    const preserveUiKey = appIsrRscKey("/feed", null, APP_RSC_RENDER_MODE_REFRESH_PRESERVE_UI);
-    const normalPayload = new TextEncoder().encode("normal-rsc").buffer;
-    const preserveUiPayload = new TextEncoder().encode("preserve-ui-rsc").buffer;
-
-    await isrSet(normalKey, buildAppPageCacheValue("", normalPayload), 60, []);
-    await isrSet(preserveUiKey, buildAppPageCacheValue("", preserveUiPayload), 60, []);
-
-    const normalEntry = await isrGet(normalKey);
-    const preserveUiEntry = await isrGet(preserveUiKey);
-
-    expect(normalEntry?.value.value?.kind).toBe("APP_PAGE");
-    expect(preserveUiEntry?.value.value?.kind).toBe("APP_PAGE");
-    if (
-      normalEntry?.value.value?.kind !== "APP_PAGE" ||
-      preserveUiEntry?.value.value?.kind !== "APP_PAGE"
-    ) {
-      throw new Error("Expected App Router page cache entries");
-    }
-
-    expect(new TextDecoder().decode(normalEntry.value.value.rscData)).toBe("normal-rsc");
-    expect(new TextDecoder().decode(preserveUiEntry.value.value.rscData)).toBe("preserve-ui-rsc");
   });
 });
 


### PR DESCRIPTION
Fixes #2505

## Problem

A Server Action revalidation on a route with `loading.tsx` remounted the current Client Component subtree and discarded local state. The refresh payload omitted the route's loading Suspense boundary even though the committed navigation tree included it, so React reconciled different element types at that position.

## Fix

- Keep route and parallel-slot loading boundaries structurally stable for navigation, refresh, and Server Action rerenders.
- Make page probing use the loading boundary that is actually present in the rendered tree.
- Remove the obsolete preserve-UI render modes and their duplicate RSC cache variants; refresh/action payloads now use the normal structural payload.
- Commit same-URL Server Action revalidations inside a React transition so genuinely suspended refreshes retain the committed UI.

This matches Next.js's model: the loading boundary remains part of the layout-router structure, while refresh behavior is controlled by the client transition rather than deleting the boundary from the server payload.

## Tests

- Extended the App Router `action-revalidate` fixture with client `useState` and `loading.tsx`.
- Added the same repro at `/action-revalidate` in the deployed `app-router-cloudflare` example, linked from its homepage.
- Added production-Worker Playwright coverage for the deployed example route.
- Verified the regression before the fix: the counter reset from `3` to `0` after `revalidatePath()`.
- The E2E now verifies server output refreshes, client state remains `3`, and the loading fallback never mounts.
- Added route and parallel-slot structural boundary coverage.

## Validation

- `vp test run tests/app-page-route-wiring.test.ts tests/app-page-dispatch.test.ts tests/app-rsc-cache-busting.test.ts tests/app-rsc-request-normalization.test.ts tests/isr-cache.test.ts tests/app-browser-entry.test.ts tests/app-server-action-execution.test.ts` — 572 passed
- App Router Playwright regression and adjacent loading-refresh guards — 3 passed
- Deployed example production-Worker regression — 1 passed
- `vp check <changed files>` — formatting, lint, and types pass
- `vp run vinext#build` — passes
- Independent review — no findings

