### PR TITLE
fix(app): log RSC render errors on the dev-server terminal

### DIFF
--- a/packages/vinext/src/server/app-rsc-errors.ts
+++ b/packages/vinext/src/server/app-rsc-errors.ts
@@ -178,9 +178,8 @@ export function createRscOnErrorHandler(
     // regardless of user instrumentation; vinext's `reportRequestError` above is a
     // no-op when no `onRequestError` hook is registered, so without this a server
     // render error would be swallowed silently in the dev server. The `!hasDigest`
-    // guard dedupes: the same error object reaches this handler on both the RSC
-    // and the SSR/HTML render passes, and the first pass stamps it with a digest
-    // below — mirroring Next.js's `silenceLog` dedup so we log it exactly once.
+    // guard intentionally suppresses every digest-bearing error, including repeat
+    // RSC callbacks after this handler stamps the error with a digest below.
     if (nodeEnv !== "production" && error && !hasDigest(error)) {
       const loggableError =
         typeof error === "object" && ORIGINAL_SERVER_ERROR in error

--- a/packages/vinext/src/server/app-rsc-errors.ts
+++ b/packages/vinext/src/server/app-rsc-errors.ts
@@ -161,6 +161,22 @@ export function createRscOnErrorHandler(
       );
     }
 
+    // Surface the error on the dev-server terminal. In Next.js the instrumentation
+    // wrapper (`onInstrumentationRequestError`) logs render errors in development
+    // regardless of user instrumentation; vinext's `reportRequestError` above is a
+    // no-op when no `onRequestError` hook is registered, so without this a server
+    // render error would be swallowed silently in the dev server. The `!hasDigest`
+    // guard dedupes: the same error object reaches this handler on both the RSC
+    // and the SSR/HTML render passes, and the first pass stamps it with a digest
+    // below — mirroring Next.js's `silenceLog` dedup so we log it exactly once.
+    if (nodeEnv !== "production" && error && !hasDigest(error)) {
+      const loggableError =
+        typeof error === "object" && ORIGINAL_SERVER_ERROR in error
+          ? Reflect.get(error, ORIGINAL_SERVER_ERROR)
+          : error;
+      console.error("[vinext] Server render error:", loggableError);
+    }
+
     // A non-signal error that already carries a digest keeps it as-is (matching
     // Next.js's err.digest branch) rather than being re-hashed — but only after
     // it has been reported above.

--- a/packages/vinext/src/server/app-rsc-errors.ts
+++ b/packages/vinext/src/server/app-rsc-errors.ts
@@ -36,6 +36,12 @@ export function hasDigest(error: unknown): error is { digest: unknown } {
 const BAILOUT_TO_CSR_DIGEST = "BAILOUT_TO_CLIENT_SIDE_RENDERING";
 const DYNAMIC_SERVER_USAGE_DIGEST = "DYNAMIC_SERVER_USAGE";
 
+function isAbortError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const name = Reflect.get(error, "name");
+  return name === "AbortError" || name === "ResponseAborted";
+}
+
 /**
  * vinext's mirror of Next.js's `getDigestForWellKnownError`: returns the digest
  * string only when the error is a genuine control-flow signal — a redirect,
@@ -111,6 +117,12 @@ export function createRscOnErrorHandler(
 ): (error: unknown) => string | undefined {
   return (error) => {
     const nodeEnv = options.nodeEnv ?? process.env.NODE_ENV;
+
+    // Ported from Next.js: packages/next/src/server/app-render/create-error-handler.tsx
+    // Expected response/HMR cancellations are not render failures.
+    if (isAbortError(error)) {
+      return undefined;
+    }
 
     // Well-known control-flow signals (redirect / notFound / bailout-to-CSR /
     // dynamic-server) carry a recognized digest and are not real failures:

--- a/tests/app-rsc-errors.test.ts
+++ b/tests/app-rsc-errors.test.ts
@@ -312,6 +312,29 @@ describe("app RSC error primitives", () => {
     }
   });
 
+  it.each(["AbortError", "ResponseAborted"])(
+    "does not report or log expected %s cancellations",
+    (name) => {
+      const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+      try {
+        const reportRequestError = vi.fn();
+        const onError = createRscOnErrorHandler({
+          errorContext: { routerKind: "App Router", routePath: "/feed", routeType: "render" },
+          nodeEnv: "development",
+          reportRequestError,
+          requestInfo: { path: "/feed", method: "GET", headers: {} },
+        });
+        const error = Object.assign(new Error("cancelled"), { name });
+
+        expect(onError(error)).toBeUndefined();
+        expect(reportRequestError).not.toHaveBeenCalled();
+        expect(consoleError).not.toHaveBeenCalled();
+      } finally {
+        consoleError.mockRestore();
+      }
+    },
+  );
+
   it("logs the original server error when a wrapped transport error reaches dev logging", () => {
     // In production `sanitizeErrorForClient` wraps the real error behind a
     // digest-only transport error keyed by ORIGINAL_SERVER_ERROR. If such a

--- a/tests/app-rsc-errors.test.ts
+++ b/tests/app-rsc-errors.test.ts
@@ -226,6 +226,120 @@ describe("app RSC error primitives", () => {
     });
   });
 
+  it("logs generic render errors to the dev-server terminal even without instrumentation", () => {
+    // Regression: `reportRequestError` is a no-op when no `onRequestError` hook
+    // is registered, so a server render error was swallowed silently in the dev
+    // server. Development must surface it on the terminal regardless.
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const onError = createRscOnErrorHandler({
+        errorContext: null,
+        nodeEnv: "development",
+        reportRequestError() {},
+        requestInfo: null,
+      });
+      const error = new Error("render failed");
+      error.stack = "stack";
+
+      onError(error);
+
+      expect(consoleError).toHaveBeenCalledWith("[vinext] Server render error:", error);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("does not log generic render errors to the terminal in production", () => {
+    // Production reports through `reportRequestError`; the transport error is
+    // returned to the client and must not be double-surfaced on the terminal.
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const onError = createRscOnErrorHandler({
+        errorContext: { routerKind: "App Router", routePath: "/feed", routeType: "render" },
+        nodeEnv: "production",
+        reportRequestError() {},
+        requestInfo: { path: "/feed", method: "GET", headers: {} },
+      });
+      const error = new Error("render failed");
+      error.stack = "stack";
+
+      onError(error);
+
+      expect(consoleError).not.toHaveBeenCalled();
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("does not re-log a digest-bearing error as it bubbles through nested onError passes", () => {
+    // The same error object reaches this handler on both the RSC and SSR/HTML
+    // render passes; the first pass stamps a digest, so a digest-bearing error
+    // must not be logged again (matching Next.js's silenceLog dedup).
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const onError = createRscOnErrorHandler({
+        errorContext: null,
+        nodeEnv: "development",
+        reportRequestError() {},
+        requestInfo: null,
+      });
+      const error = Object.assign(new Error("boom"), { digest: "customdigest123" });
+
+      onError(error);
+
+      expect(consoleError).not.toHaveBeenCalled();
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("does not double-log well-known navigation signals in development", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const onError = createRscOnErrorHandler({
+        errorContext: null,
+        nodeEnv: "development",
+        reportRequestError() {},
+        requestInfo: null,
+      });
+
+      onError({ digest: "NEXT_NOT_FOUND" });
+      onError({ digest: "BAILOUT_TO_CLIENT_SIDE_RENDERING" });
+
+      expect(consoleError).not.toHaveBeenCalled();
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("logs the original server error when a wrapped transport error reaches dev logging", () => {
+    // In production `sanitizeErrorForClient` wraps the real error behind a
+    // digest-only transport error keyed by ORIGINAL_SERVER_ERROR. If such a
+    // wrapper (with no digest) reaches the dev logger, unwrap it so the terminal
+    // shows the real error rather than the opaque transport message.
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const onError = createRscOnErrorHandler({
+        errorContext: null,
+        nodeEnv: "development",
+        reportRequestError() {},
+        requestInfo: null,
+      });
+      const original = new Error("real cause");
+      const wrapper = new Error("opaque transport");
+      Object.defineProperty(wrapper, Symbol.for("vinext.originalServerError"), {
+        enumerable: false,
+        value: original,
+      });
+
+      onError(wrapper);
+
+      expect(consoleError).toHaveBeenCalledWith("[vinext] Server render error:", original);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   it("uses process.env.NODE_ENV when no explicit environment is provided", () => {
     vi.stubEnv("NODE_ENV", "production");
 


### PR DESCRIPTION
## Problem

A server-component render error was swallowed silently by the dev server unless the project defined an `onRequestError` instrumentation hook.

The RSC `onError` handler reports through `reportRequestError`, but that function is a no-op when no user handler is registered. Next.js still surfaces these development render failures in the server terminal.

## Fix

Emit a development-only console error from `createRscOnErrorHandler` after instrumentation reporting and before digest handling.

- Production behavior is unchanged.
- The `hasDigest` noise guard intentionally suppresses every digest-bearing error, including repeat RSC callbacks after this handler stamps an error with a digest.
- Redirect, notFound, bailout-to-CSR, and dynamic-server control-flow signals still return early and are never logged.
- `AbortError` and `ResponseAborted` cancellations return early as expected cancellation paths.
- Wrapped transport errors are unwrapped so the terminal receives the original server error.

## Validation

- 23 focused App RSC error tests pass.
- Related App RSC error-handler tests pass.
- A real App Router dev render confirms the server error reaches the terminal without breaking React 19 streaming recovery.
- Scoped format, lint, and type checks pass.
- The vinext package build passes.
- Independent review and Big Bonk review are clean.
