### PR TITLE
fix(app-router): preserve hash query navigation semantics

### DIFF
--- a/packages/vinext/src/server/app-browser-navigation-controller.ts
+++ b/packages/vinext/src/server/app-browser-navigation-controller.ts
@@ -581,9 +581,13 @@ export function createAppBrowserNavigationController(
     };
 
     if (pendingRouterState) {
-      // The programmatic navigation is already running inside React.startTransition
-      // (from router.push/replace/refresh/Link), so resolving the deferred promise
-      // is sufficient.
+      // Programmatic navigation already runs inside React.startTransition, so
+      // resolving the deferred promise is normally sufficient. A same-path
+      // search+hash response whose visible tree is unchanged can be retained by
+      // React without mounting the new NavigationCommitSignal, though. In that
+      // narrow synchronous mode, publish the resolved state directly as well;
+      // the signal's layout effect remains the authority for URL and scroll
+      // effects, including when the response suspends or changes the tree.
       if (pendingRouterState.settled) return;
       const committedState = captureCandidateState(
         applyApprovedVisibleCommit(getBrowserRouterState(), commit),
@@ -593,15 +597,14 @@ export function createAppBrowserNavigationController(
       if (activePendingBrowserRouterState === pendingRouterState) {
         activePendingBrowserRouterState = null;
       }
+      if (visibleCommitMode === "synchronous") {
+        flushSync(() => {
+          setter(committedState);
+        });
+      }
       return;
     }
 
-    // `synchronous` mode assumes a null `pendingRouterState`: its only caller
-    // (gesture push) navigates with `programmaticTransition = false`, so the
-    // early return above never wins. A future caller combining `synchronous`
-    // with a programmatic transition would have its synchronous commit
-    // silently dropped in favor of the deferred resolve above.
-    //
     // This is intentionally distinct from dispatchSynchronousVisibleCommit
     // below: that path's callers (HMR, history traversal) already run inside a
     // synchronous event-handler/effect context where React flushes the plain
@@ -715,6 +718,30 @@ export function createAppBrowserNavigationController(
     lifecycleOptions?.onDiscardedRevalidation?.();
   }
 
+  function isSamePathSearchHashCommit(targetHref: string): boolean {
+    if (typeof window === "undefined") return false;
+
+    try {
+      const currentUrl = new URL(window.location.href);
+      const targetUrl = new URL(targetHref, currentUrl.href);
+      return (
+        targetUrl.origin === currentUrl.origin &&
+        targetUrl.pathname === currentUrl.pathname &&
+        targetUrl.search !== currentUrl.search &&
+        targetUrl.hash !== ""
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  function shouldForceSynchronousCommit(options: BrowserNavigationPayloadOptions): boolean {
+    if (options.actionType === "traverse") return false;
+    if (options.historyUpdateMode === undefined) return false;
+    if (options.scrollIntent?.hash == null) return false;
+    return isSamePathSearchHashCommit(options.targetHref);
+  }
+
   async function renderNavigationPayload(
     options: BrowserNavigationPayloadOptions,
   ): Promise<NavigationPayloadOutcome> {
@@ -816,7 +843,9 @@ export function createAppBrowserNavigationController(
         renderId,
         approvedCommit,
         options.pendingRouterState,
-        options.visibleCommitMode ?? "transition",
+        shouldForceSynchronousCommit(options)
+          ? "synchronous"
+          : (options.visibleCommitMode ?? "transition"),
       );
     } catch (error) {
       pendingNavigationFailureTargets.delete(renderId);

--- a/packages/vinext/src/shims/app-router-scroll-state.ts
+++ b/packages/vinext/src/shims/app-router-scroll-state.ts
@@ -55,11 +55,27 @@ export function beginAppRouterScrollIntent(hash: string | null): AppRouterScroll
 }
 
 export function clearAppRouterScrollIntent(): void {
-  getScrollIntentStore().pending = null;
+  const store = getScrollIntentStore();
+  // Clearing is itself a newer scroll decision (including `scroll: false`).
+  // Advance ownership so deferred work from the prior intent cannot run after
+  // the pending slot becomes empty.
+  store.nextId += 1;
+  store.pending = null;
 }
 
 export function getPendingAppRouterScrollIntent(): AppRouterScrollIntent | null {
   return getScrollIntentStore().pending;
+}
+
+// Deferred post-commit work must remain invalidatable after its intent has
+// already been consumed. The monotonic id records newer ownership even when
+// the newer intent is also consumed before the deferred callback runs.
+export function isLatestAppRouterScrollIntent(
+  expected: AppRouterScrollIntent | null | undefined,
+): boolean {
+  return (
+    expected !== null && expected !== undefined && getScrollIntentStore().nextId === expected.id
+  );
 }
 
 export function claimAppRouterScrollIntentForCommit(

--- a/packages/vinext/src/shims/hash-scroll.ts
+++ b/packages/vinext/src/shims/hash-scroll.ts
@@ -31,8 +31,9 @@ export function scrollToHashTarget(hash: string): void {
   window.scrollTo(0, 0);
 }
 
-export function scrollToHashTargetOnNextFrame(hash: string): void {
+export function scrollToHashTargetOnNextFrame(hash: string, shouldScroll?: () => boolean): void {
   requestAnimationFrame(() => {
+    if (shouldScroll && !shouldScroll()) return;
     scrollToHashTarget(hash);
   });
 }

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -464,6 +464,19 @@ function prefetchUrl(
   ) {
     return;
   }
+  if (
+    mode === "auto" &&
+    priority === "low" &&
+    target.origin === window.location.origin &&
+    target.pathname === window.location.pathname &&
+    target.search !== window.location.search &&
+    target.hash !== ""
+  ) {
+    // Match Next.js's same-page query+hash behavior: the visible Link does not
+    // issue its query RSC request during viewport prefetch. The click remains
+    // authoritative and fetches the changed search state before scrolling.
+    return;
+  }
 
   const runPrefetch = () => {
     void (async () => {
@@ -1186,7 +1199,9 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
   const pagesAsHref = asHref ?? dynamicRouteHref?.as;
   const unresolvedHref = pagesAsHref ?? hrefStr;
   const rawResolvedHref =
-    typeof unresolvedHref === "string" && unresolvedHref.startsWith("#")
+    typeof unresolvedHref === "string" &&
+    unresolvedHref.startsWith("#") &&
+    !getNavigationRuntime()?.functions.navigate
       ? resolvePagesQueryOnlyHref(unresolvedHref)
       : unresolvedHref;
   const concreteRouteHref = HAS_PAGES_ROUTER

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -58,12 +58,13 @@ import {
   resolveDirectHybridClientRouteOwner,
   type HybridClientOwner,
 } from "./internal/hybrid-client-route-owner-direct.js";
-import { retryScrollTo, scrollToHashTarget } from "./hash-scroll.js";
+import { retryScrollTo, scrollToHashTarget, scrollToHashTargetOnNextFrame } from "./hash-scroll.js";
 import {
   beginAppRouterScrollIntent,
   clearAppRouterScrollIntent,
   consumeAppRouterScrollIntent,
   getPendingAppRouterScrollIntent,
+  isLatestAppRouterScrollIntent,
   type AppRouterScrollIntent,
 } from "./app-router-scroll-state.js";
 import {
@@ -1855,7 +1856,10 @@ export function applyAppRouterScrollFallback(intent: AppRouterScrollIntent): voi
   }
 
   if (intent.hash !== null) {
-    scrollToHashTarget(intent.hash);
+    // Browsers can apply their own scroll restoration after the navigation's
+    // commit microtasks. Defer the fallback to the next frame so that native
+    // work cannot immediately reset the requested fragment scroll.
+    scrollToHashTargetOnNextFrame(intent.hash, () => isLatestAppRouterScrollIntent(intent));
     return;
   }
 

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -79,6 +79,10 @@ import {
   type AppElementsSlotBinding,
 } from "../packages/vinext/src/server/app-elements.js";
 import { createClientNavigationRenderSnapshot } from "../packages/vinext/src/shims/navigation.js";
+import {
+  beginAppRouterScrollIntent,
+  clearAppRouterScrollIntent,
+} from "../packages/vinext/src/shims/app-router-scroll-state.js";
 import * as navigationShim from "../packages/vinext/src/shims/navigation.js";
 import {
   createHistoryStateWithNavigationMetadata,
@@ -3454,6 +3458,178 @@ describe("app browser navigation controller", () => {
     } finally {
       detach();
       vi.unstubAllEnvs();
+    }
+  });
+
+  it("forces same-path search and hash state into a synchronous React commit", async () => {
+    const initialElements = createResolvedElements("route:/hash", "/", null, {
+      "page:/hash": React.createElement("main", null, "hash page"),
+    });
+    const initialState = createState({
+      elements: initialElements,
+      navigationSnapshot: createClientNavigationRenderSnapshot(
+        "https://example.com/hash#non-existent",
+        {},
+      ),
+      routeId: "route:/hash",
+    });
+    const { controller, detach, setBrowserRouterState, stateRef } =
+      createControllerHarness(initialState);
+    const commitEffect = vi.fn();
+    const scrollIntent = beginAppRouterScrollIntent("#hash-160");
+
+    stubWindow("https://example.com/hash#non-existent");
+
+    try {
+      const navId = controller.beginNavigation();
+      const pendingRouterState = controller.beginPendingBrowserRouterState();
+      const renderPromise = renderCurrentStateNavigationPayload(controller, {
+        payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
+        actionType: "navigate",
+        createNavigationCommitEffect: () => commitEffect,
+        historyUpdateMode: "push",
+        navigationSnapshot: createClientNavigationRenderSnapshot(
+          "https://example.com/hash?with-query-param#hash-160",
+          {},
+        ),
+        nextElements: Promise.resolve(initialElements),
+        operationLane: "navigation",
+        params: {},
+        pendingRouterState,
+        previousNextUrl: null,
+        scrollIntent,
+        targetHref: "https://example.com/hash?with-query-param#hash-160",
+        navId,
+      });
+
+      const outcome = await Promise.race([
+        renderPromise,
+        new Promise<"timeout">((resolve) => {
+          setTimeout(() => resolve("timeout"), 50);
+        }),
+      ]);
+
+      expect(outcome).toBe("timeout");
+      expect(stateRef.current.renderId).toBeGreaterThan(0);
+      expect(stateRef.current.navigationSnapshot.searchParams.get("with-query-param")).toBe("");
+      expect(setBrowserRouterState).toHaveBeenLastCalledWith(stateRef.current);
+      // URL and scroll effects still wait for NavigationCommitSignal's layout
+      // effect; hash-rsc-requests.browser.spec.ts verifies that real commit.
+      expect(commitEffect).not.toHaveBeenCalled();
+    } finally {
+      clearAppRouterScrollIntent();
+      detach();
+    }
+  });
+
+  it("waits for the commit signal when a same-path search and hash navigation changes the tree", async () => {
+    const initialElements = createResolvedElements("route:/hash", "/", null, {
+      "page:/hash": React.createElement("main", null, "old hash page"),
+    });
+    const nextElements = createResolvedElements("route:/hash", "/", null, {
+      "page:/hash": React.createElement("main", null, "new hash page"),
+    });
+    const initialState = createState({
+      elements: initialElements,
+      navigationSnapshot: createClientNavigationRenderSnapshot(
+        "https://example.com/hash?old=1#old-content",
+        {},
+      ),
+      routeId: "route:/hash",
+    });
+    const { controller, detach } = createControllerHarness(initialState);
+    const commitEffect = vi.fn();
+    const scrollIntent = beginAppRouterScrollIntent("#new-content");
+
+    stubWindow("https://example.com/hash?old=1#old-content");
+
+    try {
+      const navId = controller.beginNavigation();
+      const renderPromise = renderCurrentStateNavigationPayload(controller, {
+        payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
+        actionType: "navigate",
+        createNavigationCommitEffect: () => commitEffect,
+        historyUpdateMode: "push",
+        navigationSnapshot: createClientNavigationRenderSnapshot(
+          "https://example.com/hash?new=1#new-content",
+          {},
+        ),
+        nextElements: Promise.resolve(nextElements),
+        operationLane: "navigation",
+        params: {},
+        pendingRouterState: controller.beginPendingBrowserRouterState(),
+        previousNextUrl: null,
+        scrollIntent,
+        targetHref: "https://example.com/hash?new=1#new-content",
+        navId,
+      });
+
+      await expect(
+        Promise.race([
+          renderPromise,
+          new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 25)),
+        ]),
+      ).resolves.toBe("timeout");
+      expect(commitEffect).not.toHaveBeenCalled();
+    } finally {
+      clearAppRouterScrollIntent();
+      detach();
+    }
+  });
+
+  it("does not settle an unchanged search and hash render after a newer navigation starts", async () => {
+    const initialElements = createResolvedElements("route:/hash", "/", null, {
+      "page:/hash": React.createElement("main", null, "hash page"),
+    });
+    const initialState = createState({
+      elements: initialElements,
+      navigationSnapshot: createClientNavigationRenderSnapshot("https://example.com/hash", {}),
+      routeId: "route:/hash",
+    });
+    const { controller, detach } = createControllerHarness(initialState);
+    const commitEffect = vi.fn();
+    const scrollIntent = beginAppRouterScrollIntent("#hash-160");
+
+    stubWindow("https://example.com/hash");
+
+    try {
+      const navId = controller.beginNavigation();
+      const pendingRouterState = controller.beginPendingBrowserRouterState();
+      const renderPromise = renderCurrentStateNavigationPayload(controller, {
+        payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
+        actionType: "navigate",
+        createNavigationCommitEffect: () => commitEffect,
+        historyUpdateMode: "push",
+        navigationSnapshot: createClientNavigationRenderSnapshot(
+          "https://example.com/hash?with-query-param#hash-160",
+          {},
+        ),
+        nextElements: Promise.resolve(initialElements),
+        operationLane: "navigation",
+        params: {},
+        pendingRouterState,
+        previousNextUrl: null,
+        scrollIntent,
+        targetHref: "https://example.com/hash?with-query-param#hash-160",
+        navId,
+      });
+
+      for (let attempts = 0; attempts < 5 && !pendingRouterState.settled; attempts++) {
+        await Promise.resolve();
+      }
+      expect(pendingRouterState.settled).toBe(true);
+      controller.beginNavigation();
+
+      await expect(
+        Promise.race([
+          renderPromise,
+          new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 25)),
+        ]),
+      ).resolves.toBe("timeout");
+      expect(commitEffect).not.toHaveBeenCalled();
+    } finally {
+      clearAppRouterScrollIntent();
+      detach();
     }
   });
 

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -600,6 +600,52 @@ describe("Link App Router navigation scheduling", () => {
     expect(transitionStates).toEqual([true]);
   });
 
+  it("preserves the current query when an App Router Link changes only the hash", async () => {
+    // Ported from Next.js: test/e2e/app-dir/navigation/navigation.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/navigation/navigation.test.ts
+    const pushState = vi.fn();
+    const replaceState = vi.fn();
+    const result = await renderIsolatedLink({
+      href: "#h1",
+      nodeEnv: "production",
+      props: { prefetch: false },
+      windowOverrides: {
+        history: { pushState, replaceState, state: {} },
+        location: {
+          href: "https://example.com/nested-relative-query-and-hash?here=ok#h2",
+          origin: "https://example.com",
+          pathname: "/nested-relative-query-and-hash",
+          search: "?here=ok",
+        },
+      },
+    });
+
+    try {
+      const onClick = result.capturedAnchorProps.onClick;
+      expect(onClick).toBeTypeOf("function");
+      if (onClick === undefined) {
+        throw new Error("Expected rendered Link anchor to expose an onClick handler");
+      }
+      await onClick({
+        button: 0,
+        currentTarget: { hasAttribute: () => false, target: "" },
+        defaultPrevented: false,
+        preventDefault() {
+          this.defaultPrevented = true;
+        },
+      });
+
+      expect(pushState).toHaveBeenCalledWith(
+        null,
+        "",
+        "/nested-relative-query-and-hash?here=ok#h1",
+      );
+      expect(result.navigate).not.toHaveBeenCalled();
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
   it("lets the browser handle native URI schemes without app-router navigation", async () => {
     const userOnClick = vi.fn();
     const hrefs = ["mailto:hello@example.com", "tel:+123456789", "sms:+123456789"];
@@ -1317,6 +1363,8 @@ async function renderIsolatedLink(options: {
   vi.stubGlobal("fetch", fetch);
   vi.stubGlobal("document", {
     createElement: vi.fn(() => ({})),
+    getElementById: vi.fn(() => null),
+    getElementsByName: vi.fn(() => []),
     head: {
       appendChild: vi.fn((node: CapturedPrefetchLinkElement) => {
         pagePrefetchLinks.push(node);
@@ -1492,6 +1540,25 @@ describe("Link prefetch scheduling", () => {
           priority: "low",
         }),
       );
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("does not viewport-prefetch same-page query and hash links", async () => {
+    const observer = stubIntersectionObserver();
+    const result = await renderIsolatedLink({
+      href: "/current?with-query-param#hash-160",
+      nodeEnv: "production",
+    });
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await flushPrefetchTasks();
+
+      // Ported from Next.js: test/e2e/app-dir/navigation/navigation.test.ts
+      // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/navigation/navigation.test.ts
+      expect(result.fetch).not.toHaveBeenCalled();
     } finally {
       result.restoreNodeEnv();
     }

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -15205,6 +15205,80 @@ describe("app router scroll document-top fallback", () => {
     ],
   };
 
+  it("defers hash fallback scrolling and ignores a stale animation frame", async () => {
+    const { beginAppRouterScrollIntent, clearAppRouterScrollIntent } =
+      await import("../packages/vinext/src/shims/app-router-scroll-state.js");
+    const { applyAppRouterScrollFallback } =
+      await import("../packages/vinext/src/shims/navigation.js");
+    const scrollIntoView = vi.fn();
+    let frame: (() => void) | null = null;
+    const originalDocument = Object.getOwnPropertyDescriptor(globalThis, "document");
+    const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+    const originalRequestAnimationFrame = Object.getOwnPropertyDescriptor(
+      globalThis,
+      "requestAnimationFrame",
+    );
+
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: {
+        documentElement: { scrollTop: 0 },
+        getElementById: () => ({ scrollIntoView }),
+        getElementsByName: () => [],
+        head: { querySelectorAll: () => [] },
+      },
+    });
+    Object.defineProperty(globalThis, "window", { configurable: true, value: {} });
+    Object.defineProperty(globalThis, "requestAnimationFrame", {
+      configurable: true,
+      value: (callback: () => void) => {
+        frame = callback;
+        return 1;
+      },
+    });
+
+    try {
+      clearAppRouterScrollIntent();
+      const intent = beginAppRouterScrollIntent("#target");
+      applyAppRouterScrollFallback(intent);
+      expect(scrollIntoView).not.toHaveBeenCalled();
+      expect(frame).not.toBeNull();
+      frame!();
+      expect(scrollIntoView).toHaveBeenCalledWith({ behavior: "auto" });
+
+      scrollIntoView.mockClear();
+      frame = null;
+      const staleIntent = beginAppRouterScrollIntent("#stale");
+      applyAppRouterScrollFallback(staleIntent);
+      expect(frame).not.toBeNull();
+      beginAppRouterScrollIntent("#new");
+      frame!();
+      expect(scrollIntoView).not.toHaveBeenCalled();
+
+      clearAppRouterScrollIntent();
+      frame = null;
+      const clearedIntent = beginAppRouterScrollIntent("#cleared");
+      applyAppRouterScrollFallback(clearedIntent);
+      expect(frame).not.toBeNull();
+      clearAppRouterScrollIntent();
+      frame!();
+      expect(scrollIntoView).not.toHaveBeenCalled();
+    } finally {
+      clearAppRouterScrollIntent();
+      for (const [key, descriptor] of [
+        ["document", originalDocument],
+        ["window", originalWindow],
+        ["requestAnimationFrame", originalRequestAnimationFrame],
+      ] as const) {
+        if (descriptor) {
+          Object.defineProperty(globalThis, key, descriptor);
+        } else {
+          Reflect.deleteProperty(globalThis, key);
+        }
+      }
+    }
+  });
+
   it("scrolls to the document top even when hoisted stylesheets exist in <head>", async () => {
     const { beginAppRouterScrollIntent, clearAppRouterScrollIntent } =
       await import("../packages/vinext/src/shims/app-router-scroll-state.js");


### PR DESCRIPTION
## Summary

- preserve the current query when an App Router `<Link>` changes only the hash
- avoid automatic viewport prefetches for same-page query+hash links while keeping the click authoritative
- settle same-path query+hash commits whose visible React tree does not emit a commit signal, so scrolling completes

This is a current-main, scoped replacement for the functional navigation failures covered by #2104. The original PR is cross-repository and also carries unrelated stale changes.

## Validation

- `vp test run tests/app-browser-entry.test.ts tests/link-navigation.test.ts` — 298/298 passed
- `vp check packages/vinext/src/server/app-browser-navigation-controller.ts packages/vinext/src/shims/link.tsx tests/app-browser-entry.test.ts tests/link-navigation.test.ts` — clean
- `REPO="$(pwd)" NEXTJS_DIR="/Users/jamesanderson/Developer/vinext/.nextjs-ref" ./scripts/run-targeted-nextjs-e2e.sh test/e2e/app-dir/navigation/navigation.test.ts` — all owned hash/query/scroll cases pass; suite is 49/50, with only the separately owned #2446 async-metadata case remaining

The upstream cases now passing include the no-extra-query-prefetch assertion, hash scrolling with `scroll-padding-top`, and hash-only links preserving an existing query string.