### PR TITLE
fix(pages): align preview mode behavior

### DIFF
--- a/packages/vinext/src/build/preview-credentials.ts
+++ b/packages/vinext/src/build/preview-credentials.ts
@@ -1,0 +1,26 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { randomBytes } from "node:crypto";
+
+export type PreviewBuildCredentials = {
+  id: string;
+  signingKey: string;
+  encryptionKey: string;
+};
+
+const previewBuildCredentialsStorage = new AsyncLocalStorage<PreviewBuildCredentials>();
+
+export function createPreviewBuildCredentials(): PreviewBuildCredentials {
+  return {
+    id: randomBytes(16).toString("hex"),
+    signingKey: randomBytes(32).toString("hex"),
+    encryptionKey: randomBytes(32).toString("hex"),
+  };
+}
+
+export function getPreviewBuildCredentials(): PreviewBuildCredentials | undefined {
+  return previewBuildCredentialsStorage.getStore();
+}
+
+export function runWithPreviewBuildCredentials<T>(callback: () => T): T {
+  return previewBuildCredentialsStorage.run(createPreviewBuildCredentials(), callback);
+}

--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -531,6 +531,15 @@ async function buildApp() {
   if (!process.env.__VINEXT_SHARED_REVALIDATE_SECRET) {
     process.env.__VINEXT_SHARED_REVALIDATE_SECRET = randomBytes(32).toString("hex");
   }
+  if (!process.env.__VINEXT_SHARED_PREVIEW_MODE_ID) {
+    process.env.__VINEXT_SHARED_PREVIEW_MODE_ID = randomBytes(16).toString("hex");
+  }
+  if (!process.env.__VINEXT_SHARED_PREVIEW_MODE_SIGNING_KEY) {
+    process.env.__VINEXT_SHARED_PREVIEW_MODE_SIGNING_KEY = randomBytes(32).toString("hex");
+  }
+  if (!process.env.__VINEXT_SHARED_PREVIEW_MODE_ENCRYPTION_KEY) {
+    process.env.__VINEXT_SHARED_PREVIEW_MODE_ENCRYPTION_KEY = randomBytes(32).toString("hex");
+  }
 
   const outputMode = resolvedNextConfig.output;
   const distDir = path.resolve(root, "dist");

--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -44,6 +44,7 @@ import {
 import { emitStandaloneOutput } from "./build/standalone.js";
 import { cleanBuildOutput } from "./build/clean-output.js";
 import { clearPagesClientAssetsBuildMetadata } from "./build/pages-client-assets-module.js";
+import { runWithPreviewBuildCredentials } from "./build/preview-credentials.js";
 import { resolveVinextPackageRoot } from "./utils/vinext-root.js";
 import { parseArgs } from "./cli-args.js";
 import {
@@ -531,16 +532,6 @@ async function buildApp() {
   if (!process.env.__VINEXT_SHARED_REVALIDATE_SECRET) {
     process.env.__VINEXT_SHARED_REVALIDATE_SECRET = randomBytes(32).toString("hex");
   }
-  if (!process.env.__VINEXT_SHARED_PREVIEW_MODE_ID) {
-    process.env.__VINEXT_SHARED_PREVIEW_MODE_ID = randomBytes(16).toString("hex");
-  }
-  if (!process.env.__VINEXT_SHARED_PREVIEW_MODE_SIGNING_KEY) {
-    process.env.__VINEXT_SHARED_PREVIEW_MODE_SIGNING_KEY = randomBytes(32).toString("hex");
-  }
-  if (!process.env.__VINEXT_SHARED_PREVIEW_MODE_ENCRYPTION_KEY) {
-    process.env.__VINEXT_SHARED_PREVIEW_MODE_ENCRYPTION_KEY = randomBytes(32).toString("hex");
-  }
-
   const outputMode = resolvedNextConfig.output;
   const distDir = path.resolve(root, "dist");
 
@@ -594,86 +585,88 @@ async function buildApp() {
   if (pagesClientAssetsBuildSession) {
     process.env.__VINEXT_PAGES_CLIENT_ASSETS_BUILD_SESSION = pagesClientAssetsBuildSession;
   }
-  try {
-    const config = buildViteConfig({}, logger);
-    const builder = await vite.createBuilder(config);
-    await builder.buildApp();
+  await runWithPreviewBuildCredentials(async () => {
+    try {
+      const config = buildViteConfig({}, logger);
+      const builder = await vite.createBuilder(config);
+      await builder.buildApp();
 
-    if (isHybrid) {
-      // Hybrid app (both app/ and pages/ directories): also build the Pages Router
-      // SSR bundle so the prerender phase can render Pages Router routes.
-      // The App Router multi-env build (buildApp) doesn't include the Pages Router
-      // SSR entry, so we run it as a separate step here.
-      // We use configFile: false with vinext({ disableAppRouter: true }) to avoid
-      // loading the user's vite.config (which has vinext() without disableAppRouter)
-      // and to prevent the multi-env environments config from overriding our SSR
-      // input and entryFileNames.
-      console.log("  Building Pages Router server (hybrid)...");
-      // Inherit transform plugins from the user's vite.config (e.g. SVG loaders,
-      // CSS-in-JS) that vinext doesn't auto-register. We load the raw config via
-      // loadConfigFromFile — before any plugin config() hooks fire — so that
-      // cloudflare() hasn't yet injected its multi-env environments block.
-      // We then exclude the plugin families that vinext({ disableAppRouter: true })
-      // will re-register itself, and cloudflare() which must not run here.
-      const root = process.cwd();
-      let userTransformPlugins: import("vite").PluginOption[] = [];
-      if (hasViteConfig(process.cwd())) {
-        const loaded = await vite.loadConfigFromFile(
-          { command: "build", mode: "production", isSsrBuild: true },
-          undefined,
-          root,
-        );
-        if (loaded?.config.plugins) {
-          const flat = (loaded.config.plugins as unknown[]).flat(Infinity) as {
-            name?: string;
-          }[];
-          userTransformPlugins = flat.filter(
-            (p): p is import("vite").Plugin =>
-              !!p &&
-              typeof p.name === "string" &&
-              // vinext and its sub-plugins — re-registered below
-              !p.name.startsWith("vinext:") &&
-              // @vitejs/plugin-react — auto-registered by vinext
-              !p.name.startsWith("vite:react") &&
-              // @vitejs/plugin-rsc and its sub-plugins — App Router only
-              !p.name.startsWith("rsc:") &&
-              p.name !== "vite-rsc-load-module-dev-proxy" &&
-              // cloudflare() — injects multi-env environments block which
-              // conflicts with the plain SSR build config below
-              !p.name.startsWith("vite-plugin-cloudflare"),
+      if (isHybrid) {
+        // Hybrid app (both app/ and pages/ directories): also build the Pages Router
+        // SSR bundle so the prerender phase can render Pages Router routes.
+        // The App Router multi-env build (buildApp) doesn't include the Pages Router
+        // SSR entry, so we run it as a separate step here.
+        // We use configFile: false with vinext({ disableAppRouter: true }) to avoid
+        // loading the user's vite.config (which has vinext() without disableAppRouter)
+        // and to prevent the multi-env environments config from overriding our SSR
+        // input and entryFileNames.
+        console.log("  Building Pages Router server (hybrid)...");
+        // Inherit transform plugins from the user's vite.config (e.g. SVG loaders,
+        // CSS-in-JS) that vinext doesn't auto-register. We load the raw config via
+        // loadConfigFromFile — before any plugin config() hooks fire — so that
+        // cloudflare() hasn't yet injected its multi-env environments block.
+        // We then exclude the plugin families that vinext({ disableAppRouter: true })
+        // will re-register itself, and cloudflare() which must not run here.
+        const root = process.cwd();
+        let userTransformPlugins: import("vite").PluginOption[] = [];
+        if (hasViteConfig(process.cwd())) {
+          const loaded = await vite.loadConfigFromFile(
+            { command: "build", mode: "production", isSsrBuild: true },
+            undefined,
+            root,
           );
+          if (loaded?.config.plugins) {
+            const flat = (loaded.config.plugins as unknown[]).flat(Infinity) as {
+              name?: string;
+            }[];
+            userTransformPlugins = flat.filter(
+              (p): p is import("vite").Plugin =>
+                !!p &&
+                typeof p.name === "string" &&
+                // vinext and its sub-plugins — re-registered below
+                !p.name.startsWith("vinext:") &&
+                // @vitejs/plugin-react — auto-registered by vinext
+                !p.name.startsWith("vite:react") &&
+                // @vitejs/plugin-rsc and its sub-plugins — App Router only
+                !p.name.startsWith("rsc:") &&
+                p.name !== "vite-rsc-load-module-dev-proxy" &&
+                // cloudflare() — injects multi-env environments block which
+                // conflicts with the plain SSR build config below
+                !p.name.startsWith("vite-plugin-cloudflare"),
+            );
+          }
+        }
+        await vite.build({
+          root,
+          configFile: false,
+          plugins: [...userTransformPlugins, vinext({ disableAppRouter: true })],
+          resolve: {
+            dedupe: ["react", "react-dom", "react/jsx-runtime", "react/jsx-dev-runtime"],
+          },
+          ...(logger ? { customLogger: logger } : {}),
+          build: {
+            outDir: "dist/server",
+            emptyOutDir: false, // preserve RSC artefacts from buildApp()
+            ssr: "virtual:vinext-server-entry",
+            ...withBuildBundlerOptions({
+              output: {
+                entryFileNames: "entry.js",
+              },
+            }),
+          },
+        });
+      }
+    } finally {
+      if (pagesClientAssetsBuildSession) {
+        clearPagesClientAssetsBuildMetadata(pagesClientAssetsBuildSession);
+        if (
+          process.env.__VINEXT_PAGES_CLIENT_ASSETS_BUILD_SESSION === pagesClientAssetsBuildSession
+        ) {
+          delete process.env.__VINEXT_PAGES_CLIENT_ASSETS_BUILD_SESSION;
         }
       }
-      await vite.build({
-        root,
-        configFile: false,
-        plugins: [...userTransformPlugins, vinext({ disableAppRouter: true })],
-        resolve: {
-          dedupe: ["react", "react-dom", "react/jsx-runtime", "react/jsx-dev-runtime"],
-        },
-        ...(logger ? { customLogger: logger } : {}),
-        build: {
-          outDir: "dist/server",
-          emptyOutDir: false, // preserve RSC artefacts from buildApp()
-          ssr: "virtual:vinext-server-entry",
-          ...withBuildBundlerOptions({
-            output: {
-              entryFileNames: "entry.js",
-            },
-          }),
-        },
-      });
     }
-  } finally {
-    if (pagesClientAssetsBuildSession) {
-      clearPagesClientAssetsBuildMetadata(pagesClientAssetsBuildSession);
-      if (
-        process.env.__VINEXT_PAGES_CLIENT_ASSETS_BUILD_SESSION === pagesClientAssetsBuildSession
-      ) {
-        delete process.env.__VINEXT_PAGES_CLIENT_ASSETS_BUILD_SESSION;
-      }
-    }
-  }
+  });
 
   if (outputMode === "standalone") {
     const standalone = emitStandaloneOutput({

--- a/packages/vinext/src/global.d.ts
+++ b/packages/vinext/src/global.d.ts
@@ -415,9 +415,6 @@ declare global {
       __VINEXT_PREVIEW_MODE_ID?: string;
       __VINEXT_PREVIEW_MODE_SIGNING_KEY?: string;
       __VINEXT_PREVIEW_MODE_ENCRYPTION_KEY?: string;
-      __VINEXT_SHARED_PREVIEW_MODE_ID?: string;
-      __VINEXT_SHARED_PREVIEW_MODE_SIGNING_KEY?: string;
-      __VINEXT_SHARED_PREVIEW_MODE_ENCRYPTION_KEY?: string;
 
       /**
        * Deployment ID string injected via Vite `define` when

--- a/packages/vinext/src/global.d.ts
+++ b/packages/vinext/src/global.d.ts
@@ -412,6 +412,12 @@ declare global {
        * standalone code paths.
        */
       __VINEXT_SHARED_REVALIDATE_SECRET?: string;
+      __VINEXT_PREVIEW_MODE_ID?: string;
+      __VINEXT_PREVIEW_MODE_SIGNING_KEY?: string;
+      __VINEXT_PREVIEW_MODE_ENCRYPTION_KEY?: string;
+      __VINEXT_SHARED_PREVIEW_MODE_ID?: string;
+      __VINEXT_SHARED_PREVIEW_MODE_SIGNING_KEY?: string;
+      __VINEXT_SHARED_PREVIEW_MODE_ENCRYPTION_KEY?: string;
 
       /**
        * Deployment ID string injected via Vite `define` when

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -232,7 +232,8 @@ import path, { toSlash } from "pathslash";
 import { pathToFileURL } from "node:url";
 import { createRequire } from "node:module";
 import fs from "node:fs";
-import { createHash, randomBytes, randomUUID } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
+import { getPagesPreviewModeId } from "./server/pages-preview.js";
 import commonjs from "vite-plugin-commonjs";
 import { createIgnoreDynamicRequestsPlugin } from "./plugins/ignore-dynamic-requests.js";
 import { stripJsExtension, stripViteModuleQuery } from "./utils/path.js";
@@ -1331,7 +1332,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
   const pagesClientAssetsOutputDirs = new Set<string>();
   let pagesClientAssetsModule: string | null = null;
   let rscCompatibilityId: string | undefined;
-  const draftModeSecret = randomUUID();
+  let draftModeSecret = getPagesPreviewModeId();
   // Per-plugin-instance binding of the Sass-aware CSS Modules Loader. The
   // `config` hook injects `Loader` as `css.modules.Loader` and
   // `configResolved` binds the resolved config, so multiple vinext builds in
@@ -1893,6 +1894,13 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         if (process.env.NODE_ENV !== resolvedNodeEnv) {
           process.env.NODE_ENV = resolvedNodeEnv;
         }
+        if (env?.command === "build") {
+          process.env.__VINEXT_SHARED_PREVIEW_MODE_ID ??= randomBytes(16).toString("hex");
+          process.env.__VINEXT_SHARED_PREVIEW_MODE_SIGNING_KEY ??= randomBytes(32).toString("hex");
+          process.env.__VINEXT_SHARED_PREVIEW_MODE_ENCRYPTION_KEY ??=
+            randomBytes(32).toString("hex");
+        }
+        draftModeSecret = getPagesPreviewModeId();
 
         // Resolve the base directory for app/pages detection.
         // If appDir is provided, resolve it (supports both relative and absolute paths).

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -5501,6 +5501,22 @@ export const loadServerActionClient = ${
           serverDefines["process.env.__VINEXT_REVALIDATE_SECRET"] =
             JSON.stringify(sharedRevalidateSecret);
         }
+        const sharedPreviewModeId = process.env.__VINEXT_SHARED_PREVIEW_MODE_ID;
+        const sharedPreviewSigningKey = process.env.__VINEXT_SHARED_PREVIEW_MODE_SIGNING_KEY;
+        const sharedPreviewEncryptionKey = process.env.__VINEXT_SHARED_PREVIEW_MODE_ENCRYPTION_KEY;
+        if (sharedPreviewModeId) {
+          serverDefines["process.env.__VINEXT_PREVIEW_MODE_ID"] =
+            JSON.stringify(sharedPreviewModeId);
+        }
+        if (sharedPreviewSigningKey) {
+          serverDefines["process.env.__VINEXT_PREVIEW_MODE_SIGNING_KEY"] =
+            JSON.stringify(sharedPreviewSigningKey);
+        }
+        if (sharedPreviewEncryptionKey) {
+          serverDefines["process.env.__VINEXT_PREVIEW_MODE_ENCRYPTION_KEY"] = JSON.stringify(
+            sharedPreviewEncryptionKey,
+          );
+        }
 
         return { define: serverDefines };
       },

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -185,6 +185,11 @@ import {
   takePagesClientAssetsBuildMetadata,
   writePagesClientAssetsModuleIfMissing,
 } from "./build/pages-client-assets-module.js";
+import {
+  createPreviewBuildCredentials,
+  getPreviewBuildCredentials,
+  type PreviewBuildCredentials,
+} from "./build/preview-credentials.js";
 import { createModuleDependencyCache } from "./build/module-dependency-cache.js";
 import { resolvePostcssStringPlugins } from "./plugins/postcss.js";
 import {
@@ -1333,6 +1338,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
   let pagesClientAssetsModule: string | null = null;
   let rscCompatibilityId: string | undefined;
   let draftModeSecret = getPagesPreviewModeId();
+  let previewBuildCredentials: PreviewBuildCredentials | undefined;
   // Per-plugin-instance binding of the Sass-aware CSS Modules Loader. The
   // `config` hook injects `Loader` as `css.modules.Loader` and
   // `configResolved` binds the resolved config, so multiple vinext builds in
@@ -1895,12 +1901,9 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           process.env.NODE_ENV = resolvedNodeEnv;
         }
         if (env?.command === "build") {
-          process.env.__VINEXT_SHARED_PREVIEW_MODE_ID ??= randomBytes(16).toString("hex");
-          process.env.__VINEXT_SHARED_PREVIEW_MODE_SIGNING_KEY ??= randomBytes(32).toString("hex");
-          process.env.__VINEXT_SHARED_PREVIEW_MODE_ENCRYPTION_KEY ??=
-            randomBytes(32).toString("hex");
+          previewBuildCredentials = getPreviewBuildCredentials() ?? createPreviewBuildCredentials();
         }
-        draftModeSecret = getPagesPreviewModeId();
+        draftModeSecret = previewBuildCredentials?.id ?? getPagesPreviewModeId();
 
         // Resolve the base directory for app/pages detection.
         // If appDir is provided, resolve it (supports both relative and absolute paths).
@@ -5509,20 +5512,15 @@ export const loadServerActionClient = ${
           serverDefines["process.env.__VINEXT_REVALIDATE_SECRET"] =
             JSON.stringify(sharedRevalidateSecret);
         }
-        const sharedPreviewModeId = process.env.__VINEXT_SHARED_PREVIEW_MODE_ID;
-        const sharedPreviewSigningKey = process.env.__VINEXT_SHARED_PREVIEW_MODE_SIGNING_KEY;
-        const sharedPreviewEncryptionKey = process.env.__VINEXT_SHARED_PREVIEW_MODE_ENCRYPTION_KEY;
-        if (sharedPreviewModeId) {
-          serverDefines["process.env.__VINEXT_PREVIEW_MODE_ID"] =
-            JSON.stringify(sharedPreviewModeId);
-        }
-        if (sharedPreviewSigningKey) {
-          serverDefines["process.env.__VINEXT_PREVIEW_MODE_SIGNING_KEY"] =
-            JSON.stringify(sharedPreviewSigningKey);
-        }
-        if (sharedPreviewEncryptionKey) {
+        if (previewBuildCredentials) {
+          serverDefines["process.env.__VINEXT_PREVIEW_MODE_ID"] = JSON.stringify(
+            previewBuildCredentials.id,
+          );
+          serverDefines["process.env.__VINEXT_PREVIEW_MODE_SIGNING_KEY"] = JSON.stringify(
+            previewBuildCredentials.signingKey,
+          );
           serverDefines["process.env.__VINEXT_PREVIEW_MODE_ENCRYPTION_KEY"] = JSON.stringify(
-            sharedPreviewEncryptionKey,
+            previewBuildCredentials.encryptionKey,
           );
         }
 

--- a/packages/vinext/src/server/api-handler.ts
+++ b/packages/vinext/src/server/api-handler.ts
@@ -29,7 +29,12 @@ import { resolveRequestProtocol, resolveRequestHost } from "./proxy-trust.js";
 import { performOnDemandRevalidate, type RevalidateOptions } from "./pages-revalidate.js";
 import { NextRequest } from "vinext/shims/server";
 import { hasBasePath } from "../utils/base-path.js";
-import { attachPagesRequestCookies } from "./pages-node-compat.js";
+import {
+  attachPagesPreviewApi,
+  attachPagesRequestCookies,
+  type PagesReqResRequest,
+  type PagesReqResResponse,
+} from "./pages-node-compat.js";
 
 /**
  * Extend the Node.js request with Next.js-style helpers.
@@ -38,6 +43,8 @@ type NextApiRequest = {
   query: Record<string, string | string[]>;
   body: unknown;
   cookies: Record<string, string>;
+  preview?: true;
+  previewData: object | string | false;
 } & IncomingMessage;
 
 /**
@@ -49,6 +56,11 @@ type NextApiResponse = {
   send(data: unknown): void;
   redirect(statusOrUrl: number | string, url?: string): void;
   revalidate(urlPath: string, opts?: RevalidateOptions): Promise<void>;
+  setPreviewData(
+    data: object | string,
+    options?: { maxAge?: number; path?: string },
+  ): NextApiResponse;
+  clearPreviewData(options?: { path?: string }): NextApiResponse;
 } & ServerResponse;
 
 type EdgeApiRouteModule = {
@@ -286,7 +298,7 @@ function enhanceApiObjects(
   }) as NextApiRequest;
   attachPagesRequestCookies(apiReq);
 
-  const apiRes: NextApiResponse = Object.assign(res, {
+  const apiRes = Object.assign(res, {
     status(this: NextApiResponse, code: number) {
       this.statusCode = code;
       return this;
@@ -334,7 +346,11 @@ function enhanceApiObjects(
     async revalidate(this: NextApiResponse, urlPath: string, opts?: RevalidateOptions) {
       await performOnDemandRevalidate(req, urlPath, opts);
     },
-  });
+  }) as NextApiResponse;
+  attachPagesPreviewApi(
+    apiReq as unknown as PagesReqResRequest,
+    apiRes as unknown as PagesReqResResponse,
+  );
 
   return { apiReq, apiRes };
 }

--- a/packages/vinext/src/server/api-handler.ts
+++ b/packages/vinext/src/server/api-handler.ts
@@ -61,6 +61,7 @@ type NextApiResponse = {
     options?: { maxAge?: number; path?: string },
   ): NextApiResponse;
   clearPreviewData(options?: { path?: string }): NextApiResponse;
+  setDraftMode(options?: { enable?: boolean }): NextApiResponse;
 } & ServerResponse;
 
 type EdgeApiRouteModule = {

--- a/packages/vinext/src/server/api-handler.ts
+++ b/packages/vinext/src/server/api-handler.ts
@@ -44,6 +44,7 @@ type NextApiRequest = {
   body: unknown;
   cookies: Record<string, string>;
   preview?: true;
+  draftMode?: true;
   previewData: object | string | false;
 } & IncomingMessage;
 

--- a/packages/vinext/src/server/api-handler.ts
+++ b/packages/vinext/src/server/api-handler.ts
@@ -55,7 +55,7 @@ type NextApiResponse = {
   status(code: number): NextApiResponse;
   json(data: unknown): void;
   send(data: unknown): void;
-  redirect(statusOrUrl: number | string, url?: string): void;
+  redirect(statusOrUrl: number | string, url?: string): NextApiResponse;
   revalidate(urlPath: string, opts?: RevalidateOptions): Promise<void>;
   setPreviewData(
     data: object | string,
@@ -334,11 +334,18 @@ function enhanceApiObjects(
 
     redirect(this: NextApiResponse, statusOrUrl: number | string, url?: string) {
       if (typeof statusOrUrl === "string") {
-        this.writeHead(307, { Location: statusOrUrl });
-      } else {
-        this.writeHead(statusOrUrl, { Location: url ?? "" });
+        url = statusOrUrl;
+        statusOrUrl = 307;
       }
+      if (typeof statusOrUrl !== "number" || typeof url !== "string") {
+        throw new Error(
+          "Invalid redirect arguments. Please use a single argument URL, e.g. res.redirect('/destination') or use a status code and URL, e.g. res.redirect(307, '/destination').",
+        );
+      }
+      this.writeHead(statusOrUrl, { Location: url });
+      this.write(url);
       this.end();
+      return this;
     },
 
     // `res.revalidate(urlPath)` triggers on-demand ISR regeneration of a Pages

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -741,6 +741,9 @@ export function createSSRHandler(
       ? params
       : null;
     const query = mergeRouteParamsIntoQuery(parseQuery(url), params);
+    const requestPreviewData = getPagesPreviewDataFromCookieHeader(req.headers.cookie, {
+      isOnDemandRevalidate: isOnDemandRevalidateRequest(req.headers[PRERENDER_REVALIDATE_HEADER]),
+    });
 
     // Wrap the entire request in a single unified AsyncLocalStorage scope.
     const requestContext = createRequestContext();
@@ -795,11 +798,14 @@ export function createSSRHandler(
             // _app exists but failed to load
           }
         }
-        const pagesNextData = buildPagesReadinessNextData({
-          pageModule,
-          appComponent: AppComponent,
-          hasRewrites,
-        });
+        const pagesNextData = {
+          ...buildPagesReadinessNextData({
+            pageModule,
+            appComponent: AppComponent,
+            hasRewrites,
+          }),
+          ...(requestPreviewData === false ? {} : { isPreview: true as const }),
+        };
         const navigationIsReady =
           typeof routerShim.getPagesNavigationIsReadyFromSerializedState === "function"
             ? routerShim.getPagesNavigationIsReadyFromSerializedState(
@@ -819,6 +825,7 @@ export function createSSRHandler(
             locales: i18nConfig?.locales,
             defaultLocale: currentDefaultLocale,
             domainLocales,
+            isPreview: requestPreviewData !== false,
           });
         }
         // Mark end of compile phase: everything from here is rendering.
@@ -866,6 +873,7 @@ export function createSSRHandler(
         // Collect page props via data fetching methods
         let pageProps: Record<string, unknown> = {};
         let renderProps: Record<string, unknown> = { pageProps };
+        if (requestPreviewData !== false) renderProps.__N_PREVIEW = true;
         let isrRevalidateSeconds: number | null = null;
         // Set when `getStaticPaths: { fallback: true }` is configured and the
         // requested path is NOT in the pre-rendered list. Triggers the loading
@@ -1620,6 +1628,9 @@ export function createSSRHandler(
           const dataHeaders: Record<string, string | string[] | number> = {
             "Content-Type": "application/json",
           };
+          if (requestPreviewData !== false) {
+            dataHeaders["Cache-Control"] = ISR_NEVER_CACHE_CONTROL;
+          }
           if ((statusCode ?? 200) === 200) {
             const matchedPathname = `${locale ? `/${locale}` : ""}${patternToNextFormat(route.pattern)}`;
             dataHeaders["x-nextjs-matched-path"] = matchedPathname;
@@ -1890,7 +1901,9 @@ hydrate();
         const extraHeaders: Record<string, string | string[]> = {
           ...gsspExtraHeaders,
         };
-        if (isrRevalidateSeconds) {
+        if (requestPreviewData !== false) {
+          extraHeaders["Cache-Control"] = ISR_NEVER_CACHE_CONTROL;
+        } else if (isrRevalidateSeconds) {
           if (scriptNonce) {
             extraHeaders["Cache-Control"] = ISR_NO_STORE_CACHE_CONTROL;
           } else {

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -931,7 +931,7 @@ export function createSSRHandler(
             matchesPagesStaticPath(pathEntry, params, routeParams, url),
           );
 
-          if (fallback === false && !isValidPath) {
+          if (fallback === false && !isValidPath && requestPreviewData === false) {
             if (isDataReq) {
               // Data requests get a JSON 404 so the client router can
               // hard-navigate instead of trying to parse HTML as JSON.
@@ -967,7 +967,13 @@ export function createSSRHandler(
           const userAgentHeader = req.headers["user-agent"];
           const userAgent = Array.isArray(userAgentHeader) ? userAgentHeader[0] : userAgentHeader;
           const isBotRequest = !!userAgent && isBotUserAgent(userAgent, htmlLimitedBots);
-          if (fallback === true && !isValidPath && !isDataReq && !isBotRequest) {
+          if (
+            fallback === true &&
+            !isValidPath &&
+            !isDataReq &&
+            !isBotRequest &&
+            requestPreviewData === false
+          ) {
             const fallbackCacheKey = pagesIsrCacheKey(url.split("?")[0]);
             const generatedEntry = await isrGet(fallbackCacheKey);
             isFallbackRender = generatedEntry?.value.value?.kind !== "PAGES";
@@ -1033,6 +1039,7 @@ export function createSSRHandler(
           if (appResult.kind === "render") {
             pageProps = appResult.pageProps;
             renderProps = appResult.renderProps;
+            if (requestPreviewData !== false) renderProps.__N_PREVIEW = true;
           }
           return false;
         }

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -771,11 +771,6 @@ export function createSSRHandler(
       ? params
       : null;
     const query = mergeRouteParamsIntoQuery(parseQuery(url), params);
-    const requestPreview = getPagesPreviewState(req.headers.cookie, {
-      isOnDemandRevalidate: isOnDemandRevalidateRequest(req.headers[PRERENDER_REVALIDATE_HEADER]),
-    });
-    const requestPreviewData = requestPreview.data;
-
     // Wrap the entire request in a single unified AsyncLocalStorage scope.
     const requestContext = createRequestContext();
     return runWithRequestContext(requestContext, async () => {
@@ -815,6 +810,17 @@ export function createSSRHandler(
         // Load the page module through Vite's SSR pipeline
         // This gives us HMR and transform support for free
         const pageModule = await importModule(runner, route.filePath);
+        const supportsPreview =
+          typeof pageModule.getStaticProps === "function" ||
+          typeof pageModule.getServerSideProps === "function";
+        const requestPreview = supportsPreview
+          ? getPagesPreviewState(req.headers.cookie, {
+              isOnDemandRevalidate: isOnDemandRevalidateRequest(
+                req.headers[PRERENDER_REVALIDATE_HEADER],
+              ),
+            })
+          : ({ data: false, shouldClear: false } satisfies PagesPreviewState);
+        const requestPreviewData = requestPreview.data;
         // Try to load _app.tsx if it exists. This happens before the readiness
         // predicate so app-level getInitialProps participates in the same
         // initial Pages Router state as the client __NEXT_DATA__ payload.

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -134,6 +134,12 @@ function applyDevPagesPreviewHeaders(
   }
 }
 
+function applyDevPagesPreviewResponse(res: ServerResponse, preview: PagesPreviewState): void {
+  const headers = res.getHeaders() as Record<string, string | string[] | number>;
+  applyDevPagesPreviewHeaders(headers, preview);
+  for (const [name, value] of Object.entries(headers)) res.setHeader(name, value);
+}
+
 async function renderIsrPassToStringAsync(element: React.ReactElement): Promise<string> {
   // The cache-fill render is a second render pass for the same request.
   // Reset render-scoped state so it cannot leak from the streamed response
@@ -1111,6 +1117,7 @@ export function createSSRHandler(
             return;
           }
           if (result && "notFound" in result && result.notFound) {
+            applyDevPagesPreviewResponse(res, requestPreview);
             if (isDataReq) {
               // Mirror Next.js pages-handler.ts: set x-nextjs-deployment-id on
               // `_next/data` notFound exits for deployment-skew protection. Fixes #1829.
@@ -1561,6 +1568,7 @@ export function createSSRHandler(
             return;
           }
           if (result && "notFound" in result && result.notFound) {
+            applyDevPagesPreviewResponse(res, requestPreview);
             if (isDataReq) {
               // Mirror Next.js pages-handler.ts: set x-nextjs-deployment-id on
               // `_next/data` notFound exits for deployment-skew protection. Fixes #1829.

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -82,10 +82,13 @@ import {
   loadDevAppInitialProps,
   loadPagesGetInitialProps,
 } from "./pages-get-initial-props.js";
+import { attachPagesRequestCookies } from "./pages-node-compat.js";
 import {
-  attachPagesRequestCookies,
-  getPagesPreviewDataFromCookieHeader,
-} from "./pages-node-compat.js";
+  appendPagesPreviewClearCookies,
+  getPagesPreviewState,
+  PAGES_PREVIEW_CACHE_CONTROL,
+  type PagesPreviewState,
+} from "./pages-preview.js";
 import { isBotUserAgent } from "../utils/html-limited-bots.js";
 import { isUnknownRecord } from "../utils/record.js";
 
@@ -100,6 +103,33 @@ async function renderToStringAsync(element: React.ReactElement): Promise<string>
   const stream = await renderToReadableStream(element);
   await stream.allReady;
   return new Response(stream).text();
+}
+
+function applyDevPagesPreviewHeaders(
+  headers: Record<string, string | string[] | number>,
+  preview: PagesPreviewState,
+): void {
+  const removeHeader = (name: string) => {
+    for (const key of Object.keys(headers)) {
+      if (key.toLowerCase() === name) delete headers[key];
+    }
+  };
+  if (preview.data !== false) {
+    removeHeader("cache-control");
+    headers["Cache-Control"] = PAGES_PREVIEW_CACHE_CONTROL;
+  }
+  if (preview.shouldClear) {
+    const clearHeaders = new Headers();
+    appendPagesPreviewClearCookies(clearHeaders);
+    const existing: string[] = [];
+    for (const [key, value] of Object.entries(headers)) {
+      if (key.toLowerCase() !== "set-cookie") continue;
+      if (Array.isArray(value)) existing.push(...value.map(String));
+      else existing.push(String(value));
+      delete headers[key];
+    }
+    headers["Set-Cookie"] = [...existing, ...clearHeaders.getSetCookie()];
+  }
 }
 
 async function renderIsrPassToStringAsync(element: React.ReactElement): Promise<string> {
@@ -741,9 +771,10 @@ export function createSSRHandler(
       ? params
       : null;
     const query = mergeRouteParamsIntoQuery(parseQuery(url), params);
-    const requestPreviewData = getPagesPreviewDataFromCookieHeader(req.headers.cookie, {
+    const requestPreview = getPagesPreviewState(req.headers.cookie, {
       isOnDemandRevalidate: isOnDemandRevalidateRequest(req.headers[PRERENDER_REVALIDATE_HEADER]),
     });
+    const requestPreviewData = requestPreview.data;
 
     // Wrap the entire request in a single unified AsyncLocalStorage scope.
     const requestContext = createRequestContext();
@@ -881,7 +912,7 @@ export function createSSRHandler(
         // and `useRouter().isFallback === true`, matching Next.js render.tsx.
         let isFallbackRender = false;
         let shouldPersistFallbackData = false;
-        let staticPropsPreviewData: ReturnType<typeof getPagesPreviewDataFromCookieHeader> = false;
+        let staticPropsPreviewData = requestPreviewData;
 
         // Handle getStaticPaths for dynamic routes: validate the path,
         // respect `fallback: false` (return 404 for unlisted paths), and
@@ -1013,7 +1044,7 @@ export function createSSRHandler(
           renderProps = { ...renderProps, __N_SSP: true };
           // Snapshot existing headers so we can detect what gSSP adds.
           const headersBeforeGSSP = new Set(Object.keys(res.getHeaders()));
-          const previewData = getPagesPreviewDataFromCookieHeader(req.headers.cookie);
+          const previewData = requestPreviewData;
           const previewContext =
             previewData === false
               ? {}
@@ -1174,9 +1205,7 @@ export function createSSRHandler(
           const isOnDemandRevalidate = isOnDemandRevalidateRequest(
             req.headers[PRERENDER_REVALIDATE_HEADER],
           );
-          const previewData = getPagesPreviewDataFromCookieHeader(req.headers.cookie, {
-            isOnDemandRevalidate,
-          });
+          const previewData = requestPreviewData;
           staticPropsPreviewData = previewData;
           const previewContext =
             previewData === false
@@ -1628,9 +1657,6 @@ export function createSSRHandler(
           const dataHeaders: Record<string, string | string[] | number> = {
             "Content-Type": "application/json",
           };
-          if (requestPreviewData !== false) {
-            dataHeaders["Cache-Control"] = ISR_NEVER_CACHE_CONTROL;
-          }
           if ((statusCode ?? 200) === 200) {
             const matchedPathname = `${locale ? `/${locale}` : ""}${patternToNextFormat(route.pattern)}`;
             dataHeaders["x-nextjs-matched-path"] = matchedPathname;
@@ -1640,6 +1666,7 @@ export function createSSRHandler(
               dataHeaders[k] = v;
             }
           }
+          applyDevPagesPreviewHeaders(dataHeaders, requestPreview);
           // Mirror Next.js pages-handler.ts: set x-nextjs-deployment-id on
           // every _next/data response so the client router can detect a new
           // deployment and trigger a hard navigation (deployment-skew
@@ -1901,9 +1928,7 @@ hydrate();
         const extraHeaders: Record<string, string | string[]> = {
           ...gsspExtraHeaders,
         };
-        if (requestPreviewData !== false) {
-          extraHeaders["Cache-Control"] = ISR_NEVER_CACHE_CONTROL;
-        } else if (isrRevalidateSeconds) {
+        if (requestPreviewData === false && isrRevalidateSeconds) {
           if (scriptNonce) {
             extraHeaders["Cache-Control"] = ISR_NO_STORE_CACHE_CONTROL;
           } else {
@@ -1911,6 +1936,7 @@ hydrate();
             Object.assign(extraHeaders, buildCacheStateHeaders("MISS"));
           }
         }
+        applyDevPagesPreviewHeaders(extraHeaders, requestPreview);
 
         // Set HTTP Link header for font preloading.
         // This lets the browser (and CDN) start fetching font files before parsing HTML.

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -120,15 +120,17 @@ function applyDevPagesPreviewHeaders(
   }
   if (preview.shouldClear) {
     const clearHeaders = new Headers();
-    appendPagesPreviewClearCookies(clearHeaders);
-    const existing: string[] = [];
     for (const [key, value] of Object.entries(headers)) {
       if (key.toLowerCase() !== "set-cookie") continue;
-      if (Array.isArray(value)) existing.push(...value.map(String));
-      else existing.push(String(value));
+      if (Array.isArray(value)) {
+        for (const cookie of value) clearHeaders.append("Set-Cookie", String(cookie));
+      } else {
+        clearHeaders.append("Set-Cookie", String(value));
+      }
       delete headers[key];
     }
-    headers["Set-Cookie"] = [...existing, ...clearHeaders.getSetCookie()];
+    appendPagesPreviewClearCookies(clearHeaders);
+    headers["Set-Cookie"] = clearHeaders.getSetCookie();
   }
 }
 

--- a/packages/vinext/src/server/pages-node-compat.ts
+++ b/packages/vinext/src/server/pages-node-compat.ts
@@ -31,6 +31,7 @@ export type PagesReqResRequest = Readable & {
   body: unknown;
   cookies: Record<string, string>;
   preview?: true;
+  draftMode?: true;
   previewData: PagesPreviewData | false;
 };
 
@@ -226,6 +227,7 @@ export function attachPagesPreviewApi(req: PagesReqResRequest, res: PagesReqResR
   req.previewData = preview.data;
   if (preview.data !== false) {
     req.preview = true;
+    req.draftMode = true;
   }
   res.setPreviewData = (data, options = {}) => {
     setPagesPreviewData(res, data, options);

--- a/packages/vinext/src/server/pages-node-compat.ts
+++ b/packages/vinext/src/server/pages-node-compat.ts
@@ -24,6 +24,8 @@ export type PagesReqResRequest = Readable & {
   query: PagesRequestQuery;
   body: unknown;
   cookies: Record<string, string>;
+  preview?: true;
+  previewData?: PagesPreviewData;
 };
 
 type PagesReqResHeaders = {
@@ -46,6 +48,7 @@ export type PagesReqResResponse = Writable & {
     data: object | string,
     options?: { maxAge?: number; path?: string },
   ) => PagesReqResResponse;
+  clearPreviewData: (options?: { path?: string }) => PagesReqResResponse;
 };
 
 type PagesRequestCookiesCarrier = {
@@ -190,6 +193,20 @@ function serializePreviewCookie(
     parts.push(`Max-Age=${Math.trunc(options.maxAge)}`);
   }
   return parts.join("; ");
+}
+
+function serializeClearedPreviewCookie(
+  name: "__prerender_bypass" | "__next_preview_data",
+  options: { path?: string } = {},
+): string {
+  return [
+    `${name}=`,
+    "Expires=Thu, 01 Jan 1970 00:00:00 GMT",
+    "HttpOnly",
+    `Path=${options.path ?? "/"}`,
+    process.env.NODE_ENV !== "development" ? "SameSite=None" : "SameSite=Lax",
+    ...(process.env.NODE_ENV !== "development" ? ["Secure"] : []),
+  ].join("; ");
 }
 
 function decodePagesPreviewPayload(payload: string): PagesPreviewData | false {
@@ -393,6 +410,15 @@ class PagesResponseStream extends Writable {
     return this as PagesReqResResponse;
   }
 
+  clearPreviewData(options: { path?: string } = {}): PagesReqResResponse {
+    this.setHeader("Set-Cookie", [
+      ...normalizeSetCookieHeader(this.getHeader("Set-Cookie")),
+      serializeClearedPreviewCookie("__prerender_bypass", options),
+      serializeClearedPreviewCookie("__next_preview_data", options),
+    ]);
+    return this as PagesReqResResponse;
+  }
+
   override _write(
     chunk: Uint8Array | string,
     encoding: BufferEncoding,
@@ -530,6 +556,11 @@ export function createPagesReqRes(options: CreatePagesReqResOptions): CreatePage
     body: options.body,
   }) as PagesReqResRequest;
   attachPagesRequestCookies(req);
+  const previewData = getPagesPreviewData(options.request);
+  if (previewData !== false) {
+    req.preview = true;
+    req.previewData = previewData;
+  }
 
   let resolveResponse!: (value: Response) => void;
   let rejectResponse!: (error: Error) => void;

--- a/packages/vinext/src/server/pages-node-compat.ts
+++ b/packages/vinext/src/server/pages-node-compat.ts
@@ -48,7 +48,7 @@ export type PagesReqResResponse = Writable & {
   status: (code: number) => PagesReqResResponse;
   json: (data: unknown) => void;
   send: (data: unknown) => void;
-  redirect: (statusOrUrl: number | string, url?: string) => void;
+  redirect: (statusOrUrl: number | string, url?: string) => PagesReqResResponse;
   getHeaders: () => PagesReqResHeaders;
   revalidate: (urlPath: string, opts?: RevalidateOptions) => Promise<void>;
   setPreviewData: (
@@ -333,13 +333,20 @@ class PagesResponseStream extends Writable {
     this.end(String(data));
   }
 
-  redirect(statusOrUrl: number | string, url?: string): void {
+  redirect(statusOrUrl: number | string, url?: string): PagesReqResResponse {
     if (typeof statusOrUrl === "string") {
-      this.writeHead(307, { Location: statusOrUrl });
-    } else {
-      this.writeHead(statusOrUrl, { Location: url ?? "" });
+      url = statusOrUrl;
+      statusOrUrl = 307;
     }
+    if (typeof statusOrUrl !== "number" || typeof url !== "string") {
+      throw new Error(
+        "Invalid redirect arguments. Please use a single argument URL, e.g. res.redirect('/destination') or use a status code and URL, e.g. res.redirect(307, '/destination').",
+      );
+    }
+    this.writeHead(statusOrUrl, { Location: url });
+    this.write(url);
     this.end();
+    return this as PagesReqResResponse;
   }
 
   getHeaders(): PagesReqResHeaders {

--- a/packages/vinext/src/server/pages-node-compat.ts
+++ b/packages/vinext/src/server/pages-node-compat.ts
@@ -8,6 +8,7 @@ import { performOnDemandRevalidate, type RevalidateOptions } from "./pages-reval
 import {
   clearPagesPreviewData,
   getPagesPreviewState,
+  setPagesDraftMode,
   setPagesPreviewData,
   type PagesPreviewData,
 } from "./pages-preview.js";
@@ -54,6 +55,7 @@ export type PagesReqResResponse = Writable & {
     options?: { maxAge?: number; path?: string },
   ) => PagesReqResResponse;
   clearPreviewData: (options?: { path?: string }) => PagesReqResResponse;
+  setDraftMode: (options?: { enable?: boolean }) => PagesReqResResponse;
 };
 
 type PagesRequestCookiesCarrier = {
@@ -178,7 +180,7 @@ function parsePagesRequestCookies(cookieHeader: string | string[] | null | undef
   return parseCookieHeader(Array.isArray(cookieHeader) ? cookieHeader.join("; ") : cookieHeader);
 }
 
-export function getPagesPreviewDataFromCookieHeader(
+function getPagesPreviewDataFromCookieHeader(
   cookieHeader: string | string[] | null | undefined,
   options: { isOnDemandRevalidate?: boolean } = {},
 ): PagesPreviewData | false {
@@ -231,6 +233,10 @@ export function attachPagesPreviewApi(req: PagesReqResRequest, res: PagesReqResR
   };
   res.clearPreviewData = (options = {}) => {
     clearPagesPreviewData(res, options);
+    return res;
+  };
+  res.setDraftMode = (options = { enable: true }) => {
+    setPagesDraftMode(res, options.enable !== false);
     return res;
   };
   if (preview.shouldClear) clearPagesPreviewData(res);
@@ -356,6 +362,11 @@ class PagesResponseStream extends Writable {
 
   clearPreviewData(options: { path?: string } = {}): PagesReqResResponse {
     clearPagesPreviewData(this, options);
+    return this as PagesReqResResponse;
+  }
+
+  setDraftMode(options: { enable?: boolean } = { enable: true }): PagesReqResResponse {
+    setPagesDraftMode(this, options.enable !== false);
     return this as PagesReqResResponse;
   }
 

--- a/packages/vinext/src/server/pages-node-compat.ts
+++ b/packages/vinext/src/server/pages-node-compat.ts
@@ -5,7 +5,12 @@ import { readStreamAsTextWithLimit } from "../utils/text-stream.js";
 import { DEFAULT_PAGES_API_BODY_SIZE_LIMIT } from "./pages-body-parser-config.js";
 import { PagesBodyParseError, getMediaType, isJsonMediaType } from "./pages-media-type.js";
 import { performOnDemandRevalidate, type RevalidateOptions } from "./pages-revalidate.js";
-import { getRevalidateSecret, isRevalidateSecret } from "./isr-cache.js";
+import {
+  clearPagesPreviewData,
+  getPagesPreviewState,
+  setPagesPreviewData,
+  type PagesPreviewData,
+} from "./pages-preview.js";
 
 const MAX_PAGES_API_BODY_SIZE = DEFAULT_PAGES_API_BODY_SIZE_LIMIT;
 
@@ -25,7 +30,7 @@ export type PagesReqResRequest = Readable & {
   body: unknown;
   cookies: Record<string, string>;
   preview?: true;
-  previewData?: PagesPreviewData;
+  previewData: PagesPreviewData | false;
 };
 
 type PagesReqResHeaders = {
@@ -70,8 +75,6 @@ type CreatePagesReqResResult = {
   res: PagesReqResResponse;
   responsePromise: Promise<Response>;
 };
-
-export type PagesPreviewData = object | string;
 
 async function readPagesRequestBodyWithLimit(request: Request, maxBytes: number): Promise<string> {
   if (!request.body) {
@@ -175,68 +178,11 @@ function parsePagesRequestCookies(cookieHeader: string | string[] | null | undef
   return parseCookieHeader(Array.isArray(cookieHeader) ? cookieHeader.join("; ") : cookieHeader);
 }
 
-function serializePreviewCookie(
-  name: "__prerender_bypass" | "__next_preview_data",
-  value: string,
-  options: { maxAge?: number; path?: string } = {},
-): string {
-  const parts = [
-    `${name}=${encodeURIComponent(value)}`,
-    "HttpOnly",
-    `Path=${options.path ?? "/"}`,
-    process.env.NODE_ENV !== "development" ? "SameSite=None" : "SameSite=Lax",
-  ];
-  if (process.env.NODE_ENV !== "development") {
-    parts.push("Secure");
-  }
-  if (options.maxAge !== undefined) {
-    parts.push(`Max-Age=${Math.trunc(options.maxAge)}`);
-  }
-  return parts.join("; ");
-}
-
-function serializeClearedPreviewCookie(
-  name: "__prerender_bypass" | "__next_preview_data",
-  options: { path?: string } = {},
-): string {
-  return [
-    `${name}=`,
-    "Expires=Thu, 01 Jan 1970 00:00:00 GMT",
-    "HttpOnly",
-    `Path=${options.path ?? "/"}`,
-    process.env.NODE_ENV !== "development" ? "SameSite=None" : "SameSite=Lax",
-    ...(process.env.NODE_ENV !== "development" ? ["Secure"] : []),
-  ].join("; ");
-}
-
-function decodePagesPreviewPayload(payload: string): PagesPreviewData | false {
-  try {
-    const decoded = Buffer.from(payload, "base64url").toString("utf8");
-    const value = JSON.parse(decoded);
-    return typeof value === "object" && value !== null ? value : String(value);
-  } catch {
-    return false;
-  }
-}
-
 export function getPagesPreviewDataFromCookieHeader(
   cookieHeader: string | string[] | null | undefined,
   options: { isOnDemandRevalidate?: boolean } = {},
 ): PagesPreviewData | false {
-  // Next.js disables preview mode during on-demand revalidation so preview
-  // cookies cannot poison the regenerated ISR entry.
-  if (options.isOnDemandRevalidate) return false;
-
-  const cookies = parsePagesRequestCookies(cookieHeader);
-  const bypass = cookies.__prerender_bypass;
-  const payload = cookies.__next_preview_data;
-  if (!bypass && !payload) return false;
-  if (!isRevalidateSecret(bypass)) return false;
-  if (!payload) return {};
-
-  // vinext writes preview data as base64url(JSON) instead of Next.js's signed
-  // encrypted JWT. The writer and reader are intentionally paired internally.
-  return decodePagesPreviewPayload(payload);
+  return getPagesPreviewState(cookieHeader, options).data;
 }
 
 export function getPagesPreviewData(
@@ -244,14 +190,6 @@ export function getPagesPreviewData(
   options: { isOnDemandRevalidate?: boolean } = {},
 ): PagesPreviewData | false {
   return getPagesPreviewDataFromCookieHeader(request.headers.get("cookie"), options);
-}
-
-function normalizeSetCookieHeader(
-  value: string | number | boolean | string[] | undefined,
-): string[] {
-  if (value === undefined) return [];
-  if (Array.isArray(value)) return value.map(String);
-  return [String(value)];
 }
 
 export function attachPagesRequestCookies(req: PagesRequestCookiesCarrier): void {
@@ -279,6 +217,23 @@ export function attachPagesRequestCookies(req: PagesRequestCookiesCarrier): void
       });
     },
   });
+}
+
+export function attachPagesPreviewApi(req: PagesReqResRequest, res: PagesReqResResponse): void {
+  const preview = getPagesPreviewState(req.headers.cookie);
+  req.previewData = preview.data;
+  if (preview.data !== false) {
+    req.preview = true;
+  }
+  res.setPreviewData = (data, options = {}) => {
+    setPagesPreviewData(res, data, options);
+    return res;
+  };
+  res.clearPreviewData = (options = {}) => {
+    clearPagesPreviewData(res, options);
+    return res;
+  };
+  if (preview.shouldClear) clearPagesPreviewData(res);
 }
 
 class PagesResponseStream extends Writable {
@@ -395,27 +350,12 @@ class PagesResponseStream extends Writable {
     data: object | string,
     options: { maxAge?: number; path?: string } = {},
   ): PagesReqResResponse {
-    const payload = Buffer.from(JSON.stringify(data)).toString("base64url");
-    if (payload.length > 2048) {
-      throw new Error(
-        "Preview data is limited to 2KB currently, reduce how much data you are storing as preview data to continue",
-      );
-    }
-
-    this.setHeader("Set-Cookie", [
-      ...normalizeSetCookieHeader(this.getHeader("Set-Cookie")),
-      serializePreviewCookie("__prerender_bypass", getRevalidateSecret(), options),
-      serializePreviewCookie("__next_preview_data", payload, options),
-    ]);
+    setPagesPreviewData(this, data, options);
     return this as PagesReqResResponse;
   }
 
   clearPreviewData(options: { path?: string } = {}): PagesReqResResponse {
-    this.setHeader("Set-Cookie", [
-      ...normalizeSetCookieHeader(this.getHeader("Set-Cookie")),
-      serializeClearedPreviewCookie("__prerender_bypass", options),
-      serializeClearedPreviewCookie("__next_preview_data", options),
-    ]);
+    clearPagesPreviewData(this, options);
     return this as PagesReqResResponse;
   }
 
@@ -556,10 +496,10 @@ export function createPagesReqRes(options: CreatePagesReqResOptions): CreatePage
     body: options.body,
   }) as PagesReqResRequest;
   attachPagesRequestCookies(req);
-  const previewData = getPagesPreviewData(options.request);
-  if (previewData !== false) {
+  const preview = getPagesPreviewState(options.request.headers.get("cookie"));
+  if (preview.data !== false) {
     req.preview = true;
-    req.previewData = previewData;
+    req.previewData = preview.data;
   }
 
   let resolveResponse!: (value: Response) => void;
@@ -573,6 +513,7 @@ export function createPagesReqRes(options: CreatePagesReqResOptions): CreatePage
     rejectResponse,
     options.request.headers,
   ) as PagesReqResResponse;
+  attachPagesPreviewApi(req, res);
 
   return { req, res, responsePromise };
 }

--- a/packages/vinext/src/server/pages-node-compat.ts
+++ b/packages/vinext/src/server/pages-node-compat.ts
@@ -509,11 +509,6 @@ export function createPagesReqRes(options: CreatePagesReqResOptions): CreatePage
     body: options.body,
   }) as PagesReqResRequest;
   attachPagesRequestCookies(req);
-  const preview = getPagesPreviewState(options.request.headers.get("cookie"));
-  if (preview.data !== false) {
-    req.preview = true;
-    req.previewData = preview.data;
-  }
 
   let resolveResponse!: (value: Response) => void;
   let rejectResponse!: (error: Error) => void;

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -686,6 +686,7 @@ export async function resolvePagesPageData(
   // hydrate the page after the fallback shell ships.
   let isFallback = false;
   let shouldPersistFallbackData = false;
+  const previewData = options.isOnDemandRevalidate ? false : (options.previewData ?? false);
 
   if (typeof options.pageModule.getStaticPaths === "function" && options.route.isDynamic) {
     const pathsResult = await options.pageModule.getStaticPaths({
@@ -699,7 +700,7 @@ export async function resolvePagesPageData(
       matchesPagesStaticPath(pathEntry, options.params, routeParams, options.routeUrl),
     );
 
-    if (fallback === false && !isValidPath) {
+    if (fallback === false && !isValidPath && previewData === false) {
       // For data requests (`/_next/data/...json`), return a JSON-shaped 404
       // so the client router can `res.json()` without blowing up — matches
       // Next.js' behavior. HTML navigations still get the configured 404 page.
@@ -711,7 +712,13 @@ export async function resolvePagesPageData(
     // the loading shell ships (`fallback: 'blocking'` keeps SSRing as before).
     const isBotRequest =
       !!options.userAgent && isBotUserAgent(options.userAgent, options.htmlLimitedBots);
-    if (fallback === true && !isValidPath && !options.isDataReq && !isBotRequest) {
+    if (
+      fallback === true &&
+      !isValidPath &&
+      !options.isDataReq &&
+      !isBotRequest &&
+      previewData === false
+    ) {
       isFallback = true;
     }
     shouldPersistFallbackData = fallback === true && !isValidPath && options.isDataReq === true;
@@ -719,7 +726,6 @@ export async function resolvePagesPageData(
 
   let pageProps: Record<string, unknown> = {};
   let gsspRes: PagesMutableGsspResponse | null = null;
-  const previewData = options.isOnDemandRevalidate ? false : (options.previewData ?? false);
   const previewContext =
     previewData === false
       ? {}

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -7,7 +7,7 @@ import { applyCdnResponseHeaders } from "./cache-control.js";
 import { decideIsr } from "./isr-decision.js";
 import { buildCacheStateHeaders } from "./cache-headers.js";
 import { buildPagesCacheValue, type ISRCacheEntry } from "./isr-cache.js";
-import type { PagesPreviewData } from "./pages-node-compat.js";
+import type { PagesPreviewData } from "./pages-preview.js";
 import {
   buildPagesNextDataScript,
   etagMatches,
@@ -742,6 +742,7 @@ export async function resolvePagesPageData(
   }
 
   let renderProps: PagesRenderProps = { pageProps };
+  if (previewData !== false) renderProps.__N_PREVIEW = true;
 
   async function loadForegroundAppInitialRenderProps(): Promise<ResolvePagesPageDataResult | null> {
     const result = await loadPagesAppInitialRenderProps(options, getSharedReqRes);

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -16,7 +16,13 @@ import type { ComponentType, ReactNode } from "react";
 import { mergeRouteParamsIntoQuery, parseQueryString as parseQuery } from "../utils/query.js";
 import { patternToNextFormat } from "../routing/route-validation.js";
 import { resolvePagesI18nRequest } from "./pages-i18n.js";
-import { createPagesReqRes, getPagesPreviewData } from "./pages-node-compat.js";
+import { createPagesReqRes } from "./pages-node-compat.js";
+import {
+  appendPagesPreviewClearCookies,
+  getPagesPreviewState,
+  PAGES_PREVIEW_CACHE_CONTROL,
+  type PagesPreviewState,
+} from "./pages-preview.js";
 import { resolvePagesPageData } from "./pages-page-data.js";
 import type { PagesPageModule } from "./pages-page-data.js";
 import { resolvePagesPageMethodResponse } from "./pages-page-method.js";
@@ -54,6 +60,18 @@ import { NEXTJS_DEPLOYMENT_ID_HEADER } from "./headers.js";
 import { buildMissIsrCacheControl, ISR_NEVER_CACHE_CONTROL } from "./isr-decision.js";
 import { appendAssetDeploymentIdQuery } from "../utils/deployment-id.js";
 import { hasPagesGetInitialProps } from "./pages-get-initial-props.js";
+
+function finalizePagesPreviewResponse(response: Response, preview: PagesPreviewState): Response {
+  if (preview.data === false && !preview.shouldClear) return response;
+  const headers = new Headers(response.headers);
+  if (preview.data !== false) headers.set("Cache-Control", PAGES_PREVIEW_CACHE_CONTROL);
+  if (preview.shouldClear) appendPagesPreviewClearCookies(headers);
+  return new Response(response.body, {
+    headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -449,7 +467,10 @@ export function createPagesPageHandler(
         const isOnDemandRevalidate = isOnDemandRevalidateRequest(
           request.headers.get(PRERENDER_REVALIDATE_HEADER),
         );
-        const previewData = getPagesPreviewData(request, { isOnDemandRevalidate });
+        const preview = getPagesPreviewState(request.headers.get("cookie"), {
+          isOnDemandRevalidate,
+        });
+        const previewData = preview.data;
         const pagesNextData = {
           ...buildPagesReadinessNextData({
             pageModule,
@@ -647,21 +668,25 @@ export function createPagesPageHandler(
         if (pageDataResult.kind === "notFound") {
           const notFoundRoute = findNotFoundRoute();
           if (notFoundRoute && routePattern !== "/404" && routePattern !== "/_error") {
-            return renderPage(request, url, manifest, middlewareHeaders, {
-              statusCode: 404,
-              asPath: renderAsPath ?? routeUrl,
-              renderErrorPageOnMiss: false,
-              __forcedRoute: notFoundRoute,
-            });
+            return finalizePagesPreviewResponse(
+              await renderPage(request, url, manifest, middlewareHeaders, {
+                statusCode: 404,
+                asPath: renderAsPath ?? routeUrl,
+                renderErrorPageOnMiss: false,
+                __forcedRoute: notFoundRoute,
+              }),
+              preview,
+            );
           }
-          return buildDefaultPagesNotFoundResponse();
+          return finalizePagesPreviewResponse(buildDefaultPagesNotFoundResponse(), preview);
         }
         if (pageDataResult.kind === "response") {
-          return pageDataResult.response;
+          return finalizePagesPreviewResponse(pageDataResult.response, preview);
         }
 
         let pageProps = pageDataResult.pageProps;
         let renderProps = pageDataResult.props;
+        if (previewData !== false) renderProps = { ...renderProps, __N_PREVIEW: true };
         if (routePattern === "/_error" && typeof renderStatusCode === "number") {
           pageProps = { ...pageProps, statusCode: renderStatusCode };
           renderProps = { ...renderProps, pageProps };
@@ -745,7 +770,10 @@ export function createPagesPageHandler(
               init.headers[NEXTJS_DEPLOYMENT_ID_HEADER] = deploymentId;
             }
           }
-          return buildNextDataPropsJsonResponse(renderProps, safeJsonStringify, init);
+          return finalizePagesPreviewResponse(
+            buildNextDataPropsJsonResponse(renderProps, safeJsonStringify, init),
+            preview,
+          );
         }
 
         // Include both the global _app module and the matched page module.
@@ -765,61 +793,69 @@ export function createPagesPageHandler(
           deploymentId: process.env.__VINEXT_DEPLOYMENT_ID || process.env.NEXT_DEPLOYMENT_ID,
         });
 
-        return await renderPagesPageResponse({
-          assetTags,
-          buildId,
-          clearSsrContext() {
-            if (typeof setSSRContext === "function") setSSRContext(null);
-          },
-          createPageElement(currentProps) {
-            const el = createPageElement(PageComponent, AppComponent, currentProps);
-            return typeof wrapWithRouterContext === "function" ? wrapWithRouterContext(el) : el;
-          },
-          enhancePageElement(renderPageOpts) {
-            const el = enhancePageElement(PageComponent, AppComponent, renderProps, renderPageOpts);
-            return typeof wrapWithRouterContext === "function" ? wrapWithRouterContext(el) : el;
-          },
-          DocumentComponent,
-          err: err instanceof Error ? err : undefined,
-          flushPreloads: typeof flushPreloads === "function" ? flushPreloads : undefined,
-          fontLinkHeader,
-          fontPreloads: allFontPreloads,
-          getFontLinks,
-          getFontStyles,
-          getSSRHeadHTML: typeof getSSRHeadHTML === "function" ? getSSRHeadHTML : undefined,
-          clientTraceMetadata: shouldEmitPagesClientTraceMetadata(pageModule, AppComponent)
-            ? vinextConfig.clientTraceMetadata
-            : undefined,
-          documentReqRes,
-          gsspRes,
-          isrCacheKey: pageIsrCacheKey,
-          expireSeconds: vinextConfig.expireTime,
-          isrRevalidateSeconds,
-          isStaticPropsRoute,
-          isrSet,
-          i18n: buildI18nRenderContext(i18nConfig, locale, currentDefaultLocale, domainLocales),
-          isFallback: isFallbackRender,
-          pageProps,
-          props: renderProps,
-          params,
-          query,
-          renderDocumentToString(element) {
-            return renderToStringAsync(element);
-          },
-          renderToReadableStream,
-          resetSSRHead: typeof resetSSRHead === "function" ? resetSSRHead : undefined,
-          setDocumentInitialHead:
-            typeof setDocumentInitialHead === "function" ? setDocumentInitialHead : undefined,
-          routePattern,
-          routeUrl,
-          safeJsonStringify,
-          scriptNonce,
-          statusCode: renderStatusCode,
-          nextData: serializedPagesNextData,
-          userAgent: request.headers.get("user-agent") ?? undefined,
-          ifNoneMatch: request.headers.get("if-none-match") ?? undefined,
-          requestCacheControl: request.headers.get("cache-control") ?? undefined,
-        });
+        return finalizePagesPreviewResponse(
+          await renderPagesPageResponse({
+            assetTags,
+            buildId,
+            clearSsrContext() {
+              if (typeof setSSRContext === "function") setSSRContext(null);
+            },
+            createPageElement(currentProps) {
+              const el = createPageElement(PageComponent, AppComponent, currentProps);
+              return typeof wrapWithRouterContext === "function" ? wrapWithRouterContext(el) : el;
+            },
+            enhancePageElement(renderPageOpts) {
+              const el = enhancePageElement(
+                PageComponent,
+                AppComponent,
+                renderProps,
+                renderPageOpts,
+              );
+              return typeof wrapWithRouterContext === "function" ? wrapWithRouterContext(el) : el;
+            },
+            DocumentComponent,
+            err: err instanceof Error ? err : undefined,
+            flushPreloads: typeof flushPreloads === "function" ? flushPreloads : undefined,
+            fontLinkHeader,
+            fontPreloads: allFontPreloads,
+            getFontLinks,
+            getFontStyles,
+            getSSRHeadHTML: typeof getSSRHeadHTML === "function" ? getSSRHeadHTML : undefined,
+            clientTraceMetadata: shouldEmitPagesClientTraceMetadata(pageModule, AppComponent)
+              ? vinextConfig.clientTraceMetadata
+              : undefined,
+            documentReqRes,
+            gsspRes,
+            isrCacheKey: pageIsrCacheKey,
+            expireSeconds: vinextConfig.expireTime,
+            isrRevalidateSeconds,
+            isStaticPropsRoute,
+            isrSet,
+            i18n: buildI18nRenderContext(i18nConfig, locale, currentDefaultLocale, domainLocales),
+            isFallback: isFallbackRender,
+            pageProps,
+            props: renderProps,
+            params,
+            query,
+            renderDocumentToString(element) {
+              return renderToStringAsync(element);
+            },
+            renderToReadableStream,
+            resetSSRHead: typeof resetSSRHead === "function" ? resetSSRHead : undefined,
+            setDocumentInitialHead:
+              typeof setDocumentInitialHead === "function" ? setDocumentInitialHead : undefined,
+            routePattern,
+            routeUrl,
+            safeJsonStringify,
+            scriptNonce,
+            statusCode: renderStatusCode,
+            nextData: serializedPagesNextData,
+            userAgent: request.headers.get("user-agent") ?? undefined,
+            ifNoneMatch: request.headers.get("if-none-match") ?? undefined,
+            requestCacheControl: request.headers.get("cache-control") ?? undefined,
+          }),
+          preview,
+        );
       } catch (e) {
         console.error("[vinext] SSR error:", e);
         reportRequestError(

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -446,11 +446,18 @@ export function createPagesPageHandler(
         // mirroring Next.js's Pages adapter. See server/render.tsx readiness rule.
         const pageModule = route.module;
         const isStaticPropsRoute = typeof pageModule.getStaticProps === "function";
-        const pagesNextData = buildPagesReadinessNextData({
-          pageModule,
-          appComponent: AppComponent as { getInitialProps?: unknown } | null,
-          hasRewrites,
-        });
+        const isOnDemandRevalidate = isOnDemandRevalidateRequest(
+          request.headers.get(PRERENDER_REVALIDATE_HEADER),
+        );
+        const previewData = getPagesPreviewData(request, { isOnDemandRevalidate });
+        const pagesNextData = {
+          ...buildPagesReadinessNextData({
+            pageModule,
+            appComponent: AppComponent as { getInitialProps?: unknown } | null,
+            hasRewrites,
+          }),
+          ...(previewData === false ? {} : { isPreview: true as const }),
+        };
         const navigationIsReady =
           typeof getPagesNavigationIsReadyFromSerializedState === "function"
             ? getPagesNavigationIsReadyFromSerializedState(
@@ -485,7 +492,10 @@ export function createPagesPageHandler(
           }
         }
 
-        applySSRContext({ nextData: pagesNextData });
+        applySSRContext({
+          isPreview: previewData !== false,
+          nextData: pagesNextData,
+        });
 
         const PageComponent = pageModule.default as ComponentType | undefined;
         if (!PageComponent) {
@@ -566,9 +576,6 @@ export function createPagesPageHandler(
             url: originalRequestPathAndSearch,
           });
 
-        const isOnDemandRevalidate = isOnDemandRevalidateRequest(
-          request.headers.get(PRERENDER_REVALIDATE_HEADER),
-        );
         const pageDataResult = await resolvePagesPageData({
           isDataReq,
           err: err instanceof Error ? err : undefined,
@@ -605,7 +612,7 @@ export function createPagesPageHandler(
           // external client from forcing synchronous regeneration via an
           // arbitrary header value (cache-stampede/DoS vector).
           isOnDemandRevalidate,
-          previewData: getPagesPreviewData(request, { isOnDemandRevalidate }),
+          previewData,
           pageModule,
           AppComponent,
           params,

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -668,15 +668,12 @@ export function createPagesPageHandler(
         if (pageDataResult.kind === "notFound") {
           const notFoundRoute = findNotFoundRoute();
           if (notFoundRoute && routePattern !== "/404" && routePattern !== "/_error") {
-            return finalizePagesPreviewResponse(
-              await renderPage(request, url, manifest, middlewareHeaders, {
-                statusCode: 404,
-                asPath: renderAsPath ?? routeUrl,
-                renderErrorPageOnMiss: false,
-                __forcedRoute: notFoundRoute,
-              }),
-              preview,
-            );
+            return renderPage(request, url, manifest, middlewareHeaders, {
+              statusCode: 404,
+              asPath: renderAsPath ?? routeUrl,
+              renderErrorPageOnMiss: false,
+              __forcedRoute: notFoundRoute,
+            });
           }
           return finalizePagesPreviewResponse(buildDefaultPagesNotFoundResponse(), preview);
         }

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -65,9 +65,7 @@ function finalizePagesPreviewResponse(response: Response, preview: PagesPreviewS
   if (preview.data === false && !preview.shouldClear) return response;
   const headers = new Headers(response.headers);
   if (preview.data !== false) headers.set("Cache-Control", PAGES_PREVIEW_CACHE_CONTROL);
-  if (preview.shouldClear && headers.getSetCookie().length === 0) {
-    appendPagesPreviewClearCookies(headers);
-  }
+  if (preview.shouldClear) appendPagesPreviewClearCookies(headers);
   return new Response(response.body, {
     headers,
     status: response.status,

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -65,7 +65,9 @@ function finalizePagesPreviewResponse(response: Response, preview: PagesPreviewS
   if (preview.data === false && !preview.shouldClear) return response;
   const headers = new Headers(response.headers);
   if (preview.data !== false) headers.set("Cache-Control", PAGES_PREVIEW_CACHE_CONTROL);
-  if (preview.shouldClear) appendPagesPreviewClearCookies(headers);
+  if (preview.shouldClear && headers.getSetCookie().length === 0) {
+    appendPagesPreviewClearCookies(headers);
+  }
   return new Response(response.body, {
     headers,
     status: response.status,
@@ -467,9 +469,13 @@ export function createPagesPageHandler(
         const isOnDemandRevalidate = isOnDemandRevalidateRequest(
           request.headers.get(PRERENDER_REVALIDATE_HEADER),
         );
-        const preview = getPagesPreviewState(request.headers.get("cookie"), {
-          isOnDemandRevalidate,
-        });
+        const supportsPreview =
+          isStaticPropsRoute || typeof pageModule.getServerSideProps === "function";
+        const preview = supportsPreview
+          ? getPagesPreviewState(request.headers.get("cookie"), {
+              isOnDemandRevalidate,
+            })
+          : ({ data: false, shouldClear: false } satisfies PagesPreviewState);
         const previewData = preview.data;
         const pagesNextData = {
           ...buildPagesReadinessNextData({
@@ -668,12 +674,15 @@ export function createPagesPageHandler(
         if (pageDataResult.kind === "notFound") {
           const notFoundRoute = findNotFoundRoute();
           if (notFoundRoute && routePattern !== "/404" && routePattern !== "/_error") {
-            return renderPage(request, url, manifest, middlewareHeaders, {
-              statusCode: 404,
-              asPath: renderAsPath ?? routeUrl,
-              renderErrorPageOnMiss: false,
-              __forcedRoute: notFoundRoute,
-            });
+            return finalizePagesPreviewResponse(
+              await renderPage(request, url, manifest, middlewareHeaders, {
+                statusCode: 404,
+                asPath: renderAsPath ?? routeUrl,
+                renderErrorPageOnMiss: false,
+                __forcedRoute: notFoundRoute,
+              }),
+              preview,
+            );
           }
           return finalizePagesPreviewResponse(buildDefaultPagesNotFoundResponse(), preview);
         }

--- a/packages/vinext/src/server/pages-preview.ts
+++ b/packages/vinext/src/server/pages-preview.ts
@@ -1,0 +1,166 @@
+import {
+  createCipheriv,
+  createDecipheriv,
+  createHash,
+  createHmac,
+  randomBytes,
+  timingSafeEqual,
+} from "node:crypto";
+import { parseCookieHeader } from "../utils/parse-cookie.js";
+import { getRevalidateSecret, isRevalidateSecret } from "./isr-cache.js";
+
+export const PAGES_PREVIEW_CACHE_CONTROL =
+  "private, no-cache, no-store, max-age=0, must-revalidate";
+
+export type PagesPreviewData = object | string;
+export type PagesPreviewState = {
+  data: PagesPreviewData | false;
+  shouldClear: boolean;
+};
+
+type PreviewResponse = {
+  getHeader(name: string): string | number | boolean | string[] | undefined;
+  setHeader(name: string, value: string | number | boolean | string[]): unknown;
+};
+
+function deriveKey(purpose: "encryption" | "signing"): Buffer {
+  return createHash("sha256")
+    .update(`vinext-pages-preview-${purpose}\0${getRevalidateSecret()}`)
+    .digest();
+}
+
+function serializeCookie(
+  name: "__prerender_bypass" | "__next_preview_data",
+  value: string,
+  options: { maxAge?: number; path?: string } = {},
+): string {
+  const parts = [
+    `${name}=${encodeURIComponent(value)}`,
+    "HttpOnly",
+    `Path=${options.path ?? "/"}`,
+    process.env.NODE_ENV !== "development" ? "SameSite=None" : "SameSite=Lax",
+  ];
+  if (process.env.NODE_ENV !== "development") parts.push("Secure");
+  if (options.maxAge !== undefined) parts.push(`Max-Age=${Math.trunc(options.maxAge)}`);
+  return parts.join("; ");
+}
+
+function serializeClearedCookie(
+  name: "__prerender_bypass" | "__next_preview_data",
+  options: { path?: string } = {},
+): string {
+  return [
+    `${name}=`,
+    "Expires=Thu, 01 Jan 1970 00:00:00 GMT",
+    "HttpOnly",
+    `Path=${options.path ?? "/"}`,
+    process.env.NODE_ENV !== "development" ? "SameSite=None" : "SameSite=Lax",
+    ...(process.env.NODE_ENV !== "development" ? ["Secure"] : []),
+  ].join("; ");
+}
+
+function normalizeSetCookie(value: string | number | boolean | string[] | undefined): string[] {
+  if (value === undefined) return [];
+  return Array.isArray(value) ? value.map(String) : [String(value)];
+}
+
+function encodePayload(data: PagesPreviewData, maxAge?: number): string {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", deriveKey("encryption"), iv);
+  const plaintext = JSON.stringify({
+    data,
+    ...(maxAge === undefined ? {} : { expiresAt: Date.now() + maxAge * 1000 }),
+  });
+  const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const encryptedToken = [iv, encrypted, cipher.getAuthTag()]
+    .map((part) => part.toString("base64url"))
+    .join(".");
+  const signature = createHmac("sha256", deriveKey("signing"))
+    .update(encryptedToken)
+    .digest("base64url");
+  return `${encryptedToken}.${signature}`;
+}
+
+function decodePayload(payload: string): PagesPreviewData | false {
+  try {
+    const [ivValue, encryptedValue, tagValue, signatureValue, ...extra] = payload.split(".");
+    if (!ivValue || !encryptedValue || !tagValue || !signatureValue || extra.length > 0) {
+      return false;
+    }
+    const encryptedToken = `${ivValue}.${encryptedValue}.${tagValue}`;
+    const expected = createHmac("sha256", deriveKey("signing")).update(encryptedToken).digest();
+    const signature = Buffer.from(signatureValue, "base64url");
+    if (signature.length !== expected.length || !timingSafeEqual(signature, expected)) return false;
+
+    const decipher = createDecipheriv(
+      "aes-256-gcm",
+      deriveKey("encryption"),
+      Buffer.from(ivValue, "base64url"),
+    );
+    decipher.setAuthTag(Buffer.from(tagValue, "base64url"));
+    const decoded = Buffer.concat([
+      decipher.update(Buffer.from(encryptedValue, "base64url")),
+      decipher.final(),
+    ]).toString("utf8");
+    const value: unknown = JSON.parse(decoded);
+    if (typeof value !== "object" || value === null || !("data" in value)) return false;
+    const expiresAt = "expiresAt" in value ? value.expiresAt : undefined;
+    if (typeof expiresAt === "number" && Date.now() >= expiresAt) return false;
+    const data = value.data;
+    return typeof data === "object" && data !== null ? (data as object) : String(data);
+  } catch {
+    return false;
+  }
+}
+
+export function getPagesPreviewState(
+  cookieHeader: string | string[] | null | undefined,
+  options: { isOnDemandRevalidate?: boolean } = {},
+): PagesPreviewState {
+  if (options.isOnDemandRevalidate) return { data: false, shouldClear: false };
+  const cookies = parseCookieHeader(
+    Array.isArray(cookieHeader) ? cookieHeader.join("; ") : cookieHeader,
+  );
+  const bypass = cookies.__prerender_bypass;
+  const payload = cookies.__next_preview_data;
+  if (!bypass && !payload) return { data: false, shouldClear: false };
+  if (!bypass || !payload || !isRevalidateSecret(bypass)) {
+    return { data: false, shouldClear: true };
+  }
+  const data = decodePayload(payload);
+  return { data, shouldClear: data === false };
+}
+
+export function setPagesPreviewData(
+  response: PreviewResponse,
+  data: PagesPreviewData,
+  options: { maxAge?: number; path?: string } = {},
+): void {
+  const payload = encodePayload(data, options.maxAge);
+  if (payload.length > 2048) {
+    throw new Error(
+      "Preview data is limited to 2KB currently, reduce how much data you are storing as preview data to continue",
+    );
+  }
+  response.setHeader("Set-Cookie", [
+    ...normalizeSetCookie(response.getHeader("Set-Cookie")),
+    serializeCookie("__prerender_bypass", getRevalidateSecret(), options),
+    serializeCookie("__next_preview_data", payload, options),
+  ]);
+}
+
+export function clearPagesPreviewData(
+  response: PreviewResponse,
+  options: { path?: string } = {},
+): void {
+  response.setHeader("Set-Cookie", [
+    ...normalizeSetCookie(response.getHeader("Set-Cookie")),
+    serializeClearedCookie("__prerender_bypass", options),
+    serializeClearedCookie("__next_preview_data", options),
+  ]);
+}
+
+export function appendPagesPreviewClearCookies(headers: Headers): void {
+  headers.append("Set-Cookie", serializeClearedCookie("__prerender_bypass"));
+  headers.append("Set-Cookie", serializeClearedCookie("__next_preview_data"));
+}

--- a/packages/vinext/src/server/pages-preview.ts
+++ b/packages/vinext/src/server/pages-preview.ts
@@ -50,6 +50,10 @@ function getPagesPreviewCredentials(): PagesPreviewCredentials {
   return devCredentials;
 }
 
+export function getPagesPreviewModeId(): string {
+  return getPagesPreviewCredentials().bypassId;
+}
+
 function serializeCookie(
   name: "__prerender_bypass" | "__next_preview_data",
   value: string,
@@ -147,11 +151,22 @@ export function getPagesPreviewState(
   const bypass = cookies.__prerender_bypass;
   const payload = cookies.__next_preview_data;
   if (!bypass && !payload) return { data: false, shouldClear: false };
-  if (!bypass || !payload || bypass !== getPagesPreviewCredentials().bypassId) {
+  if (!bypass || bypass !== getPagesPreviewCredentials().bypassId) {
     return { data: false, shouldClear: true };
   }
+  if (!payload) return { data: {}, shouldClear: false };
   const data = decodePayload(payload);
   return { data, shouldClear: data === false };
+}
+
+export function setPagesDraftMode(response: PreviewResponse, enabled: boolean): void {
+  const cookie = enabled
+    ? serializeCookie("__prerender_bypass", getPagesPreviewModeId())
+    : serializeClearedCookie("__prerender_bypass");
+  response.setHeader("Set-Cookie", [
+    ...normalizeSetCookie(response.getHeader("Set-Cookie")),
+    cookie,
+  ]);
 }
 
 export function setPagesPreviewData(
@@ -167,7 +182,7 @@ export function setPagesPreviewData(
   }
   response.setHeader("Set-Cookie", [
     ...normalizeSetCookie(response.getHeader("Set-Cookie")),
-    serializeCookie("__prerender_bypass", getPagesPreviewCredentials().bypassId, options),
+    serializeCookie("__prerender_bypass", getPagesPreviewModeId(), options),
     serializeCookie("__next_preview_data", payload, options),
   ]);
 }

--- a/packages/vinext/src/server/pages-preview.ts
+++ b/packages/vinext/src/server/pages-preview.ts
@@ -21,6 +21,8 @@ type PreviewResponse = {
   setHeader(name: string, value: string | number | boolean | string[]): unknown;
 };
 
+const pagesPreviewCookiesCleared = Symbol("__prerender_bypass");
+
 type PagesPreviewCredentials = {
   bypassId: string;
   encryptionKey: Buffer;
@@ -191,11 +193,17 @@ export function clearPagesPreviewData(
   response: PreviewResponse,
   options: { path?: string } = {},
 ): void {
+  if (pagesPreviewCookiesCleared in response) return;
+
   response.setHeader("Set-Cookie", [
     ...normalizeSetCookie(response.getHeader("Set-Cookie")),
     serializeClearedCookie("__prerender_bypass", options),
     serializeClearedCookie("__next_preview_data", options),
   ]);
+  Object.defineProperty(response, pagesPreviewCookiesCleared, {
+    value: true,
+    enumerable: false,
+  });
 }
 
 export function appendPagesPreviewClearCookies(headers: Headers): void {

--- a/packages/vinext/src/server/pages-preview.ts
+++ b/packages/vinext/src/server/pages-preview.ts
@@ -209,10 +209,26 @@ export function clearPagesPreviewData(
 export function appendPagesPreviewClearCookies(headers: Headers): void {
   const cookies = headers.getSetCookie();
   const hasExpiredCookie = (name: "__prerender_bypass" | "__next_preview_data") =>
-    cookies.some(
-      (cookie) =>
-        cookie.startsWith(`${name}=`) && cookie.includes("Expires=Thu, 01 Jan 1970 00:00:00 GMT"),
-    );
+    cookies.some((cookie) => {
+      const [cookieValue, ...attributes] = cookie.split(";").map((part) => part.trim());
+      if (!cookieValue?.startsWith(`${name}=`)) return false;
+
+      let expiresAtEpoch = false;
+      let path: string | undefined;
+      let hasDomain = false;
+      for (const attribute of attributes) {
+        const separator = attribute.indexOf("=");
+        const attributeName = (separator === -1 ? attribute : attribute.slice(0, separator))
+          .trim()
+          .toLowerCase();
+        const attributeValue = separator === -1 ? "" : attribute.slice(separator + 1).trim();
+        if (attributeName === "expires") expiresAtEpoch = Date.parse(attributeValue) === 0;
+        if (attributeName === "path") path = attributeValue;
+        if (attributeName === "domain") hasDomain = true;
+      }
+
+      return expiresAtEpoch && path === "/" && !hasDomain;
+    });
   if (!hasExpiredCookie("__prerender_bypass")) {
     headers.append("Set-Cookie", serializeClearedCookie("__prerender_bypass"));
   }

--- a/packages/vinext/src/server/pages-preview.ts
+++ b/packages/vinext/src/server/pages-preview.ts
@@ -207,6 +207,16 @@ export function clearPagesPreviewData(
 }
 
 export function appendPagesPreviewClearCookies(headers: Headers): void {
-  headers.append("Set-Cookie", serializeClearedCookie("__prerender_bypass"));
-  headers.append("Set-Cookie", serializeClearedCookie("__next_preview_data"));
+  const cookies = headers.getSetCookie();
+  const hasExpiredCookie = (name: "__prerender_bypass" | "__next_preview_data") =>
+    cookies.some(
+      (cookie) =>
+        cookie.startsWith(`${name}=`) && cookie.includes("Expires=Thu, 01 Jan 1970 00:00:00 GMT"),
+    );
+  if (!hasExpiredCookie("__prerender_bypass")) {
+    headers.append("Set-Cookie", serializeClearedCookie("__prerender_bypass"));
+  }
+  if (!hasExpiredCookie("__next_preview_data")) {
+    headers.append("Set-Cookie", serializeClearedCookie("__next_preview_data"));
+  }
 }

--- a/packages/vinext/src/server/pages-preview.ts
+++ b/packages/vinext/src/server/pages-preview.ts
@@ -1,13 +1,11 @@
 import {
   createCipheriv,
   createDecipheriv,
-  createHash,
   createHmac,
   randomBytes,
   timingSafeEqual,
 } from "node:crypto";
 import { parseCookieHeader } from "../utils/parse-cookie.js";
-import { getRevalidateSecret, isRevalidateSecret } from "./isr-cache.js";
 
 export const PAGES_PREVIEW_CACHE_CONTROL =
   "private, no-cache, no-store, max-age=0, must-revalidate";
@@ -23,10 +21,33 @@ type PreviewResponse = {
   setHeader(name: string, value: string | number | boolean | string[]): unknown;
 };
 
-function deriveKey(purpose: "encryption" | "signing"): Buffer {
-  return createHash("sha256")
-    .update(`vinext-pages-preview-${purpose}\0${getRevalidateSecret()}`)
-    .digest();
+type PagesPreviewCredentials = {
+  bypassId: string;
+  encryptionKey: Buffer;
+  signingKey: Buffer;
+};
+
+let devCredentials: PagesPreviewCredentials | undefined;
+
+function decodeKey(value: string | undefined): Buffer | null {
+  if (!value || !/^[0-9a-f]{64}$/i.test(value)) return null;
+  return Buffer.from(value, "hex");
+}
+
+function getPagesPreviewCredentials(): PagesPreviewCredentials {
+  const bypassId = process.env.__VINEXT_PREVIEW_MODE_ID;
+  const encryptionKey = decodeKey(process.env.__VINEXT_PREVIEW_MODE_ENCRYPTION_KEY);
+  const signingKey = decodeKey(process.env.__VINEXT_PREVIEW_MODE_SIGNING_KEY);
+  if (bypassId && encryptionKey && signingKey) return { bypassId, encryptionKey, signingKey };
+
+  if (!devCredentials) {
+    devCredentials = {
+      bypassId: randomBytes(16).toString("hex"),
+      encryptionKey: randomBytes(32),
+      signingKey: randomBytes(32),
+    };
+  }
+  return devCredentials;
 }
 
 function serializeCookie(
@@ -66,7 +87,8 @@ function normalizeSetCookie(value: string | number | boolean | string[] | undefi
 
 function encodePayload(data: PagesPreviewData, maxAge?: number): string {
   const iv = randomBytes(12);
-  const cipher = createCipheriv("aes-256-gcm", deriveKey("encryption"), iv);
+  const credentials = getPagesPreviewCredentials();
+  const cipher = createCipheriv("aes-256-gcm", credentials.encryptionKey, iv);
   const plaintext = JSON.stringify({
     data,
     ...(maxAge === undefined ? {} : { expiresAt: Date.now() + maxAge * 1000 }),
@@ -75,7 +97,7 @@ function encodePayload(data: PagesPreviewData, maxAge?: number): string {
   const encryptedToken = [iv, encrypted, cipher.getAuthTag()]
     .map((part) => part.toString("base64url"))
     .join(".");
-  const signature = createHmac("sha256", deriveKey("signing"))
+  const signature = createHmac("sha256", credentials.signingKey)
     .update(encryptedToken)
     .digest("base64url");
   return `${encryptedToken}.${signature}`;
@@ -88,13 +110,14 @@ function decodePayload(payload: string): PagesPreviewData | false {
       return false;
     }
     const encryptedToken = `${ivValue}.${encryptedValue}.${tagValue}`;
-    const expected = createHmac("sha256", deriveKey("signing")).update(encryptedToken).digest();
+    const credentials = getPagesPreviewCredentials();
+    const expected = createHmac("sha256", credentials.signingKey).update(encryptedToken).digest();
     const signature = Buffer.from(signatureValue, "base64url");
     if (signature.length !== expected.length || !timingSafeEqual(signature, expected)) return false;
 
     const decipher = createDecipheriv(
       "aes-256-gcm",
-      deriveKey("encryption"),
+      credentials.encryptionKey,
       Buffer.from(ivValue, "base64url"),
     );
     decipher.setAuthTag(Buffer.from(tagValue, "base64url"));
@@ -124,7 +147,7 @@ export function getPagesPreviewState(
   const bypass = cookies.__prerender_bypass;
   const payload = cookies.__next_preview_data;
   if (!bypass && !payload) return { data: false, shouldClear: false };
-  if (!bypass || !payload || !isRevalidateSecret(bypass)) {
+  if (!bypass || !payload || bypass !== getPagesPreviewCredentials().bypassId) {
     return { data: false, shouldClear: true };
   }
   const data = decodePayload(payload);
@@ -144,7 +167,7 @@ export function setPagesPreviewData(
   }
   response.setHeader("Set-Cookie", [
     ...normalizeSetCookie(response.getHeader("Set-Cookie")),
-    serializeCookie("__prerender_bypass", getRevalidateSecret(), options),
+    serializeCookie("__prerender_bypass", getPagesPreviewCredentials().bypassId, options),
     serializeCookie("__next_preview_data", payload, options),
   ]);
 }

--- a/packages/vinext/src/shims/internal/pages-data-fetch-dedup.ts
+++ b/packages/vinext/src/shims/internal/pages-data-fetch-dedup.ts
@@ -52,10 +52,11 @@ const staticDataSources = new Map<string, Promise<Response>>();
 
 function getStaticDataKey(dataHref: string): string {
   if (typeof window === "undefined") return dataHref;
+  const previewVariant = window.__NEXT_DATA__?.isPreview === true ? "preview" : "normal";
   try {
-    return new URL(dataHref, window.location.href).href;
+    return `${new URL(dataHref, window.location.href).href}\n${previewVariant}`;
   } catch {
-    return dataHref;
+    return `${dataHref}\n${previewVariant}`;
   }
 }
 
@@ -146,7 +147,11 @@ function getInflightKey(dataHref: string, init?: RequestInit): string {
   }
 
   const deploymentId = new Headers(init?.headers).get(NEXT_DEPLOYMENT_ID_HEADER) ?? "";
-  return `${resolvedHref}\n${deploymentId}`;
+  const previewVariant =
+    typeof window !== "undefined" && window.__NEXT_DATA__?.isPreview === true
+      ? "preview"
+      : "normal";
+  return `${resolvedHref}\n${deploymentId}\n${previewVariant}`;
 }
 
 function cloneSharedResponse(

--- a/packages/vinext/src/shims/next-shims.d.ts
+++ b/packages/vinext/src/shims/next-shims.d.ts
@@ -8,28 +8,36 @@
 
 declare module "next" {
   import type { IncomingMessage, ServerResponse } from "node:http";
+  type Env = { [key: string]: string | undefined };
   export type PreviewData = string | false | object | undefined;
   export type NextApiRequest = {
-    query: Record<string, string | string[]>;
-    body: unknown;
-    cookies: Record<string, string>;
-    preview?: boolean;
+    query: Partial<{ [key: string]: string | string[] }>;
+    cookies: Partial<{ [key: string]: string }>;
+    body: any;
+    env: Env;
     draftMode?: boolean;
+    preview?: boolean;
     previewData?: PreviewData;
   } & IncomingMessage;
-  export type NextApiResponse<T = unknown> = {
-    status(code: number): NextApiResponse<T>;
-    json(data: T): void;
-    send(data: T): void;
-    redirect(statusOrUrl: number | string, url?: string): void;
-    setDraftMode(options: { enable: boolean }): NextApiResponse<T>;
+  export type NextApiResponse<Data = any> = ServerResponse & {
+    send: (body: Data) => void;
+    json: (body: Data) => void;
+    status: (statusCode: number) => NextApiResponse<Data>;
+    redirect(url: string): NextApiResponse<Data>;
+    redirect(status: number, url: string): NextApiResponse<Data>;
+    setDraftMode: (options: { enable: boolean }) => NextApiResponse<Data>;
     setPreviewData(
       data: object | string,
       options?: { maxAge?: number; path?: string },
-    ): NextApiResponse<T>;
-    clearPreviewData(options?: { path?: string }): NextApiResponse<T>;
+    ): NextApiResponse<Data>;
+    clearPreviewData(options?: { path?: string }): NextApiResponse<Data>;
     revalidate(urlPath: string, opts?: { unstable_onlyGenerated?: boolean }): Promise<void>;
-  } & ServerResponse;
+  };
+  export type NextApiHandler<T = any> = (
+    req: NextApiRequest,
+    res: NextApiResponse<T>,
+    // oxlint-disable-next-line typescript/no-redundant-type-constituents
+  ) => unknown | Promise<unknown>;
 }
 
 declare module "next/router" {

--- a/packages/vinext/src/shims/next-shims.d.ts
+++ b/packages/vinext/src/shims/next-shims.d.ts
@@ -21,6 +21,13 @@ declare module "next" {
     json(data: T): void;
     send(data: T): void;
     redirect(statusOrUrl: number | string, url?: string): void;
+    setDraftMode(options: { enable: boolean }): NextApiResponse<T>;
+    setPreviewData(
+      data: object | string,
+      options?: { maxAge?: number; path?: string },
+    ): NextApiResponse<T>;
+    clearPreviewData(options?: { path?: string }): NextApiResponse<T>;
+    revalidate(urlPath: string, opts?: { unstable_onlyGenerated?: boolean }): Promise<void>;
   } & ServerResponse;
 }
 

--- a/packages/vinext/src/shims/next-shims.d.ts
+++ b/packages/vinext/src/shims/next-shims.d.ts
@@ -8,13 +8,14 @@
 
 declare module "next" {
   import type { IncomingMessage, ServerResponse } from "node:http";
+  export type PreviewData = string | false | object | undefined;
   export type NextApiRequest = {
     query: Record<string, string | string[]>;
     body: unknown;
     cookies: Record<string, string>;
     preview?: boolean;
     draftMode?: boolean;
-    previewData?: string | false | object | undefined;
+    previewData?: PreviewData;
   } & IncomingMessage;
   export type NextApiResponse<T = unknown> = {
     status(code: number): NextApiResponse<T>;

--- a/packages/vinext/src/shims/next-shims.d.ts
+++ b/packages/vinext/src/shims/next-shims.d.ts
@@ -10,7 +10,8 @@ declare module "next" {
   import type { IncomingMessage, ServerResponse } from "node:http";
   type Env = { [key: string]: string | undefined };
   export type PreviewData = string | false | object | undefined;
-  export type NextApiRequest = {
+  // oxlint-disable-next-line typescript/consistent-type-definitions
+  export interface NextApiRequest extends IncomingMessage {
     query: Partial<{ [key: string]: string | string[] }>;
     cookies: Partial<{ [key: string]: string }>;
     body: any;
@@ -18,7 +19,7 @@ declare module "next" {
     draftMode?: boolean;
     preview?: boolean;
     previewData?: PreviewData;
-  } & IncomingMessage;
+  }
   export type NextApiResponse<Data = any> = ServerResponse & {
     send: (body: Data) => void;
     json: (body: Data) => void;

--- a/packages/vinext/src/shims/next-shims.d.ts
+++ b/packages/vinext/src/shims/next-shims.d.ts
@@ -15,7 +15,7 @@ declare module "next" {
     query: Partial<{ [key: string]: string | string[] }>;
     cookies: Partial<{ [key: string]: string }>;
     body: any;
-    env: Env;
+    env?: Env;
     draftMode?: boolean;
     preview?: boolean;
     previewData?: PreviewData;

--- a/packages/vinext/src/shims/next-shims.d.ts
+++ b/packages/vinext/src/shims/next-shims.d.ts
@@ -15,7 +15,7 @@ declare module "next" {
     query: Partial<{ [key: string]: string | string[] }>;
     cookies: Partial<{ [key: string]: string }>;
     body: any;
-    env?: Env;
+    env: Env;
     draftMode?: boolean;
     preview?: boolean;
     previewData?: PreviewData;

--- a/packages/vinext/src/shims/next-shims.d.ts
+++ b/packages/vinext/src/shims/next-shims.d.ts
@@ -12,6 +12,9 @@ declare module "next" {
     query: Record<string, string | string[]>;
     body: unknown;
     cookies: Record<string, string>;
+    preview?: true;
+    draftMode?: true;
+    previewData: object | string | false;
   } & IncomingMessage;
   export type NextApiResponse<T = unknown> = {
     status(code: number): NextApiResponse<T>;

--- a/packages/vinext/src/shims/next-shims.d.ts
+++ b/packages/vinext/src/shims/next-shims.d.ts
@@ -12,9 +12,9 @@ declare module "next" {
     query: Record<string, string | string[]>;
     body: unknown;
     cookies: Record<string, string>;
-    preview?: true;
-    draftMode?: true;
-    previewData: object | string | false;
+    preview?: boolean;
+    draftMode?: boolean;
+    previewData?: string | false | object | undefined;
   } & IncomingMessage;
   export type NextApiResponse<T = unknown> = {
     status(code: number): NextApiResponse<T>;

--- a/packages/vinext/src/shims/router-state.ts
+++ b/packages/vinext/src/shims/router-state.ts
@@ -29,6 +29,7 @@ export type SSRContext = {
   locale?: string;
   locales?: string[];
   defaultLocale?: string;
+  isPreview?: boolean;
   isFallback?: boolean;
 };
 

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -1951,6 +1951,7 @@ function buildPagesNavigationNextData(
     query: mergedQuery,
     buildId: target.buildId,
     isFallback: false,
+    isPreview: props.__N_PREVIEW === true,
     ...(nextLocale !== undefined ? { locale: nextLocale } : {}),
   } as unknown as NonNullable<Window["__NEXT_DATA__"]> & VinextNextData;
 }
@@ -2148,7 +2149,9 @@ async function navigateClientData(
       const deploymentId = getDeploymentId();
       if (deploymentId) headers[NEXT_DEPLOYMENT_ID_HEADER] = deploymentId;
       const dataFetch =
-        initialTarget.dataKind === "static" ? fetchStaticPagesData : dedupedPagesDataFetch;
+        initialTarget.dataKind === "static" && Router.isPreview !== true
+          ? fetchStaticPagesData
+          : dedupedPagesDataFetch;
       res = await dataFetch(initialTarget.dataHref, {
         headers,
         signal: controller.signal,
@@ -2223,6 +2226,9 @@ async function navigateClientData(
   const rawPageProps = props.pageProps;
   const pageProps: Record<string, unknown> = isUnknownRecord(rawPageProps) ? rawPageProps : {};
   if (initialTarget.dataKind === "server") {
+    evictPagesDataCache(initialTarget.dataHref);
+  }
+  if (props.__N_PREVIEW === true || Router.isPreview === true) {
     evictPagesDataCache(initialTarget.dataHref);
   }
 

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -921,6 +921,7 @@ type SSRContext = {
   locales?: string[];
   defaultLocale?: string;
   domainLocales?: VinextNextData["domainLocales"];
+  isPreview?: boolean;
   /**
    * True when rendering a `getStaticPaths` fallback shell for a path that
    * hasn't been pre-rendered yet (`fallback: true` + unlisted path). Mirrors
@@ -2734,7 +2735,8 @@ function buildRouterValue(
     defaultLocale,
     domainLocales,
     isReady,
-    isPreview: false,
+    isPreview:
+      typeof window !== "undefined" ? nextData?.isPreview === true : _ssrState?.isPreview === true,
     isFallback:
       typeof window !== "undefined"
         ? nextData?.isFallback === true
@@ -3875,7 +3877,13 @@ const Router: typeof RouterMethods & Omit<NextRouter, keyof typeof RouterMethods
         );
       },
     },
-    isPreview: { enumerable: true, value: false, writable: false },
+    isPreview: {
+      enumerable: true,
+      get(): boolean {
+        if (typeof window === "undefined") return _getSSRContext()?.isPreview === true;
+        return (window.__NEXT_DATA__ as VinextNextData | undefined)?.isPreview === true;
+      },
+    },
     isFallback: {
       enumerable: true,
       get(): boolean {

--- a/tests/api-handler.test.ts
+++ b/tests/api-handler.test.ts
@@ -222,6 +222,7 @@ describe("handleApiRoute", () => {
         mockServer({
           default(req: any, res: any) {
             observed.preview = req.preview;
+            observed.draftMode = req.draftMode;
             observed.previewData = req.previewData;
             res.setDraftMode({ enable: false });
             res.end();
@@ -233,7 +234,7 @@ describe("handleApiRoute", () => {
         [route("/api/draft")],
       );
 
-      expect(observed).toEqual({ preview: true, previewData: {} });
+      expect(observed).toEqual({ preview: true, draftMode: true, previewData: {} });
       expect(disableResponse._headers["set-cookie"]).toEqual([
         expect.stringMatching(/^__prerender_bypass=; Expires=/),
       ]);
@@ -263,6 +264,7 @@ describe("handleApiRoute", () => {
         mockServer({
           default(req: any, res: any) {
             observed.preview = req.preview;
+            observed.draftMode = req.draftMode;
             observed.previewData = req.previewData;
             res.clearPreviewData({ path: "/docs" });
             res.end();
@@ -274,7 +276,11 @@ describe("handleApiRoute", () => {
         [route("/api/preview")],
       );
 
-      expect(observed).toEqual({ preview: true, previewData: { draft: true } });
+      expect(observed).toEqual({
+        preview: true,
+        draftMode: true,
+        previewData: { draft: true },
+      });
       expect(clearResponse._headers["set-cookie"]).toEqual([
         expect.stringMatching(/^__prerender_bypass=; Expires=.*; HttpOnly; Path=\/docs;/),
         expect.stringMatching(/^__next_preview_data=; Expires=.*; HttpOnly; Path=\/docs;/),
@@ -312,7 +318,10 @@ describe("handleApiRoute", () => {
         mockServer({
           default(req: any, res: any) {
             observed.preview = req.preview;
+            observed.draftMode = req.draftMode;
             observed.previewData = req.previewData;
+            res.clearPreviewData({ path: "/docs" });
+            res.clearPreviewData();
             res.end();
           },
         }),
@@ -322,7 +331,11 @@ describe("handleApiRoute", () => {
         [route("/api/preview")],
       );
 
-      expect(observed).toEqual({ preview: undefined, previewData: false });
+      expect(observed).toEqual({
+        preview: undefined,
+        draftMode: undefined,
+        previewData: false,
+      });
       expect(response._headers["set-cookie"]).toEqual([
         expect.stringMatching(/^__prerender_bypass=; Expires=/),
         expect.stringMatching(/^__next_preview_data=; Expires=/),

--- a/tests/api-handler.test.ts
+++ b/tests/api-handler.test.ts
@@ -197,6 +197,98 @@ describe("handleApiRoute", () => {
     });
   });
 
+  describe("preview mode", () => {
+    it("sets, reads, and clears preview data in dev API routes", async () => {
+      const setResponse = mockRes();
+      await handleApiRoute(
+        mockServer({
+          default(_req: any, res: any) {
+            res.setPreviewData({ draft: true });
+            res.end();
+          },
+        }),
+        mockReq("GET", "/api/preview"),
+        setResponse,
+        "/api/preview",
+        [route("/api/preview")],
+      );
+      const setCookies = setResponse._headers["set-cookie"];
+      if (!Array.isArray(setCookies)) throw new Error("expected preview cookies");
+      const cookie = setCookies.map((value) => value.split(";", 1)[0]).join("; ");
+
+      const observed: Record<string, unknown> = {};
+      const clearResponse = mockRes();
+      await handleApiRoute(
+        mockServer({
+          default(req: any, res: any) {
+            observed.preview = req.preview;
+            observed.previewData = req.previewData;
+            res.clearPreviewData({ path: "/docs" });
+            res.end();
+          },
+        }),
+        mockReq("GET", "/api/preview", undefined, { cookie }),
+        clearResponse,
+        "/api/preview",
+        [route("/api/preview")],
+      );
+
+      expect(observed).toEqual({ preview: true, previewData: { draft: true } });
+      expect(clearResponse._headers["set-cookie"]).toEqual([
+        expect.stringMatching(/^__prerender_bypass=; Expires=.*; HttpOnly; Path=\/docs;/),
+        expect.stringMatching(/^__next_preview_data=; Expires=.*; HttpOnly; Path=\/docs;/),
+      ]);
+    });
+
+    it("rejects and clears tampered preview data in dev API routes", async () => {
+      const setResponse = mockRes();
+      await handleApiRoute(
+        mockServer({
+          default(_req: any, res: any) {
+            res.setPreviewData({ draft: true });
+            res.end();
+          },
+        }),
+        mockReq("GET", "/api/preview"),
+        setResponse,
+        "/api/preview",
+        [route("/api/preview")],
+      );
+      const setCookies = setResponse._headers["set-cookie"];
+      if (!Array.isArray(setCookies)) throw new Error("expected preview cookies");
+      const cookie = setCookies
+        .map((value) => value.split(";", 1)[0])
+        .join("; ")
+        .replace(
+          /(__next_preview_data=)([^;])([^;]*)/,
+          (_match, prefix: string, first: string, rest: string) =>
+            `${prefix}${first === "a" ? "b" : "a"}${rest}`,
+        );
+
+      const observed: Record<string, unknown> = {};
+      const response = mockRes();
+      await handleApiRoute(
+        mockServer({
+          default(req: any, res: any) {
+            observed.preview = req.preview;
+            observed.previewData = req.previewData;
+            res.end();
+          },
+        }),
+        mockReq("GET", "/api/preview", undefined, { cookie }),
+        response,
+        "/api/preview",
+        [route("/api/preview")],
+      );
+
+      expect(observed).toEqual({ preview: undefined, previewData: false });
+      expect(response._headers["set-cookie"]).toEqual([
+        expect.stringMatching(/^__prerender_bypass=; Expires=/),
+        expect.stringMatching(/^__next_preview_data=; Expires=/),
+      ]);
+    });
+  });
+
   // ── Body parsing ───────────────────────────────────────────────────
 
   describe("body parsing", () => {

--- a/tests/api-handler.test.ts
+++ b/tests/api-handler.test.ts
@@ -845,8 +845,9 @@ describe("handleApiRoute", () => {
 
   describe("res.redirect()", () => {
     it("redirects with default 307 when given only a URL", async () => {
+      let returnedResponse: unknown;
       const handler = vi.fn((_req: any, res: any) => {
-        res.redirect("/dashboard");
+        returnedResponse = res.redirect("/dashboard");
       });
       const server = mockServer({ default: handler });
       const req = mockReq("GET", "/api/login");
@@ -856,12 +857,16 @@ describe("handleApiRoute", () => {
 
       expect(res._statusCode).toBe(307);
       expect(res._headers["location"]).toBe("/dashboard");
+      expect(res._headers["content-type"]).toBeUndefined();
+      expect(Buffer.from(res._body).toString()).toBe("/dashboard");
       expect(res._ended).toBe(true);
+      expect(returnedResponse).toBe(res);
     });
 
     it("redirects with custom status code", async () => {
+      let returnedResponse: unknown;
       const handler = vi.fn((_req: any, res: any) => {
-        res.redirect(301, "/new-location");
+        returnedResponse = res.redirect(301, "/new-location");
       });
       const server = mockServer({ default: handler });
       const req = mockReq("GET", "/api/old");
@@ -871,6 +876,10 @@ describe("handleApiRoute", () => {
 
       expect(res._statusCode).toBe(301);
       expect(res._headers["location"]).toBe("/new-location");
+      expect(res._headers["content-type"]).toBeUndefined();
+      expect(Buffer.from(res._body).toString()).toBe("/new-location");
+      expect(res._ended).toBe(true);
+      expect(returnedResponse).toBe(res);
     });
 
     it("redirects with 302 status code", async () => {
@@ -885,6 +894,34 @@ describe("handleApiRoute", () => {
 
       expect(res._statusCode).toBe(302);
       expect(res._headers["location"]).toBe("https://external.com");
+    });
+
+    it.each([
+      [null, undefined],
+      [307, undefined],
+      [true, "/destination"],
+    ])("rejects invalid redirect arguments %#", async (statusOrUrl, url) => {
+      const handler = vi.fn((_req: any, res: any) => {
+        res.redirect(statusOrUrl, url);
+      });
+      const server = mockServer({ default: handler });
+      const req = mockReq("GET", "/api/invalid-redirect");
+      const res = mockRes();
+
+      await handleApiRoute(server, req, res, "/api/invalid-redirect", [
+        route("/api/invalid-redirect"),
+      ]);
+
+      expect(reportRequestError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message:
+            "Invalid redirect arguments. Please use a single argument URL, e.g. res.redirect('/destination') or use a status code and URL, e.g. res.redirect(307, '/destination').",
+        }),
+        expect.anything(),
+        expect.anything(),
+      );
+      expect(res._statusCode).toBe(500);
+      expect(res._body).toBe("Internal Server Error");
     });
   });
 

--- a/tests/api-handler.test.ts
+++ b/tests/api-handler.test.ts
@@ -198,6 +198,47 @@ describe("handleApiRoute", () => {
   });
 
   describe("preview mode", () => {
+    it("supports setDraftMode and bypass-only draft requests in dev API routes", async () => {
+      const enableResponse = mockRes();
+      await handleApiRoute(
+        mockServer({
+          default(_req: any, res: any) {
+            res.setDraftMode({ enable: true });
+            res.end();
+          },
+        }),
+        mockReq("GET", "/api/draft"),
+        enableResponse,
+        "/api/draft",
+        [route("/api/draft")],
+      );
+      const cookies = enableResponse._headers["set-cookie"];
+      if (!Array.isArray(cookies)) throw new Error("expected draft cookie");
+      expect(cookies).toHaveLength(1);
+
+      const observed: Record<string, unknown> = {};
+      const disableResponse = mockRes();
+      await handleApiRoute(
+        mockServer({
+          default(req: any, res: any) {
+            observed.preview = req.preview;
+            observed.previewData = req.previewData;
+            res.setDraftMode({ enable: false });
+            res.end();
+          },
+        }),
+        mockReq("GET", "/api/draft", undefined, { cookie: cookies[0].split(";", 1)[0] }),
+        disableResponse,
+        "/api/draft",
+        [route("/api/draft")],
+      );
+
+      expect(observed).toEqual({ preview: true, previewData: {} });
+      expect(disableResponse._headers["set-cookie"]).toEqual([
+        expect.stringMatching(/^__prerender_bypass=; Expires=/),
+      ]);
+    });
+
     it("sets, reads, and clears preview data in dev API routes", async () => {
       const setResponse = mockRes();
       await handleApiRoute(

--- a/tests/api-handler.test.ts
+++ b/tests/api-handler.test.ts
@@ -346,6 +346,31 @@ describe("handleApiRoute", () => {
   // ── Body parsing ───────────────────────────────────────────────────
 
   describe("body parsing", () => {
+    it("does not expose process environment variables on the request", async () => {
+      const previousValue = process.env.VINEXT_API_REQUEST_ENV_TEST;
+      process.env.VINEXT_API_REQUEST_ENV_TEST = "secret";
+      let capturedRequest: any;
+      const handler = vi.fn((req: any) => {
+        capturedRequest = req;
+      });
+      const server = mockServer({ default: handler });
+      const req = mockReq("GET", "/api/env");
+      const res = mockRes();
+
+      try {
+        await handleApiRoute(server, req, res, "/api/env", [route("/api/env")]);
+
+        expect(capturedRequest).not.toHaveProperty("env");
+        expect(capturedRequest.env).toBeUndefined();
+      } finally {
+        if (previousValue === undefined) {
+          delete process.env.VINEXT_API_REQUEST_ENV_TEST;
+        } else {
+          process.env.VINEXT_API_REQUEST_ENV_TEST = previousValue;
+        }
+      }
+    });
+
     it("parses JSON body with application/json content-type", async () => {
       let capturedBody: unknown;
       const handler = vi.fn((req: any) => {

--- a/tests/compiler-define.test.ts
+++ b/tests/compiler-define.test.ts
@@ -368,3 +368,74 @@ describe("build-time revalidate secret define (security: server-only)", () => {
     expect(clientResult?.define?.["process.env.__VINEXT_REVALIDATE_SECRET"]).toBeUndefined();
   }, 15000);
 });
+
+describe("build-time preview credentials (security: separated and server-only)", () => {
+  const PREVIEW_ID = "b".repeat(32);
+  const SIGNING_KEY = "c".repeat(64);
+  const ENCRYPTION_KEY = "d".repeat(64);
+  const previous = new Map<string, string | undefined>();
+
+  beforeEach(() => {
+    for (const [name, value] of Object.entries({
+      __VINEXT_SHARED_PREVIEW_MODE_ID: PREVIEW_ID,
+      __VINEXT_SHARED_PREVIEW_MODE_SIGNING_KEY: SIGNING_KEY,
+      __VINEXT_SHARED_PREVIEW_MODE_ENCRYPTION_KEY: ENCRYPTION_KEY,
+    })) {
+      previous.set(name, process.env[name]);
+      process.env[name] = value;
+    }
+  });
+
+  afterEach(() => {
+    for (const [name, value] of previous) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+    previous.clear();
+  });
+
+  async function getServerDefinePlugin(): Promise<VinextPlugin> {
+    const vinext = (await import("../packages/vinext/src/index.js")).default;
+    const plugins = vinext() as VinextPlugin[];
+    const mainPlugin = plugins.find(
+      (plugin) => plugin.name === "vinext:config" && typeof plugin.config === "function",
+    );
+    const serverDefinePlugin = plugins.find(
+      (plugin) => plugin.name === "vinext:compiler-define-server",
+    );
+    const tmpDir = await setupTmpProject(`export default {};`);
+    try {
+      await mainPlugin!.config!(
+        { root: tmpDir, build: {}, plugins: [], optimizeDeps: {} },
+        { command: "build" },
+      );
+    } finally {
+      await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    }
+    return serverDefinePlugin!;
+  }
+
+  it("bakes three independent preview values into server environments", async () => {
+    const plugin = await getServerDefinePlugin();
+    const result = plugin.configEnvironment!("ssr", {}, { command: "build" });
+    expect(result?.define).toMatchObject({
+      "process.env.__VINEXT_PREVIEW_MODE_ID": JSON.stringify(PREVIEW_ID),
+      "process.env.__VINEXT_PREVIEW_MODE_SIGNING_KEY": JSON.stringify(SIGNING_KEY),
+      "process.env.__VINEXT_PREVIEW_MODE_ENCRYPTION_KEY": JSON.stringify(ENCRYPTION_KEY),
+    });
+    expect(new Set([PREVIEW_ID, SIGNING_KEY, ENCRYPTION_KEY]).size).toBe(3);
+  }, 15000);
+
+  it("never exposes preview credentials to the client environment", async () => {
+    const plugin = await getServerDefinePlugin();
+    const result = plugin.configEnvironment!("client", {}, { command: "build" });
+    expect(result).toBeNull();
+    for (const key of [
+      "process.env.__VINEXT_PREVIEW_MODE_ID",
+      "process.env.__VINEXT_PREVIEW_MODE_SIGNING_KEY",
+      "process.env.__VINEXT_PREVIEW_MODE_ENCRYPTION_KEY",
+    ]) {
+      expect(result?.define?.[key]).toBeUndefined();
+    }
+  }, 15000);
+});

--- a/tests/compiler-define.test.ts
+++ b/tests/compiler-define.test.ts
@@ -13,6 +13,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vite-plus/test";
 import os from "node:os";
 import fsp from "node:fs/promises";
 import path from "node:path";
+import { runWithPreviewBuildCredentials } from "../packages/vinext/src/build/preview-credentials.js";
 
 // Standard `@types/...` for these Node built-ins live in the workspace, so
 // the imports above are fully typed without explicit casts.
@@ -27,11 +28,23 @@ type VinextPlugin = {
   ) => { define?: Record<string, string> } | null | void;
 };
 
-const PREVIEW_ENV_NAMES = [
-  "__VINEXT_SHARED_PREVIEW_MODE_ID",
-  "__VINEXT_SHARED_PREVIEW_MODE_SIGNING_KEY",
-  "__VINEXT_SHARED_PREVIEW_MODE_ENCRYPTION_KEY",
+const PREVIEW_DEFINE_NAMES = [
+  "process.env.__VINEXT_PREVIEW_MODE_ID",
+  "process.env.__VINEXT_PREVIEW_MODE_SIGNING_KEY",
+  "process.env.__VINEXT_PREVIEW_MODE_ENCRYPTION_KEY",
 ] as const;
+
+function getPreviewDefines(define: Record<string, string> | undefined) {
+  const previewDefines = Object.fromEntries(
+    PREVIEW_DEFINE_NAMES.map((name) => [name, define?.[name]]),
+  );
+  expect(previewDefines).toEqual({
+    "process.env.__VINEXT_PREVIEW_MODE_ID": expect.stringMatching(/^"[0-9a-f]{32}"$/),
+    "process.env.__VINEXT_PREVIEW_MODE_SIGNING_KEY": expect.stringMatching(/^"[0-9a-f]{64}"$/),
+    "process.env.__VINEXT_PREVIEW_MODE_ENCRYPTION_KEY": expect.stringMatching(/^"[0-9a-f]{64}"$/),
+  });
+  return previewDefines as Record<(typeof PREVIEW_DEFINE_NAMES)[number], string>;
+}
 
 async function setupTmpProject(nextConfigBody: string): Promise<string> {
   const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-compiler-define-"));
@@ -153,15 +166,18 @@ describe("compiler.define forwarding to Vite", () => {
 
       // NEXT_RUNTIME is always injected for server environments in addition to
       // user-configured defineServer entries.
+      const previewDefines = getPreviewDefines(rscResult?.define);
       expect(rscResult?.define).toEqual({
         MY_SERVER_VARIABLE: '"server"',
         "process.env.MY_MAGIC_SERVER_EXPR": '"serverbarbaz"',
         "process.env.NEXT_RUNTIME": '"nodejs"',
+        ...previewDefines,
       });
       expect(ssrResult?.define).toEqual({
         MY_SERVER_VARIABLE: '"server"',
         "process.env.MY_MAGIC_SERVER_EXPR": '"serverbarbaz"',
         "process.env.NEXT_RUNTIME": '"nodejs"',
+        ...previewDefines,
       });
       // Client environment must never receive server-only defines.
       expect(clientResult).toBeNull();
@@ -302,9 +318,11 @@ describe("compiler.define forwarding to Vite", () => {
       // always returns a define object (never null) even without user defineServer.
       expect(rscResult).not.toBeNull();
       expect(rscResult?.define?.["process.env.NEXT_RUNTIME"]).toBe('"nodejs"');
-      // No other keys should be present when neither defineServer nor revalidate
-      // secret are configured.
-      expect(Object.keys(rscResult!.define!)).toEqual(["process.env.NEXT_RUNTIME"]);
+      expect(Object.keys(rscResult!.define!)).toEqual([
+        "process.env.NEXT_RUNTIME",
+        ...PREVIEW_DEFINE_NAMES,
+      ]);
+      getPreviewDefines(rscResult?.define);
     } finally {
       if (prev === undefined) delete process.env.__VINEXT_SHARED_REVALIDATE_SECRET;
       else process.env.__VINEXT_SHARED_REVALIDATE_SECRET = prev;
@@ -376,30 +394,6 @@ describe("build-time revalidate secret define (security: server-only)", () => {
 });
 
 describe("build-time preview credentials (security: separated and server-only)", () => {
-  const PREVIEW_ID = "b".repeat(32);
-  const SIGNING_KEY = "c".repeat(64);
-  const ENCRYPTION_KEY = "d".repeat(64);
-  const previous = new Map<string, string | undefined>();
-
-  beforeEach(() => {
-    for (const [name, value] of Object.entries({
-      __VINEXT_SHARED_PREVIEW_MODE_ID: PREVIEW_ID,
-      __VINEXT_SHARED_PREVIEW_MODE_SIGNING_KEY: SIGNING_KEY,
-      __VINEXT_SHARED_PREVIEW_MODE_ENCRYPTION_KEY: ENCRYPTION_KEY,
-    })) {
-      previous.set(name, process.env[name]);
-      process.env[name] = value;
-    }
-  });
-
-  afterEach(() => {
-    for (const [name, value] of previous) {
-      if (value === undefined) delete process.env[name];
-      else process.env[name] = value;
-    }
-    previous.clear();
-  });
-
   async function getServerDefinePlugin(): Promise<VinextPlugin> {
     const vinext = (await import("../packages/vinext/src/index.js")).default;
     const plugins = vinext() as VinextPlugin[];
@@ -424,62 +418,52 @@ describe("build-time preview credentials (security: separated and server-only)",
   it("bakes three independent preview values into server environments", async () => {
     const plugin = await getServerDefinePlugin();
     const result = plugin.configEnvironment!("ssr", {}, { command: "build" });
-    expect(result?.define).toMatchObject({
-      "process.env.__VINEXT_PREVIEW_MODE_ID": JSON.stringify(PREVIEW_ID),
-      "process.env.__VINEXT_PREVIEW_MODE_SIGNING_KEY": JSON.stringify(SIGNING_KEY),
-      "process.env.__VINEXT_PREVIEW_MODE_ENCRYPTION_KEY": JSON.stringify(ENCRYPTION_KEY),
-    });
-    expect(new Set([PREVIEW_ID, SIGNING_KEY, ENCRYPTION_KEY]).size).toBe(3);
+    const previewDefines = getPreviewDefines(result?.define);
+    expect(new Set(Object.values(previewDefines)).size).toBe(3);
   }, 15000);
 
   it("never exposes preview credentials to the client environment", async () => {
     const plugin = await getServerDefinePlugin();
     const result = plugin.configEnvironment!("client", {}, { command: "build" });
     expect(result).toBeNull();
-    for (const key of [
-      "process.env.__VINEXT_PREVIEW_MODE_ID",
-      "process.env.__VINEXT_PREVIEW_MODE_SIGNING_KEY",
-      "process.env.__VINEXT_PREVIEW_MODE_ENCRYPTION_KEY",
-    ]) {
+    for (const key of PREVIEW_DEFINE_NAMES) {
       expect(result?.define?.[key]).toBeUndefined();
     }
   }, 15000);
 
-  it("generates stable credentials for direct non-CLI production builds", async () => {
-    const saved = new Map(PREVIEW_ENV_NAMES.map((name) => [name, process.env[name]]));
-    for (const name of PREVIEW_ENV_NAMES) delete process.env[name];
+  it("shares credentials within one build and rotates independent builds", async () => {
     const vinext = (await import("../packages/vinext/src/index.js")).default;
     const tmpDir = await setupTmpProject(`export default {};`);
+    const createBuild = () => {
+      const plugins = vinext() as VinextPlugin[];
+      const config = plugins.find(
+        (plugin) => plugin.name === "vinext:config" && typeof plugin.config === "function",
+      );
+      const define = plugins.find((plugin) => plugin.name === "vinext:compiler-define-server");
+      return async () => {
+        await config!.config!(
+          { root: tmpDir, build: {}, plugins: [], optimizeDeps: {} },
+          { command: "build" },
+        );
+        return getPreviewDefines(
+          define!.configEnvironment!("ssr", {}, { command: "build" })?.define,
+        );
+      };
+    };
     try {
-      const firstPlugins = vinext() as VinextPlugin[];
-      const firstConfig = firstPlugins.find(
-        (plugin) => plugin.name === "vinext:config" && typeof plugin.config === "function",
+      const configureFirst = createBuild();
+      const configureSecond = createBuild();
+      const [sharedFirst, sharedSecond] = await runWithPreviewBuildCredentials(async () =>
+        Promise.all([configureFirst(), configureSecond()]),
       );
-      await firstConfig!.config!(
-        { root: tmpDir, build: {}, plugins: [], optimizeDeps: {} },
-        { command: "build" },
-      );
-      const firstValues = PREVIEW_ENV_NAMES.map((name) => process.env[name]);
-      expect(firstValues).toEqual([
-        expect.stringMatching(/^[0-9a-f]{32}$/),
-        expect.stringMatching(/^[0-9a-f]{64}$/),
-        expect.stringMatching(/^[0-9a-f]{64}$/),
-      ]);
+      expect(sharedSecond).toEqual(sharedFirst);
 
-      const secondPlugins = vinext() as VinextPlugin[];
-      const secondConfig = secondPlugins.find(
-        (plugin) => plugin.name === "vinext:config" && typeof plugin.config === "function",
-      );
-      await secondConfig!.config!(
-        { root: tmpDir, build: {}, plugins: [], optimizeDeps: {} },
-        { command: "build" },
-      );
-      expect(PREVIEW_ENV_NAMES.map((name) => process.env[name])).toEqual(firstValues);
+      const configureIndependently = createBuild();
+      const independentFirst = await configureIndependently();
+      const independentSecond = await configureIndependently();
+      expect(independentFirst).not.toEqual(sharedFirst);
+      expect(independentSecond).not.toEqual(independentFirst);
     } finally {
-      for (const [name, value] of saved) {
-        if (value === undefined) delete process.env[name];
-        else process.env[name] = value;
-      }
       await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
     }
   }, 15000);

--- a/tests/compiler-define.test.ts
+++ b/tests/compiler-define.test.ts
@@ -27,6 +27,12 @@ type VinextPlugin = {
   ) => { define?: Record<string, string> } | null | void;
 };
 
+const PREVIEW_ENV_NAMES = [
+  "__VINEXT_SHARED_PREVIEW_MODE_ID",
+  "__VINEXT_SHARED_PREVIEW_MODE_SIGNING_KEY",
+  "__VINEXT_SHARED_PREVIEW_MODE_ENCRYPTION_KEY",
+] as const;
+
 async function setupTmpProject(nextConfigBody: string): Promise<string> {
   const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-compiler-define-"));
   const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");
@@ -436,6 +442,45 @@ describe("build-time preview credentials (security: separated and server-only)",
       "process.env.__VINEXT_PREVIEW_MODE_ENCRYPTION_KEY",
     ]) {
       expect(result?.define?.[key]).toBeUndefined();
+    }
+  }, 15000);
+
+  it("generates stable credentials for direct non-CLI production builds", async () => {
+    const saved = new Map(PREVIEW_ENV_NAMES.map((name) => [name, process.env[name]]));
+    for (const name of PREVIEW_ENV_NAMES) delete process.env[name];
+    const vinext = (await import("../packages/vinext/src/index.js")).default;
+    const tmpDir = await setupTmpProject(`export default {};`);
+    try {
+      const firstPlugins = vinext() as VinextPlugin[];
+      const firstConfig = firstPlugins.find(
+        (plugin) => plugin.name === "vinext:config" && typeof plugin.config === "function",
+      );
+      await firstConfig!.config!(
+        { root: tmpDir, build: {}, plugins: [], optimizeDeps: {} },
+        { command: "build" },
+      );
+      const firstValues = PREVIEW_ENV_NAMES.map((name) => process.env[name]);
+      expect(firstValues).toEqual([
+        expect.stringMatching(/^[0-9a-f]{32}$/),
+        expect.stringMatching(/^[0-9a-f]{64}$/),
+        expect.stringMatching(/^[0-9a-f]{64}$/),
+      ]);
+
+      const secondPlugins = vinext() as VinextPlugin[];
+      const secondConfig = secondPlugins.find(
+        (plugin) => plugin.name === "vinext:config" && typeof plugin.config === "function",
+      );
+      await secondConfig!.config!(
+        { root: tmpDir, build: {}, plugins: [], optimizeDeps: {} },
+        { command: "build" },
+      );
+      expect(PREVIEW_ENV_NAMES.map((name) => process.env[name])).toEqual(firstValues);
+    } finally {
+      for (const [name, value] of saved) {
+        if (value === undefined) delete process.env[name];
+        else process.env[name] = value;
+      }
+      await fsp.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
     }
   }, 15000);
 });

--- a/tests/pages-api-route.test.ts
+++ b/tests/pages-api-route.test.ts
@@ -26,6 +26,30 @@ function createMatch(
 }
 
 describe("pages api route", () => {
+  it("does not expose process environment variables on the request", async () => {
+    const previousValue = process.env.VINEXT_API_REQUEST_ENV_TEST;
+    process.env.VINEXT_API_REQUEST_ENV_TEST = "secret";
+
+    try {
+      const response = await handlePagesApiRoute({
+        match: createMatch((req, res) => {
+          res.json({ hasEnv: Object.hasOwn(req, "env") });
+        }),
+        request: new Request("https://example.com/api/env"),
+        url: "/api/env",
+      });
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({ hasEnv: false });
+    } finally {
+      if (previousValue === undefined) {
+        delete process.env.VINEXT_API_REQUEST_ENV_TEST;
+      } else {
+        process.env.VINEXT_API_REQUEST_ENV_TEST = previousValue;
+      }
+    }
+  });
+
   it("merges dynamic params with duplicate query-string values", async () => {
     const response = await handlePagesApiRoute({
       match: createMatch(

--- a/tests/pages-api-route.test.ts
+++ b/tests/pages-api-route.test.ts
@@ -191,9 +191,12 @@ describe("pages api route", () => {
   });
 
   it("res.redirect() uses 307 by default and 2-arg form uses the given status", async () => {
+    let defaultReturnedResponse: unknown;
+    let defaultHandlerResponse: unknown;
     const defaultRedirectResponse = await handlePagesApiRoute({
       match: createMatch((_req, res) => {
-        res.redirect("/new-path");
+        defaultHandlerResponse = res;
+        defaultReturnedResponse = res.redirect("/new-path");
       }),
       request: new Request("https://example.com/api/redir"),
       url: "/api/redir",
@@ -201,10 +204,16 @@ describe("pages api route", () => {
 
     expect(defaultRedirectResponse.status).toBe(307);
     expect(defaultRedirectResponse.headers.get("location")).toBe("/new-path");
+    expect(defaultRedirectResponse.headers.get("content-type")).toBeNull();
+    await expect(defaultRedirectResponse.text()).resolves.toBe("/new-path");
+    expect(defaultReturnedResponse).toBe(defaultHandlerResponse);
 
+    let customReturnedResponse: unknown;
+    let customHandlerResponse: unknown;
     const customRedirectResponse = await handlePagesApiRoute({
       match: createMatch((_req, res) => {
-        res.redirect(301, "/permanent");
+        customHandlerResponse = res;
+        customReturnedResponse = res.redirect(301, "/permanent");
       }),
       request: new Request("https://example.com/api/redir"),
       url: "/api/redir",
@@ -212,6 +221,26 @@ describe("pages api route", () => {
 
     expect(customRedirectResponse.status).toBe(301);
     expect(customRedirectResponse.headers.get("location")).toBe("/permanent");
+    expect(customRedirectResponse.headers.get("content-type")).toBeNull();
+    await expect(customRedirectResponse.text()).resolves.toBe("/permanent");
+    expect(customReturnedResponse).toBe(customHandlerResponse);
+  });
+
+  it.each([
+    [null, undefined],
+    [307, undefined],
+    [true, "/destination"],
+  ])("res.redirect() rejects invalid arguments %#", async (statusOrUrl, url) => {
+    const response = await handlePagesApiRoute({
+      match: createMatch((_req, res) => {
+        res.redirect(statusOrUrl as string | number, url);
+      }),
+      request: new Request("https://example.com/api/redir"),
+      url: "/api/redir",
+    });
+
+    expect(response.status).toBe(500);
+    await expect(response.text()).resolves.toBe("Internal Server Error");
   });
 
   it("res.writeHead() lowercases header keys and joins array values", async () => {

--- a/tests/pages-data-fetch-dedup.test.ts
+++ b/tests/pages-data-fetch-dedup.test.ts
@@ -38,6 +38,25 @@ afterEach(() => {
 });
 
 describe("dedupedPagesDataFetch", () => {
+  it("does not share in-flight requests across the preview boundary", async () => {
+    const previousWindow = (globalThis as { window?: unknown }).window;
+    const fetchSpy = vi.fn(() => new Promise<Response>(() => {}));
+    (globalThis as unknown as { fetch: unknown }).fetch = fetchSpy;
+    (globalThis as unknown as { window: unknown }).window = {
+      location: { href: "https://example.test/" },
+      __NEXT_DATA__: { isPreview: false },
+    };
+
+    try {
+      void dedupedPagesDataFetch("/_next/data/id/page.json");
+      (globalThis as any).window.__NEXT_DATA__.isPreview = true;
+      void dedupedPagesDataFetch("/_next/data/id/page.json");
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      (globalThis as { window?: unknown }).window = previousWindow;
+    }
+  });
+
   it("shares a single fetch across concurrent calls for the same URL", async () => {
     // Hold the fetch open so all 10 callers race the same in-flight Promise.
     let resolveFetch: (res: Response) => void = () => {};

--- a/tests/pages-node-compat.test.ts
+++ b/tests/pages-node-compat.test.ts
@@ -72,6 +72,7 @@ describe("Pages Node compat response", () => {
     });
 
     expect(req.preview).toBe(true);
+    expect(req.draftMode).toBe(req.preview);
     expect(req.previewData).toEqual({});
     res.setDraftMode({ enable: false });
     expect(res.getHeader("Set-Cookie")).toEqual([
@@ -126,6 +127,7 @@ describe("Pages Node compat response", () => {
     });
 
     expect(req.preview).toBe(true);
+    expect(req.draftMode).toBe(req.preview);
     expect(req.previewData).toEqual({ hello: "world" });
     res.clearPreviewData({ path: "/docs" }).end("ok");
 
@@ -138,6 +140,43 @@ describe("Pages Node compat response", () => {
       expect.stringMatching(
         /^__next_preview_data=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Path=\/docs;/,
       ),
+    ]);
+  });
+
+  it("clears preview cookies only once per response", () => {
+    const { res } = createPagesReqRes({
+      body: undefined,
+      query: {},
+      request: new Request("https://example.test/api/clear"),
+      url: "/api/clear",
+    });
+
+    res.clearPreviewData();
+    res.clearPreviewData({ path: "/docs" });
+
+    expect(res.getHeader("Set-Cookie")).toEqual([
+      expect.stringMatching(/^__prerender_bypass=; Expires=/),
+      expect.stringMatching(/^__next_preview_data=; Expires=/),
+    ]);
+  });
+
+  it("does not duplicate an automatic invalid-cookie clear", () => {
+    const { req, res } = createPagesReqRes({
+      body: undefined,
+      query: {},
+      request: new Request("https://example.test/api/clear", {
+        headers: { cookie: "__prerender_bypass=invalid; __next_preview_data=invalid" },
+      }),
+      url: "/api/clear",
+    });
+
+    expect(req.preview).toBeUndefined();
+    expect(req.draftMode).toBeUndefined();
+    res.clearPreviewData({ path: "/docs" });
+
+    expect(res.getHeader("Set-Cookie")).toEqual([
+      expect.stringMatching(/^__prerender_bypass=; Expires=/),
+      expect.stringMatching(/^__next_preview_data=; Expires=/),
     ]);
   });
 });

--- a/tests/pages-node-compat.test.ts
+++ b/tests/pages-node-compat.test.ts
@@ -23,8 +23,10 @@ function exerciseNextApiRequestPreviewTypes(req: NextApiRequest): NextApiRequest
   req.cookies.missing = undefined;
   req.body = undefined;
   req.body = { nested: true };
-  req.env.EXAMPLE = undefined;
-  req.env.EXAMPLE = "value";
+  if (req.env) {
+    req.env.EXAMPLE = undefined;
+    req.env.EXAMPLE = "value";
+  }
   req.preview = false;
   req.preview = undefined;
   req.draftMode = false;
@@ -66,6 +68,28 @@ void previewDataValues;
 void nextApiHandler;
 
 describe("Pages Node compat response", () => {
+  it("does not expose process environment variables on the request", () => {
+    const previousValue = process.env.VINEXT_API_REQUEST_ENV_TEST;
+    process.env.VINEXT_API_REQUEST_ENV_TEST = "secret";
+
+    try {
+      const { req } = createPagesReqRes({
+        body: undefined,
+        query: {},
+        request: new Request("https://example.test/api/env"),
+        url: "/api/env",
+      });
+
+      expect(req).not.toHaveProperty("env");
+    } finally {
+      if (previousValue === undefined) {
+        delete process.env.VINEXT_API_REQUEST_ENV_TEST;
+      } else {
+        process.env.VINEXT_API_REQUEST_ENV_TEST = previousValue;
+      }
+    }
+  });
+
   it("setPreviewData appends both preview cookies while preserving existing cookies", () => {
     const { res } = createPagesReqRes({
       body: undefined,

--- a/tests/pages-node-compat.test.ts
+++ b/tests/pages-node-compat.test.ts
@@ -3,7 +3,26 @@ import {
   createPagesReqRes,
   getPagesPreviewData,
 } from "../packages/vinext/src/server/pages-node-compat.js";
-import type { NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+type NextApiRequestPreviewFields = Pick<NextApiRequest, "preview" | "draftMode" | "previewData">;
+
+const emptyNextApiRequestPreviewFields: NextApiRequestPreviewFields = {};
+
+function exerciseNextApiRequestPreviewTypes(req: NextApiRequest): NextApiRequestPreviewFields {
+  req.preview = false;
+  req.preview = undefined;
+  req.draftMode = false;
+  req.draftMode = undefined;
+  req.previewData = false;
+  req.previewData = undefined;
+
+  return {
+    preview: req.preview,
+    draftMode: req.draftMode,
+    previewData: req.previewData,
+  };
+}
 
 function exerciseNextApiResponsePreviewTypes(res: NextApiResponse): Promise<void> {
   res.setPreviewData({ draft: true }, { maxAge: 60, path: "/preview" });
@@ -13,6 +32,8 @@ function exerciseNextApiResponsePreviewTypes(res: NextApiResponse): Promise<void
 }
 
 void exerciseNextApiResponsePreviewTypes;
+void exerciseNextApiRequestPreviewTypes;
+void emptyNextApiRequestPreviewFields;
 
 describe("Pages Node compat response", () => {
   it("setPreviewData appends both preview cookies while preserving existing cookies", () => {

--- a/tests/pages-node-compat.test.ts
+++ b/tests/pages-node-compat.test.ts
@@ -3,6 +3,16 @@ import {
   createPagesReqRes,
   getPagesPreviewData,
 } from "../packages/vinext/src/server/pages-node-compat.js";
+import type { NextApiResponse } from "next";
+
+function exerciseNextApiResponsePreviewTypes(res: NextApiResponse): Promise<void> {
+  res.setPreviewData({ draft: true }, { maxAge: 60, path: "/preview" });
+  res.clearPreviewData({ path: "/preview" });
+  res.setDraftMode({ enable: true });
+  return res.revalidate("/preview", { unstable_onlyGenerated: true });
+}
+
+void exerciseNextApiResponsePreviewTypes;
 
 describe("Pages Node compat response", () => {
   it("setPreviewData appends both preview cookies while preserving existing cookies", () => {

--- a/tests/pages-node-compat.test.ts
+++ b/tests/pages-node-compat.test.ts
@@ -73,4 +73,41 @@ describe("Pages Node compat response", () => {
     });
     expect(getPagesPreviewData(request)).toBe(false);
   });
+
+  it("exposes preview state on API requests and clears both cookies", async () => {
+    const enabled = createPagesReqRes({
+      body: undefined,
+      query: {},
+      request: new Request("https://example.test/api/enable"),
+      url: "/api/enable",
+    });
+    enabled.res.setPreviewData({ hello: "world" });
+    const enabledCookies = enabled.res.getHeader("Set-Cookie");
+    if (!Array.isArray(enabledCookies)) throw new Error("expected Set-Cookie array");
+    const cookieHeader = enabledCookies.map((value) => value.split(";", 1)[0]).join("; ");
+
+    const { req, res, responsePromise } = createPagesReqRes({
+      body: undefined,
+      query: {},
+      request: new Request("https://example.test/api/read", {
+        headers: { cookie: cookieHeader },
+      }),
+      url: "/api/read",
+    });
+
+    expect(req.preview).toBe(true);
+    expect(req.previewData).toEqual({ hello: "world" });
+    res.clearPreviewData({ path: "/docs" }).end("ok");
+
+    const response = await responsePromise;
+    expect(response.status).toBe(200);
+    expect(response.headers.getSetCookie()).toEqual([
+      expect.stringMatching(
+        /^__prerender_bypass=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Path=\/docs;/,
+      ),
+      expect.stringMatching(
+        /^__next_preview_data=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Path=\/docs;/,
+      ),
+    ]);
+  });
 });

--- a/tests/pages-node-compat.test.ts
+++ b/tests/pages-node-compat.test.ts
@@ -23,10 +23,9 @@ function exerciseNextApiRequestPreviewTypes(req: NextApiRequest): NextApiRequest
   req.cookies.missing = undefined;
   req.body = undefined;
   req.body = { nested: true };
-  if (req.env) {
-    req.env.EXAMPLE = undefined;
-    req.env.EXAMPLE = "value";
-  }
+  req.env.EXAMPLE = undefined;
+  req.env.EXAMPLE = "value";
+  void (req.env.EXAMPLE satisfies string | undefined);
   req.preview = false;
   req.preview = undefined;
   req.draftMode = false;

--- a/tests/pages-node-compat.test.ts
+++ b/tests/pages-node-compat.test.ts
@@ -3,11 +3,13 @@ import {
   createPagesReqRes,
   getPagesPreviewData,
 } from "../packages/vinext/src/server/pages-node-compat.js";
-import type { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse, PreviewData } from "next";
 
 type NextApiRequestPreviewFields = Pick<NextApiRequest, "preview" | "draftMode" | "previewData">;
 
 const emptyNextApiRequestPreviewFields: NextApiRequestPreviewFields = {};
+
+const previewDataValues: PreviewData[] = ["preview", false, {}, undefined];
 
 function exerciseNextApiRequestPreviewTypes(req: NextApiRequest): NextApiRequestPreviewFields {
   req.preview = false;
@@ -34,6 +36,7 @@ function exerciseNextApiResponsePreviewTypes(res: NextApiResponse): Promise<void
 void exerciseNextApiResponsePreviewTypes;
 void exerciseNextApiRequestPreviewTypes;
 void emptyNextApiRequestPreviewFields;
+void previewDataValues;
 
 describe("Pages Node compat response", () => {
   it("setPreviewData appends both preview cookies while preserving existing cookies", () => {

--- a/tests/pages-node-compat.test.ts
+++ b/tests/pages-node-compat.test.ts
@@ -49,6 +49,36 @@ describe("Pages Node compat response", () => {
     expect(getPagesPreviewData(request, { isOnDemandRevalidate: true })).toBe(false);
   });
 
+  it("accepts a bypass-only draft mode cookie with empty preview data", () => {
+    const enabled = createPagesReqRes({
+      body: undefined,
+      query: {},
+      request: new Request("https://example.test/api/enable"),
+      url: "/api/enable",
+    });
+    enabled.res.setDraftMode({ enable: true });
+    const cookies = enabled.res.getHeader("Set-Cookie");
+    if (!Array.isArray(cookies)) throw new Error("expected Set-Cookie array");
+    expect(cookies).toHaveLength(1);
+    const cookieHeader = cookies[0].split(";", 1)[0];
+
+    const { req, res } = createPagesReqRes({
+      body: undefined,
+      query: {},
+      request: new Request("https://example.test/api/read", {
+        headers: { cookie: cookieHeader },
+      }),
+      url: "/api/read",
+    });
+
+    expect(req.preview).toBe(true);
+    expect(req.previewData).toEqual({});
+    res.setDraftMode({ enable: false });
+    expect(res.getHeader("Set-Cookie")).toEqual([
+      expect.stringMatching(/^__prerender_bypass=; Expires=/),
+    ]);
+  });
+
   it("rejects preview data when the bypass cookie secret is wrong", () => {
     const { res } = createPagesReqRes({
       body: undefined,

--- a/tests/pages-node-compat.test.ts
+++ b/tests/pages-node-compat.test.ts
@@ -5,6 +5,13 @@ import {
 } from "../packages/vinext/src/server/pages-node-compat.js";
 import type { NextApiHandler, NextApiRequest, NextApiResponse, PreviewData } from "next";
 
+declare module "next" {
+  // oxlint-disable-next-line typescript/consistent-type-definitions
+  interface NextApiRequest {
+    userId?: string;
+  }
+}
+
 type NextApiRequestPreviewFields = Pick<NextApiRequest, "preview" | "draftMode" | "previewData">;
 
 const emptyNextApiRequestPreviewFields: NextApiRequestPreviewFields = {};
@@ -46,7 +53,10 @@ function exerciseNextApiResponsePreviewTypes(res: NextApiResponse): Promise<void
 const nextApiHandler: NextApiHandler<{ ok: boolean }> = (req, res) => {
   req.query.optional = undefined;
   req.cookies.optional = undefined;
+  req.userId = "user-123";
+  const userId: string | undefined = req.userId;
   res.status(200).json({ ok: true });
+  void userId;
 };
 
 void exerciseNextApiResponsePreviewTypes;

--- a/tests/pages-node-compat.test.ts
+++ b/tests/pages-node-compat.test.ts
@@ -3,7 +3,7 @@ import {
   createPagesReqRes,
   getPagesPreviewData,
 } from "../packages/vinext/src/server/pages-node-compat.js";
-import type { NextApiRequest, NextApiResponse, PreviewData } from "next";
+import type { NextApiHandler, NextApiRequest, NextApiResponse, PreviewData } from "next";
 
 type NextApiRequestPreviewFields = Pick<NextApiRequest, "preview" | "draftMode" | "previewData">;
 
@@ -12,6 +12,12 @@ const emptyNextApiRequestPreviewFields: NextApiRequestPreviewFields = {};
 const previewDataValues: PreviewData[] = ["preview", false, {}, undefined];
 
 function exerciseNextApiRequestPreviewTypes(req: NextApiRequest): NextApiRequestPreviewFields {
+  req.query.missing = undefined;
+  req.cookies.missing = undefined;
+  req.body = undefined;
+  req.body = { nested: true };
+  req.env.EXAMPLE = undefined;
+  req.env.EXAMPLE = "value";
   req.preview = false;
   req.preview = undefined;
   req.draftMode = false;
@@ -27,16 +33,27 @@ function exerciseNextApiRequestPreviewTypes(req: NextApiRequest): NextApiRequest
 }
 
 function exerciseNextApiResponsePreviewTypes(res: NextApiResponse): Promise<void> {
+  const temporaryRedirectResponse: NextApiResponse = res.redirect("/next");
+  const permanentRedirectResponse: NextApiResponse = res.redirect(308, "/next");
   res.setPreviewData({ draft: true }, { maxAge: 60, path: "/preview" });
   res.clearPreviewData({ path: "/preview" });
   res.setDraftMode({ enable: true });
+  void temporaryRedirectResponse;
+  void permanentRedirectResponse;
   return res.revalidate("/preview", { unstable_onlyGenerated: true });
 }
+
+const nextApiHandler: NextApiHandler<{ ok: boolean }> = (req, res) => {
+  req.query.optional = undefined;
+  req.cookies.optional = undefined;
+  res.status(200).json({ ok: true });
+};
 
 void exerciseNextApiResponsePreviewTypes;
 void exerciseNextApiRequestPreviewTypes;
 void emptyNextApiRequestPreviewFields;
 void previewDataValues;
+void nextApiHandler;
 
 describe("Pages Node compat response", () => {
   it("setPreviewData appends both preview cookies while preserving existing cookies", () => {

--- a/tests/pages-page-data.test.ts
+++ b/tests/pages-page-data.test.ts
@@ -227,6 +227,44 @@ describe("pages page data", () => {
     expect(result).toEqual({ kind: "notFound" });
   });
 
+  it("renders unlisted fallback false paths in preview mode without caching them", async () => {
+    const isrSet = vi.fn(async () => {});
+    const result = await resolvePagesPageData(
+      createOptions({
+        isrSet,
+        pageModule: {
+          async getStaticPaths() {
+            return {
+              fallback: false,
+              paths: [{ params: { slug: "known" } }],
+            };
+          },
+          async getStaticProps(context) {
+            return {
+              props: {
+                preview: context.preview,
+                previewData: context.previewData,
+                slug: context.params?.slug,
+              },
+            };
+          },
+        },
+        params: { slug: "missing" },
+        previewData: {},
+        query: { slug: "missing" },
+        route: { isDynamic: true },
+        routeUrl: "/posts/missing",
+      }),
+    );
+
+    expect(result).toMatchObject({
+      kind: "render",
+      isFallback: false,
+      pageProps: { preview: true, previewData: {}, slug: "missing" },
+    });
+    expect(isrSet).not.toHaveBeenCalled();
+  });
+
   it.each([
     ["null", null],
     ["undefined", undefined],

--- a/tests/pages-page-handler.test.ts
+++ b/tests/pages-page-handler.test.ts
@@ -328,6 +328,43 @@ describe("createPagesPageHandler — preview responses", () => {
       expect.stringMatching(/^__next_preview_data=; Expires=/),
     ]);
   });
+
+  it("clears tampered preview cookies once when notFound renders the 404 page", async () => {
+    const pageRoute = makeRoute("/missing", {
+      ...makePageModule(),
+      getStaticProps: async () => ({ notFound: true }),
+    });
+    const notFoundRoute = makeRoute("/404");
+    const handler = createPagesPageHandler(
+      makeOpts({
+        pageRoutes: [pageRoute, notFoundRoute],
+        matchRoute: (url, routes) => {
+          const pathname = url.split("?")[0];
+          const route = routes.find((candidate) => candidate.pattern === pathname);
+          return route ? { route, params: {} } : null;
+        },
+      }),
+    );
+    const cookie = makePreviewCookieHeader({ draft: true }).replace(
+      /(__next_preview_data=)([^;])([^;]*)/,
+      (_match, prefix: string, first: string, rest: string) =>
+        `${prefix}${first === "a" ? "b" : "a"}${rest}`,
+    );
+
+    const response = await handler(
+      new Request("http://localhost/missing", { headers: { cookie } }),
+      "/missing",
+      null,
+      null,
+      null,
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.headers.getSetCookie()).toEqual([
+      expect.stringMatching(/^__prerender_bypass=; Expires=/),
+      expect.stringMatching(/^__next_preview_data=; Expires=/),
+    ]);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/pages-page-handler.test.ts
+++ b/tests/pages-page-handler.test.ts
@@ -382,9 +382,12 @@ describe("createPagesPageHandler — preview responses", () => {
               getServerSideProps: async ({
                 res,
               }: {
-                res: { setHeader(name: string, value: string): void };
+                res: { setHeader(name: string, value: string | string[]): void };
               }) => {
-                res.setHeader("Set-Cookie", "user-session=active; Path=/; HttpOnly");
+                res.setHeader("Set-Cookie", [
+                  "user-session=active; Path=/; HttpOnly",
+                  "__prerender_bypass=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Path=/draft",
+                ]);
                 return { props: {} };
               },
             }),
@@ -408,6 +411,7 @@ describe("createPagesPageHandler — preview responses", () => {
 
     expect(response.headers.getSetCookie()).toEqual([
       "user-session=active; Path=/; HttpOnly",
+      "__prerender_bypass=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Path=/draft",
       expect.stringMatching(/^__prerender_bypass=; Expires=/),
       expect.stringMatching(/^__next_preview_data=; Expires=/),
     ]);

--- a/tests/pages-page-handler.test.ts
+++ b/tests/pages-page-handler.test.ts
@@ -372,6 +372,47 @@ describe("createPagesPageHandler — preview responses", () => {
     ]);
   });
 
+  it("preserves unrelated response cookies while clearing tampered preview cookies", async () => {
+    const handler = createPagesPageHandler(
+      makeOpts({
+        pageRoutes: [
+          makeRoute(
+            "/",
+            makePageModule({
+              getServerSideProps: async ({
+                res,
+              }: {
+                res: { setHeader(name: string, value: string): void };
+              }) => {
+                res.setHeader("Set-Cookie", "user-session=active; Path=/; HttpOnly");
+                return { props: {} };
+              },
+            }),
+          ),
+        ],
+      }),
+    );
+    const cookie = makePreviewCookieHeader({ draft: true }).replace(
+      /(__next_preview_data=)([^;])([^;]*)/,
+      (_match, prefix: string, first: string, rest: string) =>
+        `${prefix}${first === "a" ? "b" : "a"}${rest}`,
+    );
+
+    const response = await handler(
+      new Request("http://localhost/", { headers: { cookie } }),
+      "/",
+      null,
+      null,
+      null,
+    );
+
+    expect(response.headers.getSetCookie()).toEqual([
+      "user-session=active; Path=/; HttpOnly",
+      expect.stringMatching(/^__prerender_bypass=; Expires=/),
+      expect.stringMatching(/^__next_preview_data=; Expires=/),
+    ]);
+  });
+
   it("clears tampered preview cookies once when notFound renders the 404 page", async () => {
     const pageRoute = makeRoute("/missing", {
       ...makePageModule(),

--- a/tests/pages-page-handler.test.ts
+++ b/tests/pages-page-handler.test.ts
@@ -11,6 +11,10 @@ import {
   shouldEmitPagesClientTraceMetadata,
 } from "../packages/vinext/src/server/pages-page-handler.js";
 import type { CreatePagesPageHandlerOptions } from "../packages/vinext/src/server/pages-page-handler.js";
+import {
+  PAGES_PREVIEW_CACHE_CONTROL,
+  setPagesPreviewData,
+} from "../packages/vinext/src/server/pages-preview.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -18,6 +22,24 @@ import type { CreatePagesPageHandlerOptions } from "../packages/vinext/src/serve
 
 function makeRequest(pathname = "/", method = "GET"): Request {
   return new Request(`http://localhost${pathname}`, { method });
+}
+
+function makePreviewCookieHeader(data: object | string): string {
+  const headers = new Map<string, string | string[]>();
+  setPagesPreviewData(
+    {
+      getHeader(name) {
+        return headers.get(name.toLowerCase());
+      },
+      setHeader(name, value) {
+        headers.set(name.toLowerCase(), value as string | string[]);
+      },
+    },
+    data,
+  );
+  const cookies = headers.get("set-cookie");
+  if (!Array.isArray(cookies)) throw new Error("expected preview cookies");
+  return cookies.map((cookie) => cookie.split(";", 1)[0]).join("; ");
 }
 
 function makePageModule(overrides: Record<string, unknown> = {}): Record<string, unknown> {
@@ -246,6 +268,65 @@ describe("createPagesPageHandler — _next/data", () => {
       | { asPath?: string }
       | undefined;
     expect(context?.asPath).toBe("/about?x=1");
+  });
+
+  it("marks preview data and forces private no-store caching", async () => {
+    const routeModule = makePageModule({
+      getStaticProps: async ({ previewData }: { previewData: unknown }) => ({
+        props: { previewData },
+      }),
+    });
+    const handler = createPagesPageHandler(
+      makeOpts({ pageRoutes: [makeRoute("/about", routeModule)] }),
+    );
+    const dataUrl = "/_next/data/test-build-id/about.json";
+    const request = new Request(`http://localhost${dataUrl}`, {
+      headers: { cookie: makePreviewCookieHeader({ draft: true }) },
+    });
+
+    const response = await handler(request, dataUrl, null, null, null);
+
+    expect(response.headers.get("cache-control")).toBe(PAGES_PREVIEW_CACHE_CONTROL);
+    expect(await response.json()).toMatchObject({
+      __N_PREVIEW: true,
+      pageProps: { previewData: { draft: true } },
+    });
+  });
+});
+
+describe("createPagesPageHandler — preview responses", () => {
+  it("forces private no-store caching on preview HTML", async () => {
+    const handler = createPagesPageHandler(makeOpts());
+    const request = new Request("http://localhost/", {
+      headers: { cookie: makePreviewCookieHeader({ draft: true }) },
+    });
+
+    const response = await handler(request, "/", null, null, null);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe(PAGES_PREVIEW_CACHE_CONTROL);
+  });
+
+  it("clears both cookies when preview data is tampered", async () => {
+    const handler = createPagesPageHandler(makeOpts());
+    const cookie = makePreviewCookieHeader({ draft: true }).replace(
+      /(__next_preview_data=)([^;])([^;]*)/,
+      (_match, prefix: string, first: string, rest: string) =>
+        `${prefix}${first === "a" ? "b" : "a"}${rest}`,
+    );
+
+    const response = await handler(
+      new Request("http://localhost/", { headers: { cookie } }),
+      "/",
+      null,
+      null,
+      null,
+    );
+
+    expect(response.headers.getSetCookie()).toEqual([
+      expect.stringMatching(/^__prerender_bypass=; Expires=/),
+      expect.stringMatching(/^__next_preview_data=; Expires=/),
+    ]);
   });
 });
 

--- a/tests/pages-page-handler.test.ts
+++ b/tests/pages-page-handler.test.ts
@@ -295,8 +295,39 @@ describe("createPagesPageHandler — _next/data", () => {
 });
 
 describe("createPagesPageHandler — preview responses", () => {
-  it("forces private no-store caching on preview HTML", async () => {
-    const handler = createPagesPageHandler(makeOpts());
+  it("does not activate preview on pages without static or server props", async () => {
+    const setSSRContext = vi.fn();
+    const handler = createPagesPageHandler(makeOpts({ setSSRContext }));
+    const request = new Request("http://localhost/", {
+      headers: { cookie: makePreviewCookieHeader({ draft: true }) },
+    });
+
+    const response = await handler(request, "/", null, null, null);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).not.toBe(PAGES_PREVIEW_CACHE_CONTROL);
+    expect(response.headers.getSetCookie()).toEqual([]);
+    expect(setSSRContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isPreview: false,
+        nextData: expect.not.objectContaining({ isPreview: true }),
+      }),
+    );
+  });
+
+  it("activates preview on pages with server props", async () => {
+    const setSSRContext = vi.fn();
+    const handler = createPagesPageHandler(
+      makeOpts({
+        pageRoutes: [
+          makeRoute(
+            "/",
+            makePageModule({ getServerSideProps: async () => ({ props: { preview: true } }) }),
+          ),
+        ],
+        setSSRContext,
+      }),
+    );
     const request = new Request("http://localhost/", {
       headers: { cookie: makePreviewCookieHeader({ draft: true }) },
     });
@@ -305,10 +336,22 @@ describe("createPagesPageHandler — preview responses", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("cache-control")).toBe(PAGES_PREVIEW_CACHE_CONTROL);
+    expect(setSSRContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isPreview: true,
+        nextData: expect.objectContaining({ isPreview: true }),
+      }),
+    );
   });
 
-  it("clears both cookies when preview data is tampered", async () => {
-    const handler = createPagesPageHandler(makeOpts());
+  it("clears both cookies when preview data is tampered on a preview-capable page", async () => {
+    const handler = createPagesPageHandler(
+      makeOpts({
+        pageRoutes: [
+          makeRoute("/", makePageModule({ getServerSideProps: async () => ({ props: {} }) })),
+        ],
+      }),
+    );
     const cookie = makePreviewCookieHeader({ draft: true }).replace(
       /(__next_preview_data=)([^;])([^;]*)/,
       (_match, prefix: string, first: string, rest: string) =>

--- a/tests/pages-preview.test.ts
+++ b/tests/pages-preview.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import {
+  clearPagesPreviewData,
+  getPagesPreviewState,
+  setPagesPreviewData,
+} from "../packages/vinext/src/server/pages-preview.js";
+
+function createResponse() {
+  const headers = new Map<string, string | string[]>();
+  return {
+    getHeader(name: string) {
+      return headers.get(name.toLowerCase());
+    },
+    setHeader(name: string, value: string | string[]) {
+      headers.set(name.toLowerCase(), value);
+    },
+  };
+}
+
+function cookieHeader(response: ReturnType<typeof createResponse>): string {
+  const cookies = response.getHeader("set-cookie");
+  if (!Array.isArray(cookies)) throw new Error("expected preview cookies");
+  return cookies.map((cookie) => cookie.split(";", 1)[0]).join("; ");
+}
+
+describe("Pages preview tokens", () => {
+  it("encrypts and authenticates preview data", () => {
+    const response = createResponse();
+    setPagesPreviewData(response, { secret: "draft" });
+    const cookies = response.getHeader("set-cookie");
+    if (!Array.isArray(cookies)) throw new Error("expected preview cookies");
+    expect(cookies.join("\n")).not.toContain("draft");
+    expect(getPagesPreviewState(cookieHeader(response))).toEqual({
+      data: { secret: "draft" },
+      shouldClear: false,
+    });
+  });
+
+  it("rejects tampered preview data and requests cookie clearing", () => {
+    const response = createResponse();
+    setPagesPreviewData(response, { secret: "draft" });
+    const header = cookieHeader(response).replace(
+      /(__next_preview_data=)([^;])([^;]*)/,
+      (_match, prefix: string, first: string, rest: string) =>
+        `${prefix}${first === "a" ? "b" : "a"}${rest}`,
+    );
+    expect(getPagesPreviewState(header)).toEqual({ data: false, shouldClear: true });
+  });
+
+  it("rejects expired preview data", () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+      const response = createResponse();
+      setPagesPreviewData(response, { secret: "draft" }, { maxAge: 1 });
+      vi.advanceTimersByTime(1000);
+      expect(getPagesPreviewState(cookieHeader(response))).toEqual({
+        data: false,
+        shouldClear: true,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears both preview cookies", () => {
+    const response = createResponse();
+    clearPagesPreviewData(response, { path: "/docs" });
+    expect(response.getHeader("set-cookie")).toEqual([
+      expect.stringMatching(/^__prerender_bypass=; Expires=.*; HttpOnly; Path=\/docs;/),
+      expect.stringMatching(/^__next_preview_data=; Expires=.*; HttpOnly; Path=\/docs;/),
+    ]);
+  });
+});

--- a/tests/pages-preview.test.ts
+++ b/tests/pages-preview.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 import {
+  appendPagesPreviewClearCookies,
   clearPagesPreviewData,
   getPagesPreviewState,
   setPagesDraftMode,
@@ -73,6 +74,39 @@ describe("Pages preview tokens", () => {
     expect(response.getHeader("set-cookie")).toEqual([
       expect.stringMatching(/^__prerender_bypass=; Expires=.*; HttpOnly; Path=\/docs;/),
       expect.stringMatching(/^__next_preview_data=; Expires=.*; HttpOnly; Path=\/docs;/),
+    ]);
+  });
+
+  it("appends root host-only clears alongside scoped preview expirations", () => {
+    const headers = new Headers();
+    headers.append(
+      "Set-Cookie",
+      "__prerender_bypass=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Path=/draft",
+    );
+    headers.append(
+      "Set-Cookie",
+      "__next_preview_data=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Domain=example.test",
+    );
+
+    appendPagesPreviewClearCookies(headers);
+
+    expect(headers.getSetCookie()).toEqual([
+      "__prerender_bypass=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Path=/draft",
+      "__next_preview_data=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Domain=example.test",
+      expect.stringMatching(/^__prerender_bypass=; Expires=.*; HttpOnly; Path=\/;/),
+      expect.stringMatching(/^__next_preview_data=; Expires=.*; HttpOnly; Path=\/;/),
+    ]);
+  });
+
+  it("does not duplicate equivalent root host-only preview expirations", () => {
+    const headers = new Headers();
+
+    appendPagesPreviewClearCookies(headers);
+    appendPagesPreviewClearCookies(headers);
+
+    expect(headers.getSetCookie()).toEqual([
+      expect.stringMatching(/^__prerender_bypass=; Expires=/),
+      expect.stringMatching(/^__next_preview_data=; Expires=/),
     ]);
   });
 

--- a/tests/pages-preview.test.ts
+++ b/tests/pages-preview.test.ts
@@ -4,6 +4,7 @@ import {
   getPagesPreviewState,
   setPagesPreviewData,
 } from "../packages/vinext/src/server/pages-preview.js";
+import { getRevalidateSecret } from "../packages/vinext/src/server/isr-cache.js";
 
 function createResponse() {
   const headers = new Map<string, string | string[]>();
@@ -30,6 +31,7 @@ describe("Pages preview tokens", () => {
     const cookies = response.getHeader("set-cookie");
     if (!Array.isArray(cookies)) throw new Error("expected preview cookies");
     expect(cookies.join("\n")).not.toContain("draft");
+    expect(cookieHeader(response)).not.toContain(getRevalidateSecret());
     expect(getPagesPreviewState(cookieHeader(response))).toEqual({
       data: { secret: "draft" },
       shouldClear: false,

--- a/tests/pages-preview.test.ts
+++ b/tests/pages-preview.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it, vi } from "vite-plus/test";
 import {
   clearPagesPreviewData,
   getPagesPreviewState,
+  setPagesDraftMode,
   setPagesPreviewData,
 } from "../packages/vinext/src/server/pages-preview.js";
 import { getRevalidateSecret } from "../packages/vinext/src/server/isr-cache.js";
+import { isDraftModeRequest } from "../packages/vinext/src/shims/headers.js";
 
 function createResponse() {
   const headers = new Map<string, string | string[]>();
@@ -72,5 +74,39 @@ describe("Pages preview tokens", () => {
       expect.stringMatching(/^__prerender_bypass=; Expires=.*; HttpOnly; Path=\/docs;/),
       expect.stringMatching(/^__next_preview_data=; Expires=.*; HttpOnly; Path=\/docs;/),
     ]);
+  });
+
+  it("shares the bypass ID with App Router draft mode", () => {
+    const previousId = process.env.__VINEXT_PREVIEW_MODE_ID;
+    const previousSigningKey = process.env.__VINEXT_PREVIEW_MODE_SIGNING_KEY;
+    const previousEncryptionKey = process.env.__VINEXT_PREVIEW_MODE_ENCRYPTION_KEY;
+    const previewModeId = "1".repeat(32);
+    process.env.__VINEXT_PREVIEW_MODE_ID = previewModeId;
+    process.env.__VINEXT_PREVIEW_MODE_SIGNING_KEY = "2".repeat(64);
+    process.env.__VINEXT_PREVIEW_MODE_ENCRYPTION_KEY = "3".repeat(64);
+    try {
+      const response = createResponse();
+      setPagesDraftMode(response, true);
+      const cookie = cookieHeader(response);
+
+      expect(cookie).toBe(`__prerender_bypass=${previewModeId}`);
+      expect(
+        isDraftModeRequest(
+          new Request("https://example.test/app", { headers: { cookie } }),
+          previewModeId,
+        ),
+      ).toBe(true);
+      expect(getPagesPreviewState(cookie)).toEqual({ data: {}, shouldClear: false });
+    } finally {
+      if (previousId === undefined) delete process.env.__VINEXT_PREVIEW_MODE_ID;
+      else process.env.__VINEXT_PREVIEW_MODE_ID = previousId;
+      if (previousSigningKey === undefined) delete process.env.__VINEXT_PREVIEW_MODE_SIGNING_KEY;
+      else process.env.__VINEXT_PREVIEW_MODE_SIGNING_KEY = previousSigningKey;
+      if (previousEncryptionKey === undefined) {
+        delete process.env.__VINEXT_PREVIEW_MODE_ENCRYPTION_KEY;
+      } else {
+        process.env.__VINEXT_PREVIEW_MODE_ENCRYPTION_KEY = previousEncryptionKey;
+      }
+    }
   });
 });

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -2642,6 +2642,16 @@ export default function PreviewPage({ preview }) {
 }\n`,
     );
     await fsp.writeFile(
+      path.join(fixtureRoot, "pages", "gssp-not-found.tsx"),
+      `export function getServerSideProps() { return { notFound: true }; }
+export default function Page() { return null; }\n`,
+    );
+    await fsp.writeFile(
+      path.join(fixtureRoot, "pages", "gsp-not-found.tsx"),
+      `export function getStaticProps() { return { notFound: true }; }
+export default function Page() { return null; }\n`,
+    );
+    await fsp.writeFile(
       path.join(fixtureRoot, "pages", "initial-props.tsx"),
       `export default function InitialPropsPage() {
   return <p id="initial-props">page</p>;
@@ -2763,6 +2773,20 @@ export default function Page(props) {
         expect.stringMatching(/^__prerender_bypass=; Expires=/),
         expect.stringMatching(/^__next_preview_data=; Expires=/),
       ]);
+    }
+  });
+
+  it("expires tampered preview cookies on notFound HTML and data exits", async () => {
+    const cookie = tamperPreviewCookie(await enablePreview());
+    for (const page of ["gssp-not-found", "gsp-not-found"]) {
+      for (const pathname of [`/${page}`, `/_next/data/preview-build-id/${page}.json`]) {
+        const response = await fetch(`${previewBaseUrl}${pathname}`, { headers: { cookie } });
+        expect(response.status).toBe(404);
+        expect(response.headers.getSetCookie()).toEqual([
+          expect.stringMatching(/^__prerender_bypass=; Expires=/),
+          expect.stringMatching(/^__next_preview_data=; Expires=/),
+        ]);
+      }
     }
   });
 });

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -2641,6 +2641,14 @@ export default function PreviewPage({ preview }) {
   return <p id="preview">{String(preview)}</p>;
 }\n`,
     );
+    await fsp.writeFile(
+      path.join(fixtureRoot, "pages", "initial-props.tsx"),
+      `export default function InitialPropsPage() {
+  return <p id="initial-props">page</p>;
+}
+InitialPropsPage.getInitialProps = async () => ({ ok: true });
+`,
+    );
     const fallbackPage = `export function getStaticPaths() {
   return { paths: [{ params: { post: "first" } }], fallback: FALLBACK_VALUE };
 }
@@ -2727,6 +2735,23 @@ export default function Page(props) {
     );
     expect(nextDataMatch).toBeTruthy();
     expect(JSON.parse(nextDataMatch![1]!).props.__N_PREVIEW).toBe(true);
+  });
+
+  it("does not activate preview for getInitialProps-only pages", async () => {
+    const cookie = await enablePreview();
+    const response = await fetch(`${previewBaseUrl}/initial-props`, { headers: { cookie } });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).not.toBe(
+      "private, no-cache, no-store, max-age=0, must-revalidate",
+    );
+    const html = await response.text();
+    const nextDataMatch = html.match(
+      /<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/,
+    );
+    expect(nextDataMatch).toBeTruthy();
+    const nextData = JSON.parse(nextDataMatch![1]!);
+    expect(nextData.isPreview).toBeUndefined();
+    expect(nextData.props.__N_PREVIEW).toBeUndefined();
   });
 
   it("expires tampered preview cookies for HTML and data", async () => {

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -2594,6 +2594,89 @@ describe("Pages Router integration", () => {
   });
 });
 
+describe("Pages Router dev preview response boundaries", () => {
+  let fixtureRoot: string;
+  let previewServer: ViteDevServer;
+  let previewBaseUrl: string;
+
+  beforeAll(async () => {
+    fixtureRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-pages-preview-dev-"));
+    await fsp.symlink(
+      path.resolve(import.meta.dirname, "../node_modules"),
+      path.join(fixtureRoot, "node_modules"),
+      "junction",
+    );
+    await fsp.mkdir(path.join(fixtureRoot, "pages", "api"), { recursive: true });
+    await fsp.writeFile(path.join(fixtureRoot, "package.json"), JSON.stringify({ type: "module" }));
+    await fsp.writeFile(
+      path.join(fixtureRoot, "next.config.mjs"),
+      `export default { generateBuildId: async () => "preview-build-id" };\n`,
+    );
+    await fsp.writeFile(path.join(fixtureRoot, "pages", "_app.tsx"), PAGES_APP_COMPONENT);
+    await fsp.writeFile(
+      path.join(fixtureRoot, "pages", "api", "preview.ts"),
+      `export default function handler(_req, res) {
+  res.setPreviewData({ draft: true });
+  res.end();
+}\n`,
+    );
+    await fsp.writeFile(
+      path.join(fixtureRoot, "pages", "preview.tsx"),
+      `export function getServerSideProps({ preview, previewData, res }) {
+  res.setHeader("Cache-Control", "public, max-age=600");
+  return { props: { preview: preview ?? false, previewData: previewData ?? null } };
+}
+export default function PreviewPage({ preview }) {
+  return <p id="preview">{String(preview)}</p>;
+}\n`,
+    );
+    ({ server: previewServer, baseUrl: previewBaseUrl } = await startFixtureServer(fixtureRoot));
+  });
+
+  afterAll(async () => {
+    await previewServer?.close();
+    await fsp.rm(fixtureRoot, { recursive: true, force: true });
+  });
+
+  async function enablePreview(): Promise<string> {
+    const response = await fetch(`${previewBaseUrl}/api/preview`);
+    const cookies = response.headers.getSetCookie();
+    expect(cookies).toHaveLength(2);
+    return cookies.map((cookie) => cookie.split(";", 1)[0]).join("; ");
+  }
+
+  function tamperPreviewCookie(cookie: string): string {
+    return cookie.replace(
+      /(__next_preview_data=)([^;])([^;]*)/,
+      (_match, prefix: string, first: string, rest: string) =>
+        `${prefix}${first === "a" ? "b" : "a"}${rest}`,
+    );
+  }
+
+  it("applies preview no-store after user headers for HTML and data", async () => {
+    const cookie = await enablePreview();
+    for (const pathname of ["/preview", "/_next/data/preview-build-id/preview.json"]) {
+      const response = await fetch(`${previewBaseUrl}${pathname}`, { headers: { cookie } });
+      expect(response.status).toBe(200);
+      expect(response.headers.get("cache-control")).toBe(
+        "private, no-cache, no-store, max-age=0, must-revalidate",
+      );
+    }
+  });
+
+  it("expires tampered preview cookies for HTML and data", async () => {
+    const cookie = tamperPreviewCookie(await enablePreview());
+    for (const pathname of ["/preview", "/_next/data/preview-build-id/preview.json"]) {
+      const response = await fetch(`${previewBaseUrl}${pathname}`, { headers: { cookie } });
+      expect(response.status).toBe(200);
+      expect(response.headers.getSetCookie()).toEqual([
+        expect.stringMatching(/^__prerender_bypass=; Expires=/),
+        expect.stringMatching(/^__next_preview_data=; Expires=/),
+      ]);
+    }
+  });
+});
+
 describe("Pages Router dev dot-path rewrite preflight", () => {
   let server: ViteDevServer;
   let baseUrl: string;

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -2607,12 +2607,23 @@ describe("Pages Router dev preview response boundaries", () => {
       "junction",
     );
     await fsp.mkdir(path.join(fixtureRoot, "pages", "api"), { recursive: true });
+    await fsp.mkdir(path.join(fixtureRoot, "pages", "no-fallback"), { recursive: true });
+    await fsp.mkdir(path.join(fixtureRoot, "pages", "fallback"), { recursive: true });
     await fsp.writeFile(path.join(fixtureRoot, "package.json"), JSON.stringify({ type: "module" }));
     await fsp.writeFile(
       path.join(fixtureRoot, "next.config.mjs"),
       `export default { generateBuildId: async () => "preview-build-id" };\n`,
     );
-    await fsp.writeFile(path.join(fixtureRoot, "pages", "_app.tsx"), PAGES_APP_COMPONENT);
+    await fsp.writeFile(
+      path.join(fixtureRoot, "pages", "_app.tsx"),
+      `export default function App({ Component, pageProps }) {
+  return <Component {...pageProps} />;
+}
+App.getInitialProps = async ({ Component, ctx }) => ({
+  pageProps: Component.getInitialProps ? await Component.getInitialProps(ctx) : {},
+});
+`,
+    );
     await fsp.writeFile(
       path.join(fixtureRoot, "pages", "api", "preview.ts"),
       `export default function handler(_req, res) {
@@ -2629,6 +2640,24 @@ describe("Pages Router dev preview response boundaries", () => {
 export default function PreviewPage({ preview }) {
   return <p id="preview">{String(preview)}</p>;
 }\n`,
+    );
+    const fallbackPage = `export function getStaticPaths() {
+  return { paths: [{ params: { post: "first" } }], fallback: FALLBACK_VALUE };
+}
+export function getStaticProps({ params, preview, previewData }) {
+  return { props: { params, preview: preview ?? false, previewData: previewData ?? null } };
+}
+export default function Page(props) {
+  return <pre id="props">{JSON.stringify(props)}</pre>;
+}
+`;
+    await fsp.writeFile(
+      path.join(fixtureRoot, "pages", "no-fallback", "[post].tsx"),
+      fallbackPage.replace("FALLBACK_VALUE", "false"),
+    );
+    await fsp.writeFile(
+      path.join(fixtureRoot, "pages", "fallback", "[post].tsx"),
+      fallbackPage.replace("FALLBACK_VALUE", "true"),
     );
     ({ server: previewServer, baseUrl: previewBaseUrl } = await startFixtureServer(fixtureRoot));
   });
@@ -2662,6 +2691,42 @@ export default function PreviewPage({ preview }) {
         "private, no-cache, no-store, max-age=0, must-revalidate",
       );
     }
+  });
+
+  it("renders unlisted fallback false and fallback true paths with real preview props", async () => {
+    const cookie = await enablePreview();
+
+    const noFallbackWithoutPreview = await fetch(`${previewBaseUrl}/no-fallback/second`);
+    expect(noFallbackWithoutPreview.status).toBe(404);
+
+    for (const pathname of ["/no-fallback/second", "/fallback/second"]) {
+      const response = await fetch(`${previewBaseUrl}${pathname}`, { headers: { cookie } });
+      expect(response.status).toBe(200);
+      const html = await response.text();
+      const nextDataMatch = html.match(
+        /<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/,
+      );
+      expect(nextDataMatch).toBeTruthy();
+      const nextData = JSON.parse(nextDataMatch![1]!);
+      expect(nextData.props.pageProps).toEqual({
+        params: { post: "second" },
+        preview: true,
+        previewData: { draft: true },
+      });
+      expect(nextData.isFallback).toBe(false);
+    }
+  });
+
+  it("preserves __N_PREVIEW after custom App getInitialProps", async () => {
+    const cookie = await enablePreview();
+    const response = await fetch(`${previewBaseUrl}/preview`, { headers: { cookie } });
+    expect(response.status).toBe(200);
+    const html = await response.text();
+    const nextDataMatch = html.match(
+      /<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/,
+    );
+    expect(nextDataMatch).toBeTruthy();
+    expect(JSON.parse(nextDataMatch![1]!).props.__N_PREVIEW).toBe(true);
   });
 
   it("expires tampered preview cookies for HTML and data", async () => {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -18178,6 +18178,51 @@ describe("Pages Router _next/data client navigation", () => {
     }
   });
 
+  it("updates and clears isPreview from Pages data response markers", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const { win } = createDataNavWindow({
+      loaders: {
+        "/": vi.fn(async () => makePageModule("home")),
+        "/preview": vi.fn(async () => makePageModule("preview")),
+        "/published": vi.fn(async () => makePageModule("published")),
+      },
+      sspPatterns: ["/preview", "/published"],
+    });
+    (globalThis as any).window = win;
+    vi.resetModules();
+
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const href =
+        typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      return new Response(
+        JSON.stringify({
+          ...(href.includes("/preview.json") ? { __N_PREVIEW: true } : {}),
+          pageProps: {},
+        }),
+        { headers: { "Content-Type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    try {
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      const Router = routerModule.default;
+
+      await Router.push("/preview");
+      expect(Router.isPreview).toBe(true);
+      expect(win.__NEXT_DATA__.isPreview).toBe(true);
+
+      await Router.push("/published");
+      expect(Router.isPreview).toBe(false);
+      expect(win.__NEXT_DATA__.isPreview).toBe(false);
+    } finally {
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+      vi.resetModules();
+    }
+  });
+
   it("does not persist middleware-prefetched SSR data between prefetch and navigation", async () => {
     const previousWindow = (globalThis as any).window;
     const originalDocument = (globalThis as any).document;

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -2551,6 +2551,26 @@ describe("window.next debug global", () => {
     }
   });
 
+  it("reads Pages preview state from __NEXT_DATA__", async () => {
+    const previousWindow = (globalThis as any).window;
+    const win: any = {
+      location: { pathname: "/preview", search: "", hash: "", href: "http://localhost/preview" },
+      history: { state: null, pushState() {}, replaceState() {} },
+      addEventListener() {},
+      __NEXT_DATA__: { page: "/preview", query: {}, isFallback: false, isPreview: true },
+    };
+    (globalThis as any).window = win;
+
+    try {
+      vi.resetModules();
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      expect(routerModule.default.isPreview).toBe(true);
+    } finally {
+      (globalThis as any).window = previousWindow;
+      vi.resetModules();
+    }
+  });
+
   // Ported from Next.js: tests that rely on `window.next.router.events.on(...)`
   // — e.g. test/development/pages-dir/client-navigation/index.test.ts:457
   // (`window.next.router.events.on('routeChangeError', ...)`).


### PR DESCRIPTION
## Summary

- expose Pages preview state and data to API routes and implement `res.clearPreviewData()` cookie expiry semantics
- serialize and hydrate `router.isPreview` from `__NEXT_DATA__`
- allow preview requests to render unlisted `fallback: false` paths without persisting preview output

## Next.js parity

Ported against Next.js `v16.3.0-canary.80` (`9dd6d677b63b249584c8ff0bccffcc6a65288683`):

- `test/e2e/prerender-preview/prerender-preview.test.ts`
- `test/e2e/preview-fallback/preview-fallback.test.ts`

The separate `revalidate-reason > should support revalidateReason: "on-demand"` failure is already covered by #2027; I commented there with the exact run 28938793088 failure and did not duplicate it here.

## Validation

- `vp test run tests/pages-node-compat.test.ts tests/pages-page-data.test.ts` — 62 passed
- `vp test run tests/shims.test.ts -t "reads Pages preview state"` — 1 passed
- `vp check packages/vinext/src/server/pages-node-compat.ts packages/vinext/src/server/pages-page-data.ts packages/vinext/src/server/pages-page-handler.ts packages/vinext/src/shims/router-state.ts packages/vinext/src/shims/router.ts tests/pages-node-compat.test.ts tests/pages-page-data.test.ts tests/shims.test.ts` — format, lint, and types passed
- `git diff --check` — passed
- `REPO=$PWD NEXTJS_DIR=/Users/jamesanderson/Developer/vinext/.nextjs-ref-v16.3.0-canary.80 NEXTJS_PREPARE=0 VINEXT_BUILD=1 NEXT_TEST_CONCURRENCY=1 ./scripts/run-targeted-nextjs-e2e.sh test/e2e/prerender-preview/prerender-preview.test.ts test/e2e/preview-fallback/preview-fallback.test.ts` — 2 suites passed, 15 tests passed