### PR TITLE
fix(app-router): cache default static pages

### DIFF
--- a/examples/app-router-cloudflare/app/page.tsx
+++ b/examples/app-router-cloudflare/app/page.tsx
@@ -1,5 +1,7 @@
 import { Counter } from "./components/counter";
 
+export const dynamic = "force-dynamic";
+
 export default function HomePage() {
   return (
     <main>

--- a/examples/app-router-cloudflare/app/page.tsx
+++ b/examples/app-router-cloudflare/app/page.tsx
@@ -1,5 +1,6 @@
 import { Counter } from "./components/counter";
 
+// The example's E2E coverage expects the rendered timestamp to change per request.
 export const dynamic = "force-dynamic";
 
 export default function HomePage() {

--- a/packages/vinext/src/server/app-page-cache-finalizer.ts
+++ b/packages/vinext/src/server/app-page-cache-finalizer.ts
@@ -1,6 +1,6 @@
 import type { CachedAppPageValue } from "vinext/shims/cache";
 import type { AppRscRenderMode } from "./app-rsc-render-mode.js";
-import { applyCdnResponseHeaders } from "./cache-control.js";
+import { applyCdnResponseHeaders, INFINITE_CACHE_SECONDS } from "./cache-control.js";
 import { setCacheStateHeaders } from "./cache-headers.js";
 import { NEXTJS_CACHE_HEADER, VINEXT_CACHE_HEADER } from "./headers.js";
 import {
@@ -39,6 +39,7 @@ type FinalizeAppPageHtmlCacheResponseOptions = {
   capturedRscDataPromise: Promise<ArrayBuffer> | null;
   cleanPathname: string;
   consumeDynamicUsage: () => boolean;
+  dynamicUsageCheckComplete?: boolean;
   consumeRenderObservationState?: () => AppPageRenderObservationState;
   createHtmlRenderObservation?: BuildAppPageCacheRenderObservation;
   createRscRenderObservation?: BuildAppPageCacheRenderObservation;
@@ -63,6 +64,7 @@ type ScheduleAppPageRscCacheWriteOptions = {
   consumeRenderObservationState?: () => AppPageRenderObservationState;
   createRscRenderObservation?: BuildAppPageCacheRenderObservation;
   dynamicUsedDuringBuild: boolean;
+  dynamicUsageCheckComplete?: boolean;
   getPageTags: () => string[];
   getRequestCacheLife?: () => AppPageRequestCacheLife | null;
   isrDebug?: AppPageDebugLogger;
@@ -81,10 +83,14 @@ type ScheduleAppPageRscCacheWriteOptions = {
 function applyPendingDynamicCdnHeaders(
   headers: Headers,
   tags?: readonly string[],
-  options: { omitCacheState?: boolean } = {},
+  options: { dynamicUsageCheckComplete?: boolean; omitCacheState?: boolean } = {},
 ): void {
   const cacheable = headers.get("Cache-Control") ?? "";
-  applyCdnResponseHeaders(headers, { cacheControl: cacheable, pendingDynamicCheck: true, tags });
+  applyCdnResponseHeaders(headers, {
+    cacheControl: cacheable,
+    pendingDynamicCheck: options.dynamicUsageCheckComplete !== true,
+    tags,
+  });
   if (options.omitCacheState === true) {
     headers.delete(VINEXT_CACHE_HEADER);
     headers.delete(NEXTJS_CACHE_HEADER);
@@ -98,22 +104,23 @@ function resolveAppPageCacheWritePolicy(options: {
   requestCacheLife?: AppPageRequestCacheLife | null;
   revalidateSeconds: number | null;
 }): { expireSeconds?: number; revalidateSeconds: number } | null {
-  let revalidateSeconds = options.revalidateSeconds;
+  let revalidateSeconds = options.revalidateSeconds ?? INFINITE_CACHE_SECONDS;
   let expireSeconds = options.expireSeconds;
   const requestCacheLife = options.requestCacheLife;
 
   if (requestCacheLife?.revalidate !== undefined) {
-    revalidateSeconds =
-      revalidateSeconds === null
-        ? requestCacheLife.revalidate
-        : Math.min(revalidateSeconds, requestCacheLife.revalidate);
+    revalidateSeconds = Math.min(revalidateSeconds, requestCacheLife.revalidate);
   }
   if (requestCacheLife?.expire !== undefined) {
     expireSeconds = requestCacheLife.expire;
   }
 
-  if (revalidateSeconds === null || Number.isNaN(revalidateSeconds) || revalidateSeconds <= 0) {
+  if (Number.isNaN(revalidateSeconds) || revalidateSeconds <= 0) {
     return null;
+  }
+
+  if (revalidateSeconds === Infinity) {
+    revalidateSeconds = INFINITE_CACHE_SECONDS;
   }
 
   return { expireSeconds, revalidateSeconds };
@@ -138,6 +145,7 @@ export function finalizeAppPageHtmlCacheResponse(
   const clientHeaders = new Headers(response.headers);
   if (options.preserveClientResponseHeaders !== true) {
     applyPendingDynamicCdnHeaders(clientHeaders, options.getPageTags(), {
+      dynamicUsageCheckComplete: options.dynamicUsageCheckComplete,
       omitCacheState: options.omitPendingDynamicCacheState === true,
     });
   }
@@ -237,6 +245,7 @@ export function finalizeAppPageRscCacheResponse(
 
   const clientHeaders = new Headers(response.headers);
   applyPendingDynamicCdnHeaders(clientHeaders, options.getPageTags(), {
+    dynamicUsageCheckComplete: options.dynamicUsageCheckComplete,
     omitCacheState: options.omitPendingDynamicCacheState === true,
   });
 

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -461,17 +461,9 @@ export function shouldReadAppPageCache(options: {
 }
 
 function resolveAppPageCacheReadRevalidateSeconds(options: {
-  isDynamicError: boolean;
-  isForceStatic: boolean;
   revalidateSeconds: number | null;
 }): number {
-  if (options.revalidateSeconds === null && (options.isForceStatic || options.isDynamicError)) {
-    return Infinity;
-  }
-
-  // cacheLife-only routes discover their actual revalidate during the fresh
-  // render; this seed only gets them into the cache read path.
-  return options.revalidateSeconds ?? 0;
+  return options.revalidateSeconds ?? Infinity;
 }
 
 export function hasSearchParams(searchParams: URLSearchParams | null | undefined): boolean {
@@ -652,8 +644,6 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
       renderMode: options.renderMode,
       expireSeconds: options.expireSeconds,
       revalidateSeconds: resolveAppPageCacheReadRevalidateSeconds({
-        isDynamicError,
-        isForceStatic,
         revalidateSeconds: currentRevalidateSeconds,
       }),
       renderFreshPageForCache: async () => {

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import type { ReactFormState } from "react-dom/client";
 import type { NavigationContext } from "vinext/shims/navigation";
 import type { CachedAppPageValue } from "vinext/shims/cache-handler";
+import { getCdnCacheAdapter } from "vinext/shims/cdn-cache";
 import type { RootParams } from "vinext/shims/root-params";
 import { runWithFetchDedupe } from "vinext/shims/fetch-cache";
 import { AppElementsWire, isAppElementsRecord, type AppOutgoingElements } from "./app-elements.js";
@@ -20,6 +21,7 @@ import {
   type LayoutClassificationOptions,
 } from "./app-page-execution.js";
 import { probeAppPageBeforeRender } from "./app-page-probe.js";
+import { readStreamAsText } from "../utils/text-stream.js";
 import {
   buildAppPageHtmlResponse,
   buildAppPageRscResponse,
@@ -279,15 +281,9 @@ function applyRequestCacheLife(options: {
 }
 
 function resolveAppPageCacheWriteRevalidateSeconds(options: {
-  isDynamicError: boolean;
-  isForceStatic: boolean;
   revalidateSeconds: number | null;
 }): number | null {
-  if (options.revalidateSeconds === null && (options.isForceStatic || options.isDynamicError)) {
-    return Infinity;
-  }
-
-  return options.revalidateSeconds;
+  return options.revalidateSeconds ?? Infinity;
 }
 
 function readRootBoundaryId(element: Readonly<Record<string, unknown>>): string | null {
@@ -806,7 +802,18 @@ export async function renderAppPageLifecycle(
       }));
     }
 
-    const dynamicUsedDuringBuild = options.consumeDynamicUsage();
+    let dynamicUsedDuringBuild = options.consumeDynamicUsage();
+    let dynamicUsageCheckComplete = false;
+    if (
+      options.isProduction &&
+      !dynamicUsedDuringBuild &&
+      shouldCaptureRscForCacheMetadata &&
+      (options.isEdgeRuntime || !getCdnCacheAdapter().ownsBackgroundRevalidation)
+    ) {
+      await settleCapturedRscRenderForCacheMetadata(capturedRscDataRef.value);
+      dynamicUsedDuringBuild = options.consumeDynamicUsage();
+      dynamicUsageCheckComplete = true;
+    }
     // When skip transport is enabled, omit cacheState because the response is a
     // per-client payload, not a shared-cache MISS/HIT artifact. The absence also
     // keeps finalizeAppPageRscCacheResponse from overwriting no-store.
@@ -890,6 +897,7 @@ export async function renderAppPageLifecycle(
         });
       },
       dynamicUsedDuringBuild,
+      dynamicUsageCheckComplete,
       getPageTags() {
         return options.getPageTags();
       },
@@ -906,8 +914,6 @@ export async function renderAppPageLifecycle(
       preserveClientResponseHeaders: rscResponsePolicy.cacheState !== "MISS",
       expireSeconds,
       revalidateSeconds: resolveAppPageCacheWriteRevalidateSeconds({
-        isDynamicError: options.isDynamicError,
-        isForceStatic: options.isForceStatic,
         revalidateSeconds,
       }),
       waitUntil(promise) {
@@ -1074,12 +1080,26 @@ export async function renderAppPageLifecycle(
   // Clearing the context synchronously here would race those executions, causing
   // headers()/cookies() to see a null context on warm (module-cached) requests.
   // See: https://github.com/cloudflare/vinext/issues/660
-  const safeHtmlStream = deferUntilStreamConsumed(htmlStream, () => {
+  let safeHtmlStream = deferUntilStreamConsumed(htmlStream, () => {
     dynamicUsedBeforeContextCleanup =
       dynamicUsedBeforeContextCleanup || options.consumeDynamicUsage();
     dynamicUsedDuringHtmlRender = dynamicUsedBeforeContextCleanup;
     options.clearRequestContext();
   });
+
+  let dynamicUsageCheckComplete = false;
+  if (
+    options.isProduction &&
+    !dynamicUsedDuringRender &&
+    shouldCaptureRscForCacheMetadata &&
+    (options.isEdgeRuntime || !getCdnCacheAdapter().ownsBackgroundRevalidation)
+  ) {
+    const bufferedHtml = await readStreamAsText(safeHtmlStream);
+    safeHtmlStream = new Response(bufferedHtml).body!;
+    dynamicUsedDuringRender = dynamicUsedBeforeContextCleanup || options.consumeDynamicUsage();
+    dynamicUsedDuringHtmlRender = dynamicUsedDuringRender;
+    dynamicUsageCheckComplete = true;
+  }
 
   const htmlResponsePolicy = resolveAppPageHtmlResponsePolicy({
     dynamicUsedDuringRender,
@@ -1129,7 +1149,11 @@ export async function renderAppPageLifecycle(
     options.isProgressiveActionRender !== true &&
     !dynamicUsedDuringRender;
 
-  if (htmlResponsePolicy.shouldWriteToCache || shouldSpeculativelyWriteCache) {
+  if (
+    htmlResponsePolicy.shouldWriteToCache ||
+    shouldSpeculativelyWriteCache ||
+    (dynamicUsageCheckComplete && htmlResponsePolicy.cacheState === "MISS")
+  ) {
     const isrResponse = buildAppPageHtmlResponse(safeHtmlStream, {
       draftCookie,
       linkHeader,
@@ -1151,6 +1175,7 @@ export async function renderAppPageLifecycle(
       capturedRscDataPromise: capturedRscDataRef.value,
       cleanPathname: options.cleanPathname,
       consumeDynamicUsage: options.consumeDynamicUsage,
+      dynamicUsageCheckComplete,
       consumeRenderObservationState: options.consumeRenderObservationState,
       createHtmlRenderObservation(input) {
         return createAppPageRenderObservation({
@@ -1191,8 +1216,6 @@ export async function renderAppPageLifecycle(
       preserveClientResponseHeaders: !htmlResponsePolicy.shouldWriteToCache,
       expireSeconds,
       revalidateSeconds: resolveAppPageCacheWriteRevalidateSeconds({
-        isDynamicError: options.isDynamicError,
-        isForceStatic: options.isForceStatic,
         revalidateSeconds,
       }),
       waitUntil(cachePromise) {

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -1094,6 +1094,9 @@ export async function renderAppPageLifecycle(
     shouldCaptureRscForCacheMetadata &&
     (options.isEdgeRuntime || !getCdnCacheAdapter().ownsBackgroundRevalidation)
   ) {
+    // CDN-managed caches need the final cache policy before response headers
+    // leave the origin. Buffer candidate static HTML so late request-API usage
+    // can still demote the response to no-store instead of poisoning the edge.
     const bufferedHtml = await readStreamAsText(safeHtmlStream);
     safeHtmlStream = new Response(bufferedHtml).body!;
     dynamicUsedDuringRender = dynamicUsedBeforeContextCleanup || options.consumeDynamicUsage();

--- a/packages/vinext/src/server/app-page-response.ts
+++ b/packages/vinext/src/server/app-page-response.ts
@@ -155,10 +155,17 @@ export function resolveAppPageRscResponsePolicy(
     return { cacheControl: NO_STORE_CACHE_CONTROL };
   }
 
-  if (
-    ((options.isForceStatic || options.isDynamicError) && !options.revalidateSeconds) ||
-    options.revalidateSeconds === Infinity
-  ) {
+  if (options.revalidateSeconds === null) {
+    return {
+      cacheControl: STATIC_CACHE_CONTROL,
+      cacheState:
+        options.isProduction && !options.isForceStatic && !options.isDynamicError
+          ? "MISS"
+          : "STATIC",
+    };
+  }
+
+  if (options.revalidateSeconds === Infinity) {
     return {
       cacheControl: STATIC_CACHE_CONTROL,
       cacheState: "STATIC",
@@ -221,18 +228,18 @@ export function resolveAppPageHtmlResponsePolicy(
     };
   }
 
-  if ((options.isForceStatic || options.isDynamicError) && options.revalidateSeconds === null) {
-    return {
-      cacheControl: STATIC_CACHE_CONTROL,
-      cacheState: options.isProduction ? "MISS" : "STATIC",
-      shouldWriteToCache: options.isProduction,
-    };
-  }
-
   if (options.dynamicUsedDuringRender) {
     return {
       cacheControl: NO_STORE_CACHE_CONTROL,
       shouldWriteToCache: false,
+    };
+  }
+
+  if (options.revalidateSeconds === null) {
+    return {
+      cacheControl: STATIC_CACHE_CONTROL,
+      cacheState: options.isProduction ? "MISS" : "STATIC",
+      shouldWriteToCache: options.isProduction,
     };
   }
 

--- a/packages/vinext/src/server/app-page-response.ts
+++ b/packages/vinext/src/server/app-page-response.ts
@@ -156,6 +156,10 @@ export function resolveAppPageRscResponsePolicy(
   }
 
   if (options.revalidateSeconds === null) {
+    if (!options.isProduction && !options.isForceStatic && !options.isDynamicError) {
+      return {};
+    }
+
     return {
       cacheControl: STATIC_CACHE_CONTROL,
       cacheState:
@@ -236,6 +240,10 @@ export function resolveAppPageHtmlResponsePolicy(
   }
 
   if (options.revalidateSeconds === null) {
+    if (!options.isProduction && !options.isForceStatic && !options.isDynamicError) {
+      return { shouldWriteToCache: false };
+    }
+
     return {
       cacheControl: STATIC_CACHE_CONTROL,
       cacheState: options.isProduction ? "MISS" : "STATIC",

--- a/packages/vinext/src/server/cache-control.ts
+++ b/packages/vinext/src/server/cache-control.ts
@@ -6,6 +6,9 @@ export const BROWSER_REVALIDATE_CACHE_CONTROL = "public, max-age=0, must-revalid
 
 export const STATIC_CACHE_CONTROL = "s-maxage=31536000, stale-while-revalidate";
 
+// Matches Next.js's JSON-safe sentinel for `revalidate = false`.
+export const INFINITE_CACHE_SECONDS = 0xfffffffe;
+
 const STALE_REVALIDATE_CACHE_CONTROL = "s-maxage=0, stale-while-revalidate";
 
 export const NO_STORE_CACHE_CONTROL = "no-store, must-revalidate";
@@ -92,7 +95,7 @@ export function buildCachedRevalidateCacheControl(
   revalidateSeconds: number,
   expireSeconds?: number,
 ): string {
-  if (revalidateSeconds === Infinity) {
+  if (revalidateSeconds === Infinity || revalidateSeconds === INFINITE_CACHE_SECONDS) {
     return STATIC_CACHE_CONTROL;
   }
 

--- a/packages/vinext/src/server/isr-cache.ts
+++ b/packages/vinext/src/server/isr-cache.ts
@@ -31,6 +31,7 @@ import {
 } from "./app-rsc-render-mode.js";
 import { normalizeAppPageInterceptionProofPathname } from "./app-page-render-identity.js";
 import type { RenderObservation } from "./cache-proof.js";
+import { INFINITE_CACHE_SECONDS } from "./cache-control.js";
 export { normalizeMountedSlotsHeader };
 
 /**
@@ -179,14 +180,16 @@ export async function isrSet(
   tags?: string[],
   expireSeconds?: number,
 ): Promise<void> {
+  const storedRevalidateSeconds =
+    revalidateSeconds === Infinity ? INFINITE_CACHE_SECONDS : revalidateSeconds;
   await getCdnCacheAdapter().set(key, data, {
     cacheControl:
       expireSeconds === undefined
-        ? { revalidate: revalidateSeconds }
-        : { revalidate: revalidateSeconds, expire: expireSeconds },
+        ? { revalidate: storedRevalidateSeconds }
+        : { revalidate: storedRevalidateSeconds, expire: expireSeconds },
     // `revalidate` is the legacy vinext CacheHandler context field. `expire`
     // is new metadata and intentionally only lives inside cacheControl.
-    revalidate: revalidateSeconds,
+    revalidate: storedRevalidateSeconds,
     tags: tags ?? [],
   });
 }

--- a/packages/vinext/src/server/isr-decision.ts
+++ b/packages/vinext/src/server/isr-decision.ts
@@ -14,6 +14,7 @@ import type { CacheControlMetadata } from "vinext/shims/cache-handler";
 import {
   buildCachedRevalidateCacheControl,
   buildRevalidateCacheControl,
+  INFINITE_CACHE_SECONDS,
   NEVER_CACHE_CONTROL,
   NO_STORE_CACHE_CONTROL,
   STATIC_CACHE_CONTROL,
@@ -100,7 +101,9 @@ function buildCacheControl(
 ): string {
   if (kind === "app-route") {
     if (revalidate === 0) return NEVER_CACHE_CONTROL;
-    if (revalidate === Infinity) return STATIC_CACHE_CONTROL;
+    if (revalidate === Infinity || revalidate === INFINITE_CACHE_SECONDS) {
+      return STATIC_CACHE_CONTROL;
+    }
   }
   return buildCachedRevalidateCacheControl(disposition, revalidate, expire);
 }
@@ -166,7 +169,9 @@ export function buildAppRouteMissIsrCacheControl(
   expireSeconds?: number,
 ): string {
   if (revalidateSeconds === 0) return NEVER_CACHE_CONTROL;
-  if (revalidateSeconds === Infinity) return STATIC_CACHE_CONTROL;
+  if (revalidateSeconds === Infinity || revalidateSeconds === INFINITE_CACHE_SECONDS) {
+    return STATIC_CACHE_CONTROL;
+  }
   return buildRevalidateCacheControl(revalidateSeconds, expireSeconds);
 }
 

--- a/tests/app-page-cache.test.ts
+++ b/tests/app-page-cache.test.ts
@@ -1421,4 +1421,39 @@ describe("app page cache helpers", () => {
       ["RSC cache write skipped (no cache policy)", "rsc:/invalid-cache-life"],
     ]);
   });
+
+  it("uses indefinite revalidation when default static config has no cacheLife override", async () => {
+    const pendingCacheWrites: Promise<void>[] = [];
+    const isrSet = vi.fn();
+
+    const didSchedule = scheduleAppPageRscCacheWrite({
+      capturedRscDataPromise: Promise.resolve(new TextEncoder().encode("flight").buffer),
+      cleanPathname: "/default-static",
+      consumeDynamicUsage() {
+        return false;
+      },
+      dynamicUsedDuringBuild: false,
+      getPageTags() {
+        return ["/default-static"];
+      },
+      isrRscKey(pathname) {
+        return "rsc:" + pathname;
+      },
+      isrSet,
+      revalidateSeconds: null,
+      waitUntil(promise) {
+        pendingCacheWrites.push(promise);
+      },
+    });
+
+    expect(didSchedule).toBe(true);
+    await Promise.all(pendingCacheWrites);
+    expect(isrSet).toHaveBeenCalledWith(
+      "rsc:/default-static",
+      expect.anything(),
+      0xfffffffe,
+      ["/default-static"],
+      undefined,
+    );
+  });
 });

--- a/tests/app-page-dispatch.test.ts
+++ b/tests/app-page-dispatch.test.ts
@@ -1767,6 +1767,29 @@ describe("app page dispatch", () => {
     await expect(response.text()).resolves.toBe("<html>static cached</html>");
   });
 
+  it("serves cached production HTML for default-config static pages", async () => {
+    // Ported from Next.js: test/e2e/app-dir/app-static/app-static.test.ts
+    const isrGet = vi.fn(async () =>
+      buildISRCacheEntry(buildCachedAppPageValue("<html>default static cached</html>")),
+    );
+    const { options } = createDispatchOptions({
+      async buildPageElement() {
+        throw new Error("default static cache hit should not render the page");
+      },
+      isProduction: true,
+      isrGet,
+      revalidateSeconds: null,
+    });
+
+    const response = await dispatchAppPage(options);
+
+    expect(isrGet).toHaveBeenCalledWith("html:/posts/hello");
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("s-maxage=31536000, stale-while-revalidate");
+    expect(response.headers.get("x-vinext-cache")).toBe("HIT");
+    await expect(response.text()).resolves.toBe("<html>default static cached</html>");
+  });
+
   it("returns method policy responses instead of rendering unsupported methods", async () => {
     const { options } = createDispatchOptions({
       async buildPageElement() {

--- a/tests/app-page-render.test.ts
+++ b/tests/app-page-render.test.ts
@@ -492,6 +492,42 @@ describe("app page render lifecycle", () => {
     expect(common.isrSet).not.toHaveBeenCalled();
   });
 
+  it("does not expose cacheable CDN headers when default-config HTML becomes dynamic late", async () => {
+    setCdnCacheAdapter(new CloudflareCdnCacheAdapter());
+    const common = createCommonOptions();
+    let dynamicUsed = false;
+    try {
+      const response = await renderAppPageLifecycle({
+        ...common.options,
+        consumeDynamicUsage() {
+          const value = dynamicUsed;
+          dynamicUsed = false;
+          return value;
+        },
+        isProduction: true,
+        loadSsrHandler: async () => ({
+          async handleSsr() {
+            return new ReadableStream<Uint8Array>({
+              pull(controller) {
+                dynamicUsed = true;
+                controller.enqueue(new TextEncoder().encode("<html>dynamic</html>"));
+                controller.close();
+              },
+            });
+          },
+        }),
+        revalidateSeconds: null,
+      });
+
+      expect(response.headers.get("cache-control")).toBe("no-store, must-revalidate");
+      expect(response.headers.get("cdn-cache-control")).toBeNull();
+      await expect(response.text()).resolves.toBe("<html>dynamic</html>");
+      expect(common.isrSet).not.toHaveBeenCalled();
+    } finally {
+      setCdnCacheAdapter(new DefaultCdnCacheAdapter());
+    }
+  });
+
   it("recovers HTML page special errors from the real render when the page probe is skipped", async () => {
     const common = createCommonOptions();
     const notFoundError = Object.assign(new Error("NEXT_NOT_FOUND"), { digest: "NEXT_NOT_FOUND" });
@@ -702,8 +738,8 @@ describe("app page render lifecycle", () => {
     ).resolves.toBe("returned");
 
     const response = await responsePromise;
-    expect(response.headers.get("cache-control")).toBeNull();
-    expect(response.headers.get("x-vinext-cache")).toBeNull();
+    expect(response.headers.get("cache-control")).toBe("no-store, must-revalidate");
+    expect(response.headers.get("x-vinext-cache")).toBe("MISS");
     expect(common.waitUntilPromises).toHaveLength(1);
 
     releaseRsc.resolve();
@@ -847,8 +883,8 @@ describe("app page render lifecycle", () => {
     ).resolves.toBe("returned");
 
     const response = await responsePromise;
-    expect(response.headers.get("cache-control")).toBeNull();
-    expect(response.headers.get("x-vinext-cache")).toBeNull();
+    expect(response.headers.get("cache-control")).toBe("no-store, must-revalidate");
+    expect(response.headers.get("x-vinext-cache")).toBe("MISS");
     expect(common.waitUntilPromises).toHaveLength(1);
 
     releaseRsc.resolve();
@@ -872,7 +908,7 @@ describe("app page render lifecycle", () => {
     );
   });
 
-  it("preserves original production RSC response headers when speculative cacheLife never appears", async () => {
+  it("caches default-static production RSC when cacheLife never appears", async () => {
     const common = createCommonOptions();
 
     const response = await renderAppPageLifecycle({
@@ -882,16 +918,22 @@ describe("app page render lifecycle", () => {
       revalidateSeconds: null,
     });
 
-    expect(response.headers.get("cache-control")).toBeNull();
-    expect(response.headers.get("x-vinext-cache")).toBeNull();
+    expect(response.headers.get("cache-control")).toBe("no-store, must-revalidate");
+    expect(response.headers.get("x-vinext-cache")).toBe("MISS");
     expect(common.waitUntilPromises).toHaveLength(1);
 
     await expect(response.text()).resolves.toBe("flight-data");
     await Promise.all(common.waitUntilPromises);
-    expect(common.isrSet).not.toHaveBeenCalled();
+    expect(common.isrSet).toHaveBeenCalledWith(
+      "rsc:/posts/post",
+      expect.objectContaining({ kind: "APP_PAGE" }),
+      0xfffffffe,
+      ["_N_T_/posts/post"],
+      undefined,
+    );
   });
 
-  it("preserves original production HTML response headers when speculative cacheLife never appears", async () => {
+  it("caches default-static production HTML when cacheLife never appears", async () => {
     const common = createCommonOptions();
 
     const response = await renderAppPageLifecycle({
@@ -900,13 +942,13 @@ describe("app page render lifecycle", () => {
       revalidateSeconds: null,
     });
 
-    expect(response.headers.get("cache-control")).toBeNull();
-    expect(response.headers.get("x-vinext-cache")).toBeNull();
+    expect(response.headers.get("cache-control")).toBe("no-store, must-revalidate");
+    expect(response.headers.get("x-vinext-cache")).toBe("MISS");
     expect(common.waitUntilPromises).toHaveLength(1);
 
     await expect(response.text()).resolves.toBe("<html>page</html>");
     await Promise.all(common.waitUntilPromises);
-    expect(common.isrSet).not.toHaveBeenCalled();
+    expect(common.isrSet).toHaveBeenCalledTimes(2);
   });
 
   it("captures prerender cache metadata before building non-production HTML responses", async () => {
@@ -1337,6 +1379,38 @@ describe("app page render lifecycle", () => {
     });
     expect(response.headers.get(VINEXT_DYNAMIC_STALE_TIME_HEADER)).toBeNull();
     await expect(response.text()).resolves.toBe("flight-data");
+  });
+
+  it("caches default-config static production HTML indefinitely", async () => {
+    // Ported from Next.js: packages/next/src/server/app-render/app-render.tsx
+    const common = createCommonOptions();
+    const response = await renderAppPageLifecycle({
+      ...common.options,
+      isProduction: true,
+      revalidateSeconds: null,
+    });
+
+    expect(response.headers.get("cache-control")).toBe("no-store, must-revalidate");
+    await expect(response.text()).resolves.toBe("<html>page</html>");
+    await Promise.all(common.waitUntilPromises);
+
+    expect(common.isrSet).toHaveBeenCalledTimes(2);
+    expect(common.isrSet).toHaveBeenNthCalledWith(
+      1,
+      "html:/posts/post",
+      expect.anything(),
+      0xfffffffe,
+      ["_N_T_/posts/post"],
+      undefined,
+    );
+    expect(common.isrSet).toHaveBeenNthCalledWith(
+      2,
+      "rsc:/posts/post",
+      expect.anything(),
+      0xfffffffe,
+      ["_N_T_/posts/post"],
+      undefined,
+    );
   });
 
   it("streams runtime HTML responses progressively without buffering the body", async () => {

--- a/tests/app-page-response.test.ts
+++ b/tests/app-page-response.test.ts
@@ -315,6 +315,33 @@ describe("app page response helpers", () => {
     });
   });
 
+  it("keeps default-config pages uncached in development", () => {
+    expect(
+      resolveAppPageRscResponsePolicy({
+        dynamicUsedDuringBuild: false,
+        isDraftMode: false,
+        isDynamicError: false,
+        isForceDynamic: false,
+        isForceStatic: false,
+        isProduction: false,
+        revalidateSeconds: null,
+      }),
+    ).toEqual({});
+
+    expect(
+      resolveAppPageHtmlResponsePolicy({
+        dynamicUsedDuringRender: false,
+        hasScriptNonce: false,
+        isDraftMode: false,
+        isDynamicError: false,
+        isForceDynamic: false,
+        isForceStatic: false,
+        isProduction: false,
+        revalidateSeconds: null,
+      }),
+    ).toEqual({ shouldWriteToCache: false });
+  });
+
   it("treats progressive action HTML responses as no-store", () => {
     expect(
       resolveAppPageHtmlResponsePolicy({

--- a/tests/app-page-response.test.ts
+++ b/tests/app-page-response.test.ts
@@ -59,7 +59,7 @@ describe("app page response helpers", () => {
     });
   });
 
-  it("resolves RSC response policy for force-dynamic, infinity, and default cases", () => {
+  it("resolves RSC response policy for force-dynamic and indefinitely static cases", () => {
     expect(
       resolveAppPageRscResponsePolicy({
         dynamicUsedDuringBuild: false,
@@ -99,7 +99,10 @@ describe("app page response helpers", () => {
         isProduction: true,
         revalidateSeconds: null,
       }),
-    ).toEqual({});
+    ).toEqual({
+      cacheControl: "s-maxage=31536000, stale-while-revalidate",
+      cacheState: "MISS",
+    });
   });
 
   it("resolves RSC response policy as no-store when dynamic usage is detected during build", () => {
@@ -270,6 +273,44 @@ describe("app page response helpers", () => {
     ).toEqual({
       cacheControl: "s-maxage=31536000, stale-while-revalidate",
       cacheState: "STATIC",
+      shouldWriteToCache: false,
+    });
+  });
+
+  it("writes default-config static HTML responses to cache in production", () => {
+    // Ported from Next.js: packages/next/src/server/app-render/app-render.tsx
+    // Next.js initializes prerender revalidation to INFINITE_CACHE and only
+    // demotes it when explicit config or dynamic usage requires it.
+    expect(
+      resolveAppPageHtmlResponsePolicy({
+        dynamicUsedDuringRender: false,
+        hasScriptNonce: false,
+        isDraftMode: false,
+        isDynamicError: false,
+        isForceDynamic: false,
+        isForceStatic: false,
+        isProduction: true,
+        revalidateSeconds: null,
+      }),
+    ).toEqual({
+      cacheControl: "s-maxage=31536000, stale-while-revalidate",
+      cacheState: "MISS",
+      shouldWriteToCache: true,
+    });
+
+    expect(
+      resolveAppPageHtmlResponsePolicy({
+        dynamicUsedDuringRender: true,
+        hasScriptNonce: false,
+        isDraftMode: false,
+        isDynamicError: false,
+        isForceDynamic: false,
+        isForceStatic: false,
+        isProduction: true,
+        revalidateSeconds: null,
+      }),
+    ).toEqual({
+      cacheControl: "no-store, must-revalidate",
       shouldWriteToCache: false,
     });
   });

--- a/tests/app-router-production-server.test.ts
+++ b/tests/app-router-production-server.test.ts
@@ -1473,6 +1473,22 @@ describe("App Router Production server (startProdServer)", () => {
     expect(html2).not.toContain('"filter">alpha<');
   });
 
+  it("caches fully static pages without explicit segment config", async () => {
+    // Ported from Next.js: test/e2e/app-dir/app-static/app-static.test.ts
+    const first = await fetch(`${baseUrl}/default-static-cache`);
+    expect(first.status).toBe(200);
+    expect(["MISS", "HIT"]).toContain(first.headers.get("x-vinext-cache"));
+    const firstHtml = await first.text();
+    const firstValue = extractTextById(firstHtml, "default-static-value");
+    expect(firstValue).toBeTruthy();
+
+    const second = await fetch(`${baseUrl}/default-static-cache`);
+    expect(second.status).toBe(200);
+    expect(second.headers.get("x-vinext-cache")).toBe("HIT");
+    const secondHtml = await second.text();
+    expect(extractTextById(secondHtml, "default-static-value")).toBe(firstValue);
+  });
+
   // Route handler ISR caching tests
   // These tests are ORDER-DEPENDENT: they share a single production server and
   // /api/static-data cache state persists across tests. HIT depends on MISS

--- a/tests/fixtures/app-basic/app/default-static-cache/page.tsx
+++ b/tests/fixtures/app-basic/app/default-static-cache/page.tsx
@@ -1,0 +1,3 @@
+export default function DefaultStaticCachePage() {
+  return <p id="default-static-value">{Date.now()}</p>;
+}

--- a/tests/kv-cache-handler.test.ts
+++ b/tests/kv-cache-handler.test.ts
@@ -443,6 +443,27 @@ describe("KVCacheHandler", () => {
       ]);
     });
 
+    it("round-trips the JSON-safe indefinite revalidation sentinel", async () => {
+      await handler.set(
+        "rt-indefinite",
+        {
+          kind: "APP_PAGE",
+          html: "<div>static</div>",
+          rscData: undefined,
+          headers: undefined,
+          postponed: undefined,
+          status: 200,
+        },
+        { cacheControl: { revalidate: 0xfffffffe } },
+      );
+
+      const raw = store.get("cache:rt-indefinite");
+      expect(raw).toContain('"revalidate":4294967294');
+      const result = await handler.get("rt-indefinite");
+      expect(result?.cacheControl).toEqual({ revalidate: 0xfffffffe });
+      expect(result?.value?.kind).toBe("APP_PAGE");
+    });
+
     it("serves stale within expire and returns a hard miss beyond expire", async () => {
       vi.useFakeTimers({ toFake: ["Date"] });
       vi.setSystemTime(1_000);


### PR DESCRIPTION
## Summary

- treat App Router pages with no explicit `dynamic` or `revalidate` config as indefinitely cacheable by default, matching Next.js static-generation semantics
- preserve render-time dynamic bailouts and prevent CDN cache headers from escaping before late request API usage is known
- store indefinite revalidation using Next.js's JSON-safe sentinel so KV and other serialized cache adapters preserve the policy
- add unit and production-server regressions for config-less static pages, dynamic bailouts, CDN-managed responses, and KV serialization

## Next.js parity

Next.js initializes App Router prerender work with `INFINITE_CACHE` and only reduces it through explicit revalidation, uncached fetches, or dynamic request API usage. Vinext instead converted an unspecified route revalidation value to `0` on cache reads/writes, causing otherwise fully static pages to rerender and never produce reusable artifacts.

## Validation

- `vp check` on all changed source and test files
- `vp test run tests/app-page-*.test.ts tests/isr-cache.test.ts tests/isr-decision.test.ts tests/cache-control.test.ts tests/cdn-cache.test.ts tests/cloudflare-cdn-cache.test.ts tests/kv-cache-handler.test.ts` (671 tests)
- `vp test run tests/app-router-production-server.test.ts` (68 tests)
- `git diff --check`
