### PR TITLE
build(types): register package tasks with Vite+

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -27,6 +27,10 @@
       "types": "./next/upstream/*.d.ts"
     }
   },
+  "scripts": {
+    "build": "node ../../scripts/sync-next-types.mjs --check",
+    "prepack": "vp run build"
+  },
   "engines": {
     "node": ">=22"
   }


### PR DESCRIPTION
## Summary

- register `@vinext/types#build` in the Vite+ task graph
- validate the vendored declaration snapshot as the declaration-only package build
- run that validation automatically before packing or publishing

## Validation

- `vp run` lists `@vinext/types#build` and `@vinext/types#prepack`
- `vp run @vinext/types#build`
- `vp run @vinext/types#prepack`
- `pnpm pack --pack-destination <temp-dir>`

All 347 vendored declarations are in sync with Next.js 16.2.7, and the package tarball was produced successfully.