### PR TITLE
fix(benchmarks): isolate Next.js TypeScript dependency

### DIFF
--- a/benchmarks/nextjs/package.json
+++ b/benchmarks/nextjs/package.json
@@ -10,5 +10,10 @@
     "next": "16.2.7",
     "react": "19.2.7",
     "react-dom": "19.2.7"
+  },
+  "devDependencies": {
+    "@types/node": "25.9.2",
+    "@types/react": "19.2.16",
+    "typescript": "5.9.3"
   }
 }

--- a/benchmarks/perf/scenarios.json
+++ b/benchmarks/perf/scenarios.json
@@ -3,7 +3,14 @@
     { "command": ["vp", "run", "build"] },
     { "command": ["node", "benchmarks/generate-app.mjs"], "trusted": true },
     {
-      "command": ["npm", "install"],
+      "command": [
+        "npm",
+        "install",
+        "--no-save",
+        "typescript@5.9.3",
+        "@types/node@25.9.2",
+        "@types/react@19.2.16"
+      ],
       "cwd": "benchmarks/nextjs",
       "implementationId": "nextjs"
     }

--- a/tests/performance-benchmarks.test.ts
+++ b/tests/performance-benchmarks.test.ts
@@ -20,6 +20,34 @@ import {
 import { DEFAULT_PAIRED_ROUNDS, pairedRevisionOrder } from "../benchmarks/perf/pairing.mts";
 
 describe("paired performance benchmarks", () => {
+  it("pins the TypeScript dependencies required by the standalone Next.js benchmark", () => {
+    const packageJson = JSON.parse(
+      readFileSync(join(import.meta.dirname, "../benchmarks/nextjs/package.json"), "utf8"),
+    );
+    const scenarios = JSON.parse(
+      readFileSync(join(import.meta.dirname, "../benchmarks/perf/scenarios.json"), "utf8"),
+    );
+
+    expect(packageJson.devDependencies).toMatchObject({
+      "@types/node": "25.9.2",
+      "@types/react": "19.2.16",
+      // Next.js 16 resolves typescript/lib/typescript.js, which native TypeScript 7 removed.
+      typescript: "5.9.3",
+    });
+    expect(
+      scenarios.setup.find(
+        (setup: { implementationId?: string }) => setup.implementationId === "nextjs",
+      ).command,
+    ).toEqual([
+      "npm",
+      "install",
+      "--no-save",
+      "typescript@5.9.3",
+      "@types/node@25.9.2",
+      "@types/react@19.2.16",
+    ]);
+  });
+
   it("alternates base/head order across rounds", () => {
     expect(DEFAULT_PAIRED_ROUNDS % 2).toBe(0);
     expect(pairedRevisionOrder(0)).toEqual(["base", "head"]);


### PR DESCRIPTION
## Summary

- pin the standalone Next.js benchmark to TypeScript 5.9.3 and its required type packages
- prevent the benchmark from inheriting the monorepo native TypeScript 7 package
- add regression coverage for the standalone benchmark dependency contract

## Root cause

Next.js 16.2.7 checks for the legacy compiler entrypoint `typescript/lib/typescript.js`, which native TypeScript 7 no longer ships. The benchmark fixture did not declare its own TypeScript dependencies, so after the repo upgraded to TypeScript 7:

- the regular benchmark completed Turbopack compilation, then exited or aborted during TypeScript setup: https://github.com/cloudflare/vinext/actions/runs/29363030813/job/87187626470
- the isolated performance benchmark treated TypeScript as missing and attempted an automatic install; after its generated npm lockfile was removed by the harness hardening step, Next.js selected Yarn and failed against the monorepo pnpm package-manager pin: https://github.com/cloudflare/vinext/actions/runs/29363030395/job/87187625626

Next.js source contract: https://github.com/vercel/next.js/blob/v16.2.7/packages/next/src/lib/verify-typescript-setup.ts

## Validation

- `vp test run tests/performance-benchmarks.test.ts` (26 passed)
- `vp check tests/performance-benchmarks.test.ts`
- clean `npm install` in `benchmarks/nextjs`
- `CI=true ./node_modules/.bin/next build --turbopack`
- Next.js cold-start benchmark adapter served `/` successfully without installing dependencies