### PR TITLE
fix: sync middleware matcher fixture lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1575,6 +1575,8 @@ importers:
         specifier: 'catalog:'
         version: 0.2.2(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-istanbul@4.1.9(vitest@4.1.9))(@voidzero-dev/vite-plus-core@0.2.2(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(esbuild@0.27.3)(jiti@2.7.0)(msw@2.14.6(@types/node@25.9.2)(typescript@7.0.2))(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0)
 
+  tests/fixtures/middleware-matcher-auth: {}
+
   tests/fixtures/og-font-package: {}
 
   tests/fixtures/pages-app-props: {}


### PR DESCRIPTION
## Summary

- add the missing `tests/fixtures/middleware-matcher-auth` workspace importer to `pnpm-lock.yaml`
- keep `vp install` from dirtying a clean checkout of `main`
- unblock Big Bonk before it switches to PR branches, including #2657

## Validation

- ran `vp install` from clean `origin/main` and confirmed this was the only generated diff
- ran `vp install` a second time and confirmed the lockfile stayed byte-identical
- ran `vp run check`
- ran `git diff --check`
- two independent reviews: no findings