### PR TITLE
fix(app-router): isolate interception cache variants

### DIFF
--- a/packages/vinext/src/server/app-interception-context-header.ts
+++ b/packages/vinext/src/server/app-interception-context-header.ts
@@ -1,3 +1,6 @@
+import { normalizePathnameForRouteMatch } from "../routing/utils.js";
+import { isInterceptionMatchedUrlPath, normalizePath } from "./normalize-path.js";
+
 /**
  * Normalize the `x-vinext-interception-context` header from inbound requests.
  *
@@ -30,6 +33,17 @@
 /** Hard cap on the byte length of the interception-context header value. */
 const MAX_INTERCEPTION_CONTEXT_LENGTH = 1024;
 
+/**
+ * Return the canonical pathname used by both interception matching and cache
+ * identity, or null when the value cannot be a browser-produced pathname.
+ */
+export function normalizeInterceptionContextPathname(value: string): string | null {
+  if (!isInterceptionMatchedUrlPath(value)) return null;
+
+  const normalized = normalizePath(normalizePathnameForRouteMatch(value));
+  return isInterceptionMatchedUrlPath(normalized) ? normalized : null;
+}
+
 export function normalizeInterceptionContextHeader(raw: string | null | undefined): string | null {
   if (!raw) return null;
   // Strip null bytes first so length bounds can't be evaded by padding with \0.
@@ -41,5 +55,5 @@ export function normalizeInterceptionContextHeader(raw: string | null | undefine
   if (!stripped.startsWith("/")) return null;
   // Raw whitespace is not legitimate inside a pathname.
   if (/\s/.test(stripped)) return null;
-  return stripped;
+  return normalizeInterceptionContextPathname(stripped);
 }

--- a/packages/vinext/src/server/app-page-cache-finalizer.ts
+++ b/packages/vinext/src/server/app-page-cache-finalizer.ts
@@ -49,7 +49,6 @@ type FinalizeAppPageHtmlCacheResponseOptions = {
   isrHtmlKey: (pathname: string) => string;
   isrRscKey: AppPageRscCacheKeyBuilder;
   isrSet: AppPageCacheSetter;
-  interceptionContext?: string | null;
   omitPendingDynamicCacheState?: boolean;
   preserveClientResponseHeaders?: boolean;
   expireSeconds?: number;
@@ -152,12 +151,10 @@ export function finalizeAppPageHtmlCacheResponse(
 
   const [streamForClient, streamForCache] = response.body.tee();
   const htmlKey = options.isrHtmlKey(options.cleanPathname);
-  const rscKey = options.isrRscKey(
-    options.cleanPathname,
-    null,
-    undefined,
-    options.interceptionContext,
-  );
+  // A document request always renders the direct page. Its captured Flight
+  // by-product therefore belongs to the direct RSC variant regardless of any
+  // client-supplied interception header on the HTML request.
+  const rscKey = options.isrRscKey(options.cleanPathname, null, undefined, null);
   const clientHeaders = new Headers(response.headers);
   if (options.preserveClientResponseHeaders !== true) {
     applyPendingDynamicCdnHeaders(clientHeaders, options.getPageTags(), {

--- a/packages/vinext/src/server/app-page-cache.ts
+++ b/packages/vinext/src/server/app-page-cache.ts
@@ -434,12 +434,7 @@ export async function readAppPageCacheResponse(
             // computed lazily so a deduped (skipped) regen pays nothing.
             options.isRscRequest
               ? isrKey
-              : options.isrRscKey(
-                  options.cleanPathname,
-                  null,
-                  options.renderMode,
-                  options.interceptionContext,
-                ),
+              : options.isrRscKey(options.cleanPathname, null, options.renderMode, null),
             buildAppPageCacheValue(
               "",
               revalidatedPage.rscData,

--- a/packages/vinext/src/server/app-page-render-identity.ts
+++ b/packages/vinext/src/server/app-page-render-identity.ts
@@ -1,6 +1,7 @@
 import { normalizePathnameForRouteMatch } from "../routing/utils.js";
 import { AppElementsWire, type AppElementsInterception } from "./app-elements.js";
-import { isInterceptionMatchedUrlPath, normalizePath } from "./normalize-path.js";
+import { normalizeInterceptionContextPathname } from "./app-interception-context-header.js";
+import { normalizePath } from "./normalize-path.js";
 
 type AppPageRenderIdentityInput = {
   displayPathname: string;
@@ -29,8 +30,7 @@ function normalizeAppPageRenderMatchedPathname(pathname: string): string {
 }
 
 export function normalizeAppPageInterceptionProofPathname(pathname: string | null): string | null {
-  if (pathname === null || !isInterceptionMatchedUrlPath(pathname)) return null;
-  return normalizeAppPageRenderMatchedPathname(pathname);
+  return pathname === null ? null : normalizeInterceptionContextPathname(pathname);
 }
 
 export function createAppPageRenderIdentity(

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -1232,7 +1232,6 @@ export async function renderAppPageLifecycle(
       isrHtmlKey: options.isrHtmlKey,
       isrRscKey: options.isrRscKey,
       isrSet: options.isrSet,
-      interceptionContext: options.interceptionContext,
       omitPendingDynamicCacheState: options.omitPendingDynamicCacheState,
       preserveClientResponseHeaders: !htmlResponsePolicy.shouldWriteToCache,
       expireSeconds,

--- a/packages/vinext/src/server/app-rsc-cache-busting.ts
+++ b/packages/vinext/src/server/app-rsc-cache-busting.ts
@@ -66,10 +66,6 @@ function encodeBase64Url(bytes: Uint8Array): string {
   return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
 }
 
-function normalizeHeaderValue(value: string | null): string {
-  return value ?? "0";
-}
-
 function normalizeCompatibilityId(value: string | null | undefined): string | null {
   return value && value.length > 0 ? value : null;
 }
@@ -174,8 +170,8 @@ function createCacheBustingInput(
   headers: Headers,
   options: CreateCacheBustingInputOptions = {},
 ): string | null {
-  // The order of these values determines the hash. Changing it is a breaking
-  // cache-key change and requires accepting the previous hash during rollout.
+  // The order of these values determines the hash. Older clients are safely
+  // redirected to the current canonical URL when this encoding changes.
   const values = [
     headers.get(NEXT_ROUTER_PREFETCH_HEADER),
     headers.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER),
@@ -192,7 +188,11 @@ function createCacheBustingInput(
     return null;
   }
 
-  return values.map(normalizeHeaderValue).join(",");
+  // JSON array serialization is injective for this string/null tuple: field
+  // boundaries cannot be forged with commas, null remains distinct from the
+  // literal string "0", and six-field compatibility inputs cannot alias the
+  // seven-field canonical form.
+  return JSON.stringify(values);
 }
 
 async function sha256CacheBustingHash(input: string): Promise<string> {

--- a/packages/vinext/src/server/app-rsc-route-matching.ts
+++ b/packages/vinext/src/server/app-rsc-route-matching.ts
@@ -4,6 +4,7 @@ import {
   matchRoutePatternPrefix,
   type RoutePatternParams,
 } from "../routing/route-pattern.js";
+import { normalizeInterceptionContextPathname } from "./app-interception-context-header.js";
 import { splitPathnameForRouteMatch } from "../routing/utils.js";
 
 /**
@@ -137,9 +138,11 @@ export function createAppRscRouteMatcher<Route extends AppRscRouteForMatching>(
       // header for the rewrite to gate on, so we render the direct route.
       // https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/generate-interception-routes-rewrites.ts
       if (sourcePathname === null) return null;
+      const normalizedSourcePathname = normalizeInterceptionContextPathname(sourcePathname);
+      if (normalizedSourcePathname === null) return null;
 
       const urlParts = appRscPathnameParts(pathname);
-      const sourceParts = appRscPathnameParts(sourcePathname);
+      const sourceParts = appRscPathnameParts(normalizedSourcePathname);
       const matchedSourceRoute = trieMatch(routeTrie, sourceParts);
 
       for (const entry of interceptLookup) {

--- a/packages/vinext/src/server/isr-cache.ts
+++ b/packages/vinext/src/server/isr-cache.ts
@@ -410,12 +410,18 @@ export function appIsrRscKey(
   interceptionContext?: string | null,
 ): string {
   const normalizedMountedSlotsHeader = normalizeMountedSlotsHeader(mountedSlotsHeader);
-  const sourceVariant =
+  const normalizedInterceptionContext =
     interceptionContext === undefined || interceptionContext === null
       ? null
       : normalizeInterceptionContextForCacheKey(interceptionContext);
+  const sourceVariant =
+    interceptionContext === undefined || interceptionContext === null
+      ? null
+      : normalizedInterceptionContext === null
+        ? `source-invalid:${fnv1a64(interceptionContext)}`
+        : `source:${fnv1a64(normalizedInterceptionContext)}`;
   const variant = [
-    sourceVariant ? `source:${fnv1a64(sourceVariant)}` : null,
+    sourceVariant,
     normalizedMountedSlotsHeader ? `slots:${fnv1a64(normalizedMountedSlotsHeader)}` : null,
     getRscRenderModeCacheVariant(renderMode),
   ]

--- a/tests/app-cdn-cache-production.test.ts
+++ b/tests/app-cdn-cache-production.test.ts
@@ -7,6 +7,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vite-plus/test";
 import { createBuilder } from "vite";
 import { cdnAdapter } from "../packages/cloudflare/src/cache/cdn-adapter.js";
 import vinext from "../packages/vinext/src/index.js";
+import { computeRscCacheBustingSearchParam } from "../packages/vinext/src/server/app-rsc-cache-busting.js";
 import {
   DefaultCdnCacheAdapter,
   setCdnCacheAdapter,
@@ -30,7 +31,8 @@ function createWorkersLikeEdge(handler: AppHandler) {
       return originRequests;
     },
     async fetch(request: Request): Promise<Response> {
-      const cacheKey = new URL(request.url).pathname;
+      const url = new URL(request.url);
+      const cacheKey = `${url.pathname}${url.search}`;
       const cached = entries.get(cacheKey);
       if (cached) return cached.clone();
 
@@ -187,6 +189,39 @@ describe("App Router production responses with a CDN-managed cache", () => {
     expect(firstRsc.headers.get("cdn-cache-control")).toMatch(/public, max-age=31536000/);
     await rscEdge.fetch(rscRequest());
     expect(rscEdge.originRequests).toBe(1);
+  });
+
+  it("rejects a different RSC variant at an intercepted navigation's CDN cache URL", async () => {
+    const edge = createWorkersLikeEdge(handler);
+    const victimHeaders = new Headers({
+      accept: "text/x-component",
+      rsc: "1",
+      "x-vinext-interception-context": "/interception-source",
+    });
+    const victimHash = await computeRscCacheBustingSearchParam(victimHeaders);
+    const victimUrl = `https://example.com/interception-target.rsc?_rsc=${victimHash}`;
+
+    // With the old comma-joined fingerprint, this six-field compatibility
+    // input is byte-identical to the victim's seven-field input. It must be
+    // canonicalized rather than rendered and stored at the victim's URL.
+    const attacker = await edge.fetch(
+      new Request(victimUrl, {
+        headers: {
+          accept: "text/x-component",
+          rsc: "1",
+          "next-url": "0,/interception-source",
+        },
+      }),
+    );
+    expect(attacker.status).toBe(307);
+    expect(attacker.headers.get("location")).not.toContain(`_rsc=${victimHash}`);
+
+    const victim = await edge.fetch(new Request(victimUrl, { headers: victimHeaders }));
+    expect(victim.status).toBe(200);
+    const victimPayload = await victim.text();
+    expect(victimPayload).toContain("CDN_INTERCEPTED_MODAL");
+    expect(victimPayload).not.toContain("CDN_FULL_PAGE");
+    expect(edge.originRequests).toBe(2);
   });
 
   it("returns a streaming no-store response when verification exceeds its deadline", async () => {

--- a/tests/app-router-dev-server.test.ts
+++ b/tests/app-router-dev-server.test.ts
@@ -791,6 +791,22 @@ describe("App Router integration", () => {
     expect(rscPayload.includes(`route:/photos/42${nul}/feed`)).toBe(false);
   });
 
+  it("does not intercept malformed source context pathnames", async () => {
+    for (const interceptionContext of ["//feed", "/feed?tab=popular", "/feed#modal"]) {
+      const res = await fetch(`${baseUrl}/photos/42.rsc`, {
+        headers: {
+          Accept: "text/x-component",
+          "X-Vinext-Interception-Context": interceptionContext,
+        },
+      });
+      expect(res.status).toBe(200);
+
+      const rscPayload = await res.text();
+      expect(rscPayload).toContain("Full photo view");
+      expect(rscPayload).not.toContain("photo-modal");
+    }
+  });
+
   // --- Intercepting routes with dynamic source route ---
   // Regression: pickRouteParams must extract actual URL param values
   // (e.g. "42") from the request pathname, not the literal pattern strings

--- a/tests/app-router-production-server.test.ts
+++ b/tests/app-router-production-server.test.ts
@@ -532,6 +532,82 @@ describe("App Router Production server (startProdServer)", () => {
     expect(interceptCss).toContain("scroll-padding-top:20px");
   });
 
+  it("does not let a malformed interception context replace the direct RSC cache entry", async () => {
+    const target = "/interception-cache-target/malformed";
+    const flightHeaders = {
+      Accept: "text/x-component",
+      RSC: "1",
+    };
+
+    const prime = await fetch(`${baseUrl}${target}.rsc`, { headers: flightHeaders });
+    expect(prime.status).toBe(200);
+    expect(await prime.text()).toContain("FULL_PAGE:malformed");
+
+    // The vulnerable path requires a stale entry: a forged source value is
+    // matched as /interception-cache-source during regeneration while its ISR
+    // key collapses onto the direct variant.
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+    const attacker = await fetch(`${baseUrl}${target}.rsc`, {
+      headers: {
+        ...flightHeaders,
+        "X-Vinext-Interception-Context": "//interception-cache-source",
+      },
+    });
+    expect(attacker.status).toBe(200);
+    await attacker.arrayBuffer();
+
+    let settledPayload = "";
+    await waitForCondition(async () => {
+      const settled = await fetch(`${baseUrl}${target}.rsc`, {
+        headers: {
+          ...flightHeaders,
+          "X-Vinext-Interception-Context": "//interception-cache-source",
+        },
+      });
+      settledPayload = await settled.text();
+      return settled.headers.get("x-vinext-cache") === "HIT";
+    });
+    expect(settledPayload).toContain("FULL_PAGE:malformed");
+    expect(settledPayload).not.toContain("INTERCEPTED_MODAL:malformed");
+
+    const victim = await fetch(`${baseUrl}${target}.rsc`, { headers: flightHeaders });
+    expect(victim.status).toBe(200);
+    const victimPayload = await victim.text();
+    expect(victimPayload).toContain("FULL_PAGE:malformed");
+    expect(victimPayload).not.toContain("INTERCEPTED_MODAL:malformed");
+  });
+
+  it("does not let an HTML request populate an intercepted RSC cache variant", async () => {
+    const target = "/interception-cache-target/html";
+    const source = "/interception-cache-source";
+
+    const attacker = await fetch(`${baseUrl}${target}`, {
+      headers: { "X-Vinext-Interception-Context": source },
+    });
+    expect(attacker.status).toBe(200);
+    expect(await attacker.text()).toContain("FULL_PAGE:html");
+
+    // An HTML HIT proves the finalizer's Promise.all completed, including the
+    // captured RSC by-product write, before the victim navigation starts.
+    await waitForCondition(async () => {
+      const settled = await fetch(`${baseUrl}${target}`);
+      await settled.arrayBuffer();
+      return settled.headers.get("x-vinext-cache") === "HIT";
+    });
+
+    const victim = await fetch(`${baseUrl}${target}.rsc`, {
+      headers: {
+        Accept: "text/x-component",
+        RSC: "1",
+        "X-Vinext-Interception-Context": source,
+      },
+    });
+    expect(victim.status).toBe(200);
+    const victimPayload = await victim.text();
+    expect(victimPayload).toContain("INTERCEPTED_MODAL:html");
+    expect(victimPayload).not.toContain("FULL_PAGE:html");
+  });
+
   it("does not reuse cached HTML across requests with different CSP nonces", async () => {
     const firstRes = await fetch(`${baseUrl}/revalidate-test?csp-nonce=first`);
     expect(firstRes.status).toBe(200);

--- a/tests/app-rsc-cache-busting.test.ts
+++ b/tests/app-rsc-cache-busting.test.ts
@@ -108,6 +108,25 @@ describe("App Router RSC cache-busting", () => {
     expect(feedHash).not.toBe(galleryHash);
   });
 
+  it("uses an injective encoding for absent, literal, and delimiter-bearing headers", async () => {
+    const absent = createRscRequestHeaders();
+    absent.set("next-router-state-tree", "tree");
+    const literalZero = new Headers(absent);
+    literalZero.set("next-url", "0");
+    const splitFields = new Headers(absent);
+    splitFields.set("next-url", "/feed");
+    splitFields.set("x-vinext-interception-context", "/photos/42");
+    const commaSpliced = new Headers(absent);
+    commaSpliced.set("next-url", "/feed,/photos/42");
+
+    await expect(computeRscCacheBustingSearchParam(absent)).resolves.not.toBe(
+      await computeRscCacheBustingSearchParam(literalZero),
+    );
+    await expect(computeRscCacheBustingSearchParam(splitFields)).resolves.not.toBe(
+      await computeRscCacheBustingSearchParam(commaSpliced),
+    );
+  });
+
   it("varies loading-shell prefetch payloads from normal navigations", async () => {
     const navigationHash = await computeRscCacheBustingSearchParam(createRscRequestHeaders());
     const prefetchShellHash = await computeRscCacheBustingSearchParam(
@@ -234,7 +253,9 @@ describe("App Router RSC cache-busting", () => {
 
   it("accepts legacy FNV cache-busting params during rolling upgrades", async () => {
     const headers = createRscRequestHeaders({ mountedSlotsHeader: "slot:modal:/" });
-    const legacyHash = fnv1a64("0,0,0,0,0,slot:modal:/");
+    const legacyHash = fnv1a64(
+      JSON.stringify([null, null, null, null, null, "slot:modal:/", null]),
+    );
     const request = new Request(`https://example.com/photos/42.rsc?_rsc=${legacyHash}`, {
       headers,
     });
@@ -246,7 +267,9 @@ describe("App Router RSC cache-busting", () => {
 
   it("accepts previous SHA cache-busting params after adding a varying header", async () => {
     const headers = createRscRequestHeaders({ mountedSlotsHeader: "slot:modal:/" });
-    const previousHash = await sha256CacheBustingHash("0,0,0,0,0,slot:modal:/");
+    const previousHash = await sha256CacheBustingHash(
+      JSON.stringify([null, null, null, null, null, "slot:modal:/"]),
+    );
     const request = new Request(`https://example.com/photos/42.rsc?_rsc=${previousHash}`, {
       headers,
     });
@@ -254,6 +277,21 @@ describe("App Router RSC cache-busting", () => {
     await expect(
       resolveInvalidRscCacheBustingRequest({ isRscRequest: true, request }),
     ).resolves.toBeNull();
+  });
+
+  it("redirects hashes from the ambiguous pre-upgrade encoding", async () => {
+    const headers = createRscRequestHeaders({ mountedSlotsHeader: "slot:modal:/" });
+    const ambiguousHash = await sha256CacheBustingHash("0,0,0,0,0,slot:modal:/,0");
+    const request = new Request(`https://example.com/photos/42.rsc?_rsc=${ambiguousHash}`, {
+      headers,
+    });
+
+    const response = await resolveInvalidRscCacheBustingRequest({
+      isRscRequest: true,
+      request,
+    });
+    expect(response?.status).toBe(307);
+    expect(response?.headers.get("location")).not.toContain(ambiguousHash);
   });
 
   it("ignores non-RSC and mutating requests", async () => {

--- a/tests/app-rsc-request-normalization.test.ts
+++ b/tests/app-rsc-request-normalization.test.ts
@@ -304,6 +304,25 @@ describe("normalizeRscRequest — interception context sanitization", () => {
     expect(result.interceptionContextHeader).toBe("/feed/photos/42");
   });
 
+  it("canonicalizes interception context before matching and cache keying", () => {
+    const result = normalized(
+      normalizeRscRequest(
+        req("/page", { "X-Vinext-Interception-Context": "/unused/%2e%2e//feed/" }),
+        "",
+      ),
+    );
+    expect(result.interceptionContextHeader).toBe("/feed");
+  });
+
+  it("rejects interception context values that are not path-only URLs", () => {
+    for (const value of ["//feed", "/feed?tab=popular", "/feed#modal"]) {
+      const result = normalized(
+        normalizeRscRequest(req("/page", { "X-Vinext-Interception-Context": value }), ""),
+      );
+      expect(result.interceptionContextHeader).toBeNull();
+    }
+  });
+
   it("strips null bytes from interception context header to prevent header injection", () => {
     // new Request() rejects \0 in header values, so construct a structural fake.
     const request = {

--- a/tests/app-rsc-route-matching.test.ts
+++ b/tests/app-rsc-route-matching.test.ts
@@ -500,6 +500,29 @@ describe("App RSC route matching", () => {
       expect(matcher.findIntercept("/showcase/multi/slug")).toBeNull();
     });
 
+    it("uses the same canonical source pathname as the ISR cache identity", () => {
+      const matcher = createAppRscRouteMatcher([
+        route("/feed", ["feed"], {
+          modal: {
+            intercepts: [
+              {
+                sourceMatchPattern: "/feed",
+                targetPattern: "/photos/:id",
+                interceptLayouts: ["layout"],
+                page: "modal-photo",
+                params: ["id"],
+              },
+            ],
+          },
+        }),
+      ]);
+
+      expect(matcher.findIntercept("/photos/42", "/unused/%2e%2e//feed")).not.toBeNull();
+      for (const invalid of ["//feed", "/feed?tab=popular", "/feed#modal"]) {
+        expect(matcher.findIntercept("/photos/42", invalid)).toBeNull();
+      }
+    });
+
     it("accepts descendants of the intercepting route as valid sources", () => {
       // Header regex appends `(?:/.*)?` to allow any descendant of the
       // intercepting route to trigger the rewrite.

--- a/tests/e2e/app-router/nextjs-compat/client-cache.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/client-cache.spec.ts
@@ -435,4 +435,32 @@ test.describe("Next.js compat: client cache", () => {
     expect(await navigateTo(page, "#client-cache-none", "2")).toBe(refreshed);
     expect(requestsFor(requests, `${ROOT}/2`)).toEqual([]);
   });
+
+  test("HTML request headers cannot replace an intercepted navigation payload", async ({
+    page,
+  }) => {
+    // Next.js hard navigations render the direct target while soft navigation
+    // from an intercepting source renders the modal branch:
+    // https://github.com/vercel/next.js/tree/canary/test/e2e/app-dir/parallel-routes-and-interception
+    const source = "/interception-cache-source";
+    const target = "/interception-cache-target/html-browser";
+
+    await page.setExtraHTTPHeaders({ "X-Vinext-Interception-Context": source });
+    await page.goto(target);
+    await waitForAppRouterHydration(page);
+    await expect(page.getByTestId("interception-cache-full-page")).toHaveText(
+      "FULL_PAGE:html-browser",
+    );
+
+    await page.setExtraHTTPHeaders({});
+    await page.goto(source);
+    await waitForAppRouterHydration(page);
+    await page.click("#interception-cache-browser-link");
+
+    await expect(page).toHaveURL(target);
+    await expect(page.getByTestId("interception-cache-modal")).toHaveText(
+      "INTERCEPTED_MODAL:html-browser",
+    );
+    await expect(page.getByTestId("interception-cache-full-page")).not.toBeVisible();
+  });
 });

--- a/tests/fixtures/app-basic/app/interception-cache-source/@modal/(...)interception-cache-target/[case]/page.tsx
+++ b/tests/fixtures/app-basic/app/interception-cache-source/@modal/(...)interception-cache-target/[case]/page.tsx
@@ -1,0 +1,10 @@
+export const revalidate = 1;
+
+export default async function InterceptionCacheModalPage({
+  params,
+}: {
+  params: { case: string } | Promise<{ case: string }>;
+}) {
+  const { case: testCase } = await params;
+  return <div data-testid="interception-cache-modal">{`INTERCEPTED_MODAL:${testCase}`}</div>;
+}

--- a/tests/fixtures/app-basic/app/interception-cache-source/@modal/default.tsx
+++ b/tests/fixtures/app-basic/app/interception-cache-source/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function InterceptionCacheModalDefault() {
+  return null;
+}

--- a/tests/fixtures/app-basic/app/interception-cache-source/layout.tsx
+++ b/tests/fixtures/app-basic/app/interception-cache-source/layout.tsx
@@ -1,0 +1,14 @@
+export default function InterceptionCacheSourceLayout({
+  children,
+  modal,
+}: {
+  children: React.ReactNode;
+  modal: React.ReactNode;
+}) {
+  return (
+    <main data-testid="interception-cache-source-layout">
+      {children}
+      <aside data-testid="interception-cache-modal-slot">{modal}</aside>
+    </main>
+  );
+}

--- a/tests/fixtures/app-basic/app/interception-cache-source/page.tsx
+++ b/tests/fixtures/app-basic/app/interception-cache-source/page.tsx
@@ -1,0 +1,18 @@
+import Link from "next/link";
+
+export const revalidate = 1;
+
+export default function InterceptionCacheSourcePage() {
+  return (
+    <section data-testid="interception-cache-source-page">
+      <h1>Interception cache source</h1>
+      <Link href="/interception-cache-target/malformed">Malformed context target</Link>
+      <Link href="/interception-cache-target/html" id="interception-cache-html-link">
+        HTML context target
+      </Link>
+      <Link href="/interception-cache-target/html-browser" id="interception-cache-browser-link">
+        Browser interception cache target
+      </Link>
+    </section>
+  );
+}

--- a/tests/fixtures/app-basic/app/interception-cache-target/[case]/page.tsx
+++ b/tests/fixtures/app-basic/app/interception-cache-target/[case]/page.tsx
@@ -1,0 +1,10 @@
+export const revalidate = 1;
+
+export default async function InterceptionCacheTargetPage({
+  params,
+}: {
+  params: { case: string } | Promise<{ case: string }>;
+}) {
+  const { case: testCase } = await params;
+  return <main data-testid="interception-cache-full-page">{`FULL_PAGE:${testCase}`}</main>;
+}

--- a/tests/fixtures/cdn-late-dynamic/app/interception-source/@modal/(...)interception-target/page.tsx
+++ b/tests/fixtures/cdn-late-dynamic/app/interception-source/@modal/(...)interception-target/page.tsx
@@ -1,0 +1,5 @@
+export const revalidate = 60;
+
+export default function InterceptionModalPage() {
+  return <div id="intercepted-modal">CDN_INTERCEPTED_MODAL</div>;
+}

--- a/tests/fixtures/cdn-late-dynamic/app/interception-source/@modal/default.tsx
+++ b/tests/fixtures/cdn-late-dynamic/app/interception-source/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function InterceptionModalDefault() {
+  return null;
+}

--- a/tests/fixtures/cdn-late-dynamic/app/interception-source/layout.tsx
+++ b/tests/fixtures/cdn-late-dynamic/app/interception-source/layout.tsx
@@ -1,0 +1,14 @@
+export default function InterceptionSourceLayout({
+  children,
+  modal,
+}: {
+  children: React.ReactNode;
+  modal: React.ReactNode;
+}) {
+  return (
+    <main>
+      {children}
+      <aside id="interception-modal-slot">{modal}</aside>
+    </main>
+  );
+}

--- a/tests/fixtures/cdn-late-dynamic/app/interception-source/page.tsx
+++ b/tests/fixtures/cdn-late-dynamic/app/interception-source/page.tsx
@@ -1,0 +1,5 @@
+export const revalidate = 60;
+
+export default function InterceptionSourcePage() {
+  return <h1 id="interception-source">CDN interception source</h1>;
+}

--- a/tests/fixtures/cdn-late-dynamic/app/interception-target/page.tsx
+++ b/tests/fixtures/cdn-late-dynamic/app/interception-target/page.tsx
@@ -1,0 +1,5 @@
+export const revalidate = 60;
+
+export default function InterceptionTargetPage() {
+  return <main id="full-page">CDN_FULL_PAGE</main>;
+}

--- a/tests/isr-cache.test.ts
+++ b/tests/isr-cache.test.ts
@@ -227,13 +227,14 @@ describe("App Router ISR cache key primitives", () => {
     expect(duplicateSlash).toBe(decoded);
   });
 
-  it("ignores invalid source context before keying intercepted RSC variants", () => {
+  it("keeps invalid source context isolated from direct RSC variants", () => {
     delete process.env.__VINEXT_BUILD_ID;
 
     const invalidSource = appIsrRscKey("/photos/42", "modal", undefined, "/feed?tab=popular");
     const direct = appIsrRscKey("/photos/42", "modal");
 
-    expect(invalidSource).toBe(direct);
+    expect(invalidSource).not.toBe(direct);
+    expect(invalidSource).toMatch(/^app:\/photos\/42:rsc:source-invalid:[a-z0-9]+$/);
   });
 
   it("keys RSC loading-shell prefetch variants separately from normal navigation variants", () => {


### PR DESCRIPTION
## Summary

- canonicalize interception source identity consistently across matching and caching
- isolate malformed interception contexts from reusable response variants
- keep HTML-generated Flight payloads in their direct cache namespace
- make interception variant fingerprints unambiguous while preserving compatibility redirects

## Validation

- targeted cache, routing, and production server suites (508 passed)
- production Chromium interception/client-cache E2E (10 passed)
- Cloudflare Worker navigation/RSC E2E (4 passed)
- vinext and Cloudflare adapter builds
- changed-file format, lint, type, and diff checks

## Dependency

Stacked on #2582 for bounded edge-cache eligibility verification.