### PR TITLE
fix(i18n): align Accept-Language locale selection

### DIFF
--- a/packages/vinext/src/server/pages-i18n.ts
+++ b/packages/vinext/src/server/pages-i18n.ts
@@ -156,27 +156,84 @@ export function detectLocaleFromAcceptLanguage(
 ): string | null {
   if (!acceptLang) return null;
 
-  const langs = acceptLang
-    .split(",")
-    .map((part) => {
-      const [lang, qPart] = part.trim().split(";");
-      const q = qPart ? parseFloat(qPart.replace("q=", "")) : 1;
-      return { lang: lang.trim().toLowerCase(), q };
-    })
-    .sort((a, b) => b.q - a.q);
-
-  for (const { lang } of langs) {
-    const exactMatch = i18nConfig.locales.find((locale) => locale.toLowerCase() === lang);
-    if (exactMatch) return exactMatch;
-
-    const prefix = lang.split("-")[0];
-    const prefixMatch = i18nConfig.locales.find((locale) => {
-      const lowered = locale.toLowerCase();
-      return lowered === prefix || lowered.startsWith(prefix + "-");
-    });
-    if (prefixMatch) return prefixMatch;
+  // Ported from Next.js's acceptLanguage() preference selection. In
+  // particular, configured locale order breaks equal-quality ties, language
+  // ranges match configured regional variants, q=0 excludes a selection, and
+  // `*` chooses the first configured locale that was not explicitly listed.
+  const configured = new Map<string, { locale: string; position: number }>();
+  let position = 0;
+  for (const locale of i18nConfig.locales) {
+    const lower = locale.toLowerCase();
+    configured.set(lower, { locale, position: position++ });
+    const parts = lower.split("-");
+    while (parts.length > 1) {
+      parts.pop();
+      const prefix = parts.join("-");
+      if (!configured.has(prefix)) {
+        configured.set(prefix, { locale, position: position++ });
+      }
+    }
   }
 
+  type Selection = { token: string; headerPosition: number; quality: number; preference?: number };
+  const selections: Selection[] = [];
+  const listedTokens = new Set<string>();
+
+  try {
+    const parts = acceptLang.replace(/[ \t]/g, "").split(",");
+    for (let headerPosition = 0; headerPosition < parts.length; headerPosition++) {
+      const part = parts[headerPosition];
+      if (!part) continue;
+
+      const params = part.split(";");
+      if (params.length > 2) throw new Error("Invalid Accept-Language header");
+
+      const token = params[0].toLowerCase();
+      if (!token) throw new Error("Invalid Accept-Language header");
+
+      const selection: Selection = { token, headerPosition, quality: 1 };
+      const configuredMatch = configured.get(token);
+      if (configuredMatch) selection.preference = configuredMatch.position;
+      listedTokens.add(token);
+
+      if (params.length === 2) {
+        const [key, value] = params[1].split("=");
+        if (!value || (key !== "q" && key !== "Q")) {
+          throw new Error("Invalid Accept-Language header");
+        }
+        const quality = parseFloat(value);
+        if (quality === 0) continue;
+        if (Number.isFinite(quality) && quality >= 0.001 && quality <= 1) {
+          selection.quality = quality;
+        }
+      }
+
+      selections.push(selection);
+    }
+  } catch {
+    return null;
+  }
+
+  selections.sort((a, b) => {
+    if (b.quality !== a.quality) return b.quality - a.quality;
+    if (a.preference !== b.preference) {
+      if (a.preference === undefined) return 1;
+      if (b.preference === undefined) return -1;
+      return a.preference - b.preference;
+    }
+    return a.headerPosition - b.headerPosition;
+  });
+
+  for (const { token } of selections) {
+    if (token === "*") {
+      for (const [preference, { locale }] of configured) {
+        if (!listedTokens.has(preference)) return locale;
+      }
+      continue;
+    }
+    const match = configured.get(token);
+    if (match) return match.locale;
+  }
   return null;
 }
 

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -1133,12 +1133,12 @@ describe("detectLocaleFromHeaders", () => {
     expect(detectLocaleFromHeaders(fakeReq("de;q=0.9,fr;q=0.8"), i18nConfig)).toBe("de");
   });
 
-  it("detects locale via prefix match (en-US -> en)", () => {
-    expect(detectLocaleFromHeaders(fakeReq("en-US"), i18nConfig)).toBe("en");
+  it("does not truncate an unconfigured regional locale", () => {
+    expect(detectLocaleFromHeaders(fakeReq("en-US"), i18nConfig)).toBeNull();
   });
 
-  it("detects locale via prefix match (fr-FR -> fr)", () => {
-    expect(detectLocaleFromHeaders(fakeReq("fr-FR,en;q=0.5"), i18nConfig)).toBe("fr");
+  it("falls through an unconfigured regional locale to the next preference", () => {
+    expect(detectLocaleFromHeaders(fakeReq("fr-FR,en;q=0.5"), i18nConfig)).toBe("en");
   });
 
   it("returns null for unrecognized language", () => {

--- a/tests/pages-i18n.test.ts
+++ b/tests/pages-i18n.test.ts
@@ -3,6 +3,7 @@ import type { NextI18nConfig } from "../packages/vinext/src/config/next-config.j
 
 describe("Pages i18n domain helpers", () => {
   let addLocalePrefix: typeof import("../packages/vinext/src/utils/domain-locale.js").addLocalePrefix;
+  let detectLocaleFromAcceptLanguage: typeof import("../packages/vinext/src/server/pages-i18n.js").detectLocaleFromAcceptLanguage;
   let detectDomainLocale: typeof import("../packages/vinext/src/server/pages-i18n.js").detectDomainLocale;
   let getLocaleRedirect: typeof import("../packages/vinext/src/server/pages-i18n.js").getLocaleRedirect;
   let resolvePagesI18nRequest: typeof import("../packages/vinext/src/server/pages-i18n.js").resolvePagesI18nRequest;
@@ -10,6 +11,7 @@ describe("Pages i18n domain helpers", () => {
   beforeAll(async () => {
     const mod = await import("../packages/vinext/src/server/pages-i18n.js");
     ({ addLocalePrefix } = await import("../packages/vinext/src/utils/domain-locale.js"));
+    detectLocaleFromAcceptLanguage = mod.detectLocaleFromAcceptLanguage;
     detectDomainLocale = mod.detectDomainLocale;
     getLocaleRedirect = mod.getLocaleRedirect;
     resolvePagesI18nRequest = mod.resolvePagesI18nRequest;
@@ -28,6 +30,34 @@ describe("Pages i18n domain helpers", () => {
 
   it("matches configured domains ignoring port and case", () => {
     expect(detectDomainLocale(i18n.domains, "EXAMPLE.FR:3000")).toEqual(i18n.domains[1]);
+  });
+
+  it("does not select an Accept-Language entry with zero quality", () => {
+    // Ported from Next.js's Accept-Language parser, which skips q=0 entries:
+    // packages/next/src/server/accept-header.ts
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/accept-header.ts
+    expect(detectLocaleFromAcceptLanguage("fr;q=0", i18n)).toBeNull();
+  });
+
+  it("uses configured locale order to break equal-quality ties", () => {
+    expect(detectLocaleFromAcceptLanguage("fr,en", i18n)).toBe("en");
+  });
+
+  it("matches language ranges to configured regional locales", () => {
+    expect(detectLocaleFromAcceptLanguage("nl", i18n)).toBe("nl-NL");
+  });
+
+  it("uses a wildcard to select the first unlisted configured locale", () => {
+    const wildcardI18n = { ...i18n, locales: ["fr", "en"] };
+    expect(detectLocaleFromAcceptLanguage("fr;q=0,*;q=0.5", wildcardI18n)).toBe("en");
+  });
+
+  it("accepts an uppercase quality parameter", () => {
+    expect(detectLocaleFromAcceptLanguage("fr;Q=0.8,en;Q=0.5", i18n)).toBe("fr");
+  });
+
+  it("ignores an invalid Accept-Language header", () => {
+    expect(detectLocaleFromAcceptLanguage("fr;q=0.8;level=1", i18n)).toBeNull();
   });
 
   it("matches a domain by locale aliases when switching locales", () => {
@@ -98,6 +128,17 @@ describe("Pages i18n domain helpers", () => {
         urlParsed: { hostname: "example.com", pathname: "/" },
       }),
     ).toBe("http://example.fr/");
+  });
+
+  it("does not redirect to a locale explicitly rejected by Accept-Language", () => {
+    expect(
+      getLocaleRedirect({
+        headers: { "accept-language": "fr;q=0" },
+        nextConfig: { i18n, basePath: "", trailingSlash: false },
+        pathLocale: undefined,
+        urlParsed: { hostname: "example.com", pathname: "/" },
+      }),
+    ).toBeUndefined();
   });
 
   it("does not redirect non-root requests for locale detection", () => {


### PR DESCRIPTION
## Summary

- align Pages Router `Accept-Language` locale selection with Next.js
- honor quality weights and exclude entries with `q=0`
- support wildcard selection, language-range matching, configured-locale tie-breaking, and uppercase `Q=` parameters
- gracefully ignore structurally invalid headers

## Root cause

Vinext used a simplified parser that sorted header entries by quality and then picked the first matching locale. It did not implement several parts of Next.js's preference-selection behavior and treated zero-quality entries as low-priority fallbacks instead of explicit exclusions. This could redirect a request to a locale the client had rejected.

## User impact

Pages Router locale redirects now follow the same preference rules as Next.js, including regional locale matching and explicit language exclusions.

## Validation

- `pnpm test tests/pages-i18n.test.ts` — 30 tests passed
- `pnpm exec vp check packages/vinext/src/server/pages-i18n.ts tests/pages-i18n.test.ts`
- `git diff --check`

No open pull request currently modifies either changed file.
