### PR TITLE
fix(app-router): preserve streamed document context

### DIFF
--- a/packages/vinext/src/server/app-ssr-stream.ts
+++ b/packages/vinext/src/server/app-ssr-stream.ts
@@ -403,7 +403,6 @@ function rewriteInlineCssStylesheetLinks(
 /** Match the `<head ...>` opening tag in a tick-buffered batch. */
 const HEAD_OPEN_RE = /<head\b[^>]*>/;
 
-const HEAD_CLOSE_TAG = "</head>";
 const RAW_TEXT_ELEMENTS = new Set([
   "iframe",
   "noembed",
@@ -416,6 +415,9 @@ const RAW_TEXT_ELEMENTS = new Set([
   "xmp",
 ]);
 const RAW_TAG_WINDOW_LENGTH = 16;
+const CLOSING_TOKEN_LOOKAHEAD_LIMIT = 4096;
+
+type ClosingTokenMatch = { kind: "match"; length: number } | { kind: "none" } | { kind: "partial" };
 
 type HeadScannerState =
   | "bogus-comment"
@@ -440,6 +442,63 @@ function endsWithDelimitedTag(window: string, prefix: string): string | null {
   return window.endsWith(prefix + delimiter) ? delimiter : null;
 }
 
+function matchClosingEndTag(
+  input: string,
+  index: number,
+  tagName: string,
+  final: boolean,
+): ClosingTokenMatch {
+  const prefix = "</" + tagName;
+  const candidate = input.slice(index, index + prefix.length).toLowerCase();
+  if (candidate.length < prefix.length) {
+    return !final && prefix.startsWith(candidate) ? { kind: "partial" } : { kind: "none" };
+  }
+  if (candidate !== prefix) return { kind: "none" };
+
+  let cursor = index + prefix.length;
+  if (cursor >= input.length) return final ? { kind: "none" } : { kind: "partial" };
+  if (!isHtmlTagDelimiter(input[cursor])) return { kind: "none" };
+
+  let quote: '"' | "'" | null = null;
+  for (; cursor < input.length; cursor++) {
+    const character = input[cursor];
+    if (quote) {
+      if (character === quote) quote = null;
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      quote = character;
+    } else if (character === ">") {
+      return { kind: "match", length: cursor - index + 1 };
+    }
+    if (cursor - index >= CLOSING_TOKEN_LOOKAHEAD_LIMIT) return { kind: "none" };
+  }
+
+  return final ? { kind: "none" } : { kind: "partial" };
+}
+
+function matchClosingTagSequence(
+  input: string,
+  index: number,
+  tagNames: readonly string[],
+  final: boolean,
+): ClosingTokenMatch {
+  let cursor = index;
+  for (let tagIndex = 0; tagIndex < tagNames.length; tagIndex++) {
+    const result = matchClosingEndTag(input, cursor, tagNames[tagIndex], final);
+    if (result.kind !== "match") return result;
+    cursor += result.length;
+    if (tagIndex + 1 < tagNames.length) {
+      while (/[\t\n\f\r ]/.test(input[cursor] ?? "")) {
+        cursor++;
+        if (cursor - index >= CLOSING_TOKEN_LOOKAHEAD_LIMIT) return { kind: "none" };
+      }
+      if (cursor >= input.length) return final ? { kind: "none" } : { kind: "partial" };
+    }
+  }
+  return { kind: "match", length: cursor - index };
+}
+
 /**
  * Incrementally locate a real closing token outside inert HTML contexts.
  *
@@ -462,36 +521,37 @@ class HtmlClosingTokenScanner {
   #state: HeadScannerState = "data";
   #tagIsEnd = false;
   #tagName = "";
-  readonly #target: string;
+  readonly #targetTags: readonly string[];
   #templateDepth = 0;
 
-  constructor(target: string) {
-    this.#target = target.toLowerCase();
+  constructor(targetTags: readonly string[]) {
+    this.#targetTags = targetTags.map((tag) => tag.toLowerCase());
   }
 
-  scan(input: string, final: boolean): { consumed: number; tokenIndex: number } {
+  scan(
+    input: string,
+    final: boolean,
+  ): { consumed: number; tokenIndex: number; tokenLength: number } {
     for (let index = 0; index < input.length; index++) {
       let character = input[index];
 
       if (this.#state === "data") {
         if (character !== "<") {
           const nextTag = input.indexOf("<", index + 1);
-          if (nextTag === -1) return { consumed: input.length, tokenIndex: -1 };
+          if (nextTag === -1) {
+            return { consumed: input.length, tokenIndex: -1, tokenLength: 0 };
+          }
           index = nextTag;
           character = "<";
         }
 
         if (this.#templateDepth === 0) {
-          const candidate = input.slice(index, index + this.#target.length).toLowerCase();
-          if (candidate === this.#target) {
-            return { consumed: index, tokenIndex: index };
+          const match = matchClosingTagSequence(input, index, this.#targetTags, final);
+          if (match.kind === "match") {
+            return { consumed: index, tokenIndex: index, tokenLength: match.length };
           }
-          if (
-            !final &&
-            candidate.length < this.#target.length &&
-            this.#target.startsWith(candidate)
-          ) {
-            return { consumed: index, tokenIndex: -1 };
+          if (match.kind === "partial") {
+            return { consumed: index, tokenIndex: -1, tokenLength: 0 };
           }
         }
 
@@ -597,7 +657,7 @@ class HtmlClosingTokenScanner {
       }
     }
 
-    return { consumed: input.length, tokenIndex: -1 };
+    return { consumed: input.length, tokenIndex: -1, tokenLength: 0 };
   }
 
   #finishTag(): void {
@@ -751,8 +811,8 @@ export function createTickBufferedTransform(
   let pendingHtml = "";
   let pendingHeadClose = "";
   let timeoutId: ReturnType<typeof setTimeout> | null = null;
-  const documentCloseScanner = new HtmlClosingTokenScanner(DOCUMENT_CLOSE_SUFFIX);
-  const headCloseScanner = new HtmlClosingTokenScanner(HEAD_CLOSE_TAG);
+  const documentCloseScanner = new HtmlClosingTokenScanner(["body", "html"]);
+  const headCloseScanner = new HtmlClosingTokenScanner(["head"]);
   // Computed once at transform creation: every flush is a hot path, so we
   // avoid re-running Object.keys() on the manifest per chunk. Gates both the
   // split-link boundary buffering and the inline-css link rewrite below.
@@ -771,10 +831,7 @@ export function createTickBufferedTransform(
     const scan = documentCloseScanner.scan(chunk, final);
     if (scan.tokenIndex !== -1) {
       suffixStripped = true;
-      return (
-        chunk.slice(0, scan.tokenIndex) +
-        chunk.slice(scan.tokenIndex + DOCUMENT_CLOSE_SUFFIX.length)
-      );
+      return chunk.slice(0, scan.tokenIndex) + chunk.slice(scan.tokenIndex + scan.tokenLength);
     }
     pendingDocumentClose = chunk.slice(scan.consumed);
     return chunk.slice(0, scan.consumed);

--- a/packages/vinext/src/server/app-ssr-stream.ts
+++ b/packages/vinext/src/server/app-ssr-stream.ts
@@ -414,7 +414,6 @@ const RAW_TEXT_ELEMENTS = new Set([
   "title",
   "xmp",
 ]);
-const RAW_TAG_WINDOW_LENGTH = 16;
 const CLOSING_TOKEN_LOOKAHEAD_LIMIT = 4096;
 
 type ClosingTokenMatch = { kind: "match"; length: number } | { kind: "none" } | { kind: "partial" };
@@ -434,12 +433,6 @@ type HeadScannerState =
 
 function isHtmlTagDelimiter(character: string): boolean {
   return character === ">" || character === "/" || /[\t\n\f\r ]/.test(character);
-}
-
-function endsWithDelimitedTag(window: string, prefix: string): string | null {
-  const delimiter = window.at(-1);
-  if (!delimiter || !isHtmlTagDelimiter(delimiter)) return null;
-  return window.endsWith(prefix + delimiter) ? delimiter : null;
 }
 
 function matchClosingEndTag(
@@ -475,6 +468,20 @@ function matchClosingEndTag(
   }
 
   return final ? { kind: "none" } : { kind: "partial" };
+}
+
+type AsciiPrefixMatch = "match" | "none" | "partial";
+
+/** Compare an ASCII HTML token without allocating a lower-cased substring. */
+function matchAsciiPrefix(input: string, index: number, lowerCasePrefix: string): AsciiPrefixMatch {
+  const available = input.length - index;
+  const length = Math.min(available, lowerCasePrefix.length);
+  for (let offset = 0; offset < length; offset++) {
+    const code = input.charCodeAt(index + offset);
+    const lowerCaseCode = code >= 65 && code <= 90 ? code + 32 : code;
+    if (lowerCaseCode !== lowerCasePrefix.charCodeAt(offset)) return "none";
+  }
+  return available < lowerCasePrefix.length ? "partial" : "match";
 }
 
 function matchClosingTagSequence(
@@ -517,7 +524,7 @@ class HtmlClosingTokenScanner {
   #rawDoubleEscaped = false;
   #rawEscaped = false;
   #rawTag: string | null = null;
-  #rawWindow = "";
+  #rawBoundary = "";
   #state: HeadScannerState = "data";
   #tagIsEnd = false;
   #tagName = "";
@@ -653,7 +660,11 @@ class HtmlClosingTokenScanner {
       }
 
       if (this.#state === "raw-text") {
-        this.#scanRawText(character);
+        const rawTextEnd = this.#scanRawText(input, index, final);
+        if (rawTextEnd === input.length) {
+          return { consumed: input.length, tokenIndex: -1, tokenLength: 0 };
+        }
+        index = rawTextEnd;
       }
     }
 
@@ -678,7 +689,7 @@ class HtmlClosingTokenScanner {
 
     if (!isEnd && RAW_TEXT_ELEMENTS.has(name)) {
       this.#rawTag = name;
-      this.#rawWindow = "";
+      this.#rawBoundary = "";
       this.#rawEscaped = false;
       this.#rawDoubleEscaped = false;
       this.#state = "raw-text";
@@ -691,63 +702,111 @@ class HtmlClosingTokenScanner {
   #leaveRawText(): void {
     this.#quote = null;
     this.#rawTag = null;
-    this.#rawWindow = "";
+    this.#rawBoundary = "";
     this.#rawEscaped = false;
     this.#rawDoubleEscaped = false;
     this.#state = "data";
   }
 
-  #scanRawText(character: string): void {
+  /**
+   * Scan raw-text data by jumping between token candidates instead of doing
+   * rolling-string work for every byte. Only an incomplete candidate at the
+   * end of a chunk is retained for the next call.
+   */
+  #scanRawText(input: string, start: number, final: boolean): number {
     const rawTag = this.#rawTag;
     if (!rawTag) {
       this.#state = "data";
-      return;
+      return start;
     }
 
-    this.#rawWindow = (this.#rawWindow + character.toLowerCase()).slice(-RAW_TAG_WINDOW_LENGTH);
-    const closingDelimiter = endsWithDelimitedTag(this.#rawWindow, `</${rawTag}`);
+    const boundaryLength = this.#rawBoundary.length;
+    const currentInput = start === 0 ? input : input.slice(start);
+    const rawInput = boundaryLength === 0 ? currentInput : this.#rawBoundary + currentInput;
+    this.#rawBoundary = "";
+    const closingPrefix = `</${rawTag}`;
+    let cursor = 0;
 
-    if (rawTag !== "script") {
-      if (closingDelimiter === ">") {
-        this.#leaveRawText();
-      } else if (closingDelimiter) {
-        this.#quote = null;
-        this.#state = "raw-end-tag";
+    const retainPartial = (index: number): number => {
+      if (!final) this.#rawBoundary = rawInput.slice(index);
+      return input.length;
+    };
+    const inputIndex = (rawIndex: number): number => start + rawIndex - boundaryLength;
+
+    while (cursor < rawInput.length) {
+      const tagIndex = rawInput.indexOf("<", cursor);
+      const commentEndIndex =
+        rawTag === "script" && this.#rawEscaped && !this.#rawDoubleEscaped
+          ? rawInput.indexOf("-->", cursor)
+          : -1;
+
+      if (commentEndIndex !== -1 && (tagIndex === -1 || commentEndIndex < tagIndex)) {
+        this.#rawEscaped = false;
+        cursor = commentEndIndex + 3;
+        continue;
       }
-      return;
-    }
 
-    if (this.#rawDoubleEscaped) {
-      if (closingDelimiter) {
-        // In the HTML script-data-double-escaped state, `</script>` returns
-        // to escaped script data; it does not close the element yet.
-        this.#rawDoubleEscaped = false;
-        this.#rawEscaped = true;
-        this.#rawWindow = "";
+      if (tagIndex === -1) {
+        if (!final && rawTag === "script" && this.#rawEscaped) {
+          if (rawInput.endsWith("--")) this.#rawBoundary = "--";
+          else if (rawInput.endsWith("-")) this.#rawBoundary = "-";
+        }
+        return input.length;
       }
-      return;
+
+      const closingMatch = matchAsciiPrefix(rawInput, tagIndex, closingPrefix);
+      if (closingMatch === "partial") return retainPartial(tagIndex);
+      if (closingMatch === "match") {
+        const delimiterIndex = tagIndex + closingPrefix.length;
+        if (delimiterIndex === rawInput.length) return retainPartial(tagIndex);
+        const delimiter = rawInput[delimiterIndex];
+        if (isHtmlTagDelimiter(delimiter)) {
+          if (rawTag === "script" && this.#rawDoubleEscaped) {
+            // In the HTML script-data-double-escaped state, `</script>` returns
+            // to escaped script data; it does not close the element yet.
+            this.#rawDoubleEscaped = false;
+            this.#rawEscaped = true;
+            cursor = delimiterIndex + 1;
+            continue;
+          }
+          if (delimiter === ">") {
+            this.#leaveRawText();
+          } else {
+            this.#quote = null;
+            this.#state = "raw-end-tag";
+          }
+          return inputIndex(delimiterIndex);
+        }
+      }
+
+      if (rawTag === "script" && !this.#rawDoubleEscaped) {
+        if (this.#rawEscaped) {
+          const openingMatch = matchAsciiPrefix(rawInput, tagIndex, "<script");
+          if (openingMatch === "partial") return retainPartial(tagIndex);
+          if (openingMatch === "match") {
+            const delimiterIndex = tagIndex + "<script".length;
+            if (delimiterIndex === rawInput.length) return retainPartial(tagIndex);
+            if (isHtmlTagDelimiter(rawInput[delimiterIndex])) {
+              this.#rawDoubleEscaped = true;
+              cursor = delimiterIndex + 1;
+              continue;
+            }
+          }
+        }
+
+        const commentMatch = matchAsciiPrefix(rawInput, tagIndex, "<!--");
+        if (commentMatch === "partial") return retainPartial(tagIndex);
+        if (commentMatch === "match") {
+          this.#rawEscaped = true;
+          cursor = tagIndex + 4;
+          continue;
+        }
+      }
+
+      cursor = tagIndex + 1;
     }
 
-    if (closingDelimiter === ">") {
-      this.#leaveRawText();
-      return;
-    }
-    if (closingDelimiter) {
-      this.#quote = null;
-      this.#state = "raw-end-tag";
-      return;
-    }
-
-    if (this.#rawEscaped && endsWithDelimitedTag(this.#rawWindow, "<script")) {
-      this.#rawDoubleEscaped = true;
-      this.#rawWindow = "";
-      return;
-    }
-    if (this.#rawWindow.endsWith("<!--")) {
-      this.#rawEscaped = true;
-    } else if (this.#rawEscaped && this.#rawWindow.endsWith("-->")) {
-      this.#rawEscaped = false;
-    }
+    return input.length;
   }
 }
 

--- a/packages/vinext/src/server/app-ssr-stream.ts
+++ b/packages/vinext/src/server/app-ssr-stream.ts
@@ -451,6 +451,7 @@ function endsWithDelimitedTag(window: string, prefix: string): string | null {
  * prefix, preserving streaming and backpressure.
  */
 class HtmlClosingTokenScanner {
+  #commentLength = 0;
   #commentTail = "";
   #declarationPrefix = "";
   #quote: '"' | "'" | null = null;
@@ -560,6 +561,7 @@ class HtmlClosingTokenScanner {
       if (this.#state === "markup-declaration-open") {
         this.#declarationPrefix += character;
         if (this.#declarationPrefix === "--") {
+          this.#commentLength = 0;
           this.#commentTail = "";
           this.#state = "comment";
         } else if (this.#declarationPrefix.length >= 2) {
@@ -569,10 +571,18 @@ class HtmlClosingTokenScanner {
       }
 
       if (this.#state === "comment") {
-        this.#commentTail = (this.#commentTail + character).slice(-3);
-        if (this.#commentTail === "-->") {
+        const closesAbruptly =
+          character === ">" &&
+          ((this.#commentLength <= 1 && this.#commentTail === "-".repeat(this.#commentLength)) ||
+            this.#commentTail.endsWith("--") ||
+            this.#commentTail.endsWith("--!"));
+        if (closesAbruptly) {
+          this.#commentLength = 0;
           this.#commentTail = "";
           this.#state = "data";
+        } else {
+          this.#commentLength++;
+          this.#commentTail = (this.#commentTail + character).slice(-3);
         }
         continue;
       }

--- a/packages/vinext/src/server/app-ssr-stream.ts
+++ b/packages/vinext/src/server/app-ssr-stream.ts
@@ -441,16 +441,16 @@ function endsWithDelimitedTag(window: string, prefix: string): string | null {
 }
 
 /**
- * Incrementally locate the document's real `</head>` token.
+ * Incrementally locate a real closing token outside inert HTML contexts.
  *
  * The insertion transform cannot use a substring search here: raw-text
  * elements, comments, attributes, and template contents may all contain the
  * same bytes without closing the document head. This deliberately small HTML
- * tokenizer tracks exactly the contexts that affect a closing-head token. It
- * retains no document data; the caller only holds a possible split `</head>`
- * prefix (at most six characters), preserving streaming and backpressure.
+ * tokenizer tracks exactly the contexts that affect a closing token. It
+ * retains no document data; the caller only holds a possible split-token
+ * prefix, preserving streaming and backpressure.
  */
-class HtmlHeadClosingTagScanner {
+class HtmlClosingTokenScanner {
   #commentTail = "";
   #declarationPrefix = "";
   #quote: '"' | "'" | null = null;
@@ -461,26 +461,36 @@ class HtmlHeadClosingTagScanner {
   #state: HeadScannerState = "data";
   #tagIsEnd = false;
   #tagName = "";
+  readonly #target: string;
   #templateDepth = 0;
 
-  scan(input: string, final: boolean): { consumed: number; headCloseIndex: number } {
+  constructor(target: string) {
+    this.#target = target.toLowerCase();
+  }
+
+  scan(input: string, final: boolean): { consumed: number; tokenIndex: number } {
     for (let index = 0; index < input.length; index++) {
-      const character = input[index];
+      let character = input[index];
 
       if (this.#state === "data") {
-        if (character !== "<") continue;
+        if (character !== "<") {
+          const nextTag = input.indexOf("<", index + 1);
+          if (nextTag === -1) return { consumed: input.length, tokenIndex: -1 };
+          index = nextTag;
+          character = "<";
+        }
 
         if (this.#templateDepth === 0) {
-          const candidate = input.slice(index, index + HEAD_CLOSE_TAG.length).toLowerCase();
-          if (candidate === HEAD_CLOSE_TAG) {
-            return { consumed: index, headCloseIndex: index };
+          const candidate = input.slice(index, index + this.#target.length).toLowerCase();
+          if (candidate === this.#target) {
+            return { consumed: index, tokenIndex: index };
           }
           if (
             !final &&
-            candidate.length < HEAD_CLOSE_TAG.length &&
-            HEAD_CLOSE_TAG.startsWith(candidate)
+            candidate.length < this.#target.length &&
+            this.#target.startsWith(candidate)
           ) {
-            return { consumed: index, headCloseIndex: -1 };
+            return { consumed: index, tokenIndex: -1 };
           }
         }
 
@@ -577,7 +587,7 @@ class HtmlHeadClosingTagScanner {
       }
     }
 
-    return { consumed: input.length, headCloseIndex: -1 };
+    return { consumed: input.length, tokenIndex: -1 };
   }
 
   #finishTag(): void {
@@ -727,10 +737,12 @@ export function createTickBufferedTransform(
   let preHeadInjected = false;
   let suffixStripped = false;
   let buffered: string[] = [];
+  let pendingDocumentClose = "";
   let pendingHtml = "";
   let pendingHeadClose = "";
   let timeoutId: ReturnType<typeof setTimeout> | null = null;
-  const headCloseScanner = new HtmlHeadClosingTagScanner();
+  const documentCloseScanner = new HtmlClosingTokenScanner(DOCUMENT_CLOSE_SUFFIX);
+  const headCloseScanner = new HtmlClosingTokenScanner(HEAD_CLOSE_TAG);
   // Computed once at transform creation: every flush is a hot path, so we
   // avoid re-running Object.keys() on the manifest per chunk. Gates both the
   // split-link boundary buffering and the inline-css link rewrite below.
@@ -738,19 +750,24 @@ export function createTickBufferedTransform(
     inlineCssManifest !== undefined && Object.keys(inlineCssManifest).length > 0;
 
   /**
-   * Strip the first occurrence of `</body></html>` from `chunk` so it can be
-   * re-emitted at the very end of the stream. Returns the rewritten chunk and
-   * a flag indicating whether a suffix was found. If `suffixStripped` is
-   * already true (i.e. an earlier chunk contained the suffix), this is a
-   * no-op — additional matches in later chunks shouldn't happen in practice,
-   * but we leave them alone to avoid corrupting unexpected output.
+   * Strip a real `</body></html>` token from `chunk` so it can be re-emitted at
+   * the very end of the stream. The incremental scanner excludes raw-text,
+   * comment, attribute, and template lookalikes and retains only a possible
+   * split token prefix. Once the real suffix is found, later chunks pass
+   * through unchanged.
    */
-  const stripDocumentCloseSuffix = (chunk: string): string => {
+  const stripDocumentCloseSuffix = (chunk: string, final: boolean): string => {
     if (suffixStripped) return chunk;
-    const index = chunk.indexOf(DOCUMENT_CLOSE_SUFFIX);
-    if (index === -1) return chunk;
-    suffixStripped = true;
-    return chunk.slice(0, index) + chunk.slice(index + DOCUMENT_CLOSE_SUFFIX.length);
+    const scan = documentCloseScanner.scan(chunk, final);
+    if (scan.tokenIndex !== -1) {
+      suffixStripped = true;
+      return (
+        chunk.slice(0, scan.tokenIndex) +
+        chunk.slice(scan.tokenIndex + DOCUMENT_CLOSE_SUFFIX.length)
+      );
+    }
+    pendingDocumentClose = chunk.slice(scan.consumed);
+    return chunk.slice(0, scan.consumed);
   };
   const readInsertion = (): string =>
     typeof injectHTML === "function" ? injectHTML() : injectHTML;
@@ -799,9 +816,12 @@ export function createTickBufferedTransform(
     controller: TransformStreamDefaultController<Uint8Array>,
     final = false,
   ): void => {
-    if (buffered.length === 0 && !pendingHtml && !pendingHeadClose) return;
-    const rawHtml = pendingHeadClose + pendingHtml + buffered.join("");
+    if (buffered.length === 0 && !pendingDocumentClose && !pendingHtml && !pendingHeadClose) {
+      return;
+    }
+    const rawHtml = pendingHeadClose + pendingDocumentClose + pendingHtml + buffered.join("");
     buffered = [];
+    pendingDocumentClose = "";
     pendingHtml = "";
     pendingHeadClose = "";
 
@@ -843,19 +863,21 @@ export function createTickBufferedTransform(
     }
     if (!injected) {
       const scan = headCloseScanner.scan(working, final);
-      if (scan.headCloseIndex !== -1) {
-        const before = working.slice(0, scan.headCloseIndex);
-        const after = stripDocumentCloseSuffix(working.slice(scan.headCloseIndex));
-        controller.enqueue(
-          encoder.encode(before + readInlineCssPrependFallback() + readInsertion() + after),
+      if (scan.tokenIndex !== -1) {
+        const before = working.slice(0, scan.tokenIndex);
+        const after = working.slice(scan.tokenIndex);
+        working = stripDocumentCloseSuffix(
+          before + readInlineCssPrependFallback() + readInsertion() + after,
+          final,
         );
+        controller.enqueue(encoder.encode(working));
         injected = true;
         return;
       }
       pendingHeadClose = working.slice(scan.consumed);
       working = working.slice(0, scan.consumed);
     }
-    working = stripDocumentCloseSuffix(working);
+    working = stripDocumentCloseSuffix(working, final);
     if (working) {
       controller.enqueue(encoder.encode(working));
     }

--- a/packages/vinext/src/server/app-ssr-stream.ts
+++ b/packages/vinext/src/server/app-ssr-stream.ts
@@ -400,13 +400,276 @@ function rewriteInlineCssStylesheetLinks(
   return { html: rewritten, consumedPrependCss };
 }
 
-/**
- * Match the `<head ...>` opening tag in a chunk. Matches both bare `<head>`
- * and `<head class="foo">` shapes. Used to splice HTML immediately after the
- * opening tag so injected content runs before any React-emitted resource
- * hints (stylesheets, modulepreloads) that React Float hoists into `<head>`.
- */
+/** Match the `<head ...>` opening tag in a tick-buffered batch. */
 const HEAD_OPEN_RE = /<head\b[^>]*>/;
+
+const HEAD_CLOSE_TAG = "</head>";
+const RAW_TEXT_ELEMENTS = new Set([
+  "iframe",
+  "noembed",
+  "noframes",
+  "noscript",
+  "script",
+  "style",
+  "textarea",
+  "title",
+  "xmp",
+]);
+const RAW_TAG_WINDOW_LENGTH = 16;
+
+type HeadScannerState =
+  | "bogus-comment"
+  | "comment"
+  | "data"
+  | "end-tag-open"
+  | "markup-declaration-open"
+  | "plaintext"
+  | "raw-end-tag"
+  | "raw-text"
+  | "tag-body"
+  | "tag-name"
+  | "tag-open";
+
+function isHtmlTagDelimiter(character: string): boolean {
+  return character === ">" || character === "/" || /[\t\n\f\r ]/.test(character);
+}
+
+function endsWithDelimitedTag(window: string, prefix: string): string | null {
+  const delimiter = window.at(-1);
+  if (!delimiter || !isHtmlTagDelimiter(delimiter)) return null;
+  return window.endsWith(prefix + delimiter) ? delimiter : null;
+}
+
+/**
+ * Incrementally locate the document's real `</head>` token.
+ *
+ * The insertion transform cannot use a substring search here: raw-text
+ * elements, comments, attributes, and template contents may all contain the
+ * same bytes without closing the document head. This deliberately small HTML
+ * tokenizer tracks exactly the contexts that affect a closing-head token. It
+ * retains no document data; the caller only holds a possible split `</head>`
+ * prefix (at most six characters), preserving streaming and backpressure.
+ */
+class HtmlHeadClosingTagScanner {
+  #commentTail = "";
+  #declarationPrefix = "";
+  #quote: '"' | "'" | null = null;
+  #rawDoubleEscaped = false;
+  #rawEscaped = false;
+  #rawTag: string | null = null;
+  #rawWindow = "";
+  #state: HeadScannerState = "data";
+  #tagIsEnd = false;
+  #tagName = "";
+  #templateDepth = 0;
+
+  scan(input: string, final: boolean): { consumed: number; headCloseIndex: number } {
+    for (let index = 0; index < input.length; index++) {
+      const character = input[index];
+
+      if (this.#state === "data") {
+        if (character !== "<") continue;
+
+        if (this.#templateDepth === 0) {
+          const candidate = input.slice(index, index + HEAD_CLOSE_TAG.length).toLowerCase();
+          if (candidate === HEAD_CLOSE_TAG) {
+            return { consumed: index, headCloseIndex: index };
+          }
+          if (
+            !final &&
+            candidate.length < HEAD_CLOSE_TAG.length &&
+            HEAD_CLOSE_TAG.startsWith(candidate)
+          ) {
+            return { consumed: index, headCloseIndex: -1 };
+          }
+        }
+
+        this.#state = "tag-open";
+        continue;
+      }
+
+      if (this.#state === "tag-open") {
+        if (character === "/") {
+          this.#tagIsEnd = true;
+          this.#tagName = "";
+          this.#state = "end-tag-open";
+        } else if (character === "!") {
+          this.#declarationPrefix = "";
+          this.#state = "markup-declaration-open";
+        } else if (character === "?") {
+          this.#state = "bogus-comment";
+        } else if (/[A-Za-z]/.test(character)) {
+          this.#tagIsEnd = false;
+          this.#tagName = character.toLowerCase();
+          this.#state = "tag-name";
+        } else {
+          this.#state = "data";
+        }
+        continue;
+      }
+
+      if (this.#state === "end-tag-open") {
+        if (/[A-Za-z]/.test(character)) {
+          this.#tagName = character.toLowerCase();
+          this.#state = "tag-name";
+        } else {
+          this.#state = character === ">" ? "data" : "bogus-comment";
+        }
+        continue;
+      }
+
+      if (this.#state === "tag-name") {
+        if (character === ">") {
+          this.#finishTag();
+        } else if (isHtmlTagDelimiter(character)) {
+          this.#quote = null;
+          this.#state = "tag-body";
+        } else {
+          this.#tagName += character.toLowerCase();
+        }
+        continue;
+      }
+
+      if (this.#state === "tag-body" || this.#state === "raw-end-tag") {
+        if (this.#quote) {
+          if (character === this.#quote) this.#quote = null;
+          continue;
+        }
+        if (character === '"' || character === "'") {
+          this.#quote = character;
+        } else if (character === ">") {
+          if (this.#state === "raw-end-tag") {
+            this.#leaveRawText();
+          } else {
+            this.#finishTag();
+          }
+        }
+        continue;
+      }
+
+      if (this.#state === "markup-declaration-open") {
+        this.#declarationPrefix += character;
+        if (this.#declarationPrefix === "--") {
+          this.#commentTail = "";
+          this.#state = "comment";
+        } else if (this.#declarationPrefix.length >= 2) {
+          this.#state = character === ">" ? "data" : "bogus-comment";
+        }
+        continue;
+      }
+
+      if (this.#state === "comment") {
+        this.#commentTail = (this.#commentTail + character).slice(-3);
+        if (this.#commentTail === "-->") {
+          this.#commentTail = "";
+          this.#state = "data";
+        }
+        continue;
+      }
+
+      if (this.#state === "bogus-comment") {
+        if (character === ">") this.#state = "data";
+        continue;
+      }
+
+      if (this.#state === "raw-text") {
+        this.#scanRawText(character);
+      }
+    }
+
+    return { consumed: input.length, headCloseIndex: -1 };
+  }
+
+  #finishTag(): void {
+    const name = this.#tagName;
+    const isEnd = this.#tagIsEnd;
+    this.#tagName = "";
+    this.#tagIsEnd = false;
+    this.#quote = null;
+
+    if (name === "template") {
+      this.#templateDepth = isEnd ? Math.max(0, this.#templateDepth - 1) : this.#templateDepth + 1;
+    }
+
+    if (!isEnd && name === "plaintext") {
+      this.#state = "plaintext";
+      return;
+    }
+
+    if (!isEnd && RAW_TEXT_ELEMENTS.has(name)) {
+      this.#rawTag = name;
+      this.#rawWindow = "";
+      this.#rawEscaped = false;
+      this.#rawDoubleEscaped = false;
+      this.#state = "raw-text";
+      return;
+    }
+
+    this.#state = "data";
+  }
+
+  #leaveRawText(): void {
+    this.#quote = null;
+    this.#rawTag = null;
+    this.#rawWindow = "";
+    this.#rawEscaped = false;
+    this.#rawDoubleEscaped = false;
+    this.#state = "data";
+  }
+
+  #scanRawText(character: string): void {
+    const rawTag = this.#rawTag;
+    if (!rawTag) {
+      this.#state = "data";
+      return;
+    }
+
+    this.#rawWindow = (this.#rawWindow + character.toLowerCase()).slice(-RAW_TAG_WINDOW_LENGTH);
+    const closingDelimiter = endsWithDelimitedTag(this.#rawWindow, `</${rawTag}`);
+
+    if (rawTag !== "script") {
+      if (closingDelimiter === ">") {
+        this.#leaveRawText();
+      } else if (closingDelimiter) {
+        this.#quote = null;
+        this.#state = "raw-end-tag";
+      }
+      return;
+    }
+
+    if (this.#rawDoubleEscaped) {
+      if (closingDelimiter) {
+        // In the HTML script-data-double-escaped state, `</script>` returns
+        // to escaped script data; it does not close the element yet.
+        this.#rawDoubleEscaped = false;
+        this.#rawEscaped = true;
+        this.#rawWindow = "";
+      }
+      return;
+    }
+
+    if (closingDelimiter === ">") {
+      this.#leaveRawText();
+      return;
+    }
+    if (closingDelimiter) {
+      this.#quote = null;
+      this.#state = "raw-end-tag";
+      return;
+    }
+
+    if (this.#rawEscaped && endsWithDelimitedTag(this.#rawWindow, "<script")) {
+      this.#rawDoubleEscaped = true;
+      this.#rawWindow = "";
+      return;
+    }
+    if (this.#rawWindow.endsWith("<!--")) {
+      this.#rawEscaped = true;
+    } else if (this.#rawEscaped && this.#rawWindow.endsWith("-->")) {
+      this.#rawEscaped = false;
+    }
+  }
+}
 
 /**
  * Final closing tags of the streamed HTML document. We track this suffix
@@ -465,7 +728,9 @@ export function createTickBufferedTransform(
   let suffixStripped = false;
   let buffered: string[] = [];
   let pendingHtml = "";
+  let pendingHeadClose = "";
   let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  const headCloseScanner = new HtmlHeadClosingTagScanner();
   // Computed once at transform creation: every flush is a hot path, so we
   // avoid re-running Object.keys() on the manifest per chunk. Gates both the
   // split-link boundary buffering and the inline-css link rewrite below.
@@ -534,10 +799,11 @@ export function createTickBufferedTransform(
     controller: TransformStreamDefaultController<Uint8Array>,
     final = false,
   ): void => {
-    if (buffered.length === 0 && !pendingHtml) return;
-    const rawHtml = pendingHtml + buffered.join("");
+    if (buffered.length === 0 && !pendingHtml && !pendingHeadClose) return;
+    const rawHtml = pendingHeadClose + pendingHtml + buffered.join("");
     buffered = [];
     pendingHtml = "";
+    pendingHeadClose = "";
 
     const split =
       final || !hasInlineCssManifest
@@ -576,19 +842,23 @@ export function createTickBufferedTransform(
       }
     }
     if (!injected) {
-      const headEnd = working.indexOf("</head>");
-      if (headEnd !== -1) {
-        const before = working.slice(0, headEnd);
-        const after = stripDocumentCloseSuffix(working.slice(headEnd));
+      const scan = headCloseScanner.scan(working, final);
+      if (scan.headCloseIndex !== -1) {
+        const before = working.slice(0, scan.headCloseIndex);
+        const after = stripDocumentCloseSuffix(working.slice(scan.headCloseIndex));
         controller.enqueue(
           encoder.encode(before + readInlineCssPrependFallback() + readInsertion() + after),
         );
         injected = true;
         return;
       }
+      pendingHeadClose = working.slice(scan.consumed);
+      working = working.slice(0, scan.consumed);
     }
     working = stripDocumentCloseSuffix(working);
-    controller.enqueue(encoder.encode(working));
+    if (working) {
+      controller.enqueue(encoder.encode(working));
+    }
   };
 
   return new TransformStream<Uint8Array, Uint8Array>({

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -55,7 +55,11 @@ const projectServers = {
   },
   "app-router-client-cache": {
     testDir: "./tests/e2e/app-router/nextjs-compat",
-    testMatch: ["client-cache.spec.ts", "segment-cache-client-params.spec.ts"],
+    testMatch: [
+      "client-cache.spec.ts",
+      "segment-cache-client-params.spec.ts",
+      "streaming-head-insertion.spec.ts",
+    ],
     use: { baseURL: "http://localhost:4191" },
     server: {
       command:

--- a/tests/app-ssr-stream.test.ts
+++ b/tests/app-ssr-stream.test.ts
@@ -479,6 +479,16 @@ describe("createTickBufferedTransform pre-head splice", () => {
       "<!-- before </head> after -->",
     ],
     [
+      "abruptly closed comment",
+      ["<html><head><!-", "--></he", "ad><body></body></html>"],
+      "<!--->",
+    ],
+    [
+      "comment ending in --!>",
+      ["<html><head><!-- before --", "!></he", "ad><body></body></html>"],
+      "<!-- before --!>",
+    ],
+    [
       "quoted attribute",
       ['<html><head><meta content="before </he', 'ad> after">', "</head><body></body></html>"],
       '<meta content="before </head> after">',

--- a/tests/app-ssr-stream.test.ts
+++ b/tests/app-ssr-stream.test.ts
@@ -397,12 +397,44 @@ describe("createTickBufferedTransform pre-head splice", () => {
 
   it("does not treat </head> inside a beforeInteractive script as the insertion point", async () => {
     const script = '<script id="theme">self.theme = "</head><img data-payload src=x>";</script>';
-    const out = await runTransform(["<html><head></head><body></body></html>"], {
+    const out = await runDelayedTransform(["<html><head>", "</head><body></body></html>"], {
       injectHTML: '<meta data-end-of-head="true">',
       injectAfterHeadOpenHTML: script,
     });
 
     expect(out).toContain(`${script}<meta data-end-of-head="true"></head>`);
+  });
+
+  it("preserves document-close text inside a beforeInteractive script", async () => {
+    const script = '<script id="theme">self.theme = "</body></html>";</script>';
+    const transform = createTickBufferedTransform(
+      createNoopRscEmbedTransform(),
+      '<meta data-end-of-head="true">',
+      script,
+    );
+    const source = new TransformStream<Uint8Array, Uint8Array>();
+    const reader = source.readable.pipeThrough(transform).getReader();
+    const writer = source.writable.getWriter();
+    const firstRead = reader.read();
+
+    await writer.write(new TextEncoder().encode("<html><head>"));
+    const first = await firstRead;
+    expect(first.done).toBe(false);
+    expect(new TextDecoder().decode(first.value)).toContain(script);
+
+    const remainderPromise = (async () => {
+      let remainder = "";
+      while (true) {
+        const result = await reader.read();
+        if (result.done) return remainder;
+        remainder += new TextDecoder().decode(result.value);
+      }
+    })();
+    await writer.write(new TextEncoder().encode("</head><body></body></html>"));
+    await writer.close();
+    const remainder = await remainderPromise;
+
+    expect(remainder).toContain('<meta data-end-of-head="true"></head>');
   });
 
   it.each([
@@ -427,6 +459,58 @@ describe("createTickBufferedTransform pre-head splice", () => {
     });
 
     expect(out).toContain(`${script}<meta data-end-of-head="true"></head>`);
+  });
+
+  it.each([
+    [
+      "script data",
+      [
+        "<html><head><scr",
+        'ipt>self.value = "</he',
+        'ad>";</scr',
+        "ipt></he",
+        "ad><body></body></html>",
+      ],
+      '<script>self.value = "</head>";</script>',
+    ],
+    [
+      "comment",
+      ["<html><head><!-", "- before </he", "ad> after --", "></head><body></body></html>"],
+      "<!-- before </head> after -->",
+    ],
+    [
+      "quoted attribute",
+      ['<html><head><meta content="before </he', 'ad> after">', "</head><body></body></html>"],
+      '<meta content="before </head> after">',
+    ],
+    [
+      "template contents",
+      [
+        "<html><head><temp",
+        "late><div>before </he",
+        "ad> after</div></temp",
+        "late></head><body></body></html>",
+      ],
+      "<template><div>before </head> after</div></template>",
+    ],
+    [
+      "double-escaped script data",
+      [
+        "<html><head><script><!",
+        "--<scr",
+        "ipt></he",
+        "ad></scr",
+        "ipt>--></scr",
+        "ipt></head><body></body></html>",
+      ],
+      "<script><!--<script></head></script>--></script>",
+    ],
+  ])("retains %s scanner state across flush ticks", async (_label, chunks, context) => {
+    const out = await runDelayedTransform(chunks, {
+      injectHTML: '<meta data-end-of-head="true">',
+    });
+
+    expect(out).toContain(`${context}<meta data-end-of-head="true"></head>`);
   });
 
   it("finds a real closing head tag split across flush ticks", async () => {
@@ -507,6 +591,36 @@ describe("createTickBufferedTransform pre-head splice", () => {
   // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app/index.test.ts
   // (regression for #1532)
   describe("</body></html> suffix is the last thing in the stream", () => {
+    it("preserves document-close text in body scripts across flush ticks", async () => {
+      const transform = createTickBufferedTransform(createNoopRscEmbedTransform());
+      const source = new TransformStream<Uint8Array, Uint8Array>();
+      const reader = source.readable.pipeThrough(transform).getReader();
+      const writer = source.writable.getWriter();
+      let out = "";
+      const readPromise = (async () => {
+        while (true) {
+          const result = await reader.read();
+          if (result.done) return;
+          out += new TextDecoder().decode(result.value);
+        }
+      })();
+
+      await writer.write(new TextEncoder().encode("<html><head></head><body>"));
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      await writer.write(
+        new TextEncoder().encode('<script>self.value = "</body></html>";</script>'),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      await writer.write(new TextEncoder().encode("</body></ht"));
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      await writer.write(new TextEncoder().encode("ml>"));
+      await writer.close();
+      await readPromise;
+
+      expect(out).toContain('<script>self.value = "</body></html>";</script>');
+      expect(out.endsWith("</body></html>")).toBe(true);
+    });
+
     it("moves the </body></html> suffix to the end after trailing scripts and RSC chunks", async () => {
       // Simulate React Fizz emitting the closing tags BEFORE flush appends
       // trailing flight chunks / preinit scripts.

--- a/tests/app-ssr-stream.test.ts
+++ b/tests/app-ssr-stream.test.ts
@@ -262,6 +262,8 @@ async function runTransform(
 async function runDelayedTransform(
   chunks: string[],
   options: {
+    injectHTML?: string;
+    injectAfterHeadOpenHTML?: string;
     inlineCss?: Record<string, string>;
   } = {},
 ): Promise<string> {
@@ -284,7 +286,12 @@ async function runDelayedTransform(
 
   return new Response(
     source.pipeThrough(
-      createTickBufferedTransform(createNoopRscEmbedTransform(), "", "", options.inlineCss),
+      createTickBufferedTransform(
+        createNoopRscEmbedTransform(),
+        options.injectHTML ?? "",
+        options.injectAfterHeadOpenHTML ?? "",
+        options.inlineCss,
+      ),
     ),
   ).text();
 }
@@ -386,6 +393,75 @@ describe("createTickBufferedTransform pre-head splice", () => {
     expect(endIdx).toBeGreaterThan(-1);
     expect(startIdx).toBeLessThan(endIdx);
     expect(endIdx).toBeLessThan(closeIdx);
+  });
+
+  it("does not treat </head> inside a beforeInteractive script as the insertion point", async () => {
+    const script = '<script id="theme">self.theme = "</head><img data-payload src=x>";</script>';
+    const out = await runTransform(["<html><head></head><body></body></html>"], {
+      injectHTML: '<meta data-end-of-head="true">',
+      injectAfterHeadOpenHTML: script,
+    });
+
+    expect(out).toContain(`${script}<meta data-end-of-head="true"></head>`);
+  });
+
+  it.each([
+    ["script data", '<script>self.value = "</head>";</script>'],
+    ["style data", '<style>.x::after { content: "</head>"; }</style>'],
+    ["title data", "<title>before </head> after</title>"],
+    ["comment", "<!-- before </head> after -->"],
+    ["attribute", '<meta content="before </head> after">'],
+    ["template contents", "<template><div>before </head> after</div></template>"],
+  ])("ignores closing-head text in %s", async (_label, context) => {
+    const out = await runTransform([`<html><head>${context}</head><body></body></html>`], {
+      injectHTML: '<meta data-end-of-head="true">',
+    });
+
+    expect(out).toContain(`${context}<meta data-end-of-head="true"></head>`);
+  });
+
+  it("tracks script double-escaped data before finding the real head close", async () => {
+    const script = "<script><!--<script></head></script>--></script>";
+    const out = await runTransform([`<html><head>${script}</head><body></body></html>`], {
+      injectHTML: '<meta data-end-of-head="true">',
+    });
+
+    expect(out).toContain(`${script}<meta data-end-of-head="true"></head>`);
+  });
+
+  it("finds a real closing head tag split across flush ticks", async () => {
+    const out = await runDelayedTransform(
+      ["<html><head><title>x</title></he", "ad><body></body></html>"],
+      { injectHTML: '<meta data-end-of-head="true">' },
+    );
+
+    expect(out).toContain('<title>x</title><meta data-end-of-head="true"></head>');
+  });
+
+  it("continues streaming safe head content before later input arrives", async () => {
+    const transform = createTickBufferedTransform(
+      createNoopRscEmbedTransform(),
+      '<meta data-end-of-head="true">',
+    );
+    const source = new TransformStream<Uint8Array, Uint8Array>();
+    const reader = source.readable.pipeThrough(transform).getReader();
+    const writer = source.writable.getWriter();
+    const firstRead = reader.read();
+
+    await writer.write(new TextEncoder().encode("<html><head><meta name=first>"));
+    const first = await firstRead;
+    expect(first.done).toBe(false);
+    expect(new TextDecoder().decode(first.value)).toBe("<html><head><meta name=first>");
+
+    await writer.write(new TextEncoder().encode("</head><body></body></html>"));
+    await writer.close();
+    let remainder = "";
+    while (true) {
+      const result = await reader.read();
+      if (result.done) break;
+      remainder += new TextDecoder().decode(result.value);
+    }
+    expect(remainder).toContain('<meta data-end-of-head="true"></head>');
   });
 
   it("handles <head> with attributes", async () => {

--- a/tests/app-ssr-stream.test.ts
+++ b/tests/app-ssr-stream.test.ts
@@ -461,6 +461,37 @@ describe("createTickBufferedTransform pre-head splice", () => {
     expect(out).toContain(`${script}<meta data-end-of-head="true"></head>`);
   });
 
+  it("skips over large raw-text bodies without lowercasing each character", async () => {
+    const toLowerCaseDescriptor = Object.getOwnPropertyDescriptor(String.prototype, "toLowerCase");
+    if (!toLowerCaseDescriptor) throw new Error("String.prototype.toLowerCase is unavailable");
+    const originalToLowerCase = toLowerCaseDescriptor.value as (this: string) => string;
+    let singleCharacterCalls = 0;
+    Object.defineProperty(String.prototype, "toLowerCase", {
+      ...toLowerCaseDescriptor,
+      value: function (this: string): string {
+        if (this.length === 1) singleCharacterCalls++;
+        return Reflect.apply(originalToLowerCase, this, []);
+      },
+    });
+
+    let out: string;
+    try {
+      const scriptBody = "a".repeat(5 * 1024 * 1024);
+      out = await runTransform(
+        [`<html><head><script>${scriptBody}</script></head><body></body></html>`],
+        { injectHTML: '<meta data-end-of-head="true">' },
+      );
+    } finally {
+      Object.defineProperty(String.prototype, "toLowerCase", toLowerCaseDescriptor);
+    }
+
+    expect(out).toContain('</script><meta data-end-of-head="true"></head>');
+    // Tag parsing still lowercases a bounded number of individual characters.
+    // Raw-text scanning must not make that count proportional to the script.
+    expect(singleCharacterCalls).toBeGreaterThan(0);
+    expect(singleCharacterCalls).toBeLessThan(1_000);
+  });
+
   it.each([
     [
       "script data",

--- a/tests/app-ssr-stream.test.ts
+++ b/tests/app-ssr-stream.test.ts
@@ -532,6 +532,30 @@ describe("createTickBufferedTransform pre-head splice", () => {
     expect(out).toContain('<title>x</title><meta data-end-of-head="true"></head>');
   });
 
+  it.each([
+    ["uppercase", "</HEAD>"],
+    ["whitespace", "</head >"],
+    ["end-tag attributes", '</head data-marker=">">'],
+  ])("recognizes a browser-valid %s closing head tag", async (_label, closeTag) => {
+    const out = await runTransform(
+      [`<html><head><title>x</title>${closeTag}<body></body></html>`],
+      {
+        injectHTML: '<meta data-end-of-head="true">',
+      },
+    );
+
+    expect(out).toContain(`<title>x</title><meta data-end-of-head="true">${closeTag}`);
+  });
+
+  it("recognizes a browser-valid closing head tag split inside its attributes", async () => {
+    const out = await runDelayedTransform(
+      ["<html><head><title>x</title></HE", 'AD data-marker=">', '"><body></body></html>'],
+      { injectHTML: '<meta data-end-of-head="true">' },
+    );
+
+    expect(out).toContain('<title>x</title><meta data-end-of-head="true"></HEAD data-marker=">">');
+  });
+
   it("continues streaming safe head content before later input arrives", async () => {
     const transform = createTickBufferedTransform(
       createNoopRscEmbedTransform(),
@@ -651,6 +675,26 @@ describe("createTickBufferedTransform pre-head splice", () => {
       expect(out.slice(0, -suffix.length)).not.toContain(suffix);
       // Trailing scripts land before the suffix, not after it.
       expect(out).toContain('<script id="trailing-rsc">rsc()</script></body></html>');
+    });
+
+    it.each([
+      ["uppercase", "</BODY></HTML>"],
+      ["whitespace", "</body >\n</html >"],
+      ["end-tag attributes", '</body data-marker=">"></html data-marker=">">'],
+    ])("moves a browser-valid %s document suffix", async (_label, suffix) => {
+      const rsc = {
+        flush: () => "",
+        finalize: async () => '<script id="trailing-rsc">rsc()</script>',
+        getRawBuffer: async () => new ArrayBuffer(0),
+      };
+      const transform = createTickBufferedTransform(rsc);
+      const out = await new Response(
+        createTextStream([`<html><head></head><body>content${suffix}`]).pipeThrough(transform),
+      ).text();
+
+      expect(out).not.toContain(suffix);
+      expect(out).toContain('content<script id="trailing-rsc">rsc()</script></body></html>');
+      expect(out.endsWith("</body></html>")).toBe(true);
     });
 
     it("ensures the suffix is at the end even when injectHTML fallback fires", async () => {

--- a/tests/e2e/app-router/nextjs-compat/streaming-head-insertion.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/streaming-head-insertion.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "../../fixtures";
+
+test("framework head insertion stays outside beforeInteractive script data", async ({ page }) => {
+  const payload =
+    '</head><img data-head-insertion-payload src="x" onerror="self.__headInsertionPwned=true">';
+  const response = await page.goto(`/head-insertion-context?theme=${encodeURIComponent(payload)}`);
+
+  expect(response?.status()).toBe(200);
+  const rawHtml = await response!.text();
+  const parsedResponse = await page.evaluate((html) => {
+    const parsed = new DOMParser().parseFromString(html, "text/html");
+    return {
+      payloadElements: parsed.querySelectorAll("img[data-head-insertion-payload]").length,
+      themeScript: parsed.querySelector("#head-insertion-theme")?.textContent,
+    };
+  }, rawHtml);
+  expect(parsedResponse).toEqual({
+    payloadElements: 0,
+    themeScript: `self.__headInsertionTheme = ${JSON.stringify(payload)};`,
+  });
+
+  await expect(
+    page.getByRole("heading", { name: "Streaming head insertion context" }),
+  ).toBeVisible();
+  await expect(page.locator("img[data-head-insertion-payload]")).toHaveCount(0);
+
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const global = self as typeof self & {
+          __headInsertionPwned?: boolean;
+          __headInsertionTheme?: string;
+        };
+        return {
+          pwned: global.__headInsertionPwned === true,
+          theme: global.__headInsertionTheme,
+          themeScript: document.querySelector("#head-insertion-theme")?.textContent,
+        };
+      }),
+    )
+    .toEqual({
+      pwned: false,
+      theme: payload,
+      themeScript: `self.__headInsertionTheme = ${JSON.stringify(payload)};`,
+    });
+});

--- a/tests/fixtures/app-basic/app/head-insertion-context/page.tsx
+++ b/tests/fixtures/app-basic/app/head-insertion-context/page.tsx
@@ -1,0 +1,18 @@
+import HeadInsertionThemeScript from "./theme-script";
+
+export const dynamic = "force-dynamic";
+
+export default async function HeadInsertionContextPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ theme?: string }>;
+}) {
+  const theme = (await searchParams).theme ?? "light";
+
+  return (
+    <main>
+      <h1>Streaming head insertion context</h1>
+      <HeadInsertionThemeScript theme={theme} />
+    </main>
+  );
+}

--- a/tests/fixtures/app-basic/app/head-insertion-context/theme-script.tsx
+++ b/tests/fixtures/app-basic/app/head-insertion-context/theme-script.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import Script from "next/script";
+
+export default function HeadInsertionThemeScript({ theme }: { theme: string }) {
+  return (
+    <Script
+      id="head-insertion-theme"
+      strategy="beforeInteractive"
+      dangerouslySetInnerHTML={{
+        __html: `self.__headInsertionTheme = ${JSON.stringify(theme)};`,
+      }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

- preserve raw-text and document-close context across streamed HTML chunks
- keep insertion boundaries stable for scripts, styles, comments, and templates
- avoid per-character work for large inline raw-text blocks

## Testing

- streaming helper and forced chunk-boundary coverage
- App Router development and production E2E coverage
- `vp check`
- `vp run vinext#build`