### PR TITLE
refactor(lazy-chunks): normalize manifest key using pathslash

### DIFF
--- a/packages/vinext/src/utils/lazy-chunks.ts
+++ b/packages/vinext/src/utils/lazy-chunks.ts
@@ -1,3 +1,5 @@
+import { toSlash } from "pathslash";
+
 /**
  * Build-manifest chunk metadata used to compute lazy chunks.
  */
@@ -87,7 +89,7 @@ export function computeLazyChunks(buildManifest: Record<string, BuildManifestChu
 }
 
 function normalizeManifestKey(key: string): string {
-  return key.split("?")[0].replace(/\\/g, "/").replace(/^\/+/, "");
+  return toSlash(key.split("?")[0]).replace(/^\/+/, "");
 }
 
 function addFile(files: string[], seen: Set<string>, file: string | undefined): void {


### PR DESCRIPTION
## Summary

  - Use `pathslash` consistently for filesystem path handling.
  - Replace backslashes only on Windows through `toSlash()`, preserving backslashes as valid filename characters on
  POSIX systems.
  - Follow up #1605.

## Files changed

  ### `packages/vinext/src/utils/lazy-chunks.ts`

  - Import `toSlash` from `pathslash`.
  - Update `normalizeManifestKey()` to normalize manifest keys through `toSlash()` instead of a manual `replace(/\\/g,
  "/")`.