### PR TITLE
fix(metadata): add meta's 2024 crawler UAs to the html-limited bot list

### DIFF
--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -27,38 +27,23 @@ import { fnv1a52 } from "../utils/hash.js";
 import { readStreamAsText } from "../utils/text-stream.js";
 import { callDocumentGetInitialProps } from "./document-initial-head.js";
 import { appendAssetDeploymentIdQuery } from "../utils/deployment-id.js";
+import { isBotUserAgent } from "../utils/html-limited-bots.js";
 import { NEXTJS_CACHE_HEADER } from "./headers.js";
 
 // ---------------------------------------------------------------------------
 // Bot / crawler detection for Pages Router edge-runtime SSR
 //
-// Mirrors Next.js's packages/next/src/shared/lib/router/utils/html-bots.ts
-// and is-bot.ts. These bots cannot parse streamed HTML correctly (they may
-// read metadata only from the initial <head> flush), so we buffer the full
-// response and emit it in a single chunk, identical to the Node.js path.
+// These bots cannot parse streamed HTML correctly (they may read metadata
+// only from the initial <head> flush), so we buffer the full response and emit
+// it in a single chunk, identical to the Node.js path.
 // ---------------------------------------------------------------------------
-
-/**
- * Crawlers that cannot handle streamed HTML: they read metadata only from
- * the first network chunk, so streaming would give them an incomplete <head>.
- * Pattern sourced from Next.js html-bots.ts (updated to match the canary).
- */
-const HTML_LIMITED_BOT_UA_RE =
-  /[\w-]+-Google|Google-[\w-]+|Chrome-Lighthouse|Slurp|DuckDuckBot|baiduspider|yandex|sogou|bitlybot|tumblr|vkShare|quora link preview|redditbot|ia_archiver|Bingbot|BingPreview|applebot|facebookexternalhit|facebookcatalog|Twitterbot|LinkedInBot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|Yeti|googleweblight/i;
-
-/**
- * Googlebot (the main search crawler) executes JavaScript via a headless
- * browser, so it too cannot safely handle mid-stream HTML mutations.
- * Matches "Googlebot" but NOT suffixed variants like "Googlebot-Image".
- */
-const HEADLESS_BROWSER_BOT_UA_RE = /Googlebot(?!-)|Googlebot$/i;
 
 /**
  * Returns true when the User-Agent belongs to a bot or crawler that cannot
  * reliably consume a streamed HTML response.
  */
 export function isPagesStreamingBot(userAgent: string): boolean {
-  return HEADLESS_BROWSER_BOT_UA_RE.test(userAgent) || HTML_LIMITED_BOT_UA_RE.test(userAgent);
+  return isBotUserAgent(userAgent);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/vinext/src/utils/html-limited-bots.ts
+++ b/packages/vinext/src/utils/html-limited-bots.ts
@@ -1,6 +1,19 @@
 // Matches Next.js's default html-limited bot list:
 // packages/next/src/shared/lib/router/utils/html-bots.ts
-const HTML_LIMITED_BOT_UA_RE_STRING = String.raw`[\w-]+-Google|Google-[\w-]+|Chrome-Lighthouse|Slurp|DuckDuckBot|baiduspider|yandex|sogou|bitlybot|tumblr|vkShare|quora link preview|redditbot|ia_archiver|Bingbot|BingPreview|applebot|facebookexternalhit|facebookcatalog|Twitterbot|LinkedInBot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|Yeti|googleweblight`;
+//
+// Deliberate, documented divergence from Next.js (per AGENTS.md "behave
+// differently is OK when deliberate"): `meta-externalagent` and
+// `meta-externalfetcher` are appended to the default list. They are Meta's
+// current crawler UAs (introduced 2024 — see
+// https://developers.facebook.com/docs/sharing/webmasters/web-crawlers/) and,
+// like every Meta crawler, they don't execute JavaScript. With streaming
+// metadata, tags land at the end of `<body>` for UAs outside this list, so
+// these crawlers see a page without `og:*`/`title` — broken WhatsApp/IG/FB
+// link previews and blank AI-indexing snippets (observed in production).
+// Next.js's list predates Meta's UA migration and still only carries the
+// legacy `facebookexternalhit`. Users can still override via the
+// `htmlLimitedBots` config, which replaces this default entirely.
+const HTML_LIMITED_BOT_UA_RE_STRING = String.raw`[\w-]+-Google|Google-[\w-]+|Chrome-Lighthouse|Slurp|DuckDuckBot|baiduspider|yandex|sogou|bitlybot|tumblr|vkShare|quora link preview|redditbot|ia_archiver|Bingbot|BingPreview|applebot|facebookexternalhit|facebookcatalog|meta-externalagent|meta-externalfetcher|Twitterbot|LinkedInBot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|Yeti|googleweblight`;
 
 // Headless browser bot (executes JS). Mirrors Next.js
 // `HEADLESS_BROWSER_BOT_UA_RE` in

--- a/tests/pages-page-response.test.ts
+++ b/tests/pages-page-response.test.ts
@@ -131,6 +131,8 @@ describe("isPagesStreamingBot", () => {
   it("detects other known HTML-limited bots", () => {
     expect(isPagesStreamingBot("Bingbot/2.0")).toBe(true);
     expect(isPagesStreamingBot("facebookexternalhit/1.1")).toBe(true);
+    expect(isPagesStreamingBot("meta-externalagent/1.1")).toBe(true);
+    expect(isPagesStreamingBot("meta-externalfetcher/1.1")).toBe(true);
     expect(isPagesStreamingBot("Twitterbot/1.0")).toBe(true);
     expect(isPagesStreamingBot("Slackbot-LinkExpanding 1.0")).toBe(true);
   });

--- a/tests/streaming-metadata.test.ts
+++ b/tests/streaming-metadata.test.ts
@@ -11,4 +11,27 @@ describe("streaming metadata bot matching", () => {
     expect(shouldServeStreamingMetadata("Twitterbot", "")).toBe(false);
     expect(shouldServeStreamingMetadata("HeadlessChrome", "")).toBe(true);
   });
+
+  it("serves blocking metadata to Meta's current crawlers (2024+ UAs)", () => {
+    // Meta's post-2024 crawlers don't execute JS — streamed metadata (tags at
+    // the end of <body>) is invisible to them, breaking WhatsApp/IG/FB link
+    // previews. Deliberate divergence from Next.js's default list, which only
+    // carries the legacy facebookexternalhit.
+    expect(
+      shouldServeStreamingMetadata(
+        "meta-externalagent/1.1 (+https://developers.facebook.com/docs/sharing/webmasters/crawler)",
+        undefined,
+      ),
+    ).toBe(false);
+    expect(shouldServeStreamingMetadata("meta-externalfetcher/1.1", undefined)).toBe(false);
+    // The legacy Meta preview crawler stays covered.
+    expect(
+      shouldServeStreamingMetadata(
+        "facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)",
+        undefined,
+      ),
+    ).toBe(false);
+    // A user-provided htmlLimitedBots config still replaces the default list.
+    expect(shouldServeStreamingMetadata("meta-externalagent/1.1", "Minibot")).toBe(true);
+  });
 });


### PR DESCRIPTION
Link previews on WhatsApp/Instagram/Facebook can render blank for vinext sites, even when the page's metadata is correct.

Cause: Meta introduced new crawler UAs in 2024, `meta-externalagent` and `meta-externalfetcher` ([Meta's crawler docs](https://developers.facebook.com/docs/sharing/webmasters/web-crawlers/)). The default html-limited bot list only carries the legacy `facebookexternalhit`, so the new UAs get streamed metadata. Meta's crawlers don't execute JS, which means every `og:*` tag lands after `</head>` and they never see it.

I hit this in production this week on a Next.js app (vinext mirrors the same default list, so it has the same gap). Easy to reproduce:

```
$ curl -s -A "meta-externalagent/1.1" https://<site> | grep -bo 'og:title\|</head>'

# og:title byte offset AFTER </head>'s  → streamed, crawler never sees it, blank card
# og:title byte offset BEFORE </head>'s → blocking, card renders
```

The fix is two UAs appended to the default regex in `html-limited-bots.ts`. A user-provided `htmlLimitedBots` config still replaces the whole list, same as before.

This diverges from Next.js's current default on purpose (their list predates Meta's new UAs). Per AGENTS.md that's fine when it's deliberate and documented, so the source comment explains the reasoning and links Meta's docs. I plan to send the same patch to Next upstream; if it lands there, this goes back to being plain parity.

Tests: added a case to `streaming-metadata.test.ts` (new UAs get blocking metadata, legacy UA still covered, custom config still wins). Neighboring suites green (`app-page-route-wiring`, `next-config`, `pages-page-response`, 319 tests), `vp lint` and `vp fmt` clean.

🧠 Thought by a Human ([@MrIago](https://github.com/MrIago)) · 🤖 Generated with [Claude Code](https://claude.com/claude-code)
