### PR TITLE
fix(release): require package-specific publish tags

### DIFF
--- a/scripts/create-changeset.mts
+++ b/scripts/create-changeset.mts
@@ -257,6 +257,30 @@ export function latestTagVersionFromTags(tags: string[], pkgName: string): strin
 }
 
 /**
+ * Pick the latest tag that proves this package itself was published. Scoped
+ * packages must have their own `<name>@<version>` tag; a legacy global
+ * `v<version>` tag only proves that the root `vinext` package was published.
+ *
+ * This is deliberately stricter than latestTagVersionFromTags(), whose global
+ * fallback is useful as a changelog range for newly introduced packages. Using
+ * that fallback for the publish guard can otherwise leave a new package stuck
+ * "awaiting publish" forever when its package.json starts above the old global
+ * version.
+ */
+export function latestPackageTagVersionFromTags(tags: string[], pkgName: string): string | null {
+  const scopedPrefix = `${pkgName}@`;
+  const versions = tags
+    .map((tag) => {
+      if (tag.startsWith(scopedPrefix)) return tag.slice(scopedPrefix.length);
+      if (pkgName === "vinext" && /^v\d+\.\d+\.\d+/.test(tag)) return tag.slice(1);
+      return null;
+    })
+    .filter((v): v is string => v != null)
+    .sort(compareVersions);
+  return versions.at(-1) ?? null;
+}
+
+/**
  * Latest release tag version for a package, read from `git tag -l`. Returns null
  * when git fails or the package has no matching tag.
  */
@@ -268,6 +292,17 @@ function latestTagVersion(pkgName: string): string | null {
     return null;
   }
   return latestTagVersionFromTags(tags, pkgName);
+}
+
+/** Latest tag proving that this specific package was published. */
+function latestPackageTagVersion(pkgName: string): string | null {
+  let tags: string[] = [];
+  try {
+    tags = git(["tag", "-l"]).split("\n").filter(Boolean);
+  } catch {
+    return null;
+  }
+  return latestPackageTagVersionFromTags(tags, pkgName);
 }
 
 /** Git ref to diff from: prefer the scoped tag, else the global `v<version>`. */
@@ -537,7 +572,7 @@ export function run(): { written: string | null; bumps: Record<string, Bump> } {
     const pkg = JSON.parse(
       readFileSync(join(REPO_ROOT, dir, "package.json"), "utf8"),
     ) as PackageJson;
-    const decision = decideGeneration(pkg.version ?? "0.0.0", latestTagVersion(name));
+    const decision = decideGeneration(pkg.version ?? "0.0.0", latestPackageTagVersion(name));
     console.log(`[create-changeset] ${name}: ${decision.action} — ${decision.reason}`);
     if (decision.action === "generate") ranges.set(name, releaseRangeStart(name));
   }

--- a/scripts/create-changeset.test.ts
+++ b/scripts/create-changeset.test.ts
@@ -16,6 +16,7 @@ import {
   decideGeneration,
   findOverride,
   latestTagVersionFromTags,
+  latestPackageTagVersionFromTags,
   loadOverrides,
   maxBump,
   parseBumpFromSubject,
@@ -222,6 +223,24 @@ describe("latestTagVersionFromTags (release range source)", () => {
     // No matching tag → null, so releaseRangeStart falls back to firstCommit().
     expect(latestTagVersionFromTags([], "@vinext/cloudflare")).toBeNull();
     expect(latestTagVersionFromTags(["some-other-tag"], "@vinext/cloudflare")).toBeNull();
+  });
+});
+
+describe("latestPackageTagVersionFromTags (publish guard source)", () => {
+  const tags = ["v0.0.55", "vinext@1.0.0-beta.1", "@vinext/cloudflare@1.0.0-beta.1"];
+
+  it("uses a package's own scoped tag", () => {
+    expect(latestPackageTagVersionFromTags(tags, "@vinext/cloudflare")).toBe("1.0.0-beta.1");
+  });
+
+  it("keeps legacy global tags for the root package", () => {
+    expect(latestPackageTagVersionFromTags(["v0.0.55"], "vinext")).toBe("0.0.55");
+  });
+
+  it("does not mistake a global tag for a new scoped package release", () => {
+    const tagVersion = latestPackageTagVersionFromTags(tags, "@vinext/types");
+    expect(tagVersion).toBeNull();
+    expect(decideGeneration("1.0.0-beta.1", tagVersion).action).toBe("generate");
   });
 });
 


### PR DESCRIPTION
## Summary

- distinguish a package-specific publish tag from the legacy global changelog fallback
- keep `v<version>` compatibility for the root `vinext` package
- prevent newly introduced scoped packages from remaining incorrectly stuck as “awaiting publish”

This makes the current missing `@vinext/types@1.0.0-beta.1` tag self-healing: release generation can include the package instead of treating `v0.0.55` as proof that it was published.

## Validation

- `vp check scripts/create-changeset.mts scripts/create-changeset.test.ts`
- `vp test run scripts/create-changeset.test.ts` (64 tests)