### PR TITLE
fix: pass server externals to Nitro traceDeps

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1263,6 +1263,7 @@ type NitroSetupContext = {
   options: {
     dev?: boolean;
     routeRules?: Record<string, NitroRouteRuleConfig>;
+    traceDeps?: string[];
   };
   logger?: {
     warn?: (message: string) => void;
@@ -1294,6 +1295,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
   let hasCloudflarePlugin = false;
   let warnedInlineNextConfigOverride = false;
   let hasNitroPlugin = false;
+  let nitroTraceDepsFromServerExternals: string[] = [];
   let isServeCommand = false;
   let pagesOptimizeEntries: string[] = [];
   const pagesClientAssetsOutputDirs = new Set<string>();
@@ -2316,6 +2318,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           nextConfig?.serverExternalPackages,
           serverTranspilePackages,
         );
+        nitroTraceDepsFromServerExternals = nextServerExternal;
         // Detect if this is a multi-environment build (App Router or Cloudflare).
         // In multi-env builds, manualChunks must only be set per-environment
         // (on the client env), not globally — otherwise it leaks into RSC/SSR
@@ -6015,6 +6018,15 @@ export const loadServerActionClient = ${
           if (nitro.options.dev) return;
           if (!nextConfig) return;
           if (!hasAppDir && !hasPagesDir) return;
+
+          if (nitroTraceDepsFromServerExternals.length > 0) {
+            nitro.options.traceDeps = [
+              ...new Set([
+                ...(nitro.options.traceDeps ?? []),
+                ...nitroTraceDepsFromServerExternals,
+              ]),
+            ];
+          }
 
           const { collectNitroRouteRules, mergeNitroRouteRules } =
             await import("./build/nitro-route-rules.js");

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -6015,7 +6015,6 @@ export const loadServerActionClient = ${
       name: "vinext:nitro-route-rules",
       nitro: {
         setup: async (nitro: NitroSetupContext) => {
-          if (nitro.options.dev) return;
           if (!nextConfig) return;
           if (!hasAppDir && !hasPagesDir) return;
 
@@ -6027,6 +6026,8 @@ export const loadServerActionClient = ${
               ]),
             ];
           }
+
+          if (nitro.options.dev) return;
 
           const { collectNitroRouteRules, mergeNitroRouteRules } =
             await import("./build/nitro-route-rules.js");

--- a/tests/nitro-route-rules.test.ts
+++ b/tests/nitro-route-rules.test.ts
@@ -354,18 +354,22 @@ describe("vinext Nitro setup integration", () => {
     expect(warn.mock.calls[0]?.[0]).toContain("/blog/*");
   });
 
-  it("skips route rule generation during Nitro dev", async () => {
+  it("propagates server externals but skips route rule generation during Nitro dev", async () => {
     const root = createAppProject();
     const nitroPlugin = await initializeNitroSetupPlugin(root);
     const nitro = {
       options: {
         dev: true,
         routeRules: {},
+        traceDeps: ["existing-trace"],
       },
     };
 
     await nitroPlugin.nitro!.setup!(nitro);
 
     expect(nitro.options.routeRules).toEqual({});
+    expect(nitro.options.traceDeps?.slice(0, 1)).toEqual(["existing-trace"]);
+    expect(nitro.options.traceDeps).toContain("pg");
+    expect(nitro.options.traceDeps).toContain("mongodb");
   });
 });

--- a/tests/nitro-route-rules.test.ts
+++ b/tests/nitro-route-rules.test.ts
@@ -18,6 +18,7 @@ type NitroSetupTarget = {
   options: {
     dev?: boolean;
     routeRules?: Record<string, NitroRouteRuleConfig>;
+    traceDeps?: string[];
   };
   logger?: {
     warn?: (message: string) => void;
@@ -279,6 +280,32 @@ describe("collectNitroRouteRules", () => {
 });
 
 describe("vinext Nitro setup integration", () => {
+  it("propagates server externals to Nitro traceDeps", async () => {
+    const root = createAppProject();
+    writeProjectFile(
+      root,
+      "next.config.mjs",
+      `export default { serverExternalPackages: ["custom-apm", "@scope/traced"] };\n`,
+    );
+    const nitroPlugin = await initializeNitroSetupPlugin(root);
+    const nitro = {
+      options: {
+        dev: false,
+        routeRules: {},
+        traceDeps: ["existing-trace", "pg"],
+      },
+    };
+
+    await nitroPlugin.nitro!.setup!(nitro);
+
+    expect(nitro.options.traceDeps?.slice(0, 2)).toEqual(["existing-trace", "pg"]);
+    expect(nitro.options.traceDeps).toContain("pg");
+    expect(nitro.options.traceDeps).toContain("mongodb");
+    expect(nitro.options.traceDeps).toContain("custom-apm");
+    expect(nitro.options.traceDeps).toContain("@scope/traced");
+    expect(new Set(nitro.options.traceDeps).size).toBe(nitro.options.traceDeps?.length);
+  });
+
   it("merges generated route rules into Nitro before build", async () => {
     const root = createAppProject();
     const nitroPlugin = await initializeNitroSetupPlugin(root);


### PR DESCRIPTION
﻿## Summary

This addresses the `serverExternalPackages` / Nitro tracing part of #2515.

- carry the resolved Next server externals list into Nitro setup
- merge those packages into `nitro.options.traceDeps` while preserving user-provided entries
- add a regression test covering default externals (`pg`, `mongodb`), user `serverExternalPackages`, existing `traceDeps`, and de-duping

I am intentionally not claiming this fully solves the instrumentation preload-order concern from #2515. This PR keeps packages traceable/bare for the Nitro output; the `--import` / early instrumentation startup behavior can be handled separately.

## Validation

- `corepack pnpm test tests/nitro-route-rules.test.ts`
- `corepack pnpm test tests/server-external-packages.test.ts tests/next-config.test.ts`
- `corepack pnpm test tests/server-externals-manifest.test.ts`
- `corepack pnpm test tests/app-router-production-build.test.ts -t "serves TypeScript language service"`
- `corepack pnpm run check`
- `git diff --check origin/main...HEAD`
