### PR TITLE
fix(pages): normalize i18n router URLs

### DIFF
--- a/packages/vinext/src/client/pages-router-link-navigation.ts
+++ b/packages/vinext/src/client/pages-router-link-navigation.ts
@@ -45,7 +45,7 @@ export function resolvePagesRouterQueryOnlyHref(
     locales?: readonly string[];
   },
 ): string {
-  if (!href.startsWith("?")) return href;
+  if (!href.startsWith("?") && !href.startsWith("#")) return href;
 
   try {
     const fallbackUrl = new URL(fallbackHref);

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -1678,6 +1678,11 @@ export async function resolveNextConfig(
   let i18n: NextI18nConfig | null = null;
   if (config.i18n) {
     const { defaultLocale } = config.i18n;
+    if (!config.i18n.locales.includes(defaultLocale)) {
+      throw new Error(
+        "Specified i18n.defaultLocale should be included in i18n.locales.\nSee more info here: https://nextjs.org/docs/messages/invalid-i18n-config",
+      );
+    }
     const locales = [
       defaultLocale,
       ...config.i18n.locales.filter((locale) => locale !== defaultLocale),

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -1448,7 +1448,10 @@ function normalizeI18nConfig(value: unknown): NextI18nConfig | null {
 
           for (const domainItem of i18n.domains as unknown[]) {
             if (domainItem === item || !isUnknownRecord(domainItem)) continue;
-            if (Array.isArray(domainItem.locales) && domainItem.locales.includes(locale)) {
+            const domainLocales = domainItem.locales as
+              | { includes(value: unknown): boolean }
+              | undefined;
+            if (domainLocales && domainLocales.includes(locale)) {
               console.warn(
                 `Both ${item.domain} and ${String(domainItem.domain)} configured the locale (${String(locale)}) but only one can. Remove it from one i18n.domains config to continue`,
               );

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -1381,6 +1381,137 @@ function normalizePrefetchInliningConfig(value: unknown): PrefetchInliningConfig
   };
 }
 
+function normalizeI18nConfig(value: unknown): NextI18nConfig | null {
+  if (!value) return null;
+
+  const i18nType = typeof value;
+  if (i18nType !== "object") {
+    throw new Error(
+      `Specified i18n should be an object received ${i18nType}.\nSee more info here: https://nextjs.org/docs/messages/invalid-i18n-config`,
+    );
+  }
+
+  const i18n = value as Record<string, unknown>;
+  if (!Array.isArray(i18n.locales)) {
+    throw new Error(
+      `Specified i18n.locales should be an Array received ${typeof i18n.locales}.\nSee more info here: https://nextjs.org/docs/messages/invalid-i18n-config`,
+    );
+  }
+
+  if (i18n.locales.length > 100) {
+    console.warn(
+      `Received ${i18n.locales.length} i18n.locales items which exceeds the recommended max of 100.\nSee more info here: https://nextjs.org/docs/advanced-features/i18n-routing#how-does-this-work-with-static-generation`,
+    );
+  }
+
+  if (!i18n.defaultLocale || typeof i18n.defaultLocale !== "string") {
+    throw new Error(
+      "Specified i18n.defaultLocale should be a string.\nSee more info here: https://nextjs.org/docs/messages/invalid-i18n-config",
+    );
+  }
+
+  if (i18n.domains !== undefined && !Array.isArray(i18n.domains)) {
+    throw new Error(
+      `Specified i18n.domains must be an array of domain objects e.g. [ { domain: 'example.fr', defaultLocale: 'fr', locales: ['fr'] } ] received ${typeof i18n.domains}.\nSee more info here: https://nextjs.org/docs/messages/invalid-i18n-config`,
+    );
+  }
+
+  if (i18n.domains) {
+    const invalidDomainItems = i18n.domains.filter((item) => {
+      if (!isUnknownRecord(item) || !item.defaultLocale) return true;
+      if (!item.domain || typeof item.domain !== "string") return true;
+
+      if (item.domain.includes(":")) {
+        console.warn(
+          `i18n domain: "${item.domain}" is invalid it should be a valid domain without protocol (https://) or port (:3000) e.g. example.vercel.sh`,
+        );
+        return true;
+      }
+
+      const defaultLocaleDuplicate = (i18n.domains as unknown[]).find(
+        (other) =>
+          isUnknownRecord(other) &&
+          other.defaultLocale === item.defaultLocale &&
+          other.domain !== item.domain,
+      );
+      if (defaultLocaleDuplicate && isUnknownRecord(defaultLocaleDuplicate)) {
+        console.warn(
+          `Both ${item.domain} and ${String(defaultLocaleDuplicate.domain)} configured the defaultLocale ${item.defaultLocale as string} but only one can. Change one item's default locale to continue`,
+        );
+        return true;
+      }
+
+      let hasInvalidLocale = false;
+      if (Array.isArray(item.locales)) {
+        for (const locale of item.locales) {
+          if (typeof locale !== "string") hasInvalidLocale = true;
+
+          for (const domainItem of i18n.domains as unknown[]) {
+            if (domainItem === item || !isUnknownRecord(domainItem)) continue;
+            if (Array.isArray(domainItem.locales) && domainItem.locales.includes(locale)) {
+              console.warn(
+                `Both ${item.domain} and ${String(domainItem.domain)} configured the locale (${String(locale)}) but only one can. Remove it from one i18n.domains config to continue`,
+              );
+              hasInvalidLocale = true;
+              break;
+            }
+          }
+        }
+      }
+
+      return hasInvalidLocale;
+    });
+
+    if (invalidDomainItems.length > 0) {
+      throw new Error(
+        `Invalid i18n.domains values:\n${invalidDomainItems.map((item) => JSON.stringify(item)).join("\n")}\n\ndomains value must follow format { domain: 'example.fr', defaultLocale: 'fr', locales: ['fr'] }.\nSee more info here: https://nextjs.org/docs/messages/invalid-i18n-config`,
+      );
+    }
+  }
+
+  const invalidLocales = i18n.locales.filter((locale) => typeof locale !== "string");
+  if (invalidLocales.length > 0) {
+    throw new Error(
+      `Specified i18n.locales contains invalid values (${invalidLocales.map(String).join(", ")}), locales must be valid locale tags provided as strings e.g. "en-US".\n` +
+        "See here for list of valid language sub-tags: http://www.iana.org/assignments/language-subtag-registry/language-subtag-registry",
+    );
+  }
+
+  const locales = i18n.locales as string[];
+  if (!locales.includes(i18n.defaultLocale)) {
+    throw new Error(
+      "Specified i18n.defaultLocale should be included in i18n.locales.\nSee more info here: https://nextjs.org/docs/messages/invalid-i18n-config",
+    );
+  }
+
+  const normalizedLocales = new Set<string>();
+  const duplicateLocales = new Set<string>();
+  for (const locale of locales) {
+    const localeLower = locale.toLowerCase();
+    if (normalizedLocales.has(localeLower)) duplicateLocales.add(locale);
+    normalizedLocales.add(localeLower);
+  }
+  if (duplicateLocales.size > 0) {
+    throw new Error(
+      `Specified i18n.locales contains the following duplicate locales:\n${[...duplicateLocales].join(", ")}\nEach locale should be listed only once.\nSee more info here: https://nextjs.org/docs/messages/invalid-i18n-config`,
+    );
+  }
+
+  const localeDetectionType = typeof i18n.localeDetection;
+  if (localeDetectionType !== "boolean" && localeDetectionType !== "undefined") {
+    throw new Error(
+      `Specified i18n.localeDetection should be undefined or a boolean received ${localeDetectionType}.\nSee more info here: https://nextjs.org/docs/messages/invalid-i18n-config`,
+    );
+  }
+
+  return {
+    locales: [i18n.defaultLocale, ...locales.filter((locale) => locale !== i18n.defaultLocale)],
+    defaultLocale: i18n.defaultLocale,
+    localeDetection: (i18n.localeDetection as boolean | undefined) ?? true,
+    domains: i18n.domains as NextI18nConfig["domains"],
+  };
+}
+
 /**
  * Resolve a NextConfig into a fully-resolved ResolvedNextConfig.
  * Awaits async functions for redirects/rewrites/headers.
@@ -1451,6 +1582,8 @@ export async function resolveNextConfig(
   }
 
   warnDeprecatedConfigOptions(config, root);
+
+  const i18n = normalizeI18nConfig(config.i18n);
 
   // Resolve redirects
   let redirects: NextRedirect[] = [];
@@ -1673,27 +1806,6 @@ export async function resolveNextConfig(
     : Array.isArray(experimentalTurbo?.resolveExtensions)
       ? readStringArray(experimentalTurbo.resolveExtensions)
       : null;
-
-  // Parse i18n config
-  let i18n: NextI18nConfig | null = null;
-  if (config.i18n) {
-    const { defaultLocale } = config.i18n;
-    if (!config.i18n.locales.includes(defaultLocale)) {
-      throw new Error(
-        "Specified i18n.defaultLocale should be included in i18n.locales.\nSee more info here: https://nextjs.org/docs/messages/invalid-i18n-config",
-      );
-    }
-    const locales = [
-      defaultLocale,
-      ...config.i18n.locales.filter((locale) => locale !== defaultLocale),
-    ];
-    i18n = {
-      locales,
-      defaultLocale,
-      localeDetection: config.i18n.localeDetection ?? true,
-      domains: config.i18n.domains,
-    };
-  }
 
   const buildId = await resolveBuildId(config.generateBuildId);
   const deploymentId = resolveDeploymentId(config.deploymentId);

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -1677,9 +1677,14 @@ export async function resolveNextConfig(
   // Parse i18n config
   let i18n: NextI18nConfig | null = null;
   if (config.i18n) {
+    const { defaultLocale } = config.i18n;
+    const locales = [
+      defaultLocale,
+      ...config.i18n.locales.filter((locale) => locale !== defaultLocale),
+    ];
     i18n = {
-      locales: config.i18n.locales,
-      defaultLocale: config.i18n.defaultLocale,
+      locales,
+      defaultLocale,
       localeDetection: config.i18n.localeDetection ?? true,
       domains: config.i18n.domains,
     };

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -732,7 +732,11 @@ export function createSSRHandler(
     const parsedResolvedUrl = new URL(localeStrippedUrl, "http://vinext.local");
     const originalRequestSearch = new URL(originalUrl, "http://vinext.local").search;
     const gsspResolvedUrl = parsedResolvedUrl.pathname + originalRequestSearch;
-    const requestAsPath = isDataReq ? gsspResolvedUrl : originalUrl;
+    const requestAsPath = isDataReq
+      ? gsspResolvedUrl
+      : i18nConfig
+        ? extractLocaleFromUrlShared(originalUrl, i18nConfig, locale).url
+        : originalUrl;
     // Next.js exposes `params: null` to data-fetching contexts (gSSP, gSP) on
     // non-dynamic routes — see render.tsx's `...(pageIsDynamic ? { params } : undefined)`.
     // Internal use (query merging, _app router context) keeps the matched

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -15,7 +15,7 @@
 import type { ComponentType, ReactNode } from "react";
 import { mergeRouteParamsIntoQuery, parseQueryString as parseQuery } from "../utils/query.js";
 import { patternToNextFormat } from "../routing/route-validation.js";
-import { resolvePagesI18nRequest } from "./pages-i18n.js";
+import { extractLocaleFromUrl, resolvePagesI18nRequest } from "./pages-i18n.js";
 import { createPagesReqRes, getPagesPreviewData } from "./pages-node-compat.js";
 import { resolvePagesPageData } from "./pages-page-data.js";
 import type { PagesPageModule } from "./pages-page-data.js";
@@ -428,6 +428,9 @@ export function createPagesPageHandler(
     }
 
     const { route, params } = match;
+    const routerAsPath = i18nConfig
+      ? extractLocaleFromUrl(renderAsPath ?? routeUrl, i18nConfig, locale).url
+      : (renderAsPath ?? routeUrl);
     const uCtx = createRequestContext({
       executionContext: getRequestExecutionContext(),
     });
@@ -455,7 +458,7 @@ export function createPagesPageHandler(
           typeof getPagesNavigationIsReadyFromSerializedState === "function"
             ? getPagesNavigationIsReadyFromSerializedState(
                 routePattern,
-                new URL(renderAsPath ?? routeUrl, "http://_").search,
+                new URL(routerAsPath, "http://_").search,
                 pagesNextData,
               )
             : true;
@@ -465,7 +468,7 @@ export function createPagesPageHandler(
             setSSRContext({
               pathname: routePattern,
               query,
-              asPath: renderAsPath ?? routeUrl,
+              asPath: routerAsPath,
               navigationIsReady,
               locale,
               locales: i18nConfig ? i18nConfig.locales : undefined,
@@ -610,7 +613,7 @@ export function createPagesPageHandler(
           AppComponent,
           params,
           query,
-          asPath: renderAsPath ?? routeUrl,
+          asPath: routerAsPath,
           resolvedUrl: pagesResolvedUrl,
           renderIsrPassToStringAsync,
           route: { isDynamic: route.isDynamic },
@@ -642,7 +645,7 @@ export function createPagesPageHandler(
           if (notFoundRoute && routePattern !== "/404" && routePattern !== "/_error") {
             return renderPage(request, url, manifest, middlewareHeaders, {
               statusCode: 404,
-              asPath: renderAsPath ?? routeUrl,
+              asPath: routerAsPath,
               renderErrorPageOnMiss: false,
               __forcedRoute: notFoundRoute,
             });
@@ -673,7 +676,7 @@ export function createPagesPageHandler(
           setSSRContext({
             pathname: routePattern,
             query,
-            asPath: renderAsPath ?? routeUrl,
+            asPath: routerAsPath,
             navigationIsReady: false,
             locale,
             locales: i18nConfig ? i18nConfig.locales : undefined,

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -1138,8 +1138,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
   // shared/lib/router/router.ts around L987).
   const unresolvedHref = as ?? resolveHref(href);
   const rawResolvedHref =
-    typeof unresolvedHref === "string" &&
-    (unresolvedHref.startsWith("?") || unresolvedHref.startsWith("#"))
+    typeof unresolvedHref === "string" && unresolvedHref.startsWith("#")
       ? resolvePagesQueryOnlyHref(unresolvedHref)
       : unresolvedHref;
   const concreteRouteHref = HAS_PAGES_ROUTER ? resolveConcreteRouteHref(href, as) : null;

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -77,7 +77,7 @@ type NavigateEvent = {
 const HAS_PAGES_ROUTER = process.env.__VINEXT_HAS_PAGES_ROUTER !== "false";
 
 type LinkProps = {
-  href: string | { pathname?: string; query?: UrlQuery };
+  href: string | { pathname?: string; query?: UrlQuery; hash?: string };
   /** URL displayed in the browser (when href is a route pattern like /user/[id]) */
   as?: string;
   /** Replace the current history entry instead of pushing */
@@ -177,6 +177,9 @@ function resolveHref(href: LinkProps["href"]): string {
   if (href.query) {
     const params = urlQueryToSearchParams(href.query);
     url = appendSearchParamsToUrl(url, params);
+  }
+  if (href.hash) {
+    url += href.hash.startsWith("#") ? href.hash : `#${href.hash}`;
   }
   return url;
 }

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -1136,15 +1136,10 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
   // Mirrors Next.js' Router.change(): `getRouteRegex` + `interpolateAs`
   // computes `resolvedAs` for the dynamic-route branch (packages/next/src/
   // shared/lib/router/router.ts around L987).
-  const isHashOnlyUrlObject =
-    typeof href !== "string" &&
-    href.pathname === undefined &&
-    href.query === undefined &&
-    typeof href.hash === "string" &&
-    href.hash.length > 0;
   const unresolvedHref = as ?? resolveHref(href);
   const rawResolvedHref =
-    isHashOnlyUrlObject && typeof unresolvedHref === "string"
+    typeof unresolvedHref === "string" &&
+    (unresolvedHref.startsWith("?") || unresolvedHref.startsWith("#"))
       ? resolvePagesQueryOnlyHref(unresolvedHref)
       : unresolvedHref;
   const concreteRouteHref = HAS_PAGES_ROUTER ? resolveConcreteRouteHref(href, as) : null;

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -186,7 +186,9 @@ function resolveHref(href: LinkProps["href"]): string {
 
 function resolvePagesQueryOnlyHref(href: string): string {
   if (!HAS_PAGES_ROUTER) return href;
-  if (!href.startsWith("?") || typeof window === "undefined") return href;
+  if ((!href.startsWith("?") && !href.startsWith("#")) || typeof window === "undefined") {
+    return href;
+  }
 
   const pagesRouter = window.next?.appDir === true ? undefined : window.next?.router;
   const visibleHref =
@@ -1134,7 +1136,17 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
   // Mirrors Next.js' Router.change(): `getRouteRegex` + `interpolateAs`
   // computes `resolvedAs` for the dynamic-route branch (packages/next/src/
   // shared/lib/router/router.ts around L987).
-  const rawResolvedHref = as ?? resolveHref(href);
+  const isHashOnlyUrlObject =
+    typeof href !== "string" &&
+    href.pathname === undefined &&
+    href.query === undefined &&
+    typeof href.hash === "string" &&
+    href.hash.length > 0;
+  const unresolvedHref = as ?? resolveHref(href);
+  const rawResolvedHref =
+    isHashOnlyUrlObject && typeof unresolvedHref === "string"
+      ? resolvePagesQueryOnlyHref(unresolvedHref)
+      : unresolvedHref;
   const concreteRouteHref = HAS_PAGES_ROUTER ? resolveConcreteRouteHref(href, as) : null;
   const routeHrefRaw = concreteRouteHref ?? (typeof href === "string" ? href : resolveHref(href));
 

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -1264,10 +1264,11 @@ function getPathnameAndQuery(): {
     return { pathname: "/", query: {}, asPath: "/" };
   }
   const resolvedPath = stripBasePath(window.location.pathname, __basePath);
+  const canonicalResolvedPath = removeNavigationLocalePrefix(resolvedPath);
   // In Next.js, router.pathname is the route pattern (e.g., "/posts/[id]"),
   // not the resolved path ("/posts/42"). __NEXT_DATA__.page holds the route
   // pattern and is updated by navigateClient() on every client-side navigation.
-  const pathname = window.__NEXT_DATA__?.page ?? resolvedPath;
+  const pathname = window.__NEXT_DATA__?.page ?? canonicalResolvedPath;
   const nextData = window.__NEXT_DATA__;
   const routeQuery = getRouteQueryFromNextData(nextData, resolvedPath);
   // URL search params always reflect the current URL
@@ -1279,7 +1280,8 @@ function getPathnameAndQuery(): {
   const query = { ...searchQuery, ...routeQuery };
   // asPath uses the resolved browser path, not the route pattern
   const asPath =
-    getCurrentHistoryAsPath() ?? resolvedPath + window.location.search + window.location.hash;
+    getCurrentHistoryAsPath() ??
+    canonicalResolvedPath + window.location.search + window.location.hash;
   return { pathname, query, asPath };
 }
 
@@ -1289,15 +1291,19 @@ function getCurrentHistoryAsPath(): string | null {
 
   try {
     const browserUrl = new URL(window.location.href);
+    const stateLocale = state.options.locale === false ? undefined : state.options.locale;
+    const localizedStateAs = applyNavigationLocale(state.as, stateLocale);
     const stateUrl = new URL(
-      toBrowserNavigationHref(state.as, window.location.href, __basePath),
+      toBrowserNavigationHref(localizedStateAs, window.location.href, __basePath),
       window.location.href,
     );
     if (stateUrl.pathname !== browserUrl.pathname || stateUrl.search !== browserUrl.search) {
       return null;
     }
-    const stateAs = stripHash(state.as);
-    const visibleAs = `${stripBasePath(window.location.pathname, __basePath)}${window.location.search}`;
+    const stateAs = removeNavigationLocalePrefix(stripHash(state.as));
+    const visibleAs = `${removeNavigationLocalePrefix(
+      stripBasePath(window.location.pathname, __basePath),
+    )}${window.location.search}`;
     return `${stateAs || visibleAs}${window.location.hash}`;
   } catch {
     return null;

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -913,6 +913,22 @@ describe("i18n config parsing", () => {
     expect(config.i18n!.localeDetection).toBe(true);
   });
 
+  it("places the default locale first without mutating the input", async () => {
+    // Ported from Next.js: test/e2e/i18n-support-catchall/i18n-support-catchall.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/i18n-support-catchall/i18n-support-catchall.test.ts
+    const { resolveNextConfig } = await import("../packages/vinext/src/config/next-config.js");
+    const locales = ["nl-NL", "nl-BE", "nl", "fr-BE", "fr", "en-US", "en"];
+    const config = await resolveNextConfig({
+      i18n: {
+        locales,
+        defaultLocale: "en-US",
+      },
+    });
+
+    expect(config.i18n!.locales).toEqual(["en-US", "nl-NL", "nl-BE", "nl", "fr-BE", "fr", "en"]);
+    expect(locales).toEqual(["nl-NL", "nl-BE", "nl", "fr-BE", "fr", "en-US", "en"]);
+  });
+
   it("returns null i18n when not configured", async () => {
     const { resolveNextConfig } = await import("../packages/vinext/src/config/next-config.js");
     const config = await resolveNextConfig({});

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -929,6 +929,23 @@ describe("i18n config parsing", () => {
     expect(locales).toEqual(["nl-NL", "nl-BE", "nl", "fr-BE", "fr", "en-US", "en"]);
   });
 
+  it("rejects a default locale that is not included in locales", async () => {
+    // Ported from Next.js: packages/next/src/server/config.ts
+    // https://github.com/vercel/next.js/blob/v16.3.0-canary.80/packages/next/src/server/config.ts
+    const { resolveNextConfig } = await import("../packages/vinext/src/config/next-config.js");
+
+    await expect(
+      resolveNextConfig({
+        i18n: {
+          locales: ["fr"],
+          defaultLocale: "en",
+        },
+      }),
+    ).rejects.toThrow(
+      "Specified i18n.defaultLocale should be included in i18n.locales.\nSee more info here: https://nextjs.org/docs/messages/invalid-i18n-config",
+    );
+  });
+
   it("returns null i18n when not configured", async () => {
     const { resolveNextConfig } = await import("../packages/vinext/src/config/next-config.js");
     const config = await resolveNextConfig({});

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -946,6 +946,39 @@ describe("i18n config parsing", () => {
     );
   });
 
+  it("validates i18n before invoking config callbacks", async () => {
+    const { resolveNextConfig } = await import("../packages/vinext/src/config/next-config.js");
+    const redirects = vi.fn(() => []);
+
+    await expect(
+      resolveNextConfig({
+        i18n: {
+          locales: ["fr"],
+          defaultLocale: "en",
+        },
+        redirects,
+      }),
+    ).rejects.toThrow(
+      "Specified i18n.defaultLocale should be included in i18n.locales.\nSee more info here: https://nextjs.org/docs/messages/invalid-i18n-config",
+    );
+    expect(redirects).not.toHaveBeenCalled();
+  });
+
+  it("reports invalid locales before checking default locale membership", async () => {
+    const { resolveNextConfig } = await import("../packages/vinext/src/config/next-config.js");
+
+    await expect(
+      resolveNextConfig({
+        i18n: {
+          locales: [42],
+          defaultLocale: "en",
+        },
+      } as never),
+    ).rejects.toThrow(
+      'Specified i18n.locales contains invalid values (42), locales must be valid locale tags provided as strings e.g. "en-US".',
+    );
+  });
+
   it("returns null i18n when not configured", async () => {
     const { resolveNextConfig } = await import("../packages/vinext/src/config/next-config.js");
     const config = await resolveNextConfig({});

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -979,6 +979,40 @@ describe("i18n config parsing", () => {
     );
   });
 
+  it("rejects overlapping domain locales exposed by a malformed includes value", async () => {
+    const { resolveNextConfig } = await import("../packages/vinext/src/config/next-config.js");
+
+    await expect(
+      resolveNextConfig({
+        i18n: {
+          locales: ["en", "fr"],
+          defaultLocale: "en",
+          domains: [
+            { domain: "example.com", defaultLocale: "en", locales: ["fr"] },
+            { domain: "example.fr", defaultLocale: "fr", locales: "fr" },
+          ],
+        },
+      } as never),
+    ).rejects.toThrow("Invalid i18n.domains values:");
+  });
+
+  it("rejects duplicate domain default locales", async () => {
+    const { resolveNextConfig } = await import("../packages/vinext/src/config/next-config.js");
+
+    await expect(
+      resolveNextConfig({
+        i18n: {
+          locales: ["en", "fr"],
+          defaultLocale: "en",
+          domains: [
+            { domain: "example.fr", defaultLocale: "fr" },
+            { domain: "french.example.com", defaultLocale: "fr" },
+          ],
+        },
+      }),
+    ).rejects.toThrow("Invalid i18n.domains values:");
+  });
+
   it("returns null i18n when not configured", async () => {
     const { resolveNextConfig } = await import("../packages/vinext/src/config/next-config.js");
     const config = await resolveNextConfig({});

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -1113,16 +1113,19 @@ describe("i18n routing (Pages Router)", () => {
     // About page — uses getServerSideProps to expose locale
     await fsp.writeFile(
       path.join(i18nTmpDir, "pages", "about.tsx"),
-      `export function getServerSideProps({ locale, locales, defaultLocale }) {
+      `import { useRouter } from "next/router";
+export function getServerSideProps({ locale, locales, defaultLocale }) {
   return { props: { locale: locale || null, locales: locales || [], defaultLocale: defaultLocale || null } };
 }
 export default function About({ locale, locales, defaultLocale }) {
+  const router = useRouter();
   return (
     <div>
       <h1>About</h1>
       <p id="locale">{locale}</p>
       <p id="locales">{locales.join(",")}</p>
       <p id="defaultLocale">{defaultLocale}</p>
+      <p id="asPath">{router.asPath}</p>
     </div>
   );
 }`,
@@ -1215,6 +1218,16 @@ export default function About({ locale, locales, defaultLocale }) {
     expect(res.status).toBe(200);
     const html = await res.text();
     expect(html).toMatch(/<p id="locale">.*fr.*<\/p>/);
+  });
+
+  it("strips the locale prefix from router.asPath in dev SSR", async () => {
+    // Ported from Next.js:
+    // test/e2e/i18n-support-fallback-rewrite/i18n-support-fallback-rewrite.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/i18n-support-fallback-rewrite/i18n-support-fallback-rewrite.test.ts
+    const res = await fetch(`${i18nBaseUrl}/fr/about?hello=world`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toMatch(/<p id="asPath">.*\/about\?hello=world.*<\/p>/);
   });
 
   it("passes correct locale to getServerSideProps for /de/about", async () => {

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -983,9 +983,11 @@ describe("Link onNavigate prop", () => {
 
 describe("Pages Router Link onClick semantics", () => {
   async function renderPagesRouterLinkAndClick(args: {
-    href: string;
+    href: string | { pathname?: string; query?: Record<string, string>; hash?: string };
     props?: Record<string, unknown>;
     currentHref?: string;
+    pagesRouterAsPath?: string;
+    locale?: string;
   }) {
     vi.resetModules();
 
@@ -1002,15 +1004,21 @@ describe("Pages Router Link onClick semantics", () => {
     // `next/router` itself — keeps the mock surface to vinext-owned modules
     // and avoids the dynamic-import-into-unknown-module timing pitfall.
     const pagesRouterCalls: { href: string; replace: boolean }[] = [];
-    vi.doMock("../packages/vinext/src/client/pages-router-link-navigation.js", () => ({
-      navigatePagesRouterLinkWithFallback: async ({
-        navigation,
-      }: {
-        navigation: { href: string; replace: boolean };
-      }) => {
-        pagesRouterCalls.push({ href: navigation.href, replace: navigation.replace });
-      },
-    }));
+    vi.doMock(
+      "../packages/vinext/src/client/pages-router-link-navigation.js",
+      async (importOriginal) => ({
+        ...(await importOriginal<
+          typeof import("../packages/vinext/src/client/pages-router-link-navigation.js")
+        >()),
+        navigatePagesRouterLinkWithFallback: async ({
+          navigation,
+        }: {
+          navigation: { href: string; replace: boolean };
+        }) => {
+          pagesRouterCalls.push({ href: navigation.href, replace: navigation.replace });
+        },
+      }),
+    );
     // The handler still tries `await import("next/router")` before calling
     // navigatePagesRouterLink. Stub it so the import resolves cleanly (the
     // returned Router is never used because we mocked the navigation boundary).
@@ -1020,7 +1028,7 @@ describe("Pages Router Link onClick semantics", () => {
     const replaceState = vi.fn();
     const dispatchEvent = vi.fn();
     const currentUrl = new URL(args.currentHref ?? "https://example.com/current");
-    vi.stubGlobal("window", {
+    const windowValue: Record<string, unknown> = {
       // No vinext.navigationRuntime — that selects the Pages Router branch
       // inside Link's click handler.
       addEventListener: vi.fn(),
@@ -1035,7 +1043,18 @@ describe("Pages Router Link onClick semantics", () => {
       },
       scrollTo: vi.fn(),
       __NEXT_DATA__: { props: {} },
-    });
+    };
+    if (args.pagesRouterAsPath !== undefined) {
+      windowValue.next = {
+        router: { asPath: args.pagesRouterAsPath, reload() {} },
+      };
+    }
+    if (args.locale !== undefined) {
+      windowValue.__VINEXT_LOCALE__ = args.locale;
+      windowValue.__VINEXT_LOCALES__ = ["en", "fr"];
+      windowValue.__VINEXT_DEFAULT_LOCALE__ = "en";
+    }
+    vi.stubGlobal("window", windowValue);
 
     const { default: IsolatedLink } = await import("../packages/vinext/src/shims/link.js");
     const React = await vi.importActual<typeof import("react")>("react");
@@ -1095,6 +1114,23 @@ describe("Pages Router Link onClick semantics", () => {
     expect(result.clickEvent.defaultPrevented).toBe(true);
     // ...and the Pages Router navigation is actually scheduled.
     expect(result.pagesRouterCalls).toEqual([{ href: "/", replace: false }]);
+  });
+
+  it("resolves hash-only URL objects against the current locale-free asPath", async () => {
+    // Ported from Next.js:
+    // test/e2e/i18n-support-same-page-hash-change/i18n-support-same-page-hash-change.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/i18n-support-same-page-hash-change/i18n-support-same-page-hash-change.test.ts
+    const result = await renderPagesRouterLinkAndClick({
+      href: { hash: "#newhash" },
+      props: { locale: "fr" },
+      currentHref: "https://example.com/fr/about?tab=details#hash",
+      pagesRouterAsPath: "/about?tab=details",
+      locale: "fr",
+    });
+
+    expect(result.pagesRouterCalls).toEqual([
+      { href: "/fr/about?tab=details#newhash", replace: false },
+    ]);
   });
 
   it("preserves a basePath page when navigating to a hash link", async () => {

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -1003,7 +1003,11 @@ describe("Pages Router Link onClick semantics", () => {
     // Stub Pages Router navigation at our own boundary instead of mocking
     // `next/router` itself — keeps the mock surface to vinext-owned modules
     // and avoids the dynamic-import-into-unknown-module timing pitfall.
-    const pagesRouterCalls: { href: string; replace: boolean }[] = [];
+    const pagesRouterCalls: {
+      href: string;
+      replace: boolean;
+      interpolateDynamicRoute?: boolean;
+    }[] = [];
     vi.doMock(
       "../packages/vinext/src/client/pages-router-link-navigation.js",
       async (importOriginal) => ({
@@ -1013,9 +1017,17 @@ describe("Pages Router Link onClick semantics", () => {
         navigatePagesRouterLinkWithFallback: async ({
           navigation,
         }: {
-          navigation: { href: string; replace: boolean };
+          navigation: {
+            href: string;
+            replace: boolean;
+            interpolateDynamicRoute?: boolean;
+          };
         }) => {
-          pagesRouterCalls.push({ href: navigation.href, replace: navigation.replace });
+          pagesRouterCalls.push({
+            href: navigation.href,
+            replace: navigation.replace,
+            ...(navigation.interpolateDynamicRoute ? { interpolateDynamicRoute: true } : undefined),
+          });
         },
       }),
     );
@@ -1147,6 +1159,22 @@ describe("Pages Router Link onClick semantics", () => {
 
     expect(result.pagesRouterCalls).toEqual([
       { href: "/fr/about?tab=details#newhash", replace: false },
+    ]);
+  });
+
+  it("preserves dynamic interpolation for query-only string hrefs on rewritten paths", async () => {
+    const result = await renderPagesRouterLinkAndClick({
+      href: "?params=1",
+      currentHref: "https://example.com/rewrite-navigation/0",
+      pagesRouterAsPath: "/rewrite-navigation/0",
+    });
+
+    expect(result.pagesRouterCalls).toEqual([
+      {
+        href: "/rewrite-navigation/0?params=1",
+        replace: false,
+        interpolateDynamicRoute: true,
+      },
     ]);
   });
 

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -1133,6 +1133,23 @@ describe("Pages Router Link onClick semantics", () => {
     ]);
   });
 
+  it("resolves hash-only string hrefs against the current locale-free asPath", async () => {
+    // Ported from Next.js:
+    // test/e2e/i18n-support-same-page-hash-change/i18n-support-same-page-hash-change.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/i18n-support-same-page-hash-change/i18n-support-same-page-hash-change.test.ts
+    const result = await renderPagesRouterLinkAndClick({
+      href: "#newhash",
+      props: { locale: "fr" },
+      currentHref: "https://example.com/fr/about?tab=details#hash",
+      pagesRouterAsPath: "/about?tab=details",
+      locale: "fr",
+    });
+
+    expect(result.pagesRouterCalls).toEqual([
+      { href: "/fr/about?tab=details#newhash", replace: false },
+    ]);
+  });
+
   it("preserves a basePath page when navigating to a hash link", async () => {
     // Ported from Next.js: test/e2e/basepath/query-hash.test.ts
     // https://github.com/vercel/next.js/blob/canary/test/e2e/basepath/query-hash.test.ts
@@ -1145,7 +1162,7 @@ describe("Pages Router Link onClick semantics", () => {
         currentHref: "https://example.com/docs/hello",
       });
 
-      expect(result.pagesRouterCalls).toEqual([{ href: "#hashlink", replace: false }]);
+      expect(result.pagesRouterCalls).toEqual([{ href: "/hello#hashlink", replace: false }]);
     } finally {
       if (previousBasePath === undefined) {
         delete process.env.__NEXT_ROUTER_BASEPATH;

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -688,6 +688,20 @@ describe("Link locale handling", () => {
     expect(html).toContain('href="/fr/about"');
   });
 
+  it("preserves URL-object hashes while applying a locale", () => {
+    // Ported from Next.js:
+    // test/e2e/i18n-support-same-page-hash-change/i18n-support-same-page-hash-change.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/i18n-support-same-page-hash-change/i18n-support-same-page-hash-change.test.ts
+    const html = ReactDOMServer.renderToString(
+      React.createElement(
+        Link,
+        { href: { pathname: "/about", hash: "#hash" }, locale: "fr" } as any,
+        "x",
+      ),
+    );
+    expect(html).toContain('href="/fr/about#hash"');
+  });
+
   it("locale string does not double-prefix", () => {
     const html = ReactDOMServer.renderToString(
       React.createElement(Link, { href: "/fr/about", locale: "fr" } as any, "x"),

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -524,6 +524,20 @@ describe("Link resolveHref", () => {
       }),
     ).toBe("/rewrite-navigation/0?");
   });
+
+  it("resolves hash-only Pages Links against locale-free router.asPath", () => {
+    // Ported from Next.js:
+    // test/e2e/i18n-support-same-page-hash-change/i18n-support-same-page-hash-change.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/i18n-support-same-page-hash-change/i18n-support-same-page-hash-change.test.ts
+    expect(
+      resolvePagesRouterQueryOnlyHref("#newhash", {
+        asPath: "/about?tab=details",
+        basePath: "",
+        fallbackHref: "http://localhost/fr/about?tab=details#hash",
+        locales: ["en", "fr"],
+      }),
+    ).toBe("/about?tab=details#newhash");
+  });
 });
 
 // ─── isExternalUrl ──────────────────────────────────────────────────────

--- a/tests/pages-page-handler.test.ts
+++ b/tests/pages-page-handler.test.ts
@@ -462,6 +462,37 @@ describe("createPagesPageHandler — SSR context", () => {
     const ctx = setSSRContext.mock.calls[0][0] as Record<string, unknown>;
     expect(ctx.pathname).toBe("/about");
   });
+
+  it("strips the active locale prefix from the initial asPath", async () => {
+    // Ported from Next.js:
+    // test/e2e/i18n-support-fallback-rewrite/i18n-support-fallback-rewrite.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/i18n-support-fallback-rewrite/i18n-support-fallback-rewrite.test.ts
+    const setSSRContext = vi.fn();
+    const routes = [makeRoute("/about")];
+    const handler = createPagesPageHandler(
+      makeOpts({
+        pageRoutes: routes,
+        i18nConfig: {
+          locales: ["en", "fr"],
+          defaultLocale: "en",
+        },
+        setSSRContext,
+        matchRoute: (url, routeList) => {
+          const route = routeList.find((item) => item.pattern === url.split("?")[0]);
+          return route ? { route, params: {} } : null;
+        },
+      }),
+    );
+
+    await handler(makeRequest("/en/about?hello=world"), "/en/about?hello=world", null, null, {
+      asPath: "/en/about?hello=world",
+    });
+
+    const ctx = setSSRContext.mock.calls.find((call) => call[0] !== null)?.[0] as
+      | { asPath?: string }
+      | undefined;
+    expect(ctx?.asPath).toBe("/about?hello=world");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -14897,6 +14897,34 @@ describe("Pages Router concurrent navigation", () => {
     return { win, pushState, replaceState, render };
   }
 
+  it("exposes locale-free asPath for a localized browser URL", async () => {
+    // Ported from Next.js: test/e2e/i18n-support-catchall/i18n-support-catchall.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/i18n-support-catchall/i18n-support-catchall.test.ts
+    const previousWindow = (globalThis as any).window;
+    const { win } = createNavWindow();
+    Object.assign(win.location, {
+      pathname: "/nl-NL/another",
+      href: "http://localhost/nl-NL/another",
+    });
+    Object.assign(win, {
+      __VINEXT_LOCALE__: "nl-NL",
+      __VINEXT_LOCALES__: ["en-US", "nl-NL"],
+      __VINEXT_DEFAULT_LOCALE__: "en-US",
+    });
+    (win.__NEXT_DATA__ as any).page = "/[[...slug]]";
+    (globalThis as any).window = win;
+
+    try {
+      vi.resetModules();
+      const Router = (await import("../packages/vinext/src/shims/router.js")).default;
+      expect(Router.asPath).toBe("/another");
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+    }
+  });
+
   /**
    * Build a minimal HTML response that navigateClient can parse.
    * Includes __NEXT_DATA__ with a pageModuleUrl pointing to the given path.


### PR DESCRIPTION
## Summary

- expose locale-free Pages Router `asPath` while keeping browser URLs and internal history state locale-prefixed
- normalize initial SSR/page-data `asPath` at the shared Pages page handler so locale-prefixed fallback rewrite requests match Next.js
- preserve URL-object hashes through `next/link` locale navigation
- order configured locales with the default locale first without mutating user config

## Next.js parity references

- `packages/next/src/shared/lib/router/router.ts` — `cleanedAs = removeLocale(...)` and locale-aware hash transitions
- `test/e2e/i18n-support-catchall/i18n-support-catchall.test.ts`
- `test/e2e/i18n-support-fallback-rewrite-legacy/i18n-support-fallback-rewrite-legacy.test.ts`
- `test/e2e/i18n-support-fallback-rewrite/i18n-support-fallback-rewrite.test.ts`
- `test/e2e/i18n-support-same-page-hash-change/i18n-support-same-page-hash-change.test.ts`

Oracle: Next.js v16.3.0-canary.80 checkout at commit `9dd6d677b63b249584c8ff0bccffcc6a65288683`.

## Validation

- `vp check packages/vinext/src/config/next-config.ts packages/vinext/src/server/pages-page-handler.ts packages/vinext/src/shims/link.tsx packages/vinext/src/shims/router.ts tests/features.test.ts tests/link.test.ts tests/pages-page-handler.test.ts tests/shims.test.ts`
- `vp test run tests/pages-page-handler.test.ts tests/link.test.ts tests/shims.test.ts` — 1,335 passed
- `vp test run tests/features.test.ts -t "i18n config parsing"` — 5 passed
- exact targeted Next.js deploy wrapper — 11/11 passed:
  - i18n-support-catchall — 4 passed
  - i18n-support-fallback-rewrite-legacy — 2 passed
  - i18n-support-fallback-rewrite — 2 passed
  - i18n-support-same-page-hash-change — 3 passed

No Bonk review requested yet.
