### PR TITLE
fix(pages): match encoded string static paths

### DIFF
--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import type { VinextNextData } from "../client/vinext-next-data.js";
 import type { Route } from "../routing/pages-router.js";
 import { normalizeStaticPathname } from "../routing/route-pattern.js";
+import { normalizePathnameForRouteMatch } from "../routing/utils.js";
 import type { CachedPagesValue, CacheControlMetadata } from "vinext/shims/cache-handler";
 import { applyCdnResponseHeaders } from "./cache-control.js";
 import { decideIsr } from "./isr-decision.js";
@@ -522,7 +523,16 @@ export function matchesPagesStaticPath(
   routeUrl: string,
 ): boolean {
   if (typeof pathEntry === "string") {
-    return normalizeStaticPathname(pathEntry) === normalizeStaticPathname(routeUrl);
+    // Request routing intentionally preserves the raw encoded pathname until
+    // dynamic captures are decoded. Compare string-form getStaticPaths entries
+    // in the same segment-normalized space so a seeded literal value such as
+    // `[second]` matches a data URL containing `%5Bsecond%5D`. Segment-wise
+    // normalization keeps encoded delimiters such as `%2F` encoded, so they
+    // cannot become path separators during this comparison.
+    return (
+      normalizePathnameForRouteMatch(normalizeStaticPathname(pathEntry)) ===
+      normalizePathnameForRouteMatch(normalizeStaticPathname(routeUrl))
+    );
   }
   const entryParams = pathEntry.params;
   if (entryParams === undefined || entryParams === null) {

--- a/tests/pages-page-data.test.ts
+++ b/tests/pages-page-data.test.ts
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vite-plus/test";
 import {
+  getPagesRouteParams,
+  matchesPagesStaticPath,
   renderPagesIsrHtml,
   resolvePagesPageData,
   type ResolvePagesPageDataOptions,
@@ -246,6 +248,45 @@ describe("pages page data", () => {
     );
 
     expect(result).toEqual({ kind: "notFound" });
+  });
+
+  // Ported from Next.js: test/e2e/prerender.test.ts
+  // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/prerender.test.ts
+  it("matches encoded data request paths against string getStaticPaths entries", async () => {
+    const result = await resolvePagesPageData(
+      createOptions({
+        isDataReq: true,
+        pageModule: {
+          async getStaticPaths() {
+            return {
+              fallback: false,
+              paths: ["/posts/[second]"],
+            };
+          },
+          async getStaticProps({ params }) {
+            return { props: { slug: params?.slug } };
+          },
+        },
+        params: { slug: "[second]" },
+        query: { slug: "[second]" },
+        route: { isDynamic: true },
+        routeUrl: "/posts/%5Bsecond%5D",
+      }),
+    );
+
+    expect(result).toMatchObject({
+      kind: "render",
+      pageProps: { slug: "[second]" },
+    });
+
+    expect(
+      matchesPagesStaticPath(
+        "/docs/a/b",
+        { slug: "a/b" },
+        getPagesRouteParams("/docs/[slug]"),
+        "/docs/a%2Fb",
+      ),
+    ).toBe(false);
   });
 
   it("renders unlisted fallback false paths in preview mode without caching them", async () => {


### PR DESCRIPTION
## Summary

- match string-form `getStaticPaths()` entries against raw encoded request paths in the same segment-normalized space
- preserve encoded delimiters such as `%2F` while decoding literal segment characters such as `%5B` and `%5D`
- add a regression test based on Next.js v16.2.6 `test/e2e/prerender.test.ts`

This fixes the genuine pass-to-fail regression between deploy-suite runs [29302415348](https://github.com/cloudflare/vinext/actions/runs/29302415348) and [29376807785](https://github.com/cloudflare/vinext/actions/runs/29376807785): `Prerender should navigate between pages successfully`. The other four report deltas did not reproduce locally with zero retries and are intentionally not changed here.

## Validation

- `vp test run tests/pages-page-data.test.ts` (61 passed)
- `vp check packages/vinext/src/server/pages-page-data.ts tests/pages-page-data.test.ts`
- `vp run vinext#build`
- Next.js v16.2.6 `test/e2e/prerender.test.ts`: the regressed navigation assertion passes; the suite still has one pre-existing unrelated `revalidate: false` failure