### PR TITLE
fix(pages): preserve fast refresh state

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1,6 +1,7 @@
 import type {
   Alias,
   CSSModulesOptions,
+  HotUpdateOptions,
   Logger,
   Plugin,
   PluginOption,
@@ -3981,56 +3982,61 @@ export const loadServerActionClient = ${
     {
       name: "vinext:pages-router",
 
-      // HMR: trigger full-reload for Pages Router page changes.
-      // Even with @vitejs/plugin-react providing React Fast Refresh,
-      // the Pages Router injects hydration via inline <script type="module">
-      // which may not be tracked in Vite's module graph. Explicitly
-      // sending full-reload ensures changes are always reflected in
-      // the browser.
-      hotUpdate(options: { file: string; server: ViteDevServer; modules: unknown[] }) {
-        if (!hasPagesDir) return;
-        const isPagesAppFile = (filePath: string): boolean => {
-          const relativePath = normalizePathSeparators(path.relative(pagesDir, filePath));
-          return (
-            !relativePath.includes("/") &&
-            relativePath.startsWith("_app.") &&
-            fileMatcher.extensionRegex.test(filePath)
-          );
-        };
-        const isPotentialPagesAssetGraphScript = (filePath: string): boolean => {
-          const cleanPath = stripViteModuleQuery(filePath);
-          if (!path.isAbsolute(cleanPath)) return false;
-          if (!isScriptModuleId(cleanPath) || cleanPath.endsWith(".d.ts")) return false;
-          const relativeRootPath = normalizePathSeparators(path.relative(root, cleanPath));
-          if (relativeRootPath.startsWith("..") || path.isAbsolute(relativeRootPath)) return false;
-          if (
-            relativeRootPath.includes("/node_modules/") ||
-            relativeRootPath.startsWith("node_modules/")
-          ) {
-            return false;
+      // Keep the generated Pages asset manifest fresh while allowing Vite and
+      // @vitejs/plugin-react to handle normal module updates. Next.js preserves
+      // browser state for Pages Router Fast Refresh, including edits to _app.
+      hotUpdate: {
+        order: "post",
+        handler(options: HotUpdateOptions) {
+          if (!hasPagesDir) return;
+          const isPagesAppFile = (filePath: string): boolean => {
+            const relativePath = normalizePathSeparators(path.relative(pagesDir, filePath));
+            return (
+              !relativePath.includes("/") &&
+              relativePath.startsWith("_app.") &&
+              fileMatcher.extensionRegex.test(filePath)
+            );
+          };
+          const isPotentialPagesAssetGraphScript = (filePath: string): boolean => {
+            const cleanPath = stripViteModuleQuery(filePath);
+            if (!path.isAbsolute(cleanPath)) return false;
+            if (!isScriptModuleId(cleanPath) || cleanPath.endsWith(".d.ts")) return false;
+            const relativeRootPath = normalizePathSeparators(path.relative(root, cleanPath));
+            if (relativeRootPath.startsWith("..") || path.isAbsolute(relativeRootPath))
+              return false;
+            if (
+              relativeRootPath.includes("/node_modules/") ||
+              relativeRootPath.startsWith("node_modules/")
+            ) {
+              return false;
+            }
+            const relativeAppPath = normalizePathSeparators(path.relative(appDir, cleanPath));
+            return relativeAppPath.startsWith("..") || path.isAbsolute(relativeAppPath);
+          };
+          const pagesAppChanged = isPagesAppFile(options.file);
+          const pagesAssetGraphScriptChanged = isPotentialPagesAssetGraphScript(options.file);
+          const pagesAssetGraphChanged =
+            pagesAppChanged ||
+            STYLESHEET_FILE_RE.test(options.file) ||
+            pagesAssetGraphScriptChanged;
+          if (pagesAssetGraphChanged) {
+            for (const env of Object.values(options.server.environments)) {
+              const mod = env.moduleGraph.getModuleById(RESOLVED_PAGES_CLIENT_ASSETS);
+              if (mod) env.moduleGraph.invalidateModule(mod);
+            }
           }
-          const relativeAppPath = normalizePathSeparators(path.relative(appDir, cleanPath));
-          return relativeAppPath.startsWith("..") || path.isAbsolute(relativeAppPath);
-        };
-        const pagesAppChanged = isPagesAppFile(options.file);
-        const pagesAssetGraphScriptChanged = isPotentialPagesAssetGraphScript(options.file);
-        const pagesAssetGraphChanged =
-          pagesAppChanged || STYLESHEET_FILE_RE.test(options.file) || pagesAssetGraphScriptChanged;
-        if (pagesAssetGraphChanged) {
-          for (const env of Object.values(options.server.environments)) {
-            const mod = env.moduleGraph.getModuleById(RESOLVED_PAGES_CLIENT_ASSETS);
-            if (mod) env.moduleGraph.invalidateModule(mod);
+          if (this.environment?.name === "ssr" && pagesAssetGraphScriptChanged) {
+            for (const mod of options.modules) {
+              this.environment.moduleGraph.invalidateModule(
+                mod,
+                new Set(),
+                options.timestamp,
+                true,
+              );
+            }
+            return [];
           }
-        }
-        if (pagesAppChanged || (!hasAppDir && pagesAssetGraphScriptChanged)) {
-          options.server.ws.send({ type: "full-reload" });
-          return [];
-        }
-        if (hasAppDir) return;
-        if (options.file.startsWith(pagesDir) && fileMatcher.extensionRegex.test(options.file)) {
-          options.server.environments.client.hot.send({ type: "full-reload" });
-          return [];
-        }
+        },
       },
 
       configureServer(server: ViteDevServer) {
@@ -4120,13 +4126,12 @@ export const loadServerActionClient = ${
           pagesRunner?.clearCache();
         }
 
-        function invalidatePagesClientAssetsModule(reloadDocument = false) {
+        function invalidatePagesClientAssetsModule() {
           for (const env of Object.values(server.environments)) {
             const mod = env.moduleGraph.getModuleById(RESOLVED_PAGES_CLIENT_ASSETS);
             if (mod) env.moduleGraph.invalidateModule(mod);
           }
           pagesRunner?.clearCache();
-          if (reloadDocument) server.ws.send({ type: "full-reload" });
         }
 
         function invalidateAppRoutingModules() {
@@ -4264,9 +4269,7 @@ export const loadServerActionClient = ${
             hasPagesDir &&
             (pagesAppChanged || STYLESHEET_FILE_RE.test(filePath) || pagesAssetGraphScriptChanged)
           ) {
-            invalidatePagesClientAssetsModule(
-              pagesAppChanged || (!hasAppDir && pagesAssetGraphScriptChanged),
-            );
+            invalidatePagesClientAssetsModule();
           }
           if (hasPagesDir && filePath.startsWith(pagesDir) && pageExtensions.test(filePath)) {
             invalidateRouteCache(pagesDir);
@@ -4279,6 +4282,7 @@ export const loadServerActionClient = ${
           }
           if (routeChanged) {
             invalidatePagesServerEntry();
+            if (!hasAppDir) server.ws.send({ type: "full-reload" });
             invalidateHybridClientEntries();
             revalidateHybridRoutes();
           }
@@ -4290,9 +4294,7 @@ export const loadServerActionClient = ${
             hasPagesDir &&
             (pagesAppChanged || STYLESHEET_FILE_RE.test(filePath) || pagesAssetGraphScriptChanged)
           ) {
-            invalidatePagesClientAssetsModule(
-              pagesAppChanged || (!hasAppDir && pagesAssetGraphScriptChanged),
-            );
+            invalidatePagesClientAssetsModule();
           }
         });
         server.watcher.on("unlink", (filePath: string) => {
@@ -4303,9 +4305,7 @@ export const loadServerActionClient = ${
             hasPagesDir &&
             (pagesAppChanged || STYLESHEET_FILE_RE.test(filePath) || pagesAssetGraphScriptChanged)
           ) {
-            invalidatePagesClientAssetsModule(
-              pagesAppChanged || (!hasAppDir && pagesAssetGraphScriptChanged),
-            );
+            invalidatePagesClientAssetsModule();
           }
           if (hasPagesDir && filePath.startsWith(pagesDir) && pageExtensions.test(filePath)) {
             invalidateRouteCache(pagesDir);
@@ -4318,6 +4318,7 @@ export const loadServerActionClient = ${
           }
           if (routeChanged) {
             invalidatePagesServerEntry();
+            if (!hasAppDir) server.ws.send({ type: "full-reload" });
             invalidateHybridClientEntries();
             revalidateHybridRoutes();
           }

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1492,7 +1492,9 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
     return Object.keys(pluginApi.manager.serverReferenceMetaMap).length > 0;
   }
 
-  const reactOptions = options.react && options.react !== true ? options.react : undefined;
+  const configuredReactOptions =
+    options.react && options.react !== true ? options.react : undefined;
+  const reactOptions = configuredReactOptions;
 
   let reactPluginPromise: Promise<PluginOption[]> | null = null;
   if (options.react !== false) {
@@ -1506,7 +1508,36 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
     }
     const reactImport = import(pathToFileURL(resolvedReactPath).href);
     reactPluginPromise = reactImport
-      .then((mod) => (mod as VitePluginReactModule).default(reactOptions))
+      .then((mod) => {
+        const react = (mod as VitePluginReactModule).default;
+        const limitToCommand = (plugin: Plugin, command: "serve" | "build"): Plugin => {
+          const originalApply = plugin.apply;
+          return {
+            ...plugin,
+            apply(config, env) {
+              if (env.command !== command) return false;
+              if (!originalApply) return true;
+              if (typeof originalApply === "function") {
+                return originalApply(config, env);
+              }
+              return originalApply === env.command;
+            },
+          };
+        };
+        const buildPlugins = react(reactOptions).map((plugin) =>
+          limitToCommand(plugin as Plugin, "build"),
+        );
+        const hasConfiguredReactInclude =
+          configuredReactOptions !== undefined &&
+          Object.prototype.hasOwnProperty.call(configuredReactOptions, "include");
+        const serveOptions = hasConfiguredReactInclude
+          ? reactOptions
+          : { ...reactOptions, include: /\.(?:[tj]sx?|mdx)$/i };
+        const servePlugins = react(serveOptions).map((plugin) =>
+          limitToCommand(plugin as Plugin, "serve"),
+        );
+        return [...buildPlugins, ...servePlugins];
+      })
       .catch((cause) => {
         throw new Error("vinext: Failed to load @vitejs/plugin-react.", {
           cause,
@@ -1583,11 +1614,48 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
     return mdxDelegatePromise;
   }
 
+  const mdxProxyPlugin: Plugin = {
+    name: "vinext:mdx",
+    enforce: "pre",
+    transform: {
+      filter: { id: { include: /\.mdx$/i, exclude: /\?/ } },
+      async handler(code, id, options) {
+        const delegate = mdxDelegate ?? (await ensureMdxDelegate("on-demand"));
+        if (delegate?.transform) {
+          const hook = delegate.transform;
+          const transform = typeof hook === "function" ? hook : hook.handler;
+          return transform.call(this, code, id, options);
+        }
+
+        if (!hasUserMdxPlugin) {
+          throw new Error(
+            `[vinext] Encountered MDX module ${id} but no MDX plugin is configured. ` +
+              `Install @mdx-js/rollup or register an MDX plugin manually.`,
+          );
+        }
+      },
+    },
+  };
+
+  const mdxConfigProxyPlugin: Plugin = {
+    name: "vinext:mdx-config",
+    enforce: "pre",
+    config(config, env) {
+      if (!mdxDelegate?.config) return;
+      const hook = mdxDelegate.config;
+      const fn = typeof hook === "function" ? hook : hook.handler;
+      return fn.call(this, config, env);
+    },
+  };
+
   const plugins: PluginOption[] = [
     // Resolve tsconfig paths/baseUrl aliases so real-world Next.js repos
     // that use @/*, #/*, or baseUrl imports work out of the box.
     // Vite 8+ supports this natively via resolve.tsconfigPaths.
     createStyledJsxPlugin(earlyBaseDir),
+    // Compile MDX to JSX before @vitejs/plugin-react handles the generated
+    // component and injects Fast Refresh registration in dev.
+    mdxProxyPlugin,
     // React Fast Refresh + JSX transform for client components.
     reactPluginPromise,
     // Next.js ignores requests without any statically known path component
@@ -3885,48 +3953,10 @@ export const loadServerActionClient = ${
     },
     // Dedup client references from RSC proxy modules — see src/plugins/client-reference-dedup.ts
     ...(options.experimental?.clientReferenceDedup ? [clientReferenceDedupPlugin()] : []),
-    // Proxy plugin for @mdx-js/rollup. The real MDX plugin is created lazily
-    // during vinext:config's config() (when MDX files are detected), but
-    // plugins returned from config() hooks run too late in the pipeline —
-    // after vite:import-analysis. This top-level proxy with enforce:"pre"
-    // ensures MDX transforms run at the correct stage. Both vinext:config
-    // and this proxy are enforce:"pre", and vinext:config comes first in
-    // the array, so mdxDelegate is already set when this proxy's hooks fire.
-    {
-      name: "vinext:mdx",
-      enforce: "pre",
-      config(config, env) {
-        if (!mdxDelegate?.config) return;
-        const hook = mdxDelegate.config;
-        const fn = typeof hook === "function" ? hook : hook.handler;
-        return fn.call(this, config, env);
-      },
-      transform: {
-        // Native id filter so the JS handler only runs for `.mdx` files instead
-        // of being invoked for every module in the graph just to bail. The
-        // case-insensitive `\.mdx$` include covers cross-platform extension
-        // casing; `exclude: /\?/` skips query imports like `foo.mdx?raw`
-        // (@mdx-js/rollup ignores the query and would compile them as MDX) —
-        // including the `foo.mdx?something.mdx` edge case where the id still
-        // ends in `.mdx`.
-        filter: { id: { include: /\.mdx$/i, exclude: /\?/ } },
-        async handler(code, id, options) {
-          const delegate = mdxDelegate ?? (await ensureMdxDelegate("on-demand"));
-          if (delegate?.transform) {
-            const hook = delegate.transform;
-            const transform = typeof hook === "function" ? hook : hook.handler;
-            return transform.call(this, code, id, options);
-          }
-
-          if (!hasUserMdxPlugin) {
-            throw new Error(
-              `[vinext] Encountered MDX module ${id} but no MDX plugin is configured. ` +
-                `Install @mdx-js/rollup or register an MDX plugin manually.`,
-            );
-          }
-        },
-      },
-    },
+    // `vinext:config` creates the lazy MDX delegate during its config hook.
+    // Forward the delegate's config hook afterward while keeping the MDX
+    // transform itself before React in the transform pipeline.
+    mdxConfigProxyPlugin,
     createCssModuleImportCompatibilityPlugin({ compiledMdx: true }),
     // Shim React canary/experimental APIs (ViewTransition, addTransitionType)
     // that exist in Next.js's bundled React canary but not in stable React 19.

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -125,6 +125,9 @@ type PagesClientAssetsModule = {
   };
 };
 
+const transformedStylesheetAssetsCache = new WeakMap<ViteDevServer, Map<string, string[]>>();
+const transformedStylesheetAssetsWatchers = new WeakSet<ViteDevServer>();
+
 function createDevInitialStylesheetHeadHTML(options: {
   ssrManifest: Record<string, string[]> | null | undefined;
   moduleIds: (string | null | undefined)[];
@@ -148,16 +151,78 @@ function createDevInitialStylesheetHeadHTML(options: {
   return html;
 }
 
+async function collectTransformedStylesheetAssets(
+  server: ViteDevServer,
+  moduleIds: (string | null | undefined)[],
+): Promise<string[]> {
+  const clientEnvironment = server.environments.client;
+  if (!clientEnvironment) return [];
+
+  const cachedServerAssets = transformedStylesheetAssetsCache.get(server);
+  const cache = cachedServerAssets ?? new Map<string, string[]>();
+  if (!cachedServerAssets) transformedStylesheetAssetsCache.set(server, cache);
+  if (!transformedStylesheetAssetsWatchers.has(server)) {
+    transformedStylesheetAssetsWatchers.add(server);
+    const clearCache = () => cache.clear();
+    server.watcher.on("add", clearCache);
+    server.watcher.on("change", clearCache);
+    server.watcher.on("unlink", clearCache);
+  }
+
+  const cacheKey = moduleIds.filter((moduleId): moduleId is string => Boolean(moduleId)).join("\0");
+  const cachedAssets = cache.get(cacheKey);
+  if (cachedAssets) return cachedAssets;
+
+  const assets = new Set<string>();
+  const seenModules = new Set<string>();
+  async function visitModule(moduleUrl: string): Promise<void> {
+    if (seenModules.has(moduleUrl)) return;
+    seenModules.add(moduleUrl);
+    try {
+      await clientEnvironment.transformRequest(moduleUrl);
+      const moduleNode = await clientEnvironment.moduleGraph.getModuleByUrl(moduleUrl);
+      if (!moduleNode) return;
+      for (const importedModule of moduleNode.importedModules) {
+        if (
+          importedModule.type === "css" ||
+          /\.(?:css|scss|sass)(?:$|[?#])/i.test(importedModule.url)
+        ) {
+          if (importedModule.url.startsWith("//")) continue;
+          const assetUrl = importedModule.url.startsWith("\0")
+            ? `/@id/__x00__${importedModule.url.slice(1)}${importedModule.url.includes("?") ? "&" : "?"}direct`
+            : importedModule.url;
+          assets.add(assetUrl);
+        } else if (importedModule.type === "js") {
+          await visitModule(importedModule.url);
+        }
+      }
+    } catch {
+      // Preserve the source-manifest fallback when a third-party client
+      // transform fails while the server render itself remains valid.
+    }
+  }
+
+  for (const moduleId of moduleIds) {
+    if (!moduleId) continue;
+    await visitModule(createPagesDevModuleUrl(server.config.root, moduleId, "/"));
+  }
+  const result = [...assets];
+  cache.set(cacheKey, result);
+  return result;
+}
+
 async function collectDevInitialStylesheetHeadHTML(
+  server: ViteDevServer,
   runner: ModuleImporter,
   moduleIds: (string | null | undefined)[],
   nonceAttr: string,
 ): Promise<string> {
+  let manifestHTML = "";
   try {
     const pagesClientAssets = (await runner.import(
       "virtual:vinext-pages-client-assets",
     )) as PagesClientAssetsModule;
-    return createDevInitialStylesheetHeadHTML({
+    manifestHTML = createDevInitialStylesheetHeadHTML({
       ssrManifest: pagesClientAssets.default?.ssrManifest,
       moduleIds,
       nonceAttr,
@@ -165,8 +230,18 @@ async function collectDevInitialStylesheetHeadHTML(
   } catch {
     // If dev asset metadata is unavailable, keep the existing client-graph
     // CSS behavior instead of failing the page render.
-    return "";
   }
+
+  const transformedAssets = await collectTransformedStylesheetAssets(server, moduleIds);
+  if (transformedAssets.length === 0) return manifestHTML;
+
+  let html = manifestHTML;
+  for (const asset of transformedAssets) {
+    const href = asset.startsWith("/") ? asset : createPagesDevAssetUrl(asset);
+    if (html.includes(`href="${escapeHtmlAttr(href)}"`)) continue;
+    html += `<link rel="stylesheet"${nonceAttr} href="${escapeHtmlAttr(href)}" />\n  `;
+  }
+  return html;
 }
 
 /**
@@ -1619,6 +1694,7 @@ export function createSSRHandler(
         let fontHeadHTML = "";
         const appAssetPath = AppComponent ? findFileWithExts(pagesDir, "_app", matcher) : null;
         const assetHeadHTML = await collectDevInitialStylesheetHeadHTML(
+          server,
           runner,
           [appAssetPath, route.filePath],
           nonceAttr,
@@ -2098,6 +2174,7 @@ async function renderErrorPage(
       const scriptNonce = getScriptNonceFromNodeHeaderSources(req.headers, responseHeaders);
       const nonceAttr = createNonceAttribute(scriptNonce);
       const assetHeadHTML = await collectDevInitialStylesheetHeadHTML(
+        server,
         runner,
         [appAssetPath, errorAssetPath],
         nonceAttr,

--- a/tests/e2e/pages-router/hmr.spec.ts
+++ b/tests/e2e/pages-router/hmr.spec.ts
@@ -1,0 +1,44 @@
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import { waitForHydration } from "../helpers";
+
+const BASE = "http://localhost:4173";
+const pagePath = path.resolve(process.cwd(), "tests/fixtures/pages-basic/pages/hmr-state.tsx");
+
+// Ported from Next.js:
+// test/development/pages-dir/custom-app-hmr/index.test.ts
+// test/development/basic/hmr/run-error-recovery-hmr-test.util.ts
+// https://github.com/vercel/next.js/tree/canary/test/development/pages-dir/custom-app-hmr
+test("Pages Fast Refresh preserves state and recovers from syntax errors", async ({ page }) => {
+  const original = await readFile(pagePath, "utf8");
+
+  try {
+    await page.goto(`${BASE}/hmr-state`);
+    await waitForHydration(page);
+    await page.getByTestId("increment").click();
+    await expect(page.getByTestId("count")).toHaveText("Count: 1");
+    await page.evaluate(() => {
+      (window as unknown as { __HMR_MARKER__: true }).__HMR_MARKER__ = true;
+    });
+
+    await writeFile(pagePath, original.replace("Version one", "Version two"));
+    await expect(page.getByTestId("version")).toHaveText("Version two");
+    await expect(page.getByTestId("count")).toHaveText("Count: 1");
+    expect(
+      await page.evaluate(() => (window as unknown as { __HMR_MARKER__?: true }).__HMR_MARKER__),
+    ).toBe(true);
+
+    await writeFile(pagePath, original.replace("return (", "return <<<BROKEN>>> ("));
+    await page.waitForTimeout(1_000);
+
+    await writeFile(pagePath, original.replace("Version one", "Version recovered"));
+    await expect(page.getByTestId("version")).toHaveText("Version recovered");
+    await expect(page.getByTestId("count")).toHaveText("Count: 1");
+    expect(
+      await page.evaluate(() => (window as unknown as { __HMR_MARKER__?: true }).__HMR_MARKER__),
+    ).toBe(true);
+  } finally {
+    await writeFile(pagePath, original);
+  }
+});

--- a/tests/e2e/pages-router/hmr.spec.ts
+++ b/tests/e2e/pages-router/hmr.spec.ts
@@ -5,6 +5,7 @@ import { waitForHydration } from "../helpers";
 
 const BASE = "http://localhost:4173";
 const pagePath = path.resolve(process.cwd(), "tests/fixtures/pages-basic/pages/hmr-state.tsx");
+const mdxPagePath = path.resolve(process.cwd(), "tests/fixtures/pages-basic/pages/hmr-mdx.mdx");
 
 // Ported from Next.js:
 // test/development/pages-dir/custom-app-hmr/index.test.ts
@@ -40,5 +41,35 @@ test("Pages Fast Refresh preserves state and recovers from syntax errors", async
     ).toBe(true);
   } finally {
     await writeFile(pagePath, original);
+  }
+});
+
+// Ported from Next.js:
+// test/development/acceptance/ReactRefreshRegression.test.ts
+// https://github.com/vercel/next.js/blob/canary/test/development/acceptance/ReactRefreshRegression.test.ts
+test("Pages Fast Refresh updates MDX routes without a full reload", async ({ page }) => {
+  const original = await readFile(mdxPagePath, "utf8");
+
+  try {
+    await page.goto(`${BASE}/hmr-mdx`);
+    await waitForHydration(page);
+    await expect(page.getByRole("heading", { level: 1 })).toHaveText("MDX version one");
+    await page.evaluate(() => {
+      (window as unknown as { __HMR_MARKER__: true }).__HMR_MARKER__ = true;
+    });
+
+    await writeFile(mdxPagePath, original.replace("version one", "version two"));
+    await expect(page.getByRole("heading", { level: 1 })).toHaveText("MDX version two");
+    expect(
+      await page.evaluate(() => (window as unknown as { __HMR_MARKER__?: true }).__HMR_MARKER__),
+    ).toBe(true);
+
+    await writeFile(mdxPagePath, original.replace("version one", "version three"));
+    await expect(page.getByRole("heading", { level: 1 })).toHaveText("MDX version three");
+    expect(
+      await page.evaluate(() => (window as unknown as { __HMR_MARKER__?: true }).__HMR_MARKER__),
+    ).toBe(true);
+  } finally {
+    await writeFile(mdxPagePath, original);
   }
 });

--- a/tests/fixtures/pages-basic/next.config.mjs
+++ b/tests/fixtures/pages-basic/next.config.mjs
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  pageExtensions: ["js", "jsx", "ts", "tsx", "mdx"],
   generateBuildId: () => "test-build-id",
   env: {
     CUSTOM_VAR: "hello-from-config",

--- a/tests/fixtures/pages-basic/pages/hmr-mdx.mdx
+++ b/tests/fixtures/pages-basic/pages/hmr-mdx.mdx
@@ -1,0 +1,1 @@
+# MDX version one

--- a/tests/fixtures/pages-basic/pages/hmr-state.tsx
+++ b/tests/fixtures/pages-basic/pages/hmr-state.tsx
@@ -1,0 +1,14 @@
+import { useState } from "react";
+
+export default function HmrStatePage() {
+  const [count, setCount] = useState(0);
+  return (
+    <main>
+      <h1 data-testid="version">Version one</h1>
+      <p data-testid="count">Count: {count}</p>
+      <button data-testid="increment" onClick={() => setCount((value) => value + 1)}>
+        Increment
+      </button>
+    </main>
+  );
+}

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -3032,6 +3032,75 @@ describe("Virtual server entry generation", () => {
     }
   });
 
+  it("dev Pages client assets expose virtual CSS added by client transforms", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-virtual-css-"));
+    fs.mkdirSync(path.join(tmpDir, "pages"), { recursive: true });
+    fs.symlinkSync(path.join(process.cwd(), "node_modules"), path.join(tmpDir, "node_modules"));
+    const pagePath = path.join(tmpDir, "pages", "index.tsx");
+    fs.writeFileSync(
+      pagePath,
+      'export default function Home() { return <div className="virtual-css-test">Virtual CSS</div>; }\n',
+    );
+
+    const virtualCssId = "\0virtual:generated-pages-style.css";
+    const realTmpDir = fs.realpathSync.native(tmpDir);
+    const testServer = await createServer({
+      root: realTmpDir,
+      configFile: false,
+      plugins: [
+        {
+          name: "test:generated-pages-css",
+          resolveId(id) {
+            const [cleanId, query] = id.split("?", 2);
+            if (cleanId === "virtual:generated-pages-style.css" || cleanId === virtualCssId) {
+              return query ? `${virtualCssId}?${query}` : virtualCssId;
+            }
+          },
+          load(id) {
+            if (id.split("?", 1)[0] === virtualCssId) {
+              return ".virtual-css-test { color: rgb(12, 34, 56); }\n";
+            }
+          },
+          transform(code, id) {
+            if (id.split("?", 1)[0].endsWith("/pages/index.tsx")) {
+              return `${code}\nimport "virtual:generated-pages-style.css";`;
+            }
+          },
+        },
+        vinext({ appDir: realTmpDir }),
+      ],
+      base: "/docs/",
+      server: { port: 0, cors: false },
+      logLevel: "silent",
+    });
+
+    try {
+      await testServer.listen();
+      const addr = testServer.httpServer?.address();
+      if (!addr || typeof addr !== "object") throw new Error("Expected dev server address");
+
+      const res = await fetch(`http://localhost:${addr.port}/docs/`);
+      const html = await res.text();
+      expect(res.status).toBe(200);
+      expect(html).toContain("Virtual CSS");
+      const virtualStylesheetHref = getStylesheetHrefs(html).find((href) =>
+        href.includes("generated-pages-style.css"),
+      );
+      expect(virtualStylesheetHref).toBeDefined();
+      expect(virtualStylesheetHref).toMatch(/^\/docs\//);
+
+      const stylesheetRes = await fetch(`http://localhost:${addr.port}${virtualStylesheetHref}`, {
+        headers: { accept: "text/css,*/*;q=0.1" },
+      });
+      expect(stylesheetRes.status).toBe(200);
+      expect(stylesheetRes.headers.get("content-type")).toContain("text/css");
+      expect(await stylesheetRes.text()).toContain("rgb(12, 34, 56)");
+    } finally {
+      await testServer.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("dev Pages cached ISR HTML keeps initial stylesheet links", async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-app-css-isr-"));
     const fixture = writePagesAppGlobalCssFixture(tmpDir);
@@ -3981,10 +4050,15 @@ describe("Plugin config", () => {
   it("registers vinext:mdx proxy plugin with enforce pre for correct ordering", async () => {
     const plugins = vinext() as any[];
     const mdxProxy = plugins.find((p) => p.name === "vinext:mdx");
+    const mdxConfigProxy = plugins.find((p) => p.name === "vinext:mdx-config");
     expect(mdxProxy).toBeDefined();
+    expect(mdxConfigProxy).toBeDefined();
     expect(mdxProxy.enforce).toBe("pre");
-    // Proxy forwards config and transform to the delegate (@mdx-js/rollup)
-    expect(typeof mdxProxy.config).toBe("function");
+    expect(mdxConfigProxy.enforce).toBe("pre");
+    // The transform proxy runs before React so compiled MDX receives Fast Refresh.
+    // The config proxy remains after vinext:config, which creates the delegate.
+    expect(mdxProxy.config).toBeUndefined();
+    expect(typeof mdxConfigProxy.config).toBe("function");
     // transform is an object-form hook: a native id filter gates the JS handler
     // so it only runs for .mdx files instead of every module in the graph.
     expect(typeof mdxProxy.transform).toBe("object");
@@ -3992,8 +4066,8 @@ describe("Plugin config", () => {
     const { include, exclude } = mdxProxy.transform.filter.id;
     expect(include.test("/app/page.mdx") && !exclude.test("/app/page.mdx")).toBe(true);
     expect(include.test("./foo.ts")).toBe(false);
-    // Proxy config is inert when no MDX files are detected (mdxDelegate is null)
-    expect(mdxProxy.config({}, { command: "build", mode: "production" })).toBeUndefined();
+    // Config proxy is inert when no MDX files are detected (mdxDelegate is null)
+    expect(mdxConfigProxy.config({}, { command: "build", mode: "production" })).toBeUndefined();
   });
 
   it("vinext:mdx filter skips ids that contain a query string (regression: ?raw)", () => {

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -3426,6 +3426,7 @@ describe("Virtual server entry generation", () => {
       expect(pagesPlugin).toBeDefined();
       const hotUpdate = pagesPlugin.hotUpdate;
       expect(hotUpdate).toBeDefined();
+      expect(hotUpdate).toMatchObject({ order: "post" });
       const hotUpdateResult =
         typeof hotUpdate === "function"
           ? await hotUpdate.call(pagesPlugin, {
@@ -3442,6 +3443,115 @@ describe("Virtual server entry generation", () => {
       expect(hotUpdateResult).toBeUndefined();
       expect(wsSend).not.toHaveBeenCalledWith({ type: "full-reload" });
       expect(clientHotSend).not.toHaveBeenCalledWith({ type: "full-reload" });
+    } finally {
+      wsSend.mockRestore();
+      clientHotSend.mockRestore();
+      await testServer.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not force full reload for Pages Router Fast Refresh updates", async () => {
+    // Ported from Next.js:
+    // test/development/pages-dir/custom-app-hmr/index.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/development/pages-dir/custom-app-hmr/index.test.ts
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-fast-refresh-"));
+    const sharedPath = path.join(tmpDir, "lib", "shared.ts");
+    const appPath = path.join(tmpDir, "pages", "_app.tsx");
+    const pagePath = path.join(tmpDir, "pages", "index.tsx");
+    fs.mkdirSync(path.join(tmpDir, "pages"), { recursive: true });
+    fs.mkdirSync(path.dirname(sharedPath), { recursive: true });
+    fs.symlinkSync(path.join(process.cwd(), "node_modules"), path.join(tmpDir, "node_modules"));
+    fs.writeFileSync(sharedPath, 'export const shared = "shared";\n');
+    fs.writeFileSync(appPath, PAGES_APP_COMPONENT);
+    fs.writeFileSync(
+      pagePath,
+      'import { shared } from "../lib/shared";\n' +
+        "export default function Home() { return <div>{shared}</div>; }\n",
+    );
+
+    const testServer = await createServer({
+      root: tmpDir,
+      configFile: false,
+      plugins: [vinext({ appDir: tmpDir })],
+      server: { port: 0, cors: false },
+      logLevel: "silent",
+    });
+    const wsSend = vi.spyOn(testServer.ws, "send");
+    const clientHotSend = vi.spyOn(testServer.environments.client.hot, "send");
+
+    try {
+      const pagesPlugin = testServer.config.plugins.find(
+        (plugin): plugin is any => plugin.name === "vinext:pages-router",
+      );
+      expect(pagesPlugin).toBeDefined();
+      const hotUpdate = pagesPlugin.hotUpdate;
+      expect(hotUpdate).toBeDefined();
+
+      for (const file of [sharedPath, appPath, pagePath]) {
+        const hotUpdateResult =
+          typeof hotUpdate === "function"
+            ? await hotUpdate.call(pagesPlugin, {
+                file,
+                server: testServer,
+                modules: [{ id: file }],
+              })
+            : await hotUpdate.handler.call(pagesPlugin, {
+                file,
+                server: testServer,
+                modules: [{ id: file }],
+              });
+
+        expect(hotUpdateResult).toBeUndefined();
+      }
+
+      expect(wsSend).not.toHaveBeenCalledWith({ type: "full-reload" });
+      expect(clientHotSend).not.toHaveBeenCalledWith({ type: "full-reload" });
+
+      const ssrModule = testServer.environments.ssr.moduleGraph.createFileOnlyEntry(pagePath);
+      const invalidateModule = vi.spyOn(
+        testServer.environments.ssr.moduleGraph,
+        "invalidateModule",
+      );
+      const ssrHotUpdateResult =
+        typeof hotUpdate === "function"
+          ? await hotUpdate.call(
+              { environment: testServer.environments.ssr },
+              {
+                type: "update",
+                file: pagePath,
+                timestamp: Date.now(),
+                modules: [ssrModule],
+                read: () => fs.readFileSync(pagePath, "utf8"),
+                server: testServer,
+              },
+            )
+          : await hotUpdate.handler.call(
+              { environment: testServer.environments.ssr },
+              {
+                type: "update",
+                file: pagePath,
+                timestamp: Date.now(),
+                modules: [ssrModule],
+                read: () => fs.readFileSync(pagePath, "utf8"),
+                server: testServer,
+              },
+            );
+
+      expect(ssrHotUpdateResult).toEqual([]);
+      expect(invalidateModule).toHaveBeenCalledWith(
+        ssrModule,
+        expect.any(Set),
+        expect.any(Number),
+        true,
+      );
+
+      wsSend.mockClear();
+      testServer.watcher.emit("add", pagePath);
+      testServer.watcher.emit("unlink", pagePath);
+      expect(wsSend).toHaveBeenCalledTimes(2);
+      expect(wsSend).toHaveBeenNthCalledWith(1, { type: "full-reload" });
+      expect(wsSend).toHaveBeenNthCalledWith(2, { type: "full-reload" });
     } finally {
       wsSend.mockRestore();
       clientHotSend.mockRestore();


### PR DESCRIPTION
## Summary

- preserve Pages Router Fast Refresh state instead of forcing full document reloads for ordinary script edits
- consume Pages SSR dead-end updates after downstream HMR plugins run, while retaining full reloads for route additions and deletions
- preload CSS introduced by client transforms, including virtual CSS modules, so dev HTML has blocking first-paint styles
- compile MDX before the development React transform and extend the default dev-only React include so MDX routes also receive Fast Refresh without changing production parsing
- add unit and browser regression coverage for state preservation, syntax-error recovery, transformed CSS, and MDX route updates

## Motivation

DigitecGalaxus/next-yak#569 added vinext to its bundler compatibility suite and exposed two dev-only gaps:

- seven HMR cases failed because vinext reloaded the document for every Pages Router script edit, clearing browser state
- pseudo-element styles raced the first computed-style read because next-yak's transformed virtual CSS was only injected during hydration

The HMR behavior now matches Next.js Pages Router Fast Refresh. Dev stylesheet discovery now follows Vite's transformed client module graph and emits blocking stylesheet links for generated CSS, matching production's first-paint behavior.

The automatic React integration now uses command-scoped plugin instances: production keeps the existing configured include behavior, while development adds `.mdx` only when the user did not explicitly configure `react.include`. The MDX delegate is split into an early transform proxy and a later config proxy so compiled JSX reaches React Fast Refresh while the delegate is still initialized during `vinext:config`.

## Validation

- `vp check packages/vinext/src/index.ts packages/vinext/src/server/dev-server.ts tests/pages-router.test.ts tests/fixtures/pages-basic/pages/hmr-state.tsx tests/e2e/pages-router/hmr.spec.ts`
- targeted Pages Router transformed-CSS tests — pass
- Pages Router HMR Playwright regression — pass
- MDX Pages Router Fast Refresh regression — pass
- failed CI Vitest shard (`integration 4/10`) — 398/398 pass locally
- next-yak `vinext-pages` dev matrix — 27/27 pass, including all seven HMR cases and `pseudo-elements`

Related: DigitecGalaxus/next-yak#569
