### PR TITLE
fix(og): resolve dot-hash wasm fallbacks

### DIFF
--- a/packages/vinext/src/plugins/og-assets.ts
+++ b/packages/vinext/src/plugins/og-assets.ts
@@ -221,8 +221,9 @@ function findEmittedWasmAsset(
   baseName: string,
 ): string | null {
   const stem = baseName.replace(/\.wasm$/, "");
-  // Matches `resvg.wasm` or `resvg-<hash>.wasm` as the basename.
-  const re = new RegExp(`^${stem}(?:-[\\w-]+)?\\.wasm$`);
+  // Matches `resvg.wasm`, Vite's default `resvg-<hash>.wasm`, or the
+  // Next-shaped `media/resvg.<hash8>.wasm` basename used by RSC builds.
+  const re = new RegExp(`^${stem}(?:[-.][\\w-]+)?\\.wasm$`);
   for (const output of Object.values(bundle)) {
     if (output.type !== "asset") continue;
     if (re.test(path.basename(output.fileName))) return output.fileName;

--- a/tests/og-font-patch.test.ts
+++ b/tests/og-font-patch.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from "vite-plus/test";
 import vinext from "../packages/vinext/src/index.js";
+import { createOgAssetsPlugin } from "../packages/vinext/src/plugins/og-assets.js";
 import type { Plugin } from "vite-plus";
 import fs from "node:fs";
 import fsp from "node:fs/promises";
@@ -177,5 +178,38 @@ describe("vinext:og-font-patch plugin", () => {
     const yogaPath = path.posix.join(writeDistDir, "yoga.wasm");
     expect(fs.existsSync(yogaPath)).toBe(true);
     expect(fs.readFileSync(yogaPath)).toEqual(Buffer.from(FAKE_YOGA_B64, "base64"));
+  });
+});
+
+describe("vinext:og-assets plugin", () => {
+  it.each([
+    ["resvg.wasm", "resvg.Cjh1zH0p.wasm"],
+    ["yoga.wasm", "yoga.sbSbVeWy.wasm"],
+    ["resvg.wasm", "resvg-legacyhash.wasm"],
+  ])("rewrites the %s Node fallback to emitted asset %s", (baseName, emittedName) => {
+    const plugin = createOgAssetsPlugin();
+    const generateBundle = unwrapHook(plugin.generateBundle);
+    const chunk = {
+      type: "chunk",
+      fileName: "_next/static/index.edge.js",
+      code: `const wasm = import("./media/${emittedName}").catch(() => new URL("./${baseName}", import.meta.url));`,
+      map: null,
+    };
+    const emittedFileName = `_next/static/media/${emittedName}`;
+    const bundle = {
+      [chunk.fileName]: chunk,
+      [emittedFileName]: {
+        type: "asset",
+        fileName: emittedFileName,
+      },
+    };
+
+    generateBundle.call({ environment: { name: "rsc" } }, {}, bundle);
+
+    // Next.js verifies ImageResponse in the Node runtime and verifies copied
+    // WASM/assets in standalone output:
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/og-api/index.test.ts
+    expect(chunk.code).not.toContain(`new URL("./${baseName}", import.meta.url)`);
+    expect(chunk.code).toContain(`new URL("./media/${emittedName}", import.meta.url)`);
   });
 });


### PR DESCRIPTION
## Problem

`vinext:og-assets` recognizes `resvg.wasm` and Vite's default `resvg-<hash>.wasm`, but RSC builds now route non-CSS assets through `createClientAssetFileNames`, which emits Next-shaped dot-hash names such as:

- `_next/static/media/resvg.Cjh1zH0p.wasm`
- `_next/static/media/yoga.sbSbVeWy.wasm`

Because `findEmittedWasmAsset` rejects those basenames, `generateBundle` leaves the Node fallback as `new URL("./resvg.wasm", import.meta.url)`. In a real Cloudflare production build that path does not exist; only the dot-hash file exists under `media/`. Workerd normally succeeds through the dynamic wasm import, which masks the broken Node fallback.

## Verification before change

Built `examples/app-router-cloudflare` from pristine upstream main. The build emitted the dot-hash files above, while `dist/server/_next/static/index.edge-*.js` still contained the bare `new URL("./resvg.wasm", import.meta.url)` fallback.

Also built App and Pages Router fixtures importing an SVG. Their server-rendered URLs already matched client-emitted files on current main, so this PR intentionally does **not** include the older broad `index.ts` asset-alignment changes.

## Change

Accept both separators in emitted wasm basenames:

- `resvg-<hash>.wasm` — legacy/default Vite naming
- `resvg.<hash>.wasm` — Next-shaped RSC media naming

The plugin can then rewrite the Node fallback to the actual emitted relative path and avoid a duplicate/root copy.

## Tests

Added behavior-level `vinext:og-assets` regression coverage for:

- dot-hash `resvg` output
- dot-hash `yoga` output
- legacy dash-hash output

The tests run the plugin's `generateBundle` hook and assert the bare Node fallback is replaced with the emitted `media/` path. They reference Next.js's Node-runtime and copied-WASM coverage at `test/e2e/og-api/index.test.ts`.

Verification:

- `pnpm test tests/og-font-patch.test.ts` — 15 passed
- `pnpm test tests/og-font-patch.test.ts tests/app-router-production-server.test.ts` — 83 passed
- `pnpm run check` — format, lint, and types clean
- `pnpm run build` — package build passed
- `pnpm --dir examples/app-router-cloudflare build` — production build passed; generated fallbacks reference the emitted `media/resvg.<hash>.wasm` and `media/yoga.<hash>.wasm` files