### PR TITLE
Fix route param percent-literal decoding

### DIFF
--- a/packages/vinext/src/routing/route-matching.ts
+++ b/packages/vinext/src/routing/route-matching.ts
@@ -54,5 +54,5 @@ export function matchRouteWithTrie<R extends { patternParts: string[] }>(
   // Split URL once, look up via trie
   const urlParts = normalizedUrl.split("/").filter(Boolean);
   const trie = getOrBuildTrie(cache, routes);
-  return trieMatch(trie, urlParts);
+  return trieMatch(trie, urlParts, { decodeParams: "path-delimiters" });
 }

--- a/packages/vinext/src/routing/route-pattern.ts
+++ b/packages/vinext/src/routing/route-pattern.ts
@@ -1,6 +1,10 @@
-import { decodeMatchedParams } from "./utils";
+import { decodeMatchedParams, decodeMatchedPathDelimiterParams } from "./utils";
 
 export type RoutePatternParams = Record<string, string | string[]>;
+
+export type RoutePatternMatchOptions = {
+  decodeParams?: boolean | "path-delimiters";
+};
 
 function routePatternPart(segment: string): string {
   if (segment.startsWith("[[...") && segment.endsWith("]]")) {
@@ -91,6 +95,7 @@ export function fillRoutePatternSegments(
 export function matchRoutePattern(
   urlParts: readonly string[],
   patternParts: readonly string[],
+  options: RoutePatternMatchOptions = {},
 ): RoutePatternParams | null {
   const params: RoutePatternParams = Object.create(null);
 
@@ -138,7 +143,11 @@ export function matchRoutePattern(
   }
 
   if (!matchFrom(0, 0)) return null;
-  decodeMatchedParams(params);
+  if (options.decodeParams === "path-delimiters") {
+    decodeMatchedPathDelimiterParams(params);
+  } else if (options.decodeParams !== false) {
+    decodeMatchedParams(params);
+  }
   return params;
 }
 

--- a/packages/vinext/src/routing/route-trie.ts
+++ b/packages/vinext/src/routing/route-trie.ts
@@ -1,4 +1,4 @@
-import { buildParams, decodeMatchedParams } from "./utils";
+import { buildParams, decodeMatchedParams, decodeMatchedPathDelimiterParams } from "./utils";
 
 /**
  * Trie (prefix tree) for O(depth) route matching.
@@ -20,6 +20,10 @@ export type TrieNode<R> = {
   catchAllChild: { paramName: string; route: R } | null;
   optionalCatchAllChild: { paramName: string; route: R } | null;
   route: R | null;
+};
+
+export type TrieMatchOptions = {
+  decodeParams?: boolean | "path-delimiters";
 };
 
 function createNode<R>(): TrieNode<R> {
@@ -139,9 +143,12 @@ export function buildRouteTrie<R extends { patternParts: string[] }>(routes: R[]
 export function trieMatch<R>(
   root: TrieNode<R>,
   urlParts: string[],
+  options: TrieMatchOptions = {},
 ): { route: R; params: Record<string, string | string[]> } | null {
   const result = match(root, urlParts, 0, []);
-  if (result) {
+  if (result && options.decodeParams === "path-delimiters") {
+    decodeMatchedPathDelimiterParams(result.params);
+  } else if (result && options.decodeParams !== false) {
     decodeMatchedParams(result.params);
   }
   return result;

--- a/packages/vinext/src/routing/utils.ts
+++ b/packages/vinext/src/routing/utils.ts
@@ -225,6 +225,37 @@ function decodeMatchedParam(value: string): string {
   }
 }
 
+const MATCHED_PATH_DELIMITER_REGEX = /%25(2f|23|3f|5c)|%(2f|23|3f|5c)/gi;
+
+function decodeMatchedPathDelimitersParam(value: string): string {
+  return value.replace(
+    MATCHED_PATH_DELIMITER_REGEX,
+    (_match, escapedDelimiter: string | undefined, directDelimiter: string | undefined) => {
+      const matchedDelimiter = escapedDelimiter ?? directDelimiter;
+      if (!matchedDelimiter) {
+        return _match;
+      }
+
+      const delimiter = matchedDelimiter.toLowerCase();
+      if (escapedDelimiter) {
+        return `%${delimiter.toUpperCase()}`;
+      }
+      switch (delimiter) {
+        case "2f":
+          return "/";
+        case "23":
+          return "#";
+        case "3f":
+          return "?";
+        case "5c":
+          return "\\";
+        default:
+          return _match;
+      }
+    },
+  );
+}
+
 /**
  * Build a params object from ordered entries, preserving insertion order.
  *
@@ -257,6 +288,22 @@ export function decodeMatchedParams(params: Record<string, string | string[]>): 
       params[key] = value.map(decodeMatchedParam);
     } else {
       params[key] = decodeMatchedParam(value);
+    }
+  }
+}
+
+/**
+ * Decode only the path-delimiter escapes left behind by
+ * normalizePathnameForRouteMatch. The URL segment has already had one normal
+ * decode pass, so this must not decode ordinary percent literals such as %20.
+ */
+export function decodeMatchedPathDelimiterParams(params: Record<string, string | string[]>): void {
+  for (const key of Object.keys(params)) {
+    const value = params[key];
+    if (Array.isArray(value)) {
+      params[key] = value.map(decodeMatchedPathDelimitersParam);
+    } else {
+      params[key] = decodeMatchedPathDelimitersParam(value);
     }
   }
 }

--- a/packages/vinext/src/server/app-optimistic-routing.ts
+++ b/packages/vinext/src/server/app-optimistic-routing.ts
@@ -1,7 +1,7 @@
 import { createElement, isValidElement, Suspense } from "react";
 import { isUnknownRecord } from "../utils/record.js";
 import { stripBasePath } from "../utils/base-path.js";
-import { buildParams, decodeMatchedParams, splitPathnameForRouteMatch } from "../routing/utils.js";
+import { buildParams, splitPathnameForRouteMatch } from "../routing/utils.js";
 import type { RouteManifest, RouteManifestRoute } from "../routing/app-route-graph.js";
 import { matchRoutePattern } from "../routing/route-pattern.js";
 import { stripRscCacheBustingSearchParam, stripRscSuffix } from "./app-rsc-cache-busting.js";
@@ -174,7 +174,7 @@ function matchNode(
     return { route: node.catchAllChild.route, params };
   }
 
-  // At this point index < urlParts.length, so remaining always has ≥1 segment.
+  // At this point index < urlParts.length, so remaining always has at least one segment.
   if (node.optionalCatchAllChild !== null) {
     const params = buildParams(entries);
     params[node.optionalCatchAllChild.paramName] = urlParts.slice(index);
@@ -209,7 +209,6 @@ export function matchOptimisticRouteManifestRoute(options: {
   const match = matchNode(getRouteTrie(options.routeManifest), urlParts, 0, []);
   if (match === null) return null;
 
-  decodeMatchedParams(match.params);
   return match;
 }
 
@@ -242,13 +241,10 @@ function resolveOptimisticNavigationParams(options: {
       continue;
     }
 
-    // Slot params are decoded once (from urlParts via splitPathnameForRouteMatch),
-    // matching the server-side resolveSlotParamOverrides decode pass. Route params
-    // are decoded a second time via decodeMatchedParams(match.params) above — a
-    // pre-existing asymmetry that has no practical effect for normal segments but
-    // means an encoded catch-all (%25/%2F) could differ between route and slot
-    // params in the same payload. TODO: converge the decode passes.
-    const matched = matchRoutePattern(options.urlParts, patternParts);
+    // urlParts are already decoded once by splitPathnameForRouteMatch.
+    const matched = matchRoutePattern(options.urlParts, patternParts, {
+      decodeParams: "path-delimiters",
+    });
     if (matched) {
       mergeParams(navigationParams, matched);
     }

--- a/packages/vinext/src/server/app-rsc-route-matching.ts
+++ b/packages/vinext/src/server/app-rsc-route-matching.ts
@@ -128,7 +128,9 @@ export function createAppRscRouteMatcher<Route extends AppRscRouteForMatching>(
 
   return {
     matchRoute(url) {
-      return trieMatch(routeTrie, appRscPathnameParts(url));
+      return trieMatch(routeTrie, appRscPathnameParts(url), {
+        decodeParams: "path-delimiters",
+      });
     },
     findIntercept(pathname, sourcePathname = null) {
       // Mirror Next.js' rewrite semantics: interception only fires when the
@@ -140,7 +142,9 @@ export function createAppRscRouteMatcher<Route extends AppRscRouteForMatching>(
 
       const urlParts = appRscPathnameParts(pathname);
       const sourceParts = appRscPathnameParts(sourcePathname);
-      const matchedSourceRoute = trieMatch(routeTrie, sourceParts);
+      const matchedSourceRoute = trieMatch(routeTrie, sourceParts, {
+        decodeParams: "path-delimiters",
+      });
 
       for (const entry of interceptLookup) {
         // Primary gate: when the intercept declares a `sourceMatchPattern`
@@ -335,7 +339,7 @@ export function matchAppRscRoutePattern(
   urlParts: string[],
   patternParts: string[],
 ): AppRscRouteParams | null {
-  return matchRoutePattern(urlParts, patternParts);
+  return matchRoutePattern(urlParts, patternParts, { decodeParams: "path-delimiters" });
 }
 
 function mergeMatchedParams(

--- a/tests/app-optimistic-routing.test.ts
+++ b/tests/app-optimistic-routing.test.ts
@@ -190,6 +190,47 @@ describe("App Router optimistic routing", () => {
     ).toBe("route:/blog/featured");
   });
 
+  it("decodes percent-literal dynamic route params exactly once", () => {
+    const routes = manifest([
+      route({
+        id: "route:/blog/:id",
+        isDynamic: true,
+        paramNames: ["id"],
+        pattern: "/blog/:id",
+        patternParts: ["blog", ":id"],
+      }),
+      route({
+        id: "route:/docs/:slug+",
+        isDynamic: true,
+        paramNames: ["slug"],
+        pattern: "/docs/:slug+",
+        patternParts: ["docs", ":slug+"],
+      }),
+    ]);
+
+    expect(
+      matchOptimisticRouteManifestRoute({
+        basePath: "",
+        href: "/blog/a%2520b",
+        routeManifest: routes,
+      })?.params,
+    ).toEqual({ id: "a%20b" });
+    expect(
+      matchOptimisticRouteManifestRoute({
+        basePath: "",
+        href: "/blog/%2541",
+        routeManifest: routes,
+      })?.params,
+    ).toEqual({ id: "%41" });
+    expect(
+      matchOptimisticRouteManifestRoute({
+        basePath: "",
+        href: "/docs/a%2520b/%2541",
+        routeManifest: routes,
+      })?.params,
+    ).toEqual({ slug: ["a%20b", "%41"] });
+  });
+
   it("preserves dynamic route param key order", () => {
     const twoSegment = manifest([
       route({

--- a/tests/app-rsc-route-matching.test.ts
+++ b/tests/app-rsc-route-matching.test.ts
@@ -80,6 +80,23 @@ describe("App RSC route matching", () => {
     });
   });
 
+  it("decodes non-delimiter percent-literal params exactly once", () => {
+    const matcher = createAppRscRouteMatcher([
+      route("/blog/:id", ["blog", ":id"]),
+      route("/docs/:slug+", ["docs", ":slug+"]),
+    ]);
+
+    expect(matcher.matchRoute("/blog/a%2520b")).toMatchObject({
+      params: { id: "a%20b" },
+    });
+    expect(matcher.matchRoute("/blog/%2541")).toMatchObject({
+      params: { id: "%41" },
+    });
+    expect(matcher.matchRoute("/docs/a%2520b/%2541")).toMatchObject({
+      params: { slug: ["a%20b", "%41"] },
+    });
+  });
+
   it("matches standalone route patterns for dynamic metadata routes", () => {
     expect(
       matchAppRscRoutePattern(["blog", "hello", "sitemap.xml"], ["blog", ":slug", "sitemap.xml"]),

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -63,6 +63,18 @@ function makeTestAppRoute(
   };
 }
 
+function makeTestPageRoute(pattern: string, patternParts: string[]): Route {
+  return {
+    pattern,
+    patternParts,
+    filePath: `/tmp/pages${pattern}.tsx`,
+    isDynamic: pattern.includes(":"),
+    params: patternParts
+      .filter((part) => part.startsWith(":"))
+      .map((part) => part.slice(1).replace(/[+*]$/, "")),
+  };
+}
+
 describe("pagesRouter - route discovery", () => {
   it("discovers pages from the fixture directory", async () => {
     const routes = await pagesRouter(FIXTURE_DIR);
@@ -180,6 +192,19 @@ describe("matchRoute - URL matching", () => {
     expect(result).not.toBeNull();
     expect(result!.route.pattern).toBe("/posts/:id");
     expect(result!.params).toEqual({ id: "42" });
+  });
+
+  it("decodes percent-literal dynamic params exactly once", () => {
+    const routes = [
+      makeTestPageRoute("/blog/:id", ["blog", ":id"]),
+      makeTestPageRoute("/docs/:slug+", ["docs", ":slug+"]),
+    ];
+
+    expect(matchRoute("/blog/a%2520b", routes)?.params).toEqual({ id: "a%20b" });
+    expect(matchRoute("/blog/%2541", routes)?.params).toEqual({ id: "%41" });
+    expect(matchRoute("/docs/a%2520b/%2541", routes)?.params).toEqual({
+      slug: ["a%20b", "%41"],
+    });
   });
 
   it("preserves encoded slashes within a single static segment", () => {
@@ -1054,6 +1079,19 @@ describe("matchAppRoute - URL matching", () => {
     expect(result).not.toBeNull();
     expect(result!.route.pattern).toBe("/blog/:slug");
     expect(result!.params).toEqual({ slug: "hello-world" });
+  });
+
+  it("decodes percent-literal dynamic params exactly once", () => {
+    const routes = [
+      makeTestAppRoute("/blog/:id", ["blog", ":id"]),
+      makeTestAppRoute("/docs/:slug+", ["docs", ":slug+"]),
+    ];
+
+    expect(matchAppRoute("/blog/a%2520b", routes)?.params).toEqual({ id: "a%20b" });
+    expect(matchAppRoute("/blog/%2541", routes)?.params).toEqual({ id: "%41" });
+    expect(matchAppRoute("/docs/a%2520b/%2541", routes)?.params).toEqual({
+      slug: ["a%20b", "%41"],
+    });
   });
 
   it("returns null for unmatched routes", async () => {


### PR DESCRIPTION
﻿## Summary
- avoid a second full `decodeURIComponent` pass for params captured after `normalizePathnameForRouteMatch`
- keep protected path delimiters (`%2F`, `%23`, `%3F`, `%5C`) decoding correctly while preserving literal percent sequences such as `%20` and `%41`
- cover Pages Router, App Router, App RSC route matching, and optimistic route manifest matching

Closes #1963

## Test plan
- `corepack pnpm test tests/routing.test.ts tests/app-rsc-route-matching.test.ts tests/app-optimistic-routing.test.ts -t "percent-literal"` (failed before the fix with `a%2520b` becoming `a b`, passes after)
- `corepack pnpm test tests/app-rsc-route-matching.test.ts tests/app-optimistic-routing.test.ts tests/route-trie.test.ts tests/route-pattern.test.ts`
- `corepack pnpm test tests/routing.test.ts -t "percent-literal|encoded slashes|decoded URL-encoded routes|keeps encoded slashes"`
- `corepack pnpm run check`
- `git diff --check HEAD^..HEAD`

Local note: I also ran the broader related command including full `tests/routing.test.ts`; the decode-related tests passed, while the remaining failures on this Windows checkout were existing route-discovery/path separator or invalid Windows filename cases unrelated to this change.
