### PR TITLE
fix(shims): preserve response cookie metadata

### DIFF
--- a/packages/vinext/src/shims/internal/cookie-serialize.ts
+++ b/packages/vinext/src/shims/internal/cookie-serialize.ts
@@ -1,10 +1,10 @@
 /**
- * Shared Set-Cookie serialization for the next/headers and next/server shims.
+ * Set-Cookie serialization for the mutable next/headers shim.
  *
- * Two call sites — `cookies().set()` in headers.ts and `ResponseCookies.set()`
- * in server.ts — produce identical Set-Cookie header strings. Keep the
- * encoding, attribute order, and validation in one place so subtle RFC 6265
- * details (escaping, attribute ordering, etc.) cannot drift between them.
+ * `ResponseCookies` in server.ts deliberately uses the exact
+ * @edge-runtime/cookies serialization order and casing instead. It also has to
+ * preserve the absence of a default path when parsing an existing Set-Cookie
+ * header, while this helper always defaults new mutable cookies to `Path=/`.
  *
  * Note: this is a value-encoding helper for response cookies only. The
  * request `Cookie:` header serialization in `RequestCookies._serialize`

--- a/packages/vinext/src/shims/server.ts
+++ b/packages/vinext/src/shims/server.ts
@@ -15,7 +15,7 @@ import {
   MIDDLEWARE_SET_COOKIE_HEADER,
 } from "../server/headers.js";
 import { encodeMiddlewareRequestHeaders } from "../utils/middleware-request-headers.js";
-import { serializeSetCookie, validateCookieName } from "./internal/cookie-serialize.js";
+import { validateCookieAttributeValue, validateCookieName } from "./internal/cookie-serialize.js";
 import { parseEdgeRequestCookieHeader } from "../utils/parse-cookie.js";
 import { getRequestExecutionContext } from "./request-context.js";
 import { assertSafeNavigationUrl } from "./url-safety.js";
@@ -804,15 +804,16 @@ export function sealRequestCookies(cookies: RequestCookies): RequestCookies {
 export class ResponseCookies {
   private _headers: Headers;
   /** Internal map keyed by cookie name — single source of truth. */
-  private _parsed: Map<string, { serialized: string; entry: ResponseCookieEntry }> = new Map();
+  private _parsed: Map<string, ResponseCookieEntry> = new Map();
 
   constructor(headers: Headers) {
     this._headers = headers;
 
-    // Hydrate internal map from any existing Set-Cookie headers
-    for (const header of headers.getSetCookie()) {
+    const setCookie = headers.getSetCookie?.() ?? headers.get("set-cookie") ?? [];
+    const cookieStrings = Array.isArray(setCookie) ? setCookie : splitSetCookieString(setCookie);
+    for (const header of cookieStrings) {
       const entry = parseSetCookieHeader(header);
-      if (entry) this._parsed.set(entry.name, { serialized: header, entry });
+      if (entry) this._parsed.set(entry.name, entry);
     }
   }
 
@@ -825,28 +826,15 @@ export class ResponseCookies {
     validateCookieName(name);
 
     const entry = normalizeResponseCookie(name, value, opts);
-    const sameSite =
-      entry.sameSite === true
-        ? "Strict"
-        : typeof entry.sameSite === "string"
-          ? ((entry.sameSite[0].toUpperCase() + entry.sameSite.slice(1)) as
-              | "Strict"
-              | "Lax"
-              | "None")
-          : undefined;
-    const serialized = serializeSetCookie(name, value, {
-      ...entry,
-      expires: typeof entry.expires === "number" ? new Date(entry.expires) : entry.expires,
-      sameSite,
-    });
-    this._parsed.set(name, { serialized, entry });
+    validateResponseCookieAttributes(entry);
+    this._parsed.set(name, entry);
     this._syncHeaders();
     return this;
   }
 
   get(...args: [name: string] | [options: { name: string }]): ResponseCookieEntry | undefined {
     const key = typeof args[0] === "string" ? args[0] : args[0].name;
-    return this._parsed.get(key)?.entry;
+    return this._parsed.get(key);
   }
 
   has(name: string): boolean {
@@ -854,7 +842,7 @@ export class ResponseCookies {
   }
 
   getAll(...args: [name: string] | [options: { name: string }] | []): ResponseCookieEntry[] {
-    const all = [...this._parsed.values()].map((v) => v.entry);
+    const all = [...this._parsed.values()];
     if (args.length === 0) return all;
     const key = typeof args[0] === "string" ? args[0] : args[0].name;
     return all.filter((c) => c.name === key);
@@ -865,35 +853,26 @@ export class ResponseCookies {
       | [name: string]
       | [options: Omit<CookieOptions & { name: string }, "maxAge" | "expires">]
   ): this {
-    const [name, opts] =
+    const [name, options] =
       typeof args[0] === "string" ? [args[0], undefined] : [args[0].name, args[0]];
-    return this.set({
-      name,
-      value: "",
-      expires: new Date(0),
-      path: opts?.path,
-      domain: opts?.domain,
-      httpOnly: opts?.httpOnly,
-      secure: opts?.secure,
-      sameSite: opts?.sameSite,
-    });
+    return this.set({ ...options, name, value: "", expires: new Date(0) });
   }
 
   [Symbol.iterator](): MapIterator<[string, ResponseCookieEntry]> {
     return new Map(
-      [...this._parsed.values()].map(({ entry }) => [entry.name, entry] as const),
+      [...this._parsed.values()].map((entry) => [entry.name, entry] as const),
     ).entries();
   }
 
   toString(): string {
-    return [...this._parsed.values()].map(({ serialized }) => serialized).join("; ");
+    return [...this._parsed.values()].map(stringifyResponseCookie).join("; ");
   }
 
   /** Delete all Set-Cookie headers and re-append from the internal map. */
   private _syncHeaders(): void {
     this._headers.delete("Set-Cookie");
-    for (const { serialized } of this._parsed.values()) {
-      this._headers.append("Set-Cookie", serialized);
+    for (const entry of this._parsed.values()) {
+      this._headers.append("Set-Cookie", stringifyResponseCookie(entry));
     }
   }
 }
@@ -949,24 +928,17 @@ type CookieOptions = {
   priority?: "low" | "medium" | "high";
 };
 
-type ResponseCookieEntry = CookieEntry &
-  Omit<CookieOptions, "sameSite"> & {
-    sameSite?: true | false | "strict" | "lax" | "none";
-  };
+type ResponseCookieEntry = CookieEntry & CookieOptions;
 
 function normalizeResponseCookie(
   name: string,
   value: string,
   options?: CookieOptions,
 ): ResponseCookieEntry {
-  const { sameSite, ...rest } = options ?? {};
-  const normalizedSameSite =
-    typeof sameSite === "string" ? (sameSite.toLowerCase() as "strict" | "lax" | "none") : sameSite;
   const cookie: ResponseCookieEntry = {
     name,
     value,
-    ...rest,
-    ...(normalizedSameSite !== undefined && { sameSite: normalizedSameSite }),
+    ...options,
   };
   if (typeof cookie.expires === "number") {
     cookie.expires = new Date(cookie.expires);
@@ -981,79 +953,133 @@ function normalizeResponseCookie(
 }
 
 function parseSetCookieHeader(header: string): ResponseCookieEntry | undefined {
-  const [nameValue, ...attributes] = header.split(/;\s*/);
-  const separator = nameValue.indexOf("=");
-  if (separator === -1) return undefined;
+  if (!header) return undefined;
 
-  const name = nameValue.slice(0, separator).trim();
-  if (!name) return undefined;
-
-  const cookie: ResponseCookieEntry = {
+  const [[name, value], ...attributes] = parseResponseCookiePairs(header);
+  const { domain, expires, httponly, maxage, path, samesite, secure, partitioned, priority } =
+    Object.fromEntries(
+      attributes.map(([key, attributeValue]) => [
+        key.toLowerCase().replaceAll("-", ""),
+        attributeValue,
+      ]),
+    );
+  const cookie = {
     name,
-    value: decodeCookieComponent(nameValue.slice(separator + 1)),
+    value: decodeURIComponent(value),
+    domain,
+    ...(expires && { expires: new Date(expires) }),
+    ...(httponly && { httpOnly: true }),
+    ...(typeof maxage === "string" && { maxAge: Number(maxage) }),
+    path,
+    ...(samesite && { sameSite: parseResponseCookieSameSite(samesite) }),
+    ...(secure && { secure: true }),
+    ...(priority && { priority: parseResponseCookiePriority(priority) }),
+    ...(partitioned && { partitioned: true }),
   };
 
-  for (const attribute of attributes) {
-    const attributeSeparator = attribute.indexOf("=");
-    const key = (attributeSeparator === -1 ? attribute : attribute.slice(0, attributeSeparator))
-      .trim()
-      .toLowerCase()
-      .replaceAll("-", "");
-    const value =
-      attributeSeparator === -1
-        ? undefined
-        : decodeCookieComponent(attribute.slice(attributeSeparator + 1).trim());
+  return compactResponseCookie(cookie) as ResponseCookieEntry;
+}
 
-    switch (key) {
-      case "domain":
-        if (value) cookie.domain = value;
-        break;
-      case "expires":
-        if (value) cookie.expires = new Date(value);
-        break;
-      case "httponly":
-        cookie.httpOnly = true;
-        break;
-      case "maxage": {
-        const maxAge = Number(value);
-        if (maxAge) cookie.maxAge = maxAge;
-        break;
+function parseResponseCookiePairs(cookie: string): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const pair of cookie.split(/; */)) {
+    if (!pair) continue;
+    const splitAt = pair.indexOf("=");
+    if (splitAt === -1) {
+      map.set(pair, "true");
+      continue;
+    }
+    const key = pair.slice(0, splitAt);
+    const value = pair.slice(splitAt + 1);
+    try {
+      map.set(key, decodeURIComponent(value ?? "true"));
+    } catch {
+      // Match @edge-runtime/cookies: ignore malformed encoded pairs.
+    }
+  }
+  return map;
+}
+
+function compactResponseCookie<T extends object>(cookie: T): T {
+  const compact = {} as T;
+  for (const key in cookie) {
+    if (cookie[key]) compact[key] = cookie[key];
+  }
+  return compact;
+}
+
+function parseResponseCookieSameSite(value: string): CookieOptions["sameSite"] {
+  const sameSite = value.toLowerCase();
+  return sameSite === "strict" || sameSite === "lax" || sameSite === "none" ? sameSite : undefined;
+}
+
+function parseResponseCookiePriority(value: string): CookieOptions["priority"] {
+  const priority = value.toLowerCase();
+  return priority === "low" || priority === "medium" || priority === "high" ? priority : undefined;
+}
+
+function validateResponseCookieAttributes(cookie: ResponseCookieEntry): void {
+  if (cookie.path) validateCookieAttributeValue(cookie.path, "Path");
+  if (cookie.domain) validateCookieAttributeValue(cookie.domain, "Domain");
+}
+
+function stringifyResponseCookie(cookie: ResponseCookieEntry): string {
+  const attributes = [
+    cookie.path && `Path=${cookie.path}`,
+    (cookie.expires || cookie.expires === 0) &&
+      `Expires=${(typeof cookie.expires === "number" ? new Date(cookie.expires) : cookie.expires).toUTCString()}`,
+    typeof cookie.maxAge === "number" && `Max-Age=${cookie.maxAge}`,
+    cookie.domain && `Domain=${cookie.domain}`,
+    cookie.secure && "Secure",
+    cookie.httpOnly && "HttpOnly",
+    cookie.sameSite && `SameSite=${cookie.sameSite}`,
+    cookie.partitioned && "Partitioned",
+    cookie.priority && `Priority=${cookie.priority}`,
+  ].filter(Boolean);
+  const stringified = `${cookie.name}=${encodeURIComponent(cookie.value ?? "")}`;
+  return attributes.length === 0 ? stringified : `${stringified}; ${attributes.join("; ")}`;
+}
+
+function splitSetCookieString(value: string): string[] {
+  const cookies: string[] = [];
+  let position = 0;
+  let start = 0;
+
+  const skipWhitespace = (): boolean => {
+    while (position < value.length && /\s/.test(value.charAt(position))) position++;
+    return position < value.length;
+  };
+
+  while (position < value.length) {
+    start = position;
+    let separatorFound = false;
+
+    while (skipWhitespace()) {
+      if (value.charAt(position) !== ",") {
+        position++;
+        continue;
       }
-      case "path":
-        if (value) cookie.path = value;
-        break;
-      case "samesite": {
-        const sameSite = value?.toLowerCase();
-        if (sameSite === "strict" || sameSite === "lax" || sameSite === "none") {
-          cookie.sameSite = sameSite;
-        }
-        break;
+
+      const lastComma = position++;
+      skipWhitespace();
+      const nextStart = position;
+      while (position < value.length && !"=;,".includes(value.charAt(position))) position++;
+      if (position < value.length && value.charAt(position) === "=") {
+        separatorFound = true;
+        position = nextStart;
+        cookies.push(value.substring(start, lastComma));
+        start = position;
+      } else {
+        position = lastComma + 1;
       }
-      case "secure":
-        cookie.secure = true;
-        break;
-      case "partitioned":
-        cookie.partitioned = true;
-        break;
-      case "priority": {
-        const priority = value?.toLowerCase();
-        if (priority === "low" || priority === "medium" || priority === "high") {
-          cookie.priority = priority;
-        }
-        break;
-      }
+    }
+
+    if (!separatorFound || position >= value.length) {
+      cookies.push(value.substring(start));
     }
   }
 
-  return cookie;
-}
-
-function decodeCookieComponent(value: string): string {
-  try {
-    return decodeURIComponent(value);
-  } catch {
-    return value;
-  }
+  return cookies;
 }
 
 /**

--- a/packages/vinext/src/shims/server.ts
+++ b/packages/vinext/src/shims/server.ts
@@ -804,25 +804,15 @@ export function sealRequestCookies(cookies: RequestCookies): RequestCookies {
 export class ResponseCookies {
   private _headers: Headers;
   /** Internal map keyed by cookie name — single source of truth. */
-  private _parsed: Map<string, { serialized: string; entry: CookieEntry }> = new Map();
+  private _parsed: Map<string, { serialized: string; entry: ResponseCookieEntry }> = new Map();
 
   constructor(headers: Headers) {
     this._headers = headers;
 
     // Hydrate internal map from any existing Set-Cookie headers
     for (const header of headers.getSetCookie()) {
-      const eq = header.indexOf("=");
-      if (eq === -1) continue;
-      const cookieName = header.slice(0, eq);
-      const semi = header.indexOf(";", eq);
-      const raw = header.slice(eq + 1, semi === -1 ? undefined : semi);
-      let value: string;
-      try {
-        value = decodeURIComponent(raw);
-      } catch {
-        value = raw;
-      }
-      this._parsed.set(cookieName, { serialized: header, entry: { name: cookieName, value } });
+      const entry = parseSetCookieHeader(header);
+      if (entry) this._parsed.set(entry.name, { serialized: header, entry });
     }
   }
 
@@ -834,23 +824,27 @@ export class ResponseCookies {
     const [name, value, opts] = parseCookieSetArgs(args);
     validateCookieName(name);
 
+    const entry = normalizeResponseCookie(name, value, opts);
     const sameSite =
-      opts?.sameSite === true
+      entry.sameSite === true
         ? "Strict"
-        : typeof opts?.sameSite === "string"
-          ? ((opts.sameSite[0].toUpperCase() + opts.sameSite.slice(1)) as "Strict" | "Lax" | "None")
+        : typeof entry.sameSite === "string"
+          ? ((entry.sameSite[0].toUpperCase() + entry.sameSite.slice(1)) as
+              | "Strict"
+              | "Lax"
+              | "None")
           : undefined;
     const serialized = serializeSetCookie(name, value, {
-      ...opts,
-      expires: typeof opts?.expires === "number" ? new Date(opts.expires) : opts?.expires,
+      ...entry,
+      expires: typeof entry.expires === "number" ? new Date(entry.expires) : entry.expires,
       sameSite,
     });
-    this._parsed.set(name, { serialized, entry: { name, value } });
+    this._parsed.set(name, { serialized, entry });
     this._syncHeaders();
     return this;
   }
 
-  get(...args: [name: string] | [options: { name: string }]): CookieEntry | undefined {
+  get(...args: [name: string] | [options: { name: string }]): ResponseCookieEntry | undefined {
     const key = typeof args[0] === "string" ? args[0] : args[0].name;
     return this._parsed.get(key)?.entry;
   }
@@ -859,7 +853,7 @@ export class ResponseCookies {
     return this._parsed.has(name);
   }
 
-  getAll(...args: [name: string] | [options: { name: string }] | []): CookieEntry[] {
+  getAll(...args: [name: string] | [options: { name: string }] | []): ResponseCookieEntry[] {
     const all = [...this._parsed.values()].map((v) => v.entry);
     if (args.length === 0) return all;
     const key = typeof args[0] === "string" ? args[0] : args[0].name;
@@ -885,10 +879,14 @@ export class ResponseCookies {
     });
   }
 
-  [Symbol.iterator](): MapIterator<[string, CookieEntry]> {
+  [Symbol.iterator](): MapIterator<[string, ResponseCookieEntry]> {
     return new Map(
       [...this._parsed.values()].map(({ entry }) => [entry.name, entry] as const),
     ).entries();
+  }
+
+  toString(): string {
+    return [...this._parsed.values()].map(({ serialized }) => serialized).join("; ");
   }
 
   /** Delete all Set-Cookie headers and re-append from the internal map. */
@@ -950,6 +948,113 @@ type CookieOptions = {
   partitioned?: boolean;
   priority?: "low" | "medium" | "high";
 };
+
+type ResponseCookieEntry = CookieEntry &
+  Omit<CookieOptions, "sameSite"> & {
+    sameSite?: true | false | "strict" | "lax" | "none";
+  };
+
+function normalizeResponseCookie(
+  name: string,
+  value: string,
+  options?: CookieOptions,
+): ResponseCookieEntry {
+  const { sameSite, ...rest } = options ?? {};
+  const normalizedSameSite =
+    typeof sameSite === "string" ? (sameSite.toLowerCase() as "strict" | "lax" | "none") : sameSite;
+  const cookie: ResponseCookieEntry = {
+    name,
+    value,
+    ...rest,
+    ...(normalizedSameSite !== undefined && { sameSite: normalizedSameSite }),
+  };
+  if (typeof cookie.expires === "number") {
+    cookie.expires = new Date(cookie.expires);
+  }
+  if (cookie.maxAge) {
+    cookie.expires = new Date(Date.now() + cookie.maxAge * 1000);
+  }
+  if (cookie.path == null) {
+    cookie.path = "/";
+  }
+  return cookie;
+}
+
+function parseSetCookieHeader(header: string): ResponseCookieEntry | undefined {
+  const [nameValue, ...attributes] = header.split(/;\s*/);
+  const separator = nameValue.indexOf("=");
+  if (separator === -1) return undefined;
+
+  const name = nameValue.slice(0, separator).trim();
+  if (!name) return undefined;
+
+  const cookie: ResponseCookieEntry = {
+    name,
+    value: decodeCookieComponent(nameValue.slice(separator + 1)),
+  };
+
+  for (const attribute of attributes) {
+    const attributeSeparator = attribute.indexOf("=");
+    const key = (attributeSeparator === -1 ? attribute : attribute.slice(0, attributeSeparator))
+      .trim()
+      .toLowerCase()
+      .replaceAll("-", "");
+    const value =
+      attributeSeparator === -1
+        ? undefined
+        : decodeCookieComponent(attribute.slice(attributeSeparator + 1).trim());
+
+    switch (key) {
+      case "domain":
+        if (value) cookie.domain = value;
+        break;
+      case "expires":
+        if (value) cookie.expires = new Date(value);
+        break;
+      case "httponly":
+        cookie.httpOnly = true;
+        break;
+      case "maxage": {
+        const maxAge = Number(value);
+        if (maxAge) cookie.maxAge = maxAge;
+        break;
+      }
+      case "path":
+        if (value) cookie.path = value;
+        break;
+      case "samesite": {
+        const sameSite = value?.toLowerCase();
+        if (sameSite === "strict" || sameSite === "lax" || sameSite === "none") {
+          cookie.sameSite = sameSite;
+        }
+        break;
+      }
+      case "secure":
+        cookie.secure = true;
+        break;
+      case "partitioned":
+        cookie.partitioned = true;
+        break;
+      case "priority": {
+        const priority = value?.toLowerCase();
+        if (priority === "low" || priority === "medium" || priority === "high") {
+          cookie.priority = priority;
+        }
+        break;
+      }
+    }
+  }
+
+  return cookie;
+}
+
+function decodeCookieComponent(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
 
 /**
  * Parse the overloaded arguments for ResponseCookies.set():

--- a/packages/vinext/src/shims/server.ts
+++ b/packages/vinext/src/shims/server.ts
@@ -923,7 +923,7 @@ type CookieOptions = {
   expires?: Date | number;
   httpOnly?: boolean;
   secure?: boolean;
-  sameSite?: true | false | "strict" | "lax" | "none" | "Strict" | "Lax" | "None";
+  sameSite?: true | false | "strict" | "lax" | "none";
   partitioned?: boolean;
   priority?: "low" | "medium" | "high";
 };

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -9397,7 +9397,7 @@ describe("ResponseCookies API", () => {
 
     cookies.set("token", "xyz");
     const result = cookies.get("token");
-    expect(result).toEqual({ name: "token", value: "xyz" });
+    expect(result).toEqual({ name: "token", value: "xyz", path: "/" });
   });
 
   it("getAll() returns all set cookies", async () => {
@@ -9411,9 +9411,9 @@ describe("ResponseCookies API", () => {
 
     const all = cookies.getAll();
     expect(all).toHaveLength(3);
-    expect(all).toContainEqual({ name: "a", value: "1" });
-    expect(all).toContainEqual({ name: "b", value: "2" });
-    expect(all).toContainEqual({ name: "c", value: "3" });
+    expect(all).toContainEqual({ name: "a", value: "1", path: "/" });
+    expect(all).toContainEqual({ name: "b", value: "2", path: "/" });
+    expect(all).toContainEqual({ name: "c", value: "3", path: "/" });
   });
 
   it("has() checks whether a response cookie exists", async () => {
@@ -9467,9 +9467,9 @@ describe("ResponseCookies API", () => {
     const entries = [...cookies];
     expect(entries).toHaveLength(2);
     expect(entries[0][0]).toBe("x");
-    expect(entries[0][1]).toEqual({ name: "x", value: "1" });
+    expect(entries[0][1]).toEqual({ name: "x", value: "1", path: "/" });
     expect(entries[1][0]).toBe("y");
-    expect(entries[1][1]).toEqual({ name: "y", value: "2" });
+    expect(entries[1][1]).toEqual({ name: "y", value: "2", path: "/" });
   });
 
   it("set() with domain option includes Domain directive", async () => {
@@ -9591,7 +9591,7 @@ describe("ResponseCookies correctness", () => {
 
     const filtered = cookies.getAll("b");
     expect(filtered).toHaveLength(1);
-    expect(filtered[0]).toEqual({ name: "b", value: "2" });
+    expect(filtered[0]).toEqual({ name: "b", value: "2", path: "/" });
   });
 
   it("getAll({ name }) filters by cookie name (object form)", async () => {
@@ -9604,7 +9604,7 @@ describe("ResponseCookies correctness", () => {
 
     const filtered = cookies.getAll({ name: "x" });
     expect(filtered).toHaveLength(1);
-    expect(filtered[0]).toEqual({ name: "x", value: "10" });
+    expect(filtered[0]).toEqual({ name: "x", value: "10", path: "/" });
   });
 
   it("getAll() with no args returns all cookies", async () => {
@@ -9693,6 +9693,83 @@ describe("ResponseCookies correctness", () => {
     const cookies = new ResponseCookies(headers);
     const result = cookies.get("existing");
     expect(result?.value).toBe("value");
+  });
+
+  it("get() and getAll() retain response cookie attributes", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+
+    try {
+      const { ResponseCookies } = await import("../packages/vinext/src/shims/server.js");
+      const cookies = new ResponseCookies(new Headers());
+
+      cookies.set("session", "abc", {
+        path: "/admin",
+        domain: "example.com",
+        maxAge: 60,
+        httpOnly: true,
+        secure: true,
+        sameSite: "lax",
+        partitioned: true,
+        priority: "high",
+      });
+
+      const expected = {
+        name: "session",
+        value: "abc",
+        path: "/admin",
+        domain: "example.com",
+        maxAge: 60,
+        expires: new Date("2026-01-01T00:01:00.000Z"),
+        httpOnly: true,
+        secure: true,
+        sameSite: "lax",
+        partitioned: true,
+        priority: "high",
+      };
+      expect(cookies.get("session")).toEqual(expected);
+      expect(cookies.getAll()).toEqual([expected]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("constructor retains attributes from existing Set-Cookie headers", async () => {
+    const { ResponseCookies } = await import("../packages/vinext/src/shims/server.js");
+    const headers = new Headers();
+    headers.append(
+      "Set-Cookie",
+      "session=hello%20world; Path=/admin; Domain=example.com; Max-Age=60; " +
+        "Expires=Thu, 01 Jan 2026 00:01:00 GMT; HttpOnly; Secure; SameSite=Lax; " +
+        "Partitioned; Priority=High",
+    );
+
+    const cookies = new ResponseCookies(headers);
+
+    expect(cookies.get("session")).toEqual({
+      name: "session",
+      value: "hello world",
+      path: "/admin",
+      domain: "example.com",
+      maxAge: 60,
+      expires: new Date("2026-01-01T00:01:00.000Z"),
+      httpOnly: true,
+      secure: true,
+      sameSite: "lax",
+      partitioned: true,
+      priority: "high",
+    });
+  });
+
+  it("toString() serializes all response cookies", async () => {
+    const { ResponseCookies } = await import("../packages/vinext/src/shims/server.js");
+    const headers = new Headers();
+    const cookies = new ResponseCookies(headers);
+
+    cookies.set("a", "1");
+    cookies.set("b", "two words", { httpOnly: true });
+
+    expect(cookies.toString()).toBe(headers.getSetCookie().join("; "));
   });
 
   // has() should work with internal map

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -4701,10 +4701,10 @@ describe("next/server shim", () => {
     res.cookies.set("session", "abc", { partitioned: true, priority: "medium" });
 
     expect(res.headers.getSetCookie()).toEqual([
-      "session=abc; Path=/; Partitioned; Priority=Medium",
+      "session=abc; Path=/; Partitioned; Priority=medium",
     ]);
     expect(res.headers.get("x-middleware-set-cookie")).toBe(
-      "session=abc; Path=/; Partitioned; Priority=Medium",
+      "session=abc; Path=/; Partitioned; Priority=medium",
     );
   });
 
@@ -9766,10 +9766,86 @@ describe("ResponseCookies correctness", () => {
     const headers = new Headers();
     const cookies = new ResponseCookies(headers);
 
-    cookies.set("a", "1");
-    cookies.set("b", "two words", { httpOnly: true });
+    cookies.set("first-name", "first-value", {
+      domain: "custom-domain",
+      path: "custom-path",
+      secure: true,
+      sameSite: "strict",
+      expires: new Date(0),
+      httpOnly: true,
+      maxAge: 0,
+      priority: "high",
+      partitioned: true,
+    });
 
-    expect(cookies.toString()).toBe(headers.getSetCookie().join("; "));
+    // Ported from @edge-runtime/cookies:
+    // packages/cookies/test/response-cookies.test.ts
+    // https://github.com/vercel/edge-runtime/blob/main/packages/cookies/test/response-cookies.test.ts
+    const expected =
+      "first-name=first-value; Path=custom-path; " +
+      "Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Domain=custom-domain; " +
+      "Secure; HttpOnly; SameSite=strict; Partitioned; Priority=high";
+    expect(cookies.toString()).toBe(expected);
+    expect(headers.getSetCookie()).toEqual([expected]);
+  });
+
+  it("uses parsed cookie entries as the serialization source of truth", async () => {
+    const { ResponseCookies } = await import("../packages/vinext/src/shims/server.js");
+    const headers = new Headers({
+      "Set-Cookie": "session=old; HttpOnly; Secure; SameSite=Lax; Priority=High",
+    });
+    const cookies = new ResponseCookies(headers);
+
+    const session = cookies.get("session");
+    expect(session).toBeDefined();
+    session!.value = "updated";
+
+    expect(cookies.toString()).toBe(
+      "session=updated; Secure; HttpOnly; SameSite=lax; Priority=high",
+    );
+
+    cookies.set("other", "2");
+    expect(headers.getSetCookie()).toEqual([
+      "session=updated; Secure; HttpOnly; SameSite=lax; Priority=high",
+      "other=2; Path=/",
+    ]);
+  });
+
+  it("matches Next.js double decoding for existing response-cookie values", async () => {
+    const { ResponseCookies } = await import("../packages/vinext/src/shims/server.js");
+    const cookies = new ResponseCookies(new Headers({ "Set-Cookie": "encoded=%252F" }));
+
+    expect(cookies.get("encoded")?.value).toBe("/");
+    expect(cookies.toString()).toBe("encoded=%2F");
+  });
+
+  it("falls back to splitting a joined Set-Cookie header", async () => {
+    const { ResponseCookies } = await import("../packages/vinext/src/shims/server.js");
+    const headers = {
+      get(name: string) {
+        return name.toLowerCase() === "set-cookie"
+          ? "a=1; Expires=Thu, 01 Jan 2026 00:00:00 GMT, b=2; Secure"
+          : null;
+      },
+    } as Headers;
+
+    const cookies = new ResponseCookies(headers);
+    expect(cookies.getAll()).toEqual([
+      { name: "a", value: "1", expires: new Date("2026-01-01T00:00:00.000Z") },
+      { name: "b", value: "2", secure: true },
+    ]);
+  });
+
+  it("delete() preserves partitioned and priority options", async () => {
+    const { ResponseCookies } = await import("../packages/vinext/src/shims/server.js");
+    const headers = new Headers();
+    const cookies = new ResponseCookies(headers);
+
+    cookies.delete({ name: "session", partitioned: true, priority: "high" });
+
+    expect(headers.getSetCookie()).toEqual([
+      "session=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Partitioned; Priority=high",
+    ]);
   });
 
   // has() should work with internal map

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -9362,7 +9362,7 @@ describe("ResponseCookies API", () => {
       path: "/",
       httpOnly: true,
       secure: true,
-      sameSite: "Lax",
+      sameSite: "lax",
       maxAge: 3600,
     });
 
@@ -9372,7 +9372,7 @@ describe("ResponseCookies API", () => {
     expect(setCookie[0]).toContain("Path=/");
     expect(setCookie[0]).toContain("HttpOnly");
     expect(setCookie[0]).toContain("Secure");
-    expect(setCookie[0]).toContain("SameSite=Lax");
+    expect(setCookie[0]).toContain("SameSite=lax");
     expect(setCookie[0]).toContain("Max-Age=3600");
   });
 
@@ -9657,14 +9657,14 @@ describe("ResponseCookies correctness", () => {
       path: "/app",
       httpOnly: true,
       secure: true,
-      sameSite: "Lax",
+      sameSite: "lax",
     });
 
     const setCookie = headers.getSetCookie();
     expect(setCookie).toHaveLength(1);
     expect(setCookie[0]).toContain("HttpOnly");
     expect(setCookie[0]).toContain("Secure");
-    expect(setCookie[0]).toContain("SameSite=Lax");
+    expect(setCookie[0]).toContain("SameSite=lax");
     expect(setCookie[0]).toContain("Path=/app");
     expect(setCookie[0]).toContain("Expires=");
   });


### PR DESCRIPTION
## Summary

- retain `path`, `domain`, `expires`, `maxAge`, `httpOnly`, `secure`, `sameSite`, `partitioned`, and `priority` metadata in `ResponseCookies.get()` and `getAll()`
- parse the same metadata when constructing `ResponseCookies` from existing `Set-Cookie` headers
- add the missing `ResponseCookies.toString()` implementation
- normalize default paths, `maxAge` expiry, and returned `sameSite` values to match Next.js

## Upstream parity

Next.js stores and returns the full response-cookie object, parses existing `Set-Cookie` attributes, and serializes the cookie map from `toString()`:
https://github.com/vercel/next.js/blob/491f78099c3ea23be14e66c6d848b50204590e90/packages/next/src/compiled/@edge-runtime/cookies/index.js#L253-L330

Before this change, vinext discarded every attribute after serialization and `cookies.toString()` returned `[object Object]`. That could silently remove security attributes when application code reads a cookie and writes it again.

## Tests

- `pnpm run check`
- `pnpm test tests/shims.test.ts -t "ResponseCookies"` (34 passed)
- `pnpm test tests/shims.test.ts` (1,232 passed; one unrelated existing Windows subprocess assertion failed in `next/error shim > allows the upstream CustomError static getInitialProps override` because `spawnSync` returned null output)