### PR TITLE
docs(cloudflare): drop duplicate rsc() from App Router config examples

### DIFF
--- a/.agents/skills/migrate-to-vinext/references/config-examples.md
+++ b/.agents/skills/migrate-to-vinext/references/config-examples.md
@@ -50,30 +50,26 @@ export default defineConfig({
 
 ## App Router — Cloudflare Workers
 
-Full manual config with explicit RSC plugin registration and Cloudflare multi-environment setup:
+Cloudflare multi-environment setup. RSC plugin registration stays automatic — do **not** add an explicit
+`rsc()` call, or the build fails with `[vinext] Duplicate @vitejs/plugin-rsc detected`.
 
 ```ts
 import { defineConfig } from "vite";
 import vinext from "vinext";
-import rsc from "@vitejs/plugin-rsc";
 import { cloudflare } from "@cloudflare/vite-plugin";
 
 export default defineConfig({
   plugins: [
     vinext(),
-    rsc({
-      entries: {
-        rsc: "virtual:vinext-rsc-entry",
-        ssr: "virtual:vinext-app-ssr-entry",
-        client: "virtual:vinext-app-browser-entry",
-      },
-    }),
     cloudflare({
       viteEnvironment: { name: "rsc", childEnvironments: ["ssr"] },
     }),
   ],
 });
 ```
+
+`@vitejs/plugin-rsc` is an optional peer dependency: it must be installed in the project, but vinext
+registers it for you. Only register it yourself after passing `rsc: false` to `vinext()`.
 
 In most cases `npx @vinext/cloudflare deploy` generates this automatically. Only use manual config when customizing the worker entry or adding bindings.
 

--- a/README.md
+++ b/README.md
@@ -345,30 +345,27 @@ Requires a custom domain (zone analytics are unavailable on `*.workers.dev`) and
 
 #### Custom Vite configuration
 
-If you need to customize the Vite config, create a `vite.config.ts`. vinext will merge its config with yours. This is required for Cloudflare Workers deployment with the App Router (RSC needs explicit plugin configuration):
+If you need to customize the Vite config, create a `vite.config.ts`. vinext will merge its config with yours. For Cloudflare Workers deployment with the App Router, configure `@cloudflare/vite-plugin` so the RSC environment runs in workerd:
 
 ```ts
 import { defineConfig } from "vite";
 import vinext from "vinext";
-import rsc from "@vitejs/plugin-rsc";
 import { cloudflare } from "@cloudflare/vite-plugin";
 
 export default defineConfig({
   plugins: [
     vinext(),
-    rsc({
-      entries: {
-        rsc: "virtual:vinext-rsc-entry",
-        ssr: "virtual:vinext-app-ssr-entry",
-        client: "virtual:vinext-app-browser-entry",
-      },
-    }),
     cloudflare({
       viteEnvironment: { name: "rsc", childEnvironments: ["ssr"] },
     }),
   ],
 });
 ```
+
+> **Do not register `@vitejs/plugin-rsc` yourself.** It is an optional peer dependency, so it must be
+> _installed_ in your project, but vinext auto-registers it whenever an `app/` directory is detected.
+> Adding an explicit `rsc()` call fails the build with `[vinext] Duplicate @vitejs/plugin-rsc detected`.
+> Pass `rsc: false` to `vinext()` only if you want to own that registration.
 
 See the [examples](#live-examples) for complete working configurations.
 


### PR DESCRIPTION
## What

Removes the explicit `rsc()` registration from the two Cloudflare App Router `vite.config.ts` examples:

- `README.md` → *Cloudflare Workers → Custom Vite configuration*
- `.agents/skills/migrate-to-vinext/references/config-examples.md` → *App Router — Cloudflare Workers*

## Why

Copying either example verbatim fails the build immediately:

```
Error: [vinext] Duplicate @vitejs/plugin-rsc detected.
       vinext auto-registers @vitejs/plugin-rsc when app/ is detected.
       Your config also registers it manually, which doubles build time.
       Fix: remove the explicit rsc() call from your plugins array.
       Or: pass rsc: false to vinext() if you want to configure rsc() yourself.
```

The runtime error is great — the docs are the stale part. `packages/vinext/src/index.ts` auto-registers
`@vitejs/plugin-rsc` when an `app/` directory is detected, and every deployed App Router example in this
repo already omits `rsc()`:

| example | `vite.config.ts` |
| --- | --- |
| `examples/app-router-cloudflare` | `vinext()` + `cloudflare({ viteEnvironment })` |
| `examples/app-router-playground` | same |
| `examples/hackernews` | same |

The skill reference is also internally inconsistent today: its *App Router — Local Development* section
already says "vinext auto-registers `@vitejs/plugin-rsc` … No extra config needed", and then the
Cloudflare section registers it manually.

## Also added

A short note on the genuinely non-obvious part: `@vitejs/plugin-rsc` is an **optional peer dependency**,
so it must be *installed* but must not be *registered* — and `rsc: false` is the escape hatch if you want
to own the registration. Hitting the duplicate error naturally suggests uninstalling the package, which
then fails with `App Router detected but @vitejs/plugin-rsc is not installed`.

## How this was found

Generating vinext apps from a scaffolding tool ([Prophecy Studio](https://github.com/prophecy-dev/studio),
a generator that emits vinext venues) against `vinext@1.0.0-beta.2`, starting from the README config.
Reproduced on a clean standalone install (Node 24.17, Windows) and re-verified against `main` today.

## Testing

Docs-only; no source or test changes. Verified by diffing the examples against the deployed
`examples/*` configs and against the duplicate-detection branch in `packages/vinext/src/index.ts`.
