### PR TITLE
fix(app-router): delay dynamic SSR stream pulls

### DIFF
--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -38,6 +38,7 @@ import {
   createNavigationRuntimeRscMetadataScript,
   createRscEmbedTransform,
   createTickBufferedTransform,
+  waitAtLeastOneReactRenderTask,
   type InitialNavigationCacheMetadata,
 } from "./app-ssr-stream.js";
 import type { AppSsrRenderResult } from "./app-page-stream.js";
@@ -612,6 +613,7 @@ export async function handleSsr(
 
         let htmlStream: ReadableStream<Uint8Array>;
         let shellErrorRecovered = false;
+        let shouldDelayInitialHtmlPull = false;
         if (pprFallbackShellSignal) {
           const prerender = await loadStaticPrerender();
           const htmlAbortController = new AbortController();
@@ -630,6 +632,8 @@ export async function handleSsr(
 
             if (options?.waitForAllReady === true) {
               await streamingHtmlStream.allReady;
+            } else {
+              shouldDelayInitialHtmlPull = true;
             }
 
             htmlStream = streamingHtmlStream;
@@ -704,6 +708,10 @@ export async function handleSsr(
         // ordering applies to scripts rendered in the initial shell.
         const getBeforeInteractiveHeadHTML = (): string =>
           renderBeforeInteractiveInlineScripts(beforeInteractiveInlineScripts);
+
+        if (shouldDelayInitialHtmlPull) {
+          await waitAtLeastOneReactRenderTask();
+        }
 
         const finalStream = deferUntilStreamConsumed(
           htmlStream.pipeThrough(

--- a/packages/vinext/src/server/app-ssr-stream.ts
+++ b/packages/vinext/src/server/app-ssr-stream.ts
@@ -30,6 +30,13 @@ type InlineCssRewriteResult = {
   consumedPrependCss: boolean;
 };
 
+// React's edge renderer schedules render continuations on timer tasks. Dynamic
+// SSR must let one such task run before the first stream pull, or fast Suspense
+// boundaries can flush fallback HTML that would otherwise resolve in place.
+export function waitAtLeastOneReactRenderTask(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 const NAVIGATION_RUNTIME_REFERENCE = `self[Symbol.for(${safeJsonStringify(
   NAVIGATION_RUNTIME_SYMBOL_DESCRIPTION,
 )})]`;

--- a/tests/app-ssr-stream.test.ts
+++ b/tests/app-ssr-stream.test.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect } from "vite-plus/test";
+import { createElement, Suspense, use } from "react";
+import { renderToReadableStream } from "react-dom/server.edge";
 import {
   createNavigationRuntimeRscMetadataScript,
   createRscEmbedTransform,
   createTickBufferedTransform,
   fixFlightHints,
   fixPreloadAs,
+  waitAtLeastOneReactRenderTask,
 } from "../packages/vinext/src/server/app-ssr-stream.js";
 
 it("serializes dynamic stale time into the hydration bootstrap", () => {
@@ -305,6 +308,52 @@ async function readSingleTransformChunk(
 
   return new TextDecoder().decode(result.value);
 }
+
+function createFastSuspenseDocument() {
+  const ready = new Promise<void>((resolve) => queueMicrotask(resolve));
+
+  function FastContent() {
+    use(ready);
+    return createElement("p", { id: "resolved-fast" }, "resolved-fast");
+  }
+
+  return createElement(
+    "html",
+    null,
+    createElement("head"),
+    createElement(
+      "body",
+      null,
+      createElement(
+        Suspense,
+        { fallback: createElement("p", { id: "fallback-fast" }, "fallback-fast") },
+        createElement(FastContent),
+      ),
+    ),
+  );
+}
+
+async function renderFastSuspenseDocument(waitBeforePipe: boolean): Promise<string> {
+  const stream = await renderToReadableStream(createFastSuspenseDocument());
+  if (waitBeforePipe) {
+    await waitAtLeastOneReactRenderTask();
+  }
+  return new Response(
+    stream.pipeThrough(createTickBufferedTransform(createNoopRscEmbedTransform())),
+  ).text();
+}
+
+describe("dynamic App SSR stream pull scheduling", () => {
+  it("waits one React render task before pulling dynamic HTML streams", async () => {
+    const immediateHtml = await renderFastSuspenseDocument(false);
+    expect(immediateHtml).toContain("fallback-fast");
+    expect(immediateHtml).toContain("resolved-fast");
+
+    const delayedHtml = await renderFastSuspenseDocument(true);
+    expect(delayedHtml).not.toContain("fallback-fast");
+    expect(delayedHtml).toContain("resolved-fast");
+  });
+});
 
 describe("createTickBufferedTransform pre-head splice", () => {
   it("emits injectAfterHeadOpenHTML immediately after <head> opens", async () => {


### PR DESCRIPTION
Closes #1723.

## Overview

| Field | Details |
| --- | --- |
| Goal | Match Next.js dynamic App Router SSR stream timing so fast Suspense boundaries can resolve before the initial HTML pull flushes fallback markup. |
| Core change | Wait one React render task before piping successful dynamic SSR streams through vinext's HTML transform. |
| Boundary | Applies only after a successful dynamic `renderToReadableStream()` call. `waitForAllReady`, PPR fallback-shell, and recovered shell-error paths keep their existing behavior. |
| Expected impact | Removes fallback HTML flicker/leak for Suspense boundaries that settle in the next render task. |

## Why

Dynamic SSR should not make the first stream pull the event that forces React to flush a fallback when the boundary can resolve in the next render continuation. Next.js handles this by delaying the dynamic HTML pull/pipe by one React render task. vinext uses React's edge stream entry for App SSR, so the equivalent ownership point is `handleSsr()` immediately before `pipeThrough()` starts reading the HTML stream.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Dynamic SSR | The first pull should happen after React's fast continuation work has had one task to settle. | Marks successful dynamic streams and awaits one render task before `pipeThrough()`. |
| Static/cache writes | Paths that already wait for `allReady` should not get extra timing behavior. | Leaves `waitForAllReady` unchanged. |
| Fallback shells | Synthetic PPR or recovered error shells are not React dynamic HTML streams. | Does not apply the delay to those paths. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| Fast Suspense boundary resolves on the next render task | Immediate HTML pull can flush fallback markup, then later emit resolved content. | Initial HTML pull waits one task and emits resolved content without the fallback marker. |
| Slow Suspense boundary | Fallback remains streamable. | Unchanged. |
| Static prerender or ISR cache write | Waits for `allReady`. | Unchanged. |

<details>
<summary>Validation</summary>

- `vp test run tests/app-ssr-stream.test.ts`
- `vp test run tests/nextjs-compat/streaming.test.ts`
- `vp check`
- `git diff --check`

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: none.
- Config: none.
- Build output shape: none expected.
- Runtime: adds one timer task before the first pull of successful dynamic App SSR HTML streams.
- Compatibility: aligns vinext with Next.js stream-pull timing for this Suspense edge case while leaving `waitForAllReady`, PPR fallback-shell, and recovered shell-error paths unchanged.

</details>

<details>
<summary>Non-goals</summary>

- Does not suppress legitimate fallbacks for Suspense boundaries that take longer than the next render task.
- Does not change RSC streaming or cache-write `allReady` behavior.

</details>

## References

| Link | Why it matters |
| --- | --- |
| [vinext issue #1723](https://github.com/cloudflare/vinext/issues/1723) | Tracking issue and expected audit/fix shape. |
| [Next.js commit 8bb6aa9](https://github.com/vercel/next.js/commit/8bb6aa9708fb3e4a816e74108d4c6599915af80c) | Upstream behavior change that triggered the issue. |
| [Next.js Node stream delay](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/stream-ops.node.ts#L620-L623) | Current canary delays `pipeable.pipe(pt)` until after one render task. |
| [Next.js web continuation delay](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/stream-utils/node-web-streams-helper.ts#L939-L946) | Dynamic web-stream continuation waits before pulling the render stream. |
| [Next.js scheduler helper](https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/scheduler.ts#L58-L63) | Shows the render-task scheduling distinction used by Next. |
