### PR TITLE
fix(cloudflare): stream deploy logs

### DIFF
--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -11,7 +11,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { createRequire } from "node:module";
-import { execFileSync, type ExecFileSyncOptions } from "node:child_process";
+import { spawn, type SpawnOptions } from "node:child_process";
 import { parseArgs as nodeParseArgs } from "node:util";
 import { pathToFileURL } from "node:url";
 import { runPrerender } from "vinext/internal/build/run-prerender";
@@ -271,15 +271,14 @@ export function buildWranglerInvocation(
   return { ...buildNodeCliInvocation(wranglerBin, args, nodeExecutable), env };
 }
 
-export function runWranglerDeploy(
+export async function runWranglerDeploy(
   root: string,
   options: Pick<DeployOptions, "preview" | "env">,
-  execute: typeof execFileSync = execFileSync,
-): string {
-  const execOpts: ExecFileSyncOptions = {
+  execute: typeof spawn = spawn,
+): Promise<string> {
+  const spawnOptions: SpawnOptions = {
     cwd: root,
-    stdio: "pipe",
-    encoding: "utf-8",
+    stdio: ["inherit", "pipe", "pipe"],
     shell: false,
   };
 
@@ -291,19 +290,37 @@ export function runWranglerDeploy(
     console.log("\n  Deploying to production...");
   }
 
-  const output = execute(file, args, execOpts) as string;
+  const child = execute(file, args, spawnOptions);
+  let output = "";
+
+  child.stdout?.on("data", (chunk: Buffer | string) => {
+    const text = chunk.toString();
+    output += text;
+    process.stdout.write(text);
+  });
+  child.stderr?.on("data", (chunk: Buffer | string) => {
+    const text = chunk.toString();
+    output += text;
+    process.stderr.write(text);
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", (code, signal) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+
+      const exitReason = signal ? `signal ${signal}` : `exit code ${code ?? "unknown"}`;
+      reject(new Error(`Wrangler deploy failed with ${exitReason}.`));
+    });
+  });
 
   // Parse the deployed URL from wrangler output
   // Wrangler prints: "Published <name> (version_id)\n  https://<name>.<subdomain>.workers.dev"
   const urlMatch = output.match(/https:\/\/[^\s]+\.workers\.dev[^\s]*/);
   const deployedUrl = urlMatch ? urlMatch[0] : null;
-
-  // Also print raw output for transparency
-  if (output.trim()) {
-    for (const line of output.trim().split("\n")) {
-      console.log(`  ${line}`);
-    }
-  }
 
   return deployedUrl ?? "(URL not detected in wrangler output)";
 }
@@ -440,7 +457,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
   }
 
   // Step 7: Deploy via wrangler
-  const url = runWranglerDeploy(root, {
+  const url = await runWranglerDeploy(root, {
     env: deployEnv === "production" && !options.env ? undefined : deployEnv,
   });
 

--- a/tests/deploy-prerender-config.test.ts
+++ b/tests/deploy-prerender-config.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import fs from "node:fs";
 import path from "node:path";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import type { ChildProcess } from "node:child_process";
 
 const runPrerenderMock = vi.hoisted(() => vi.fn(async () => ({ routes: [] })));
 
@@ -20,7 +23,17 @@ vi.mock("node:child_process", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:child_process")>();
   return {
     ...actual,
-    execFileSync: vi.fn(() => "Published app\n  https://app.example.workers.dev\n"),
+    spawn: vi.fn(() => {
+      const child = new EventEmitter() as ChildProcess;
+      const childStdout = new PassThrough();
+      child.stdout = childStdout;
+      child.stderr = new PassThrough();
+      queueMicrotask(() => {
+        childStdout.write("Published app\n  https://app.example.workers.dev\n");
+        child.emit("close", 0, null);
+      });
+      return child;
+    }),
   };
 });
 

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vite-plus/test"
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
-import { execFileSync } from "node:child_process";
+import { execFileSync, type ChildProcess, type spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
 import {
   deploy,
   buildNodeCliInvocation,
@@ -355,20 +357,50 @@ describe("resolveWranglerBin", () => {
     );
   });
 
-  it("executes Wrangler with shell disabled and literal metacharacters", () => {
+  it("executes Wrangler with shell disabled and literal metacharacters", async () => {
     writeWranglerPackage();
     const payload = "preview & whoami > vinext-pwned.txt & rem";
-    let observed: Parameters<typeof execFileSync> | undefined;
-    const execute = ((...args: Parameters<typeof execFileSync>) => {
+    let observed: Parameters<typeof spawn> | undefined;
+    const execute = ((...args: Parameters<typeof spawn>) => {
       observed = args;
-      return "";
-    }) as typeof execFileSync;
+      const child = new EventEmitter() as ChildProcess;
+      child.stdout = new PassThrough();
+      child.stderr = new PassThrough();
+      queueMicrotask(() => child.emit("close", 0, null));
+      return child;
+    }) as typeof spawn;
 
-    runWranglerDeploy(tmpDir, { env: payload }, execute);
+    await runWranglerDeploy(tmpDir, { env: payload }, execute);
 
     expect(observed?.[0]).toBe(process.execPath);
     expect(observed?.[1]).toEqual([expectedWranglerBin(), "deploy", "--env", payload]);
     expect(observed?.[2]).toMatchObject({ shell: false });
+  });
+
+  it("streams Wrangler output before the process exits", async () => {
+    writeWranglerPackage();
+    const child = new EventEmitter() as ChildProcess;
+    const childStdout = new PassThrough();
+    const childStderr = new PassThrough();
+    child.stdout = childStdout;
+    child.stderr = childStderr;
+    const execute = vi.fn(() => child) as unknown as typeof spawn;
+    const stdoutWrite = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    const deployment = runWranglerDeploy(tmpDir, {}, execute);
+    childStdout.write("Uploading assets...\n");
+    childStderr.write("Uploaded 10/20 files\n");
+
+    expect(stdoutWrite).toHaveBeenCalledWith("Uploading assets...\n");
+    expect(stderrWrite).toHaveBeenCalledWith("Uploaded 10/20 files\n");
+
+    childStdout.write("https://app.example.workers.dev\n");
+    child.emit("close", 0, null);
+
+    await expect(deployment).resolves.toBe("https://app.example.workers.dev");
+    stdoutWrite.mockRestore();
+    stderrWrite.mockRestore();
   });
 
   it("does not execute metacharacters in a real subprocess", () => {


### PR DESCRIPTION
## Summary

- stream Wrangler stdout and stderr while Cloudflare deploys are running
- continue collecting output to detect the deployed Workers URL
- preserve shell-free invocation and surface non-zero process exits
- add regression coverage proving logs are forwarded before Wrangler exits

## Testing

- `vp check packages/cloudflare/src/deploy.ts tests/deploy.test.ts tests/deploy-prerender-config.test.ts`
- `vp test run tests/deploy.test.ts tests/deploy-prerender-config.test.ts`
