### PR TITLE
fix(pages): preserve raw production request paths

### DIFF
--- a/packages/vinext/src/server/app-page-request.ts
+++ b/packages/vinext/src/server/app-page-request.ts
@@ -383,9 +383,9 @@ function areStaticParamsAllowed(
   allowMissingValues = false,
 ): boolean {
   const paramKeys = Object.keys(params);
-  // Next.js compares the request pathname against generated encoded pathnames
-  // exactly. Dynamic route-pattern matching is case-insensitive, but the
-  // concrete values returned by generateStaticParams are not.
+  // Next.js compares the concrete request pathname against generated encoded
+  // pathnames exactly. This generated-path gate is case-sensitive even though
+  // custom redirect, rewrite, and header sources are case-insensitive by default.
   const stringParamMatches = (value: string, staticValue: string): boolean =>
     value === encodeURIComponent(staticValue);
 

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -1801,12 +1801,13 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
         res.end("This page could not be found");
         return;
       }
-      // Preserve parser-ignored bytes until route param decoding. The literal
-      // characters would otherwise disappear when constructing webRequest.
-      pathname = encodeUrlParserIgnoredCharacters(pathname);
+      // Preserve parser-ignored bytes until route param decoding. Keep using
+      // the raw request pathname here so unrelated escapes retain their route
+      // identity and dynamic captures are decoded exactly once.
+      requestPathname = encodeUrlParserIgnoredCharacters(requestPathname);
       {
         const qs = url.includes("?") ? url.slice(url.indexOf("?")) : "";
-        url = pathname + qs;
+        url = requestPathname + qs;
       }
       // ── 3b. `_next/data` normalization ────────────────────────────
       // Pages Router client-side navigations fetch


### PR DESCRIPTION
## Summary

- preserve the raw encoded Pages Router request pathname when escaping URL-parser-ignored controls in the Node production adapter
- prevent encoded static aliases, repeated dynamic-param decoding, and decoded trailing-slash redirect locations
- clarify that generated App path admission is case-sensitive, unlike case-insensitive custom redirect, rewrite, and header source matching

## Regression analysis

PR #2580 (`8c2e4bb11`) rebuilt the production request URL from the decoded route-matching pathname. That crossed the raw-path and route-match-path contracts introduced by PR #2556 (`4f7eec967`):

- `/%61bout` incorrectly selected `/about`
- `/posts/a%2561` decoded twice to `aa` instead of once to `a%61`
- `/docs/%68ello` redirected to `/docs/hello/` instead of preserving `/docs/%68ello/`

The full #2580 merge has two runtime call sites. Only the Node production adapter discarded raw identity. The dev adapter retains separate raw `routeUrl` and `middlewareUrl` values, and the Cloudflare path continues through the shared request pipeline; their targeted parity tests pass without further changes.

Next.js 16.2.7 was used as the behavior oracle for the encoded static, dynamic, encoded-slash, and basePath/trailingSlash cases.

## Validation

- `vp test run tests/pages-data-route.test.ts tests/pages-request-pipeline.test.ts` (110 passed)
- `vp test run tests/pages-router.test.ts -t "encoded URL controls|percent-encoded header source alias"` (5 passed)
- `PLAYWRIGHT_PROJECT=pages-router vp exec playwright test tests/e2e/pages-router/encoded-path-routing.spec.ts` (3 passed)
- `PLAYWRIGHT_PROJECT=pages-router-prod vp exec playwright test tests/e2e/pages-router-prod/encoded-path-routing.spec.ts` (3 passed)
- `PLAYWRIGHT_PROJECT=pages-router-basepath vp exec playwright test tests/e2e/pages-router-basepath/trailing-slash.spec.ts` (3 passed)
- `PLAYWRIGHT_PROJECT=cloudflare-pages-router vp exec playwright test tests/e2e/cloudflare-pages-router/middleware.spec.ts` (8 passed)
- `vp run vinext#build`
- `vp fmt --check packages/vinext/src/server/prod-server.ts packages/vinext/src/server/app-page-request.ts`
- `git diff --check`
