### PR TITLE
test(app-route-graph): build the dot-directory expectation with canonical()

### DIFF
--- a/tests/app-route-graph.test.ts
+++ b/tests/app-route-graph.test.ts
@@ -1454,9 +1454,7 @@ describe("App Router route graph builder", () => {
       const graph = await buildAppRouteGraph(appDir, createValidFileMatcher());
       const route = findRoute(graph.routes, "/.well-known/openid-configuration");
 
-      expect(route.routePath).toBe(
-        path.posix.join(appDir, ".well-known/openid-configuration/route.ts"),
-      );
+      expect(route.routePath).toBe(canonical(appDir, ".well-known/openid-configuration/route.ts"));
       expect(route.ids.routeHandler).toBe("route-handler:/.well-known/openid-configuration");
       expect(graph.routeManifest.segmentGraph.routeHandlers.get(route.ids.routeHandler!)).toEqual({
         id: "route-handler:/.well-known/openid-configuration",


### PR DESCRIPTION
## What

One-line fixture conform: the dot-directory route-handler test (#2531) built its `routePath` expectation with `path.posix.join(appDir, ...)`, which produces a mixed-separator value on Windows (`C:\...\app/.well-known/...`) because `appDir` comes from `mkdtemp` in native form. The route graph returns canonical forward-slash paths, so the expectation now goes through the file's existing `canonical()` helper like every other path assertion in this suite.

## Why

No source change is needed for dot-directory scanning itself: the scanner's `{**,**/.*/**}` pattern is correct, and the only reason it misbehaved locally was Node's globstar bug (nodejs/node#56321, `**` never descends into dot-directories; fixed by nodejs/node#61012). Current Node releases carry the fix — verified empirically on 26.4.0, where every pattern variant matches `.well-known/...` — so the resolution on dev machines is upgrading Node (`pnpm env use --global latest`) rather than adding a workaround for unfixed versions.

## Testing

- `tests/app-route-graph.test.ts` "discovers route handlers inside dot-directories like .well-known": red → green on Windows / Node 26.4.0.
- `tests/file-matcher.test.ts` "scans route files inside dot-directories": green on Node 26.4.0 with no changes (was red on 24.12.0 purely due to the Node bug).
- `vp check` clean on the changed file.
- POSIX unaffected: `canonical()` is byte-identical to the previous expression there.
