### PR TITLE
test(types): run tsc portably on Windows

### DIFF
--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -22787,7 +22787,9 @@ describe("next/error shim", () => {
     // https://github.com/vercel/next.js/blob/v16.3.0-canary.80/test/e2e/typescript/pages/_error.tsx
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "vinext-next-error-types-"));
     const fixturePath = path.join(tempDir, "_error.tsx");
-    const declarationPath = new URL("../packages/types/next/index.d.ts", import.meta.url).pathname;
+    const declarationPath = fileURLToPath(
+      new URL("../packages/types/next/index.d.ts", import.meta.url),
+    );
 
     try {
       await writeFile(
@@ -22810,8 +22812,9 @@ export default CustomError;
         new URL("bin/tsc", import.meta.resolve("typescript/package.json")),
       );
       const result = spawnSync(
-        tscPath,
+        process.execPath,
         [
+          tscPath,
           fixturePath,
           declarationPath,
           "--ignoreConfig",
@@ -22831,6 +22834,7 @@ export default CustomError;
         { encoding: "utf8" },
       );
 
+      expect(result.error).toBeUndefined();
       expect(result.stdout + result.stderr).toBe("");
       expect(result.status).toBe(0);
     } finally {


### PR DESCRIPTION
## Summary

- launch TypeScript's JavaScript CLI through `process.execPath` instead of executing `bin/tsc` as a native binary
- convert the vendored declaration URL with `fileURLToPath` so its path is valid on Windows
- assert subprocess launch errors directly for clearer failures

## Problem

The `next/error` type-contract test passed on POSIX because `bin/tsc` has a shebang, but `spawnSync()` could not execute that JavaScript file directly on Windows. Its null output then produced the opaque assertion `expected NaN to be ""` and made the complete shim suite fail locally.

## Tests

- `pnpm test tests/shims.test.ts -t "allows the upstream CustomError static getInitialProps override"`
- `pnpm test tests/shims.test.ts` (1,230 passed on Windows)
- `pnpm run check`