### PR TITLE
fix(pages): populate route in app initial props router

### DIFF
--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -389,6 +389,7 @@ const _renderPage = __createPagesPageHandler({
       : null,
   setI18nContext: typeof setI18nContext === "function" ? setI18nContext : null,
   wrapWithRouterContext: typeof wrapWithRouterContext === "function" ? wrapWithRouterContext : null,
+  router: Router,
   resetSSRHead: typeof resetSSRHead === "function" ? resetSSRHead : undefined,
   getSSRHeadHTML: typeof getSSRHeadHTML === "function" ? getSSRHeadHTML : undefined,
   setDocumentInitialHead: typeof setDocumentInitialHead === "function" ? setDocumentInitialHead : undefined,

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -1065,6 +1065,7 @@ export function createSSRHandler(
             pathname: patternToNextFormat(route.pattern),
             query,
             asPath: requestAsPath,
+            router: routerShim.default,
             locale: locale ?? currentDefaultLocale,
             locales: i18nConfig?.locales,
             defaultLocale: currentDefaultLocale,
@@ -1379,11 +1380,7 @@ export function createSSRHandler(
                           : appTree;
                       },
                       Component: pageModule.default,
-                      router: {
-                        pathname: patternToNextFormat(route.pattern),
-                        query,
-                        asPath: requestAsPath,
-                      },
+                      router: routerShim.default,
                       ctx: {
                         req: regenReq,
                         res: regenRes,

--- a/packages/vinext/src/server/pages-get-initial-props.ts
+++ b/packages/vinext/src/server/pages-get-initial-props.ts
@@ -1,3 +1,5 @@
+import type { NextRouter } from "vinext/shims/router";
+
 type PagesGetInitialPropsContext = {
   req?: unknown;
   res?: unknown;
@@ -9,6 +11,34 @@ type PagesGetInitialPropsContext = {
   locales?: string[];
   defaultLocale?: string;
 } & Record<string, unknown>;
+
+export type PagesGetInitialPropsRouter = Omit<
+  Pick<NextRouter, "route" | "pathname" | "query" | "asPath">,
+  "query"
+> & {
+  query: Record<string, unknown>;
+};
+
+/**
+ * Build the URL-state subset of Next.js's ServerRouter used by isolated
+ * initial-props helpers. Real request handlers pass their full `next/router`
+ * instance; this fallback keeps direct helper callers and tests aligned with
+ * the same required fields.
+ */
+export function createPagesGetInitialPropsRouter(
+  pathname: string,
+  query: Record<string, unknown>,
+  asPath: string,
+): PagesGetInitialPropsRouter {
+  return {
+    // Mirrors Next.js ServerRouter: render.tsx removes one trailing slash and
+    // preserves `/` for the root route.
+    route: pathname.replace(/\/$/, "") || "/",
+    pathname,
+    query,
+    asPath,
+  };
+}
 
 type PagesGetInitialProps = (context: PagesGetInitialPropsContext) => unknown;
 
@@ -126,6 +156,8 @@ export type DevAppInitialPropsContext = {
   pathname: string;
   query: Record<string, unknown>;
   asPath: string;
+  /** The request-scoped `next/router` server instance when available. */
+  router?: PagesGetInitialPropsRouter;
   locale?: string;
   locales?: string[];
   defaultLocale?: string;
@@ -151,7 +183,7 @@ export async function loadDevAppInitialProps(
   const initialProps = await loadPagesGetInitialProps(ctx.appComponent, {
     AppTree: ctx.appTree,
     Component: ctx.component,
-    router: { pathname: ctx.pathname, query: ctx.query, asPath: ctx.asPath },
+    router: ctx.router ?? createPagesGetInitialPropsRouter(ctx.pathname, ctx.query, ctx.asPath),
     ctx: {
       req: ctx.req,
       res: ctx.res,

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -19,9 +19,11 @@ import {
   type PagesNextDataExtras,
 } from "./pages-page-response.js";
 import {
+  createPagesGetInitialPropsRouter,
   hasPagesGetInitialProps,
   isResponseSent,
   loadPagesGetInitialProps,
+  type PagesGetInitialPropsRouter,
 } from "./pages-get-initial-props.js";
 import { buildNextDataPropsJsonResponse } from "./pages-data-route.js";
 import { NEXTJS_DEPLOYMENT_ID_HEADER } from "./headers.js";
@@ -208,6 +210,8 @@ export type ResolvePagesPageDataOptions = {
   htmlLimitedBots?: string;
   pageModule: PagesPageModule;
   AppComponent?: unknown;
+  /** The request-scoped `next/router` server instance when available. */
+  router?: PagesGetInitialPropsRouter;
   params: Record<string, unknown>;
   query: Record<string, unknown>;
   asPath?: string;
@@ -345,6 +349,7 @@ async function loadPagesAppInitialRenderProps(
     | "i18n"
     | "pageModule"
     | "query"
+    | "router"
     | "routePattern"
     | "routeUrl"
     | "asPath"
@@ -362,11 +367,13 @@ async function loadPagesAppInitialRenderProps(
   const initialProps = await loadPagesGetInitialProps(options.AppComponent, {
     AppTree: options.createAppTree ?? options.createPageElement,
     Component: options.pageModule.default,
-    router: {
-      pathname: options.routePattern,
-      query: options.query,
-      asPath: options.asPath ?? options.routeUrl,
-    },
+    router:
+      options.router ??
+      createPagesGetInitialPropsRouter(
+        options.routePattern,
+        options.query,
+        options.asPath ?? options.routeUrl,
+      ),
     ctx: {
       req,
       res,

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -59,7 +59,10 @@ import { collectAssetTags, resolveClientModuleUrl } from "./pages-asset-tags.js"
 import { NEXTJS_DEPLOYMENT_ID_HEADER } from "./headers.js";
 import { buildMissIsrCacheControl, ISR_NEVER_CACHE_CONTROL } from "./isr-decision.js";
 import { appendAssetDeploymentIdQuery } from "../utils/deployment-id.js";
-import { hasPagesGetInitialProps } from "./pages-get-initial-props.js";
+import {
+  hasPagesGetInitialProps,
+  type PagesGetInitialPropsRouter,
+} from "./pages-get-initial-props.js";
 
 function finalizePagesPreviewResponse(response: Response, preview: PagesPreviewState): Response {
   if (preview.data === false && !preview.shouldClear) return response;
@@ -168,6 +171,8 @@ export type CreatePagesPageHandlerOptions = {
   setI18nContext: ((ctx: Record<string, unknown>) => void) | null;
   /** `wrapWithRouterContext` from `next/router`. */
   wrapWithRouterContext: ((element: ReactNode) => ReactNode) | null;
+  /** Request-scoped `next/router` server instance. */
+  router?: PagesGetInitialPropsRouter;
   /** `resetSSRHead` from `next/head`. */
   resetSSRHead: (() => void) | undefined;
   /** `getSSRHeadHTML` from `next/head`. */
@@ -272,6 +277,7 @@ export function createPagesPageHandler(
     getPagesNavigationIsReadyFromSerializedState,
     setI18nContext,
     wrapWithRouterContext,
+    router,
     resetSSRHead,
     getSSRHeadHTML,
     setDocumentInitialHead,
@@ -648,6 +654,7 @@ export function createPagesPageHandler(
           previewData,
           pageModule,
           AppComponent,
+          router,
           params,
           query,
           asPath: routerAsPath,

--- a/scripts/check-shim-types.mjs
+++ b/scripts/check-shim-types.mjs
@@ -45,6 +45,10 @@ function resolveShim(shim) {
 }
 
 function renderContracts(tempDir) {
+  // These contracts verify the public values exported by each `next/*` shim.
+  // Request handlers can also construct values described by those public
+  // types (for example AppContext.router); those runtime construction sites
+  // need their own typed boundaries and behavioral tests.
   const lines = [
     `/// <reference path=${JSON.stringify(toImportSpecifier(tempDir, path.join(typesRoot, "index.d.ts")))} />`,
     `/// <reference path=${JSON.stringify(toImportSpecifier(tempDir, path.join(repoRoot, "packages/vinext/src/global.d.ts")))} />`,

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -1135,6 +1135,9 @@ describe("Pages Router entry template", () => {
       );
 
       expect(code).toContain("export const hasMiddleware = false");
+      expect(code).toMatch(
+        /wrapWithRouterContext: typeof wrapWithRouterContext[\s\S]*?router: Router,/,
+      );
       const globalsImportIndex = code.indexOf("/server-globals.js");
       const firstUserImportIndex = code.indexOf(
         `import * as page_0 from ${JSON.stringify(path.join(pagesDir, "index.tsx"))}`,

--- a/tests/pages-get-initial-props.test.ts
+++ b/tests/pages-get-initial-props.test.ts
@@ -125,7 +125,12 @@ describe("loadDevAppInitialProps", () => {
     expect(received).toMatchObject({
       Component: expect.any(Function),
       AppTree: expect.any(Function),
-      router: { pathname: "/posts/[slug]", query: { slug: "post" }, asPath: "/posts/post" },
+      router: {
+        route: "/posts/[slug]",
+        pathname: "/posts/[slug]",
+        query: { slug: "post" },
+        asPath: "/posts/post",
+      },
       ctx: {
         pathname: "/posts/[slug]",
         query: { slug: "post" },
@@ -134,6 +139,30 @@ describe("loadDevAppInitialProps", () => {
         locales: ["en", "fr"],
         defaultLocale: "en",
       },
+    });
+  });
+
+  // Next.js passes its ServerRouter to App.getInitialProps. Its `route` is the
+  // route pattern, not the concrete URL: packages/next/src/server/render.tsx.
+  it("provides the route pattern to App.getInitialProps router consumers", async () => {
+    const appComponent = Object.assign(
+      function App() {
+        return null;
+      },
+      {
+        getInitialProps({ router }: { router: { route: string } }) {
+          return {
+            pageProps: { routeTag: router.route.replaceAll("/", "_") },
+          };
+        },
+      },
+    );
+
+    const result = await loadDevAppInitialProps(createContext({ appComponent }));
+
+    expect(result).toMatchObject({
+      kind: "render",
+      pageProps: { routeTag: "_posts_[slug]" },
     });
   });
 });

--- a/tests/pages-page-data.test.ts
+++ b/tests/pages-page-data.test.ts
@@ -63,6 +63,27 @@ function createOptions(
 }
 
 describe("pages page data", () => {
+  // Next.js passes its ServerRouter to App.getInitialProps. Its `route` is the
+  // route pattern, not the concrete URL: packages/next/src/server/render.tsx.
+  it("provides the route pattern to App.getInitialProps router consumers", async () => {
+    const result = await resolvePagesPageData(
+      createOptions({
+        AppComponent: Object.assign(function App() {}, {
+          getInitialProps({ router }: { router: { route: string } }) {
+            return {
+              pageProps: { routeTag: router.route.replaceAll("/", "_") },
+            };
+          },
+        }),
+      }),
+    );
+
+    expect(result).toMatchObject({
+      kind: "render",
+      pageProps: { routeTag: "_posts_[slug]" },
+    });
+  });
+
   it("preserves non-object pageProps returned by custom app getInitialProps", async () => {
     const result = await resolvePagesPageData(
       createOptions({

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -390,6 +390,7 @@ function writeGsspAppInitialPropsContextFixture(rootDir: string): void {
 class MyApp extends App {
   static async getInitialProps(ctx) {
     const { req, query, pathname, asPath } = ctx.ctx;
+    const routeTag = ctx.router.route.replaceAll("/", "_");
     let pageProps = {};
 
     if (ctx.Component.getInitialProps) {
@@ -402,6 +403,8 @@ class MyApp extends App {
         query,
         pathname,
         asPath,
+        route: ctx.router.route,
+        routeTag,
       },
       pageProps,
     };
@@ -441,6 +444,8 @@ export default function BlogPost({ post, params, appProps, appRouter, resolvedUr
       <div id="app-query">{JSON.stringify(appProps.query)}</div>
       <div id="app-url">{appProps.url}</div>
       <div id="app-router-pathname">{appRouter.pathname}</div>
+      <div id="app-router-route">{appProps.route}</div>
+      <div id="app-router-route-tag">{appProps.routeTag}</div>
       <div id="resolved-url">{resolvedUrl}</div>
       <div id="as-path">{router.asPath}</div>
     </>
@@ -1913,6 +1918,8 @@ describe("Pages Router integration", () => {
       expectElementJson(dynamicHtml, "app-query", { post: "post-1" });
       expectElementText(dynamicHtml, "app-url", "/blog/post-1");
       expectElementText(dynamicHtml, "app-router-pathname", "/blog/[post]");
+      expectElementText(dynamicHtml, "app-router-route", "/blog/[post]");
+      expectElementText(dynamicHtml, "app-router-route-tag", "_blog_[post]");
       expectElementText(dynamicHtml, "resolved-url", "/blog/post-1");
       expectElementText(dynamicHtml, "as-path", "/blog/post-1");
       const dynamicNextDataMatch = dynamicHtml.match(
@@ -1926,6 +1933,8 @@ describe("Pages Router integration", () => {
         query: { post: "post-1" },
         asPath: "/blog/post-1",
         pathname: "/blog/[post]",
+        route: "/blog/[post]",
+        routeTag: "_blog_[post]",
       });
 
       const dataRes = await fetch(
@@ -1940,6 +1949,8 @@ describe("Pages Router integration", () => {
         query: { post: "post-1", hello: "world" },
         asPath: "/blog/post-1?hello=world",
         pathname: "/blog/[post]",
+        route: "/blog/[post]",
+        routeTag: "_blog_[post]",
       });
 
       const queryRes = await fetch(`${fixtureUrl}/something?hello=world`);


### PR DESCRIPTION
## Summary

- pass the full Pages Router instance to custom App.getInitialProps in dev, ISR regeneration, and production/data rendering
- require the route-pattern field at isolated initial-props helper boundaries
- add a regression that calls router.route.replaceAll on a dynamic route for HTML and _next/data requests
- document why public shim type compatibility checks cannot cover server-constructed runtime values

Next.js parity reference: https://github.com/vercel/next.js/blob/canary/packages/next/src/server/render.tsx#L144-L187

## Testing

- vp test run tests/pages-get-initial-props.test.ts tests/pages-page-data.test.ts tests/pages-page-handler.test.ts tests/entry-templates.test.ts
- vp test run tests/pages-router.test.ts -t "passes original req.url, query, asPath, and resolvedUrl through _app.getInitialProps on GSSP pages"
- vp check on the 10 changed files
- node scripts/check-shim-types.mjs
- vp run vinext#build

Independent review: no findings.