### PR TITLE
fix(pages): mark auto exports in next data

### DIFF
--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -111,13 +111,20 @@ type PagesFontPreload = {
 /**
  * The `__NEXT_DATA__` fields beyond the always-present core that the Pages
  * renderer serializes: the `__vinext` block plus the readiness flags
- * (gssp/gsp/gip/appGip/autoExport/isExperimentalCompile) the client uses to
+ * (gssp/gsp/gip/appGip/autoExport/nextExport/isExperimentalCompile) the client uses to
  * recompute the initial `router.isReady`. Shared by every render path
  * (initial, ISR regeneration) so they emit identical readiness state.
  */
 export type PagesNextDataExtras = Pick<
   VinextNextData,
-  "__vinext" | "appGip" | "autoExport" | "gip" | "gsp" | "gssp" | "isExperimentalCompile"
+  | "__vinext"
+  | "appGip"
+  | "autoExport"
+  | "gip"
+  | "gsp"
+  | "gssp"
+  | "isExperimentalCompile"
+  | "nextExport"
 >;
 
 export type PagesI18nRenderContext = {

--- a/packages/vinext/src/server/pages-readiness.ts
+++ b/packages/vinext/src/server/pages-readiness.ts
@@ -31,7 +31,7 @@ type PagesReadinessNextData = Pick<
  */
 export function buildPagesReadinessNextData(options: {
   pageModule: PagesPageModule;
-  appComponent: { getInitialProps?: unknown } | null | undefined;
+  appComponent: { getInitialProps?: unknown; origGetInitialProps?: unknown } | null | undefined;
   hasRewrites: boolean;
 }): PagesReadinessNextData {
   const hasPageGssp = typeof options.pageModule.getServerSideProps === "function";
@@ -39,7 +39,9 @@ export function buildPagesReadinessNextData(options: {
   const hasPageGip =
     typeof (options.pageModule.default as { getInitialProps?: unknown } | undefined)
       ?.getInitialProps === "function";
-  const hasAppGip = typeof options.appComponent?.getInitialProps === "function";
+  const hasAppGip =
+    typeof options.appComponent?.getInitialProps === "function" &&
+    options.appComponent.getInitialProps !== options.appComponent.origGetInitialProps;
   const autoExport = !hasPageGssp && !hasPageGsp && !hasPageGip && !hasAppGip;
   return {
     gssp: hasPageGssp,

--- a/packages/vinext/src/server/pages-readiness.ts
+++ b/packages/vinext/src/server/pages-readiness.ts
@@ -20,7 +20,7 @@ import type { PagesPageModule } from "./pages-page-data.js";
  */
 type PagesReadinessNextData = Pick<
   VinextNextData,
-  "gssp" | "gsp" | "gip" | "appGip" | "autoExport"
+  "gssp" | "gsp" | "gip" | "appGip" | "autoExport" | "nextExport"
 > & {
   __vinext: Pick<NonNullable<VinextNextData["__vinext"]>, "hasRewrites">;
 };
@@ -40,12 +40,14 @@ export function buildPagesReadinessNextData(options: {
     typeof (options.pageModule.default as { getInitialProps?: unknown } | undefined)
       ?.getInitialProps === "function";
   const hasAppGip = typeof options.appComponent?.getInitialProps === "function";
+  const autoExport = !hasPageGssp && !hasPageGsp && !hasPageGip && !hasAppGip;
   return {
     gssp: hasPageGssp,
     gsp: hasPageGsp ? true : undefined,
     gip: hasPageGip,
     appGip: hasAppGip,
-    autoExport: !hasPageGssp && !hasPageGsp && !hasPageGip && !hasAppGip,
+    autoExport,
+    nextExport: autoExport ? true : undefined,
     __vinext: { hasRewrites: options.hasRewrites },
   };
 }

--- a/tests/pages-readiness.test.ts
+++ b/tests/pages-readiness.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vite-plus/test";
+import { buildPagesReadinessNextData } from "../packages/vinext/src/server/pages-readiness.js";
+
+describe("buildPagesReadinessNextData", () => {
+  // Ported from Next.js: test/e2e/auto-export/auto-export.test.ts
+  // https://github.com/vercel/next.js/blob/v16.3.0-canary.80/test/e2e/auto-export/auto-export.test.ts
+  it("marks automatically exported pages with nextExport", () => {
+    expect(
+      buildPagesReadinessNextData({
+        pageModule: { default: () => null },
+        appComponent: null,
+        hasRewrites: false,
+      }),
+    ).toMatchObject({
+      autoExport: true,
+      nextExport: true,
+    });
+  });
+
+  it("omits nextExport for data-driven pages", () => {
+    expect(
+      buildPagesReadinessNextData({
+        pageModule: {
+          default: () => null,
+          getServerSideProps: async () => ({ props: {} }),
+        },
+        appComponent: null,
+        hasRewrites: false,
+      }).nextExport,
+    ).toBeUndefined();
+  });
+});

--- a/tests/pages-readiness.test.ts
+++ b/tests/pages-readiness.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 import { buildPagesReadinessNextData } from "../packages/vinext/src/server/pages-readiness.js";
+import App from "../packages/vinext/src/shims/app.js";
+import { getPagesNavigationIsReadyFromSerializedState } from "../packages/vinext/src/shims/router.js";
 
 describe("buildPagesReadinessNextData", () => {
   // Ported from Next.js: test/e2e/auto-export/auto-export.test.ts
@@ -28,5 +30,68 @@ describe("buildPagesReadinessNextData", () => {
         hasRewrites: false,
       }).nextExport,
     ).toBeUndefined();
+  });
+
+  // Next.js classifies a custom _app as data-driven only when it overrides the
+  // built-in implementation. A subclass that inherits both static functions
+  // remains automatically optimized.
+  // Ported from Next.js: packages/next/src/server/render.tsx
+  // https://github.com/vercel/next.js/blob/v16.3.0-canary.80/packages/next/src/server/render.tsx
+  it("keeps an _app inheriting the default getInitialProps automatically optimized", () => {
+    class InheritedApp extends App {}
+
+    expect(InheritedApp.getInitialProps).toBe(InheritedApp.origGetInitialProps);
+
+    const nextData = buildPagesReadinessNextData({
+      pageModule: { default: () => null },
+      appComponent: InheritedApp,
+      hasRewrites: false,
+    });
+
+    expect(nextData).toMatchObject({
+      appGip: false,
+      autoExport: true,
+      nextExport: true,
+    });
+
+    // The auto-export markers keep the dynamic route pre-ready so the client
+    // can replace the route-pattern query/asPath with the live URL state on
+    // mount, matching Next.js's auto-export router transition.
+    expect(
+      getPagesNavigationIsReadyFromSerializedState("/[post]", "", {
+        props: {},
+        page: "/[post]",
+        query: {},
+        ...nextData,
+      }),
+    ).toBe(false);
+    expect(
+      getPagesNavigationIsReadyFromSerializedState("/zeit/[slug]", "?from=query", {
+        props: {},
+        page: "/zeit/[slug]",
+        query: {},
+        ...nextData,
+      }),
+    ).toBe(false);
+  });
+
+  it("marks an _app override as appGip", () => {
+    class CustomApp extends App {
+      static override async getInitialProps() {
+        return { pageProps: {} };
+      }
+    }
+
+    expect(
+      buildPagesReadinessNextData({
+        pageModule: { default: () => null },
+        appComponent: CustomApp,
+        hasRewrites: false,
+      }),
+    ).toMatchObject({
+      appGip: true,
+      autoExport: false,
+      nextExport: undefined,
+    });
   });
 });

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -21813,6 +21813,10 @@ describe("next/app shim", () => {
     expect(typeof AppDefault.getInitialProps).toBe("function");
     // origGetInitialProps is preserved for userland code that introspects it.
     expect(typeof AppDefault.origGetInitialProps).toBe("function");
+    expect(AppDefault.getInitialProps).toBe(AppDefault.origGetInitialProps);
+
+    class InheritedApp extends AppDefault {}
+    expect(InheritedApp.getInitialProps).toBe(InheritedApp.origGetInitialProps);
 
     const pageCtx = { req: { url: "/test" } };
     const Component = Object.assign(() => null, {


### PR DESCRIPTION
## Summary
- serialize `nextExport: true` for automatically exported Pages routes
- share the marker across dev, production, and Worker Pages render paths
- add focused coverage for auto-export and data-driven page payloads

## Next.js parity
Ported from `test/e2e/auto-export/auto-export.test.ts` in Next.js `v16.3.0-canary.80`. The failing run rendered the CommonJS pages and refreshed dynamic query state correctly, but omitted the `nextExport` marker from `__NEXT_DATA__`.

## Validation
- `vp test run tests/pages-readiness.test.ts tests/pages-page-response.test.ts`
- `vp test run tests/pages-readiness.test.ts tests/pages-page-response.test.ts tests/pages-page-handler.test.ts tests/pages-router.test.ts` (425 passed; one unrelated global-CSS fixture flake passed immediately in isolation)
- `vp test run tests/pages-router.test.ts -t "dev Pages client assets expose _app global CSS"`
- `REPO="$(pwd)" NEXTJS_DIR="/Users/jamesanderson/Developer/vinext/.nextjs-ref-v16.3.0-canary.80" ./scripts/run-targeted-nextjs-e2e.sh test/e2e/auto-export/auto-export.test.ts` (5/5)
- `vp check tests/pages-readiness.test.ts packages/vinext/src/server/pages-readiness.ts packages/vinext/src/server/pages-page-response.ts`
- `vp run vinext#build`
