### PR TITLE
fix(app-router): cancel live RSC redirect bodies before refetch

### DIFF
--- a/packages/vinext/src/server/navigation-planner.ts
+++ b/packages/vinext/src/server/navigation-planner.ts
@@ -525,7 +525,10 @@ function classifyRscFetchResult(facts: RscFetchResultFacts): RscFetchResultDecis
     }
     if (redirectDecision.kind === "follow") {
       return createRscFetchResultFollowRedirectDecision({
-        discardBody: false,
+        // The browser executor follows live response-URL redirects by fetching
+        // the target in a new loop iteration. The current response body is not
+        // read, so release it before the next fetch.
+        discardBody: facts.source === "live",
         facts,
         redirect: {
           href: redirectDecision.href,

--- a/tests/navigation-planner-rsc-fetch-result.test.ts
+++ b/tests/navigation-planner-rsc-fetch-result.test.ts
@@ -115,7 +115,7 @@ describe("navigationPlanner RSC fetch-result classification", () => {
     });
   });
 
-  it("follows response-URL redirects without discarding the body", () => {
+  it("follows live response-URL redirects and requires body discard", () => {
     const decision = classify({
       effectiveHistoryUpdateMode: "push",
       redirectDepth: 2,
@@ -124,7 +124,7 @@ describe("navigationPlanner RSC fetch-result classification", () => {
     });
 
     expect(decision).toEqual({
-      discardBody: false,
+      discardBody: true,
       kind: "followRedirect",
       redirect: {
         href: "/target?tab=1",


### PR DESCRIPTION
## Overview

| Field | Details |
| --- | --- |
| Goal | Close #1987 by releasing abandoned live RSC response bodies before response-URL redirect replay. |
| Core change | Response-URL `followRedirect` decisions now set `discardBody: true` for live fetch results. Cached-source redirect decisions stay non-discarding because they have no live stream to release. |
| Boundary | `navigation-planner` owns the discard decision. `app-browser-entry` already owns the effect by cancelling bodies for discarded fetch results before continuing. |
| Primary files | `navigation-planner.ts` updates the planner contract. `navigation-planner-rsc-fetch-result.test.ts` covers live and cached redirect decisions. |
| Expected impact | Same navigation target, history, and trace behavior. Better stream and connection cleanup on fetch implementations that keep unread bodies open until consumed or cancelled. |

## Why

RSC redirect replay is a resource-ownership boundary: once the client decides to ignore a live response and fetch the redirected target, it no longer has a consumer for the original body. The planner already tells the browser executor when streamed-header redirect bodies are discarded; live response-URL follow hops need the same signal so the executor can release the unread body before the next fetch.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Live response-URL redirect replay | A live body abandoned by redirect replay must be released before the next request starts. | Marks live response-URL `followRedirect` decisions as `discardBody: true`. |
| Planner and executor split | The planner returns a pure decision; the browser executor performs effects. | Keeps cancellation in the existing `app-browser-entry` discard path instead of adding a second effect path. |
| Cached response reuse | Cached-source decisions do not represent an owned live response stream. | Preserves `discardBody: false` for cached response-URL redirect decisions. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| Live response-URL follow redirect | Planner returned `discardBody: false`; executor continued the redirect loop without cancelling the old body. | Planner returns `discardBody: true`; existing executor code cancels the old body before refetching the target. |
| Cached response-URL follow redirect | Planner returned `discardBody: false`. | Unchanged, because no live stream is being abandoned. |
| Streamed-header redirects | Planner returned `discardBody: true`. | Unchanged. |

Fixes #1987.

<details>
<summary>Validation</summary>

- `vp test run tests/navigation-planner-rsc-fetch-result.test.ts -t "follows live response-URL redirects and requires body discard"`
  - Red phase before source change: failed with `discardBody: false`.
  - Green phase after source change: passed.
- `vp test run tests/navigation-planner-rsc-fetch-result.test.ts`
- `vp test run tests/app-browser-entry.test.ts -t "app browser RSC redirect lifecycle"`
- `vp test run tests/navigation-planner-rsc-fetch-result.test.ts tests/app-browser-entry.test.ts`
- `vp check`
- `git diff --check`
- Commit hook also ran staged checks, full check, staged unit and integration tests, and Knip.

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: none. This changes an internal planner decision consumed by the existing browser executor.
- Runtime behavior: redirect target, redirect depth, history mode, previous-next URL, and traces are unchanged.
- Resource behavior: live unread response bodies are now cancelled before response-URL redirect replay starts the next fetch.
- Next.js compatibility: current Next.js canary still has a TODO to abort the previous request in its equivalent redirect replay loop. This PR intentionally hardens vinext for Workers-compatible fetch runtimes while keeping navigation semantics aligned.

</details>

<details>
<summary>Non-goals</summary>

- No change to invalid-payload, compatibility-mismatch, or terminal response-URL hard-navigation body handling.
- No change to redirect depth limits, external redirect handling, or streamed-header redirect semantics.
- No attempt to change Next.js itself in this PR.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| #1987 | Tracks the unread body leak on response-URL RSC redirect replay. |
| [Next.js fetch-server-response redirect replay](https://github.com/vercel/next.js/blob/3c0fd70fc04a9bf26e7c510df9a1b7d393ac65c4/packages/next/src/client/components/router-reducer/fetch-server-response.ts#L761-L799) | Shows the equivalent Next.js redirect replay loop and the existing abort TODO. |
| [Next.js CDN cache-busting redirect test](https://github.com/vercel/next.js/blob/3c0fd70fc04a9bf26e7c510df9a1b7d393ac65c4/test/e2e/app-dir/segment-cache/cdn-cache-busting/cdn-cache-busting.test.ts#L101-L126) | Confirms the intended response-URL redirect/cache-busting semantics, separate from stream cleanup. |
