### PR TITLE
fix(pages): pass AppTree to page initial props

### DIFF
--- a/packages/vinext/src/entries/pages-client-entry.ts
+++ b/packages/vinext/src/entries/pages-client-entry.ts
@@ -244,6 +244,7 @@ async function hydrate() {
     console.error("[vinext] Page module has no default export");
     return;
   }
+  window.__VINEXT_PAGE_COMPONENT__ = PageComponent;
 
   let element;
   ${

--- a/packages/vinext/src/global.d.ts
+++ b/packages/vinext/src/global.d.ts
@@ -83,6 +83,9 @@ declare global {
         }>
       | undefined;
 
+    /** The currently committed Pages Router page component. */
+    __VINEXT_PAGE_COMPONENT__: React.ComponentType<Record<string, unknown>> | undefined;
+
     /**
      * Pages Router code-split loader map. Keys are route patterns in Next.js
      * bracket format (e.g. `/blog/[slug]`), values are dynamic `import()`

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -956,6 +956,22 @@ export function createSSRHandler(
         const gsspExtraHeaders: Record<string, string | string[]> = {};
 
         const hasAppGetInitialProps = hasPagesGetInitialProps(AppComponent);
+        const createAppTree = (appTreeProps: Record<string, unknown>) => {
+          const appTree = AppComponent
+            ? React.createElement(AppComponent, {
+                ...appTreeProps,
+                Component: PageComponent,
+                pageProps: appTreeProps.pageProps,
+                router: routerShim.default,
+              })
+            : React.createElement(
+                PageComponent,
+                isUnknownRecord(appTreeProps.pageProps) ? appTreeProps.pageProps : {},
+              );
+          return typeof routerShim.wrapWithRouterContext === "function"
+            ? routerShim.wrapWithRouterContext(appTree)
+            : appTree;
+        };
 
         // Thin glue over loadDevAppInitialProps: build the React AppTree closure,
         // delegate the decision to the tested helper, and apply the result.
@@ -966,17 +982,7 @@ export function createSSRHandler(
           }
           const appResult = await loadDevAppInitialProps({
             appComponent: AppComponent,
-            appTree: (appTreeProps: Record<string, unknown>) => {
-              const appTree = React.createElement(AppComponent, {
-                ...appTreeProps,
-                Component: PageComponent,
-                pageProps: appTreeProps.pageProps,
-                router: routerShim.default,
-              });
-              return typeof routerShim.wrapWithRouterContext === "function"
-                ? routerShim.wrapWithRouterContext(appTree)
-                : appTree;
-            },
+            appTree: createAppTree,
             component: PageComponent,
             req,
             res,
@@ -1565,6 +1571,7 @@ export function createSSRHandler(
           !hasAppGetInitialProps
         ) {
           const initialProps = await loadPagesGetInitialProps(PageComponent, {
+            AppTree: createAppTree,
             req,
             res,
             pathname: patternToNextFormat(route.pattern),

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -1808,6 +1808,7 @@ async function hydrate() {
 
   const pageModule = await import("${pageModuleSource}");
   const PageComponent = pageModule.default;
+  window.__VINEXT_PAGE_COMPONENT__ = PageComponent;
   let element;
   ${
     appModuleSource

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -1281,8 +1281,9 @@ export function createSSRHandler(
                         return {};
                       },
                     };
-                    const initialProps = await loadPagesGetInitialProps(RegenApp, {
-                      AppTree: (appTreeProps: Record<string, unknown>) => {
+                    const appResult = await loadDevAppInitialProps({
+                      appComponent: RegenApp,
+                      appTree: (appTreeProps: Record<string, unknown>) => {
                         const appTree = React.createElement(RegenApp, {
                           ...appTreeProps,
                           Component: pageModule.default,
@@ -1293,29 +1294,20 @@ export function createSSRHandler(
                           ? routerShim.wrapWithRouterContext(appTree)
                           : appTree;
                       },
-                      Component: pageModule.default,
-                      router: {
-                        pathname: patternToNextFormat(route.pattern),
-                        query,
-                        asPath: requestAsPath,
-                      },
-                      ctx: {
-                        req: regenReq,
-                        res: regenRes,
-                        pathname: patternToNextFormat(route.pattern),
-                        query,
-                        asPath: requestAsPath,
-                        locale: locale ?? currentDefaultLocale,
-                        locales: i18nConfig?.locales,
-                        defaultLocale: currentDefaultLocale,
-                      },
+                      component: pageModule.default,
+                      req: regenReq,
+                      res: regenRes,
+                      pathname: patternToNextFormat(route.pattern),
+                      query,
+                      asPath: requestAsPath,
+                      locale: locale ?? currentDefaultLocale,
+                      locales: i18nConfig?.locales,
+                      defaultLocale: currentDefaultLocale,
                     });
-                    if (regenRes.headersSent || regenRes.writableEnded) return;
-                    if (initialProps) {
-                      freshRenderProps = initialProps;
-                      freshPageProps = isUnknownRecord(initialProps.pageProps)
-                        ? initialProps.pageProps
-                        : {};
+                    if (appResult.kind === "response-sent") return;
+                    if (appResult.kind === "render") {
+                      freshRenderProps = appResult.renderProps;
+                      freshPageProps = appResult.pageProps;
                     }
                   }
 
@@ -2115,28 +2107,71 @@ async function renderErrorPage(
       }
 
       const createElement = React.createElement;
-      const initialErrorProps = await loadPagesGetInitialProps(ErrorComponent, {
-        req,
-        res,
-        err,
-        pathname: candidate === "_error" ? "/_error" : `/${candidate}`,
-        query: parseQuery(url),
-        asPath: url,
-      });
-      if (res.headersSent || res.writableEnded) return;
-      const errorProps = { ...initialErrorProps, statusCode };
-
       // If the caller didn't supply wrapWithRouterContext, load it now.
       // runner.import() caches internally so the cost is negligible.
       let wrapFn = wrapWithRouterContext;
-      if (!wrapFn) {
-        try {
-          const errRouterShim = await importModule(runner, "next/router");
-          wrapFn = errRouterShim.wrapWithRouterContext;
-        } catch {
-          // router shim not available — continue without it
-        }
+      let errorRouter: Record<string, unknown> = {};
+      try {
+        const errRouterShim = await importModule(runner, "next/router");
+        if (!wrapFn) wrapFn = errRouterShim.wrapWithRouterContext;
+        errorRouter = (errRouterShim.default as Record<string, unknown> | undefined) ?? {};
+      } catch {
+        // router shim not available — continue without it
       }
+
+      const errorPathname = candidate === "_error" ? "/_error" : `/${candidate}`;
+      const errorQuery = parseQuery(url);
+      const createErrorAppTree = (appTreeProps: Record<string, unknown>) => {
+        let appTree: React.ReactElement = AppComponent
+          ? createElement(AppComponent, {
+              ...appTreeProps,
+              Component: ErrorComponent,
+              pageProps: appTreeProps.pageProps,
+              router: errorRouter,
+            })
+          : createElement(
+              ErrorComponent,
+              isUnknownRecord(appTreeProps.pageProps) ? appTreeProps.pageProps : {},
+            );
+        if (wrapFn) appTree = wrapFn(appTree);
+        return appTree;
+      };
+
+      let renderProps: Record<string, unknown> = { pageProps: {} };
+      let errorProps: Record<string, unknown> = {};
+      if (AppComponent && hasPagesGetInitialProps(AppComponent)) {
+        const appResult = await loadDevAppInitialProps({
+          appComponent: AppComponent,
+          appTree: createErrorAppTree,
+          component: ErrorComponent,
+          req,
+          res,
+          err,
+          pathname: errorPathname,
+          query: errorQuery,
+          asPath: url,
+        });
+        if (appResult.kind === "response-sent") return;
+        if (appResult.kind === "render") {
+          errorProps = appResult.pageProps;
+          renderProps = appResult.renderProps;
+        }
+      } else {
+        const initialErrorProps = await loadPagesGetInitialProps(ErrorComponent, {
+          AppTree: createErrorAppTree,
+          req,
+          res,
+          err,
+          pathname: errorPathname,
+          query: errorQuery,
+          asPath: url,
+        });
+        if (res.headersSent || res.writableEnded) return;
+        errorProps = initialErrorProps ?? {};
+        renderProps = { pageProps: errorProps };
+      }
+      errorProps = { ...errorProps, statusCode };
+      renderProps = { ...renderProps, pageProps: errorProps };
 
       // Try custom _document
       // oxlint-disable-next-line typescript/no-explicit-any
@@ -2159,8 +2194,10 @@ async function renderErrorPage(
       ): React.ReactElement => {
         let errorElement: React.ReactElement = FinalApp
           ? createElement(FinalApp, {
+              ...renderProps,
               Component: FinalComponent,
               pageProps: errorProps,
+              router: errorRouter,
             })
           : createElement(FinalComponent, errorProps);
         if (wrapFn) errorElement = wrapFn(errorElement);
@@ -2181,7 +2218,6 @@ async function renderErrorPage(
       );
 
       if (DocumentComponent) {
-        const errorPathname = candidate === "_error" ? "/_error" : `/${candidate}`;
         await streamPageToResponse(res, element, {
           url,
           server,

--- a/packages/vinext/src/server/pages-get-initial-props.ts
+++ b/packages/vinext/src/server/pages-get-initial-props.ts
@@ -123,6 +123,7 @@ export type DevAppInitialPropsContext = {
   component: unknown;
   req: unknown;
   res: unknown;
+  err?: unknown;
   pathname: string;
   query: Record<string, unknown>;
   asPath: string;
@@ -156,6 +157,7 @@ export async function loadDevAppInitialProps(
       AppTree: ctx.appTree,
       req: ctx.req,
       res: ctx.res,
+      err: ctx.err,
       pathname: ctx.pathname,
       query: ctx.query,
       asPath: ctx.asPath,

--- a/packages/vinext/src/server/pages-get-initial-props.ts
+++ b/packages/vinext/src/server/pages-get-initial-props.ts
@@ -153,6 +153,7 @@ export async function loadDevAppInitialProps(
     Component: ctx.component,
     router: { pathname: ctx.pathname, query: ctx.query, asPath: ctx.asPath },
     ctx: {
+      AppTree: ctx.appTree,
       req: ctx.req,
       res: ctx.res,
       pathname: ctx.pathname,

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -368,6 +368,7 @@ async function loadPagesAppInitialRenderProps(
       asPath: options.asPath ?? options.routeUrl,
     },
     ctx: {
+      AppTree: options.createAppTree ?? options.createPageElement,
       req,
       res,
       err: options.err,

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -1092,7 +1092,9 @@ export async function resolvePagesPageData(
     hasPagesGetInitialProps(options.pageModule.default)
   ) {
     const { req, res, responsePromise } = getSharedReqRes();
+    const AppTree = options.createAppTree ?? options.createPageElement;
     const initialProps = await loadPagesGetInitialProps(options.pageModule.default, {
+      AppTree,
       req,
       res,
       err: options.err,

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -431,6 +431,8 @@ type PagesRouterRuntimeState = {
   deprecatedEventBridgeInstalled: boolean;
   pagesRouterReady: boolean;
   publicRouter?: Record<string, unknown>;
+  committedComponent?: PagesComponent;
+  committedSnapshot?: RouterSnapshot;
 };
 
 type PagesRouterRuntimeComponents = {
@@ -1975,23 +1977,30 @@ async function loadComponentOnlyProps(
     locales: window.__VINEXT_LOCALES__,
     defaultLocale: window.__VINEXT_DEFAULT_LOCALE__,
   };
+  if (!routerRuntimeState.committedComponent) {
+    const committedPage = window.__NEXT_DATA__?.page;
+    const committedLoader = committedPage ? window.__VINEXT_PAGE_LOADERS__?.[committedPage] : null;
+    if (committedLoader) {
+      const committedModule = await committedLoader();
+      if (isPageComponent(committedModule.default)) {
+        routerRuntimeState.committedComponent = committedModule.default;
+      }
+    }
+  }
+  const committedComponent = routerRuntimeState.committedComponent ?? PageComponent;
+  const committedSnapshot = routerRuntimeState.committedSnapshot ?? getRouterSnapshot();
   const AppTree = (appProps: Record<string, unknown>) => {
     const element = AppComponent
       ? createElement(AppComponent as ComponentType<Record<string, unknown>>, {
           ...appProps,
-          Component: PageComponent,
+          Component: committedComponent,
           router: Router,
         })
       : createElement(
-          PageComponent as ComponentType<Record<string, unknown>>,
+          committedComponent as ComponentType<Record<string, unknown>>,
           propsObject(appProps.pageProps),
         );
-    return wrapWithRouterContext(element, noopCommit, noopCommit, {
-      pathname: target.pattern,
-      query,
-      asPath,
-      isReady: true,
-    });
+    return wrapWithRouterContext(element, noopCommit, noopCommit, committedSnapshot);
   };
 
   if (typeof AppComponent?.getInitialProps === "function") {
@@ -2061,6 +2070,13 @@ async function renderPagesNavigationTarget(
   applyVinextLocaleGlobals(window, nextData);
   await renderPagesRouterElement(element, options.scroll);
   assertStillCurrent();
+  routerRuntimeState.committedComponent = PageComponent;
+  routerRuntimeState.committedSnapshot = {
+    pathname: target.pattern,
+    query: mergeRouteParamsIntoQuery(parseQueryString(target.search), target.params),
+    asPath: url,
+    isReady: true,
+  };
 }
 
 async function navigateClientNoData(
@@ -2433,6 +2449,8 @@ async function navigateClientHtml(
   applyVinextLocaleGlobals(window, nextData);
   await renderPagesRouterElement(element, options.scroll);
   assertStillCurrent();
+  routerRuntimeState.committedComponent = PageComponent;
+  routerRuntimeState.committedSnapshot = getRouterSnapshot();
 }
 
 /**
@@ -2884,6 +2902,8 @@ async function performNavigation(
   if (typeof window === "undefined") {
     throwNoRouterInstance();
   }
+
+  routerRuntimeState.committedSnapshot ??= getRouterSnapshot();
 
   // Defence-in-depth dangerous-scheme guard. The synchronous guard inside
   // `Router.push` / `Router.replace` (see RouterMethods below) is the primary

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -1985,7 +1985,7 @@ async function loadComponentOnlyProps(
       await AppComponent.getInitialProps({
         Component: PageComponent,
         AppTree,
-        ctx,
+        ctx: { ...ctx, AppTree },
         router: Router,
       }),
     );

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -1977,17 +1977,8 @@ async function loadComponentOnlyProps(
     locales: window.__VINEXT_LOCALES__,
     defaultLocale: window.__VINEXT_DEFAULT_LOCALE__,
   };
-  if (!routerRuntimeState.committedComponent) {
-    const committedPage = window.__NEXT_DATA__?.page;
-    const committedLoader = committedPage ? window.__VINEXT_PAGE_LOADERS__?.[committedPage] : null;
-    if (committedLoader) {
-      const committedModule = await committedLoader();
-      if (isPageComponent(committedModule.default)) {
-        routerRuntimeState.committedComponent = committedModule.default;
-      }
-    }
-  }
-  const committedComponent = routerRuntimeState.committedComponent ?? PageComponent;
+  const committedComponent =
+    routerRuntimeState.committedComponent ?? window.__VINEXT_PAGE_COMPONENT__ ?? PageComponent;
   const committedSnapshot = routerRuntimeState.committedSnapshot ?? getRouterSnapshot();
   const AppTree = (appProps: Record<string, unknown>) => {
     const element = AppComponent
@@ -2071,6 +2062,7 @@ async function renderPagesNavigationTarget(
   await renderPagesRouterElement(element, options.scroll);
   assertStillCurrent();
   routerRuntimeState.committedComponent = PageComponent;
+  window.__VINEXT_PAGE_COMPONENT__ = PageComponent;
   routerRuntimeState.committedSnapshot = {
     pathname: target.pattern,
     query: mergeRouteParamsIntoQuery(parseQueryString(target.search), target.params),
@@ -2450,6 +2442,7 @@ async function navigateClientHtml(
   await renderPagesRouterElement(element, options.scroll);
   assertStillCurrent();
   routerRuntimeState.committedComponent = PageComponent;
+  window.__VINEXT_PAGE_COMPONENT__ = PageComponent;
   routerRuntimeState.committedSnapshot = getRouterSnapshot();
 }
 

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -1975,19 +1975,26 @@ async function loadComponentOnlyProps(
     locales: window.__VINEXT_LOCALES__,
     defaultLocale: window.__VINEXT_DEFAULT_LOCALE__,
   };
-
-  if (typeof AppComponent?.getInitialProps === "function") {
-    const AppTree = (appProps: Record<string, unknown>) =>
-      wrapWithRouterContext(
-        createElement(AppComponent as ComponentType<Record<string, unknown>>, {
+  const AppTree = (appProps: Record<string, unknown>) => {
+    const element = AppComponent
+      ? createElement(AppComponent as ComponentType<Record<string, unknown>>, {
           ...appProps,
           Component: PageComponent,
           router: Router,
-        }),
-        noopCommit,
-        noopCommit,
-        { pathname: target.pattern, query, asPath, isReady: true },
-      );
+        })
+      : createElement(
+          PageComponent as ComponentType<Record<string, unknown>>,
+          propsObject(appProps.pageProps),
+        );
+    return wrapWithRouterContext(element, noopCommit, noopCommit, {
+      pathname: target.pattern,
+      query,
+      asPath,
+      isReady: true,
+    });
+  };
+
+  if (typeof AppComponent?.getInitialProps === "function") {
     return propsObject(
       await AppComponent.getInitialProps({
         Component: PageComponent,
@@ -1999,7 +2006,7 @@ async function loadComponentOnlyProps(
   }
 
   if (typeof PageComponent.getInitialProps === "function") {
-    return { pageProps: propsObject(await PageComponent.getInitialProps(ctx)) };
+    return { pageProps: propsObject(await PageComponent.getInitialProps({ ...ctx, AppTree })) };
   }
 
   return { pageProps: {} };

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -439,8 +439,10 @@ type PagesRouterRuntimeComponents = {
     onCommit: () => void;
     onError: (error: Error) => void;
   }>;
-  Provider: ComponentType<{ children: ReactNode }>;
+  Provider: ComponentType<{ children?: ReactNode; initialSnapshot?: RouterSnapshot }>;
 };
+
+type RouterSnapshot = ReturnType<typeof getPathnameAndQuery> & { isReady: boolean };
 
 const PAGES_ROUTER_RUNTIME_STATE_KEY = Symbol.for("vinext.pagesRouter.runtimeState");
 
@@ -1393,7 +1395,7 @@ function PagesRouterHydrationMarker(): null {
   return null;
 }
 
-function getRouterSnapshot(): ReturnType<typeof getPathnameAndQuery> & { isReady: boolean } {
+function getRouterSnapshot(): RouterSnapshot {
   // On the server, derive `router.isReady` from the SSR navigation-readiness
   // context (auto-export dynamic / query-string / rewrite-capable routes are
   // not ready until the client router publishes the live URL). Mirrors Next.js
@@ -1976,11 +1978,16 @@ async function loadComponentOnlyProps(
 
   if (typeof AppComponent?.getInitialProps === "function") {
     const AppTree = (appProps: Record<string, unknown>) =>
-      createElement(AppComponent as ComponentType<Record<string, unknown>>, {
-        ...appProps,
-        Component: PageComponent,
-        router: Router,
-      });
+      wrapWithRouterContext(
+        createElement(AppComponent as ComponentType<Record<string, unknown>>, {
+          ...appProps,
+          Component: PageComponent,
+          router: Router,
+        }),
+        noopCommit,
+        noopCommit,
+        { pathname: target.pattern, query, asPath, isReady: true },
+      );
     return propsObject(
       await AppComponent.getInitialProps({
         Component: PageComponent,
@@ -3269,8 +3276,16 @@ export function useRouter(): NextRouter {
   );
 }
 
-function PagesRouterProvider({ children }: { children: ReactNode }): ReactElement {
-  const [{ pathname, query, asPath, isReady }, setState] = useState(getRouterSnapshot);
+function PagesRouterProvider({
+  children,
+  initialSnapshot,
+}: {
+  children?: ReactNode;
+  initialSnapshot?: RouterSnapshot;
+}): ReactElement {
+  const [{ pathname, query, asPath, isReady }, setState] = useState(
+    initialSnapshot ?? getRouterSnapshot,
+  );
 
   // Popstate is handled by the Pages Router client entry via
   // installPagesRouterRuntime() so beforePopState() is consistently enforced
@@ -3615,6 +3630,7 @@ export function wrapWithRouterContext(
   element: ReactElement,
   onCommit: () => void = noopCommit,
   onError: (error: Error) => void = noopCommit,
+  initialSnapshot?: RouterSnapshot,
 ): ReactElement {
   const { CommitBoundary, Provider } = getPagesRouterRuntimeComponents();
   // React Strict Mode (Pages Router). When `reactStrictMode: true`, wrap the
@@ -3627,7 +3643,7 @@ export function wrapWithRouterContext(
   // navigations, mirroring Next.js's `doRender` closure used for both. The
   // CommitBoundary stays outside StrictMode so its commit `useLayoutEffect`
   // is not double-invoked (Next.js keeps `<Root>` outside <StrictMode> too).
-  let inner: ReactElement = createElement(Provider, null, element);
+  let inner: ReactElement = createElement(Provider, { initialSnapshot }, element);
   // Re-read the static page-load flag on each render so hydration and
   // navigation share this single wrapping path.
   if (typeof window !== "undefined" && window.__VINEXT_REACT_STRICT_MODE__ === true) {

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -1385,6 +1385,7 @@ describe("Pages Router entry template", () => {
       expect(code).toContain("_initializePagesRouterReadyFromNextData(nextData);");
       expect(code).toContain("router: Router,");
       expect(code).toContain("pageProps: rawPageProps,");
+      expect(code).toContain("window.__VINEXT_PAGE_COMPONENT__ = PageComponent;");
       expect(code).toContain("element = wrapWithRouterContext(element, resolveHydrationCommit);");
       expect(code).toContain("await hydrationCommitted;");
       expect(code).toContain("if (nextData.isFallback) {");

--- a/tests/pages-get-initial-props.test.ts
+++ b/tests/pages-get-initial-props.test.ts
@@ -127,6 +127,7 @@ describe("loadDevAppInitialProps", () => {
       AppTree: expect.any(Function),
       router: { pathname: "/posts/[slug]", query: { slug: "post" }, asPath: "/posts/post" },
       ctx: {
+        AppTree: expect.any(Function),
         pathname: "/posts/[slug]",
         query: { slug: "post" },
         asPath: "/posts/post",

--- a/tests/pages-page-data.test.ts
+++ b/tests/pages-page-data.test.ts
@@ -380,6 +380,49 @@ describe("pages page data", () => {
     });
   });
 
+  it("passes AppTree through custom app getInitialProps to page getInitialProps", async () => {
+    // Ported from Next.js: test/e2e/app-tree/app-tree.test.ts
+    // https://github.com/vercel/next.js/blob/v16.3.0-canary.80/test/e2e/app-tree/app-tree.test.ts
+    const appTree = vi.fn(() => "app-tree");
+    const Page = Object.assign(
+      function Page() {
+        return null;
+      },
+      {
+        getInitialProps(context: { AppTree?: (props: Record<string, unknown>) => ReactNode }) {
+          return { rendered: context.AppTree?.({ pageProps: {} }) };
+        },
+      },
+    );
+    const App = Object.assign(
+      function App() {
+        return null;
+      },
+      {
+        async getInitialProps(context: {
+          Component: typeof Page;
+          ctx: { AppTree?: (props: Record<string, unknown>) => ReactNode };
+        }) {
+          return { pageProps: context.Component.getInitialProps(context.ctx) };
+        },
+      },
+    );
+
+    const result = await resolvePagesPageData(
+      createOptions({
+        AppComponent: App,
+        createAppTree: appTree,
+        pageModule: { default: Page },
+      }),
+    );
+
+    expect(appTree).toHaveBeenCalledWith({ pageProps: {} });
+    expect(result).toMatchObject({
+      kind: "render",
+      pageProps: { rendered: "app-tree" },
+    });
+  });
+
   it("preserves getInitialProps this binding via component receiver", async () => {
     const Page = Object.assign(
       function Page() {

--- a/tests/pages-page-data.test.ts
+++ b/tests/pages-page-data.test.ts
@@ -423,6 +423,35 @@ describe("pages page data", () => {
     });
   });
 
+  it("passes AppTree directly to page getInitialProps without custom app getInitialProps", async () => {
+    // Ported from Next.js: test/e2e/app-tree/app-tree.test.ts
+    // https://github.com/vercel/next.js/blob/v16.3.0-canary.80/test/e2e/app-tree/app-tree.test.ts
+    const appTree = vi.fn(() => "default-app-tree");
+    const Page = Object.assign(
+      function Page() {
+        return null;
+      },
+      {
+        getInitialProps(context: { AppTree?: (props: Record<string, unknown>) => ReactNode }) {
+          return { rendered: context.AppTree?.({ pageProps: {} }) };
+        },
+      },
+    );
+
+    const result = await resolvePagesPageData(
+      createOptions({
+        createAppTree: appTree,
+        pageModule: { default: Page },
+      }),
+    );
+
+    expect(appTree).toHaveBeenCalledWith({ pageProps: {} });
+    expect(result).toMatchObject({
+      kind: "render",
+      pageProps: { rendered: "default-app-tree" },
+    });
+  });
+
   it("preserves getInitialProps this binding via component receiver", async () => {
     const Page = Object.assign(
       function Page() {

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -2903,6 +2903,49 @@ describe("Pages Router allowedDevOrigins config", () => {
 });
 
 describe("Virtual server entry generation", () => {
+  it("passes a route-aware AppTree to page getInitialProps without a custom app", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-dev-default-app-tree-"));
+    const pagesDir = path.join(tmpDir, "pages");
+    fs.mkdirSync(pagesDir, { recursive: true });
+    fs.symlinkSync(path.join(process.cwd(), "node_modules"), path.join(tmpDir, "node_modules"));
+    fs.writeFileSync(
+      path.join(pagesDir, "about.tsx"),
+      `import { renderToStaticMarkup } from "react-dom/server";
+import { useRouter } from "next/router";
+export default function Page({ saved }) {
+  const router = useRouter();
+  return <><p id="route">{router.pathname}</p><div id="saved">{saved}</div></>;
+}
+Page.getInitialProps = ({ AppTree }) => ({
+  saved: renderToStaticMarkup(<AppTree pageProps={{}} />),
+});
+`,
+    );
+
+    const testServer = await createServer({
+      root: tmpDir,
+      configFile: false,
+      plugins: [vinext({ appDir: tmpDir })],
+      server: { port: 0, cors: false },
+      logLevel: "silent",
+    });
+
+    try {
+      await testServer.listen();
+      const addr = testServer.httpServer?.address();
+      if (!addr || typeof addr !== "object") throw new Error("Expected dev server address");
+
+      const res = await fetch(`http://localhost:${addr.port}/about`);
+      const html = await res.text();
+      expect(res.status).toBe(200);
+      expect(html).toContain('<p id="route">/about</p>');
+      expect(html).toContain("&lt;p id=&quot;route&quot;&gt;/about&lt;/p&gt;");
+    } finally {
+      await testServer.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("runs custom app getInitialProps for dev error rendering with nested AppTree", async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-dev-error-app-tree-"));
     const pagesDir = path.join(tmpDir, "pages");

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -2903,6 +2903,62 @@ describe("Pages Router allowedDevOrigins config", () => {
 });
 
 describe("Virtual server entry generation", () => {
+  it("runs custom app getInitialProps for dev error rendering with nested AppTree", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-dev-error-app-tree-"));
+    const pagesDir = path.join(tmpDir, "pages");
+    fs.mkdirSync(pagesDir, { recursive: true });
+    fs.symlinkSync(path.join(process.cwd(), "node_modules"), path.join(tmpDir, "node_modules"));
+    fs.writeFileSync(
+      path.join(pagesDir, "_app.tsx"),
+      `export default function App({ Component, pageProps, appMarker }) {
+  return <><p id="app-marker">{appMarker}</p><Component {...pageProps} /></>;
+}
+App.getInitialProps = async ({ Component, ctx }) => ({
+  appMarker: "app-ran",
+  pageProps: Component.getInitialProps ? await Component.getInitialProps(ctx) : {},
+});
+`,
+    );
+    fs.writeFileSync(
+      path.join(pagesDir, "_error.tsx"),
+      `import { renderToStaticMarkup } from "react-dom/server";
+export default function ErrorPage({ saved }) {
+  return <p id="saved">{saved}</p>;
+}
+ErrorPage.getInitialProps = ({ AppTree }) => ({
+  saved: renderToStaticMarkup(<AppTree pageProps={{ saved: "nested" }} />),
+});
+`,
+    );
+    fs.writeFileSync(
+      path.join(pagesDir, "index.tsx"),
+      `export default function Page() { return null; }`,
+    );
+
+    const testServer = await createServer({
+      root: tmpDir,
+      configFile: false,
+      plugins: [vinext({ appDir: tmpDir })],
+      server: { port: 0, cors: false },
+      logLevel: "silent",
+    });
+
+    try {
+      await testServer.listen();
+      const addr = testServer.httpServer?.address();
+      if (!addr || typeof addr !== "object") throw new Error("Expected dev server address");
+
+      const res = await fetch(`http://localhost:${addr.port}/missing`);
+      const html = await res.text();
+      expect(res.status).toBe(404);
+      expect(html).toContain('<p id="app-marker">app-ran</p>');
+      expect(html).toContain("nested");
+    } finally {
+      await testServer.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("generates valid JavaScript for the server entry", async () => {
     // Create a minimal server just to access the plugin's virtual module
     const testServer = await createServer({
@@ -8403,11 +8459,14 @@ describe("Pages Router dev ISR regeneration", () => {
       let regenUnifiedExecutionContext: unknown;
       let regenSsrContext: unknown;
       let regenI18nContext: unknown;
+      let regenPageContext: Record<string, unknown> | undefined;
       let appTreeWrapCount = 0;
       const App = Object.assign(({ Component, pageProps }: any) => Component(pageProps), {
-        getInitialProps: vi.fn(async () => ({
+        getInitialProps: vi.fn(async ({ Component, ctx }: any) => ({
           appLevel: "preserved",
-          pageProps: { fromApp: true },
+          pageProps: Component.getInitialProps
+            ? await Component.getInitialProps(ctx)
+            : { fromApp: true },
         })),
       });
       const outerExecutionContext = {
@@ -8440,9 +8499,19 @@ describe("Pages Router dev ISR regeneration", () => {
 
         if (id === routeFile) {
           return {
-            default() {
-              return null;
-            },
+            default: Object.assign(
+              function Page() {
+                return null;
+              },
+              {
+                getInitialProps(context: Record<string, unknown>) {
+                  regenPageContext = context;
+                  const AppTree = context.AppTree as (props: Record<string, unknown>) => unknown;
+                  AppTree({ pageProps: {} });
+                  return { fromApp: true };
+                },
+              },
+            ),
             async getStaticProps() {
               regenSawUnifiedScope = isInsideUnifiedScope();
               regenTags = [...getRequestContext().currentRequestTags];
@@ -8537,7 +8606,8 @@ describe("Pages Router dev ISR regeneration", () => {
         asPath: "/isr-test",
       });
       expect(regenI18nContext).toBeNull();
-      expect(appTreeWrapCount).toBe(1);
+      expect(regenPageContext).toMatchObject({ AppTree: expect.any(Function) });
+      expect(appTreeWrapCount).toBe(2);
       expect(isrSetSpy).toHaveBeenCalledOnce();
       expect(isrSetSpy.mock.calls[0]?.[1]).toMatchObject({
         kind: "PAGES",

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -18163,33 +18163,46 @@ describe("Pages Router _next/data client navigation", () => {
     const originalFetch = globalThis.fetch;
     let receivedPageContext: Record<string, unknown> | undefined;
 
-    const Page = Object.assign(() => "page", {
-      getInitialProps(context: Record<string, unknown>) {
-        receivedPageContext = context;
-        const AppTree = context.AppTree as (props: Record<string, unknown>) => unknown;
-        return { rendered: AppTree({ pageProps: {} }) };
-      },
-    });
-    const App = Object.assign(({ Component, pageProps }: any) => Component(pageProps), {
-      async getInitialProps(context: { Component: typeof Page; ctx: Record<string, unknown> }) {
-        return { pageProps: context.Component.getInitialProps(context.ctx) };
-      },
-    });
-    const { win } = createDataNavWindow({
-      loaders: {
-        "/": vi.fn(async () => makePageModule("home")),
-        "/about": vi.fn(async () => ({ default: Page })),
-      },
-      appLoader: vi.fn(async () => ({ default: App })),
-      ssgPatterns: [],
-      sspPatterns: [],
-    });
-    (globalThis as any).window = win;
-    globalThis.fetch = vi.fn() as any;
-    vi.resetModules();
-
     try {
-      const Router = (await import("../packages/vinext/src/shims/router.js")).default;
+      const React = await import("react");
+      const { renderToStaticMarkup } = await import("react-dom/server");
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      const Router = routerModule.default;
+      const Page = Object.assign(
+        function Page() {
+          const router = routerModule.useRouter();
+          return React.createElement("p", { id: "route" }, router.pathname);
+        },
+        {
+          getInitialProps(context: Record<string, unknown>) {
+            receivedPageContext = context;
+            const AppTree = context.AppTree as (props: Record<string, unknown>) => unknown;
+            return {
+              rendered: renderToStaticMarkup(AppTree({ pageProps: {} }) as React.ReactElement),
+            };
+          },
+        },
+      );
+      const App = Object.assign(
+        ({ Component, pageProps }: any) => React.createElement(Component, pageProps),
+        {
+          async getInitialProps(context: { Component: typeof Page; ctx: Record<string, unknown> }) {
+            return { pageProps: context.Component.getInitialProps(context.ctx) };
+          },
+        },
+      );
+      const { win } = createDataNavWindow({
+        loaders: {
+          "/": vi.fn(async () => makePageModule("home")),
+          "/about": vi.fn(async () => ({ default: Page })),
+        },
+        appLoader: vi.fn(async () => ({ default: App })),
+        ssgPatterns: [],
+        sspPatterns: [],
+      });
+      (globalThis as any).window = win;
+      globalThis.fetch = vi.fn() as any;
+
       await Router.push("/about");
 
       expect(receivedPageContext).toMatchObject({
@@ -18197,6 +18210,7 @@ describe("Pages Router _next/data client navigation", () => {
         pathname: "/about",
         asPath: "/about",
       });
+      expect(win.__NEXT_DATA__.props.pageProps.rendered).toContain('<p id="route">/about</p>');
       expect(globalThis.fetch).not.toHaveBeenCalled();
     } finally {
       if (previousWindow === undefined) delete (globalThis as any).window;

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -14859,6 +14859,7 @@ describe("Pages Router concurrent navigation", () => {
       },
       __VINEXT_ROOT__: { render },
       __VINEXT_APP__: undefined,
+      __VINEXT_PAGE_COMPONENT__: undefined,
       __VINEXT_LOCALE__: undefined as string | undefined,
       __VINEXT_LOCALES__: undefined as string[] | undefined,
       __VINEXT_DEFAULT_LOCALE__: undefined as string | undefined,
@@ -18062,6 +18063,7 @@ describe("Pages Router _next/data client navigation", () => {
       } as any,
       __VINEXT_ROOT__: { render },
       __VINEXT_APP__: undefined,
+      __VINEXT_PAGE_COMPONENT__: undefined as unknown,
       __VINEXT_LOCALE__: opts.locale,
       __VINEXT_LOCALES__: undefined,
       __VINEXT_DEFAULT_LOCALE__: undefined,
@@ -18215,6 +18217,7 @@ describe("Pages Router _next/data client navigation", () => {
         ssgPatterns: [],
         sspPatterns: [],
       });
+      win.__VINEXT_PAGE_COMPONENT__ = Home;
       (globalThis as any).window = win;
       globalThis.fetch = vi.fn() as any;
 
@@ -18275,6 +18278,7 @@ describe("Pages Router _next/data client navigation", () => {
         ssgPatterns: [],
         sspPatterns: [],
       });
+      win.__VINEXT_PAGE_COMPONENT__ = Home;
       (globalThis as any).window = win;
       globalThis.fetch = vi.fn() as any;
 

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -18158,6 +18158,54 @@ describe("Pages Router _next/data client navigation", () => {
     }
   });
 
+  it("passes AppTree through custom app getInitialProps during no-data navigation", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    let receivedPageContext: Record<string, unknown> | undefined;
+
+    const Page = Object.assign(() => "page", {
+      getInitialProps(context: Record<string, unknown>) {
+        receivedPageContext = context;
+        const AppTree = context.AppTree as (props: Record<string, unknown>) => unknown;
+        return { rendered: AppTree({ pageProps: {} }) };
+      },
+    });
+    const App = Object.assign(({ Component, pageProps }: any) => Component(pageProps), {
+      async getInitialProps(context: { Component: typeof Page; ctx: Record<string, unknown> }) {
+        return { pageProps: context.Component.getInitialProps(context.ctx) };
+      },
+    });
+    const { win } = createDataNavWindow({
+      loaders: {
+        "/": vi.fn(async () => makePageModule("home")),
+        "/about": vi.fn(async () => ({ default: Page })),
+      },
+      appLoader: vi.fn(async () => ({ default: App })),
+      ssgPatterns: [],
+      sspPatterns: [],
+    });
+    (globalThis as any).window = win;
+    globalThis.fetch = vi.fn() as any;
+    vi.resetModules();
+
+    try {
+      const Router = (await import("../packages/vinext/src/shims/router.js")).default;
+      await Router.push("/about");
+
+      expect(receivedPageContext).toMatchObject({
+        AppTree: expect.any(Function),
+        pathname: "/about",
+        asPath: "/about",
+      });
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    } finally {
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+      vi.resetModules();
+    }
+  });
+
   it("does not persist middleware-prefetched SSR data between prefetch and navigation", async () => {
     const previousWindow = (globalThis as any).window;
     const originalDocument = (globalThis as any).document;

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -18158,7 +18158,7 @@ describe("Pages Router _next/data client navigation", () => {
     }
   });
 
-  it("passes AppTree through custom app getInitialProps during no-data navigation", async () => {
+  it("passes the committed AppTree through custom app getInitialProps during no-data navigation", async () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;
     let receivedPageContext: Record<string, unknown> | undefined;
@@ -18168,10 +18168,22 @@ describe("Pages Router _next/data client navigation", () => {
       const { renderToStaticMarkup } = await import("react-dom/server");
       const routerModule = await import("../packages/vinext/src/shims/router.js");
       const Router = routerModule.default;
-      const Page = Object.assign(
-        function Page() {
+      function Home() {
+        const router = routerModule.useRouter();
+        return React.createElement(
+          "p",
+          { id: "route" },
+          `home:${router.pathname}:${router.asPath}`,
+        );
+      }
+      const Another = Object.assign(
+        function Another() {
           const router = routerModule.useRouter();
-          return React.createElement("p", { id: "route" }, router.pathname);
+          return React.createElement(
+            "p",
+            { id: "route" },
+            `another:${router.pathname}:${router.asPath}`,
+          );
         },
         {
           getInitialProps(context: Record<string, unknown>) {
@@ -18186,15 +18198,18 @@ describe("Pages Router _next/data client navigation", () => {
       const App = Object.assign(
         ({ Component, pageProps }: any) => React.createElement(Component, pageProps),
         {
-          async getInitialProps(context: { Component: typeof Page; ctx: Record<string, unknown> }) {
+          async getInitialProps(context: {
+            Component: typeof Another;
+            ctx: Record<string, unknown>;
+          }) {
             return { pageProps: context.Component.getInitialProps(context.ctx) };
           },
         },
       );
       const { win } = createDataNavWindow({
         loaders: {
-          "/": vi.fn(async () => makePageModule("home")),
-          "/about": vi.fn(async () => ({ default: Page })),
+          "/": vi.fn(async () => ({ default: Home })),
+          "/another": vi.fn(async () => ({ default: Another })),
         },
         appLoader: vi.fn(async () => ({ default: App })),
         ssgPatterns: [],
@@ -18203,14 +18218,14 @@ describe("Pages Router _next/data client navigation", () => {
       (globalThis as any).window = win;
       globalThis.fetch = vi.fn() as any;
 
-      await Router.push("/about");
+      await Router.push("/another");
 
       expect(receivedPageContext).toMatchObject({
         AppTree: expect.any(Function),
-        pathname: "/about",
-        asPath: "/about",
+        pathname: "/another",
+        asPath: "/another",
       });
-      expect(win.__NEXT_DATA__.props.pageProps.rendered).toContain('<p id="route">/about</p>');
+      expect(win.__NEXT_DATA__.props.pageProps.rendered).toContain('<p id="route">home:/:/</p>');
       expect(globalThis.fetch).not.toHaveBeenCalled();
     } finally {
       if (previousWindow === undefined) delete (globalThis as any).window;
@@ -18220,35 +18235,42 @@ describe("Pages Router _next/data client navigation", () => {
     }
   });
 
-  it("passes a route-aware AppTree to page getInitialProps during no-data navigation", async () => {
+  it("keeps page getInitialProps AppTree on the committed component and router state", async () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;
-    let receivedPageContext: Record<string, unknown> | undefined;
+    const receivedPageContexts: Record<string, unknown>[] = [];
 
     try {
       const React = await import("react");
       const { renderToStaticMarkup } = await import("react-dom/server");
       const routerModule = await import("../packages/vinext/src/shims/router.js");
       const Router = routerModule.default;
-      const Page = Object.assign(
-        function Page() {
-          const router = routerModule.useRouter();
-          return React.createElement("p", { id: "route" }, router.pathname);
-        },
-        {
-          getInitialProps(context: Record<string, unknown>) {
-            receivedPageContext = context;
-            const AppTree = context.AppTree as (props: Record<string, unknown>) => unknown;
-            return {
-              rendered: renderToStaticMarkup(AppTree({ pageProps: {} }) as React.ReactElement),
-            };
+      const createPage = (name: string) =>
+        Object.assign(
+          function Page() {
+            const router = routerModule.useRouter();
+            return React.createElement(
+              "p",
+              { id: "route" },
+              `${name}:${router.pathname}:${router.asPath}`,
+            );
           },
-        },
-      );
+          {
+            getInitialProps(context: Record<string, unknown>) {
+              receivedPageContexts.push(context);
+              const AppTree = context.AppTree as (props: Record<string, unknown>) => unknown;
+              return {
+                rendered: renderToStaticMarkup(AppTree({ pageProps: {} }) as React.ReactElement),
+              };
+            },
+          },
+        );
+      const Home = createPage("home");
+      const Another = createPage("another");
       const { win } = createDataNavWindow({
         loaders: {
-          "/": vi.fn(async () => makePageModule("home")),
-          "/about": vi.fn(async () => ({ default: Page })),
+          "/": vi.fn(async () => ({ default: Home })),
+          "/another": vi.fn(async () => ({ default: Another })),
         },
         ssgPatterns: [],
         sspPatterns: [],
@@ -18256,14 +18278,25 @@ describe("Pages Router _next/data client navigation", () => {
       (globalThis as any).window = win;
       globalThis.fetch = vi.fn() as any;
 
-      await Router.push("/about");
+      await Router.push("/another");
 
-      expect(receivedPageContext).toMatchObject({
+      expect(receivedPageContexts[0]).toMatchObject({
         AppTree: expect.any(Function),
-        pathname: "/about",
-        asPath: "/about",
+        pathname: "/another",
+        asPath: "/another",
       });
-      expect(win.__NEXT_DATA__.props.pageProps.rendered).toContain('<p id="route">/about</p>');
+      expect(win.__NEXT_DATA__.props.pageProps.rendered).toContain('<p id="route">home:/:/</p>');
+
+      await Router.push("/");
+
+      expect(receivedPageContexts[1]).toMatchObject({
+        AppTree: expect.any(Function),
+        pathname: "/",
+        asPath: "/",
+      });
+      expect(win.__NEXT_DATA__.props.pageProps.rendered).toContain(
+        '<p id="route">another:/another:/another</p>',
+      );
       expect(globalThis.fetch).not.toHaveBeenCalled();
     } finally {
       if (previousWindow === undefined) delete (globalThis as any).window;

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -18220,6 +18220,59 @@ describe("Pages Router _next/data client navigation", () => {
     }
   });
 
+  it("passes a route-aware AppTree to page getInitialProps during no-data navigation", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    let receivedPageContext: Record<string, unknown> | undefined;
+
+    try {
+      const React = await import("react");
+      const { renderToStaticMarkup } = await import("react-dom/server");
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      const Router = routerModule.default;
+      const Page = Object.assign(
+        function Page() {
+          const router = routerModule.useRouter();
+          return React.createElement("p", { id: "route" }, router.pathname);
+        },
+        {
+          getInitialProps(context: Record<string, unknown>) {
+            receivedPageContext = context;
+            const AppTree = context.AppTree as (props: Record<string, unknown>) => unknown;
+            return {
+              rendered: renderToStaticMarkup(AppTree({ pageProps: {} }) as React.ReactElement),
+            };
+          },
+        },
+      );
+      const { win } = createDataNavWindow({
+        loaders: {
+          "/": vi.fn(async () => makePageModule("home")),
+          "/about": vi.fn(async () => ({ default: Page })),
+        },
+        ssgPatterns: [],
+        sspPatterns: [],
+      });
+      (globalThis as any).window = win;
+      globalThis.fetch = vi.fn() as any;
+
+      await Router.push("/about");
+
+      expect(receivedPageContext).toMatchObject({
+        AppTree: expect.any(Function),
+        pathname: "/about",
+        asPath: "/about",
+      });
+      expect(win.__NEXT_DATA__.props.pageProps.rendered).toContain('<p id="route">/about</p>');
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    } finally {
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+      vi.resetModules();
+    }
+  });
+
   it("does not persist middleware-prefetched SSR data between prefetch and navigation", async () => {
     const previousWindow = (globalThis as any).window;
     const originalDocument = (globalThis as any).document;


### PR DESCRIPTION
## Summary

- pass the Pages `AppTree` renderer through the nested `NextPageContext` supplied to `_app.getInitialProps`
- keep development and production Pages rendering behavior aligned
- add focused regression coverage for `_app` forwarding `ctx` to `Page.getInitialProps`

## Root cause

Next.js includes `AppTree` both on the outer `AppContext` and the nested `ctx` passed to `_app.getInitialProps`. Vinext only populated the outer field. Custom apps that call `Component.getInitialProps(ctx)` therefore forwarded a context without `AppTree`, causing page-level rendering through `AppTree` to throw.

## Next.js parity

Fixes run 28938793088:

- `test/e2e/app-tree/app-tree.test.ts` — `should pass AppTree to NextPageContext`

Oracle: Next.js `v16.3.0-canary.80` at `9dd6d677b63b249584c8ff0bccffcc6a65288683`.

## Validation

- `vp test run tests/pages-page-data.test.ts tests/pages-get-initial-props.test.ts` — 63 passed
- `vp check packages/vinext/src/server/pages-page-data.ts packages/vinext/src/server/pages-get-initial-props.ts tests/pages-page-data.test.ts tests/pages-get-initial-props.test.ts` — clean
- `vp run vinext#build` — passed
- `NEXTJS_DIR=/Users/jamesanderson/Developer/vinext/.nextjs-ref-v16.3.0-canary.80 VINEXT_BUILD=0 REPO=$PWD ./scripts/run-targeted-nextjs-e2e.sh test/e2e/app-tree/app-tree.test.ts` — 3 passed

## Separate backlog

`test/e2e/no-page-props/no-page-props.test.ts` remains queued separately. Its custom `_app` 404 visibility failures are not demonstrably caused by the missing nested `AppTree`, so they are intentionally excluded from this PR.

Bonk has not been requested yet.