### PR TITLE
fix(server): defer after callbacks until response close

### DIFF
--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -22,7 +22,11 @@ import {
   setHeadersContext,
 } from "vinext/shims/headers";
 import { getRequestExecutionContext } from "vinext/shims/request-context";
-import { createRequestContext, runWithRequestContext } from "vinext/shims/unified-request-context";
+import {
+  closeAfterResponse,
+  createRequestContext,
+  runWithRequestContext,
+} from "vinext/shims/unified-request-context";
 import {
   ensureFetchPatch,
   type FetchCacheMode,
@@ -524,7 +528,7 @@ async function runAppPageRevalidationContext<
     unstableCacheRevalidation: "foreground",
   });
 
-  return runWithRequestContext(requestContext, async () => {
+  const revalidation = runWithRequestContext(requestContext, async () => {
     ensureFetchPatch();
     setRefreshStaleFetchesInForeground(process.env.VINEXT_PRERENDER === "1");
     setCurrentFetchSoftTags(buildAppPageTags(options.cleanPathname, [], options.routeSegments));
@@ -535,6 +539,11 @@ async function runAppPageRevalidationContext<
     });
     return await runWithFetchDedupe(renderFn);
   });
+  try {
+    return await revalidation;
+  } finally {
+    await closeAfterResponse(requestContext);
+  }
 }
 
 function toInterceptOptions(

--- a/packages/vinext/src/server/app-route-handler-dispatch.ts
+++ b/packages/vinext/src/server/app-route-handler-dispatch.ts
@@ -19,7 +19,11 @@ import {
 } from "vinext/shims/headers";
 import { setNavigationContext } from "vinext/shims/navigation";
 import { getRequestExecutionContext } from "vinext/shims/request-context";
-import { createRequestContext, runWithRequestContext } from "vinext/shims/unified-request-context";
+import {
+  closeAfterResponse,
+  createRequestContext,
+  runWithRequestContext,
+} from "vinext/shims/unified-request-context";
 import type { ISRCacheEntry } from "./isr-cache.js";
 import {
   getAppRouteHandlerRevalidateSeconds,
@@ -131,7 +135,7 @@ async function runInRouteHandlerRevalidationContext(
     unstableCacheRevalidation: "foreground",
   });
 
-  await runWithRequestContext(requestContext, async () => {
+  const revalidation = runWithRequestContext(requestContext, async () => {
     ensureFetchPatch();
     setCurrentFetchSoftTags(
       buildRouteHandlerPageCacheTags(options.cleanPathname, [], options.routeSegments),
@@ -149,6 +153,11 @@ async function runInRouteHandlerRevalidationContext(
       await _drainPendingRevalidations();
     }
   });
+  try {
+    await revalidation;
+  } finally {
+    await closeAfterResponse(requestContext);
+  }
 }
 
 export async function dispatchAppRouteHandler(

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -28,6 +28,7 @@ import {
 } from "vinext/shims/request-context";
 import { pickRootParams, setRootParams, type RootParams } from "vinext/shims/root-params";
 import {
+  closeAfterResponse,
   closeAfterResponseWithBody,
   createRequestContext,
   runWithRequestContext,
@@ -1399,7 +1400,7 @@ export function createAppRscHandler<TRoute extends AppRscHandlerRoute>(
       unstableCacheRevalidation: "background",
     });
 
-    const response = await runWithRequestContext(requestContext, () =>
+    const responsePromise = runWithRequestContext(requestContext, () =>
       runWithPrerenderWorkUnit(
         async () => {
           ensureFetchPatch();
@@ -1432,6 +1433,13 @@ export function createAppRscHandler<TRoute extends AppRscHandlerRoute>(
         { route: () => new URL(request.url).pathname },
       ),
     );
+    let response: Response;
+    try {
+      response = await responsePromise;
+    } catch (error) {
+      await closeAfterResponse(requestContext);
+      throw error;
+    }
     return closeAfterResponseWithBody(response, requestContext);
   };
 }

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -27,7 +27,11 @@ import {
   type ExecutionContextLike,
 } from "vinext/shims/request-context";
 import { pickRootParams, setRootParams, type RootParams } from "vinext/shims/root-params";
-import { createRequestContext, runWithRequestContext } from "vinext/shims/unified-request-context";
+import {
+  closeAfterResponseWithBody,
+  createRequestContext,
+  runWithRequestContext,
+} from "vinext/shims/unified-request-context";
 import { flattenErrorCauses } from "../utils/error-cause.js";
 import { addBasePathToPathname, hasBasePath, stripBasePath } from "../utils/base-path.js";
 import { mergeRewriteQuery } from "../utils/query.js";
@@ -1395,7 +1399,7 @@ export function createAppRscHandler<TRoute extends AppRscHandlerRoute>(
       unstableCacheRevalidation: "background",
     });
 
-    return runWithRequestContext(requestContext, () =>
+    const response = await runWithRequestContext(requestContext, () =>
       runWithPrerenderWorkUnit(
         async () => {
           ensureFetchPatch();
@@ -1428,5 +1432,6 @@ export function createAppRscHandler<TRoute extends AppRscHandlerRoute>(
         { route: () => new URL(request.url).pathname },
       ),
     );
+    return closeAfterResponseWithBody(response, requestContext);
   };
 }

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -28,7 +28,11 @@ import type { CachedPagesValue } from "vinext/shims/cache-handler";
 import { _runWithCacheState } from "vinext/shims/cache-request-state";
 import { runWithPrivateCache } from "vinext/shims/cache-runtime";
 import { ensureFetchPatch, runWithFetchCache } from "vinext/shims/fetch-cache";
-import { createRequestContext, runWithRequestContext } from "vinext/shims/unified-request-context";
+import {
+  closeAfterResponse,
+  createRequestContext,
+  runWithRequestContext,
+} from "vinext/shims/unified-request-context";
 // Import server-only state modules to register ALS-backed accessors.
 // These modules must be imported before any rendering occurs.
 import "vinext/shims/router-state";
@@ -775,6 +779,9 @@ export function createSSRHandler(
       }
       // No route matched — try to render custom 404 page
       const requestContext = createRequestContext();
+      const closeRequest = () => void closeAfterResponse(requestContext);
+      res.on("finish", closeRequest);
+      res.on("close", closeRequest);
       await runWithRequestContext(requestContext, async () => {
         await _alsRegistration;
         await renderErrorPage(
@@ -817,6 +824,9 @@ export function createSSRHandler(
     let query = mergeRouteParamsIntoQuery(parseQuery(url), params);
     // Wrap the entire request in a single unified AsyncLocalStorage scope.
     const requestContext = createRequestContext();
+    const closeRequest = () => void closeAfterResponse(requestContext);
+    res.on("finish", closeRequest);
+    res.on("close", closeRequest);
     return runWithRequestContext(requestContext, async () => {
       ensureFetchPatch();
       try {
@@ -1369,7 +1379,7 @@ export function createSSRHandler(
                       }
                     : null,
                 });
-                return runWithRequestContext(regenContext, async () => {
+                const regeneration = runWithRequestContext(regenContext, async () => {
                   ensureFetchPatch();
                   let freshPageProps: Record<string, unknown> = {};
                   let freshRenderProps: Record<string, unknown> = { pageProps: freshPageProps };
@@ -1543,6 +1553,11 @@ export function createSSRHandler(
                     }
                   }
                 });
+                try {
+                  return await regeneration;
+                } finally {
+                  await closeAfterResponse(regenContext);
+                }
               },
               {
                 routerKind: "Pages Router",

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -52,7 +52,12 @@ import {
 } from "./isr-cache.js";
 import { getScriptNonceFromHeaderSources } from "./csp.js";
 import { reportRequestError } from "./instrumentation.js";
-import { createRequestContext, runWithRequestContext } from "vinext/shims/unified-request-context";
+import {
+  closeAfterResponse,
+  closeAfterResponseWithBody,
+  createRequestContext,
+  runWithRequestContext,
+} from "vinext/shims/unified-request-context";
 import { getRequestExecutionContext } from "vinext/shims/request-context";
 import { ensureFetchPatch } from "vinext/shims/fetch-cache";
 import { collectAssetTags, resolveClientModuleUrl } from "./pages-asset-tags.js";
@@ -470,7 +475,7 @@ export function createPagesPageHandler(
       executionContext: getRequestExecutionContext(),
     });
 
-    return runWithRequestContext(uCtx, async () => {
+    const response = await runWithRequestContext(uCtx, async () => {
       ensureFetchPatch();
       try {
         const routePattern = patternToNextFormat(route.pattern);
@@ -684,7 +689,11 @@ export function createPagesPageHandler(
             });
             return runWithRequestContext(revalCtx, async () => {
               ensureFetchPatch();
-              return callback();
+              try {
+                return await callback();
+              } finally {
+                await closeAfterResponse(revalCtx);
+              }
             });
           },
           safeJsonStringify,
@@ -942,6 +951,7 @@ export function createPagesPageHandler(
         return new Response("Internal Server Error", { status: 500 });
       }
     });
+    return closeAfterResponseWithBody(response, uCtx);
   }
 
   return renderPage;

--- a/packages/vinext/src/shims/server.ts
+++ b/packages/vinext/src/shims/server.ts
@@ -1210,29 +1210,64 @@ export type UserAgent = {
 export function after<T>(task: Promise<T> | (() => T | Promise<T>)): void {
   _throwIfInsideCacheScope("after()");
 
-  const promise = typeof task === "function" ? Promise.resolve().then(task) : task;
-  // NOTE: vinext runs function tasks concurrently with response streaming (next microtask),
-  // whereas Next.js queues them to run strictly after the response is sent via onClose.
-  // This is a known simplification — function tasks here are not guaranteed to run
-  // after the response completes, only after the current synchronous execution.
-  //
-  // `.catch()` is attached synchronously in the same tick as `promise` is created, so
-  // there is no window where a pre-rejected `task` promise could trigger an
-  // `unhandledrejection` event before the handler is in place.
-  const guarded = promise.catch((err) => {
-    console.error("[vinext] after() task failed:", err);
-  });
+  const unifiedAls = _g[Symbol.for("vinext.unifiedRequestContext.als")] as
+    | {
+        getStore(): Record<string, unknown> | undefined;
+        run<T>(store: Record<string, unknown>, callback: () => T): T;
+      }
+    | undefined;
+  const requestContext = unifiedAls?.getStore();
 
-  // TODO: Next.js throws when after() is called outside a request context or when
-  // waitUntil is unavailable, preventing silent task loss. vinext falls back to
-  // fire-and-forget here, which is correct for the Node.js dev server (where
-  // getRequestExecutionContext() always returns null). On Workers, a misconfigured
-  // entry that omits runWithExecutionContext would silently drop tasks — consider
-  // a one-time console.warn on the fallback path, gated to production only (e.g.
-  // `process.env.NODE_ENV === 'production'` or `typeof caches !== 'undefined'` for
-  // a Workers runtime check) with a module-level `let _warned = false` guard so it
-  // fires at most once and doesn't spam the dev-server console.
-  getRequestExecutionContext()?.waitUntil(guarded);
+  if (!requestContext || !unifiedAls) {
+    const executionContext = getRequestExecutionContext();
+    if (executionContext) {
+      if (typeof task !== "function" && typeof (task as PromiseLike<T>).then !== "function") {
+        throw new TypeError("`after()`: Argument must be a promise or a function");
+      }
+      const promise = typeof task === "function" ? Promise.resolve().then(task) : task;
+      const guarded = Promise.resolve(promise).catch((error) => {
+        console.error("[vinext] after() task failed:", error);
+      });
+      executionContext.waitUntil(guarded);
+      return;
+    }
+    throw new Error("`after()` was called outside a request scope");
+  }
+
+  if (typeof task !== "function") {
+    if (typeof (task as PromiseLike<T>).then !== "function") {
+      throw new TypeError("`after()`: Argument must be a promise or a function");
+    }
+    const guarded = Promise.resolve(task).catch((error) => {
+      console.error("[vinext] after() task failed:", error);
+    });
+    requestContext.afterPromiseScheduled = true;
+    getRequestExecutionContext()?.waitUntil(guarded);
+    return;
+  }
+
+  if (requestContext.afterResponseClosed === true) {
+    const guarded = Promise.resolve()
+      .then(() => unifiedAls.run(requestContext, task))
+      .catch((error) => {
+        console.error("[vinext] after() task failed:", error);
+      });
+    getRequestExecutionContext()?.waitUntil(guarded);
+    return;
+  }
+
+  const callbacks = requestContext.afterCallbacks as Array<() => unknown>;
+  callbacks.push(() => unifiedAls.run(requestContext, task));
+
+  if (!requestContext.afterCompletion) {
+    let resolveCompletion!: () => void;
+    const completion = new Promise<void>((resolve) => {
+      resolveCompletion = resolve;
+    });
+    requestContext.afterCompletion = completion;
+    requestContext.resolveAfterCompletion = resolveCompletion;
+    getRequestExecutionContext()?.waitUntil(completion);
+  }
 }
 
 /**

--- a/packages/vinext/src/shims/server.ts
+++ b/packages/vinext/src/shims/server.ts
@@ -1246,7 +1246,16 @@ export function after<T>(task: Promise<T> | (() => T | Promise<T>)): void {
     return;
   }
 
-  if (requestContext.afterResponseClosed === true) {
+  const callbacks = requestContext.afterCallbacks as Array<() => unknown>;
+
+  // Callbacks registered by a callback that is currently draining belong to
+  // the same queue. Array iteration observes appended entries, so completion
+  // is not released until nested work settles. Once the drain has fully
+  // completed, later registrations run independently.
+  if (
+    requestContext.afterResponseClosed === true &&
+    requestContext.resolveAfterCompletion === null
+  ) {
     const guarded = Promise.resolve()
       .then(() => unifiedAls.run(requestContext, task))
       .catch((error) => {
@@ -1256,7 +1265,6 @@ export function after<T>(task: Promise<T> | (() => T | Promise<T>)): void {
     return;
   }
 
-  const callbacks = requestContext.afterCallbacks as Array<() => unknown>;
   callbacks.push(() => unifiedAls.run(requestContext, task));
 
   if (!requestContext.afterCompletion) {

--- a/packages/vinext/src/shims/server.ts
+++ b/packages/vinext/src/shims/server.ts
@@ -18,6 +18,12 @@ import { encodeMiddlewareRequestHeaders } from "../utils/middleware-request-head
 import { validateCookieAttributeValue, validateCookieName } from "./internal/cookie-serialize.js";
 import { parseEdgeRequestCookieHeader } from "../utils/parse-cookie.js";
 import { getRequestExecutionContext } from "./request-context.js";
+import {
+  bindRequestContextSnapshot,
+  getRequestContext,
+  isInsideUnifiedScope,
+  queueAfterCallback,
+} from "./unified-request-context.js";
 import { assertSafeNavigationUrl } from "./url-safety.js";
 import { hasBasePath, stripBasePath } from "../utils/base-path.js";
 
@@ -1201,8 +1207,7 @@ export type UserAgent = {
  *
  * Uses the platform's `waitUntil` (via the per-request ExecutionContext) when
  * available so the task survives past the response on Cloudflare Workers.
- * Falls back to a fire-and-forget microtask on runtimes without an execution
- * context (e.g. Node.js dev server).
+ * Node.js dev drains callbacks from its response finish/close lifecycle.
  *
  * Throws when called inside a cached scope — request-specific
  * side-effects must not leak into cached results.
@@ -1210,18 +1215,15 @@ export type UserAgent = {
 export function after<T>(task: Promise<T> | (() => T | Promise<T>)): void {
   _throwIfInsideCacheScope("after()");
 
-  const unifiedAls = _g[Symbol.for("vinext.unifiedRequestContext.als")] as
-    | {
-        getStore(): Record<string, unknown> | undefined;
-        run<T>(store: Record<string, unknown>, callback: () => T): T;
-      }
-    | undefined;
-  const requestContext = unifiedAls?.getStore();
+  const requestContext = isInsideUnifiedScope() ? getRequestContext() : null;
 
-  if (!requestContext || !unifiedAls) {
+  if (!requestContext) {
     const executionContext = getRequestExecutionContext();
     if (executionContext) {
-      if (typeof task !== "function" && typeof (task as PromiseLike<T>).then !== "function") {
+      if (
+        typeof task !== "function" &&
+        (task == null || typeof (task as PromiseLike<T>).then !== "function")
+      ) {
         throw new TypeError("`after()`: Argument must be a promise or a function");
       }
       const promise = typeof task === "function" ? Promise.resolve().then(task) : task;
@@ -1235,47 +1237,17 @@ export function after<T>(task: Promise<T> | (() => T | Promise<T>)): void {
   }
 
   if (typeof task !== "function") {
-    if (typeof (task as PromiseLike<T>).then !== "function") {
+    if (task == null || typeof (task as PromiseLike<T>).then !== "function") {
       throw new TypeError("`after()`: Argument must be a promise or a function");
     }
     const guarded = Promise.resolve(task).catch((error) => {
       console.error("[vinext] after() task failed:", error);
     });
-    requestContext.afterPromiseScheduled = true;
     getRequestExecutionContext()?.waitUntil(guarded);
     return;
   }
 
-  const callbacks = requestContext.afterCallbacks as Array<() => unknown>;
-
-  // Callbacks registered by a callback that is currently draining belong to
-  // the same queue. Array iteration observes appended entries, so completion
-  // is not released until nested work settles. Once the drain has fully
-  // completed, later registrations run independently.
-  if (
-    requestContext.afterResponseClosed === true &&
-    requestContext.resolveAfterCompletion === null
-  ) {
-    const guarded = Promise.resolve()
-      .then(() => unifiedAls.run(requestContext, task))
-      .catch((error) => {
-        console.error("[vinext] after() task failed:", error);
-      });
-    getRequestExecutionContext()?.waitUntil(guarded);
-    return;
-  }
-
-  callbacks.push(() => unifiedAls.run(requestContext, task));
-
-  if (!requestContext.afterCompletion) {
-    let resolveCompletion!: () => void;
-    const completion = new Promise<void>((resolve) => {
-      resolveCompletion = resolve;
-    });
-    requestContext.afterCompletion = completion;
-    requestContext.resolveAfterCompletion = resolveCompletion;
-    getRequestExecutionContext()?.waitUntil(completion);
-  }
+  queueAfterCallback(requestContext, bindRequestContextSnapshot(requestContext, task));
 }
 
 /**

--- a/packages/vinext/src/shims/unified-request-context.ts
+++ b/packages/vinext/src/shims/unified-request-context.ts
@@ -45,6 +45,18 @@ export type UnifiedRequestContext = {
   /** Per-request cache for cacheForRequest(). Keyed by factory function reference. */
   // oxlint-disable-next-line @typescript-eslint/no-explicit-any
   requestCache: WeakMap<(...args: any[]) => any, unknown>;
+
+  // ── next/server after() ───────────────────────────────────────────
+  /** Function callbacks deferred until the response body closes. */
+  afterCallbacks: Array<() => unknown>;
+  /** True once response completion has released deferred callbacks. */
+  afterResponseClosed: boolean;
+  /** True when eager promise work may register a nested callback later. */
+  afterPromiseScheduled: boolean;
+  /** Shared completion promise registered with the platform's waitUntil. */
+  afterCompletion: Promise<void> | null;
+  /** Resolves afterCompletion once all deferred callbacks settle. */
+  resolveAfterCompletion: (() => void) | null;
 } & VinextHeadersShimState &
   I18nState &
   NavigationState &
@@ -113,12 +125,83 @@ export function createRequestContext(opts?: Partial<UnifiedRequestContext>): Uni
     currentFetchDedupeEntries: new Map(),
     executionContext: _getInheritedExecutionContext(), // inherits from standalone ALS if present
     requestCache: new WeakMap(),
+    afterCallbacks: [],
+    afterResponseClosed: false,
+    afterPromiseScheduled: false,
+    afterCompletion: null,
+    resolveAfterCompletion: null,
     ssrContext: null,
     ssrHeadChildren: [],
     documentInitialHead: [],
     rootParams: null,
     ...opts,
   };
+}
+
+/**
+ * Release function-form `after()` work once the response body has closed.
+ * Callbacks run serially in registration order, matching Next.js' queue.
+ */
+export async function closeAfterResponse(ctx: UnifiedRequestContext): Promise<void> {
+  if (ctx.afterResponseClosed) return ctx.afterCompletion ?? Promise.resolve();
+  ctx.afterResponseClosed = true;
+
+  try {
+    for (const callback of ctx.afterCallbacks) {
+      try {
+        await callback();
+      } catch (error) {
+        console.error("[vinext] after() task failed:", error);
+      }
+    }
+  } finally {
+    ctx.afterCallbacks.length = 0;
+    ctx.resolveAfterCompletion?.();
+    ctx.resolveAfterCompletion = null;
+  }
+}
+
+/** Wrap a response so deferred callbacks start on stream completion or cancellation. */
+export function closeAfterResponseWithBody(
+  response: Response,
+  ctx: UnifiedRequestContext,
+): Response {
+  if (ctx.afterCallbacks.length === 0 && !ctx.afterPromiseScheduled) return response;
+  if (!response.body) {
+    queueMicrotask(() => void closeAfterResponse(ctx));
+    return response;
+  }
+
+  const reader = response.body.getReader();
+  const body = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const result = await reader.read();
+        if (result.done) {
+          controller.close();
+          void closeAfterResponse(ctx);
+        } else {
+          controller.enqueue(result.value);
+        }
+      } catch (error) {
+        controller.error(error);
+        void closeAfterResponse(ctx);
+      }
+    },
+    async cancel(reason) {
+      try {
+        await reader.cancel(reason);
+      } finally {
+        void closeAfterResponse(ctx);
+      }
+    },
+  });
+
+  return new Response(body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
 }
 
 /**

--- a/packages/vinext/src/shims/unified-request-context.ts
+++ b/packages/vinext/src/shims/unified-request-context.ts
@@ -47,16 +47,8 @@ export type UnifiedRequestContext = {
   requestCache: WeakMap<(...args: any[]) => any, unknown>;
 
   // ── next/server after() ───────────────────────────────────────────
-  /** Function callbacks deferred until the response body closes. */
-  afterCallbacks: Array<() => unknown>;
-  /** True once response completion has released deferred callbacks. */
-  afterResponseClosed: boolean;
-  /** True when eager promise work may register a nested callback later. */
-  afterPromiseScheduled: boolean;
-  /** Shared completion promise registered with the platform's waitUntil. */
-  afterCompletion: Promise<void> | null;
-  /** Resolves afterCompletion once all deferred callbacks settle. */
-  resolveAfterCompletion: (() => void) | null;
+  /** Shared lifecycle state for work deferred until the response closes. */
+  afterContext: AfterRequestContext;
 } & VinextHeadersShimState &
   I18nState &
   NavigationState &
@@ -66,6 +58,14 @@ export type UnifiedRequestContext = {
   RouterState &
   HeadState &
   RootParamsState;
+
+export type AfterRequestContext = {
+  callbacks: Array<() => unknown>;
+  responseClosed: boolean;
+  pendingCallbacks: number;
+  completion: Promise<void> | null;
+  resolveCompletion: (() => void) | null;
+};
 
 // ---------------------------------------------------------------------------
 // ALS setup — stored on globalThis via Symbol.for so all Vite environments
@@ -125,11 +125,13 @@ export function createRequestContext(opts?: Partial<UnifiedRequestContext>): Uni
     currentFetchDedupeEntries: new Map(),
     executionContext: _getInheritedExecutionContext(), // inherits from standalone ALS if present
     requestCache: new WeakMap(),
-    afterCallbacks: [],
-    afterResponseClosed: false,
-    afterPromiseScheduled: false,
-    afterCompletion: null,
-    resolveAfterCompletion: null,
+    afterContext: {
+      callbacks: [],
+      responseClosed: false,
+      pendingCallbacks: 0,
+      completion: null,
+      resolveCompletion: null,
+    },
     ssrContext: null,
     ssrHeadChildren: [],
     documentInitialHead: [],
@@ -138,27 +140,90 @@ export function createRequestContext(opts?: Partial<UnifiedRequestContext>): Uni
   };
 }
 
+function ensureAfterCompletion(ctx: UnifiedRequestContext): void {
+  const state = ctx.afterContext;
+  if (state.resolveCompletion && state.completion) return;
+
+  let resolveCompletion!: () => void;
+  const completion = new Promise<void>((resolve) => {
+    resolveCompletion = resolve;
+  });
+  state.completion = completion;
+  state.resolveCompletion = resolveCompletion;
+  ctx.executionContext?.waitUntil(completion);
+}
+
+function finishAfterCallbacksIfIdle(ctx: UnifiedRequestContext): void {
+  const state = ctx.afterContext;
+  if (
+    !state.responseClosed ||
+    state.pendingCallbacks !== 0 ||
+    state.callbacks.length !== 0 ||
+    !state.resolveCompletion
+  ) {
+    return;
+  }
+
+  const resolveCompletion = state.resolveCompletion;
+  state.resolveCompletion = null;
+  resolveCompletion();
+}
+
+function startAfterCallback(ctx: UnifiedRequestContext, callback: () => unknown): void {
+  const state = ctx.afterContext;
+  ensureAfterCompletion(ctx);
+  state.pendingCallbacks += 1;
+  void Promise.resolve()
+    .then(callback)
+    .catch((error) => {
+      console.error("[vinext] after() task failed:", error);
+    })
+    .finally(() => {
+      state.pendingCallbacks -= 1;
+      finishAfterCallbacksIfIdle(ctx);
+    });
+}
+
+/** Queue a callback until response close, or start it immediately once closed. */
+export function queueAfterCallback(ctx: UnifiedRequestContext, callback: () => unknown): void {
+  ensureAfterCompletion(ctx);
+  if (ctx.afterContext.responseClosed) {
+    startAfterCallback(ctx, callback);
+  } else {
+    ctx.afterContext.callbacks.push(callback);
+  }
+}
+
+/** Bind a callback to every AsyncLocalStorage context active at registration. */
+export function bindRequestContextSnapshot<T>(
+  ctx: UnifiedRequestContext,
+  callback: () => T,
+): () => T {
+  const constructor = _als.constructor as {
+    snapshot?: () => <TResult>(callback: () => TResult) => TResult;
+  };
+  try {
+    const runInSnapshot = constructor.snapshot?.();
+    if (runInSnapshot) return () => runInSnapshot(callback);
+  } catch {
+    // Runtimes with partial AsyncLocalStorage implementations may not support snapshots.
+  }
+  return () => _als.run(ctx, callback);
+}
+
 /**
  * Release function-form `after()` work once the response body has closed.
- * Callbacks run serially in registration order, matching Next.js' queue.
+ * All queued callbacks start together, matching Next.js' unbounded PromiseQueue.
  */
 export async function closeAfterResponse(ctx: UnifiedRequestContext): Promise<void> {
-  if (ctx.afterResponseClosed) return ctx.afterCompletion ?? Promise.resolve();
-  ctx.afterResponseClosed = true;
-
-  try {
-    for (const callback of ctx.afterCallbacks) {
-      try {
-        await callback();
-      } catch (error) {
-        console.error("[vinext] after() task failed:", error);
-      }
-    }
-  } finally {
-    ctx.afterCallbacks.length = 0;
-    ctx.resolveAfterCompletion?.();
-    ctx.resolveAfterCompletion = null;
+  const state = ctx.afterContext;
+  if (!state.responseClosed) {
+    state.responseClosed = true;
+    const callbacks = state.callbacks.splice(0);
+    for (const callback of callbacks) startAfterCallback(ctx, callback);
+    finishAfterCallbacksIfIdle(ctx);
   }
+  return state.completion ?? Promise.resolve();
 }
 
 /** Wrap a response so deferred callbacks start on stream completion or cancellation. */
@@ -166,42 +231,26 @@ export function closeAfterResponseWithBody(
   response: Response,
   ctx: UnifiedRequestContext,
 ): Response {
-  if (ctx.afterCallbacks.length === 0 && !ctx.afterPromiseScheduled) return response;
   if (!response.body) {
     queueMicrotask(() => void closeAfterResponse(ctx));
     return response;
   }
 
-  const reader = response.body.getReader();
-  const body = new ReadableStream<Uint8Array>({
-    async pull(controller) {
-      try {
-        const result = await reader.read();
-        if (result.done) {
-          controller.close();
-          void closeAfterResponse(ctx);
-        } else {
-          controller.enqueue(result.value);
-        }
-      } catch (error) {
-        controller.error(error);
-        void closeAfterResponse(ctx);
-      }
-    },
-    async cancel(reason) {
-      try {
-        await reader.cancel(reason);
-      } finally {
-        void closeAfterResponse(ctx);
-      }
-    },
-  });
+  const passthrough = new TransformStream<Uint8Array, Uint8Array>();
+  void response.body.pipeTo(passthrough.writable).then(
+    () => void closeAfterResponse(ctx),
+    () => void closeAfterResponse(ctx),
+  );
 
-  return new Response(body, {
+  const wrapped = new Response(passthrough.readable, {
     status: response.status,
     statusText: response.statusText,
     headers: response.headers,
   });
+  (wrapped as { __vinextStreamedHtmlResponse?: boolean }).__vinextStreamedHtmlResponse = (
+    response as { __vinextStreamedHtmlResponse?: boolean }
+  ).__vinextStreamedHtmlResponse;
+  return wrapped;
 }
 
 /**
@@ -249,7 +298,7 @@ export function runWithUnifiedStateMutation<T>(
   if (!parentCtx) return fn();
 
   const childCtx = { ...parentCtx };
-  // NOTE: This is a shallow clone. Array fields (pendingSetCookies,
+  // NOTE: This is a shallow clone. Object/array fields (afterContext, pendingSetCookies,
   // serverInsertedHTMLCallbacks, currentRequestTags, ssrHeadChildren), Set
   // fields (renderRequestApiUsage, pendingRevalidatedTags, pendingRevalidations,
   // cacheableFetchUrls, dynamicFetchUrls),

--- a/tests/after-deploy.test.ts
+++ b/tests/after-deploy.test.ts
@@ -88,13 +88,14 @@ describe("after() in deploy mode — ctx.waitUntil wiring", () => {
     // the ctx via the unified scope so server components / route handlers
     // can schedule deferred work.
     const { after } = await import("../packages/vinext/src/shims/server.js");
-    const { createRequestContext, runWithRequestContext } =
+    const { closeAfterResponse, createRequestContext, runWithRequestContext } =
       await import("../packages/vinext/src/shims/unified-request-context.js");
 
     const ctx = createMockCtx();
+    const requestContext = createRequestContext({ executionContext: ctx });
     let ran = false;
 
-    await runWithRequestContext(createRequestContext({ executionContext: ctx }), async () => {
+    await runWithRequestContext(requestContext, async () => {
       after(async () => {
         await Promise.resolve();
         ran = true;
@@ -102,6 +103,8 @@ describe("after() in deploy mode — ctx.waitUntil wiring", () => {
     });
 
     expect(ctx.promises).toHaveLength(1);
+    expect(ran).toBe(false);
+    await closeAfterResponse(requestContext);
     await ctx.promises[0];
     expect(ran).toBe(true);
   });

--- a/tests/app-page-dispatch.test.ts
+++ b/tests/app-page-dispatch.test.ts
@@ -33,7 +33,7 @@ import {
 } from "../packages/vinext/src/server/cache-proof.js";
 import { APP_RSC_RENDER_MODE_PREFETCH_DYNAMIC_SHELL } from "../packages/vinext/src/server/app-rsc-render-mode.js";
 import { makeThenableParams } from "../packages/vinext/src/shims/thenable-params.js";
-import { connection } from "../packages/vinext/src/shims/server.js";
+import { after, connection } from "../packages/vinext/src/shims/server.js";
 import type { AppPageMiddlewareContext } from "../packages/vinext/src/server/app-page-response.js";
 import type { ISRCacheEntry } from "../packages/vinext/src/server/isr-cache.js";
 import type { CachedAppPageValue } from "../packages/vinext/src/shims/cache.js";
@@ -2647,10 +2647,14 @@ describe("app page dispatch", () => {
     let capturedWaitForAllReady: boolean | undefined;
     let capturedFallbackToErrorDocument: boolean | undefined;
     let capturedServeStreamingMetadata: boolean | undefined;
+    let afterRan = false;
     const isrSet = vi.fn(async () => {});
     const { options } = createDispatchOptions({
       buildPageElement: async (_route, _params, _opts, _searchParams, _layout, buildOptions) => {
         capturedServeStreamingMetadata = buildOptions?.serveStreamingMetadata;
+        after(() => {
+          afterRan = true;
+        });
         return React.createElement("main", null, "fresh");
       },
       cleanPathname: "/posts/hello",
@@ -2696,6 +2700,7 @@ describe("app page dispatch", () => {
     expect(capturedServeStreamingMetadata).toBe(false);
     expect(capturedFallbackToErrorDocument).toBeUndefined();
     expect(isrSet).toHaveBeenCalled();
+    expect(afterRan).toBe(true);
   });
 
   it.each(["page", "metadata"] as const)(

--- a/tests/app-route-handler-dispatch.test.ts
+++ b/tests/app-route-handler-dispatch.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../packages/vinext/src/shims/cache-handler.js";
 import type { ISRCacheEntry } from "../packages/vinext/src/server/isr-cache.js";
 import { draftMode, setHeadersContext } from "../packages/vinext/src/shims/headers.js";
+import { after } from "../packages/vinext/src/shims/server.js";
 
 function buildCachedRouteValue(body: string): CachedRouteValue {
   return {
@@ -513,6 +514,7 @@ describe("app route handler dispatch", () => {
     let scheduledRender: (() => Promise<void>) | undefined;
     let forceDynamicDefaultAtRegenTime: boolean | undefined;
     let fetchCacheModeAtRegenTime: unknown = "unset";
+    let afterRan = false;
 
     const response = await dispatchAppRouteHandler({
       cleanPathname: "/api/stale-fetch-cache",
@@ -540,6 +542,9 @@ describe("app route handler dispatch", () => {
           GET() {
             forceDynamicDefaultAtRegenTime = forceDynamicSpy.mock.calls.at(-1)?.[0];
             fetchCacheModeAtRegenTime = modeSpy.mock.calls.at(-1)?.[0];
+            after(() => {
+              afterRan = true;
+            });
             return new Response("regenerated");
           },
         },
@@ -561,6 +566,7 @@ describe("app route handler dispatch", () => {
 
     expect(forceDynamicDefaultAtRegenTime).toBe(false);
     expect(fetchCacheModeAtRegenTime).toBe("force-cache");
+    expect(afterRan).toBe(true);
 
     modeSpy.mockRestore();
     forceDynamicSpy.mockRestore();

--- a/tests/pages-page-handler.test.ts
+++ b/tests/pages-page-handler.test.ts
@@ -15,6 +15,7 @@ import {
   PAGES_PREVIEW_CACHE_CONTROL,
   setPagesPreviewData,
 } from "../packages/vinext/src/server/pages-preview.js";
+import { after } from "../packages/vinext/src/shims/server.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -141,6 +142,37 @@ describe("shouldEmitPagesClientTraceMetadata", () => {
     const app = Object.assign(() => null, { getInitialProps: async () => ({}) });
     expect(shouldEmitPagesClientTraceMetadata(makePageModule({ default: page }), null)).toBe(true);
     expect(shouldEmitPagesClientTraceMetadata(makePageModule(), app)).toBe(true);
+  });
+});
+
+// Ported from Next.js: test/e2e/app-dir/next-after-pages/index.test.ts
+// https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/next-after-pages/index.test.ts
+describe("createPagesPageHandler — after() lifecycle", () => {
+  it("runs callbacks only after the response body closes", async () => {
+    let callbackRan = false;
+    const handler = createPagesPageHandler(
+      makeOpts({
+        pageRoutes: [
+          makeRoute(
+            "/",
+            makePageModule({
+              getServerSideProps: async () => {
+                after(() => {
+                  callbackRan = true;
+                });
+                return { props: {} };
+              },
+            }),
+          ),
+        ],
+      }),
+    );
+
+    const response = await handler(makeRequest(), "/", null, null, null);
+    expect(callbackRan).toBe(false);
+
+    await response.text();
+    await vi.waitFor(() => expect(callbackRan).toBe(true));
   });
 });
 

--- a/tests/pages-page-handler.test.ts
+++ b/tests/pages-page-handler.test.ts
@@ -145,8 +145,6 @@ describe("shouldEmitPagesClientTraceMetadata", () => {
   });
 });
 
-// Ported from Next.js: test/e2e/app-dir/next-after-pages/index.test.ts
-// https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/next-after-pages/index.test.ts
 describe("createPagesPageHandler — after() lifecycle", () => {
   it("runs callbacks only after the response body closes", async () => {
     let callbackRan = false;

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -8616,6 +8616,88 @@ export default function middleware() {
 });
 
 describe("Pages Router dev ISR regeneration", () => {
+  it("drains after() callbacks when a Node response finishes", async () => {
+    vi.resetModules();
+
+    try {
+      const [{ createSSRHandler }, { after }] = await Promise.all([
+        import("../packages/vinext/src/server/dev-server.js"),
+        import("../packages/vinext/src/shims/server.js"),
+      ]);
+      const routeFile = "/virtual/after-page.tsx";
+      let callbackRan = false;
+      const runner = {
+        async import(id: string) {
+          if (id === "vinext/head-state" || id === "vinext/router-state") return {};
+          if (id === "next/router") {
+            return {
+              default: {},
+              setSSRContext() {},
+            };
+          }
+          if (id === routeFile) {
+            return {
+              default() {
+                return null;
+              },
+              getServerSideProps({ res }: { res: { end(body: string): void } }) {
+                after(() => {
+                  callbackRan = true;
+                });
+                res.end("done");
+                return { props: {} };
+              },
+            };
+          }
+          throw new Error(`Unexpected module load: ${id}`);
+        },
+      };
+      const server = {
+        config: { root: "/", base: "/" },
+      } as unknown as ViteDevServer;
+      const handler = createSSRHandler(
+        server,
+        runner,
+        [
+          {
+            pattern: "/after",
+            patternParts: ["after"],
+            filePath: routeFile,
+            isDynamic: false,
+            params: [],
+          },
+        ],
+        "/virtual/pages",
+      );
+
+      const listeners = new Map<string, Array<() => void>>();
+      const res = {
+        statusCode: 200,
+        writableEnded: false,
+        on(event: string, listener: () => void) {
+          const eventListeners = listeners.get(event) ?? [];
+          eventListeners.push(listener);
+          listeners.set(event, eventListeners);
+          return this;
+        },
+        getHeaders() {
+          return {};
+        },
+        end(body: string) {
+          expect(body).toBe("done");
+          this.writableEnded = true;
+          for (const listener of listeners.get("finish") ?? []) listener();
+        },
+      } as any;
+
+      await handler({ method: "GET", headers: {} } as any, res, "/after");
+      await vi.waitFor(() => expect(callbackRan).toBe(true));
+    } finally {
+      vi.resetModules();
+      vi.restoreAllMocks();
+    }
+  });
+
   it("wraps stale regeneration in a fresh unified request context", async () => {
     vi.resetModules();
 
@@ -8652,10 +8734,12 @@ describe("Pages Router dev ISR regeneration", () => {
         { createSSRHandler },
         { getRequestContext, isInsideUnifiedScope },
         { getRequestExecutionContext, runWithExecutionContext },
+        { after },
       ] = await Promise.all([
         import("../packages/vinext/src/server/dev-server.js"),
         import("../packages/vinext/src/shims/unified-request-context.js"),
         import("../packages/vinext/src/shims/request-context.js"),
+        import("../packages/vinext/src/shims/server.js"),
       ]);
 
       let parentRequestTags: string[] = [];
@@ -8665,6 +8749,7 @@ describe("Pages Router dev ISR regeneration", () => {
       let regenUnifiedExecutionContext: unknown;
       let regenSsrContext: unknown;
       let regenI18nContext: unknown;
+      let regenAfterRan = false;
       let appTreeWrapCount = 0;
       const App = Object.assign(({ Component, pageProps }: any) => Component(pageProps), {
         getInitialProps: vi.fn(async () => ({
@@ -8712,6 +8797,9 @@ describe("Pages Router dev ISR regeneration", () => {
               regenUnifiedExecutionContext = getRequestContext().executionContext;
               regenSsrContext = getRequestContext().ssrContext;
               regenI18nContext = getRequestContext().i18nContext;
+              after(() => {
+                regenAfterRan = true;
+              });
               return {
                 props: {
                   timestamp: Date.now(),
@@ -8799,6 +8887,7 @@ describe("Pages Router dev ISR regeneration", () => {
         asPath: "/isr-test",
       });
       expect(regenI18nContext).toBeNull();
+      expect(regenAfterRan).toBe(true);
       expect(appTreeWrapCount).toBe(1);
       expect(isrSetSpy).toHaveBeenCalledOnce();
       expect(isrSetSpy.mock.calls[0]?.[1]).toMatchObject({

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -4905,19 +4905,31 @@ describe("next/server shim", () => {
     expect(human.isBot).toBe(false);
   });
 
-  it("after() runs a callback asynchronously without throwing", async () => {
+  it("after() waits for the response body to close before running a callback", async () => {
     const { after } = await import("../packages/vinext/src/shims/server.js");
+    const { closeAfterResponseWithBody, createRequestContext, runWithRequestContext } =
+      await import("../packages/vinext/src/shims/unified-request-context.js");
     let called = false;
-    after(() => {
-      called = true;
+    const requestContext = createRequestContext();
+    let response!: Response;
+    await runWithRequestContext(requestContext, () => {
+      after(() => {
+        called = true;
+      });
+      response = closeAfterResponseWithBody(new Response("streamed"), requestContext);
     });
-    // after() schedules as a microtask, so await a tick
-    await new Promise((r) => setTimeout(r, 10));
+
+    await Promise.resolve();
+    expect(called).toBe(false);
+    await response.text();
+    await requestContext.afterCompletion;
     expect(called).toBe(true);
   });
 
   it("after() handles a promise argument", async () => {
     const { after } = await import("../packages/vinext/src/shims/server.js");
+    const { createRequestContext, runWithRequestContext } =
+      await import("../packages/vinext/src/shims/unified-request-context.js");
     let resolved = false;
     const p = new Promise<void>((resolve) => {
       setTimeout(() => {
@@ -4925,21 +4937,23 @@ describe("next/server shim", () => {
         resolve();
       }, 5);
     });
-    after(p);
+    await runWithRequestContext(createRequestContext(), () => after(p));
     await new Promise((r) => setTimeout(r, 20));
     expect(resolved).toBe(true);
   });
 
   it("after() swallows errors from failing tasks", async () => {
     const { after } = await import("../packages/vinext/src/shims/server.js");
+    const { closeAfterResponse, createRequestContext, runWithRequestContext } =
+      await import("../packages/vinext/src/shims/unified-request-context.js");
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
-    after(() => {
-      throw new Error("task failed");
+    const requestContext = createRequestContext();
+    await runWithRequestContext(requestContext, () => {
+      after(() => {
+        throw new Error("task failed");
+      });
     });
-    // after() wraps function tasks in Promise.resolve().then(task) — two microtask
-    // ticks are sufficient and more deterministic than a setTimeout.
-    await Promise.resolve();
-    await Promise.resolve();
+    await closeAfterResponse(requestContext);
     expect(consoleError).toHaveBeenCalledWith("[vinext] after() task failed:", expect.any(Error));
     consoleError.mockRestore();
   });
@@ -4970,19 +4984,10 @@ describe("next/server shim", () => {
     expect(called).toBe(true);
   });
 
-  it("after() falls back to fire-and-forget when no execution context exists", async () => {
+  it("after() throws outside a request or execution context", async () => {
     const { after } = await import("../packages/vinext/src/shims/server.js");
 
-    // Outside any execution context scope — should still run the task
-    let called = false;
-    after(() => {
-      called = true;
-    });
-    // after() wraps function tasks in Promise.resolve().then(task) — two microtask
-    // ticks are sufficient and more deterministic than a setTimeout.
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(called).toBe(true);
+    expect(() => after(() => {})).toThrow("outside a request scope");
   });
 
   it('after() throws inside "use cache" scope', async () => {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -4922,8 +4922,41 @@ describe("next/server shim", () => {
     await Promise.resolve();
     expect(called).toBe(false);
     await response.text();
-    await requestContext.afterCompletion;
+    await requestContext.afterContext.completion;
     expect(called).toBe(true);
+  });
+
+  // Ported from Next.js: packages/next/src/server/after/after-context.test.ts
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/after/after-context.test.ts
+  it("after() captures callbacks registered while the response is streaming", async () => {
+    const { after } = await import("../packages/vinext/src/shims/server.js");
+    const { closeAfterResponseWithBody, createRequestContext, runWithRequestContext } =
+      await import("../packages/vinext/src/shims/unified-request-context.js");
+    let releaseStream!: () => void;
+    const streamGate = new Promise<void>((resolve) => {
+      releaseStream = resolve;
+    });
+    let called = false;
+    const requestContext = createRequestContext();
+    let response!: Response;
+
+    await runWithRequestContext(requestContext, () => {
+      const body = new ReadableStream<Uint8Array>({
+        async start(controller) {
+          await streamGate;
+          after(() => {
+            called = true;
+          });
+          controller.enqueue(new TextEncoder().encode("streamed"));
+          controller.close();
+        },
+      });
+      response = closeAfterResponseWithBody(new Response(body), requestContext);
+    });
+
+    releaseStream();
+    await response.text();
+    await vi.waitFor(() => expect(called).toBe(true));
   });
 
   // Ported from Next.js: packages/next/src/server/after/after-context.test.ts
@@ -4957,16 +4990,72 @@ describe("next/server shim", () => {
     expect(nestedFinished).toBe(false);
 
     let completed = false;
-    void requestContext.afterCompletion?.then(() => {
+    void requestContext.afterContext.completion?.then(() => {
       completed = true;
     });
     await Promise.resolve();
     expect(completed).toBe(false);
 
     releaseNested();
-    await requestContext.afterCompletion;
+    await requestContext.afterContext.completion;
     expect(nestedFinished).toBe(true);
     expect(completed).toBe(true);
+  });
+
+  // Next.js uses an unbounded PromiseQueue for after callbacks, so callbacks
+  // registered together start concurrently rather than blocking each other.
+  it("after() starts sibling callbacks concurrently", async () => {
+    const { after } = await import("../packages/vinext/src/shims/server.js");
+    const { closeAfterResponse, createRequestContext, runWithRequestContext } =
+      await import("../packages/vinext/src/shims/unified-request-context.js");
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let firstStarted = false;
+    let secondStarted = false;
+    const requestContext = createRequestContext();
+
+    await runWithRequestContext(requestContext, () => {
+      after(async () => {
+        firstStarted = true;
+        await firstGate;
+      });
+      after(() => {
+        secondStarted = true;
+      });
+    });
+
+    const completion = closeAfterResponse(requestContext);
+    await vi.waitFor(() => {
+      expect(firstStarted).toBe(true);
+      expect(secondStarted).toBe(true);
+    });
+    releaseFirst();
+    await completion;
+  });
+
+  // Ported from Next.js: packages/next/src/server/after/after-context.test.ts
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/after/after-context.test.ts
+  it("after() preserves the AsyncLocalStorage context from registration", async () => {
+    const { AsyncLocalStorage } = await import("node:async_hooks");
+    const { after } = await import("../packages/vinext/src/shims/server.js");
+    const { closeAfterResponse, createRequestContext, runWithRequestContext } =
+      await import("../packages/vinext/src/shims/unified-request-context.js");
+    const storage = new AsyncLocalStorage<string>();
+    const requestContext = createRequestContext();
+    let observed: string | undefined;
+
+    await storage.run("registration-scope", () =>
+      runWithRequestContext(requestContext, () => {
+        after(() => {
+          observed = storage.getStore();
+        });
+      }),
+    );
+
+    await closeAfterResponse(requestContext);
+    expect(observed).toBe("registration-scope");
   });
 
   it("after() handles a promise argument", async () => {
@@ -5023,6 +5112,35 @@ describe("next/server shim", () => {
     // waitUntil is called synchronously — no microtask delay needed
     expect(waitUntilCalls).toHaveLength(1);
     // Await the guarded promise to verify the callback ran
+    await waitUntilCalls[0];
+    expect(called).toBe(true);
+  });
+
+  it("after() shares lifecycle state through nested unified scopes", async () => {
+    const { after } = await import("../packages/vinext/src/shims/server.js");
+    const { runWithExecutionContext } =
+      await import("../packages/vinext/src/shims/request-context.js");
+    const { closeAfterResponse, createRequestContext, runWithRequestContext } =
+      await import("../packages/vinext/src/shims/unified-request-context.js");
+    const waitUntilCalls: Promise<unknown>[] = [];
+    const executionContext = {
+      waitUntil(promise: Promise<unknown>) {
+        waitUntilCalls.push(promise);
+      },
+    };
+    const requestContext = createRequestContext();
+    let called = false;
+
+    await runWithRequestContext(requestContext, () =>
+      runWithExecutionContext(executionContext, () => {
+        after(() => {
+          called = true;
+        });
+      }),
+    );
+
+    expect(waitUntilCalls).toHaveLength(1);
+    await closeAfterResponse(requestContext);
     await waitUntilCalls[0];
     expect(called).toBe(true);
   });

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -4926,6 +4926,49 @@ describe("next/server shim", () => {
     expect(called).toBe(true);
   });
 
+  // Ported from Next.js: packages/next/src/server/after/after-context.test.ts
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/after/after-context.test.ts
+  it("after() waits for callbacks added within another callback", async () => {
+    const { after } = await import("../packages/vinext/src/shims/server.js");
+    const { closeAfterResponseWithBody, createRequestContext, runWithRequestContext } =
+      await import("../packages/vinext/src/shims/unified-request-context.js");
+    let releaseNested!: () => void;
+    const nestedGate = new Promise<void>((resolve) => {
+      releaseNested = resolve;
+    });
+    let nestedStarted = false;
+    let nestedFinished = false;
+    const requestContext = createRequestContext();
+    let response!: Response;
+
+    await runWithRequestContext(requestContext, () => {
+      after(() => {
+        after(async () => {
+          nestedStarted = true;
+          await nestedGate;
+          nestedFinished = true;
+        });
+      });
+      response = closeAfterResponseWithBody(new Response("streamed"), requestContext);
+    });
+
+    await response.text();
+    await vi.waitFor(() => expect(nestedStarted).toBe(true));
+    expect(nestedFinished).toBe(false);
+
+    let completed = false;
+    void requestContext.afterCompletion?.then(() => {
+      completed = true;
+    });
+    await Promise.resolve();
+    expect(completed).toBe(false);
+
+    releaseNested();
+    await requestContext.afterCompletion;
+    expect(nestedFinished).toBe(true);
+    expect(completed).toBe(true);
+  });
+
   it("after() handles a promise argument", async () => {
     const { after } = await import("../packages/vinext/src/shims/server.js");
     const { createRequestContext, runWithRequestContext } =


### PR DESCRIPTION
## What changed

- queue function-form `after()` callbacks in the unified request context
- release callbacks only when App and Pages Router response bodies complete or are cancelled
- keep nested callbacks in the active drain until all queued work settles
- keep deferred work alive through `ExecutionContext.waitUntil()`
- preserve the original request context while callbacks execute
- reject calls made outside a request scope

## Why

The shim previously started callbacks on the next microtask, so deferred work could run while the response was still streaming. This diverged from Next.js response-lifecycle behavior and could let side effects race the response.

## Validation

- 43 focused `after()` tests passed across `tests/shims.test.ts`, `tests/pages-page-handler.test.ts`, and `tests/after-deploy.test.ts`
- nested callback coverage ported from Next.js `packages/next/src/server/after/after-context.test.ts`
- targeted formatting, lint, and type checks passed
- `git diff --check` passed