### PR TITLE
fix: honor build --mode dotenv files

### DIFF
--- a/packages/vinext/src/cli-args.ts
+++ b/packages/vinext/src/cli-args.ts
@@ -2,13 +2,14 @@
  * CLI argument parser for the vinext CLI.
  *
  * Parses flags for `vinext dev`, `vinext start`, `vinext build`, etc.
- * Validates that value-taking flags (`--port`, `--hostname`) have actual values
+ * Validates that value-taking flags (`--port`, `--hostname`, `--mode`) have actual values
  * rather than silently consuming the next flag or returning NaN/undefined.
  */
 
 type ParsedArgs = {
   port?: number;
   hostname?: string;
+  mode?: string;
   help?: boolean;
   verbose?: boolean;
   turbopack?: boolean;
@@ -149,6 +150,12 @@ export function parseArgs(args: string[]): ParsedArgs {
         break;
       }
 
+      case "--mode": {
+        result.mode = takeValue(arg, args, i);
+        i++;
+        break;
+      }
+
       default: {
         // Handle --flag=value forms (e.g. --port=3000, --hostname=0.0.0.0).
         const eqRaw = tryEqualsForm(arg, "port");
@@ -162,6 +169,14 @@ export function parseArgs(args: string[]): ParsedArgs {
             throw new Error(`--hostname requires a value, but none was provided.`);
           }
           result.hostname = hostRaw;
+          break;
+        }
+        const modeRaw = tryEqualsForm(arg, "mode");
+        if (modeRaw !== null) {
+          if (modeRaw === "") {
+            throw new Error(`--mode requires a value, but none was provided.`);
+          }
+          result.mode = modeRaw;
           break;
         }
         const prerenderConcurrencyRaw = tryEqualsForm(arg, "prerender-concurrency");

--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -472,9 +472,11 @@ async function buildApp() {
   const buildMode = parsed.mode ?? "production";
 
   // Vite modes select config and dotenv files independently of NODE_ENV.
-  // A build always runs with production semantics, including while loading
-  // user Vite/Next configs before the vinext plugin's config hook executes.
-  Reflect.set(process.env, "NODE_ENV", "production");
+  // Seed production semantics before dotenv/config loading, but preserve an
+  // explicit caller value just like Next.js and normal process-env precedence.
+  if (!process.env.NODE_ENV) {
+    Reflect.set(process.env, "NODE_ENV", "production");
+  }
 
   if (parsed.precompress) {
     process.env.VINEXT_PRECOMPRESS = "1";

--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -471,6 +471,11 @@ async function buildApp() {
   if (parsed.help) return printHelp("build");
   const buildMode = parsed.mode ?? "production";
 
+  // Vite modes select config and dotenv files independently of NODE_ENV.
+  // A build always runs with production semantics, including while loading
+  // user Vite/Next configs before the vinext plugin's config hook executes.
+  Reflect.set(process.env, "NODE_ENV", "production");
+
   if (parsed.precompress) {
     process.env.VINEXT_PRECOMPRESS = "1";
   }

--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -239,6 +239,7 @@ type BuildViteConfigMetadata = {
 async function loadBuildViteConfigMetadata(
   vite: ViteModule,
   root: string,
+  mode: string,
 ): Promise<BuildViteConfigMetadata> {
   if (!hasViteConfig(root)) {
     return { nextConfig: null, prerenderConfig: null, routeRootConfig: null };
@@ -246,11 +247,7 @@ async function loadBuildViteConfigMetadata(
 
   // Read the raw user config before the multi-environment build so
   // `build.emptyOutDir: false` remains an escape hatch for vinext's upfront clean.
-  const loaded = await vite.loadConfigFromFile(
-    { command: "build", mode: "production" },
-    undefined,
-    root,
-  );
+  const loaded = await vite.loadConfigFromFile({ command: "build", mode }, undefined, root);
   const emptyOutDir = loaded?.config.build?.emptyOutDir;
   return {
     emptyOutDir: typeof emptyOutDir === "boolean" ? emptyOutDir : undefined,
@@ -265,7 +262,11 @@ async function loadBuildViteConfigMetadata(
  * project, Vite will merge our config with it (theirs takes precedence).
  * If there's no vite.config, this provides everything needed.
  */
-function buildViteConfig(overrides: Record<string, unknown> = {}, logger?: import("vite").Logger) {
+function buildViteConfig(
+  overrides: Record<string, unknown> = {},
+  logger?: import("vite").Logger,
+  mode?: string,
+) {
   const hasConfig = hasViteConfig(process.cwd());
 
   // If a vite.config exists, let Vite load it — only set root and overrides.
@@ -275,6 +276,7 @@ function buildViteConfig(overrides: Record<string, unknown> = {}, logger?: impor
   if (hasConfig) {
     return {
       root: process.cwd(),
+      ...(mode ? { mode } : {}),
       ...(logger ? { customLogger: logger } : {}),
       ...overrides,
     };
@@ -285,6 +287,7 @@ function buildViteConfig(overrides: Record<string, unknown> = {}, logger?: impor
   // so we only need vinext() in the plugins array.
   const config: Record<string, unknown> = {
     root: process.cwd(),
+    ...(mode ? { mode } : {}),
     configFile: false,
     plugins: [vinext()],
     // Deduplicate React packages to prevent "Invalid hook call" errors
@@ -466,6 +469,7 @@ async function dev() {
 async function buildApp() {
   const parsed = parseArgs(rawArgs);
   if (parsed.help) return printHelp("build");
+  const buildMode = parsed.mode ?? "production";
 
   if (parsed.precompress) {
     process.env.VINEXT_PRECOMPRESS = "1";
@@ -473,7 +477,7 @@ async function buildApp() {
 
   loadDotenv({
     root: process.cwd(),
-    mode: "production",
+    mode: buildMode,
   });
 
   // Ensure "type": "module" in package.json before Vite loads vite.config.ts.
@@ -491,7 +495,7 @@ async function buildApp() {
 
   const root = toSlash(process.cwd());
   const isApp = hasAppDir(root);
-  const buildConfigMetadata = await loadBuildViteConfigMetadata(vite, root);
+  const buildConfigMetadata = await loadBuildViteConfigMetadata(vite, root, buildMode);
   const rawNextConfig = buildConfigMetadata.nextConfig
     ? await resolveNextConfigInput(buildConfigMetadata.nextConfig, PHASE_PRODUCTION_BUILD)
     : await loadNextConfig(root, PHASE_PRODUCTION_BUILD);
@@ -587,7 +591,7 @@ async function buildApp() {
   }
   await runWithPreviewBuildCredentials(async () => {
     try {
-      const config = buildViteConfig({}, logger);
+      const config = buildViteConfig({}, logger, buildMode);
       const builder = await vite.createBuilder(config);
       await builder.buildApp();
 
@@ -611,7 +615,7 @@ async function buildApp() {
         let userTransformPlugins: import("vite").PluginOption[] = [];
         if (hasViteConfig(process.cwd())) {
           const loaded = await vite.loadConfigFromFile(
-            { command: "build", mode: "production", isSsrBuild: true },
+            { command: "build", mode: buildMode, isSsrBuild: true },
             undefined,
             root,
           );
@@ -638,6 +642,7 @@ async function buildApp() {
         }
         await vite.build({
           root,
+          mode: buildMode,
           configFile: false,
           plugins: [...userTransformPlugins, vinext({ disableAppRouter: true })],
           resolve: {
@@ -909,6 +914,7 @@ function printHelp(cmd?: string) {
                          to vinext({ prerender: true }) and takes priority.
     --prerender-concurrency <count>
                          Maximum number of routes to pre-render in parallel
+    --mode <mode>        Load .env.<mode>* files and pass mode to Vite
     --precompress        Precompress static assets at build time (.br, .gz, .zst)
     -h, --help           Show this help
 `);

--- a/packages/vinext/src/config/dotenv.ts
+++ b/packages/vinext/src/config/dotenv.ts
@@ -2,8 +2,6 @@ import fs from "node:fs";
 import path from "pathslash";
 import { parseEnv } from "node:util";
 
-type VinextEnvMode = "development" | "production" | "test";
-
 /**
  * Environment-variable bag accepted by {@link loadDotenv}.
  *
@@ -17,12 +15,12 @@ type EnvBag = Record<string, string | undefined>;
 
 type LoadDotenvOptions = {
   root: string;
-  mode: VinextEnvMode;
+  mode: string;
   processEnv?: EnvBag;
 };
 
 type LoadDotenvResult = {
-  mode: VinextEnvMode;
+  mode: string;
   loadedFiles: string[];
   loadedEnv: Record<string, string>;
 };
@@ -30,7 +28,7 @@ type LoadDotenvResult = {
 /**
  * Next.js-compatible dotenv lookup order (highest priority first).
  */
-export function getDotenvFiles(mode: VinextEnvMode): string[] {
+export function getDotenvFiles(mode: string): string[] {
   return [`.env.${mode}.local`, ...(mode === "test" ? [] : [".env.local"]), `.env.${mode}`, ".env"];
 }
 

--- a/packages/vinext/src/config/dotenv.ts
+++ b/packages/vinext/src/config/dotenv.ts
@@ -87,47 +87,49 @@ export function loadDotenv({
   };
 }
 
-const ENV_REF_RE = /(\\)?\$(?:\{([A-Za-z_][A-Za-z0-9_]*)\}|([A-Za-z_][A-Za-z0-9_]*))/g;
-
 function expandEnv(parsed: Record<string, string>, processEnv: EnvBag): Record<string, string> {
-  const expanded: Record<string, string> = {};
-  const resolving = new Set<string>();
-  const context: Record<string, string | undefined> = {
-    ...parsed,
-    ...processEnv,
-  };
+  const expanded = { ...parsed };
+  for (const key of Object.keys(expanded)) {
+    const processValue = processEnv[key];
+    const value =
+      processValue && processValue !== expanded[key]
+        ? processValue
+        : expandValue(expanded[key], processEnv, expanded);
+    expanded[key] = value.replace(/\\\$/g, "$");
+  }
+  return expanded;
+}
 
-  function resolveValue(key: string): string {
-    const cached = expanded[key];
-    if (cached !== undefined) return cached;
+function expandValue(value: string, processEnv: EnvBag, parsed: Record<string, string>): string {
+  const env: EnvBag = { ...parsed, ...processEnv };
+  const envRefRe = /(?<!\\)\${([^{}]+)}|(?<!\\)\$([A-Za-z_][A-Za-z0-9_]*)/g;
+  const seen = new Set<string>();
+  let result = value;
+  let match: RegExpExecArray | null;
 
-    if (resolving.has(key)) {
-      return context[key] ?? "";
+  while ((match = envRefRe.exec(result)) !== null) {
+    seen.add(result);
+    const [template, braced, bare] = match;
+    const expression = (braced || bare) as string;
+    const operator = expression.match(/(:\+|\+|:-|-)/)?.[0];
+    const parts = operator ? expression.split(operator) : [expression];
+    const refKey = parts.shift() as string;
+    const operand = parts.join(operator ?? "");
+    const refValue = env[refKey];
+
+    let replacement: string;
+    if (operator === ":+" || operator === "+") {
+      replacement = refValue ? operand : "";
+    } else if (refValue) {
+      replacement = seen.has(refValue) ? operand : refValue;
+    } else {
+      replacement = operand;
     }
 
-    const raw = context[key];
-    if (raw === undefined) return "";
-
-    resolving.add(key);
-    let value = raw.replace(ENV_REF_RE, (match, escaped, braced, bare) => {
-      if (escaped) return match.slice(1);
-
-      const refKey = (braced || bare) as string;
-      return resolveValue(refKey);
-    });
-    // Strip remaining \$ escapes not caught by the regex (e.g. \$100 where
-    // what follows $ isn't a valid variable name).
-    value = value.replace(/\\\$/g, "$");
-    resolving.delete(key);
-
-    expanded[key] = value;
-    context[key] = value;
-    return value;
+    result = result.replace(template, replacement);
+    if (result === parsed[refKey]) break;
+    envRefRe.lastIndex = 0;
   }
 
-  for (const key of Object.keys(parsed)) {
-    resolveValue(key);
-  }
-
-  return expanded;
+  return result;
 }

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -11,7 +11,7 @@ import type {
   UserConfig,
   ViteDevServer,
 } from "vite";
-import { createLogger, loadEnv, parseAst, transformWithOxc } from "vite";
+import { createLogger, parseAst, transformWithOxc } from "vite";
 import {
   pagesRouter,
   apiRouter,
@@ -82,6 +82,7 @@ import {
   type NextConfigInput,
   type ResolvedNextConfig,
 } from "./config/next-config.js";
+import { loadDotenv } from "./config/dotenv.js";
 import { mergeServerExternalPackages } from "./config/server-external-packages.js";
 
 import { findMiddlewareFile, isProxyFile, runMiddleware } from "./server/middleware.js";
@@ -1983,14 +1984,10 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         // Next.js loads .env files before evaluating next.config.js, so
         // env vars are available in config, server-side code, and as
         // NEXT_PUBLIC_* defines for the client bundle.
-        // Pass '' as prefix to load ALL vars, not just VITE_-prefixed ones.
         const mode = env?.mode ?? "development";
-        const envDir = config.envDir ?? root;
-        const dotenvVars = loadEnv(mode, envDir, "");
-        for (const [key, value] of Object.entries(dotenvVars)) {
-          if (process.env[key] === undefined) {
-            process.env[key] = value;
-          }
+        if (config.envDir !== false) {
+          const envDir = config.envDir ?? root;
+          loadDotenv({ root: envDir, mode });
         }
         // Align NODE_ENV with Next.js semantics: build/preview -> production,
         // development server -> development. Next.js unconditionally forces

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1993,10 +1993,10 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         // development server -> development. Next.js unconditionally forces
         // NODE_ENV during build/dev, so we do the same.
         let resolvedNodeEnv: string;
-        if (mode === "test") {
-          resolvedNodeEnv = "test";
-        } else if (env?.command === "build" || env?.isPreview === true) {
+        if (env?.command === "build" || env?.isPreview === true) {
           resolvedNodeEnv = "production";
+        } else if (mode === "test") {
+          resolvedNodeEnv = "test";
         } else {
           resolvedNodeEnv = "development";
         }

--- a/tests/build-optimization.test.ts
+++ b/tests/build-optimization.test.ts
@@ -836,6 +836,22 @@ describe("process.env.NODE_ENV define", () => {
     }
   }, 15000);
 
+  it("keeps NODE_ENV production for builds using test mode", async () => {
+    const { mainPlugin, tmpDir, fsp } = await setupTmpProject();
+    try {
+      const mockConfig = { root: tmpDir, build: {}, plugins: [] };
+      const result = await mainPlugin.config(mockConfig, {
+        command: "build",
+        mode: "test",
+      });
+
+      expect(result.define?.["process.env.NODE_ENV"]).toBe(JSON.stringify("production"));
+      expect(process.env.NODE_ENV).toBe("production");
+    } finally {
+      await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 15000);
+
   it("is injected as production for build without explicit mode", async () => {
     // Other tests in this file pass { command: "build" } with no mode.
     // The mode defaults to "development" via env?.mode ?? "development",

--- a/tests/cli-args.test.ts
+++ b/tests/cli-args.test.ts
@@ -2,7 +2,7 @@
  * CLI argument parser tests.
  *
  * Tests the parseArgs function extracted from cli.ts, validating that:
- *  - Value-taking flags (`--port`, `--hostname`) error on missing values
+ *  - Value-taking flags (`--port`, `--hostname`, `--mode`) error on missing values
  *  - Value-taking flags error when the next arg is another flag
  *  - `--port` uses strict integer parsing (Number, not parseInt) and range checks
  *  - `--flag=value` forms work correctly
@@ -45,6 +45,30 @@ describe("boolean flags", () => {
 });
 
 // ─── --port flag ────────────────────────────────────────────────────────────
+
+describe("--mode", () => {
+  it("parses a build mode value", () => {
+    expect(parseArgs(["--mode", "staging"])).toMatchObject({ mode: "staging" });
+  });
+
+  it("parses --mode=value form", () => {
+    expect(parseArgs(["--mode=test"])).toMatchObject({ mode: "test" });
+  });
+
+  it("throws when --mode has no value", () => {
+    expect(() => parseArgs(["--mode"])).toThrow("--mode requires a value, but none was provided.");
+  });
+
+  it("throws when --mode value is another flag", () => {
+    expect(() => parseArgs(["--mode", "--verbose"])).toThrow(
+      '--mode requires a value, but got "--verbose" which looks like another flag.',
+    );
+  });
+
+  it("throws when --mode= has empty value", () => {
+    expect(() => parseArgs(["--mode="])).toThrow("--mode requires a value, but none was provided.");
+  });
+});
 
 describe("--port / -p", () => {
   it("parses a numeric port value", () => {
@@ -280,6 +304,15 @@ describe("combined flags", () => {
 });
 
 // ─── Positional arguments ───────────────────────────────────────────────────
+
+describe("build flags", () => {
+  it("parses build mode alongside precompress", () => {
+    expect(parseArgs(["--mode", "staging", "--precompress"])).toMatchObject({
+      mode: "staging",
+      precompress: true,
+    });
+  });
+});
 
 describe("positional arguments", () => {
   it("keeps positional arguments for commands with directory targets", () => {

--- a/tests/client-global-define.test.ts
+++ b/tests/client-global-define.test.ts
@@ -21,6 +21,8 @@ import os from "node:os";
 import fs from "node:fs";
 import fsp from "node:fs/promises";
 import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
 import vinext from "../packages/vinext/src/index.js";
 
 type VinextPlugin = {
@@ -152,6 +154,49 @@ describe("client `global` define (config)", () => {
       await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
     }
   }, 15000);
+
+  it("evaluates build configs with production NODE_ENV in test mode", async () => {
+    const tmpDir = await setupTmpProject(`
+      if (process.env.NODE_ENV !== "production") {
+        throw new Error(\`next.config saw NODE_ENV=\${process.env.NODE_ENV}\`);
+      }
+      export default {};
+    `);
+    const vinextEntryUrl = pathToFileURL(
+      path.resolve(import.meta.dirname, "../packages/vinext/dist/index.js"),
+    ).href;
+    const cliPath = path.resolve(import.meta.dirname, "../packages/vinext/dist/cli.js");
+
+    try {
+      await fsp.writeFile(path.join(tmpDir, ".env.test"), "NODE_ENV=test\n");
+      await fsp.writeFile(
+        path.join(tmpDir, "vite.config.mjs"),
+        `
+          import vinext from ${JSON.stringify(vinextEntryUrl)};
+          export default ({ mode }) => {
+            if (mode !== "test") throw new Error(\`vite.config saw mode=\${mode}\`);
+            if (process.env.NODE_ENV !== "production") {
+              throw new Error(\`vite.config saw NODE_ENV=\${process.env.NODE_ENV}\`);
+            }
+            return { plugins: [vinext()] };
+          };
+        `,
+      );
+
+      const childEnv = { ...process.env };
+      Reflect.deleteProperty(childEnv, "NODE_ENV");
+      expect(() =>
+        execFileSync(process.execPath, [cliPath, "build", "--mode", "test"], {
+          cwd: tmpDir,
+          env: childEnv,
+          stdio: "pipe",
+          timeout: 30000,
+        }),
+      ).not.toThrow();
+    } finally {
+      await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 30000);
 });
 
 describe("client `global` define (dev server behavior)", () => {

--- a/tests/client-global-define.test.ts
+++ b/tests/client-global-define.test.ts
@@ -25,7 +25,7 @@ import vinext from "../packages/vinext/src/index.js";
 
 type VinextPlugin = {
   name: string;
-  config?: (config: unknown, env: { command: string }) => unknown;
+  config?: (config: unknown, env: { command: string; mode?: string }) => unknown;
   configEnvironment?: (
     name: string,
     config: unknown,
@@ -104,6 +104,51 @@ describe("client `global` define (config)", () => {
       );
       expect(globalDefinePlugin!.configEnvironment!("client", {}, { command: "build" })).toBeNull();
     } finally {
+      await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }, 15000);
+
+  it("excludes .env.local from NEXT_PUBLIC defines in test mode", async () => {
+    const previousFromTest = process.env.NEXT_PUBLIC_FROM_TEST_MODE;
+    const previousLocalOnly = process.env.NEXT_PUBLIC_LOCAL_ONLY;
+    delete process.env.NEXT_PUBLIC_FROM_TEST_MODE;
+    delete process.env.NEXT_PUBLIC_LOCAL_ONLY;
+
+    const plugins = vinext() as VinextPlugin[];
+    const mainPlugin = plugins.find(
+      (p) => p.name === "vinext:config" && typeof p.config === "function",
+    );
+    expect(mainPlugin).toBeDefined();
+
+    const tmpDir = await setupTmpProject(`export default {};`);
+    try {
+      await fsp.writeFile(path.join(tmpDir, ".env.local"), "NEXT_PUBLIC_LOCAL_ONLY=from-local\n");
+      await fsp.writeFile(path.join(tmpDir, ".env.test"), "NEXT_PUBLIC_FROM_TEST_MODE=from-test\n");
+
+      const configResult = (await mainPlugin!.config!(
+        { root: tmpDir, build: {}, plugins: [], optimizeDeps: {} },
+        { command: "build", mode: "test" },
+      )) as { define?: Record<string, string> };
+
+      expect(configResult.define?.["process.env.NEXT_PUBLIC_FROM_TEST_MODE"]).toBe(
+        JSON.stringify("from-test"),
+      );
+      expect(Object.hasOwn(configResult.define ?? {}, "process.env.NEXT_PUBLIC_LOCAL_ONLY")).toBe(
+        false,
+      );
+      expect(process.env.NEXT_PUBLIC_FROM_TEST_MODE).toBe("from-test");
+      expect(process.env.NEXT_PUBLIC_LOCAL_ONLY).toBeUndefined();
+    } finally {
+      if (previousFromTest === undefined) {
+        delete process.env.NEXT_PUBLIC_FROM_TEST_MODE;
+      } else {
+        process.env.NEXT_PUBLIC_FROM_TEST_MODE = previousFromTest;
+      }
+      if (previousLocalOnly === undefined) {
+        delete process.env.NEXT_PUBLIC_LOCAL_ONLY;
+      } else {
+        process.env.NEXT_PUBLIC_LOCAL_ONLY = previousLocalOnly;
+      }
       await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
     }
   }, 15000);

--- a/tests/client-global-define.test.ts
+++ b/tests/client-global-define.test.ts
@@ -170,29 +170,33 @@ describe("client `global` define (config)", () => {
     }
   }, 15000);
 
-  it("evaluates build configs with production NODE_ENV in test mode", async () => {
-    const tmpDir = await setupTmpProject(`
-      if (process.env.NODE_ENV !== "production") {
-        throw new Error(\`next.config saw NODE_ENV=\${process.env.NODE_ENV}\`);
-      }
-      export default {};
-    `);
+  it("defaults config NODE_ENV to production without overriding caller values", async () => {
+    const tmpDir = await setupTmpProject(`export default {};`);
     const vinextEntryUrl = pathToFileURL(
       path.resolve(import.meta.dirname, "../packages/vinext/dist/index.js"),
     ).href;
     const cliPath = path.resolve(import.meta.dirname, "../packages/vinext/dist/cli.js");
+    const viteConfigNodeEnvLog = path.join(tmpDir, "vite-config-node-env.log");
+    const nextConfigNodeEnvLog = path.join(tmpDir, "next-config-node-env.log");
 
     try {
       await fsp.writeFile(path.join(tmpDir, ".env.test"), "NODE_ENV=test\n");
       await fsp.writeFile(
+        path.join(tmpDir, "next.config.mjs"),
+        `
+          import { appendFileSync } from "node:fs";
+          appendFileSync(${JSON.stringify(nextConfigNodeEnvLog)}, \`\${process.env.NODE_ENV}\n\`);
+          export default {};
+        `,
+      );
+      await fsp.writeFile(
         path.join(tmpDir, "vite.config.mjs"),
         `
+          import { appendFileSync } from "node:fs";
           import vinext from ${JSON.stringify(vinextEntryUrl)};
           export default ({ mode }) => {
             if (mode !== "test") throw new Error(\`vite.config saw mode=\${mode}\`);
-            if (process.env.NODE_ENV !== "production") {
-              throw new Error(\`vite.config saw NODE_ENV=\${process.env.NODE_ENV}\`);
-            }
+            appendFileSync(${JSON.stringify(viteConfigNodeEnvLog)}, \`\${process.env.NODE_ENV}\n\`);
             return { plugins: [vinext()] };
           };
         `,
@@ -200,14 +204,26 @@ describe("client `global` define (config)", () => {
 
       const childEnv = { ...process.env };
       Reflect.deleteProperty(childEnv, "NODE_ENV");
-      expect(() =>
+      const build = () =>
         execFileSync(process.execPath, [cliPath, "build", "--mode", "test"], {
           cwd: tmpDir,
           env: childEnv,
           stdio: "pipe",
           timeout: 30000,
-        }),
-      ).not.toThrow();
+        });
+
+      expect(build).not.toThrow();
+      expect((await fsp.readFile(viteConfigNodeEnvLog, "utf-8")).split("\n")[0]).toBe("production");
+      expect((await fsp.readFile(nextConfigNodeEnvLog, "utf-8")).split("\n")[0]).toBe("production");
+
+      await Promise.all([
+        fsp.rm(viteConfigNodeEnvLog, { force: true }),
+        fsp.rm(nextConfigNodeEnvLog, { force: true }),
+      ]);
+      childEnv.NODE_ENV = "test";
+      expect(build).not.toThrow();
+      expect((await fsp.readFile(viteConfigNodeEnvLog, "utf-8")).split("\n")[0]).toBe("test");
+      expect((await fsp.readFile(nextConfigNodeEnvLog, "utf-8")).split("\n")[0]).toBe("test");
     } finally {
       await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
     }

--- a/tests/client-global-define.test.ts
+++ b/tests/client-global-define.test.ts
@@ -113,8 +113,10 @@ describe("client `global` define (config)", () => {
   it("excludes .env.local from NEXT_PUBLIC defines in test mode", async () => {
     const previousFromTest = process.env.NEXT_PUBLIC_FROM_TEST_MODE;
     const previousLocalOnly = process.env.NEXT_PUBLIC_LOCAL_ONLY;
+    const previousFallback = process.env.NEXT_PUBLIC_WITH_FALLBACK;
     delete process.env.NEXT_PUBLIC_FROM_TEST_MODE;
     delete process.env.NEXT_PUBLIC_LOCAL_ONLY;
+    delete process.env.NEXT_PUBLIC_WITH_FALLBACK;
 
     const plugins = vinext() as VinextPlugin[];
     const mainPlugin = plugins.find(
@@ -125,7 +127,11 @@ describe("client `global` define (config)", () => {
     const tmpDir = await setupTmpProject(`export default {};`);
     try {
       await fsp.writeFile(path.join(tmpDir, ".env.local"), "NEXT_PUBLIC_LOCAL_ONLY=from-local\n");
-      await fsp.writeFile(path.join(tmpDir, ".env.test"), "NEXT_PUBLIC_FROM_TEST_MODE=from-test\n");
+      await fsp.writeFile(
+        path.join(tmpDir, ".env.test"),
+        "NEXT_PUBLIC_FROM_TEST_MODE=from-test\n" +
+          "NEXT_PUBLIC_WITH_FALLBACK=${MISSING_VALUE:-fallback}\n",
+      );
 
       const configResult = (await mainPlugin!.config!(
         { root: tmpDir, build: {}, plugins: [], optimizeDeps: {} },
@@ -138,8 +144,12 @@ describe("client `global` define (config)", () => {
       expect(Object.hasOwn(configResult.define ?? {}, "process.env.NEXT_PUBLIC_LOCAL_ONLY")).toBe(
         false,
       );
+      expect(configResult.define?.["process.env.NEXT_PUBLIC_WITH_FALLBACK"]).toBe(
+        JSON.stringify("fallback"),
+      );
       expect(process.env.NEXT_PUBLIC_FROM_TEST_MODE).toBe("from-test");
       expect(process.env.NEXT_PUBLIC_LOCAL_ONLY).toBeUndefined();
+      expect(process.env.NEXT_PUBLIC_WITH_FALLBACK).toBe("fallback");
     } finally {
       if (previousFromTest === undefined) {
         delete process.env.NEXT_PUBLIC_FROM_TEST_MODE;
@@ -150,6 +160,11 @@ describe("client `global` define (config)", () => {
         delete process.env.NEXT_PUBLIC_LOCAL_ONLY;
       } else {
         process.env.NEXT_PUBLIC_LOCAL_ONLY = previousLocalOnly;
+      }
+      if (previousFallback === undefined) {
+        delete process.env.NEXT_PUBLIC_WITH_FALLBACK;
+      } else {
+        process.env.NEXT_PUBLIC_WITH_FALLBACK = previousFallback;
       }
       await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
     }

--- a/tests/dotenv.test.ts
+++ b/tests/dotenv.test.ts
@@ -188,6 +188,36 @@ describe("loadDotenv", () => {
     expect(env.URL).toBe("http://localhost:3000");
   });
 
+  it("supports dotenv-expand default and alternate operators", () => {
+    writeFile(
+      ".env",
+      [
+        "SET=value",
+        "EMPTY=",
+        "DEFAULT_UNSET=${MISSING:-fallback}",
+        "DEFAULT_EMPTY=${EMPTY:-fallback}",
+        "DEFAULT_DASH=${MISSING-fallback}",
+        "ALTERNATE_SET=${SET:+alternate}",
+        "ALTERNATE_PLUS=${SET+alternate}",
+        "ALTERNATE_MISSING=${MISSING:+alternate}",
+        "NESTED_DEFAULT=${MISSING:-${SET}}",
+        "SELF_DEFAULT=${SELF_DEFAULT:-self-fallback}",
+      ].join("\n"),
+    );
+
+    const env: Record<string, string | undefined> = {};
+    loadDotenv({ root: tmpDir, mode: "development", processEnv: env });
+
+    expect(env.DEFAULT_UNSET).toBe("fallback");
+    expect(env.DEFAULT_EMPTY).toBe("fallback");
+    expect(env.DEFAULT_DASH).toBe("fallback");
+    expect(env.ALTERNATE_SET).toBe("alternate");
+    expect(env.ALTERNATE_PLUS).toBe("alternate");
+    expect(env.ALTERNATE_MISSING).toBe("");
+    expect(env.NESTED_DEFAULT).toBe("value");
+    expect(env.SELF_DEFAULT).toBe("self-fallback");
+  });
+
   it("expansion prefers process.env over file values", () => {
     writeFile(
       ".env.development.local",

--- a/tests/dotenv.test.ts
+++ b/tests/dotenv.test.ts
@@ -44,6 +44,15 @@ describe("getDotenvFiles", () => {
     expect(files).toEqual([".env.test.local", ".env.test", ".env"]);
     expect(files).not.toContain(".env.local");
   });
+
+  it("returns mode-specific files for custom build modes", () => {
+    expect(getDotenvFiles("staging")).toEqual([
+      ".env.staging.local",
+      ".env.local",
+      ".env.staging",
+      ".env",
+    ]);
+  });
 });
 
 describe("loadDotenv", () => {
@@ -129,6 +138,31 @@ describe("loadDotenv", () => {
     expect(result.loadedFiles).not.toContain(".env.local");
     expect(result.loadedFiles).toContain(".env.test");
     expect(result.loadedEnv.TEST_VALUE).toBe("from-test");
+  });
+
+  it("loads custom build mode files with normal local precedence", () => {
+    writeFile(".env", "NEXT_PUBLIC_TARGET=env\nFALLBACK=env\n");
+    writeFile(".env.staging", "NEXT_PUBLIC_TARGET=mode\n");
+    writeFile(".env.local", "LOCAL_ONLY=local\n");
+    writeFile(".env.staging.local", "NEXT_PUBLIC_TARGET=mode-local\n");
+
+    const env: Record<string, string | undefined> = {};
+    const result = loadDotenv({
+      root: tmpDir,
+      mode: "staging",
+      processEnv: env,
+    });
+
+    expect(env.NEXT_PUBLIC_TARGET).toBe("mode-local");
+    expect(env.LOCAL_ONLY).toBe("local");
+    expect(env.FALLBACK).toBe("env");
+    expect(result.loadedFiles).toEqual([
+      ".env.staging.local",
+      ".env.local",
+      ".env.staging",
+      ".env",
+    ]);
+    expect(result.mode).toBe("staging");
   });
 
   it("expands variables using $VAR syntax", () => {


### PR DESCRIPTION
## Summary

Closes #2393.

This adds Vite-style `vinext build --mode <mode>` support for build-time dotenv loading:

- parse `--mode` / `--mode=<mode>` in the shared CLI parser
- load `.env.<mode>*` through vinext's Next-compatible dotenv loader before Vite config/build setup
- pass the same mode into Vite config metadata loading, `createBuilder`, and the hybrid Pages Router server build
- allow custom dotenv modes such as `staging`/`cdn` while preserving the existing test-mode `.env.local` skip
- document the build flag in `vinext build --help`

## Validation

- `corepack pnpm test tests/cli-args.test.ts tests/dotenv.test.ts` (75/75)
- `corepack pnpm exec tsc --noEmit --pretty false --project packages/vinext/tsconfig.json`
- `corepack pnpm run check`
- `corepack pnpm --filter vinext build`
- `git diff --check origin/main...HEAD`
- Manual smoke: built a temporary Pages fixture with `.env`, `.env.production`, and `.env.staging`, ran `node packages/vinext/dist/cli.js build --mode staging`, and verified every `vite.config` load saw `mode: "staging"` plus `process.env.NEXT_PUBLIC_TARGET === "from-staging"` before the build completed.