### PR TITLE
feat(router): expose opt-in navigation diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -472,6 +472,10 @@ jobs:
             label: app-router-bfcache
             shardIndex: 1
             shardTotal: 1
+          - project: app-router-navigation-debug
+            label: app-router-navigation-debug
+            shardIndex: 1
+            shardTotal: 1
           - project: app-router-prefetch-searchparams
             label: app-router-prefetch-searchparams
             shardIndex: 1

--- a/README.md
+++ b/README.md
@@ -591,6 +591,14 @@ Override behavior:
 
 - To override any `.env*` value, set it in your shell/CI environment before running vinext. Existing `process.env` always wins.
 
+#### App Router navigation diagnostics
+
+Start `vinext dev` or a production build with `VINEXT_DEBUG_NAVIGATION=1` to emit structured
+App Router lifecycle events to the browser console. The events identify navigation reuse,
+prefetch handoff, optimistic shells, RSC fetches, supersession, and visible commit outcomes.
+They include application URLs, so review them before sharing logs. Response bodies, cookies,
+and request headers are never included.
+
 ### Caching
 
 The cache is pluggable. The default `MemoryCacheHandler` works out of the box. Swap in your own backend for production.

--- a/README.md
+++ b/README.md
@@ -597,7 +597,8 @@ Start `vinext dev` or a production build with `VINEXT_DEBUG_NAVIGATION=1` to emi
 App Router lifecycle events to the browser console. The events identify navigation reuse,
 prefetch handoff, optimistic shells, RSC fetches, supersession, and visible commit outcomes.
 They include application URLs, so review them before sharing logs. Response bodies, cookies,
-and request headers are never included.
+and request headers are never included. The diagnostic event schema is internal; field names,
+values, and lifecycle phase names may change between releases.
 
 ### Caching
 

--- a/packages/vinext/src/client/app-navigation-debug.ts
+++ b/packages/vinext/src/client/app-navigation-debug.ts
@@ -1,4 +1,8 @@
 import type { AppNavigationPayloadOrigin } from "../server/app-browser-state.js";
+import type {
+  NavigationReuseDecision,
+  NavigationReuseFacts,
+} from "../server/navigation-planner.js";
 import type { NavigationTrace } from "../server/navigation-trace.js";
 
 type AppNavigationDebugBase = Readonly<{
@@ -8,17 +12,13 @@ type AppNavigationDebugBase = Readonly<{
 
 type AppNavigationStartDebugInput = AppNavigationDebugBase &
   Readonly<{
-    navigationKind: "navigate" | "refresh" | "traverse";
+    navigationKind: NavigationReuseFacts["navigationKind"];
   }>;
 
 type AppNavigationReuseDebugInput = AppNavigationDebugBase &
   Readonly<{
     additionalPrefetchRscUrls: readonly string[];
-    decision:
-      | "attemptOptimisticRouteShell"
-      | "consumePrefetch"
-      | "fetchFresh"
-      | "reuseVisitedResponse";
+    decision: NavigationReuseDecision["kind"];
     rscUrl: string;
     trace: NavigationTrace;
     visitedResponseCacheKey: string;

--- a/packages/vinext/src/client/app-navigation-debug.ts
+++ b/packages/vinext/src/client/app-navigation-debug.ts
@@ -3,7 +3,7 @@ import type {
   NavigationReuseDecision,
   NavigationReuseFacts,
 } from "../server/navigation-planner.js";
-import type { NavigationTrace } from "../server/navigation-trace.js";
+import type { NavigationCommitDecision } from "../server/app-browser-visible-commit.js";
 
 type AppNavigationDebugBase = Readonly<{
   navigationId: number;
@@ -15,14 +15,14 @@ type AppNavigationStartDebugInput = AppNavigationDebugBase &
     navigationKind: NavigationReuseFacts["navigationKind"];
   }>;
 
-type AppNavigationReuseDebugInput = AppNavigationDebugBase &
-  Readonly<{
-    additionalPrefetchRscUrls: readonly string[];
-    decision: NavigationReuseDecision["kind"];
-    rscUrl: string;
-    trace: NavigationTrace;
-    visitedResponseCacheKey: string;
-  }>;
+type AppNavigationReuseDebugInput = Readonly<{
+  additionalPrefetchRscUrls: readonly string[];
+  decision: NavigationReuseDecision;
+  facts: NavigationReuseFacts;
+  navigationId: number;
+  rscUrl: string;
+  visitedResponseCacheKey: string;
+}>;
 
 type AppNavigationPrefetchDebugInput = AppNavigationDebugBase &
   Readonly<{
@@ -45,9 +45,9 @@ type AppNavigationFetchResponseDebugInput = AppNavigationFetchDebugInput &
 export type AppNavigationCommitDebugInput = AppNavigationDebugBase &
   Readonly<{
     navigationCommitKind: "authoritative" | "detached" | null;
-    outcome: "committed" | "hard-navigate" | "no-commit";
+    approval: NavigationCommitDecision;
     payloadOrigin: AppNavigationPayloadOrigin["origin"];
-    trace: NavigationTrace;
+    visibleOutcome: "committed" | "hard-navigate" | "no-commit";
   }>;
 
 type AppNavigationDebugEvent =

--- a/packages/vinext/src/client/app-navigation-debug.ts
+++ b/packages/vinext/src/client/app-navigation-debug.ts
@@ -1,0 +1,145 @@
+import type { AppNavigationPayloadOrigin } from "../server/app-browser-state.js";
+import type { NavigationTrace } from "../server/navigation-trace.js";
+
+type AppNavigationDebugBase = Readonly<{
+  navigationId: number;
+  targetHref: string;
+}>;
+
+type AppNavigationStartDebugInput = AppNavigationDebugBase &
+  Readonly<{
+    navigationKind: "navigate" | "refresh" | "traverse";
+  }>;
+
+type AppNavigationReuseDebugInput = AppNavigationDebugBase &
+  Readonly<{
+    additionalPrefetchRscUrls: readonly string[];
+    decision:
+      | "attemptOptimisticRouteShell"
+      | "consumePrefetch"
+      | "fetchFresh"
+      | "reuseVisitedResponse";
+    rscUrl: string;
+    trace: NavigationTrace;
+    visitedResponseCacheKey: string;
+  }>;
+
+type AppNavigationPrefetchDebugInput = AppNavigationDebugBase &
+  Readonly<{
+    outcome: "hit" | "miss";
+    responseUrl: string | null;
+    rscUrl: string;
+  }>;
+
+type AppNavigationFetchDebugInput = AppNavigationDebugBase &
+  Readonly<{
+    rscUrl: string;
+  }>;
+
+type AppNavigationFetchResponseDebugInput = AppNavigationFetchDebugInput &
+  Readonly<{
+    responseUrl: string;
+    status: number;
+  }>;
+
+export type AppNavigationCommitDebugInput = AppNavigationDebugBase &
+  Readonly<{
+    navigationCommitKind: "authoritative" | "detached" | null;
+    outcome: "committed" | "hard-navigate" | "no-commit";
+    payloadOrigin: AppNavigationPayloadOrigin["origin"];
+    trace: NavigationTrace;
+  }>;
+
+type AppNavigationDebugEvent =
+  | (AppNavigationStartDebugInput & Readonly<{ phase: "start" }>)
+  | (AppNavigationDebugBase &
+      Readonly<{
+        phase: "abort";
+        reason: "history-restore" | "superseded";
+      }>)
+  | (AppNavigationReuseDebugInput & Readonly<{ phase: "reuse" }>)
+  | (AppNavigationPrefetchDebugInput & Readonly<{ phase: "prefetch" }>)
+  | (AppNavigationDebugBase &
+      Readonly<{
+        phase: "optimistic-shell";
+        routeId: string;
+      }>)
+  | (AppNavigationFetchDebugInput &
+      Readonly<{
+        phase: "fetch";
+        stage: "start";
+      }>)
+  | (AppNavigationFetchResponseDebugInput &
+      Readonly<{
+        phase: "fetch";
+        stage: "response";
+      }>)
+  | (AppNavigationCommitDebugInput & Readonly<{ phase: "commit" }>);
+
+export type AppNavigationDebugSink = (event: AppNavigationDebugEvent) => void;
+
+export type AppNavigationDebugReporter = Readonly<{
+  abort(reason: "history-restore" | "superseded"): void;
+  commit(input: AppNavigationCommitDebugInput): void;
+  fetchResponse(input: AppNavigationFetchResponseDebugInput): void;
+  fetchStart(input: AppNavigationFetchDebugInput): void;
+  optimisticShell(input: AppNavigationDebugBase & Readonly<{ routeId: string }>): void;
+  prefetch(input: AppNavigationPrefetchDebugInput): void;
+  retarget(navigationId: number, targetHref: string): void;
+  reuse(input: AppNavigationReuseDebugInput): void;
+  settle(navigationId: number): void;
+  start(input: AppNavigationStartDebugInput): void;
+}>;
+
+function writeAppNavigationDebugEvent(event: AppNavigationDebugEvent): void {
+  console.info("[vinext:navigation]", event);
+}
+
+export function createAppNavigationDebugReporter(options: {
+  enabled: boolean;
+  sink?: AppNavigationDebugSink;
+}): AppNavigationDebugReporter | null {
+  if (!options.enabled) return null;
+
+  const sink = options.sink ?? writeAppNavigationDebugEvent;
+  let activeNavigation: AppNavigationDebugBase | null = null;
+
+  return {
+    abort(reason) {
+      if (activeNavigation === null) return;
+      sink({ ...activeNavigation, phase: "abort", reason });
+      activeNavigation = null;
+    },
+    commit(input) {
+      sink({ ...input, phase: "commit" });
+    },
+    fetchResponse(input) {
+      sink({ ...input, phase: "fetch", stage: "response" });
+    },
+    fetchStart(input) {
+      sink({ ...input, phase: "fetch", stage: "start" });
+    },
+    optimisticShell(input) {
+      sink({ ...input, phase: "optimistic-shell" });
+    },
+    prefetch(input) {
+      sink({ ...input, phase: "prefetch" });
+    },
+    retarget(navigationId, targetHref) {
+      if (activeNavigation?.navigationId !== navigationId) return;
+      activeNavigation = { navigationId, targetHref };
+    },
+    reuse(input) {
+      sink({ ...input, phase: "reuse" });
+    },
+    settle(navigationId) {
+      if (activeNavigation?.navigationId === navigationId) {
+        activeNavigation = null;
+      }
+    },
+    start(input) {
+      activeNavigation = { navigationId: input.navigationId, targetHref: input.targetHref };
+      sink({ ...input, phase: "start" });
+    },
+  };
+}

--- a/packages/vinext/src/global.d.ts
+++ b/packages/vinext/src/global.d.ts
@@ -429,6 +429,13 @@ declare global {
       __VINEXT_PREFETCH_INLINING?: string;
 
       /**
+       * `"true"` when the vinext process starts with
+       * `VINEXT_DEBUG_NAVIGATION=1`. Enables structured browser-side App
+       * Router lifecycle diagnostics.
+       */
+      __VINEXT_DEBUG_NAVIGATION?: string;
+
+      /**
        * JSON-encoded array of `RemotePattern` objects from
        * `next.config.js` → `images.remotePatterns`.
        */

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2056,6 +2056,12 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         defines["process.env.__VINEXT_PREFETCH_INLINING"] = JSON.stringify(
           nextConfig.prefetchInlining ? "true" : "false",
         );
+        // Navigation tracing is an explicit build-time diagnostic. Keep the
+        // browser runtime branch statically false unless the build or dev
+        // server starts with VINEXT_DEBUG_NAVIGATION=1.
+        defines["process.env.__VINEXT_DEBUG_NAVIGATION"] = JSON.stringify(
+          process.env.VINEXT_DEBUG_NAVIGATION === "1" ? "true" : "false",
+        );
         // Emit a raw boolean (not the "true"/"false" string form used by the
         // sibling defines above): the consumer guards with
         // `if (process.env.__NEXT_GESTURE_TRANSITION)`, so the literal `false`

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -70,6 +70,7 @@ import {
 } from "vinext/shims/app-router-scroll-state";
 import { resolveHybridClientRewriteHref } from "vinext/shims/internal/hybrid-client-route-owner";
 import { installWindowNext, setWindowNextInternalSourcePage } from "../client/window-next.js";
+import { createAppNavigationDebugReporter } from "../client/app-navigation-debug.js";
 import {
   chunksToReadableStream,
   createProgressiveRscStream,
@@ -258,9 +259,14 @@ const historyController = new AppBrowserHistoryController({
   },
 });
 
+const navigationDebug = createAppNavigationDebugReporter({
+  enabled: process.env.__VINEXT_DEBUG_NAVIGATION === "true",
+});
+
 const browserNavigationController = createAppBrowserNavigationController({
   basePath: __basePath,
   getRouteManifest: getBrowserRouteManifest,
+  onNavigationCommitDebug: navigationDebug?.commit,
   syncHistoryStatePreviousNextUrl: (previousNextUrl, bfcacheIds) =>
     historyController.syncCurrentHistoryStatePreviousNextUrl(previousNextUrl, bfcacheIds),
 });
@@ -1632,7 +1638,8 @@ function bootstrapHydration(
 
   let activeNavigationAbortController: AbortController | null = null;
 
-  function abortSupersededNavigation(): void {
+  function abortSupersededNavigation(reason: "history-restore" | "superseded"): void {
+    if (activeNavigationAbortController !== null) navigationDebug?.abort(reason);
     activeNavigationAbortController?.abort();
     activeNavigationAbortController = null;
   }
@@ -1648,12 +1655,17 @@ function bootstrapHydration(
     scrollIntent?: AppRouterScrollIntent | null,
     visibleCommitMode: NavigationRuntimeVisibleCommitMode = "transition",
   ): Promise<void> {
-    abortSupersededNavigation();
+    abortSupersededNavigation("superseded");
     const navigationAbortController = new AbortController();
     activeNavigationAbortController = navigationAbortController;
     let pendingRouterState: PendingBrowserRouterState | null = null;
     // Hoist navId above try so the catch and finally blocks can reference it.
     const navId = browserNavigationController.beginNavigation();
+    navigationDebug?.start({
+      navigationId: navId,
+      navigationKind,
+      targetHref: href,
+    });
     const navigationCacheGeneration = clientNavigationCacheGeneration;
     discardedServerActionRefreshScheduler.markNavigationStart();
 
@@ -1714,6 +1726,7 @@ function bootstrapHydration(
       }
 
       while (true) {
+        navigationDebug?.retarget(navId, currentHref);
         const url = new URL(currentHref, window.location.origin);
         const requestState = getRequestState(
           navigationKind,
@@ -1831,6 +1844,15 @@ function bootstrapHydration(
           targetHref: currentHref,
           visitedResponse,
         });
+        navigationDebug?.reuse({
+          additionalPrefetchRscUrls,
+          decision: reuseDecision.kind,
+          navigationId: navId,
+          rscUrl,
+          targetHref: currentHref,
+          trace: reuseDecision.trace,
+          visitedResponseCacheKey: visitedResponseCandidate.cacheKey,
+        });
         if (reuseDecision.kind === "reuseVisitedResponse" && cachedRoute) {
           const cachedFetchDecision = navigationPlanner.classifyRscFetchResult({
             clientCompatibilityId: CLIENT_RSC_COMPATIBILITY_ID,
@@ -1937,6 +1959,13 @@ function bootstrapHydration(
             },
           );
           if (!browserNavigationController.isCurrentNavigation(navId)) return;
+          navigationDebug?.prefetch({
+            navigationId: navId,
+            outcome: prefetchedResponse === null ? "miss" : "hit",
+            responseUrl: prefetchedResponse?.url ?? null,
+            rscUrl,
+            targetHref: currentHref,
+          });
           if (prefetchedResponse) {
             navResponse = restoreRscResponse(prefetchedResponse, false);
             navResponseExpiresAt = prefetchedResponse.expiresAt;
@@ -1988,6 +2017,11 @@ function bootstrapHydration(
             });
 
             if (optimisticPayload !== null) {
+              navigationDebug?.optimisticShell({
+                navigationId: navId,
+                routeId: optimisticPayload.template.routeId,
+                targetHref: currentHref,
+              });
               detachedNavigationCommits = true;
               const optimisticNavigationSnapshot = createClientNavigationRenderSnapshot(
                 currentHref,
@@ -2039,10 +2073,22 @@ function bootstrapHydration(
               requestHeaders.set(VINEXT_CLIENT_REUSE_MANIFEST_HEADER, clientReuseManifestHeader);
             }
           }
+          navigationDebug?.fetchStart({
+            navigationId: navId,
+            rscUrl,
+            targetHref: currentHref,
+          });
           navResponse = await fetch(rscUrl, {
             headers: requestHeaders,
             credentials: "include",
             signal: navigationAbortController.signal,
+          });
+          navigationDebug?.fetchResponse({
+            navigationId: navId,
+            responseUrl: navResponse.url,
+            rscUrl,
+            status: navResponse.status,
+            targetHref: currentHref,
           });
         }
 
@@ -2292,6 +2338,7 @@ function bootstrapHydration(
       if (activeNavigationAbortController === navigationAbortController) {
         activeNavigationAbortController = null;
       }
+      navigationDebug?.settle(navId);
       // Single settlement site: covers normal return, early returns on stale-id
       // checks, and error paths. The finally runs even when the catch returns.
       // settlePendingBrowserRouterState is idempotent via the settled flag.
@@ -2350,7 +2397,7 @@ function bootstrapHydration(
     const snapshotNavigationId = browserNavigationController.beginNavigation();
     if (
       restoreHistoryStateSnapshot(event.state, snapshotNavigationId, () => {
-        abortSupersededNavigation();
+        abortSupersededNavigation("history-restore");
         notifyAppRouterTransitionStart(href, "traverse");
       })
     ) {

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -1833,7 +1833,7 @@ function bootstrapHydration(
               notifyInvalidation: false,
             },
           );
-        const reuseDecision = navigationPlanner.classifyNavigationReuse({
+        const reuseFacts: NavigationReuseFacts = {
           bypassNavigationCache: shouldBypassNavigationCache,
           navigationKind,
           optimisticRouteShell:
@@ -1843,14 +1843,14 @@ function bootstrapHydration(
           prefetch: hasPrefetchCandidate ? { status: "available" } : { status: "unavailable" },
           targetHref: currentHref,
           visitedResponse,
-        });
+        };
+        const reuseDecision = navigationPlanner.classifyNavigationReuse(reuseFacts);
         navigationDebug?.reuse({
           additionalPrefetchRscUrls,
-          decision: reuseDecision.kind,
+          decision: reuseDecision,
+          facts: reuseFacts,
           navigationId: navId,
           rscUrl,
-          targetHref: currentHref,
-          trace: reuseDecision.trace,
           visitedResponseCacheKey: visitedResponseCandidate.cacheKey,
         });
         if (reuseDecision.kind === "reuseVisitedResponse" && cachedRoute) {

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -193,7 +193,7 @@ type DevErrorOverlayModule = typeof import("../client/dev-error-overlay.js");
 
 type ServerActionResult = AppBrowserServerActionResult<AppWireElements>;
 
-type NavigationKind = "navigate" | "traverse" | "refresh";
+type NavigationKind = NavigationReuseFacts["navigationKind"];
 type MpaNavigationState = {
   href: string;
   historyUpdateMode: HistoryUpdateMode;

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -2395,12 +2395,27 @@ function bootstrapHydration(
       return;
     }
     const snapshotNavigationId = browserNavigationController.beginNavigation();
-    if (
-      restoreHistoryStateSnapshot(event.state, snapshotNavigationId, () => {
-        abortSupersededNavigation("history-restore");
-        notifyAppRouterTransitionStart(href, "traverse");
-      })
-    ) {
+    let snapshotDebugStarted = false;
+    let restoredHistorySnapshot = false;
+    try {
+      restoredHistorySnapshot = restoreHistoryStateSnapshot(
+        event.state,
+        snapshotNavigationId,
+        () => {
+          abortSupersededNavigation("history-restore");
+          notifyAppRouterTransitionStart(href, "traverse");
+          navigationDebug?.start({
+            navigationId: snapshotNavigationId,
+            navigationKind: "traverse",
+            targetHref: href,
+          });
+          snapshotDebugStarted = true;
+        },
+      );
+    } finally {
+      if (snapshotDebugStarted) navigationDebug?.settle(snapshotNavigationId);
+    }
+    if (restoredHistorySnapshot) {
       window.__VINEXT_RSC_PENDING__ = null;
       restoreSynchronousPopstateScrollPosition(
         {

--- a/packages/vinext/src/server/app-browser-navigation-controller.ts
+++ b/packages/vinext/src/server/app-browser-navigation-controller.ts
@@ -47,6 +47,7 @@ import {
   clearAppNavigationFailureTarget,
   getAppNavigationFailureTarget,
 } from "../client/app-nav-failure-handler.js";
+import type { AppNavigationCommitDebugInput } from "../client/app-navigation-debug.js";
 
 export type HistoryUpdateMode = "push" | "replace";
 
@@ -84,6 +85,7 @@ type SameUrlServerActionLifecycleOptions = {
 type BrowserNavigationControllerDeps = {
   basePath?: string;
   commitClientNavigationState?: typeof commitClientNavigationState;
+  onNavigationCommitDebug?: (input: AppNavigationCommitDebugInput) => void;
   performHardNavigation?: (href: string, mode?: HardNavigationMode) => boolean;
   getRouteManifest?: () => RouteManifest | null;
   syncHistoryStatePreviousNextUrl?: (
@@ -266,6 +268,7 @@ export function createAppBrowserNavigationController(
   const basePath = deps.basePath ?? "";
   const commitClientNavigationStateImpl =
     deps.commitClientNavigationState ?? commitClientNavigationState;
+  const onNavigationCommitDebug = deps.onNavigationCommitDebug;
   const performHardNavigation = deps.performHardNavigation ?? performHardNavigationWithLoopGuard;
   const getRouteManifest = deps.getRouteManifest ?? (() => null);
   const syncHistoryStatePreviousNextUrl = deps.syncHistoryStatePreviousNextUrl ?? (() => {});
@@ -693,11 +696,27 @@ export function createAppBrowserNavigationController(
     });
 
     if (approval.approvedCommit === null) {
+      onNavigationCommitDebug?.({
+        navigationCommitKind: null,
+        navigationId: options.navId,
+        outcome: "no-commit",
+        payloadOrigin: "committed-cache",
+        targetHref: options.targetHref,
+        trace: approval.decision.trace,
+      });
       return false;
     }
 
     options.beforeCommit?.();
     dispatchSynchronousVisibleCommit(approval.approvedCommit);
+    onNavigationCommitDebug?.({
+      navigationCommitKind: null,
+      navigationId: options.navId,
+      outcome: "committed",
+      payloadOrigin: "committed-cache",
+      targetHref: options.targetHref,
+      trace: approval.decision.trace,
+    });
     return true;
   }
 
@@ -751,6 +770,7 @@ export function createAppBrowserNavigationController(
     });
 
     let snapshotActivated = false;
+    let commitDebugInput: Omit<AppNavigationCommitDebugInput, "outcome"> | null = null;
     try {
       const startedState = getBrowserRouterState();
       const pending = await createPendingNavigationCommit({
@@ -778,6 +798,14 @@ export function createAppBrowserNavigationController(
       });
 
       if (approval.decision.disposition === "no-commit") {
+        onNavigationCommitDebug?.({
+          navigationCommitKind: options.navigationCommitKind ?? null,
+          navigationId: options.navId,
+          outcome: "no-commit",
+          payloadOrigin: options.payloadOrigin.origin,
+          targetHref: options.targetHref,
+          trace: approval.decision.trace,
+        });
         settlePendingBrowserRouterState(options.pendingRouterState);
         pendingNavigationFailureTargets.delete(renderId);
         if (failureTarget) {
@@ -795,17 +823,42 @@ export function createAppBrowserNavigationController(
         pendingNavigationCommits.delete(renderId);
         consumeAppRouterScrollIntent(options.scrollIntent ?? null);
         if (performHardNavigation(options.targetHref)) {
+          onNavigationCommitDebug?.({
+            navigationCommitKind: options.navigationCommitKind ?? null,
+            navigationId: options.navId,
+            outcome: "hard-navigate",
+            payloadOrigin: options.payloadOrigin.origin,
+            targetHref: options.targetHref,
+            trace: approval.decision.trace,
+          });
           return "hard-navigate";
         }
         if (failureTarget) {
           clearAppNavigationFailureTarget(failureTarget);
         }
+        onNavigationCommitDebug?.({
+          navigationCommitKind: options.navigationCommitKind ?? null,
+          navigationId: options.navId,
+          outcome: "no-commit",
+          payloadOrigin: options.payloadOrigin.origin,
+          targetHref: options.targetHref,
+          trace: approval.decision.trace,
+        });
         return "no-commit";
       }
 
       const approvedCommit = approval.approvedCommit;
       if (approvedCommit === null) {
         throw new Error("[vinext] Commit decision did not approve a visible commit");
+      }
+      if (onNavigationCommitDebug !== undefined) {
+        commitDebugInput = {
+          navigationCommitKind: options.navigationCommitKind ?? null,
+          navigationId: options.navId,
+          payloadOrigin: options.payloadOrigin.origin,
+          targetHref: options.targetHref,
+          trace: approval.decision.trace,
+        };
       }
 
       queuePrePaintNavigationEffect(
@@ -841,7 +894,11 @@ export function createAppBrowserNavigationController(
       throw error;
     }
 
-    return committed.then((didCommit) => (didCommit ? "committed" : "no-commit"));
+    return committed.then((didCommit) => {
+      const outcome = didCommit ? "committed" : "no-commit";
+      if (commitDebugInput !== null) onNavigationCommitDebug?.({ ...commitDebugInput, outcome });
+      return outcome;
+    });
   }
 
   async function commitSameUrlNavigatePayload(

--- a/packages/vinext/src/server/app-browser-navigation-controller.ts
+++ b/packages/vinext/src/server/app-browser-navigation-controller.ts
@@ -697,12 +697,12 @@ export function createAppBrowserNavigationController(
 
     if (approval.approvedCommit === null) {
       onNavigationCommitDebug?.({
+        approval: approval.decision,
         navigationCommitKind: null,
         navigationId: options.navId,
-        outcome: "no-commit",
         payloadOrigin: "committed-cache",
         targetHref: options.targetHref,
-        trace: approval.decision.trace,
+        visibleOutcome: "no-commit",
       });
       return false;
     }
@@ -710,12 +710,12 @@ export function createAppBrowserNavigationController(
     options.beforeCommit?.();
     dispatchSynchronousVisibleCommit(approval.approvedCommit);
     onNavigationCommitDebug?.({
+      approval: approval.decision,
       navigationCommitKind: null,
       navigationId: options.navId,
-      outcome: "committed",
       payloadOrigin: "committed-cache",
       targetHref: options.targetHref,
-      trace: approval.decision.trace,
+      visibleOutcome: "committed",
     });
     return true;
   }
@@ -770,7 +770,7 @@ export function createAppBrowserNavigationController(
     });
 
     let snapshotActivated = false;
-    let commitDebugInput: Omit<AppNavigationCommitDebugInput, "outcome"> | null = null;
+    let commitDebugInput: Omit<AppNavigationCommitDebugInput, "visibleOutcome"> | null = null;
     try {
       const startedState = getBrowserRouterState();
       const pending = await createPendingNavigationCommit({
@@ -799,12 +799,12 @@ export function createAppBrowserNavigationController(
 
       if (approval.decision.disposition === "no-commit") {
         onNavigationCommitDebug?.({
+          approval: approval.decision,
           navigationCommitKind: options.navigationCommitKind ?? null,
           navigationId: options.navId,
-          outcome: "no-commit",
           payloadOrigin: options.payloadOrigin.origin,
           targetHref: options.targetHref,
-          trace: approval.decision.trace,
+          visibleOutcome: "no-commit",
         });
         settlePendingBrowserRouterState(options.pendingRouterState);
         pendingNavigationFailureTargets.delete(renderId);
@@ -824,12 +824,12 @@ export function createAppBrowserNavigationController(
         consumeAppRouterScrollIntent(options.scrollIntent ?? null);
         if (performHardNavigation(options.targetHref)) {
           onNavigationCommitDebug?.({
+            approval: approval.decision,
             navigationCommitKind: options.navigationCommitKind ?? null,
             navigationId: options.navId,
-            outcome: "hard-navigate",
             payloadOrigin: options.payloadOrigin.origin,
             targetHref: options.targetHref,
-            trace: approval.decision.trace,
+            visibleOutcome: "hard-navigate",
           });
           return "hard-navigate";
         }
@@ -837,12 +837,12 @@ export function createAppBrowserNavigationController(
           clearAppNavigationFailureTarget(failureTarget);
         }
         onNavigationCommitDebug?.({
+          approval: approval.decision,
           navigationCommitKind: options.navigationCommitKind ?? null,
           navigationId: options.navId,
-          outcome: "no-commit",
           payloadOrigin: options.payloadOrigin.origin,
           targetHref: options.targetHref,
-          trace: approval.decision.trace,
+          visibleOutcome: "no-commit",
         });
         return "no-commit";
       }
@@ -853,11 +853,11 @@ export function createAppBrowserNavigationController(
       }
       if (onNavigationCommitDebug !== undefined) {
         commitDebugInput = {
+          approval: approval.decision,
           navigationCommitKind: options.navigationCommitKind ?? null,
           navigationId: options.navId,
           payloadOrigin: options.payloadOrigin.origin,
           targetHref: options.targetHref,
-          trace: approval.decision.trace,
         };
       }
 
@@ -895,9 +895,11 @@ export function createAppBrowserNavigationController(
     }
 
     return committed.then((didCommit) => {
-      const outcome = didCommit ? "committed" : "no-commit";
-      if (commitDebugInput !== null) onNavigationCommitDebug?.({ ...commitDebugInput, outcome });
-      return outcome;
+      const visibleOutcome = didCommit ? "committed" : "no-commit";
+      if (commitDebugInput !== null) {
+        onNavigationCommitDebug?.({ ...commitDebugInput, visibleOutcome });
+      }
+      return visibleOutcome;
     });
   }
 

--- a/packages/vinext/src/server/app-browser-visible-commit.ts
+++ b/packages/vinext/src/server/app-browser-visible-commit.ts
@@ -43,7 +43,10 @@ type NoCommitDecision = {
   disposition: "no-commit";
   trace: NavigationTrace;
 };
-type CommitDecision = VisibleCommitDecision | HardNavigateCommitDecision | NoCommitDecision;
+export type NavigationCommitDecision =
+  | VisibleCommitDecision
+  | HardNavigateCommitDecision
+  | NoCommitDecision;
 const approvedVisibleCommitBrand: unique symbol = Symbol("ApprovedVisibleCommit");
 export type ApprovedVisibleCommit = {
   readonly [approvedVisibleCommitBrand]: true;
@@ -66,7 +69,7 @@ type NonVisibleCommitApproval = {
 type CommitApproval = VisibleCommitApproval | NonVisibleCommitApproval;
 type ClassifiedPendingNavigationCommit = {
   approvedCommit: ApprovedVisibleCommit | null;
-  decision: CommitDecision;
+  decision: NavigationCommitDecision;
   pending: PendingNavigationCommit;
   trace: NavigationTrace;
 };
@@ -247,7 +250,7 @@ function resolvePendingNavigationCommitDecision(options: {
   routeManifest?: RouteManifest | null;
   startedNavigationId: number;
   targetHref: string;
-}): CommitDecision {
+}): NavigationCommitDecision {
   const decision = resolvePendingNavigationCommitDispositionDecision(options);
 
   switch (decision.disposition) {
@@ -331,9 +334,9 @@ function prependCommitTransactionTrace(
 }
 
 function addCommitTransactionTrace(
-  decision: CommitDecision,
+  decision: NavigationCommitDecision,
   pending: PendingNavigationCommit,
-): CommitDecision {
+): NavigationCommitDecision {
   switch (decision.disposition) {
     case "commit":
       return {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -90,9 +90,8 @@ const projectServers = {
     testDir: "./tests/e2e/app-router-navigation-debug",
     use: { baseURL: "http://localhost:4195" },
     server: {
-      command: "npx vp dev --port 4195",
+      command: "npx vp dev --config vite.navigation-debug.config.ts --force --port 4195",
       cwd: "./tests/fixtures/app-basic",
-      env: { VINEXT_DEBUG_NAVIGATION: "1" },
       port: 4195,
       reuseExistingServer: !process.env.CI,
       timeout: 30_000,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "@playwright/test";
 
 const appRouterBrowserSpecificTests = "**/app-router/**/*.browser.spec.ts";
 const appRouterServer = {
-  command: "npx vp dev --port 4174",
+  command: "VINEXT_DEBUG_NAVIGATION=1 npx vp dev --port 4174",
   cwd: "./tests/fixtures/app-basic",
   port: 4174,
   reuseExistingServer: !process.env.CI,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "@playwright/test";
 
 const appRouterBrowserSpecificTests = "**/app-router/**/*.browser.spec.ts";
 const appRouterServer = {
-  command: "VINEXT_DEBUG_NAVIGATION=1 npx vp dev --port 4174",
+  command: "npx vp dev --port 4174",
   cwd: "./tests/fixtures/app-basic",
   port: 4174,
   reuseExistingServer: !process.env.CI,
@@ -85,6 +85,18 @@ const projectServers = {
     testDir: "./tests/e2e/app-router-bfcache",
     use: { baseURL: "http://localhost:4183" },
     server: appRouterBfcacheServer,
+  },
+  "app-router-navigation-debug": {
+    testDir: "./tests/e2e/app-router-navigation-debug",
+    use: { baseURL: "http://localhost:4195" },
+    server: {
+      command: "npx vp dev --port 4195",
+      cwd: "./tests/fixtures/app-basic",
+      env: { VINEXT_DEBUG_NAVIGATION: "1" },
+      port: 4195,
+      reuseExistingServer: !process.env.CI,
+      timeout: 30_000,
+    },
   },
   "catch-error": {
     testDir: "./tests/e2e/catch-error",

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -1282,6 +1282,7 @@ describe("app browser entry navigation scheduling", () => {
   });
 
   it("restores visible history snapshots through an approved traversal commit", () => {
+    const onNavigationCommitDebug = vi.fn();
     const currentState = createState({
       elements: createResolvedElements("route:/scroll-restoration/other", "/"),
       navigationSnapshot: createClientNavigationRenderSnapshot(
@@ -1300,7 +1301,9 @@ describe("app browser entry navigation scheduling", () => {
       routeId: "route:/scroll-restoration",
       visibleCommitVersion: 2,
     });
-    const { controller, stateRef } = createControllerHarness(currentState);
+    const { controller, stateRef } = createControllerHarness(currentState, {
+      onNavigationCommitDebug,
+    });
     const navId = controller.beginNavigation();
 
     const restored = controller.restoreHistorySnapshotVisibleState({
@@ -1318,6 +1321,14 @@ describe("app browser entry navigation scheduling", () => {
       state: "committed",
       visibleCommitVersion: 8,
     });
+    expect(onNavigationCommitDebug).toHaveBeenCalledWith(
+      expect.objectContaining({
+        navigationId: navId,
+        outcome: "committed",
+        payloadOrigin: "committed-cache",
+        targetHref: "https://example.com/scroll-restoration",
+      }),
+    );
   });
 
   it("matches visible history snapshot targets after stripping basePath and canonicalizing search", () => {
@@ -3163,6 +3174,7 @@ describe("app browser navigation controller", () => {
   it("reads RouteManifest lazily after generated browser globals are assigned", async () => {
     let routeManifest: RouteManifest | null = null;
     const performHardNavigation = vi.fn(() => true);
+    const onNavigationCommitDebug = vi.fn();
     const { controller, detach, stateRef } = createControllerHarness(
       createState({
         layoutIds: ["layout:/stale"],
@@ -3172,6 +3184,7 @@ describe("app browser navigation controller", () => {
       }),
       {
         getRouteManifest: () => routeManifest,
+        onNavigationCommitDebug,
         performHardNavigation,
       },
     );
@@ -3219,6 +3232,14 @@ describe("app browser navigation controller", () => {
       await expect(result).resolves.toBe("hard-navigate");
       await expect(pendingRouterState.promise).resolves.toBe(stateRef.current);
       expect(performHardNavigation).toHaveBeenCalledWith("https://example.com/marketing");
+      expect(onNavigationCommitDebug).toHaveBeenCalledWith(
+        expect.objectContaining({
+          navigationId: navId,
+          outcome: "hard-navigate",
+          payloadOrigin: "fresh",
+          targetHref: "https://example.com/marketing",
+        }),
+      );
       expect(stateRef.current.routeId).toBe("route:/app");
     } finally {
       detach();

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -1323,10 +1323,11 @@ describe("app browser entry navigation scheduling", () => {
     });
     expect(onNavigationCommitDebug).toHaveBeenCalledWith(
       expect.objectContaining({
+        approval: expect.objectContaining({ disposition: "commit" }),
         navigationId: navId,
-        outcome: "committed",
         payloadOrigin: "committed-cache",
         targetHref: "https://example.com/scroll-restoration",
+        visibleOutcome: "committed",
       }),
     );
   });
@@ -3234,10 +3235,11 @@ describe("app browser navigation controller", () => {
       expect(performHardNavigation).toHaveBeenCalledWith("https://example.com/marketing");
       expect(onNavigationCommitDebug).toHaveBeenCalledWith(
         expect.objectContaining({
+          approval: expect.objectContaining({ disposition: "hard-navigate" }),
           navigationId: navId,
-          outcome: "hard-navigate",
           payloadOrigin: "fresh",
           targetHref: "https://example.com/marketing",
+          visibleOutcome: "hard-navigate",
         }),
       );
       expect(stateRef.current.routeId).toBe("route:/app");

--- a/tests/app-navigation-debug-config.test.ts
+++ b/tests/app-navigation-debug-config.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { createServer, type ViteDevServer } from "vite-plus";
+import vinext from "../packages/vinext/src/index.js";
+import { PAGES_FIXTURE_DIR } from "./helpers.js";
+import { withEnvVar } from "./env-test-helpers.js";
+
+const NAVIGATION_DEBUG_DEFINE = "process.env.__VINEXT_DEBUG_NAVIGATION";
+
+async function createConfigServer(): Promise<ViteDevServer> {
+  return createServer({
+    root: PAGES_FIXTURE_DIR,
+    configFile: false,
+    plugins: [vinext()],
+    server: { port: 0 },
+    logLevel: "silent",
+  });
+}
+
+describe("App Router navigation debug configuration", () => {
+  let server: ViteDevServer | null = null;
+
+  afterEach(async () => {
+    await server?.close();
+    server = null;
+  });
+
+  it("defaults the client diagnostic define to disabled", async () => {
+    server = await withEnvVar("VINEXT_DEBUG_NAVIGATION", undefined, createConfigServer);
+    expect(server.config.define?.[NAVIGATION_DEBUG_DEFINE]).toBe(JSON.stringify("false"));
+  });
+
+  it("enables the client diagnostic define from VINEXT_DEBUG_NAVIGATION=1", async () => {
+    server = await withEnvVar("VINEXT_DEBUG_NAVIGATION", "1", createConfigServer);
+    expect(server.config.define?.[NAVIGATION_DEBUG_DEFINE]).toBe(JSON.stringify("true"));
+  });
+});

--- a/tests/app-navigation-debug.test.ts
+++ b/tests/app-navigation-debug.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { createAppNavigationDebugReporter } from "../packages/vinext/src/client/app-navigation-debug.js";
+import {
+  NavigationTraceReasonCodes,
+  createNavigationTrace,
+} from "../packages/vinext/src/server/navigation-trace.js";
+
+describe("App Router navigation diagnostics", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("does not create a reporter when navigation debugging is disabled", () => {
+    expect(createAppNavigationDebugReporter({ enabled: false })).toBeNull();
+  });
+
+  it("emits deterministic start, retarget, and abort events", () => {
+    const sink = vi.fn();
+    const reporter = createAppNavigationDebugReporter({ enabled: true, sink });
+    if (reporter === null) throw new Error("Expected navigation debug reporter");
+
+    reporter.start({
+      navigationId: 3,
+      navigationKind: "navigate",
+      targetHref: "/projects/A",
+    });
+    reporter.retarget(3, "/projects/B");
+    reporter.abort("superseded");
+
+    expect(sink.mock.calls).toEqual([
+      [
+        {
+          navigationId: 3,
+          navigationKind: "navigate",
+          phase: "start",
+          targetHref: "/projects/A",
+        },
+      ],
+      [
+        {
+          navigationId: 3,
+          phase: "abort",
+          reason: "superseded",
+          targetHref: "/projects/B",
+        },
+      ],
+    ]);
+  });
+
+  it("emits reuse, fetch, and commit facts without transport payload data", () => {
+    const sink = vi.fn();
+    const reporter = createAppNavigationDebugReporter({ enabled: true, sink });
+    if (reporter === null) throw new Error("Expected navigation debug reporter");
+    const trace = createNavigationTrace(NavigationTraceReasonCodes.fetchFresh, {
+      eventKind: "navigate",
+      freshFetchReason: "cacheMiss",
+      targetHref: "/projects/B",
+    });
+
+    reporter.reuse({
+      additionalPrefetchRscUrls: [],
+      decision: "fetchFresh",
+      navigationId: 4,
+      rscUrl: "/projects/B?_rsc=key",
+      targetHref: "/projects/B",
+      trace,
+      visitedResponseCacheKey: "/projects/B?_rsc=key",
+    });
+    reporter.fetchStart({
+      navigationId: 4,
+      rscUrl: "/projects/B?_rsc=key",
+      targetHref: "/projects/B",
+    });
+    reporter.fetchResponse({
+      navigationId: 4,
+      responseUrl: "https://example.com/projects/B?_rsc=key",
+      rscUrl: "/projects/B?_rsc=key",
+      status: 200,
+      targetHref: "/projects/B",
+    });
+    reporter.commit({
+      navigationCommitKind: "authoritative",
+      navigationId: 4,
+      outcome: "committed",
+      payloadOrigin: "fresh",
+      targetHref: "/projects/B",
+      trace,
+    });
+
+    expect(sink.mock.calls.map(([event]) => event.phase)).toEqual([
+      "reuse",
+      "fetch",
+      "fetch",
+      "commit",
+    ]);
+    for (const [event] of sink.mock.calls) {
+      expect(event).not.toHaveProperty("body");
+      expect(event).not.toHaveProperty("headers");
+      expect(event).not.toHaveProperty("params");
+    }
+  });
+
+  it("writes enabled events to the browser console by default", () => {
+    const info = vi.spyOn(console, "info").mockImplementation(() => {});
+    const reporter = createAppNavigationDebugReporter({ enabled: true });
+    if (reporter === null) throw new Error("Expected navigation debug reporter");
+
+    reporter.start({
+      navigationId: 5,
+      navigationKind: "navigate",
+      targetHref: "/dashboard",
+    });
+
+    expect(info).toHaveBeenCalledWith(
+      "[vinext:navigation]",
+      expect.objectContaining({ navigationId: 5, phase: "start" }),
+    );
+  });
+});

--- a/tests/app-navigation-debug.test.ts
+++ b/tests/app-navigation-debug.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import { createAppNavigationDebugReporter } from "../packages/vinext/src/client/app-navigation-debug.js";
 import {
+  navigationPlanner,
+  type NavigationReuseFacts,
+} from "../packages/vinext/src/server/navigation-planner.js";
+import {
   NavigationTraceReasonCodes,
   createNavigationTrace,
 } from "../packages/vinext/src/server/navigation-trace.js";
@@ -57,14 +61,22 @@ describe("App Router navigation diagnostics", () => {
       freshFetchReason: "cacheMiss",
       targetHref: "/projects/B",
     });
+    const facts: NavigationReuseFacts = {
+      bypassNavigationCache: false,
+      navigationKind: "navigate",
+      optimisticRouteShell: { reason: "routeManifestMissing", status: "unavailable" },
+      prefetch: { status: "unavailable" },
+      targetHref: "/projects/B",
+      visitedResponse: { status: "unavailable" },
+    };
+    const decision = navigationPlanner.classifyNavigationReuse(facts);
 
     reporter.reuse({
       additionalPrefetchRscUrls: [],
-      decision: "fetchFresh",
+      decision,
+      facts,
       navigationId: 4,
       rscUrl: "/projects/B?_rsc=key",
-      targetHref: "/projects/B",
-      trace,
       visitedResponseCacheKey: "/projects/B?_rsc=key",
     });
     reporter.fetchStart({
@@ -80,12 +92,18 @@ describe("App Router navigation diagnostics", () => {
       targetHref: "/projects/B",
     });
     reporter.commit({
+      approval: {
+        disposition: "commit",
+        preserveAbsentSlots: true,
+        preserveElementIds: [],
+        preservePreviousSlotIds: [],
+        trace,
+      },
       navigationCommitKind: "authoritative",
       navigationId: 4,
-      outcome: "committed",
       payloadOrigin: "fresh",
       targetHref: "/projects/B",
-      trace,
+      visibleOutcome: "committed",
     });
 
     expect(sink.mock.calls.map(([event]) => event.phase)).toEqual([

--- a/tests/e2e/app-router-navigation-debug/navigation-debug.spec.ts
+++ b/tests/e2e/app-router-navigation-debug/navigation-debug.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "@playwright/test";
+import { waitForAppRouterHydration } from "../helpers";
+
+type NavigationDebugEvent = {
+  decision?: { kind?: string };
+  navigationId: number;
+  phase: string;
+  stage?: string;
+};
+
+function isNavigationDebugEvent(value: unknown): value is NavigationDebugEvent {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "navigationId" in value &&
+    typeof value.navigationId === "number" &&
+    "phase" in value &&
+    typeof value.phase === "string"
+  );
+}
+
+test("emits a correlated refresh lifecycle through the real navigation runtime", async ({
+  page,
+}) => {
+  const events: NavigationDebugEvent[] = [];
+  let captureEvents = Promise.resolve();
+  page.on("console", (message) => {
+    captureEvents = captureEvents.then(async () => {
+      if (!message.text().startsWith("[vinext:navigation]")) return;
+      const event = await message.args()[1]?.jsonValue();
+      if (isNavigationDebugEvent(event)) events.push(event);
+    });
+  });
+
+  await page.goto("/about");
+  await waitForAppRouterHydration(page);
+  await page.evaluate(() => {
+    const router = window.next?.router;
+    if (router === undefined) throw new Error("window.next.router is not installed");
+    if (!("refresh" in router)) throw new Error("App Router refresh is not installed");
+    router.refresh();
+  });
+
+  await expect
+    .poll(async () => {
+      await captureEvents;
+      return events.some((event) => event.phase === "commit");
+    })
+    .toBe(true);
+
+  const navigationId = events.find((event) => event.phase === "start")?.navigationId;
+  expect(navigationId).toBeDefined();
+  const correlated = events.filter((event) => event.navigationId === navigationId);
+  const sequence = correlated.map((event) =>
+    event.phase === "reuse"
+      ? `${event.phase}:${event.decision?.kind}`
+      : event.phase === "fetch"
+        ? `${event.phase}:${event.stage}`
+        : event.phase,
+  );
+
+  expect(sequence).toEqual([
+    "start",
+    "reuse:fetchFresh",
+    "fetch:start",
+    "fetch:response",
+    "commit",
+  ]);
+});

--- a/tests/e2e/app-router-navigation-debug/navigation-debug.spec.ts
+++ b/tests/e2e/app-router-navigation-debug/navigation-debug.spec.ts
@@ -1,11 +1,17 @@
 import { expect, test } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import { waitForAppRouterHydration } from "../helpers";
 
 type NavigationDebugEvent = {
   decision?: { kind?: string };
+  navigationKind?: string;
   navigationId: number;
+  payloadOrigin?: string;
   phase: string;
+  rscUrl?: string;
   stage?: string;
+  targetHref?: string;
+  visibleOutcome?: string;
 };
 
 function isNavigationDebugEvent(value: unknown): value is NavigationDebugEvent {
@@ -19,9 +25,7 @@ function isNavigationDebugEvent(value: unknown): value is NavigationDebugEvent {
   );
 }
 
-test("emits a correlated refresh lifecycle through the real navigation runtime", async ({
-  page,
-}) => {
+function captureNavigationDebugEvents(page: Page) {
   const events: NavigationDebugEvent[] = [];
   let captureEvents = Promise.resolve();
   page.on("console", (message) => {
@@ -31,6 +35,17 @@ test("emits a correlated refresh lifecycle through the real navigation runtime",
       if (isNavigationDebugEvent(event)) events.push(event);
     });
   });
+
+  return {
+    events,
+    flush: async () => captureEvents,
+  };
+}
+
+test("emits a correlated refresh lifecycle through the real navigation runtime", async ({
+  page,
+}) => {
+  const captured = captureNavigationDebugEvents(page);
 
   await page.goto("/about");
   await waitForAppRouterHydration(page);
@@ -43,14 +58,14 @@ test("emits a correlated refresh lifecycle through the real navigation runtime",
 
   await expect
     .poll(async () => {
-      await captureEvents;
-      return events.some((event) => event.phase === "commit");
+      await captured.flush();
+      return captured.events.some((event) => event.phase === "commit");
     })
     .toBe(true);
 
-  const navigationId = events.find((event) => event.phase === "start")?.navigationId;
+  const navigationId = captured.events.find((event) => event.phase === "start")?.navigationId;
   expect(navigationId).toBeDefined();
-  const correlated = events.filter((event) => event.navigationId === navigationId);
+  const correlated = captured.events.filter((event) => event.navigationId === navigationId);
   const sequence = correlated.map((event) =>
     event.phase === "reuse"
       ? `${event.phase}:${event.decision?.kind}`
@@ -65,5 +80,98 @@ test("emits a correlated refresh lifecycle through the real navigation runtime",
     "fetch:start",
     "fetch:response",
     "commit",
+  ]);
+});
+
+test("keeps a shared dynamic layout current after traversing back and entering another param", async ({
+  page,
+}) => {
+  const captured = captureNavigationDebugEvents(page);
+  const rscRequests: string[] = [];
+  page.on("request", (request) => {
+    const url = new URL(request.url());
+    if (url.searchParams.has("_rsc")) rscRequests.push(`${url.pathname}${url.search}`);
+  });
+
+  await page.goto("/navigation-debug");
+  await waitForAppRouterHydration(page);
+
+  await page.getByTestId("project-a-link").click();
+  await expect(page.getByTestId("server-project")).toHaveText("server project: A");
+  await expect(page.getByTestId("client-project")).toHaveText("client project: A");
+
+  await page.goBack();
+  await expect(page.getByRole("heading", { name: "Navigation debug dashboard" })).toBeVisible();
+
+  rscRequests.length = 0;
+  await page.getByTestId("project-b-link").click();
+  await expect(page.getByTestId("server-project")).toHaveText("server project: B");
+  await expect(page.getByTestId("client-project")).toHaveText("client project: B");
+  await expect(page.getByTestId("client-pathname")).toHaveText(
+    "client pathname: /navigation-debug/projects/B",
+  );
+
+  await captured.flush();
+  expect(rscRequests.some((request) => request.startsWith("/navigation-debug/projects/B?"))).toBe(
+    true,
+  );
+  const projectBNavigationId = captured.events.find(
+    (event) =>
+      event.phase === "start" && event.targetHref?.endsWith("/navigation-debug/projects/B"),
+  )?.navigationId;
+  expect(projectBNavigationId).toBeDefined();
+  const projectBEvents = captured.events.filter(
+    (event) => event.navigationId === projectBNavigationId,
+  );
+  expect(projectBEvents).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ navigationKind: "navigate", phase: "start" }),
+      expect.objectContaining({ phase: "fetch", stage: "start" }),
+      expect.objectContaining({ phase: "fetch", stage: "response" }),
+      expect.objectContaining({ phase: "commit", visibleOutcome: "committed" }),
+    ]),
+  );
+});
+
+test("restores matching server and client state when traversing from a sibling child route", async ({
+  page,
+}) => {
+  const captured = captureNavigationDebugEvents(page);
+
+  await page.goto("/navigation-debug/projects/A");
+  await waitForAppRouterHydration(page);
+  await expect(page.getByTestId("client-pathname")).toHaveText(
+    "client pathname: /navigation-debug/projects/A",
+  );
+
+  await page.getByTestId("project-child-link").click();
+  await expect(page.getByTestId("server-page")).toHaveText("server page: child");
+  await expect(page.getByTestId("client-pathname")).toHaveText(
+    "client pathname: /navigation-debug/projects/A/child",
+  );
+
+  await page.goBack();
+  await expect(page.getByTestId("server-page")).toHaveText("server page: index");
+  await expect(page.getByTestId("server-project")).toHaveText("server project: A");
+  await expect(page.getByTestId("client-project")).toHaveText("client project: A");
+  await expect(page.getByTestId("client-pathname")).toHaveText(
+    "client pathname: /navigation-debug/projects/A",
+  );
+
+  await captured.flush();
+  const traverseNavigationId = captured.events.find(
+    (event) => event.phase === "start" && event.navigationKind === "traverse",
+  )?.navigationId;
+  expect(traverseNavigationId).toBeDefined();
+  const traverseEvents = captured.events.filter(
+    (event) => event.navigationId === traverseNavigationId,
+  );
+  expect(traverseEvents).toEqual([
+    expect.objectContaining({ navigationKind: "traverse", phase: "start" }),
+    expect.objectContaining({
+      payloadOrigin: "committed-cache",
+      phase: "commit",
+      visibleOutcome: "committed",
+    }),
   ]);
 });

--- a/tests/e2e/app-router/navigation-flows.spec.ts
+++ b/tests/e2e/app-router/navigation-flows.spec.ts
@@ -3,74 +3,7 @@ import { disableDevErrorOverlay, waitForAppRouterHydration } from "../helpers";
 
 const BASE = "http://localhost:4174";
 
-type NavigationDebugEvent = {
-  decision?: { kind?: string };
-  navigationId: number;
-  phase: string;
-  stage?: string;
-};
-
-function isNavigationDebugEvent(value: unknown): value is NavigationDebugEvent {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "navigationId" in value &&
-    typeof value.navigationId === "number" &&
-    "phase" in value &&
-    typeof value.phase === "string"
-  );
-}
-
 test.describe("App Router navigation flows", () => {
-  test("emits a correlated refresh lifecycle through the real navigation runtime", async ({
-    page,
-  }) => {
-    const events: NavigationDebugEvent[] = [];
-    let captureEvents = Promise.resolve();
-    page.on("console", (message) => {
-      captureEvents = captureEvents.then(async () => {
-        if (!message.text().startsWith("[vinext:navigation]")) return;
-        const event = await message.args()[1]?.jsonValue();
-        if (isNavigationDebugEvent(event)) events.push(event);
-      });
-    });
-
-    await page.goto(`${BASE}/about`);
-    await waitForAppRouterHydration(page);
-    await page.evaluate(() => {
-      const router = window.next?.router;
-      if (router === undefined) throw new Error("window.next.router is not installed");
-      if (!("refresh" in router)) throw new Error("App Router refresh is not installed");
-      router.refresh();
-    });
-
-    await expect
-      .poll(async () => {
-        await captureEvents;
-        return events.some((event) => event.phase === "commit");
-      })
-      .toBe(true);
-
-    const navigationId = events.find((event) => event.phase === "start")?.navigationId;
-    expect(navigationId).toBeDefined();
-    const correlated = events.filter((event) => event.navigationId === navigationId);
-    const sequence = correlated.map((event) =>
-      event.phase === "reuse"
-        ? `${event.phase}:${event.decision?.kind}`
-        : event.phase === "fetch"
-          ? `${event.phase}:${event.stage}`
-          : event.phase,
-    );
-
-    expect(sequence).toEqual([
-      "start",
-      "reuse:fetchFresh",
-      "fetch:start",
-      "fetch:response",
-      "commit",
-    ]);
-  });
-
   test("multi-page navigation chain without reload", async ({ page }) => {
     await page.goto(`${BASE}/`);
     await expect(page.locator("h1")).toHaveText("Welcome to App Router");

--- a/tests/e2e/app-router/navigation-flows.spec.ts
+++ b/tests/e2e/app-router/navigation-flows.spec.ts
@@ -4,7 +4,7 @@ import { disableDevErrorOverlay, waitForAppRouterHydration } from "../helpers";
 const BASE = "http://localhost:4174";
 
 type NavigationDebugEvent = {
-  decision?: string;
+  decision?: { kind?: string };
   navigationId: number;
   phase: string;
   stage?: string;
@@ -56,7 +56,7 @@ test.describe("App Router navigation flows", () => {
     const correlated = events.filter((event) => event.navigationId === navigationId);
     const sequence = correlated.map((event) =>
       event.phase === "reuse"
-        ? `${event.phase}:${event.decision}`
+        ? `${event.phase}:${event.decision?.kind}`
         : event.phase === "fetch"
           ? `${event.phase}:${event.stage}`
           : event.phase,

--- a/tests/e2e/app-router/navigation-flows.spec.ts
+++ b/tests/e2e/app-router/navigation-flows.spec.ts
@@ -3,7 +3,74 @@ import { disableDevErrorOverlay, waitForAppRouterHydration } from "../helpers";
 
 const BASE = "http://localhost:4174";
 
+type NavigationDebugEvent = {
+  decision?: string;
+  navigationId: number;
+  phase: string;
+  stage?: string;
+};
+
+function isNavigationDebugEvent(value: unknown): value is NavigationDebugEvent {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "navigationId" in value &&
+    typeof value.navigationId === "number" &&
+    "phase" in value &&
+    typeof value.phase === "string"
+  );
+}
+
 test.describe("App Router navigation flows", () => {
+  test("emits a correlated refresh lifecycle through the real navigation runtime", async ({
+    page,
+  }) => {
+    const events: NavigationDebugEvent[] = [];
+    let captureEvents = Promise.resolve();
+    page.on("console", (message) => {
+      captureEvents = captureEvents.then(async () => {
+        if (!message.text().startsWith("[vinext:navigation]")) return;
+        const event = await message.args()[1]?.jsonValue();
+        if (isNavigationDebugEvent(event)) events.push(event);
+      });
+    });
+
+    await page.goto(`${BASE}/about`);
+    await waitForAppRouterHydration(page);
+    await page.evaluate(() => {
+      const router = window.next?.router;
+      if (router === undefined) throw new Error("window.next.router is not installed");
+      if (!("refresh" in router)) throw new Error("App Router refresh is not installed");
+      router.refresh();
+    });
+
+    await expect
+      .poll(async () => {
+        await captureEvents;
+        return events.some((event) => event.phase === "commit");
+      })
+      .toBe(true);
+
+    const navigationId = events.find((event) => event.phase === "start")?.navigationId;
+    expect(navigationId).toBeDefined();
+    const correlated = events.filter((event) => event.navigationId === navigationId);
+    const sequence = correlated.map((event) =>
+      event.phase === "reuse"
+        ? `${event.phase}:${event.decision}`
+        : event.phase === "fetch"
+          ? `${event.phase}:${event.stage}`
+          : event.phase,
+    );
+
+    expect(sequence).toEqual([
+      "start",
+      "reuse:fetchFresh",
+      "fetch:start",
+      "fetch:response",
+      "commit",
+    ]);
+  });
+
   test("multi-page navigation chain without reload", async ({ page }) => {
     await page.goto(`${BASE}/`);
     await expect(page.locator("h1")).toHaveText("Welcome to App Router");

--- a/tests/e2e/pages-router/instrumentation.spec.ts
+++ b/tests/e2e/pages-router/instrumentation.spec.ts
@@ -22,10 +22,17 @@ import { test, expect } from "@playwright/test";
 
 test.describe("instrumentation.ts onRequestError (Pages Router)", () => {
   test.beforeEach(async ({ request }) => {
-    // Reset captured state before each test so errors from earlier tests
-    // don't bleed through.
+    // Clear request errors before each test without erasing the one-time
+    // register() startup signal asserted by instrumentation-startup.spec.ts.
     const res = await request.delete("/api/instrumentation-test");
     expect(res.status()).toBe(200);
+  });
+
+  test("clearing captured errors preserves the startup signal", async ({ request }) => {
+    const stateRes = await request.get("/api/instrumentation-test");
+    const data = await stateRes.json();
+    expect(data.registerCalled).toBe(true);
+    expect(data.errors).toEqual([]);
   });
 
   test("successful requests do not trigger onRequestError()", async ({ request }) => {

--- a/tests/fixtures/app-basic/app/navigation-debug/page.tsx
+++ b/tests/fixtures/app-basic/app/navigation-debug/page.tsx
@@ -1,0 +1,15 @@
+import Link from "next/link";
+
+export default function NavigationDebugDashboard() {
+  return (
+    <main>
+      <h1>Navigation debug dashboard</h1>
+      <Link href="/navigation-debug/projects/A" data-testid="project-a-link">
+        Project A
+      </Link>
+      <Link href="/navigation-debug/projects/B" data-testid="project-b-link">
+        Project B
+      </Link>
+    </main>
+  );
+}

--- a/tests/fixtures/app-basic/app/navigation-debug/projects/[pid]/child/page.tsx
+++ b/tests/fixtures/app-basic/app/navigation-debug/projects/[pid]/child/page.tsx
@@ -1,0 +1,3 @@
+export default function ProjectChildPage() {
+  return <h1 data-testid="server-page">server page: child</h1>;
+}

--- a/tests/fixtures/app-basic/app/navigation-debug/projects/[pid]/client-shell.tsx
+++ b/tests/fixtures/app-basic/app/navigation-debug/projects/[pid]/client-shell.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useParams, usePathname } from "next/navigation";
+
+export function ClientShell({ serverProject }: { serverProject: string }) {
+  const params = useParams<{ pid: string }>();
+  const pathname = usePathname();
+
+  return (
+    <section>
+      <p data-testid="server-project">server project: {serverProject}</p>
+      <p data-testid="client-project">client project: {params.pid}</p>
+      <p data-testid="client-pathname">client pathname: {pathname}</p>
+    </section>
+  );
+}

--- a/tests/fixtures/app-basic/app/navigation-debug/projects/[pid]/layout.tsx
+++ b/tests/fixtures/app-basic/app/navigation-debug/projects/[pid]/layout.tsx
@@ -1,0 +1,25 @@
+import Link from "next/link";
+import { ClientShell } from "./client-shell";
+
+export default async function ProjectLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ pid: string }>;
+}) {
+  const { pid } = await params;
+
+  return (
+    <main>
+      <ClientShell serverProject={pid} />
+      <nav>
+        <Link href={`/navigation-debug/projects/${pid}`}>Project index</Link>
+        <Link href={`/navigation-debug/projects/${pid}/child`} data-testid="project-child-link">
+          Project child
+        </Link>
+      </nav>
+      {children}
+    </main>
+  );
+}

--- a/tests/fixtures/app-basic/app/navigation-debug/projects/[pid]/page.tsx
+++ b/tests/fixtures/app-basic/app/navigation-debug/projects/[pid]/page.tsx
@@ -1,0 +1,3 @@
+export default function ProjectIndexPage() {
+  return <h1 data-testid="server-page">server page: index</h1>;
+}

--- a/tests/fixtures/app-basic/vite.navigation-debug.config.ts
+++ b/tests/fixtures/app-basic/vite.navigation-debug.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vite";
+import vinext from "vinext";
+
+// This fixture owns the build-time diagnostic flag so the dedicated Playwright
+// project cannot inherit a non-diagnostic optimized graph from another app-basic run.
+process.env.VINEXT_DEBUG_NAVIGATION = "1";
+
+export default defineConfig({
+  plugins: [vinext({ appDir: import.meta.dirname })],
+});

--- a/tests/fixtures/pages-basic/instrumentation-state.ts
+++ b/tests/fixtures/pages-basic/instrumentation-state.ts
@@ -56,8 +56,7 @@ export function recordRequestError(entry: CapturedRequestError): void {
   _errors().push(entry);
 }
 
-/** Reset all state (used between test runs). */
-export function resetInstrumentationState(): void {
-  (globalThis as any)[REGISTER_KEY] = false;
+/** Clear request-error records without erasing the one-time startup signal. */
+export function resetCapturedErrors(): void {
   (globalThis as any)[ERRORS_KEY] = [];
 }

--- a/tests/fixtures/pages-basic/pages/api/instrumentation-test.ts
+++ b/tests/fixtures/pages-basic/pages/api/instrumentation-test.ts
@@ -2,7 +2,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import {
   isRegisterCalled,
   getCapturedErrors,
-  resetInstrumentationState,
+  resetCapturedErrors,
 } from "../../instrumentation-state";
 
 /**
@@ -14,11 +14,11 @@ import {
  *   onRequestError() fired for any unhandled route errors.
  *
  * DELETE /api/instrumentation-test
- *   Resets the captured state so tests can start from a clean slate.
+ *   Clears captured request errors while preserving the one-time startup signal.
  */
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === "DELETE") {
-    resetInstrumentationState();
+    resetCapturedErrors();
     return res.status(200).json({ ok: true });
   }
 


### PR DESCRIPTION
## Overview

| Area | Change |
| --- | --- |
| Configuration | Adds the disabled-by-default `VINEXT_DEBUG_NAVIGATION=1` build-time flag |
| Runtime | Emits correlated reuse, prefetch, optimistic-shell, fetch, abort, synchronous history-restore, and commit events |
| Architecture | Keeps browser entry points wiring-only and places deterministic event construction and navigation correlation in a separate client module |
| Safety | Includes application URLs for correlation, but never response bodies, cookies, or request headers |
| Coverage | Exercises fresh dynamic-param navigation and committed-cache sibling-route Back restoration in a self-contained Playwright project |

## Why

Issue [#2597](https://github.com/cloudflare/vinext/issues/2597) reports a navigation race whose final DOM mixes stale server-layout data with current client params. The reporter needs the existing structured `NavigationTrace` decisions at runtime together with the concrete RSC URL, cache key, fetch lifecycle, supersession, history-snapshot restoration, and final commit outcome.

Running the PR preview against the reporter's public reproduction now captures the failure: the B RSC request succeeds and reaches an authoritative commit, but that commit preserves the dynamic layout identity carried through the detached optimistic shell. The diagnostics therefore narrow the follow-up fix to the optimistic-to-authoritative preservation boundary rather than history snapshot restoration.

The original diagnostic path entered through `navigateRsc()`. Synchronous history-snapshot restores bypass that function, even though they can commit a cached route tree directly. Leaving that boundary unreported made the diagnostics incomplete for the issue's sibling-route Back symptom.

This PR adds observability without changing navigation decisions. Refs #2597.

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| Fresh or prefetched navigation | Correlated reuse, fetch, abort, and commit events | Unchanged |
| Synchronous history-snapshot restore | Commit event had no correlated start lifecycle | Emits a correlated `traverse` start followed by a `committed-cache` commit |
| Dynamic param A → Back → B | No issue-shaped diagnostic regression | Verifies B issues an RSC request and commits matching server/client params |
| Sibling child → Back | Restore path was not covered by diagnostics E2E | Verifies server page, client params, and `usePathname()` restore together |
| Diagnostic E2E bootstrap | Relied on inherited process state and could reuse a non-diagnostic optimized graph locally | Owns the build-time flag in a dedicated Vite config and forces optimizer isolation |
| Pages Router instrumentation tests | Request-error cleanup could erase the one-time startup signal in a parallel test | Clears only request errors and preserves the startup invariant |

The diagnostic schema remains internal and may change between releases.

<details>
<summary>Validation</summary>

- `vp check` on all seven touched source, fixture, and E2E files
- `vp test run tests/app-navigation-debug.test.ts tests/app-browser-entry.test.ts` (228 tests)
- `vp run vinext#build`
- Dedicated `app-router-navigation-debug` Playwright project (3 tests)
- Pages Router instrumentation startup and error-reporting specs together (6 tests, 2 workers)
- The two #2597-shaped browser cases repeated 10 times each (20 passes)
- Repository pre-commit staged checks, full check, and knip

</details>

<details>
<summary>Risk and compatibility</summary>

- No public API change.
- Diagnostics remain disabled by default.
- Navigation, history restoration, and cache decisions are unchanged.
- The restore lifecycle is started only after a snapshot is approved, so cache misses still fall through to the existing `navigateRsc()` lifecycle without a phantom diagnostic event.
- The reporter is settled in `finally` so failed restore attempts cannot leave stale diagnostic correlation state.

</details>

<details>
<summary>Non-goals</summary>

- This PR does not claim to fix #2597.
- It does not expose a stable telemetry schema.
- It does not include response bodies, cookies, request headers, or rendered application data.
- It does not enable diagnostics for the shared App Router E2E suite.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Issue #2597](https://github.com/cloudflare/vinext/issues/2597) | Reports stale dynamic-layout data and mixed sibling-route history restoration |
| [Prior test-only debugger #1168](https://github.com/cloudflare/vinext/pull/1168) | Earlier invariant debugger that did not expose browser lifecycle telemetry |
| [Existing vinext navigation trace model](https://github.com/cloudflare/vinext/blob/8d0a18d44015c15b5770eb08cff5dc65c246733f/packages/vinext/src/server/navigation-trace.ts) | Structured planner and commit decision model reused by this PR |
| [Next.js navigation debug-info boundary](https://github.com/vercel/next.js/blob/1bd2fd585aac793ca2589e6f18f17a412fd11005/packages/next/src/client/components/router-reducer/ppr-navigations.ts#L2257-L2267) | Upstream precedent for retaining navigation debug context |

Refs #2597
