### PR TITLE
fix(build): gate native typeof window folding

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -5429,10 +5429,11 @@ export const loadServerActionClient = ${
         };
       },
     },
-    // Before Vite 8.1.4, native define folding can run too late to prune dead
-    // imports, so retain the custom fold for every build. Newer Vite versions
-    // only need it for plugin-RSC's write-less analysis builds, which replace
-    // modules with lexer-discovered imports before native folding runs.
+    // Toolchains before Vite 8.1.4 / Rolldown 1.1.4 can run native define
+    // folding too late to prune dead imports, so retain the custom fold for
+    // every build. Newer toolchains only need it for plugin-RSC's write-less
+    // analysis builds, which replace modules with lexer-discovered imports
+    // before native folding runs.
     {
       name: "vinext:typeof-window-scan",
       apply(_config, environment) {

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1295,7 +1295,8 @@ type NitroSetupContext = {
 };
 
 export default function vinext(options: VinextOptions = {}): PluginOption[] {
-  assertSupportedViteVersion();
+  const { supportsNativeTypeofWindowFolding: useNativeTypeofWindowFolding } =
+    assertSupportedViteVersion();
   const prerenderConfig = normalizeVinextPrerenderConfig(options.prerender);
   let root: string;
   let pagesDir: string;
@@ -5420,6 +5421,7 @@ export const loadServerActionClient = ${
     {
       name: "vinext:typeof-window",
       configEnvironment(_name, environment) {
+        if (!useNativeTypeofWindowFolding) return null;
         return {
           define: {
             "typeof window": environment.consumer === "client" ? '"object"' : '"undefined"',
@@ -5427,18 +5429,22 @@ export const loadServerActionClient = ${
         };
       },
     },
-    // plugin-RSC's analysis builds replace each module with lexer-discovered
-    // imports before Rolldown's native define folding runs. Fold only in those
-    // write-less analysis builds so dead browser/server imports are absent from
-    // the synthetic graph; real builds continue to use native Oxc folding.
+    // Before Vite 8.1.4, native define folding can run too late to prune dead
+    // imports, so retain the custom fold for every build. Newer Vite versions
+    // only need it for plugin-RSC's write-less analysis builds, which replace
+    // modules with lexer-discovered imports before native folding runs.
     {
       name: "vinext:typeof-window-scan",
-      apply: "build",
+      apply(_config, environment) {
+        return !useNativeTypeofWindowFolding || environment.command === "build";
+      },
       enforce: "post",
       transform: {
         filter: { code: /\btypeof\s+window\b/ },
         handler(code, id) {
-          if (this.environment.config.build.write !== false) return null;
+          if (useNativeTypeofWindowFolding && this.environment.config.build.write !== false) {
+            return null;
+          }
           const cacheDir = `${toSlash(this.environment.config.cacheDir).replace(/\/$/, "")}/`;
           if (toSlash(id).startsWith(cacheDir)) return null;
           return replaceTypeofWindow(code, getTypeofWindowReplacement(this.environment), id);

--- a/packages/vinext/src/utils/vite-version.ts
+++ b/packages/vinext/src/utils/vite-version.ts
@@ -55,12 +55,19 @@ export function getDepOptimizeNodeEnvOptions(nodeEnvDefine: string): {
 }
 
 /**
- * Detect Vite major version at runtime. Prefer the project cwd, then fall back
- * to vinext's own dependency graph for tests and linked source checkouts.
+ * Detect the Vite toolchain version at runtime. Prefer the project cwd, then
+ * fall back to vinext's own dependency graph for tests and linked checkouts.
  */
-function getViteVersion(): string {
+type ViteToolchainVersion = {
+  vite: string;
+  rolldown?: string;
+};
+
+function getViteToolchainVersion(): ViteToolchainVersion {
   try {
-    return getViteVersionFromRequire(createRequire(path.join(process.cwd(), "package.json")));
+    return getViteToolchainVersionFromRequire(
+      createRequire(path.join(process.cwd(), "package.json")),
+    );
   } catch (error) {
     if (!isModuleNotFoundError(error)) {
       const message = error instanceof Error ? error.message : String(error);
@@ -69,7 +76,7 @@ function getViteVersion(): string {
   }
 
   try {
-    return getViteVersionFromRequire(createRequire(import.meta.url));
+    return getViteToolchainVersionFromRequire(createRequire(import.meta.url));
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(
@@ -78,15 +85,19 @@ function getViteVersion(): string {
   }
 }
 
-function getViteVersionFromRequire(require: NodeRequire): string {
+function getViteToolchainVersionFromRequire(require: NodeRequire): ViteToolchainVersion {
   const vitePkg = require("vite/package.json");
   if (vitePkg?.name === "vite" && parseViteVersion(vitePkg.version)) {
-    return vitePkg.version;
+    return { vite: vitePkg.version };
   }
 
   const bundledViteVersion = vitePkg?.bundledVersions?.vite;
   if (parseViteVersion(bundledViteVersion)) {
-    return bundledViteVersion;
+    const bundledRolldownVersion = vitePkg?.bundledVersions?.rolldown;
+    return {
+      vite: bundledViteVersion,
+      rolldown: parseViteVersion(bundledRolldownVersion) ? bundledRolldownVersion : undefined,
+    };
   }
 
   throw new Error(`could not determine Vite version from ${vitePkg?.name ?? "vite/package.json"}`);
@@ -107,25 +118,41 @@ function isModuleNotFoundError(error: unknown): boolean {
   );
 }
 
-export function supportsNativeTypeofWindowFolding(viteVersion: string): boolean {
-  const parsedVersion = parseViteVersion(viteVersion);
+export function supportsNativeTypeofWindowFolding(
+  viteVersion: string,
+  bundledRolldownVersion?: string,
+): boolean {
+  if (bundledRolldownVersion && isVersionAtLeast(bundledRolldownVersion, 1, 1, 4)) return true;
+  return isVersionAtLeast(viteVersion, 8, 1, 4);
+}
+
+function isVersionAtLeast(
+  version: string,
+  requiredMajor: number,
+  requiredMinor: number,
+  requiredPatch: number,
+): boolean {
+  const parsedVersion = parseViteVersion(version);
   if (!parsedVersion) return false;
   const [major, minor, patch, prerelease] = parsedVersion;
-  if (major !== 8) return major > 8;
-  if (minor !== 1) return minor > 1;
-  if (patch !== 4) return patch > 4;
+  if (major !== requiredMajor) return major > requiredMajor;
+  if (minor !== requiredMinor) return minor > requiredMinor;
+  if (patch !== requiredPatch) return patch > requiredPatch;
   return !prerelease;
 }
 
 export function assertSupportedViteVersion(): {
   supportsNativeTypeofWindowFolding: boolean;
 } {
-  const viteVersion = getViteVersion();
-  const [major] = parseViteVersion(viteVersion)!;
+  const toolchainVersion = getViteToolchainVersion();
+  const [major] = parseViteVersion(toolchainVersion.vite)!;
   if (major < 8) {
     throw new Error(`[vinext] Vite 8 or newer is required. Detected Vite ${major}.`);
   }
   return {
-    supportsNativeTypeofWindowFolding: supportsNativeTypeofWindowFolding(viteVersion),
+    supportsNativeTypeofWindowFolding: supportsNativeTypeofWindowFolding(
+      toolchainVersion.vite,
+      toolchainVersion.rolldown,
+    ),
   };
 }

--- a/packages/vinext/src/utils/vite-version.ts
+++ b/packages/vinext/src/utils/vite-version.ts
@@ -92,11 +92,13 @@ function getViteVersionFromRequire(require: NodeRequire): string {
   throw new Error(`could not determine Vite version from ${vitePkg?.name ?? "vite/package.json"}`);
 }
 
-function parseViteVersion(version: unknown): [major: number, minor: number, patch: number] | null {
+function parseViteVersion(
+  version: unknown,
+): [major: number, minor: number, patch: number, prerelease: boolean] | null {
   if (typeof version !== "string") return null;
-  const match = /^(\d+)\.(\d+)\.(\d+)/.exec(version);
+  const match = /^(\d+)\.(\d+)\.(\d+)(-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.exec(version);
   if (!match) return null;
-  return [Number(match[1]), Number(match[2]), Number(match[3])];
+  return [Number(match[1]), Number(match[2]), Number(match[3]), !!match[4]];
 }
 
 function isModuleNotFoundError(error: unknown): boolean {
@@ -105,18 +107,25 @@ function isModuleNotFoundError(error: unknown): boolean {
   );
 }
 
+export function supportsNativeTypeofWindowFolding(viteVersion: string): boolean {
+  const parsedVersion = parseViteVersion(viteVersion);
+  if (!parsedVersion) return false;
+  const [major, minor, patch, prerelease] = parsedVersion;
+  if (major !== 8) return major > 8;
+  if (minor !== 1) return minor > 1;
+  if (patch !== 4) return patch > 4;
+  return !prerelease;
+}
+
 export function assertSupportedViteVersion(): {
-  major: number;
   supportsNativeTypeofWindowFolding: boolean;
 } {
   const viteVersion = getViteVersion();
-  const [major, minor, patch] = parseViteVersion(viteVersion)!;
+  const [major] = parseViteVersion(viteVersion)!;
   if (major < 8) {
     throw new Error(`[vinext] Vite 8 or newer is required. Detected Vite ${major}.`);
   }
   return {
-    major,
-    supportsNativeTypeofWindowFolding:
-      major > 8 || (major === 8 && (minor > 1 || (minor === 1 && patch >= 4))),
+    supportsNativeTypeofWindowFolding: supportsNativeTypeofWindowFolding(viteVersion),
   };
 }

--- a/packages/vinext/src/utils/vite-version.ts
+++ b/packages/vinext/src/utils/vite-version.ts
@@ -122,7 +122,9 @@ export function supportsNativeTypeofWindowFolding(
   viteVersion: string,
   bundledRolldownVersion?: string,
 ): boolean {
-  if (bundledRolldownVersion && isVersionAtLeast(bundledRolldownVersion, 1, 1, 4)) return true;
+  if (bundledRolldownVersion !== undefined) {
+    return isVersionAtLeast(bundledRolldownVersion, 1, 1, 4);
+  }
   return isVersionAtLeast(viteVersion, 8, 1, 4);
 }
 

--- a/packages/vinext/src/utils/vite-version.ts
+++ b/packages/vinext/src/utils/vite-version.ts
@@ -58,9 +58,9 @@ export function getDepOptimizeNodeEnvOptions(nodeEnvDefine: string): {
  * Detect Vite major version at runtime. Prefer the project cwd, then fall back
  * to vinext's own dependency graph for tests and linked source checkouts.
  */
-function getViteMajorVersion(): number {
+function getViteVersion(): string {
   try {
-    return getViteMajorVersionFromRequire(createRequire(path.join(process.cwd(), "package.json")));
+    return getViteVersionFromRequire(createRequire(path.join(process.cwd(), "package.json")));
   } catch (error) {
     if (!isModuleNotFoundError(error)) {
       const message = error instanceof Error ? error.message : String(error);
@@ -69,7 +69,7 @@ function getViteMajorVersion(): number {
   }
 
   try {
-    return getViteMajorVersionFromRequire(createRequire(import.meta.url));
+    return getViteVersionFromRequire(createRequire(import.meta.url));
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(
@@ -78,19 +78,25 @@ function getViteMajorVersion(): number {
   }
 }
 
-function getViteMajorVersionFromRequire(require: NodeRequire): number {
+function getViteVersionFromRequire(require: NodeRequire): string {
   const vitePkg = require("vite/package.json");
-  const viteMajor = parseInt(vitePkg?.version, 10);
-  if (vitePkg?.name === "vite" && Number.isFinite(viteMajor)) {
-    return viteMajor;
+  if (vitePkg?.name === "vite" && parseViteVersion(vitePkg.version)) {
+    return vitePkg.version;
   }
 
-  const bundledViteMajor = parseInt(vitePkg?.bundledVersions?.vite, 10);
-  if (Number.isFinite(bundledViteMajor)) {
-    return bundledViteMajor;
+  const bundledViteVersion = vitePkg?.bundledVersions?.vite;
+  if (parseViteVersion(bundledViteVersion)) {
+    return bundledViteVersion;
   }
 
   throw new Error(`could not determine Vite version from ${vitePkg?.name ?? "vite/package.json"}`);
+}
+
+function parseViteVersion(version: unknown): [major: number, minor: number, patch: number] | null {
+  if (typeof version !== "string") return null;
+  const match = /^(\d+)\.(\d+)\.(\d+)/.exec(version);
+  if (!match) return null;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
 }
 
 function isModuleNotFoundError(error: unknown): boolean {
@@ -99,10 +105,18 @@ function isModuleNotFoundError(error: unknown): boolean {
   );
 }
 
-export function assertSupportedViteVersion(): number {
-  const viteMajorVersion = getViteMajorVersion();
-  if (viteMajorVersion < 8) {
-    throw new Error(`[vinext] Vite 8 or newer is required. Detected Vite ${viteMajorVersion}.`);
+export function assertSupportedViteVersion(): {
+  major: number;
+  supportsNativeTypeofWindowFolding: boolean;
+} {
+  const viteVersion = getViteVersion();
+  const [major, minor, patch] = parseViteVersion(viteVersion)!;
+  if (major < 8) {
+    throw new Error(`[vinext] Vite 8 or newer is required. Detected Vite ${major}.`);
   }
-  return viteMajorVersion;
+  return {
+    major,
+    supportsNativeTypeofWindowFolding:
+      major > 8 || (major === 8 && (minor > 1 || (minor === 1 && patch >= 4))),
+  };
 }

--- a/tests/tsconfig-paths-vite8.test.ts
+++ b/tests/tsconfig-paths-vite8.test.ts
@@ -97,6 +97,88 @@ describe("Vite tsconfig paths support", () => {
     expect(resolvedConfig?.resolve?.tsconfigPaths).toBe(true);
   });
 
+  it("uses custom typeof window folding before Vite 8.1.4", async () => {
+    const root = setupProject({ name: "vite", version: "8.1.3" });
+    process.chdir(root);
+
+    const plugins = vinext({ appDir: root });
+    const definePlugin = await findNamedPlugin(plugins, "vinext:typeof-window");
+    const scanPlugin = await findNamedPlugin(plugins, "vinext:typeof-window-scan");
+    if (typeof definePlugin?.configEnvironment !== "function") {
+      throw new Error("vinext:typeof-window configEnvironment hook not found");
+    }
+    if (!scanPlugin?.transform || typeof scanPlugin.transform === "function") {
+      throw new Error("vinext:typeof-window-scan transform hook not found");
+    }
+
+    expect(typeof scanPlugin.apply).toBe("function");
+    expect((scanPlugin.apply as Function)({}, { command: "serve" })).toBe(true);
+    expect(
+      definePlugin.configEnvironment.call(
+        {} as never,
+        "server",
+        { consumer: "server" },
+        {} as never,
+      ),
+    ).toBeNull();
+    expect(
+      await scanPlugin.transform.handler.call(
+        {
+          environment: {
+            config: {
+              build: { write: true },
+              cacheDir: path.join(root, ".vite"),
+              consumer: "server",
+            },
+          },
+        } as never,
+        `export const browser = typeof window !== "undefined"`,
+        path.join(root, "app.js"),
+      ),
+    ).not.toBeNull();
+  });
+
+  it("uses native typeof window folding from Vite 8.1.4", async () => {
+    const root = setupProject({ name: "vite", version: "8.1.4" });
+    process.chdir(root);
+
+    const plugins = vinext({ appDir: root });
+    const definePlugin = await findNamedPlugin(plugins, "vinext:typeof-window");
+    const scanPlugin = await findNamedPlugin(plugins, "vinext:typeof-window-scan");
+    if (typeof definePlugin?.configEnvironment !== "function") {
+      throw new Error("vinext:typeof-window configEnvironment hook not found");
+    }
+    if (!scanPlugin?.transform || typeof scanPlugin.transform === "function") {
+      throw new Error("vinext:typeof-window-scan transform hook not found");
+    }
+
+    expect(typeof scanPlugin.apply).toBe("function");
+    expect((scanPlugin.apply as Function)({}, { command: "serve" })).toBe(false);
+    expect(
+      definePlugin.configEnvironment.call(
+        {} as never,
+        "server",
+        { consumer: "server" },
+        {} as never,
+      ),
+    ).toEqual({ define: { "typeof window": '"undefined"' } });
+    expect(
+      await scanPlugin.transform.handler.call(
+        {
+          environment: {
+            config: {
+              build: { write: true },
+              cacheDir: path.join(root, ".vite"),
+              consumer: "server",
+            },
+          },
+        } as never,
+        `export const browser = typeof window !== "undefined"`,
+        path.join(root, "app.js"),
+      ),
+    ).toBeNull();
+  });
+
   it("materializes simple tsconfig path aliases into resolve.alias on Vite 8", async () => {
     const root = setupProject({ name: "vite", version: "8.0.0" });
     process.chdir(root);

--- a/tests/tsconfig-paths-vite8.test.ts
+++ b/tests/tsconfig-paths-vite8.test.ts
@@ -179,6 +179,73 @@ describe("Vite tsconfig paths support", () => {
     ).toBeNull();
   });
 
+  it("uses bundled Rolldown capability from npm alias packages", async () => {
+    const root = setupProject({
+      name: "@voidzero-dev/vite-plus-core",
+      version: "0.2.2",
+      bundledVersions: { vite: "8.1.2", rolldown: "1.1.4" },
+    });
+    process.chdir(root);
+
+    const plugins = vinext({ appDir: root });
+    const definePlugin = await findNamedPlugin(plugins, "vinext:typeof-window");
+    const scanPlugin = await findNamedPlugin(plugins, "vinext:typeof-window-scan");
+    if (typeof definePlugin?.configEnvironment !== "function") {
+      throw new Error("vinext:typeof-window configEnvironment hook not found");
+    }
+    if (!scanPlugin?.transform || typeof scanPlugin.transform === "function") {
+      throw new Error("vinext:typeof-window-scan transform hook not found");
+    }
+
+    expect(
+      definePlugin.configEnvironment.call(
+        {} as never,
+        "server",
+        { consumer: "server" },
+        {} as never,
+      ),
+    ).toEqual({ define: { "typeof window": '"undefined"' } });
+    expect(
+      await scanPlugin.transform.handler.call(
+        {
+          environment: {
+            config: {
+              build: { write: true },
+              cacheDir: path.join(root, ".vite"),
+              consumer: "server",
+            },
+          },
+        } as never,
+        `export const browser = typeof window !== "undefined"`,
+        path.join(root, "app.js"),
+      ),
+    ).toBeNull();
+  });
+
+  it("keeps custom folding for npm alias packages with older bundled Rolldown", async () => {
+    const root = setupProject({
+      name: "@voidzero-dev/vite-plus-core",
+      version: "0.2.1",
+      bundledVersions: { vite: "8.1.2", rolldown: "1.1.3" },
+    });
+    process.chdir(root);
+
+    const plugins = vinext({ appDir: root });
+    const definePlugin = await findNamedPlugin(plugins, "vinext:typeof-window");
+    if (typeof definePlugin?.configEnvironment !== "function") {
+      throw new Error("vinext:typeof-window configEnvironment hook not found");
+    }
+
+    expect(
+      definePlugin.configEnvironment.call(
+        {} as never,
+        "server",
+        { consumer: "server" },
+        {} as never,
+      ),
+    ).toBeNull();
+  });
+
   it("materializes simple tsconfig path aliases into resolve.alias on Vite 8", async () => {
     const root = setupProject({ name: "vite", version: "8.0.0" });
     process.chdir(root);

--- a/tests/type-of-window.test.ts
+++ b/tests/type-of-window.test.ts
@@ -12,6 +12,7 @@ import {
   getTypeofWindowReplacement,
   replaceTypeofWindow,
 } from "../packages/vinext/src/plugins/typeof-window.js";
+import { supportsNativeTypeofWindowFolding } from "../packages/vinext/src/utils/vite-version.js";
 
 const temporaryDirectories: string[] = [];
 
@@ -40,9 +41,7 @@ describe("typeof window compilation", () => {
     const bundledViteVersion = (await import("vite/package.json", { with: { type: "json" } }))
       .default.bundledVersions?.vite;
     const viteVersion = bundledViteVersion ?? (await import("vite")).version;
-    const [major, minor, patch] = viteVersion.split(".").map(Number);
-    const usesNativeFolding =
-      major > 8 || (major === 8 && (minor > 1 || (minor === 1 && patch >= 4)));
+    const usesNativeFolding = supportsNativeTypeofWindowFolding(viteVersion);
 
     expect(builder.environments.client?.config.define?.["typeof window"]).toBe(
       usesNativeFolding ? '"object"' : undefined,
@@ -50,6 +49,15 @@ describe("typeof window compilation", () => {
     expect(builder.environments.server?.config.define?.["typeof window"]).toBe(
       usesNativeFolding ? '"undefined"' : undefined,
     );
+  });
+
+  it("uses native folding only from the stable Vite 8.1.4 release", () => {
+    expect(supportsNativeTypeofWindowFolding("8.1.3")).toBe(false);
+    expect(supportsNativeTypeofWindowFolding("8.1.4-beta.1")).toBe(false);
+    expect(supportsNativeTypeofWindowFolding("8.1.4")).toBe(true);
+    expect(supportsNativeTypeofWindowFolding("8.1.4+build.1")).toBe(true);
+    expect(supportsNativeTypeofWindowFolding("8.2.0-beta.1")).toBe(true);
+    expect(supportsNativeTypeofWindowFolding("9.0.0-beta.1")).toBe(true);
   });
 
   it("skips custom scan folding for modules in the Vite cache directory", async () => {

--- a/tests/type-of-window.test.ts
+++ b/tests/type-of-window.test.ts
@@ -24,7 +24,7 @@ afterEach(async () => {
 });
 
 describe("typeof window compilation", () => {
-  it("configures native typeof window folding per environment", async () => {
+  it("configures the installed Vite typeof window folding strategy", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-typeof-window-define-"));
     temporaryDirectories.push(root);
     const builder = await createBuilder({
@@ -37,8 +37,19 @@ describe("typeof window compilation", () => {
       plugins: [vinext({ react: false, rsc: false })],
     });
 
-    expect(builder.environments.client?.config.define?.["typeof window"]).toBe('"object"');
-    expect(builder.environments.server?.config.define?.["typeof window"]).toBe('"undefined"');
+    const bundledViteVersion = (await import("vite/package.json", { with: { type: "json" } }))
+      .default.bundledVersions?.vite;
+    const viteVersion = bundledViteVersion ?? (await import("vite")).version;
+    const [major, minor, patch] = viteVersion.split(".").map(Number);
+    const usesNativeFolding =
+      major > 8 || (major === 8 && (minor > 1 || (minor === 1 && patch >= 4)));
+
+    expect(builder.environments.client?.config.define?.["typeof window"]).toBe(
+      usesNativeFolding ? '"object"' : undefined,
+    );
+    expect(builder.environments.server?.config.define?.["typeof window"]).toBe(
+      usesNativeFolding ? '"undefined"' : undefined,
+    );
   });
 
   it("skips custom scan folding for modules in the Vite cache directory", async () => {

--- a/tests/type-of-window.test.ts
+++ b/tests/type-of-window.test.ts
@@ -63,6 +63,7 @@ describe("typeof window compilation", () => {
     expect(supportsNativeTypeofWindowFolding("8.1.2", "1.1.3")).toBe(false);
     expect(supportsNativeTypeofWindowFolding("8.1.2", "1.1.4-beta.1")).toBe(false);
     expect(supportsNativeTypeofWindowFolding("8.1.2", "1.1.4")).toBe(true);
+    expect(supportsNativeTypeofWindowFolding("8.2.0", "1.1.3")).toBe(false);
   });
 
   it("skips custom scan folding for modules in the Vite cache directory", async () => {

--- a/tests/type-of-window.test.ts
+++ b/tests/type-of-window.test.ts
@@ -38,10 +38,12 @@ describe("typeof window compilation", () => {
       plugins: [vinext({ react: false, rsc: false })],
     });
 
-    const bundledViteVersion = (await import("vite/package.json", { with: { type: "json" } }))
-      .default.bundledVersions?.vite;
-    const viteVersion = bundledViteVersion ?? (await import("vite")).version;
-    const usesNativeFolding = supportsNativeTypeofWindowFolding(viteVersion);
+    const vitePackage = (await import("vite/package.json", { with: { type: "json" } })).default;
+    const viteVersion = vitePackage.bundledVersions?.vite ?? (await import("vite")).version;
+    const usesNativeFolding = supportsNativeTypeofWindowFolding(
+      viteVersion,
+      vitePackage.bundledVersions?.rolldown,
+    );
 
     expect(builder.environments.client?.config.define?.["typeof window"]).toBe(
       usesNativeFolding ? '"object"' : undefined,
@@ -58,6 +60,9 @@ describe("typeof window compilation", () => {
     expect(supportsNativeTypeofWindowFolding("8.1.4+build.1")).toBe(true);
     expect(supportsNativeTypeofWindowFolding("8.2.0-beta.1")).toBe(true);
     expect(supportsNativeTypeofWindowFolding("9.0.0-beta.1")).toBe(true);
+    expect(supportsNativeTypeofWindowFolding("8.1.2", "1.1.3")).toBe(false);
+    expect(supportsNativeTypeofWindowFolding("8.1.2", "1.1.4-beta.1")).toBe(false);
+    expect(supportsNativeTypeofWindowFolding("8.1.2", "1.1.4")).toBe(true);
   });
 
   it("skips custom scan folding for modules in the Vite cache directory", async () => {


### PR DESCRIPTION
## Summary

- use native `typeof window` define folding on Vite 8.1.4 or newer
- also detect equivalent support from npm alias packages that declare bundled Rolldown 1.1.4 or newer
- retain the custom scope-aware transform for dev and production builds on older toolchains
- preserve the custom transform for plugin-RSC analysis builds on newer toolchains
- cover direct Vite and Vite+ boundary cases, including prereleases

Regular Vite first receives the required Rolldown update in Vite 8.1.4. The workspace currently aliases Vite to Vite+ 0.2.2, which reports bundled Vite 8.1.2 but already reports bundled Rolldown 1.1.4, so it can safely keep the native fast path.

## Validation

- `vp check`
- `vp test run tests/tsconfig-paths-vite8.test.ts tests/type-of-window.test.ts`
- `vp test run tests/app-browser-server-action-client.test.ts tests/app-server-action-execution.test.ts`
