### PR TITLE
fix(navigation): avoid rewriting URL for history metadata

### DIFF
--- a/packages/vinext/src/server/app-browser-history-controller.ts
+++ b/packages/vinext/src/server/app-browser-history-controller.ts
@@ -31,7 +31,7 @@ type AppBrowserHistoryControllerDeps = {
   /** Wraps `pushHistoryStateWithoutNotify(state, "", href)`. */
   pushHistoryState: (state: unknown, href: string) => void;
   /** Wraps `replaceHistoryStateWithoutNotify(state, "", href)`. */
-  replaceHistoryState: (state: unknown, href: string) => void;
+  replaceHistoryState: (state: unknown, href?: string) => void;
   readVisibleNavigationMetadata: () => VisibleNavigationMetadata | null;
 };
 
@@ -101,7 +101,7 @@ export class AppBrowserHistoryController {
   readonly #readHistoryState: () => unknown;
   readonly #readCurrentHref: () => string;
   readonly #pushHistoryState: (state: unknown, href: string) => void;
-  readonly #replaceHistoryState: (state: unknown, href: string) => void;
+  readonly #replaceHistoryState: (state: unknown, href?: string) => void;
   readonly #readVisibleNavigationMetadata: () => VisibleNavigationMetadata | null;
 
   // Highest app-owned traversal index we know about (`#next`) versus the index
@@ -318,7 +318,11 @@ export class AppBrowserHistoryController {
     // rather than the patched window.history.replaceState, because this is a
     // URL-unchanged metadata sync (refresh or traversal commit) that must not
     // run the patched-path side effects.
-    this.#replaceHistoryState(nextHistoryState, this.#readCurrentHref());
+    // Do not pass the current URL for a state-only update. Chromium keeps
+    // userinfo in document.URL while stripping it from location.href; passing
+    // that credential-free absolute URL would make replaceState reject the
+    // otherwise valid metadata write with SecurityError (#2614).
+    this.#replaceHistoryState(nextHistoryState);
     if (
       this.#isHistoryStateNavigationMetadataInSync(
         this.#readHistoryState(),
@@ -328,7 +332,7 @@ export class AppBrowserHistoryController {
     ) {
       return;
     }
-    this.#replaceHistoryState(nextHistoryState, this.#readCurrentHref());
+    this.#replaceHistoryState(nextHistoryState);
   }
 
   #isHistoryStateNavigationMetadataInSync(
@@ -367,7 +371,6 @@ export class AppBrowserHistoryController {
         previousNextUrl: options.previousNextUrl,
         traversalIndex: this.#currentHistoryTraversalIndex,
       }),
-      this.#readCurrentHref(),
     );
   }
 

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -1781,7 +1781,15 @@ export function pushHistoryStateWithoutNotify(
 ): void {
   withSuppressedUrlNotifications(() => {
     const state = getClientNavigationState();
-    state?.originalPushState.call(window.history, data, unused, url);
+    try {
+      state?.originalPushState.call(window.history, data, unused, url);
+    } catch (error) {
+      // history.pushState can throw a SecurityError (userinfo in document.URL,
+      // sandboxed/opaque origins, per-origin call quota). These calls only write
+      // vinext metadata, so failing to persist it must not abort hydration or
+      // navigation (#2614).
+      console.warn("[vinext] history.pushState failed:", error);
+    }
   });
 }
 
@@ -1792,7 +1800,13 @@ export function replaceHistoryStateWithoutNotify(
 ): void {
   withSuppressedUrlNotifications(() => {
     const state = getClientNavigationState();
-    state?.originalReplaceState.call(window.history, data, unused, url);
+    try {
+      state?.originalReplaceState.call(window.history, data, unused, url);
+    } catch (error) {
+      // See pushHistoryStateWithoutNotify: a metadata-write failure must not
+      // abort hydration or navigation (#2614).
+      console.warn("[vinext] history.replaceState failed:", error);
+    }
   });
 }
 

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -1781,15 +1781,7 @@ export function pushHistoryStateWithoutNotify(
 ): void {
   withSuppressedUrlNotifications(() => {
     const state = getClientNavigationState();
-    try {
-      state?.originalPushState.call(window.history, data, unused, url);
-    } catch (error) {
-      // history.pushState can throw a SecurityError (userinfo in document.URL,
-      // sandboxed/opaque origins, per-origin call quota). These calls only write
-      // vinext metadata, so failing to persist it must not abort hydration or
-      // navigation (#2614).
-      console.warn("[vinext] history.pushState failed:", error);
-    }
+    state?.originalPushState.call(window.history, data, unused, url);
   });
 }
 
@@ -1800,13 +1792,7 @@ export function replaceHistoryStateWithoutNotify(
 ): void {
   withSuppressedUrlNotifications(() => {
     const state = getClientNavigationState();
-    try {
-      state?.originalReplaceState.call(window.history, data, unused, url);
-    } catch (error) {
-      // See pushHistoryStateWithoutNotify: a metadata-write failure must not
-      // abort hydration or navigation (#2614).
-      console.warn("[vinext] history.replaceState failed:", error);
-    }
+    state?.originalReplaceState.call(window.history, data, unused, url);
   });
 }
 

--- a/tests/app-browser-history-controller.test.ts
+++ b/tests/app-browser-history-controller.test.ts
@@ -20,7 +20,7 @@ import {
 import { createClientNavigationRenderSnapshot } from "../packages/vinext/src/shims/navigation.js";
 import type { AppRouterState } from "../packages/vinext/src/server/app-browser-state.js";
 
-type HistoryWrite = { state: unknown; href: string };
+type HistoryWrite = { state: unknown; href?: string };
 
 function readWrittenState(write: HistoryWrite | undefined): Record<string, unknown> {
   const state = write?.state;
@@ -69,10 +69,12 @@ function createHistoryStore(initialState: unknown = null, initialHref = "https:/
       state = next;
       href = new URL(nextHref, href).href;
     },
-    replaceHistoryState: (next: unknown, nextHref: string) => {
+    replaceHistoryState: (next: unknown, nextHref?: string) => {
       replaced.push({ state: next, href: nextHref });
       state = next;
-      href = new URL(nextHref, href).href;
+      if (nextHref !== undefined) {
+        href = new URL(nextHref, href).href;
+      }
     },
   };
 }
@@ -246,6 +248,24 @@ describe("AppBrowserHistoryController history metadata sync", () => {
     expect(createCanonicalBrowserHistoryHref("https://example.com/page?value=1#section")).toBe(
       "/page?value=1#section",
     );
+  });
+
+  it("omits the URL from hydrated metadata writes", () => {
+    const { controller, store } = createController();
+
+    controller.writeHydratedHistoryMetadata({ bfcacheIds: {}, previousNextUrl: null });
+
+    expect(store.replaced).toHaveLength(1);
+    expect(store.replaced[0]?.href).toBeUndefined();
+  });
+
+  it("omits the URL from current-entry metadata synchronization", () => {
+    const { controller, store } = createController();
+
+    controller.syncCurrentHistoryStatePreviousNextUrl("/previous");
+
+    expect(store.replaced).toHaveLength(1);
+    expect(store.replaced[0]?.href).toBeUndefined();
   });
 
   it("preserves the BFCache epoch check when deciding whether to re-sync", () => {

--- a/tests/e2e/app-router/hydration.spec.ts
+++ b/tests/e2e/app-router/hydration.spec.ts
@@ -1,10 +1,32 @@
 import { test, expect } from "../fixtures";
+import { waitForAppRouterHydration } from "../helpers";
 
 const BASE = "http://localhost:4174";
 
 test.describe("App Router Hydration", () => {
   // The consoleErrors fixture automatically fails tests if any console errors occur.
   // This catches React hydration mismatches (error #418), runtime errors, etc.
+
+  test("hydrates when Chromium strips userinfo from location.href (#2614)", async ({
+    page,
+    consoleErrors,
+  }) => {
+    await page.goto(BASE.replace("://", "://user:pass@"));
+
+    expect(
+      await page.evaluate(() => ({
+        documentUrl: document.URL,
+        locationHref: window.location.href,
+      })),
+    ).toEqual({
+      documentUrl: "http://user:pass@localhost:4174/",
+      locationHref: `${BASE}/`,
+    });
+    await waitForAppRouterHydration(page);
+    await expect(page.getByRole("heading", { name: "Welcome to App Router" })).toBeVisible();
+
+    void consoleErrors;
+  });
 
   test("use client Counter component hydrates and becomes interactive", async ({
     page,

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -17925,14 +17925,8 @@ describe("Pages Router concurrent navigation", () => {
   });
 });
 
-describe("history metadata writes with a rejecting History API", () => {
-  // history.pushState/replaceState can throw a SecurityError when document.URL
-  // still contains userinfo credentials (e.g. https://user:pass@host/ behind
-  // HTTP Basic auth — Chromium strips them from location.href but not from
-  // document.URL). The notify-suppressed primitives only persist vinext
-  // metadata, so the failure must be swallowed instead of aborting hydration
-  // with a blank page (#2614).
-  it("swallows SecurityError from replaceState/pushState instead of throwing (#2614)", async () => {
+describe("notify-suppressed history writes", () => {
+  it("preserves native errors from URL-changing history writes", async () => {
     const previousWindow = (globalThis as any).window;
     const securityError = new DOMException(
       "A history state object with URL 'https://example.com/' cannot be created in a " +
@@ -17957,27 +17951,21 @@ describe("history metadata writes with a rejecting History API", () => {
       addEventListener: vi.fn(),
     };
     (globalThis as any).window = win;
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-
     try {
       vi.resetModules();
       const { pushHistoryStateWithoutNotify, replaceHistoryStateWithoutNotify } =
         await import("../packages/vinext/src/shims/navigation.js");
 
-      expect(() =>
-        replaceHistoryStateWithoutNotify({ __vinext_historyIndex: 0 }, "", "/"),
-      ).not.toThrow();
+      expect(() => replaceHistoryStateWithoutNotify({ __vinext_historyIndex: 0 }, "", "/")).toThrow(
+        securityError,
+      );
       expect(() =>
         pushHistoryStateWithoutNotify({ __vinext_historyIndex: 1 }, "", "/next"),
-      ).not.toThrow();
+      ).toThrow(securityError);
 
-      // The underlying History API was attempted, rejected, and reported.
       expect(replaceState).toHaveBeenCalledTimes(1);
       expect(pushState).toHaveBeenCalledTimes(1);
-      expect(warn).toHaveBeenCalledWith("[vinext] history.replaceState failed:", securityError);
-      expect(warn).toHaveBeenCalledWith("[vinext] history.pushState failed:", securityError);
     } finally {
-      warn.mockRestore();
       vi.resetModules();
       if (previousWindow === undefined) {
         delete (globalThis as any).window;

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -17925,6 +17925,69 @@ describe("Pages Router concurrent navigation", () => {
   });
 });
 
+describe("history metadata writes with a rejecting History API", () => {
+  // history.pushState/replaceState can throw a SecurityError when document.URL
+  // still contains userinfo credentials (e.g. https://user:pass@host/ behind
+  // HTTP Basic auth — Chromium strips them from location.href but not from
+  // document.URL). The notify-suppressed primitives only persist vinext
+  // metadata, so the failure must be swallowed instead of aborting hydration
+  // with a blank page (#2614).
+  it("swallows SecurityError from replaceState/pushState instead of throwing (#2614)", async () => {
+    const previousWindow = (globalThis as any).window;
+    const securityError = new DOMException(
+      "A history state object with URL 'https://example.com/' cannot be created in a " +
+        "document with origin 'https://example.com' and URL 'https://user:pass@example.com/'.",
+      "SecurityError",
+    );
+    const pushState = vi.fn(() => {
+      throw securityError;
+    });
+    const replaceState = vi.fn(() => {
+      throw securityError;
+    });
+    const win = {
+      location: {
+        pathname: "/",
+        search: "",
+        hash: "",
+        href: "https://example.com/",
+        hostname: "example.com",
+      },
+      history: { state: null, pushState: pushState as any, replaceState: replaceState as any },
+      addEventListener: vi.fn(),
+    };
+    (globalThis as any).window = win;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      vi.resetModules();
+      const { pushHistoryStateWithoutNotify, replaceHistoryStateWithoutNotify } =
+        await import("../packages/vinext/src/shims/navigation.js");
+
+      expect(() =>
+        replaceHistoryStateWithoutNotify({ __vinext_historyIndex: 0 }, "", "/"),
+      ).not.toThrow();
+      expect(() =>
+        pushHistoryStateWithoutNotify({ __vinext_historyIndex: 1 }, "", "/next"),
+      ).not.toThrow();
+
+      // The underlying History API was attempted, rejected, and reported.
+      expect(replaceState).toHaveBeenCalledTimes(1);
+      expect(pushState).toHaveBeenCalledTimes(1);
+      expect(warn).toHaveBeenCalledWith("[vinext] history.replaceState failed:", securityError);
+      expect(warn).toHaveBeenCalledWith("[vinext] history.pushState failed:", securityError);
+    } finally {
+      warn.mockRestore();
+      vi.resetModules();
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+    }
+  });
+});
+
 describe("deprecated Router.on<Event> property bridge", () => {
   // These tests verify that assigning a function to a deprecated property such
   // as `Router.onRouteChangeComplete` causes that function to be invoked when


### PR DESCRIPTION
Closes #2614

## Customer Summary

- Pages opened through a URL containing HTTP Basic auth credentials, such as `https://user:pass@example.com/`, no longer crash to a blank page during hydration in Chromium-based browsers.
- Native History API failures from real URL-changing navigations are still surfaced normally.

## Technical Summary

- Metadata-only `replaceState` calls in `AppBrowserHistoryController` now omit the optional URL argument.
- This avoids asking Chromium to rewrite a credential-bearing `document.URL` to the credential-free absolute URL exposed by `location.href`.
- `pushHistoryStateWithoutNotify` and `replaceHistoryStateWithoutNotify` retain native exception behavior so failed route or hash navigations cannot silently desynchronize vinext router state from browser history.

## Why

Chromium retains userinfo in `document.URL` but strips it from `location.href`. Passing that clean absolute URL to `history.replaceState` during hydrated metadata synchronization fails the same-document URL rewrite check with `SecurityError`.

The write only needs to update the current entry state. Omitting the URL performs that state-only update without triggering URL validation, which fixes the reported case without masking failures from actual navigation writes.

## Testing

- Added a real Chromium App Router E2E reproduction that verifies the `document.URL` and `location.href` mismatch, waits for hydration, and checks that the rendered page remains visible with no console or page errors.
- Confirmed the E2E test fails before the fix with the reported uncaught `SecurityError` and blank page, then passes with the fix.
- Added controller unit coverage proving hydrated and current-entry metadata synchronization omit the URL.
- Added shim coverage proving URL-changing push and replace failures still propagate.
- `vp test run tests/app-browser-history-controller.test.ts tests/shims.test.ts`
- `PLAYWRIGHT_PROJECT=app-router pnpm exec playwright test tests/e2e/app-router/hydration.spec.ts`
- `vp check packages/vinext/src/server/app-browser-history-controller.ts packages/vinext/src/shims/navigation.ts tests/app-browser-history-controller.test.ts tests/shims.test.ts tests/e2e/app-router/hydration.spec.ts`