### PR TITLE
fix: honor custom TypeScript config path

### DIFF
--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -176,6 +176,12 @@ export type NextConfig = {
   assetPrefix?: string;
   /** Whether to add trailing slashes */
   trailingSlash?: boolean;
+  /** TypeScript build settings. */
+  typescript?: {
+    /** Project-relative path to the TypeScript configuration file. */
+    tsconfigPath?: string;
+    [key: string]: unknown;
+  };
   /** Internationalization routing config */
   i18n?: NextI18nConfig;
   /** URL redirect rules */
@@ -390,6 +396,7 @@ export type ResolvedNextConfig = {
    */
   assetPrefix: string;
   trailingSlash: boolean;
+  typescript: { tsconfigPath?: string };
   output: "" | "export" | "standalone";
   pageExtensions: string[];
   resolveExtensions: string[] | null;
@@ -1534,6 +1541,7 @@ export async function resolveNextConfig(
       basePath: "",
       assetPrefix: "",
       trailingSlash: false,
+      typescript: {},
       output: "",
       pageExtensions: normalizePageExtensions(),
       resolveExtensions: null,
@@ -1865,6 +1873,10 @@ export async function resolveNextConfig(
     basePath: config.basePath ?? "",
     assetPrefix: normalizeAssetPrefix(config.assetPrefix),
     trailingSlash: config.trailingSlash ?? false,
+    typescript:
+      typeof config.typescript?.tsconfigPath === "string"
+        ? { tsconfigPath: config.typescript.tsconfigPath }
+        : {},
     output: output === "export" || output === "standalone" ? output : "",
     pageExtensions,
     resolveExtensions: resolveExtensions ?? webpackProbe.resolveExtensions,

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -871,20 +871,26 @@ function sortTsconfigAliasesBySpecificity(aliases: Record<string, string>): Reco
   return Object.fromEntries(Object.entries(aliases).sort((a, b) => b[0].length - a[0].length));
 }
 
-function resolveTsconfigAliases(projectRoot: string): Record<string, string> {
-  if (_tsconfigAliasCache.has(projectRoot)) {
-    return _tsconfigAliasCache.get(projectRoot)!;
+function resolveTsconfigAliases(
+  projectRoot: string,
+  configuredPath?: string,
+): Record<string, string> {
+  const configPath = configuredPath ? path.resolve(projectRoot, configuredPath) : undefined;
+  const cacheKey = configPath ?? projectRoot;
+  if (_tsconfigAliasCache.has(cacheKey)) {
+    return _tsconfigAliasCache.get(cacheKey)!;
   }
 
   let aliases: Record<string, string> = {};
-  for (const name of TSCONFIG_FILES) {
-    const candidate = path.join(projectRoot, name);
+  for (const candidate of configPath
+    ? [configPath]
+    : TSCONFIG_FILES.map((name) => path.join(projectRoot, name))) {
     if (!fs.existsSync(candidate)) continue;
     aliases = sortTsconfigAliasesBySpecificity(loadTsconfigPathAliases(candidate, projectRoot));
     break;
   }
 
-  _tsconfigAliasCache.set(projectRoot, aliases);
+  _tsconfigAliasCache.set(cacheKey, aliases);
   return aliases;
 }
 
@@ -1867,21 +1873,9 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         isServeCommand = env.command === "serve";
         root = toSlash(config.root ?? process.cwd());
         const userResolve = config.resolve as UserResolveConfigWithTsconfigPaths | undefined;
-        const shouldEnableNativeTsconfigPaths = userResolve?.tsconfigPaths === undefined;
-        const tsconfigPathAliases = resolveTsconfigAliases(root);
+        let shouldEnableNativeTsconfigPaths = userResolve?.tsconfigPaths === undefined;
+        let tsconfigPathAliases: Record<string, string> = {};
         const swcHelpersAlias = resolveSwcHelpersAlias(root);
-
-        // tsconfig-derived alias entries carry a customResolver, which Vite 8
-        // reports as deprecated during config resolution. Filter that warning
-        // (see suppressAliasCustomResolverDeprecationWarning). Mutating
-        // config.customLogger (rather than returning it) keeps mergeConfig
-        // from deep-cloning the logger and flattening its hasWarned getter.
-        if (Object.keys(tsconfigPathAliases).length > 0) {
-          config.customLogger = suppressAliasCustomResolverDeprecationWarning(
-            config.customLogger ??
-              createLogger(config.logLevel, { allowClearScreen: config.clearScreen }),
-          );
-        }
 
         // Load .env files into process.env before anything else.
         // Next.js loads .env files before evaluating next.config.js, so
@@ -2012,6 +2006,28 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           if (sharedBuildId && sharedBuildId.length > 0) {
             nextConfig = { ...nextConfig, buildId: sharedBuildId };
           }
+        }
+        const configuredTsconfigPath = isRecord(nextConfig.typescript)
+          ? typeof nextConfig.typescript.tsconfigPath === "string"
+            ? nextConfig.typescript.tsconfigPath
+            : undefined
+          : undefined;
+        tsconfigPathAliases = resolveTsconfigAliases(root, configuredTsconfigPath);
+        // Native tsconfig discovery always starts from tsconfig.json. For an
+        // explicitly selected file, use the aliases materialized above so the
+        // default config cannot override the user's next.config selection.
+        if (configuredTsconfigPath) shouldEnableNativeTsconfigPaths = false;
+
+        // tsconfig-derived alias entries carry a customResolver, which Vite 8
+        // reports as deprecated during config resolution. Filter that warning
+        // (see suppressAliasCustomResolverDeprecationWarning). Mutating
+        // config.customLogger (rather than returning it) keeps mergeConfig
+        // from deep-cloning the logger and flattening its hasWarned getter.
+        if (Object.keys(tsconfigPathAliases).length > 0) {
+          config.customLogger = suppressAliasCustomResolverDeprecationWarning(
+            config.customLogger ??
+              createLogger(config.logLevel, { allowClearScreen: config.clearScreen }),
+          );
         }
         // RSC-compat ID coordination across plugin instances — same rationale as
         // the build ID above. createRscCompatibilityId() falls back to a random

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1873,7 +1873,6 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         isServeCommand = env.command === "serve";
         root = toSlash(config.root ?? process.cwd());
         const userResolve = config.resolve as UserResolveConfigWithTsconfigPaths | undefined;
-        let shouldEnableNativeTsconfigPaths = userResolve?.tsconfigPaths === undefined;
         let tsconfigPathAliases: Record<string, string> = {};
         const swcHelpersAlias = resolveSwcHelpersAlias(root);
 
@@ -2013,10 +2012,11 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             : undefined
           : undefined;
         tsconfigPathAliases = resolveTsconfigAliases(root, configuredTsconfigPath);
-        // Native tsconfig discovery always starts from tsconfig.json. For an
-        // explicitly selected file, use the aliases materialized above so the
-        // default config cannot override the user's next.config selection.
-        if (configuredTsconfigPath) shouldEnableNativeTsconfigPaths = false;
+        // Vite's native option discovers tsconfig.json and cannot receive Next's
+        // typescript.tsconfigPath. Only auto-enable it for the default config;
+        // an explicit user resolve.tsconfigPaths value remains untouched.
+        const shouldAutoEnableNativeTsconfigPaths =
+          userResolve?.tsconfigPaths === undefined && configuredTsconfigPath === undefined;
 
         // tsconfig-derived alias entries carry a customResolver, which Vite 8
         // reports as deprecated during config resolution. Filter that warning
@@ -2756,7 +2756,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             // causing cryptic "Invalid hook call" errors. This is a no-op
             // when only one copy exists.
             dedupe: ["react", "react-dom", "react/jsx-runtime", "react/jsx-dev-runtime"],
-            ...(shouldEnableNativeTsconfigPaths ? { tsconfigPaths: true } : {}),
+            ...(shouldAutoEnableNativeTsconfigPaths ? { tsconfigPaths: true } : {}),
           },
           // NOTE: top-level optimizeDeps is now set below (after capturing
           // incoming values from earlier plugins) so both Pages Router and

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -2030,6 +2030,7 @@ describe("detectNextIntlConfig", () => {
       assetPrefix: "",
       basePath: "",
       trailingSlash: false,
+      typescript: {},
       output: "",
       pageExtensions: ["tsx", "ts", "jsx", "js"],
       resolveExtensions: null,

--- a/tests/tsconfig-paths-vite8.test.ts
+++ b/tests/tsconfig-paths-vite8.test.ts
@@ -285,6 +285,37 @@ describe("Vite tsconfig paths support", () => {
     expect(alias["@"].replace(/\\/g, "/")).toContain(root.replace(/\\/g, "/"));
   });
 
+  it("honors typescript.tsconfigPath from next.config", async () => {
+    const root = setupProject({ name: "vite", version: "8.0.0" });
+    process.chdir(root);
+    fs.writeFileSync(
+      path.join(root, "tsconfig.json"),
+      JSON.stringify({ compilerOptions: { paths: { "@/*": ["./default/*"] } } }),
+    );
+    fs.writeFileSync(
+      path.join(root, "tsconfig.app.json"),
+      JSON.stringify({ compilerOptions: { paths: { "@/*": ["./custom/*"] } } }),
+    );
+
+    const plugins = vinext({
+      appDir: root,
+      nextConfig: { typescript: { tsconfigPath: "./tsconfig.app.json" } },
+    });
+    const configPlugin = (await findNamedPlugin(plugins, "vinext:config")) as {
+      config?: (
+        config: { root: string },
+        env: { command: "serve"; mode: string },
+      ) => Promise<{ resolve?: Record<string, unknown> }>;
+    };
+    const resolvedConfig = await configPlugin.config?.(
+      { root },
+      { command: "serve", mode: "development" },
+    );
+
+    expect(aliasEntriesToRecord(resolvedConfig?.resolve?.alias)["@"]).toBe("/custom");
+    expect(resolvedConfig?.resolve?.tsconfigPaths).toBeUndefined();
+  });
+
   it("orders overlapping tsconfig path aliases longest-prefix-first on Vite 8", async () => {
     const root = setupProject({ name: "vite", version: "8.0.0" });
     process.chdir(root);

--- a/tests/tsconfig-paths-vite8.test.ts
+++ b/tests/tsconfig-paths-vite8.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import type { Plugin, PluginOption } from "vite-plus";
+import { mergeConfig, type Plugin, type PluginOption } from "vite-plus";
 import vinext from "../packages/vinext/src/index.js";
 import { aliasEntriesToRecord } from "./helpers.js";
 
@@ -285,7 +285,7 @@ describe("Vite tsconfig paths support", () => {
     expect(alias["@"].replace(/\\/g, "/")).toContain(root.replace(/\\/g, "/"));
   });
 
-  it("honors typescript.tsconfigPath from next.config", async () => {
+  it("uses custom aliases without auto-enabling native tsconfig discovery", async () => {
     const root = setupProject({ name: "vite", version: "8.0.0" });
     process.chdir(root);
     fs.writeFileSync(
@@ -314,6 +314,35 @@ describe("Vite tsconfig paths support", () => {
 
     expect(aliasEntriesToRecord(resolvedConfig?.resolve?.alias)["@"]).toBe("/custom");
     expect(resolvedConfig?.resolve?.tsconfigPaths).toBeUndefined();
+  });
+
+  it("preserves explicitly enabled native discovery with a custom tsconfig path", async () => {
+    const root = setupProject({ name: "vite", version: "8.0.0" });
+    process.chdir(root);
+    fs.writeFileSync(
+      path.join(root, "tsconfig.app.json"),
+      JSON.stringify({ compilerOptions: { paths: { "@/*": ["./custom/*"] } } }),
+    );
+
+    const plugins = vinext({
+      appDir: root,
+      nextConfig: { typescript: { tsconfigPath: "./tsconfig.app.json" } },
+    });
+    const configPlugin = (await findNamedPlugin(plugins, "vinext:config")) as {
+      config?: (
+        config: { root: string; resolve?: Record<string, unknown> },
+        env: { command: "serve"; mode: string },
+      ) => Promise<{ resolve?: Record<string, unknown> }>;
+    };
+    const userConfig = { root, resolve: { tsconfigPaths: true } };
+    const pluginConfig = await configPlugin.config?.(userConfig, {
+      command: "serve",
+      mode: "development",
+    });
+    const mergedConfig = mergeConfig(userConfig, pluginConfig ?? {});
+
+    expect(aliasEntriesToRecord(mergedConfig.resolve?.alias)["@"]).toBe("/custom");
+    expect(mergedConfig.resolve?.tsconfigPaths).toBe(true);
   });
 
   it("orders overlapping tsconfig path aliases longest-prefix-first on Vite 8", async () => {


### PR DESCRIPTION
## What changed

- preserve `typescript.tsconfigPath` while resolving `next.config`
- materialize path aliases from the explicitly selected TypeScript config
- disable Vite's default `tsconfig.json` auto-discovery when a custom config is selected

## Why

vinext always loaded aliases from the default `tsconfig.json`, even when Next.js configuration selected another file. As a result, production and development resolution could use the wrong `paths` mappings and fail builds that work in Next.js.

The custom path is resolved relative to the project root, matching Next.js configuration semantics. Existing default discovery and explicit Vite `resolve.tsconfigPaths` overrides remain unchanged.

Closes #1449.

## Validation

- `pnpm test tests/tsconfig-paths-vite8.test.ts tests/next-config.test.ts` — 225 tests passed
- `pnpm exec vp check packages/vinext/src/index.ts packages/vinext/src/config/next-config.ts tests/tsconfig-paths-vite8.test.ts` — passed with no warnings or errors
- commit hook `vp check --fix` — passed
