### PR TITLE
perf(pages): reuse dev stylesheet dependency analysis

### DIFF
--- a/packages/vinext/src/build/module-dependency-cache.ts
+++ b/packages/vinext/src/build/module-dependency-cache.ts
@@ -1,0 +1,14 @@
+export function createModuleDependencyCache<T>(
+  collect: (moduleId: string) => Promise<T>,
+): (moduleId: string) => Promise<T> {
+  const cache = new Map<string, Promise<T>>();
+
+  return function getModuleDependencies(moduleId: string): Promise<T> {
+    const cached = cache.get(moduleId);
+    if (cached) return cached;
+
+    const pending = collect(moduleId);
+    cache.set(moduleId, pending);
+    return pending;
+  };
+}

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -185,6 +185,7 @@ import {
   takePagesClientAssetsBuildMetadata,
   writePagesClientAssetsModuleIfMissing,
 } from "./build/pages-client-assets-module.js";
+import { createModuleDependencyCache } from "./build/module-dependency-cache.js";
 import { resolvePostcssStringPlugins } from "./plugins/postcss.js";
 import {
   buildSassPreprocessorOptions,
@@ -562,16 +563,7 @@ type DevPagesModuleDependency =
   | { type: "script"; id: string };
 
 function createDevPagesModuleDependencyReader(root: string, resolve: ResolveFromImporter) {
-  const cache = new Map<string, Promise<DevPagesModuleDependency[]>>();
-
-  return function getModuleDependencies(modulePath: string): Promise<DevPagesModuleDependency[]> {
-    const cached = cache.get(modulePath);
-    if (cached) return cached;
-
-    const pending = collectModuleDependencies(modulePath);
-    cache.set(modulePath, pending);
-    return pending;
-  };
+  return createModuleDependencyCache(collectModuleDependencies);
 
   async function collectModuleDependencies(
     modulePath: string,
@@ -622,8 +614,6 @@ function createDevPagesModuleDependencyReader(root: string, resolve: ResolveFrom
     return dependencies;
   }
 }
-
-export const _createDevPagesModuleDependencyReader = createDevPagesModuleDependencyReader;
 
 const TSCONFIG_FILES = ["tsconfig.json", "jsconfig.json"];
 

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -539,11 +539,10 @@ async function collectDevPagesAppStylesheetAssets(
   const seenModules = new Set<string>();
 
   async function visitModule(modulePath: string): Promise<void> {
-    const cleanModulePath = stripViteModuleQuery(modulePath);
-    if (seenModules.has(cleanModulePath)) return;
-    seenModules.add(cleanModulePath);
+    if (seenModules.has(modulePath)) return;
+    seenModules.add(modulePath);
 
-    for (const dependency of await getModuleDependencies(cleanModulePath)) {
+    for (const dependency of await getModuleDependencies(modulePath)) {
       if (dependency.type === "stylesheet") {
         if (seenAssets.has(dependency.asset)) continue;
         seenAssets.add(dependency.asset);
@@ -566,18 +565,18 @@ function createDevPagesModuleDependencyReader(root: string, resolve: ResolveFrom
   const cache = new Map<string, Promise<DevPagesModuleDependency[]>>();
 
   return function getModuleDependencies(modulePath: string): Promise<DevPagesModuleDependency[]> {
-    const cleanModulePath = stripViteModuleQuery(modulePath);
-    const cached = cache.get(cleanModulePath);
+    const cached = cache.get(modulePath);
     if (cached) return cached;
 
-    const pending = collectModuleDependencies(cleanModulePath);
-    cache.set(cleanModulePath, pending);
+    const pending = collectModuleDependencies(modulePath);
+    cache.set(modulePath, pending);
     return pending;
   };
 
   async function collectModuleDependencies(
-    cleanModulePath: string,
+    modulePath: string,
   ): Promise<DevPagesModuleDependency[]> {
+    const cleanModulePath = stripViteModuleQuery(modulePath);
     if (!path.isAbsolute(cleanModulePath) || !fs.existsSync(cleanModulePath)) return [];
 
     let ast: ReturnType<typeof parseAst>;
@@ -623,6 +622,8 @@ function createDevPagesModuleDependencyReader(root: string, resolve: ResolveFrom
     return dependencies;
   }
 }
+
+export const _createDevPagesModuleDependencyReader = createDevPagesModuleDependencyReader;
 
 const TSCONFIG_FILES = ["tsconfig.json", "jsconfig.json"];
 

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -531,9 +531,8 @@ function resolvedStylesheetToDevManifestAsset(root: string, resolvedId: string):
 }
 
 async function collectDevPagesAppStylesheetAssets(
-  root: string,
   appFilePath: string,
-  resolve: ResolveFromImporter,
+  getModuleDependencies: (modulePath: string) => Promise<DevPagesModuleDependency[]>,
 ): Promise<string[]> {
   const stylesheetAssets: string[] = [];
   const seenAssets = new Set<string>();
@@ -541,9 +540,45 @@ async function collectDevPagesAppStylesheetAssets(
 
   async function visitModule(modulePath: string): Promise<void> {
     const cleanModulePath = stripViteModuleQuery(modulePath);
-    if (!path.isAbsolute(cleanModulePath) || !fs.existsSync(cleanModulePath)) return;
     if (seenModules.has(cleanModulePath)) return;
     seenModules.add(cleanModulePath);
+
+    for (const dependency of await getModuleDependencies(cleanModulePath)) {
+      if (dependency.type === "stylesheet") {
+        if (seenAssets.has(dependency.asset)) continue;
+        seenAssets.add(dependency.asset);
+        stylesheetAssets.push(dependency.asset);
+      } else {
+        await visitModule(dependency.id);
+      }
+    }
+  }
+
+  await visitModule(appFilePath);
+  return stylesheetAssets;
+}
+
+type DevPagesModuleDependency =
+  | { type: "stylesheet"; asset: string }
+  | { type: "script"; id: string };
+
+function createDevPagesModuleDependencyReader(root: string, resolve: ResolveFromImporter) {
+  const cache = new Map<string, Promise<DevPagesModuleDependency[]>>();
+
+  return function getModuleDependencies(modulePath: string): Promise<DevPagesModuleDependency[]> {
+    const cleanModulePath = stripViteModuleQuery(modulePath);
+    const cached = cache.get(cleanModulePath);
+    if (cached) return cached;
+
+    const pending = collectModuleDependencies(cleanModulePath);
+    cache.set(cleanModulePath, pending);
+    return pending;
+  };
+
+  async function collectModuleDependencies(
+    cleanModulePath: string,
+  ): Promise<DevPagesModuleDependency[]> {
+    if (!path.isAbsolute(cleanModulePath) || !fs.existsSync(cleanModulePath)) return [];
 
     let ast: ReturnType<typeof parseAst>;
     try {
@@ -551,9 +586,10 @@ async function collectDevPagesAppStylesheetAssets(
         lang: parserLanguageForScript(cleanModulePath),
       });
     } catch {
-      return;
+      return [];
     }
 
+    const dependencies: DevPagesModuleDependency[] = [];
     for (const statement of ast.body as AstStaticDependencyDeclaration[]) {
       if (
         statement.type !== "ImportDeclaration" &&
@@ -575,21 +611,17 @@ async function collectDevPagesAppStylesheetAssets(
 
       if (isStylesheetSpecifier(specifier)) {
         const asset = resolvedStylesheetToDevManifestAsset(root, resolved.id);
-        if (!asset || seenAssets.has(asset)) continue;
-        seenAssets.add(asset);
-        stylesheetAssets.push(asset);
-        continue;
-      }
-
-      if (specifier.includes("?") || specifier.includes("#")) continue;
-      if (isScriptModuleId(resolved.id)) {
-        await visitModule(resolved.id);
+        if (asset) dependencies.push({ type: "stylesheet", asset });
+      } else if (
+        !specifier.includes("?") &&
+        !specifier.includes("#") &&
+        isScriptModuleId(resolved.id)
+      ) {
+        dependencies.push({ type: "script", id: resolved.id });
       }
     }
+    return dependencies;
   }
-
-  await visitModule(appFilePath);
-  return stylesheetAssets;
 }
 
 const TSCONFIG_FILES = ["tsconfig.json", "jsconfig.json"];
@@ -3538,11 +3570,14 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               ...(appFilePath ? [appFilePath] : []),
               ...pagesRoutes.map((route) => route.filePath),
             ];
+            const getModuleDependencies = createDevPagesModuleDependencyReader(
+              root,
+              this.resolve.bind(this),
+            );
             for (const moduleFilePath of moduleFilePaths) {
               const stylesheetAssets = await collectDevPagesAppStylesheetAssets(
-                root,
                 moduleFilePath,
-                this.resolve.bind(this),
+                getModuleDependencies,
               );
               if (stylesheetAssets.length > 0) {
                 ssrManifest[toSlash(moduleFilePath)] = stylesheetAssets;

--- a/packages/vinext/src/plugins/ignore-dynamic-requests.ts
+++ b/packages/vinext/src/plugins/ignore-dynamic-requests.ts
@@ -24,8 +24,10 @@ import {
 } from "./ast-scope.js";
 
 const DYNAMIC_REQUEST_ERROR = "Cannot find module as expression is too dynamic";
+const REQUIRE_PRESCAN = /(?:\brequire\b|\\u(?:[\da-f]{4}|\{[\da-f]+\}))/i;
 const DYNAMIC_REQUEST_PRESCAN = new RegExp(
-  String.raw`(?:\brequire\b|${DYNAMIC_IMPORT_PRESCAN.source})`,
+  String.raw`(?:${REQUIRE_PRESCAN.source}|${DYNAMIC_IMPORT_PRESCAN.source})`,
+  "i",
 );
 const MAX_CONSTANT_BINDING_DEPTH = 1_500;
 const VINEXT_SOURCE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -730,7 +732,7 @@ function transformVeryDynamicRequests(code: string, id: string) {
   // narrowed to dynamic-call syntax via the shared `mayContainDynamicImport`:
   // bare `import` (static ESM) otherwise matched ~every module, so this plugin
   // parsed the whole graph. See DYNAMIC_IMPORT_PRESCAN for the rationale.
-  if (!code.includes("require") && !mayContainDynamicImport(code)) return null;
+  if (!REQUIRE_PRESCAN.test(code) && !mayContainDynamicImport(code)) return null;
 
   const extension = path.extname(id.split("?", 1)[0]);
   const lang =

--- a/packages/vinext/src/plugins/ignore-dynamic-requests.ts
+++ b/packages/vinext/src/plugins/ignore-dynamic-requests.ts
@@ -24,7 +24,8 @@ import {
 } from "./ast-scope.js";
 
 const DYNAMIC_REQUEST_ERROR = "Cannot find module as expression is too dynamic";
-const REQUIRE_PRESCAN = /(?:\brequire\b|\\u(?:[\da-f]{4}|\{[\da-f]+\}))/i;
+const REQUIRE_PRESCAN =
+  /(?:\brequire\b|(?:r|\\u(?:0072|\{0*72\}))(?:e|\\u(?:0065|\{0*65\}))(?:q|\\u(?:0071|\{0*71\}))(?:u|\\u(?:0075|\{0*75\}))(?:i|\\u(?:0069|\{0*69\}))(?:r|\\u(?:0072|\{0*72\}))(?:e|\\u(?:0065|\{0*65\})))/i;
 const DYNAMIC_REQUEST_PRESCAN = new RegExp(
   String.raw`(?:${REQUIRE_PRESCAN.source}|${DYNAMIC_IMPORT_PRESCAN.source})`,
   "i",

--- a/packages/vinext/src/plugins/ignore-dynamic-requests.ts
+++ b/packages/vinext/src/plugins/ignore-dynamic-requests.ts
@@ -4,6 +4,7 @@ import MagicString from "magic-string";
 import { parseAst, type Plugin } from "vite";
 import {
   collectBindingNames,
+  DYNAMIC_IMPORT_PRESCAN,
   forEachAstChild,
   hasRange,
   isAstRecord,
@@ -23,6 +24,9 @@ import {
 } from "./ast-scope.js";
 
 const DYNAMIC_REQUEST_ERROR = "Cannot find module as expression is too dynamic";
+const DYNAMIC_REQUEST_PRESCAN = new RegExp(
+  String.raw`(?:\brequire\b|${DYNAMIC_IMPORT_PRESCAN.source})`,
+);
 const MAX_CONSTANT_BINDING_DEPTH = 1_500;
 const VINEXT_SOURCE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const PLUGIN_RSC_PATH =
@@ -885,6 +889,7 @@ export function createIgnoreDynamicRequestsPlugin(
         id: {
           include: /\.(?:[cm]?[jt]s|[jt]sx)(?:\?.*)?$/,
         },
+        code: DYNAMIC_REQUEST_PRESCAN,
       },
       handler(code, id) {
         const cleanId = id.split("?", 1)[0];

--- a/tests/dynamic-requests-build.test.ts
+++ b/tests/dynamic-requests-build.test.ts
@@ -132,6 +132,25 @@ function dynamic() {
 }
 
 describe("App Router dynamic requests", () => {
+  it("natively filters source that cannot contain dynamic requests", () => {
+    const transform = createIgnoreDynamicRequestsPlugin().transform;
+    if (!transform || typeof transform === "function") {
+      throw new Error("dynamic request transform hook not found");
+    }
+    const codeFilter = transform.filter?.code;
+    if (!(codeFilter instanceof RegExp)) {
+      throw new Error("dynamic request code filter not found");
+    }
+
+    expect(codeFilter.test('import value from "package";')).toBe(false);
+    expect(codeFilter.test("export const value = getValue();")).toBe(false);
+    expect(codeFilter.test("require(request)")).toBe(true);
+    expect(codeFilter.test("require /* comment */ (request)")).toBe(true);
+    expect(codeFilter.test("import(request)")).toBe(true);
+    expect(codeFilter.test("import /* comment */ (request)")).toBe(true);
+    expect(codeFilter.test("import\n// comment\n(request)")).toBe(true);
+  });
+
   it("matches Next.js environment scoping", () => {
     const transform = createIgnoreDynamicRequestsPlugin(() => [
       "transpiled",

--- a/tests/dynamic-requests-build.test.ts
+++ b/tests/dynamic-requests-build.test.ts
@@ -145,10 +145,21 @@ describe("App Router dynamic requests", () => {
     expect(codeFilter.test('import value from "package";')).toBe(false);
     expect(codeFilter.test("export const value = getValue();")).toBe(false);
     expect(codeFilter.test("require(request)")).toBe(true);
+    expect(codeFilter.test(String.raw`requ\u0069re(request)`)).toBe(true);
+    expect(codeFilter.test(String.raw`\u{72}equire(request)`)).toBe(true);
+    expect(codeFilter.test(String.raw`\u{00072}equire(request)`)).toBe(true);
     expect(codeFilter.test("require /* comment */ (request)")).toBe(true);
     expect(codeFilter.test("import(request)")).toBe(true);
     expect(codeFilter.test("import /* comment */ (request)")).toBe(true);
     expect(codeFilter.test("import\n// comment\n(request)")).toBe(true);
+  });
+
+  it("transforms escaped require identifiers", () => {
+    const transformed = _transformVeryDynamicRequests(
+      String.raw`const request = getRequest(); requ\u0069re(request);`,
+      "/app/page.tsx",
+    );
+    expect(transformed?.code).toContain("MODULE_NOT_FOUND");
   });
 
   it("matches Next.js environment scoping", () => {

--- a/tests/dynamic-requests-build.test.ts
+++ b/tests/dynamic-requests-build.test.ts
@@ -148,6 +148,7 @@ describe("App Router dynamic requests", () => {
     expect(codeFilter.test(String.raw`requ\u0069re(request)`)).toBe(true);
     expect(codeFilter.test(String.raw`\u{72}equire(request)`)).toBe(true);
     expect(codeFilter.test(String.raw`\u{00072}equire(request)`)).toBe(true);
+    expect(codeFilter.test(String.raw`const label = "caf\u00e9";`)).toBe(false);
     expect(codeFilter.test("require /* comment */ (request)")).toBe(true);
     expect(codeFilter.test("import(request)")).toBe(true);
     expect(codeFilter.test("import /* comment */ (request)")).toBe(true);

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -8,7 +8,7 @@ import os from "node:os";
 import { Readable } from "node:stream";
 import { pathToFileURL } from "node:url";
 import zlib from "node:zlib";
-import vinext from "../packages/vinext/src/index.js";
+import vinext, { _createDevPagesModuleDependencyReader } from "../packages/vinext/src/index.js";
 import {
   PHASE_DEVELOPMENT_SERVER,
   PHASE_PRODUCTION_BUILD,
@@ -3360,6 +3360,39 @@ describe("Virtual server entry generation", () => {
       expect(Object.values(assets.ssrManifest ?? {}).flat()).not.toContain("styles/site.less");
     } finally {
       await testServer.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("dev Pages dependency metadata reuses exact module ids", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-shared-assets-"));
+    fs.mkdirSync(path.join(tmpDir, "lib"), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, "styles"), { recursive: true });
+    const sharedPath = path.join(tmpDir, "lib", "shared.ts");
+    const stylesheetPath = path.join(tmpDir, "styles", "shared.module.css");
+    fs.writeFileSync(
+      sharedPath,
+      'import styles from "../styles/shared.module.css";\n' +
+        "export const sharedClassName = styles.shared;\n",
+    );
+    fs.writeFileSync(stylesheetPath, ".shared { color: red; }\n");
+
+    const resolve = vi.fn(async (id: string) =>
+      id === "../styles/shared.module.css" ? { id: stylesheetPath } : null,
+    );
+    const getModuleDependencies = _createDevPagesModuleDependencyReader(tmpDir, resolve);
+
+    try {
+      const first = getModuleDependencies(sharedPath);
+      expect(getModuleDependencies(sharedPath)).toBe(first);
+      await expect(first).resolves.toEqual([
+        { type: "stylesheet", asset: "styles/shared.module.css" },
+      ]);
+      expect(resolve).toHaveBeenCalledTimes(1);
+
+      await getModuleDependencies(`${sharedPath}?variant=a`);
+      expect(resolve).toHaveBeenCalledTimes(2);
+    } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -8,7 +8,8 @@ import os from "node:os";
 import { Readable } from "node:stream";
 import { pathToFileURL } from "node:url";
 import zlib from "node:zlib";
-import vinext, { _createDevPagesModuleDependencyReader } from "../packages/vinext/src/index.js";
+import vinext from "../packages/vinext/src/index.js";
+import { createModuleDependencyCache } from "../packages/vinext/src/build/module-dependency-cache.js";
 import {
   PHASE_DEVELOPMENT_SERVER,
   PHASE_PRODUCTION_BUILD,
@@ -3377,10 +3378,14 @@ describe("Virtual server entry generation", () => {
     );
     fs.writeFileSync(stylesheetPath, ".shared { color: red; }\n");
 
-    const resolve = vi.fn(async (id: string) =>
-      id === "../styles/shared.module.css" ? { id: stylesheetPath } : null,
-    );
-    const getModuleDependencies = _createDevPagesModuleDependencyReader(tmpDir, resolve);
+    const collect = vi.fn(async (moduleId: string) => {
+      const cleanModulePath = moduleId.split("?", 1)[0];
+      const source = fs.readFileSync(cleanModulePath, "utf8");
+      return source.includes("../styles/shared.module.css")
+        ? [{ type: "stylesheet", asset: "styles/shared.module.css" }]
+        : [];
+    });
+    const getModuleDependencies = createModuleDependencyCache(collect);
 
     try {
       const first = getModuleDependencies(sharedPath);
@@ -3388,10 +3393,10 @@ describe("Virtual server entry generation", () => {
       await expect(first).resolves.toEqual([
         { type: "stylesheet", asset: "styles/shared.module.css" },
       ]);
-      expect(resolve).toHaveBeenCalledTimes(1);
+      expect(collect).toHaveBeenCalledTimes(1);
 
       await getModuleDependencies(`${sharedPath}?variant=a`);
-      expect(resolve).toHaveBeenCalledTimes(2);
+      expect(collect).toHaveBeenCalledTimes(2);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

- cache parsed and resolved dependency metadata while building the Pages Router dev stylesheet manifest
- reuse that dependency graph across `_app` and all page entry traversals while preserving per-entry CSS order and deduplication
- retain full resolved IDs as cache identities while reading their underlying filesystem paths
- keep the generic promise cache in an internal module with direct regression coverage
- move the existing dynamic request source prescan into the native transform filter so irrelevant modules skip JavaScript hook dispatch
- cover shared dependency reuse, query-distinct cache identities, and escaped `require` identifiers without admitting unrelated Unicode escapes

## Performance

Measured with an excluded local Pages Router fixture containing 485 routes and a heavily shared import graph. Each round cleared the fixture's Vite caches and waited for a rendered route marker.

After the latest review fixes, six alternating cold rounds at the exact PR base and head:

| Revision | Mean | Median | Range |
| --- | ---: | ---: | ---: |
| base | 4.033s | 4.034s | 3.986–4.070s |
| head | 0.996s | 0.994s | 0.990–1.009s |

Mean cold readiness improved by **75.3%**.

## Validation

- `vp test run tests/pages-router.test.ts -t 'dev Pages (client assets expose|cached ISR HTML keeps|custom error HTML includes|_app stylesheet links use|_app stylesheet metadata|client assets do not treat|dependency metadata reuses exact module ids)'`
- `vp test run tests/dynamic-requests-build.test.ts`
- `vp run vinext#build`
