### PR TITLE
fix(metadata): pass parent to regular metadata resolvers

### DIFF
--- a/packages/vinext/src/shims/metadata.tsx
+++ b/packages/vinext/src/shims/metadata.tsx
@@ -8,6 +8,8 @@ import React from "react";
 import { makeThenableParams, type ThenableParamsObserver } from "./thenable-params.js";
 import { isAbsoluteOrProtocolRelativeUrl } from "./url-utils.js";
 
+const USE_CACHE_FUNCTION_SYMBOL = Symbol.for("vinext.useCacheFunction");
+
 // ---------------------------------------------------------------------------
 // Viewport types and resolution
 // ---------------------------------------------------------------------------
@@ -548,6 +550,7 @@ export async function resolveModuleMetadata(
   searchParamsObserver?: ThenableParamsObserver,
 ): Promise<Metadata | null> {
   if (typeof mod.generateMetadata === "function") {
+    const generateMetadata = mod.generateMetadata;
     // Next.js 16 passes params/searchParams as Promises (async pattern).
     // makeThenableParams() normalises null-prototype + preserves sync access.
     const asyncParams = makeThenableParams(params);
@@ -558,20 +561,14 @@ export async function resolveModuleMetadata(
             params: asyncParams,
             searchParams: makeThenableParams(searchParams, searchParamsObserver),
           };
-    // Only pass the `parent` metadata when `generateMetadata` actually declares
-    // it (arity >= 2). Next.js omits the parent argument for `generateMetadata`
-    // functions that don't use it, which matters for `'use cache'` functions:
-    // the cache-key encoder (encodeReply) would otherwise try to serialize the
-    // resolved parent metadata, which can contain a non-serializable `URL`
-    // `metadataBase` and throws "URL objects are not supported".
-    // See Next.js resolve-metadata.ts (getResult / useCacheFunctionInfo.usedArgs[1]).
-    //
-    // Note: `fn.length` approximates Next.js's static usage analysis. It can
-    // diverge on default-parameter signatures — e.g. `(props, parent = x)`
-    // reports length 1, and `(props = {}, parent)` reports length 0 — but a
-    // default value on `generateMetadata`'s `parent` is unusual in practice.
-    const usesParent = mod.generateMetadata.length >= 2;
-    return await (usesParent ? mod.generateMetadata(props, parent) : mod.generateMetadata(props));
+    // Next.js always passes `parent` to regular resolvers. Cached resolvers are
+    // different: an unused parent must stay out of the cache key because it can
+    // contain non-serializable values such as a URL metadataBase. vinext uses
+    // function arity as an approximation of Next.js's transform-time used-arg
+    // analysis, so restrict that approximation to `use cache` wrappers.
+    const isUseCacheFunction = Reflect.get(generateMetadata, USE_CACHE_FUNCTION_SYMBOL) === true;
+    const passesParent = !isUseCacheFunction || generateMetadata.length >= 2;
+    return await (passesParent ? generateMetadata(props, parent) : generateMetadata(props));
   }
   if (mod.metadata && typeof mod.metadata === "object") {
     return mod.metadata as Metadata;

--- a/tests/app-page-head.test.ts
+++ b/tests/app-page-head.test.ts
@@ -623,14 +623,49 @@ describe("app page head resolution", () => {
     expect(seen).toEqual([{ owner: "root" }, { owner: "root", team: "alpha" }]);
   });
 
-  // Regression: a `generateMetadata` that does not declare the `parent`
-  // argument must NOT receive it. Matches Next.js, which omits the parent
-  // argument for cached `generateMetadata` functions that don't use it
-  // (resolve-metadata.ts `getResult` / `useCacheFunctionInfo.usedArgs[1]`).
-  // Passing the parent into a `'use cache'` function feeds it to the cache-key
-  // encoder (encodeReply), which throws on non-serializable values such as a
-  // `URL` `metadataBase` ("URL objects are not supported").
-  it("omits the parent argument for generateMetadata that does not declare it", async () => {
+  // Extends Next.js's generateMetadata parent-resolution coverage:
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/metadata/app/dynamic/%5Bslug%5D/page.tsx
+  it("passes the parent to regular generateMetadata with default and rest parameters", async () => {
+    const fallbackMetadata = { description: "Fallback description" };
+    const receivedArgCounts: number[] = [];
+    const withDefault = async function (
+      _props: unknown,
+      parent = Promise.resolve(fallbackMetadata),
+    ) {
+      receivedArgCounts.push(arguments.length);
+      return { title: String((await parent).description) };
+    };
+    const withRest = async function (...args: [unknown, Promise<Record<string, unknown>>?]) {
+      receivedArgCounts.push(args.length);
+      const parent = args[1] ?? Promise.resolve(fallbackMetadata);
+      return { title: String((await parent).description) };
+    };
+    const titles: unknown[] = [];
+
+    for (const generateMetadata of [withDefault, withRest]) {
+      const result = await resolveAppPageHead<Record<string, unknown>>({
+        layoutModules: [{ metadata: { description: "Root description" } }],
+        layoutTreePositions: [0],
+        metadataRoutes: [],
+        pageModule: { generateMetadata },
+        params: {},
+        routePath: "/",
+        routeSegments: [],
+      });
+      titles.push(result.metadata?.title);
+    }
+
+    expect(withDefault.length).toBe(1);
+    expect(withRest.length).toBe(0);
+    expect(receivedArgCounts).toEqual([2, 2]);
+    expect(titles).toEqual(["Root description", "Root description"]);
+  });
+
+  // Regression: a cached `generateMetadata` that does not declare the
+  // `parent` argument must NOT receive it. Passing the parent into the cache
+  // wrapper feeds it to the cache-key encoder, which throws on non-serializable
+  // values such as a `URL` `metadataBase` ("URL objects are not supported").
+  it("omits the parent argument for cached generateMetadata that does not declare it", async () => {
     const receivedArgCounts: number[] = [];
     const rootLayout = {
       metadata: {
@@ -638,19 +673,19 @@ describe("app page head resolution", () => {
         title: "Root",
       },
     };
-    const page = {
-      // Arity 0 — declares no `parent` parameter.
-      generateMetadata: async function () {
-        receivedArgCounts.push(arguments.length);
-        return { title: "Page" };
-      },
+    const generateMetadata = async function () {
+      receivedArgCounts.push(arguments.length);
+      return { title: "Page" };
     };
+    Object.assign(generateMetadata, {
+      [Symbol.for("vinext.useCacheFunction")]: true,
+    });
 
     const result = await resolveAppPageHead<Record<string, unknown>>({
       layoutModules: [rootLayout],
       layoutTreePositions: [0],
       metadataRoutes: [],
-      pageModule: page,
+      pageModule: { generateMetadata },
       params: {},
       routePath: "/",
       routeSegments: [],
@@ -664,7 +699,7 @@ describe("app page head resolution", () => {
     expect(result.metadata?.title).toBe("Page");
   });
 
-  it("still passes the parent argument to generateMetadata that declares it", async () => {
+  it("passes the parent argument to cached generateMetadata that declares it", async () => {
     const receivedArgCounts: number[] = [];
     const rootLayout = {
       metadata: {
@@ -672,20 +707,23 @@ describe("app page head resolution", () => {
         description: "Root description",
       },
     };
-    const page = {
-      // Arity 2 — declares `parent`, so it must receive it.
-      generateMetadata: async function (_props: unknown, parent: Promise<Record<string, unknown>>) {
-        receivedArgCounts.push(arguments.length);
-        const parentMetadata = await parent;
-        return { title: String(parentMetadata.description) };
-      },
+    const generateMetadata = async function (
+      _props: unknown,
+      parent: Promise<Record<string, unknown>>,
+    ) {
+      receivedArgCounts.push(arguments.length);
+      const parentMetadata = await parent;
+      return { title: String(parentMetadata.description) };
     };
+    Object.assign(generateMetadata, {
+      [Symbol.for("vinext.useCacheFunction")]: true,
+    });
 
     const result = await resolveAppPageHead<Record<string, unknown>>({
       layoutModules: [rootLayout],
       layoutTreePositions: [0],
       metadataRoutes: [],
-      pageModule: page,
+      pageModule: { generateMetadata },
       params: {},
       routePath: "/",
       routeSegments: [],


### PR DESCRIPTION
Closes: #2645

## Summary

Pass accumulated parent metadata to regular App Router `generateMetadata` resolvers regardless of their JavaScript `Function.length`.

This matches Next.js for valid default-parameter and rest-parameter declarations while preserving vinext's existing cache-key safeguard for `use cache` wrappers.

Parent metadata support was originally added in #375 and #376. The arity check added in #1719 fixed serialization failures for cached metadata resolvers, but it also caused regular resolvers with default or rest parameters to miss the parent value. This change narrows that check to the cached path where it is needed.

## What changed

- identify `use cache` wrappers through vinext's existing function marker
- always pass `parent` to regular `generateMetadata` resolvers
- restrict the existing arity approximation to cached resolvers
- add regression coverage for regular default and rest parameters
- keep coverage showing that cached resolvers receive or omit `parent` according to their declared arity

## Tests

- `pnpm test tests/app-page-head.test.ts` - 24 tests passed
- `pnpm test tests/app-page-head.test.ts tests/shims.test.ts tests/nextjs-compat/metadata.test.ts` - 1,311 tests passed
- `pnpm run check` - passed
- `pnpm exec vp run vinext#build` - passed
- production build of the minimal reproduction rendered `<title>parent-description</title>`
- `git diff --check` - passed

## References

- [Issue #375: support the parent parameter in `generateMetadata`](https://github.com/cloudflare/vinext/issues/375)
- [PR #376: pass the parent promise to `generateMetadata`](https://github.com/cloudflare/vinext/pull/376)
- [PR #1719: omit an unused parent for cached `generateMetadata`](https://github.com/cloudflare/vinext/pull/1719)
- [PR #1719 review describing the default-parameter limitation](https://github.com/cloudflare/vinext/pull/1719#pullrequestreview-4408653712)
- [Next.js metadata resolution source](https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/metadata/resolve-metadata.ts)
- [Next.js parent metadata example](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/metadata/app/dynamic/%5Bslug%5D/page.tsx)
