### PR TITLE
fix(create): make create-vinext-app work with npm and npx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,7 +388,7 @@ jobs:
       - name: Scaffold a fresh create-vinext-app project
         working-directory: ${{ runner.temp }}/cva-runner
         run: >-
-          vp exec create-vinext-app "${{ runner.temp }}/cva-cloudflare"
+          npx create-vinext-app "${{ runner.temp }}/cva-cloudflare"
           --yes
           --skip-install
           --disable-git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -378,17 +378,12 @@ jobs:
           cd ../create-vinext-app
           vp pm pack --pack-destination "${{ runner.temp }}"
 
-      - name: Install packed create-vinext-app runner
-        run: |
-          mkdir -p "${{ runner.temp }}/cva-runner"
-          cd "${{ runner.temp }}/cva-runner"
-          node -e 'require("fs").writeFileSync("package.json", JSON.stringify({ private: true, type: "module" }, null, 2) + "\n")'
-          vp add "${{ runner.temp }}"/create-vinext-app-*.tgz
-
       - name: Scaffold a fresh create-vinext-app project
-        working-directory: ${{ runner.temp }}/cva-runner
+        working-directory: ${{ runner.temp }}
         run: >-
-          npx create-vinext-app "${{ runner.temp }}/cva-cloudflare"
+          npx --yes
+          --package "${{ runner.temp }}"/create-vinext-app-*.tgz
+          create-vinext-app "${{ runner.temp }}/cva-cloudflare"
           --yes
           --skip-install
           --disable-git

--- a/.github/workflows/create-vinext-app-cloudflare-deploy.yml
+++ b/.github/workflows/create-vinext-app-cloudflare-deploy.yml
@@ -44,17 +44,12 @@ jobs:
           cd ../create-vinext-app
           vp pm pack --pack-destination "${{ runner.temp }}"
 
-      - name: Install packed create-vinext-app runner
-        run: |
-          mkdir -p "${{ runner.temp }}/cva-runner"
-          cd "${{ runner.temp }}/cva-runner"
-          node -e 'require("fs").writeFileSync("package.json", JSON.stringify({ private: true, type: "module" }, null, 2) + "\n")'
-          vp add "${{ runner.temp }}"/create-vinext-app-*.tgz
-
       - name: Scaffold a fresh create-vinext-app project
-        working-directory: ${{ runner.temp }}/cva-runner
+        working-directory: ${{ runner.temp }}
         run: >-
-          npx create-vinext-app "${{ runner.temp }}/cva-cloudflare"
+          npx --yes
+          --package "${{ runner.temp }}"/create-vinext-app-*.tgz
+          create-vinext-app "${{ runner.temp }}/cva-cloudflare"
           --yes
           --skip-install
           --disable-git

--- a/.github/workflows/create-vinext-app-cloudflare-deploy.yml
+++ b/.github/workflows/create-vinext-app-cloudflare-deploy.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Scaffold a fresh create-vinext-app project
         working-directory: ${{ runner.temp }}/cva-runner
         run: >-
-          vp exec create-vinext-app "${{ runner.temp }}/cva-cloudflare"
+          npx create-vinext-app "${{ runner.temp }}/cva-cloudflare"
           --yes
           --skip-install
           --disable-git

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -62,7 +62,7 @@
     "vite-plus": "catalog:"
   },
   "peerDependencies": {
-    "vinext": ">=0.0.0"
+    "vinext": "workspace:^"
   },
   "engines": {
     "node": ">=22"

--- a/packages/create-vinext-app/package.json
+++ b/packages/create-vinext-app/package.json
@@ -9,7 +9,7 @@
     "directory": "packages/create-vinext-app"
   },
   "bin": {
-    "create-vinext-app": "dist/index.js"
+    "create-vinext-app": "dist/cli.js"
   },
   "files": [
     "dist"

--- a/packages/create-vinext-app/src/cli.ts
+++ b/packages/create-vinext-app/src/cli.ts
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+import { runCreateVinextAppCli } from "./index.js";
+
+runCreateVinextAppCli(process.argv.slice(2)).catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/packages/create-vinext-app/src/index.ts
+++ b/packages/create-vinext-app/src/index.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 import fs from "node:fs";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
@@ -538,7 +536,7 @@ async function promptForDirectory(options: PlatformPromptOptions, yes: boolean):
   }
 }
 
-async function main(args: string[]): Promise<void> {
+export async function runCreateVinextAppCli(args: string[]): Promise<void> {
   const parsed = parseArgs(args);
   if (parsed.help) {
     printHelp();
@@ -564,12 +562,5 @@ async function main(args: string[]): Promise<void> {
     git: parsed.git,
     yes: parsed.yes,
     initOptions,
-  });
-}
-
-if (process.argv[1] && import.meta.url === new URL(process.argv[1], "file:").href) {
-  main(process.argv.slice(2)).catch((error: unknown) => {
-    console.error(error instanceof Error ? error.message : String(error));
-    process.exit(1);
   });
 }

--- a/scripts/e2e-deploy.sh
+++ b/scripts/e2e-deploy.sh
@@ -363,16 +363,25 @@ const localVinextPkgDir = path.join(process.cwd(), '.vinext-local-package')
 const localCloudflarePkgDir = path.join(process.cwd(), '.vinext-local-cloudflare-package')
 const localTypesPkgDir = path.join(process.cwd(), '.vinext-local-types-package')
 const localWorkspacePackages = new Map([
+  [vinextPkg.name, localVinextPkgDir],
   [cloudflarePkg.name, localCloudflarePkgDir],
   [typesPkg.name, localTypesPkgDir],
 ])
 
-function workspaceDependencySpecFor(name) {
-  const packageDir = localWorkspacePackages.get(name)
-  if (!packageDir) throw new Error(`Unable to resolve workspace dependency spec for ${name}`)
+function workspaceDependencySpecFor(name, fromPackageDir) {
+  const targetPackageDir = localWorkspacePackages.get(name)
+  if (!targetPackageDir) throw new Error(`Unable to resolve workspace dependency spec for ${name}`)
 
-  const relativeDir = path.relative(localVinextPkgDir, packageDir).split(path.sep).join('/')
+  const relativeDir = path.relative(fromPackageDir, targetPackageDir).split(path.sep).join('/') || '.'
   return `file:${relativeDir}`
+}
+
+function manifestDependencySpecFor(name, spec, fromPackageDir) {
+  if (spec.startsWith('workspace:')) return workspaceDependencySpecFor(name, fromPackageDir)
+  if (spec !== 'catalog:') return spec
+  if (catalog[name]) return catalog[name]
+
+  throw new Error(`Unable to resolve dependency spec for ${name}`)
 }
 
 function dependencySpecFor(name) {
@@ -385,25 +394,21 @@ function dependencySpecFor(name) {
   ]) {
     const spec = deps?.[name]
     if (!spec) continue
-    if (spec.startsWith('workspace:')) return workspaceDependencySpecFor(name)
-    if (spec !== 'catalog:') return spec
-    if (catalog[name]) return catalog[name]
+    return manifestDependencySpecFor(name, spec, localVinextPkgDir)
   }
 
-  if (catalog[name]) {
-    return catalog[name]
-  }
+  if (catalog[name]) return catalog[name]
 
   throw new Error(`Unable to resolve dependency spec for ${name}`)
 }
 
-function resolveManifestDeps(deps) {
+function resolveManifestDeps(deps, packageDir) {
   if (!deps) return undefined
 
   return Object.fromEntries(
     Object.entries(deps).map(([name, spec]) => [
       name,
-      spec === 'catalog:' || spec.startsWith('workspace:') ? dependencySpecFor(name) : spec,
+      manifestDependencySpecFor(name, spec, packageDir),
     ]),
   )
 }
@@ -433,7 +438,7 @@ fs.writeFileSync(
       type: cloudflarePkg.type,
       files: ['dist'],
       exports: cloudflarePkg.exports,
-      peerDependencies: resolveManifestDeps(cloudflarePkg.peerDependencies),
+      peerDependencies: resolveManifestDeps(cloudflarePkg.peerDependencies, localCloudflarePkgDir),
       engines: cloudflarePkg.engines,
     },
     null,
@@ -460,8 +465,8 @@ fs.writeFileSync(
       type: typesPkg.type,
       sideEffects: typesPkg.sideEffects,
       exports: typesPkg.exports,
-      dependencies: resolveManifestDeps(typesPkg.dependencies),
-      peerDependencies: resolveManifestDeps(typesPkg.peerDependencies),
+      dependencies: resolveManifestDeps(typesPkg.dependencies, localTypesPkgDir),
+      peerDependencies: resolveManifestDeps(typesPkg.peerDependencies, localTypesPkgDir),
       peerDependenciesMeta: typesPkg.peerDependenciesMeta,
       engines: typesPkg.engines,
     },
@@ -487,8 +492,8 @@ fs.writeFileSync(
       bin: vinextPkg.bin,
       files: ['dist'],
       exports: vinextPkg.exports,
-      dependencies: resolveManifestDeps(vinextPkg.dependencies),
-      peerDependencies: resolveManifestDeps(vinextPkg.peerDependencies),
+      dependencies: resolveManifestDeps(vinextPkg.dependencies, localVinextPkgDir),
+      peerDependencies: resolveManifestDeps(vinextPkg.peerDependencies, localVinextPkgDir),
       peerDependenciesMeta: vinextPkg.peerDependenciesMeta,
       engines: vinextPkg.engines,
     },

--- a/tests/create-vinext-app.test.ts
+++ b/tests/create-vinext-app.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vite-plus/test"
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { createVinextApp } from "../packages/create-vinext-app/src/index.js";
+import { createVinextApp, runCreateVinextAppCli } from "../packages/create-vinext-app/src/index.js";
 import type { ResolvedInitOptions } from "../packages/vinext/src/init-platform.js";
 
 let tmpDir: string;
@@ -268,5 +268,28 @@ describe("createVinextApp", () => {
         }),
       ),
     ).rejects.toThrow("contains files that could conflict");
+  });
+});
+
+describe("create-vinext-app CLI", () => {
+  it("uses a dedicated executable entry point", () => {
+    const packageJson = JSON.parse(
+      fs.readFileSync(
+        path.join(import.meta.dirname, "../packages/create-vinext-app/package.json"),
+        "utf-8",
+      ),
+    ) as { bin: Record<string, string> };
+
+    expect(packageJson.bin).toEqual({ "create-vinext-app": "dist/cli.js" });
+  });
+
+  it("prints help through the CLI runner", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      await runCreateVinextAppCli(["--help"]);
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("Usage: create-vinext-app"));
+    } finally {
+      logSpy.mockRestore();
+    }
   });
 });

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -116,6 +116,15 @@ function readVinextPackageExports(): Record<string, unknown> {
   return parsed.exports;
 }
 
+function readCloudflarePackagePeerDependencies(): Record<string, unknown> {
+  const packageJsonPath = path.resolve("packages/cloudflare/package.json");
+  const parsed: unknown = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
+  if (!isUnknownRecord(parsed) || !isUnknownRecord(parsed.peerDependencies)) {
+    throw new Error("packages/cloudflare/package.json must define peerDependencies");
+  }
+  return parsed.peerDependencies;
+}
+
 function hasPackageExport(exportsMap: Record<string, unknown>, subpath: string): boolean {
   if (Object.hasOwn(exportsMap, subpath)) return true;
 
@@ -1412,6 +1421,11 @@ describe("readPagesRouterEntrySource", () => {
       true,
     );
     expect(hasPackageExport(exportsMap, "./internal/utils/project")).toBe(true);
+  });
+
+  it("publishes a vinext peer range that includes matching prereleases", () => {
+    const peerDependencies = readCloudflarePackagePeerDependencies();
+    expect(peerDependencies.vinext).toBe("workspace:^");
   });
 
   it("merges middleware and config headers into responses with correct precedence", () => {

--- a/tests/e2e-deploy-script.test.ts
+++ b/tests/e2e-deploy-script.test.ts
@@ -49,10 +49,17 @@ describe("Next.js deploy harness logging", () => {
       const localVinext = JSON.parse(
         fs.readFileSync(path.join(appRoot, ".vinext-local-package/package.json"), "utf8"),
       );
+      const localCloudflare = JSON.parse(
+        fs.readFileSync(
+          path.join(appRoot, ".vinext-local-cloudflare-package/package.json"),
+          "utf8",
+        ),
+      );
       const localTypes = JSON.parse(
         fs.readFileSync(path.join(appRoot, ".vinext-local-types-package/package.json"), "utf8"),
       );
       expect(localVinext.dependencies["@vinext/types"]).toBe("file:../.vinext-local-types-package");
+      expect(localCloudflare.peerDependencies.vinext).toBe("file:../.vinext-local-package");
       expect(localTypes.name).toBe("@vinext/types");
       expect(fs.existsSync(path.join(appRoot, ".vinext-local-types-package/next/index.d.ts"))).toBe(
         true,


### PR DESCRIPTION
## Summary

- split the importable create-vinext-app API from its executable CLI entry point
- point the package bin at an unconditional CLI runner so npx .bin symlinks execute correctly
- exercise the packed package directly through npx in both Cloudflare scaffold workflows
- publish the @vinext/cloudflare vinext peer from workspace:^ so matching prereleases satisfy npm
- materialize workspace dependencies relative to each local package in the Next.js deploy harness

## Root causes

The published creator only called its CLI when import.meta.url exactly matched process.argv[1]. npx launches package binaries through a node_modules/.bin symlink, while Node resolves import.meta.url to the real package file, so the comparison failed and the process exited successfully without doing anything.

Separately, @vinext/cloudflare published vinext >=0.0.0. npm semver excludes prereleases from that range, so an app explicitly using vinext 1.0.0-beta.x failed peer resolution. The workspace:^ source range is rewritten during packing to the matching prerelease range, currently ^1.0.0-beta.1, and will become ^1.0.0 for a stable release.

## Validation

- vp test run tests/create-vinext-app.test.ts tests/init.test.ts tests/deploy.test.ts tests/e2e-deploy-script.test.ts
- 428 focused tests passed
- vp run create-vinext-app#build
- vp check
- packed create-vinext-app and scaffolded Node and Cloudflare projects through npx
- packed vinext and @vinext/cloudflare and confirmed npm resolves both beta.1 tarballs without ERESOLVE
- confirmed the packed Cloudflare peer is ^1.0.0-beta.1
- independent sub-agent reviews: NO FINDINGS
- replacement Check, create-vinext-app Cloudflare build, and all unit shards passed