### PR TITLE
test(app-router): reproduce action revalidation remount

### DIFF
--- a/examples/app-router-cloudflare/app/action-revalidate/actions.ts
+++ b/examples/app-router-cloudflare/app/action-revalidate/actions.ts
@@ -1,0 +1,7 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+export async function revalidateAction() {
+  revalidatePath("/action-revalidate");
+}

--- a/examples/app-router-cloudflare/app/action-revalidate/loading.tsx
+++ b/examples/app-router-cloudflare/app/action-revalidate/loading.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function Loading() {
+  useEffect(() => {
+    console.log("Action revalidate loading mounted");
+  }, []);
+
+  return <p data-testid="action-revalidate-loading">Loading...</p>;
+}

--- a/examples/app-router-cloudflare/app/action-revalidate/page.tsx
+++ b/examples/app-router-cloudflare/app/action-revalidate/page.tsx
@@ -1,0 +1,18 @@
+import { RevalidateForm } from "./revalidate-form";
+
+export default async function ActionRevalidatePage() {
+  await new Promise((resolve) => setTimeout(resolve, 200));
+
+  return (
+    <main>
+      <h1>Action revalidation</h1>
+      <p>
+        Increment the client count, then revalidate the path. The timestamp should change without
+        resetting the client count or mounting the loading fallback.
+      </p>
+      <p data-testid="action-revalidate-time">Rendered at: {Date.now()}</p>
+      <RevalidateForm />
+      <a href="/">Back to home</a>
+    </main>
+  );
+}

--- a/examples/app-router-cloudflare/app/action-revalidate/revalidate-form.tsx
+++ b/examples/app-router-cloudflare/app/action-revalidate/revalidate-form.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useState } from "react";
+import { revalidateAction } from "./actions";
+
+export function RevalidateForm() {
+  const [count, setCount] = useState(0);
+
+  return (
+    <>
+      <p data-testid="action-revalidate-client-count">Client count: {count}</p>
+      <button
+        data-testid="action-revalidate-increment"
+        type="button"
+        onClick={() => setCount((value) => value + 1)}
+      >
+        Increment client count
+      </button>
+      <form action={revalidateAction}>
+        <button data-testid="action-revalidate-submit" type="submit">
+          Revalidate path
+        </button>
+      </form>
+    </>
+  );
+}

--- a/examples/app-router-cloudflare/app/page.tsx
+++ b/examples/app-router-cloudflare/app/page.tsx
@@ -10,6 +10,7 @@ export default function HomePage() {
       <nav>
         <ul>
           <li><a href="/about">About</a></li>
+          <li><a href="/action-revalidate">Action revalidation</a></li>
           <li><a href="/api/hello">API Route</a></li>
         </ul>
       </nav>

--- a/tests/e2e/cloudflare-workers/action-revalidate.spec.ts
+++ b/tests/e2e/cloudflare-workers/action-revalidate.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from "../fixtures";
+
+const BASE = "http://localhost:4176";
+
+// Ported from Next.js: test/e2e/app-dir/actions-revalidate-remount/actions-revalidate-remount.test.ts
+// https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/actions-revalidate-remount/actions-revalidate-remount.test.ts
+test("server action revalidation preserves client state under loading.tsx", async ({
+  page,
+  consoleErrors,
+}) => {
+  const loadingLogs: string[] = [];
+  page.on("console", (message) => {
+    if (message.text() === "Action revalidate loading mounted") {
+      loadingLogs.push(message.text());
+    }
+  });
+
+  await page.goto(`${BASE}/action-revalidate`);
+  await expect(page.getByTestId("action-revalidate-client-count")).toHaveText("Client count: 0");
+  loadingLogs.length = 0;
+
+  await page.getByTestId("action-revalidate-increment").click();
+  await page.getByTestId("action-revalidate-increment").click();
+  await page.getByTestId("action-revalidate-increment").click();
+  await expect(page.getByTestId("action-revalidate-client-count")).toHaveText("Client count: 3");
+
+  const initialTime = await page.getByTestId("action-revalidate-time").textContent();
+  expect(initialTime).toBeTruthy();
+
+  await page.getByTestId("action-revalidate-submit").click();
+
+  await expect(page.getByTestId("action-revalidate-time")).not.toHaveText(initialTime!);
+  await expect(page.getByTestId("action-revalidate-client-count")).toHaveText("Client count: 3");
+  await expect(page.getByTestId("action-revalidate-loading")).toHaveCount(0);
+  expect(loadingLogs).toEqual([]);
+
+  void consoleErrors;
+});


### PR DESCRIPTION
## Purpose

Adds a deployed App Router reproduction for the Server Action revalidation remount bug on current `main`. This PR intentionally contains **no runtime fix** so the behavior can be exercised in its Cloudflare preview.

## Reproduction

1. Open the `app-router-cloudflare` preview at `/action-revalidate`.
2. Click **Increment client count** three times.
3. Click **Revalidate path**.
4. Observe the server-rendered timestamp changes, but the client count resets from `3` to `0`.

The route is also linked from the example homepage.

## Expected behavior

The timestamp should update while the client count remains `3`, and the `loading.tsx` fallback should not mount.

## Automated coverage

Adds a `cloudflare-workers` Playwright test for the same flow. It is expected to fail on this reproduction-only branch until the runtime fix lands.

Confirmed locally against production Worker output:

```text
Expected: "Client count: 3"
Received: "Client count: 0"
```
