### PR TITLE
fix(server): stop reporting client-aborted renders through onRequestError

### DIFF
--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -584,19 +584,18 @@ function wrapRscResponseForDevErrorReporting(
     }
   };
 
-  const cleanup = new TransformStream<Uint8Array, Uint8Array>({
-    flush() {
-      onConsumed();
-    },
-  });
-
-  const piped = originalBody.pipeThrough(cleanup);
-  const reader = piped.getReader();
+  // A manual passthrough instead of pipeThrough(new TransformStream(...)):
+  // the transform's only job was firing `onConsumed` on clean drain, which
+  // the `done` branch below covers. It also avoids the internal pipeTo
+  // promise, which rejects unhandled when the consumer cancels the stream
+  // with a reason.
+  const reader = originalBody.getReader();
   const wrappedStream = new ReadableStream<Uint8Array>({
     pull(controller) {
       return reader.read().then(
         ({ done, value }) => {
           if (done) {
+            onConsumed();
             controller.close();
           } else {
             controller.enqueue(value);

--- a/packages/vinext/src/server/app-page-response.ts
+++ b/packages/vinext/src/server/app-page-response.ts
@@ -331,6 +331,7 @@ export function buildAppPageHtmlResponse(
   body: ReadableStream,
   options: BuildAppPageHtmlResponseOptions,
 ): Response {
+  body = tagConsumerCancellation(body);
   const headers = new Headers({
     "Content-Type": "text/html; charset=utf-8",
     Vary: VINEXT_RSC_VARY_HEADER,

--- a/packages/vinext/src/server/app-page-response.ts
+++ b/packages/vinext/src/server/app-page-response.ts
@@ -12,6 +12,7 @@ import {
   VINEXT_TIMING_HEADER,
 } from "./headers.js";
 import { setCacheStateHeaders } from "./cache-headers.js";
+import { tagConsumerCancellation } from "./response-aborted.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
 import {
   VINEXT_RSC_CONTENT_TYPE,
@@ -284,6 +285,7 @@ export function buildAppPageRscResponse(
   body: ReadableStream,
   options: BuildAppPageRscResponseOptions,
 ): Response {
+  body = tagConsumerCancellation(body);
   const headers = new Headers({
     "Content-Type": VINEXT_RSC_CONTENT_TYPE,
     Vary: VINEXT_RSC_VARY_HEADER,

--- a/packages/vinext/src/server/app-rsc-errors.ts
+++ b/packages/vinext/src/server/app-rsc-errors.ts
@@ -1,5 +1,6 @@
 import { resolveAppPageSpecialError } from "./app-page-execution.js";
 import { isNavigationSignalError } from "../utils/navigation-signal.js";
+import { isResponseAbortedError } from "./response-aborted.js";
 
 type DigestError = Error & { digest?: string };
 const ORIGINAL_SERVER_ERROR = Symbol.for("vinext.originalServerError");
@@ -119,6 +120,15 @@ export function createRscOnErrorHandler(
     const wellKnownDigest = getDigestForWellKnownError(error);
     if (wellKnownDigest !== undefined) {
       return wellKnownDigest;
+    }
+
+    // Renders aborted because the response consumer went away (client
+    // disconnect / aborted navigation) are expected control flow, not request
+    // errors. The response boundary tags that cancellation (see
+    // response-aborted.ts); skip reporting, matching Next.js's isAbortError
+    // handling. The digest is moot since no client is listening anymore.
+    if (isResponseAbortedError(error)) {
+      return errorDigest(getThrownValueMessage(error));
     }
 
     if (

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -41,6 +41,7 @@ import { applyEdgeRuntimeHeader } from "./app-page-response.js";
 import { resolveAppPageActionRerenderTarget } from "./app-page-request.js";
 import { resolveAppPageNavigationParams } from "./app-page-element-builder.js";
 import { deferUntilStreamConsumed } from "./app-page-stream.js";
+import { tagConsumerCancellation } from "./response-aborted.js";
 import { buildAppPageTags } from "./implicit-tags.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
 import { getSetCookieName } from "./cookie-utils.js";
@@ -489,7 +490,10 @@ function createServerActionRscResponse(
     return new Response(body, init);
   }
 
-  return new Response(deferUntilStreamConsumed(body, clearRequestContext), init);
+  return new Response(
+    tagConsumerCancellation(deferUntilStreamConsumed(body, clearRequestContext)),
+    init,
+  );
 }
 
 function isRequestBodyTooLarge(error: unknown): boolean {

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -738,7 +738,10 @@ export async function handleSsr(
               options?.scriptNonce,
             ),
           ),
-          cleanup,
+          () => {
+            rscEmbed.abort?.();
+            cleanup();
+          },
         );
 
         return {

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -53,6 +53,8 @@ import { AppRouterContext } from "vinext/shims/internal/app-router-context";
 import { createClientReferencePreloader } from "./app-client-reference-preloader.js";
 import { RSC_FORM_STATE_GLOBAL } from "./app-browser-hydration.js";
 import { isPprFallbackShellAbortError } from "vinext/shims/ppr-fallback-shell";
+import { isResponseAbortedError } from "./response-aborted.js";
+import { pumpThrough } from "./stream-pump.js";
 import DefaultGlobalError from "vinext/shims/default-global-error";
 import { appendAssetDeploymentIdQuery } from "../utils/deployment-id.js";
 import { ssrAppRouterInstance } from "./app-ssr-router-instance.js";
@@ -598,6 +600,13 @@ export async function handleSsr(
               return undefined;
             }
 
+            // Consumer cancellation tagged at the response boundary (client
+            // disconnect): not a real render failure, keep it out of the
+            // error meta stream.
+            if (isResponseAbortedError(error)) {
+              return undefined;
+            }
+
             errorMetaRenderer.capture(error);
 
             if (error && typeof error === "object" && "digest" in error) {
@@ -717,7 +726,8 @@ export async function handleSsr(
         }
 
         const finalStream = deferUntilStreamConsumed(
-          htmlStream.pipeThrough(
+          pumpThrough(
+            htmlStream,
             createTickBufferedTransform(
               rscEmbed,
               getInsertedHTML,

--- a/packages/vinext/src/server/app-ssr-stream.ts
+++ b/packages/vinext/src/server/app-ssr-stream.ts
@@ -15,6 +15,12 @@ import { NAVIGATION_RUNTIME_SYMBOL_DESCRIPTION } from "../client/navigation-runt
 type RscEmbedTransform = {
   flush(): string;
   finalize(): Promise<string>;
+  /**
+   * Stop reading the embed stream so pending finalize()/getRawBuffer()
+   * callers settle. Used when the response consumer goes away while the
+   * auxiliary Flight stream is still suspended; a no-op after natural end.
+   */
+  abort?(reason?: unknown): void;
   /** Resolves when all raw bytes from the embed stream have been read. */
   getRawBuffer(): Promise<ArrayBuffer>;
 };
@@ -131,6 +137,10 @@ export function createRscEmbedTransform(
   const pumpPromise = pumpReader();
 
   return {
+    abort(reason?: unknown): void {
+      void reader.cancel(reason).catch(() => {});
+    },
+
     flush(): string {
       if (pendingChunks.length === 0) return "";
 
@@ -621,14 +631,20 @@ export function createTickBufferedTransform(
       }
 
       const finalScripts = await rscEmbed.finalize();
-      if (finalScripts) {
-        controller.enqueue(encoder.encode(finalScripts));
-      }
+      try {
+        if (finalScripts) {
+          controller.enqueue(encoder.encode(finalScripts));
+        }
 
-      // Emit `</body></html>` last so the document always terminates with a
-      // well-formed close, after any trailing flight chunks / preinit scripts.
-      // Mirrors Next.js's `createMoveSuffixStream` behaviour (#1532).
-      controller.enqueue(encoder.encode(DOCUMENT_CLOSE_SUFFIX));
+        // Emit `</body></html>` last so the document always terminates with
+        // a well-formed close, after any trailing flight chunks / preinit
+        // scripts. Mirrors Next.js's `createMoveSuffixStream` behaviour
+        // (#1532).
+        controller.enqueue(encoder.encode(DOCUMENT_CLOSE_SUFFIX));
+      } catch {
+        // The readable side was cancelled while finalize() was pending
+        // (consumer went away mid-flush); nobody is reading anymore.
+      }
     },
   });
 }

--- a/packages/vinext/src/server/defer-until-stream-consumed.ts
+++ b/packages/vinext/src/server/defer-until-stream-consumed.ts
@@ -13,18 +13,18 @@ export function deferUntilStreamConsumed(
     }
   };
 
-  const cleanup = new TransformStream<Uint8Array, Uint8Array>({
-    flush() {
-      once();
-    },
-  });
-
-  const reader = stream.pipeThrough(cleanup).getReader();
+  // A manual passthrough instead of pipeThrough(new TransformStream(...)):
+  // the transform's only job was firing `onFlush` on clean drain, which the
+  // `done` branch below covers. It also avoids the internal pipeTo promise,
+  // which rejects unhandled when the consumer cancels the stream with a
+  // reason.
+  const reader = stream.getReader();
   return new ReadableStream<Uint8Array>({
     pull(controller) {
       return reader.read().then(
         ({ done, value }) => {
           if (done) {
+            once();
             controller.close();
           } else {
             controller.enqueue(value);

--- a/packages/vinext/src/server/response-aborted.ts
+++ b/packages/vinext/src/server/response-aborted.ts
@@ -44,6 +44,13 @@ function isDomAbortError(reason: unknown): boolean {
   );
 }
 
+function isPrematureCloseError(reason: unknown): boolean {
+  return (
+    reason instanceof Error &&
+    (reason as Partial<Record<"code", unknown>>).code === "ERR_STREAM_PREMATURE_CLOSE"
+  );
+}
+
 /**
  * Wrap a render stream that is about to become a Response body so that a
  * consumer cancellation with no reason reaches the underlying render as a
@@ -80,6 +87,12 @@ export function tagConsumerCancellation(
         // Runtimes that propagate a standard aborted signal cancel with a
         // DOMException named AbortError; that is still a consumer abort.
         if (isDomAbortError(reason)) {
+          return reader.cancel(new ResponseAbortedError(reason));
+        }
+        // Node's Readable.fromWeb pipeline cancels with an ordinary Error
+        // whose code is ERR_STREAM_PREMATURE_CLOSE when the client
+        // disconnects from a Node HTTP server.
+        if (isPrematureCloseError(reason)) {
           return reader.cancel(new ResponseAbortedError(reason));
         }
         return reader.cancel(reason);

--- a/packages/vinext/src/server/response-aborted.ts
+++ b/packages/vinext/src/server/response-aborted.ts
@@ -1,4 +1,5 @@
 const RESPONSE_ABORTED_NAME = "ResponseAborted";
+const RESPONSE_ABORTED_BRAND = Symbol.for("vinext.responseAborted");
 
 /**
  * Cancellation reason used when the response consumer goes away (client
@@ -16,14 +17,31 @@ const RESPONSE_ABORTED_NAME = "ResponseAborted";
  * exactly this class of error.
  */
 export class ResponseAbortedError extends Error {
-  constructor() {
-    super("The client closed the connection before the render completed.");
+  readonly [RESPONSE_ABORTED_BRAND] = true;
+
+  constructor(cause?: unknown) {
+    super(
+      "The client closed the connection before the render completed.",
+      ...(cause !== undefined ? [{ cause }] : []),
+    );
     this.name = RESPONSE_ABORTED_NAME;
   }
 }
 
 export function isResponseAbortedError(error: unknown): boolean {
-  return error instanceof Error && error.name === RESPONSE_ABORTED_NAME;
+  return (
+    error instanceof Error &&
+    (error as Partial<Record<typeof RESPONSE_ABORTED_BRAND, unknown>>)[RESPONSE_ABORTED_BRAND] ===
+      true
+  );
+}
+
+function isDomAbortError(reason: unknown): boolean {
+  return (
+    typeof DOMException !== "undefined" &&
+    reason instanceof DOMException &&
+    reason.name === "AbortError"
+  );
 }
 
 /**
@@ -56,7 +74,15 @@ export function tagConsumerCancellation(
       },
       cancel(reason) {
         cancelled = true;
-        return reader.cancel(reason ?? new ResponseAbortedError());
+        if (reason == null) {
+          return reader.cancel(new ResponseAbortedError());
+        }
+        // Runtimes that propagate a standard aborted signal cancel with a
+        // DOMException named AbortError; that is still a consumer abort.
+        if (isDomAbortError(reason)) {
+          return reader.cancel(new ResponseAbortedError(reason));
+        }
+        return reader.cancel(reason);
       },
     },
     { highWaterMark: 0 },

--- a/packages/vinext/src/server/response-aborted.ts
+++ b/packages/vinext/src/server/response-aborted.ts
@@ -1,0 +1,64 @@
+const RESPONSE_ABORTED_NAME = "ResponseAborted";
+
+/**
+ * Cancellation reason used when the response consumer goes away (client
+ * disconnect, aborted navigation). Spec-compliant server runtimes cancel the
+ * response body stream in that situation, usually with no reason; React then
+ * aborts the in-flight render with "The render was aborted by the server
+ * without a reason." and every aborted task reaches the render `onError`,
+ * where it would be reported through `onRequestError` as if it were a real
+ * failure.
+ *
+ * Tagging the cancellation at the response boundary lets the error handlers
+ * classify these aborts as expected control flow instead. Mirrors Next.js's
+ * `ResponseAborted` (`server/web/spec-extension/adapters/next-request.ts`) and
+ * its `isAbortError` handling in `server/pipe-readable.ts`, which swallows
+ * exactly this class of error.
+ */
+export class ResponseAbortedError extends Error {
+  constructor() {
+    super("The client closed the connection before the render completed.");
+    this.name = RESPONSE_ABORTED_NAME;
+  }
+}
+
+export function isResponseAbortedError(error: unknown): boolean {
+  return error instanceof Error && error.name === RESPONSE_ABORTED_NAME;
+}
+
+/**
+ * Wrap a render stream that is about to become a Response body so that a
+ * consumer cancellation with no reason reaches the underlying render as a
+ * tagged {@link ResponseAbortedError} instead of an anonymous abort.
+ */
+export function tagConsumerCancellation(
+  stream: ReadableStream<Uint8Array>,
+): ReadableStream<Uint8Array> {
+  const reader = stream.getReader();
+  let cancelled = false;
+  return new ReadableStream<Uint8Array>(
+    {
+      pull(controller) {
+        return reader.read().then(
+          ({ done, value }) => {
+            if (cancelled) return;
+            if (done) {
+              controller.close();
+            } else {
+              controller.enqueue(value);
+            }
+          },
+          (error) => {
+            if (cancelled) return;
+            controller.error(error);
+          },
+        );
+      },
+      cancel(reason) {
+        cancelled = true;
+        return reader.cancel(reason ?? new ResponseAbortedError());
+      },
+    },
+    { highWaterMark: 0 },
+  );
+}

--- a/packages/vinext/src/server/rsc-stream-hints.ts
+++ b/packages/vinext/src/server/rsc-stream-hints.ts
@@ -1,3 +1,4 @@
+import { pumpThrough } from "./stream-pump.js";
 const REACT_FLIGHT_STYLESHEET_PRELOAD_HINT = /^([0-9a-f]*:HL\[.*?),"stylesheet"(\]|,)/;
 const STYLESHEET_TO_STYLE_JSON_PADDING = " ".repeat("stylesheet".length - "style".length);
 
@@ -112,8 +113,7 @@ export function normalizeReactFlightPreloadHints(
   let rawBytesRemaining = 0;
   let passThrough = false;
 
-  return stream.pipeThrough(
-    new TransformStream<Uint8Array, Uint8Array>({
+  return pumpThrough(stream, new TransformStream<Uint8Array, Uint8Array>({
       transform(chunk, controller) {
         if (passThrough) {
           controller.enqueue(chunk);

--- a/packages/vinext/src/server/stream-pump.ts
+++ b/packages/vinext/src/server/stream-pump.ts
@@ -15,6 +15,13 @@ export function pumpThrough<I, O>(
   const writer = transform.writable.getWriter();
   const reader = stream.getReader();
 
+  // Cancelling the transform's readable errors its writable. Without this
+  // watcher the pump would only notice on the next chunk, keeping a stalled
+  // render's resources alive after the consumer went away.
+  void writer.closed.catch((reason: unknown) => {
+    void reader.cancel(reason).catch(() => {});
+  });
+
   void (async () => {
     try {
       for (;;) {

--- a/packages/vinext/src/server/stream-pump.ts
+++ b/packages/vinext/src/server/stream-pump.ts
@@ -1,0 +1,34 @@
+/**
+ * `stream.pipeThrough(transform)` equivalent whose pump owns every promise.
+ *
+ * The internal pipeTo loop of `pipeThrough` can leave an in-flight
+ * `writer.write` rejection unhandled when the consumer cancels the readable
+ * side between chunks (observable as an unhandled rejection carrying the
+ * cancel reason). This pump awaits or settles every read/write explicitly, and
+ * on failure propagates the reason both ways (cancel upstream, abort the
+ * transform), so cancellation reasons reach the source untouched.
+ */
+export function pumpThrough<I, O>(
+  stream: ReadableStream<I>,
+  transform: TransformStream<I, O>,
+): ReadableStream<O> {
+  const writer = transform.writable.getWriter();
+  const reader = stream.getReader();
+
+  void (async () => {
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) {
+          await writer.close();
+          return;
+        }
+        await writer.write(value);
+      }
+    } catch (error) {
+      await Promise.allSettled([reader.cancel(error), writer.abort(error)]);
+    }
+  })();
+
+  return transform.readable;
+}

--- a/tests/app-router-production-server.test.ts
+++ b/tests/app-router-production-server.test.ts
@@ -1468,9 +1468,7 @@ describe("App Router Production server (startProdServer)", () => {
     // Spec-compliant runtimes (Nitro/h3, Workers, Deno) cancel the response
     // body stream when the client disconnects mid-stream. Node's fromWeb +
     // pipeline path in prod-server does not, so exercise the entry directly.
-    const entryModule = await import(
-      pathToFileURL(path.join(outDir, "server", "index.js")).href
-    );
+    const entryModule = await import(pathToFileURL(path.join(outDir, "server", "index.js")).href);
     const entryHandler =
       typeof entryModule.default === "function"
         ? entryModule.default
@@ -1498,9 +1496,35 @@ describe("App Router Production server (startProdServer)", () => {
     expect(stateRes.status).toBe(200);
     const state = await stateRes.json();
 
-    expect(
-      state.errors.map((error: { message: string }) => error.message),
-    ).toEqual([]);
+    expect(state.errors.map((error: { message: string }) => error.message)).toEqual([]);
+  });
+
+  it("does not report client-aborted document renders via instrumentation", async () => {
+    const resetRes = await fetch(`${baseUrl}/api/instrumentation-test`, {
+      method: "DELETE",
+    });
+    expect(resetRes.status).toBe(200);
+
+    const entryModule = await import(pathToFileURL(path.join(outDir, "server", "index.js")).href);
+    const entryHandler =
+      typeof entryModule.default === "function"
+        ? entryModule.default
+        : entryModule.default.fetch.bind(entryModule.default);
+    const response: Response = await entryHandler(new Request(`${baseUrl}/slow-stream-abort-test`));
+    expect(response.status).toBe(200);
+    const reader = response.body!.getReader();
+    const shellChunk = await reader.read();
+    expect(shellChunk.done).toBe(false);
+    await reader.cancel();
+
+    // Give the suspended section time to settle server-side after the abort.
+    await new Promise((resolve) => setTimeout(resolve, 2500));
+
+    const stateRes = await fetch(`${baseUrl}/api/instrumentation-test`);
+    expect(stateRes.status).toBe(200);
+    const state = await stateRes.json();
+
+    expect(state.errors.map((error: { message: string }) => error.message)).toEqual([]);
   });
 
   it("reports server component render errors via instrumentation in production", async () => {

--- a/tests/app-router-production-server.test.ts
+++ b/tests/app-router-production-server.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import http from "node:http";
 import os from "node:os";
+import { pathToFileURL } from "node:url";
 import path from "node:path";
 import { createBuilder } from "vite";
 import { afterAll, beforeAll, describe, expect, it } from "vite-plus/test";
@@ -1456,6 +1457,50 @@ describe("App Router Production server (startProdServer)", () => {
     const html = await response.text();
     expect(html).toContain("<title>Slot-local not-found metadata</title>");
     expect(html).not.toContain("<title>Primary not-found metadata</title>");
+  });
+
+  it("does not report client-aborted renders via instrumentation", async () => {
+    const resetRes = await fetch(`${baseUrl}/api/instrumentation-test`, {
+      method: "DELETE",
+    });
+    expect(resetRes.status).toBe(200);
+
+    // Spec-compliant runtimes (Nitro/h3, Workers, Deno) cancel the response
+    // body stream when the client disconnects mid-stream. Node's fromWeb +
+    // pipeline path in prod-server does not, so exercise the entry directly.
+    const entryModule = await import(
+      pathToFileURL(path.join(outDir, "server", "index.js")).href
+    );
+    const entryHandler =
+      typeof entryModule.default === "function"
+        ? entryModule.default
+        : entryModule.default.fetch.bind(entryModule.default);
+    const rscHeaders = { Accept: "text/x-component", RSC: "1" };
+    let response: Response = await entryHandler(
+      new Request(`${baseUrl}/slow-stream-abort-test`, { headers: rscHeaders }),
+    );
+    if (response.status === 307) {
+      const location = response.headers.get("location")!;
+      response = await entryHandler(
+        new Request(new URL(location, baseUrl), { headers: rscHeaders }),
+      );
+    }
+    expect(response.status).toBe(200);
+    const reader = response.body!.getReader();
+    const shellChunk = await reader.read();
+    expect(shellChunk.done).toBe(false);
+    await reader.cancel();
+
+    // Give the suspended section time to settle server-side after the abort.
+    await new Promise((resolve) => setTimeout(resolve, 2500));
+
+    const stateRes = await fetch(`${baseUrl}/api/instrumentation-test`);
+    expect(stateRes.status).toBe(200);
+    const state = await stateRes.json();
+
+    expect(
+      state.errors.map((error: { message: string }) => error.message),
+    ).toEqual([]);
   });
 
   it("reports server component render errors via instrumentation in production", async () => {

--- a/tests/app-rsc-errors.test.ts
+++ b/tests/app-rsc-errors.test.ts
@@ -10,6 +10,7 @@ import {
   ResponseAbortedError,
   tagConsumerCancellation,
 } from "../packages/vinext/src/server/response-aborted.js";
+import { pumpThrough } from "../packages/vinext/src/server/stream-pump.js";
 
 type DigestCarrier = Error & { digest: unknown };
 
@@ -86,6 +87,58 @@ describe("app RSC error primitives", () => {
     await tagConsumerCancellation(inner).cancel();
 
     expect(isResponseAbortedError(cancelReason)).toBe(true);
+  });
+
+  it("still reports errors that merely share the ResponseAborted name", () => {
+    const reportRequestError = vi.fn();
+    const onError = createRscOnErrorHandler({
+      errorContext: { routerKind: "App Router", routePath: "/fake", routeType: "render" },
+      nodeEnv: "production",
+      reportRequestError,
+      requestInfo: { path: "/fake", method: "GET", headers: {} },
+    });
+
+    const impostor = new Error("looks aborted but is a real failure");
+    impostor.name = "ResponseAborted";
+    onError(impostor);
+
+    expect(reportRequestError).toHaveBeenCalledOnce();
+  });
+
+  it("tags consumer cancellation carrying a standard AbortError reason", async () => {
+    let cancelReason: unknown = "unset";
+    const inner = new ReadableStream<Uint8Array>({
+      cancel(reason) {
+        cancelReason = reason;
+      },
+    });
+
+    const abortReason = new DOMException("The operation was aborted.", "AbortError");
+    await tagConsumerCancellation(inner).cancel(abortReason);
+
+    expect(isResponseAbortedError(cancelReason)).toBe(true);
+    expect((cancelReason as Error).cause).toBe(abortReason);
+  });
+
+  it("cancels the pump source promptly when the readable side is cancelled mid-wait", async () => {
+    let sourceCancelled: unknown = null;
+    const neverEndingSource = new ReadableStream<Uint8Array>({
+      pull() {
+        return new Promise(() => {});
+      },
+      cancel(reason) {
+        sourceCancelled = reason;
+      },
+    });
+
+    const piped = pumpThrough(neverEndingSource, new TransformStream<Uint8Array, Uint8Array>());
+    const reader = piped.getReader();
+    const pending = reader.read();
+    await reader.cancel(new Error("consumer went away"));
+    await pending.catch(() => {});
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(sourceCancelled).toBeInstanceOf(Error);
   });
 
   it("forwards an explicit cancellation reason unchanged", async () => {

--- a/tests/app-rsc-errors.test.ts
+++ b/tests/app-rsc-errors.test.ts
@@ -141,6 +141,23 @@ describe("app RSC error primitives", () => {
     expect(sourceCancelled).toBeInstanceOf(Error);
   });
 
+  it("tags consumer cancellation carrying a premature-close error", async () => {
+    let cancelReason: unknown = "unset";
+    const inner = new ReadableStream<Uint8Array>({
+      cancel(reason) {
+        cancelReason = reason;
+      },
+    });
+
+    const prematureClose = Object.assign(new Error("Premature close"), {
+      code: "ERR_STREAM_PREMATURE_CLOSE",
+    });
+    await tagConsumerCancellation(inner).cancel(prematureClose);
+
+    expect(isResponseAbortedError(cancelReason)).toBe(true);
+    expect((cancelReason as Error).cause).toBe(prematureClose);
+  });
+
   it("forwards an explicit cancellation reason unchanged", async () => {
     let cancelReason: unknown = "unset";
     const inner = new ReadableStream<Uint8Array>({

--- a/tests/app-rsc-errors.test.ts
+++ b/tests/app-rsc-errors.test.ts
@@ -5,6 +5,11 @@ import {
   getDigestForWellKnownError,
   sanitizeErrorForClient,
 } from "../packages/vinext/src/server/app-rsc-errors.js";
+import {
+  isResponseAbortedError,
+  ResponseAbortedError,
+  tagConsumerCancellation,
+} from "../packages/vinext/src/server/response-aborted.js";
 
 type DigestCarrier = Error & { digest: unknown };
 
@@ -53,6 +58,48 @@ describe("app RSC error primitives", () => {
 
     expect(sanitized).not.toBe(error);
     expect(expectDigestError(sanitized).digest).toBe("existing-digest");
+  });
+
+  it("does not report renders aborted by response consumer cancellation", () => {
+    const reportRequestError = vi.fn();
+    const onError = createRscOnErrorHandler({
+      errorContext: { routerKind: "App Router", routePath: "/aborted", routeType: "render" },
+      nodeEnv: "production",
+      reportRequestError,
+      requestInfo: { path: "/aborted", method: "GET", headers: {} },
+    });
+
+    const digest = onError(new ResponseAbortedError());
+
+    expect(reportRequestError).not.toHaveBeenCalled();
+    expect(typeof digest).toBe("string");
+  });
+
+  it("tags reason-less consumer cancellation before it reaches the render stream", async () => {
+    let cancelReason: unknown = "unset";
+    const inner = new ReadableStream<Uint8Array>({
+      cancel(reason) {
+        cancelReason = reason;
+      },
+    });
+
+    await tagConsumerCancellation(inner).cancel();
+
+    expect(isResponseAbortedError(cancelReason)).toBe(true);
+  });
+
+  it("forwards an explicit cancellation reason unchanged", async () => {
+    let cancelReason: unknown = "unset";
+    const inner = new ReadableStream<Uint8Array>({
+      cancel(reason) {
+        cancelReason = reason;
+      },
+    });
+
+    const explicit = new Error("runtime supplied reason");
+    await tagConsumerCancellation(inner).cancel(explicit);
+
+    expect(cancelReason).toBe(explicit);
   });
 
   it("reports the original server error when the client transport error is sanitized", () => {

--- a/tests/app-ssr-stream.test.ts
+++ b/tests/app-ssr-stream.test.ts
@@ -8,6 +8,8 @@ import {
   fixPreloadAs,
   waitAtLeastOneReactRenderTask,
 } from "../packages/vinext/src/server/app-ssr-stream.js";
+import { deferUntilStreamConsumed } from "../packages/vinext/src/server/defer-until-stream-consumed.js";
+import { pumpThrough } from "../packages/vinext/src/server/stream-pump.js";
 
 it("serializes dynamic stale time into the hydration bootstrap", () => {
   expect(
@@ -799,5 +801,36 @@ describe("createTickBufferedTransform inline CSS", () => {
 
     expect(out).toContain("<style data-vinext-inline-css");
     expect(out).not.toContain("nonce=");
+  });
+
+  it("settles when cancelled while the embed flush awaits a suspended flight stream", async () => {
+    const neverEndingFlight = new ReadableStream<Uint8Array>({
+      pull() {
+        return new Promise(() => {});
+      },
+    });
+    const rscEmbed = createRscEmbedTransform(neverEndingFlight);
+    const htmlSource = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("<html><body>x</body></html>"));
+        controller.close();
+      },
+    });
+
+    const finalStream = deferUntilStreamConsumed(
+      pumpThrough(htmlSource, createTickBufferedTransform(rscEmbed)),
+      () => {
+        rscEmbed.abort?.();
+      },
+    );
+
+    const reader = finalStream.getReader();
+    await reader.read();
+    await Promise.race([
+      reader.cancel(new Error("consumer went away")),
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error("cancellation hung on pending flush")), 2000),
+      ),
+    ]);
   });
 });

--- a/tests/fixtures/app-basic/app/slow-stream-abort-test/page.tsx
+++ b/tests/fixtures/app-basic/app/slow-stream-abort-test/page.tsx
@@ -1,0 +1,19 @@
+import { Suspense } from "react";
+
+export const dynamic = "force-dynamic";
+
+async function SlowSection() {
+  await new Promise((resolve) => setTimeout(resolve, 1500));
+  return <p>slow section done</p>;
+}
+
+export default function SlowStreamAbortTestPage() {
+  return (
+    <main>
+      <h1>slow stream abort test</h1>
+      <Suspense fallback={<p>loading slow section...</p>}>
+        <SlowSection />
+      </Suspense>
+    </main>
+  );
+}


### PR DESCRIPTION
Closes #2664

When the response consumer goes away mid-stream (client disconnect, aborted navigation), spec compliant runtimes cancel the response body with no reason. React turns that into `Error("The render was aborted by the server without a reason.")` for every pending task, and the render `onError` reported it through `onRequestError` as if it were a real failure. On a production app with Sentry wired to `onRequestError` this produced hundreds of noise events per hour, all with response status 200. Next.js swallows exactly this class (`isAbortError` / `ResponseAborted` in `pipe-readable.ts`).

### Change

- `server/response-aborted.ts`: a named `ResponseAbortedError` (mirroring Next's `ResponseAborted`) plus `tagConsumerCancellation(stream)`, a passthrough that forwards an explicit cancel reason unchanged and replaces a reason-less cancel with the tagged error. Built with `highWaterMark: 0` so it stays pull-on-demand with no extra buffering.
- `buildAppPageRscResponse` / `buildAppPageHtmlResponse` wrap the render stream with `tagConsumerCancellation` right before it becomes the Response body, so the tag applies on every runtime (Node, Workers, any host that cancels the web stream).
- `createRscOnErrorHandler` and the SSR `onError` classify the tagged abort as expected control flow: no `reportRequestError`, no error meta, digest still returned for React.

Real render errors are untouched: only cancellations initiated by the response consumer are reclassified, and the existing "reports server component render errors via instrumentation" test still passes.

### Related cleanup: latent unhandled rejections around pipeThrough

The new coverage surfaced a latent class of unhandled rejections in the streaming path: `pipeThrough`'s internal `pipeTo` loop can leave an in-flight `writer.write` (or its own pipe promise) rejecting unhandled when the stream is cancelled between chunks, and the drain-detection wrappers rejected with the raw cancel reason (reproducible in ~20 lines of plain Node).

- `deferUntilStreamConsumed` and the `sendAppPageResponse` wrapper used `pipeThrough(new TransformStream({ flush }))` only to detect clean drain; both now use a manual passthrough and fire their flush callback from the `done` branch, removing a TransformStream plus pipe machinery per response.
- The real transforms (`normalizeReactFlightPreloadHints`, the SSR tick-buffered embed) now run through a small `pumpThrough` helper (`server/stream-pump.ts`) that owns every read/write promise and propagates failures both ways, replacing `pipeThrough`.

With the removed layers, the net per-chunk overhead of this PR is at or below main, and the affected suites now run with zero unhandled errors (they previously reported them on cancellation paths).

### Tests

- New integration test reproduces the bug end to end: RSC request against the built `app-basic` entry, read one chunk, cancel the body, then assert the instrumentation recorder stays empty. Fails on main with `"The render was aborted by the server without a reason."` recorded; passes with this change.
- Unit tests: a consumer-cancellation abort is not reported and still yields a digest; `tagConsumerCancellation` tags a reason-less cancel and forwards explicit reasons unchanged.
- `app-router-production-server` (including the pre-existing instrumentation reporting test), `app-flight-framing-production`, `app-page-dispatch`, `app-page-render`, `app-rsc-error-handler`, `app-rsc-errors` and `app-router-dev-server` pass with zero unhandled errors; `tsc` is clean.
