### PR TITLE
fix(pages): clear fallback route params before hydration

### DIFF
--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -1851,7 +1851,7 @@ hydrate();
           {
             props: renderProps,
             page: patternToNextFormat(route.pattern),
-            query: renderQuery,
+            query: isFallbackRender ? renderQuery : params,
             buildId: process.env.__VINEXT_BUILD_ID,
             isFallback: isFallbackRender,
             locale: locale ?? currentDefaultLocale,

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -741,6 +741,7 @@ export function createSSRHandler(
       ? params
       : null;
     const query = mergeRouteParamsIntoQuery(parseQuery(url), params);
+    let renderQuery: Record<string, string | string[]> = query;
 
     // Wrap the entire request in a single unified AsyncLocalStorage scope.
     const requestContext = createRequestContext();
@@ -932,10 +933,11 @@ export function createSSRHandler(
             const fallbackCacheKey = pagesIsrCacheKey(url.split("?")[0]);
             const generatedEntry = await isrGet(fallbackCacheKey);
             isFallbackRender = generatedEntry?.value.value?.kind !== "PAGES";
+            if (isFallbackRender) renderQuery = {};
             if (isFallbackRender && typeof routerShim.setSSRContext === "function") {
               routerShim.setSSRContext({
                 pathname: patternToNextFormat(route.pattern),
-                query,
+                query: renderQuery,
                 asPath: requestAsPath,
                 navigationIsReady: false,
                 locale: locale ?? currentDefaultLocale,
@@ -981,7 +983,7 @@ export function createSSRHandler(
             req,
             res,
             pathname: patternToNextFormat(route.pattern),
-            query,
+            query: renderQuery,
             asPath: requestAsPath,
             locale: locale ?? currentDefaultLocale,
             locales: i18nConfig?.locales,
@@ -1849,7 +1851,7 @@ hydrate();
           {
             props: renderProps,
             page: patternToNextFormat(route.pattern),
-            query: params,
+            query: renderQuery,
             buildId: process.env.__VINEXT_BUILD_ID,
             isFallback: isFallbackRender,
             locale: locale ?? currentDefaultLocale,
@@ -1925,7 +1927,7 @@ hydrate();
           // DocumentContext for `getInitialProps`, matching prod parity.
           documentContext: {
             pathname: patternToNextFormat(route.pattern),
-            query,
+            query: renderQuery,
             asPath: requestAsPath,
             ...(pagesNextData.autoExport === true ? {} : { req, res }),
           },

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -738,7 +738,10 @@ export async function resolvePagesPageData(
   let renderProps: PagesRenderProps = { pageProps };
 
   async function loadForegroundAppInitialRenderProps(): Promise<ResolvePagesPageDataResult | null> {
-    const result = await loadPagesAppInitialRenderProps(options, getSharedReqRes);
+    const result = await loadPagesAppInitialRenderProps(
+      isFallback ? { ...options, query: {} } : options,
+      getSharedReqRes,
+    );
     if (result.kind === "response") {
       return {
         kind: "response",

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -666,13 +666,15 @@ export function createPagesPageHandler(
             : (pageDataResult.documentReqRes ?? createPageReqRes());
         const isrRevalidateSeconds = pageDataResult.isrRevalidateSeconds;
         const isFallbackRender = pageDataResult.isFallback === true;
+        const renderQuery = isFallbackRender ? {} : query;
 
-        // Republish SSR context with isFallback flipped on so `useRouter().isFallback`
-        // returns true during render, matching Next.js render.tsx fallback shell.
+        // Next.js removes all query values from a fallback shell before rendering.
+        // The client starts with an empty router query, then its hydration replace
+        // fetches the concrete page data and publishes the matched route params.
         if (isFallbackRender && typeof setSSRContext === "function") {
           setSSRContext({
             pathname: routePattern,
-            query,
+            query: renderQuery,
             asPath: renderAsPath ?? routeUrl,
             navigationIsReady: false,
             locale,
@@ -795,7 +797,7 @@ export function createPagesPageHandler(
           pageProps,
           props: renderProps,
           params,
-          query,
+          query: renderQuery,
           renderDocumentToString(element) {
             return renderToStringAsync(element);
           },

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -267,6 +267,7 @@ export function buildPagesNextDataScript(
     | "pageProps"
     | "props"
     | "params"
+    | "query"
     | "routePattern"
     | "safeJsonStringify"
     | "scriptNonce"
@@ -278,7 +279,7 @@ export function buildPagesNextDataScript(
   const nextDataPayload: Record<string, unknown> = {
     props: options.props ?? { pageProps: options.pageProps },
     page: options.routePattern,
-    query: options.params,
+    query: options.query ?? options.params,
     buildId: options.buildId,
     isFallback: options.isFallback === true,
   };
@@ -496,6 +497,7 @@ export async function renderPagesPageResponse(
     pageProps: options.pageProps,
     props: renderProps,
     params: options.params,
+    query: options.query,
     routePattern: options.routePattern,
     safeJsonStringify: options.safeJsonStringify,
     scriptNonce: options.scriptNonce,

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -279,7 +279,7 @@ export function buildPagesNextDataScript(
   const nextDataPayload: Record<string, unknown> = {
     props: options.props ?? { pageProps: options.pageProps },
     page: options.routePattern,
-    query: options.query ?? options.params,
+    query: options.isFallback ? (options.query ?? {}) : options.params,
     buildId: options.buildId,
     isFallback: options.isFallback === true,
   };

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -1277,16 +1277,14 @@ function getPathnameAndQuery(): {
   // pattern and is updated by navigateClient() on every client-side navigation.
   const pathname = window.__NEXT_DATA__?.page ?? resolvedPath;
   const nextData = window.__NEXT_DATA__;
-  const routeQuery = nextData?.isFallback
-    ? copySerializedRouteQuery(nextData.query)
-    : getRouteQueryFromNextData(nextData, resolvedPath);
+  const routeQuery = getRouteQueryFromNextData(nextData, resolvedPath);
   // URL search params always reflect the current URL
   const searchQuery: Record<string, string | string[]> = {};
   const params = new URLSearchParams(window.location.search);
   for (const [key, value] of params) {
     addQueryParam(searchQuery, key, value);
   }
-  const query = { ...searchQuery, ...routeQuery };
+  const query = nextData?.isFallback ? {} : { ...searchQuery, ...routeQuery };
   // asPath uses the resolved browser path, not the route pattern
   const asPath =
     getCurrentHistoryAsPath() ?? resolvedPath + window.location.search + window.location.hash;

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -1183,6 +1183,21 @@ type RouteQueryNextData = {
   query?: Record<string, string | string[] | undefined>;
 };
 
+function copySerializedRouteQuery(
+  query: RouteQueryNextData["query"],
+): Record<string, string | string[]> {
+  const routeQuery: Record<string, string | string[]> = {};
+  if (!query) return routeQuery;
+  for (const [key, value] of Object.entries(query)) {
+    if (typeof value === "string") {
+      routeQuery[key] = value;
+    } else if (Array.isArray(value)) {
+      routeQuery[key] = [...value];
+    }
+  }
+  return routeQuery;
+}
+
 function extractRouteParamsFromPath(
   pattern: string,
   pathname: string,
@@ -1220,14 +1235,7 @@ function getRouteQueryFromNextData(
   if (!nextData?.query || !nextData.page) return routeQuery;
 
   if (extractRouteParamsFromPath(nextData.page, resolvedPath) === null) {
-    for (const [key, value] of Object.entries(nextData.query)) {
-      if (typeof value === "string") {
-        routeQuery[key] = value;
-      } else if (Array.isArray(value)) {
-        routeQuery[key] = [...value];
-      }
-    }
-    return routeQuery;
+    return copySerializedRouteQuery(nextData.query);
   }
 
   const routeParamNames = extractRouteParamNames(nextData.page);
@@ -1269,7 +1277,9 @@ function getPathnameAndQuery(): {
   // pattern and is updated by navigateClient() on every client-side navigation.
   const pathname = window.__NEXT_DATA__?.page ?? resolvedPath;
   const nextData = window.__NEXT_DATA__;
-  const routeQuery = getRouteQueryFromNextData(nextData, resolvedPath);
+  const routeQuery = nextData?.isFallback
+    ? copySerializedRouteQuery(nextData.query)
+    : getRouteQueryFromNextData(nextData, resolvedPath);
   // URL search params always reflect the current URL
   const searchQuery: Record<string, string | string[]> = {};
   const params = new URLSearchParams(window.location.search);

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -4964,8 +4964,7 @@ describe("Next.js edge cases", () => {
     expect(data.props.pageProps.id).toBe("1");
     expect(data.props.pageProps.title).toBe("First Article");
     // getStaticProps params should only contain route params, not URL query
-    expect(data.query).not.toHaveProperty("utm_source");
-    expect(data.query).not.toHaveProperty("ref");
+    expect(data.query).toEqual({ id: "1" });
   });
 
   it("__NEXT_DATA__ query contains dynamic params for static pages", async () => {

--- a/tests/pages-page-data.test.ts
+++ b/tests/pages-page-data.test.ts
@@ -114,8 +114,10 @@ describe("pages page data", () => {
   });
 
   it("preserves custom app props in fallback shells", async () => {
+    const queries: unknown[] = [];
     const AppComponent = Object.assign(function App() {}, {
-      getInitialProps() {
+      getInitialProps(context: { router: { query: unknown } }) {
+        queries.push(context.router.query);
         return { appValue: "preserved", pageProps: { discarded: true } };
       },
     });
@@ -138,6 +140,7 @@ describe("pages page data", () => {
       pageProps: {},
       props: { appValue: "preserved", pageProps: {} },
     });
+    expect(queries).toEqual([{}]);
   });
 
   it("preserves custom app props during stale ISR regeneration", async () => {

--- a/tests/pages-page-response.test.ts
+++ b/tests/pages-page-response.test.ts
@@ -147,6 +147,25 @@ describe("isPagesStreamingBot", () => {
 });
 
 describe("pages page response", () => {
+  it("serializes only route params for non-fallback pages", async () => {
+    const common = createCommonOptions();
+    const response = await renderPagesPageResponse({
+      ...common.options,
+      isFallback: false,
+      params: { slug: "first" },
+      query: { slug: "first", utm_source: "test", ref: "google" },
+      routePattern: "/[slug]",
+      routeUrl: "/first?utm_source=test&ref=google",
+    });
+
+    const html = await response.text();
+    const nextDataMatch = html.match(
+      /<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/,
+    );
+    expect(nextDataMatch).not.toBeNull();
+    expect(JSON.parse(nextDataMatch![1]!).query).toEqual({ slug: "first" });
+  });
+
   it("serializes the fallback shell render query instead of matched params", async () => {
     const common = createCommonOptions();
     const response = await renderPagesPageResponse({

--- a/tests/pages-page-response.test.ts
+++ b/tests/pages-page-response.test.ts
@@ -147,6 +147,25 @@ describe("isPagesStreamingBot", () => {
 });
 
 describe("pages page response", () => {
+  it("serializes the fallback shell render query instead of matched params", async () => {
+    const common = createCommonOptions();
+    const response = await renderPagesPageResponse({
+      ...common.options,
+      isFallback: true,
+      params: { slug: "first" },
+      query: {},
+      routePattern: "/[slug]",
+      routeUrl: "/first",
+    });
+
+    const html = await response.text();
+    const nextDataMatch = html.match(
+      /<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/,
+    );
+    expect(nextDataMatch).not.toBeNull();
+    expect(JSON.parse(nextDataMatch![1]!).query).toEqual({});
+  });
+
   it("renders the document shell, merges gSSP headers, and marks streamed HTML responses", async () => {
     const common = createCommonOptions();
 

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -2247,6 +2247,7 @@ describe("Pages Router integration", () => {
     expect(match).toBeTruthy();
     const nextData = JSON.parse(match![1]);
     expect(nextData.isFallback).toBe(true);
+    expect(nextData.query).toEqual({});
     // Empty pageProps on the fallback shell — client fetches them later.
     expect(nextData.props).toEqual({ pageProps: {} });
   });

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -14346,7 +14346,7 @@ describe("next/compat/router shim", () => {
     (globalThis as any).window = {
       location: {
         pathname: "/second",
-        search: "",
+        search: "?foo=bar",
         hash: "",
       },
       history: { state: null },
@@ -14371,12 +14371,12 @@ describe("next/compat/router shim", () => {
 
       (globalThis as any).window.__NEXT_DATA__ = {
         page: "/[slug]",
-        query: { slug: "second" },
+        query: { slug: "second", foo: "bar" },
         isFallback: false,
       };
 
       expect(renderToStaticMarkup(wrapWithRouterContext(React.createElement(Probe)))).toBe(
-        "<span>{&quot;slug&quot;:&quot;second&quot;}</span>",
+        "<span>{&quot;foo&quot;:&quot;bar&quot;,&quot;slug&quot;:&quot;second&quot;}</span>",
       );
     } finally {
       if (previousWindow === undefined) {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -14334,6 +14334,59 @@ describe("next/compat/router shim", () => {
     }
   });
 
+  // Ported from Next.js: test/e2e/fallback-route-params/fallback-route-params.test.ts
+  // https://github.com/vercel/next.js/blob/v16.3.0-canary.80/test/e2e/fallback-route-params/fallback-route-params.test.ts
+  it("keeps fallback route params empty until hydration data commits", async () => {
+    const React = await import("react");
+    const { renderToStaticMarkup } = await import("react-dom/server");
+    const { useRouter, wrapWithRouterContext } =
+      await import("../packages/vinext/src/shims/router.js");
+
+    const previousWindow = (globalThis as any).window;
+    (globalThis as any).window = {
+      location: {
+        pathname: "/second",
+        search: "",
+        hash: "",
+      },
+      history: { state: null },
+      __NEXT_DATA__: {
+        page: "/[slug]",
+        query: {},
+        isFallback: true,
+      },
+      __VINEXT_LOCALE__: undefined,
+      __VINEXT_LOCALES__: undefined,
+      __VINEXT_DEFAULT_LOCALE__: undefined,
+    };
+
+    try {
+      function Probe() {
+        return React.createElement("span", null, JSON.stringify(useRouter().query));
+      }
+
+      expect(renderToStaticMarkup(wrapWithRouterContext(React.createElement(Probe)))).toBe(
+        "<span>{}</span>",
+      );
+
+      (globalThis as any).window.__NEXT_DATA__ = {
+        page: "/[slug]",
+        query: { slug: "second" },
+        isFallback: false,
+      };
+
+      expect(renderToStaticMarkup(wrapWithRouterContext(React.createElement(Probe)))).toBe(
+        "<span>{&quot;slug&quot;:&quot;second&quot;}</span>",
+      );
+    } finally {
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+    }
+  });
+
   it("prefers dynamic route params over same-key search params in client router state", async () => {
     const React = await import("react");
     const { renderToStaticMarkup } = await import("react-dom/server");


### PR DESCRIPTION
## Summary

- clear Pages Router fallback-shell query state before `_app`, page, and `_document` rendering
- serialize an empty `__NEXT_DATA__.query` for fallback shells across dev, production, and Worker request paths
- keep the client router on the serialized empty query until the hydration `_h` replace fetches page data and commits the concrete route params

## Next.js parity

Ported from Next.js `v16.3.0-canary.80` (`9dd6d677b63b249584c8ff0bccffcc6a65288683`):

- `test/e2e/fallback-route-params/fallback-route-params.test.ts`
- `packages/next/src/server/render.tsx` — fallback renders clear `query`
- `packages/next/src/client/index.tsx` — fallback hydration performs a non-shallow router replace

## Validation

- `vp test run tests/pages-page-data.test.ts tests/pages-page-response.test.ts tests/pages-page-handler.test.ts` — 131 passed
- `vp test run tests/pages-router.test.ts -t "fallback shell|fallback: true"` — 6 passed
- `vp test run tests/shims.test.ts -t "keeps fallback route params empty until hydration data commits"` — 1 passed
- targeted `vp check` for all 9 touched files — clean
- `vp run vinext#build` — passed
- exact prepared Next.js deploy wrapper:
  - `test/e2e/fallback-route-params/fallback-route-params.test.ts` — 2 passed
  - skeleton `__NEXT_DATA__.query` is empty
  - initial hydrated render has no slug, then the data navigation commits `{ slug: "second" }`

Run source: `28938793088`.
