### PR TITLE
fix(config): preserve destination path boundaries

### DIFF
--- a/packages/vinext/src/config/config-matchers.ts
+++ b/packages/vinext/src/config/config-matchers.ts
@@ -1214,16 +1214,10 @@ function substituteDestinationParams(
 
     const pathnameStart = value.indexOf("/", authorityStart);
     if (pathnameStart === -1) {
-      return replaceParams(value, (param, key) =>
-        conditionCaptureParams && Object.hasOwn(conditionCaptureParams, key)
-          ? encodeURIComponent(param)
-          : param,
-      );
+      return replaceParams(value, (param) => encodeURIComponent(param));
     }
-    const authority = replaceParams(value.slice(0, pathnameStart), (param, key) =>
-      conditionCaptureParams && Object.hasOwn(conditionCaptureParams, key)
-        ? encodeURIComponent(param)
-        : param,
+    const authority = replaceParams(value.slice(0, pathnameStart), (param) =>
+      encodeURIComponent(param),
     );
     return authority + replaceParams(value.slice(pathnameStart), encodePathParam);
   };

--- a/packages/vinext/src/config/config-matchers.ts
+++ b/packages/vinext/src/config/config-matchers.ts
@@ -72,6 +72,8 @@ const _compiledConditionCache = new Map<string, RegExp | null>();
  * for repeated redirect/rewrite calls that use the same param shape.
  */
 const _compiledDestinationParamCache = new Map<string, RegExp>();
+const ENCODED_DOT_SEGMENT_RE = /^%2e$/i;
+const ENCODED_DOT_DOT_SEGMENT_RE = /^(?:%2e){2}$/i;
 
 /**
  * Generic helper for the regex compilation caches above.
@@ -1197,12 +1199,20 @@ function substituteDestinationParams(
     );
 
   const encodePathParam = (value: string, key: string, modifier: string | undefined): string => {
-    if (!conditionCaptureParams || !Object.hasOwn(conditionCaptureParams, key)) return value;
+    const isConditionCapture = conditionCaptureParams && Object.hasOwn(conditionCaptureParams, key);
     const encodeSegment = (segment: string): string => {
-      if (segment === ".") return "%252e";
-      if (segment === "..") return "%252e%252e";
+      if (segment === "." || ENCODED_DOT_SEGMENT_RE.test(segment)) return "%252e";
+      if (segment === ".." || ENCODED_DOT_DOT_SEGMENT_RE.test(segment)) return "%252e%252e";
+      if (!isConditionCapture) return segment;
       return encodeURIComponent(segment);
     };
+    if (!isConditionCapture) {
+      // Source captures have already been decoded segment-by-segment. Keep
+      // ordinary pchars and catch-all separators unchanged, but restore the
+      // encoding layer on double-encoded dot segments before URL parsing can
+      // normalize them into traversal (e.g. `%252e%252e` -> `%2e%2e`).
+      return value.split("/").map(encodeSegment).join("/");
+    }
     return modifier === "*" || modifier === "+"
       ? value.split("/").map(encodeSegment).join("/")
       : encodeSegment(value);

--- a/packages/vinext/src/config/config-matchers.ts
+++ b/packages/vinext/src/config/config-matchers.ts
@@ -73,7 +73,7 @@ const _compiledConditionCache = new Map<string, RegExp | null>();
  */
 const _compiledDestinationParamCache = new Map<string, RegExp>();
 const ENCODED_DOT_SEGMENT_RE = /^%2e$/i;
-const ENCODED_DOT_DOT_SEGMENT_RE = /^(?:%2e){2}$/i;
+const ENCODED_DOT_DOT_SEGMENT_RE = /^(?:%2e%2e|%2e\.|\.%2e)$/i;
 
 /**
  * Generic helper for the regex compilation caches above.
@@ -1201,8 +1201,11 @@ function substituteDestinationParams(
   const encodePathParam = (value: string, key: string, modifier: string | undefined): string => {
     const isConditionCapture = conditionCaptureParams && Object.hasOwn(conditionCaptureParams, key);
     const encodeSegment = (segment: string): string => {
-      if (segment === "." || ENCODED_DOT_SEGMENT_RE.test(segment)) return "%252e";
-      if (segment === ".." || ENCODED_DOT_DOT_SEGMENT_RE.test(segment)) return "%252e%252e";
+      if (segment === ".") return "%252e";
+      if (segment === "..") return "%252e%252e";
+      if (ENCODED_DOT_SEGMENT_RE.test(segment) || ENCODED_DOT_DOT_SEGMENT_RE.test(segment)) {
+        return segment.replaceAll("%", "%25");
+      }
       if (!isConditionCapture) return segment;
       return encodeURIComponent(segment);
     };

--- a/packages/vinext/src/config/config-matchers.ts
+++ b/packages/vinext/src/config/config-matchers.ts
@@ -1269,14 +1269,25 @@ function substituteAndSanitizeDestination(
   );
 }
 
-// URL rejects encoded host delimiters such as `%2F`, `%3A`, and `%40`. Treat
-// such substitutions as a non-matching rule instead of proxying or redirecting
-// to a request-selected authority.
+const URL_SCHEME_RE = /^([a-z][a-z0-9+.-]*):/i;
+
+// A substitution must not introduce or change a URL scheme. Besides keeping
+// relative destinations relative, this makes the pre-substitution component
+// split authoritative: a template such as `:scheme://:host` cannot evade the
+// authority encoder by acquiring its scheme only after source params are
+// inserted. Next.js rejects that template at config-load time; vinext does not
+// yet perform the same full validation, so the runtime must still fail closed.
+// For hierarchical absolute URLs, parsing also rejects encoded host delimiters
+// such as `%2F`, `%3A`, and `%40`.
 function isValidSubstitutedExternalDestination(template: string, destination: string): boolean {
-  if (!/^https?:\/\//i.test(template)) return true;
+  const templateScheme = URL_SCHEME_RE.exec(template)?.[1]?.toLowerCase();
+  const destinationScheme = URL_SCHEME_RE.exec(destination)?.[1]?.toLowerCase();
+  if (templateScheme !== destinationScheme) return false;
+  if (!templateScheme || !template.slice(template.indexOf(":") + 1).startsWith("//")) return true;
+
   try {
     const parsed = new URL(destination);
-    return parsed.protocol === "http:" || parsed.protocol === "https:";
+    return parsed.protocol.toLowerCase() === `${templateScheme}:`;
   } catch {
     return false;
   }

--- a/packages/vinext/src/config/config-matchers.ts
+++ b/packages/vinext/src/config/config-matchers.ts
@@ -1004,10 +1004,15 @@ export function matchRedirect(
             : _emptyParams();
         if (!conditionParams) continue;
         // Locale was omitted (the `?` made it optional) — param value is "".
-        const dest = substituteAndSanitizeDestination(redirect.destination, {
-          [entry.paramName]: "",
-          ...conditionParams,
-        });
+        const dest = substituteAndSanitizeDestination(
+          redirect.destination,
+          {
+            [entry.paramName]: "",
+            ...conditionParams,
+          },
+          conditionParams,
+        );
+        if (!isValidSubstitutedExternalDestination(redirect.destination, dest)) continue;
         localeMatch = { destination: dest, permanent: redirect.permanent };
         localeMatchIndex = entry.originalIndex;
         break; // bucket entries are in insertion order = original order
@@ -1034,10 +1039,15 @@ export function matchRedirect(
               ? collectConditionParams(redirect.has, redirect.missing, ctx)
               : _emptyParams();
           if (!conditionParams) continue;
-          const dest = substituteAndSanitizeDestination(redirect.destination, {
-            [entry.paramName]: localePart,
-            ...conditionParams,
-          });
+          const dest = substituteAndSanitizeDestination(
+            redirect.destination,
+            {
+              [entry.paramName]: localePart,
+              ...conditionParams,
+            },
+            conditionParams,
+          );
+          if (!isValidSubstitutedExternalDestination(redirect.destination, dest)) continue;
           localeMatch = { destination: dest, permanent: redirect.permanent };
           localeMatchIndex = entry.originalIndex;
           break; // bucket entries are in insertion order = original order
@@ -1065,10 +1075,15 @@ export function matchRedirect(
           : _emptyParams();
       if (!conditionParams) continue;
       // Collapse protocol-relative URLs (e.g. //evil.com from decoded %2F in catch-all params).
-      const dest = substituteAndSanitizeDestination(redirect.destination, {
-        ...params,
-        ...conditionParams,
-      });
+      const dest = substituteAndSanitizeDestination(
+        redirect.destination,
+        {
+          ...params,
+          ...conditionParams,
+        },
+        conditionParams,
+      );
+      if (!isValidSubstitutedExternalDestination(redirect.destination, dest)) continue;
       return { destination: dest, permanent: redirect.permanent };
     }
   }
@@ -1105,7 +1120,13 @@ export function matchRewrite(
         ...conditionParams,
       };
       // Collapse protocol-relative URLs (e.g. //evil.com from decoded %2F in catch-all params).
-      return substituteAndSanitizeRewriteDestination(rewrite.destination, rewriteParams);
+      const destination = substituteAndSanitizeRewriteDestination(
+        rewrite.destination,
+        rewriteParams,
+        conditionParams,
+      );
+      if (!isValidSubstitutedExternalDestination(rewrite.destination, destination)) continue;
+      return destination;
     }
   }
   return null;
@@ -1136,8 +1157,18 @@ export function matchesRewriteSource(
  *
  * Handles repeated params (e.g. `/api/:id/:id`) and catch-all suffix forms
  * (`:path*`, `:path+`) in a single pass. Unknown params are left intact.
+ * Request-condition captures are encoded for the URL component receiving
+ * them so request data cannot introduce new path, query, fragment, or
+ * authority structure. This is an intentional defense-in-depth divergence
+ * from Next.js's raw `prepareDestination` substitution.
+ *
+ * https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/prepare-destination.ts
  */
-function substituteDestinationParams(destination: string, params: Record<string, string>): string {
+function substituteDestinationParams(
+  destination: string,
+  params: Record<string, string>,
+  conditionCaptureParams?: Readonly<Record<string, string>>,
+): string {
   const keys = Object.keys(params);
   if (keys.length === 0) return destination;
 
@@ -1157,8 +1188,45 @@ function substituteDestinationParams(destination: string, params: Record<string,
     _compiledDestinationParamCache.set(cacheKey, paramRe);
   }
 
-  const replaceParams = (value: string, encodeParam: (value: string) => string): string =>
-    value.replace(paramRe, (_token, key: string) => encodeParam(params[key]));
+  const replaceParams = (
+    value: string,
+    encodeParam: (value: string, key: string, modifier: string | undefined) => string,
+  ): string =>
+    value.replace(paramRe, (_token, key: string, modifier: string | undefined) =>
+      encodeParam(params[key], key, modifier),
+    );
+
+  const encodePathParam = (value: string, key: string, modifier: string | undefined): string => {
+    if (!conditionCaptureParams || !Object.hasOwn(conditionCaptureParams, key)) return value;
+    const encodeSegment = (segment: string): string => {
+      if (segment === ".") return "%252e";
+      if (segment === "..") return "%252e%252e";
+      return encodeURIComponent(segment);
+    };
+    return modifier === "*" || modifier === "+"
+      ? value.split("/").map(encodeSegment).join("/")
+      : encodeSegment(value);
+  };
+
+  const replaceAuthorityAndPathParams = (value: string): string => {
+    const authorityStart = value.match(/^[A-Za-z][A-Za-z\d+.-]*:\/\//)?.[0].length;
+    if (authorityStart === undefined) return replaceParams(value, encodePathParam);
+
+    const pathnameStart = value.indexOf("/", authorityStart);
+    if (pathnameStart === -1) {
+      return replaceParams(value, (param, key) =>
+        conditionCaptureParams && Object.hasOwn(conditionCaptureParams, key)
+          ? encodeURIComponent(param)
+          : param,
+      );
+    }
+    const authority = replaceParams(value.slice(0, pathnameStart), (param, key) =>
+      conditionCaptureParams && Object.hasOwn(conditionCaptureParams, key)
+        ? encodeURIComponent(param)
+        : param,
+    );
+    return authority + replaceParams(value.slice(pathnameStart), encodePathParam);
+  };
 
   const hashIndex = destination.indexOf("#");
   const beforeHash = hashIndex === -1 ? destination : destination.slice(0, hashIndex);
@@ -1168,13 +1236,21 @@ function substituteDestinationParams(destination: string, params: Record<string,
   if (queryIndex !== -1) {
     const beforeQuery = beforeHash.slice(0, queryIndex);
     const query = beforeHash.slice(queryIndex + 1);
-    return `${replaceParams(beforeQuery, (value) => value)}?${replaceParams(
+    return `${replaceAuthorityAndPathParams(beforeQuery)}?${replaceParams(
       query,
       encodeDestinationQueryParamValue,
-    )}${replaceParams(hash, (value) => value)}`;
+    )}${replaceParams(hash, (value, key) =>
+      conditionCaptureParams && Object.hasOwn(conditionCaptureParams, key)
+        ? encodeURIComponent(value)
+        : value,
+    )}`;
   }
 
-  return replaceParams(destination, (value) => value);
+  return `${replaceAuthorityAndPathParams(beforeHash)}${replaceParams(hash, (value, key) =>
+    conditionCaptureParams && Object.hasOwn(conditionCaptureParams, key)
+      ? encodeURIComponent(value)
+      : value,
+  )}`;
 }
 
 function encodeDestinationQueryParamValue(value: string): string {
@@ -1192,8 +1268,24 @@ function encodeDestinationQueryParamValue(value: string): string {
 function substituteAndSanitizeDestination(
   destination: string,
   params: Record<string, string>,
+  conditionCaptureParams?: Readonly<Record<string, string>>,
 ): string {
-  return sanitizeDestination(substituteDestinationParams(destination, params));
+  return sanitizeDestination(
+    substituteDestinationParams(destination, params, conditionCaptureParams),
+  );
+}
+
+// URL rejects encoded host delimiters such as `%2F`, `%3A`, and `%40`. Treat
+// such substitutions as a non-matching rule instead of proxying or redirecting
+// to a request-selected authority.
+function isValidSubstitutedExternalDestination(template: string, destination: string): boolean {
+  if (!/^https?:\/\//i.test(template)) return true;
+  try {
+    const parsed = new URL(destination);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -1206,8 +1298,9 @@ function substituteAndSanitizeDestination(
 function substituteAndSanitizeRewriteDestination(
   destination: string,
   params: Record<string, string>,
+  conditionCaptureParams?: Readonly<Record<string, string>>,
 ): string {
-  const rewritten = substituteAndSanitizeDestination(destination, params);
+  const rewritten = substituteAndSanitizeDestination(destination, params, conditionCaptureParams);
   if (!shouldAppendRewriteParamsToQuery(destination, params)) return rewritten;
 
   const existingQueryKeys = getDestinationQueryKeys(destination);

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -4399,7 +4399,15 @@ export const loadServerActionClient = ${
         // BEFORE Vite's built-in middleware. This ensures all requests
         // (including /@*, /__vite*, /node_modules* paths) are validated
         // before Vite serves any content.
+        type DevPagesMiddleware = (
+          req: import("node:http").IncomingMessage,
+          res: import("node:http").ServerResponse,
+          next: (err?: unknown) => void,
+        ) => Promise<void>;
+        let handlePagesMiddleware: DevPagesMiddleware | undefined;
+        const preVitePagesRequests = new WeakSet<import("node:http").IncomingMessage>();
         server.middlewares.use((req, res, next) => {
+          const rawRequestUrl = req.url ?? "/";
           const blockReason = validateDevRequest(
             {
               origin: req.headers.origin as string | undefined,
@@ -4414,6 +4422,21 @@ export const loadServerActionClient = ${
             console.warn(`[vinext] Blocked dev request: ${blockReason} (${req.url})`);
             res.writeHead(403, { "Content-Type": "text/plain" });
             res.end("Forbidden");
+            return;
+          }
+          const rawPathname = rawRequestUrl.split("?", 1)[0];
+          if (
+            hasPagesDir &&
+            middlewarePath &&
+            /%25(?:2e|2E)[.]|[.]%25(?:2e|2E)/.test(rawPathname) &&
+            handlePagesMiddleware
+          ) {
+            // Vite treats the literal half of these mixed encoded-dot segments
+            // as a file extension and can 404 before vinext middleware runs.
+            // Dispatch them through the Pages pipeline while the raw URL is
+            // still intact; the post-Vite registration skips the same request.
+            preVitePagesRequests.add(req);
+            void handlePagesMiddleware(req, res, next);
             return;
           }
           next();
@@ -4648,14 +4671,19 @@ export const loadServerActionClient = ${
             });
           }
 
-          const handlePagesMiddleware = async (
+          handlePagesMiddleware = async (
             req: import("node:http").IncomingMessage,
             res: import("node:http").ServerResponse,
             next: (err?: unknown) => void,
           ): Promise<void> => {
             try {
               let url: string = req.url ?? "/";
+              const rawRequestUrl = url;
               const originalRequestUrl = url;
+              const rawRequestPathname = rawRequestUrl.split("?", 1)[0];
+              const hasMixedEncodedDotSegment = /%25(?:2e|2E)[.]|[.]%25(?:2e|2E)/.test(
+                rawRequestPathname,
+              );
 
               // If no pages directory, skip this middleware entirely
               // (app router is handled by @vitejs/plugin-rsc's built-in middleware)
@@ -4736,6 +4764,18 @@ export const loadServerActionClient = ${
                 url = url.replace(/\.html(?=\?|$)/, "");
               }
 
+              // Preserve the encoded request path for middleware-visible
+              // request.url / request.nextUrl. Internal routing below uses a
+              // decoded and normalized pathname, but writing that value back
+              // into a WHATWG URL can collapse encoded dot segments.
+              let middlewareUrl = rawRequestUrl;
+              const rawMiddlewarePathname = middlewareUrl.split("?", 1)[0];
+              if (rawMiddlewarePathname.endsWith("/index.html")) {
+                middlewareUrl = middlewareUrl.replace("/index.html", "/");
+              } else if (rawMiddlewarePathname.endsWith(".html")) {
+                middlewareUrl = middlewareUrl.replace(/\.html(?=\?|$)/, "");
+              }
+
               let pathname = url.split("?")[0];
 
               // Guard against protocol-relative URL open redirects.
@@ -4785,6 +4825,13 @@ export const loadServerActionClient = ${
                 const qs = url.includes("?") ? url.slice(url.indexOf("?")) : "";
                 url = stripped + qs;
                 pathname = stripped;
+                const middlewarePathname = middlewareUrl.split("?", 1)[0];
+                if (middlewarePathname === bp || middlewarePathname.startsWith(bp + "/")) {
+                  const middlewareQs = middlewareUrl.includes("?")
+                    ? middlewareUrl.slice(middlewareUrl.indexOf("?"))
+                    : "";
+                  middlewareUrl = (middlewarePathname.slice(bp.length) || "/") + middlewareQs;
+                }
               }
 
               if (nextConfig) {
@@ -4840,6 +4887,7 @@ export const loadServerActionClient = ${
                   );
                   url = pagePathname + qs;
                   pathname = pagePathname;
+                  middlewareUrl = pagePathname + qs;
                   // Rewrite req.url so downstream middleware sees the page
                   // path, not the raw _next/data URL.
                   req.url = url;
@@ -4875,7 +4923,8 @@ export const loadServerActionClient = ${
                   hadBasePath: true,
                 }),
               );
-              const isFilePathRequest = pathname.includes(".") && !pathname.endsWith(".html");
+              const isFilePathRequest =
+                !hasMixedEncodedDotSegment && pathname.includes(".") && !pathname.endsWith(".html");
               let filePathMatchesPagesRoute = false;
               const requestHostname = getUrlHostname(requestOrigin);
               if (isFilePathRequest && !filePathMatchesRewrite) {
@@ -4973,7 +5022,7 @@ export const loadServerActionClient = ${
                       const mwProto =
                         rawProto === "https" || rawProto === "http" ? rawProto : "http";
                       const mwOrigin = `${mwProto}://${requestHost}`;
-                      const middlewareRequest = new Request(new URL(url, mwOrigin), {
+                      const middlewareRequest = new Request(new URL(middlewareUrl, mwOrigin), {
                         method: req.method,
                         headers: nodeRequestHeaders,
                       });
@@ -5287,6 +5336,8 @@ export const loadServerActionClient = ${
           };
 
           server.middlewares.use((req, res, next) => {
+            if (preVitePagesRequests.has(req)) return next();
+            if (!handlePagesMiddleware) return next();
             void handlePagesMiddleware(req, res, next);
           });
         };

--- a/packages/vinext/src/server/middleware-runtime.ts
+++ b/packages/vinext/src/server/middleware-runtime.ts
@@ -224,7 +224,6 @@ function resolveMiddlewarePathname(request: Request): string | Response {
 
 function createNextRequest(
   request: Request,
-  normalizedPathname: string,
   i18nConfig?: NextI18nConfig | null,
   basePath?: string,
   trailingSlash?: boolean,
@@ -235,19 +234,13 @@ function createNextRequest(
   // the original request body.
   let mwRequest = request.body && !request.bodyUsed ? request.clone() : request;
   // NextURL._stripBasePath only recognises basePath when the URL's pathname
-  // actually starts with the basePath prefix. normalizedPathname may already
-  // be basePath-stripped (App Router passes cleanPathname, the dev server
-  // receives Vite-stripped URLs), so for in-basePath requests we re-add the
-  // basePath prefix here to mirror the un-stripped URL that Next.js's
-  // middleware adapter always receives. NextURL will strip it back during
-  // construction, and request.nextUrl.basePath will correctly reflect the
-  // configured value. Out-of-basePath ("absolute path") requests must stay
-  // un-prefixed so the middleware observes nextUrl.basePath === "" (Next.js
-  // getNextPathnameInfo semantics).
+  // actually starts with the basePath prefix. Some callers pass a URL with
+  // that prefix already stripped, so restore it from the original encoded
+  // pathname. The normalized matcher pathname must not be written back into
+  // the URL: WHATWG URL parsing would collapse encoded dot segments and make
+  // middleware observe a different request path than the client sent.
   const mwPathname =
-    basePath && hadBasePath
-      ? addBasePathToPathname(normalizedPathname, basePath)
-      : normalizedPathname;
+    basePath && hadBasePath ? addBasePathToPathname(url.pathname, basePath) : url.pathname;
   if (mwPathname !== url.pathname) {
     const mwUrl = new URL(url);
     mwUrl.pathname = mwPathname;
@@ -315,7 +308,6 @@ export async function executeMiddleware(
 
   const nextRequest = createNextRequest(
     options.request,
-    normalizedPathname,
     options.i18nConfig,
     options.basePath,
     options.trailingSlash,

--- a/packages/vinext/src/server/pages-request-pipeline.ts
+++ b/packages/vinext/src/server/pages-request-pipeline.ts
@@ -113,6 +113,10 @@ export type PagesPipelineDeps = {
   // pass it so the redirect query isn't re-encoded by URL parsing (e.g. a literal "#"
   // would otherwise be truncated as a fragment). Falls back to url.search when omitted.
   rawSearch?: string;
+  // Node production keeps Request.url encoded until userland sees it, but its
+  // adapter has already performed the canonical pathname normalization used
+  // for routing/config matching. Other adapters derive from Request.url.
+  normalizedPathname?: string;
 
   // Route + render/api callbacks (optional — if absent, emit intent instead of Response)
   matchPageRoute?: ((pathname: string, request: Request) => PageRouteMatch | null) | null;
@@ -254,7 +258,7 @@ export async function runPagesRequest(
       : proxyExternalRequest(currentReq, externalUrl);
 
   const url = new URL(request.url);
-  let pathname = url.pathname;
+  let pathname = deps.normalizedPathname ?? url.pathname;
   const search = url.search;
 
   // Step 1: Reconstruct basePathState

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -1435,14 +1435,15 @@ async function startAppRouterServer(options: AppRouterServerOptions) {
     }
 
     try {
-      // Build the normalized URL (pathname + original query string) so the
-      // RSC handler receives an already-canonical path and doesn't need to
-      // re-normalize. This deduplicates the normalizePath work done above.
+      // Keep the request pathname encoded for the RSC handler, which owns the
+      // single decode + normalize pass. Passing `pathname` here would decode
+      // twice and let Request's WHATWG URL parser collapse encoded dot
+      // segments before config redirects/rewrites can preserve them.
       const qs = rawUrl.includes("?") ? rawUrl.slice(rawUrl.indexOf("?")) : "";
-      const normalizedUrl = pathname + qs;
+      const requestUrl = normalizedRawPathname + qs;
 
       // Convert Node.js request to Web Request and call the RSC handler
-      const request = nodeToWebRequest(req, normalizedUrl, prerenderSecret);
+      const request = nodeToWebRequest(req, requestUrl, prerenderSecret);
       const response = await rscHandler(request);
 
       const staticFileSignal = response.headers.get(VINEXT_STATIC_FILE_HEADER);
@@ -1645,12 +1646,13 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
       return;
     }
 
-    // Normalize backslashes (browsers treat /\ as //), then decode and normalize path.
-    // Rebuild `url` from the decoded pathname + original query string so all
-    // downstream consumers (resolvedUrl, resolvedPathname, config matchers)
-    // always work with the decoded, canonical path.
+    // Normalize backslashes (browsers treat /\ as //), then decode and normalize
+    // once for routing/static lookup. The Web Request below retains the encoded
+    // pathname; runPagesRequest receives this canonical value separately so a
+    // WHATWG URL parse cannot collapse encoded dot segments first.
     const rawPagesPathname = rawPagesPathnameBeforeNormalize.replaceAll("\\", "/");
     const rawQs = rawUrl.includes("?") ? rawUrl.slice(rawUrl.indexOf("?")) : "";
+    let requestPathname = rawPagesPathname;
     let pathname: string;
     try {
       pathname = normalizePath(normalizePathnameForRouteMatchStrict(rawPagesPathname));
@@ -1784,6 +1786,7 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
           const qs = url.includes("?") ? url.slice(url.indexOf("?")) : "";
           url = stripped + qs;
           pathname = stripped;
+          requestPathname = stripBasePath(requestPathname, basePath);
         }
       }
       // ── 3b. `_next/data` normalization ────────────────────────────
@@ -1813,6 +1816,7 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
         );
         url = pagePathname + qs;
         pathname = pagePathname;
+        requestPathname = pagePathname;
       }
 
       // Convert Node.js req to Web Request for the server entry
@@ -1828,7 +1832,7 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
       const reqHeaders = filterInternalHeaders(rawReqHeaders);
       const method = req.method ?? "GET";
       const hasBody = method !== "GET" && method !== "HEAD";
-      const webRequest = new Request(`${protocol}://${hostHeader}${url}`, {
+      const webRequest = new Request(`${protocol}://${hostHeader}${requestPathname}${rawQs}`, {
         method,
         headers: reqHeaders,
         body: hasBody ? readNodeStream(req) : undefined,
@@ -1851,6 +1855,10 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
         ctx: undefined, // Node has no ExecutionContext
         // Raw query from req.url so redirect Locations aren't re-encoded by URL parsing.
         rawSearch: rawQs,
+        // Preserve the once-normalized pathname separately from Request.url.
+        // Request retains the encoded inbound path for middleware/userland,
+        // while config matching sees the same decoded path as dev.
+        normalizedPathname: pathname,
         matchPageRoute: matchPageRoute ?? null,
         // Pass the original (pre-basePath-stripping) URL to middleware so that
         // request.nextUrl.basePath reflects whether the URL actually had the

--- a/tests/app-router-dev-server.test.ts
+++ b/tests/app-router-dev-server.test.ts
@@ -75,13 +75,64 @@ async function withCountingFetchTarget<T>(
 describe("App Router integration", () => {
   let server: ViteDevServer;
   let baseUrl: string;
+  let configCapturePathTarget: http.Server;
+  const configCapturePathRequests: string[] = [];
 
   beforeAll(async () => {
-    ({ server, baseUrl } = await startFixtureServer(APP_FIXTURE_DIR, { appRouter: true }));
+    configCapturePathTarget = http.createServer((req, res) => {
+      configCapturePathRequests.push(req.url ?? "");
+      res.end("proxied");
+    });
+    await new Promise<void>((resolve, reject) => {
+      configCapturePathTarget.once("error", reject);
+      configCapturePathTarget.listen(0, "127.0.0.1", () => {
+        configCapturePathTarget.off("error", reject);
+        resolve();
+      });
+    });
+    const address = configCapturePathTarget.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Config capture target did not bind to a TCP port");
+    }
+    process.env.TEST_CONFIG_CAPTURE_PATH_TARGET = `http://127.0.0.1:${address.port}`;
+    try {
+      ({ server, baseUrl } = await startFixtureServer(APP_FIXTURE_DIR, { appRouter: true }));
+    } finally {
+      delete process.env.TEST_CONFIG_CAPTURE_PATH_TARGET;
+    }
   }, 30000);
 
   afterAll(async () => {
-    await server?.close();
+    try {
+      await server?.close();
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        configCapturePathTarget?.close((error) => (error ? reject(error) : resolve()));
+      });
+      delete process.env.TEST_CONFIG_CAPTURE_PATH_TARGET;
+    }
+  });
+
+  // Next.js custom-route encoding oracle:
+  // https://github.com/vercel/next.js/blob/canary/test/integration/custom-routes/test/index.test.ts
+  // Double-encoded traversal oracle:
+  // https://github.com/vercel/next.js/blob/canary/test/integration/file-serving/test/index.test.ts
+  it("preserves encoded dot segments in config redirect source captures", async () => {
+    const res = await fetch(`${baseUrl}/source-capture-dot-redirect/%252e%252e/admin`, {
+      redirect: "manual",
+    });
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe("/safe/%252e%252e/admin");
+  });
+
+  it("preserves encoded dot segments in external rewrite source captures", async () => {
+    configCapturePathRequests.length = 0;
+    const res = await fetch(`${baseUrl}/source-capture-dot-rewrite/%252e%252e/admin`);
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("proxied");
+    expect(configCapturePathRequests).toEqual(["/safe/%252e%252e/admin"]);
   });
 
   it("renders the home page with root layout", async () => {

--- a/tests/app-router-dev-server.test.ts
+++ b/tests/app-router-dev-server.test.ts
@@ -72,6 +72,12 @@ async function withCountingFetchTarget<T>(
   }
 }
 
+const ENCODED_DOT_SEGMENT_CASES = [
+  ["%252e%252e", "%252e%252e"],
+  ["%252e.", "%252e."],
+  [".%252e", ".%252e"],
+] as const;
+
 describe("App Router integration", () => {
   let server: ViteDevServer;
   let baseUrl: string;
@@ -117,23 +123,31 @@ describe("App Router integration", () => {
   // https://github.com/vercel/next.js/blob/canary/test/integration/custom-routes/test/index.test.ts
   // Double-encoded traversal oracle:
   // https://github.com/vercel/next.js/blob/canary/test/integration/file-serving/test/index.test.ts
-  it("preserves encoded dot segments in config redirect source captures", async () => {
-    const res = await fetch(`${baseUrl}/source-capture-dot-redirect/%252e%252e/admin`, {
-      redirect: "manual",
-    });
+  it.each(ENCODED_DOT_SEGMENT_CASES)(
+    "preserves encoded dot segment %s in config redirect source captures",
+    async (requestSegment, destinationSegment) => {
+      const res = await fetch(`${baseUrl}/source-capture-dot-redirect/${requestSegment}/admin`, {
+        redirect: "manual",
+      });
 
-    expect(res.status).toBe(307);
-    expect(res.headers.get("location")).toBe("/safe/%252e%252e/admin");
-  });
+      expect(res.status).toBe(307);
+      expect(res.headers.get("location")).toBe(
+        `https://redirect.example.test/safe/${destinationSegment}/admin`,
+      );
+    },
+  );
 
-  it("preserves encoded dot segments in external rewrite source captures", async () => {
-    configCapturePathRequests.length = 0;
-    const res = await fetch(`${baseUrl}/source-capture-dot-rewrite/%252e%252e/admin`);
+  it.each(ENCODED_DOT_SEGMENT_CASES)(
+    "preserves encoded dot segment %s in external rewrite source captures",
+    async (requestSegment, destinationSegment) => {
+      configCapturePathRequests.length = 0;
+      const res = await fetch(`${baseUrl}/source-capture-dot-rewrite/${requestSegment}/admin`);
 
-    expect(res.status).toBe(200);
-    expect(await res.text()).toBe("proxied");
-    expect(configCapturePathRequests).toEqual(["/safe/%252e%252e/admin"]);
-  });
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe("proxied");
+      expect(configCapturePathRequests).toEqual([`/safe/${destinationSegment}/admin`]);
+    },
+  );
 
   it("renders the home page with root layout", async () => {
     const { res, html } = await fetchHtml(baseUrl, "/");

--- a/tests/app-router-dev-server.test.ts
+++ b/tests/app-router-dev-server.test.ts
@@ -253,6 +253,21 @@ describe("App Router integration", () => {
     expect(nestedRes.headers.get("e2e-headers")).toBe("middleware");
   });
 
+  // Ported from Next.js middleware request construction and encoded traversal coverage:
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/adapter.ts
+  // https://github.com/vercel/next.js/blob/canary/test/integration/file-serving/test/index.test.ts
+  it("preserves encoded dot segments in middleware-visible URLs in dev", async () => {
+    for (const segment of ["%252e%252e", "%252e.", ".%252e"]) {
+      const pathname = `/protected/${segment}/public`;
+      const res = await fetch(`${baseUrl}${pathname}`);
+
+      expect(res.status).toBe(403);
+      expect(res.headers.get("x-mw-permissive")).toBe("false");
+      expect(res.headers.get("x-mw-url-pathname")).toBe(pathname);
+      expect(res.headers.get("x-mw-next-url-pathname")).toBe(pathname);
+    }
+  });
+
   it("handles GET API route handlers", async () => {
     const res = await fetch(`${baseUrl}/api/hello`);
     expect(res.status).toBe(200);

--- a/tests/app-router-production-server.test.ts
+++ b/tests/app-router-production-server.test.ts
@@ -273,13 +273,18 @@ describe("App Router Production server (startProdServer)", () => {
 
     try {
       // Build the app-basic fixture to the default dist/ directory
-      const builder = await createBuilder({
-        root: APP_FIXTURE_DIR,
-        configFile: false,
-        plugins: [vinext({ appDir: APP_FIXTURE_DIR })],
-        logLevel: "silent",
-      });
-      await builder.buildApp();
+      process.env.TEST_CONFIG_CAPTURE_EXTERNAL = "1";
+      try {
+        const builder = await createBuilder({
+          root: APP_FIXTURE_DIR,
+          configFile: false,
+          plugins: [vinext({ appDir: APP_FIXTURE_DIR })],
+          logLevel: "silent",
+        });
+        await builder.buildApp();
+      } finally {
+        delete process.env.TEST_CONFIG_CAPTURE_EXTERNAL;
+      }
 
       // Start the production server on a random available port
       const { startProdServer } = await import("../packages/vinext/src/server/prod-server.js");
@@ -303,6 +308,7 @@ describe("App Router Production server (startProdServer)", () => {
         delete process.env.TEST_APP_STATIC_DYNAMIC_TARGET;
         delete process.env.TEST_APP_STATIC_REVALIDATE_TARGET;
         delete process.env.TEST_REVALIDATE_PATH_REWRITES_TARGET;
+        delete process.env.TEST_CONFIG_CAPTURE_EXTERNAL;
       }
       throw error;
     }
@@ -318,6 +324,7 @@ describe("App Router Production server (startProdServer)", () => {
     delete process.env.TEST_APP_STATIC_DYNAMIC_TARGET;
     delete process.env.TEST_APP_STATIC_REVALIDATE_TARGET;
     delete process.env.TEST_REVALIDATE_PATH_REWRITES_TARGET;
+    delete process.env.TEST_CONFIG_CAPTURE_EXTERNAL;
     fs.rmSync(outDir, { recursive: true, force: true });
   });
 
@@ -1223,6 +1230,45 @@ describe("App Router Production server (startProdServer)", () => {
     // recomputing the cache-busting `_rsc` param from the request headers
     // (rather than echoing the literal client value), so assert presence.
     expect(location).toContain("_rsc");
+  });
+
+  it("keeps request condition captures inert in config redirect paths", async () => {
+    const res = await fetch(`${baseUrl}/condition-capture-redirect`, {
+      redirect: "manual",
+      headers: { "x-redirect-segment": "safe?admin=1#fragment" },
+    });
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe(
+      "/config-capture-redirect/safe%3Fadmin%3D1%23fragment",
+    );
+  });
+
+  it("does not turn request condition captures into config rewrite query syntax", async () => {
+    const res = await fetch(`${baseUrl}/condition-capture-rewrite`, {
+      headers: { "x-rewrite-segment": "safe?admin=1" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      slug: ["safe?admin=1"],
+      query: {},
+    });
+  });
+
+  it("does not let request condition captures change a config rewrite authority", async () => {
+    await withCountingFetchTarget(async (targetUrl, getRequestCount) => {
+      const target = new URL(targetUrl);
+      const res = await fetch(`${baseUrl}/condition-capture-external`, {
+        headers: {
+          "x-rewrite-host": `${target.hostname}:${target.port}/reached?ignored=`,
+        },
+      });
+
+      expect(res.status).toBe(404);
+      await res.arrayBuffer();
+      expect(getRequestCount()).toBe(0);
+    });
   });
 
   it("serves static assets with cache headers", async () => {

--- a/tests/app-router-production-server.test.ts
+++ b/tests/app-router-production-server.test.ts
@@ -924,6 +924,21 @@ describe("App Router Production server (startProdServer)", () => {
     expect(nestedRes.headers.get("e2e-headers")).toBe("middleware");
   });
 
+  // Ported from Next.js middleware request construction and encoded traversal coverage:
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/adapter.ts
+  // https://github.com/vercel/next.js/blob/canary/test/integration/file-serving/test/index.test.ts
+  it("preserves encoded dot segments in middleware-visible URLs in production", async () => {
+    for (const segment of ["%252e%252e", "%252e.", ".%252e"]) {
+      const pathname = `/protected/${segment}/public`;
+      const res = await fetch(`${baseUrl}${pathname}`);
+
+      expect(res.status).toBe(403);
+      expect(res.headers.get("x-mw-permissive")).toBe("false");
+      expect(res.headers.get("x-mw-url-pathname")).toBe(pathname);
+      expect(res.headers.get("x-mw-next-url-pathname")).toBe(pathname);
+    }
+  });
+
   // Regression test for issue 1487 — App Router page-segment `revalidate`
   // should produce a stable cached response. Two requests inside the
   // revalidate window must return identical HTML bytes (same Date.now()

--- a/tests/app-router-production-server.test.ts
+++ b/tests/app-router-production-server.test.ts
@@ -1284,6 +1284,19 @@ describe("App Router Production server (startProdServer)", () => {
     });
   });
 
+  it("does not let source captures construct a config rewrite scheme and authority", async () => {
+    await withCountingFetchTarget(async (targetUrl, getRequestCount) => {
+      const target = new URL(targetUrl);
+      const res = await fetch(
+        `${baseUrl}/source-capture-scheme/http/${target.hostname}:${target.port}/reached`,
+      );
+
+      expect(res.status).toBe(404);
+      await res.arrayBuffer();
+      expect(getRequestCount()).toBe(0);
+    });
+  });
+
   it("serves static assets with cache headers", async () => {
     // Find an actual hashed JS asset from the build.
     const assetsDir = path.join(outDir, "client", "_next", "static", "chunks");

--- a/tests/app-router-production-server.test.ts
+++ b/tests/app-router-production-server.test.ts
@@ -1297,6 +1297,25 @@ describe("App Router Production server (startProdServer)", () => {
     });
   });
 
+  it("preserves mixed encoded dot segments after production request normalization", async () => {
+    // The Node production entry and App request handler each normalize one
+    // layer, so use an additional encoding layer to exercise the config
+    // matcher with the same `%2e.` / `.%2e` captures seen in dev and Workers.
+    for (const [requestSegment, destinationSegment] of [
+      ["%25252e.", "%252e."],
+      [".%25252e", ".%252e"],
+    ]) {
+      const res = await fetch(`${baseUrl}/source-capture-dot-redirect/${requestSegment}/admin`, {
+        redirect: "manual",
+      });
+
+      expect(res.status).toBe(307);
+      expect(res.headers.get("location")).toBe(
+        `https://redirect.example.test/safe/${destinationSegment}/admin`,
+      );
+    }
+  });
+
   it("serves static assets with cache headers", async () => {
     // Find an actual hashed JS asset from the build.
     const assetsDir = path.join(outDir, "client", "_next", "static", "chunks");

--- a/tests/app-router-production-server.test.ts
+++ b/tests/app-router-production-server.test.ts
@@ -217,6 +217,8 @@ describe("App Router Production server (startProdServer)", () => {
   let appStaticDynamicTarget: StartedTextSequenceTarget | undefined;
   let appStaticRevalidateTarget: StartedTextSequenceTarget | undefined;
   let revalidatePathFetchTarget: StartedTextSequenceTarget | undefined;
+  let configCapturePathTarget: StartedTextSequenceTarget | undefined;
+  const configCapturePathRequests: string[] = [];
 
   function extractRequestId(html: string): string | undefined {
     return (
@@ -266,10 +268,16 @@ describe("App Router Production server (startProdServer)", () => {
     appStaticDynamicTarget = await startTextSequenceTarget({ prefix: "dynamic" });
     appStaticRevalidateTarget = await startTextSequenceTarget({ prefix: "revalidate" });
     revalidatePathFetchTarget = await startTextSequenceTarget();
+    configCapturePathTarget = await startTextSequenceTarget({
+      recordRequest(req) {
+        configCapturePathRequests.push(req.url ?? "");
+      },
+    });
     process.env.TEST_APP_STATIC_DELAY_TARGET = appStaticDelayTarget.url;
     process.env.TEST_APP_STATIC_DYNAMIC_TARGET = appStaticDynamicTarget.url;
     process.env.TEST_APP_STATIC_REVALIDATE_TARGET = appStaticRevalidateTarget.url;
     process.env.TEST_REVALIDATE_PATH_REWRITES_TARGET = revalidatePathFetchTarget.url;
+    process.env.TEST_CONFIG_CAPTURE_PATH_TARGET = configCapturePathTarget.url;
 
     try {
       // Build the app-basic fixture to the default dist/ directory
@@ -284,6 +292,7 @@ describe("App Router Production server (startProdServer)", () => {
         await builder.buildApp();
       } finally {
         delete process.env.TEST_CONFIG_CAPTURE_EXTERNAL;
+        delete process.env.TEST_CONFIG_CAPTURE_PATH_TARGET;
       }
 
       // Start the production server on a random available port
@@ -299,16 +308,19 @@ describe("App Router Production server (startProdServer)", () => {
         await appStaticDynamicTarget?.close();
         await appStaticRevalidateTarget?.close();
         await revalidatePathFetchTarget?.close();
+        await configCapturePathTarget?.close();
       } finally {
         appStaticDelayTarget = undefined;
         appStaticDynamicTarget = undefined;
         appStaticRevalidateTarget = undefined;
         revalidatePathFetchTarget = undefined;
+        configCapturePathTarget = undefined;
         delete process.env.TEST_APP_STATIC_DELAY_TARGET;
         delete process.env.TEST_APP_STATIC_DYNAMIC_TARGET;
         delete process.env.TEST_APP_STATIC_REVALIDATE_TARGET;
         delete process.env.TEST_REVALIDATE_PATH_REWRITES_TARGET;
         delete process.env.TEST_CONFIG_CAPTURE_EXTERNAL;
+        delete process.env.TEST_CONFIG_CAPTURE_PATH_TARGET;
       }
       throw error;
     }
@@ -320,11 +332,13 @@ describe("App Router Production server (startProdServer)", () => {
     await appStaticDynamicTarget?.close();
     await appStaticRevalidateTarget?.close();
     await revalidatePathFetchTarget?.close();
+    await configCapturePathTarget?.close();
     delete process.env.TEST_APP_STATIC_DELAY_TARGET;
     delete process.env.TEST_APP_STATIC_DYNAMIC_TARGET;
     delete process.env.TEST_APP_STATIC_REVALIDATE_TARGET;
     delete process.env.TEST_REVALIDATE_PATH_REWRITES_TARGET;
     delete process.env.TEST_CONFIG_CAPTURE_EXTERNAL;
+    delete process.env.TEST_CONFIG_CAPTURE_PATH_TARGET;
     fs.rmSync(outDir, { recursive: true, force: true });
   });
 
@@ -1298,12 +1312,12 @@ describe("App Router Production server (startProdServer)", () => {
   });
 
   it("preserves mixed encoded dot segments after production request normalization", async () => {
-    // The Node production entry and App request handler each normalize one
-    // layer, so use an additional encoding layer to exercise the config
-    // matcher with the same `%2e.` / `.%2e` captures seen in dev and Workers.
+    // Node production leaves the single decode/normalize pass to the App
+    // request handler, matching dev and Workers.
     for (const [requestSegment, destinationSegment] of [
-      ["%25252e.", "%252e."],
-      [".%25252e", ".%252e"],
+      ["%252e%252e", "%252e%252e"],
+      ["%252e.", "%252e."],
+      [".%252e", ".%252e"],
     ]) {
       const res = await fetch(`${baseUrl}/source-capture-dot-redirect/${requestSegment}/admin`, {
         redirect: "manual",
@@ -1313,6 +1327,21 @@ describe("App Router Production server (startProdServer)", () => {
       expect(res.headers.get("location")).toBe(
         `https://redirect.example.test/safe/${destinationSegment}/admin`,
       );
+    }
+  });
+
+  it("keeps encoded dot segments under the external rewrite prefix in production", async () => {
+    for (const [requestSegment, destinationSegment] of [
+      ["%252e%252e", "%252e%252e"],
+      ["%252e.", "%252e."],
+      [".%252e", ".%252e"],
+    ]) {
+      configCapturePathRequests.length = 0;
+      const res = await fetch(`${baseUrl}/source-capture-dot-rewrite/${requestSegment}/admin`);
+
+      expect(res.status).toBe(200);
+      await res.arrayBuffer();
+      expect(configCapturePathRequests).toEqual([`/safe/${destinationSegment}/admin`]);
     }
   });
 

--- a/tests/app-router-production-server.test.ts
+++ b/tests/app-router-production-server.test.ts
@@ -1271,6 +1271,19 @@ describe("App Router Production server (startProdServer)", () => {
     });
   });
 
+  it("does not let source captures change a config rewrite authority", async () => {
+    await withCountingFetchTarget(async (targetUrl, getRequestCount) => {
+      const target = new URL(targetUrl);
+      const res = await fetch(
+        `${baseUrl}/source-capture-external/${target.hostname}:${target.port}/reached`,
+      );
+
+      expect(res.status).toBe(404);
+      await res.arrayBuffer();
+      expect(getRequestCount()).toBe(0);
+    });
+  });
+
   it("serves static assets with cache headers", async () => {
     // Find an actual hashed JS asset from the build.
     const assetsDir = path.join(outDir, "client", "_next", "static", "chunks");

--- a/tests/e2e/pages-router-prod/production.spec.ts
+++ b/tests/e2e/pages-router-prod/production.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { request as httpRequest } from "node:http";
 
 /**
  * Production build E2E tests for Pages Router.
@@ -9,7 +10,37 @@ import { test, expect } from "@playwright/test";
  */
 const BASE = "http://localhost:4175";
 
+function requestRawPath(path: string) {
+  return new Promise<{ headers: Record<string, string | string[] | undefined>; status: number }>(
+    (resolve, reject) => {
+      const req = httpRequest({ hostname: "localhost", path, port: 4175 }, (response) => {
+        response.resume();
+        response.once("end", () =>
+          resolve({ headers: response.headers, status: response.statusCode ?? 0 }),
+        );
+      });
+      req.once("error", reject);
+      req.end();
+    },
+  );
+}
+
 test.describe("Pages Router Production Build", () => {
+  // Ported from Next.js middleware request construction and encoded traversal coverage:
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/adapter.ts
+  // https://github.com/vercel/next.js/blob/canary/test/integration/file-serving/test/index.test.ts
+  test("preserves encoded dot segments in middleware-visible URLs", async () => {
+    for (const segment of ["%252e%252e", "%252e.", ".%252e"]) {
+      const pathname = `/protected/${segment}/public`;
+      const response = await requestRawPath(pathname);
+
+      expect(response.status).toBe(403);
+      expect(response.headers["x-mw-permissive"]).toBe("false");
+      expect(response.headers["x-mw-url-pathname"]).toBe(pathname);
+      expect(response.headers["x-mw-next-url-pathname"]).toBe(pathname);
+    }
+  });
+
   test("index page renders with correct content", async ({ page }) => {
     const response = await page.goto(`${BASE}/`);
     expect(response?.status()).toBe(200);

--- a/tests/e2e/pages-router-prod/production.spec.ts
+++ b/tests/e2e/pages-router-prod/production.spec.ts
@@ -53,6 +53,25 @@ test.describe("Pages Router Production Build", () => {
     expect(response?.status()).toBe(404);
   });
 
+  test("config redirects preserve mixed encoded dot segments", async ({ request }) => {
+    // The Node production entry and Pages request pipeline each normalize one
+    // layer before config matching, hence the additional encoding layer here.
+    for (const [requestSegment, destinationSegment] of [
+      ["%25252e.", "%252e."],
+      [".%25252e", ".%252e"],
+    ]) {
+      const response = await request.get(
+        `${BASE}/source-capture-dot-redirect/${requestSegment}/admin`,
+        { maxRedirects: 0 },
+      );
+
+      expect(response.status()).toBe(307);
+      expect(response.headers().location).toBe(
+        `https://redirect.example.test/safe/${destinationSegment}/admin`,
+      );
+    }
+  });
+
   test("dynamic route renders with params", async ({ page }) => {
     const response = await page.goto(`${BASE}/blog/hello-world`);
     expect(response?.status()).toBe(200);

--- a/tests/e2e/pages-router-prod/production.spec.ts
+++ b/tests/e2e/pages-router-prod/production.spec.ts
@@ -54,11 +54,11 @@ test.describe("Pages Router Production Build", () => {
   });
 
   test("config redirects preserve mixed encoded dot segments", async ({ request }) => {
-    // The Node production entry and Pages request pipeline each normalize one
-    // layer before config matching, hence the additional encoding layer here.
+    // Pages production uses the same single normalization pass as dev.
     for (const [requestSegment, destinationSegment] of [
-      ["%25252e.", "%252e."],
-      [".%25252e", ".%252e"],
+      ["%252e%252e", "%252e%252e"],
+      ["%252e.", "%252e."],
+      [".%252e", ".%252e"],
     ]) {
       const response = await request.get(
         `${BASE}/source-capture-dot-redirect/${requestSegment}/admin`,

--- a/tests/e2e/pages-router/middleware.spec.ts
+++ b/tests/e2e/pages-router/middleware.spec.ts
@@ -1,9 +1,40 @@
 import { test, expect } from "@playwright/test";
+import { request as httpRequest } from "node:http";
 import { waitForHydration } from "../helpers";
 
 const BASE = "http://localhost:4173";
 
+function requestRawPath(path: string) {
+  return new Promise<{ headers: Record<string, string | string[] | undefined>; status: number }>(
+    (resolve, reject) => {
+      const req = httpRequest({ hostname: "localhost", path, port: 4173 }, (response) => {
+        response.resume();
+        response.once("end", () =>
+          resolve({ headers: response.headers, status: response.statusCode ?? 0 }),
+        );
+      });
+      req.once("error", reject);
+      req.end();
+    },
+  );
+}
+
 test.describe("Middleware (Pages Router)", () => {
+  // Ported from Next.js middleware request construction and encoded traversal coverage:
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/adapter.ts
+  // https://github.com/vercel/next.js/blob/canary/test/integration/file-serving/test/index.test.ts
+  test("preserves encoded dot segments in middleware-visible URLs", async () => {
+    for (const segment of ["%252e%252e", "%252e.", ".%252e"]) {
+      const pathname = `/protected/${segment}/public`;
+      const response = await requestRawPath(pathname);
+
+      expect(response.status).toBe(403);
+      expect(response.headers["x-mw-permissive"]).toBe("false");
+      expect(response.headers["x-mw-url-pathname"]).toBe(pathname);
+      expect(response.headers["x-mw-next-url-pathname"]).toBe(pathname);
+    }
+  });
+
   test("redirects /old-page to /about", async ({ page }) => {
     const response = await page.goto(`${BASE}/old-page`);
 

--- a/tests/fixtures/app-basic/app/api/config-capture/[...slug]/route.ts
+++ b/tests/fixtures/app-basic/app/api/config-capture/[...slug]/route.ts
@@ -1,0 +1,7 @@
+export async function GET(request: Request, { params }: { params: Promise<{ slug: string[] }> }) {
+  const { slug } = await params;
+  return Response.json({
+    slug,
+    query: Object.fromEntries(new URL(request.url).searchParams),
+  });
+}

--- a/tests/fixtures/app-basic/middleware.ts
+++ b/tests/fixtures/app-basic/middleware.ts
@@ -17,6 +17,25 @@ export async function middleware(request: NextRequest, event: NextFetchEvent) {
   // Test NextRequest.nextUrl - this would fail with TypeError if request is plain Request
   const { pathname } = request.nextUrl;
 
+  // Next.js constructs the middleware request from the original request URL;
+  // normalized pathnames are used only for routing and matcher decisions.
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/adapter.ts
+  if (pathname === "/public") {
+    return new Response("public", {
+      headers: { "x-mw-permissive": "true" },
+    });
+  }
+  if (pathname.startsWith("/protected/")) {
+    return new Response("protected", {
+      status: 403,
+      headers: {
+        "x-mw-next-url-pathname": pathname,
+        "x-mw-permissive": "false",
+        "x-mw-url-pathname": new URL(request.url).pathname,
+      },
+    });
+  }
+
   // Ported from Next.js: test/e2e/app-dir/app/middleware.js
   // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/app/middleware.js
   // The source also exists in pages/, so the client must honor the middleware
@@ -405,5 +424,7 @@ export const config = {
     "/actions",
     "/beforeinteractive-head-ordering/:path*",
     "/beforeinteractive-head-ordering",
+    "/protected/:path*",
+    "/public",
   ],
 };

--- a/tests/fixtures/app-basic/next.config.ts
+++ b/tests/fixtures/app-basic/next.config.ts
@@ -166,6 +166,10 @@ const nextConfig: NextConfig = {
                 source: "/source-capture-external/:target*",
                 destination: "http://:target.internal.invalid/capture",
               },
+              {
+                source: "/source-capture-scheme/:scheme/:target*",
+                destination: ":scheme://:target.internal.invalid/capture",
+              },
             ]
           : []),
       ],

--- a/tests/fixtures/app-basic/next.config.ts
+++ b/tests/fixtures/app-basic/next.config.ts
@@ -162,6 +162,10 @@ const nextConfig: NextConfig = {
                 ],
                 destination: "http://:target.internal.invalid/capture",
               },
+              {
+                source: "/source-capture-external/:target*",
+                destination: "http://:target.internal.invalid/capture",
+              },
             ]
           : []),
       ],

--- a/tests/fixtures/app-basic/next.config.ts
+++ b/tests/fixtures/app-basic/next.config.ts
@@ -84,6 +84,22 @@ const nextConfig: NextConfig = {
         destination: "/about",
         permanent: false,
       },
+      // Named captures from has conditions are request-controlled. Keep them
+      // inert when they are substituted into destination path syntax.
+      // Next.js reference for named has captures:
+      // https://github.com/vercel/next.js/blob/canary/test/integration/custom-routes/next.config.js
+      {
+        source: "/condition-capture-redirect",
+        has: [
+          {
+            type: "header",
+            key: "x-redirect-segment",
+            value: "(?<segment>.+)",
+          },
+        ],
+        destination: "/config-capture-redirect/:segment",
+        permanent: false,
+      },
     ];
   },
 
@@ -122,6 +138,32 @@ const nextConfig: NextConfig = {
           source: "/rewrite-search-param/:term",
           destination: "/search?q=from-rewrite",
         },
+        {
+          source: "/condition-capture-rewrite",
+          has: [
+            {
+              type: "header",
+              key: "x-rewrite-segment",
+              value: "(?<segment>.+)",
+            },
+          ],
+          destination: "/api/config-capture/:segment",
+        },
+        ...(process.env.TEST_CONFIG_CAPTURE_EXTERNAL === "1"
+          ? [
+              {
+                source: "/condition-capture-external",
+                has: [
+                  {
+                    type: "header" as const,
+                    key: "x-rewrite-host",
+                    value: "(?<target>.+)",
+                  },
+                ],
+                destination: "http://:target.internal.invalid/capture",
+              },
+            ]
+          : []),
       ],
       afterFiles: [
         // Used by Vitest: app-router.test.ts

--- a/tests/fixtures/app-basic/next.config.ts
+++ b/tests/fixtures/app-basic/next.config.ts
@@ -102,7 +102,7 @@ const nextConfig: NextConfig = {
       },
       {
         source: "/source-capture-dot-redirect/:path*",
-        destination: "/safe/:path*",
+        destination: "https://redirect.example.test/safe/:path*",
         permanent: false,
       },
     ];

--- a/tests/fixtures/app-basic/next.config.ts
+++ b/tests/fixtures/app-basic/next.config.ts
@@ -100,6 +100,11 @@ const nextConfig: NextConfig = {
         destination: "/config-capture-redirect/:segment",
         permanent: false,
       },
+      {
+        source: "/source-capture-dot-redirect/:path*",
+        destination: "/safe/:path*",
+        permanent: false,
+      },
     ];
   },
 
@@ -120,6 +125,14 @@ const nextConfig: NextConfig = {
               {
                 source: "/proxy-external-test/:path*",
                 destination: `${process.env.TEST_EXTERNAL_PROXY_TARGET}/:path*`,
+              },
+            ]
+          : []),
+        ...(process.env.TEST_CONFIG_CAPTURE_PATH_TARGET
+          ? [
+              {
+                source: "/source-capture-dot-rewrite/:path*",
+                destination: `${new URL(process.env.TEST_CONFIG_CAPTURE_PATH_TARGET).origin}/safe/:path*`,
               },
             ]
           : []),

--- a/tests/fixtures/pages-basic/middleware.ts
+++ b/tests/fixtures/pages-basic/middleware.ts
@@ -4,6 +4,25 @@ import type { NextRequest } from "next/server";
 export function middleware(request: NextRequest) {
   const url = new URL(request.url);
 
+  // Next.js constructs the middleware request from the original request URL;
+  // normalized pathnames are used only for routing and matcher decisions.
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/adapter.ts
+  if (request.nextUrl.pathname === "/public") {
+    return new Response("public", {
+      headers: { "x-mw-permissive": "true" },
+    });
+  }
+  if (request.nextUrl.pathname.startsWith("/protected/")) {
+    return new Response("protected", {
+      status: 403,
+      headers: {
+        "x-mw-next-url-pathname": request.nextUrl.pathname,
+        "x-mw-permissive": "false",
+        "x-mw-url-pathname": url.pathname,
+      },
+    });
+  }
+
   // Add a custom header to all matched requests
   const response = NextResponse.next();
   response.headers.set("x-custom-middleware", "active");

--- a/tests/fixtures/pages-basic/next.config.mjs
+++ b/tests/fixtures/pages-basic/next.config.mjs
@@ -27,6 +27,18 @@ const nextConfig = {
         destination: "/about",
         permanent: false,
       },
+      {
+        source: "/condition-capture-redirect",
+        has: [
+          {
+            type: "header",
+            key: "x-redirect-segment",
+            value: "(?<segment>.+)",
+          },
+        ],
+        destination: "/config-capture-redirect/:segment",
+        permanent: false,
+      },
     ];
   },
   async rewrites() {
@@ -67,6 +79,20 @@ const nextConfig = {
           source: "/mw-gated-before",
           has: [{ type: "cookie", key: "mw-before-user" }],
           destination: "/about",
+        },
+        // Request-controlled condition captures must remain data when inserted
+        // into path components. The named-capture shape mirrors:
+        // https://github.com/vercel/next.js/blob/canary/test/integration/custom-routes/next.config.js
+        {
+          source: "/condition-capture-rewrite",
+          has: [
+            {
+              type: "header",
+              key: "x-rewrite-segment",
+              value: "(?<segment>.+)",
+            },
+          ],
+          destination: "/api/config-capture/:segment",
         },
       ],
       afterFiles: [

--- a/tests/fixtures/pages-basic/next.config.mjs
+++ b/tests/fixtures/pages-basic/next.config.mjs
@@ -39,6 +39,11 @@ const nextConfig = {
         destination: "/config-capture-redirect/:segment",
         permanent: false,
       },
+      {
+        source: "/source-capture-dot-redirect/:path*",
+        destination: "https://redirect.example.test/safe/:path*",
+        permanent: false,
+      },
     ];
   },
   async rewrites() {

--- a/tests/fixtures/pages-basic/pages/api/config-capture/[...slug].ts
+++ b/tests/fixtures/pages-basic/pages/api/config-capture/[...slug].ts
@@ -1,0 +1,6 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { slug, ...query } = req.query;
+  res.status(200).json({ slug, query });
+}

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -7613,6 +7613,30 @@ describe("Production server next.config.js features (Pages Router)", () => {
     expect(res.headers.get("location")).toBe("/docs/hello/hello");
   });
 
+  it("keeps request condition captures inert in production config redirect paths", async () => {
+    const res = await fetch(`${prodUrl}/condition-capture-redirect`, {
+      redirect: "manual",
+      headers: { "x-redirect-segment": "safe?admin=1#fragment" },
+    });
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe(
+      "/config-capture-redirect/safe%3Fadmin%3D1%23fragment",
+    );
+  });
+
+  it("does not turn request condition captures into production config rewrite query syntax", async () => {
+    const res = await fetch(`${prodUrl}/condition-capture-rewrite`, {
+      headers: { "x-rewrite-segment": "safe?admin=1" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      slug: ["safe?admin=1"],
+      query: {},
+    });
+  });
+
   it("applies beforeFiles rewrites from next.config.js (/before-rewrite -> /about)", async () => {
     const res = await fetch(`${prodUrl}/before-rewrite`);
     expect(res.status).toBe(200);

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -12230,7 +12230,8 @@ describe("matchRewrite with external URLs", () => {
   });
 
   it("restores the encoding layer on dot segments captured from config sources", async () => {
-    const { matchRewrite } = await import("../packages/vinext/src/config/config-matchers.js");
+    const { matchRedirect, matchRewrite } =
+      await import("../packages/vinext/src/config/config-matchers.js");
     const { normalizePathnameForRouteMatchStrict } =
       await import("../packages/vinext/src/routing/utils.js");
     const rewrites = [
@@ -12244,6 +12245,28 @@ describe("matchRewrite with external URLs", () => {
     expect(matchRewrite(pathname, rewrites, emptyCtx)).toBe(
       "https://api.example.test/safe/%252e%252e/admin",
     );
+    expect(
+      matchRewrite(normalizePathnameForRouteMatchStrict("/proxy/%252E./admin"), rewrites, emptyCtx),
+    ).toBe("https://api.example.test/safe/%252E./admin");
+    expect(
+      matchRewrite(normalizePathnameForRouteMatchStrict("/proxy/.%252e/admin"), rewrites, emptyCtx),
+    ).toBe("https://api.example.test/safe/.%252e/admin");
+    expect(
+      matchRedirect(
+        normalizePathnameForRouteMatchStrict("/proxy/%252e./admin"),
+        [
+          {
+            source: "/proxy/:path*",
+            destination: "https://redirect.example.test/safe/:path*",
+            permanent: false,
+          },
+        ],
+        emptyCtx,
+      ),
+    ).toEqual({
+      destination: "https://redirect.example.test/safe/%252e./admin",
+      permanent: false,
+    });
   });
 
   it("keeps ordinary pchars, encoded delimiters, and catch-all separators in source paths", async () => {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -12107,6 +12107,75 @@ describe("matchRewrite with external URLs", () => {
     expect(result).toBe("/home?authorized=yes&path=docs%2Fintro");
   });
 
+  it("encodes condition captures substituted into rewrite path syntax", async () => {
+    const { matchRewrite } = await import("../packages/vinext/src/config/config-matchers.js");
+    const rewrites = [
+      {
+        source: "/source",
+        has: [{ type: "header" as const, key: "x-segment", value: "(?<segment>.+)" }],
+        destination: "/target/:segment",
+      },
+    ];
+    const result = matchRewrite("/source", rewrites, {
+      ...emptyCtx,
+      headers: new Headers({ "x-segment": "safe?admin=1#fragment" }),
+    });
+
+    expect(result).toBe("/target/safe%3Fadmin%3D1%23fragment");
+  });
+
+  it("keeps catch-all condition captures inert while preserving path separators", async () => {
+    const { matchRewrite } = await import("../packages/vinext/src/config/config-matchers.js");
+    const rewrites = [
+      {
+        source: "/source",
+        has: [{ type: "header" as const, key: "x-path", value: "(?<path>.+)" }],
+        destination: "/target/:path*",
+      },
+    ];
+    const result = matchRewrite("/source", rewrites, {
+      ...emptyCtx,
+      headers: new Headers({ "x-path": "safe/../../admin?role=root" }),
+    });
+
+    expect(result).toBe("/target/safe/%252e%252e/%252e%252e/admin%3Frole%3Droot");
+  });
+
+  it("fails closed when a condition capture would change an external rewrite authority", async () => {
+    const { matchRewrite } = await import("../packages/vinext/src/config/config-matchers.js");
+    const rules = [
+      {
+        source: "/source",
+        has: [{ type: "header" as const, key: "x-target", value: "(?<target>.+)" }],
+        destination: "http://:target.internal.invalid/capture",
+      },
+      { source: "/source", destination: "/safe-fallback" },
+    ];
+    const result = matchRewrite("/source", rules, {
+      ...emptyCtx,
+      headers: new Headers({ "x-target": "127.0.0.1:8080/reached?ignored=" }),
+    });
+
+    expect(result).toBe("/safe-fallback");
+  });
+
+  it("preserves valid condition captures in external rewrite hostnames", async () => {
+    const { matchRewrite } = await import("../packages/vinext/src/config/config-matchers.js");
+    const rules = [
+      {
+        source: "/source",
+        has: [{ type: "header" as const, key: "x-tenant", value: "(?<tenant>.+)" }],
+        destination: "https://:tenant.example.com/capture",
+      },
+    ];
+    const result = matchRewrite("/source", rules, {
+      ...emptyCtx,
+      headers: new Headers({ "x-tenant": "customer-1" }),
+    });
+
+    expect(result).toBe("https://customer-1.example.com/capture");
+  });
+
   it("escapes source params substituted into rewrite destination query values", async () => {
     const { matchRewrite } = await import("../packages/vinext/src/config/config-matchers.js");
     const { normalizePathnameForRouteMatchStrict } =
@@ -12248,6 +12317,27 @@ describe("matchRedirect destination param substitution", () => {
       headers: new Headers({ "x-authorized": "yes" }),
     });
     expect(result).toEqual({ destination: "/home?authorized=yes", permanent: false });
+  });
+
+  it("encodes condition captures substituted into redirect fragments", async () => {
+    const { matchRedirect } = await import("../packages/vinext/src/config/config-matchers.js");
+    const redirects = [
+      {
+        source: "/",
+        has: [{ type: "header" as const, key: "x-section", value: "(?<section>.+)" }],
+        destination: "/docs#:section",
+        permanent: false,
+      },
+    ];
+    const result = matchRedirect("/", redirects, {
+      ...emptyCtx,
+      headers: new Headers({ "x-section": "intro#admin?enabled=1" }),
+    });
+
+    expect(result).toEqual({
+      destination: "/docs#intro%23admin%3Fenabled%3D1",
+      permanent: false,
+    });
   });
 
   it("escapes source params substituted into redirect destination query values", async () => {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -12159,6 +12159,18 @@ describe("matchRewrite with external URLs", () => {
     expect(result).toBe("/safe-fallback");
   });
 
+  it("fails closed when a source capture would change an external rewrite authority", async () => {
+    const { matchRewrite } = await import("../packages/vinext/src/config/config-matchers.js");
+    const rules = [
+      {
+        source: "/source/:target*",
+        destination: "http://:target.internal.invalid/capture",
+      },
+    ];
+
+    expect(matchRewrite("/source/127.0.0.1:8080/reached", rules, emptyCtx)).toBeNull();
+  });
+
   it("preserves valid condition captures in external rewrite hostnames", async () => {
     const { matchRewrite } = await import("../packages/vinext/src/config/config-matchers.js");
     const rules = [

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -12171,6 +12171,18 @@ describe("matchRewrite with external URLs", () => {
     expect(matchRewrite("/source/127.0.0.1:8080/reached", rules, emptyCtx)).toBeNull();
   });
 
+  it("fails closed when source captures construct an external rewrite scheme and authority", async () => {
+    const { matchRewrite } = await import("../packages/vinext/src/config/config-matchers.js");
+    const rules = [
+      {
+        source: "/source/:scheme/:target*",
+        destination: ":scheme://:target.internal.invalid/capture",
+      },
+    ];
+
+    expect(matchRewrite("/source/http/127.0.0.1:8080/reached", rules, emptyCtx)).toBeNull();
+  });
+
   it("preserves valid condition captures in external rewrite hostnames", async () => {
     const { matchRewrite } = await import("../packages/vinext/src/config/config-matchers.js");
     const rules = [
@@ -12367,6 +12379,23 @@ describe("matchRedirect destination param substitution", () => {
 
     expect(result).toEqual({
       destination: "/login?next=/foo%26next%3Devil.example&safe=1",
+      permanent: false,
+    });
+  });
+
+  it("fails closed when source captures construct a redirect scheme", async () => {
+    const { matchRedirect } = await import("../packages/vinext/src/config/config-matchers.js");
+    const redirects = [
+      {
+        source: "/go/:scheme/:target*",
+        destination: ":scheme://:target",
+        permanent: false,
+      },
+      { source: "/go/:path*", destination: "/safe-fallback", permanent: false },
+    ];
+
+    expect(matchRedirect("/go/https/evil.example/path", redirects, emptyCtx)).toEqual({
+      destination: "/safe-fallback",
       permanent: false,
     });
   });

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -8080,7 +8080,7 @@ describe("double-encoded path handling in middleware", () => {
     expect(routeMatchingSource).not.toMatch(/\bdecodeURIComponent\s*\(/);
   });
 
-  it("App Router middleware receives a Request with the decoded pathname (not raw URL)", async () => {
+  it("App Router middleware receives the original encoded request URL", async () => {
     const { applyAppMiddleware } = await import("../packages/vinext/src/server/app-middleware.js");
     let capturedUrl: string | undefined;
     const module = {
@@ -8103,8 +8103,10 @@ describe("double-encoded path handling in middleware", () => {
     expect(result.kind).toBe("continue");
     expect(capturedUrl).toBeDefined();
     const mwPathname = new URL(capturedUrl!).pathname;
-    expect(mwPathname).toBe("/%64ashboard");
-    expect(mwPathname).not.toBe("/%2564ashboard");
+    // Next.js constructs NextRequest from the original adapter request URL.
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/adapter.ts
+    expect(mwPathname).toBe("/%2564ashboard");
+    expect(mwPathname).not.toBe("/%64ashboard");
   });
 
   it("App Router middleware preserves status from NextResponse.next()", async () => {
@@ -8307,7 +8309,7 @@ describe("double-encoded path handling in middleware", () => {
     }
   });
 
-  it("Pages Router runMiddleware passes decoded pathname to middleware function", async () => {
+  it("Pages Router runMiddleware passes the original encoded URL to middleware", async () => {
     const { runMiddleware } = await import("../packages/vinext/src/server/middleware.js");
     // Create a mock Vite server that returns a middleware module
     let capturedUrl: string | undefined;
@@ -8323,18 +8325,17 @@ describe("double-encoded path handling in middleware", () => {
       }),
     };
 
-    // Send a double-encoded path — after single decode, it should be /%64ashboard
+    // Send a double-encoded path. Routing uses its once-decoded form, while
+    // middleware observes the original request URL like Next.js.
     const testUrl = "http://localhost:3000/%2564ashboard";
     const request = new Request(testUrl);
     await runMiddleware(mockRunner as any, "/tmp/middleware.ts", request);
 
-    // Middleware should have received the decoded+normalized URL
     expect(capturedUrl).toBeDefined();
     const mwPathname = new URL(capturedUrl!).pathname;
-    // After single decode: %25 → %, so /%2564 → /%64
-    expect(mwPathname).toBe("/%64ashboard");
-    // It must NOT be the raw /%2564ashboard
-    expect(mwPathname).not.toBe("/%2564ashboard");
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/adapter.ts
+    expect(mwPathname).toBe("/%2564ashboard");
+    expect(mwPathname).not.toBe("/%64ashboard");
     // It must NOT be double-decoded to /dashboard
     expect(mwPathname).not.toBe("/dashboard");
   });

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -12229,6 +12229,33 @@ describe("matchRewrite with external URLs", () => {
     expect(result).toBe("/api/foo&admin=true?q=foo%26admin%3Dtrue");
   });
 
+  it("restores the encoding layer on dot segments captured from config sources", async () => {
+    const { matchRewrite } = await import("../packages/vinext/src/config/config-matchers.js");
+    const { normalizePathnameForRouteMatchStrict } =
+      await import("../packages/vinext/src/routing/utils.js");
+    const rewrites = [
+      {
+        source: "/proxy/:path*",
+        destination: "https://api.example.test/safe/:path*",
+      },
+    ];
+    const pathname = normalizePathnameForRouteMatchStrict("/proxy/%252e%252e/admin");
+
+    expect(matchRewrite(pathname, rewrites, emptyCtx)).toBe(
+      "https://api.example.test/safe/%252e%252e/admin",
+    );
+  });
+
+  it("keeps ordinary pchars, encoded delimiters, and catch-all separators in source paths", async () => {
+    const { matchRewrite } = await import("../packages/vinext/src/config/config-matchers.js");
+    const { normalizePathnameForRouteMatchStrict } =
+      await import("../packages/vinext/src/routing/utils.js");
+    const rewrites = [{ source: "/proxy/:path*", destination: "/safe/:path*" }];
+    const pathname = normalizePathnameForRouteMatchStrict("/proxy/a%26b/nested%2Fvalue");
+
+    expect(matchRewrite(pathname, rewrites, emptyCtx)).toBe("/safe/a&b/nested%2Fvalue");
+  });
+
   it("uses the same query value encoding for inline and appended rewrite params", async () => {
     const { matchRewrite } = await import("../packages/vinext/src/config/config-matchers.js");
     const { normalizePathnameForRouteMatchStrict } =


### PR DESCRIPTION
## Summary

- preserve encoded request path components during redirect and rewrite substitution
- keep middleware matching normalization separate from request URL construction
- align App and Pages behavior across development and production

## Testing

- targeted App and Pages development/production E2E coverage
- config matcher, middleware, and request-pipeline tests
- `vp check`
- `vp run vinext#build`