### PR TITLE
feat(web): classify compatibility suite support

### DIFF
--- a/apps/web/app/compatibility/compatibility-line-chart.tsx
+++ b/apps/web/app/compatibility/compatibility-line-chart.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 /**
- * Pass-rate over time. One point per recorded run, oldest left to newest right.
- * Pure SVG — no ECharts dependency. Hover shows date + pass rate.
+ * Supported-surface and overall pass rates over time. One point per recorded
+ * run, oldest left to newest right. Pure SVG — no ECharts dependency.
  *
  * The chart respects a router filter, owned by the parent (CompatibilityViews).
  * Each TrendPoint carries per-router rollups (`all` / `app` / `pages` / `both`
@@ -22,6 +22,8 @@ type SeriesCounts = {
   passed: number;
   failed: number;
   skipped: number;
+  supportedPassed: number;
+  supportedFailed: number;
 };
 
 export type TrendPoint = {
@@ -61,18 +63,16 @@ function formatDateTime(ms: number): string {
 }
 
 /**
- * Pass rate as a 0..1 ratio (NOT a percentage). Excludes skipped tests:
- * skipped → "not relevant", not "failure". Denominator is passed + failed
- * (the tests that actually ran a verdict). Returns 0 when nothing ran
- * (rather than NaN).
+ * Pass rate as a 0..1 ratio (NOT a percentage). Excludes skipped tests and
+ * returns 0 when nothing ran (rather than NaN).
  *
  * Distinct name from `bucketPassRate` (in router-buckets.ts) which returns
  * 0..100 — the chart needs a ratio for plotting Y coordinates, while the
  * stat cards need a percentage for display.
  */
-function computePassRateRatio(c: SeriesCounts): number {
-  const denom = c.passed + c.failed;
-  return denom > 0 ? c.passed / denom : 0;
+function computePassRateRatio(passed: number, failed: number): number {
+  const denom = passed + failed;
+  return denom > 0 ? passed / denom : 0;
 }
 
 export function CompatibilityLineChart({
@@ -88,14 +88,18 @@ export function CompatibilityLineChart({
 }) {
   const [hover, setHover] = useState<{ index: number; x: number; y: number } | null>(null);
 
-  // Reduce TrendPoint → { createdAt, counts, passRate } for the selected
-  // filter. Recomputed when filter changes, but that's a cheap O(n) over
-  // ≤90 points so no measurable cost.
+  // Reduce TrendPoint to both pass-rate definitions for the selected router.
+  // Recomputed when filter changes, but that's a cheap O(n) over <=90 points.
   const series = useMemo(
     () =>
       points.map((p) => {
         const counts = p.byRouter[filter];
-        return { createdAt: p.createdAt, counts, passRate: computePassRateRatio(counts) };
+        return {
+          createdAt: p.createdAt,
+          counts,
+          overallPassRate: computePassRateRatio(counts.passed, counts.failed),
+          supportedPassRate: computePassRateRatio(counts.supportedPassed, counts.supportedFailed),
+        };
       }),
     [points, filter],
   );
@@ -113,8 +117,9 @@ export function CompatibilityLineChart({
         series.length === 1
           ? PADDING.left + plotW / 2
           : PADDING.left + ((p.createdAt - minX) / xRange) * plotW;
-      const y = PADDING.top + (1 - p.passRate) * plotH;
-      return { x, y, index: i };
+      const overallY = PADDING.top + (1 - p.overallPassRate) * plotH;
+      const supportedY = PADDING.top + (1 - p.supportedPassRate) * plotH;
+      return { x, overallY, supportedY, index: i };
     });
     return { xy, minX, maxX, plotW, plotH };
   }, [series]);
@@ -127,7 +132,12 @@ export function CompatibilityLineChart({
     );
   }
 
-  const path = view.xy.map((p, i) => `${i === 0 ? "M" : "L"} ${p.x} ${p.y}`).join(" ");
+  const supportedPath = view.xy
+    .map((p, i) => `${i === 0 ? "M" : "L"} ${p.x} ${p.supportedY}`)
+    .join(" ");
+  const overallPath = view.xy
+    .map((p, i) => `${i === 0 ? "M" : "L"} ${p.x} ${p.overallY}`)
+    .join(" ");
 
   // Y-axis ticks at 0, 25, 50, 75, 100%.
   const yTicks = [0, 0.25, 0.5, 0.75, 1];
@@ -137,7 +147,7 @@ export function CompatibilityLineChart({
     <div className="relative">
       <svg
         role="img"
-        aria-label="Compatibility pass rate over time"
+        aria-label="Supported and overall compatibility pass rates over time"
         viewBox={`0 0 ${W} ${H}`}
         width="100%"
         style={{ maxWidth: "100%", display: "block" }}
@@ -190,20 +200,29 @@ export function CompatibilityLineChart({
             );
           })}
 
-        {/* Line */}
-        <path d={path} fill="none" stroke="#2da44e" strokeWidth={2} strokeLinejoin="round" />
+        {/* Overall raw rate, including deferred and out-of-scope files. */}
+        <path d={overallPath} fill="none" stroke="#0969da" strokeWidth={2} strokeLinejoin="round" />
+
+        {/* Supported-surface rate. */}
+        <path
+          d={supportedPath}
+          fill="none"
+          stroke="#2da44e"
+          strokeWidth={2}
+          strokeLinejoin="round"
+        />
 
         {/* Points */}
         {view.xy.map((p, i) => (
           <circle
             key={series[i].createdAt}
             cx={p.x}
-            cy={p.y}
+            cy={p.supportedY}
             r={4}
             fill="#2da44e"
             stroke="var(--color-kumo-base, #fff)"
             strokeWidth={1.5}
-            onMouseEnter={() => setHover({ index: i, x: p.x, y: p.y })}
+            onMouseEnter={() => setHover({ index: i, x: p.x, y: p.supportedY })}
             onMouseLeave={() => setHover(null)}
             style={{ cursor: "pointer" }}
           />
@@ -221,22 +240,37 @@ export function CompatibilityLineChart({
         >
           {(() => {
             const p = series[hover.index];
-            // Pass rate is computed against tests that ran a verdict, so
-            // the denominator the user sees should match: passed + failed.
-            const denom = p.counts.passed + p.counts.failed;
-            const parts = [`${p.counts.passed}/${denom} passed`];
-            if (p.counts.failed > 0) parts.push(`${p.counts.failed} failed`);
-            if (p.counts.skipped > 0) parts.push(`${p.counts.skipped} skipped`);
+            const supportedDenom = p.counts.supportedPassed + p.counts.supportedFailed;
+            const overallDenom = p.counts.passed + p.counts.failed;
             return (
               <>
-                <div className="font-medium">{(p.passRate * 100).toFixed(1)}% pass rate</div>
+                <div className="font-medium">
+                  {(p.supportedPassRate * 100).toFixed(1)}% supported
+                </div>
+                <div className="text-kumo-subtle">
+                  {p.counts.supportedPassed}/{supportedDenom} supported tests passed
+                </div>
+                <div className="mt-1 font-medium">
+                  {(p.overallPassRate * 100).toFixed(1)}% overall
+                </div>
+                <div className="text-kumo-subtle">
+                  {p.counts.passed}/{overallDenom} tests passed
+                  {p.counts.skipped > 0 ? `, ${p.counts.skipped} skipped` : ""}
+                </div>
                 <div className="mt-1 text-kumo-subtle">{formatDateTime(p.createdAt)}</div>
-                <div className="text-kumo-subtle">{parts.join(", ")}</div>
               </>
             );
           })()}
         </div>
       ) : null}
+      <div className="mt-2 flex flex-wrap items-center gap-4 text-xs text-kumo-subtle">
+        <span className="flex items-center gap-2">
+          <span className="h-0.5 w-5 bg-[#2da44e]" aria-hidden="true" /> Supported
+        </span>
+        <span className="flex items-center gap-2">
+          <span className="h-0.5 w-5 bg-[#0969da]" aria-hidden="true" /> Overall
+        </span>
+      </div>
     </div>
   );
 }

--- a/apps/web/app/compatibility/compatibility-views.tsx
+++ b/apps/web/app/compatibility/compatibility-views.tsx
@@ -17,8 +17,8 @@
 import { Tabs } from "@cloudflare/kumo/components/tabs";
 import { useMemo, useState } from "react";
 import { CompatibilityLineChart, type TrendPoint } from "./compatibility-line-chart";
-import { ContributionGrid, type GridCell } from "./contribution-grid";
-import { countByFilter, type RouterFilter } from "./router-buckets";
+import { CompatibilityTableDialog, ContributionGrid, type GridCell } from "./contribution-grid";
+import { cellMatchesFilter, countByFilter, type RouterFilter } from "./router-buckets";
 
 /**
  * Tab definitions for the router filter. Mirrors the bucket logic in
@@ -46,6 +46,10 @@ export function CompatibilityViews({ cells, trend }: { cells: GridCell[]; trend:
   // cells changes, not when filter changes. Counting rules (Mixed cells
   // counted toward both `app` and `pages`) live in ./router-buckets.
   const counts = useMemo(() => countByFilter(cells), [cells]);
+  const filteredCells = useMemo(
+    () => (filter === "all" ? cells : cells.filter((cell) => cellMatchesFilter(cell, filter))),
+    [cells, filter],
+  );
 
   const tabItems = useMemo(
     () =>
@@ -72,7 +76,10 @@ export function CompatibilityViews({ cells, trend }: { cells: GridCell[]; trend:
       </div>
 
       <section>
-        <h3 className="mb-3 text-sm font-medium text-kumo-subtle">Test files</h3>
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <h3 className="text-sm font-medium text-kumo-subtle">Test files</h3>
+          <CompatibilityTableDialog cells={filteredCells} />
+        </div>
         <ContributionGrid cells={cells} filter={filter} />
       </section>
 

--- a/apps/web/app/compatibility/contribution-grid.tsx
+++ b/apps/web/app/compatibility/contribution-grid.tsx
@@ -17,6 +17,10 @@
  * scaling, so tooltip positioning math stays straightforward.
  */
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { Button } from "@cloudflare/kumo/components/button";
+import { Dialog } from "@cloudflare/kumo/components/dialog";
+import { Table } from "@cloudflare/kumo/components/table";
+import { Table as TableIcon, X } from "@phosphor-icons/react";
 import type { FileStatus, RouterKind } from "@/app/lib/db/schema";
 import { cellMatchesFilter, type RouterFilter } from "./router-buckets";
 import type { SuiteSupportStatus } from "./suite-support";
@@ -64,6 +68,20 @@ const LABELS: Record<DisplayStatus, string> = {
   unsupported: "Unsupported by vinext",
 };
 
+const SUPPORT_LABELS: Record<SuiteSupportStatus, string> = {
+  supported: "Supported",
+  deferred: "Deferred",
+  "needs-vite-equivalent": "Needs Vite-equivalent coverage",
+  unsupported: "Unsupported by vinext",
+};
+
+const SUPPORT_COLORS: Record<SuiteSupportStatus, string> = {
+  supported: "#2da44e",
+  deferred: COLORS.deferred,
+  "needs-vite-equivalent": COLORS["needs-vite-equivalent"],
+  unsupported: COLORS.unsupported,
+};
+
 const LEGEND_ORDER: DisplayStatus[] = [
   "pass",
   "partial",
@@ -104,6 +122,100 @@ function summarize(cell: GridCell): string {
 
 function getDisplayStatus(cell: GridCell): DisplayStatus {
   return cell.supportStatus === "supported" ? cell.status : cell.supportStatus;
+}
+
+function CompatibilityTableDialog({ cells }: { cells: GridCell[] }) {
+  return (
+    <Dialog.Root>
+      <Dialog.Trigger
+        render={(props) => (
+          <Button
+            {...props}
+            size="sm"
+            variant="outline"
+            icon={TableIcon}
+            disabled={cells.length === 0}
+          >
+            View table
+          </Button>
+        )}
+      />
+      <Dialog
+        size="xl"
+        className="flex max-h-[90vh] w-[min(96vw,80rem)] max-w-none flex-col overflow-hidden p-0"
+      >
+        <div className="flex items-start justify-between gap-4 border-b border-kumo-hairline px-5 py-4">
+          <div>
+            <Dialog.Title className="text-xl font-semibold tracking-tight text-kumo-default">
+              Compatibility test files
+            </Dialog.Title>
+            <Dialog.Description className="mt-1 text-sm text-kumo-subtle">
+              Showing {cells.length} files for the current router filter. Classifications do not
+              alter the raw test results.
+            </Dialog.Description>
+          </div>
+          <Dialog.Close
+            render={(props) => (
+              <Button
+                {...props}
+                shape="square"
+                size="sm"
+                variant="ghost"
+                icon={X}
+                aria-label="Close compatibility table"
+              />
+            )}
+          />
+        </div>
+        <div className="min-h-0 overflow-auto">
+          <Table aria-label="Compatibility test files">
+            <Table.Header sticky>
+              <Table.Row>
+                <Table.Head>Test file</Table.Head>
+                <Table.Head>Classification</Table.Head>
+                <Table.Head>Feature</Table.Head>
+                <Table.Head>Raw result</Table.Head>
+                <Table.Head className="text-right">Passed</Table.Head>
+                <Table.Head className="text-right">Failed</Table.Head>
+                <Table.Head className="text-right">Skipped</Table.Head>
+              </Table.Row>
+            </Table.Header>
+            <Table.Body>
+              {cells.map((cell) => (
+                <Table.Row key={cell.suite}>
+                  <Table.Cell className="min-w-80 font-mono text-xs break-all">
+                    {cell.suite}
+                  </Table.Cell>
+                  <Table.Cell className="min-w-48">
+                    <div className="flex items-center gap-2">
+                      <span
+                        className="inline-block h-2.5 w-2.5 shrink-0 rounded-sm"
+                        style={{ backgroundColor: SUPPORT_COLORS[cell.supportStatus] }}
+                        aria-hidden="true"
+                      />
+                      <span className="text-sm font-medium">
+                        {SUPPORT_LABELS[cell.supportStatus]}
+                      </span>
+                    </div>
+                    {cell.reason ? (
+                      <div className="mt-1 max-w-72 text-xs text-kumo-subtle">{cell.reason}</div>
+                    ) : null}
+                  </Table.Cell>
+                  <Table.Cell className="min-w-56 text-sm">{cell.feature ?? "—"}</Table.Cell>
+                  <Table.Cell className="whitespace-nowrap text-sm">
+                    {LABELS[cell.status]}
+                  </Table.Cell>
+                  <Table.Cell className="text-right font-mono text-sm">{cell.passed}</Table.Cell>
+                  <Table.Cell className="text-right font-mono text-sm">{cell.failed}</Table.Cell>
+                  <Table.Cell className="text-right font-mono text-sm">{cell.skipped}</Table.Cell>
+                </Table.Row>
+              ))}
+            </Table.Body>
+          </Table>
+        </div>
+      </Dialog>
+    </Dialog.Root>
+  );
 }
 
 /**
@@ -211,6 +323,9 @@ export function ContributionGrid({
 
   return (
     <div ref={containerRef} className="relative w-full">
+      <div className="mb-3 flex justify-end">
+        <CompatibilityTableDialog cells={visibleCells} />
+      </div>
       {visibleCells.length === 0 ? (
         <div className="py-8 text-center text-sm text-kumo-subtle">
           No test files in this category.

--- a/apps/web/app/compatibility/contribution-grid.tsx
+++ b/apps/web/app/compatibility/contribution-grid.tsx
@@ -19,6 +19,8 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { Button } from "@cloudflare/kumo/components/button";
 import { Dialog } from "@cloudflare/kumo/components/dialog";
+import { Input } from "@cloudflare/kumo/components/input";
+import { Select } from "@cloudflare/kumo/components/select";
 import { Table } from "@cloudflare/kumo/components/table";
 import { Table as TableIcon, X } from "@phosphor-icons/react";
 import type { FileStatus, RouterKind } from "@/app/lib/db/schema";
@@ -124,7 +126,26 @@ function getDisplayStatus(cell: GridCell): DisplayStatus {
   return cell.supportStatus === "supported" ? cell.status : cell.supportStatus;
 }
 
-function CompatibilityTableDialog({ cells }: { cells: GridCell[] }) {
+type SupportFilter = "all" | SuiteSupportStatus;
+type ResultFilter = "all" | FileStatus;
+
+export function CompatibilityTableDialog({ cells }: { cells: GridCell[] }) {
+  const [query, setQuery] = useState("");
+  const [supportFilter, setSupportFilter] = useState<SupportFilter>("all");
+  const [resultFilter, setResultFilter] = useState<ResultFilter>("all");
+  const filteredCells = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    return cells.filter((cell) => {
+      if (supportFilter !== "all" && cell.supportStatus !== supportFilter) return false;
+      if (resultFilter !== "all" && cell.status !== resultFilter) return false;
+      if (!normalizedQuery) return true;
+      return [cell.suite, cell.feature, cell.reason, ROUTER_LABELS[cell.router]]
+        .filter((value): value is string => value !== null)
+        .some((value) => value.toLowerCase().includes(normalizedQuery));
+    });
+  }, [cells, query, resultFilter, supportFilter]);
+  const hasFilters = query !== "" || supportFilter !== "all" || resultFilter !== "all";
+
   return (
     <Dialog.Root>
       <Dialog.Trigger
@@ -150,8 +171,8 @@ function CompatibilityTableDialog({ cells }: { cells: GridCell[] }) {
               Compatibility test files
             </Dialog.Title>
             <Dialog.Description className="mt-1 text-sm text-kumo-subtle">
-              Showing {cells.length} files for the current router filter. Classifications do not
-              alter the raw test results.
+              Showing {filteredCells.length} of {cells.length} files for the current router filter.
+              Classifications do not alter the raw test results.
             </Dialog.Description>
           </div>
           <Dialog.Close
@@ -167,6 +188,52 @@ function CompatibilityTableDialog({ cells }: { cells: GridCell[] }) {
             )}
           />
         </div>
+        <div className="grid gap-3 border-b border-kumo-hairline bg-kumo-base px-5 py-3 sm:grid-cols-[minmax(16rem,1fr)_14rem_12rem_auto] sm:items-center">
+          <Input
+            size="sm"
+            value={query}
+            onChange={(event) => setQuery(event.currentTarget.value)}
+            placeholder="Search test files and features"
+            aria-label="Search compatibility test files"
+            className="w-full"
+          />
+          <Select
+            size="sm"
+            value={supportFilter}
+            onValueChange={(value) => setSupportFilter(value as SupportFilter)}
+            aria-label="Filter by classification"
+          >
+            <Select.Option value="all">All classifications</Select.Option>
+            <Select.Option value="supported">Supported</Select.Option>
+            <Select.Option value="deferred">Deferred</Select.Option>
+            <Select.Option value="needs-vite-equivalent">Needs Vite equivalent</Select.Option>
+            <Select.Option value="unsupported">Unsupported</Select.Option>
+          </Select>
+          <Select
+            size="sm"
+            value={resultFilter}
+            onValueChange={(value) => setResultFilter(value as ResultFilter)}
+            aria-label="Filter by raw result"
+          >
+            <Select.Option value="all">All raw results</Select.Option>
+            <Select.Option value="pass">Pass</Select.Option>
+            <Select.Option value="partial">Partial</Select.Option>
+            <Select.Option value="fail">Fail</Select.Option>
+            <Select.Option value="skip">Skipped by Next.js</Select.Option>
+          </Select>
+          <Button
+            size="sm"
+            variant="ghost"
+            disabled={!hasFilters}
+            onClick={() => {
+              setQuery("");
+              setSupportFilter("all");
+              setResultFilter("all");
+            }}
+          >
+            Clear
+          </Button>
+        </div>
         <div className="min-h-0 overflow-auto">
           <Table aria-label="Compatibility test files">
             <Table.Header sticky>
@@ -181,7 +248,7 @@ function CompatibilityTableDialog({ cells }: { cells: GridCell[] }) {
               </Table.Row>
             </Table.Header>
             <Table.Body>
-              {cells.map((cell) => (
+              {filteredCells.map((cell) => (
                 <Table.Row key={cell.suite}>
                   <Table.Cell className="min-w-80 font-mono text-xs break-all">
                     {cell.suite}
@@ -210,6 +277,13 @@ function CompatibilityTableDialog({ cells }: { cells: GridCell[] }) {
                   <Table.Cell className="text-right font-mono text-sm">{cell.skipped}</Table.Cell>
                 </Table.Row>
               ))}
+              {filteredCells.length === 0 ? (
+                <Table.Row>
+                  <Table.Cell colSpan={7} className="py-10 text-center text-sm text-kumo-subtle">
+                    No test files match these filters.
+                  </Table.Cell>
+                </Table.Row>
+              ) : null}
             </Table.Body>
           </Table>
         </div>
@@ -323,9 +397,6 @@ export function ContributionGrid({
 
   return (
     <div ref={containerRef} className="relative w-full">
-      <div className="mb-3 flex justify-end">
-        <CompatibilityTableDialog cells={visibleCells} />
-      </div>
       {visibleCells.length === 0 ? (
         <div className="py-8 text-center text-sm text-kumo-subtle">
           No test files in this category.

--- a/apps/web/app/compatibility/contribution-grid.tsx
+++ b/apps/web/app/compatibility/contribution-grid.tsx
@@ -3,14 +3,10 @@
 /**
  * GitHub-style contribution grid for compatibility test files.
  *
- * Each dot is one test file. Color encodes status:
- *   green  → all tests in the file passed
- *   orange → some tests passed, some failed (partial)
- *   red    → at least one test failed and none passed (or only failures)
- *   gray   → no verdict (all tests in the file were skipped by Next.js — via
- *            it.skip() / it.todo() / conditional runtime skips). Vinext does
- *            not add its own skips; we either run a file or filter it out
- *            of the manifest entirely.
+ * Each dot is one test file. Raw pass/partial/fail/skip colors are overridden
+ * by compatibility-scope colors for deferred, unsupported, and
+ * Vite-equivalent suites. The raw result remains visible in the tooltip and
+ * continues to contribute to the overall pass rate.
  *
  * Hovering a dot shows the file path and counts.
  *
@@ -23,6 +19,7 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { FileStatus, RouterKind } from "@/app/lib/db/schema";
 import { cellMatchesFilter, type RouterFilter } from "./router-buckets";
+import type { SuiteSupportStatus } from "./suite-support";
 
 // (Tabs / filter UI now lives in compatibility-views.tsx; the grid receives
 // the active filter as a prop. Filter semantics — what each value means and
@@ -36,25 +33,46 @@ export type GridCell = {
   suite: string;
   status: FileStatus;
   router: RouterKind;
+  supportStatus: SuiteSupportStatus;
+  feature: string | null;
+  reason: string | null;
   total: number;
   passed: number;
   failed: number;
   skipped: number;
 };
 
-const COLORS: Record<FileStatus, string> = {
+type DisplayStatus = FileStatus | Exclude<SuiteSupportStatus, "supported">;
+
+const COLORS: Record<DisplayStatus, string> = {
   pass: "#2da44e", // green
   partial: "#e08600", // orange
   fail: "#cf222e", // red
-  skip: "#8c959f", // gray
+  skip: "#afb8c1", // light gray
+  deferred: "#0969da", // blue
+  "needs-vite-equivalent": "#8250df", // purple
+  unsupported: "#6e7781", // dark gray
 };
 
-const LABELS: Record<FileStatus, string> = {
+const LABELS: Record<DisplayStatus, string> = {
   pass: "Pass",
   partial: "Partial",
   fail: "Fail",
   skip: "Skipped by Next.js",
+  deferred: "Deferred",
+  "needs-vite-equivalent": "Needs Vite-equivalent coverage",
+  unsupported: "Unsupported by vinext",
 };
+
+const LEGEND_ORDER: DisplayStatus[] = [
+  "pass",
+  "partial",
+  "fail",
+  "deferred",
+  "needs-vite-equivalent",
+  "unsupported",
+  "skip",
+];
 
 const ROUTER_LABELS: Record<RouterKind, string> = {
   app: "App Router",
@@ -79,7 +97,13 @@ function summarize(cell: GridCell): string {
   const group = deriveSuiteGroup(cell.suite);
   const prefix = group ? `[${group}] ${cell.suite}` : cell.suite;
   const routerTag = ROUTER_LABELS[cell.router];
-  return `${prefix} — ${LABELS[cell.status]} · ${routerTag} (${parts.join(", ")})`;
+  const displayStatus = getDisplayStatus(cell);
+  const rawStatus = displayStatus === cell.status ? "" : ` · raw result: ${LABELS[cell.status]}`;
+  return `${prefix} — ${LABELS[displayStatus]}${rawStatus} · ${routerTag} (${parts.join(", ")})`;
+}
+
+function getDisplayStatus(cell: GridCell): DisplayStatus {
+  return cell.supportStatus === "supported" ? cell.status : cell.supportStatus;
 }
 
 /**
@@ -200,6 +224,7 @@ export function ContributionGrid({
           style={{ display: "block", maxWidth: "100%" }}
         >
           {visibleCells.map((cell, i) => {
+            const displayStatus = getDisplayStatus(cell);
             const col = i % effectiveCols;
             const row = Math.floor(i / effectiveCols);
             const x = col * STRIDE;
@@ -213,7 +238,7 @@ export function ContributionGrid({
                 height={CELL_SIZE}
                 rx={2}
                 ry={2}
-                fill={COLORS[cell.status]}
+                fill={COLORS[displayStatus]}
                 onMouseEnter={(e) => {
                   const container = containerRef.current;
                   if (!container) return;
@@ -250,12 +275,18 @@ export function ContributionGrid({
                 </div>
                 <div className="font-mono break-all">{hover.cell.suite}</div>
                 <div className="mt-1 text-kumo-subtle">{summarize(hover.cell).split(" — ")[1]}</div>
+                {hover.cell.feature ? (
+                  <div className="mt-1 font-medium text-kumo-default">{hover.cell.feature}</div>
+                ) : null}
+                {hover.cell.reason ? (
+                  <div className="mt-1 text-kumo-subtle">{hover.cell.reason}</div>
+                ) : null}
               </div>
             );
           })()
         : null}
       <div className="mt-4 flex flex-wrap items-center gap-4 text-xs text-kumo-subtle">
-        {(Object.keys(COLORS) as FileStatus[]).map((s) => (
+        {LEGEND_ORDER.map((s) => (
           <div key={s} className="flex items-center gap-2">
             <span
               className="inline-block h-3 w-3 rounded-sm"

--- a/apps/web/app/compatibility/page.tsx
+++ b/apps/web/app/compatibility/page.tsx
@@ -2,9 +2,9 @@
  * /compatibility — shows the vinext ↔ Next.js compatibility picture.
  *
  * Top: a GitHub contribution-graph-style grid of test files for the most
- * recent run. Color encodes per-file status (green / orange / red / gray).
+ * recent run. Color encodes raw result and support classification.
  *
- * Below: a line chart of overall pass-rate over time, one point per run.
+ * Below: supported-surface and overall pass rates over time.
  *
  * Data is read from the `DB` D1 binding via Drizzle. Results are filtered by
  * `kind` (defaults to "deploy"; future suites can be selected via ?kind=...).
@@ -23,7 +23,8 @@ import {
 import { CompatibilityViews } from "./compatibility-views";
 import type { GridCell } from "./contribution-grid";
 import type { TrendPoint } from "./compatibility-line-chart";
-import { bucketByRouter, bucketPassRate } from "./router-buckets";
+import { bucketByRouter, bucketPassRate, bucketSupportedPassRate } from "./router-buckets";
+import { getSuiteSupport, NON_SUPPORTED_SUITES } from "./suite-support";
 
 // ISR: rebuild this page at most every 5 minutes. Compat data only changes
 // when a nightly deploy-suite run lands, so 5 minutes of staleness is fine
@@ -109,23 +110,42 @@ async function runQueries(
     all_passed: number;
     all_failed: number;
     all_skipped: number;
+    all_supported_passed: number;
+    all_supported_failed: number;
     app_total: number;
     app_passed: number;
     app_failed: number;
     app_skipped: number;
+    app_supported_passed: number;
+    app_supported_failed: number;
     pages_total: number;
     pages_passed: number;
     pages_failed: number;
     pages_skipped: number;
+    pages_supported_passed: number;
+    pages_supported_failed: number;
     both_total: number;
     both_passed: number;
     both_failed: number;
     both_skipped: number;
+    both_supported_passed: number;
+    both_supported_failed: number;
     unknown_total: number;
     unknown_passed: number;
     unknown_failed: number;
     unknown_skipped: number;
+    unknown_supported_passed: number;
+    unknown_supported_failed: number;
   };
+
+  // The support policy is intentionally joined at read time. Historical
+  // compat_file_results rows therefore need no migration or backfill: changing
+  // a suite's policy immediately reclassifies every recorded run. Only
+  // non-supported suites need rows because supported is the default.
+  const outOfScopeValues = sql.join(
+    NON_SUPPORTED_SUITES.map((suite) => sql`(${suite})`),
+    sql.raw(", "),
+  );
 
   const [latestRows, trendRowsDesc] = await Promise.all([
     db
@@ -146,31 +166,43 @@ async function runQueries(
     // with default settings) rejects this; if the query is ever ported,
     // add `r.created_at` to the GROUP BY or wrap it in `MIN()`/`MAX()`.
     db.all(sql`
+      WITH out_of_scope(suite) AS (VALUES ${outOfScopeValues})
       SELECT
         r.created_at AS created_at,
         SUM(f.total)   AS all_total,
         SUM(f.passed)  AS all_passed,
         SUM(f.failed)  AS all_failed,
         SUM(f.skipped) AS all_skipped,
+        SUM(CASE WHEN o.suite IS NULL THEN f.passed ELSE 0 END) AS all_supported_passed,
+        SUM(CASE WHEN o.suite IS NULL THEN f.failed ELSE 0 END) AS all_supported_failed,
         SUM(CASE WHEN m.router IN ('app','both') THEN f.total   ELSE 0 END) AS app_total,
         SUM(CASE WHEN m.router IN ('app','both') THEN f.passed  ELSE 0 END) AS app_passed,
         SUM(CASE WHEN m.router IN ('app','both') THEN f.failed  ELSE 0 END) AS app_failed,
         SUM(CASE WHEN m.router IN ('app','both') THEN f.skipped ELSE 0 END) AS app_skipped,
+        SUM(CASE WHEN m.router IN ('app','both') AND o.suite IS NULL THEN f.passed ELSE 0 END) AS app_supported_passed,
+        SUM(CASE WHEN m.router IN ('app','both') AND o.suite IS NULL THEN f.failed ELSE 0 END) AS app_supported_failed,
         SUM(CASE WHEN m.router IN ('pages','both') THEN f.total   ELSE 0 END) AS pages_total,
         SUM(CASE WHEN m.router IN ('pages','both') THEN f.passed  ELSE 0 END) AS pages_passed,
         SUM(CASE WHEN m.router IN ('pages','both') THEN f.failed  ELSE 0 END) AS pages_failed,
         SUM(CASE WHEN m.router IN ('pages','both') THEN f.skipped ELSE 0 END) AS pages_skipped,
+        SUM(CASE WHEN m.router IN ('pages','both') AND o.suite IS NULL THEN f.passed ELSE 0 END) AS pages_supported_passed,
+        SUM(CASE WHEN m.router IN ('pages','both') AND o.suite IS NULL THEN f.failed ELSE 0 END) AS pages_supported_failed,
         SUM(CASE WHEN m.router = 'both' THEN f.total   ELSE 0 END) AS both_total,
         SUM(CASE WHEN m.router = 'both' THEN f.passed  ELSE 0 END) AS both_passed,
         SUM(CASE WHEN m.router = 'both' THEN f.failed  ELSE 0 END) AS both_failed,
         SUM(CASE WHEN m.router = 'both' THEN f.skipped ELSE 0 END) AS both_skipped,
+        SUM(CASE WHEN m.router = 'both' AND o.suite IS NULL THEN f.passed ELSE 0 END) AS both_supported_passed,
+        SUM(CASE WHEN m.router = 'both' AND o.suite IS NULL THEN f.failed ELSE 0 END) AS both_supported_failed,
         SUM(CASE WHEN m.router IS NULL OR m.router = 'unknown' THEN f.total   ELSE 0 END) AS unknown_total,
         SUM(CASE WHEN m.router IS NULL OR m.router = 'unknown' THEN f.passed  ELSE 0 END) AS unknown_passed,
         SUM(CASE WHEN m.router IS NULL OR m.router = 'unknown' THEN f.failed  ELSE 0 END) AS unknown_failed,
-        SUM(CASE WHEN m.router IS NULL OR m.router = 'unknown' THEN f.skipped ELSE 0 END) AS unknown_skipped
+        SUM(CASE WHEN m.router IS NULL OR m.router = 'unknown' THEN f.skipped ELSE 0 END) AS unknown_skipped,
+        SUM(CASE WHEN (m.router IS NULL OR m.router = 'unknown') AND o.suite IS NULL THEN f.passed ELSE 0 END) AS unknown_supported_passed,
+        SUM(CASE WHEN (m.router IS NULL OR m.router = 'unknown') AND o.suite IS NULL THEN f.failed ELSE 0 END) AS unknown_supported_failed
       FROM compat_runs r
       JOIN compat_file_results f ON f.run_id = r.id
       LEFT JOIN compat_suite_meta m ON m.suite = f.suite
+      LEFT JOIN out_of_scope o ON o.suite = f.suite
       WHERE r.kind = ${kind}
       GROUP BY r.id
       ORDER BY r.created_at DESC
@@ -200,15 +232,21 @@ async function runQueries(
           .leftJoin(compatSuiteMeta, eq(compatFileResults.suite, compatSuiteMeta.suite))
           .where(and(eq(compatFileResults.kind, kind), eq(compatFileResults.runId, latestRun.id)))
           .orderBy(compatFileResults.suite)
-      ).map((r) => ({
-        suite: r.suite,
-        status: r.status,
-        router: (r.router ?? "unknown") as RouterKind,
-        total: r.total,
-        passed: r.passed,
-        failed: r.failed,
-        skipped: r.skipped,
-      }))
+      ).map((r) => {
+        const support = getSuiteSupport(r.suite);
+        return {
+          suite: r.suite,
+          status: r.status,
+          router: (r.router ?? "unknown") as RouterKind,
+          supportStatus: support.status,
+          feature: support.feature,
+          reason: support.reason,
+          total: r.total,
+          passed: r.passed,
+          failed: r.failed,
+          skipped: r.skipped,
+        };
+      })
     : [];
 
   // Convert the raw per-router columns into the chart's TrendPoint shape.
@@ -227,30 +265,40 @@ async function runQueries(
           passed: r.all_passed,
           failed: r.all_failed,
           skipped: r.all_skipped,
+          supportedPassed: r.all_supported_passed,
+          supportedFailed: r.all_supported_failed,
         },
         app: {
           total: r.app_total,
           passed: r.app_passed,
           failed: r.app_failed,
           skipped: r.app_skipped,
+          supportedPassed: r.app_supported_passed,
+          supportedFailed: r.app_supported_failed,
         },
         pages: {
           total: r.pages_total,
           passed: r.pages_passed,
           failed: r.pages_failed,
           skipped: r.pages_skipped,
+          supportedPassed: r.pages_supported_passed,
+          supportedFailed: r.pages_supported_failed,
         },
         both: {
           total: r.both_total,
           passed: r.both_passed,
           failed: r.both_failed,
           skipped: r.both_skipped,
+          supportedPassed: r.both_supported_passed,
+          supportedFailed: r.both_supported_failed,
         },
         unknown: {
           total: r.unknown_total,
           passed: r.unknown_passed,
           failed: r.unknown_failed,
           skipped: r.unknown_skipped,
+          supportedPassed: r.unknown_supported_passed,
+          supportedFailed: r.unknown_supported_failed,
         },
       },
     }));
@@ -260,24 +308,15 @@ async function runQueries(
 
 export default async function CompatibilityPage() {
   const { latestRun, latestFiles, trend, error } = await loadData(KIND);
-
-  const fileCounts = latestFiles.reduce(
-    (acc, f) => {
-      acc[f.status]++;
-      return acc;
-    },
-    { pass: 0, partial: 0, fail: 0, skip: 0 },
-  );
-
   const byRouter = bucketByRouter(latestFiles);
-
-  // Skipped tests don't count against the pass rate; denominator is the
-  // tests that actually ran (passed + failed).
-  const passRate = (() => {
-    if (!latestRun) return 0;
-    const denom = latestRun.passed + latestRun.failed;
-    return denom > 0 ? (latestRun.passed / denom) * 100 : 0;
-  })();
+  const supportedPassRate = bucketSupportedPassRate(byRouter.all);
+  const overallPassRate = bucketPassRate(byRouter.all);
+  const verdicts = byRouter.all.passed + byRouter.all.failed;
+  const supportedVerdicts = byRouter.all.supportedPassed + byRouter.all.supportedFailed;
+  const supportedCoverage = verdicts > 0 ? (supportedVerdicts / verdicts) * 100 : 0;
+  const supportedFailingFiles = latestFiles.filter(
+    (file) => file.supportStatus === "supported" && file.failed > 0,
+  ).length;
 
   return (
     <>
@@ -287,7 +326,8 @@ export default async function CompatibilityPage() {
         </h1>
         <p className="mt-4 max-w-2xl text-kumo-subtle">
           Results from the Next.js deploy test suite, run against vinext. Each dot below is one test
-          file. Hover for details. The line chart tracks overall pass rate across runs.
+          file. Hover for details. The line chart tracks supported and overall pass rates across
+          runs.
         </p>
         {latestRun ? (
           <p className="mt-3 text-sm text-kumo-subtle">
@@ -323,27 +363,27 @@ export default async function CompatibilityPage() {
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
           <div className={CARD}>
             <div className="text-3xl font-semibold tracking-tight text-kumo-default">
-              {passRate.toFixed(1)}%
+              {supportedPassRate.toFixed(1)}%
             </div>
-            <div className="text-sm text-kumo-subtle">Pass rate (latest run)</div>
+            <div className="text-sm text-kumo-subtle">Supported pass rate</div>
           </div>
           <div className={CARD}>
             <div className="text-3xl font-semibold tracking-tight text-kumo-default">
-              {latestFiles.length}
+              {overallPassRate.toFixed(1)}%
             </div>
-            <div className="text-sm text-kumo-subtle">Test files</div>
+            <div className="text-sm text-kumo-subtle">Overall pass rate</div>
           </div>
           <div className={CARD}>
             <div className="text-3xl font-semibold tracking-tight text-kumo-default">
-              {fileCounts.pass}
+              {supportedCoverage.toFixed(1)}%
             </div>
-            <div className="text-sm text-kumo-subtle">Files fully passing</div>
+            <div className="text-sm text-kumo-subtle">Supported surface coverage</div>
           </div>
           <div className={CARD}>
             <div className="text-3xl font-semibold tracking-tight text-kumo-default">
-              {fileCounts.fail + fileCounts.partial}
+              {supportedFailingFiles}
             </div>
-            <div className="text-sm text-kumo-subtle">Files with failures</div>
+            <div className="text-sm text-kumo-subtle">Supported files with failures</div>
           </div>
         </div>
       </section>
@@ -357,26 +397,26 @@ export default async function CompatibilityPage() {
         <div className="grid gap-4 sm:grid-cols-3">
           <div className={CARD}>
             <div className="text-3xl font-semibold tracking-tight text-kumo-default">
-              {bucketPassRate(byRouter.app).toFixed(1)}%
+              {bucketSupportedPassRate(byRouter.app).toFixed(1)}%
             </div>
             <div className="text-sm text-kumo-subtle">
-              App Router pass rate · {byRouter.app.files} files
+              App Router supported · {bucketPassRate(byRouter.app).toFixed(1)}% overall
             </div>
           </div>
           <div className={CARD}>
             <div className="text-3xl font-semibold tracking-tight text-kumo-default">
-              {bucketPassRate(byRouter.pages).toFixed(1)}%
+              {bucketSupportedPassRate(byRouter.pages).toFixed(1)}%
             </div>
             <div className="text-sm text-kumo-subtle">
-              Pages Router pass rate · {byRouter.pages.files} files
+              Pages Router supported · {bucketPassRate(byRouter.pages).toFixed(1)}% overall
             </div>
           </div>
           <div className={CARD}>
             <div className="text-3xl font-semibold tracking-tight text-kumo-default">
-              {bucketPassRate(byRouter.both).toFixed(1)}%
+              {bucketSupportedPassRate(byRouter.both).toFixed(1)}%
             </div>
             <div className="text-sm text-kumo-subtle">
-              Mixed pass rate · {byRouter.both.files} files
+              Mixed supported · {bucketPassRate(byRouter.both).toFixed(1)}% overall
             </div>
           </div>
         </div>
@@ -414,9 +454,16 @@ export default async function CompatibilityPage() {
             without schema changes.
           </p>
           <p className="text-sm leading-relaxed text-kumo-subtle">
-            Per-router trend lines use the latest classification snapshot, so reclassifying a suite
-            (when the Next.js ref bumps, or when the heuristic improves) updates how it appears
-            across every historical run. The aggregate &quot;All&quot; line is unaffected.
+            The supported pass rate excludes suites classified as deferred, specific to the Next.js
+            compiler, or awaiting equivalent Vite coverage. The overall pass rate retains their raw
+            results. Both rates exclude tests skipped by Next.js itself. Support classifications are
+            joined when this page is read, so they apply consistently to historical runs without
+            rewriting stored results.
+          </p>
+          <p className="text-sm leading-relaxed text-kumo-subtle">
+            Router and support classifications are both applied at read time. Reclassifying a suite
+            therefore updates its supported rate, color, and router bucket across every historical
+            run while leaving the stored raw results and overall rate unchanged.
           </p>
           <LinkButton
             variant="outline"

--- a/apps/web/app/compatibility/router-buckets.ts
+++ b/apps/web/app/compatibility/router-buckets.ts
@@ -20,6 +20,7 @@
  * documented in the "How this works" card on /compatibility.
  */
 import type { RouterKind } from "@/app/lib/db/schema";
+import type { SuiteSupportStatus } from "./suite-support";
 
 /**
  * The filter / bucket key set used across the compat UI. Matches the
@@ -66,6 +67,8 @@ type RouterBucket = {
   passed: number;
   failed: number;
   skipped: number;
+  supportedPassed: number;
+  supportedFailed: number;
 };
 
 type RouterBuckets = Record<RouterFilter, RouterBucket>;
@@ -77,9 +80,22 @@ type RouterBuckets = Record<RouterFilter, RouterBucket>;
  * stat cards can compute per-router pass rates.
  */
 export function bucketByRouter<
-  T extends { router: RouterKind; passed: number; failed: number; skipped: number },
+  T extends {
+    router: RouterKind;
+    supportStatus: SuiteSupportStatus;
+    passed: number;
+    failed: number;
+    skipped: number;
+  },
 >(cells: T[]): RouterBuckets {
-  const empty = (): RouterBucket => ({ files: 0, passed: 0, failed: 0, skipped: 0 });
+  const empty = (): RouterBucket => ({
+    files: 0,
+    passed: 0,
+    failed: 0,
+    skipped: 0,
+    supportedPassed: 0,
+    supportedFailed: 0,
+  });
   const out: RouterBuckets = {
     all: empty(),
     app: empty(),
@@ -93,6 +109,10 @@ export function bucketByRouter<
     b.passed += c.passed;
     b.failed += c.failed;
     b.skipped += c.skipped;
+    if (c.supportStatus === "supported") {
+      b.supportedPassed += c.passed;
+      b.supportedFailed += c.failed;
+    }
   };
 
   for (const c of cells) {
@@ -114,4 +134,13 @@ export function bucketByRouter<
 export function bucketPassRate(b: { passed: number; failed: number }): number {
   const denom = b.passed + b.failed;
   return denom > 0 ? (b.passed / denom) * 100 : 0;
+}
+
+/** Supported-surface pass rate (0..100), excluding deferred/out-of-scope files. */
+export function bucketSupportedPassRate(b: {
+  supportedPassed: number;
+  supportedFailed: number;
+}): number {
+  const denom = b.supportedPassed + b.supportedFailed;
+  return denom > 0 ? (b.supportedPassed / denom) * 100 : 0;
 }

--- a/apps/web/app/compatibility/suite-support.ts
+++ b/apps/web/app/compatibility/suite-support.ts
@@ -116,7 +116,7 @@ export const SUITE_SUPPORT_POLICY = {
 } as const satisfies Record<string, ScopedSuiteSupport>;
 
 /** Feature labels for the supported failures classified in run 29551314872. */
-export const SUPPORTED_SUITE_FEATURES = {
+const SUPPORTED_SUITE_FEATURES = {
   "test/e2e/app-dir/app-client-cache/client-cache.parallel-routes.test.ts":
     "App Router prefetch and client cache",
   "test/e2e/app-dir/app-prefetch-false-loading/app-prefetch-false-loading.test.ts":

--- a/apps/web/app/compatibility/suite-support.ts
+++ b/apps/web/app/compatibility/suite-support.ts
@@ -1,0 +1,199 @@
+/**
+ * Compatibility scope for Next.js deploy-suite files.
+ *
+ * This is intentionally file-level: historical compatibility rows only retain
+ * per-file counts. Keeping the policy here lets every historical run be
+ * reclassified at read time without rewriting D1 data. Suites absent from this
+ * map are supported by default so newly-added Next.js tests remain visible.
+ */
+
+export type SuiteSupportStatus = "supported" | "deferred" | "needs-vite-equivalent" | "unsupported";
+
+export type SuiteSupport = {
+  status: SuiteSupportStatus;
+  feature: string | null;
+  reason: string | null;
+};
+
+type ScopedSuiteSupport = SuiteSupport & {
+  status: Exclude<SuiteSupportStatus, "supported">;
+};
+
+const DEFERRED_CACHE_COMPONENTS = {
+  status: "deferred",
+  feature: "Cache Components and use cache",
+  reason: "Cache Components are not implemented yet.",
+} as const satisfies ScopedSuiteSupport;
+
+const DEFERRED_PARTIAL_PRERENDERING = {
+  status: "deferred",
+  feature: "Partial prerendering and fallback shells",
+  reason: "Depends on Cache Components and partial prerendering support.",
+} as const satisfies ScopedSuiteSupport;
+
+const DEFERRED_SEGMENT_CACHE = {
+  status: "deferred",
+  feature: "Segment cache and Cache Components prefetching",
+  reason: "Depends on the Cache Components segment-cache protocol.",
+} as const satisfies ScopedSuiteSupport;
+
+const NEXT_BUNDLER_SPECIFIC = {
+  status: "unsupported",
+  feature: "Webpack, Turbopack, or Babel customization",
+  reason: "Exercises a Next.js compiler surface rather than Vite or Rolldown behavior.",
+} as const satisfies ScopedSuiteSupport;
+
+const VITE_RUNTIME_CONDITIONS = {
+  status: "needs-vite-equivalent",
+  feature: "React and runtime export conditions",
+  reason:
+    "The capability needs Vite, RSC, and Workers coverage; exact edge-light assertions are Next.js-specific.",
+} as const satisfies ScopedSuiteSupport;
+
+export const SUITE_SUPPORT_POLICY = {
+  "test/e2e/app-dir/app-root-params-getters/use-cache.test.ts": DEFERRED_CACHE_COMPONENTS,
+  "test/e2e/app-dir/cache-components-allow-otel-spans/cache-components-allow-otel-spans.test.ts":
+    DEFERRED_CACHE_COMPONENTS,
+  "test/e2e/app-dir/cache-components/cache-components.server-action.test.ts":
+    DEFERRED_CACHE_COMPONENTS,
+  "test/e2e/app-dir/concurrent-navigations/mismatching-prefetch.test.ts":
+    DEFERRED_PARTIAL_PRERENDERING,
+  "test/e2e/app-dir/fallback-shells/fallback-shells.test.ts": DEFERRED_PARTIAL_PRERENDERING,
+  "test/e2e/app-dir/next-config/index.test.ts": NEXT_BUNDLER_SPECIFIC,
+  "test/e2e/app-dir/prefetch-true-instant/prefetch-true-instant.test.ts":
+    DEFERRED_PARTIAL_PRERENDERING,
+  "test/e2e/app-dir/resume-data-cache/resume-data-cache.test.ts": DEFERRED_PARTIAL_PRERENDERING,
+  "test/e2e/app-dir/rsc-basic/rsc-basic-react-experimental.test.ts": {
+    status: "unsupported",
+    feature: "Next.js experimental React channel selection",
+    reason:
+      "Vinext should support portable React APIs rather than Next.js package-channel selection.",
+  },
+  "test/e2e/app-dir/scss/npm-import-tilde/npm-import-tilde.test.ts": NEXT_BUNDLER_SPECIFIC,
+  "test/e2e/app-dir/segment-cache/basic/segment-cache-basic.test.ts": DEFERRED_SEGMENT_CACHE,
+  "test/e2e/app-dir/segment-cache/cached-navigations/cached-navigations.test.ts":
+    DEFERRED_SEGMENT_CACHE,
+  "test/e2e/app-dir/segment-cache/dynamic-on-hover/dynamic-on-hover.test.ts":
+    DEFERRED_SEGMENT_CACHE,
+  "test/e2e/app-dir/segment-cache/encoded-slash-params/encoded-slash-params.test.ts":
+    DEFERRED_SEGMENT_CACHE,
+  "test/e2e/app-dir/segment-cache/force-stale/force-stale.test.ts": DEFERRED_SEGMENT_CACHE,
+  "test/e2e/app-dir/segment-cache/prefetch-inlining/prefetch-inlining.test.ts":
+    DEFERRED_SEGMENT_CACHE,
+  "test/e2e/app-dir/segment-cache/prefetch-layout-sharing/prefetch-layout-sharing.test.ts":
+    DEFERRED_SEGMENT_CACHE,
+  "test/e2e/app-dir/segment-cache/prefetch-scheduling/prefetch-scheduling.test.ts":
+    DEFERRED_SEGMENT_CACHE,
+  "test/e2e/app-dir/segment-cache/refresh/segment-cache-refresh.test.ts": DEFERRED_SEGMENT_CACHE,
+  "test/e2e/app-dir/segment-cache/search-params/segment-cache-search-params-shared-loading-state.test.ts":
+    DEFERRED_SEGMENT_CACHE,
+  "test/e2e/app-dir/segment-cache/search-params/segment-cache-search-params.test.ts":
+    DEFERRED_SEGMENT_CACHE,
+  "test/e2e/app-dir/segment-cache/staleness/segment-cache-per-page-dynamic-stale-time.test.ts":
+    DEFERRED_SEGMENT_CACHE,
+  "test/e2e/app-dir/segment-cache/staleness/segment-cache-stale-time.test.ts":
+    DEFERRED_SEGMENT_CACHE,
+  "test/e2e/app-dir/segment-cache/vary-params-base-dynamic/vary-params-base-dynamic.test.ts":
+    DEFERRED_SEGMENT_CACHE,
+  "test/e2e/app-dir/segment-cache/vary-params/root-params-segment-prefetch.test.ts":
+    DEFERRED_SEGMENT_CACHE,
+  "test/e2e/app-dir/segment-cache/vary-params/vary-params.test.ts": DEFERRED_SEGMENT_CACHE,
+  "test/e2e/app-dir/use-cache-metadata-route-handler/use-cache-metadata-route-handler.test.ts":
+    DEFERRED_CACHE_COMPONENTS,
+  "test/e2e/app-dir/use-cache-with-server-function-props/use-cache-with-server-function-props.test.ts":
+    DEFERRED_CACHE_COMPONENTS,
+  "test/e2e/app-dir/webpack-loader-set-environment-variable/webpack-loader-set-environment-variable.test.ts":
+    NEXT_BUNDLER_SPECIFIC,
+  "test/e2e/app-dir/worker/worker.test.ts": {
+    status: "needs-vite-equivalent",
+    feature: "Browser Web Workers and emitted worker assets",
+    reason:
+      "Web Worker behavior needs Vite and Rolldown coverage; Next.js deployment-token assertions are not portable.",
+  },
+  "test/e2e/babel/index.test.ts": NEXT_BUNDLER_SPECIFIC,
+  "test/e2e/import-conditions/import-conditions.test.ts": VITE_RUNTIME_CONDITIONS,
+  "test/e2e/react-version/react-version.test.ts": VITE_RUNTIME_CONDITIONS,
+} as const satisfies Record<string, ScopedSuiteSupport>;
+
+/** Feature labels for the supported failures classified in run 29551314872. */
+export const SUPPORTED_SUITE_FEATURES = {
+  "test/e2e/app-dir/app-client-cache/client-cache.parallel-routes.test.ts":
+    "App Router prefetch and client cache",
+  "test/e2e/app-dir/app-prefetch-false-loading/app-prefetch-false-loading.test.ts":
+    "App Router loading UI, Suspense, and streaming",
+  "test/e2e/app-dir/app-prefetch-false/app-prefetch-false.test.ts":
+    "App Router prefetch and client cache",
+  "test/e2e/app-dir/app-prefetch/prefetching.test.ts": "App Router prefetch and client cache",
+  "test/e2e/app-dir/app-static/app-static.test.ts":
+    "App Router streaming, static rendering, and revalidation",
+  "test/e2e/app-dir/app/index.test.ts": "App Router navigation, streaming, and routing",
+  "test/e2e/app-dir/client-module-with-package-type/index.test.ts":
+    "Module formats, externals, and package resolution",
+  "test/e2e/app-dir/metadata-icons/metadata-icons.test.ts": "Metadata rendering and navigation",
+  "test/e2e/app-dir/metadata-navigation/metadata-navigation.test.ts":
+    "Metadata rendering and navigation",
+  "test/e2e/app-dir/metadata-streaming/metadata-streaming.test.ts":
+    "Metadata rendering and navigation",
+  "test/e2e/app-dir/navigation/navigation.test.ts": "App Router navigation and metadata",
+  "test/e2e/app-dir/next-after-app-deploy/index.test.ts": "ISR, tags, revalidation, and after()",
+  "test/e2e/app-dir/next-config-ts-native-mts/dynamic-import-esm/next-config-ts-dynamic-import-esm.test.ts":
+    "next.config and custom tsconfig loading",
+  "test/e2e/app-dir/next-config-ts-native-ts/dynamic-import-esm/next-config-ts-dynamic-import-esm.test.ts":
+    "next.config and custom tsconfig loading",
+  "test/e2e/app-dir/next-dynamic-css/next-dynamic-css.test.ts":
+    "CSS ordering, styled-jsx, and dynamic CSS",
+  "test/e2e/app-dir/parallel-routes-and-interception-from-root/parallel-routes-and-interception-from-root.test.ts":
+    "Parallel routes, interception, dynamic params, and RSC routing",
+  "test/e2e/app-dir/parallel-routes-revalidation/parallel-routes-revalidation.test.ts":
+    "Parallel routes, interception, dynamic params, and RSC routing",
+  "test/e2e/app-dir/parallel-routes-root-param-dynamic-child/parallel-routes-root-param-dynamic-child.test.ts":
+    "Parallel routes, interception, dynamic params, and RSC routing",
+  "test/e2e/app-dir/rsc-query-routing/rsc-query-routing.test.ts":
+    "Parallel routes, interception, dynamic params, and RSC routing",
+  "test/e2e/app-dir/shallow-routing/shallow-routing.test.ts":
+    "App Router navigation, Link, and history",
+  "test/e2e/app-document/rendering.test.ts": "Pages Router rendering and data APIs",
+  "test/e2e/basepath/router-events.test.ts": "Pages Router rendering and data APIs",
+  "test/e2e/edge-compiler-can-import-blob-assets/index.test.ts":
+    "Worker/edge fetch and imported assets",
+  "test/e2e/esm-externals/esm-externals.test.ts":
+    "Module formats, externals, and package resolution",
+  "test/e2e/externals-transitive/externals-transitive.test.ts":
+    "Module formats, externals, and package resolution",
+  "test/e2e/getserversideprops/test/index.test.ts": "Pages Router rendering and data APIs",
+  "test/e2e/middleware-general/test/index.test.ts":
+    "Middleware rewrites, query propagation, and trailing slash",
+  "test/e2e/middleware-general/test/node-runtime.test.ts":
+    "Middleware rewrites, query propagation, and trailing slash",
+  "test/e2e/middleware-rewrites/test/index.test.ts":
+    "Middleware rewrites, query propagation, and trailing slash",
+  "test/e2e/middleware-trailing-slash/test/index.test.ts":
+    "Middleware rewrites, query propagation, and trailing slash",
+  "test/e2e/next-head/index.test.ts": "Pages Router rendering and data APIs",
+  "test/e2e/prerender.test.ts": "ISR, tags, revalidation, and after()",
+  "test/e2e/revalidate-reason/revalidate-reason.test.ts": "ISR, tags, revalidation, and after()",
+  "test/e2e/streaming-ssr/index.test.ts": "CSS ordering, styled-jsx, and dynamic CSS",
+  "test/e2e/tsconfig-path/index.test.ts": "next.config and custom tsconfig loading",
+  "test/e2e/typescript-custom-tsconfig/test/index.test.ts":
+    "next.config and custom tsconfig loading",
+} as const satisfies Record<string, string>;
+
+const DEFAULT_SUPPORT: SuiteSupport = {
+  status: "supported",
+  feature: null,
+  reason: null,
+};
+
+export const NON_SUPPORTED_SUITES = Object.keys(SUITE_SUPPORT_POLICY);
+export const CLASSIFIED_SUITES = [
+  ...NON_SUPPORTED_SUITES,
+  ...Object.keys(SUPPORTED_SUITE_FEATURES),
+];
+
+export function getSuiteSupport(suite: string): SuiteSupport {
+  const scoped = SUITE_SUPPORT_POLICY[suite as keyof typeof SUITE_SUPPORT_POLICY];
+  if (scoped) return scoped;
+
+  const feature = SUPPORTED_SUITE_FEATURES[suite as keyof typeof SUPPORTED_SUITE_FEATURES];
+  return feature ? { status: "supported", feature, reason: null } : DEFAULT_SUPPORT;
+}

--- a/tests/compatibility-support.test.ts
+++ b/tests/compatibility-support.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import {
+  CLASSIFIED_SUITES,
+  getSuiteSupport,
+  NON_SUPPORTED_SUITES,
+  SUITE_SUPPORT_POLICY,
+} from "../apps/web/app/compatibility/suite-support";
+import {
+  bucketByRouter,
+  bucketPassRate,
+  bucketSupportedPassRate,
+} from "../apps/web/app/compatibility/router-buckets";
+
+describe("compatibility suite support policy", () => {
+  it("defaults newly-added suites to supported", () => {
+    expect(getSuiteSupport("test/e2e/new-suite/new-suite.test.ts")).toEqual({
+      status: "supported",
+      feature: null,
+      reason: null,
+    });
+  });
+
+  it("keeps deferred, Vite-equivalent, and unsupported states distinct", () => {
+    const counts = Object.values(SUITE_SUPPORT_POLICY).reduce(
+      (result, policy) => {
+        result[policy.status]++;
+        return result;
+      },
+      { deferred: 0, "needs-vite-equivalent": 0, unsupported: 0 },
+    );
+
+    expect(counts).toEqual({
+      deferred: 25,
+      "needs-vite-equivalent": 3,
+      unsupported: 5,
+    });
+    expect(NON_SUPPORTED_SUITES).toHaveLength(33);
+    expect(CLASSIFIED_SUITES).toHaveLength(69);
+    expect(new Set(CLASSIFIED_SUITES).size).toBe(69);
+  });
+
+  it("uses canonical Next.js suite paths", () => {
+    for (const suite of NON_SUPPORTED_SUITES) {
+      expect(suite).toMatch(/^test\/e2e\/.+\.test\.[jt]sx?$/);
+      expect(getSuiteSupport(suite).reason).toBeTruthy();
+    }
+  });
+});
+
+describe("compatibility rate buckets", () => {
+  it("retains raw results while excluding non-supported suites from the supported rate", () => {
+    const buckets = bucketByRouter([
+      {
+        router: "app" as const,
+        supportStatus: "supported" as const,
+        passed: 8,
+        failed: 2,
+        skipped: 1,
+      },
+      {
+        router: "app" as const,
+        supportStatus: "deferred" as const,
+        passed: 1,
+        failed: 9,
+        skipped: 0,
+      },
+      {
+        router: "both" as const,
+        supportStatus: "supported" as const,
+        passed: 5,
+        failed: 0,
+        skipped: 0,
+      },
+    ]);
+
+    expect(buckets.all).toEqual({
+      files: 3,
+      passed: 14,
+      failed: 11,
+      skipped: 1,
+      supportedPassed: 13,
+      supportedFailed: 2,
+    });
+    expect(bucketPassRate(buckets.all)).toBeCloseTo(56, 2);
+    expect(bucketSupportedPassRate(buckets.all)).toBeCloseTo(86.67, 2);
+
+    // Mixed suites continue to count toward both router buckets.
+    expect(buckets.app.supportedPassed).toBe(13);
+    expect(buckets.pages.supportedPassed).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary

- add a file-level support policy derived from deploy-suite run 29551314872, with unknown suites defaulting to supported
- distinguish deferred suites in blue, Vite-equivalent coverage in purple, unsupported suites in dark gray, and Next-native skips in light gray
- show supported and overall pass rates in the latest-run cards, router breakdowns, and historical trend chart
- add an inline table action with router-scoped rows, text search, classification and raw-result filters, rationale, feature area, and pass/fail/skip counts
- apply classifications at read time so every historical D1 run works without a migration, backfill, ingest, or workflow change

The classified failures break down into 36 supported suites, 25 deferred suites, 3 suites needing Vite-equivalent coverage, and 5 unsupported suites. Raw results remain unchanged and continue to power the overall rate.

## Validation

- `vp test run tests/compatibility-support.test.ts`
- `vp check apps/web/app/compatibility/suite-support.ts apps/web/app/compatibility/page.tsx apps/web/app/compatibility/router-buckets.ts apps/web/app/compatibility/contribution-grid.tsx apps/web/app/compatibility/compatibility-views.tsx apps/web/app/compatibility/compatibility-line-chart.tsx tests/compatibility-support.test.ts`
- `pnpm exec tsc -p apps/web/tsconfig.json --noEmit`
- `vp run @apps/web#build:vinext`

The production build emits only the expected warning for the missing local `COMPAT_INGEST_SECRET`.