### PR TITLE
fix(release): publish betas as latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
         run: node scripts/create-changeset.mts
 
       - name: Version PR / publish
+        id: changesets
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           version: node scripts/version.mts
@@ -56,3 +57,10 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           NPM_CONFIG_PROVENANCE: "true"
           NPM_CONFIG_REGISTRY: https://registry.npmjs.org
+
+      - name: Promote beta GitHub Releases
+        if: steps.changesets.outputs.published == 'true'
+        run: node scripts/promote-github-prereleases.mts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.published-packages }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,8 @@ name: Release
 #      the git tag + GitHub Release.
 #
 # `version:` runs scripts/version.mts (`changeset version` + the `## Contributors`
-# list). `publish:` is `changeset publish`, which publishes only changed packages.
+# list). `publish:` runs scripts/publish.mts, which publishes only changed packages
+# and makes prerelease versions the default npm install via the `latest` dist-tag.
 
 on:
   push:
@@ -47,8 +48,7 @@ jobs:
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           version: node scripts/version.mts
-          # `vp exec` runs the pinned, installed @changesets/cli (not a floating dlx fetch).
-          publish: vp exec changeset publish
+          publish: node scripts/publish.mts
           title: "chore: version packages"
           commit: "chore: version packages"
         env:

--- a/scripts/promote-github-prereleases.mts
+++ b/scripts/promote-github-prereleases.mts
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+/** Make newly published beta GitHub Releases normal releases and promote vinext. */
+
+import { execFileSync } from "node:child_process";
+
+export type PublishedPackage = { name: string; version: string };
+
+export function releaseTag({ name, version }: PublishedPackage): string {
+  return `${name}@${version}`;
+}
+
+export function releasePatchArgs(repository: string, releaseId: number, latest: boolean): string[] {
+  const args = [
+    "api",
+    "--method",
+    "PATCH",
+    `repos/${repository}/releases/${releaseId}`,
+    "-F",
+    "prerelease=false",
+  ];
+  if (latest) args.push("-f", "make_latest=true");
+  return args;
+}
+
+export function prereleasePackages(value: string): PublishedPackage[] {
+  const parsed: unknown = JSON.parse(value);
+  if (!Array.isArray(parsed)) throw new Error("Published packages must be a JSON array");
+
+  return parsed.filter((item): item is PublishedPackage => {
+    if (!item || typeof item !== "object") return false;
+    const candidate = item as Partial<PublishedPackage>;
+    return (
+      typeof candidate.name === "string" &&
+      typeof candidate.version === "string" &&
+      candidate.version.includes("-")
+    );
+  });
+}
+
+export function main(): void {
+  const repository = process.env.GITHUB_REPOSITORY;
+  if (!repository) throw new Error("GITHUB_REPOSITORY is required");
+
+  const packages = prereleasePackages(process.env.PUBLISHED_PACKAGES || "[]");
+  for (const pkg of packages) {
+    const tag = releaseTag(pkg);
+    const releaseId = Number.parseInt(
+      execFileSync("gh", ["api", `repos/${repository}/releases/tags/${tag}`, "--jq", ".id"], {
+        encoding: "utf8",
+      }).trim(),
+      10,
+    );
+    if (!Number.isSafeInteger(releaseId)) throw new Error(`Invalid release id for ${tag}`);
+
+    execFileSync("gh", releasePatchArgs(repository, releaseId, pkg.name === "vinext"), {
+      stdio: "inherit",
+    });
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main();

--- a/scripts/promote-github-prereleases.test.ts
+++ b/scripts/promote-github-prereleases.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { prereleasePackages, releasePatchArgs, releaseTag } from "./promote-github-prereleases.mts";
+
+describe("prereleasePackages", () => {
+  it("selects only newly published prerelease versions", () => {
+    expect(
+      prereleasePackages(
+        JSON.stringify([
+          { name: "vinext", version: "1.0.0-beta.1" },
+          { name: "@vinext/cloudflare", version: "1.0.0-beta.1" },
+          { name: "stable", version: "1.0.0" },
+        ]),
+      ),
+    ).toEqual([
+      { name: "vinext", version: "1.0.0-beta.1" },
+      { name: "@vinext/cloudflare", version: "1.0.0-beta.1" },
+    ]);
+  });
+
+  it("rejects a non-array payload", () => {
+    expect(() => prereleasePackages("{}")).toThrow("Published packages must be a JSON array");
+  });
+});
+
+describe("releaseTag", () => {
+  it("matches Changesets package tag names", () => {
+    expect(releaseTag({ name: "@vinext/cloudflare", version: "1.0.0-beta.1" })).toBe(
+      "@vinext/cloudflare@1.0.0-beta.1",
+    );
+  });
+});
+
+describe("releasePatchArgs", () => {
+  it("clears prerelease status for every package", () => {
+    expect(releasePatchArgs("cloudflare/vinext", 123, false)).toEqual([
+      "api",
+      "--method",
+      "PATCH",
+      "repos/cloudflare/vinext/releases/123",
+      "-F",
+      "prerelease=false",
+    ]);
+  });
+
+  it("also marks the primary vinext release latest", () => {
+    expect(releasePatchArgs("cloudflare/vinext", 123, true)).toEqual([
+      "api",
+      "--method",
+      "PATCH",
+      "repos/cloudflare/vinext/releases/123",
+      "-F",
+      "prerelease=false",
+      "-f",
+      "make_latest=true",
+    ]);
+  });
+});

--- a/scripts/publish.mts
+++ b/scripts/publish.mts
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+/**
+ * Publish versioned packages with Changesets while making prereleases the
+ * default npm install.
+ *
+ * Changesets derives beta version numbers from `.changeset/pre.json`, but in
+ * pre mode it forces npm's dist-tag to the prerelease name and rejects
+ * `changeset publish --tag latest`. Temporarily hiding the pre-state file lets
+ * us preserve the already-versioned `-beta.*` package versions while publishing
+ * them under `latest`. The file is restored even when publishing fails.
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, renameSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..");
+
+export function withHiddenPrereleaseState<T>(repoRoot: string, publish: () => T): T {
+  const preStatePath = join(repoRoot, ".changeset", "pre.json");
+  if (!existsSync(preStatePath)) return publish();
+
+  const backupPath = `${preStatePath}.publish-backup`;
+  if (existsSync(backupPath)) {
+    throw new Error(`Refusing to overwrite existing prerelease backup: ${backupPath}`);
+  }
+
+  renameSync(preStatePath, backupPath);
+  try {
+    return publish();
+  } finally {
+    renameSync(backupPath, preStatePath);
+  }
+}
+
+export function publishArgs(prerelease: boolean): string[] {
+  const args = ["exec", "changeset", "publish"];
+  if (prerelease) args.push("--tag", "latest");
+  return args;
+}
+
+export function main(): void {
+  const preStatePath = join(REPO_ROOT, ".changeset", "pre.json");
+  const prerelease = existsSync(preStatePath);
+
+  withHiddenPrereleaseState(REPO_ROOT, () => {
+    execFileSync("vp", publishArgs(prerelease), { cwd: REPO_ROOT, stdio: "inherit" });
+  });
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main();

--- a/scripts/publish.test.ts
+++ b/scripts/publish.test.ts
@@ -1,0 +1,58 @@
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vite-plus/test";
+
+import { publishArgs, withHiddenPrereleaseState } from "./publish.mts";
+
+function prereleaseRepo(): { root: string; preStatePath: string; contents: string } {
+  const root = mkdtempSync(join(tmpdir(), "vinext-publish-"));
+  const changesetDir = join(root, ".changeset");
+  const preStatePath = join(changesetDir, "pre.json");
+  const contents = '{\n  "mode": "pre",\n  "tag": "beta"\n}\n';
+  mkdirSync(changesetDir);
+  writeFileSync(preStatePath, contents);
+  return { root, preStatePath, contents };
+}
+
+describe("withHiddenPrereleaseState", () => {
+  it("hides pre.json while publishing and restores it afterward", () => {
+    const { root, preStatePath, contents } = prereleaseRepo();
+
+    const result = withHiddenPrereleaseState(root, () => {
+      expect(() => readFileSync(preStatePath)).toThrow();
+      return "published";
+    });
+
+    expect(result).toBe("published");
+    expect(readFileSync(preStatePath, "utf8")).toBe(contents);
+  });
+
+  it("restores pre.json when publishing fails", () => {
+    const { root, preStatePath, contents } = prereleaseRepo();
+
+    expect(() =>
+      withHiddenPrereleaseState(root, () => {
+        throw new Error("publish failed");
+      }),
+    ).toThrow("publish failed");
+
+    expect(readFileSync(preStatePath, "utf8")).toBe(contents);
+  });
+
+  it("publishes normally when prerelease state is absent", () => {
+    const root = mkdtempSync(join(tmpdir(), "vinext-publish-"));
+    expect(withHiddenPrereleaseState(root, () => "published")).toBe("published");
+  });
+});
+
+describe("publishArgs", () => {
+  it("publishes prereleases under latest", () => {
+    expect(publishArgs(true)).toEqual(["exec", "changeset", "publish", "--tag", "latest"]);
+  });
+
+  it("leaves stable publishing unchanged", () => {
+    expect(publishArgs(false)).toEqual(["exec", "changeset", "publish"]);
+  });
+});


### PR DESCRIPTION
## Summary

- publish prerelease package versions under npm's `latest` dist-tag
- preserve Changesets beta version numbering and prerelease state
- restore `.changeset/pre.json` even if publishing fails
- leave stable publishing unchanged

## Validation

- `vp test run scripts/publish.test.ts`
- `vp check scripts/publish.mts scripts/publish.test.ts .github/workflows/release.yml`
- `git diff --check`