### PR TITLE
fix(shims): preserve basePath config in NextURL clones

### DIFF
--- a/packages/vinext/src/shims/server.ts
+++ b/packages/vinext/src/shims/server.ts
@@ -615,7 +615,10 @@ export class NextURL {
       nextConfig.trailingSlash = true;
     }
     const config: NextURLConfig = {
-      basePath: this._basePath,
+      // Preserve the configured basePath even when it is not active for the
+      // current pathname. Next.js retains the original constructor options in
+      // clone(), allowing a later href assignment to re-activate the prefix.
+      basePath: this._configBasePath,
       nextConfig: Object.keys(nextConfig).length > 0 ? nextConfig : undefined,
     };
     // Pass the full href (with locale/basePath re-added) so the constructor

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -10440,6 +10440,22 @@ describe("NextURL basePath and locale properties", () => {
     expect(cloned.basePath).toBe("");
   });
 
+  it("clone retains the configured basePath for later href assignments", async () => {
+    // Next.js keeps the original constructor options in clone():
+    // packages/next/src/server/web/next-url.ts
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/next-url.ts
+    const { NextURL } = await import("../packages/vinext/src/shims/server.js");
+    const url = new NextURL("http://localhost/dashboard", undefined, {
+      basePath: "/docs",
+    });
+    const cloned = url.clone();
+
+    expect(cloned.basePath).toBe("");
+    cloned.href = "http://localhost/docs/settings";
+    expect(cloned.basePath).toBe("/docs");
+    expect(cloned.pathname).toBe("/settings");
+  });
+
   it("basePath is preserved through clone() when URL has the prefix", async () => {
     const { NextURL } = await import("../packages/vinext/src/shims/server.js");
     const url = new NextURL("http://localhost/docs/page", undefined, {


### PR DESCRIPTION
## Summary

- preserve the configured `basePath` when cloning a `NextURL`
- allow a cloned URL outside the configured prefix to reactivate that prefix after an `href` assignment
- add focused regression coverage for the state transition

## Root cause

`NextURL.clone()` rebuilt its configuration from the currently active `basePath`. When the current pathname was outside the configured prefix, the active value was empty, so the clone permanently lost the original configuration. Next.js retains the original constructor options when cloning.

## Validation

- `pnpm test tests/shims.test.ts -t "clone retains the configured basePath|basePath is empty in clone|basePath is preserved through clone"`
- `pnpm exec vp check packages/vinext/src/shims/server.ts`
- `pnpm exec vp check tests/shims.test.ts`
- `git diff --check`
