### PR TITLE
perf(app-router): serialize streamed metadata once

### DIFF
--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -31,7 +31,7 @@ import {
 } from "vinext/shims/metadata";
 import { Children, ParallelSlot, Slot } from "vinext/shims/slot";
 import { StreamedIconsInsertion } from "vinext/shims/streamed-icons";
-import { createInlineScriptTag } from "./html.js";
+import { createInlineScriptTag, escapeHtmlAttr } from "./html.js";
 import type { AppPageParams } from "./app-page-boundary.js";
 import type { AppLayoutParamAccessTracker } from "./app-layout-param-observation.js";
 import type { ThenableParamsObserver } from "vinext/shims/thenable-params";
@@ -673,6 +673,8 @@ function createStreamedIconKey(pathname: string, metadataHtml: string): string {
   return `${pathname}:${(hash >>> 0).toString(36)}`;
 }
 
+const STREAMED_ICON_KEY_PLACEHOLDER = "vinext-pending-streamed-icon-key";
+
 const REINSERT_STREAMED_ICONS_SCRIPT = `document.querySelectorAll('body link[rel="icon"], body link[rel="apple-touch-icon"]').forEach(el => document.head.appendChild(el));const a='data-vinext-streamed-icon',o=el=>{const m=el.getAttribute(a),i=m.lastIndexOf(':');return Number(m.slice(i+1))};[...document.querySelectorAll('link['+a+']')].sort((l,r)=>o(l)-o(r)).forEach(el=>document.head.appendChild(el))`;
 
 export function createAppPageRouteBodyMetadata(
@@ -683,12 +685,17 @@ export function createAppPageRouteBodyMetadata(
   scriptNonce?: string,
 ): ReactNode {
   if (!metadata || metadataPlacement !== "body") return null;
-  const renderedMetadataHtml = renderMetadataToHtml(metadata, pathname, { trailingSlash });
-  const metadataKey = hasStreamedIcons(metadata)
-    ? createStreamedIconKey(pathname, renderedMetadataHtml)
-    : "";
-  const metadataHtml = metadataKey
-    ? renderMetadataToHtml(metadata, pathname, { trailingSlash, streamedIconKey: metadataKey })
+  const streamedIconKey = hasStreamedIcons(metadata) ? STREAMED_ICON_KEY_PLACEHOLDER : undefined;
+  const renderedMetadataHtml = renderMetadataToHtml(metadata, pathname, {
+    trailingSlash,
+    streamedIconKey,
+  });
+  const metadataKey = streamedIconKey ? createStreamedIconKey(pathname, renderedMetadataHtml) : "";
+  const metadataHtml = streamedIconKey
+    ? renderedMetadataHtml.replaceAll(
+        `<link data-vinext-streamed-icon="${STREAMED_ICON_KEY_PLACEHOLDER}:`,
+        `<link data-vinext-streamed-icon="${escapeHtmlAttr(metadataKey)}:`,
+      )
     : renderedMetadataHtml;
   const parserInsertedMetadataHtml =
     metadataHtml + createInlineScriptTag(REINSERT_STREAMED_ICONS_SCRIPT, scriptNonce);

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -3510,6 +3510,31 @@ describe("createAppPageRouteBodyMetadata (body-placement canonical)", () => {
     expect(html).toMatch(/<script>document\.querySelectorAll[\s\S]*<\/script><\/div>$/);
   });
 
+  it("body placement: serializes icon-bearing metadata once", () => {
+    let titleReads = 0;
+    const title = 'data-vinext-streamed-icon="vinext-pending-streamed-icon-key:0';
+    const node = createAppPageRouteBodyMetadata(
+      {
+        get title() {
+          titleReads += 1;
+          return title;
+        },
+        icons: { icon: "/favicon.ico" },
+      },
+      '/icons" data-injected="true',
+      "body",
+    );
+    const html = renderToStaticMarkup(node as React.ReactElement);
+
+    // MetadataHead reads a string title twice per serialization: once for the
+    // type check and once for the value. A second serialization would read it
+    // four times.
+    expect(titleReads).toBe(2);
+    expect(html).toContain(`<title>${title}</title>`);
+    expect(html).not.toContain(' data-injected="true"');
+    expect(html).toContain("/icons&quot; data-injected=&quot;true:");
+  });
+
   it("body placement: includes icon cleanup reconciliation without streamed icons", () => {
     const node = createAppPageRouteBodyMetadata({ title: "Streamed title" }, "/metadata", "body");
     const html = renderToStaticMarkup(node as React.ReactElement);


### PR DESCRIPTION
## Summary
- follow up on #2320 by serializing streamed metadata once for icon-bearing App Router responses
- preserve the content-derived reconciliation key with a generated marker placeholder
- keep post-serialization marker replacement HTML-attribute safe
- add regression coverage that detects a second metadata serialization

## Validation
- `vp check packages/vinext/src/server/app-page-route-wiring.tsx tests/features.test.ts`
- `vp test run tests/features.test.ts` (355/355)
- `vp test run tests/app-router-metadata-routes.test.ts` (36/36)
- `PLAYWRIGHT_PROJECT=app-router pnpm run test:e2e -- tests/e2e/app-router/metadata-icons.spec.ts` (8/8)

Follow-up to #2320.