### PR TITLE
fix(shims): reject invalid NextResponse JSON bodies

### DIFF
--- a/packages/vinext/src/shims/server.ts
+++ b/packages/vinext/src/shims/server.ts
@@ -277,14 +277,8 @@ export class NextResponse<_Body = unknown> extends Response {
    * Create a JSON response.
    */
   static json<JsonBody>(body: JsonBody, init?: ResponseInit): NextResponse<JsonBody> {
-    const headers = new Headers(init?.headers);
-    if (!headers.has("content-type")) {
-      headers.set("content-type", "application/json");
-    }
-    return new NextResponse(JSON.stringify(body), {
-      ...init,
-      headers,
-    }) as NextResponse<JsonBody>;
+    const response = Response.json(body, init);
+    return new NextResponse(response.body, response) as NextResponse<JsonBody>;
   }
 
   /**

--- a/tests/next-response.test.ts
+++ b/tests/next-response.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+describe("NextResponse", () => {
+  // Next.js delegates JSON serialization to Response.json(), including its
+  // top-level serialization failures:
+  // https://github.com/vercel/next.js/blob/491f78099c3ea23be14e66c6d848b50204590e90/packages/next/src/server/web/spec-extension/response.ts#L109-L115
+  it.each([
+    { name: "undefined", value: undefined },
+    { name: "a function", value: () => undefined },
+    { name: "a symbol", value: Symbol("invalid-json") },
+  ])("rejects $name as a JSON response body", async ({ value }) => {
+    const { NextResponse } = await import("../packages/vinext/src/shims/server.js");
+
+    expect(() => NextResponse.json(value)).toThrow(TypeError);
+  });
+});


### PR DESCRIPTION
## Summary

- Delegate `NextResponse.json()` serialization to the platform `Response.json()` implementation.
- Reject top-level `undefined`, function, and symbol bodies with `TypeError`, matching Next.js.
- Add focused regression coverage for invalid JSON response bodies.

## Problem

vinext previously called `JSON.stringify(body)` directly. For values such as `undefined`, functions, and symbols, `JSON.stringify()` returns `undefined`. The `Response` constructor then treated that as an empty body and returned a successful `200` response labeled `application/json`.

Next.js instead throws a `TypeError`, preventing invalid empty JSON responses from being returned or cached.

## Next.js parity

Next.js delegates serialization to `Response.json()`:

https://github.com/vercel/next.js/blob/491f78099c3ea23be14e66c6d848b50204590e90/packages/next/src/server/web/spec-extension/response.ts#L109-L115

## Validation

- `pnpm test tests/next-response.test.ts tests/shims.test.ts -t "NextResponse"`: 28 passed
- `pnpm exec vp check packages/vinext/src/shims/server.ts tests/next-response.test.ts`: passed
- `pnpm exec vp run vinext#build`: passed

The complete shim suite reached 1,232/1,233 tests. The remaining unrelated `next/error` subprocess test fails locally on Windows because its `spawnSync` invocation returns no captured output.