### PR TITLE
chore(release): reclassify prerender KV population as minor

### DIFF
--- a/.changeset/454dfbdf6b8429624f583f494f742a10452a782a.md
+++ b/.changeset/454dfbdf6b8429624f583f494f742a10452a782a.md
@@ -2,4 +2,3 @@
 "@vinext/cloudflare": minor
 "vinext": minor
 ---
-

--- a/.changeset/454dfbdf6b8429624f583f494f742a10452a782a.md
+++ b/.changeset/454dfbdf6b8429624f583f494f742a10452a782a.md
@@ -1,0 +1,5 @@
+---
+"@vinext/cloudflare": minor
+"vinext": minor
+---
+


### PR DESCRIPTION
## Summary

- reclassify commit `454dfbdf6b8429624f583f494f742a10452a782a` as a minor release
- preserve the original changelog message with a blank changeset body
- apply the override to both `vinext` and `@vinext/cloudflare`

## Validation

- `vp test run scripts/create-changeset.test.ts`
- `git diff --check`