### PR TITLE
fix(init): use built Wrangler config for deploy script

### DIFF
--- a/packages/create-vinext-app/src/index.ts
+++ b/packages/create-vinext-app/src/index.ts
@@ -91,8 +91,8 @@ function getTemplateFiles(platform: InitPlatform, warmCdnCache = false): Record<
     : "This App Router project is wired for vinext and Tailwind CSS.";
   const buildOutput = isCloudflare ? "Worker-ready production output" : "production output";
   const deployCommand = warmCdnCache
-    ? "pnpm exec vinext-cloudflare deploy --warm-cdn-cache"
-    : "pnpm exec vinext-cloudflare deploy";
+    ? "pnpm exec vinext-cloudflare deploy --config dist/server/wrangler.json --warm-cdn-cache"
+    : "pnpm exec vinext-cloudflare deploy --config dist/server/wrangler.json";
   const actionCard = isCloudflare
     ? `<div className="rounded-lg border border-slate-200 bg-white p-5">
             <h2 className="font-semibold">Deploy</h2>

--- a/packages/vinext/src/init.ts
+++ b/packages/vinext/src/init.ts
@@ -193,8 +193,8 @@ export function addScripts(
 
     if (platform === "cloudflare" && !pkg.scripts["deploy:vinext"]) {
       pkg.scripts["deploy:vinext"] = options.warmCdnCache
-        ? "vinext-cloudflare deploy --warm-cdn-cache"
-        : "vinext-cloudflare deploy";
+        ? "vinext-cloudflare deploy --config dist/server/wrangler.json --warm-cdn-cache"
+        : "vinext-cloudflare deploy --config dist/server/wrangler.json";
       added.push("deploy:vinext");
     }
 

--- a/tests/__snapshots__/init.test.ts.snap
+++ b/tests/__snapshots__/init.test.ts.snap
@@ -26,7 +26,7 @@ export default function Home() { return <div>hi</div> }
     "dev:vinext": "vinext dev --port 3001",
     "build:vinext": "vinext build",
     "start:vinext": "wrangler dev --config dist/server/wrangler.json",
-    "deploy:vinext": "vinext-cloudflare deploy --warm-cdn-cache"
+    "deploy:vinext": "vinext-cloudflare deploy --config dist/server/wrangler.json --warm-cdn-cache"
   }
 }
 
@@ -142,7 +142,7 @@ export default function Home() { return <div>hi</div> }
     "dev:vinext": "vinext dev --port 3001",
     "build:vinext": "vinext build",
     "start:vinext": "wrangler dev --config dist/server/wrangler.json",
-    "deploy:vinext": "vinext-cloudflare deploy --warm-cdn-cache"
+    "deploy:vinext": "vinext-cloudflare deploy --config dist/server/wrangler.json --warm-cdn-cache"
   }
 }
 

--- a/tests/create-vinext-app.test.ts
+++ b/tests/create-vinext-app.test.ts
@@ -84,7 +84,9 @@ describe("createVinextApp", () => {
     expect(fs.existsSync(path.join(appPath, "src"))).toBe(false);
     expect(readFile(appPath, "app/page.tsx")).toContain("vinext + Cloudflare Workers");
     expect(readFile(appPath, "app/page.tsx")).toContain("pnpm run dev:vinext");
-    expect(readFile(appPath, "app/page.tsx")).toContain("pnpm exec vinext-cloudflare deploy");
+    expect(readFile(appPath, "app/page.tsx")).toContain(
+      "pnpm exec vinext-cloudflare deploy --config dist/server/wrangler.json",
+    );
     expect(readFile(appPath, "app/page.tsx")).not.toMatch(/\bnpm\b|\bnpx\b/);
     expect(readFile(appPath, "README.md")).toContain("pnpm run build:vinext");
     expect(readFile(appPath, "README.md")).not.toMatch(/\bnpm\b|\bnpx\b/);
@@ -135,10 +137,12 @@ describe("createVinextApp", () => {
     );
 
     expect(readFile(appPath, "app/page.tsx")).toContain(
-      "pnpm exec vinext-cloudflare deploy --warm-cdn-cache",
+      "pnpm exec vinext-cloudflare deploy --config dist/server/wrangler.json --warm-cdn-cache",
     );
     const pkg = readPkg(appPath);
-    expect(pkg.scripts?.["deploy:vinext"]).toBe("vinext-cloudflare deploy --warm-cdn-cache");
+    expect(pkg.scripts?.["deploy:vinext"]).toBe(
+      "vinext-cloudflare deploy --config dist/server/wrangler.json --warm-cdn-cache",
+    );
   });
 
   it("uses the selected package manager through the shared init install path", async () => {

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -288,7 +288,9 @@ describe("addScripts", () => {
     expect(added).toContain("deploy:vinext");
     const pkg = readPkg(tmpDir) as { scripts: Record<string, string> };
     expect(pkg.scripts["start:vinext"]).toBe("wrangler dev --config dist/server/wrangler.json");
-    expect(pkg.scripts["deploy:vinext"]).toBe("vinext-cloudflare deploy");
+    expect(pkg.scripts["deploy:vinext"]).toBe(
+      "vinext-cloudflare deploy --config dist/server/wrangler.json",
+    );
   });
 
   it("adds the warm CDN cache flag to deploy:vinext when requested", () => {
@@ -298,7 +300,9 @@ describe("addScripts", () => {
 
     expect(added).toContain("deploy:vinext");
     const pkg = readPkg(tmpDir) as { scripts: Record<string, string> };
-    expect(pkg.scripts["deploy:vinext"]).toBe("vinext-cloudflare deploy --warm-cdn-cache");
+    expect(pkg.scripts["deploy:vinext"]).toBe(
+      "vinext-cloudflare deploy --config dist/server/wrangler.json --warm-cdn-cache",
+    );
   });
 
   it("uses custom port", () => {
@@ -840,7 +844,9 @@ export default { plugins: [vinext({ cache: { data: customData() } })] };
     expect(pkg.scripts["dev:vinext"]).toBe("vinext dev --port 3001");
     expect(pkg.scripts["build:vinext"]).toBe("vinext build");
     expect(pkg.scripts["start:vinext"]).toBe("wrangler dev --config dist/server/wrangler.json");
-    expect(pkg.scripts["deploy:vinext"]).toBe("vinext-cloudflare deploy --warm-cdn-cache");
+    expect(pkg.scripts["deploy:vinext"]).toBe(
+      "vinext-cloudflare deploy --config dist/server/wrangler.json --warm-cdn-cache",
+    );
   });
 
   it("adds a warm CDN cache deploy script by default for Workers Cache init", async () => {
@@ -849,7 +855,9 @@ export default { plugins: [vinext({ cache: { data: customData() } })] };
     await runInit(tmpDir);
 
     const pkg = readPkg(tmpDir) as { scripts: Record<string, string> };
-    expect(pkg.scripts["deploy:vinext"]).toBe("vinext-cloudflare deploy --warm-cdn-cache");
+    expect(pkg.scripts["deploy:vinext"]).toBe(
+      "vinext-cloudflare deploy --config dist/server/wrangler.json --warm-cdn-cache",
+    );
   });
 
   it("skips the warm CDN cache deploy flag when Cloudflare init opts out", async () => {
@@ -865,7 +873,9 @@ export default { plugins: [vinext({ cache: { data: customData() } })] };
     });
 
     const pkg = readPkg(tmpDir) as { scripts: Record<string, string> };
-    expect(pkg.scripts["deploy:vinext"]).toBe("vinext-cloudflare deploy");
+    expect(pkg.scripts["deploy:vinext"]).toBe(
+      "vinext-cloudflare deploy --config dist/server/wrangler.json",
+    );
   });
 
   it("does not add deploy:vinext for Node init", async () => {
@@ -1014,7 +1024,8 @@ describe("init — dependency installation", () => {
         "dev:vinext": "vinext dev --port 3001",
         "build:vinext": "vinext build",
         "start:vinext": "wrangler dev --config dist/server/wrangler.json",
-        "deploy:vinext": "vinext-cloudflare deploy --warm-cdn-cache",
+        "deploy:vinext":
+          "vinext-cloudflare deploy --config dist/server/wrangler.json --warm-cdn-cache",
       });
       expect(setup.viteConfigExists).toBe(true);
       expect(setup.wranglerConfigExists).toBe(true);
@@ -1041,7 +1052,8 @@ describe("init — dependency installation", () => {
         "dev:vinext": "vinext dev --port 3001",
         "build:vinext": "vinext build",
         "start:vinext": "wrangler dev --config dist/server/wrangler.json",
-        "deploy:vinext": "vinext-cloudflare deploy --warm-cdn-cache",
+        "deploy:vinext":
+          "vinext-cloudflare deploy --config dist/server/wrangler.json --warm-cdn-cache",
       },
     });
     expect(fs.existsSync(path.join(tmpDir, "vite.config.ts"))).toBe(true);


### PR DESCRIPTION
## Summary
- add `--config dist/server/wrangler.json` to generated Cloudflare `deploy:vinext` scripts
- update create-vinext-app visible deploy command and init snapshots

## Test plan
- `vp check packages/vinext/src/init.ts packages/create-vinext-app/src/index.ts tests/create-vinext-app.test.ts tests/init.test.ts tests/__snapshots__/init.test.ts.snap`
- `vp test run tests/create-vinext-app.test.ts tests/init.test.ts`