### PR TITLE
fix(app-router): install default not-found boundary

### DIFF
--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -1349,10 +1349,15 @@ export function buildAppPageElements<
   // Next's app loader injects its built-in not-found convention when the app has
   // no custom fallback. Keep the equivalent boundary around late client-side
   // signals such as a streaming MetadataOutlet rejection.
+  const configuredNotFoundComponent =
+    getDefaultExport(options.route.notFound) ?? getDefaultExport(options.rootNotFoundModule);
+  // The built-in convention belongs to the root layout's children slot. Keep
+  // the route-level fallback only for layoutless synthetic/test routes.
+  const defaultNotFoundOwnerLayoutId =
+    configuredNotFoundComponent === null ? (layoutEntries[0]?.id ?? null) : null;
   const notFoundComponent =
-    getDefaultExport(options.route.notFound) ??
-    getDefaultExport(options.rootNotFoundModule) ??
-    DEFAULT_NOT_FOUND_COMPONENT;
+    configuredNotFoundComponent ??
+    (defaultNotFoundOwnerLayoutId === null ? DEFAULT_NOT_FOUND_COMPONENT : null);
   if (notFoundComponent) {
     const NotFoundComponent = notFoundComponent;
     routeChildren = (
@@ -1430,7 +1435,9 @@ export function buildAppPageElements<
     // Building bottom-up means Loading must wrap the leaf subtree first, then
     // access/error boundaries, Template, and finally the Layout slot.
     if (layoutEntry) {
-      const layoutNotFoundComponent = getDefaultExport(layoutEntry.notFoundModule);
+      const layoutNotFoundComponent =
+        getDefaultExport(layoutEntry.notFoundModule) ??
+        (layoutEntry.id === defaultNotFoundOwnerLayoutId ? DEFAULT_NOT_FOUND_COMPONENT : null);
       if (layoutNotFoundComponent) {
         const LayoutNotFoundComponent = layoutNotFoundComponent;
         segmentChildren = (

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -18,6 +18,7 @@ import {
 } from "vinext/shims/error-boundary";
 import { AppRouterScrollTarget } from "vinext/shims/app-router-scroll";
 import DefaultGlobalError from "vinext/shims/default-global-error";
+import DefaultNotFound from "vinext/shims/default-not-found";
 import type { AppRouteSemanticIds } from "../routing/app-route-graph.js";
 import { LayoutSegmentProvider } from "vinext/shims/layout-segment-context";
 import {
@@ -70,6 +71,7 @@ type AppPageComponent = ComponentType<AppPageComponentProps>;
 type AppPageErrorComponent = ComponentType<{ error: unknown; reset: () => void }>;
 const APP_PAGE_LAYOUT_PROBE_CHILD = <Fragment />;
 const DEFAULT_GLOBAL_ERROR_COMPONENT = DefaultGlobalError as AppPageErrorComponent;
+const DEFAULT_NOT_FOUND_COMPONENT = DefaultNotFound as AppPageComponent;
 
 function resolveSlotLayoutParams(
   routeSegments: readonly string[],
@@ -1344,8 +1346,13 @@ export function buildAppPageElements<
     errorEntries.length > 0 ? errorEntries[errorEntries.length - 1].errorModule : null;
   // Next.js nesting (outer to inner): Error > Unauthorized > Forbidden > NotFound > children.
   // Building bottom-up means NotFoundBoundary must wrap first, then Forbidden, Unauthorized, Error.
+  // Next's app loader injects its built-in not-found convention when the app has
+  // no custom fallback. Keep the equivalent boundary around late client-side
+  // signals such as a streaming MetadataOutlet rejection.
   const notFoundComponent =
-    getDefaultExport(options.route.notFound) ?? getDefaultExport(options.rootNotFoundModule);
+    getDefaultExport(options.route.notFound) ??
+    getDefaultExport(options.rootNotFoundModule) ??
+    DEFAULT_NOT_FOUND_COMPONENT;
   if (notFoundComponent) {
     const NotFoundComponent = notFoundComponent;
     routeChildren = (

--- a/tests/app-page-route-wiring.test.ts
+++ b/tests/app-page-route-wiring.test.ts
@@ -2388,6 +2388,54 @@ describe("app page route wiring helpers", () => {
     ).not.toBeNull();
   });
 
+  it("owns the built-in not-found boundary at the root layout", () => {
+    const elements = buildAppPageElements({
+      element: createElement(PageProbe),
+      makeThenableParams(params) {
+        return Promise.resolve(params);
+      },
+      matchedParams: {},
+      resolvedMetadata: null,
+      resolvedViewport: {},
+      route: {
+        error: null,
+        errors: [null, null],
+        layoutTreePositions: [0, 1],
+        layouts: [{ default: RootLayout }, { default: GroupLayout }],
+        loading: null,
+        notFound: null,
+        notFounds: [null, null],
+        routeSegments: ["dashboard", "reports"],
+        slots: {},
+        templateTreePositions: [],
+        templates: [],
+      },
+      routePath: "/dashboard/reports",
+      rootNotFoundModule: null,
+    });
+
+    const routeEntry = elements["route:/dashboard/reports"];
+    const rootLayoutSlot = findSlotById(routeEntry, "layout:/");
+    const nestedLayoutSlot = findSlotById(routeEntry, "layout:/dashboard");
+    expect(rootLayoutSlot).not.toBeNull();
+    expect(nestedLayoutSlot).not.toBeNull();
+    if (!rootLayoutSlot || !nestedLayoutSlot) {
+      throw new Error("Expected both root and nested layout slots");
+    }
+
+    const rootNotFoundBoundary = findElementByTypeName(
+      rootLayoutSlot.props.children,
+      "NotFoundBoundary",
+    );
+    expect(rootNotFoundBoundary).not.toBeNull();
+    if (!rootNotFoundBoundary) throw new Error("Expected the built-in not-found boundary");
+    expect(getElementTypeName((rootNotFoundBoundary.props.fallback as ReactElement).type)).toBe(
+      "DefaultNotFound",
+    );
+    expect(findSlotById(rootNotFoundBoundary.props.children, "layout:/dashboard")).not.toBeNull();
+    expect(findElementByTypeName(nestedLayoutSlot.props.children, "NotFoundBoundary")).toBeNull();
+  });
+
   it("nests per-segment NotFoundBoundary inside the template wrapper", () => {
     function RootNotFound() {
       return createElement("div", { "data-not-found": "root" }, "Not Found");

--- a/tests/app-page-route-wiring.test.ts
+++ b/tests/app-page-route-wiring.test.ts
@@ -2340,6 +2340,54 @@ describe("app page route wiring helpers", () => {
     expect(body).toContain("Blog page");
   });
 
+  // Ported from Next.js: test/e2e/app-dir/metadata-streaming/metadata-streaming.test.ts
+  // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/metadata-streaming/metadata-streaming.test.ts
+  it("wraps the streaming metadata outlet in the built-in not-found boundary", () => {
+    const elements = buildAppPageElements({
+      element: createElement(PageProbe),
+      makeThenableParams(params) {
+        return Promise.resolve(params);
+      },
+      matchedParams: {},
+      resolvedMetadata: null,
+      resolvedViewport: {},
+      streamingMetadataOutlet: Promise.resolve(null),
+      streamingMetadataOutletSuspended: true,
+      route: {
+        error: null,
+        errors: [null],
+        layoutTreePositions: [0],
+        layouts: [{ default: RootLayout }],
+        loading: null,
+        notFound: null,
+        notFounds: [null],
+        routeSegments: ["metadata-not-found"],
+        slots: {},
+        templateTreePositions: [],
+        templates: [],
+      },
+      routePath: "/metadata-not-found",
+      rootNotFoundModule: null,
+    });
+
+    const notFoundBoundary = findElementByTypeName(
+      elements["route:/metadata-not-found"],
+      "NotFoundBoundary",
+    );
+
+    expect(notFoundBoundary).not.toBeNull();
+    if (!notFoundBoundary) throw new Error("Expected the built-in not-found boundary");
+    expect(getElementTypeName((notFoundBoundary.props.fallback as ReactElement).type)).toBe(
+      "DefaultNotFound",
+    );
+    expect(
+      findSlotById(
+        notFoundBoundary.props.children,
+        "__vinext_streaming_metadata_outlet:route:/metadata-not-found",
+      ),
+    ).not.toBeNull();
+  });
+
   it("nests per-segment NotFoundBoundary inside the template wrapper", () => {
     function RootNotFound() {
       return createElement("div", { "data-not-found": "root" }, "Not Found");


### PR DESCRIPTION
## Summary

- install vinext's built-in App Router not-found boundary when an app does not define a route or root `not-found.tsx`
- keep custom route/root not-found conventions authoritative
- add focused coverage that the streaming metadata outlet sits beneath the built-in boundary

## Failure

Actions run `29871622126`, job `88775791401`:

- `test/e2e/app-dir/metadata-streaming/metadata-streaming.test.ts`
- `navigation API should trigger not-found boundary when call notFound`

On current main, `/notfound` hydrated after `generateMetadata()` called `notFound()`, but the streamed metadata rejection escaped to the global error path and the expected built-in `<h1>404</h1>` never committed.

## Root cause

Next.js injects its built-in not-found convention into the App Router loader tree when the app has no custom fallback:

- https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/build/webpack/loaders/next-app-loader/index.ts#L70-L79
- https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/build/webpack/loaders/next-app-loader/index.ts#L380-L398

Vinext only created `NotFoundBoundary` when a route/root not-found module existed. Consequently, late client-side routing signals, including the streaming metadata outlet rejection, had no default boundary to catch them. The fallback selection now uses `DefaultNotFound` only after route and root conventions are exhausted.

## Validation

Pinned Next.js oracle: v16.2.6 at `ee6e79b1792a4d401ddf2480f40a83549fe8e722`.

- exact `metadata-streaming.test.ts`: current-main baseline 18/19 -> branch 19/19
- target row: 38.7s timeout on baseline -> 843ms pass on branch
- `vp test run tests/app-page-route-wiring.test.ts tests/app-page-element-builder.test.ts tests/error-boundary.test.ts tests/nextjs-compat/not-found.test.ts` — 180/180 passed
- scoped format, lint, and type checks — clean
- vinext package build — passed as part of the exact targeted wrapper
