### PR TITLE
fix(pages): preserve document import order

### DIFF
--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -290,11 +290,10 @@ async function _renderIsrPassToStringAsync(element) {
   );
 }
 
+${docImportCode}
+${appImportCode}
 ${pageImports.join("\n")}
 ${apiImports.join("\n")}
-
-${appImportCode}
-${docImportCode}
 ${errorImportCode}
 
 export const pageRoutes = [

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -244,6 +244,44 @@ async function collectDevInitialStylesheetHeadHTML(
   return html;
 }
 
+async function loadPagesRootComponents(
+  runner: ModuleImporter,
+  pagesDir: string,
+  matcher: ValidFileMatcher,
+): Promise<{
+  // oxlint-disable-next-line typescript/no-explicit-any
+  DocumentComponent: any;
+  // oxlint-disable-next-line typescript/no-explicit-any
+  AppComponent: any;
+  appAssetPath: string | null;
+}> {
+  // oxlint-disable-next-line typescript/no-explicit-any
+  let DocumentComponent: any = null;
+  const documentAssetPath = findFileWithExts(pagesDir, "_document", matcher);
+  if (documentAssetPath) {
+    try {
+      const documentModule = await importModule(runner, documentAssetPath);
+      DocumentComponent = documentModule.default ?? null;
+    } catch {
+      // _document exists but failed to load
+    }
+  }
+
+  // oxlint-disable-next-line typescript/no-explicit-any
+  let AppComponent: any = null;
+  const appAssetPath = findFileWithExts(pagesDir, "_app", matcher);
+  if (appAssetPath) {
+    try {
+      const appModule = await importModule(runner, appAssetPath);
+      AppComponent = appModule.default ?? null;
+    } catch {
+      // _app exists but failed to load
+    }
+  }
+
+  return { DocumentComponent, AppComponent, appAssetPath };
+}
+
 /**
  * Emit a `getServerSideProps` / `getStaticProps` `{ redirect }` result.
  *
@@ -778,35 +816,13 @@ export function createSSRHandler(
           }
         }
 
-        // Next.js evaluates the root modules in _document > _app > page order
-        // so their top-level side effects observe the same sequence in dev and
-        // production.
-        // oxlint-disable-next-line typescript/no-explicit-any
-        let DocumentComponent: any = null;
-        const docPath = path.join(pagesDir, "_document");
-        if (findFileWithExtensions(docPath, matcher)) {
-          try {
-            const docModule = await importModule(runner, docPath);
-            DocumentComponent = docModule.default ?? null;
-          } catch {
-            // _document exists but failed to load
-          }
-        }
-
-        // Try to load _app.tsx if it exists. This happens before the readiness
-        // predicate so app-level getInitialProps participates in the same
-        // initial Pages Router state as the client __NEXT_DATA__ payload.
-        // oxlint-disable-next-line typescript/no-explicit-any
-        let AppComponent: any = null;
-        const appPath = path.join(pagesDir, "_app");
-        if (findFileWithExtensions(appPath, matcher)) {
-          try {
-            const appModule = await importModule(runner, appPath);
-            AppComponent = appModule.default ?? null;
-          } catch {
-            // _app exists but failed to load
-          }
-        }
+        // Next.js evaluates root modules before the matched page so top-level
+        // side effects observe _document > _app > page on every dev path.
+        const { DocumentComponent, AppComponent } = await loadPagesRootComponents(
+          runner,
+          pagesDir,
+          matcher,
+        );
         // Load the page module through Vite's SSR pipeline after the root
         // components. This gives us HMR and transform support for free while
         // preserving Next.js module evaluation order.
@@ -2093,6 +2109,11 @@ async function renderErrorPage(
   // Try specific status page first, then _error, then fallback
   const candidates =
     statusCode === 404 ? ["404", "_error"] : statusCode === 500 ? ["500", "_error"] : ["_error"];
+  const { DocumentComponent, AppComponent, appAssetPath } = await loadPagesRootComponents(
+    runner,
+    pagesDir,
+    matcher,
+  );
 
   for (const candidate of candidates) {
     try {
@@ -2102,20 +2123,6 @@ async function renderErrorPage(
       const errorModule = await importModule(runner, errorAssetPath);
       const ErrorComponent = errorModule.default;
       if (!ErrorComponent) continue;
-
-      // Try to load _app.tsx to wrap the error page
-      // oxlint-disable-next-line typescript/no-explicit-any
-      let AppComponent: any = null;
-      const appPathErr = path.join(pagesDir, "_app");
-      const appAssetPath = findFileWithExts(pagesDir, "_app", matcher);
-      if (findFileWithExtensions(appPathErr, matcher)) {
-        try {
-          const appModule = await importModule(runner, appAssetPath ?? appPathErr);
-          AppComponent = appModule.default ?? null;
-        } catch {
-          // _app exists but failed to load
-        }
-      }
 
       const createElement = React.createElement;
       const initialErrorProps = await loadPagesGetInitialProps(ErrorComponent, {
@@ -2138,19 +2145,6 @@ async function renderErrorPage(
           wrapFn = errRouterShim.wrapWithRouterContext;
         } catch {
           // router shim not available — continue without it
-        }
-      }
-
-      // Try custom _document
-      // oxlint-disable-next-line typescript/no-explicit-any
-      let DocumentComponent: any = null;
-      const docPathErr = path.join(pagesDir, "_document");
-      if (findFileWithExtensions(docPathErr, matcher)) {
-        try {
-          const docModule = await importModule(runner, docPathErr);
-          DocumentComponent = docModule.default ?? null;
-        } catch {
-          // _document exists but failed to load
         }
       }
 

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -778,9 +778,21 @@ export function createSSRHandler(
           }
         }
 
-        // Load the page module through Vite's SSR pipeline
-        // This gives us HMR and transform support for free
-        const pageModule = await importModule(runner, route.filePath);
+        // Next.js evaluates the root modules in _document > _app > page order
+        // so their top-level side effects observe the same sequence in dev and
+        // production.
+        // oxlint-disable-next-line typescript/no-explicit-any
+        let DocumentComponent: any = null;
+        const docPath = path.join(pagesDir, "_document");
+        if (findFileWithExtensions(docPath, matcher)) {
+          try {
+            const docModule = await importModule(runner, docPath);
+            DocumentComponent = docModule.default ?? null;
+          } catch {
+            // _document exists but failed to load
+          }
+        }
+
         // Try to load _app.tsx if it exists. This happens before the readiness
         // predicate so app-level getInitialProps participates in the same
         // initial Pages Router state as the client __NEXT_DATA__ payload.
@@ -795,6 +807,10 @@ export function createSSRHandler(
             // _app exists but failed to load
           }
         }
+        // Load the page module through Vite's SSR pipeline after the root
+        // components. This gives us HMR and transform support for free while
+        // preserving Next.js module evaluation order.
+        const pageModule = await importModule(runner, route.filePath);
         const pagesNextData = buildPagesReadinessNextData({
           pageModule,
           appComponent: AppComponent,
@@ -1859,19 +1875,6 @@ hydrate();
             ...serializedPagesNextData,
           },
         )}</script>`;
-
-        // Try to load custom _document.tsx
-        const docPath = path.join(pagesDir, "_document");
-        // oxlint-disable-next-line typescript/no-explicit-any
-        let DocumentComponent: any = null;
-        if (findFileWithExtensions(docPath, matcher)) {
-          try {
-            const docModule = (await runner.import(docPath)) as Record<string, unknown>;
-            DocumentComponent = docModule.default ?? null;
-          } catch {
-            // _document exists but failed to load
-          }
-        }
 
         // Expose page route patterns on window before hydration so the
         // next/navigation compat hooks can resolve a dynamic pattern from a

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -259,24 +259,16 @@ async function loadPagesRootComponents(
   let DocumentComponent: any = null;
   const documentAssetPath = findFileWithExts(pagesDir, "_document", matcher);
   if (documentAssetPath) {
-    try {
-      const documentModule = await importModule(runner, documentAssetPath);
-      DocumentComponent = documentModule.default ?? null;
-    } catch {
-      // _document exists but failed to load
-    }
+    const documentModule = await importModule(runner, documentAssetPath);
+    DocumentComponent = documentModule.default ?? null;
   }
 
   // oxlint-disable-next-line typescript/no-explicit-any
   let AppComponent: any = null;
   const appAssetPath = findFileWithExts(pagesDir, "_app", matcher);
   if (appAssetPath) {
-    try {
-      const appModule = await importModule(runner, appAssetPath);
-      AppComponent = appModule.default ?? null;
-    } catch {
-      // _app exists but failed to load
-    }
+    const appModule = await importModule(runner, appAssetPath);
+    AppComponent = appModule.default ?? null;
   }
 
   return { DocumentComponent, AppComponent, appAssetPath };

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -248,6 +248,7 @@ async function loadPagesRootComponents(
   runner: ModuleImporter,
   pagesDir: string,
   matcher: ValidFileMatcher,
+  options: { includeDocument?: boolean } = {},
 ): Promise<{
   // oxlint-disable-next-line typescript/no-explicit-any
   DocumentComponent: any;
@@ -255,12 +256,15 @@ async function loadPagesRootComponents(
   AppComponent: any;
   appAssetPath: string | null;
 }> {
+  const { includeDocument = true } = options;
   // oxlint-disable-next-line typescript/no-explicit-any
   let DocumentComponent: any = null;
-  const documentAssetPath = findFileWithExts(pagesDir, "_document", matcher);
-  if (documentAssetPath) {
-    const documentModule = await importModule(runner, documentAssetPath);
-    DocumentComponent = documentModule.default ?? null;
+  if (includeDocument) {
+    const documentAssetPath = findFileWithExts(pagesDir, "_document", matcher);
+    if (documentAssetPath) {
+      const documentModule = await importModule(runner, documentAssetPath);
+      DocumentComponent = documentModule.default ?? null;
+    }
   }
 
   // oxlint-disable-next-line typescript/no-explicit-any
@@ -808,12 +812,13 @@ export function createSSRHandler(
           }
         }
 
-        // Next.js evaluates root modules before the matched page so top-level
-        // side effects observe _document > _app > page on every dev path.
+        // Next.js evaluates _app before the matched page on every dev path,
+        // while _document is only evaluated for HTML rendering.
         const { DocumentComponent, AppComponent } = await loadPagesRootComponents(
           runner,
           pagesDir,
           matcher,
+          { includeDocument: !isDataReq },
         );
         // Load the page module through Vite's SSR pipeline after the root
         // components. This gives us HMR and transform support for free while

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -1148,6 +1148,53 @@ describe("Pages Router entry template", () => {
     }
   });
 
+  it("imports Pages root components in _document > _app > page order", async () => {
+    // Ported from Next.js: test/e2e/app-document-import-order/app-document-import-order.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-document-import-order/app-document-import-order.test.ts
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-import-order-entry-"));
+    const pagesDir = path.join(tmpDir, "pages");
+
+    try {
+      fs.mkdirSync(pagesDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(pagesDir, "_document.tsx"),
+        "export default function Document() { return null; }",
+      );
+      fs.writeFileSync(
+        path.join(pagesDir, "_app.tsx"),
+        "export default function App() { return null; }",
+      );
+      fs.writeFileSync(
+        path.join(pagesDir, "index.tsx"),
+        "export default function Page() { return null; }",
+      );
+
+      const code = await generateServerEntry(
+        pagesDir,
+        await resolveNextConfig({}),
+        createValidFileMatcher(),
+        null,
+        null,
+      );
+
+      const documentImportIndex = code.indexOf(
+        `import { default as DocumentComponent } from ${JSON.stringify(path.join(pagesDir, "_document.tsx"))}`,
+      );
+      const appImportIndex = code.indexOf(
+        `import { default as AppComponent } from ${JSON.stringify(path.join(pagesDir, "_app.tsx"))}`,
+      );
+      const pageImportIndex = code.indexOf(
+        `import * as page_0 from ${JSON.stringify(path.join(pagesDir, "index.tsx"))}`,
+      );
+
+      expect(documentImportIndex).toBeGreaterThanOrEqual(0);
+      expect(appImportIndex).toBeGreaterThan(documentImportIndex);
+      expect(pageImportIndex).toBeGreaterThan(appImportIndex);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("precomputes Pages route dataKind in the server entry", async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-data-kind-entry-"));
     const pagesDir = path.join(tmpDir, "pages");

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -3033,6 +3033,67 @@ describe("Virtual server entry generation", () => {
     }
   });
 
+  it("evaluates Pages root components in _document > _app > page order in dev", async () => {
+    // Ported from Next.js: test/e2e/app-document-import-order/app-document-import-order.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-document-import-order/app-document-import-order.test.ts
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-import-order-dev-"));
+    const pagesDir = path.join(tmpDir, "pages");
+    fs.mkdirSync(pagesDir, { recursive: true });
+    fs.symlinkSync(path.join(process.cwd(), "node_modules"), path.join(tmpDir, "node_modules"));
+    fs.writeFileSync(
+      path.join(tmpDir, "side-effect.ts"),
+      `const calls = ((globalThis as any).__VINEXT_IMPORT_ORDER__ ??= []);
+export function record(name: string) { calls.push(name); }
+export function read() { return calls; }
+`,
+    );
+    fs.writeFileSync(
+      path.join(pagesDir, "_document.tsx"),
+      `import Document, { Html, Head, Main, NextScript } from "next/document";
+import { record } from "../side-effect";
+record("_document");
+export default class CustomDocument extends Document {
+  render() { return <Html><Head /><body><Main /><NextScript /></body></Html>; }
+}
+`,
+    );
+    fs.writeFileSync(
+      path.join(pagesDir, "_app.tsx"),
+      `import { record } from "../side-effect";
+record("_app");
+export default function App({ Component, pageProps }) { return <Component {...pageProps} />; }
+`,
+    );
+    fs.writeFileSync(
+      path.join(pagesDir, "index.tsx"),
+      `import { read, record } from "../side-effect";
+record("page");
+export default function Page() { return <p id="import-order">{read().join(",")}</p>; }
+`,
+    );
+
+    const testServer = await createServer({
+      root: tmpDir,
+      configFile: false,
+      plugins: [vinext({ appDir: tmpDir })],
+      server: { port: 0, cors: false },
+      logLevel: "silent",
+    });
+
+    try {
+      await testServer.listen();
+      const addr = testServer.httpServer?.address();
+      if (!addr || typeof addr !== "object") throw new Error("Expected dev server address");
+
+      const res = await fetch(`http://localhost:${addr.port}/`);
+      expect(res.status).toBe(200);
+      expect(await res.text()).toContain('<p id="import-order">_document,_app,page</p>');
+    } finally {
+      await testServer.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("dev Pages client assets expose virtual CSS added by client transforms", async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-virtual-css-"));
     fs.mkdirSync(path.join(tmpDir, "pages"), { recursive: true });

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -3094,6 +3094,67 @@ export default function Page() { return <p id="import-order">{read().join(",")}<
     }
   });
 
+  it("evaluates Pages root components before a cold-start missing route in dev", async () => {
+    // Ported from Next.js: test/e2e/app-document-import-order/app-document-import-order.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-document-import-order/app-document-import-order.test.ts
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-error-import-order-dev-"));
+    const pagesDir = path.join(tmpDir, "pages");
+    fs.mkdirSync(pagesDir, { recursive: true });
+    fs.symlinkSync(path.join(process.cwd(), "node_modules"), path.join(tmpDir, "node_modules"));
+    fs.writeFileSync(
+      path.join(tmpDir, "side-effect.ts"),
+      `const calls = ((globalThis as any).__VINEXT_ERROR_IMPORT_ORDER__ ??= []);
+export function record(name: string) { calls.push(name); }
+export function read() { return calls; }
+`,
+    );
+    fs.writeFileSync(
+      path.join(pagesDir, "_document.tsx"),
+      `import Document, { Html, Head, Main, NextScript } from "next/document";
+import { record } from "../side-effect";
+record("_document");
+export default class CustomDocument extends Document {
+  render() { return <Html><Head /><body><Main /><NextScript /></body></Html>; }
+}
+`,
+    );
+    fs.writeFileSync(
+      path.join(pagesDir, "_app.tsx"),
+      `import { record } from "../side-effect";
+record("_app");
+export default function App({ Component, pageProps }) { return <Component {...pageProps} />; }
+`,
+    );
+    fs.writeFileSync(
+      path.join(pagesDir, "404.tsx"),
+      `import { read, record } from "../side-effect";
+record("404");
+export default function NotFound() { return <p id="import-order">{read().join(",")}</p>; }
+`,
+    );
+
+    const testServer = await createServer({
+      root: tmpDir,
+      configFile: false,
+      plugins: [vinext({ appDir: tmpDir })],
+      server: { port: 0, cors: false },
+      logLevel: "silent",
+    });
+
+    try {
+      await testServer.listen();
+      const addr = testServer.httpServer?.address();
+      if (!addr || typeof addr !== "object") throw new Error("Expected dev server address");
+
+      const res = await fetch(`http://localhost:${addr.port}/missing`);
+      expect(res.status).toBe(404);
+      expect(await res.text()).toContain('<p id="import-order">_document,_app,404</p>');
+    } finally {
+      await testServer.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("dev Pages client assets expose virtual CSS added by client transforms", async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-virtual-css-"));
     fs.mkdirSync(path.join(tmpDir, "pages"), { recursive: true });

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -3196,6 +3196,59 @@ export default function Document() { return null; }
     }
   });
 
+  it("does not evaluate _document for a dev data request", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-data-document-dev-"));
+    const pagesDir = path.join(tmpDir, "pages");
+    fs.mkdirSync(pagesDir, { recursive: true });
+    fs.symlinkSync(path.join(process.cwd(), "node_modules"), path.join(tmpDir, "node_modules"));
+    fs.writeFileSync(
+      path.join(tmpDir, "next.config.js"),
+      `module.exports = { generateBuildId: () => "test-build-id" };\n`,
+    );
+    fs.writeFileSync(
+      path.join(pagesDir, "_document.tsx"),
+      `throw new Error("document import failed");
+export default function Document() { return null; }
+`,
+    );
+    fs.writeFileSync(
+      path.join(pagesDir, "_app.tsx"),
+      `export default function App({ Component, pageProps }) { return <Component {...pageProps} />; }
+`,
+    );
+    fs.writeFileSync(
+      path.join(pagesDir, "index.tsx"),
+      `export async function getServerSideProps() { return { props: { value: "data response" } }; }
+export default function Page({ value }) { return <p>{value}</p>; }
+`,
+    );
+
+    const testServer = await createServer({
+      root: tmpDir,
+      configFile: false,
+      plugins: [vinext({ appDir: tmpDir })],
+      server: { port: 0, cors: false },
+      logLevel: "silent",
+    });
+
+    try {
+      await testServer.listen();
+      const addr = testServer.httpServer?.address();
+      if (!addr || typeof addr !== "object") throw new Error("Expected dev server address");
+
+      const res = await fetch(`http://localhost:${addr.port}/_next/data/test-build-id/index.json`);
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("application/json");
+      expect(await res.json()).toEqual({
+        pageProps: { value: "data response" },
+        __N_SSP: true,
+      });
+    } finally {
+      await testServer.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("propagates a throwing _app import on a cold-start missing dev route", async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-app-import-error-"));
     const pagesDir = path.join(tmpDir, "pages");

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -3155,6 +3155,88 @@ export default function NotFound() { return <p id="import-order">{read().join(",
     }
   });
 
+  it("propagates a throwing _document import on a normal dev route", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-document-import-error-"));
+    const pagesDir = path.join(tmpDir, "pages");
+    fs.mkdirSync(pagesDir, { recursive: true });
+    fs.symlinkSync(path.join(process.cwd(), "node_modules"), path.join(tmpDir, "node_modules"));
+    fs.writeFileSync(
+      path.join(pagesDir, "_document.tsx"),
+      `throw new Error("document import failed");
+export default function Document() { return null; }
+`,
+    );
+    fs.writeFileSync(
+      path.join(pagesDir, "index.tsx"),
+      `export default function Page() { return <p>page rendered</p>; }
+`,
+    );
+
+    const testServer = await createServer({
+      root: tmpDir,
+      configFile: false,
+      plugins: [vinext({ appDir: tmpDir })],
+      server: { port: 0, cors: false },
+      logLevel: "silent",
+    });
+
+    try {
+      await testServer.listen();
+      const addr = testServer.httpServer?.address();
+      if (!addr || typeof addr !== "object") throw new Error("Expected dev server address");
+
+      const res = await fetch(`http://localhost:${addr.port}/`);
+      expect(res.status).toBe(500);
+      const html = await res.text();
+      expect(html).toContain("document import failed");
+      expect(html).not.toContain("page rendered");
+    } finally {
+      await testServer.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("propagates a throwing _app import on a cold-start missing dev route", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-app-import-error-"));
+    const pagesDir = path.join(tmpDir, "pages");
+    fs.mkdirSync(pagesDir, { recursive: true });
+    fs.symlinkSync(path.join(process.cwd(), "node_modules"), path.join(tmpDir, "node_modules"));
+    fs.writeFileSync(
+      path.join(pagesDir, "_app.tsx"),
+      `throw new Error("app import failed");
+export default function App({ Component, pageProps }) { return <Component {...pageProps} />; }
+`,
+    );
+    fs.writeFileSync(
+      path.join(pagesDir, "404.tsx"),
+      `export default function NotFound() { return <p>404 rendered</p>; }
+`,
+    );
+
+    const testServer = await createServer({
+      root: tmpDir,
+      configFile: false,
+      plugins: [vinext({ appDir: tmpDir })],
+      server: { port: 0, cors: false },
+      logLevel: "silent",
+    });
+
+    try {
+      await testServer.listen();
+      const addr = testServer.httpServer?.address();
+      if (!addr || typeof addr !== "object") throw new Error("Expected dev server address");
+
+      const res = await fetch(`http://localhost:${addr.port}/missing`);
+      expect(res.status).toBe(500);
+      const html = await res.text();
+      expect(html).toContain("app import failed");
+      expect(html).not.toContain("404 rendered");
+    } finally {
+      await testServer.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("dev Pages client assets expose virtual CSS added by client transforms", async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-virtual-css-"));
     fs.mkdirSync(path.join(tmpDir, "pages"), { recursive: true });
@@ -8556,7 +8638,11 @@ describe("Pages Router dev ISR regeneration", () => {
           };
         }
 
-        if (id === path.join(FIXTURE_DIR, "pages", "_app")) {
+        if (/[/\\]_document(?:\.[^/\\]+)?$/.test(id)) {
+          return { default: null };
+        }
+
+        if (/[/\\]_app(?:\.[^/\\]+)?$/.test(id)) {
           return { default: App };
         }
 


### PR DESCRIPTION
## Summary

- load Pages Router root modules in Next.js order: `_document` → `_app` → page
- preserve that ordering in both the dev SSR module runner and generated production server entry
- add focused dev-runtime and generated-entry regressions ported from the pinned Next.js suite

## Failure addressed

From Actions run 28938793088:

- `test/e2e/app-document-import-order/app-document-import-order.test.ts` — `root components should be imported in order _document > _app > page`

The two `test/e2e/app-document/rendering.test.ts` nonce/crossOrigin failures are already owned by #2044; I commented there with the exact failing tests and intentionally did not duplicate that work.

## Next.js oracle

Pinned Next.js `v16.3.0-canary.80` at `9dd6d677b63b249584c8ff0bccffcc6a65288683`.

## Validation

- `vp test run tests/entry-templates.test.ts tests/pages-router.test.ts` — 395 passed
- `vp check packages/vinext/src/entries/pages-server-entry.ts packages/vinext/src/server/dev-server.ts tests/entry-templates.test.ts tests/pages-router.test.ts` — passed
- `git diff --check` — passed
- `REPO="$(pwd)" NEXTJS_DIR="/Users/jamesanderson/Developer/vinext/.nextjs-ref-v16.3.0-canary.80" ./scripts/run-targeted-nextjs-e2e.sh test/e2e/app-document-import-order/app-document-import-order.test.ts` — 1 passed, 1 upstream Turbopack skip

## Notes

- No Bonk requested yet.
- Concurrent unstaged Pages data-props edits in the shared worktree were excluded from this commit.