### PR TITLE
fix(app-router): stream nested loading boundaries

### DIFF
--- a/packages/vinext/src/entries/app-browser-entry.ts
+++ b/packages/vinext/src/entries/app-browser-entry.ts
@@ -49,12 +49,12 @@ import ${JSON.stringify(entryPath)};`;
  * emitting the same manifest for hybrid builds — see issue #1526 and
  * `pages-client-entry.ts`.
  */
-export function isLinkPrefetchRoute(route: AppRoute): boolean {
+function isLinkPrefetchRoute(route: AppRoute): boolean {
   if (route.pagePath !== null) return true;
   return route.routePath === null && route.layouts.length > 0;
 }
 
-export function toDocumentOnlyAppRoute(route: AppRoute): VinextLinkPrefetchRoute {
+function toDocumentOnlyAppRoute(route: AppRoute): VinextLinkPrefetchRoute {
   return {
     canPrefetchLoadingShell: false,
     documentOnly: true,

--- a/packages/vinext/src/entries/app-browser-entry.ts
+++ b/packages/vinext/src/entries/app-browser-entry.ts
@@ -4,7 +4,7 @@ import type {
   VinextPagesLinkPrefetchRoute,
 } from "../client/vinext-next-data.js";
 import type { AppRoute } from "../routing/app-router.js";
-import type { RouteManifest } from "../routing/app-route-graph.js";
+import { patternsStructurallyEquivalent, type RouteManifest } from "../routing/app-route-graph.js";
 import type { NextRewrite } from "../config/next-config.js";
 
 /**
@@ -26,9 +26,7 @@ export function generateBrowserEntry(
 ): string {
   const entryPath = resolveRuntimeEntryModule("app-browser-entry");
   const navigationRuntimePath = resolveClientRuntimeModule("navigation-runtime");
-  const prefetchRoutes: VinextLinkPrefetchRoute[] = routes.map((route) =>
-    isLinkPrefetchRoute(route) ? toLinkPrefetchRoute(route) : toDocumentOnlyAppRoute(route),
-  );
+  const prefetchRoutes = toLinkPrefetchRoutes(routes);
 
   return `import { registerNavigationRuntimeBootstrap } from ${JSON.stringify(navigationRuntimePath)};
 
@@ -69,14 +67,73 @@ function requiresDynamicNavigationRequest(route: AppRoute): boolean {
   return route.isDynamic && route.parallelSlots.length > 0;
 }
 
+function splitPatternParts(pattern: string): string[] {
+  return pattern.split("/").filter(Boolean);
+}
+
+function interceptTargetsRoute(interceptTargetPattern: string, route: AppRoute): boolean {
+  return patternsStructurallyEquivalent(
+    splitPatternParts(interceptTargetPattern),
+    route.patternParts,
+  );
+}
+
+function hasLoadingBoundary(route: AppRoute, hasSiblingInterceptLoading: boolean): boolean {
+  return (
+    route.loadingPath !== null ||
+    (route.loadingPaths?.length ?? 0) > 0 ||
+    route.parallelSlots.some(
+      (slot) =>
+        slot.loadingPath !== null ||
+        (slot.loadingPaths?.length ?? 0) > 0 ||
+        slot.interceptingRoutes.some(
+          (intercept) =>
+            interceptTargetsRoute(intercept.targetPattern, route) &&
+            (intercept.loadingPaths?.length ?? 0) > 0,
+        ),
+    ) ||
+    hasSiblingInterceptLoading
+  );
+}
+
 /** Project an `AppRoute` down to the public `VinextLinkPrefetchRoute` shape. */
-export function toLinkPrefetchRoute(route: AppRoute): VinextLinkPrefetchRoute {
+export function toLinkPrefetchRoute(
+  route: AppRoute,
+  hasSiblingInterceptLoading = route.siblingIntercepts.some(
+    (intercept) =>
+      interceptTargetsRoute(intercept.targetPattern, route) &&
+      (intercept.loadingPaths?.length ?? 0) > 0,
+  ),
+): VinextLinkPrefetchRoute {
   return {
-    canPrefetchLoadingShell: route.loadingPath !== null,
+    canPrefetchLoadingShell: hasLoadingBoundary(route, hasSiblingInterceptLoading),
     patternParts: [...route.patternParts],
     isDynamic: route.isDynamic,
     ...(requiresDynamicNavigationRequest(route) ? { requiresDynamicNavigationRequest: true } : {}),
   };
+}
+
+/** Project App routes together so sibling-intercept loading is applied to its target route. */
+export function toLinkPrefetchRoutes(routes: readonly AppRoute[]): VinextLinkPrefetchRoute[] {
+  const siblingInterceptLoadingTargets: string[][] = [];
+  for (const route of routes) {
+    for (const intercept of route.siblingIntercepts) {
+      if ((intercept.loadingPaths?.length ?? 0) > 0) {
+        siblingInterceptLoadingTargets.push(splitPatternParts(intercept.targetPattern));
+      }
+    }
+  }
+
+  return routes.map((route) =>
+    isLinkPrefetchRoute(route)
+      ? toLinkPrefetchRoute(
+          route,
+          siblingInterceptLoadingTargets.some((targetParts) =>
+            patternsStructurallyEquivalent(targetParts, route.patternParts),
+          ),
+        )
+      : toDocumentOnlyAppRoute(route),
+  );
 }
 
 function buildRouteManifestExpression(routeManifest: RouteManifest | null): string {

--- a/packages/vinext/src/entries/app-rsc-manifest.ts
+++ b/packages/vinext/src/entries/app-rsc-manifest.ts
@@ -192,6 +192,9 @@ function registerRouteModules(routes: AppRoute[], imports: ImportAllocator): voi
         imports.getLazyLoaderVar(layoutPath);
       }
       if (slot.loadingPath) imports.getLazyLoaderVar(slot.loadingPath);
+      for (const loadingPath of slot.loadingPaths ?? []) {
+        imports.getLazyLoaderVar(loadingPath);
+      }
       if (slot.errorPath) imports.getLazyLoaderVar(slot.errorPath);
       if (slot.notFoundPath) imports.getLazyLoaderVar(slot.notFoundPath);
       for (const ir of slot.interceptingRoutes) {
@@ -199,6 +202,9 @@ function registerRouteModules(routes: AppRoute[], imports: ImportAllocator): voi
         if (ir.notFoundPath) imports.getLazyLoaderVar(ir.notFoundPath);
         for (const layoutPath of ir.layoutPaths) {
           imports.getLazyLoaderVar(layoutPath);
+        }
+        for (const loadingPath of ir.loadingPaths ?? []) {
+          imports.getLazyLoaderVar(loadingPath);
         }
       }
     }
@@ -210,6 +216,9 @@ function registerRouteModules(routes: AppRoute[], imports: ImportAllocator): voi
       if (ir.notFoundPath) imports.getLazyLoaderVar(ir.notFoundPath);
       for (const layoutPath of ir.layoutPaths) {
         imports.getLazyLoaderVar(layoutPath);
+      }
+      for (const loadingPath of ir.loadingPaths ?? []) {
+        imports.getLazyLoaderVar(loadingPath);
       }
     }
   }
@@ -259,6 +268,9 @@ function buildRouteEntries(routes: AppRoute[], imports: ImportAllocator): string
       __loadInterceptLayouts: ${lazyLoaderArray(ir.layoutPaths, imports)},
       interceptLayoutSegments: ${JSON.stringify(ir.layoutSegments ?? [])},
       interceptBranchSegments: ${JSON.stringify(ir.branchSegments ?? [])},
+      interceptLoadings: ${moduleArray(ir.loadingPaths?.length ?? 0)},
+      __loadInterceptLoadings: ${lazyLoaderArray(ir.loadingPaths ?? [], imports)},
+      interceptLoadingTreePositions: ${JSON.stringify(ir.loadingTreePositions ?? [])},
       interceptNotFoundBranchSegments: ${JSON.stringify(ir.notFoundBranchSegments ?? ir.branchSegments ?? [])},
       page: null,
       __pageLoader: ${imports.getLazyLoaderVar(ir.pagePath)},
@@ -279,6 +291,9 @@ function buildRouteEntries(routes: AppRoute[], imports: ImportAllocator): string
           __loadInterceptLayouts: ${lazyLoaderArray(ir.layoutPaths, imports)},
           interceptLayoutSegments: ${JSON.stringify(ir.layoutSegments ?? [])},
           interceptBranchSegments: ${JSON.stringify(ir.branchSegments ?? [])},
+          interceptLoadings: ${moduleArray(ir.loadingPaths?.length ?? 0)},
+          __loadInterceptLoadings: ${lazyLoaderArray(ir.loadingPaths ?? [], imports)},
+          interceptLoadingTreePositions: ${JSON.stringify(ir.loadingTreePositions ?? [])},
           interceptNotFoundBranchSegments: ${JSON.stringify(ir.notFoundBranchSegments ?? ir.branchSegments ?? [])},
           page: null,
           __pageLoader: ${imports.getLazyLoaderVar(ir.pagePath)},
@@ -291,6 +306,7 @@ function buildRouteEntries(routes: AppRoute[], imports: ImportAllocator): string
       return `      ${JSON.stringify(slot.key)}: {
         id: ${JSON.stringify(slot.id ?? null)},
         name: ${JSON.stringify(slot.name)},
+        ownerTreePosition: ${slot.ownerTreePosition ?? "null"},
         page: null,
         __loadPage: ${slot.pagePath ? imports.getLazyLoaderVar(slot.pagePath) : "null"},
         default: null,
@@ -302,6 +318,9 @@ function buildRouteEntries(routes: AppRoute[], imports: ImportAllocator): string
         configLayoutTreePositions: ${JSON.stringify(slot.configLayoutTreePositions ?? [])},
         loading: null,
         __loadLoading: ${slot.loadingPath ? imports.getLazyLoaderVar(slot.loadingPath) : "null"},
+        loadings: ${moduleArray(slot.loadingPaths?.length ?? 0)},
+        __loadLoadings: ${lazyLoaderArray(slot.loadingPaths ?? [], imports)},
+        loadingTreePositions: ${JSON.stringify(slot.loadingTreePositions ?? [])},
         error: null,
         __loadError: ${slot.errorPath ? imports.getLazyLoaderVar(slot.errorPath) : "null"},
         notFound: null,

--- a/packages/vinext/src/entries/app-rsc-manifest.ts
+++ b/packages/vinext/src/entries/app-rsc-manifest.ts
@@ -152,6 +152,9 @@ function registerRouteModules(routes: AppRoute[], imports: ImportAllocator): voi
     for (const layout of route.layouts) imports.getLazyLoaderVar(layout);
     for (const tmpl of route.templates) imports.getLazyLoaderVar(tmpl);
     if (route.loadingPath) imports.getLazyLoaderVar(route.loadingPath);
+    for (const loadingPath of route.loadingPaths ?? []) {
+      imports.getLazyLoaderVar(loadingPath);
+    }
     if (route.errorPath) imports.getLazyLoaderVar(route.errorPath);
     if (route.layoutErrorPaths) {
       for (const ep of route.layoutErrorPaths) {
@@ -237,10 +240,12 @@ function buildRouteEntries(routes: AppRoute[], imports: ImportAllocator): string
     // module cache after the eager import rather than evaluating them twice.
     const layoutLoaders = lazyLoaderArray(route.layouts, imports);
     const templateLoaders = lazyLoaderArray(route.templates, imports);
+    const loadingPaths = route.loadingPaths ?? [];
     const notFoundPaths = route.notFoundPaths ?? [];
     const forbiddenPaths = route.forbiddenPaths ?? [];
     const unauthorizedPaths = route.unauthorizedPaths ?? [];
     const notFoundLoaders = lazyLoaderArray(notFoundPaths, imports);
+    const loadingLoaders = lazyLoaderArray(loadingPaths, imports);
     const forbiddenLoaders = lazyLoaderArray(forbiddenPaths, imports);
     const unauthorizedLoaders = lazyLoaderArray(unauthorizedPaths, imports);
     const siblingInterceptEntries = (route.siblingIntercepts ?? []).map(
@@ -343,6 +348,9 @@ ${interceptEntries.join(",\n")}
     layoutTreePositions: ${JSON.stringify(route.layoutTreePositions)},
     templates: ${moduleArray(route.templates.length)},
     __loadTemplates: ${templateLoaders},
+    loadings: ${moduleArray(loadingPaths.length)},
+    __loadLoadings: ${loadingLoaders},
+    loadingTreePositions: ${JSON.stringify(route.loadingTreePositions ?? null)},
     errors: ${moduleArray(layoutErrorPaths.length)},
     __loadErrors: ${layoutErrorLoaders},
     errorPaths: ${moduleArray(errorPaths.length)},

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -58,12 +58,7 @@ import {
   generateImageAdaptersModule,
   type VinextImageConfig,
 } from "./image/image-adapters-virtual.js";
-import {
-  generateBrowserEntry,
-  isLinkPrefetchRoute,
-  toDocumentOnlyAppRoute,
-  toLinkPrefetchRoute,
-} from "./entries/app-browser-entry.js";
+import { generateBrowserEntry, toLinkPrefetchRoutes } from "./entries/app-browser-entry.js";
 import {
   collectRouteClassificationManifest,
   type RouteClassificationManifest,
@@ -1433,9 +1428,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
     // with `{ __appRouter: true }`. See `pages-client-entry.ts` and issue
     // #1526 for the Next.js parity rationale.
     const appPrefetchRoutes = hasAppDir
-      ? (await appRouter(appDir, nextConfig?.pageExtensions, fileMatcher)).map((route) =>
-          isLinkPrefetchRoute(route) ? toLinkPrefetchRoute(route) : toDocumentOnlyAppRoute(route),
-        )
+      ? toLinkPrefetchRoutes(await appRouter(appDir, nextConfig?.pageExtensions, fileMatcher))
       : [];
     return _generateClientEntry(pagesDir, nextConfig, fileMatcher, {
       appPrefetchRoutes,

--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -41,6 +41,10 @@ type InterceptingRoute = {
   layoutPaths: string[];
   /** Normalized branch segments accumulated at each intercept layout. */
   layoutSegments?: string[][];
+  /** Loading conventions inside the intercepted branch, outermost to innermost. */
+  loadingPaths?: string[];
+  /** Tree positions for loadingPaths in the normalized interception branch. */
+  loadingTreePositions?: number[];
   /** Full normalized interception branch segments through the page. */
   branchSegments?: string[];
   /** Nearest not-found convention inside the interception branch. */
@@ -69,6 +73,8 @@ type ParallelSlot = {
   ownerDir: string;
   /** Stable tree path for the directory whose layout owns this slot. */
   ownerTreePath: string;
+  /** Directory depth of the slot owner from app/ root. */
+  ownerTreePosition?: number;
   /** Whether the slot owner directory declares its own page component. */
   hasPage: boolean;
   /** Absolute path to the slot's page component */
@@ -83,6 +89,10 @@ type ParallelSlot = {
   configLayoutTreePositions?: number[];
   /** Absolute path to the slot's loading component */
   loadingPath: string | null;
+  /** Per-segment loading components from the slot root to its active page. */
+  loadingPaths?: string[];
+  /** Slot-root-relative tree positions aligned with loadingPaths. */
+  loadingTreePositions?: number[];
   /** Absolute path to the slot's error component */
   errorPath: string | null;
   /** Nearest not-found convention for the slot's active branch. */
@@ -1158,18 +1168,22 @@ function discoverSlotSubRoutes(
       if (subPage !== undefined) {
         const configLayoutPaths = findSlotConfigLayoutPaths(slot.ownerDir, subPage, matcher);
         const notFoundBoundary = findSlotNotFoundBoundary(slot.ownerDir, subPage, matcher);
-        return {
-          ...slot,
-          pagePath: subPage,
-          configLayoutPaths,
-          configLayoutTreePositions: findSlotConfigLayoutTreePositions(
-            slot.ownerDir,
+        return withSlotLoadingEntries(
+          {
+            ...slot,
+            pagePath: subPage,
             configLayoutPaths,
-          ),
-          notFoundPath: notFoundBoundary.path,
-          notFoundTreePosition: notFoundBoundary.treePosition,
-          routeSegments: rawSegments,
-        };
+            configLayoutTreePositions: findSlotConfigLayoutTreePositions(
+              slot.ownerDir,
+              configLayoutPaths,
+            ),
+            notFoundPath: notFoundBoundary.path,
+            notFoundTreePosition: notFoundBoundary.treePosition,
+            routeSegments: rawSegments,
+          },
+          subPage,
+          matcher,
+        );
       }
       return slot;
     });
@@ -1369,18 +1383,22 @@ function discoverSlotSubRoutes(
           matcher,
         );
         const notFoundBoundary = findSlotNotFoundBoundary(slot.ownerDir, subPage ?? null, matcher);
-        return {
-          ...slot,
-          pagePath: subPage || null,
-          configLayoutPaths,
-          configLayoutTreePositions: findSlotConfigLayoutTreePositions(
-            slot.ownerDir,
+        return withSlotLoadingEntries(
+          {
+            ...slot,
+            pagePath: subPage || null,
             configLayoutPaths,
-          ),
-          notFoundPath: notFoundBoundary.path,
-          notFoundTreePosition: notFoundBoundary.treePosition,
-          routeSegments: subPage ? rawSegments : null,
-        };
+            configLayoutTreePositions: findSlotConfigLayoutTreePositions(
+              slot.ownerDir,
+              configLayoutPaths,
+            ),
+            notFoundPath: notFoundBoundary.path,
+            notFoundTreePosition: notFoundBoundary.treePosition,
+            routeSegments: subPage ? rawSegments : null,
+          },
+          subPage ?? null,
+          matcher,
+        );
       });
 
       const newRoute: AppRouteGraphRoute = {
@@ -1556,6 +1574,43 @@ function findSlotConfigLayoutTreePositions(
     const relativeDir = path.relative(slotDir, path.dirname(layoutPath));
     return relativeDir ? relativeDir.split(path.sep).filter(Boolean).length : 0;
   });
+}
+
+function findSlotLoadingEntries(
+  slotDir: string,
+  pagePath: string | null,
+  matcher: ValidFileMatcher,
+): { path: string; treePosition: number }[] {
+  const pageDir = pagePath ? path.dirname(pagePath) : slotDir;
+  if (pageDir !== slotDir && !pageDir.startsWith(`${slotDir}${path.sep}`)) return [];
+
+  const relativeDir = path.relative(slotDir, pageDir);
+  const segments = relativeDir ? relativeDir.split(path.sep).filter(Boolean) : [];
+  const loadings: { path: string; treePosition: number }[] = [];
+  let currentDir = slotDir;
+
+  const rootLoading = findFile(currentDir, "loading", matcher);
+  if (rootLoading) loadings.push({ path: rootLoading, treePosition: 0 });
+
+  for (let index = 0; index < segments.length; index++) {
+    currentDir = path.join(currentDir, segments[index]);
+    const loading = findFile(currentDir, "loading", matcher);
+    if (loading) loadings.push({ path: loading, treePosition: index + 1 });
+  }
+  return loadings;
+}
+
+function withSlotLoadingEntries<TSlot extends ParallelSlot>(
+  slot: TSlot,
+  pagePath: string | null,
+  matcher: ValidFileMatcher,
+): TSlot {
+  const loadingEntries = findSlotLoadingEntries(slot.ownerDir, pagePath, matcher);
+  return {
+    ...slot,
+    loadingPaths: loadingEntries.map((entry) => entry.path),
+    loadingTreePositions: loadingEntries.map((entry) => entry.treePosition),
+  };
 }
 
 function findSlotNotFoundBoundary(
@@ -2146,20 +2201,24 @@ function discoverInheritedParallelSlots(
           mirror?.pagePath ?? null,
           matcher,
         );
-        const inheritedSlot: AppRouteGraphParallelSlot = {
-          ...slot,
-          pagePath: mirror?.pagePath ?? null,
-          configLayoutPaths,
-          configLayoutTreePositions: findSlotConfigLayoutTreePositions(
-            slot.ownerDir,
+        const inheritedSlot = withSlotLoadingEntries(
+          {
+            ...slot,
+            pagePath: mirror?.pagePath ?? null,
             configLayoutPaths,
-          ),
-          layoutIndex: slotLayoutIdx,
-          routeSegments: mirror?.segments ?? null,
-          slotPatternParts,
-          slotParamNames,
-          // defaultPath, loadingPath, errorPath, interceptingRoutes remain
-        };
+            configLayoutTreePositions: findSlotConfigLayoutTreePositions(
+              slot.ownerDir,
+              configLayoutPaths,
+            ),
+            layoutIndex: slotLayoutIdx,
+            routeSegments: mirror?.segments ?? null,
+            slotPatternParts,
+            slotParamNames,
+            // defaultPath, loadingPath, errorPath, interceptingRoutes remain
+          },
+          mirror?.pagePath ?? null,
+          matcher,
+        );
         slotMap.set(slot.key, inheritedSlot);
       }
     }
@@ -2313,7 +2372,10 @@ function segmentTreeNodeType(seg: string): string {
   return "dynamic";
 }
 
-function patternsStructurallyEquivalent(a: readonly string[], b: readonly string[]): boolean {
+export function patternsStructurallyEquivalent(
+  a: readonly string[],
+  b: readonly string[],
+): boolean {
   if (a.length !== b.length) return false;
   for (let i = 0; i < a.length; i++) {
     if (segmentTreeNodeType(a[i]) !== segmentTreeNodeType(b[i])) return false;
@@ -2394,6 +2456,7 @@ function discoverParallelSlots(
     const ownerTreePath = createAppRouteGraphTreePath(ownerSegments, ownerSegments.length);
 
     const configLayoutPaths = findSlotConfigLayoutPaths(slotDir, pagePath, matcher);
+    const loadingEntries = findSlotLoadingEntries(slotDir, pagePath, matcher);
     const notFoundBoundary = findSlotNotFoundBoundary(slotDir, pagePath, matcher);
     slots.push({
       id: createAppRouteGraphSlotId(slotName, ownerTreePath),
@@ -2401,6 +2464,7 @@ function discoverParallelSlots(
       name: slotName,
       ownerDir: slotDir,
       ownerTreePath,
+      ownerTreePosition: ownerSegments.length,
       hasPage: pagePath !== null,
       pagePath,
       defaultPath,
@@ -2408,6 +2472,8 @@ function discoverParallelSlots(
       configLayoutPaths,
       configLayoutTreePositions: findSlotConfigLayoutTreePositions(slotDir, configLayoutPaths),
       loadingPath: findFile(slotDir, "loading", matcher),
+      loadingPaths: loadingEntries.map((loading) => loading.path),
+      loadingTreePositions: loadingEntries.map((loading) => loading.treePosition),
       errorPath: findFile(slotDir, "error", matcher),
       notFoundPath: notFoundBoundary.path,
       notFoundTreePosition: notFoundBoundary.treePosition,
@@ -2620,6 +2686,7 @@ function scanForInterceptingPages(
   appDir: string,
   results: InterceptingRoute[],
   matcher: ValidFileMatcher,
+  parentLoadingEntries: readonly { path: string; treePosition: number }[] = [],
 ): void {
   if (!fs.existsSync(currentDir)) return;
 
@@ -2654,10 +2721,32 @@ function scanForInterceptingPages(
         slotRootDir,
         results,
         matcher,
+        [],
+        parentLoadingEntries,
+        path.relative(slotRootDir, currentDir).split(path.sep).filter(Boolean).length,
       );
     } else {
       // Regular subdirectory — keep scanning for intercepting dirs
-      scanForInterceptingPages(interceptDir, slotRootDir, routeDir, appDir, results, matcher);
+      const loading = findFile(interceptDir, "loading", matcher);
+      const loadingEntries = loading
+        ? [
+            ...parentLoadingEntries,
+            {
+              path: loading,
+              treePosition: path.relative(slotRootDir, interceptDir).split(path.sep).filter(Boolean)
+                .length,
+            },
+          ]
+        : parentLoadingEntries;
+      scanForInterceptingPages(
+        interceptDir,
+        slotRootDir,
+        routeDir,
+        appDir,
+        results,
+        matcher,
+        loadingEntries,
+      );
     }
   }
 }
@@ -2698,11 +2787,22 @@ function collectInterceptingPages(
   results: InterceptingRoute[],
   matcher: ValidFileMatcher,
   parentLayoutPaths: readonly string[] = [],
+  parentLoadingEntries: readonly { path: string; treePosition: number }[] = [],
+  treePositionOffset = 0,
 ): void {
   const currentLayoutPath = findFile(currentDir, "layout", matcher);
   const layoutPaths = currentLayoutPath
     ? [...parentLayoutPaths, currentLayoutPath]
     : parentLayoutPaths;
+  const currentLoadingPath = findFile(currentDir, "loading", matcher);
+  const relativeCurrentDir = path.relative(interceptRoot, currentDir);
+  const currentTreePosition =
+    treePositionOffset +
+    1 +
+    (relativeCurrentDir ? relativeCurrentDir.split(path.sep).filter(Boolean).length : 0);
+  const loadingEntries = currentLoadingPath
+    ? [...parentLoadingEntries, { path: currentLoadingPath, treePosition: currentTreePosition }]
+    : parentLoadingEntries;
 
   // Check for page.tsx in current directory
   const page = findFile(currentDir, "page", matcher);
@@ -2722,22 +2822,29 @@ function collectInterceptingPages(
         page,
         matcher,
       );
-      const branchSegments = [
-        interceptSegment,
-        ...path.relative(interceptRoot, path.dirname(page)).split(path.sep).filter(Boolean),
-      ];
       const slotParentSegments = slotRootDir
         ? path.relative(slotRootDir, interceptParentDir).split(path.sep).filter(Boolean)
         : [];
+      const branchSegments = [
+        ...slotParentSegments,
+        interceptSegment,
+        ...path.relative(interceptRoot, path.dirname(page)).split(path.sep).filter(Boolean),
+      ];
       results.push({
         branchSegments,
         convention,
         layoutPaths: [...layoutPaths],
         layoutSegments: layoutPaths.map((layoutPath) => {
           const relativeDir = path.relative(interceptRoot, path.dirname(layoutPath));
-          return [interceptSegment, ...relativeDir.split(path.sep).filter(Boolean)];
+          return [
+            ...slotParentSegments,
+            interceptSegment,
+            ...relativeDir.split(path.sep).filter(Boolean),
+          ];
         }),
-        notFoundBranchSegments: [...slotParentSegments, ...branchSegments],
+        loadingPaths: loadingEntries.map((loading) => loading.path),
+        loadingTreePositions: loadingEntries.map((loading) => loading.treePosition),
+        notFoundBranchSegments: branchSegments,
         notFoundPath: notFoundBoundary.path,
         notFoundTreePosition:
           notFoundBoundary.treePosition === null
@@ -2773,6 +2880,8 @@ function collectInterceptingPages(
       results,
       matcher,
       layoutPaths,
+      loadingEntries,
+      treePositionOffset,
     );
   }
 }

--- a/packages/vinext/src/routing/app-route-graph.ts
+++ b/packages/vinext/src/routing/app-route-graph.ts
@@ -147,8 +147,12 @@ export type AppRoute = {
    * Empty array when there are no sibling-style interception markers.
    */
   siblingIntercepts: InterceptingRoute[];
-  /** Loading component path */
+  /** Loading component path (leaf directory only) */
   loadingPath: string | null;
+  /** Per-segment loading component paths, aligned with loadingTreePositions. */
+  loadingPaths?: string[];
+  /** Tree position (directory depth from app/ root) for each loading boundary. */
+  loadingTreePositions?: number[];
   /** Error component path (leaf directory only) */
   errorPath: string | null;
   /**
@@ -1402,7 +1406,11 @@ function discoverSlotSubRoutes(
           ownerTreePath: childrenOwnerTreePath,
           state: childrenDefault ? "default" : childrenCatchAll ? "active" : "unmatched",
         },
-        loadingPath: parentRoute.loadingPath,
+        // The parent loading convention becomes an ancestor boundary for the
+        // synthetic sub-route; it is no longer the synthetic route's leaf.
+        loadingPath: null,
+        loadingPaths: parentRoute.loadingPaths,
+        loadingTreePositions: parentRoute.loadingTreePositions,
         errorPath: parentRoute.errorPath,
         layoutErrorPaths: parentRoute.layoutErrorPaths,
         notFoundPath: parentRoute.notFoundPath,
@@ -1672,6 +1680,9 @@ function directoryToAppRoute(
   // In Next.js, each segment independently wraps its children with an ErrorBoundary.
   // This array enables interleaving error boundaries with layouts in the rendering.
   const layoutErrorPaths = discoverLayoutAlignedErrors(segments, appDir, matcher);
+  const loadingEntries = discoverSegmentLoadings(segments, appDir, matcher);
+  const loadingPaths = loadingEntries.map((entry) => entry.path);
+  const loadingTreePositions = loadingEntries.map((entry) => entry.treePosition);
   const errorEntries = discoverSegmentErrors(segments, appDir, matcher);
   const errorPaths = errorEntries.map((entry) => entry.path);
   const errorTreePositions = errorEntries.map((entry) => entry.treePosition);
@@ -1725,6 +1736,8 @@ function directoryToAppRoute(
     templates,
     parallelSlots,
     loadingPath,
+    loadingPaths,
+    loadingTreePositions,
     errorPath,
     layoutErrorPaths,
     errorPaths,
@@ -1935,6 +1948,37 @@ function discoverSegmentErrors(
   }
 
   return errors;
+}
+
+/**
+ * Discover loading.tsx files by segment tree position.
+ *
+ * Loading conventions belong to loader-tree segments rather than layouts. A
+ * segment without layout.tsx can therefore provide the boundary that suspends
+ * while its child layout renders.
+ */
+function discoverSegmentLoadings(
+  segments: string[],
+  appDir: string,
+  matcher: ValidFileMatcher,
+): { path: string; treePosition: number }[] {
+  const loadings: { path: string; treePosition: number }[] = [];
+
+  const rootLoading = findFile(appDir, "loading", matcher);
+  if (rootLoading) {
+    loadings.push({ path: rootLoading, treePosition: 0 });
+  }
+
+  let currentDir = appDir;
+  for (let index = 0; index < segments.length; index++) {
+    currentDir = path.join(currentDir, segments[index]);
+    const loading = findFile(currentDir, "loading", matcher);
+    if (loading) {
+      loadings.push({ path: loading, treePosition: index + 1 });
+    }
+  }
+
+  return loadings;
 }
 
 /**

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -128,6 +128,8 @@ type AppPageDispatchIntercept<TPage = unknown> = {
   interceptLayouts?: readonly unknown[] | null;
   interceptLayoutSegments?: readonly (readonly string[])[] | null;
   interceptBranchSegments?: readonly string[] | null;
+  interceptLoadings?: readonly unknown[] | null;
+  interceptLoadingTreePositions?: readonly number[] | null;
   interceptNotFoundBranchSegments?: readonly string[] | null;
   notFound?: unknown;
   notFoundTreePosition?: number | null;
@@ -145,6 +147,8 @@ type AppPageDispatchInterceptOptions<TPage = unknown> = {
   interceptLayouts?: readonly unknown[] | null;
   interceptLayoutSegments?: readonly (readonly string[])[] | null;
   interceptBranchSegments?: readonly string[] | null;
+  interceptLoadings?: readonly unknown[] | null;
+  interceptLoadingTreePositions?: readonly number[] | null;
   interceptNotFoundBranchSegments?: readonly string[] | null;
   interceptNotFound?: unknown;
   interceptNotFoundTreePosition?: number | null;
@@ -164,6 +168,8 @@ type AppPageModule = {
 
 type AppPageDispatchSlot = {
   default?: AppPageModule | null;
+  loading?: AppPageModule | null;
+  loadings?: readonly (AppPageModule | null | undefined)[] | null;
   page?: AppPageModule | null;
   slotPatternParts?: readonly string[] | null;
   slotParamNames?: readonly string[] | null;
@@ -191,6 +197,8 @@ export type AppPageDispatchRoute = {
   layouts: readonly AppPageModule[];
   layoutTreePositions?: readonly number[];
   loading?: AppPageModule | null;
+  loadings?: readonly (AppPageModule | null | undefined)[];
+  loadingTreePositions?: readonly number[];
   notFound?: AppPageModule | null;
   notFounds?: readonly (AppPageModule | null | undefined)[];
   params: readonly string[];
@@ -201,6 +209,38 @@ export type AppPageDispatchRoute = {
   unauthorizedTreePosition?: number | null;
   unauthorizeds?: readonly (AppPageModule | null | undefined)[];
 };
+
+function getActiveLoadingTreePositions(route: AppPageDispatchRoute): number[] {
+  const positions: number[] = [];
+  for (const [index, loadingModule] of (route.loadings ?? []).entries()) {
+    if (!loadingModule?.default) continue;
+    const treePosition = route.loadingTreePositions?.[index];
+    if (treePosition !== undefined) positions.push(treePosition);
+  }
+
+  // Older/eager route fixtures may only expose the leaf field. Keep that
+  // representation working while the generated manifest carries both forms.
+  if (positions.length === 0 && route.loading?.default) {
+    positions.push(route.routeSegments.length);
+  }
+  return positions;
+}
+
+function getAppPageLayoutProbeCount(
+  route: AppPageDispatchRoute,
+  loadingTreePositions: readonly number[],
+): number {
+  const firstLoadingTreePosition = loadingTreePositions.reduce<number | null>(
+    (first, position) => (first === null || position < first ? position : first),
+    null,
+  );
+  if (firstLoadingTreePosition === null) return route.layouts.length;
+
+  const firstSuspendedLayoutIndex = (route.layoutTreePositions ?? []).findIndex(
+    (position) => position > firstLoadingTreePosition,
+  );
+  return firstSuspendedLayoutIndex === -1 ? route.layouts.length : firstSuspendedLayoutIndex;
+}
 
 function resolveAppPageRouteBoundaryModule(
   route: AppPageDispatchRoute,
@@ -546,6 +586,8 @@ function toInterceptOptions(
     interceptLayouts: intercept.interceptLayouts,
     interceptLayoutSegments: intercept.interceptLayoutSegments,
     interceptBranchSegments: intercept.interceptBranchSegments,
+    interceptLoadings: intercept.interceptLoadings,
+    interceptLoadingTreePositions: intercept.interceptLoadingTreePositions,
     interceptNotFoundBranchSegments: intercept.interceptNotFoundBranchSegments,
     interceptNotFound: intercept.notFound,
     interceptNotFoundTreePosition: intercept.notFoundTreePosition,
@@ -598,7 +640,8 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
     ? new URLSearchParams()
     : options.searchParams;
   const layoutParamAccess = createAppLayoutParamAccessTracker();
-  const hasActiveLoadingBoundary = Boolean(route.loading?.default);
+  const activeLoadingTreePositions = getActiveLoadingTreePositions(route);
+  const hasActiveLoadingBoundary = activeLoadingTreePositions.length > 0;
 
   setCurrentFetchSoftTags(buildAppPageTags(options.cleanPathname, [], route.routeSegments));
   setCurrentFetchCacheMode(options.fetchCache ?? null);
@@ -954,7 +997,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
         );
       },
       async probePageSpecialError() {
-        if (route.loading?.default) {
+        if (hasActiveLoadingBoundary) {
           return null;
         }
         const pageError = await probeAppPageThrownError({
@@ -1070,7 +1113,11 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
     isrSet: options.isrSet,
     interceptionContext: options.interceptionContext,
     expireSeconds: options.expireSeconds,
-    layoutCount: route.layouts.length,
+    // A loading convention at tree position N wraps descendants, but not a
+    // layout co-located at N. Probing any deeper async layout before creating
+    // the RSC stream would serialize on work that its ancestor Suspense
+    // boundary is specifically meant to stream behind.
+    layoutCount: getAppPageLayoutProbeCount(route, activeLoadingTreePositions),
     loadSsrHandler: options.loadSsrHandler,
     middlewareContext: options.middlewareContext,
     navigationParams,

--- a/packages/vinext/src/server/app-page-element-builder.ts
+++ b/packages/vinext/src/server/app-page-element-builder.ts
@@ -1,4 +1,4 @@
-import { createElement } from "react";
+import { Suspense, createElement } from "react";
 import { makeThenableParams } from "vinext/shims/thenable-params";
 import {
   prepareAppPageHead,
@@ -82,6 +82,8 @@ export type AppPageInterceptOptions<TModule extends AppPageModule = AppPageModul
   interceptLayouts?: readonly (TModule | null | undefined)[] | null;
   interceptLayoutSegments?: readonly (readonly string[])[] | null;
   interceptBranchSegments?: readonly string[] | null;
+  interceptLoadings?: readonly (TModule | null | undefined)[] | null;
+  interceptLoadingTreePositions?: readonly number[] | null;
   interceptNotFoundBranchSegments?: readonly string[] | null;
   interceptNotFound?: TModule | null;
   interceptNotFoundTreePosition?: number | null;
@@ -517,23 +519,51 @@ export async function buildPageElements<
     isSiblingIntercept && EffectivePageComponent
       ? createPageElement(EffectivePageComponent, pageProps)
       : null;
-  if (isSiblingIntercept && siblingInterceptElement !== null && opts?.interceptLayouts?.length) {
-    for (let i = opts.interceptLayouts.length - 1; i >= 0; i--) {
-      const layoutMod = opts.interceptLayouts[i] as AppPageModule | null | undefined;
-      const LayoutComponent = layoutMod?.default;
-      if (LayoutComponent) {
-        const interceptLayoutSegments = opts.interceptLayoutSegments?.[i] ?? [];
+  if (isSiblingIntercept && siblingInterceptElement !== null) {
+    const layoutIndexesByTreePosition = new Map<number, number[]>();
+    for (const [index, layoutModule] of (opts?.interceptLayouts ?? []).entries()) {
+      if (!layoutModule?.default) continue;
+      const treePosition = opts?.interceptLayoutSegments?.[index]?.length ?? 0;
+      const indexes = layoutIndexesByTreePosition.get(treePosition) ?? [];
+      indexes.push(index);
+      layoutIndexesByTreePosition.set(treePosition, indexes);
+    }
+    const loadingIndexesByTreePosition = new Map<number, number>();
+    for (const [index, loadingModule] of (opts?.interceptLoadings ?? []).entries()) {
+      if (!loadingModule?.default) continue;
+      const treePosition = opts?.interceptLoadingTreePositions?.[index];
+      if (treePosition !== undefined) loadingIndexesByTreePosition.set(treePosition, index);
+    }
+    const treePositions = Array.from(
+      new Set([...layoutIndexesByTreePosition.keys(), ...loadingIndexesByTreePosition.keys()]),
+    ).sort((left, right) => left - right);
+
+    for (let index = treePositions.length - 1; index >= 0; index--) {
+      const treePosition = treePositions[index];
+      const loadingIndex = loadingIndexesByTreePosition.get(treePosition);
+      const LoadingComponent =
+        loadingIndex === undefined ? null : opts?.interceptLoadings?.[loadingIndex]?.default;
+      if (LoadingComponent) {
+        siblingInterceptElement = createElement(
+          Suspense,
+          { fallback: createElement(LoadingComponent) },
+          siblingInterceptElement,
+        );
+      }
+
+      const layoutIndexes = layoutIndexesByTreePosition.get(treePosition) ?? [];
+      for (let layoutOffset = layoutIndexes.length - 1; layoutOffset >= 0; layoutOffset--) {
+        const layoutIndex = layoutIndexes[layoutOffset];
+        const LayoutComponent = opts?.interceptLayouts?.[layoutIndex]?.default;
+        if (!LayoutComponent) continue;
+        const interceptLayoutSegments = opts?.interceptLayoutSegments?.[layoutIndex] ?? [];
         const interceptLayoutParams = resolveInterceptLayoutParams(
-          opts.interceptBranchSegments ?? interceptLayoutSegments,
+          opts?.interceptBranchSegments ?? interceptLayoutSegments,
           interceptLayoutSegments,
           effectiveParams,
         );
-        // Layout component types vary; cast to any to avoid overload-resolution
-        // issues in createElement while preserving runtime safety.
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const LC = LayoutComponent as (props: any) => any;
         siblingInterceptElement = createElement(
-          LC,
+          LayoutComponent,
           { params: makeThenableParams(interceptLayoutParams) },
           siblingInterceptElement,
         );
@@ -613,6 +643,8 @@ function buildSlotOverrides<TModule extends AppPageModule, TErrorModule extends 
       branchSegments: opts.interceptBranchSegments ?? null,
       layoutModules: opts.interceptLayouts || null,
       layoutSegments: opts.interceptLayoutSegments ?? null,
+      loadingModules: opts.interceptLoadings || null,
+      loadingTreePositions: opts.interceptLoadingTreePositions ?? null,
       pageModule: opts.interceptPage,
       params: opts.interceptParams || routeParams,
       routeSegments: resolveInterceptedSlotSegments(

--- a/packages/vinext/src/server/app-page-probe.ts
+++ b/packages/vinext/src/server/app-page-probe.ts
@@ -278,7 +278,15 @@ export function probeAppPage(options: {
 
 type AppPageProbeModule = Readonly<{ default?: unknown }> | null | undefined;
 
-type AppPageProbeSlot = Readonly<{ page?: AppPageProbeModule }> | null | undefined;
+type AppPageProbeSlot =
+  | Readonly<{
+      page?: AppPageProbeModule;
+      loading?: AppPageProbeModule;
+      loadings?: readonly AppPageProbeModule[] | null;
+      loadingTreePositions?: readonly number[] | null;
+    }>
+  | null
+  | undefined;
 
 type AppPageProbeRoute = Readonly<{
   slots?: Readonly<Record<string, AppPageProbeSlot>> | null;
@@ -287,6 +295,7 @@ type AppPageProbeRoute = Readonly<{
 type AppPageProbeIntercept =
   | Readonly<{
       page?: AppPageProbeModule;
+      interceptLoadings?: readonly AppPageProbeModule[] | null;
       matchedParams?: unknown;
       /**
        * Key of the parallel-route slot this interception overrides. At render
@@ -375,6 +384,9 @@ export function buildAppPageProbes(options: {
     if (overriddenSlotKey !== null && slotKey === overriddenSlotKey) {
       continue;
     }
+    if (slot?.loading?.default || slot?.loadings?.some((loading) => loading?.default)) {
+      continue;
+    }
     probes.push(
       probeAppPage({
         pageComponent: slot?.page?.default,
@@ -384,7 +396,18 @@ export function buildAppPageProbes(options: {
     );
   }
 
-  if (intercept) {
+  const interceptedSlot = intercept?.slotKey ? route.slots?.[intercept.slotKey] : null;
+  const interceptedSlotHasRootLoading = Boolean(
+    interceptedSlot?.loading?.default ||
+    interceptedSlot?.loadings?.some(
+      (loading, index) => loading?.default && interceptedSlot.loadingTreePositions?.[index] === 0,
+    ),
+  );
+  const interceptHasLoadingBoundary = Boolean(
+    intercept?.interceptLoadings?.some((loading) => loading?.default) ||
+    interceptedSlotHasRootLoading,
+  );
+  if (intercept && !interceptHasLoadingBoundary) {
     probes.push(
       probeAppPage({
         pageComponent: intercept.page?.default,

--- a/packages/vinext/src/server/app-page-request.ts
+++ b/packages/vinext/src/server/app-page-request.ts
@@ -76,8 +76,11 @@ type AppPageInterceptMatch<TPage = unknown> = {
   interceptLayouts?: readonly unknown[] | null;
   interceptLayoutSegments?: readonly (readonly string[])[] | null;
   interceptBranchSegments?: readonly string[] | null;
+  interceptLoadings?: readonly unknown[] | null;
+  interceptLoadingTreePositions?: readonly number[] | null;
   interceptNotFoundBranchSegments?: readonly string[] | null;
   __loadInterceptLayouts?: readonly (() => Promise<unknown>)[] | null;
+  __loadInterceptLoadings?: readonly (() => Promise<unknown>)[] | null;
   matchedParams: AppPageParams;
   sourceMatchedParams?: AppPageParams;
   page: TPage;
@@ -708,7 +711,7 @@ async function resolveAppPageInterceptState<TRoute, TPage, TInterceptOpts>(
     if (loadState) loadState.notFoundLoading = loading;
     await loading;
   }
-  if (intercept.__loadInterceptLayouts) {
+  if (intercept.__loadInterceptLayouts || intercept.__loadInterceptLoadings) {
     await loadAppInterceptLayouts(intercept);
   }
 

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -129,6 +129,8 @@ export type AppPageRouteWiringRoute<
   layoutTreePositions?: readonly number[] | null;
   layouts: readonly (TModule | null | undefined)[];
   loading?: TModule | null;
+  loadings?: readonly (TModule | null | undefined)[] | null;
+  loadingTreePositions?: readonly number[] | null;
   notFound?: TModule | null;
   notFounds?: readonly (TModule | null | undefined)[] | null;
   notFoundTreePosition?: number | null;
@@ -250,6 +252,11 @@ type AppPageTemplateEntry<TModule extends AppPageModule = AppPageModule> = {
 
 type AppPageErrorEntry<TErrorModule extends AppPageErrorModule = AppPageErrorModule> = {
   errorModule?: TErrorModule | null | undefined;
+  treePosition: number;
+};
+
+type AppPageLoadingEntry<TModule extends AppPageModule = AppPageModule> = {
+  loadingModule?: TModule | null | undefined;
   treePosition: number;
 };
 
@@ -423,6 +430,17 @@ function createAppPageErrorEntries<TErrorModule extends AppPageErrorModule>(
     const treePosition = route.errorTreePositions?.[index];
     if (treePosition === undefined) return [];
     return [{ errorModule, treePosition }];
+  });
+}
+
+function createAppPageLoadingEntries<TModule extends AppPageModule>(
+  route: Pick<AppPageRouteWiringRoute<TModule>, "loadings" | "loadingTreePositions">,
+): AppPageLoadingEntry<TModule>[] {
+  return (route.loadings ?? []).flatMap((loadingModule, index) => {
+    if (!loadingModule) return [];
+    const treePosition = route.loadingTreePositions?.[index];
+    if (treePosition === undefined) return [];
+    return [{ loadingModule, treePosition }];
   });
 }
 
@@ -643,16 +661,21 @@ export function buildAppPageElements<
     : null;
   const layoutEntries = createAppPageLayoutEntries(options.route);
   const templateEntries = createAppPageTemplateEntries(options.route);
+  const loadingEntries = createAppPageLoadingEntries(options.route);
   const errorEntries = createAppPageErrorEntries(options.route);
   const metadataPlacement = options.metadataPlacement ?? "head";
   const layoutEntriesByTreePosition = new Map<number, AppPageLayoutEntry<TModule, TErrorModule>>();
   const templateEntriesByTreePosition = new Map<number, AppPageTemplateEntry<TModule>>();
+  const loadingEntriesByTreePosition = new Map<number, AppPageLoadingEntry<TModule>>();
   const errorEntriesByTreePosition = new Map<number, AppPageErrorEntry<TErrorModule>>();
   for (const layoutEntry of layoutEntries) {
     layoutEntriesByTreePosition.set(layoutEntry.treePosition, layoutEntry);
   }
   for (const templateEntry of templateEntries) {
     templateEntriesByTreePosition.set(templateEntry.treePosition, templateEntry);
+  }
+  for (const loadingEntry of loadingEntries) {
+    loadingEntriesByTreePosition.set(loadingEntry.treePosition, loadingEntry);
   }
   for (const errorEntry of errorEntries) {
     errorEntriesByTreePosition.set(errorEntry.treePosition, errorEntry);
@@ -678,6 +701,7 @@ export function buildAppPageElements<
     new Set<number>([
       ...layoutEntries.map((entry) => entry.treePosition),
       ...templateEntries.map((entry) => entry.treePosition),
+      ...loadingEntries.map((entry) => entry.treePosition),
       ...errorEntries.map((entry) => entry.treePosition),
     ]),
   ).sort((left, right) => left - right);
@@ -1128,11 +1152,28 @@ export function buildAppPageElements<
     let segmentChildren: ReactNode = routeChildren;
     const layoutEntry = layoutEntriesByTreePosition.get(treePosition);
     const templateEntry = templateEntriesByTreePosition.get(treePosition);
+    const loadingEntry = loadingEntriesByTreePosition.get(treePosition);
     const errorEntry = errorEntriesByTreePosition.get(treePosition);
 
-    // Next.js nesting per segment (outer to inner): Layout > Template > Error > Unauthorized > Forbidden > NotFound > children.
-    // Building bottom-up means NotFoundBoundary must wrap the leaf subtree first,
-    // then ErrorBoundary, then Template, with the Layout slot outermost.
+    // The leaf loading convention keeps using the route-level wrapper above so
+    // its ordering relative to page access/error boundaries and scroll handling
+    // remains unchanged. Ancestor segment boundaries are inserted here so they
+    // can suspend while a child layout entry renders.
+    if (treePosition < routeSegments.length) {
+      const segmentLoadingComponent = getDefaultExport(loadingEntry?.loadingModule);
+      if (segmentLoadingComponent) {
+        const SegmentLoadingComponent = segmentLoadingComponent;
+        segmentChildren = (
+          <Suspense key={segmentResetKey || routeResetKey} fallback={<SegmentLoadingComponent />}>
+            {segmentChildren}
+          </Suspense>
+        );
+      }
+    }
+
+    // Next.js nesting per segment (outer to inner): Layout > Template > Error > Unauthorized > Forbidden > NotFound > Loading > children.
+    // Building bottom-up means Loading must wrap the leaf subtree first, then
+    // access/error boundaries, Template, and finally the Layout slot.
     if (layoutEntry) {
       const layoutNotFoundComponent = getDefaultExport(layoutEntry.notFoundModule);
       if (layoutNotFoundComponent) {

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -102,6 +102,9 @@ type AppPageRouteWiringSlot<
   layout?: TModule | null;
   layoutIndex: number;
   loading?: TModule | null;
+  loadings?: readonly (TModule | null | undefined)[] | null;
+  loadingTreePositions?: readonly number[] | null;
+  ownerTreePosition?: number | null;
   notFound?: TModule | null;
   notFoundTreePosition?: number | null;
   page?: TModule | null;
@@ -172,6 +175,8 @@ export type AppPageSlotOverride<TModule extends AppPageModule = AppPageModule> =
   branchSegments?: readonly string[] | null;
   layoutSegments?: readonly (readonly string[])[] | null;
   layoutModules?: readonly (TModule | null | undefined)[] | null;
+  loadingModules?: readonly (TModule | null | undefined)[] | null;
+  loadingTreePositions?: readonly number[] | null;
   /**
    * The page module to render for this slot. Optional — when omitted, the
    * slot's existing `page` is used (e.g. when the override only changes the
@@ -444,6 +449,67 @@ function createAppPageLoadingEntries<TModule extends AppPageModule>(
   });
 }
 
+function getPrefetchLoadingEntry<TModule extends AppPageModule>(
+  route: Pick<
+    AppPageRouteWiringRoute<TModule>,
+    "loading" | "loadings" | "loadingTreePositions" | "routeSegments"
+  >,
+): AppPageLoadingEntry<TModule> | null {
+  let firstEntry: AppPageLoadingEntry<TModule> | null = null;
+  for (const [index, loadingModule] of (route.loadings ?? []).entries()) {
+    if (!getDefaultExport(loadingModule)) continue;
+    const treePosition = route.loadingTreePositions?.[index];
+    if (treePosition === undefined) continue;
+    if (firstEntry === null || treePosition < firstEntry.treePosition) {
+      firstEntry = { loadingModule, treePosition };
+    }
+  }
+  if (firstEntry) return firstEntry;
+
+  // Legacy/eager route fixtures may only expose the leaf loading field.
+  return getDefaultExport(route.loading)
+    ? { loadingModule: route.loading, treePosition: route.routeSegments?.length ?? 0 }
+    : null;
+}
+
+function createAppPageSlotLoadingEntries<TModule extends AppPageModule>(
+  slot: Pick<AppPageRouteWiringSlot<TModule>, "loading" | "loadings" | "loadingTreePositions">,
+  override: Pick<AppPageSlotOverride<TModule>, "loadingModules" | "loadingTreePositions"> | null,
+): AppPageLoadingEntry<TModule>[] {
+  const entries: AppPageLoadingEntry<TModule>[] = [];
+  const slotLoadingModules =
+    (slot.loadings?.length ?? 0) > 0 ? slot.loadings! : slot.loading ? [slot.loading] : [];
+  const slotLoadingTreePositions =
+    (slot.loadingTreePositions?.length ?? 0) > 0 ? slot.loadingTreePositions! : [0];
+
+  for (const [index, loadingModule] of slotLoadingModules.entries()) {
+    const treePosition = slotLoadingTreePositions[index];
+    if (!getDefaultExport(loadingModule) || treePosition === undefined) continue;
+    // An interception replaces the slot's normal active branch. Only the slot
+    // root is necessarily shared; nested normal-branch loadings belong to a
+    // sibling subtree and must not wrap the intercepting page.
+    if (override && treePosition !== 0) continue;
+    entries.push({ loadingModule, treePosition });
+  }
+
+  for (const [index, loadingModule] of (override?.loadingModules ?? []).entries()) {
+    const treePosition = override?.loadingTreePositions?.[index];
+    if (!getDefaultExport(loadingModule) || treePosition === undefined) continue;
+    entries.push({ loadingModule, treePosition });
+  }
+
+  return entries;
+}
+
+function getFirstLoadingEntry<TModule extends AppPageModule>(
+  entries: readonly AppPageLoadingEntry<TModule>[],
+): AppPageLoadingEntry<TModule> | null {
+  return entries.reduce<AppPageLoadingEntry<TModule> | null>(
+    (first, entry) => (first === null || entry.treePosition < first.treePosition ? entry : first),
+    null,
+  );
+}
+
 function createAppPageParallelSlotEntries<
   TModule extends AppPageModule,
   TErrorModule extends AppPageErrorModule,
@@ -663,6 +729,32 @@ export function buildAppPageElements<
   const templateEntries = createAppPageTemplateEntries(options.route);
   const loadingEntries = createAppPageLoadingEntries(options.route);
   const errorEntries = createAppPageErrorEntries(options.route);
+  const findNearestAncestorLoadingEntry = (
+    treePosition: number,
+  ): AppPageLoadingEntry<TModule> | undefined => {
+    for (let index = loadingEntries.length - 1; index >= 0; index--) {
+      if (loadingEntries[index].treePosition < treePosition) return loadingEntries[index];
+    }
+    return undefined;
+  };
+  const findNearestLoadingEntryAtOrAbove = (
+    treePosition: number,
+  ): AppPageLoadingEntry<TModule> | undefined => {
+    let nearest: AppPageLoadingEntry<TModule> | undefined;
+    for (const entry of loadingEntries) {
+      if (
+        entry.treePosition <= treePosition &&
+        (!nearest || entry.treePosition > nearest.treePosition)
+      ) {
+        nearest = entry;
+      }
+    }
+    return nearest;
+  };
+  const isPrefetchLoadingShell = renderMode === APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL;
+  const prefetchLoadingEntry = isPrefetchLoadingShell
+    ? getPrefetchLoadingEntry(options.route)
+    : null;
   const metadataPlacement = options.metadataPlacement ?? "head";
   const layoutEntriesByTreePosition = new Map<number, AppPageLayoutEntry<TModule, TErrorModule>>();
   const templateEntriesByTreePosition = new Map<number, AppPageTemplateEntry<TModule>>();
@@ -719,6 +811,27 @@ export function buildAppPageElements<
 
     return undefined;
   };
+  const prefetchSlotLoadingEntries = isPrefetchLoadingShell
+    ? Object.entries(options.route.slots ?? {}).flatMap(([slotKey, slot]) => {
+        const override = resolveSlotOverride(slotKey, slot.name) ?? null;
+        const firstLoadingEntry = getFirstLoadingEntry(
+          createAppPageSlotLoadingEntries(slot, override),
+        );
+        return firstLoadingEntry ? [{ ownerTreePosition: slot.ownerTreePosition ?? 0 }] : [];
+      })
+    : [];
+  // The children spine must reach every slot owner whose branch has a loading
+  // boundary. A loading on the spine itself stops traversal first, matching
+  // Next.js's per-parallel-route pre-PPR component-tree walk.
+  const prefetchCutoffTreePosition = isPrefetchLoadingShell
+    ? (prefetchLoadingEntry?.treePosition ??
+      prefetchSlotLoadingEntries.reduce(
+        (deepest, entry) => Math.max(deepest, entry.ownerTreePosition),
+        0,
+      ))
+    : null;
+  const includesPrefetchTreePosition = (treePosition: number): boolean =>
+    prefetchCutoffTreePosition === null || treePosition <= prefetchCutoffTreePosition;
   const elements: Record<
     string,
     | ReactNode
@@ -769,6 +882,7 @@ export function buildAppPageElements<
     resolveSlotOverride(slotKey, slotName)?.params ?? options.matchedParams;
 
   for (const treePosition of orderedTreePositions) {
+    if (isPrefetchLoadingShell && !includesPrefetchTreePosition(treePosition)) continue;
     const layoutIndex = layoutIndicesByTreePosition.get(treePosition);
     if (layoutIndex !== undefined) {
       const layoutEntry = layoutEntries[layoutIndex];
@@ -794,8 +908,10 @@ export function buildAppPageElements<
   }
 
   const routeLoadingComponent = getDefaultExport(options.route.loading);
-  const isPrefetchLoadingShell = renderMode === APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL;
-  const shouldRenderPrefetchLoadingShell = isPrefetchLoadingShell && routeLoadingComponent !== null;
+  const prefetchLoadingComponent = getDefaultExport(prefetchLoadingEntry?.loadingModule);
+  const shouldRenderPrefetchLoadingShell =
+    isPrefetchLoadingShell &&
+    (prefetchLoadingComponent !== null || prefetchSlotLoadingEntries.length > 0);
   if (shouldRenderPrefetchLoadingShell) {
     // Client loading components serialize as module references in Flight. Keep
     // a durable marker in the shell payload so external router tests and
@@ -809,13 +925,16 @@ export function buildAppPageElements<
     : renderAfterAppDependencies(options.element, pageDependencies);
 
   for (const templateEntry of templateEntries) {
+    if (isPrefetchLoadingShell && !includesPrefetchTreePosition(templateEntry.treePosition)) {
+      continue;
+    }
     const templateComponent = getDefaultExport(templateEntry.templateModule);
     if (!templateComponent) {
       continue;
     }
     const TemplateComponent = templateComponent;
     const templateDependency = templateDependenciesById.get(templateEntry.id);
-    const templateElement = templateDependency ? (
+    let templateElement: ReactNode = templateDependency ? (
       renderWithAppDependencyBarrier(
         <TemplateComponent>
           <Children />
@@ -827,6 +946,21 @@ export function buildAppPageElements<
         <Children />
       </TemplateComponent>
     );
+    const ancestorLoadingEntry = findNearestAncestorLoadingEntry(templateEntry.treePosition);
+    const ancestorLoadingComponent = getDefaultExport(ancestorLoadingEntry?.loadingModule);
+    if (ancestorLoadingComponent && ancestorLoadingEntry) {
+      const AncestorLoadingComponent = ancestorLoadingComponent;
+      const loadingResetKey = resolveAppPageSegmentStateKey(
+        routeSegments,
+        ancestorLoadingEntry.treePosition,
+        options.matchedParams,
+      );
+      templateElement = (
+        <Suspense key={loadingResetKey || routeResetKey} fallback={<AncestorLoadingComponent />}>
+          {templateElement}
+        </Suspense>
+      );
+    }
     elements[templateEntry.id] = renderAfterAppDependencies(
       templateElement,
       templateDependenciesBeforeById.get(templateEntry.id) ?? [],
@@ -835,6 +969,9 @@ export function buildAppPageElements<
 
   for (let index = 0; index < layoutEntries.length; index++) {
     const layoutEntry = layoutEntries[index];
+    if (isPrefetchLoadingShell && !includesPrefetchTreePosition(layoutEntry.treePosition)) {
+      continue;
+    }
     const layoutComponent = getDefaultExport(layoutEntry.layoutModule);
     if (!layoutComponent) {
       continue;
@@ -870,7 +1007,7 @@ export function buildAppPageElements<
 
     const LayoutComponent = layoutComponent;
     const layoutDependency = layoutDependenciesByIndex.get(index);
-    const layoutElement = layoutDependency ? (
+    let layoutElement: ReactNode = layoutDependency ? (
       renderWithAppDependencyBarrier(
         <LayoutComponent {...layoutProps}>
           <Children />
@@ -882,6 +1019,21 @@ export function buildAppPageElements<
         <Children />
       </LayoutComponent>
     );
+    const ancestorLoadingEntry = findNearestAncestorLoadingEntry(layoutEntry.treePosition);
+    const ancestorLoadingComponent = getDefaultExport(ancestorLoadingEntry?.loadingModule);
+    if (ancestorLoadingComponent && ancestorLoadingEntry) {
+      const AncestorLoadingComponent = ancestorLoadingComponent;
+      const loadingResetKey = resolveAppPageSegmentStateKey(
+        routeSegments,
+        ancestorLoadingEntry.treePosition,
+        options.matchedParams,
+      );
+      layoutElement = (
+        <Suspense key={loadingResetKey || routeResetKey} fallback={<AncestorLoadingComponent />}>
+          {layoutElement}
+        </Suspense>
+      );
+    }
     elements[layoutEntry.id] = renderAfterAppDependencies(
       layoutElement,
       layoutDependenciesBefore[index] ?? [],
@@ -891,6 +1043,20 @@ export function buildAppPageElements<
   for (const [slotKey, slot] of Object.entries(options.route.slots ?? {})) {
     const slotName = slot.name;
     const targetIndex = slot.layoutIndex >= 0 ? slot.layoutIndex : layoutEntries.length - 1;
+    const targetTreePosition = layoutEntries[targetIndex]?.treePosition ?? 0;
+    const ownerTreePosition = slot.ownerTreePosition ?? targetTreePosition;
+    const isOwnedAtRoutePrefetchCutoff =
+      isPrefetchLoadingShell &&
+      prefetchLoadingEntry !== null &&
+      ownerTreePosition === prefetchLoadingEntry.treePosition;
+    if (
+      isPrefetchLoadingShell &&
+      (prefetchLoadingEntry
+        ? ownerTreePosition > prefetchLoadingEntry.treePosition
+        : !includesPrefetchTreePosition(targetTreePosition))
+    ) {
+      continue;
+    }
     const treePath = layoutEntries[targetIndex]?.treePath ?? "/";
     const slotId = resolveAppPageSlotId(slot, treePath);
     const slotOverride = resolveSlotOverride(slotKey, slotName);
@@ -902,6 +1068,20 @@ export function buildAppPageElements<
       options.matchedParams,
     );
     const slotResetKey = resolveAppPageRouteStateKey(slotRouteSegments, slotParams);
+    const hasSlotTreeOverride =
+      slotOverride?.pageModule != null || slotOverride?.layoutModules !== undefined;
+    const slotLoadingEntries = createAppPageSlotLoadingEntries(
+      slot,
+      hasSlotTreeOverride ? (slotOverride ?? null) : null,
+    );
+    const prefetchSlotLoadingEntry = isOwnedAtRoutePrefetchCutoff
+      ? prefetchLoadingEntry
+      : isPrefetchLoadingShell
+        ? getFirstLoadingEntry(slotLoadingEntries)
+        : null;
+    if (isPrefetchLoadingShell && prefetchSlotLoadingEntry === null) {
+      continue;
+    }
     const overrideOrPageComponent =
       getDefaultExport(slotOverride?.pageModule) ?? getDefaultExport(slot.page);
     const defaultComponent = getDefaultExport(slot.default);
@@ -921,100 +1101,165 @@ export function buildAppPageElements<
 
     const slotComponent = overrideOrPageComponent ?? defaultComponent;
 
-    if (!slotComponent) {
+    if (!slotComponent && !isOwnedAtRoutePrefetchCutoff) {
       elements[slotId] = AppElementsWire.unmatchedSlotValue;
       continue;
     }
 
-    const slotThenableParams = options.makeThenableParams(slotParams);
-    const slotProps: Record<string, unknown> = {
-      params: slotThenableParams,
-    };
-    if (options.searchParams !== undefined) {
-      slotProps.searchParams = options.searchParams;
-    }
-    if (slotOverride?.props) {
-      Object.assign(slotProps, slotOverride.props);
-    }
-
-    let slotElement: ReactNode = options.createPageElement
-      ? options.createPageElement(slotComponent, slotProps)
-      : (() => {
-          const SlotComponent = slotComponent;
-          return <SlotComponent {...slotProps} />;
-        })();
-    const hasSlotTreeOverride =
-      slotOverride?.pageModule != null || slotOverride?.layoutModules !== undefined;
-    const interceptLayouts = slotOverride?.layoutModules ?? [];
-
-    for (let layoutIndex = interceptLayouts.length - 1; layoutIndex >= 0; layoutIndex--) {
-      const interceptLayoutComponent = getDefaultExport(interceptLayouts[layoutIndex]);
-      if (!interceptLayoutComponent) {
-        continue;
+    let slotElement: ReactNode;
+    if (prefetchSlotLoadingEntry) {
+      const PrefetchSlotLoadingComponent = getDefaultExport(
+        prefetchSlotLoadingEntry.loadingModule,
+      )!;
+      slotElement = <PrefetchSlotLoadingComponent />;
+    } else {
+      const slotThenableParams = options.makeThenableParams(slotParams);
+      const slotProps: Record<string, unknown> = {
+        params: slotThenableParams,
+      };
+      if (options.searchParams !== undefined) {
+        slotProps.searchParams = options.searchParams;
       }
-      const InterceptLayoutComponent = interceptLayoutComponent;
-      const interceptLayoutParams = resolveSlotLayoutParams(
-        slotOverride?.branchSegments ?? slotRouteSegments,
-        slotOverride?.layoutSegments?.[layoutIndex]?.length ?? slotRouteSegments.length,
-        slotParams,
-      );
-      slotElement = (
-        <InterceptLayoutComponent params={options.makeThenableParams(interceptLayoutParams)}>
-          {slotElement}
-        </InterceptLayoutComponent>
-      );
+      if (slotOverride?.props) {
+        Object.assign(slotProps, slotOverride.props);
+      }
+      slotElement = options.createPageElement
+        ? options.createPageElement(slotComponent!, slotProps)
+        : (() => {
+            const SlotComponent = slotComponent!;
+            return <SlotComponent {...slotProps} />;
+          })();
     }
+    const branchSegments = slotOverride?.branchSegments ?? slotRouteSegments;
+    const branchLayouts = new Map<
+      number,
+      { component: AppPageComponent; params: AppPageParams }[]
+    >();
+    const addBranchLayout = (
+      treePosition: number,
+      entry: { component: AppPageComponent; params: AppPageParams },
+    ) => {
+      const entries = branchLayouts.get(treePosition) ?? [];
+      entries.push(entry);
+      branchLayouts.set(treePosition, entries);
+    };
 
-    if (!hasSlotTreeOverride) {
-      for (
-        let layoutIndex = (slot.configLayouts?.length ?? 0) - 1;
-        layoutIndex >= 0;
-        layoutIndex--
-      ) {
-        const nestedLayoutComponent = getDefaultExport(slot.configLayouts?.[layoutIndex]);
-        if (!nestedLayoutComponent) continue;
-        const NestedLayoutComponent = nestedLayoutComponent;
-        const nestedLayoutParams = resolveSlotLayoutParams(
-          slotRouteSegments,
-          slot.configLayoutTreePositions?.[layoutIndex] ?? 0,
-          slotParams,
-        );
-        slotElement = (
-          <NestedLayoutComponent
-            params={options.makeThenableParams({ ...slotOwnerParams, ...nestedLayoutParams })}
-          >
-            {slotElement}
-          </NestedLayoutComponent>
-        );
+    if (hasSlotTreeOverride) {
+      for (const [layoutIndex, layoutModule] of (slotOverride?.layoutModules ?? []).entries()) {
+        const component = getDefaultExport(layoutModule);
+        if (!component) continue;
+        const treePosition =
+          slotOverride?.layoutSegments?.[layoutIndex]?.length ?? branchSegments.length;
+        addBranchLayout(treePosition, {
+          component,
+          params: resolveSlotLayoutParams(branchSegments, treePosition, slotParams),
+        });
+      }
+    } else {
+      for (const [layoutIndex, layoutModule] of (slot.configLayouts ?? []).entries()) {
+        const component = getDefaultExport(layoutModule);
+        if (!component) continue;
+        const treePosition = slot.configLayoutTreePositions?.[layoutIndex] ?? 0;
+        addBranchLayout(treePosition, {
+          component,
+          params: {
+            ...slotOwnerParams,
+            ...resolveSlotLayoutParams(slotRouteSegments, treePosition, slotParams),
+          },
+        });
       }
     }
 
     const slotLayoutComponent = overrideOrPageComponent ? getDefaultExport(slot.layout) : null;
     if (slotLayoutComponent) {
-      const SlotLayoutComponent = slotLayoutComponent;
-      slotElement = (
-        <SlotLayoutComponent params={options.makeThenableParams(slotOwnerParams)}>
-          {slotElement}
-        </SlotLayoutComponent>
-      );
+      const rootEntries = branchLayouts.get(0) ?? [];
+      branchLayouts.set(0, [
+        { component: slotLayoutComponent, params: slotOwnerParams },
+        ...rootEntries,
+      ]);
     }
 
-    const slotLoadingComponent = getDefaultExport(slot.loading);
-    if (slotLoadingComponent) {
-      const SlotLoadingComponent = slotLoadingComponent;
-      slotElement = (
-        <Suspense key={slotResetKey} fallback={<SlotLoadingComponent />}>
-          {slotElement}
-        </Suspense>
-      );
+    const branchLoadings = new Map<number, AppPageComponent[]>();
+    for (const entry of slotLoadingEntries) {
+      const component = getDefaultExport(entry.loadingModule);
+      if (!component) continue;
+      const components = branchLoadings.get(entry.treePosition) ?? [];
+      components.push(component);
+      branchLoadings.set(entry.treePosition, components);
     }
 
     const slotErrorComponent = getErrorBoundaryExport(slot.error);
-    if (slotErrorComponent) {
+    const branchTreePositions = Array.from(
+      new Set([
+        ...branchLayouts.keys(),
+        ...branchLoadings.keys(),
+        ...(slotErrorComponent ? [0] : []),
+      ]),
+    )
+      .filter(
+        (treePosition) =>
+          !prefetchSlotLoadingEntry ||
+          (!isOwnedAtRoutePrefetchCutoff && treePosition <= prefetchSlotLoadingEntry.treePosition),
+      )
+      .sort((left, right) => left - right);
+    for (let index = branchTreePositions.length - 1; index >= 0; index--) {
+      const treePosition = branchTreePositions[index];
+      const loadingComponents = prefetchSlotLoadingEntry
+        ? []
+        : (branchLoadings.get(treePosition) ?? []);
+      for (let loadingIndex = loadingComponents.length - 1; loadingIndex >= 0; loadingIndex--) {
+        const LoadingComponent = loadingComponents[loadingIndex];
+        const loadingResetKey = resolveAppPageSegmentStateKey(
+          branchSegments,
+          treePosition,
+          slotParams,
+        );
+        slotElement = (
+          <Suspense key={loadingResetKey || slotResetKey} fallback={<LoadingComponent />}>
+            {slotElement}
+          </Suspense>
+        );
+      }
+
+      if (treePosition === 0 && slotErrorComponent) {
+        slotElement = (
+          <ErrorBoundary resetKey={slotResetKey} fallback={slotErrorComponent}>
+            {slotElement}
+          </ErrorBoundary>
+        );
+      }
+
+      const layoutEntriesAtPosition = branchLayouts.get(treePosition) ?? [];
+      for (let layoutIndex = layoutEntriesAtPosition.length - 1; layoutIndex >= 0; layoutIndex--) {
+        const layoutEntry = layoutEntriesAtPosition[layoutIndex];
+        const LayoutComponent = layoutEntry.component;
+        slotElement = (
+          <LayoutComponent params={options.makeThenableParams(layoutEntry.params)}>
+            {slotElement}
+          </LayoutComponent>
+        );
+      }
+    }
+
+    // A loading convention on the owning segment applies to every parallel
+    // child slot, not only the flattened `children` branch. The slot payload is
+    // serialized as a separate element entry, so the boundary must wrap this
+    // entry directly rather than only the <Slot> placeholder in routeChildren.
+    const ownerLoadingEntry = isPrefetchLoadingShell
+      ? undefined
+      : findNearestLoadingEntryAtOrAbove(ownerTreePosition);
+    const ownerLoadingComponent = getDefaultExport(ownerLoadingEntry?.loadingModule);
+    if (ownerLoadingComponent && ownerLoadingEntry) {
+      const OwnerLoadingComponent = ownerLoadingComponent;
+      const ownerResetKey = resolveAppPageSegmentStateKey(
+        routeSegments,
+        ownerLoadingEntry.treePosition,
+        options.matchedParams,
+      );
       slotElement = (
-        <ErrorBoundary resetKey={slotResetKey} fallback={slotErrorComponent}>
+        <Suspense key={ownerResetKey || slotResetKey} fallback={<OwnerLoadingComponent />}>
           {slotElement}
-        </ErrorBoundary>
+        </Suspense>
       );
     }
 
@@ -1044,11 +1289,11 @@ export function buildAppPageElements<
     // so it intentionally does not mount AppRouterScrollTarget — the scroll/focus
     // effect belongs to the real render that replaces this shell (handled in the
     // else branch below).
-    if (routeLoadingComponent === null) {
+    if (prefetchLoadingComponent === null) {
       routeChildren = null;
     } else {
-      const RouteLoadingComponent = routeLoadingComponent;
-      routeChildren = <RouteLoadingComponent />;
+      const PrefetchLoadingComponent = prefetchLoadingComponent;
+      routeChildren = <PrefetchLoadingComponent />;
     }
   } else {
     // Wrap the page slot in a per-segment RedirectBoundary so that a
@@ -1142,8 +1387,11 @@ export function buildAppPageElements<
     );
   }
 
-  for (let index = orderedTreePositions.length - 1; index >= 0; index--) {
-    const treePosition = orderedTreePositions[index];
+  const renderedTreePositions = isPrefetchLoadingShell
+    ? orderedTreePositions.filter(includesPrefetchTreePosition)
+    : orderedTreePositions;
+  for (let index = renderedTreePositions.length - 1; index >= 0; index--) {
+    const treePosition = renderedTreePositions[index];
     const segmentResetKey = resolveAppPageSegmentStateKey(
       routeSegments,
       treePosition,
@@ -1159,7 +1407,7 @@ export function buildAppPageElements<
     // its ordering relative to page access/error boundaries and scroll handling
     // remains unchanged. Ancestor segment boundaries are inserted here so they
     // can suspend while a child layout entry renders.
-    if (treePosition < routeSegments.length) {
+    if (!isPrefetchLoadingShell && treePosition < routeSegments.length) {
       const segmentLoadingComponent = getDefaultExport(loadingEntry?.loadingModule);
       if (segmentLoadingComponent) {
         const SegmentLoadingComponent = segmentLoadingComponent;

--- a/packages/vinext/src/server/app-route-module-loader.ts
+++ b/packages/vinext/src/server/app-route-module-loader.ts
@@ -58,6 +58,7 @@ export type LazyLoadableRoute = {
   routeHandler?: unknown;
   layouts?: unknown[];
   templates?: unknown[];
+  loadings?: unknown[];
   errors?: unknown[];
   errorPaths?: unknown[];
   notFounds?: unknown[];
@@ -76,6 +77,7 @@ export type LazyLoadableRoute = {
   __loadRouteHandler?: LazyModuleThunk | null;
   __loadLayouts?: LazyModuleLoaderArray | null;
   __loadTemplates?: LazyModuleLoaderArray | null;
+  __loadLoadings?: LazyModuleLoaderArray | null;
   __loadErrors?: LazyModuleLoaderArray | null;
   __loadErrorPaths?: LazyModuleLoaderArray | null;
   __loadNotFounds?: LazyModuleLoaderArray | null;
@@ -177,6 +179,7 @@ export function ensureAppRouteModulesLoaded<TRoute extends LazyLoadableRoute>(
   pushFieldLoad(loads, route as Record<string, unknown>, "unauthorized", route.__loadUnauthorized);
   pushArrayLoads(loads, route.layouts, route.__loadLayouts);
   pushArrayLoads(loads, route.templates, route.__loadTemplates);
+  pushArrayLoads(loads, route.loadings, route.__loadLoadings);
   pushArrayLoads(loads, route.errors, route.__loadErrors);
   pushArrayLoads(loads, route.errorPaths, route.__loadErrorPaths);
   pushArrayLoads(loads, route.notFounds, route.__loadNotFounds);

--- a/packages/vinext/src/server/app-route-module-loader.ts
+++ b/packages/vinext/src/server/app-route-module-loader.ts
@@ -29,6 +29,8 @@ type LazyModuleLoaderArray = readonly (LazyModuleThunk | null | undefined)[];
 type LazyLoadableIntercept = {
   interceptLayouts?: readonly unknown[] | null;
   __loadInterceptLayouts?: LazyModuleLoaderArray | null;
+  interceptLoadings?: readonly unknown[] | null;
+  __loadInterceptLoadings?: LazyModuleLoaderArray | null;
   __loadState?: {
     interceptLayoutsLoading: Promise<readonly unknown[]> | null;
   };
@@ -40,6 +42,7 @@ type LazyLoadableSlot = {
   layout?: unknown;
   configLayouts?: readonly unknown[];
   loading?: unknown;
+  loadings?: readonly unknown[];
   error?: unknown;
   notFound?: unknown;
   __loadPage?: LazyModuleThunk | null;
@@ -47,6 +50,7 @@ type LazyLoadableSlot = {
   __loadLayout?: LazyModuleThunk | null;
   __loadConfigLayouts?: LazyModuleLoaderArray | null;
   __loadLoading?: LazyModuleThunk | null;
+  __loadLoadings?: LazyModuleLoaderArray | null;
   __loadError?: LazyModuleThunk | null;
   __loadNotFound?: LazyModuleThunk | null;
   /** Hydrated only after an intercept matches, not with the slot's base modules. */
@@ -139,6 +143,7 @@ export function loadAppInterceptLayouts(
 
   const loads: Promise<unknown>[] = [];
   pushArrayLoads(loads, intercept.interceptLayouts, intercept.__loadInterceptLayouts);
+  pushArrayLoads(loads, intercept.interceptLoadings, intercept.__loadInterceptLoadings);
   if (loads.length === 0) return Promise.resolve(intercept.interceptLayouts ?? []);
 
   const loading = Promise.all(loads)
@@ -192,6 +197,7 @@ export function ensureAppRouteModulesLoaded<TRoute extends LazyLoadableRoute>(
     pushFieldLoad(loads, slot as Record<string, unknown>, "layout", slot.__loadLayout);
     pushArrayLoads(loads, slot.configLayouts, slot.__loadConfigLayouts);
     pushFieldLoad(loads, slot as Record<string, unknown>, "loading", slot.__loadLoading);
+    pushArrayLoads(loads, slot.loadings, slot.__loadLoadings);
     pushFieldLoad(loads, slot as Record<string, unknown>, "error", slot.__loadError);
     pushFieldLoad(loads, slot as Record<string, unknown>, "notFound", slot.__loadNotFound);
   }

--- a/packages/vinext/src/server/app-rsc-route-matching.ts
+++ b/packages/vinext/src/server/app-rsc-route-matching.ts
@@ -45,8 +45,11 @@ type AppRscInterceptForMatching = {
   interceptLayouts: readonly unknown[];
   interceptLayoutSegments?: readonly (readonly string[])[];
   interceptBranchSegments?: readonly string[];
+  interceptLoadings?: readonly unknown[];
+  interceptLoadingTreePositions?: readonly number[];
   interceptNotFoundBranchSegments?: readonly string[];
   __loadInterceptLayouts?: readonly (() => Promise<unknown>)[] | null;
+  __loadInterceptLoadings?: readonly (() => Promise<unknown>)[] | null;
   page: unknown;
   __pageLoader?: (() => Promise<unknown>) | null;
   notFound?: unknown;
@@ -68,8 +71,11 @@ type AppRscSiblingInterceptForMatching = {
   interceptLayouts: readonly unknown[];
   interceptLayoutSegments?: readonly (readonly string[])[];
   interceptBranchSegments?: readonly string[];
+  interceptLoadings?: readonly unknown[];
+  interceptLoadingTreePositions?: readonly number[];
   interceptNotFoundBranchSegments?: readonly string[];
   __loadInterceptLayouts?: readonly (() => Promise<unknown>)[] | null;
+  __loadInterceptLoadings?: readonly (() => Promise<unknown>)[] | null;
   page: unknown;
   // Sibling intercept pages are lazy-loaded (manifest emits `page: null` plus a
   // `__pageLoader`) so the intercepting page's CSS chunk stays isolated in
@@ -115,8 +121,11 @@ type AppRscInterceptLookupEntry = {
   interceptLayouts: readonly unknown[];
   interceptLayoutSegments?: readonly (readonly string[])[];
   interceptBranchSegments?: readonly string[];
+  interceptLoadings?: readonly unknown[];
+  interceptLoadingTreePositions?: readonly number[];
   interceptNotFoundBranchSegments?: readonly string[];
   __loadInterceptLayouts?: readonly (() => Promise<unknown>)[] | null;
+  __loadInterceptLoadings?: readonly (() => Promise<unknown>)[] | null;
   page: unknown;
   __pageLoader?: (() => Promise<unknown>) | null;
   notFound: unknown;
@@ -398,8 +407,11 @@ function createInterceptLookup<Route extends AppRscRouteForMatching>(
             interceptLayouts: intercept.interceptLayouts,
             interceptLayoutSegments: intercept.interceptLayoutSegments,
             interceptBranchSegments: intercept.interceptBranchSegments,
+            interceptLoadings: intercept.interceptLoadings,
+            interceptLoadingTreePositions: intercept.interceptLoadingTreePositions,
             interceptNotFoundBranchSegments: intercept.interceptNotFoundBranchSegments,
             __loadInterceptLayouts: intercept.__loadInterceptLayouts,
+            __loadInterceptLoadings: intercept.__loadInterceptLoadings,
             page: intercept.page,
             __pageLoader: intercept.__pageLoader,
             notFound: intercept.notFound,
@@ -435,8 +447,11 @@ function createInterceptLookup<Route extends AppRscRouteForMatching>(
           interceptLayouts: intercept.interceptLayouts,
           interceptLayoutSegments: intercept.interceptLayoutSegments,
           interceptBranchSegments: intercept.interceptBranchSegments,
+          interceptLoadings: intercept.interceptLoadings,
+          interceptLoadingTreePositions: intercept.interceptLoadingTreePositions,
           interceptNotFoundBranchSegments: intercept.interceptNotFoundBranchSegments,
           __loadInterceptLayouts: intercept.__loadInterceptLayouts,
+          __loadInterceptLoadings: intercept.__loadInterceptLoadings,
           page: intercept.page,
           __pageLoader: intercept.__pageLoader,
           notFound: intercept.notFound,

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -542,7 +542,6 @@ function prefetchUrl(
         const hasSearchParams = new URL(fullHref, window.location.href).search !== "";
         const isAutomaticSearchParamShell =
           mode === "auto" && isOptimisticRouteShellPrefetch && hasSearchParams;
-        if (isOptimisticRouteShellPrefetch && interceptionContext !== null) return;
         const hasSearchAgnosticShell =
           isAutomaticSearchParamShell &&
           hasSearchAgnosticPrefetchShellForRoute(

--- a/tests/app-page-dispatch.test.ts
+++ b/tests/app-page-dispatch.test.ts
@@ -68,6 +68,8 @@ type TestRoute = {
   layouts: readonly { default?: unknown; dynamic?: unknown; revalidate?: unknown }[];
   layoutTreePositions?: readonly number[];
   loading?: { default?: unknown } | null;
+  loadings?: readonly ({ default?: unknown } | null | undefined)[];
+  loadingTreePositions?: readonly number[];
   notFounds?: readonly ({ default?: unknown } | null | undefined)[];
   params: readonly string[];
   pattern: string;
@@ -77,6 +79,9 @@ type TestRoute = {
       string,
       {
         default?: { default?: unknown } | null;
+        loading?: { default?: unknown } | null;
+        loadings?: readonly ({ default?: unknown } | null | undefined)[] | null;
+        loadingTreePositions?: readonly number[] | null;
         page?: { default?: unknown; generateMetadata?: unknown } | null;
         slotParamNames?: readonly string[] | null;
         slotPatternParts?: readonly string[] | null;
@@ -575,6 +580,28 @@ function createLayoutParamProbe(
 }
 
 describe("app page dispatch", () => {
+  it("does not probe layouts below an active ancestor loading boundary", async () => {
+    const probeLayoutAt = vi.fn((_layoutIndex: number) => null);
+    const probePage = vi.fn(() => null);
+    const route = createRoute({
+      layouts: [{}, {}, {}],
+      layoutTreePositions: [0, 1, 2],
+      loading: null,
+      loadings: [{ default: () => null }],
+      loadingTreePositions: [1],
+      routeSegments: ["parent", "slow"],
+    });
+    const { options } = createDispatchOptions({ probeLayoutAt, probePage, route });
+
+    const response = await dispatchAppPage(options);
+    await response.text();
+
+    // The loading at position 1 catches descendants, but not a layout at the
+    // same position. Probe the root and co-located layout only.
+    expect(probeLayoutAt.mock.calls.map(([layoutIndex]) => layoutIndex)).toEqual([1, 0]);
+    expect(probePage).not.toHaveBeenCalled();
+  });
+
   it("disables streaming metadata while producing prerendered HTML", async () => {
     vi.stubEnv("VINEXT_PRERENDER", "1");
     const buildPageElement = vi.fn<DispatchOptions["buildPageElement"]>(async () =>

--- a/tests/app-page-probe.test.ts
+++ b/tests/app-page-probe.test.ts
@@ -813,6 +813,95 @@ describe("buildAppPageProbes", () => {
     expect(probed.sort()).toEqual(["modal", "page"]);
   });
 
+  it("does not await slot pages protected by branch-local loading boundaries", async () => {
+    const probed: string[] = [];
+    const probes = buildAppPageProbes({
+      route: {
+        slots: {
+          modal: {
+            loading: { default: () => "loading" },
+            page: { default: recordingPage("modal", probed) },
+          },
+          sidebar: {
+            loadings: [{ default: () => "loading" }],
+            page: { default: recordingPage("sidebar", probed) },
+          },
+          team: { page: { default: recordingPage("team", probed) } },
+        },
+      },
+      pageComponent: recordingPage("page", probed),
+      asyncRouteParams: makeThenableParams({}),
+      searchParams: null,
+      isRscRequest: true,
+      matchedParams: {},
+      makeThenableParams: makeThenableParamsLoose,
+    });
+
+    await Promise.all(probes);
+
+    expect(probed.sort()).toEqual(["page", "team"]);
+  });
+
+  it("does not await intercepted pages protected by slot or intercept loading boundaries", async () => {
+    const probed: string[] = [];
+    const buildProbes = (interceptLoadings?: readonly { default?: unknown }[]) =>
+      buildAppPageProbes({
+        route: {
+          slots: {
+            modal: {
+              loading: interceptLoadings ? null : { default: () => "slot loading" },
+              page: { default: recordingPage("modal", probed) },
+            },
+          },
+        },
+        pageComponent: recordingPage("page", probed),
+        asyncRouteParams: makeThenableParams({}),
+        searchParams: null,
+        intercept: {
+          interceptLoadings,
+          page: { default: recordingPage("intercept", probed) },
+          slotKey: "modal",
+        },
+        isRscRequest: true,
+        matchedParams: {},
+        makeThenableParams: makeThenableParamsLoose,
+      });
+
+    await Promise.all(buildProbes([{ default: () => "intercept loading" }]));
+    await Promise.all(buildProbes());
+
+    expect(probed).toEqual(["page", "page"]);
+  });
+
+  it("does await intercepted pages when only a sibling normal branch has loading", async () => {
+    const probed: string[] = [];
+    const probes = buildAppPageProbes({
+      route: {
+        slots: {
+          modal: {
+            loadings: [{ default: () => "gallery loading" }],
+            loadingTreePositions: [1],
+            page: { default: recordingPage("gallery", probed) },
+          },
+        },
+      },
+      pageComponent: recordingPage("page", probed),
+      asyncRouteParams: makeThenableParams({}),
+      searchParams: null,
+      intercept: {
+        page: { default: recordingPage("intercept", probed) },
+        slotKey: "modal",
+      },
+      isRscRequest: true,
+      matchedParams: {},
+      makeThenableParams: makeThenableParamsLoose,
+    });
+
+    await Promise.all(probes);
+
+    expect(probed.sort()).toEqual(["intercept", "page"]);
+  });
+
   it("skips slots without a page default export", async () => {
     const probed: string[] = [];
     const probes = buildAppPageProbes({

--- a/tests/app-page-route-wiring.test.ts
+++ b/tests/app-page-route-wiring.test.ts
@@ -994,6 +994,157 @@ describe("app page route wiring helpers", () => {
     expect(containsElementType(elements["slot:sidebar:/"], SlotLoadingProbe)).toBe(true);
   });
 
+  it("applies an owning segment loading boundary to named parallel slots", () => {
+    const elements = buildAppPageElements({
+      element: createElement(PageProbe),
+      makeThenableParams(params) {
+        return Promise.resolve(params);
+      },
+      matchedParams: {},
+      resolvedMetadata: null,
+      resolvedViewport: {},
+      route: {
+        error: null,
+        errors: [],
+        layoutTreePositions: [],
+        layouts: [],
+        loading: null,
+        loadings: [{ default: RouteLoadingProbe }],
+        loadingTreePositions: [0],
+        notFound: null,
+        notFounds: [null],
+        routeSegments: ["dashboard"],
+        slots: {
+          sidebar: {
+            default: null,
+            error: null,
+            layout: null,
+            layoutIndex: -1,
+            loading: null,
+            name: "sidebar",
+            ownerTreePosition: 0,
+            page: { default: SlotPage },
+            routeSegments: [],
+          },
+        },
+        templateTreePositions: [],
+        templates: [],
+      },
+      routePath: "/dashboard",
+      rootNotFoundModule: null,
+    });
+
+    expect(
+      containsElementType(
+        elements[AppElementsWire.encodeSlotId("sidebar", "/")],
+        RouteLoadingProbe,
+      ),
+    ).toBe(true);
+  });
+
+  it("applies the nearest loading boundary above a named-slot owner", () => {
+    const elements = buildAppPageElements({
+      element: createElement(PageProbe),
+      makeThenableParams(params) {
+        return Promise.resolve(params);
+      },
+      matchedParams: {},
+      resolvedMetadata: null,
+      resolvedViewport: {},
+      route: {
+        error: null,
+        errors: [],
+        layoutTreePositions: [],
+        layouts: [],
+        loading: null,
+        loadings: [{ default: RouteLoadingProbe }],
+        loadingTreePositions: [0],
+        notFound: null,
+        notFounds: [],
+        routeSegments: ["dashboard", "members"],
+        slots: {
+          sidebar: {
+            default: null,
+            error: null,
+            layout: null,
+            layoutIndex: -1,
+            loading: null,
+            name: "sidebar",
+            ownerTreePosition: 1,
+            page: { default: SlotPage },
+            routeSegments: [],
+          },
+        },
+        templateTreePositions: [],
+        templates: [],
+      },
+      routePath: "/dashboard/members",
+      rootNotFoundModule: null,
+    });
+
+    expect(
+      containsElementType(
+        elements[AppElementsWire.encodeSlotId("sidebar", "/")],
+        RouteLoadingProbe,
+      ),
+    ).toBe(true);
+  });
+
+  it("positions nested named-slot loading boundaries inside co-located layouts", () => {
+    const elements = buildAppPageElements({
+      element: createElement(PageProbe),
+      makeThenableParams(params) {
+        return Promise.resolve(params);
+      },
+      matchedParams: {},
+      resolvedMetadata: null,
+      resolvedViewport: {},
+      route: {
+        error: null,
+        errors: [],
+        layoutTreePositions: [],
+        layouts: [],
+        loading: null,
+        notFound: null,
+        notFounds: [null],
+        routeSegments: ["dashboard"],
+        slots: {
+          sidebar: {
+            configLayouts: [{ default: NestedSlotLayout }],
+            configLayoutTreePositions: [1],
+            default: null,
+            error: null,
+            layout: null,
+            layoutIndex: -1,
+            loading: null,
+            loadings: [{ default: SlotLoadingProbe }],
+            loadingTreePositions: [1],
+            name: "sidebar",
+            page: { default: SlotPage },
+            routeSegments: ["members"],
+          },
+        },
+        templateTreePositions: [],
+        templates: [],
+      },
+      routePath: "/dashboard",
+      rootNotFoundModule: null,
+    });
+
+    const slotEntry = elements[AppElementsWire.encodeSlotId("sidebar", "/")];
+    const nestedLayout = findElementByTypeName(slotEntry, "NestedSlotLayout");
+    expect(nestedLayout).not.toBeNull();
+    expect(
+      findSuspenseWithFallback(nestedLayout?.props.children, "SlotLoadingProbe"),
+    ).not.toBeNull();
+    expect(
+      containsElementType(
+        findSuspenseWithFallback(nestedLayout?.props.children, "SlotLoadingProbe")?.props.children,
+        NestedSlotLayout,
+      ),
+    ).toBe(false);
+  });
+
   it("serializes route loading UI instead of page content for loading-shell prefetches", async () => {
     const elements = buildAppPageElements({
       element: createElement(PageProbe),
@@ -1026,6 +1177,245 @@ describe("app page route wiring helpers", () => {
 
     expect(html).toContain("Route loading");
     expect(html).not.toContain("Page");
+  });
+
+  it("serializes the nearest ancestor loading UI for loading-shell prefetches", async () => {
+    const elements = buildAppPageElements({
+      element: createElement(PageProbe),
+      makeThenableParams(params) {
+        return Promise.resolve(params);
+      },
+      matchedParams: {},
+      resolvedMetadata: null,
+      resolvedViewport: {},
+      route: {
+        error: null,
+        errors: [null],
+        layoutTreePositions: [0],
+        layouts: [{ default: RootLayout }],
+        loading: null,
+        loadings: [{ default: RouteLoadingProbe }],
+        loadingTreePositions: [0],
+        notFound: null,
+        notFounds: [null],
+        routeSegments: ["dashboard", "slow"],
+        templateTreePositions: [],
+        templates: [],
+      },
+      routePath: "/dashboard/slow",
+      rootNotFoundModule: null,
+      renderMode: APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+    });
+
+    expect(elements[APP_PREFETCH_LOADING_SHELL_MARKER_KEY]).toBe("LoadingBoundary");
+    const html = await renderRouteEntry(elements, "route:/dashboard/slow");
+    expect(html).toContain("Route loading");
+    expect(html).not.toContain("Page");
+  });
+
+  it("stops loading-shell prefetches at the first ancestor boundary", async () => {
+    function ParentLoading(): ReactNode {
+      return createElement("p", null, "Parent loading");
+    }
+    function LeafLoading(): ReactNode {
+      return createElement("p", null, "Leaf loading");
+    }
+    function DescendantLayout(props: Record<string, unknown>): ReactNode {
+      return createElement("section", { "data-descendant": "true" }, readChildren(props.children));
+    }
+
+    const elements = buildAppPageElements({
+      element: createElement(PageProbe),
+      makeThenableParams(params) {
+        return Promise.resolve(params);
+      },
+      matchedParams: {},
+      resolvedMetadata: null,
+      resolvedViewport: {},
+      route: {
+        error: null,
+        errors: [null, null],
+        layoutTreePositions: [0, 2],
+        layouts: [{ default: RootLayout }, { default: DescendantLayout }],
+        loading: { default: LeafLoading },
+        loadings: [{ default: ParentLoading }, { default: LeafLoading }],
+        loadingTreePositions: [1, 2],
+        notFound: null,
+        notFounds: [null, null],
+        routeSegments: ["parent", "slow"],
+        slots: {},
+        templateTreePositions: [],
+        templates: [],
+      },
+      routePath: "/parent/slow",
+      rootNotFoundModule: null,
+      renderMode: APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+    });
+
+    expect(elements["layout:/parent/slow"]).toBeUndefined();
+    const html = await renderRouteEntry(elements, "route:/parent/slow");
+    expect(html).toContain("Parent loading");
+    expect(html).not.toContain("Leaf loading");
+    expect(html).not.toContain('data-descendant="true"');
+  });
+
+  it("builds slot-only loading shells and omits unprotected parallel branches", async () => {
+    function SlotLoading(): ReactNode {
+      return createElement("p", null, "Slot loading shell");
+    }
+    function UnprotectedPage(): ReactNode {
+      return createElement("p", null, "Unprotected slot page");
+    }
+
+    const elements = buildAppPageElements({
+      element: createElement(PageProbe),
+      makeThenableParams(params) {
+        return Promise.resolve(params);
+      },
+      matchedParams: {},
+      resolvedMetadata: null,
+      resolvedViewport: {},
+      route: {
+        error: null,
+        errors: [null],
+        layoutTreePositions: [0],
+        layouts: [{ default: RootLayout }],
+        loading: null,
+        notFound: null,
+        notFounds: [null],
+        routeSegments: ["dashboard"],
+        slots: {
+          sidebar: {
+            default: null,
+            error: null,
+            layout: null,
+            layoutIndex: 0,
+            loading: null,
+            loadings: [{ default: SlotLoading }],
+            loadingTreePositions: [1],
+            name: "sidebar",
+            ownerTreePosition: 0,
+            page: { default: SlotPage },
+            routeSegments: ["slow"],
+          },
+          panel: {
+            default: null,
+            error: null,
+            layout: null,
+            layoutIndex: 0,
+            loading: null,
+            name: "panel",
+            ownerTreePosition: 0,
+            page: { default: UnprotectedPage },
+            routeSegments: [],
+          },
+        },
+        templateTreePositions: [],
+        templates: [],
+      },
+      routePath: "/dashboard",
+      rootNotFoundModule: null,
+      renderMode: APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+    });
+
+    expect(elements[APP_PREFETCH_LOADING_SHELL_MARKER_KEY]).toBe("LoadingBoundary");
+    expect(elements[AppElementsWire.encodeSlotId("panel", "/")]).toBeUndefined();
+    const html = await renderRouteEntry(elements, "route:/dashboard");
+    expect(html).toContain("Slot loading shell");
+    expect(html).not.toContain("Unprotected slot page");
+    expect(html).not.toContain("Page");
+  });
+
+  it("emits the route loading fallback for slots owned at the shell cutoff", async () => {
+    const elements = buildAppPageElements({
+      element: createElement(PageProbe),
+      makeThenableParams(params) {
+        return Promise.resolve(params);
+      },
+      matchedParams: {},
+      resolvedMetadata: null,
+      resolvedViewport: {},
+      route: {
+        error: null,
+        errors: [null],
+        layoutTreePositions: [0],
+        layouts: [{ default: RootLayout }],
+        loading: { default: RouteLoadingProbe },
+        loadings: [{ default: RouteLoadingProbe }],
+        loadingTreePositions: [0],
+        notFound: null,
+        notFounds: [null],
+        routeSegments: ["dashboard"],
+        slots: {
+          sidebar: {
+            default: null,
+            error: null,
+            layout: null,
+            layoutIndex: 0,
+            loading: { default: SlotLoadingProbe },
+            name: "sidebar",
+            ownerTreePosition: 0,
+            page: { default: SlotPage },
+            routeSegments: [],
+          },
+        },
+        templateTreePositions: [],
+        templates: [],
+      },
+      routePath: "/dashboard",
+      rootNotFoundModule: null,
+      renderMode: APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+    });
+
+    const html = await renderRouteEntry(elements, "route:/dashboard");
+    expect(html.match(/Route loading/g)).toHaveLength(2);
+    expect(html).not.toContain("Slot page");
+  });
+
+  it("uses the slot owner position when no layout exists at the loading cutoff", async () => {
+    const elements = buildAppPageElements({
+      element: createElement(PageProbe),
+      makeThenableParams(params) {
+        return Promise.resolve(params);
+      },
+      matchedParams: {},
+      resolvedMetadata: null,
+      resolvedViewport: {},
+      route: {
+        error: null,
+        errors: [null],
+        layoutTreePositions: [0],
+        layouts: [{ default: RootLayout }],
+        loading: null,
+        loadings: [{ default: RouteLoadingProbe }],
+        loadingTreePositions: [1],
+        notFound: null,
+        notFounds: [null],
+        routeSegments: ["foo", "photo"],
+        slots: {
+          sidebar: {
+            default: null,
+            error: null,
+            layout: null,
+            layoutIndex: 0,
+            loading: { default: SlotLoadingProbe },
+            name: "sidebar",
+            ownerTreePosition: 1,
+            page: { default: SlotPage },
+            routeSegments: ["photo"],
+          },
+        },
+        templateTreePositions: [],
+        templates: [],
+      },
+      routePath: "/foo/photo",
+      rootNotFoundModule: null,
+      renderMode: APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+    });
+
+    const html = await renderRouteEntry(elements, "route:/foo/photo");
+    expect(html.match(/Route loading/g)).toHaveLength(2);
+    expect(html).not.toContain("Slot page");
   });
 
   it("does not render page content for loading-shell prefetches without a route loading boundary", async () => {
@@ -1229,8 +1619,14 @@ describe("app page route wiring helpers", () => {
   });
 
   it("wraps intercepted slot overrides with intercept layout modules inside the slot layout", async () => {
+    function SlotRootLoading() {
+      return createElement("p", null, "Slot root loading");
+    }
+
     const sidebarOverride: AppPageSlotOverride<AppPageModule> = {
       layoutModules: [{ default: InterceptOuterLayout }, { default: InterceptInnerLayout }],
+      loadingModules: [{ default: SlotLoadingProbe }],
+      loadingTreePositions: [1],
       pageModule: { default: SlotPage },
       props: { label: "intercepted" },
     };
@@ -1258,7 +1654,7 @@ describe("app page route wiring helpers", () => {
             error: null,
             layout: { default: SlotLayout },
             layoutIndex: 0,
-            loading: null,
+            loading: { default: SlotRootLoading },
             name: "sidebar",
             page: { default: SlotPage },
             routeSegments: [],
@@ -1280,7 +1676,6 @@ describe("app page route wiring helpers", () => {
     expect(html).toContain('data-intercept-layout="outer"');
     expect(html).toContain('data-intercept-layout="inner"');
     expect(html).toContain('data-slot-page="intercepted"');
-
     const slotLayoutPos = html.indexOf('data-slot-layout="sidebar"');
     const outerLayoutPos = html.indexOf('data-intercept-layout="outer"');
     const innerLayoutPos = html.indexOf('data-intercept-layout="inner"');
@@ -1289,6 +1684,71 @@ describe("app page route wiring helpers", () => {
     expect(slotLayoutPos).toBeLessThan(outerLayoutPos);
     expect(outerLayoutPos).toBeLessThan(innerLayoutPos);
     expect(innerLayoutPos).toBeLessThan(pagePos);
+  });
+
+  it("retains slot-root loading outside intercepted branch loading", () => {
+    function SlotRootLoading() {
+      return createElement("p", null, "Slot root loading");
+    }
+    function NormalBranchLoading() {
+      return createElement("p", null, "Normal branch loading");
+    }
+
+    const elements = buildAppPageElements({
+      element: createElement(PageProbe),
+      makeThenableParams(params) {
+        return Promise.resolve(params);
+      },
+      matchedParams: {},
+      resolvedMetadata: null,
+      resolvedViewport: {},
+      route: {
+        error: null,
+        errors: [],
+        layoutTreePositions: [],
+        layouts: [],
+        loading: null,
+        notFound: null,
+        notFounds: [],
+        routeSegments: ["dashboard"],
+        slots: {
+          sidebar: {
+            default: null,
+            error: null,
+            layout: null,
+            layoutIndex: -1,
+            loading: { default: SlotRootLoading },
+            loadings: [{ default: SlotRootLoading }, { default: NormalBranchLoading }],
+            loadingTreePositions: [0, 1],
+            name: "sidebar",
+            page: { default: SlotPage },
+            routeSegments: [],
+          },
+        },
+        templateTreePositions: [],
+        templates: [],
+      },
+      routePath: "/dashboard",
+      rootNotFoundModule: null,
+      slotOverrides: {
+        sidebar: {
+          loadingModules: [{ default: SlotLoadingProbe }],
+          loadingTreePositions: [1],
+          pageModule: { default: SlotPage },
+          routeSegments: ["photo"],
+        },
+      },
+    });
+
+    const slotEntry = elements[AppElementsWire.encodeSlotId("sidebar", "/")];
+    const rootBoundary = findSuspenseWithFallback(slotEntry, "SlotRootLoading");
+    const interceptBoundary = findSuspenseWithFallback(slotEntry, "SlotLoadingProbe");
+    expect(rootBoundary).not.toBeNull();
+    expect(interceptBoundary).not.toBeNull();
+    expect(findSuspenseWithFallback(slotEntry, "NormalBranchLoading")).toBeNull();
+    expect(
+      findSuspenseWithFallback(rootBoundary?.props.children, "SlotLoadingProbe"),
+    ).not.toBeNull();
   });
 
   it("renders same-named slot props independently at different layout levels", async () => {
@@ -1705,6 +2165,58 @@ describe("app page route wiring helpers", () => {
         layoutTreePositions: [],
         layouts: [],
         loading: null,
+        notFound: null,
+        notFounds: [],
+        routeSegments: ["blog"],
+        slots: null,
+        templateTreePositions: [1],
+        templates: [{ default: AsyncTemplate }],
+      },
+      routePath: "/blog",
+      rootNotFoundModule: null,
+    });
+
+    const body = await renderHtml(
+      createElement(
+        Fragment,
+        null,
+        readChildren(elements["template:/blog"]),
+        readChildren(elements["page:/blog"]),
+      ),
+    );
+
+    expect(body).toContain("page:de");
+    expect(body).not.toContain("page:en");
+  });
+
+  it("preserves parent-before-child execution under an ancestor loading boundary", async () => {
+    let activeLocale = "en";
+
+    async function AsyncTemplate(props: Record<string, unknown>) {
+      await Promise.resolve();
+      activeLocale = "de";
+      return createElement("div", null, readChildren(props.children));
+    }
+    function LocalePage() {
+      return createElement("main", null, `page:${activeLocale}`);
+    }
+
+    const elements = buildAppPageElements({
+      element: createElement(LocalePage),
+      makeThenableParams(params) {
+        return Promise.resolve(params);
+      },
+      matchedParams: {},
+      resolvedMetadata: null,
+      resolvedViewport: {},
+      route: {
+        error: null,
+        errors: [],
+        layoutTreePositions: [],
+        layouts: [],
+        loading: null,
+        loadings: [{ default: RouteLoadingProbe }],
+        loadingTreePositions: [0],
         notFound: null,
         notFounds: [],
         routeSegments: ["blog"],

--- a/tests/app-page-route-wiring.test.ts
+++ b/tests/app-page-route-wiring.test.ts
@@ -149,6 +149,30 @@ function findSuspenseWithFallback(
   return match as ReactElement<Record<string, unknown>> | null;
 }
 
+function countSuspenseWithFallback(node: unknown, fallbackTypeName: string): number {
+  if (Array.isArray(node)) {
+    return node.reduce(
+      (count, child) => count + countSuspenseWithFallback(child, fallbackTypeName),
+      0,
+    );
+  }
+
+  if (!isValidElement<InspectableElementProps>(node)) {
+    return 0;
+  }
+
+  const fallback = node.props.fallback;
+  const isMatch =
+    getElementTypeName(node.type) === "Symbol(react.suspense)" &&
+    isValidElement(fallback) &&
+    getElementTypeName(fallback.type) === fallbackTypeName;
+
+  return Object.values(node.props).reduce<number>(
+    (count, value) => count + countSuspenseWithFallback(value, fallbackTypeName),
+    isMatch ? 1 : 0,
+  );
+}
+
 async function readStream(stream: ReadableStream<Uint8Array>): Promise<string> {
   const reader = stream.getReader();
   const decoder = new TextDecoder();
@@ -1917,6 +1941,53 @@ describe("app page route wiring helpers", () => {
 
     expect(templateSlot).not.toBeNull();
     expect(templateSlot?.key).toBe("slug|launch|d");
+  });
+
+  it("nests per-segment loading boundaries around slow child layouts without duplicating the leaf", () => {
+    function ParentLoading() {
+      return createElement("p", null, "Loading layout");
+    }
+
+    function LeafLoading() {
+      return createElement("p", null, "Loading page");
+    }
+
+    const elements = buildAppPageElements({
+      element: createElement(PageProbe),
+      makeThenableParams(params) {
+        return Promise.resolve(params);
+      },
+      matchedParams: {},
+      resolvedMetadata: null,
+      resolvedViewport: {},
+      route: {
+        error: null,
+        errors: [null, null],
+        layoutTreePositions: [0, 2],
+        layouts: [{ default: RootLayout }, { default: GroupLayout }],
+        loading: { default: LeafLoading },
+        loadings: [{ default: ParentLoading }, { default: LeafLoading }],
+        loadingTreePositions: [1, 2],
+        notFound: null,
+        notFounds: [null, null],
+        routeSegments: ["parent", "slow"],
+        slots: {},
+        templateTreePositions: [],
+        templates: [],
+      },
+      routePath: "/parent/slow",
+      rootNotFoundModule: null,
+    });
+
+    const routeEntry = elements["route:/parent/slow"];
+    const parentBoundary = findSuspenseWithFallback(routeEntry, "ParentLoading");
+    const leafBoundary = findSuspenseWithFallback(routeEntry, "LeafLoading");
+
+    expect(parentBoundary?.key).toBe("slow");
+    expect(leafBoundary?.key).toBe(JSON.stringify(["parent", "slow"]));
+    expect(findSuspenseWithFallback(parentBoundary?.props.children, "LeafLoading")).not.toBeNull();
+    expect(findSlotById(parentBoundary?.props.children, "layout:/parent/slow")).not.toBeNull();
+    expect(countSuspenseWithFallback(routeEntry, "LeafLoading")).toBe(1);
   });
 
   it("threads route state reset keys into loading, error, and not-found boundaries", () => {

--- a/tests/app-route-module-loader.test.ts
+++ b/tests/app-route-module-loader.test.ts
@@ -171,20 +171,24 @@ describe("ensureAppRouteModulesLoaded", () => {
     const slotLayout = { default: () => null };
     const slotNotFound = { default: () => null, metadata: { title: "slot not found" } };
     const nestedSlotLayout = { default: () => null, revalidate: 30 };
+    const nestedSlotLoading = { default: () => null };
     const __loadPage = vi.fn(async () => slotPage);
     const __loadLayout = vi.fn(async () => slotLayout);
     const __loadNotFound = vi.fn(async () => slotNotFound);
     const __loadConfigLayout = vi.fn(async () => nestedSlotLayout);
+    const __loadSlotLoading = vi.fn(async () => nestedSlotLoading);
     const route: LazyLoadableRoute = {
       slots: {
         "@modal": {
           page: null,
           layout: null,
           configLayouts: [null],
+          loadings: [null],
           __loadPage,
           __loadLayout,
           __loadNotFound,
           __loadConfigLayouts: [__loadConfigLayout],
+          __loadLoadings: [__loadSlotLoading],
         },
       },
     };
@@ -195,6 +199,7 @@ describe("ensureAppRouteModulesLoaded", () => {
     expect(route.slots?.["@modal"].layout).toBe(slotLayout);
     expect(route.slots?.["@modal"].notFound).toBe(slotNotFound);
     expect(route.slots?.["@modal"].configLayouts).toEqual([nestedSlotLayout]);
+    expect(route.slots?.["@modal"].loadings).toEqual([nestedSlotLoading]);
   });
 });
 
@@ -202,14 +207,18 @@ describe("loadAppInterceptLayouts", () => {
   it("hydrates intercept layouts from their loaders and returns the array", async () => {
     const layoutA = { default: () => null };
     const layoutB = { default: () => null };
+    const loading = { default: () => null };
     const intercept = {
       interceptLayouts: [null, null],
       __loadInterceptLayouts: [async () => layoutA, async () => layoutB],
+      interceptLoadings: [null],
+      __loadInterceptLoadings: [async () => loading],
     };
 
     const result = await loadAppInterceptLayouts(intercept);
 
     expect(intercept.interceptLayouts).toEqual([layoutA, layoutB]);
+    expect(intercept.interceptLoadings).toEqual([loading]);
     expect(result).toBe(intercept.interceptLayouts);
   });
 

--- a/tests/app-route-module-loader.test.ts
+++ b/tests/app-route-module-loader.test.ts
@@ -136,6 +136,22 @@ describe("ensureAppRouteModulesLoaded", () => {
     expect(__loadLayouts[2]).not.toHaveBeenCalled();
   });
 
+  it("hydrates per-segment loading modules positionally", async () => {
+    const parentLoading = { default: () => null };
+    const leafLoading = { default: () => null };
+    const __loadLoadings = [vi.fn(async () => parentLoading), vi.fn(async () => leafLoading)];
+    const route: LazyLoadableRoute = {
+      loadings: [null, null],
+      __loadLoadings,
+    };
+
+    await ensureAppRouteModulesLoaded(route);
+
+    expect(route.loadings).toEqual([parentLoading, leafLoading]);
+    expect(__loadLoadings[0]).toHaveBeenCalledTimes(1);
+    expect(__loadLoadings[1]).toHaveBeenCalledTimes(1);
+  });
+
   it("ignores array loaders beyond the manifest placeholder length", async () => {
     const layout = { default: () => null };
     const outOfRangeLoader = vi.fn(async () => layout);

--- a/tests/e2e/app-router/loading.spec.ts
+++ b/tests/e2e/app-router/loading.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { waitForAppRouterHydration } from "../helpers";
 
 const BASE = "http://localhost:4174";
 
@@ -48,14 +49,124 @@ test.describe("Loading boundaries (loading.tsx)", () => {
 
   // Ported from Next.js: test/e2e/app-dir/app/index.test.ts
   // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app/index.test.ts
-  test("slow nested layout includes its ancestor loading fallback in initial HTML", async ({
-    request,
-  }) => {
-    const response = await request.get(`${BASE}/slow-layout-with-loading/slow`);
-    const html = await response.text();
+  test("slow nested layout streams its ancestor loading fallback before resolving", async () => {
+    const streamFallback = async () => {
+      const response = await fetch(`${BASE}/slow-layout-with-loading/slow`);
+      if (!response.body) throw new Error("Expected a streaming response body");
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let html = "";
+      try {
+        while (!html.includes('id="slow-layout-loading"')) {
+          const { done, value } = await reader.read();
+          if (done) throw new Error("Response ended before the loading fallback was streamed");
+          html += decoder.decode(value, { stream: true });
+        }
+      } finally {
+        await reader.cancel();
+      }
+    };
 
-    expect(response.status()).toBe(200);
-    expect(html).toContain('id="slow-layout-loading"');
+    // Compile this route before starting the timing assertion. Vite's first
+    // request can spend longer than the threshold transforming a new fixture;
+    // the second request isolates server-render streaming from dev compilation.
+    await streamFallback();
+    await expect(
+      Promise.race([
+        streamFallback(),
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error("Loading fallback did not stream promptly")), 1_500),
+        ),
+      ]),
+    ).resolves.toBeUndefined();
+  });
+
+  test("ancestor loading-shell prefetch stops before the slow descendant layout", async () => {
+    const fetchLoadingShell = () =>
+      fetch(`${BASE}/slow-layout-with-loading/slow?_rsc=loading-shell`, {
+        headers: {
+          RSC: "1",
+          "Next-Router-Prefetch": "1",
+          "Next-Router-Segment-Prefetch": "1",
+          "X-Vinext-Rsc-Render-Mode": "prefetch-loading-shell",
+        },
+      });
+
+    // Warm the generated route before measuring request-time tree traversal.
+    await (await fetchLoadingShell()).text();
+    const startedAt = performance.now();
+    const response = await fetchLoadingShell();
+    const body = await response.text();
+    const durationMs = performance.now() - startedAt;
+
+    expect(response.status).toBe(200);
+    expect(durationMs).toBeLessThan(1_500);
+    expect(body).toContain("Loading layout");
+    expect(body).not.toContain("Slow layout resolved");
+    expect(body).not.toContain("slow-layout-message");
+  });
+
+  test("client navigation uses an ancestor-only loading shell", async ({ page }) => {
+    await page.goto(BASE);
+    const link = page.getByTestId("slow-layout-with-loading-link");
+    await link.waitFor();
+    await page.waitForTimeout(250);
+
+    await link.click();
+    await expect(page.locator("#slow-layout-loading")).toBeVisible({ timeout: 1_500 });
+    await expect(page.locator("#slow-layout-message")).toHaveText("Slow layout resolved", {
+      timeout: 10_000,
+    });
+  });
+
+  test("slot-only loading-shell prefetch stops before the slow slot page", async () => {
+    const fetchLoadingShell = () =>
+      fetch(`${BASE}/slow-slot-loading/slow?_rsc=slot-loading-shell`, {
+        headers: {
+          RSC: "1",
+          "Next-Router-Prefetch": "1",
+          "Next-Router-Segment-Prefetch": "1",
+          "X-Vinext-Rsc-Render-Mode": "prefetch-loading-shell",
+        },
+      });
+
+    await (await fetchLoadingShell()).text();
+    const startedAt = performance.now();
+    const response = await fetchLoadingShell();
+    const body = await response.text();
+    const durationMs = performance.now() - startedAt;
+
+    expect(response.status).toBe(200);
+    expect(durationMs).toBeLessThan(1_500);
+    expect(body).toContain("Loading named slot");
+    expect(body).not.toContain("Slow named slot resolved");
+  });
+
+  test("client navigation streams a slot-only loading boundary", async ({ page }) => {
+    await page.goto(BASE);
+    const link = page.getByTestId("slow-slot-loading-link");
+    await link.waitFor();
+    await page.waitForTimeout(250);
+
+    await link.click();
+    await expect(page.locator("#slow-slot-loading")).toBeVisible({ timeout: 1_500 });
+    await expect(page.locator("#slow-slot-message")).toHaveText("Slow named slot resolved", {
+      timeout: 10_000,
+    });
+  });
+
+  test("client interception streams its branch loading boundary", async ({ page }) => {
+    await page.goto(`${BASE}/slow-intercept`);
+    await waitForAppRouterHydration(page);
+    const link = page.getByTestId("slow-intercept-link");
+    await link.waitFor();
+
+    await link.click();
+    await expect(page.locator("#slow-intercept-loading")).toBeVisible({ timeout: 1_500 });
+    await expect(page.locator("#slow-intercept-message")).toHaveText(
+      "Slow intercepted photo resolved",
+      { timeout: 10_000 },
+    );
   });
 
   test("slow nested layout and page include both loading fallbacks in initial HTML", async ({

--- a/tests/e2e/app-router/loading.spec.ts
+++ b/tests/e2e/app-router/loading.spec.ts
@@ -45,4 +45,38 @@ test.describe("Loading boundaries (loading.tsx)", () => {
       timeout: 10_000,
     });
   });
+
+  // Ported from Next.js: test/e2e/app-dir/app/index.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app/index.test.ts
+  test("slow nested layout includes its ancestor loading fallback in initial HTML", async ({
+    request,
+  }) => {
+    const response = await request.get(`${BASE}/slow-layout-with-loading/slow`);
+    const html = await response.text();
+
+    expect(response.status()).toBe(200);
+    expect(html).toContain('id="slow-layout-loading"');
+  });
+
+  test("slow nested layout and page include both loading fallbacks in initial HTML", async ({
+    request,
+  }) => {
+    const response = await request.get(`${BASE}/slow-layout-and-page-with-loading/slow`);
+    const html = await response.text();
+
+    expect(response.status()).toBe(200);
+    expect(html).toContain('id="slow-combined-layout-loading"');
+    expect(html).toContain('id="slow-combined-page-loading"');
+  });
+
+  test("slow nested layout and page eventually render final content", async ({ page }) => {
+    await page.goto(`${BASE}/slow-layout-and-page-with-loading/slow`);
+
+    await expect(page.locator("#slow-combined-layout-message")).toHaveText("Slow layout resolved", {
+      timeout: 10_000,
+    });
+    await expect(page.locator("#slow-combined-page-message")).toHaveText("Slow page resolved", {
+      timeout: 10_000,
+    });
+  });
 });

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -9,7 +9,11 @@ import fs from "node:fs";
 import os from "node:os";
 import vm from "node:vm";
 import { describe, it, expect } from "vite-plus/test";
-import { generateBrowserEntry } from "../packages/vinext/src/entries/app-browser-entry.js";
+import {
+  generateBrowserEntry,
+  toLinkPrefetchRoute,
+  toLinkPrefetchRoutes,
+} from "../packages/vinext/src/entries/app-browser-entry.js";
 import { buildAppRscManifestCode } from "../packages/vinext/src/entries/app-rsc-manifest.js";
 import { generateRscEntry } from "../packages/vinext/src/entries/app-rsc-entry.js";
 import { generateClientEntry } from "../packages/vinext/src/entries/pages-client-entry.js";
@@ -145,7 +149,27 @@ describe("App Router generated manifest construction", () => {
         routePath: null,
         layouts: ["/tmp/test/app/layout.tsx", "/tmp/test/app/modal-host/layout.tsx"],
         templates: [],
-        parallelSlots: [],
+        parallelSlots: [
+          {
+            id: "slot:panel:/modal-host",
+            key: "panel@modal-host/@panel",
+            name: "panel",
+            ownerDir: "/tmp/test/app/modal-host/@panel",
+            ownerTreePath: "/modal-host",
+            ownerTreePosition: 1,
+            hasPage: true,
+            pagePath: "/tmp/test/app/modal-host/@panel/slow/page.tsx",
+            defaultPath: null,
+            layoutPath: null,
+            loadingPath: null,
+            loadingPaths: ["/tmp/test/app/modal-host/@panel/slow/loading.tsx"],
+            loadingTreePositions: [1],
+            errorPath: null,
+            interceptingRoutes: [],
+            layoutIndex: 1,
+            routeSegments: ["slow"],
+          },
+        ],
         loadingPath: null,
         errorPath: null,
         layoutErrorPaths: [null, null],
@@ -251,6 +275,16 @@ describe("App Router generated manifest construction", () => {
         params: [],
         siblingIntercepts: [],
       },
+      {
+        ...minimalAppRoutes[0],
+        pattern: "/ancestor-loading/slow",
+        patternParts: ["ancestor-loading", "slow"],
+        pagePath: "/tmp/test/app/ancestor-loading/slow/page.tsx",
+        loadingPath: null,
+        loadingPaths: ["/tmp/test/app/ancestor-loading/loading.tsx"],
+        loadingTreePositions: [1],
+        routeSegments: ["ancestor-loading", "slow"],
+      },
     ]);
 
     expect(code).toContain("import { registerNavigationRuntimeBootstrap } from ");
@@ -267,14 +301,114 @@ describe("App Router generated manifest construction", () => {
       '{"canPrefetchLoadingShell":true,"patternParts":["docs",":slug"],"isDynamic":true}',
     );
     expect(code).toContain(
+      '{"canPrefetchLoadingShell":true,"patternParts":["ancestor-loading","slow"],"isDynamic":false}',
+    );
+    expect(code).toContain(
       '{"canPrefetchLoadingShell":false,"patternParts":["teams",":team","dashboard"],"isDynamic":true,"requiresDynamicNavigationRequest":true}',
     );
     expect(code).toContain(
-      '{"canPrefetchLoadingShell":false,"patternParts":["modal-host"],"isDynamic":false}',
+      '{"canPrefetchLoadingShell":true,"patternParts":["modal-host"],"isDynamic":false}',
     );
     expect(code).not.toContain(
       '{"canPrefetchLoadingShell":false,"patternParts":["api"],"isDynamic":false}',
     );
+  });
+
+  it("advertises loading-shell prefetch for intercept-only loading boundaries", () => {
+    const route = {
+      ...minimalAppRoutes[0],
+      pattern: "/slow-intercept/photo",
+      patternParts: ["slow-intercept", "photo"],
+      parallelSlots: [
+        {
+          id: "slot:modal:/slow-intercept",
+          key: "modal@slow-intercept/@modal",
+          name: "modal",
+          ownerDir: "/tmp/test/app/slow-intercept/@modal",
+          ownerTreePath: "/slow-intercept",
+          ownerTreePosition: 1,
+          hasPage: false,
+          pagePath: null,
+          defaultPath: "/tmp/test/app/slow-intercept/@modal/default.tsx",
+          layoutPath: null,
+          loadingPath: null,
+          loadingPaths: [],
+          loadingTreePositions: [],
+          errorPath: null,
+          interceptingRoutes: [
+            {
+              convention: ".",
+              targetPattern: "/slow-intercept/photo",
+              sourceMatchPattern: "/slow-intercept",
+              pagePath: "/tmp/test/app/slow-intercept/@modal/(.)photo/page.tsx",
+              layoutPaths: [],
+              loadingPaths: ["/tmp/test/app/slow-intercept/@modal/(.)photo/loading.tsx"],
+              loadingTreePositions: [1],
+              params: [],
+            },
+          ],
+          layoutIndex: 0,
+          routeSegments: null,
+        },
+      ],
+      routeSegments: ["slow-intercept", "photo"],
+    } satisfies AppRoute;
+
+    expect(toLinkPrefetchRoute(route).canPrefetchLoadingShell).toBe(true);
+    expect(
+      toLinkPrefetchRoute({
+        ...route,
+        pattern: "/slow-intercept",
+        patternParts: ["slow-intercept"],
+        routeSegments: ["slow-intercept"],
+      }).canPrefetchLoadingShell,
+    ).toBe(false);
+  });
+
+  it("advertises sibling-intercept loading only on the target route", () => {
+    const sourceRoute = {
+      ...minimalAppRoutes[0],
+      pattern: "/feed",
+      patternParts: ["feed"],
+      routeSegments: ["feed"],
+      siblingIntercepts: [
+        {
+          convention: ".",
+          targetPattern: "/feed/photo/:photoId",
+          sourceMatchPattern: "/feed",
+          pagePath: "/tmp/test/app/feed/(.)photo/[photoId]/page.tsx",
+          layoutPaths: [],
+          loadingPaths: ["/tmp/test/app/feed/(.)photo/[photoId]/loading.tsx"],
+          loadingTreePositions: [1],
+          params: ["photoId"],
+        },
+      ],
+    } satisfies AppRoute;
+    const targetRoute = {
+      ...minimalAppRoutes[0],
+      pattern: "/feed/photo/:id",
+      patternParts: ["feed", "photo", ":id"],
+      routeSegments: ["feed", "photo", ":id"],
+      isDynamic: true,
+      params: ["id"],
+    } satisfies AppRoute;
+    const unrelatedRoute = {
+      ...minimalAppRoutes[0],
+      pattern: "/feed/video/:id",
+      patternParts: ["feed", "video", ":id"],
+      routeSegments: ["feed", "video", ":id"],
+      isDynamic: true,
+      params: ["id"],
+    } satisfies AppRoute;
+
+    const [source, target, unrelated] = toLinkPrefetchRoutes([
+      sourceRoute,
+      targetRoute,
+      unrelatedRoute,
+    ]);
+    expect(source.canPrefetchLoadingShell).toBe(false);
+    expect(target.canPrefetchLoadingShell).toBe(true);
+    expect(unrelated.canPrefetchLoadingShell).toBe(false);
   });
 
   it("embeds the RouteManifest read model in the browser entry", async () => {
@@ -471,6 +605,61 @@ describe("App Router generated manifest construction", () => {
     expect(routeEntry).toContain("loadings: [null, null]");
     expect(routeEntry).toContain("__loadLoadings: [load_");
     expect(routeEntry).toContain("loadingTreePositions: [1,2]");
+  });
+
+  it("emits positional loading modules for named slots and intercepted branches", () => {
+    const route = {
+      ...minimalAppRoutes[0],
+      parallelSlots: [
+        {
+          id: "slot:modal:/",
+          key: "modal@modal",
+          name: "modal",
+          ownerDir: "/tmp/test/app/@modal",
+          ownerTreePath: "/",
+          ownerTreePosition: 0,
+          hasPage: true,
+          pagePath: "/tmp/test/app/@modal/nested/page.tsx",
+          defaultPath: null,
+          layoutPath: null,
+          configLayoutPaths: [],
+          configLayoutTreePositions: [],
+          loadingPath: "/tmp/test/app/@modal/loading.tsx",
+          loadingPaths: [
+            "/tmp/test/app/@modal/loading.tsx",
+            "/tmp/test/app/@modal/nested/loading.tsx",
+          ],
+          loadingTreePositions: [0, 1],
+          errorPath: null,
+          interceptingRoutes: [
+            {
+              convention: ".",
+              targetPattern: "/photo/:id",
+              sourceMatchPattern: "/",
+              pagePath: "/tmp/test/app/@modal/(.)photo/[id]/page.tsx",
+              layoutPaths: [],
+              loadingPaths: ["/tmp/test/app/@modal/(.)photo/loading.tsx"],
+              loadingTreePositions: [1],
+              params: ["id"],
+            },
+          ],
+          layoutIndex: 0,
+          routeSegments: ["nested"],
+        },
+      ],
+    } satisfies AppRoute;
+
+    const manifest = buildAppRscManifestCode({ routes: [route] });
+    const imports = manifest.imports.join("\n");
+    const routeEntry = manifest.routeEntries[0];
+
+    expect(imports).toContain("/tmp/test/app/@modal/nested/loading.tsx");
+    expect(imports).toContain("/tmp/test/app/@modal/(.)photo/loading.tsx");
+    expect(routeEntry).toContain("ownerTreePosition: 0");
+    expect(routeEntry).toContain("loadings: [null, null]");
+    expect(routeEntry).toContain("loadingTreePositions: [0,1]");
+    expect(routeEntry).toContain("interceptLoadings: [null]");
+    expect(routeEntry).toContain("interceptLoadingTreePositions: [1]");
   });
 
   it("derives route-miss root boundaries when the app has no root page", () => {

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -451,6 +451,28 @@ describe("App Router generated manifest construction", () => {
     ]);
   });
 
+  it("emits lazy per-segment loading modules with their tree positions", () => {
+    const route = {
+      ...minimalAppRoutes[0],
+      pattern: "/parent/slow",
+      patternParts: ["parent", "slow"],
+      pagePath: "/tmp/test/app/parent/slow/page.tsx",
+      loadingPath: "/tmp/test/app/parent/slow/loading.tsx",
+      loadingPaths: ["/tmp/test/app/parent/loading.tsx", "/tmp/test/app/parent/slow/loading.tsx"],
+      loadingTreePositions: [1, 2],
+      routeSegments: ["parent", "slow"],
+    } satisfies AppRoute;
+
+    const manifest = buildAppRscManifestCode({ routes: [route] });
+    const routeEntry = manifest.routeEntries[0];
+
+    expect(manifest.imports.join("\n")).toContain("/tmp/test/app/parent/loading.tsx");
+    expect(manifest.imports.join("\n")).toContain("/tmp/test/app/parent/slow/loading.tsx");
+    expect(routeEntry).toContain("loadings: [null, null]");
+    expect(routeEntry).toContain("__loadLoadings: [load_");
+    expect(routeEntry).toContain("loadingTreePositions: [1,2]");
+  });
+
   it("derives route-miss root boundaries when the app has no root page", () => {
     const routes = [
       {

--- a/tests/fixtures/app-basic/app/page.tsx
+++ b/tests/fixtures/app-basic/app/page.tsx
@@ -40,6 +40,12 @@ export default function HomePage() {
         <Link href="/delayed-protected-loading" data-testid="delayed-protected-loading-link">
           Delayed Protected Loading
         </Link>
+        <Link href="/slow-layout-with-loading/slow" data-testid="slow-layout-with-loading-link">
+          Slow Layout With Ancestor Loading
+        </Link>
+        <Link href="/slow-slot-loading/slow" data-testid="slow-slot-loading-link">
+          Slow Named Slot With Loading
+        </Link>
         <Link href="/metadata-redirect-test" prefetch={false} data-testid="metadata-redirect-link">
           Metadata Redirect
         </Link>

--- a/tests/fixtures/app-basic/app/slow-intercept/@modal/(.)photo/loading.tsx
+++ b/tests/fixtures/app-basic/app/slow-intercept/@modal/(.)photo/loading.tsx
@@ -1,0 +1,3 @@
+export default function SlowInterceptLoading() {
+  return <p id="slow-intercept-loading">Loading intercepted photo</p>;
+}

--- a/tests/fixtures/app-basic/app/slow-intercept/@modal/(.)photo/page.tsx
+++ b/tests/fixtures/app-basic/app/slow-intercept/@modal/(.)photo/page.tsx
@@ -1,0 +1,4 @@
+export default async function SlowInterceptPhotoPage() {
+  await new Promise((resolve) => setTimeout(resolve, 3_000));
+  return <p id="slow-intercept-message">Slow intercepted photo resolved</p>;
+}

--- a/tests/fixtures/app-basic/app/slow-intercept/@modal/default.tsx
+++ b/tests/fixtures/app-basic/app/slow-intercept/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function SlowInterceptDefault() {
+  return null;
+}

--- a/tests/fixtures/app-basic/app/slow-intercept/layout.tsx
+++ b/tests/fixtures/app-basic/app/slow-intercept/layout.tsx
@@ -1,0 +1,14 @@
+export default function SlowInterceptLayout({
+  children,
+  modal,
+}: {
+  children: React.ReactNode;
+  modal: React.ReactNode;
+}) {
+  return (
+    <main>
+      {children}
+      <aside>{modal}</aside>
+    </main>
+  );
+}

--- a/tests/fixtures/app-basic/app/slow-intercept/page.tsx
+++ b/tests/fixtures/app-basic/app/slow-intercept/page.tsx
@@ -1,0 +1,9 @@
+import Link from "next/link";
+
+export default function SlowInterceptPage() {
+  return (
+    <Link href="/slow-intercept/photo" data-testid="slow-intercept-link">
+      Open slow photo
+    </Link>
+  );
+}

--- a/tests/fixtures/app-basic/app/slow-intercept/photo/page.tsx
+++ b/tests/fixtures/app-basic/app/slow-intercept/photo/page.tsx
@@ -1,0 +1,3 @@
+export default function SlowPhotoPage() {
+  return <p>Full slow photo page</p>;
+}

--- a/tests/fixtures/app-basic/app/slow-layout-and-page-with-loading/loading.tsx
+++ b/tests/fixtures/app-basic/app/slow-layout-and-page-with-loading/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <p id="slow-combined-layout-loading">Loading layout...</p>;
+}

--- a/tests/fixtures/app-basic/app/slow-layout-and-page-with-loading/slow/layout.tsx
+++ b/tests/fixtures/app-basic/app/slow-layout-and-page-with-loading/slow/layout.tsx
@@ -1,0 +1,14 @@
+async function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export default async function SlowLayout({ children }: { children: React.ReactNode }) {
+  await delay(750);
+
+  return (
+    <section>
+      <p id="slow-combined-layout-message">Slow layout resolved</p>
+      {children}
+    </section>
+  );
+}

--- a/tests/fixtures/app-basic/app/slow-layout-and-page-with-loading/slow/loading.tsx
+++ b/tests/fixtures/app-basic/app/slow-layout-and-page-with-loading/slow/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <p id="slow-combined-page-loading">Loading page...</p>;
+}

--- a/tests/fixtures/app-basic/app/slow-layout-and-page-with-loading/slow/page.tsx
+++ b/tests/fixtures/app-basic/app/slow-layout-and-page-with-loading/slow/page.tsx
@@ -1,0 +1,9 @@
+async function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export default async function SlowPage() {
+  await delay(2000);
+
+  return <h1 id="slow-combined-page-message">Slow page resolved</h1>;
+}

--- a/tests/fixtures/app-basic/app/slow-layout-with-loading/loading.tsx
+++ b/tests/fixtures/app-basic/app/slow-layout-with-loading/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <p id="slow-layout-loading">Loading layout...</p>;
+}

--- a/tests/fixtures/app-basic/app/slow-layout-with-loading/slow/layout.tsx
+++ b/tests/fixtures/app-basic/app/slow-layout-with-loading/slow/layout.tsx
@@ -1,0 +1,14 @@
+async function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export default async function SlowLayout({ children }: { children: React.ReactNode }) {
+  await delay(1500);
+
+  return (
+    <section>
+      <p id="slow-layout-message">Slow layout resolved</p>
+      {children}
+    </section>
+  );
+}

--- a/tests/fixtures/app-basic/app/slow-layout-with-loading/slow/layout.tsx
+++ b/tests/fixtures/app-basic/app/slow-layout-with-loading/slow/layout.tsx
@@ -3,7 +3,7 @@ async function delay(ms: number) {
 }
 
 export default async function SlowLayout({ children }: { children: React.ReactNode }) {
-  await delay(1500);
+  await delay(3000);
 
   return (
     <section>

--- a/tests/fixtures/app-basic/app/slow-layout-with-loading/slow/page.tsx
+++ b/tests/fixtures/app-basic/app/slow-layout-with-loading/slow/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1 id="slow-layout-page">Slow layout page</h1>;
+}

--- a/tests/fixtures/app-basic/app/slow-slot-loading/@sidebar/default.tsx
+++ b/tests/fixtures/app-basic/app/slow-slot-loading/@sidebar/default.tsx
@@ -1,0 +1,3 @@
+export default function SlowSlotDefault() {
+  return null;
+}

--- a/tests/fixtures/app-basic/app/slow-slot-loading/@sidebar/slow/loading.tsx
+++ b/tests/fixtures/app-basic/app/slow-slot-loading/@sidebar/slow/loading.tsx
@@ -1,0 +1,3 @@
+export default function SlowSlotLoading() {
+  return <p id="slow-slot-loading">Loading named slot</p>;
+}

--- a/tests/fixtures/app-basic/app/slow-slot-loading/@sidebar/slow/page.tsx
+++ b/tests/fixtures/app-basic/app/slow-slot-loading/@sidebar/slow/page.tsx
@@ -1,0 +1,4 @@
+export default async function SlowSlotPage() {
+  await new Promise((resolve) => setTimeout(resolve, 3_000));
+  return <p id="slow-slot-message">Slow named slot resolved</p>;
+}

--- a/tests/fixtures/app-basic/app/slow-slot-loading/layout.tsx
+++ b/tests/fixtures/app-basic/app/slow-slot-loading/layout.tsx
@@ -1,0 +1,14 @@
+export default function SlowSlotLayout({
+  children,
+  sidebar,
+}: {
+  children: React.ReactNode;
+  sidebar: React.ReactNode;
+}) {
+  return (
+    <main>
+      <section>{children}</section>
+      <aside>{sidebar}</aside>
+    </main>
+  );
+}

--- a/tests/fixtures/app-basic/app/slow-slot-loading/page.tsx
+++ b/tests/fixtures/app-basic/app/slow-slot-loading/page.tsx
@@ -1,0 +1,3 @@
+export default function SlowSlotLandingPage() {
+  return <p>Slow slot landing page</p>;
+}

--- a/tests/fixtures/app-basic/app/slow-slot-loading/slow/page.tsx
+++ b/tests/fixtures/app-basic/app/slow-slot-loading/slow/page.tsx
@@ -1,0 +1,3 @@
+export default function SlowSlotMainPage() {
+  return <p id="slow-slot-main">Slow slot main content</p>;
+}

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -15,9 +15,11 @@ import {
 import {
   NEXT_ROUTER_PREFETCH_HEADER,
   NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
+  VINEXT_INTERCEPTION_CONTEXT_HEADER,
   VINEXT_RSC_RENDER_MODE_HEADER,
 } from "../packages/vinext/src/server/headers.js";
 import type { VinextLinkPrefetchRoute } from "../packages/vinext/src/client/vinext-next-data.js";
+import type { RouteManifest } from "../packages/vinext/src/routing/app-route-graph.js";
 
 type CapturedEffect = () => void | (() => void);
 
@@ -65,12 +67,20 @@ const linkPrefetchRoutes = [
     isDynamic: true,
     requiresDynamicNavigationRequest: true,
   },
+  {
+    canPrefetchLoadingShell: true,
+    patternParts: ["slow-intercept", "photo"],
+    isDynamic: false,
+  },
 ] satisfies VinextLinkPrefetchRoute[];
 
-function createTestNavigationRuntime(navigate: unknown) {
+function createTestNavigationRuntime(
+  navigate: unknown,
+  routeManifest: RouteManifest | null = null,
+) {
   return {
     bootstrap: {
-      routeManifest: null,
+      routeManifest,
       rsc: undefined,
     },
     functions: {
@@ -1234,6 +1244,7 @@ async function renderIsolatedLink(options: {
   nodeEnv: string;
   props?: Record<string, unknown>;
   requireRef?: boolean;
+  routeManifest?: RouteManifest;
   windowOverrides?: Record<string, unknown>;
 }) {
   vi.resetModules();
@@ -1271,7 +1282,9 @@ async function renderIsolatedLink(options: {
     search: "",
   };
   const navigationRuntime =
-    options.appNavigation === false ? undefined : createTestNavigationRuntime(navigate);
+    options.appNavigation === false
+      ? undefined
+      : createTestNavigationRuntime(navigate, options.routeManifest ?? null);
 
   vi.stubGlobal("fetch", fetch);
   vi.stubGlobal("document", {
@@ -2256,6 +2269,70 @@ describe("Link prefetch scheduling", () => {
       expect((fetchInit?.headers as Headers | undefined)?.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBe(
         APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
       );
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("automatically prefetches intercepted loading shells with their source context", async () => {
+    const observer = stubIntersectionObserver();
+    const interception = {
+      id: "interception:slot:modal:/slow-intercept->/slow-intercept/photo",
+      interceptingRouteId: "route:/slow-intercept",
+      ownerLayoutId: "layout:/slow-intercept",
+      slotId: "slot:modal:/slow-intercept",
+      sourcePattern: "/slow-intercept",
+      sourcePatternParts: ["slow-intercept"],
+      targetPattern: "/slow-intercept/photo",
+      targetPatternParts: ["slow-intercept", "photo"],
+      targetRouteId: "route:/slow-intercept/photo",
+    } as const;
+    const routeManifest: RouteManifest = {
+      graphVersion: "test",
+      segmentGraph: {
+        boundaries: new Map(),
+        defaults: new Map(),
+        interceptions: new Map([[interception.id, interception]]),
+        interceptionsBySlotId: new Map(),
+        layouts: new Map(),
+        pages: new Map(),
+        rootBoundaries: new Map(),
+        routeHandlers: new Map(),
+        routes: new Map(),
+        slotBindings: new Map(),
+        slots: new Map(),
+        templates: new Map(),
+      },
+    };
+    const result = await renderIsolatedLink({
+      href: "/slow-intercept/photo",
+      nodeEnv: "production",
+      routeManifest,
+      windowOverrides: {
+        location: {
+          href: "https://example.com/slow-intercept",
+          origin: "https://example.com",
+          pathname: "/slow-intercept",
+          search: "",
+        },
+      },
+    });
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[0],
+        "/slow-intercept/photo",
+        expect.objectContaining({ credentials: "include", priority: "low" }),
+      );
+      const fetchInit = result.fetch.mock.calls[0]?.[1] as RequestInit | undefined;
+      const headers = fetchInit?.headers as Headers | undefined;
+      expect(headers?.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBe(
+        APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+      );
+      expect(headers?.get(VINEXT_INTERCEPTION_CONTEXT_HEADER)).toBe("/slow-intercept");
     } finally {
       result.restoreNodeEnv();
     }

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -1625,7 +1625,9 @@ describe("matchAppRoute - URL matching", () => {
       await writeFile(path.join(appDir, "page.tsx"), EMPTY_PAGE);
       await writeFile(path.join(appDir, "@modal", "default.tsx"), EMPTY_PAGE);
       await writeFile(path.join(appDir, "@modal", "(.)foo", "layout.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "@modal", "(.)foo", "loading.tsx"), EMPTY_PAGE);
       await writeFile(path.join(appDir, "@modal", "(.)foo", "bar", "layout.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "@modal", "(.)foo", "bar", "loading.tsx"), EMPTY_PAGE);
       await writeFile(path.join(appDir, "@modal", "(.)foo", "bar", "baz", "page.tsx"), EMPTY_PAGE);
       await writeFile(path.join(appDir, "foo", "page.tsx"), EMPTY_PAGE);
       await writeFile(path.join(appDir, "foo", "bar", "page.tsx"), EMPTY_PAGE);
@@ -1644,6 +1646,44 @@ describe("matchAppRoute - URL matching", () => {
         canonical(path.join(appDir, "@modal", "(.)foo", "layout.tsx")),
         canonical(path.join(appDir, "@modal", "(.)foo", "bar", "layout.tsx")),
       ]);
+      expect(modalSlot!.interceptingRoutes[0]?.loadingPaths).toEqual([
+        canonical(path.join(appDir, "@modal", "(.)foo", "loading.tsx")),
+        canonical(path.join(appDir, "@modal", "(.)foo", "bar", "loading.tsx")),
+      ]);
+      expect(modalSlot!.interceptingRoutes[0]?.loadingTreePositions).toEqual([1, 2]);
+    });
+  });
+
+  it("includes loading boundaries on common slot ancestry before an intercept marker", async () => {
+    await withTempDir("vinext-app-intercept-common-loading-", async (tmpDir) => {
+      const appDir = path.join(tmpDir, "app");
+
+      await mkdir(path.join(appDir, "@modal", "gallery", "(.)photo"), { recursive: true });
+      await mkdir(path.join(appDir, "gallery", "photo"), { recursive: true });
+      await writeFile(path.join(appDir, "layout.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "page.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "@modal", "default.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "@modal", "gallery", "loading.tsx"), EMPTY_PAGE);
+      await writeFile(
+        path.join(appDir, "@modal", "gallery", "(.)photo", "loading.tsx"),
+        EMPTY_PAGE,
+      );
+      await writeFile(path.join(appDir, "@modal", "gallery", "(.)photo", "page.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "gallery", "page.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "gallery", "photo", "page.tsx"), EMPTY_PAGE);
+
+      invalidateAppRouteCache();
+      const routes = await appRouter(appDir);
+      const galleryRoute = routes.find((route) => route.pattern === "/gallery");
+      const modalSlot = galleryRoute?.parallelSlots.find((slot) => slot.name === "modal");
+      const intercept = modalSlot?.interceptingRoutes[0];
+
+      expect(intercept?.loadingPaths).toEqual([
+        canonical(path.join(appDir, "@modal", "gallery", "loading.tsx")),
+        canonical(path.join(appDir, "@modal", "gallery", "(.)photo", "loading.tsx")),
+      ]);
+      expect(intercept?.loadingTreePositions).toEqual([1, 2]);
+      expect(intercept?.branchSegments).toEqual(["gallery", "photo"]);
     });
   });
 
@@ -1846,6 +1886,10 @@ describe("matchAppRoute - URL matching", () => {
         path.join(appDir, "parallel-nested", "home", "@parallelB", "nested", "page.tsx"),
         EMPTY_PAGE,
       );
+      await writeFile(
+        path.join(appDir, "parallel-nested", "home", "@parallelB", "nested", "loading.tsx"),
+        EMPTY_PAGE,
+      );
 
       invalidateAppRouteCache();
       const routes = await appRouter(appDir);
@@ -1869,6 +1913,12 @@ describe("matchAppRoute - URL matching", () => {
       expect(parallelBSlot.pagePath).toContain(
         canonical(path.join("@parallelB", "nested", "page.tsx")),
       );
+      expect(parallelBSlot.loadingPaths).toEqual([
+        canonical(
+          path.join(appDir, "parallel-nested", "home", "@parallelB", "nested", "loading.tsx"),
+        ),
+      ]);
+      expect(parallelBSlot.loadingTreePositions).toEqual([1]);
     });
   });
 

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -466,6 +466,31 @@ describe("appRouter - route discovery", () => {
     expect(homeRoute!.layouts[0]).toContain("layout.tsx");
   });
 
+  // Ported from Next.js: test/e2e/app-dir/app/index.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app/index.test.ts
+  it("records loading boundaries at every segment, including segments without layouts", async () => {
+    await withTempDir("vinext-app-segment-loading-", async (tmpDir) => {
+      const appDir = path.join(tmpDir, "app");
+      await mkdir(path.join(appDir, "parent", "slow"), { recursive: true });
+      await writeFile(path.join(appDir, "layout.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "parent", "loading.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "parent", "slow", "layout.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "parent", "slow", "loading.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "parent", "slow", "page.tsx"), EMPTY_PAGE);
+
+      invalidateAppRouteCache();
+      const routes = await appRouter(appDir);
+      const route = routes.find((candidate) => candidate.pattern === "/parent/slow");
+
+      expect(route?.loadingPath).toBe(canonical(appDir, "parent/slow/loading.tsx"));
+      expect(route?.loadingPaths).toEqual([
+        canonical(appDir, "parent/loading.tsx"),
+        canonical(appDir, "parent/slow/loading.tsx"),
+      ]);
+      expect(route?.loadingTreePositions).toEqual([1, 2]);
+    });
+  });
+
   it("records the owner position of a not-found boundary without a layout", async () => {
     await withTempDir("vinext-app-not-found-owner-", async (tmpDir) => {
       const appDir = path.join(tmpDir, "app");
@@ -1812,6 +1837,7 @@ describe("matchAppRoute - URL matching", () => {
       await writeFile(path.join(appDir, "layout.tsx"), EMPTY_PAGE);
       await writeFile(path.join(appDir, "parallel-nested", "layout.tsx"), EMPTY_PAGE);
       await writeFile(path.join(appDir, "parallel-nested", "home", "layout.tsx"), EMPTY_PAGE);
+      await writeFile(path.join(appDir, "parallel-nested", "home", "loading.tsx"), EMPTY_PAGE);
       await writeFile(
         path.join(appDir, "parallel-nested", "home", "@parallelB", "default.tsx"),
         EMPTY_PAGE,
@@ -1829,11 +1855,15 @@ describe("matchAppRoute - URL matching", () => {
       expect(patterns).toContain("/parallel-nested/home");
       const parentRoute = routes.find((r) => r.pattern === "/parallel-nested/home")!;
       expect(parentRoute.pagePath).toBeNull();
+      expect(parentRoute.loadingPath).toContain(canonical(path.join("home", "loading.tsx")));
       expect(parentRoute.parallelSlots.map((slot) => slot.name).sort()).toEqual(["parallelB"]);
 
       // Nested slot sub-route should be discovered even though parent has no page.tsx
       expect(patterns).toContain("/parallel-nested/home/nested");
       const nestedRoute = routes.find((r) => r.pattern === "/parallel-nested/home/nested")!;
+      expect(nestedRoute.loadingPath).toBeNull();
+      expect(nestedRoute.loadingPaths).toEqual(parentRoute.loadingPaths);
+      expect(nestedRoute.loadingTreePositions).toEqual(parentRoute.loadingTreePositions);
       expect(nestedRoute.parallelSlots.map((slot) => slot.name).sort()).toEqual(["parallelB"]);
       const parallelBSlot = nestedRoute.parallelSlots.find((slot) => slot.name === "parallelB")!;
       expect(parallelBSlot.pagePath).toContain(


### PR DESCRIPTION
## Summary

- discover `loading.tsx` conventions at every App Router segment, including segments without a `layout.tsx`
- carry each loading module and its loader-tree position through the generated RSC manifest and lazy module loader
- compose ancestor `Suspense` boundaries around child layouts while preserving the existing leaf loading and prefetch behavior
- keep inherited loading boundaries correctly positioned for synthetic parallel-slot routes

## Root cause

App route metadata only retained the leaf route's `loading.tsx`. That works when the page itself suspends, but an ancestor loading convention was absent from the flat route element tree when a nested layout suspended. The response therefore waited for the layout instead of streaming the ancestor fallback.

This change models loading conventions the same way the route graph already models other segment-owned boundaries: as module paths paired with loader-tree positions. Ancestor boundaries are inserted during bottom-up segment composition; the leaf boundary stays on the existing route-level path to avoid changing page error/access ordering, scroll behavior, or link-prefetch shells.

The regression fixtures and assertions follow the nested-layout cases covered by Next.js's App Router E2E suite.

## Validation

- `pnpm test tests/routing.test.ts tests/app-route-module-loader.test.ts tests/entry-templates.test.ts tests/app-page-route-wiring.test.ts` — 226 passed
- `PLAYWRIGHT_PROJECT=app-router pnpm exec playwright test tests/e2e/app-router/loading.spec.ts` — 6 passed
- `pnpm run check` — format, lint, types, Next.js type sync, and public shim checks passed
- `pnpm run build` — passed

Risk class: behavior-changing App Router rendering fix; no public API, dependency, or data changes.

Fixes #1528
