### PR TITLE
fix(link): interpolate Pages Router dynamic hrefs

### DIFF
--- a/packages/vinext/src/shims/internal/interpolate-as.ts
+++ b/packages/vinext/src/shims/internal/interpolate-as.ts
@@ -34,6 +34,13 @@ export type DynamicRouteHrefProjection = {
   routePathname: string;
 };
 
+export type DynamicRouteHrefResolution = {
+  /** Route-pattern URL passed to the Pages Router. */
+  href: string;
+  /** Interpolated URL rendered in the anchor and displayed in the browser. */
+  as: string;
+};
+
 function normalizeQuery(query: UrlQuery | undefined): ParsedUrlQuery {
   const normalized: ParsedUrlQuery = {};
   if (!query) return normalized;
@@ -278,14 +285,13 @@ export function interpolateDynamicRouteHref(
   asHref: string,
   queryInput?: UrlQuery,
 ): DynamicRouteHrefProjection | null {
-  if (!routeHref.includes("[")) return null;
-
   const hashIndex = routeHref.indexOf("#");
   const queryIndex = routeHref.indexOf("?");
   const pathEnd = [hashIndex, queryIndex]
     .filter((index) => index !== -1)
     .reduce((earliest, index) => Math.min(earliest, index), routeHref.length);
   const routePathname = routeHref.slice(0, pathEnd);
+  if (!routePathname.includes("[")) return null;
   const trailing = routeHref.slice(pathEnd);
   const asPathname = asHref.split(/[?#]/, 1)[0];
   const query = queryInput
@@ -298,5 +304,36 @@ export function interpolateDynamicRouteHref(
     params,
     query,
     routePathname,
+  };
+}
+
+/**
+ * Resolve the two URLs that Next.js' Pages Router derives from a dynamic
+ * href: the original route-pattern URL used to load the page and the
+ * interpolated browser URL. Dynamic params are consumed from the latter's
+ * query string while unrelated query values and the hash are retained.
+ *
+ * Mirrors `resolveHref(router, href, true)` from Next.js:
+ * packages/next/src/client/resolve-href.ts.
+ */
+export function resolveDynamicRouteHref(routeHref: string): DynamicRouteHrefResolution | null {
+  const projection = interpolateDynamicRouteHref(routeHref, routeHref);
+  if (!projection?.href) return null;
+
+  const hashIndex = projection.href.indexOf("#");
+  const hash = hashIndex === -1 ? "" : projection.href.slice(hashIndex);
+  const hrefWithoutHash = hashIndex === -1 ? projection.href : projection.href.slice(0, hashIndex);
+  const queryIndex = hrefWithoutHash.indexOf("?");
+  const pathname = queryIndex === -1 ? hrefWithoutHash : hrefWithoutHash.slice(0, queryIndex);
+  const searchParams = new URLSearchParams(
+    queryIndex === -1 ? "" : hrefWithoutHash.slice(queryIndex + 1),
+  );
+
+  for (const param of projection.params) searchParams.delete(param);
+
+  const search = searchParams.toString();
+  return {
+    href: routeHref,
+    as: `${pathname}${search ? `?${search}` : ""}${hash}`,
   };
 }

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -55,8 +55,9 @@ import {
   prefetchPagesData,
   resolvePagesDataNavigationTarget,
 } from "./internal/pages-data-target.js";
-import { interpolateDynamicRouteHref } from "./internal/interpolate-as.js";
+import { interpolateDynamicRouteHref, resolveDynamicRouteHref } from "./internal/interpolate-as.js";
 import { markAppRouteDetectedOnPrefetch } from "./internal/app-route-detection.js";
+import { RouterContext } from "./internal/router-context.js";
 import { getCurrentBrowserLocale } from "./client-locale.js";
 import {
   clearLinkForCurrentNavigation,
@@ -1125,7 +1126,9 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
   },
   forwardedRef,
 ) {
+  const pagesRouter = useContext(RouterContext);
   const asHref = as === undefined ? undefined : resolveHref(as);
+  const hrefStr = resolveHref(href);
   // Extract locale from rest props
   const { locale, ...restWithoutLocale } = rest;
 
@@ -1141,6 +1144,11 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
 
   // If `as` is provided, use it as the actual URL (legacy Next.js pattern
   // where href is a route pattern like "/user/[id]" and as is "/user/1").
+  // Pages Router object hrefs with dynamic segments implicitly derive the
+  // same pair: the bracket-pattern href is retained for the router while the
+  // interpolated URL is rendered and displayed. This is gated on the mounted
+  // Pages Router context because App Router intentionally rejects dynamic
+  // href patterns instead of interpolating them.
   // The rendered anchor / prefetch / locale / trailingSlash / basePath math
   // all run on the display value below; a concrete route-pattern href is
   // retained as `routeHrefRaw` so the Pages Router click branch can forward
@@ -1160,13 +1168,40 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
   // Mirrors Next.js' Router.change(): `getRouteRegex` + `interpolateAs`
   // computes `resolvedAs` for the dynamic-route branch (packages/next/src/
   // shared/lib/router/router.ts around L987).
-  const unresolvedHref = asHref ?? resolveHref(href);
+  const hrefForImplicitInterpolation = isAbsoluteOrProtocolRelativeUrl(hrefStr)
+    ? hrefStr.startsWith("//")
+      ? null
+      : toSameOriginAppPath(hrefStr, __basePath)
+    : hrefStr;
+  const implicitDynamicRouteHref =
+    HAS_PAGES_ROUTER &&
+    pagesRouter !== null &&
+    asHref === undefined &&
+    hrefForImplicitInterpolation !== null
+      ? resolveDynamicRouteHref(hrefForImplicitInterpolation)
+      : null;
+  const dynamicRouteHref = implicitDynamicRouteHref
+    ? { ...implicitDynamicRouteHref, href: hrefStr }
+    : null;
+  const pagesAsHref = asHref ?? dynamicRouteHref?.as;
+  const unresolvedHref = pagesAsHref ?? hrefStr;
   const rawResolvedHref =
     typeof unresolvedHref === "string" && unresolvedHref.startsWith("#")
       ? resolvePagesQueryOnlyHref(unresolvedHref)
       : unresolvedHref;
-  const concreteRouteHref = HAS_PAGES_ROUTER ? resolveConcreteRouteHref(href, asHref) : null;
-  const routeHrefRaw = concreteRouteHref ?? (typeof href === "string" ? href : resolveHref(href));
+  const concreteRouteHref = HAS_PAGES_ROUTER
+    ? resolveConcreteRouteHref(
+        dynamicRouteHref ? (hrefForImplicitInterpolation ?? href) : href,
+        pagesAsHref,
+      )
+    : null;
+  const routeHrefRaw = dynamicRouteHref?.href ?? concreteRouteHref ?? hrefStr;
+  const prefetchRouteHrefRaw = concreteRouteHref ?? routeHrefRaw;
+  const hasPagesHrefAsPair =
+    HAS_PAGES_ROUTER &&
+    typeof pagesAsHref === "string" &&
+    typeof routeHrefRaw === "string" &&
+    pagesAsHref !== routeHrefRaw;
 
   // Mirror Next.js: emit a console.error when the href contains repeated
   // forward-slashes (e.g. "/foo//bar") or backslashes, and then normalize the
@@ -1188,16 +1223,12 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
   // it once after locale prefixing (for prefetch/navigation paths that bypass
   // basePath) and again after `withBasePath` for the rendered `href` attribute.
   const normalizedHref = normalizePathTrailingSlash(localizedHref, __trailingSlash);
-  const normalizedRouteHref =
-    HAS_PAGES_ROUTER &&
-    typeof asHref === "string" &&
-    typeof routeHrefRaw === "string" &&
-    asHref !== routeHrefRaw
-      ? normalizePathTrailingSlash(
-          applyLocaleToHref(isDangerous ? "/" : routeHrefRaw, locale),
-          __trailingSlash,
-        )
-      : normalizedHref;
+  const normalizedRouteHref = hasPagesHrefAsPair
+    ? normalizePathTrailingSlash(
+        applyLocaleToHref(isDangerous ? "/" : prefetchRouteHrefRaw, locale),
+        __trailingSlash,
+      )
+    : normalizedHref;
   // Full href with basePath for browser URLs and fetches, normalised again so
   // that combining a non-empty basePath with the bare root (`/`) still
   // produces a canonical href under `trailingSlash: false` (e.g. `/foo`
@@ -1406,13 +1437,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
     // `as` drives the address bar — matching upstream Next.js Link → Router
     // semantics. When no mask is present, leave `pagesAsForLink` undefined so
     // existing single-arg navigation (the dominant code path) is unaffected.
-    const pagesAsForLink =
-      HAS_PAGES_ROUTER &&
-      typeof asHref === "string" &&
-      typeof routeHrefRaw === "string" &&
-      asHref !== routeHrefRaw
-        ? pagesNavigateHref
-        : undefined;
+    const pagesAsForLink = hasPagesHrefAsPair ? pagesNavigateHref : undefined;
     const pagesHrefForLink = pagesAsForLink === undefined ? pagesNavigateHref : routeHrefRaw;
     // Resolve relative hrefs (#hash, ?query) for onNavigate and the navigation fallback.
     // Pages query-only links must use the rewrite-aware target resolved above,

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -3021,10 +3021,9 @@ async function performNavigation(
   //
   // Match-source priority: `as` first (extracts param values from the
   // resolved display URL), query second (object-form callers passing
-  // `{pathname, query}`). When neither yields all required params, fall back
-  // to the display URL — the user's typical intent for a literal bracket
-  // pathname is "navigate to the address as written", and `resolved` is the
-  // best concrete URL we have.
+  // `{pathname, query}`). An explicit dynamic href with unresolved required
+  // params throws Next.js's canonical interpolation error. UrlObjects that
+  // merely inherit the current pathname keep their existing display fallback.
   let interpolatedRoute = resolvedRoute;
   if (resolvedRoute.includes("[")) {
     const projection = interpolateDynamicRouteHref(
@@ -3059,9 +3058,36 @@ async function performNavigation(
         );
       }
     } else {
-      // Required params missing — `resolved` (display URL) is the best
-      // concrete URL we can use. Matches the pre-mask behaviour and avoids
-      // serving a 404 from the data endpoint.
+      const missingParams = projection
+        ? routePatternParts(projection.routePathname)
+            .filter((part) => part.startsWith(":") && !part.endsWith("*"))
+            .map((part) => part.slice(1, part.endsWith("+") ? -1 : undefined))
+            .filter((paramName) => {
+              const value = projection.query[paramName];
+              return (
+                value === undefined || value === "" || (Array.isArray(value) && value.length === 0)
+              );
+            })
+        : [];
+      const hasExplicitHrefPathname = typeof url === "string" || url.pathname !== undefined;
+      const isMiddlewareMatch =
+        options?.shallow !== true && getPagesMiddlewareDataHref(resolved, __basePath) !== null;
+      if (missingParams.length > 0 && hasExplicitHrefPathname && !isMiddlewareMatch) {
+        const asPathname = stripHash(resolved).split("?", 1)[0];
+        const routePathname =
+          projection?.routePathname ?? stripHash(resolvedRoute).split("?", 1)[0];
+        const shouldInterpolate = asPathname === routePathname;
+        throw new HrefInterpolationError(
+          shouldInterpolate
+            ? `The provided \`href\` (${resolvedRoute}) value is missing query values (${missingParams.join(
+                ", ",
+              )}) to be interpolated properly. Read more: https://nextjs.org/docs/messages/href-interpolation-failed`
+            : `The provided \`as\` value (${asPathname}) is incompatible with the \`href\` value (${routePathname}). Read more: https://nextjs.org/docs/messages/incompatible-href-as`,
+        );
+      }
+
+      // If the bracket syntax was not a recognized dynamic route pattern,
+      // keep the display URL as the safest navigation fallback.
       interpolatedRoute = resolved;
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1575,6 +1575,8 @@ importers:
         specifier: 'catalog:'
         version: 0.2.2(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-istanbul@4.1.9(vitest@4.1.9))(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(esbuild@0.27.3)(jiti@2.7.0)(msw@2.14.6(@types/node@25.9.2)(typescript@7.0.2))(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0)
 
+  tests/fixtures/middleware-matcher-auth: {}
+
   tests/fixtures/og-font-package: {}
 
   tests/fixtures/pages-app-props: {}

--- a/tests/e2e/pages-router/link-advanced.spec.ts
+++ b/tests/e2e/pages-router/link-advanced.spec.ts
@@ -312,6 +312,27 @@ test.describe("Link onNavigate prop (Pages Router, OnNavigate fixture)", () => {
 });
 
 test.describe("Link href/as bracket-pattern interpolation (Pages Router)", () => {
+  // Ported from Next.js: test/e2e/dynamic-routing/pages/index.js
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/dynamic-routing/pages/index.js
+  test("object href query values fill dynamic segments", async ({ page }) => {
+    await page.goto(`${BASE}/link-test`);
+    await page.waitForFunction(() => (window as any).__VINEXT_ROOT__);
+
+    const link = page.locator('[data-testid="link-object-dynamic"]');
+    await expect(link).toHaveAttribute("href", "/link-dynamic/a/b/c?q=q");
+
+    await page.evaluate(() => {
+      (window as any).__softNavMarker = true;
+    });
+    await link.scrollIntoViewIfNeeded();
+    await link.click();
+
+    await expect(page.locator("h1")).toHaveText("Dynamic object Link target");
+    await expect(page.locator('[data-testid="dynamic-object-params"]')).toHaveText("a/b/q");
+    expect(page.url()).toBe(`${BASE}/link-dynamic/a/b/c?q=q`);
+    expect(await page.evaluate(() => (window as any).__softNavMarker)).toBe(true);
+  });
+
   // Regression coverage for the dynamic-route `<Link href="/posts/[id]" as="/posts/1">`
   // pattern: when the link mask collapses to a concrete URL, the navigation
   // must target the interpolated `/posts/1`, not the literal `/posts/[id]`

--- a/tests/fixtures/pages-basic/pages/link-dynamic/[a]/[b]/c.tsx
+++ b/tests/fixtures/pages-basic/pages/link-dynamic/[a]/[b]/c.tsx
@@ -1,0 +1,14 @@
+import { useRouter } from "next/router";
+
+export default function DynamicObjectLinkTarget() {
+  const router = useRouter();
+
+  return (
+    <main>
+      <h1>Dynamic object Link target</h1>
+      <p data-testid="dynamic-object-params">
+        {router.query.a}/{router.query.b}/{router.query.q}
+      </p>
+    </main>
+  );
+}

--- a/tests/fixtures/pages-basic/pages/link-test.tsx
+++ b/tests/fixtures/pages-basic/pages/link-test.tsx
@@ -36,6 +36,17 @@ export default function LinkTestPage() {
           As Prop Dynamic Link
         </Link>
 
+        {/* object href with query-backed dynamic segments */}
+        <Link
+          href={{
+            pathname: "/link-dynamic/[a]/[b]/c",
+            query: { a: "a", b: "b", q: "q" },
+          }}
+          data-testid="link-object-dynamic"
+        >
+          Object Dynamic Link
+        </Link>
+
         {/* onClick with preventDefault */}
         <Link
           href="/about"

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -1015,6 +1015,7 @@ describe("Pages Router Link onClick semantics", () => {
     // and avoids the dynamic-import-into-unknown-module timing pitfall.
     const pagesRouterCalls: {
       href: string;
+      as?: string;
       replace: boolean;
       interpolateDynamicRoute?: boolean;
     }[] = [];
@@ -1029,12 +1030,14 @@ describe("Pages Router Link onClick semantics", () => {
         }: {
           navigation: {
             href: string;
+            as?: string;
             replace: boolean;
             interpolateDynamicRoute?: boolean;
           };
         }) => {
           pagesRouterCalls.push({
             href: navigation.href,
+            ...(navigation.as === undefined ? undefined : { as: navigation.as }),
             replace: navigation.replace,
             ...(navigation.interpolateDynamicRoute ? { interpolateDynamicRoute: true } : undefined),
           });
@@ -1079,13 +1082,19 @@ describe("Pages Router Link onClick semantics", () => {
     vi.stubGlobal("window", windowValue);
 
     const { default: IsolatedLink } = await import("../packages/vinext/src/shims/link.js");
+    const { RouterContext } =
+      await import("../packages/vinext/src/shims/internal/router-context.js");
     const React = await vi.importActual<typeof import("react")>("react");
 
     ReactDOMServer.renderToString(
       React.createElement(
-        IsolatedLink,
-        { href: args.href, prefetch: false, ...args.props },
-        "target",
+        RouterContext.Provider,
+        { value: {} as never },
+        React.createElement(
+          IsolatedLink,
+          { href: args.href, prefetch: false, ...args.props },
+          "target",
+        ),
       ),
     );
 
@@ -1184,6 +1193,25 @@ describe("Pages Router Link onClick semantics", () => {
         href: "/rewrite-navigation/0?params=1",
         replace: false,
         interpolateDynamicRoute: true,
+      },
+    ]);
+  });
+
+  // Ported from Next.js: test/e2e/dynamic-routing/pages/index.js
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/dynamic-routing/pages/index.js
+  it("passes the route pattern and interpolated URL when object hrefs fill dynamic segments", async () => {
+    const result = await renderPagesRouterLinkAndClick({
+      href: {
+        pathname: "/[a]/[b]/c",
+        query: { a: "a", b: "b", q: "q" },
+      },
+    });
+
+    expect(result.pagesRouterCalls).toEqual([
+      {
+        href: "/[a]/[b]/c?a=a&b=b&q=q",
+        as: "/a/b/c?q=q",
+        replace: false,
       },
     ]);
   });
@@ -1316,11 +1344,19 @@ async function renderIsolatedLink(options: {
   });
 
   const { default: IsolatedLink } = await import("../packages/vinext/src/shims/link.js");
+  const { RouterContext } = await import("../packages/vinext/src/shims/internal/router-context.js");
   const React = await vi.importActual<typeof import("react")>("react");
 
   try {
+    const link = React.createElement(
+      IsolatedLink,
+      { href: options.href, ...options.props },
+      "target",
+    );
     ReactDOMServer.renderToString(
-      React.createElement(IsolatedLink, { href: options.href, ...options.props }, "target"),
+      options.appNavigation === false
+        ? React.createElement(RouterContext.Provider, { value: {} as never }, link)
+        : link,
     );
 
     if (capturedAnchorProps === undefined) {
@@ -2684,6 +2720,43 @@ describe("Link prefetch scheduling", () => {
       expect(aboutLoader).toHaveBeenCalled();
       expect(result.fetch).not.toHaveBeenCalled();
       expect(result.pagePrefetchLinks).toEqual([]);
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("prefetches implicit dynamic Pages Router links through a concrete route URL", async () => {
+    const observer = stubIntersectionObserver();
+    const dynamicLoader = vi.fn(async () => ({ default: null }));
+    const routePattern = "/link-dynamic/[a]/[b]/c";
+    const result = await renderIsolatedLink({
+      appNavigation: false,
+      href: `${routePattern}?a=a&b=b&q=q`,
+      nodeEnv: "production",
+      windowOverrides: {
+        __NEXT_DATA__: { buildId: "build-id" },
+        __VINEXT_PAGE_LOADERS__: { [routePattern]: dynamicLoader },
+        __VINEXT_PAGE_PATTERNS__: [routePattern],
+        __VINEXT_PAGES_SSG_PATTERNS__: [routePattern],
+        __VINEXT_PAGES_SSP_PATTERNS__: [],
+      },
+    });
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor, true);
+      await waitForFetchCalls(result.fetch, 1);
+
+      expect(dynamicLoader).toHaveBeenCalled();
+      expect(result.fetch).toHaveBeenCalledWith(
+        "/_next/data/build-id/link-dynamic/a/b/c.json?a=a&b=b&q=q",
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Accept: "application/json",
+            purpose: "prefetch",
+            "x-nextjs-data": "1",
+          }),
+        }),
+      );
     } finally {
       result.restoreNodeEnv();
     }

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -21,6 +21,7 @@ import Link, {
   resolveLinkPrefetchMode,
   useLinkStatus,
 } from "../packages/vinext/src/shims/link.js";
+import { RouterContext } from "../packages/vinext/src/shims/internal/router-context.js";
 import {
   navigatePagesRouterLink,
   navigatePagesRouterLinkWithFallback,
@@ -401,6 +402,79 @@ describe("Link resolveHref", () => {
     );
     // URLSearchParams preserves insertion order
     expect(html).toMatch(/href="\/items\?page=2&(?:amp;)?sort=name"/);
+  });
+
+  // Ported from Next.js: test/e2e/dynamic-routing/pages/index.js
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/dynamic-routing/pages/index.js
+  it("interpolates dynamic segments from object href query values", () => {
+    const html = ReactDOMServer.renderToString(
+      React.createElement(
+        RouterContext.Provider,
+        { value: {} as never },
+        React.createElement(
+          Link,
+          {
+            href: {
+              pathname: "/[a]/[b]/c",
+              query: { a: "a", b: "b", q: "q" },
+            },
+          },
+          "hello",
+        ),
+      ),
+    );
+
+    expect(html).toContain('href="/a/b/c?q=q"');
+  });
+
+  it("does not interpolate dynamic object hrefs outside the Pages Router context", () => {
+    const html = ReactDOMServer.renderToString(
+      React.createElement(Link, { href: { pathname: "/posts/[id]", query: { id: "42" } } }, "post"),
+    );
+
+    expect(html).toContain('href="/posts/[id]?id=42"');
+  });
+
+  it("does not interpolate dynamic-looking external hrefs in the Pages Router", () => {
+    const html = ReactDOMServer.renderToString(
+      React.createElement(
+        RouterContext.Provider,
+        { value: {} as never },
+        React.createElement(Link, { href: "https://example.com/[id]?id=42" }, "external"),
+      ),
+    );
+
+    expect(html).toContain('href="https://example.com/[id]?id=42"');
+  });
+
+  it("interpolates same-origin absolute dynamic hrefs in the Pages Router", () => {
+    const previousWindow = (globalThis as any).window;
+    (globalThis as any).window = {
+      addEventListener() {},
+      location: {
+        hash: "",
+        href: "https://local.test/current",
+        hostname: "local.test",
+        origin: "https://local.test",
+        pathname: "/current",
+        search: "",
+      },
+    };
+
+    try {
+      const html = ReactDOMServer.renderToString(
+        React.createElement(
+          RouterContext.Provider,
+          { value: {} as never },
+          React.createElement(Link, { href: "https://local.test/posts/[id]?id=42" }, "post"),
+        ),
+      );
+
+      expect(html).toContain('href="/posts/42"');
+    } finally {
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+    }
   });
 
   it("object href preserves array query values as repeated params", () => {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -55,6 +55,35 @@ describe("vinext next data client helpers", () => {
 });
 
 describe("dynamic route href interpolation", () => {
+  // Ported from Next.js: test/e2e/dynamic-routing/pages/index.js
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/dynamic-routing/pages/index.js
+  it("resolves a Pages Router href/as pair and omits consumed params from as", async () => {
+    const { resolveDynamicRouteHref } =
+      await import("../packages/vinext/src/shims/internal/interpolate-as.js");
+
+    expect(resolveDynamicRouteHref("/[a]/[b]/c?a=a&b=b&q=q#section")).toEqual({
+      href: "/[a]/[b]/c?a=a&b=b&q=q#section",
+      as: "/a/b/c?q=q#section",
+    });
+  });
+
+  it("resolves repeated query values into catch-all segments", async () => {
+    const { resolveDynamicRouteHref } =
+      await import("../packages/vinext/src/shims/internal/interpolate-as.js");
+
+    expect(resolveDynamicRouteHref("/docs/[...slug]?slug=one&slug=two&preview=1")).toEqual({
+      href: "/docs/[...slug]?slug=one&slug=two&preview=1",
+      as: "/docs/one/two?preview=1",
+    });
+  });
+
+  it("does not treat brackets in a query value as a dynamic route", async () => {
+    const { resolveDynamicRouteHref } =
+      await import("../packages/vinext/src/shims/internal/interpolate-as.js");
+
+    expect(resolveDynamicRouteHref("/search?q=[literal]")).toBeNull();
+  });
+
   it("preserves query and hash suffixes while interpolating", async () => {
     const { interpolateDynamicRouteHref } =
       await import("../packages/vinext/src/shims/internal/interpolate-as.js");
@@ -16449,6 +16478,53 @@ describe("Pages Router concurrent navigation", () => {
     }
   });
 
+  // Ported from Next.js: test/e2e/dynamic-routing/dynamic-routing.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/dynamic-routing/dynamic-routing.test.ts
+  it("throws href-interpolation-failed when a full dynamic href omits a required param", async () => {
+    const previousWindow = (globalThis as any).window;
+    const { win } = createNavWindow();
+    (globalThis as any).window = win;
+
+    try {
+      vi.resetModules();
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+
+      await expect(
+        Router.push({
+          pathname: "/catalog/[category]/[item]",
+          query: { category: "music" },
+        }),
+      ).rejects.toThrow(
+        "The provided `href` (/catalog/[category]/[item]?category=music) value is missing query values (item) to be interpolated properly. Read more: https://nextjs.org/docs/messages/href-interpolation-failed",
+      );
+      expect(win.history.pushState).not.toHaveBeenCalled();
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+    }
+  });
+
+  it("throws incompatible-href-as when an explicit as does not match a dynamic href", async () => {
+    const previousWindow = (globalThis as any).window;
+    const { win } = createNavWindow();
+    (globalThis as any).window = win;
+
+    try {
+      vi.resetModules();
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+
+      await expect(Router.push("/catalog/[id]", "/wrong")).rejects.toThrow(
+        "The provided `as` value (/wrong) is incompatible with the `href` value (/catalog/[id]). Read more: https://nextjs.org/docs/messages/incompatible-href-as",
+      );
+      expect(win.history.pushState).not.toHaveBeenCalled();
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+    }
+  });
+
   it("allows an omitted optional catch-all during same-segment interpolation", async () => {
     const previousWindow = (globalThis as any).window;
     const { win } = createNavWindow();
@@ -19526,6 +19602,46 @@ describe("Pages Router _next/data client navigation", () => {
   function makePageModule(name: string): { default: unknown } {
     return { default: ((): string => `page:${name}`) as unknown };
   }
+
+  it("allows middleware to resolve an incomplete explicit dynamic href", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const routePattern = "/catalog/[category]/[item]";
+    const { win } = createDataNavWindow({
+      loaders: {
+        "/": vi.fn(async () => makePageModule("home")),
+        [routePattern]: vi.fn(async () => makePageModule("catalog")),
+      },
+      sspPatterns: [routePattern],
+    });
+    (win.__NEXT_DATA__ as any).__vinext = { hasMiddleware: true };
+    (win as any).__VINEXT_MIDDLEWARE_MATCHER__ = ["/:path*"];
+    (globalThis as any).window = win;
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ pageProps: { resolvedByMiddleware: true } }), {
+          headers: { "Content-Type": "application/json" },
+        }),
+    ) as typeof fetch;
+
+    try {
+      vi.resetModules();
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+
+      await expect(
+        Router.push({
+          pathname: routePattern,
+          query: { category: "music" },
+        }),
+      ).resolves.toBe(true);
+      expect(globalThis.fetch).toHaveBeenCalled();
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+    }
+  });
 
   it("fetches /_next/data/<buildId>/<page>.json instead of the HTML page", async () => {
     const previousWindow = (globalThis as any).window;


### PR DESCRIPTION
Closes #2656

## Summary

- interpolate Pages Router dynamic segments from object/string href query values and omit consumed params from the displayed URL
- retain the Next.js `(href, as)` router contract while prefetching through a concrete route URL
- preserve App Router and external-URL behavior, including same-origin absolute URL parity
- align missing-param, incompatible-`as`, and middleware-handled navigation behavior with Next.js

## Validation

- `vp check` on all touched source, fixture, and test files
- `vp test run tests/link.test.ts tests/shims.test.ts tests/link-navigation.test.ts` (1,449 passed)
- `PLAYWRIGHT_PROJECT=pages-router pnpm exec playwright test tests/e2e/pages-router/link-advanced.spec.ts --grep "object href query values fill dynamic segments" --retries=0`
- `vp run vinext#build`