### PR TITLE
test(deploy): skip suites that stall deploy shards

### DIFF
--- a/scripts/nextjs-deploy-manifest.mjs
+++ b/scripts/nextjs-deploy-manifest.mjs
@@ -58,6 +58,10 @@ function isAppDirSuite(suite) {
  */
 const APP_ROUTER_NON_APP_DIR_SUITES = ["test/e2e/next-form/default/next-form-prefetch.test.ts"];
 
+const CUSTOM_DEPLOY_ADAPTER_EXCLUDES = [
+  "test/e2e/app-dir/segment-cache/memory-pressure/segment-cache-memory-pressure.test.ts",
+];
+
 const CUSTOM_DEPLOY_ADAPTER_SUITE_OVERRIDES = {
   // Custom deploy adapters snapshot cliOutput during setup, before this test emits runtime logs.
   "test/e2e/repeated-forward-slashes-error/repeated-forward-slashes-error.test.ts": {
@@ -118,11 +122,11 @@ async function main() {
       failed: Array.from(new Set([...(current.failed ?? []), ...(override.failed ?? [])])),
     };
   }
-  let extraExcludes = [];
+  let extraExcludes = [...CUSTOM_DEPLOY_ADAPTER_EXCLUDES];
 
   if (filter === "pages") {
     suites = Object.fromEntries(Object.entries(suites).filter(([suite]) => !isAppDirSuite(suite)));
-    extraExcludes = ["test/e2e/app-dir/**/*", ...APP_ROUTER_NON_APP_DIR_SUITES];
+    extraExcludes.push("test/e2e/app-dir/**/*", ...APP_ROUTER_NON_APP_DIR_SUITES);
   } else if (filter === "app") {
     suites = Object.fromEntries(Object.entries(suites).filter(([suite]) => isAppDirSuite(suite)));
   }

--- a/scripts/nextjs-deploy-manifest.mjs
+++ b/scripts/nextjs-deploy-manifest.mjs
@@ -59,6 +59,7 @@ function isAppDirSuite(suite) {
 const APP_ROUTER_NON_APP_DIR_SUITES = ["test/e2e/next-form/default/next-form-prefetch.test.ts"];
 
 const CUSTOM_DEPLOY_ADAPTER_EXCLUDES = [
+  "test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts",
   "test/e2e/app-dir/segment-cache/memory-pressure/segment-cache-memory-pressure.test.ts",
 ];
 


### PR DESCRIPTION
## Summary

- exclude `segment-cache-memory-pressure` from the custom deploy adapter suite
- exclude `instant-navigation-testing-api` from the custom deploy adapter suite
- keep these exclusions additive with the existing Pages/App Router filtering

## Why

Both suites can leave their deploy shard running far beyond the normal shard duration:

- `segment-cache-memory-pressure` was the suspicious predecessor in shard 14 of run 28934621751, which did not complete normally
- `instant-navigation-testing-api` took 862 seconds in shard 11 of the same canary run and caused the shard to take about 16 minutes

The first diagnostic run skipped only `segment-cache-memory-pressure`; shard 14 then completed in about 6.5 minutes, while shard 11 remained slow. The second diagnostic run skipped both suites; shards 11 and 14 both completed in about 6.5 minutes.

The deploy suite still reports unrelated compatibility failures; this change only prevents these two suites from stalling the shards.

## Validation

- generated the deploy manifest against Next.js `v16.3.0-canary.80` and verified both exact paths are in `rules.exclude`
- diagnostic run with both exclusions: https://github.com/cloudflare/vinext/actions/runs/28938793088
