### PR TITLE
fix(app-router): honor reactStrictMode

### DIFF
--- a/packages/vinext/src/check.ts
+++ b/packages/vinext/src/check.ts
@@ -293,9 +293,9 @@ const CONFIG_SUPPORT: Record<string, { status: Status; detail?: string }> = {
     detail: "supported for Pages Router; App Router unchanged",
   },
   reactStrictMode: {
-    status: "partial",
+    status: "supported",
     detail:
-      "enforced for the Pages Router (client root wrapped in <React.StrictMode> when true); App Router is not yet wrapped (Next.js defaults App Router strict mode on)",
+      "enforced for both routers; App Router defaults on and Pages Router defaults off, matching Next.js",
   },
   poweredByHeader: {
     status: "supported",

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2196,6 +2196,12 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         }
         // Expose basePath to client-side code
         defines["process.env.__NEXT_ROUTER_BASEPATH"] = JSON.stringify(nextConfig.basePath);
+        // Next.js enables Strict Mode by default for the App Router while
+        // preserving an explicit `reactStrictMode: false`.
+        // See: packages/next/src/build/define-env.ts
+        defines["process.env.__NEXT_STRICT_MODE_APP"] = JSON.stringify(
+          nextConfig.reactStrictMode === null ? true : nextConfig.reactStrictMode,
+        );
         // Let shared client shims compile out Pages-only behavior in pure App
         // Router builds while retaining it for Pages and hybrid applications.
         defines["process.env.__VINEXT_HAS_PAGES_ROUTER"] = JSON.stringify(String(hasPagesDir));

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -2,7 +2,9 @@
 
 import {
   createElement,
+  Fragment,
   startTransition,
+  StrictMode,
   use,
   useEffect,
   useLayoutEffect,
@@ -191,6 +193,7 @@ import {
 import { hasServerActions, loadServerActionClient } from "virtual:vinext-app-capabilities";
 
 const HAS_CLIENT_REWRITES = process.env.__VINEXT_HAS_CLIENT_REWRITES !== "false";
+const StrictModeIfEnabled = process.env.__NEXT_STRICT_MODE_APP ? StrictMode : Fragment;
 
 type SearchParamInput = ConstructorParameters<typeof URLSearchParams>[0];
 type DevErrorOverlayModule = typeof import("../client/dev-error-overlay.js");
@@ -1592,11 +1595,15 @@ function bootstrapHydration(
           onRecoverableError,
           onUncaughtError,
         });
-  const children = createElement(BrowserRoot, {
-    hydrationCachePublication,
-    initialElements: root,
-    initialNavigationSnapshot,
-  });
+  const children = createElement(
+    StrictModeIfEnabled,
+    null,
+    createElement(BrowserRoot, {
+      hydrationCachePublication,
+      initialElements: root,
+      initialNavigationSnapshot,
+    }),
+  );
   const errorShellStyles = document.querySelectorAll("style[data-vinext-error-shell-style]");
   if (document.documentElement.id === "__next_error__") {
     // Next.js client/app-index.tsx uses the document id alone to select CSR

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -301,10 +301,7 @@ describe("analyzeConfig", () => {
     const items = analyzeConfig(tmpDir);
     expect(items.find((i) => i.name === "basePath")?.status).toBe("supported");
     expect(items.find((i) => i.name === "trailingSlash")?.status).toBe("supported");
-    // reactStrictMode is enforced for the Pages Router (client root wrapped in
-    // `<React.StrictMode>` when `true`) but the App Router is not yet wrapped,
-    // so the status is `partial`. See `packages/vinext/src/check.ts`.
-    expect(items.find((i) => i.name === "reactStrictMode")?.status).toBe("partial");
+    expect(items.find((i) => i.name === "reactStrictMode")?.status).toBe("supported");
   });
 
   it("detects unsupported webpack config", () => {

--- a/tests/e2e/app-router/react-strict-mode.spec.ts
+++ b/tests/e2e/app-router/react-strict-mode.spec.ts
@@ -1,0 +1,9 @@
+import { expect, test } from "@playwright/test";
+import { waitForAppRouterHydration } from "../helpers";
+
+test("enables Strict Mode by default for the App Router", async ({ page }) => {
+  await page.goto("/react-strict-mode");
+  await waitForAppRouterHydration(page);
+
+  await expect(page.getByTestId("strict-mode-render-count")).toHaveText("2");
+});

--- a/tests/e2e/app-router/react-strict-mode.spec.ts
+++ b/tests/e2e/app-router/react-strict-mode.spec.ts
@@ -1,9 +1,62 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { expect, test } from "@playwright/test";
 import { waitForAppRouterHydration } from "../helpers";
+import {
+  startChildViteDevServer,
+  stopChildProductionServer,
+  type ChildProductionServer,
+} from "../production-server";
+
+const disabledFixtureSource = path.resolve(
+  process.cwd(),
+  "tests/fixtures/app-basic/react-strict-mode-disabled",
+);
 
 test("enables Strict Mode by default for the App Router", async ({ page }) => {
   await page.goto("/react-strict-mode");
   await waitForAppRouterHydration(page);
 
   await expect(page.getByTestId("strict-mode-render-count")).toHaveText("2");
+});
+
+test.describe("reactStrictMode: false", () => {
+  let disabledFixtureRoot: string | undefined;
+  let disabledServer: ChildProductionServer | undefined;
+
+  test.beforeAll(async () => {
+    disabledFixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-strict-mode-disabled-"));
+    await fs.cp(disabledFixtureSource, disabledFixtureRoot, { recursive: true });
+    const sourceNodeModules = path.resolve(process.cwd(), "tests/fixtures/app-basic/node_modules");
+    const fixtureNodeModules = path.join(disabledFixtureRoot, "node_modules");
+    await fs.mkdir(fixtureNodeModules);
+    for (const entry of await fs.readdir(sourceNodeModules)) {
+      if (entry.startsWith(".")) continue;
+      await fs.symlink(
+        path.join(sourceNodeModules, entry),
+        path.join(fixtureNodeModules, entry),
+        "junction",
+      );
+    }
+    disabledServer = await startChildViteDevServer(disabledFixtureRoot);
+  });
+
+  test.afterAll(async () => {
+    try {
+      if (disabledServer) await stopChildProductionServer(disabledServer);
+    } finally {
+      if (disabledFixtureRoot) {
+        await fs.rm(disabledFixtureRoot, { recursive: true, force: true });
+      }
+    }
+  });
+
+  test("preserves the App Router Strict Mode opt-out", async ({ page }) => {
+    if (!disabledServer) throw new Error("Disabled Strict Mode fixture server did not start");
+    await page.goto(`http://127.0.0.1:${disabledServer.port}/`);
+    await waitForAppRouterHydration(page);
+
+    await expect(page.getByTestId("strict-mode-render-count")).toHaveText("1");
+  });
 });

--- a/tests/fixtures/app-basic/app/react-strict-mode/page.tsx
+++ b/tests/fixtures/app-basic/app/react-strict-mode/page.tsx
@@ -1,0 +1,10 @@
+import { RenderProbe } from "./render-probe";
+
+export default function ReactStrictModePage() {
+  return (
+    <main>
+      <h1>React Strict Mode</h1>
+      <RenderProbe />
+    </main>
+  );
+}

--- a/tests/fixtures/app-basic/app/react-strict-mode/render-probe.tsx
+++ b/tests/fixtures/app-basic/app/react-strict-mode/render-probe.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect } from "react";
+
+let clientRenderCount = 0;
+
+export function RenderProbe() {
+  if (typeof window !== "undefined") {
+    clientRenderCount += 1;
+  }
+
+  useEffect(() => {
+    const output = document.querySelector("[data-testid=strict-mode-render-count]");
+    // Avoid scheduling another React render, which would contaminate the value
+    // this fixture is measuring.
+    if (output) output.textContent = String(clientRenderCount);
+  }, []);
+
+  return <p data-testid="strict-mode-render-count">0</p>;
+}

--- a/tests/fixtures/app-basic/react-strict-mode-disabled/app/layout.tsx
+++ b/tests/fixtures/app-basic/react-strict-mode-disabled/app/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from "react";
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/tests/fixtures/app-basic/react-strict-mode-disabled/app/page.tsx
+++ b/tests/fixtures/app-basic/react-strict-mode-disabled/app/page.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect } from "react";
+
+let clientRenderCount = 0;
+
+export default function Page() {
+  if (typeof window !== "undefined") {
+    clientRenderCount += 1;
+  }
+
+  useEffect(() => {
+    const output = document.querySelector("[data-testid=strict-mode-render-count]");
+    // Avoid scheduling another React render, which would contaminate the value
+    // this fixture is measuring.
+    if (output) output.textContent = String(clientRenderCount);
+  }, []);
+
+  return <p data-testid="strict-mode-render-count">0</p>;
+}

--- a/tests/fixtures/app-basic/react-strict-mode-disabled/next.config.ts
+++ b/tests/fixtures/app-basic/react-strict-mode-disabled/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from "vinext";
+
+const nextConfig: NextConfig = {
+  reactStrictMode: false,
+};
+
+export default nextConfig;

--- a/tests/fixtures/app-basic/react-strict-mode-disabled/package.json
+++ b/tests/fixtures/app-basic/react-strict-mode-disabled/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/tests/fixtures/app-basic/react-strict-mode-disabled/vite.config.ts
+++ b/tests/fixtures/app-basic/react-strict-mode-disabled/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import vinext from "vinext";
+
+export default defineConfig({
+  plugins: [vinext({ appDir: import.meta.dirname })],
+});

--- a/tests/react-strict-mode.test.ts
+++ b/tests/react-strict-mode.test.ts
@@ -1,0 +1,60 @@
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vite-plus/test";
+
+type VinextPlugin = {
+  name: string;
+  config?: (config: unknown, env: { command: string }) => unknown;
+};
+
+async function readAppStrictModeDefine(nextConfigBody: string): Promise<string | undefined> {
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-app-strict-mode-"));
+  const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");
+
+  try {
+    await fsp.symlink(rootNodeModules, path.join(tmpDir, "node_modules"), "junction");
+    await fsp.mkdir(path.join(tmpDir, "app"), { recursive: true });
+    await fsp.writeFile(
+      path.join(tmpDir, "app", "layout.tsx"),
+      "export default function Layout({ children }) { return <html><body>{children}</body></html>; }",
+    );
+    await fsp.writeFile(
+      path.join(tmpDir, "app", "page.tsx"),
+      "export default function Page() { return null; }",
+    );
+    await fsp.writeFile(path.join(tmpDir, "next.config.mjs"), nextConfigBody);
+
+    const vinext = (await import("../packages/vinext/src/index.js")).default;
+    const plugins = vinext() as VinextPlugin[];
+    const configPlugin = plugins.find(
+      (plugin) => plugin.name === "vinext:config" && typeof plugin.config === "function",
+    );
+    expect(configPlugin).toBeDefined();
+
+    const result = (await configPlugin!.config!(
+      { root: tmpDir, build: {}, plugins: [], optimizeDeps: {} },
+      { command: "build" },
+    )) as { define?: Record<string, string> };
+
+    return result.define?.["process.env.__NEXT_STRICT_MODE_APP"];
+  } finally {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+describe("App Router reactStrictMode define", () => {
+  it("enables Strict Mode by default", async () => {
+    expect(await readAppStrictModeDefine("export default {};")).toBe("true");
+  });
+
+  it("enables Strict Mode when configured", async () => {
+    expect(await readAppStrictModeDefine("export default { reactStrictMode: true };")).toBe("true");
+  });
+
+  it("disables Strict Mode when configured", async () => {
+    expect(await readAppStrictModeDefine("export default { reactStrictMode: false };")).toBe(
+      "false",
+    );
+  });
+});


### PR DESCRIPTION
Fixes #2676.

## Summary

| goal | core change | primary files | expected impact |
| --- | --- | --- | --- |
| Match the Next.js App Router `reactStrictMode` contract | Publish `__NEXT_STRICT_MODE_APP` from resolved config and wrap the shared hydration/CSR root with `StrictMode` or `Fragment` | `src/index.ts`, `server/app-browser-entry.ts` | App Router strict checks run by default in development; `reactStrictMode: false` remains an opt-out |

## Why

Next.js enables Strict Mode by default for the App Router and preserves an explicit `reactStrictMode: false`. vinext already preserved the resolved `boolean | null` value, but the App Router build did not publish that value to its browser entry and the browser root was never wrapped. As a result, the App Router ignored both the default and explicit `true` configuration.

This follows Next.js's implementation: resolve the App Router default in the build define, select `StrictMode` or `Fragment` once, and use that wrapper for both hydration and the CSR error fallback. I found no dedicated Next.js behavioral test for this config; the pinned build and client sources below are the executable contract.

## What changed

| scenario | before | after |
| --- | --- | --- |
| App Router, config unset | No Strict Mode wrapper | Strict Mode enabled |
| App Router, `reactStrictMode: true` | No Strict Mode wrapper | Strict Mode enabled |
| App Router, `reactStrictMode: false` | No Strict Mode wrapper | Fragment used; Strict Mode disabled |
| Pages Router | Existing behavior | Unchanged |
| `vinext check` | Reports `reactStrictMode` as partial | Reports it as supported |

The browser regressions count client renders without scheduling a React state update. The default fixture expects two development renders; an isolated fixture with `reactStrictMode: false` expects one. The latter exercises the complete path from `next.config.ts` through Vite's define replacement and the browser root wrapper.

## Validation

- Reproduced the original behavior: the App Router fixture rendered once when the test expected the default Strict Mode count of two.
- Verified the default regression fails when the completed root wrapper is forced to `Fragment`: expected `2`, received `1`.
- Verified the opt-out regression fails when the browser entry treats raw boolean `false` as though it were the string `"false"`: expected `1`, received `2`.
- Verified config define output for unset, explicit `true`, and explicit `false`.
- Ran 381 targeted unit tests across the config, compatibility scanner, and App Router browser entry.
- Ran both App Router Playwright regressions: 2 passed.
- Built the `vinext` package.
- Ran scoped formatting, lint, and type checks. The pre-commit full check and knip check also passed.

<details>
<summary>Commands</summary>

```sh
vp check packages/vinext/src/check.ts packages/vinext/src/index.ts packages/vinext/src/server/app-browser-entry.ts tests/check.test.ts tests/react-strict-mode.test.ts tests/e2e/app-router/react-strict-mode.spec.ts tests/fixtures/app-basic/app/react-strict-mode/render-probe.tsx tests/fixtures/app-basic/app/react-strict-mode/page.tsx
vp check tests/e2e/app-router/react-strict-mode.spec.ts tests/fixtures/app-basic/react-strict-mode-disabled/app/layout.tsx tests/fixtures/app-basic/react-strict-mode-disabled/app/page.tsx tests/fixtures/app-basic/react-strict-mode-disabled/next.config.ts tests/fixtures/app-basic/react-strict-mode-disabled/vite.config.ts
vp test run tests/react-strict-mode.test.ts tests/check.test.ts tests/app-browser-entry.test.ts
vp run vinext#build
PLAYWRIGHT_PROJECT=app-router npx playwright test tests/e2e/app-router/react-strict-mode.spec.ts --retries=0
```

</details>

## Risk

Low. The change is confined to the App Router client root and its build-time boolean. React Strict Mode's additional checks are development-only, while an explicit `false` selects `Fragment`. Existing Pages Router behavior and defaults are unchanged. App Router applications may now expose non-idempotent development behavior that Strict Mode is intended to detect.

## References

| reference | why it matters |
| --- | --- |
| [Issue #2676](https://github.com/cloudflare/vinext/issues/2676) | Bug report and affected configuration |
| [Prior Pages Router work in #2433](https://github.com/cloudflare/vinext/pull/2433) | Deliberately left the App Router root out of scope |
| [Next.js build define](https://github.com/vercel/next.js/blob/89c94877667f1692ae979cc553bf86c763b0a6b0/packages/next/src/build/define-env.ts#L296-L300) | Defaults App Router Strict Mode on and preserves explicit false |
| [Next.js client root](https://github.com/vercel/next.js/blob/89c94877667f1692ae979cc553bf86c763b0a6b0/packages/next/src/client/app-index.tsx#L313-L315) | Selects `StrictMode` or `Fragment` |
| [Next.js hydration and CSR wrapper](https://github.com/vercel/next.js/blob/89c94877667f1692ae979cc553bf86c763b0a6b0/packages/next/src/client/app-index.tsx#L388-L410) | Shares the wrapped tree between both root paths |
| [Next.js config documentation](https://github.com/vercel/next.js/blob/89c94877667f1692ae979cc553bf86c763b0a6b0/docs/01-app/03-api-reference/05-config/01-next-config-js/reactStrictMode.mdx#L8-L12) | Documents the App Router default and explicit opt-out |
| [Browser regressions](https://github.com/NathanDrake2406/vinext/blob/7db6b7bd83e5754abbfd798e44a9fc259c4af2b1/tests/e2e/app-router/react-strict-mode.spec.ts#L17-L61) | Exercise default-on and explicit-false behavior after hydration |
| [Explicit-false config](https://github.com/NathanDrake2406/vinext/blob/7db6b7bd83e5754abbfd798e44a9fc259c4af2b1/tests/fixtures/app-basic/react-strict-mode-disabled/next.config.ts#L1-L7) | Drives the full opt-out path from `next.config.ts` |
| [Opt-out render probe](https://github.com/NathanDrake2406/vinext/blob/7db6b7bd83e5754abbfd798e44a9fc259c4af2b1/tests/fixtures/app-basic/react-strict-mode-disabled/app/page.tsx#L1-L20) | Observes one render without scheduling another |
| [Config regression](https://github.com/NathanDrake2406/vinext/blob/7db6b7bd83e5754abbfd798e44a9fc259c4af2b1/tests/react-strict-mode.test.ts#L46-L60) | Covers unset, enabled, and disabled define values |