### PR TITLE
fix(init): complete an existing Cloudflare config instead of only adding to it

### DIFF
--- a/packages/vinext/src/init-cloudflare.ts
+++ b/packages/vinext/src/init-cloudflare.ts
@@ -55,7 +55,7 @@ export function validateCloudflarePlatformSetup(
     .find((candidate) => fs.existsSync(candidate));
   const wranglerCode = wranglerPath ? fs.readFileSync(wranglerPath, "utf-8") : undefined;
   const updatedWranglerCode = wranglerCode
-    ? updateWranglerConfigForCloudflare(wranglerCode, cloudflare)
+    ? updateWranglerConfigForCloudflare(wranglerCode, cloudflare, { root: context.root })
     : undefined;
   const imagesBinding = updatedWranglerCode
     ? getWranglerImagesBinding(updatedWranglerCode)
@@ -125,7 +125,9 @@ export function setupCloudflarePlatform(
     );
     generatedPlatformFiles.push("wrangler.jsonc");
   } else if (wranglerCode) {
-    const updatedConfig = updateWranglerConfigForCloudflare(wranglerCode, cloudflare);
+    const updatedConfig = updateWranglerConfigForCloudflare(wranglerCode, cloudflare, {
+      root: context.root,
+    });
     if (updatedConfig !== wranglerCode) {
       fs.writeFileSync(wranglerPath, updatedConfig, "utf-8");
       generatedPlatformFiles.push(path.basename(wranglerPath));
@@ -163,18 +165,25 @@ export function setupCloudflarePlatform(
   };
 }
 
+/**
+ * `main` is what makes a Wrangler config a Worker rather than a static-assets
+ * project. A custom `worker/index.*` wins when present; otherwise the
+ * router-selected entry resolves to the App or Pages Router handler at build
+ * time.
+ */
+function resolveWorkerEntry(root: string): string {
+  if (fs.existsSync(path.join(root, "worker", "index.ts"))) return "./worker/index.ts";
+  if (fs.existsSync(path.join(root, "worker", "index.js"))) return "./worker/index.js";
+  return "vinext/server/fetch-handler";
+}
+
 // Cloudflare deployment scaffolding belongs to `vinext init`.
 export function generateWranglerConfig(
   info: CloudflareProjectInfo,
   options: CloudflareInitOptions = DEFAULT_CLOUDFLARE_INIT_OPTIONS,
   today = new Date().toISOString().split("T")[0],
 ): string {
-  const customWorkerEntry = fs.existsSync(path.join(info.root, "worker", "index.ts"))
-    ? "./worker/index.ts"
-    : fs.existsSync(path.join(info.root, "worker", "index.js"))
-      ? "./worker/index.js"
-      : undefined;
-  const workerEntry = customWorkerEntry ?? "vinext/server/fetch-handler";
+  const workerEntry = resolveWorkerEntry(info.root);
 
   const config: Record<string, unknown> = {
     $schema: "node_modules/wrangler/config-schema.json",
@@ -365,6 +374,7 @@ function appendTopLevelJsonProperty(code: string, property: string): string {
 export function updateWranglerConfigForCloudflare(
   code: string,
   options: CloudflareInitOptions,
+  context: { root?: string } = {},
 ): string {
   try {
     JSON.parse(stripJsonComments(code));
@@ -372,6 +382,20 @@ export function updateWranglerConfigForCloudflare(
     throw new Error("Could not parse the existing Wrangler JSON/JSONC config.", { cause });
   }
   let output = code;
+  // Without `main` and `assets` the Cloudflare plugin builds the project as
+  // assets-only: the build emits no `dist/server/wrangler.json`, and the deploy
+  // reports success while every route 404s. Keep these in sync with
+  // `generateWranglerConfig`, which writes them on the from-scratch path.
+  if (!findTopLevelJsonProperty(output, "main")) {
+    const workerEntry = resolveWorkerEntry(context.root ?? process.cwd());
+    output = appendTopLevelJsonProperty(output, `  "main": ${JSON.stringify(workerEntry)}`);
+  }
+  if (!findTopLevelJsonProperty(output, "assets")) {
+    output = appendTopLevelJsonProperty(
+      output,
+      '  "assets": { "directory": "dist/client", "not_found_handling": "none", "binding": "ASSETS" }',
+    );
+  }
   if (options.cdnCache === "workers-cache") {
     const cacheProperty = findTopLevelJsonProperty(output, "cache");
     if (!cacheProperty) {
@@ -975,6 +999,39 @@ function cloudflarePluginExpression(isAppRouter: boolean, binding: string): stri
     : `${binding}()`;
 }
 
+/**
+ * An existing bare `cloudflare()` call is left as-is by `ensurePlugins`, which
+ * only adds plugins that are absent. For the App Router that silently drops
+ * `viteEnvironment`, so the RSC environment never runs in workerd.
+ */
+function ensureCloudflareViteEnvironment(
+  output: MagicString,
+  config: AstObject,
+  binding: string,
+  isAppRouter: boolean,
+  code: string,
+): void {
+  if (!isAppRouter) return;
+  const call = findPluginCall(config, binding);
+  if (!call) return;
+  const viteEnvironment = `viteEnvironment: { name: "rsc", childEnvironments: ["ssr"] }`;
+  const firstArgument = call.arguments[0];
+  if (!firstArgument) {
+    output.appendLeft(call.end - 1, `{ ${viteEnvironment} }`);
+    return;
+  }
+  if (firstArgument.type !== "ObjectExpression") return;
+  const argumentObject = firstArgument as AstObject;
+  if (findProperty(argumentObject, "viteEnvironment")) return;
+  const callIndent =
+    code
+      .slice(0, (call as AstNode).start)
+      .split("\n")
+      .at(-1)
+      ?.match(/^\s*/)?.[0] ?? "";
+  insertObjectProperty(output, argumentObject, `${callIndent}  ${viteEnvironment},`, code);
+}
+
 function findPluginCall(
   config: AstObject,
   binding: string,
@@ -1460,6 +1517,7 @@ export function updateViteConfigForCloudflare(
     ],
     code,
   );
+  ensureCloudflareViteEnvironment(output, config, cloudflareBinding, options.isAppRouter, code);
   if (existingVinextCall) {
     if (
       existingVinextCall.arguments.length === 0 &&

--- a/packages/vinext/src/init-cloudflare.ts
+++ b/packages/vinext/src/init-cloudflare.ts
@@ -376,10 +376,16 @@ export function updateWranglerConfigForCloudflare(
   options: CloudflareInitOptions,
   context: { root?: string } = {},
 ): string {
+  let config: Record<string, unknown>;
   try {
-    JSON.parse(stripJsonComments(code));
+    config = JSON.parse(stripJsonComments(code)) as Record<string, unknown>;
   } catch (cause) {
     throw new Error("Could not parse the existing Wrangler JSON/JSONC config.", { cause });
+  }
+  if (Object.hasOwn(config, "pages_build_output_dir")) {
+    throw new Error(
+      'The existing Wrangler config uses "pages_build_output_dir", which cannot be combined with the Worker "main" required by vinext. Remove "pages_build_output_dir" and rerun vinext init.',
+    );
   }
   let output = code;
   // Without `main` and `assets` the Cloudflare plugin builds the project as
@@ -1020,9 +1026,61 @@ function ensureCloudflareViteEnvironment(
     output.appendLeft(call.end - 1, `{ ${viteEnvironment} }`);
     return;
   }
-  if (firstArgument.type !== "ObjectExpression") return;
+  if (firstArgument.type === "SpreadElement" || firstArgument.type !== "ObjectExpression") {
+    throw new Error(
+      "The cloudflare() plugin options must be a static object for vinext init to configure the App Router Vite environment.",
+    );
+  }
   const argumentObject = firstArgument as AstObject;
-  if (findProperty(argumentObject, "viteEnvironment")) return;
+  const viteEnvironmentProperties = argumentObject.properties.filter(
+    (property): property is AstProperty =>
+      property.type === "Property" && propertyName(property) === "viteEnvironment",
+  );
+  const existingViteEnvironment = viteEnvironmentProperties.at(-1);
+  if (existingViteEnvironment) {
+    const propertyIndex = argumentObject.properties.lastIndexOf(existingViteEnvironment);
+    if (
+      argumentObject.properties
+        .slice(propertyIndex + 1)
+        .some((property) => property.type === "SpreadElement")
+    ) {
+      throw new Error(
+        "The cloudflare() viteEnvironment option must appear after any spread properties so vinext init can verify it.",
+      );
+    }
+    if (existingViteEnvironment.value.type !== "ObjectExpression") {
+      throw new Error(
+        'The cloudflare() viteEnvironment option must be a static object with name: "rsc" and childEnvironments containing "ssr".',
+      );
+    }
+    const environmentObject = existingViteEnvironment.value as AstObject;
+    const nameProperties = environmentObject.properties.filter(
+      (property): property is AstProperty =>
+        property.type === "Property" && propertyName(property) === "name",
+    );
+    const childEnvironmentProperties = environmentObject.properties.filter(
+      (property): property is AstProperty =>
+        property.type === "Property" && propertyName(property) === "childEnvironments",
+    );
+    const name = nameProperties[0];
+    const childEnvironments = childEnvironmentProperties[0];
+    const hasAmbiguousProperties =
+      environmentObject.properties.some((property) => property.type === "SpreadElement") ||
+      nameProperties.length !== 1 ||
+      childEnvironmentProperties.length !== 1;
+    const hasRequiredName = name?.value.type === "Literal" && name.value.value === "rsc";
+    const hasRequiredChild =
+      childEnvironments?.value.type === "ArrayExpression" &&
+      childEnvironments.value.elements.some(
+        (element) => element?.type === "Literal" && element.value === "ssr",
+      );
+    if (hasAmbiguousProperties || !hasRequiredName || !hasRequiredChild) {
+      throw new Error(
+        'The cloudflare() viteEnvironment option must statically set name: "rsc" and include "ssr" in childEnvironments.',
+      );
+    }
+    return;
+  }
   const callIndent =
     code
       .slice(0, (call as AstNode).start)

--- a/tests/init-cloudflare.test.ts
+++ b/tests/init-cloudflare.test.ts
@@ -41,6 +41,70 @@ export default defineConfig({
     expect(output).toContain('childEnvironments: ["ssr"]');
   });
 
+  it("adds viteEnvironment to an existing bare cloudflare() call", () => {
+    const input = `import { defineConfig } from "vite";
+import vinext from "vinext";
+import { cloudflare } from "@cloudflare/vite-plugin";
+
+export default defineConfig({
+  plugins: [vinext(), cloudflare()],
+});
+`;
+
+    const output = updateViteConfigForCloudflare("vite.config.ts", input, {
+      isAppRouter: true,
+      nativeModulesToStub: [],
+    });
+
+    expectValidConfig(output);
+    expect(output).toContain('childEnvironments: ["ssr"]');
+    expect(output.match(/cloudflare\(/g)).toHaveLength(1);
+    expect(
+      updateViteConfigForCloudflare("vite.config.ts", output, {
+        isAppRouter: true,
+        nativeModulesToStub: [],
+      }),
+    ).toBe(output);
+  });
+
+  it("adds viteEnvironment to an existing configured cloudflare() call", () => {
+    const input = `import { defineConfig } from "vite";
+import vinext from "vinext";
+import { cloudflare } from "@cloudflare/vite-plugin";
+
+export default defineConfig({
+  plugins: [vinext(), cloudflare({ configPath: "./wrangler.jsonc" })],
+});
+`;
+
+    const output = updateViteConfigForCloudflare("vite.config.ts", input, {
+      isAppRouter: true,
+      nativeModulesToStub: [],
+    });
+
+    expectValidConfig(output);
+    expect(output).toContain('configPath: "./wrangler.jsonc"');
+    expect(output).toContain('childEnvironments: ["ssr"]');
+  });
+
+  it("leaves an existing cloudflare() call alone for the Pages Router", () => {
+    const input = `import { defineConfig } from "vite";
+import vinext from "vinext";
+import { cloudflare } from "@cloudflare/vite-plugin";
+
+export default defineConfig({
+  plugins: [vinext(), cloudflare()],
+});
+`;
+
+    const output = updateViteConfigForCloudflare("vite.config.ts", input, {
+      isAppRouter: false,
+      nativeModulesToStub: [],
+    });
+
+    expect(output).not.toContain("viteEnvironment");
+  });
+
   it("updates a CommonJS Pages Router config", () => {
     const input = `const { defineConfig } = require("vite");
 const vinext = require("vinext");
@@ -456,6 +520,34 @@ export default { plugins: [vinext({ imageOptimization: true })] };
     ).toBe(output);
   });
 
+  it("adds a Worker entry and assets to an existing Wrangler config", () => {
+    const options = {
+      dataCache: "none" as const,
+      cdnCache: "data-cache" as const,
+      imageOptimization: "none" as const,
+    };
+    const output = updateWranglerConfigForCloudflare(`{ "name": "existing" }\n`, options);
+    expect(JSON.parse(output)).toEqual({
+      name: "existing",
+      main: "vinext/server/fetch-handler",
+      assets: { directory: "dist/client", not_found_handling: "none", binding: "ASSETS" },
+    });
+    expect(updateWranglerConfigForCloudflare(output, options)).toBe(output);
+  });
+
+  it("preserves an existing Worker entry and assets", () => {
+    const input = `{
+  "main": "./worker/index.ts",
+  "assets": { "not_found_handling": "none", "binding": "ASSETS" }
+}\n`;
+    const output = updateWranglerConfigForCloudflare(input, {
+      dataCache: "none",
+      cdnCache: "data-cache",
+      imageOptimization: "none",
+    });
+    expect(output).toBe(input);
+  });
+
   it("keeps additive Wrangler JSON updates valid strict JSON", () => {
     const output = updateWranglerConfigForCloudflare(`{ "name": "existing" }\n`, {
       dataCache: "kv",
@@ -482,6 +574,8 @@ export default { plugins: [vinext({ imageOptimization: true })] };
     const output = updateWranglerConfigForCloudflare(input, options);
     expect(output).toContain("// keep this comment");
     expect(JSON.parse(output.replace("  // keep this comment\n", ""))).toEqual({
+      main: "vinext/server/fetch-handler",
+      assets: { directory: "dist/client", not_found_handling: "none", binding: "ASSETS" },
       images: { binding: "IMAGES" },
     });
     expect(updateWranglerConfigForCloudflare(output, options)).toBe(output);
@@ -493,7 +587,11 @@ export default { plugins: [vinext({ imageOptimization: true })] };
       cdnCache: "workers-cache",
       imageOptimization: "none",
     });
-    expect(JSON.parse(output)).toEqual({ cache: { enabled: true } });
+    expect(JSON.parse(output)).toEqual({
+      main: "vinext/server/fetch-handler",
+      assets: { directory: "dist/client", not_found_handling: "none", binding: "ASSETS" },
+      cache: { enabled: true },
+    });
   });
 
   it("preserves a custom Wrangler Images binding for the Vite adapter", () => {

--- a/tests/init-cloudflare.test.ts
+++ b/tests/init-cloudflare.test.ts
@@ -87,6 +87,61 @@ export default defineConfig({
     expect(output).toContain('childEnvironments: ["ssr"]');
   });
 
+  it("rejects dynamic cloudflare() options instead of leaving App Router misconfigured", () => {
+    const input = `import vinext from "vinext";
+import { cloudflare } from "@cloudflare/vite-plugin";
+const cloudflareOptions = {};
+export default { plugins: [vinext(), cloudflare(cloudflareOptions)] };
+`;
+
+    expect(() =>
+      updateViteConfigForCloudflare("vite.config.ts", input, {
+        isAppRouter: true,
+        nativeModulesToStub: [],
+        cache: {
+          dataCache: "none",
+          cdnCache: "data-cache",
+          imageOptimization: "none",
+        },
+      }),
+    ).toThrow("cloudflare() plugin options must be a static object");
+  });
+
+  it("rejects an incomplete existing viteEnvironment", () => {
+    const input = `import vinext from "vinext";
+import { cloudflare } from "@cloudflare/vite-plugin";
+export default { plugins: [vinext(), cloudflare({ viteEnvironment: {} })] };
+`;
+
+    expect(() =>
+      updateViteConfigForCloudflare("vite.config.ts", input, {
+        isAppRouter: true,
+        nativeModulesToStub: [],
+      }),
+    ).toThrow('viteEnvironment option must statically set name: "rsc"');
+  });
+
+  it("preserves a complete existing viteEnvironment", () => {
+    const input = `import vinext from "vinext";
+import { cloudflare } from "@cloudflare/vite-plugin";
+export default { plugins: [vinext(), cloudflare({
+  viteEnvironment: { name: "rsc", childEnvironments: ["ssr", "other"] },
+})] };
+`;
+
+    expect(
+      updateViteConfigForCloudflare("vite.config.ts", input, {
+        isAppRouter: true,
+        nativeModulesToStub: [],
+        cache: {
+          dataCache: "none",
+          cdnCache: "data-cache",
+          imageOptimization: "none",
+        },
+      }),
+    ).toBe(input);
+  });
+
   it("leaves an existing cloudflare() call alone for the Pages Router", () => {
     const input = `import { defineConfig } from "vite";
 import vinext from "vinext";
@@ -546,6 +601,18 @@ export default { plugins: [vinext({ imageOptimization: true })] };
       imageOptimization: "none",
     });
     expect(output).toBe(input);
+  });
+
+  it("rejects an existing Cloudflare Pages config instead of adding an incompatible main", () => {
+    const input = `{ "pages_build_output_dir": "./dist/client" }\n`;
+
+    expect(() =>
+      updateWranglerConfigForCloudflare(input, {
+        dataCache: "none",
+        cdnCache: "data-cache",
+        imageOptimization: "none",
+      }),
+    ).toThrow('"pages_build_output_dir", which cannot be combined with the Worker "main"');
   });
 
   it("keeps additive Wrangler JSON updates valid strict JSON", () => {


### PR DESCRIPTION
## The bug

`vinext init --platform=cloudflare` has two paths for `wrangler.jsonc`, and they disagree about what a
valid Cloudflare config is:

| path | writes |
| --- | --- |
| no config yet → `generateWranglerConfig()` | `main`, `assets`, `cache`, `images`, `kv_namespaces` |
| config exists → `updateWranglerConfigForCloudflare()` | `cache`, `images`, `kv_namespaces` |

So a project that already has a `wrangler.jsonc` — any generator or template that emits the app and its
Cloudflare config together — comes out of `init` without `main` or `assets`, and nothing warns.

## Why that's worse than it sounds

With no `main`, `@cloudflare/vite-plugin` builds the project as **assets-only**:

1. The RSC environment (`outDir: dist/server`) emits no `dist/server/wrangler.json`.
2. That breaks the npm scripts `init` itself just wrote, which reference exactly that path:
   ```json
   "start:vinext":  "wrangler dev --config dist/server/wrangler.json",
   "deploy:vinext": "vinext-cloudflare deploy --config dist/server/wrangler.json"
   ```
3. Falling back to default config resolution, the deploy picks up the assets-only config, **reports
   success**, and ships a Worker with no SSR entry. Static assets return 200; every route returns 404.
   For an SSR app there's no `index.html` to fall back on, so the site is simply blank.

A deploy that reports success into a site where every route 404s is an expensive failure to diagnose —
nothing in the output points at `main`.

## Same shape of bug in the Vite config

`ensurePlugins()` only adds plugins that are *absent*, so an existing bare `cloudflare()` is left with its
defaults. For an App Router project that silently drops
`viteEnvironment: { name: "rsc", childEnvironments: ["ssr"] }`, and the RSC environment never runs in
workerd. Also no warning.

## The fix

- `updateWranglerConfigForCloudflare()` now fills in `main` and `assets` when absent, reusing the same
  worker-entry resolution `generateWranglerConfig()` already used (extracted to `resolveWorkerEntry()`:
  a custom `worker/index.{ts,js}` wins, otherwise `vinext/server/fetch-handler`). Existing values are
  untouched and the update stays idempotent.
- New `ensureCloudflareViteEnvironment()` adds `viteEnvironment` to an existing `cloudflare()` call for
  App Router projects — bare or already carrying other options — and leaves Pages Router alone.

Both stay non-destructive, which is the property the rest of `init` is built around.

## Tests

Five new cases in `tests/init-cloudflare.test.ts`:

- adds `main` + `assets` to an existing config, and is idempotent
- preserves an existing `main`/`assets` byte-for-byte
- adds `viteEnvironment` to a bare `cloudflare()`, idempotent, without duplicating the plugin
- adds `viteEnvironment` to a `cloudflare({ … })` that already has other options
- leaves `cloudflare()` alone for the Pages Router

Two existing `toEqual` assertions were widened for the new keys.

```
pnpm test tests/init-cloudflare.test.ts   44 passed
pnpm test tests/init.test.ts tests/create-vinext-app.test.ts   127 passed
pnpm test tests/deploy.test.ts   295 passed
pnpm run check   clean
```

## Not included

`@vinext/cloudflare deploy` will still happily ship an assets-only Worker and report success when the
resolved config has no `main`, whatever the reason. A guard there would have turned this into a one-line
error. Left out to keep this PR to one behavior change — happy to follow up if you want it.

## Found via

Generating vinext apps from [Prophecy Studio](https://github.com/prophecy-dev/studio), a generator that
emits vinext venues. Reproduced on `vinext@1.0.0-beta.2` / `@vinext/cloudflare@1.0.0-beta.2` /
`@cloudflare/vite-plugin@1.45.1` / `vite@8.1.5` / React 19.2.7 / Node 24.17 on Windows, both in a
workspace and on a clean standalone install.
