### PR TITLE
fix(pages): preserve data route path identity

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -86,6 +86,7 @@ import { mergeServerExternalPackages } from "./config/server-external-packages.j
 
 import { findMiddlewareFile, isProxyFile, runMiddleware } from "./server/middleware.js";
 import {
+  encodeUrlParserIgnoredCharacters,
   isNextDataPathname,
   normalizeNextDataPagePathname,
   parseNextDataPathname,
@@ -4762,17 +4763,20 @@ export const loadServerActionClient = ${
                 res.end("Bad Request");
                 return;
               }
+              if (urlParserCreatesPagesDataPath(pathname)) {
+                res.writeHead(404);
+                res.end("This page could not be found");
+                return;
+              }
+
+              // Preserve parser-ignored bytes until route param decoding. The
+              // literal characters would otherwise disappear in new URL().
+              pathname = encodeUrlParserIgnoredCharacters(pathname);
               // Keep url in sync with the normalized pathname so the pipeline
               // receives the decoded path for config rule matching.
               {
                 const qs = url.includes("?") ? url.slice(url.indexOf("?")) : "";
                 url = pathname + qs;
-              }
-
-              if (urlParserCreatesPagesDataPath(pathname)) {
-                res.writeHead(404);
-                res.end("This page could not be found");
-                return;
               }
 
               const capturedMiddlewarePath = middlewarePath;

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -89,6 +89,7 @@ import {
   isNextDataPathname,
   normalizeNextDataPagePathname,
   parseNextDataPathname,
+  urlParserCreatesPagesDataPath,
 } from "./server/pages-data-route.js";
 import { resolvePagesI18nRequest, stripI18nLocaleForApiRoute } from "./server/pages-i18n.js";
 import {
@@ -4766,6 +4767,12 @@ export const loadServerActionClient = ${
               {
                 const qs = url.includes("?") ? url.slice(url.indexOf("?")) : "";
                 url = pathname + qs;
+              }
+
+              if (urlParserCreatesPagesDataPath(pathname)) {
+                res.writeHead(404);
+                res.end("This page could not be found");
+                return;
               }
 
               const capturedMiddlewarePath = middlewarePath;

--- a/packages/vinext/src/server/pages-data-route.ts
+++ b/packages/vinext/src/server/pages-data-route.ts
@@ -59,6 +59,14 @@ export function urlParserCreatesPagesDataPath(pathname: string): boolean {
 }
 
 /**
+ * Keep URL-parser-ignored characters encoded until route matching decodes the
+ * captured parameter. Passing them literally to `new URL()` would remove them.
+ */
+export function encodeUrlParserIgnoredCharacters(pathname: string): string {
+  return pathname.replaceAll("\t", "%09").replaceAll("\n", "%0A").replaceAll("\r", "%0D");
+}
+
+/**
  * Parse `/_next/data/<buildId>/<...page>.json` and return the normalized page
  * pathname. Returns `null` if the pathname does not match the pattern or if
  * the buildId segment does not match the server's buildId.

--- a/packages/vinext/src/server/pages-data-route.ts
+++ b/packages/vinext/src/server/pages-data-route.ts
@@ -46,6 +46,19 @@ export function isNextDataPathname(pathname: string): boolean {
 }
 
 /**
+ * WHATWG URL parsing removes TAB, LF, and CR characters. Reject paths where
+ * that normalization would manufacture the internal Pages data namespace.
+ */
+export function urlParserCreatesPagesDataPath(pathname: string): boolean {
+  const parsedPathname = pathname.replaceAll("\t", "").replaceAll("\n", "").replaceAll("\r", "");
+  return (
+    pathname !== parsedPathname &&
+    !isNextDataPathname(pathname) &&
+    isNextDataPathname(parsedPathname)
+  );
+}
+
+/**
  * Parse `/_next/data/<buildId>/<...page>.json` and return the normalized page
  * pathname. Returns `null` if the pathname does not match the pattern or if
  * the buildId segment does not match the server's buildId.

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -49,6 +49,7 @@ import {
   isNextDataPathname,
   parseNextDataPathname,
   buildNextDataNotFoundResponse,
+  urlParserCreatesPagesDataPath,
 } from "./pages-data-route.js";
 import { hasBasePath, stripBasePath } from "../utils/base-path.js";
 import {
@@ -1550,15 +1551,6 @@ function isPagesServerEntryPageRoute(value: unknown): value is PagesServerEntryP
 
 function readPagesServerEntryPageRoutes(value: unknown): PagesServerEntryPageRoute[] | undefined {
   return Array.isArray(value) && value.every(isPagesServerEntryPageRoute) ? value : undefined;
-}
-
-function urlParserCreatesPagesDataPath(pathname: string): boolean {
-  const parsedPathname = pathname.replaceAll("\t", "").replaceAll("\n", "").replaceAll("\r", "");
-  return (
-    pathname !== parsedPathname &&
-    !isNextDataPathname(pathname) &&
-    isNextDataPathname(parsedPathname)
-  );
 }
 
 /**

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -49,6 +49,7 @@ import {
   isNextDataPathname,
   parseNextDataPathname,
   buildNextDataNotFoundResponse,
+  encodeUrlParserIgnoredCharacters,
   urlParserCreatesPagesDataPath,
 } from "./pages-data-route.js";
 import { hasBasePath, stripBasePath } from "../utils/base-path.js";
@@ -1793,6 +1794,13 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
         res.writeHead(404);
         res.end("This page could not be found");
         return;
+      }
+      // Preserve parser-ignored bytes until route param decoding. The literal
+      // characters would otherwise disappear when constructing webRequest.
+      pathname = encodeUrlParserIgnoredCharacters(pathname);
+      {
+        const qs = url.includes("?") ? url.slice(url.indexOf("?")) : "";
+        url = pathname + qs;
       }
       // ── 3b. `_next/data` normalization ────────────────────────────
       // Pages Router client-side navigations fetch

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -1552,6 +1552,15 @@ function readPagesServerEntryPageRoutes(value: unknown): PagesServerEntryPageRou
   return Array.isArray(value) && value.every(isPagesServerEntryPageRoute) ? value : undefined;
 }
 
+function urlParserCreatesPagesDataPath(pathname: string): boolean {
+  const parsedPathname = pathname.replaceAll("\t", "").replaceAll("\n", "").replaceAll("\r", "");
+  return (
+    pathname !== parsedPathname &&
+    !isNextDataPathname(pathname) &&
+    isNextDataPathname(parsedPathname)
+  );
+}
+
 /**
  * Start the Pages Router production server.
  *
@@ -1785,6 +1794,13 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
           url = stripped + qs;
           pathname = stripped;
         }
+      }
+      // WHATWG URL parsing removes TAB, LF, and CR. Do not let that transform
+      // an otherwise ordinary path into the internal Pages data namespace.
+      if (urlParserCreatesPagesDataPath(pathname)) {
+        res.writeHead(404);
+        res.end("This page could not be found");
+        return;
       }
       // ── 3b. `_next/data` normalization ────────────────────────────
       // Pages Router client-side navigations fetch

--- a/tests/e2e/cloudflare-pages-router/middleware.spec.ts
+++ b/tests/e2e/cloudflare-pages-router/middleware.spec.ts
@@ -69,4 +69,15 @@ test.describe("middleware.ts on Pages Router Cloudflare Workers (prod build)", (
       expect(await response.text()).not.toContain("Server-Side Rendered on Workers");
     }
   });
+
+  test("preserves encoded URL controls in data route parameters", async ({ page, request }) => {
+    await page.goto(`${BASE}/ssr`);
+    const buildId = await page.evaluate(() => (window as any).__NEXT_DATA__.buildId as string);
+
+    const response = await request.get(`${BASE}/_next/data/${buildId}/posts/foo%09.json`);
+    expect(response.status()).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      pageProps: { id: "foo\t" },
+    });
+  });
 });

--- a/tests/e2e/cloudflare-pages-router/middleware.spec.ts
+++ b/tests/e2e/cloudflare-pages-router/middleware.spec.ts
@@ -54,4 +54,19 @@ test.describe("middleware.ts on Pages Router Cloudflare Workers (prod build)", (
     expect(unhandled.headers()["content-type"]).toBe("text/plain; charset=utf-8");
     expect(await unhandled.text()).toBe("Not Found");
   });
+
+  test("does not reinterpret encoded URL controls as data paths", async ({ page, request }) => {
+    await page.goto(`${BASE}/ssr`);
+    const buildId = await page.evaluate(() => (window as any).__NEXT_DATA__.buildId as string);
+
+    for (const pathname of [
+      `/%09_next/data/${buildId}/ssr.json`,
+      `/_ne%0Axt/data/${buildId}/ssr.json`,
+      `/_next/%0Ddata/${buildId}/ssr.json`,
+    ]) {
+      const response = await request.get(`${BASE}${pathname}`);
+      expect(response.status()).toBe(404);
+      expect(await response.text()).not.toContain("Server-Side Rendered on Workers");
+    }
+  });
 });

--- a/tests/fixtures/pages-basic/middleware.ts
+++ b/tests/fixtures/pages-basic/middleware.ts
@@ -189,6 +189,10 @@ export function middleware(request: NextRequest) {
     return res;
   }
 
+  if (url.pathname === "/middleware-protected-data") {
+    return new Response("Access Denied", { status: 403 });
+  }
+
   // Return a binary response (PNG 1x1 pixel) to test binary body preservation
   if (url.pathname === "/binary-response") {
     const pixel = new Uint8Array([

--- a/tests/fixtures/pages-basic/pages/middleware-protected-data.tsx
+++ b/tests/fixtures/pages-basic/pages/middleware-protected-data.tsx
@@ -1,0 +1,15 @@
+export async function getServerSideProps() {
+  return {
+    props: {
+      confidentialValue: "only visible after middleware",
+    },
+  };
+}
+
+export default function MiddlewareProtectedData({
+  confidentialValue,
+}: {
+  confidentialValue: string;
+}) {
+  return <p>{confidentialValue}</p>;
+}

--- a/tests/pages-data-route.test.ts
+++ b/tests/pages-data-route.test.ts
@@ -5,6 +5,7 @@ import {
   parseNextDataPathname,
   buildNextDataJsonResponse,
   buildNextDataNotFoundResponse,
+  encodeUrlParserIgnoredCharacters,
   normalizePagesDataRequest,
   normalizeNextDataPagePathname,
   urlParserCreatesPagesDataPath,
@@ -41,6 +42,10 @@ describe("pages-data-route", () => {
       expect(urlParserCreatesPagesDataPath("/_next/data/abc/about.json")).toBe(false);
       expect(urlParserCreatesPagesDataPath("/about")).toBe(false);
     });
+  });
+
+  it("keeps URL-parser-ignored characters encoded for later parameter decoding", () => {
+    expect(encodeUrlParserIgnoredCharacters("/posts/a\tb\nc\rd")).toBe("/posts/a%09b%0Ac%0Dd");
   });
 
   describe("parseNextDataPathname", () => {

--- a/tests/pages-data-route.test.ts
+++ b/tests/pages-data-route.test.ts
@@ -7,6 +7,7 @@ import {
   buildNextDataNotFoundResponse,
   normalizePagesDataRequest,
   normalizeNextDataPagePathname,
+  urlParserCreatesPagesDataPath,
 } from "../packages/vinext/src/server/pages-data-route.js";
 
 // Helper mirroring vinext/html safeJsonStringify behavior for tests.
@@ -25,6 +26,20 @@ describe("pages-data-route", () => {
       expect(isNextDataPathname("/_next/static/chunks/foo.js")).toBe(false);
       expect(isNextDataPathname("/_next/data/abc/about")).toBe(false); // no .json
       expect(isNextDataPathname("/data/abc/about.json")).toBe(false);
+    });
+  });
+
+  describe("urlParserCreatesPagesDataPath", () => {
+    it("detects ignored controls that manufacture a data path", () => {
+      expect(urlParserCreatesPagesDataPath("/\t_next/data/abc/about.json")).toBe(true);
+      expect(urlParserCreatesPagesDataPath("/_ne\nxt/data/abc/about.json")).toBe(true);
+      expect(urlParserCreatesPagesDataPath("/_next/\rdata/abc/about.json")).toBe(true);
+    });
+
+    it("preserves ordinary controls and canonical data paths", () => {
+      expect(urlParserCreatesPagesDataPath("/posts/foo\t")).toBe(false);
+      expect(urlParserCreatesPagesDataPath("/_next/data/abc/about.json")).toBe(false);
+      expect(urlParserCreatesPagesDataPath("/about")).toBe(false);
     });
   });
 

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -2467,6 +2467,29 @@ describe("Pages Router integration", () => {
       expect(res.headers.get("x-custom-middleware")).toBe("active");
     });
 
+    it("does not reinterpret encoded URL controls as data paths in development", async () => {
+      const paths = [
+        `/%09_next/data/${BUILD_ID}/middleware-protected-data.json`,
+        `/_ne%0Axt/data/${BUILD_ID}/middleware-protected-data.json`,
+        `/_next/%0Ddata/${BUILD_ID}/middleware-protected-data.json`,
+      ];
+      for (const pathname of paths) {
+        const response = await fetch(`${baseUrl}${pathname}`);
+        expect(response.status).toBe(404);
+      }
+    });
+
+    it("preserves encoded URL controls in dynamic page parameters in development", async () => {
+      const page = await fetch(`${baseUrl}/posts/foo%09`);
+      expect(page.status).toBe(200);
+
+      const data = await fetch(`${baseUrl}/_next/data/${BUILD_ID}/posts/foo%09.json`);
+      expect(data.status).toBe(200);
+      await expect(data.json()).resolves.toMatchObject({
+        pageProps: { id: "foo" },
+      });
+    });
+
     it("returns the middleware data-miss protocol for an unknown page", async () => {
       const res = await fetch(`${baseUrl}/_next/data/${BUILD_ID}/totally-missing-page.json`);
       expect(res.status).toBe(200);
@@ -6892,6 +6915,35 @@ describe("Production server middleware (Pages Router)", () => {
       // in the deploy suite.
       expect(res.headers.get("x-mw-pathname")).toBe("/ssr");
       expect(res.headers.get("x-custom-middleware")).toBe("active");
+    });
+
+    it("does not expose middleware-protected props through encoded data paths", async () => {
+      const canonical = await fetch(
+        `${prodUrl}/_next/data/${BUILD_ID}/middleware-protected-data.json`,
+      );
+      expect(canonical.status).toBe(403);
+
+      const paths = [
+        `/%09_next/data/${BUILD_ID}/middleware-protected-data.json`,
+        `/_ne%0Axt/data/${BUILD_ID}/middleware-protected-data.json`,
+        `/_next/%0Ddata/${BUILD_ID}/middleware-protected-data.json`,
+      ];
+      for (const pathname of paths) {
+        const response = await fetch(`${prodUrl}${pathname}`);
+        expect(response.status).toBe(404);
+        expect(await response.text()).not.toContain("only visible after middleware");
+      }
+    });
+
+    it("preserves encoded URL controls in dynamic page parameters in production", async () => {
+      const page = await fetch(`${prodUrl}/posts/foo%09`);
+      expect(page.status).toBe(200);
+
+      const data = await fetch(`${prodUrl}/_next/data/${BUILD_ID}/posts/foo%09.json`);
+      expect(data.status).toBe(200);
+      await expect(data.json()).resolves.toMatchObject({
+        pageProps: { id: "foo" },
+      });
     });
 
     it("returns the middleware data-miss protocol for an unknown page", async () => {

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -2468,6 +2468,11 @@ describe("Pages Router integration", () => {
     });
 
     it("does not reinterpret encoded URL controls as data paths in development", async () => {
+      const canonical = await fetch(
+        `${baseUrl}/_next/data/${BUILD_ID}/middleware-protected-data.json`,
+      );
+      expect(canonical.status).toBe(403);
+
       const paths = [
         `/%09_next/data/${BUILD_ID}/middleware-protected-data.json`,
         `/_ne%0Axt/data/${BUILD_ID}/middleware-protected-data.json`,
@@ -2476,6 +2481,7 @@ describe("Pages Router integration", () => {
       for (const pathname of paths) {
         const response = await fetch(`${baseUrl}${pathname}`);
         expect(response.status).toBe(404);
+        expect(await response.text()).not.toContain("only visible after middleware");
       }
     });
 

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -2492,7 +2492,7 @@ describe("Pages Router integration", () => {
       const data = await fetch(`${baseUrl}/_next/data/${BUILD_ID}/posts/foo%09.json`);
       expect(data.status).toBe(200);
       await expect(data.json()).resolves.toMatchObject({
-        pageProps: { id: "foo" },
+        pageProps: { id: "foo\t" },
       });
     });
 
@@ -6948,7 +6948,7 @@ describe("Production server middleware (Pages Router)", () => {
       const data = await fetch(`${prodUrl}/_next/data/${BUILD_ID}/posts/foo%09.json`);
       expect(data.status).toBe(200);
       await expect(data.json()).resolves.toMatchObject({
-        pageProps: { id: "foo" },
+        pageProps: { id: "foo\t" },
       });
     });
 


### PR DESCRIPTION
## Summary

- keep Pages data-route classification stable when URL parsing removes ignored controls
- preserve ordinary dynamic page and canonical data-route parameter behavior
- add dev and built-production fixture coverage for protected data routes and dynamic params

## Validation

- targeted Pages data-route integration matrix (25 tests)
- targeted format, lint, and type checks
- independent parity/security review against current Next.js: no findings