### PR TITLE
feat(init): mark CDN warmup flag experimental

### DIFF
--- a/packages/cloudflare/src/deploy-help.ts
+++ b/packages/cloudflare/src/deploy-help.ts
@@ -21,8 +21,9 @@ export function formatDeployHelp(): string {
                              releases will auto-populate the remote cache)
     --prerender-concurrency <count>
                              Maximum number of routes to pre-render in parallel
-    --warm-cdn-cache         Upload a Worker version, warm build-discovered paths
-                             through the production URL, then promote it
+    --experimental-warm-cdn-cache
+                             Upload a Worker version, warm build-discovered paths
+                             through the production URL, then promote it (experimental)
     --warm-cdn-concurrency <count>
                              Maximum number of CDN warmup requests in parallel
     --warm-cdn-timeout <ms>  Per-request CDN warmup timeout (default: 5000)
@@ -56,7 +57,7 @@ export function formatDeployHelp(): string {
     vinext-cloudflare deploy --config dist/server/wrangler.json        Deploy using a generated Wrangler config
     vinext-cloudflare deploy --dry-run                                 Validate setup without building or deploying
     vinext-cloudflare deploy --name my-app                             Deploy with a custom Worker name
-    vinext-cloudflare deploy --warm-cdn-cache                           Warm build-discovered paths during version deploy
+    vinext-cloudflare deploy --experimental-warm-cdn-cache              Warm build-discovered paths during version deploy (experimental)
     vinext-cloudflare deploy --experimental-tpr                        Enable TPR during deploy
     vinext-cloudflare deploy --experimental-tpr --tpr-coverage 95      Cover 95% of traffic
     vinext-cloudflare deploy --experimental-tpr --tpr-limit 500        Cap at 500 pages

--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -141,7 +141,7 @@ const deployArgOptions = {
   "dry-run": { type: "boolean", default: false },
   "prerender-all": { type: "boolean", default: false },
   "prerender-concurrency": { type: "string" },
-  "warm-cdn-cache": { type: "boolean", default: false },
+  "experimental-warm-cdn-cache": { type: "boolean", default: false },
   "warm-cdn-concurrency": { type: "string" },
   "warm-cdn-timeout": { type: "string" },
   "warm-cdn-retries": { type: "string" },
@@ -179,7 +179,7 @@ export function parseDeployArgs(args: string[]) {
       values["prerender-concurrency"] === undefined
         ? undefined
         : parsePositiveIntegerArg(values["prerender-concurrency"], "--prerender-concurrency"),
-    warmCdnCache: values["warm-cdn-cache"],
+    warmCdnCache: values["experimental-warm-cdn-cache"],
     warmCdnConcurrency:
       values["warm-cdn-concurrency"] === undefined
         ? undefined

--- a/packages/cloudflare/src/version-deploy.ts
+++ b/packages/cloudflare/src/version-deploy.ts
@@ -227,7 +227,7 @@ function isMissingWorkerVersionUploadError(error: unknown): boolean {
 function withInitialDeployRequiredMessage(): Error {
   const message =
     "CDN pre-warm needs an existing Cloudflare Worker before it can upload a new Worker version. " +
-    "Run `vinext-cloudflare deploy` once without `--warm-cdn-cache` to create the Worker, then rerun your pre-warm deploy.";
+    "Run `vinext-cloudflare deploy` once without `--experimental-warm-cdn-cache` to create the Worker, then rerun your pre-warm deploy.";
   return new Error(message);
 }
 

--- a/packages/create-vinext-app/src/index.ts
+++ b/packages/create-vinext-app/src/index.ts
@@ -91,7 +91,7 @@ function getTemplateFiles(platform: InitPlatform, warmCdnCache = false): Record<
     : "This App Router project is wired for vinext and Tailwind CSS.";
   const buildOutput = isCloudflare ? "Worker-ready production output" : "production output";
   const deployCommand = warmCdnCache
-    ? "pnpm exec vinext-cloudflare deploy --config dist/server/wrangler.json --warm-cdn-cache"
+    ? "pnpm exec vinext-cloudflare deploy --config dist/server/wrangler.json --experimental-warm-cdn-cache"
     : "pnpm exec vinext-cloudflare deploy --config dist/server/wrangler.json";
   const actionCard = isCloudflare
     ? `<div className="rounded-lg border border-slate-200 bg-white p-5">
@@ -288,8 +288,10 @@ function printHelp(): void {
     --image-optimization <type>  Cloudflare image optimization: cloudflare-images or none
     --prerender                  Configure vinext to pre-render static routes
     --no-prerender               Do not configure pre-rendering
-    --warm-cdn-cache             Add CDN pre-warming to the Cloudflare deploy script
-    --no-warm-cdn-cache          Do not add CDN pre-warming to the deploy script
+    --experimental-warm-cdn-cache
+                                 Add experimental CDN pre-warming to the Cloudflare deploy script
+    --no-experimental-warm-cdn-cache
+                                 Do not add experimental CDN pre-warming to the deploy script
     --use-npm                    Use npm
     --use-pnpm                   Use pnpm
     --use-yarn                   Use Yarn

--- a/packages/create-vinext-app/src/index.ts
+++ b/packages/create-vinext-app/src/index.ts
@@ -447,8 +447,7 @@ function writeTemplate(
   fs.mkdirSync(root, { recursive: true });
   writePackageJson(root, appName, packageManager);
   const warmCdnCache =
-    initOptions.platform === "cloudflare" &&
-    (initOptions.cloudflare?.warmCdnCache ?? initOptions.cloudflare?.cdnCache === "workers-cache");
+    initOptions.platform === "cloudflare" && (initOptions.cloudflare?.warmCdnCache ?? false);
   for (const [relativePath, content] of Object.entries(
     getTemplateFiles(initOptions.platform, warmCdnCache),
   )) {

--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -958,7 +958,7 @@ function printHelp(cmd?: string) {
                          (default: prompt, with No selected by default)
     --experimental-warm-cdn-cache
                          Add experimental CDN pre-warming to the Cloudflare deploy script
-                         (Workers Cache CDN only, default: prompt with Yes)
+                         (Workers Cache CDN only, default: prompt with No)
     --cdn-cache <type>   Cloudflare CDN cache: workers-cache or data-cache
                          (default: workers-cache)
     --data-cache <type>  Cloudflare data cache: kv or none (default: kv)

--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -956,7 +956,8 @@ function printHelp(cmd?: string) {
     --platform <target>  Deployment target: cloudflare or node
     --prerender          Configure vinext build to pre-render all static routes
                          (default: prompt, with No selected by default)
-    --warm-cdn-cache     Add --warm-cdn-cache to the Cloudflare deploy script
+    --experimental-warm-cdn-cache
+                         Add experimental CDN pre-warming to the Cloudflare deploy script
                          (Workers Cache CDN only, default: prompt with Yes)
     --cdn-cache <type>   Cloudflare CDN cache: workers-cache or data-cache
                          (default: workers-cache)
@@ -975,8 +976,8 @@ function printHelp(cmd?: string) {
     vinext init --platform=cloudflare --image-optimization=none
                                 Do not configure Cloudflare Images
     vinext init --prerender     Add prerender: { routes: "*" } to vite.config.ts
-    vinext init --warm-cdn-cache
-                                Add CDN pre-warming to deploy:vinext
+    vinext init --experimental-warm-cdn-cache
+                                Add experimental CDN pre-warming to deploy:vinext
     vinext init --platform=node   Configure a Node deployment
     vinext init -p 4000           Use port 4000 for dev:vinext
     vinext init --force           Overwrite existing vite.config.ts

--- a/packages/vinext/src/init-platform.ts
+++ b/packages/vinext/src/init-platform.ts
@@ -130,9 +130,9 @@ export function parsePrerenderArg(args: string[]): boolean | undefined {
 export function parseWarmCdnCacheArg(args: string[]): boolean | undefined {
   return parseBooleanArg(
     args,
-    "--warm-cdn-cache",
-    "--no-warm-cdn-cache",
-    '--warm-cdn-cache expects true or false when using the "--warm-cdn-cache=value" form.',
+    "--experimental-warm-cdn-cache",
+    "--no-experimental-warm-cdn-cache",
+    '--experimental-warm-cdn-cache expects true or false when using the "--experimental-warm-cdn-cache=value" form.',
   );
 }
 
@@ -216,7 +216,7 @@ export async function resolveInitOptions(
   const explicitWarmCdnCache = parseWarmCdnCacheArg(args);
   if (platform === "cloudflare" && platformOptions?.cdnCache !== "workers-cache") {
     if (explicitWarmCdnCache === true) {
-      throw new Error("--warm-cdn-cache requires --cdn-cache=workers-cache.");
+      throw new Error("--experimental-warm-cdn-cache requires --cdn-cache=workers-cache.");
     }
   }
 
@@ -296,7 +296,9 @@ export async function resolveInitWarmCdnCache(
 
   try {
     while (true) {
-      const answer = (await question("  Pre-warm Workers Cache during deploy? [Y/n]: "))
+      const answer = (
+        await question("  Enable experimental Workers Cache pre-warm during deploy? [Y/n]: ")
+      )
         .trim()
         .toLowerCase();
       if (answer === "") {

--- a/packages/vinext/src/init-platform.ts
+++ b/packages/vinext/src/init-platform.ts
@@ -289,7 +289,7 @@ export async function resolveInitWarmCdnCache(
   const output = options.output ?? process.stdout;
   const isInteractive =
     options.isInteractive ?? Boolean(process.stdin.isTTY && process.stdout.isTTY);
-  if (isAgentEnvironment(env) || !isInteractive) return true;
+  if (isAgentEnvironment(env) || !isInteractive) return false;
 
   const readline = options.question ? undefined : createInterface({ input, output });
   const question = options.question ?? ((prompt: string) => readline!.question(prompt));
@@ -297,13 +297,13 @@ export async function resolveInitWarmCdnCache(
   try {
     while (true) {
       const answer = (
-        await question("  Enable Workers Cache experimental pre-warm during deploy? [Y/n]: ")
+        await question("  Enable Workers Cache experimental pre-warm during deploy? [y/N]: ")
       )
         .trim()
         .toLowerCase();
       if (answer === "") {
         output.write("\n");
-        return true;
+        return false;
       }
       if (answer === "y" || answer === "yes") {
         output.write("\n");

--- a/packages/vinext/src/init-platform.ts
+++ b/packages/vinext/src/init-platform.ts
@@ -297,7 +297,7 @@ export async function resolveInitWarmCdnCache(
   try {
     while (true) {
       const answer = (
-        await question("  Enable experimental Workers Cache pre-warm during deploy? [Y/n]: ")
+        await question("  Enable Workers Cache experimental pre-warm during deploy? [Y/n]: ")
       )
         .trim()
         .toLowerCase();

--- a/packages/vinext/src/init.ts
+++ b/packages/vinext/src/init.ts
@@ -193,7 +193,7 @@ export function addScripts(
 
     if (platform === "cloudflare" && !pkg.scripts["deploy:vinext"]) {
       pkg.scripts["deploy:vinext"] = options.warmCdnCache
-        ? "vinext-cloudflare deploy --config dist/server/wrangler.json --warm-cdn-cache"
+        ? "vinext-cloudflare deploy --config dist/server/wrangler.json --experimental-warm-cdn-cache"
         : "vinext-cloudflare deploy --config dist/server/wrangler.json";
       added.push("deploy:vinext");
     }

--- a/packages/vinext/src/init.ts
+++ b/packages/vinext/src/init.ts
@@ -565,8 +565,7 @@ export async function init(options: InitOptions): Promise<InitResult> {
   // ── Step 3: Add scripts ────────────────────────────────────────────────
 
   const addedScripts = addScripts(root, port, platform, {
-    warmCdnCache:
-      options.cloudflare?.warmCdnCache ?? options.cloudflare?.cdnCache === "workers-cache",
+    warmCdnCache: options.cloudflare?.warmCdnCache ?? false,
   });
 
   // ── Step 4: Generate vite.config.ts ────────────────────────────────────

--- a/tests/__snapshots__/init.test.ts.snap
+++ b/tests/__snapshots__/init.test.ts.snap
@@ -26,7 +26,7 @@ export default function Home() { return <div>hi</div> }
     "dev:vinext": "vinext dev --port 3001",
     "build:vinext": "vinext build",
     "start:vinext": "wrangler dev --config dist/server/wrangler.json",
-    "deploy:vinext": "vinext-cloudflare deploy --config dist/server/wrangler.json --warm-cdn-cache"
+    "deploy:vinext": "vinext-cloudflare deploy --config dist/server/wrangler.json --experimental-warm-cdn-cache"
   }
 }
 
@@ -142,7 +142,7 @@ export default function Home() { return <div>hi</div> }
     "dev:vinext": "vinext dev --port 3001",
     "build:vinext": "vinext build",
     "start:vinext": "wrangler dev --config dist/server/wrangler.json",
-    "deploy:vinext": "vinext-cloudflare deploy --config dist/server/wrangler.json --warm-cdn-cache"
+    "deploy:vinext": "vinext-cloudflare deploy --config dist/server/wrangler.json --experimental-warm-cdn-cache"
   }
 }
 

--- a/tests/__snapshots__/init.test.ts.snap
+++ b/tests/__snapshots__/init.test.ts.snap
@@ -26,7 +26,7 @@ export default function Home() { return <div>hi</div> }
     "dev:vinext": "vinext dev --port 3001",
     "build:vinext": "vinext build",
     "start:vinext": "wrangler dev --config dist/server/wrangler.json",
-    "deploy:vinext": "vinext-cloudflare deploy --config dist/server/wrangler.json --experimental-warm-cdn-cache"
+    "deploy:vinext": "vinext-cloudflare deploy --config dist/server/wrangler.json"
   }
 }
 
@@ -142,7 +142,7 @@ export default function Home() { return <div>hi</div> }
     "dev:vinext": "vinext dev --port 3001",
     "build:vinext": "vinext build",
     "start:vinext": "wrangler dev --config dist/server/wrangler.json",
-    "deploy:vinext": "vinext-cloudflare deploy --config dist/server/wrangler.json --experimental-warm-cdn-cache"
+    "deploy:vinext": "vinext-cloudflare deploy --config dist/server/wrangler.json"
   }
 }
 

--- a/tests/cloudflare-version-deploy.test.ts
+++ b/tests/cloudflare-version-deploy.test.ts
@@ -141,7 +141,7 @@ describe("Cloudflare Wrangler version deployment helpers", () => {
     });
 
     expect(() => runWranglerVersionUpload("/tmp/app", {}, execute as never)).toThrow(
-      "Run `vinext-cloudflare deploy` once without `--warm-cdn-cache` to create the Worker",
+      "Run `vinext-cloudflare deploy` once without `--experimental-warm-cdn-cache` to create the Worker",
     );
   });
 

--- a/tests/create-vinext-app.test.ts
+++ b/tests/create-vinext-app.test.ts
@@ -123,7 +123,7 @@ describe("createVinextApp", () => {
     });
   });
 
-  it("shows the warm CDN cache deploy command by default for Workers Cache init", async () => {
+  it("does not show the warm CDN cache deploy command by default for Workers Cache init", async () => {
     const appPath = path.join(tmpDir, "warm-app");
 
     await withQuietConsole(() =>
@@ -137,11 +137,12 @@ describe("createVinextApp", () => {
     );
 
     expect(readFile(appPath, "app/page.tsx")).toContain(
-      "pnpm exec vinext-cloudflare deploy --config dist/server/wrangler.json --experimental-warm-cdn-cache",
+      "pnpm exec vinext-cloudflare deploy --config dist/server/wrangler.json",
     );
+    expect(readFile(appPath, "app/page.tsx")).not.toContain("--experimental-warm-cdn-cache");
     const pkg = readPkg(appPath);
     expect(pkg.scripts?.["deploy:vinext"]).toBe(
-      "vinext-cloudflare deploy --config dist/server/wrangler.json --experimental-warm-cdn-cache",
+      "vinext-cloudflare deploy --config dist/server/wrangler.json",
     );
   });
 

--- a/tests/create-vinext-app.test.ts
+++ b/tests/create-vinext-app.test.ts
@@ -137,11 +137,11 @@ describe("createVinextApp", () => {
     );
 
     expect(readFile(appPath, "app/page.tsx")).toContain(
-      "pnpm exec vinext-cloudflare deploy --config dist/server/wrangler.json --warm-cdn-cache",
+      "pnpm exec vinext-cloudflare deploy --config dist/server/wrangler.json --experimental-warm-cdn-cache",
     );
     const pkg = readPkg(appPath);
     expect(pkg.scripts?.["deploy:vinext"]).toBe(
-      "vinext-cloudflare deploy --config dist/server/wrangler.json --warm-cdn-cache",
+      "vinext-cloudflare deploy --config dist/server/wrangler.json --experimental-warm-cdn-cache",
     );
   });
 

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -697,7 +697,7 @@ describe("parseDeployArgs", () => {
 
   it("parses CDN warmup flags", () => {
     const parsed = parseDeployArgs([
-      "--warm-cdn-cache",
+      "--experimental-warm-cdn-cache",
       "--warm-cdn-concurrency",
       "6",
       "--warm-cdn-timeout=1500",

--- a/tests/init-platform.test.ts
+++ b/tests/init-platform.test.ts
@@ -261,7 +261,7 @@ describe("warm CDN cache init choice", () => {
       }),
     ).resolves.toBe(true);
     expect(prompts).toEqual([
-      "  Enable experimental Workers Cache pre-warm during deploy? [Y/n]: ",
+      "  Enable Workers Cache experimental pre-warm during deploy? [Y/n]: ",
     ]);
     expect(output.read()?.toString()).toBe("\n");
   });
@@ -392,7 +392,7 @@ describe("resolveInitOptions", () => {
       "  Choose a data cache:\n    1. Cloudflare KV (default)\n    2. None\n  Data cache [1]: ",
       "  Choose image optimization:\n    1. Cloudflare Images (default)\n    2. None\n  Image optimization [1]: ",
       "  Pre-render all static routes after build? [y/N]: ",
-      "  Enable experimental Workers Cache pre-warm during deploy? [Y/n]: ",
+      "  Enable Workers Cache experimental pre-warm during deploy? [Y/n]: ",
     ]);
   });
 

--- a/tests/init-platform.test.ts
+++ b/tests/init-platform.test.ts
@@ -225,15 +225,15 @@ describe("prerender init choice", () => {
 
 describe("warm CDN cache init choice", () => {
   it("parses explicit warm CDN cache flags", () => {
-    expect(parseWarmCdnCacheArg(["--warm-cdn-cache"])).toBe(true);
-    expect(parseWarmCdnCacheArg(["--no-warm-cdn-cache"])).toBe(false);
-    expect(parseWarmCdnCacheArg(["--warm-cdn-cache=true"])).toBe(true);
-    expect(parseWarmCdnCacheArg(["--warm-cdn-cache=false"])).toBe(false);
+    expect(parseWarmCdnCacheArg(["--experimental-warm-cdn-cache"])).toBe(true);
+    expect(parseWarmCdnCacheArg(["--no-experimental-warm-cdn-cache"])).toBe(false);
+    expect(parseWarmCdnCacheArg(["--experimental-warm-cdn-cache=true"])).toBe(true);
+    expect(parseWarmCdnCacheArg(["--experimental-warm-cdn-cache=false"])).toBe(false);
   });
 
   it("rejects unsupported explicit values", () => {
-    expect(() => parseWarmCdnCacheArg(["--warm-cdn-cache=maybe"])).toThrow(
-      "--warm-cdn-cache expects true or false",
+    expect(() => parseWarmCdnCacheArg(["--experimental-warm-cdn-cache=maybe"])).toThrow(
+      "--experimental-warm-cdn-cache expects true or false",
     );
   });
 
@@ -260,7 +260,9 @@ describe("warm CDN cache init choice", () => {
         },
       }),
     ).resolves.toBe(true);
-    expect(prompts).toEqual(["  Pre-warm Workers Cache during deploy? [Y/n]: "]);
+    expect(prompts).toEqual([
+      "  Enable experimental Workers Cache pre-warm during deploy? [Y/n]: ",
+    ]);
     expect(output.read()?.toString()).toBe("\n");
   });
 });
@@ -390,7 +392,7 @@ describe("resolveInitOptions", () => {
       "  Choose a data cache:\n    1. Cloudflare KV (default)\n    2. None\n  Data cache [1]: ",
       "  Choose image optimization:\n    1. Cloudflare Images (default)\n    2. None\n  Image optimization [1]: ",
       "  Pre-render all static routes after build? [y/N]: ",
-      "  Pre-warm Workers Cache during deploy? [Y/n]: ",
+      "  Enable experimental Workers Cache pre-warm during deploy? [Y/n]: ",
     ]);
   });
 
@@ -434,10 +436,10 @@ describe("resolveInitOptions", () => {
           "--cdn-cache=data-cache",
           "--data-cache=kv",
           "--image-optimization=none",
-          "--warm-cdn-cache",
+          "--experimental-warm-cdn-cache",
         ],
         { env: {}, isInteractive: false },
       ),
-    ).rejects.toThrow("--warm-cdn-cache requires --cdn-cache=workers-cache");
+    ).rejects.toThrow("--experimental-warm-cdn-cache requires --cdn-cache=workers-cache");
   });
 });

--- a/tests/init-platform.test.ts
+++ b/tests/init-platform.test.ts
@@ -237,16 +237,16 @@ describe("warm CDN cache init choice", () => {
     );
   });
 
-  it("defaults non-interactive and agent environments to enabled", async () => {
+  it("defaults non-interactive and agent environments to disabled", async () => {
     await expect(resolveInitWarmCdnCache([], { env: {}, isInteractive: false })).resolves.toBe(
-      true,
+      false,
     );
     await expect(
       resolveInitWarmCdnCache([], { env: { CODEX_THREAD_ID: "test" }, isInteractive: true }),
-    ).resolves.toBe(true);
+    ).resolves.toBe(false);
   });
 
-  it("defaults the interactive prompt to Yes", async () => {
+  it("defaults the interactive prompt to No", async () => {
     const prompts: string[] = [];
     const output = new PassThrough();
     await expect(
@@ -259,9 +259,9 @@ describe("warm CDN cache init choice", () => {
           return "";
         },
       }),
-    ).resolves.toBe(true);
+    ).resolves.toBe(false);
     expect(prompts).toEqual([
-      "  Enable Workers Cache experimental pre-warm during deploy? [Y/n]: ",
+      "  Enable Workers Cache experimental pre-warm during deploy? [y/N]: ",
     ]);
     expect(output.read()?.toString()).toBe("\n");
   });
@@ -326,7 +326,7 @@ describe("resolveInitPlatform", () => {
 });
 
 describe("resolveInitOptions", () => {
-  it("defaults Cloudflare Workers Cache init to CDN pre-warming", async () => {
+  it("defaults Cloudflare Workers Cache init away from CDN pre-warming", async () => {
     await expect(resolveInitOptions([], { env: {}, isInteractive: false })).resolves.toEqual({
       platform: "cloudflare",
       prerender: false,
@@ -334,7 +334,7 @@ describe("resolveInitOptions", () => {
         dataCache: "kv",
         cdnCache: "workers-cache",
         imageOptimization: "cloudflare-images",
-        warmCdnCache: true,
+        warmCdnCache: false,
       },
     });
   });
@@ -383,7 +383,7 @@ describe("resolveInitOptions", () => {
         dataCache: "kv",
         cdnCache: "workers-cache",
         imageOptimization: "cloudflare-images",
-        warmCdnCache: true,
+        warmCdnCache: false,
       },
     });
 
@@ -392,7 +392,7 @@ describe("resolveInitOptions", () => {
       "  Choose a data cache:\n    1. Cloudflare KV (default)\n    2. None\n  Data cache [1]: ",
       "  Choose image optimization:\n    1. Cloudflare Images (default)\n    2. None\n  Image optimization [1]: ",
       "  Pre-render all static routes after build? [y/N]: ",
-      "  Enable Workers Cache experimental pre-warm during deploy? [Y/n]: ",
+      "  Enable Workers Cache experimental pre-warm during deploy? [y/N]: ",
     ]);
   });
 

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -301,7 +301,7 @@ describe("addScripts", () => {
     expect(added).toContain("deploy:vinext");
     const pkg = readPkg(tmpDir) as { scripts: Record<string, string> };
     expect(pkg.scripts["deploy:vinext"]).toBe(
-      "vinext-cloudflare deploy --config dist/server/wrangler.json --warm-cdn-cache",
+      "vinext-cloudflare deploy --config dist/server/wrangler.json --experimental-warm-cdn-cache",
     );
   });
 
@@ -845,7 +845,7 @@ export default { plugins: [vinext({ cache: { data: customData() } })] };
     expect(pkg.scripts["build:vinext"]).toBe("vinext build");
     expect(pkg.scripts["start:vinext"]).toBe("wrangler dev --config dist/server/wrangler.json");
     expect(pkg.scripts["deploy:vinext"]).toBe(
-      "vinext-cloudflare deploy --config dist/server/wrangler.json --warm-cdn-cache",
+      "vinext-cloudflare deploy --config dist/server/wrangler.json --experimental-warm-cdn-cache",
     );
   });
 
@@ -856,7 +856,7 @@ export default { plugins: [vinext({ cache: { data: customData() } })] };
 
     const pkg = readPkg(tmpDir) as { scripts: Record<string, string> };
     expect(pkg.scripts["deploy:vinext"]).toBe(
-      "vinext-cloudflare deploy --config dist/server/wrangler.json --warm-cdn-cache",
+      "vinext-cloudflare deploy --config dist/server/wrangler.json --experimental-warm-cdn-cache",
     );
   });
 
@@ -1025,7 +1025,7 @@ describe("init — dependency installation", () => {
         "build:vinext": "vinext build",
         "start:vinext": "wrangler dev --config dist/server/wrangler.json",
         "deploy:vinext":
-          "vinext-cloudflare deploy --config dist/server/wrangler.json --warm-cdn-cache",
+          "vinext-cloudflare deploy --config dist/server/wrangler.json --experimental-warm-cdn-cache",
       });
       expect(setup.viteConfigExists).toBe(true);
       expect(setup.wranglerConfigExists).toBe(true);
@@ -1053,7 +1053,7 @@ describe("init — dependency installation", () => {
         "build:vinext": "vinext build",
         "start:vinext": "wrangler dev --config dist/server/wrangler.json",
         "deploy:vinext":
-          "vinext-cloudflare deploy --config dist/server/wrangler.json --warm-cdn-cache",
+          "vinext-cloudflare deploy --config dist/server/wrangler.json --experimental-warm-cdn-cache",
       },
     });
     expect(fs.existsSync(path.join(tmpDir, "vite.config.ts"))).toBe(true);

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -845,18 +845,18 @@ export default { plugins: [vinext({ cache: { data: customData() } })] };
     expect(pkg.scripts["build:vinext"]).toBe("vinext build");
     expect(pkg.scripts["start:vinext"]).toBe("wrangler dev --config dist/server/wrangler.json");
     expect(pkg.scripts["deploy:vinext"]).toBe(
-      "vinext-cloudflare deploy --config dist/server/wrangler.json --experimental-warm-cdn-cache",
+      "vinext-cloudflare deploy --config dist/server/wrangler.json",
     );
   });
 
-  it("adds a warm CDN cache deploy script by default for Workers Cache init", async () => {
+  it("does not add a warm CDN cache deploy script by default for Workers Cache init", async () => {
     setupProject(tmpDir, { router: "app" });
 
     await runInit(tmpDir);
 
     const pkg = readPkg(tmpDir) as { scripts: Record<string, string> };
     expect(pkg.scripts["deploy:vinext"]).toBe(
-      "vinext-cloudflare deploy --config dist/server/wrangler.json --experimental-warm-cdn-cache",
+      "vinext-cloudflare deploy --config dist/server/wrangler.json",
     );
   });
 
@@ -1024,8 +1024,7 @@ describe("init — dependency installation", () => {
         "dev:vinext": "vinext dev --port 3001",
         "build:vinext": "vinext build",
         "start:vinext": "wrangler dev --config dist/server/wrangler.json",
-        "deploy:vinext":
-          "vinext-cloudflare deploy --config dist/server/wrangler.json --experimental-warm-cdn-cache",
+        "deploy:vinext": "vinext-cloudflare deploy --config dist/server/wrangler.json",
       });
       expect(setup.viteConfigExists).toBe(true);
       expect(setup.wranglerConfigExists).toBe(true);
@@ -1052,8 +1051,7 @@ describe("init — dependency installation", () => {
         "dev:vinext": "vinext dev --port 3001",
         "build:vinext": "vinext build",
         "start:vinext": "wrangler dev --config dist/server/wrangler.json",
-        "deploy:vinext":
-          "vinext-cloudflare deploy --config dist/server/wrangler.json --experimental-warm-cdn-cache",
+        "deploy:vinext": "vinext-cloudflare deploy --config dist/server/wrangler.json",
       },
     });
     expect(fs.existsSync(path.join(tmpDir, "vite.config.ts"))).toBe(true);


### PR DESCRIPTION
## Summary
- rename the CDN warmup deploy flag to `--experimental-warm-cdn-cache`
- update vinext init/create-vinext-app generated deploy scripts and prompt/help text to mark pre-warm experimental
- update the first-deploy guidance and tests for the experimental flag

## Test plan
- `vp check packages/cloudflare/src/deploy-help.ts packages/cloudflare/src/deploy.ts packages/cloudflare/src/version-deploy.ts packages/create-vinext-app/src/index.ts packages/vinext/src/cli.ts packages/vinext/src/init-platform.ts packages/vinext/src/init.ts tests/cloudflare-version-deploy.test.ts tests/create-vinext-app.test.ts tests/deploy.test.ts tests/init-platform.test.ts tests/init.test.ts tests/__snapshots__/init.test.ts.snap`
- `vp test run tests/init-platform.test.ts tests/init.test.ts tests/create-vinext-app.test.ts tests/deploy.test.ts tests/cloudflare-version-deploy.test.ts`