### PR TITLE
fix(build): honor inline next config for static export

### DIFF
--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -276,7 +276,9 @@ async function loadDeployViteConfigMetadata(root: string): Promise<DeployViteCon
   );
   const plugins = loaded?.config.plugins;
   return {
-    cacheConfig: await findVinextCacheConfigInPlugins(plugins),
+    cacheConfig: viteConfigHasCacheAdapter(root)
+      ? await findVinextCacheConfigInPlugins(plugins)
+      : null,
     nextConfig: await findVinextNextConfigInPlugins(plugins),
     prerenderConfig: await findVinextPrerenderConfigInPlugins(plugins),
     routeRootConfig: await findVinextRouteRootConfigInPlugins(plugins),

--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -276,10 +276,10 @@ async function loadDeployViteConfigMetadata(root: string): Promise<DeployViteCon
   );
   const plugins = loaded?.config.plugins;
   return {
-    cacheConfig: findVinextCacheConfigInPlugins(plugins),
+    cacheConfig: await findVinextCacheConfigInPlugins(plugins),
     nextConfig: await findVinextNextConfigInPlugins(plugins),
-    prerenderConfig: findVinextPrerenderConfigInPlugins(plugins),
-    routeRootConfig: findVinextRouteRootConfigInPlugins(plugins),
+    prerenderConfig: await findVinextPrerenderConfigInPlugins(plugins),
+    routeRootConfig: await findVinextRouteRootConfigInPlugins(plugins),
   };
 }
 
@@ -843,6 +843,8 @@ export async function deploy(options: DeployOptions): Promise<void> {
   }
 
   const buildEnv = deployEnv === "production" && !options.env ? undefined : deployEnv;
+  // This load is intentionally eager: inline `vinext({ nextConfig })` can decide
+  // export/prerender behavior, so deploy cannot safely short-circuit before reading it.
   const viteConfigMetadata = await withCloudflareEnv(buildEnv, () =>
     loadDeployViteConfigMetadata(info.root),
   );
@@ -876,7 +878,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
   if (shouldEmitPrerenderPathManifest) {
     await emitPrerenderPathManifest({
       root: info.root,
-      nextConfigOverride: nextConfig,
+      nextConfig,
       routeRootConfig: viteConfigMetadata.routeRootConfig,
     });
   }

--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -309,8 +309,6 @@ async function populateKVCacheFromPrerenderedArtifacts(
   wranglerEnv: string | undefined,
   cacheConfig: VinextCacheConfig | null,
 ): Promise<void> {
-  if (!viteConfigHasCacheAdapter(root)) return;
-
   const kvConfig = resolveKvDataAdapterConfig(cacheConfig);
   if (!kvConfig) return;
 

--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -18,7 +18,12 @@ import { pathToFileURL } from "node:url";
 import { emitPrerenderPathManifest } from "vinext/internal/build/prerender-paths";
 import { runPrerender } from "vinext/internal/build/run-prerender";
 import { loadDotenv } from "vinext/internal/config/dotenv";
-import { loadNextConfig, resolveNextConfig } from "vinext/internal/config/next-config";
+import {
+  loadNextConfig,
+  loadVinextNextConfigFromViteConfig,
+  resolveNextConfig,
+  resolveNextConfigInput,
+} from "vinext/internal/config/next-config";
 import {
   formatVinextPrerenderLabel,
   loadVinextCacheConfigFromViteConfig,
@@ -814,9 +819,15 @@ export async function deploy(options: DeployOptions): Promise<void> {
     return;
   }
 
-  const rawNextConfig = await loadNextConfig(info.root, PHASE_PRODUCTION_BUILD);
-  const nextConfig = await resolveNextConfig(rawNextConfig, info.root);
   const buildEnv = deployEnv === "production" && !options.env ? undefined : deployEnv;
+  const nextConfig = await withCloudflareEnv(buildEnv, async () => {
+    const vite = await loadProjectViteApi(info.root);
+    const inlineNextConfig = await loadVinextNextConfigFromViteConfig(vite, info.root);
+    const rawNextConfig = inlineNextConfig
+      ? await resolveNextConfigInput(inlineNextConfig, PHASE_PRODUCTION_BUILD)
+      : await loadNextConfig(info.root, PHASE_PRODUCTION_BUILD);
+    return resolveNextConfig(rawNextConfig, info.root);
+  });
 
   const shouldLoadVinextPrerenderConfig = !options.prerenderAll && nextConfig.output !== "export";
   const vinextPrerenderConfig = shouldLoadVinextPrerenderConfig
@@ -863,7 +874,11 @@ export async function deploy(options: DeployOptions): Promise<void> {
       process.setSourceMapsEnabled(true);
       Error.stackTraceLimit = Math.max(Error.stackTraceLimit, 50);
     }
-    await runPrerender({ root: info.root, concurrency: options.prerenderConcurrency });
+    await runPrerender({
+      root: info.root,
+      concurrency: options.prerenderConcurrency,
+      nextConfigOverride: nextConfig,
+    });
     ranPrerender = true;
   }
 

--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -309,6 +309,7 @@ async function populateKVCacheFromPrerenderedArtifacts(
   wranglerEnv: string | undefined,
   cacheConfig: VinextCacheConfig | null,
 ): Promise<void> {
+  // `loadDeployViteConfigMetadata` returns null unless a cache adapter is declared.
   const kvConfig = resolveKvDataAdapterConfig(cacheConfig);
   if (!kvConfig) return;
 

--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -19,17 +19,21 @@ import { emitPrerenderPathManifest } from "vinext/internal/build/prerender-paths
 import { runPrerender } from "vinext/internal/build/run-prerender";
 import { loadDotenv } from "vinext/internal/config/dotenv";
 import {
+  findVinextNextConfigInPlugins,
   loadNextConfig,
-  loadVinextNextConfigFromViteConfig,
   resolveNextConfig,
   resolveNextConfigInput,
+  type NextConfigInput,
 } from "vinext/internal/config/next-config";
 import {
+  findVinextCacheConfigInPlugins,
+  findVinextPrerenderConfigInPlugins,
+  findVinextRouteRootConfigInPlugins,
   formatVinextPrerenderLabel,
-  loadVinextCacheConfigFromViteConfig,
-  loadVinextPrerenderConfigFromViteConfig,
-  loadVinextRouteRootConfigFromViteConfig,
   resolveVinextPrerenderDecision,
+  type ResolvedVinextPrerenderConfig,
+  type VinextCacheConfig,
+  type VinextRouteRootConfig,
 } from "vinext/internal/config/prerender";
 import {
   detectProject,
@@ -105,6 +109,13 @@ export type DeployOptions = {
 };
 
 type ProjectViteApi = Pick<typeof import("vite"), "createBuilder" | "loadConfigFromFile">;
+
+type DeployViteConfigMetadata = {
+  cacheConfig: VinextCacheConfig | null;
+  nextConfig: NextConfigInput | null;
+  prerenderConfig: ResolvedVinextPrerenderConfig | null;
+  routeRootConfig: VinextRouteRootConfig | null;
+};
 
 function parsePositiveIntegerArg(raw: string, flag: string): number {
   if (raw === "") {
@@ -256,6 +267,22 @@ async function loadProjectViteApi(root: string): Promise<ProjectViteApi> {
   return (await import(/* @vite-ignore */ viteUrl)) as ProjectViteApi;
 }
 
+async function loadDeployViteConfigMetadata(root: string): Promise<DeployViteConfigMetadata> {
+  const vite = await loadProjectViteApi(root);
+  const loaded = await vite.loadConfigFromFile(
+    { command: "build", mode: "production" },
+    undefined,
+    root,
+  );
+  const plugins = loaded?.config.plugins;
+  return {
+    cacheConfig: findVinextCacheConfigInPlugins(plugins),
+    nextConfig: await findVinextNextConfigInPlugins(plugins),
+    prerenderConfig: findVinextPrerenderConfigInPlugins(plugins),
+    routeRootConfig: findVinextRouteRootConfigInPlugins(plugins),
+  };
+}
+
 async function runBuild(info: ProjectInfo, env: string | undefined): Promise<void> {
   console.log("\n  Building for Cloudflare Workers...\n");
 
@@ -277,15 +304,11 @@ async function runBuild(info: ProjectInfo, env: string | undefined): Promise<voi
 
 async function populateKVCacheFromPrerenderedArtifacts(
   root: string,
-  buildEnv: string | undefined,
   wranglerEnv: string | undefined,
+  cacheConfig: VinextCacheConfig | null,
 ): Promise<void> {
   if (!viteConfigHasCacheAdapter(root)) return;
 
-  const vite = await loadProjectViteApi(root);
-  const cacheConfig = await withCloudflareEnv(buildEnv, () =>
-    loadVinextCacheConfigFromViteConfig(vite, root),
-  );
   const kvConfig = resolveKvDataAdapterConfig(cacheConfig);
   if (!kvConfig) return;
 
@@ -820,9 +843,11 @@ export async function deploy(options: DeployOptions): Promise<void> {
   }
 
   const buildEnv = deployEnv === "production" && !options.env ? undefined : deployEnv;
+  const viteConfigMetadata = await withCloudflareEnv(buildEnv, () =>
+    loadDeployViteConfigMetadata(info.root),
+  );
   const nextConfig = await withCloudflareEnv(buildEnv, async () => {
-    const vite = await loadProjectViteApi(info.root);
-    const inlineNextConfig = await loadVinextNextConfigFromViteConfig(vite, info.root);
+    const inlineNextConfig = viteConfigMetadata.nextConfig;
     const rawNextConfig = inlineNextConfig
       ? await resolveNextConfigInput(inlineNextConfig, PHASE_PRODUCTION_BUILD)
       : await loadNextConfig(info.root, PHASE_PRODUCTION_BUILD);
@@ -831,10 +856,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
 
   const shouldLoadVinextPrerenderConfig = !options.prerenderAll && nextConfig.output !== "export";
   const vinextPrerenderConfig = shouldLoadVinextPrerenderConfig
-    ? await withCloudflareEnv(buildEnv, async () => {
-        const vite = await loadProjectViteApi(info.root);
-        return loadVinextPrerenderConfigFromViteConfig(vite, info.root);
-      })
+    ? viteConfigMetadata.prerenderConfig
     : null;
   const prerenderDecision = resolveVinextPrerenderDecision({
     prerenderAllFlag: options.prerenderAll,
@@ -852,14 +874,10 @@ export async function deploy(options: DeployOptions): Promise<void> {
   }
 
   if (shouldEmitPrerenderPathManifest) {
-    const routeRootConfig = await withCloudflareEnv(buildEnv, async () => {
-      const vite = await loadProjectViteApi(info.root);
-      return loadVinextRouteRootConfigFromViteConfig(vite, info.root);
-    });
     await emitPrerenderPathManifest({
       root: info.root,
       nextConfigOverride: nextConfig,
-      routeRootConfig,
+      routeRootConfig: viteConfigMetadata.routeRootConfig,
     });
   }
 
@@ -877,7 +895,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
     await runPrerender({
       root: info.root,
       concurrency: options.prerenderConcurrency,
-      nextConfigOverride: nextConfig,
+      nextConfig,
     });
     ranPrerender = true;
   }
@@ -886,8 +904,8 @@ export async function deploy(options: DeployOptions): Promise<void> {
     try {
       await populateKVCacheFromPrerenderedArtifacts(
         root,
-        buildEnv,
         deployEnv === "production" && !options.env ? undefined : deployEnv,
+        viteConfigMetadata.cacheConfig,
       );
     } catch (error) {
       console.log(

--- a/packages/vinext/src/build/prerender-paths.ts
+++ b/packages/vinext/src/build/prerender-paths.ts
@@ -37,7 +37,12 @@ const PATH_DISCOVERY_FETCH_TIMEOUT_MS = 30_000;
 
 type EmitPrerenderPathManifestOptions = {
   root: string;
+  /** Fully resolved Next.js config from the production build/deploy caller. */
   nextConfig?: ResolvedNextConfig;
+  /**
+   * Override next.config values. Merged on top of the config loaded from disk.
+   * Ignored when `nextConfig` is supplied.
+   */
   nextConfigOverride?: Partial<ResolvedNextConfig>;
   appDir?: string | null;
   pagesDir?: string | null;

--- a/packages/vinext/src/build/prerender-paths.ts
+++ b/packages/vinext/src/build/prerender-paths.ts
@@ -37,13 +37,8 @@ const PATH_DISCOVERY_FETCH_TIMEOUT_MS = 30_000;
 
 type EmitPrerenderPathManifestOptions = {
   root: string;
-  /** Fully resolved Next.js config from the production build/deploy caller. */
+  /** Fully resolved Next.js config. Loaded from disk when omitted. */
   nextConfig?: ResolvedNextConfig;
-  /**
-   * Override next.config values. Merged on top of the config loaded from disk.
-   * Ignored when `nextConfig` is supplied.
-   */
-  nextConfigOverride?: Partial<ResolvedNextConfig>;
   appDir?: string | null;
   pagesDir?: string | null;
   routeRootConfig?: VinextRouteRootConfig | null;
@@ -384,10 +379,7 @@ export async function emitPrerenderPathManifest(
   const manifestDir = path.join(root, "dist", "server");
   const config = options.nextConfig
     ? { ...options.nextConfig }
-    : {
-        ...(await resolveNextConfig(await loadNextConfig(root, PHASE_PRODUCTION_BUILD), root)),
-        ...options.nextConfigOverride,
-      };
+    : { ...(await resolveNextConfig(await loadNextConfig(root, PHASE_PRODUCTION_BUILD), root)) };
   const builtBuildId = readBuiltBuildId(manifestDir) ?? readBuiltBuildId(bundleServerDir);
   if (builtBuildId) {
     config.buildId = builtBuildId;

--- a/packages/vinext/src/build/prerender-paths.ts
+++ b/packages/vinext/src/build/prerender-paths.ts
@@ -1,7 +1,11 @@
 import fs from "node:fs";
 import path from "node:path";
 import type { Server as HttpServer } from "node:http";
-import { loadNextConfig, resolveNextConfig } from "../config/next-config.js";
+import {
+  loadNextConfig,
+  resolveNextConfig,
+  type ResolvedNextConfig,
+} from "../config/next-config.js";
 import { appRouter } from "../routing/app-router.js";
 import { apiRouter, pagesRouter } from "../routing/pages-router.js";
 import { normalizeStaticPathsEntry, type StaticPathsEntry } from "../routing/route-pattern.js";
@@ -33,7 +37,8 @@ const PATH_DISCOVERY_FETCH_TIMEOUT_MS = 30_000;
 
 type EmitPrerenderPathManifestOptions = {
   root: string;
-  nextConfigOverride?: Partial<import("../config/next-config.js").ResolvedNextConfig>;
+  nextConfig?: ResolvedNextConfig;
+  nextConfigOverride?: Partial<ResolvedNextConfig>;
   appDir?: string | null;
   pagesDir?: string | null;
   routeRootConfig?: VinextRouteRootConfig | null;
@@ -372,13 +377,12 @@ export async function emitPrerenderPathManifest(
     ? path.dirname(rscBundlePath)
     : path.dirname(pagesBundlePath);
   const manifestDir = path.join(root, "dist", "server");
-  const loadedConfig = await resolveNextConfig(
-    await loadNextConfig(root, PHASE_PRODUCTION_BUILD),
-    root,
-  );
-  const config = options.nextConfigOverride
-    ? { ...loadedConfig, ...options.nextConfigOverride }
-    : { ...loadedConfig };
+  const config = options.nextConfig
+    ? { ...options.nextConfig }
+    : {
+        ...(await resolveNextConfig(await loadNextConfig(root, PHASE_PRODUCTION_BUILD), root)),
+        ...options.nextConfigOverride,
+      };
   const builtBuildId = readBuiltBuildId(manifestDir) ?? readBuiltBuildId(bundleServerDir);
   if (builtBuildId) {
     config.buildId = builtBuildId;

--- a/packages/vinext/src/build/run-prerender.ts
+++ b/packages/vinext/src/build/run-prerender.ts
@@ -89,14 +89,8 @@ function readBuiltBuildId(serverDir: string): string | null {
 type RunPrerenderOptions = {
   /** Project root directory. */
   root: string;
-  /** Fully resolved Next.js config from the production build/deploy caller. */
+  /** Fully resolved Next.js config. Loaded from disk when omitted. */
   nextConfig?: import("../config/next-config.js").ResolvedNextConfig;
-  /**
-   * Override next.config values. Merged on top of the config loaded from disk.
-   * Intended for tests that need to exercise a specific config (e.g. output: 'export')
-   * without writing a next.config file.
-   */
-  nextConfigOverride?: Partial<import("../config/next-config.js").ResolvedNextConfig>;
   /**
    * Override the path to the Pages Router server bundle.
    * Defaults to `<root>/dist/server/entry.js`.
@@ -189,14 +183,7 @@ export async function runPrerender(options: RunPrerenderOptions): Promise<Preren
 
   const config = options.nextConfig
     ? { ...options.nextConfig }
-    : {
-        ...(await resolveNextConfig(await loadNextConfig(root), root)),
-        // Note: shallow merge — nested keys like `images` or `i18n` in
-        // nextConfigOverride replace the entire nested object from loadedConfig.
-        // This is intentional for test usage (top-level overrides only); a deep
-        // merge would be needed to support partial nested overrides in the future.
-        ...options.nextConfigOverride,
-      };
+    : { ...(await resolveNextConfig(await loadNextConfig(root), root)) };
   // Prerender must reuse the exact BUILD_ID that `vinext build` wrote to disk
   // rather than re-resolving a fresh one. `config.buildId` is consumed when
   // computing prerendered-output identity (prerender.ts), so re-resolving here

--- a/packages/vinext/src/build/run-prerender.ts
+++ b/packages/vinext/src/build/run-prerender.ts
@@ -89,6 +89,8 @@ function readBuiltBuildId(serverDir: string): string | null {
 type RunPrerenderOptions = {
   /** Project root directory. */
   root: string;
+  /** Fully resolved Next.js config from the production build/deploy caller. */
+  nextConfig?: import("../config/next-config.js").ResolvedNextConfig;
   /**
    * Override next.config values. Merged on top of the config loaded from disk.
    * Intended for tests that need to exercise a specific config (e.g. output: 'export')
@@ -185,14 +187,16 @@ export async function runPrerender(options: RunPrerenderOptions): Promise<Preren
   const rscBundlePath = options.rscBundlePath ?? path.join(root, "dist", "server", "index.js");
   const serverDir = path.dirname(rscBundlePath);
 
-  const loadedConfig = await resolveNextConfig(await loadNextConfig(root), root);
-  const config = options.nextConfigOverride
-    ? { ...loadedConfig, ...options.nextConfigOverride }
-    : // Note: shallow merge — nested keys like `images` or `i18n` in
-      // nextConfigOverride replace the entire nested object from loadedConfig.
-      // This is intentional for test usage (top-level overrides only); a deep
-      // merge would be needed to support partial nested overrides in the future.
-      { ...loadedConfig };
+  const config = options.nextConfig
+    ? { ...options.nextConfig }
+    : {
+        ...(await resolveNextConfig(await loadNextConfig(root), root)),
+        // Note: shallow merge — nested keys like `images` or `i18n` in
+        // nextConfigOverride replace the entire nested object from loadedConfig.
+        // This is intentional for test usage (top-level overrides only); a deep
+        // merge would be needed to support partial nested overrides in the future.
+        ...options.nextConfigOverride,
+      };
   // Prerender must reuse the exact BUILD_ID that `vinext build` wrote to disk
   // rather than re-resolving a fresh one. `config.buildId` is consumed when
   // computing prerendered-output identity (prerender.ts), so re-resolving here

--- a/packages/vinext/src/cache/cache-adapters-virtual.ts
+++ b/packages/vinext/src/cache/cache-adapters-virtual.ts
@@ -14,6 +14,7 @@
  * never touches the Workers runtime — instantiation is deferred to the first
  * request.
  */
+import { flattenPluginOptions } from "../utils/plugin-options.js";
 
 /**
  * A serializable pointer to a cache adapter module — the shape of each `cache`
@@ -59,23 +60,10 @@ type ViteConfigLoader = {
   loadConfigFromFile: typeof import("vite").loadConfigFromFile;
 };
 
-async function flattenPluginOptions(value: unknown, target: unknown[]): Promise<void> {
-  if (value instanceof Promise) {
-    await flattenPluginOptions(await value, target);
-    return;
-  }
-  if (Array.isArray(value)) {
-    for (const item of value) await flattenPluginOptions(item, target);
-    return;
-  }
-  if (value) target.push(value);
-}
-
 export async function findVinextCacheConfigInPlugins(
   plugins: import("vite").PluginOption[] | undefined,
 ): Promise<VinextCacheConfig | null> {
-  const flattened: unknown[] = [];
-  await flattenPluginOptions(plugins, flattened);
+  const flattened = await flattenPluginOptions(plugins);
 
   for (const plugin of flattened) {
     if (!plugin || typeof plugin !== "object") continue;

--- a/packages/vinext/src/cache/cache-adapters-virtual.ts
+++ b/packages/vinext/src/cache/cache-adapters-virtual.ts
@@ -59,19 +59,23 @@ type ViteConfigLoader = {
   loadConfigFromFile: typeof import("vite").loadConfigFromFile;
 };
 
-function flattenPluginOptions(value: unknown, target: unknown[]): void {
+async function flattenPluginOptions(value: unknown, target: unknown[]): Promise<void> {
+  if (value instanceof Promise) {
+    await flattenPluginOptions(await value, target);
+    return;
+  }
   if (Array.isArray(value)) {
-    for (const item of value) flattenPluginOptions(item, target);
+    for (const item of value) await flattenPluginOptions(item, target);
     return;
   }
   if (value) target.push(value);
 }
 
-export function findVinextCacheConfigInPlugins(
+export async function findVinextCacheConfigInPlugins(
   plugins: import("vite").PluginOption[] | undefined,
-): VinextCacheConfig | null {
+): Promise<VinextCacheConfig | null> {
   const flattened: unknown[] = [];
-  flattenPluginOptions(plugins, flattened);
+  await flattenPluginOptions(plugins, flattened);
 
   for (const plugin of flattened) {
     if (!plugin || typeof plugin !== "object") continue;
@@ -91,7 +95,7 @@ export async function loadVinextCacheConfigFromViteConfig(
     undefined,
     root,
   );
-  return findVinextCacheConfigInPlugins(loaded?.config.plugins);
+  return await findVinextCacheConfigInPlugins(loaded?.config.plugins);
 }
 
 /**

--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -53,7 +53,6 @@ import {
 } from "./server/dev-lockfile.js";
 import { generateRouteTypes } from "./typegen.js";
 import { normalizePathSeparators } from "./utils/path.js";
-import { selectHybridPagesUserPlugins } from "./utils/plugin-options.js";
 import { createDevServerConfigPlugin, normalizeDevServerHostname } from "./cli-dev-config.js";
 import {
   findVinextRouteRootConfigInPlugins,
@@ -617,7 +616,24 @@ async function buildApp() {
           root,
         );
         if (loaded?.config.plugins) {
-          userTransformPlugins = await selectHybridPagesUserPlugins(loaded.config.plugins);
+          const flat = (loaded.config.plugins as unknown[]).flat(Infinity) as {
+            name?: string;
+          }[];
+          userTransformPlugins = flat.filter(
+            (p): p is import("vite").Plugin =>
+              !!p &&
+              typeof p.name === "string" &&
+              // vinext and its sub-plugins — re-registered below
+              !p.name.startsWith("vinext:") &&
+              // @vitejs/plugin-react — auto-registered by vinext
+              !p.name.startsWith("vite:react") &&
+              // @vitejs/plugin-rsc and its sub-plugins — App Router only
+              !p.name.startsWith("rsc:") &&
+              p.name !== "vite-rsc-load-module-dev-proxy" &&
+              // cloudflare() — injects multi-env environments block which
+              // conflicts with the plain SSR build config below
+              !p.name.startsWith("vite-plugin-cloudflare"),
+          );
         }
       }
       await vite.build({

--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -53,6 +53,7 @@ import {
 } from "./server/dev-lockfile.js";
 import { generateRouteTypes } from "./typegen.js";
 import { normalizePathSeparators } from "./utils/path.js";
+import { selectHybridPagesUserPlugins } from "./utils/plugin-options.js";
 import { createDevServerConfigPlugin, normalizeDevServerHostname } from "./cli-dev-config.js";
 import {
   findVinextRouteRootConfigInPlugins,
@@ -616,24 +617,7 @@ async function buildApp() {
           root,
         );
         if (loaded?.config.plugins) {
-          const flat = (loaded.config.plugins as unknown[]).flat(Infinity) as {
-            name?: string;
-          }[];
-          userTransformPlugins = flat.filter(
-            (p): p is import("vite").Plugin =>
-              !!p &&
-              typeof p.name === "string" &&
-              // vinext and its sub-plugins — re-registered below
-              !p.name.startsWith("vinext:") &&
-              // @vitejs/plugin-react — auto-registered by vinext
-              !p.name.startsWith("vite:react") &&
-              // @vitejs/plugin-rsc and its sub-plugins — App Router only
-              !p.name.startsWith("rsc:") &&
-              p.name !== "vite-rsc-load-module-dev-proxy" &&
-              // cloudflare() — injects multi-env environments block which
-              // conflicts with the plain SSR build config below
-              !p.name.startsWith("vite-plugin-cloudflare"),
-          );
+          userTransformPlugins = await selectHybridPagesUserPlugins(loaded.config.plugins);
         }
       }
       await vite.build({

--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -255,8 +255,8 @@ async function loadBuildViteConfigMetadata(
   return {
     emptyOutDir: typeof emptyOutDir === "boolean" ? emptyOutDir : undefined,
     nextConfig: await findVinextNextConfigInPlugins(loaded?.config.plugins),
-    prerenderConfig: findVinextPrerenderConfigInPlugins(loaded?.config.plugins),
-    routeRootConfig: findVinextRouteRootConfigInPlugins(loaded?.config.plugins),
+    prerenderConfig: await findVinextPrerenderConfigInPlugins(loaded?.config.plugins),
+    routeRootConfig: await findVinextRouteRootConfigInPlugins(loaded?.config.plugins),
   };
 }
 
@@ -703,7 +703,7 @@ async function buildApp() {
     });
     await emitPrerenderPathManifest({
       root: normalizePathSeparators(process.cwd()),
-      nextConfigOverride: resolvedNextConfig,
+      nextConfig: resolvedNextConfig,
       routeRootConfig: buildConfigMetadata.routeRootConfig,
     });
   }

--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -699,7 +699,7 @@ async function buildApp() {
     prerenderResult = await runPrerender({
       root: normalizePathSeparators(process.cwd()),
       concurrency: parsed.prerenderConcurrency,
-      nextConfigOverride: resolvedNextConfig,
+      nextConfig: resolvedNextConfig,
     });
     await emitPrerenderPathManifest({
       root: normalizePathSeparators(process.cwd()),

--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -34,9 +34,12 @@ import { resolveInitOptions } from "./init-platform.js";
 import { loadDotenv } from "./config/dotenv.js";
 import {
   createRscCompatibilityId,
+  findVinextNextConfigInPlugins,
   loadNextConfig,
   resolveNextConfig,
+  resolveNextConfigInput,
   PHASE_PRODUCTION_BUILD,
+  type NextConfigInput,
 } from "./config/next-config.js";
 import { emitStandaloneOutput } from "./build/standalone.js";
 import { cleanBuildOutput } from "./build/clean-output.js";
@@ -228,6 +231,7 @@ function hasPagesDir(): boolean {
 
 type BuildViteConfigMetadata = {
   emptyOutDir?: boolean;
+  nextConfig: NextConfigInput | null;
   prerenderConfig: ResolvedVinextPrerenderConfig | null;
   routeRootConfig: VinextRouteRootConfig | null;
 };
@@ -236,7 +240,9 @@ async function loadBuildViteConfigMetadata(
   vite: ViteModule,
   root: string,
 ): Promise<BuildViteConfigMetadata> {
-  if (!hasViteConfig(root)) return { prerenderConfig: null, routeRootConfig: null };
+  if (!hasViteConfig(root)) {
+    return { nextConfig: null, prerenderConfig: null, routeRootConfig: null };
+  }
 
   // Read the raw user config before the multi-environment build so
   // `build.emptyOutDir: false` remains an escape hatch for vinext's upfront clean.
@@ -248,6 +254,7 @@ async function loadBuildViteConfigMetadata(
   const emptyOutDir = loaded?.config.build?.emptyOutDir;
   return {
     emptyOutDir: typeof emptyOutDir === "boolean" ? emptyOutDir : undefined,
+    nextConfig: await findVinextNextConfigInPlugins(loaded?.config.plugins),
     prerenderConfig: findVinextPrerenderConfigInPlugins(loaded?.config.plugins),
     routeRootConfig: findVinextRouteRootConfigInPlugins(loaded?.config.plugins),
   };
@@ -484,10 +491,11 @@ async function buildApp() {
 
   const root = process.cwd();
   const isApp = hasAppDir(normalizePathSeparators(root));
-  const resolvedNextConfig = await resolveNextConfig(
-    await loadNextConfig(root, PHASE_PRODUCTION_BUILD),
-    root,
-  );
+  const buildConfigMetadata = await loadBuildViteConfigMetadata(vite, root);
+  const rawNextConfig = buildConfigMetadata.nextConfig
+    ? await resolveNextConfigInput(buildConfigMetadata.nextConfig, PHASE_PRODUCTION_BUILD)
+    : await loadNextConfig(root, PHASE_PRODUCTION_BUILD);
+  const resolvedNextConfig = await resolveNextConfig(rawNextConfig, root);
 
   // Coordinate a single build ID across every vinext() plugin instance in this
   // build. A hybrid app+pages build runs the App Router multi-environment build
@@ -562,8 +570,6 @@ async function buildApp() {
       });
     }
   }
-
-  const buildConfigMetadata = await loadBuildViteConfigMetadata(vite, root);
 
   cleanBuildOutput({
     root,
@@ -693,6 +699,7 @@ async function buildApp() {
     prerenderResult = await runPrerender({
       root: normalizePathSeparators(process.cwd()),
       concurrency: parsed.prerenderConcurrency,
+      nextConfigOverride: resolvedNextConfig,
     });
     await emitPrerenderPathManifest({
       root: normalizePathSeparators(process.cwd()),

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -9,6 +9,7 @@ import { createRequire } from "node:module";
 import fs from "node:fs";
 import { fileURLToPath } from "node:url";
 import { randomUUID } from "node:crypto";
+import type { PluginOption } from "vite";
 import commonjs from "vite-plugin-commonjs";
 import { PHASE_DEVELOPMENT_SERVER } from "vinext/shims/constants";
 import { normalizePageExtensions } from "../routing/file-matcher.js";
@@ -17,6 +18,7 @@ import { isUnknownRecord } from "../utils/record.js";
 import { applyLocaleToRoutes, isExternalUrl } from "./config-matchers.js";
 import { loadTsconfigResolutionForRoot } from "./tsconfig-paths.js";
 import { loadCommonJsModule, shouldRetryAsCommonJs } from "../utils/commonjs-loader.js";
+export const VINEXT_NEXT_CONFIG_PLUGIN_PROPERTY = "__vinextNextConfig";
 
 /**
  * Parse a body size limit value (string or number) into bytes.
@@ -345,6 +347,53 @@ type NextConfigFactory = (
 ) => NextConfig | Promise<NextConfig>;
 
 export type NextConfigInput = NextConfig | NextConfigFactory;
+
+type VinextNextConfigPlugin = {
+  [VINEXT_NEXT_CONFIG_PLUGIN_PROPERTY]?: NextConfigInput | null;
+};
+
+type ViteConfigLoader = {
+  loadConfigFromFile: typeof import("vite").loadConfigFromFile;
+};
+
+async function flattenPluginOptions(value: unknown, target: unknown[]): Promise<void> {
+  if (value instanceof Promise) {
+    await flattenPluginOptions(await value, target);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) await flattenPluginOptions(item, target);
+    return;
+  }
+  if (value) target.push(value);
+}
+
+export async function findVinextNextConfigInPlugins(
+  plugins: PluginOption[] | undefined,
+): Promise<NextConfigInput | null> {
+  const flattened: unknown[] = [];
+  await flattenPluginOptions(plugins, flattened);
+
+  for (const plugin of flattened) {
+    if (!isUnknownRecord(plugin)) continue;
+    const nextConfig = (plugin as VinextNextConfigPlugin)[VINEXT_NEXT_CONFIG_PLUGIN_PROPERTY];
+    if (nextConfig) return nextConfig;
+  }
+
+  return null;
+}
+
+export async function loadVinextNextConfigFromViteConfig(
+  vite: ViteConfigLoader,
+  root: string,
+): Promise<NextConfigInput | null> {
+  const loaded = await vite.loadConfigFromFile(
+    { command: "build", mode: "production" },
+    undefined,
+    root,
+  );
+  return await findVinextNextConfigInPlugins(loaded?.config.plugins);
+}
 
 /**
  * Resolved configuration with all async values awaited.

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -14,6 +14,7 @@ import commonjs from "vite-plugin-commonjs";
 import { PHASE_DEVELOPMENT_SERVER } from "vinext/shims/constants";
 import { normalizePageExtensions } from "../routing/file-matcher.js";
 import { getHtmlLimitedBotRegex } from "../utils/html-limited-bots.js";
+import { flattenPluginOptions } from "../utils/plugin-options.js";
 import { isUnknownRecord } from "../utils/record.js";
 import { applyLocaleToRoutes, isExternalUrl } from "./config-matchers.js";
 import { loadTsconfigResolutionForRoot } from "./tsconfig-paths.js";
@@ -356,23 +357,10 @@ type ViteConfigLoader = {
   loadConfigFromFile: typeof import("vite").loadConfigFromFile;
 };
 
-async function flattenPluginOptions(value: unknown, target: unknown[]): Promise<void> {
-  if (value instanceof Promise) {
-    await flattenPluginOptions(await value, target);
-    return;
-  }
-  if (Array.isArray(value)) {
-    for (const item of value) await flattenPluginOptions(item, target);
-    return;
-  }
-  if (value) target.push(value);
-}
-
 export async function findVinextNextConfigInPlugins(
   plugins: PluginOption[] | undefined,
 ): Promise<NextConfigInput | null> {
-  const flattened: unknown[] = [];
-  await flattenPluginOptions(plugins, flattened);
+  const flattened = await flattenPluginOptions(plugins);
 
   for (const plugin of flattened) {
     if (!isUnknownRecord(plugin)) continue;

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -353,10 +353,6 @@ type VinextNextConfigPlugin = {
   [VINEXT_NEXT_CONFIG_PLUGIN_PROPERTY]?: NextConfigInput | null;
 };
 
-type ViteConfigLoader = {
-  loadConfigFromFile: typeof import("vite").loadConfigFromFile;
-};
-
 export async function findVinextNextConfigInPlugins(
   plugins: PluginOption[] | undefined,
 ): Promise<NextConfigInput | null> {
@@ -369,18 +365,6 @@ export async function findVinextNextConfigInPlugins(
   }
 
   return null;
-}
-
-export async function loadVinextNextConfigFromViteConfig(
-  vite: ViteConfigLoader,
-  root: string,
-): Promise<NextConfigInput | null> {
-  const loaded = await vite.loadConfigFromFile(
-    { command: "build", mode: "production" },
-    undefined,
-    root,
-  );
-  return await findVinextNextConfigInPlugins(loaded?.config.plugins);
 }
 
 /**

--- a/packages/vinext/src/config/prerender.ts
+++ b/packages/vinext/src/config/prerender.ts
@@ -1,4 +1,5 @@
 import type { PluginOption } from "vite";
+import { flattenPluginOptions } from "../utils/plugin-options.js";
 import { isUnknownRecord } from "../utils/record.js";
 export {
   findVinextCacheConfigInPlugins,
@@ -67,23 +68,10 @@ export function normalizeVinextPrerenderConfig(
   );
 }
 
-async function flattenPluginOptions(value: unknown, target: unknown[]): Promise<void> {
-  if (value instanceof Promise) {
-    await flattenPluginOptions(await value, target);
-    return;
-  }
-  if (Array.isArray(value)) {
-    for (const item of value) await flattenPluginOptions(item, target);
-    return;
-  }
-  if (value) target.push(value);
-}
-
 export async function findVinextPrerenderConfigInPlugins(
   plugins: PluginOption[] | undefined,
 ): Promise<ResolvedVinextPrerenderConfig | null> {
-  const flattened: unknown[] = [];
-  await flattenPluginOptions(plugins, flattened);
+  const flattened = await flattenPluginOptions(plugins);
 
   for (const plugin of flattened) {
     if (!isUnknownRecord(plugin)) continue;
@@ -99,8 +87,7 @@ export async function findVinextPrerenderConfigInPlugins(
 export async function findVinextRouteRootConfigInPlugins(
   plugins: PluginOption[] | undefined,
 ): Promise<VinextRouteRootConfig | null> {
-  const flattened: unknown[] = [];
-  await flattenPluginOptions(plugins, flattened);
+  const flattened = await flattenPluginOptions(plugins);
 
   for (const plugin of flattened) {
     if (!isUnknownRecord(plugin)) continue;

--- a/packages/vinext/src/config/prerender.ts
+++ b/packages/vinext/src/config/prerender.ts
@@ -67,19 +67,23 @@ export function normalizeVinextPrerenderConfig(
   );
 }
 
-function flattenPluginOptions(value: unknown, target: unknown[]): void {
+async function flattenPluginOptions(value: unknown, target: unknown[]): Promise<void> {
+  if (value instanceof Promise) {
+    await flattenPluginOptions(await value, target);
+    return;
+  }
   if (Array.isArray(value)) {
-    for (const item of value) flattenPluginOptions(item, target);
+    for (const item of value) await flattenPluginOptions(item, target);
     return;
   }
   if (value) target.push(value);
 }
 
-export function findVinextPrerenderConfigInPlugins(
+export async function findVinextPrerenderConfigInPlugins(
   plugins: PluginOption[] | undefined,
-): ResolvedVinextPrerenderConfig | null {
+): Promise<ResolvedVinextPrerenderConfig | null> {
   const flattened: unknown[] = [];
-  flattenPluginOptions(plugins, flattened);
+  await flattenPluginOptions(plugins, flattened);
 
   for (const plugin of flattened) {
     if (!isUnknownRecord(plugin)) continue;
@@ -92,11 +96,11 @@ export function findVinextPrerenderConfigInPlugins(
   return null;
 }
 
-export function findVinextRouteRootConfigInPlugins(
+export async function findVinextRouteRootConfigInPlugins(
   plugins: PluginOption[] | undefined,
-): VinextRouteRootConfig | null {
+): Promise<VinextRouteRootConfig | null> {
   const flattened: unknown[] = [];
-  flattenPluginOptions(plugins, flattened);
+  await flattenPluginOptions(plugins, flattened);
 
   for (const plugin of flattened) {
     if (!isUnknownRecord(plugin)) continue;
@@ -118,7 +122,7 @@ export async function loadVinextPrerenderConfigFromViteConfig(
     undefined,
     root,
   );
-  return findVinextPrerenderConfigInPlugins(loaded?.config.plugins);
+  return await findVinextPrerenderConfigInPlugins(loaded?.config.plugins);
 }
 
 export async function loadVinextRouteRootConfigFromViteConfig(
@@ -130,7 +134,7 @@ export async function loadVinextRouteRootConfigFromViteConfig(
     undefined,
     root,
   );
-  return findVinextRouteRootConfigInPlugins(loaded?.config.plugins);
+  return await findVinextRouteRootConfigInPlugins(loaded?.config.plugins);
 }
 
 export function resolveVinextPrerenderDecision(options: {

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -73,6 +73,7 @@ import { normalizePathnameForRouteMatchStrict } from "./routing/utils.js";
 import {
   createRscCompatibilityId,
   findNextConfigPath,
+  VINEXT_NEXT_CONFIG_PLUGIN_PROPERTY,
   loadNextConfig,
   resolveNextConfigInput,
   resolveNextConfig,
@@ -1731,6 +1732,10 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
       // Expose normalized prerender config to build/deploy metadata loaders that
       // inspect the Vite plugin array after a fresh config load.
       ...({ [VINEXT_PRERENDER_CONFIG_PLUGIN_PROPERTY]: prerenderConfig } as Record<
+        string,
+        unknown
+      >),
+      ...({ [VINEXT_NEXT_CONFIG_PLUGIN_PROPERTY]: options.nextConfig ?? null } as Record<
         string,
         unknown
       >),

--- a/packages/vinext/src/utils/plugin-options.ts
+++ b/packages/vinext/src/utils/plugin-options.ts
@@ -1,0 +1,27 @@
+export async function flattenPluginOptions(value: unknown): Promise<unknown[]> {
+  if (value instanceof Promise) {
+    return flattenPluginOptions(await value);
+  }
+  if (Array.isArray(value)) {
+    return (await Promise.all(value.map((item) => flattenPluginOptions(item)))).flat();
+  }
+  return value ? [value] : [];
+}
+
+export async function selectHybridPagesUserPlugins(
+  value: unknown,
+): Promise<import("vite").Plugin[]> {
+  const flattened = await flattenPluginOptions(value);
+  return flattened.filter(
+    (plugin): plugin is import("vite").Plugin =>
+      !!plugin &&
+      typeof plugin === "object" &&
+      "name" in plugin &&
+      typeof plugin.name === "string" &&
+      !plugin.name.startsWith("vinext:") &&
+      !plugin.name.startsWith("vite:react") &&
+      !plugin.name.startsWith("rsc:") &&
+      plugin.name !== "vite-rsc-load-module-dev-proxy" &&
+      !plugin.name.startsWith("vite-plugin-cloudflare"),
+  );
+}

--- a/packages/vinext/src/utils/plugin-options.ts
+++ b/packages/vinext/src/utils/plugin-options.ts
@@ -7,21 +7,3 @@ export async function flattenPluginOptions(value: unknown): Promise<unknown[]> {
   }
   return value ? [value] : [];
 }
-
-export async function selectHybridPagesUserPlugins(
-  value: unknown,
-): Promise<import("vite").Plugin[]> {
-  const flattened = await flattenPluginOptions(value);
-  return flattened.filter(
-    (plugin): plugin is import("vite").Plugin =>
-      !!plugin &&
-      typeof plugin === "object" &&
-      "name" in plugin &&
-      typeof plugin.name === "string" &&
-      !plugin.name.startsWith("vinext:") &&
-      !plugin.name.startsWith("vite:react") &&
-      !plugin.name.startsWith("rsc:") &&
-      plugin.name !== "vite-rsc-load-module-dev-proxy" &&
-      !plugin.name.startsWith("vite-plugin-cloudflare"),
-  );
-}

--- a/tests/cache-adapters-config.test.ts
+++ b/tests/cache-adapters-config.test.ts
@@ -121,13 +121,22 @@ describe("generateCacheAdaptersModule", () => {
 });
 
 describe("findVinextCacheConfigInPlugins", () => {
-  it("reads cache metadata from nested plugin arrays", () => {
+  it("reads cache metadata from nested plugin arrays", async () => {
     const cache = { data: { adapter: "adapter", options: { binding: "MY_KV" } } };
     const plugins = [[{ [VINEXT_CACHE_CONFIG_PLUGIN_PROPERTY]: cache }]] as unknown as Parameters<
       typeof findVinextCacheConfigInPlugins
     >[0];
 
-    expect(findVinextCacheConfigInPlugins(plugins)).toBe(cache);
+    expect(await findVinextCacheConfigInPlugins(plugins)).toBe(cache);
+  });
+
+  it("reads cache metadata from promised plugin composition", async () => {
+    const cache = { data: { adapter: "adapter", options: { binding: "MY_KV" } } };
+    const plugins = [
+      Promise.resolve([{ [VINEXT_CACHE_CONFIG_PLUGIN_PROPERTY]: cache }]),
+    ] as unknown as Parameters<typeof findVinextCacheConfigInPlugins>[0];
+
+    expect(await findVinextCacheConfigInPlugins(plugins)).toBe(cache);
   });
 });
 

--- a/tests/cache-adapters-config.test.ts
+++ b/tests/cache-adapters-config.test.ts
@@ -14,6 +14,7 @@ import path from "node:path";
 import { describe, it, expect } from "vite-plus/test";
 import {
   findVinextCacheConfigInPlugins,
+  loadVinextCacheConfigFromViteConfig,
   generateCacheAdaptersModule,
   VINEXT_CACHE_CONFIG_PLUGIN_PROPERTY,
   VIRTUAL_CACHE_ADAPTERS,
@@ -137,6 +138,19 @@ describe("findVinextCacheConfigInPlugins", () => {
     ] as unknown as Parameters<typeof findVinextCacheConfigInPlugins>[0];
 
     expect(await findVinextCacheConfigInPlugins(plugins)).toBe(cache);
+  });
+
+  it("preserves promise-aware cache loading through the internal Vite wrapper", async () => {
+    const cache = { data: { adapter: "adapter", options: { binding: "MY_KV" } } };
+    const vite = {
+      loadConfigFromFile: async () => ({
+        config: {
+          plugins: [Promise.resolve({ [VINEXT_CACHE_CONFIG_PLUGIN_PROPERTY]: cache })],
+        },
+      }),
+    } as never;
+
+    await expect(loadVinextCacheConfigFromViteConfig(vite, "/tmp/app")).resolves.toBe(cache);
   });
 });
 

--- a/tests/deploy-prerender-config.test.ts
+++ b/tests/deploy-prerender-config.test.ts
@@ -90,6 +90,33 @@ function writeProject(prerenderConfig: string, cacheConfig?: string): void {
   );
 }
 
+function writeProjectWithInlineNextConfig(nextConfig: string): void {
+  writeFile("package.json", JSON.stringify({ name: "inline-next-config-app", type: "module" }));
+  writeFile("app/page.tsx", "export default function Page() { return <div>home</div>; }\n");
+  writeFile(
+    "node_modules/@cloudflare/vite-plugin/package.json",
+    JSON.stringify({ name: "@cloudflare/vite-plugin", type: "module", main: "index.js" }),
+  );
+  writeFile(
+    "node_modules/@cloudflare/vite-plugin/index.js",
+    "export function cloudflare() { return { name: 'test-cloudflare-plugin' }; }\n",
+  );
+  writeFile(
+    "wrangler.jsonc",
+    '{"main":"vinext/server/app-router-entry","assets":{"directory":"dist/client"}}\n',
+  );
+  writeFile(
+    "vite.config.ts",
+    [
+      'import { cloudflare } from "@cloudflare/vite-plugin";',
+      'import vinext from "../packages/vinext/src/index";',
+      "",
+      `export default { plugins: [vinext({ nextConfig: ${nextConfig} }), cloudflare()] };`,
+      "",
+    ].join("\n"),
+  );
+}
+
 function writeApiOnlyProject(): void {
   writeFile("package.json", JSON.stringify({ name: "warm-skip-build-app", type: "module" }));
   writeFile(
@@ -125,37 +152,6 @@ function writeApiOnlyProject(): void {
   writeFile("dist/server/index.js", "export default {};\n");
 }
 
-function writeProjectWithThrowingViteConfig(): void {
-  writeFile("package.json", JSON.stringify({ name: "prerender-config-app", type: "module" }));
-  writeFile("app/page.tsx", "export default function Page() { return <div>home</div>; }\n");
-  writeFile(
-    "node_modules/@cloudflare/vite-plugin/package.json",
-    JSON.stringify({ name: "@cloudflare/vite-plugin", type: "module", main: "index.js" }),
-  );
-  writeFile(
-    "node_modules/@cloudflare/vite-plugin/index.js",
-    "export function cloudflare() { return { name: 'test-cloudflare-plugin' }; }\n",
-  );
-  writeFile(
-    "wrangler.jsonc",
-    '{"main":"vinext/server/app-router-entry","assets":{"directory":"dist/client"}}\n',
-  );
-  writeFile("throws-on-load.js", 'throw new Error("vite config loaded unexpectedly");\n');
-  writeFile(
-    "vite.config.ts",
-    [
-      'import "./throws-on-load.js";',
-      'import { cloudflare } from "@cloudflare/vite-plugin";',
-      'import vinext from "../packages/vinext/src/index";',
-      "",
-      "export default {",
-      "  plugins: [vinext(), cloudflare({ viteEnvironment: { name: 'rsc', childEnvironments: ['ssr'] } })],",
-      "};",
-      "",
-    ].join("\n"),
-  );
-}
-
 describe("deploy prerender config wiring", () => {
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(process.cwd(), ".tmp-vinext-deploy-prerender-"));
@@ -173,7 +169,13 @@ describe("deploy prerender config wiring", () => {
 
     await deploy({ root: tmpDir, skipBuild: true });
 
-    expect(runPrerenderMock).toHaveBeenCalledWith({ root: tmpDir, concurrency: undefined });
+    expect(runPrerenderMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        root: tmpDir,
+        concurrency: undefined,
+        nextConfigOverride: expect.any(Object),
+      }),
+    );
     expect(
       vi.mocked(spawn).mock.calls.some(([, args]) => {
         const wranglerArgs = args as string[];
@@ -188,7 +190,28 @@ describe("deploy prerender config wiring", () => {
 
     await deploy({ root: tmpDir, skipBuild: true });
 
-    expect(runPrerenderMock).toHaveBeenCalledWith({ root: tmpDir, concurrency: undefined });
+    expect(runPrerenderMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        root: tmpDir,
+        concurrency: undefined,
+        nextConfigOverride: expect.any(Object),
+      }),
+    );
+  });
+
+  it("runs static export during deploy when output export is configured inline", async () => {
+    writeProjectWithInlineNextConfig('{ output: "export" }');
+    const { deploy } = await import("../packages/cloudflare/src/deploy.js");
+
+    await deploy({ root: tmpDir, skipBuild: true });
+
+    expect(runPrerenderMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        root: tmpDir,
+        concurrency: undefined,
+        nextConfigOverride: expect.objectContaining({ output: "export" }),
+      }),
+    );
   });
 
   it("passes deploy prerender concurrency through config-triggered prerender", async () => {
@@ -197,27 +220,24 @@ describe("deploy prerender config wiring", () => {
 
     await deploy({ root: tmpDir, skipBuild: true, prerenderConcurrency: 3 });
 
-    expect(runPrerenderMock).toHaveBeenCalledWith({ root: tmpDir, concurrency: 3 });
+    expect(runPrerenderMock).toHaveBeenCalledWith(
+      expect.objectContaining({ root: tmpDir, concurrency: 3 }),
+    );
   });
 
-  it("does not load Vite config when the prerender-all flag already wins", async () => {
-    writeProjectWithThrowingViteConfig();
+  it("resolves function-form inline config inside the selected Cloudflare environment", async () => {
+    writeProjectWithInlineNextConfig(
+      '() => ({ output: process.env.CLOUDFLARE_ENV === "preview" ? "export" : undefined, generateBuildId: () => process.env.CLOUDFLARE_ENV ?? "missing" })',
+    );
     const { deploy } = await import("../packages/cloudflare/src/deploy.js");
 
-    await deploy({ root: tmpDir, skipBuild: true, prerenderAll: true });
+    await deploy({ root: tmpDir, skipBuild: true, env: "preview" });
 
-    expect(runPrerenderMock).toHaveBeenCalledWith({ root: tmpDir, concurrency: undefined });
-    expect(fs.existsSync(path.join(tmpDir, "dist/server/vinext-prerender-paths.json"))).toBe(false);
-  });
-
-  it("does not load Vite config when static export already wins", async () => {
-    writeProjectWithThrowingViteConfig();
-    writeFile("next.config.mjs", 'export default { output: "export" };\n');
-    const { deploy } = await import("../packages/cloudflare/src/deploy.js");
-
-    await deploy({ root: tmpDir, skipBuild: true });
-
-    expect(runPrerenderMock).toHaveBeenCalledWith({ root: tmpDir, concurrency: undefined });
+    expect(runPrerenderMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nextConfigOverride: expect.objectContaining({ output: "export", buildId: "preview" }),
+      }),
+    );
   });
 
   it("uploads prerendered App Router artifacts to KV only when configured in Vite", async () => {

--- a/tests/deploy-prerender-config.test.ts
+++ b/tests/deploy-prerender-config.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
-import { spawn, type ChildProcess } from "node:child_process";
+import { execFileSync, spawn, type ChildProcess } from "node:child_process";
 
 const runPrerenderMock = vi.hoisted(() => vi.fn(async () => ({ routes: [] })));
 
@@ -23,6 +23,21 @@ vi.mock("node:child_process", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:child_process")>();
   return {
     ...actual,
+    execFileSync: vi.fn((_file: string, args: string[]) => {
+      if (args.includes("upload")) {
+        return "Uploaded version 22222222-2222-4222-8222-222222222222\n";
+      }
+      if (args.includes("status")) {
+        return JSON.stringify({ versions: [] });
+      }
+      if (args.includes("deploy")) {
+        return "Deployed version\n";
+      }
+      if (args.includes("triggers")) {
+        return "Triggers deployed\n";
+      }
+      throw new Error(`Unexpected Wrangler args: ${args.join(" ")}`);
+    }),
     spawn: vi.fn(() => {
       const child = new EventEmitter() as ChildProcess;
       const childStdout = new PassThrough();
@@ -156,6 +171,7 @@ describe("deploy prerender config wiring", () => {
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(process.cwd(), ".tmp-vinext-deploy-prerender-"));
     runPrerenderMock.mockClear();
+    vi.mocked(execFileSync).mockClear();
     vi.mocked(spawn).mockClear();
   });
 
@@ -173,7 +189,7 @@ describe("deploy prerender config wiring", () => {
       expect.objectContaining({
         root: tmpDir,
         concurrency: undefined,
-        nextConfigOverride: expect.any(Object),
+        nextConfig: expect.any(Object),
       }),
     );
     expect(
@@ -194,9 +210,54 @@ describe("deploy prerender config wiring", () => {
       expect.objectContaining({
         root: tmpDir,
         concurrency: undefined,
-        nextConfigOverride: expect.any(Object),
+        nextConfig: expect.any(Object),
       }),
     );
+  });
+
+  it("loads Vite config once for all deploy metadata", async () => {
+    writeProject("true", '{ data: kvDataAdapter({ binding: "MY_KV" }) }');
+    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile("dist/server/index.js", "export default {};\n");
+    runPrerenderMock.mockImplementationOnce(async () => {
+      writeFile(
+        "dist/server/vinext-prerender.json",
+        JSON.stringify({
+          buildId: "build-a",
+          routes: [{ route: "/about", status: "rendered", revalidate: 60, router: "app" }],
+        }),
+      );
+      writeFile("dist/server/prerendered-routes/about.html", "<html>About</html>");
+      writeFile("dist/server/prerendered-routes/about.rsc", "flight");
+      return { routes: [] };
+    });
+    writeFile(
+      "count-config-load.js",
+      [
+        'import fs from "node:fs";',
+        'const countPath = new URL("./config-load-count.txt", import.meta.url);',
+        'const count = fs.existsSync(countPath) ? Number(fs.readFileSync(countPath, "utf8")) : 0;',
+        "fs.writeFileSync(countPath, String(count + 1));",
+        "",
+      ].join("\n"),
+    );
+    const viteConfigPath = path.join(tmpDir, "vite.config.ts");
+    fs.writeFileSync(
+      viteConfigPath,
+      `import "./count-config-load.js";\n${fs.readFileSync(viteConfigPath, "utf8")}`,
+    );
+    const { deploy } = await import("../packages/cloudflare/src/deploy.js");
+
+    await deploy({ root: tmpDir, skipBuild: true, warmCdnCache: true });
+
+    expect(fs.readFileSync(path.join(tmpDir, "config-load-count.txt"), "utf8")).toBe("1");
+    expect(fs.existsSync(path.join(tmpDir, "dist/server/vinext-prerender-paths.json"))).toBe(true);
+    expect(
+      vi.mocked(spawn).mock.calls.some(([, args]) => {
+        const wranglerArgs = args as string[];
+        return wranglerArgs.includes("kv") && wranglerArgs.includes("bulk");
+      }),
+    ).toBe(true);
   });
 
   it("runs static export during deploy when output export is configured inline", async () => {
@@ -209,7 +270,7 @@ describe("deploy prerender config wiring", () => {
       expect.objectContaining({
         root: tmpDir,
         concurrency: undefined,
-        nextConfigOverride: expect.objectContaining({ output: "export" }),
+        nextConfig: expect.objectContaining({ output: "export" }),
       }),
     );
   });
@@ -235,7 +296,7 @@ describe("deploy prerender config wiring", () => {
 
     expect(runPrerenderMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        nextConfigOverride: expect.objectContaining({ output: "export", buildId: "preview" }),
+        nextConfig: expect.objectContaining({ output: "export", buildId: "preview" }),
       }),
     );
   });

--- a/tests/deploy-prerender-config.test.ts
+++ b/tests/deploy-prerender-config.test.ts
@@ -215,6 +215,31 @@ describe("deploy prerender config wiring", () => {
     );
   });
 
+  it("loads Vite config even when the prerender-all flag already decides prerendering", async () => {
+    writeProject("true");
+    fs.appendFileSync(
+      path.join(tmpDir, "vite.config.ts"),
+      '\nthrow new Error("vite config loaded");\n',
+    );
+    const { deploy } = await import("../packages/cloudflare/src/deploy.js");
+
+    await expect(deploy({ root: tmpDir, skipBuild: true, prerenderAll: true })).rejects.toThrow(
+      "vite config loaded",
+    );
+  });
+
+  it("loads Vite config even when disk config already enables static export", async () => {
+    writeProject("true");
+    writeFile("next.config.mjs", 'export default { output: "export" };\n');
+    fs.appendFileSync(
+      path.join(tmpDir, "vite.config.ts"),
+      '\nthrow new Error("vite config loaded");\n',
+    );
+    const { deploy } = await import("../packages/cloudflare/src/deploy.js");
+
+    await expect(deploy({ root: tmpDir, skipBuild: true })).rejects.toThrow("vite config loaded");
+  });
+
   it("loads Vite config once for all deploy metadata", async () => {
     writeProject("true", '{ data: kvDataAdapter({ binding: "MY_KV" }) }');
     writeFile("dist/server/BUILD_ID", "build-a\n");

--- a/tests/plugin-options.test.ts
+++ b/tests/plugin-options.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from "vite-plus/test";
-import {
-  flattenPluginOptions,
-  selectHybridPagesUserPlugins,
-} from "../packages/vinext/src/utils/plugin-options.js";
+import { flattenPluginOptions } from "../packages/vinext/src/utils/plugin-options.js";
 
 describe("flattenPluginOptions", () => {
   it("resolves nested promised plugin composition in order", async () => {
@@ -12,20 +9,5 @@ describe("flattenPluginOptions", () => {
     await expect(
       flattenPluginOptions([Promise.resolve([first, false]), [[Promise.resolve(second)]]]),
     ).resolves.toEqual([first, second]);
-  });
-
-  it("selects promised hybrid user plugins and excludes framework plugin families", async () => {
-    const userPlugin = { name: "vite:svgr" };
-    const selected = await selectHybridPagesUserPlugins([
-      Promise.resolve(userPlugin),
-      { name: "vinext:config" },
-      { name: "vite:react-babel" },
-      { name: "rsc:build" },
-      { name: "vite-rsc-load-module-dev-proxy" },
-      { name: "vite-plugin-cloudflare" },
-      false,
-    ]);
-
-    expect(selected).toEqual([userPlugin]);
   });
 });

--- a/tests/plugin-options.test.ts
+++ b/tests/plugin-options.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  flattenPluginOptions,
+  selectHybridPagesUserPlugins,
+} from "../packages/vinext/src/utils/plugin-options.js";
+
+describe("flattenPluginOptions", () => {
+  it("resolves nested promised plugin composition in order", async () => {
+    const first = { name: "first" };
+    const second = { name: "second" };
+
+    await expect(
+      flattenPluginOptions([Promise.resolve([first, false]), [[Promise.resolve(second)]]]),
+    ).resolves.toEqual([first, second]);
+  });
+
+  it("selects promised hybrid user plugins and excludes framework plugin families", async () => {
+    const userPlugin = { name: "vite:svgr" };
+    const selected = await selectHybridPagesUserPlugins([
+      Promise.resolve(userPlugin),
+      { name: "vinext:config" },
+      { name: "vite:react-babel" },
+      { name: "rsc:build" },
+      { name: "vite-rsc-load-module-dev-proxy" },
+      { name: "vite-plugin-cloudflare" },
+      false,
+    ]);
+
+    expect(selected).toEqual([userPlugin]);
+  });
+});

--- a/tests/prerender-config.test.ts
+++ b/tests/prerender-config.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vite-plus/test";
 import vinext from "../packages/vinext/src/index.js";
 import {
+  findVinextNextConfigInPlugins,
+  resolveNextConfigInput,
+} from "../packages/vinext/src/config/next-config.js";
+import { PHASE_PRODUCTION_BUILD } from "../packages/vinext/src/shims/constants.js";
+import {
   findVinextPrerenderConfigInPlugins,
   formatVinextPrerenderLabel,
   normalizeVinextPrerenderConfig,
@@ -40,6 +45,31 @@ describe("vinext prerender config", () => {
   it("exposes object-form config on the vinext plugin", () => {
     const plugins = vinext({ prerender: { routes: "*" } });
     expect(findVinextPrerenderConfigInPlugins(plugins)).toEqual({ routes: "*" });
+  });
+
+  it("exposes inline Next.js config on the vinext plugin for CLI build metadata", async () => {
+    const nextConfig = { output: "export" } as const;
+    const plugins = vinext({ nextConfig });
+    expect(await findVinextNextConfigInPlugins(plugins)).toBe(nextConfig);
+  });
+
+  it("discovers inline Next.js config through promised plugin composition", async () => {
+    const nextConfig = { output: "export" } as const;
+    const plugins = Promise.resolve(vinext({ nextConfig }));
+    expect(await findVinextNextConfigInPlugins([plugins])).toBe(nextConfig);
+  });
+
+  it("preserves function-form inline config for production build resolution", async () => {
+    const nextConfig = (phase: string) => ({
+      output: phase === PHASE_PRODUCTION_BUILD ? ("export" as const) : undefined,
+    });
+    const plugins = vinext({ nextConfig });
+    const discoveredConfig = await findVinextNextConfigInPlugins(plugins);
+
+    expect(discoveredConfig).toBe(nextConfig);
+    expect(await resolveNextConfigInput(discoveredConfig!, PHASE_PRODUCTION_BUILD)).toEqual({
+      output: "export",
+    });
   });
 
   it("chooses the CLI flag before config or static export", () => {

--- a/tests/prerender-config.test.ts
+++ b/tests/prerender-config.test.ts
@@ -7,6 +7,7 @@ import {
 import { PHASE_PRODUCTION_BUILD } from "../packages/vinext/src/shims/constants.js";
 import {
   findVinextPrerenderConfigInPlugins,
+  findVinextRouteRootConfigInPlugins,
   formatVinextPrerenderLabel,
   normalizeVinextPrerenderConfig,
   resolveVinextPrerenderDecision,
@@ -37,14 +38,27 @@ describe("vinext prerender config", () => {
     ).toThrow('Currently only `routes: "*"` is supported');
   });
 
-  it("exposes normalized config on the vinext plugin for build-time config loading", () => {
+  it("exposes normalized config on the vinext plugin for build-time config loading", async () => {
     const plugins = vinext({ prerender: true });
-    expect(findVinextPrerenderConfigInPlugins(plugins)).toEqual({ routes: "*" });
+    expect(await findVinextPrerenderConfigInPlugins(plugins)).toEqual({ routes: "*" });
   });
 
-  it("exposes object-form config on the vinext plugin", () => {
+  it("exposes object-form config on the vinext plugin", async () => {
     const plugins = vinext({ prerender: { routes: "*" } });
-    expect(findVinextPrerenderConfigInPlugins(plugins)).toEqual({ routes: "*" });
+    expect(await findVinextPrerenderConfigInPlugins(plugins)).toEqual({ routes: "*" });
+  });
+
+  it("discovers prerender config through promised plugin composition", async () => {
+    const plugins = [Promise.resolve(vinext({ prerender: true }))];
+    expect(await findVinextPrerenderConfigInPlugins(plugins)).toEqual({ routes: "*" });
+  });
+
+  it("discovers route-root config through promised plugin composition", async () => {
+    const plugins = [Promise.resolve(vinext({ appDir: "custom-app", disableAppRouter: true }))];
+    expect(await findVinextRouteRootConfigInPlugins(plugins)).toMatchObject({
+      appDir: "custom-app",
+      disableAppRouter: true,
+    });
   });
 
   it("exposes inline Next.js config on the vinext plugin for CLI build metadata", async () => {

--- a/tests/prerender-config.test.ts
+++ b/tests/prerender-config.test.ts
@@ -10,6 +10,8 @@ import {
   findVinextRouteRootConfigInPlugins,
   formatVinextPrerenderLabel,
   normalizeVinextPrerenderConfig,
+  loadVinextPrerenderConfigFromViteConfig,
+  loadVinextRouteRootConfigFromViteConfig,
   resolveVinextPrerenderDecision,
 } from "../packages/vinext/src/config/prerender.js";
 
@@ -58,6 +60,20 @@ describe("vinext prerender config", () => {
     expect(await findVinextRouteRootConfigInPlugins(plugins)).toMatchObject({
       appDir: "custom-app",
       disableAppRouter: true,
+    });
+  });
+
+  it("preserves promise-aware metadata loading through the internal Vite wrappers", async () => {
+    const plugins = Promise.resolve(vinext({ prerender: true, appDir: "custom-app" }));
+    const vite = {
+      loadConfigFromFile: async () => ({ config: { plugins: [plugins] } }),
+    } as never;
+
+    await expect(loadVinextPrerenderConfigFromViteConfig(vite, "/tmp/app")).resolves.toEqual({
+      routes: "*",
+    });
+    await expect(loadVinextRouteRootConfigFromViteConfig(vite, "/tmp/app")).resolves.toMatchObject({
+      appDir: "custom-app",
     });
   });
 

--- a/tests/prerender-paths.test.ts
+++ b/tests/prerender-paths.test.ts
@@ -245,4 +245,23 @@ describe("prerender path manifest", () => {
 
     expect(manifest?.paths).toEqual(["/pages-only"]);
   });
+
+  it("does not reload disk config when supplied resolved config", async () => {
+    writeFile("package.json", JSON.stringify({ type: "module" }));
+    writeFile("next.config.mjs", 'throw new Error("disk config loaded unexpectedly");\n');
+    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile("dist/server/index.js", "export default {};\n");
+    writeFile("app/page.tsx", "export default function Page() { return null; }\n");
+
+    const [{ emitPrerenderPathManifest }, { resolveNextConfig }] = await Promise.all([
+      import("../packages/vinext/src/build/prerender-paths.js"),
+      import("../packages/vinext/src/config/next-config.js"),
+    ]);
+    const nextConfig = await resolveNextConfig({ trailingSlash: true }, tmpDir);
+
+    const manifest = await emitPrerenderPathManifest({ root: tmpDir, nextConfig });
+
+    expect(manifest?.trailingSlash).toBe(true);
+    expect(manifest?.paths).toEqual(["/"]);
+  });
 });

--- a/tests/prerender.test.ts
+++ b/tests/prerender.test.ts
@@ -1525,6 +1525,30 @@ describe("runPrerender — output: 'export' wiring", () => {
     ).rejects.toThrow(/Static export failed/);
   });
 
+  it("does not reload disk config when the caller supplies resolved config", async () => {
+    const configPath = path.join(PAGES_FIXTURE, "next.config.mjs");
+    const originalConfig = fs.readFileSync(configPath, "utf-8");
+
+    try {
+      fs.writeFileSync(configPath, 'throw new Error("disk config loaded unexpectedly");\n');
+      const [{ runPrerender }, { resolveNextConfig }] = await Promise.all([
+        import("../packages/vinext/src/build/run-prerender.js"),
+        import("../packages/vinext/src/config/next-config.js"),
+      ]);
+      const nextConfig = await resolveNextConfig({ output: "export" }, PAGES_FIXTURE);
+
+      await expect(
+        runPrerender({
+          root: PAGES_FIXTURE,
+          nextConfig,
+          pagesBundlePath,
+        }),
+      ).rejects.toThrow(/Static export failed/);
+    } finally {
+      fs.writeFileSync(configPath, originalConfig);
+    }
+  });
+
   it("does not rewrite the Worker entry when prerender validation fails", async () => {
     const workerEntry = path.join(PAGES_FIXTURE, "dist", "server", "index.js");
     const source = 'export default { fetch() { return new Response("unchanged"); } };\n';

--- a/tests/prerender.test.ts
+++ b/tests/prerender.test.ts
@@ -1506,12 +1506,17 @@ describe("prerenderApp — cacheComponents PPR fallback-shell artifacts", () => 
 
 describe("runPrerender — output: 'export' wiring", () => {
   let pagesBundlePath: string;
+  let exportNextConfig: Awaited<
+    ReturnType<typeof import("../packages/vinext/src/config/next-config.js").resolveNextConfig>
+  >;
 
   beforeAll(async () => {
     // Build pages-basic to a fresh tmpdir — no fixture copying needed.
-    // Pass the bundle path and a nextConfigOverride to runPrerender so it
+    // Pass the bundle path and resolved config to runPrerender so it
     // exercises output: 'export' without touching the real next.config.mjs.
     pagesBundlePath = await buildPagesFixture(PAGES_FIXTURE);
+    const { resolveNextConfig } = await import("../packages/vinext/src/config/next-config.js");
+    exportNextConfig = await resolveNextConfig({ output: "export" }, PAGES_FIXTURE);
   }, 120_000);
 
   it("throws when next.config output: 'export' and SSR routes exist", async () => {
@@ -1519,7 +1524,7 @@ describe("runPrerender — output: 'export' wiring", () => {
     await expect(
       runPrerender({
         root: PAGES_FIXTURE,
-        nextConfigOverride: { output: "export" },
+        nextConfig: exportNextConfig,
         pagesBundlePath,
       }),
     ).rejects.toThrow(/Static export failed/);
@@ -1560,7 +1565,7 @@ describe("runPrerender — output: 'export' wiring", () => {
       await expect(
         runPrerender({
           root: PAGES_FIXTURE,
-          nextConfigOverride: { output: "export" },
+          nextConfig: exportNextConfig,
           pagesBundlePath,
         }),
       ).rejects.toThrow(/Static export failed/);
@@ -1576,7 +1581,7 @@ describe("runPrerender — output: 'export' wiring", () => {
     await expect(
       runPrerender({
         root: PAGES_FIXTURE,
-        nextConfigOverride: { output: "export" },
+        nextConfig: exportNextConfig,
         pagesBundlePath,
       }),
     ).rejects.toThrow(/\/ssr/);


### PR DESCRIPTION
## Summary

- expose `vinext({ nextConfig })` through Vite plugin metadata for CLI/deploy config discovery
- resolve inline object/function config before output-mode decisions and pass the resolved config into prerender execution
- keep Cloudflare deploy config resolution inside the selected `CLOUDFLARE_ENV`
- support promised/nested Vite plugin composition when discovering inline config

## Root cause

`vinext build` and `vinext-cloudflare deploy` decided whether to use static export from `next.config.*` before reading the Vite plugin's inline `nextConfig`. Even after selecting prerendering, the prerender runner reloaded disk config, so inline-only `output: "export"` did not receive export output/error semantics.

## Validation

- `vp test run tests/deploy-prerender-config.test.ts tests/prerender-config.test.ts` (23 tests)
- `vp check packages/cloudflare/src/deploy.ts packages/vinext/src/cli.ts packages/vinext/src/config/next-config.ts packages/vinext/src/index.ts tests/deploy-prerender-config.test.ts tests/prerender-config.test.ts`
- `vp run @vinext/cloudflare#build`
- `vp run vinext#build`
- manual real CLI reproduction with inline `nextConfig.output = "export"`; confirmed export-mode log and HTML at `dist/client/index.html` and `dist/client/old-school.html`
- two independent reviews: no findings

Closes #2542
