### PR TITLE
feat(metadata): support viewport fields and parent resolution

### DIFF
--- a/packages/vinext/src/server/app-page-element-builder.ts
+++ b/packages/vinext/src/server/app-page-element-builder.ts
@@ -334,8 +334,8 @@ export async function buildPageElements<
       }
     : null;
   const parallelRoutes = [
-    ...activeParallelRouteHeadInputs.map((input) => input.head),
     ...(primaryParallelRouteHeadInput ? [primaryParallelRouteHeadInput.head] : []),
+    ...activeParallelRouteHeadInputs.map((input) => input.head),
   ];
   const metadataSearchParamsObserver = observeMetadataSearchParamsAccess
     ? createAppPageSearchParamsObserver()

--- a/packages/vinext/src/server/app-page-head.ts
+++ b/packages/vinext/src/server/app-page-head.ts
@@ -725,6 +725,20 @@ function prepareAppPageHeadInner<TModule extends AppPageHeadModule>(
   );
   const parallelRouteViewportPromises: Promise<(Viewport | null)[]>[] = [];
   let accumulatedViewport = layoutViewport.resolvedViewport;
+  const pageParentViewport = accumulatedViewport;
+  const pageViewportPromise = options.pageModule
+    ? resolveModuleViewport(
+        options.pageModule,
+        options.params,
+        pageSearchParams,
+        pageParentViewport,
+        options.searchParamsObserver,
+      )
+    : Promise.resolve(null);
+  if (options.pageModule) {
+    accumulatedViewport = mergeResolvedViewport(pageParentViewport, pageViewportPromise);
+    void accumulatedViewport.catch(() => null);
+  }
   for (const parallelRoute of parallelRoutes) {
     const parallelViewport = resolveParallelRouteViewport(
       parallelRoute,
@@ -738,15 +752,6 @@ function prepareAppPageHeadInner<TModule extends AppPageHeadModule>(
     accumulatedViewport = parallelViewport.resolvedViewport;
   }
   const parallelRouteViewportPromise = Promise.all(parallelRouteViewportPromises);
-  const pageViewportPromise = options.pageModule
-    ? resolveModuleViewport(
-        options.pageModule,
-        options.params,
-        pageSearchParams,
-        accumulatedViewport,
-        options.searchParamsObserver,
-      )
-    : Promise.resolve(null);
   const hasDynamicMetadata =
     primaryHasDynamicMetadata || parallelRoutes.some(parallelRouteHasDynamicMetadata);
 
@@ -796,8 +801,8 @@ function prepareAppPageHeadInner<TModule extends AppPageHeadModule>(
   ]).then(([layoutViewportResults, pageViewport, parallelRouteViewports]) =>
     mergeViewport([
       ...layoutViewportResults.filter(isPresent),
-      ...parallelRouteViewports.flat().filter(isPresent),
       ...(pageViewport ? [pageViewport] : []),
+      ...parallelRouteViewports.flat().filter(isPresent),
     ]),
   );
 

--- a/packages/vinext/src/server/app-page-head.ts
+++ b/packages/vinext/src/server/app-page-head.ts
@@ -182,7 +182,7 @@ type PreparedViewportBranch = {
 export function resolveActiveParallelRouteHeadInputs<TModule extends AppPageHeadModule>(
   options: ResolveActiveParallelRouteHeadInputsOptions<TModule>,
 ): ActiveParallelRouteHeadInput<TModule>[] {
-  return Object.entries(options.slots ?? {}).map(([slotKey, slot]) => {
+  const inputs = Object.entries(options.slots ?? {}).map(([slotKey, slot]) => {
     const ownerTreePosition = options.layoutTreePositions?.[slot.layoutIndex ?? 0] ?? 0;
     const ownerParams = resolveAppPageSegmentParams(
       options.routeSegments,
@@ -281,6 +281,7 @@ export function resolveActiveParallelRouteHeadInputs<TModule extends AppPageHead
       ownerTreePosition,
     };
   });
+  return inputs.sort((left, right) => right.ownerTreePosition - left.ownerTreePosition);
 }
 
 function isPresent<T>(value: T | null | undefined): value is T {

--- a/packages/vinext/src/server/app-page-head.ts
+++ b/packages/vinext/src/server/app-page-head.ts
@@ -6,6 +6,7 @@ import {
   resolveModuleViewport,
   type Metadata,
   type MetadataMergeEntry,
+  type ResolvedViewport,
   type Viewport,
 } from "vinext/shims/metadata";
 import { runWithFetchDedupe } from "vinext/shims/fetch-cache";
@@ -155,12 +156,12 @@ export type ResolveAppPageHeadResult = {
   hasSearchParams: boolean;
   metadata: Metadata | null;
   pageSearchParams: AppPageSearchParams;
-  viewport: Viewport;
+  viewport: ResolvedViewport;
 };
 
 export type PreparedAppPageHead = Omit<ResolveAppPageHeadResult, "metadata" | "viewport"> & {
   metadata: Promise<Metadata | null>;
-  viewport: Promise<Viewport>;
+  viewport: Promise<ResolvedViewport>;
 };
 
 type AppPageSearchParamsCollection = {
@@ -171,6 +172,11 @@ type AppPageSearchParamsCollection = {
 type ResolvedParallelRouteMetadata = {
   metadataResults: (Metadata | null)[];
   metadataSources: AppPageHeadSource[];
+};
+
+type PreparedViewportBranch = {
+  resolvedViewport: Promise<ResolvedViewport>;
+  viewportResults: Promise<(Viewport | null)[]>;
 };
 
 export function resolveActiveParallelRouteHeadInputs<TModule extends AppPageHeadModule>(
@@ -430,20 +436,46 @@ async function resolveLayoutMetadata<TModule extends AppPageHeadModule>(
   return Promise.all(layoutMetadataPromises);
 }
 
-async function resolveLayoutViewport<TModule extends AppPageHeadModule>(
+function resolveLayoutViewport<TModule extends AppPageHeadModule>(
   layoutInputs: readonly AppPageHeadLayout<TModule>[],
   params: AppPageParams,
   routeSegments: readonly string[],
-): Promise<(Viewport | null)[]> {
-  return Promise.all(
-    layoutInputs.map((layoutInput) => {
-      const layoutParams = resolveAppPageSegmentParams(
-        routeSegments,
-        layoutInput.treePosition,
-        params,
-      );
-      return resolveModuleViewport(layoutInput.module, layoutParams);
-    }),
+): PreparedViewportBranch {
+  const viewportPromises: Promise<Viewport | null>[] = [];
+  let accumulatedViewport = Promise.resolve(mergeViewport([]));
+
+  for (const layoutInput of layoutInputs) {
+    const parentForLayout = accumulatedViewport;
+    const layoutParams = resolveAppPageSegmentParams(
+      routeSegments,
+      layoutInput.treePosition,
+      params,
+    );
+    const viewportPromise = resolveModuleViewport(
+      layoutInput.module,
+      layoutParams,
+      undefined,
+      parentForLayout,
+    );
+    viewportPromises.push(viewportPromise);
+    void viewportPromise.catch(() => null);
+
+    accumulatedViewport = mergeResolvedViewport(parentForLayout, viewportPromise);
+    void accumulatedViewport.catch(() => null);
+  }
+
+  return {
+    resolvedViewport: accumulatedViewport,
+    viewportResults: Promise.all(viewportPromises),
+  };
+}
+
+function mergeResolvedViewport(
+  parent: Promise<ResolvedViewport>,
+  viewport: Promise<Viewport | null>,
+): Promise<ResolvedViewport> {
+  return Promise.all([parent, viewport]).then(([resolvedParent, resolvedViewport]) =>
+    resolvedViewport ? mergeViewport([resolvedParent, resolvedViewport]) : resolvedParent,
   );
 }
 
@@ -518,41 +550,56 @@ async function resolveParallelRouteMetadata<TModule extends AppPageHeadModule>(
   return { metadataResults, metadataSources };
 }
 
-async function resolveParallelRouteViewport<TModule extends AppPageHeadModule>(
+function resolveParallelRouteViewport<TModule extends AppPageHeadModule>(
   parallelRoute: AppPageHeadParallelRoute<TModule>,
   fallbackParams: AppPageParams,
   fallbackRouteSegments: readonly string[],
   pageSearchParams: AppPageSearchParams,
+  parent: Promise<ResolvedViewport>,
   searchParamsObserver?: ThenableParamsObserver,
-): Promise<(Viewport | null)[]> {
+): PreparedViewportBranch {
   const params = parallelRoute.params ?? fallbackParams;
   const routeSegments = parallelRoute.routeSegments ?? fallbackRouteSegments;
   const layoutModules = getParallelRouteModules(parallelRoute);
   const layoutTreePositions = parallelRoute.layoutTreePositions ?? [];
   const layoutParams = parallelRoute.layoutParams ?? [];
-  const layoutViewportPromise = Promise.all(
-    layoutModules.map((layoutModule, index) =>
-      resolveModuleViewport(
-        layoutModule,
-        layoutParams[index] ??
-          resolveParallelLayoutParams(routeSegments, layoutTreePositions[index] ?? 0, params),
-      ),
-    ),
-  );
-  const pageViewportPromise = parallelRoute.pageModule
-    ? resolveModuleViewport(
-        parallelRoute.pageModule,
-        params,
-        pageSearchParams,
-        searchParamsObserver,
-      )
-    : Promise.resolve(null);
-  const [layoutViewports, pageViewport] = await Promise.all([
-    layoutViewportPromise,
-    pageViewportPromise,
-  ]);
+  const viewportPromises: Promise<Viewport | null>[] = [];
+  let accumulatedViewport = parent;
 
-  return parallelRoute.pageModule ? [...layoutViewports, pageViewport] : layoutViewports;
+  for (const [index, layoutModule] of layoutModules.entries()) {
+    const parentForLayout = accumulatedViewport;
+    const viewportPromise = resolveModuleViewport(
+      layoutModule,
+      layoutParams[index] ??
+        resolveParallelLayoutParams(routeSegments, layoutTreePositions[index] ?? 0, params),
+      undefined,
+      parentForLayout,
+    );
+    viewportPromises.push(viewportPromise);
+    void viewportPromise.catch(() => null);
+    accumulatedViewport = mergeResolvedViewport(parentForLayout, viewportPromise);
+    void accumulatedViewport.catch(() => null);
+  }
+
+  if (parallelRoute.pageModule) {
+    const parentForPage = accumulatedViewport;
+    const viewportPromise = resolveModuleViewport(
+      parallelRoute.pageModule,
+      params,
+      pageSearchParams,
+      parentForPage,
+      searchParamsObserver,
+    );
+    viewportPromises.push(viewportPromise);
+    void viewportPromise.catch(() => null);
+    accumulatedViewport = mergeResolvedViewport(parentForPage, viewportPromise);
+    void accumulatedViewport.catch(() => null);
+  }
+
+  return {
+    resolvedViewport: accumulatedViewport,
+    viewportResults: Promise.all(viewportPromises),
+  };
 }
 
 /**
@@ -641,7 +688,8 @@ function prepareAppPageHeadInner<TModule extends AppPageHeadModule>(
     hasGenerateMetadata(options.pageModule);
   const { hasSearchParams, pageSearchParams } = collectAppPageSearchParams(options.searchParams);
   const layoutMetadataPromise = resolveLayoutMetadata(layoutInputs, options.params, routeSegments);
-  const layoutViewportPromise = resolveLayoutViewport(layoutInputs, options.params, routeSegments);
+  const layoutViewport = resolveLayoutViewport(layoutInputs, options.params, routeSegments);
+  const layoutViewportPromise = layoutViewport.viewportResults;
 
   const layoutMetadataResultsForParent = layoutMetadataPromise.then((metadataResults) =>
     metadataResults.filter(isPresent),
@@ -662,14 +710,6 @@ function prepareAppPageHeadInner<TModule extends AppPageHeadModule>(
         options.searchParamsObserver,
       )
     : Promise.resolve(null);
-  const pageViewportPromise = options.pageModule
-    ? resolveModuleViewport(
-        options.pageModule,
-        options.params,
-        pageSearchParams,
-        options.searchParamsObserver,
-      )
-    : Promise.resolve(null);
   const parallelRoutes = options.parallelRoutes ?? [];
   const parallelRouteMetadataPromise = Promise.all(
     parallelRoutes.map((parallelRoute) =>
@@ -683,17 +723,30 @@ function prepareAppPageHeadInner<TModule extends AppPageHeadModule>(
       ),
     ),
   );
-  const parallelRouteViewportPromise = Promise.all(
-    parallelRoutes.map((parallelRoute) =>
-      resolveParallelRouteViewport(
-        parallelRoute,
+  const parallelRouteViewportPromises: Promise<(Viewport | null)[]>[] = [];
+  let accumulatedViewport = layoutViewport.resolvedViewport;
+  for (const parallelRoute of parallelRoutes) {
+    const parallelViewport = resolveParallelRouteViewport(
+      parallelRoute,
+      options.params,
+      routeSegments,
+      pageSearchParams,
+      accumulatedViewport,
+      options.searchParamsObserver,
+    );
+    parallelRouteViewportPromises.push(parallelViewport.viewportResults);
+    accumulatedViewport = parallelViewport.resolvedViewport;
+  }
+  const parallelRouteViewportPromise = Promise.all(parallelRouteViewportPromises);
+  const pageViewportPromise = options.pageModule
+    ? resolveModuleViewport(
+        options.pageModule,
         options.params,
-        routeSegments,
         pageSearchParams,
+        accumulatedViewport,
         options.searchParamsObserver,
-      ),
-    ),
-  );
+      )
+    : Promise.resolve(null);
   const hasDynamicMetadata =
     primaryHasDynamicMetadata || parallelRoutes.some(parallelRouteHasDynamicMetadata);
 
@@ -743,8 +796,8 @@ function prepareAppPageHeadInner<TModule extends AppPageHeadModule>(
   ]).then(([layoutViewportResults, pageViewport, parallelRouteViewports]) =>
     mergeViewport([
       ...layoutViewportResults.filter(isPresent),
-      ...(pageViewport ? [pageViewport] : []),
       ...parallelRouteViewports.flat().filter(isPresent),
+      ...(pageViewport ? [pageViewport] : []),
     ]),
   );
 

--- a/packages/vinext/src/server/app-page-http-access-fallback-metadata.ts
+++ b/packages/vinext/src/server/app-page-http-access-fallback-metadata.ts
@@ -2,7 +2,7 @@ import {
   mergeViewport,
   resolveModuleViewport,
   type Metadata,
-  type Viewport,
+  type ResolvedViewport,
 } from "vinext/shims/metadata";
 import type { AppPageParams } from "./app-page-boundary.js";
 import {
@@ -180,11 +180,23 @@ export function resolveHttpAccessFallbackMetadata<TModule extends AppPageHeadMod
 
 export async function resolveHttpAccessFallbackViewport<TModule extends AppPageHeadModule>(
   options: HttpAccessFallbackMetadataPlanOptions<TModule>,
-): Promise<Viewport> {
-  const viewports = await Promise.all(
-    createHttpAccessFallbackPlan(options, "snapshot").map((source) =>
-      resolveModuleViewport(source.module, source.params),
-    ),
-  );
-  return mergeViewport(viewports.filter(isPresent));
+): Promise<ResolvedViewport> {
+  let accumulatedViewport = Promise.resolve(mergeViewport([]));
+
+  for (const source of createHttpAccessFallbackPlan(options, "snapshot")) {
+    const parentForSource = accumulatedViewport;
+    const viewportPromise = resolveModuleViewport(
+      source.module,
+      source.params,
+      undefined,
+      parentForSource,
+    );
+    void viewportPromise.catch(() => null);
+    accumulatedViewport = Promise.all([parentForSource, viewportPromise]).then(
+      ([parent, viewport]) => (viewport ? mergeViewport([parent, viewport]) : parent),
+    );
+    void accumulatedViewport.catch(() => null);
+  }
+
+  return accumulatedViewport;
 }

--- a/packages/vinext/src/shims/metadata.tsx
+++ b/packages/vinext/src/shims/metadata.tsx
@@ -164,7 +164,7 @@ function resolveThemeColor(themeColor: Viewport["themeColor"]): ResolvedViewport
   return descriptors.map((descriptor) =>
     typeof descriptor === "string"
       ? { color: descriptor }
-      : { color: descriptor.color, ...(descriptor.media ? { media: descriptor.media } : {}) },
+      : { color: descriptor.color, media: descriptor.media },
   );
 }
 

--- a/packages/vinext/src/shims/metadata.tsx
+++ b/packages/vinext/src/shims/metadata.tsx
@@ -5,6 +5,11 @@
  * Resolves metadata from layouts and pages (pages override layouts).
  */
 import React from "react";
+import type { ViewportLayout } from "@vinext/types/next/upstream/dist/lib/metadata/types/extra-types";
+import type {
+  ResolvedViewport as NextResolvedViewport,
+  Viewport as NextViewport,
+} from "@vinext/types/next/upstream/dist/lib/metadata/types/metadata-interface";
 import { makeThenableParams, type ThenableParamsObserver } from "./thenable-params.js";
 import { isAbsoluteOrProtocolRelativeUrl } from "./url-utils.js";
 
@@ -12,24 +17,8 @@ import { isAbsoluteOrProtocolRelativeUrl } from "./url-utils.js";
 // Viewport types and resolution
 // ---------------------------------------------------------------------------
 
-export type Viewport = {
-  /** Viewport width (default: "device-width") */
-  width?: string | number;
-  /** Viewport height */
-  height?: string | number;
-  /** Initial scale */
-  initialScale?: number;
-  /** Minimum scale */
-  minimumScale?: number;
-  /** Maximum scale */
-  maximumScale?: number;
-  /** Whether user can scale */
-  userScalable?: boolean;
-  /** Theme color — single color or array of { media, color } */
-  themeColor?: string | Array<{ media?: string; color: string }>;
-  /** Color scheme: 'light' | 'dark' | 'light dark' | 'normal' */
-  colorScheme?: string;
-};
+export type Viewport = NextViewport;
+export type ResolvedViewport = NextResolvedViewport;
 
 /**
  * Resolve viewport config from a module. Handles both static `viewport` export
@@ -37,8 +26,9 @@ export type Viewport = {
  */
 export async function resolveModuleViewport(
   mod: Record<string, unknown>,
-  params: Record<string, string | string[]>,
+  params: Record<string, string | string[]> = {},
   searchParams?: Record<string, string | string[]>,
+  parent: Promise<ResolvedViewport> = Promise.resolve(mergeViewport([])),
   searchParamsObserver?: ThenableParamsObserver,
 ): Promise<Viewport | null> {
   if (typeof mod.generateViewport === "function") {
@@ -50,7 +40,7 @@ export async function resolveModuleViewport(
             params: asyncParams,
             searchParams: makeThenableParams(searchParams, searchParamsObserver),
           };
-    return await mod.generateViewport(props);
+    return await mod.generateViewport(props, parent);
   }
   if (mod.viewport && typeof mod.viewport === "object") {
     return mod.viewport as Viewport;
@@ -62,64 +52,120 @@ export async function resolveModuleViewport(
  * Merge viewport configs from multiple sources (layouts + page).
  * Later entries override earlier ones.
  */
-export const DEFAULT_VIEWPORT: Viewport = {
+export const DEFAULT_VIEWPORT: ResolvedViewport = {
   width: "device-width",
   initialScale: 1,
+  themeColor: null,
+  colorScheme: null,
 };
 
-export function mergeViewport(viewportList: Viewport[]): Viewport {
-  const merged: Viewport = { ...DEFAULT_VIEWPORT };
-  for (const vp of viewportList) {
-    Object.assign(merged, vp);
+export function mergeViewport(viewportList: readonly Viewport[]): ResolvedViewport {
+  const merged: ResolvedViewport = { ...DEFAULT_VIEWPORT };
+  for (const viewport of viewportList) {
+    for (const viewportKey in viewport) {
+      const key = viewportKey as keyof Viewport;
+      switch (key) {
+        case "themeColor":
+          merged.themeColor = resolveThemeColor(viewport.themeColor);
+          break;
+        case "colorScheme":
+          merged.colorScheme = viewport.colorScheme || null;
+          break;
+        case "width":
+          merged.width = viewport.width;
+          break;
+        case "height":
+          merged.height = viewport.height;
+          break;
+        case "initialScale":
+          merged.initialScale = viewport.initialScale;
+          break;
+        case "minimumScale":
+          merged.minimumScale = viewport.minimumScale;
+          break;
+        case "maximumScale":
+          merged.maximumScale = viewport.maximumScale;
+          break;
+        case "userScalable":
+          merged.userScalable = viewport.userScalable;
+          break;
+        case "viewportFit":
+          merged.viewportFit = viewport.viewportFit;
+          break;
+        case "interactiveWidget":
+          merged.interactiveWidget = viewport.interactiveWidget;
+          break;
+        default:
+          key satisfies never;
+      }
+    }
   }
   return merged;
 }
+
+const VIEWPORT_META_NAMES = {
+  width: "width",
+  height: "height",
+  initialScale: "initial-scale",
+  minimumScale: "minimum-scale",
+  maximumScale: "maximum-scale",
+  userScalable: "user-scalable",
+  viewportFit: "viewport-fit",
+  interactiveWidget: "interactive-widget",
+} as const satisfies Record<keyof ViewportLayout, string>;
 
 /**
  * React component that renders viewport meta tags into <head>.
  */
 export function ViewportHead({ viewport }: { viewport: Viewport }) {
+  const resolvedViewport = mergeViewport([viewport]);
   const elements: React.ReactElement[] = [];
   let key = 0;
 
   // Build viewport content string
   const parts: string[] = [];
-  if (viewport.width !== undefined) parts.push(`width=${viewport.width}`);
-  if (viewport.height !== undefined) parts.push(`height=${viewport.height}`);
-  if (viewport.initialScale !== undefined) parts.push(`initial-scale=${viewport.initialScale}`);
-  if (viewport.minimumScale !== undefined) parts.push(`minimum-scale=${viewport.minimumScale}`);
-  if (viewport.maximumScale !== undefined) parts.push(`maximum-scale=${viewport.maximumScale}`);
-  if (viewport.userScalable !== undefined)
-    parts.push(`user-scalable=${viewport.userScalable ? "yes" : "no"}`);
+  for (const key of Object.keys(VIEWPORT_META_NAMES) as Array<keyof ViewportLayout>) {
+    const value = resolvedViewport[key];
+    if (value == null) continue;
+    parts.push(
+      `${VIEWPORT_META_NAMES[key]}=${key === "userScalable" ? (value ? "yes" : "no") : value}`,
+    );
+  }
 
   if (parts.length > 0) {
     elements.push(<meta key={key++} name="viewport" content={parts.join(", ")} />);
   }
 
   // Theme color
-  if (viewport.themeColor) {
-    if (typeof viewport.themeColor === "string") {
-      elements.push(<meta key={key++} name="theme-color" content={viewport.themeColor} />);
-    } else if (Array.isArray(viewport.themeColor)) {
-      for (const entry of viewport.themeColor) {
-        elements.push(
-          <meta
-            key={key++}
-            name="theme-color"
-            content={entry.color}
-            {...(entry.media ? { media: entry.media } : {})}
-          />,
-        );
-      }
+  if (resolvedViewport.themeColor) {
+    for (const entry of resolvedViewport.themeColor) {
+      elements.push(
+        <meta
+          key={key++}
+          name="theme-color"
+          content={entry.color}
+          {...(entry.media ? { media: entry.media } : {})}
+        />,
+      );
     }
   }
 
   // Color scheme
-  if (viewport.colorScheme) {
-    elements.push(<meta key={key++} name="color-scheme" content={viewport.colorScheme} />);
+  if (resolvedViewport.colorScheme) {
+    elements.push(<meta key={key++} name="color-scheme" content={resolvedViewport.colorScheme} />);
   }
 
   return <>{elements}</>;
+}
+
+function resolveThemeColor(themeColor: Viewport["themeColor"]): ResolvedViewport["themeColor"] {
+  if (!themeColor) return null;
+  const descriptors = Array.isArray(themeColor) ? themeColor : [themeColor];
+  return descriptors.map((descriptor) =>
+    typeof descriptor === "string"
+      ? { color: descriptor }
+      : { color: descriptor.color, ...(descriptor.media ? { media: descriptor.media } : {}) },
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/app-page-element-builder.test.ts
+++ b/tests/app-page-element-builder.test.ts
@@ -1805,6 +1805,60 @@ describe("buildPageElements", () => {
     expect(boundaryParents).toEqual(["Intercept layout"]);
   });
 
+  it("resolves a sibling intercept viewport before active slot viewports", async () => {
+    const viewportParents: Array<{ source: string; width: unknown }> = [];
+    const route = createSyntheticRoute({
+      page: createSyntheticPageModule(() => React.createElement("div", null, "source")),
+      layouts: [],
+      routeSegments: ["feed"],
+      pattern: "/feed",
+      slots: {
+        sidebar: {
+          name: "sidebar",
+          layoutIndex: 0,
+          page: {
+            default: () => React.createElement("aside", null, "sidebar"),
+            async generateViewport(
+              _props: Record<string, unknown>,
+              parent: Promise<{ width?: unknown }>,
+            ) {
+              viewportParents.push({ source: "slot", width: (await parent).width });
+              return { width: "slot-width" };
+            },
+          } as AppPageModule,
+        },
+      },
+    });
+    const interceptPage = {
+      default: () => React.createElement("div", null, "intercept"),
+      async generateViewport(
+        _props: Record<string, unknown>,
+        parent: Promise<{ width?: unknown }>,
+      ) {
+        viewportParents.push({ source: "intercept", width: (await parent).width });
+        return { width: "intercept-width" };
+      },
+    } as AppPageModule;
+
+    await buildPageElements(
+      createBaseOptions({
+        route,
+        routePath: "/photo/42",
+        opts: {
+          interceptPage,
+          interceptParams: {},
+          interceptSlotKey: SIBLING_PAGE_INTERCEPT_SLOT_KEY,
+          interceptSourcePageSegments: ["feed", "(..)photo", "[id]"],
+        },
+      }),
+    );
+
+    expect(viewportParents).toEqual([
+      { source: "intercept", width: "device-width" },
+      { source: "slot", width: "intercept-width" },
+    ]);
+  });
+
   it("does not inherit not-found metadata from an intercepted slot's ordinary sibling branch", async () => {
     // Next walks conventions on the active intercept loader-tree branch; a
     // not-found below the ordinary slot page is not an intercept ancestor.

--- a/tests/app-page-head.test.ts
+++ b/tests/app-page-head.test.ts
@@ -33,7 +33,9 @@ describe("app page head resolution", () => {
     });
 
     expect(prepared.hasDynamicMetadata).toBe(true);
-    await expect(prepared.viewport).resolves.toMatchObject({ themeColor: "#123456" });
+    await expect(prepared.viewport).resolves.toMatchObject({
+      themeColor: [{ color: "#123456" }],
+    });
 
     let metadataSettled = false;
     void prepared.metadata.then(() => {
@@ -208,7 +210,9 @@ describe("app page head resolution", () => {
       },
     });
     expect(result.viewport).toEqual({
+      colorScheme: null,
       initialScale: 1,
+      themeColor: null,
       width: "device-width",
     });
     expect(result.pageSearchParams).toEqual({ tag: ["next", "vinext"] });
@@ -216,6 +220,88 @@ describe("app page head resolution", () => {
     expect(layoutSearchParamsSeen).toEqual([undefined]);
     expect(layoutParamsSeen).toEqual([{}]);
     expect(pageParentImages).toEqual(["/root-og.png", "/nested-og.png"]);
+  });
+
+  it("resolves viewport descriptors with parent chaining", async () => {
+    // Matches Next.js's sequential parent resolution in accumulateViewport:
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/metadata/resolve-metadata.ts
+    const parentViewports: unknown[] = [];
+    const rootLayout = {
+      viewport: {
+        themeColor: "#111111",
+        viewportFit: "cover",
+        width: "device-width",
+      },
+    };
+    const nestedLayout = {
+      async generateViewport(
+        _props: unknown,
+        parent: Promise<unknown> = Promise.resolve({ height: "default-parent" }),
+      ) {
+        parentViewports.push(await parent);
+        return {
+          initialScale: 2,
+          themeColor: {
+            color: "#222222",
+            media: "(prefers-color-scheme: dark)",
+          },
+        };
+      },
+    };
+    const page = {
+      async generateViewport(...args: [unknown, Promise<unknown>]) {
+        parentViewports.push(await args[1]);
+        return {
+          interactiveWidget: "overlays-content",
+          viewportFit: undefined,
+        };
+      },
+    };
+
+    const result = await resolveAppPageHead<Record<string, unknown>>({
+      layoutModules: [rootLayout, nestedLayout],
+      layoutTreePositions: [0, 1],
+      metadataRoutes: [],
+      pageModule: page,
+      params: {},
+      routePath: "/nested",
+      routeSegments: ["nested"],
+    });
+
+    expect(parentViewports).toEqual([
+      {
+        colorScheme: null,
+        initialScale: 1,
+        themeColor: [{ color: "#111111" }],
+        viewportFit: "cover",
+        width: "device-width",
+      },
+      {
+        colorScheme: null,
+        initialScale: 2,
+        themeColor: [
+          {
+            color: "#222222",
+            media: "(prefers-color-scheme: dark)",
+          },
+        ],
+        viewportFit: "cover",
+        width: "device-width",
+      },
+    ]);
+    expect(result.viewport).toEqual({
+      colorScheme: null,
+      initialScale: 2,
+      interactiveWidget: "overlays-content",
+      themeColor: [
+        {
+          color: "#222222",
+          media: "(prefers-color-scheme: dark)",
+        },
+      ],
+      viewportFit: undefined,
+      width: "device-width",
+    });
   });
 
   it("keeps layout tree positions aligned when layout module slots are empty", async () => {
@@ -340,7 +426,117 @@ describe("app page head resolution", () => {
 
     expect(viewportColors).toEqual(["red", "red"]);
     expect(observeParamAccess).toHaveBeenCalled();
-    expect(result.viewport.themeColor).toBe("red");
+    expect(result.viewport.themeColor).toEqual([{ color: "red" }]);
+  });
+
+  it("accumulates named slot viewports before the primary page", async () => {
+    // Next.js walks named parallel routes before the primary children route and
+    // passes the accumulated viewport to each subsequent resolver.
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/metadata/resolve-metadata.ts
+    const parentViewports: Array<{ source: string; viewport: unknown }> = [];
+    const firstSlotLayout = {
+      async generateViewport(_props: unknown, parent: Promise<unknown>) {
+        parentViewports.push({ source: "first layout", viewport: await parent });
+        return { height: 111 };
+      },
+    };
+    const firstSlotPage = {
+      async generateViewport(_props: unknown, parent: Promise<unknown>) {
+        parentViewports.push({ source: "first page", viewport: await parent });
+        return { maximumScale: 7, minimumScale: 0.5 };
+      },
+    };
+    const secondSlotPage = {
+      async generateViewport(_props: unknown, parent: Promise<Record<string, unknown>>) {
+        const viewport = await parent;
+        parentViewports.push({ source: "second page", viewport });
+        return { initialScale: viewport.minimumScale === 0.5 ? 4 : 5 };
+      },
+    };
+    const primaryPage = {
+      async generateViewport(_props: unknown, parent: Promise<Record<string, unknown>>) {
+        const viewport = await parent;
+        parentViewports.push({ source: "primary page", viewport });
+        return { maximumScale: viewport.initialScale === 4 ? 2 : 9 };
+      },
+    };
+
+    const result = await resolveAppPageHead<Record<string, unknown>>({
+      layoutModules: [{ viewport: { viewportFit: "cover" } }],
+      metadataRoutes: [],
+      pageModule: primaryPage,
+      parallelRoutes: [
+        {
+          layoutModules: [firstSlotLayout],
+          pageModule: firstSlotPage,
+          routeSegments: ["dashboard"],
+        },
+        {
+          pageModule: secondSlotPage,
+          routeSegments: ["dashboard"],
+        },
+      ],
+      params: {},
+      routePath: "/dashboard",
+      routeSegments: ["dashboard"],
+    });
+
+    expect(parentViewports).toEqual([
+      {
+        source: "first layout",
+        viewport: {
+          colorScheme: null,
+          initialScale: 1,
+          themeColor: null,
+          viewportFit: "cover",
+          width: "device-width",
+        },
+      },
+      {
+        source: "first page",
+        viewport: {
+          colorScheme: null,
+          height: 111,
+          initialScale: 1,
+          themeColor: null,
+          viewportFit: "cover",
+          width: "device-width",
+        },
+      },
+      {
+        source: "second page",
+        viewport: {
+          colorScheme: null,
+          height: 111,
+          initialScale: 1,
+          maximumScale: 7,
+          minimumScale: 0.5,
+          themeColor: null,
+          viewportFit: "cover",
+          width: "device-width",
+        },
+      },
+      {
+        source: "primary page",
+        viewport: {
+          colorScheme: null,
+          height: 111,
+          initialScale: 4,
+          maximumScale: 7,
+          minimumScale: 0.5,
+          themeColor: null,
+          viewportFit: "cover",
+          width: "device-width",
+        },
+      },
+    ]);
+    expect(result.viewport).toMatchObject({
+      height: 111,
+      initialScale: 4,
+      maximumScale: 2,
+      minimumScale: 0.5,
+      viewportFit: "cover",
+    });
   });
 
   it("bubbles layout metadata errors", async () => {

--- a/tests/app-page-head.test.ts
+++ b/tests/app-page-head.test.ts
@@ -682,6 +682,25 @@ describe("app page head resolution", () => {
     ]);
   });
 
+  it("orders nested slot head inputs like Next.js's children-first tree walk", () => {
+    const outerFirst = {};
+    const outerSecond = {};
+    const inner = {};
+
+    const inputs = resolveActiveParallelRouteHeadInputs({
+      layoutTreePositions: [0, 2],
+      params: {},
+      routeSegments: ["dashboard", "settings"],
+      slots: {
+        outerFirst: { layoutIndex: 0, page: outerFirst },
+        outerSecond: { layoutIndex: 0, page: outerSecond },
+        inner: { layoutIndex: 1, page: inner },
+      },
+    });
+
+    expect(inputs.map((input) => input.head.pageModule)).toEqual([inner, outerFirst, outerSecond]);
+  });
+
   it("carries slot-local not-found metadata with owner-scoped params", () => {
     const slotNotFound = {};
 

--- a/tests/app-page-head.test.ts
+++ b/tests/app-page-head.test.ts
@@ -429,9 +429,10 @@ describe("app page head resolution", () => {
     expect(result.viewport.themeColor).toEqual([{ color: "red" }]);
   });
 
-  it("accumulates named slot viewports before the primary page", async () => {
-    // Next.js walks named parallel routes before the primary children route and
-    // passes the accumulated viewport to each subsequent resolver.
+  it("accumulates the primary page viewport before named slots", async () => {
+    // Next.js seeds the loader tree with `children` before named parallel
+    // segments, then walks those branches in insertion order.
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
     // https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/metadata/resolve-metadata.ts
     const parentViewports: Array<{ source: string; viewport: unknown }> = [];
     const firstSlotLayout = {
@@ -483,10 +484,21 @@ describe("app page head resolution", () => {
 
     expect(parentViewports).toEqual([
       {
+        source: "primary page",
+        viewport: {
+          colorScheme: null,
+          initialScale: 1,
+          themeColor: null,
+          viewportFit: "cover",
+          width: "device-width",
+        },
+      },
+      {
         source: "first layout",
         viewport: {
           colorScheme: null,
           initialScale: 1,
+          maximumScale: 9,
           themeColor: null,
           viewportFit: "cover",
           width: "device-width",
@@ -498,6 +510,7 @@ describe("app page head resolution", () => {
           colorScheme: null,
           height: 111,
           initialScale: 1,
+          maximumScale: 9,
           themeColor: null,
           viewportFit: "cover",
           width: "device-width",
@@ -516,24 +529,11 @@ describe("app page head resolution", () => {
           width: "device-width",
         },
       },
-      {
-        source: "primary page",
-        viewport: {
-          colorScheme: null,
-          height: 111,
-          initialScale: 4,
-          maximumScale: 7,
-          minimumScale: 0.5,
-          themeColor: null,
-          viewportFit: "cover",
-          width: "device-width",
-        },
-      },
     ]);
     expect(result.viewport).toMatchObject({
       height: 111,
       initialScale: 4,
-      maximumScale: 2,
+      maximumScale: 7,
       minimumScale: 0.5,
       viewportFit: "cover",
     });

--- a/tests/app-page-http-access-fallback-metadata.test.ts
+++ b/tests/app-page-http-access-fallback-metadata.test.ts
@@ -72,9 +72,11 @@ describe("HTTP-access fallback metadata planning", () => {
   it("snapshots the active viewport convention at each fallback leaf", async () => {
     const boundary = { viewport: { width: "primary-only" } };
     const seenParams: unknown[] = [];
+    const seenParents: unknown[] = [];
     const slotBoundary = {
-      generateViewport({ params }: { params: Promise<unknown> }) {
+      async generateViewport({ params }: { params: Promise<unknown> }, parent: Promise<unknown>) {
         seenParams.push(params);
+        seenParents.push(await parent);
         return { themeColor: "slot" };
       },
     };
@@ -95,9 +97,17 @@ describe("HTTP-access fallback metadata planning", () => {
       routeSegments: ["[locale]", "posts"],
     });
 
-    expect(viewport.themeColor).toBe("slot");
+    expect(viewport.themeColor).toEqual([{ color: "slot" }]);
     expect(viewport.width).toBe("primary-only");
     expect(await Promise.all(seenParams)).toEqual([{ locale: "en", slug: "hello" }]);
+    expect(seenParents).toEqual([
+      {
+        colorScheme: null,
+        initialScale: 1,
+        themeColor: null,
+        width: "primary-only",
+      },
+    ]);
   });
 
   it("uses a sibling intercept as the primary leaf without inventing another leaf", () => {

--- a/tests/app-router-dev-server.test.ts
+++ b/tests/app-router-dev-server.test.ts
@@ -1610,8 +1610,11 @@ describe("App Router integration", () => {
     expect(html).toMatch(/name="viewport".*content="[^"]*width=device-width/);
     expect(html).toMatch(/name="viewport".*content="[^"]*initial-scale=1/);
     expect(html).toMatch(/name="viewport".*content="[^"]*maximum-scale=1/);
+    expect(html).toMatch(/name="viewport".*content="[^"]*viewport-fit=cover/);
+    expect(html).toMatch(/name="viewport".*content="[^"]*interactive-widget=resizes-visual/);
     // Theme color
     expect(html).toMatch(/name="theme-color".*content="#0070f3"/);
+    expect(html).toMatch(/name="theme-color".*media="\(prefers-color-scheme: light\)"/);
     // Color scheme
     expect(html).toMatch(/name="color-scheme".*content="light dark"/);
   });

--- a/tests/e2e/app-router/metadata.spec.ts
+++ b/tests/e2e/app-router/metadata.spec.ts
@@ -37,11 +37,18 @@ test.describe("Static Metadata", () => {
     await expect(ogType).toHaveAttribute("content", "website");
   });
 
-  test("viewport export renders theme-color and color-scheme", async ({ page }) => {
+  test("viewport export renders all viewport metadata", async ({ page }) => {
     await page.goto(`${BASE}/metadata-test`);
+
+    const viewport = page.locator('meta[name="viewport"]');
+    await expect(viewport).toHaveAttribute(
+      "content",
+      "width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover, interactive-widget=resizes-visual",
+    );
 
     const themeColor = page.locator('meta[name="theme-color"]');
     await expect(themeColor).toHaveAttribute("content", "#0070f3");
+    await expect(themeColor).toHaveAttribute("media", "(prefers-color-scheme: light)");
 
     const colorScheme = page.locator('meta[name="color-scheme"]');
     await expect(colorScheme).toHaveAttribute("content", "light dark");

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -3561,6 +3561,13 @@ describe("ViewportHead rendering", () => {
     expect(result.themeColor).toEqual([{ color: "#fff" }]);
   });
 
+  it("preserves an undefined media field on a theme-color descriptor", () => {
+    // Next.js's resolveThemeColor copies the descriptor fields explicitly:
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/metadata/resolvers/resolve-basics.ts
+    const result = mergeViewport([{ themeColor: { color: "#000" } }]);
+    expect(result.themeColor).toEqual([{ color: "#000", media: undefined }]);
+  });
+
   it("renders viewport meta even when only themeColor is provided (defaults injected)", () => {
     const merged = mergeViewport([{ themeColor: "#000" }]);
     const html = renderToStaticMarkup(React.createElement(ViewportHead, { viewport: merged }));

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -3448,7 +3448,7 @@ describe("ViewportHead rendering", () => {
   it("renders default viewport with width=device-width and initial-scale=1", () => {
     const html = renderToStaticMarkup(
       React.createElement(ViewportHead, {
-        viewport: { width: "device-width", initialScale: 1 },
+        viewport: mergeViewport([{ width: "device-width", initialScale: 1 }]),
       }),
     );
     expect(html).toContain('name="viewport"');
@@ -3457,41 +3457,65 @@ describe("ViewportHead rendering", () => {
   });
 
   it("renders custom viewport with all options", () => {
+    // Ported from Next.js: packages/next/src/lib/metadata/resolve-metadata.test.ts
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/metadata/resolve-metadata.test.ts
     const html = renderToStaticMarkup(
       React.createElement(ViewportHead, {
-        viewport: {
-          width: "device-width",
-          initialScale: 1,
-          maximumScale: 1,
-          userScalable: false,
-        },
+        viewport: mergeViewport([
+          {
+            width: "device-width",
+            height: "device-height",
+            initialScale: 1,
+            minimumScale: 0.5,
+            maximumScale: 1,
+            userScalable: false,
+            viewportFit: "cover",
+            interactiveWidget: "overlays-content",
+          },
+        ]),
       }),
     );
-    expect(html).toContain("width=device-width");
-    expect(html).toContain("initial-scale=1");
-    expect(html).toContain("maximum-scale=1");
-    expect(html).toContain("user-scalable=no");
+    expect(html).toContain(
+      'content="width=device-width, height=device-height, initial-scale=1, minimum-scale=0.5, maximum-scale=1, user-scalable=no, viewport-fit=cover, interactive-widget=overlays-content"',
+    );
   });
 
   it("renders theme-color meta tag", () => {
     const html = renderToStaticMarkup(
       React.createElement(ViewportHead, {
-        viewport: { themeColor: "#000000" },
+        viewport: mergeViewport([{ themeColor: "#000000" }]),
       }),
     );
     expect(html).toContain('name="theme-color"');
     expect(html).toContain('content="#000000"');
   });
 
+  it("renders a single theme-color descriptor with its media query", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(ViewportHead, {
+        viewport: mergeViewport([
+          {
+            themeColor: { media: "(prefers-color-scheme: dark)", color: "#000000" },
+          },
+        ]),
+      }),
+    );
+    expect(html).toContain('name="theme-color"');
+    expect(html).toContain('content="#000000"');
+    expect(html).toContain('media="(prefers-color-scheme: dark)"');
+  });
+
   it("renders multiple theme-color entries with media queries", () => {
     const html = renderToStaticMarkup(
       React.createElement(ViewportHead, {
-        viewport: {
-          themeColor: [
-            { media: "(prefers-color-scheme: light)", color: "#fff" },
-            { media: "(prefers-color-scheme: dark)", color: "#000" },
-          ],
-        },
+        viewport: mergeViewport([
+          {
+            themeColor: [
+              { media: "(prefers-color-scheme: light)", color: "#fff" },
+              { media: "(prefers-color-scheme: dark)", color: "#000" },
+            ],
+          },
+        ]),
       }),
     );
     expect(html).toContain('content="#fff"');
@@ -3503,7 +3527,7 @@ describe("ViewportHead rendering", () => {
   it("renders color-scheme meta tag", () => {
     const html = renderToStaticMarkup(
       React.createElement(ViewportHead, {
-        viewport: { colorScheme: "dark" },
+        viewport: mergeViewport([{ colorScheme: "dark" }]),
       }),
     );
     expect(html).toContain('name="color-scheme"');
@@ -3515,7 +3539,7 @@ describe("ViewportHead rendering", () => {
     const result = mergeViewport([{ themeColor: "#000" }]);
     expect(result.width).toBe("device-width");
     expect(result.initialScale).toBe(1);
-    expect(result.themeColor).toBe("#000");
+    expect(result.themeColor).toEqual([{ color: "#000" }]);
   });
 
   it("mergeViewport allows overriding defaults", () => {
@@ -3534,7 +3558,7 @@ describe("ViewportHead rendering", () => {
     const result = mergeViewport([{ width: 800 }, { width: 1024, themeColor: "#fff" }]);
     expect(result.width).toBe(1024);
     expect(result.initialScale).toBe(1);
-    expect(result.themeColor).toBe("#fff");
+    expect(result.themeColor).toEqual([{ color: "#fff" }]);
   });
 
   it("renders viewport meta even when only themeColor is provided (defaults injected)", () => {

--- a/tests/fixtures/app-basic/app/metadata-test/page.tsx
+++ b/tests/fixtures/app-basic/app/metadata-test/page.tsx
@@ -10,11 +10,16 @@ export const metadata = {
 };
 
 export const viewport = {
-  themeColor: "#0070f3",
+  themeColor: {
+    color: "#0070f3",
+    media: "(prefers-color-scheme: light)",
+  },
   colorScheme: "light dark",
   width: "device-width",
   initialScale: 1,
   maximumScale: 1,
+  viewportFit: "cover",
+  interactiveWidget: "resizes-visual",
 };
 
 export default function MetadataTestPage() {


### PR DESCRIPTION

Close: #2643

## Summary

Bring vinext's App Router Viewport Metadata handling in line with the current public Next.js API.

This adds the missing viewport descriptors, uses the synchronized Next.js viewport types, normalizes resolved values consistently, and passes accumulated parent viewport values through every App Router metadata resolution path.

## What changed

- use the synchronized Next.js `Viewport` and `ResolvedViewport` types instead of a partial handwritten type
- emit `viewport-fit` and `interactive-widget` in `<meta name="viewport">`
- support string, single descriptor, and descriptor array forms of `themeColor`
- normalize viewport values to the same resolved shape used by Next.js
- make the viewport directive mapping exhaustive at type-check time
- pass the accumulated viewport promise to `generateViewport`
- chain the accumulated parent viewport through layouts, the primary page, named parallel routes, and HTTP access fallbacks so each resolver sees the correct parent

## Tests

- Added coverage for every current viewport directive and resolved `themeColor` form
- Added parent chaining coverage for layouts and pages, including default and rest parameter declarations
- Added named parallel route accumulation coverage
- Added HTTP access fallback parent coverage
- Added App Router SSR and Playwright assertions for the rendered viewport and theme color tags

Validation performed:

- `pnpm test tests/features.test.ts tests/app-page-head.test.ts tests/app-page-http-access-fallback-metadata.test.ts tests/app-router-dev-server.test.ts` - 553 tests passed
- `PLAYWRIGHT_PROJECT=app-router pnpm run test:e2e tests/e2e/app-router/metadata.spec.ts` - 12 tests passed
- `pnpm exec vp run vinext#build` passed
- `pnpm run check` passed, including formatting for 2,600 files and lint/type checks for 1,143 files
- synchronized Next.js type check passed for 347 files as part of `pnpm run check`
- public shim type check passed for 24 modules as part of `pnpm run check`
- `git diff --check` passed

Production SSR was also manually verified to emit:

```html
<meta
  name="viewport"
  content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-visual"
/>
```

## References

- [Next.js `generateViewport` documentation](https://nextjs.org/docs/app/api-reference/functions/generate-viewport)
- [Next.js viewport resolution source](https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/metadata/resolve-metadata.ts)
- [Next.js viewport resolution tests](https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/metadata/resolve-metadata.test.ts)
