### PR TITLE
perf(build): use native typeof window folding

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -236,7 +236,6 @@ import { createHash, randomBytes, randomUUID } from "node:crypto";
 import commonjs from "vite-plugin-commonjs";
 import { createIgnoreDynamicRequestsPlugin } from "./plugins/ignore-dynamic-requests.js";
 import { stripJsExtension, stripViteModuleQuery } from "./utils/path.js";
-import { escapeRegExp } from "./utils/regex.js";
 import {
   assertSupportedViteVersion,
   getDepOptimizeNodeEnvOptions,
@@ -277,11 +276,6 @@ const ANSI_ESCAPE_RE = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g");
 installSocketErrorBackstop();
 
 type ASTNode = ReturnType<typeof parseAst>["body"][number]["parent"];
-
-function getCacheDirPrefix(cacheDir: string): string {
-  const normalizedCacheDir = toSlash(cacheDir);
-  return normalizedCacheDir.endsWith("/") ? normalizedCacheDir : `${normalizedCacheDir}/`;
-}
 
 function isInsideDirectory(dir: string, filePath: string): boolean {
   const relativePath = path.relative(dir, filePath);
@@ -1337,10 +1331,6 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
   // `configResolved` binds the resolved config, so multiple vinext builds in
   // one process never preprocess `composes` deps with another build's config.
   const sassComposesLoader = createSassAwareFileSystemLoader();
-
-  // Populated from the resolved Vite config before transform filters are
-  // compiled, while keeping the filter object referenced by the plugin stable.
-  const typeofWindowIdFilter = { exclude: /(?!)/ };
 
   // Build-time layout classification manifest, captured in the RSC virtual
   // module's load hook and consumed in renderChunk to patch the generated
@@ -3279,8 +3269,6 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
       },
 
       async configResolved(config) {
-        const cacheDirPrefix = getCacheDirPrefix(config.cacheDir);
-        typeofWindowIdFilter.exclude = new RegExp(`^${escapeRegExp(cacheDirPrefix)}`);
         if (isServeCommand && hasCloudflarePlugin && hasPagesDir && !hasAppDir) {
           suppressOptionalOptimizeDepsWarnings(config.logger);
         }
@@ -5429,22 +5417,29 @@ export const loadServerActionClient = ${
         },
       },
     },
-    // Fold `typeof window` like Next.js before Rolldown resolves imports. This
-    // removes browser-only dynamic imports from server bundles before package
-    // conditional exports are evaluated.
     {
       name: "vinext:typeof-window",
+      configEnvironment(_name, environment) {
+        return {
+          define: {
+            "typeof window": environment.consumer === "client" ? '"object"' : '"undefined"',
+          },
+        };
+      },
+    },
+    // plugin-RSC's analysis builds replace each module with lexer-discovered
+    // imports before Rolldown's native define folding runs. Fold only in those
+    // write-less analysis builds so dead browser/server imports are absent from
+    // the synthetic graph; real builds continue to use native Oxc folding.
+    {
+      name: "vinext:typeof-window-scan",
       enforce: "post",
       transform: {
-        filter: {
-          id: typeofWindowIdFilter,
-          code: /typeof\s+window/,
-        },
+        filter: { code: /\btypeof\s+window\b/ },
         handler(code, id) {
-          const cacheDirPrefix = getCacheDirPrefix(this.environment.config.cacheDir);
-          if (toSlash(id).startsWith(cacheDirPrefix)) {
-            return null;
-          }
+          if (this.environment.config.build.write !== false) return null;
+          const cacheDir = `${toSlash(this.environment.config.cacheDir).replace(/\/$/, "")}/`;
+          if (toSlash(id).startsWith(cacheDir)) return null;
           return replaceTypeofWindow(code, getTypeofWindowReplacement(this.environment), id);
         },
       },

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -5433,6 +5433,7 @@ export const loadServerActionClient = ${
     // the synthetic graph; real builds continue to use native Oxc folding.
     {
       name: "vinext:typeof-window-scan",
+      apply: "build",
       enforce: "post",
       transform: {
         filter: { code: /\btypeof\s+window\b/ },

--- a/tests/type-of-window.test.ts
+++ b/tests/type-of-window.test.ts
@@ -6,13 +6,12 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vite-plus/test";
-import { createBuilder, createServer } from "vite";
+import { createBuilder } from "vite";
 import vinext from "../packages/vinext/src/index.js";
 import {
   getTypeofWindowReplacement,
   replaceTypeofWindow,
 } from "../packages/vinext/src/plugins/typeof-window.js";
-import { toSlash } from "pathslash";
 
 const temporaryDirectories: string[] = [];
 
@@ -25,73 +24,21 @@ afterEach(async () => {
 });
 
 describe("typeof window compilation", () => {
-  it("does not fold prebundles when plugin instances are reused across servers", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-typeof-window-reuse-"));
+  it("configures native typeof window folding per environment", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-typeof-window-define-"));
     temporaryDirectories.push(root);
-    const plugins = [vinext({ react: false, rsc: false })];
-    const transform = async (server: Awaited<ReturnType<typeof createServer>>, id: string) => {
-      const source = `export const browser = typeof window !== "undefined"`;
-      try {
-        return (await server.pluginContainer.transform(source, id))?.code;
-      } catch (error) {
-        const viteError = error as { code?: string; pluginCode?: string };
-        if (viteError.code !== "ERR_OUTDATED_OPTIMIZED_DEP") throw error;
-        return viteError.pluginCode;
-      }
-    };
-
-    for (const name of ["first-cache", "second-cache"]) {
-      const cacheDir = path.join(root, name);
-      const server = await createServer({
-        root,
-        cacheDir,
-        configFile: false,
-        logLevel: "silent",
-        plugins,
-      });
-
-      try {
-        const prebundleId = path.join(cacheDir, "deps_ssr/react.js");
-        const prebundleCode = await transform(server, prebundleId);
-        expect(prebundleCode).toContain("typeof window");
-
-        const sourceCode = await transform(server, path.join(root, `${name}.js`));
-        expect(sourceCode).not.toContain("typeof window");
-      } finally {
-        await server.close();
-      }
-    }
-  });
-
-  it("configures the hook filter to skip the resolved Vite cache directory", async () => {
-    // Normalize the root to forward slashes up front so everything below stays
-    // in the same POSIX space the plugin's exclude regex (and Vite's ids) use.
-    const root = toSlash(await fs.mkdtemp(path.join(os.tmpdir(), "vinext-typeof-window-filter-")));
-    temporaryDirectories.push(root);
-    const cacheDir = path.posix.join(root, ".vite-cache[custom]");
-    const server = await createServer({
+    const builder = await createBuilder({
       root,
-      cacheDir,
       configFile: false,
       logLevel: "silent",
+      environments: {
+        server: { consumer: "server" },
+      },
       plugins: [vinext({ react: false, rsc: false })],
     });
 
-    try {
-      const plugin = server.config.plugins.find(
-        (candidate) => candidate?.name === "vinext:typeof-window",
-      );
-      if (!plugin?.transform || typeof plugin.transform === "function") {
-        throw new Error("vinext:typeof-window transform hook not found");
-      }
-      const idFilter = plugin.transform.filter?.id as { exclude?: RegExp } | undefined;
-      expect(idFilter?.exclude).toBeInstanceOf(RegExp);
-      expect(idFilter?.exclude?.test(path.posix.join(cacheDir, "deps_ssr/react.js"))).toBe(true);
-      expect(idFilter?.exclude?.test(path.posix.join(root, "app/page.js"))).toBe(false);
-      expect(idFilter?.exclude?.test(`${cacheDir}-other/deps/react.js`)).toBe(false);
-    } finally {
-      await server.close();
-    }
+    expect(builder.environments.client?.config.define?.["typeof window"]).toBe('"object"');
+    expect(builder.environments.server?.config.define?.["typeof window"]).toBe('"undefined"');
   });
 
   it("only folds references to the global window binding", () => {

--- a/tests/type-of-window.test.ts
+++ b/tests/type-of-window.test.ts
@@ -41,6 +41,44 @@ describe("typeof window compilation", () => {
     expect(builder.environments.server?.config.define?.["typeof window"]).toBe('"undefined"');
   });
 
+  it("skips custom scan folding for modules in the Vite cache directory", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-typeof-window-cache-"));
+    temporaryDirectories.push(root);
+    const cacheDir = path.join(root, ".vite-cache[custom]");
+    const builder = await createBuilder({
+      root,
+      cacheDir,
+      configFile: false,
+      logLevel: "silent",
+      plugins: [vinext({ react: false, rsc: false })],
+    });
+    const plugin = builder.config.plugins.find(
+      (candidate) => candidate.name === "vinext:typeof-window-scan",
+    );
+    if (!plugin?.transform || typeof plugin.transform === "function") {
+      throw new Error("vinext:typeof-window-scan transform hook not found");
+    }
+
+    const transform = plugin.transform.handler;
+    const context = {
+      environment: {
+        config: {
+          build: { write: false },
+          cacheDir,
+          consumer: "server",
+        },
+      },
+    };
+    const source = `if (typeof window !== "undefined") import("browser-only")`;
+
+    expect(
+      await transform.call(context as never, source, path.join(cacheDir, "deps_ssr/react.js")),
+    ).toBeNull();
+    expect(
+      await transform.call(context as never, source, path.join(root, "app/page.js")),
+    ).not.toBeNull();
+  });
+
   it("only folds references to the global window binding", () => {
     const source = `
 if (typeof window !== "undefined") globalBrowserOnly()


### PR DESCRIPTION
## Summary

- configure native per-environment `typeof window` defines so real client/server builds use Oxc/Rolldown folding
- retain vinext's scope-aware fold only for plugin-RSC's write-less analysis builds, where the lexer replaces source before native define folding runs
- remove the broad custom transform and its mutable cache-directory hook filter

## Performance

The custom AST fold no longer runs for normal production modules. It is limited to plugin-RSC's two analysis builds and is invoked only for modules matching the native `typeof window` hook filter.

Same-worktree hyperfine A/B on the action fixture showed no regression; the analysis fold trended 5-8% faster because dead imports were omitted from the synthetic scan graph.

## Validation

- `pnpm exec vitest run tests/type-of-window.test.ts`
- 10 tests passed
