### PR TITLE
fix(pages): normalize decoded edge responses

### DIFF
--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -467,11 +467,12 @@ export async function renderPage(request, url, manifest, ctx, middlewareHeaders,
 
 
 
-export async function handleApiRoute(request, url, ctx, trustedRevalidateOrigin) {
+export async function handleApiRoute(request, url, ctx, trustedRevalidateOrigin, edgeRuntime = "worker") {
   __registerConfiguredCacheAdapters();
   const match = matchRoute(url, apiRoutes);
   return __handlePagesApiRoute({
     ctx,
+    edgeRuntime,
     match,
     nextConfig: vinextConfig,
     request,

--- a/packages/vinext/src/server/api-handler.ts
+++ b/packages/vinext/src/server/api-handler.ts
@@ -20,7 +20,7 @@ import {
   urlQueryToSearchParams,
 } from "../utils/query.js";
 import { PagesBodyParseError, getMediaType, isJsonMediaType } from "./pages-media-type.js";
-import { isEdgeApiRuntime } from "./edge-api-runtime.js";
+import { finalizeEdgeApiResponse, isEdgeApiRuntime } from "./edge-api-runtime.js";
 import {
   DEFAULT_PAGES_API_BODY_SIZE_LIMIT,
   resolveBodyParserConfig,
@@ -416,10 +416,11 @@ export async function handleApiRoute(
             }
           : undefined,
       );
-      const response = await apiModule.default(nextRequest);
-      if (!(response instanceof Response)) {
+      const handlerResponse = await apiModule.default(nextRequest);
+      if (!(handlerResponse instanceof Response)) {
         throw new Error("Edge API route did not return a Response");
       }
+      const response = finalizeEdgeApiResponse(handlerResponse, "node");
 
       res.statusCode = response.status;
       res.statusMessage = response.statusText;

--- a/packages/vinext/src/server/app-pages-bridge.ts
+++ b/packages/vinext/src/server/app-pages-bridge.ts
@@ -1,4 +1,5 @@
 import type { AppMiddlewareContext } from "./app-middleware.js";
+import type { EdgeApiExecutionRuntime } from "./edge-api-runtime.js";
 import { getRequestExecutionContext } from "vinext/shims/request-context";
 import { pagesRouteHasPriorityOverAppRoute } from "./hybrid-route-priority.js";
 import { cloneRequestWithHeaders, cloneRequestWithUrl } from "./request-pipeline.js";
@@ -7,8 +8,9 @@ export type PagesEntry = {
   handleApiRoute?: (
     request: Request,
     url: string,
-    ctx?: unknown,
-    trustedRevalidateOrigin?: string,
+    ctx: unknown,
+    trustedRevalidateOrigin: string | undefined,
+    edgeRuntime: EdgeApiExecutionRuntime,
   ) => Promise<Response> | Response;
   matchApiRoute?: (url: string, request: Request) => PagesRouteMatch | null;
   matchPageRoute?: (url: string, request: Request) => PagesRouteMatch | null;
@@ -139,11 +141,13 @@ export async function renderPagesFallback(
         return null;
       }
     }
+    const executionContext = getRequestExecutionContext();
     const pagesApiResponse = await pagesEntry.handleApiRoute(
       pagesRequest,
       pagesUrl,
       undefined,
-      getRequestExecutionContext()?.trustedRevalidateOrigin ?? new URL(pagesRequest.url).origin,
+      executionContext?.trustedRevalidateOrigin ?? new URL(pagesRequest.url).origin,
+      executionContext?.hostRuntime ?? "node",
     );
     const draftCookie = getDraftModeCookieHeader();
     return applyDraftModeCookie(

--- a/packages/vinext/src/server/edge-api-runtime.ts
+++ b/packages/vinext/src/server/edge-api-runtime.ts
@@ -1,3 +1,40 @@
 export function isEdgeApiRuntime(runtime: string | undefined): boolean {
   return runtime === "edge" || runtime === "experimental-edge";
 }
+
+export type EdgeApiExecutionRuntime = "node" | "worker";
+
+const NODE_EDGE_RESPONSE_FORBIDDEN_HEADERS = [
+  "content-length",
+  "content-encoding",
+  "transfer-encoding",
+] as const;
+
+/**
+ * Remove wire-level body headers after Node's fetch implementation has decoded
+ * an Edge API response. Next.js applies the same boundary in its edge sandbox.
+ *
+ * Workers keep the original response untouched: workerd preserves the encoded
+ * body/header pair and can stream it directly to the client.
+ */
+export function finalizeEdgeApiResponse(
+  response: Response,
+  runtime: EdgeApiExecutionRuntime,
+): Response {
+  if (runtime === "worker") return response;
+
+  const headers = new Headers(response.headers);
+  let changed = false;
+  for (const name of NODE_EDGE_RESPONSE_FORBIDDEN_HEADERS) {
+    if (!headers.has(name)) continue;
+    headers.delete(name);
+    changed = true;
+  }
+  if (!changed) return response;
+
+  return new Response(response.body, {
+    headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
+}

--- a/packages/vinext/src/server/pages-api-route.ts
+++ b/packages/vinext/src/server/pages-api-route.ts
@@ -17,7 +17,11 @@ import {
 import { resolveBodyParserConfig } from "./pages-body-parser-config.js";
 import { internalServerErrorResponse } from "./http-error-responses.js";
 import { cloneRequestWithUrl } from "./request-pipeline.js";
-import { isEdgeApiRuntime } from "./edge-api-runtime.js";
+import {
+  finalizeEdgeApiResponse,
+  isEdgeApiRuntime,
+  type EdgeApiExecutionRuntime,
+} from "./edge-api-runtime.js";
 import { runWithExecutionContext, type ExecutionContextLike } from "vinext/shims/request-context";
 import { NextRequest } from "vinext/shims/server";
 
@@ -92,6 +96,7 @@ type HandlePagesApiRouteOptions = {
    * response. Omit on Node.js dev where no Workers lifecycle exists.
    */
   ctx?: ExecutionContextLike;
+  edgeRuntime?: EdgeApiExecutionRuntime;
   match: PagesApiRouteMatch | null;
   reportRequestError?: (error: Error, routePattern: string) => void | Promise<void>;
   request: Request;
@@ -163,7 +168,7 @@ async function _handlePagesApiRoute(options: HandlePagesApiRouteOptions): Promis
       );
       const response = await route.module.default(nextRequest);
       if (response instanceof Response) {
-        return response;
+        return finalizeEdgeApiResponse(response, options.edgeRuntime ?? "worker");
       }
 
       throw new Error("Edge API route did not return a Response");

--- a/packages/vinext/src/server/pages-router-entry.ts
+++ b/packages/vinext/src/server/pages-router-entry.ts
@@ -212,7 +212,7 @@ async function handleRequest(
           : null,
       handleApi:
         typeof handleApiRoute === "function"
-          ? (req, apiUrl) => handleApiRoute(req, apiUrl, ctx, new URL(req.url).origin)
+          ? (req, apiUrl) => handleApiRoute(req, apiUrl, ctx, new URL(req.url).origin, "worker")
           : null,
       serveFilesystemRoute: async (requestPathname, _stagedHeaders, phase) => {
         if (!env?.ASSETS) return false;

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -1052,6 +1052,7 @@ type WorkerAppRouterEntry = {
 
 function createNodeExecutionContext(trustedRevalidateOrigin?: string): ExecutionContextLike {
   return {
+    hostRuntime: "node",
     waitUntil(promise: Promise<unknown>) {
       // Node doesn't provide a Workers lifecycle, but we still attach a
       // rejection handler so background waitUntil work doesn't surface as an

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -1971,6 +1971,7 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
                   apiUrl,
                   createNodeExecutionContext(),
                   resolveTrustedNodeRevalidateOrigin(req, host, port),
+                  "node",
                 )
             : null,
         // ── 5b. Serve public-directory static files (post-middleware) ──

--- a/packages/vinext/src/server/worker-revalidation-context.ts
+++ b/packages/vinext/src/server/worker-revalidation-context.ts
@@ -22,6 +22,7 @@ function deriveExecutionContext(
           },
         }
       : {}),
+    hostRuntime: "worker",
     ...(base?.cache === undefined ? {} : { cache: base.cache }),
     ...(base?.trustedRevalidateOrigin === undefined
       ? {}

--- a/packages/vinext/src/shims/request-context.ts
+++ b/packages/vinext/src/shims/request-context.ts
@@ -39,6 +39,8 @@ import {
 export type ExecutionContextLike = {
   waitUntil(promise: Promise<unknown>): void;
   passThroughOnException?(): void;
+  /** Host runtime executing the current request. */
+  hostRuntime?: "node" | "worker";
   /**
    * Optional host-provided cache handle that some runtimes expose on the
    * execution context. Typed as `unknown` to keep this module runtime-agnostic;

--- a/tests/after-deploy.test.ts
+++ b/tests/after-deploy.test.ts
@@ -146,7 +146,9 @@ describe("after() in deploy mode — Pages Router worker entry", () => {
     // After #1336 item 3 the dispatch URL is `apiLookupUrl` (the locale-
     // stripped form of `resolvedUrl`), but `ctx` is still threaded through.
     const content = readPagesRouterEntrySource();
-    expect(content).toContain("handleApiRoute(req, apiUrl, ctx, new URL(req.url).origin)");
+    expect(content).toContain(
+      'handleApiRoute(req, apiUrl, ctx, new URL(req.url).origin, "worker")',
+    );
   });
 
   it("forwards ctx and staged middleware headers to renderPage so page renders can call after() and apply CSP nonces", () => {

--- a/tests/api-handler.test.ts
+++ b/tests/api-handler.test.ts
@@ -15,6 +15,7 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import { PassThrough } from "node:stream";
 import http from "node:http";
 import type { AddressInfo } from "node:net";
+import { gzipSync } from "node:zlib";
 import { handleApiRoute } from "../packages/vinext/src/server/api-handler.js";
 import {
   reportRequestError,
@@ -1274,6 +1275,41 @@ describe("handleApiRoute", () => {
         hello: "world",
         query: { a: "b" },
       });
+    });
+
+    it("does not forward stale encoding headers from Node fetch responses", async () => {
+      const body = "Example Domain";
+      const compressedBody = gzipSync(body);
+      const upstream = http.createServer((_req, res) => {
+        res.writeHead(200, {
+          "content-encoding": "gzip",
+          "content-length": String(compressedBody.byteLength),
+          "content-type": "text/plain",
+        });
+        res.end(compressedBody);
+      });
+      await new Promise<void>((resolve) => upstream.listen(0, "127.0.0.1", resolve));
+
+      try {
+        const address = upstream.address() as AddressInfo;
+        const server = mockServer({
+          config: { runtime: "edge" },
+          default: () => fetch(`http://127.0.0.1:${address.port}`),
+        });
+        const req = mockReq("GET", "/api/proxy", undefined, { host: "example.com" });
+        const res = mockRes();
+
+        await handleApiRoute(server, req, res, "/api/proxy", [route("/api/proxy")]);
+
+        expect(res._headers["content-encoding"]).toBeUndefined();
+        expect(res._headers["content-length"]).toBeUndefined();
+        expect(res._body.toString()).toBe(body);
+      } finally {
+        upstream.closeAllConnections();
+        await new Promise<void>((resolve, reject) => {
+          upstream.close((error) => (error ? reject(error) : resolve()));
+        });
+      }
     });
 
     it("applies basePath and i18n config to edge API nextUrl", async () => {

--- a/tests/app-pages-bridge.test.ts
+++ b/tests/app-pages-bridge.test.ts
@@ -1,9 +1,15 @@
+import { gzipSync } from "node:zlib";
 import { describe, expect, it, vi } from "vite-plus/test";
 import {
   renderPagesFallback,
   type PagesEntry,
 } from "../packages/vinext/src/server/app-pages-bridge.js";
 import type { AppMiddlewareContext } from "../packages/vinext/src/server/app-middleware.js";
+import { handlePagesApiRoute } from "../packages/vinext/src/server/pages-api-route.js";
+import {
+  runWithExecutionContext,
+  type ExecutionContextLike,
+} from "../packages/vinext/src/shims/request-context.js";
 
 describe("renderPagesFallback", () => {
   const defaultDeps = {
@@ -30,6 +36,76 @@ describe("renderPagesFallback", () => {
     },
     getDraftModeCookieHeader: (): string | null | undefined => null,
   };
+
+  async function renderHybridEdgeApiResponse(hostRuntime: "node" | "worker") {
+    const text = "Example Domain";
+    const encodedBody = gzipSync(text);
+    const handlerResponse =
+      hostRuntime === "node"
+        ? new Response(text, {
+            headers: {
+              "content-encoding": "gzip",
+              "content-length": String(encodedBody.byteLength),
+              "content-type": "text/plain",
+              "transfer-encoding": "chunked",
+            },
+          })
+        : new Response(encodedBody, {
+            headers: {
+              "content-encoding": "gzip",
+              "content-length": String(encodedBody.byteLength),
+              "content-type": "text/plain",
+              "transfer-encoding": "chunked",
+            },
+          });
+    const observedRuntimes: Array<"node" | "worker"> = [];
+    const handleApiRoute: NonNullable<PagesEntry["handleApiRoute"]> = (
+      request,
+      url,
+      _ctx,
+      trustedRevalidateOrigin,
+      edgeRuntime,
+    ) => {
+      observedRuntimes.push(edgeRuntime);
+      return handlePagesApiRoute({
+        edgeRuntime,
+        match: {
+          params: {},
+          route: {
+            pattern: "/api/proxy",
+            module: {
+              config: { runtime: "edge" },
+              default: () => handlerResponse,
+            },
+          },
+        },
+        request,
+        trustedRevalidateOrigin,
+        url,
+      });
+    };
+    const executionContext: ExecutionContextLike = {
+      hostRuntime,
+      waitUntil(_promise) {},
+    };
+    const request = new Request("http://localhost/api/proxy");
+    const response = await runWithExecutionContext(executionContext, () =>
+      renderPagesFallback(
+        {
+          isRscRequest: false,
+          middlewareContext: { headers: null, requestHeaders: null, status: null },
+          request,
+          url: new URL(request.url),
+        },
+        {
+          ...defaultDeps,
+          loadPagesEntry: () => ({ handleApiRoute }),
+        },
+      ),
+    );
+
+    return { encodedBody, observedRuntimes, response };
+  }
 
   it("returns null for RSC requests and does not call the Pages loader", async () => {
     const loadPagesEntry = vi.fn(() => ({}) as PagesEntry);
@@ -378,6 +454,26 @@ describe("renderPagesFallback", () => {
     expect(await res!.text()).toBe("api-response");
   });
 
+  it("strips decoded response headers for hybrid Node API fallbacks", async () => {
+    const { observedRuntimes, response } = await renderHybridEdgeApiResponse("node");
+
+    expect(observedRuntimes).toEqual(["node"]);
+    expect(response?.headers.get("content-encoding")).toBeNull();
+    expect(response?.headers.get("content-length")).toBeNull();
+    expect(response?.headers.get("transfer-encoding")).toBeNull();
+    await expect(response?.text()).resolves.toBe("Example Domain");
+  });
+
+  it("preserves encoded response headers for hybrid Worker API fallbacks", async () => {
+    const { encodedBody, observedRuntimes, response } = await renderHybridEdgeApiResponse("worker");
+
+    expect(observedRuntimes).toEqual(["worker"]);
+    expect(response?.headers.get("content-encoding")).toBe("gzip");
+    expect(response?.headers.get("content-length")).toBe(String(encodedBody.byteLength));
+    expect(response?.headers.get("transfer-encoding")).toBe("chunked");
+    expect(Buffer.from(await response!.arrayBuffer())).toEqual(encodedBody);
+  });
+
   it("routes normal paths through renderPage and passes decoded pathname + search", async () => {
     const renderPage = vi.fn((_req: Request, _url: string) => new Response("page-response"));
     const deps = {
@@ -543,6 +639,7 @@ describe("renderPagesFallback", () => {
       "/api/café?value=hello%20world",
       undefined,
       "http://localhost",
+      "node",
     );
   });
 

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -1397,7 +1397,9 @@ describe("readPagesRouterEntrySource", () => {
     // Locale stripping, /api/ prefix check, and ctx forwarding are all inside the owner.
     expect(content).toContain("handleApi:");
     expect(content).toContain('typeof handleApiRoute === "function"');
-    expect(content).toContain("handleApiRoute(req, apiUrl, ctx, new URL(req.url).origin)");
+    expect(content).toContain(
+      'handleApiRoute(req, apiUrl, ctx, new URL(req.url).origin, "worker")',
+    );
     expect(content).toContain("runPagesRequest(request, deps)");
   });
 

--- a/tests/pages-api-route.test.ts
+++ b/tests/pages-api-route.test.ts
@@ -1,5 +1,8 @@
 import { AsyncLocalStorage } from "node:async_hooks";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
 import { PassThrough } from "node:stream";
+import { gzipSync } from "node:zlib";
 import { describe, expect, it, vi } from "vite-plus/test";
 import {
   handlePagesApiRoute,
@@ -399,6 +402,70 @@ describe("pages api route", () => {
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ id: "req-42" });
+  });
+
+  it("removes stale encoding headers after Node fetch decodes an edge API response", async () => {
+    // Ported from Next.js: packages/next/src/server/web/sandbox/sandbox.ts
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/sandbox/sandbox.ts
+    const body = "Example Domain";
+    const compressedBody = gzipSync(body);
+    const upstream = http.createServer((_req, res) => {
+      res.writeHead(200, {
+        "content-encoding": "gzip",
+        "content-length": String(compressedBody.byteLength),
+        "content-type": "text/plain",
+      });
+      res.end(compressedBody);
+    });
+    await new Promise<void>((resolve) => upstream.listen(0, "127.0.0.1", resolve));
+
+    try {
+      const address = upstream.address() as AddressInfo;
+      const response = await handlePagesApiRoute({
+        edgeRuntime: "node",
+        match: createMatch(
+          () => fetch(`http://127.0.0.1:${address.port}`),
+          {},
+          { runtime: "edge" },
+        ),
+        request: new Request("https://example.com/api/proxy"),
+        url: "/api/proxy",
+      });
+
+      expect(response.headers.get("content-encoding")).toBeNull();
+      expect(response.headers.get("content-length")).toBeNull();
+      await expect(response.text()).resolves.toBe(body);
+    } finally {
+      upstream.closeAllConnections();
+      await new Promise<void>((resolve, reject) => {
+        upstream.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
+  it("preserves encoded edge API responses in the Worker runtime", async () => {
+    const body = gzipSync("Example Domain");
+    const response = await handlePagesApiRoute({
+      edgeRuntime: "worker",
+      match: createMatch(
+        () =>
+          new Response(body, {
+            headers: {
+              "content-encoding": "gzip",
+              "content-length": String(body.byteLength),
+              "content-type": "text/plain",
+            },
+          }),
+        {},
+        { runtime: "edge" },
+      ),
+      request: new Request("https://example.com/api/proxy"),
+      url: "/api/proxy",
+    });
+
+    expect(response.headers.get("content-encoding")).toBe("gzip");
+    expect(response.headers.get("content-length")).toBe(String(body.byteLength));
+    expect(Buffer.from(await response.arrayBuffer())).toEqual(body);
   });
 
   it("passes a NextRequest with nextUrl.searchParams to edge API handlers", async () => {


### PR DESCRIPTION
## Summary

- strip `content-length`, `content-encoding`, and `transfer-encoding` after Node decodes a Pages Edge API response
- apply the boundary in both Vite dev and the Node production server, matching the Next.js edge sandbox
- leave Cloudflare Worker responses untouched so encoded bodies and their headers continue streaming together

## Failure

Actions run `29871622126`, job `88775791401`:

- `test/e2e/edge-compiler-can-import-blob-assets/index.test.ts` — `allows to fetch a remote URL`
- `test/e2e/edge-compiler-can-import-blob-assets/index.test.ts` — `allows to fetch a remote URL with a path and basename`

Both returned raw gzip bytes instead of `Example Domain`.

The three imported text/image/node_modules asset failures are intentionally out of scope. PR #1833 owns that build/compiler lane; its diff does not touch runtime response decoding.

## Root cause

Node fetch decodes compressed response bodies but retains the origin encoding metadata. Vinext forwarded those stale headers through an Edge API response; the production response buffer then recompressed the already-decoded body while retaining the old encoding metadata. Clients therefore received an invalid encoding chain and exposed raw gzip bytes.

Next.js removes the three wire-level body headers in `packages/next/src/server/web/sandbox/sandbox.ts`. Vinext now applies that same rule only for Node-hosted Edge API execution. The Worker path keeps the original response object: Workers require an encoded body and `Content-Encoding` to remain paired, and direct streaming avoids buffering.

## Validation

Pinned Next.js oracle: `v16.2.6` at `ee6e79b1792a4d401ddf2480f40a83549fe8e722`.

```bash
REPO="/private/tmp/vinext-worker-fetch-content-encoding" \
NEXTJS_DIR="/Users/jamesanderson/Developer/vinext/.nextjs-ref" \
./scripts/run-targeted-nextjs-e2e.sh test/e2e/edge-compiler-can-import-blob-assets/index.test.ts
```

Result:

- 2/2 scoped remote-fetch assertions pass
- 3/3 out-of-scope imported-asset compiler assertions remain red

Focused vinext validation:

- `vp test run tests/pages-api-route.test.ts tests/api-handler.test.ts tests/deploy.test.ts tests/entry-templates.test.ts` — 451 passed
- targeted `vp check` for all 9 changed files — clean
- `vp run vinext#build` — passed as part of the exact targeted wrapper

Cloudflare runtime references:

- https://developers.cloudflare.com/workers/runtime-apis/response/#the-encodebody-option
- https://developers.cloudflare.com/workers/best-practices/workers-best-practices/#stream-request-and-response-bodies

Review and Bonk have not been requested yet.
