### PR TITLE
fix(routing): discover dot-directory routes

### DIFF
--- a/packages/vinext/src/routing/file-matcher.ts
+++ b/packages/vinext/src/routing/file-matcher.ts
@@ -25,6 +25,11 @@ function buildExtensionGlob(stem: string, extensions: readonly string[]): string
   return `${stem}.{${extensions.join(",")}}`;
 }
 
+function includeDotDirectoryMatches(pattern: string): string {
+  if (!pattern.startsWith("**/")) return pattern;
+  return `{**,**/.*/**}/${pattern.slice(3)}`;
+}
+
 export type ValidFileMatcher = {
   extensions: string[];
   dottedExtensions: string[];
@@ -186,7 +191,7 @@ export async function* scanWithExtensions(
   extensions: readonly string[],
   exclude?: (name: string) => boolean,
 ): AsyncGenerator<string> {
-  const pattern = buildExtensionGlob(stem, extensions);
+  const pattern = includeDotDirectoryMatches(buildExtensionGlob(stem, extensions));
   for await (const file of glob(pattern, {
     cwd,
     ...(exclude ? { exclude } : {}),

--- a/tests/app-route-graph.test.ts
+++ b/tests/app-route-graph.test.ts
@@ -9,6 +9,7 @@ import {
   type AppRouteGraphRoute,
   type RouteManifest,
 } from "../packages/vinext/src/routing/app-route-graph.js";
+import { matchAppRoute } from "../packages/vinext/src/routing/app-router.js";
 
 // normalizePathSeparators is a platform-gated no-op on POSIX. CI never runs
 // Windows, so force the Windows behavior to let the separator-mismatch tests
@@ -1424,6 +1425,30 @@ describe("App Router route graph builder", () => {
 
       expect(patterns).toContain("/products/:variant.id");
       expect(patterns).toContain("/users/:user@domain");
+    });
+  });
+
+  it("discovers route handlers inside dot-directories like .well-known", async () => {
+    await withTempApp(async (appDir) => {
+      await writeAppFile(appDir, "layout.tsx", EMPTY_LAYOUT);
+      await writeAppFile(appDir, ".well-known/openid-configuration/route.ts", EMPTY_ROUTE);
+
+      const graph = await buildAppRouteGraph(appDir, createValidFileMatcher());
+      const route = findRoute(graph.routes, "/.well-known/openid-configuration");
+
+      expect(route.routePath).toBe(
+        path.posix.join(appDir, ".well-known/openid-configuration/route.ts"),
+      );
+      expect(route.ids.routeHandler).toBe("route-handler:/.well-known/openid-configuration");
+      expect(graph.routeManifest.segmentGraph.routeHandlers.get(route.ids.routeHandler!)).toEqual({
+        id: "route-handler:/.well-known/openid-configuration",
+        routeId: "route:/.well-known/openid-configuration",
+        pattern: "/.well-known/openid-configuration",
+      });
+      expect(matchAppRoute("/.well-known/openid-configuration", graph.routes)).toEqual({
+        params: {},
+        route,
+      });
     });
   });
 

--- a/tests/file-matcher.test.ts
+++ b/tests/file-matcher.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vite-plus/test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import {
   createValidFileMatcher,
   normalizePageExtensions,
+  scanWithExtensions,
 } from "../packages/vinext/src/routing/file-matcher.js";
 import { shouldInvalidateAppRouteFile } from "../packages/vinext/src/server/dev-route-files.js";
 
@@ -41,6 +45,32 @@ describe("file matcher", () => {
     expect(matcher.stripExtension("about.mdx")).toBe("about");
     expect(matcher.stripExtension("index.m+d")).toBe("index");
     expect(matcher.stripExtension("about.tsx")).toBe("about.tsx");
+  });
+
+  it("scans route files inside dot-directories", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "vinext-dot-route-scan-"));
+    try {
+      await mkdir(path.join(tmpDir, "api"), { recursive: true });
+      await mkdir(path.join(tmpDir, ".well-known", "openid-configuration"), {
+        recursive: true,
+      });
+      await writeFile(path.join(tmpDir, "route.ts"), "");
+      await writeFile(path.join(tmpDir, "api", "route.ts"), "");
+      await writeFile(path.join(tmpDir, ".well-known", "openid-configuration", "route.ts"), "");
+
+      const files = [];
+      for await (const file of scanWithExtensions("**/route", tmpDir, ["ts"])) {
+        files.push(file);
+      }
+
+      expect(files.sort()).toEqual([
+        ".well-known/openid-configuration/route.ts",
+        "api/route.ts",
+        "route.ts",
+      ]);
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
   });
 
   it("classifies only app route structure files as dev route invalidations", () => {


### PR DESCRIPTION
## Summary

- expand route file scanning so `**/` stems also descend into dot-prefixed directories such as `.well-known`
- add scanner coverage for root, normal nested, and `.well-known` route files
- add an App Router regression proving `app/.well-known/openid-configuration/route.ts` is discovered and matched

Closes #2014.

## Root cause

The route scanner builds `**/route.{ts,tsx,...}`-style patterns. Node's `fs.promises.glob` does not traverse dot-directories for that pattern, so route handlers under `app/.well-known/...` are invisible and never reach the App Router graph.

## Validation

- `corepack pnpm test tests/file-matcher.test.ts tests/app-route-graph.test.ts -t dot-directories`
- `corepack pnpm test tests/file-matcher.test.ts`
- `corepack pnpm run check`
- `git diff --check`

Pre-push duplicate/ownership check: #2014 is still open, unassigned, and uncommented, and no open PR matched #2014 / `.well-known` / dot-directory route scanning terms.