### PR TITLE
fix(cache): serve stale use cache entries during refresh

### DIFF
--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -565,7 +565,7 @@ async function runAppPageRevalidationContext<
     currentFetchCacheMode: options.currentFetchCacheMode ?? null,
     currentForceDynamicFetchDefault: options.dynamicConfig === "force-dynamic",
     executionContext: getRequestExecutionContext(),
-    unstableCacheRevalidation: "foreground",
+    cacheRevalidationMode: "foreground",
   });
 
   const revalidation = runWithRequestContext(requestContext, async () => {

--- a/packages/vinext/src/server/app-route-handler-dispatch.ts
+++ b/packages/vinext/src/server/app-route-handler-dispatch.ts
@@ -132,7 +132,7 @@ async function runInRouteHandlerRevalidationContext(
   const requestContext = createRequestContext({
     headersContext,
     executionContext: getRequestExecutionContext(),
-    unstableCacheRevalidation: "foreground",
+    cacheRevalidationMode: "foreground",
   });
 
   const revalidation = runWithRequestContext(requestContext, async () => {

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -1428,7 +1428,7 @@ export function createAppRscHandler<TRoute extends AppRscHandlerRoute>(
     const requestContext = createRequestContext({
       headersContext,
       executionContext,
-      unstableCacheRevalidation: "background",
+      cacheRevalidationMode: "background",
     });
 
     const responsePromise = runWithRequestContext(requestContext, () =>

--- a/packages/vinext/src/shims/cache-request-state.ts
+++ b/packages/vinext/src/shims/cache-request-state.ts
@@ -41,7 +41,7 @@ export function getRegisteredCacheContext(): CacheContextLike | null {
   return getCacheContext?.() ?? null;
 }
 
-export type UnstableCacheRevalidationMode = "foreground" | "background";
+export type CacheRevalidationMode = "foreground" | "background";
 export type ActionRevalidationKind = 0 | 1 | 2;
 export type UnstableCacheObservation = Readonly<{
   kind: "unstable_cache";
@@ -57,7 +57,7 @@ export type CacheState = {
   pendingRevalidations: Set<Promise<void>>;
   requestScopedCacheLife: CacheLifeConfig | null;
   unstableCacheObservations: Map<string, UnstableCacheObservation>;
-  unstableCacheRevalidation: UnstableCacheRevalidationMode;
+  cacheRevalidationMode: CacheRevalidationMode;
 };
 
 const FALLBACK_KEY = Symbol.for("vinext.cache.fallback");
@@ -74,7 +74,7 @@ const fallbackState = (globalState[FALLBACK_KEY] ??= {
   pendingRevalidations: new Set<Promise<void>>(),
   requestScopedCacheLife: null,
   unstableCacheObservations: new Map<string, UnstableCacheObservation>(),
-  unstableCacheRevalidation: "foreground",
+  cacheRevalidationMode: "foreground",
 } satisfies CacheState) as CacheState;
 
 function getCacheState(): CacheState {
@@ -92,7 +92,7 @@ export function _runWithCacheState<T>(fn: () => T | Promise<T>): T | Promise<T> 
       context.actionRevalidationKind = ACTION_DID_NOT_REVALIDATE;
       context.requestScopedCacheLife = null;
       context.unstableCacheObservations = new Map<string, UnstableCacheObservation>();
-      context.unstableCacheRevalidation = "foreground";
+      context.cacheRevalidationMode = "foreground";
     }, fn);
   }
   const state: CacheState = {
@@ -101,7 +101,7 @@ export function _runWithCacheState<T>(fn: () => T | Promise<T>): T | Promise<T> 
     pendingRevalidations: new Set<Promise<void>>(),
     requestScopedCacheLife: null,
     unstableCacheObservations: new Map<string, UnstableCacheObservation>(),
-    unstableCacheRevalidation: "foreground",
+    cacheRevalidationMode: "foreground",
   };
   return cacheAls.run(state, fn);
 }
@@ -245,6 +245,6 @@ export function _peekUnstableCacheObservations(): UnstableCacheObservation[] {
   );
 }
 
-export function shouldServeStaleUnstableCacheEntry(): boolean {
-  return getCacheState().unstableCacheRevalidation === "background";
+export function shouldServeStaleCacheEntry(): boolean {
+  return getCacheState().cacheRevalidationMode === "background";
 }

--- a/packages/vinext/src/shims/cache-request-state.ts
+++ b/packages/vinext/src/shims/cache-request-state.ts
@@ -41,7 +41,12 @@ export function getRegisteredCacheContext(): CacheContextLike | null {
   return getCacheContext?.() ?? null;
 }
 
+/**
+ * Controls stale function/data-cache reads. Patched fetch response caching has
+ * a separate policy because it owns response streams and refetch timeouts.
+ */
 export type CacheRevalidationMode = "foreground" | "background";
+export type CacheReadAction = "serve" | "serve-and-revalidate" | "revalidate";
 export type ActionRevalidationKind = 0 | 1 | 2;
 export type UnstableCacheObservation = Readonly<{
   kind: "unstable_cache";
@@ -245,6 +250,22 @@ export function _peekUnstableCacheObservations(): UnstableCacheObservation[] {
   );
 }
 
-export function shouldServeStaleCacheEntry(): boolean {
-  return getCacheState().cacheRevalidationMode === "background";
+export function getCacheRevalidationMode(): CacheRevalidationMode {
+  return getCacheState().cacheRevalidationMode;
+}
+
+/**
+ * Decide whether a function/data-cache value can satisfy the current read.
+ * An absent state is a fresh value. Stale values are policy-dependent, while
+ * expired or unrecognized states must be regenerated before use.
+ */
+export function decideCacheRead(
+  cacheState: string | undefined,
+  mode: CacheRevalidationMode,
+): CacheReadAction {
+  if (cacheState === undefined) return "serve";
+  if (cacheState === "stale") {
+    return mode === "background" ? "serve-and-revalidate" : "revalidate";
+  }
+  return "revalidate";
 }

--- a/packages/vinext/src/shims/cache-runtime.ts
+++ b/packages/vinext/src/shims/cache-runtime.ts
@@ -32,6 +32,7 @@ import {
   getDataCacheHandler,
   type CachedFetchValue,
   type CacheControlMetadata,
+  type CacheHandler,
   type CacheHandlerValue,
 } from "./cache-handler.js";
 import {
@@ -45,13 +46,16 @@ import { VINEXT_RSC_MARKER_HEADER } from "../server/headers.js";
 import { addCollectedRequestTags, getCurrentFetchSoftTags } from "./fetch-cache.js";
 import { getOrCreateAls } from "./internal/als-registry.js";
 import {
+  createRequestContext,
   isInsideUnifiedScope,
   getRequestContext,
+  runWithRequestContext,
   runWithUnifiedStateMutation,
 } from "./unified-request-context.js";
 import { markDynamicUsage } from "./headers.js";
 import { trackPprFallbackShellCacheTask } from "./ppr-fallback-shell.js";
 import { isMarkedAppPagePropsObject } from "./internal/app-page-props-cache-key.js";
+import { getRequestExecutionContext } from "./request-context.js";
 
 export { markAppPagePropsForUseCache } from "./internal/app-page-props-cache-key.js";
 
@@ -564,29 +568,40 @@ export function registerCachedFunction<TArgs extends unknown[], TResult>(
           console.error("[vinext] use cache: handler.get failed; treating as a cache miss:", error);
         }
       }
+      const shouldRefreshStaleInForeground =
+        existing?.cacheState === "stale" &&
+        typeof process !== "undefined" &&
+        process.env.VINEXT_PRERENDER === "1";
       if (
         existing?.value &&
         existing.value.kind === "FETCH" &&
-        existing.cacheState !== "stale" &&
+        !shouldRefreshStaleInForeground &&
         !_hasPendingRevalidatedTag([...(existing.value.tags ?? []), ...softTags])
       ) {
         try {
-          // Surface the cached entry's tags to the surrounding request so the
-          // enclosing page / route-handler ISR entry carries them even on a data
-          // cache HIT — otherwise `revalidateTag()` could not evict the rendered
-          // output that embeds this cached value (issue #1453).
-          propagateCacheTagsToRequest(existing.value.tags);
+          let result: TResult;
           if (rsc && existing.value.data.headers[VINEXT_RSC_MARKER_HEADER] === "1") {
             // RSC-serialized entry: base64 → bytes → stream → deserialize
             const bytes = base64ToUint8(existing.value.data.body);
             const stream = uint8ToStream(bytes);
-            const result = await rsc.createFromReadableStream<TResult>(stream);
-            recordRequestScopedCacheControl(existing.cacheControl);
-            return result;
+            result = await rsc.createFromReadableStream<TResult>(stream);
+          } else {
+            // JSON-serialized entry (legacy or no RSC available)
+            result = JSON.parse(existing.value.data.body);
           }
-          // JSON-serialized entry (legacy or no RSC available)
-          const result = JSON.parse(existing.value.data.body);
+          // Surface tags only after deserialization succeeds. A corrupted
+          // entry falls through to foreground execution and must not affect
+          // the enclosing page's cache metadata.
+          propagateCacheTagsToRequest(existing.value.tags);
           recordRequestScopedCacheControl(existing.cacheControl);
+          if (existing.cacheState === "stale") {
+            scheduleSharedCacheRevalidation(cacheKey, () =>
+              refreshSharedCacheEntry(fn, args, cacheVariant, cacheKey, handler, rsc, {
+                skipOuterPropagation: true,
+                reportCacheWriteErrors: true,
+              }),
+            );
+          }
           return result;
         } catch {
           // Corrupted entry, fall through to re-execute
@@ -594,65 +609,7 @@ export function registerCachedFunction<TArgs extends unknown[], TResult>(
       }
 
       // Cache miss (or stale) — execute with context
-      const { result, ctx, effectiveLife } = await runCachedFunctionWithContext(
-        fn,
-        args,
-        cacheVariant,
-      );
-
-      recordRequestScopedCacheLife(effectiveLife);
-      // Bubble the cache scope's tags up to the surrounding request so the
-      // enclosing page / route-handler ISR entry is tagged for on-demand
-      // revalidation (issue #1453). `ctx.tags` already includes any nested
-      // child cache's tags via `runCachedFunctionWithContext`.
-      propagateCacheTagsToRequest(ctx.tags);
-      const revalidateSeconds =
-        effectiveLife.revalidate ?? cacheLifeProfiles.default.revalidate ?? 900;
-
-      // Store in cache — use RSC stream serialization when available (handles
-      // React elements, client refs, Promises, etc.), JSON otherwise.
-      try {
-        let body: string;
-        const headers: Record<string, string> = {};
-
-        if (rsc) {
-          // RSC serialization: result → stream → bytes → base64.
-          // No temporaryReferences — cached values must be self-contained
-          // since they're persisted across requests.
-          const stream = rsc.renderToReadableStream(result);
-          const bytes = await collectStream(stream);
-          body = uint8ToBase64(bytes);
-          headers[VINEXT_RSC_MARKER_HEADER] = "1";
-        } else {
-          // JSON fallback
-          body = JSON.stringify(result);
-          if (body === undefined) return result;
-        }
-
-        const cacheValue = {
-          kind: "FETCH",
-          data: {
-            headers,
-            body,
-            url: cacheKey,
-          },
-          tags: ctx.tags,
-          revalidate: revalidateSeconds,
-        } satisfies CachedFetchValue;
-
-        await handler.set(cacheKey, cacheValue, {
-          fetchCache: true,
-          tags: ctx.tags,
-          cacheControl: {
-            revalidate: revalidateSeconds,
-            expire: effectiveLife.expire,
-          },
-        });
-      } catch {
-        // Result not serializable — skip caching, still return the result
-      }
-
-      return result;
+      return refreshSharedCacheEntry(fn, args, cacheVariant, cacheKey, handler, rsc);
     }, cacheVariant);
 
   // Preserve the original function's arity on the wrapper. The wrapper is
@@ -676,6 +633,160 @@ export function registerCachedFunction<TArgs extends unknown[], TResult>(
   }
 
   return cachedFn;
+}
+
+type CacheExecutionOptions = {
+  skipOuterPropagation?: boolean;
+  reportCacheWriteErrors?: boolean;
+};
+
+async function refreshSharedCacheEntry<TArgs extends unknown[], TResult>(
+  fn: (...args: TArgs) => Promise<TResult>,
+  args: TArgs,
+  cacheVariant: string,
+  cacheKey: string,
+  handler: CacheHandler,
+  rsc: RscModule | null,
+  options: CacheExecutionOptions = {},
+): Promise<TResult> {
+  const { result, ctx, effectiveLife } = await runCachedFunctionWithContext(
+    fn,
+    args,
+    cacheVariant,
+    options,
+  );
+
+  if (!options.skipOuterPropagation) {
+    recordRequestScopedCacheLife(effectiveLife);
+    // Bubble the cache scope's tags up to the surrounding request so the
+    // enclosing page / route-handler ISR entry is tagged for on-demand
+    // revalidation (issue #1453). `ctx.tags` already includes any nested
+    // child cache's tags via `runCachedFunctionWithContext`.
+    propagateCacheTagsToRequest(ctx.tags);
+  }
+  const revalidateSeconds = effectiveLife.revalidate ?? cacheLifeProfiles.default.revalidate ?? 900;
+
+  // Serialize first so unsupported values retain the existing non-fatal
+  // behavior without hiding storage failures from background refreshes.
+  let cacheValue: CachedFetchValue;
+  try {
+    let body: string;
+    const headers: Record<string, string> = {};
+
+    if (rsc) {
+      // RSC serialization: result → stream → bytes → base64.
+      // No temporaryReferences — cached values must be self-contained
+      // since they're persisted across requests.
+      const stream = rsc.renderToReadableStream(result);
+      const bytes = await collectStream(stream);
+      body = uint8ToBase64(bytes);
+      headers[VINEXT_RSC_MARKER_HEADER] = "1";
+    } else {
+      // JSON fallback
+      body = JSON.stringify(result);
+      if (body === undefined) return result;
+    }
+
+    cacheValue = {
+      kind: "FETCH",
+      data: {
+        headers,
+        body,
+        url: cacheKey,
+      },
+      tags: ctx.tags,
+      revalidate: revalidateSeconds,
+    } satisfies CachedFetchValue;
+  } catch {
+    // Result not serializable — skip caching, still return the result
+    return result;
+  }
+
+  try {
+    await handler.set(cacheKey, cacheValue, {
+      fetchCache: true,
+      tags: ctx.tags,
+      cacheControl: {
+        revalidate: revalidateSeconds,
+        expire: effectiveLife.expire,
+      },
+    });
+  } catch (error) {
+    if (options.reportCacheWriteErrors) {
+      console.error("[vinext] use cache background revalidation cache write failed:", error);
+    }
+  }
+
+  return result;
+}
+
+const _USE_CACHE_PENDING_REVALIDATIONS_KEY = Symbol.for("vinext.useCache.pendingRevalidations");
+
+function getPendingSharedCacheRevalidations(): Map<string, Promise<void>> {
+  const existing = _g[_USE_CACHE_PENDING_REVALIDATIONS_KEY];
+  if (existing instanceof Map) return existing;
+
+  const pending = new Map<string, Promise<void>>();
+  _g[_USE_CACHE_PENDING_REVALIDATIONS_KEY] = pending;
+  return pending;
+}
+
+function scheduleSharedCacheRevalidation(cacheKey: string, refresh: () => Promise<unknown>): void {
+  const pending = getPendingSharedCacheRevalidations();
+  if (pending.has(cacheKey)) return;
+
+  const outerRequestContext = isInsideUnifiedScope() ? getRequestContext() : null;
+  const executionContext = getRequestExecutionContext();
+  // A stale response has already selected its cache metadata. Regeneration
+  // therefore runs in a fresh request-state container so cacheLife(), tags,
+  // and fetch observations produced by the refresh cannot mutate that response.
+  // Preserve only inputs that affect cache reads and runtime lifetime.
+  const revalidationContext = createRequestContext({
+    executionContext,
+    headersContext: outerRequestContext?.headersContext
+      ? {
+          ...outerRequestContext.headersContext,
+          headers: new Headers(outerRequestContext.headersContext.headers),
+          cookies: new Map(outerRequestContext.headersContext.cookies),
+          mutableCookies: undefined,
+          readonlyCookies: undefined,
+          readonlyHeaders: undefined,
+        }
+      : null,
+    pendingRevalidatedTags: new Set(outerRequestContext?.pendingRevalidatedTags ?? []),
+    currentFetchSoftTags: [...getCurrentFetchSoftTags()],
+    currentFetchCacheMode: outerRequestContext?.currentFetchCacheMode ?? null,
+    currentForceDynamicFetchDefault: outerRequestContext?.currentForceDynamicFetchDefault ?? false,
+    isFetchDedupeActive: outerRequestContext?.isFetchDedupeActive ?? false,
+    currentFetchDedupeEntries: new Map(),
+    rootParams: outerRequestContext?.rootParams
+      ? Object.fromEntries(
+          Object.entries(outerRequestContext.rootParams).map(([name, value]) => [
+            name,
+            Array.isArray(value) ? [...value] : value,
+          ]),
+        )
+      : null,
+  });
+
+  const revalidation = Promise.resolve()
+    .then(() => runWithRequestContext(revalidationContext, refresh))
+    .then(() => undefined)
+    .catch((error) => {
+      console.error("[vinext] use cache background revalidation failed:", error);
+    });
+  const trackedRevalidation = revalidation.finally(() => {
+    if (pending.get(cacheKey) === trackedRevalidation) {
+      pending.delete(cacheKey);
+    }
+  });
+
+  pending.set(cacheKey, trackedRevalidation);
+  if (executionContext) {
+    executionContext.waitUntil(trackedRevalidation);
+  } else {
+    void trackedRevalidation;
+  }
 }
 
 /** @internal Symbol used to identify "use cache" wrapper functions. */
@@ -797,8 +908,10 @@ async function runCachedFunctionWithContext<T extends (...args: any[]) => Promis
   // oxlint-disable-next-line @typescript-eslint/no-explicit-any
   args: any[],
   variant: string,
+  options: CacheExecutionOptions = {},
 ): Promise<CachedFunctionResult<Awaited<ReturnType<T>>>> {
   const parentCtx = cacheContextStorage.getStore();
+  const shouldPropagateToOuter = !options.skipOuterPropagation;
 
   // Eagerly capture an error at the call site if we're inside a public cache.
   // Private parents are intentionally excluded — "use cache: private" is
@@ -819,7 +932,7 @@ async function runCachedFunctionWithContext<T extends (...args: any[]) => Promis
   // bottleneck for cache-heavy workloads, switching to a lazy capture would
   // be the optimization — at the cost of less useful stack frames.
   let eagerError: Error | undefined;
-  if (parentCtx && parentCtx.variant !== "private") {
+  if (shouldPropagateToOuter && parentCtx && parentCtx.variant !== "private") {
     eagerError = new NestedDynamicUseCacheError();
     if (typeof Error.captureStackTrace === "function") {
       Error.captureStackTrace(eagerError, runCachedFunctionWithContext);
@@ -875,7 +988,7 @@ async function runCachedFunctionWithContext<T extends (...args: any[]) => Promis
   // threshold checks below would evaluate false, and the throw would never
   // fire. (The `hasExplicit*` guards then independently decide whether to
   // suppress the throw — see the longer comment below.)
-  if (parentCtx) {
+  if (shouldPropagateToOuter && parentCtx) {
     parentCtx.lifeConfigs.push(effectiveLife);
     // Bubble this inner cache's tags into the parent cache scope so the
     // outer entry (and ultimately the request) is invalidated when a tag
@@ -894,6 +1007,7 @@ async function runCachedFunctionWithContext<T extends (...args: any[]) => Promis
   // Next.js: see `dynamicNestedCacheError ??=` in
   // packages/next/src/server/use-cache/use-cache-wrapper.ts.
   if (
+    shouldPropagateToOuter &&
     parentCtx &&
     eagerError &&
     (effectiveLife.revalidate === 0 ||

--- a/packages/vinext/src/shims/cache-runtime.ts
+++ b/packages/vinext/src/shims/cache-runtime.ts
@@ -40,7 +40,8 @@ import {
   _hasPendingRevalidatedTag,
   _setRequestScopedCacheLife,
   _registerCacheContextAccessor,
-  shouldServeStaleCacheEntry,
+  decideCacheRead,
+  getCacheRevalidationMode,
   type CacheLifeConfig,
 } from "./cache-request-state.js";
 import { VINEXT_RSC_MARKER_HEADER } from "../server/headers.js";
@@ -576,11 +577,11 @@ export function registerCachedFunction<TArgs extends unknown[], TResult>(
           console.error("[vinext] use cache: handler.get failed; treating as a cache miss:", error);
         }
       }
-      const shouldUseCachedEntry = existing?.cacheState !== "stale" || shouldServeStaleCacheEntry();
+      const cacheReadAction = decideCacheRead(existing?.cacheState, getCacheRevalidationMode());
       if (
         existing?.value &&
         existing.value.kind === "FETCH" &&
-        shouldUseCachedEntry &&
+        cacheReadAction !== "revalidate" &&
         !_hasPendingRevalidatedTag([...(existing.value.tags ?? []), ...softTags])
       ) {
         try {
@@ -599,7 +600,7 @@ export function registerCachedFunction<TArgs extends unknown[], TResult>(
           // the enclosing page's cache metadata.
           propagateCacheTagsToRequest(existing.value.tags);
           recordRequestScopedCacheControl(existing.cacheControl);
-          if (existing.cacheState === "stale") {
+          if (cacheReadAction === "serve-and-revalidate") {
             scheduleBackgroundCacheRevalidation(
               cacheKey,
               () =>
@@ -620,7 +621,7 @@ export function registerCachedFunction<TArgs extends unknown[], TResult>(
         }
       }
 
-      // Cache miss (or stale) — execute with context
+      // Cache miss or unusable entry — execute with context
       return refreshSharedCacheEntry(fn, args, cacheVariant, cacheKey, handler, rsc);
     }, cacheVariant);
 

--- a/packages/vinext/src/shims/cache-runtime.ts
+++ b/packages/vinext/src/shims/cache-runtime.ts
@@ -40,13 +40,15 @@ import {
   _hasPendingRevalidatedTag,
   _setRequestScopedCacheLife,
   _registerCacheContextAccessor,
+  shouldServeStaleCacheEntry,
   type CacheLifeConfig,
 } from "./cache-request-state.js";
 import { VINEXT_RSC_MARKER_HEADER } from "../server/headers.js";
 import { addCollectedRequestTags, getCurrentFetchSoftTags } from "./fetch-cache.js";
 import { getOrCreateAls } from "./internal/als-registry.js";
+import { scheduleBackgroundCacheRevalidation } from "./internal/cache-revalidation.js";
 import {
-  createRequestContext,
+  createCacheRevalidationContext,
   isInsideUnifiedScope,
   getRequestContext,
   runWithRequestContext,
@@ -55,7 +57,6 @@ import {
 import { markDynamicUsage } from "./headers.js";
 import { trackPprFallbackShellCacheTask } from "./ppr-fallback-shell.js";
 import { isMarkedAppPagePropsObject } from "./internal/app-page-props-cache-key.js";
-import { getRequestExecutionContext } from "./request-context.js";
 
 export { markAppPagePropsForUseCache } from "./internal/app-page-props-cache-key.js";
 
@@ -568,14 +569,11 @@ export function registerCachedFunction<TArgs extends unknown[], TResult>(
           console.error("[vinext] use cache: handler.get failed; treating as a cache miss:", error);
         }
       }
-      const shouldRefreshStaleInForeground =
-        existing?.cacheState === "stale" &&
-        typeof process !== "undefined" &&
-        process.env.VINEXT_PRERENDER === "1";
+      const shouldUseCachedEntry = existing?.cacheState !== "stale" || shouldServeStaleCacheEntry();
       if (
         existing?.value &&
         existing.value.kind === "FETCH" &&
-        !shouldRefreshStaleInForeground &&
+        shouldUseCachedEntry &&
         !_hasPendingRevalidatedTag([...(existing.value.tags ?? []), ...softTags])
       ) {
         try {
@@ -595,11 +593,18 @@ export function registerCachedFunction<TArgs extends unknown[], TResult>(
           propagateCacheTagsToRequest(existing.value.tags);
           recordRequestScopedCacheControl(existing.cacheControl);
           if (existing.cacheState === "stale") {
-            scheduleSharedCacheRevalidation(cacheKey, () =>
-              refreshSharedCacheEntry(fn, args, cacheVariant, cacheKey, handler, rsc, {
-                skipOuterPropagation: true,
-                reportCacheWriteErrors: true,
-              }),
+            scheduleBackgroundCacheRevalidation(
+              cacheKey,
+              () =>
+                runWithRequestContext(createCacheRevalidationContext(softTags), () =>
+                  refreshSharedCacheEntry(fn, args, cacheVariant, cacheKey, handler, rsc, {
+                    skipOuterPropagation: true,
+                    reportCacheWriteErrors: true,
+                  }),
+                ),
+              (error) => {
+                console.error("[vinext] use cache background revalidation failed:", error);
+              },
             );
           }
           return result;
@@ -718,75 +723,6 @@ async function refreshSharedCacheEntry<TArgs extends unknown[], TResult>(
   }
 
   return result;
-}
-
-const _USE_CACHE_PENDING_REVALIDATIONS_KEY = Symbol.for("vinext.useCache.pendingRevalidations");
-
-function getPendingSharedCacheRevalidations(): Map<string, Promise<void>> {
-  const existing = _g[_USE_CACHE_PENDING_REVALIDATIONS_KEY];
-  if (existing instanceof Map) return existing;
-
-  const pending = new Map<string, Promise<void>>();
-  _g[_USE_CACHE_PENDING_REVALIDATIONS_KEY] = pending;
-  return pending;
-}
-
-function scheduleSharedCacheRevalidation(cacheKey: string, refresh: () => Promise<unknown>): void {
-  const pending = getPendingSharedCacheRevalidations();
-  if (pending.has(cacheKey)) return;
-
-  const outerRequestContext = isInsideUnifiedScope() ? getRequestContext() : null;
-  const executionContext = getRequestExecutionContext();
-  // A stale response has already selected its cache metadata. Regeneration
-  // therefore runs in a fresh request-state container so cacheLife(), tags,
-  // and fetch observations produced by the refresh cannot mutate that response.
-  // Preserve only inputs that affect cache reads and runtime lifetime.
-  const revalidationContext = createRequestContext({
-    executionContext,
-    headersContext: outerRequestContext?.headersContext
-      ? {
-          ...outerRequestContext.headersContext,
-          headers: new Headers(outerRequestContext.headersContext.headers),
-          cookies: new Map(outerRequestContext.headersContext.cookies),
-          mutableCookies: undefined,
-          readonlyCookies: undefined,
-          readonlyHeaders: undefined,
-        }
-      : null,
-    pendingRevalidatedTags: new Set(outerRequestContext?.pendingRevalidatedTags ?? []),
-    currentFetchSoftTags: [...getCurrentFetchSoftTags()],
-    currentFetchCacheMode: outerRequestContext?.currentFetchCacheMode ?? null,
-    currentForceDynamicFetchDefault: outerRequestContext?.currentForceDynamicFetchDefault ?? false,
-    isFetchDedupeActive: outerRequestContext?.isFetchDedupeActive ?? false,
-    currentFetchDedupeEntries: new Map(),
-    rootParams: outerRequestContext?.rootParams
-      ? Object.fromEntries(
-          Object.entries(outerRequestContext.rootParams).map(([name, value]) => [
-            name,
-            Array.isArray(value) ? [...value] : value,
-          ]),
-        )
-      : null,
-  });
-
-  const revalidation = Promise.resolve()
-    .then(() => runWithRequestContext(revalidationContext, refresh))
-    .then(() => undefined)
-    .catch((error) => {
-      console.error("[vinext] use cache background revalidation failed:", error);
-    });
-  const trackedRevalidation = revalidation.finally(() => {
-    if (pending.get(cacheKey) === trackedRevalidation) {
-      pending.delete(cacheKey);
-    }
-  });
-
-  pending.set(cacheKey, trackedRevalidation);
-  if (executionContext) {
-    executionContext.waitUntil(trackedRevalidation);
-  } else {
-    void trackedRevalidation;
-  }
 }
 
 /** @internal Symbol used to identify "use cache" wrapper functions. */

--- a/packages/vinext/src/shims/cache-runtime.ts
+++ b/packages/vinext/src/shims/cache-runtime.ts
@@ -54,7 +54,7 @@ import {
   runWithRequestContext,
   runWithUnifiedStateMutation,
 } from "./unified-request-context.js";
-import { markDynamicUsage } from "./headers.js";
+import { isDraftModeEnabled, markDynamicUsage } from "./headers.js";
 import { trackPprFallbackShellCacheTask } from "./ppr-fallback-shell.js";
 import { isMarkedAppPagePropsObject } from "./internal/app-page-props-cache-key.js";
 
@@ -477,6 +477,13 @@ export function registerCachedFunction<TArgs extends unknown[], TResult>(
 
   const cachedFn = (...args: TArgs): Promise<TResult> =>
     trackPprFallbackShellCacheTask(async (): Promise<TResult> => {
+      // Preview data may differ from published data. Draft requests still run
+      // inside the normal cache scope so cacheLife() and cache API restrictions
+      // apply, but they must never read or populate shared storage.
+      if (cacheVariant !== "private" && isDraftModeEnabled()) {
+        return executeWithContext(fn, args, cacheVariant);
+      }
+
       const rsc = await getRscModule();
       const keySeed = getUseCacheKeySeed();
 

--- a/packages/vinext/src/shims/cache.ts
+++ b/packages/vinext/src/shims/cache.ts
@@ -42,10 +42,11 @@ import {
   _queuePendingRevalidation,
   _setRequestScopedCacheLife,
   cacheLifeProfiles,
+  decideCacheRead,
+  getCacheRevalidationMode,
   getRegisteredCacheContext,
   markActionRevalidation,
   recordUnstableCacheObservation,
-  shouldServeStaleCacheEntry,
   type CacheLifeConfig,
 } from "./cache-request-state.js";
 
@@ -585,8 +586,8 @@ export function unstable_cache<T extends (...args: any[]) => Promise<any>>(
     const isDraftMode = isDraftModeEnabled();
     if (!isDraftMode) {
       // Try to get from cache. Stale entries are usable in normal App Router
-      // requests, but foreground-refresh inside revalidation scopes so the
-      // regenerated page/route stores fresh data.
+      // requests, but revalidation scopes and unusable states must refresh in
+      // the foreground so the caller receives fresh data.
       const softTags = getCurrentFetchSoftTags();
       const existing = _hasPendingRevalidatedTag([...tags, ...softTags])
         ? null
@@ -596,10 +597,11 @@ export function unstable_cache<T extends (...args: any[]) => Promise<any>>(
             softTags,
           });
       if (existing?.value && existing.value.kind === "FETCH") {
-        const cached = tryDeserializeUnstableCacheResult(existing.value.data.body);
-        if (cached.ok) {
-          if (existing.cacheState === "stale") {
-            if (shouldServeStaleCacheEntry()) {
+        const cacheReadAction = decideCacheRead(existing.cacheState, getCacheRevalidationMode());
+        if (cacheReadAction !== "revalidate") {
+          const cached = tryDeserializeUnstableCacheResult(existing.value.data.body);
+          if (cached.ok) {
+            if (cacheReadAction === "serve-and-revalidate") {
               scheduleBackgroundCacheRevalidation(
                 cacheKey,
                 () => refreshUnstableCacheResult(fn, args, cacheKey, tags, revalidateSeconds),
@@ -610,13 +612,12 @@ export function unstable_cache<T extends (...args: any[]) => Promise<any>>(
                   );
                 },
               );
-              return cached.value;
             }
-          } else {
             return cached.value;
           }
         }
-        // Corrupted entries fall through to a foreground refresh.
+        // Expired, unrecognized, and corrupted entries fall through to a
+        // foreground refresh.
       }
     }
 

--- a/packages/vinext/src/shims/cache.ts
+++ b/packages/vinext/src/shims/cache.ts
@@ -25,8 +25,8 @@ import {
   markDynamicUsage as _markDynamic,
 } from "./headers.js";
 import { getOrCreateAls } from "./internal/als-registry.js";
+import { scheduleBackgroundCacheRevalidation } from "./internal/cache-revalidation.js";
 import { fnv1a64 } from "../utils/hash.js";
-import { isInsideUnifiedScope, getRequestContext } from "./unified-request-context.js";
 import { workUnitAsyncStorage } from "./internal/work-unit-async-storage.js";
 import { makeHangingPromise } from "./internal/make-hanging-promise.js";
 import { encodeCacheTag, encodeCacheTags } from "../utils/encode-cache-tag.js";
@@ -45,14 +45,12 @@ import {
   getRegisteredCacheContext,
   markActionRevalidation,
   recordUnstableCacheObservation,
-  shouldServeStaleUnstableCacheEntry,
+  shouldServeStaleCacheEntry,
   type CacheLifeConfig,
 } from "./cache-request-state.js";
 
 export * from "./cache-handler.js";
 export * from "./cache-request-state.js";
-
-const _g = globalThis as unknown as Record<PropertyKey, unknown>;
 
 // ---------------------------------------------------------------------------
 // Request-scoped ExecutionContext ALS
@@ -513,46 +511,6 @@ type UnstableCacheOptions = {
   tags?: string[];
 };
 
-const _UNSTABLE_CACHE_PENDING_REVALIDATIONS_KEY = Symbol.for(
-  "vinext.unstableCache.pendingRevalidations",
-);
-
-function getPendingUnstableCacheRevalidations(): Map<string, Promise<void>> {
-  const existing = _g[_UNSTABLE_CACHE_PENDING_REVALIDATIONS_KEY];
-  if (existing instanceof Map) return existing;
-
-  const pending = new Map<string, Promise<void>>();
-  _g[_UNSTABLE_CACHE_PENDING_REVALIDATIONS_KEY] = pending;
-  return pending;
-}
-
-function waitUntilUnstableCacheRevalidation(promise: Promise<void>): void {
-  if (!isInsideUnifiedScope()) return;
-  getRequestContext().executionContext?.waitUntil(promise);
-}
-
-function scheduleUnstableCacheBackgroundRevalidation(
-  cacheKey: string,
-  refresh: () => Promise<unknown>,
-): void {
-  const pending = getPendingUnstableCacheRevalidations();
-  if (pending.has(cacheKey)) return;
-
-  const revalidation = refresh()
-    .then(() => undefined)
-    .catch((err) => {
-      console.error(`[vinext] unstable_cache background revalidation failed for ${cacheKey}:`, err);
-    });
-  const trackedRevalidation = revalidation.finally(() => {
-    if (pending.get(cacheKey) === trackedRevalidation) {
-      pending.delete(cacheKey);
-    }
-  });
-
-  pending.set(cacheKey, trackedRevalidation);
-  waitUntilUnstableCacheRevalidation(trackedRevalidation);
-}
-
 async function refreshUnstableCacheResult<Args extends unknown[], Result>(
   fn: (...args: Args) => Promise<Result>,
   args: Args,
@@ -641,9 +599,16 @@ export function unstable_cache<T extends (...args: any[]) => Promise<any>>(
         const cached = tryDeserializeUnstableCacheResult(existing.value.data.body);
         if (cached.ok) {
           if (existing.cacheState === "stale") {
-            if (shouldServeStaleUnstableCacheEntry()) {
-              scheduleUnstableCacheBackgroundRevalidation(cacheKey, () =>
-                refreshUnstableCacheResult(fn, args, cacheKey, tags, revalidateSeconds),
+            if (shouldServeStaleCacheEntry()) {
+              scheduleBackgroundCacheRevalidation(
+                cacheKey,
+                () => refreshUnstableCacheResult(fn, args, cacheKey, tags, revalidateSeconds),
+                (error) => {
+                  console.error(
+                    `[vinext] unstable_cache background revalidation failed for ${cacheKey}:`,
+                    error,
+                  );
+                },
               );
               return cached.value;
             }

--- a/packages/vinext/src/shims/internal/cache-revalidation.ts
+++ b/packages/vinext/src/shims/internal/cache-revalidation.ts
@@ -1,0 +1,51 @@
+import { getRequestExecutionContext } from "../request-context.js";
+
+const PENDING_BACKGROUND_CACHE_REVALIDATIONS = Symbol.for(
+  "vinext.cache.pendingBackgroundRevalidations",
+);
+const globalState = globalThis as unknown as Record<PropertyKey, unknown>;
+
+function getPendingBackgroundCacheRevalidations(): Map<string, Promise<void>> {
+  const existing = globalState[PENDING_BACKGROUND_CACHE_REVALIDATIONS];
+  if (existing instanceof Map) return existing;
+
+  const pending = new Map<string, Promise<void>>();
+  globalState[PENDING_BACKGROUND_CACHE_REVALIDATIONS] = pending;
+  return pending;
+}
+
+/**
+ * Start at most one background refresh for a logical data-cache key.
+ *
+ * The caller owns the refresh's execution context and error message. This
+ * helper owns only isolate-wide deduplication, cleanup, rejection guarding,
+ * and attachment to the triggering request's runtime lifetime.
+ */
+export function scheduleBackgroundCacheRevalidation(
+  cacheKey: string,
+  refresh: () => Promise<unknown>,
+  reportError: (error: unknown) => void,
+): void {
+  const pending = getPendingBackgroundCacheRevalidations();
+  if (pending.has(cacheKey)) return;
+
+  const revalidation = Promise.resolve()
+    .then(refresh)
+    .then(() => undefined)
+    .catch((error) => {
+      reportError(error);
+    });
+  const trackedRevalidation = revalidation.finally(() => {
+    if (pending.get(cacheKey) === trackedRevalidation) {
+      pending.delete(cacheKey);
+    }
+  });
+
+  pending.set(cacheKey, trackedRevalidation);
+  const executionContext = getRequestExecutionContext();
+  if (executionContext) {
+    executionContext.waitUntil(trackedRevalidation);
+  } else {
+    void trackedRevalidation;
+  }
+}

--- a/packages/vinext/src/shims/unified-request-context.ts
+++ b/packages/vinext/src/shims/unified-request-context.ts
@@ -144,10 +144,10 @@ export function createRequestContext(opts?: Partial<UnifiedRequestContext>): Uni
  * Create the isolated request state used to regenerate a shared data-cache
  * entry after serving stale data.
  *
- * Cache callbacks retain only cache-specific read inputs from the triggering
- * request, while request APIs and every response-owned output container start
- * fresh. The refresh runs in foreground mode so nested stale dependencies are
- * resolved before the refreshed entry is stored.
+ * Cache callbacks retain only supported cache-scope inputs from the triggering
+ * request, while request headers, cookies, and every response-owned output
+ * container start fresh. The refresh runs in foreground mode so nested stale
+ * dependencies are resolved before the refreshed entry is stored.
  */
 export function createCacheRevalidationContext(
   fallbackSoftTags: readonly string[] = [],
@@ -164,6 +164,15 @@ export function createCacheRevalidationContext(
 
   return createRequestContext({
     executionContext: outer ? outer.executionContext : _getInheritedExecutionContext(),
+    // draftMode().isEnabled is readable inside public cache scopes. Preserve
+    // that API with a disabled provider, without exposing request data to the
+    // detached refresh. headers() and cookies() remain blocked by cache scope.
+    headersContext: {
+      headers: new Headers(),
+      cookies: new Map<string, string>(),
+      draftModeEnabled: false,
+      draftModeSecret: outer?.headersContext?.draftModeSecret,
+    },
     pendingRevalidatedTags: new Set(outer?.pendingRevalidatedTags ?? []),
     currentFetchSoftTags: [...(outer?.currentFetchSoftTags ?? fallbackSoftTags)],
     currentFetchCacheMode: outer?.currentFetchCacheMode ?? null,

--- a/packages/vinext/src/shims/unified-request-context.ts
+++ b/packages/vinext/src/shims/unified-request-context.ts
@@ -144,25 +144,15 @@ export function createRequestContext(opts?: Partial<UnifiedRequestContext>): Uni
  * Create the isolated request state used to regenerate a shared data-cache
  * entry after serving stale data.
  *
- * Cache callbacks retain supported read inputs from the triggering request,
- * while every response-owned output container starts fresh. The refresh runs
- * in foreground mode so nested stale dependencies are resolved before the
- * refreshed entry is stored.
+ * Cache callbacks retain only cache-specific read inputs from the triggering
+ * request, while request APIs and every response-owned output container start
+ * fresh. The refresh runs in foreground mode so nested stale dependencies are
+ * resolved before the refreshed entry is stored.
  */
 export function createCacheRevalidationContext(
   fallbackSoftTags: readonly string[] = [],
 ): UnifiedRequestContext {
   const outer = _als.getStore();
-  const headersContext = outer?.headersContext
-    ? {
-        ...outer.headersContext,
-        headers: new Headers(outer.headersContext.headers),
-        cookies: new Map(outer.headersContext.cookies),
-        mutableCookies: undefined,
-        readonlyCookies: undefined,
-        readonlyHeaders: undefined,
-      }
-    : null;
   const rootParams = outer?.rootParams
     ? Object.fromEntries(
         Object.entries(outer.rootParams).map(([name, value]) => [
@@ -174,7 +164,6 @@ export function createCacheRevalidationContext(
 
   return createRequestContext({
     executionContext: outer ? outer.executionContext : _getInheritedExecutionContext(),
-    headersContext,
     pendingRevalidatedTags: new Set(outer?.pendingRevalidatedTags ?? []),
     currentFetchSoftTags: [...(outer?.currentFetchSoftTags ?? fallbackSoftTags)],
     currentFetchCacheMode: outer?.currentFetchCacheMode ?? null,

--- a/packages/vinext/src/shims/unified-request-context.ts
+++ b/packages/vinext/src/shims/unified-request-context.ts
@@ -112,7 +112,7 @@ export function createRequestContext(opts?: Partial<UnifiedRequestContext>): Uni
     serverInsertedHTMLCallbacks: [],
     requestScopedCacheLife: null,
     unstableCacheObservations: new Map(),
-    unstableCacheRevalidation: "foreground",
+    cacheRevalidationMode: "foreground",
     _privateCache: null,
     cacheableFetchUrls: new Set<string>(),
     currentRequestTags: [],
@@ -138,6 +138,52 @@ export function createRequestContext(opts?: Partial<UnifiedRequestContext>): Uni
     rootParams: null,
     ...opts,
   };
+}
+
+/**
+ * Create the isolated request state used to regenerate a shared data-cache
+ * entry after serving stale data.
+ *
+ * Cache callbacks retain supported read inputs from the triggering request,
+ * while every response-owned output container starts fresh. The refresh runs
+ * in foreground mode so nested stale dependencies are resolved before the
+ * refreshed entry is stored.
+ */
+export function createCacheRevalidationContext(
+  fallbackSoftTags: readonly string[] = [],
+): UnifiedRequestContext {
+  const outer = _als.getStore();
+  const headersContext = outer?.headersContext
+    ? {
+        ...outer.headersContext,
+        headers: new Headers(outer.headersContext.headers),
+        cookies: new Map(outer.headersContext.cookies),
+        mutableCookies: undefined,
+        readonlyCookies: undefined,
+        readonlyHeaders: undefined,
+      }
+    : null;
+  const rootParams = outer?.rootParams
+    ? Object.fromEntries(
+        Object.entries(outer.rootParams).map(([name, value]) => [
+          name,
+          Array.isArray(value) ? [...value] : value,
+        ]),
+      )
+    : null;
+
+  return createRequestContext({
+    executionContext: outer ? outer.executionContext : _getInheritedExecutionContext(),
+    headersContext,
+    pendingRevalidatedTags: new Set(outer?.pendingRevalidatedTags ?? []),
+    currentFetchSoftTags: [...(outer?.currentFetchSoftTags ?? fallbackSoftTags)],
+    currentFetchCacheMode: outer?.currentFetchCacheMode ?? null,
+    currentForceDynamicFetchDefault: outer?.currentForceDynamicFetchDefault ?? false,
+    isFetchDedupeActive: outer?.isFetchDedupeActive ?? false,
+    currentFetchDedupeEntries: new Map(),
+    rootParams,
+    cacheRevalidationMode: "foreground",
+  });
 }
 
 function ensureAfterCompletion(ctx: UnifiedRequestContext): void {

--- a/tests/app-page-element-builder.test.ts
+++ b/tests/app-page-element-builder.test.ts
@@ -40,6 +40,7 @@ const { markDynamicUsageMock, markRenderRequestApiUsageMock } = vi.hoisted(() =>
 
 vi.mock("../packages/vinext/src/shims/headers.js", () => ({
   getHeadersAccessPhase: () => "render",
+  isDraftModeEnabled: () => false,
   markDynamicUsage: markDynamicUsageMock,
   markRenderRequestApiUsage: markRenderRequestApiUsageMock,
   throwIfInsideCacheScope: vi.fn(),

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -6506,6 +6506,283 @@ describe('"use cache" runtime', () => {
     expect(callCount).toBe(1);
   });
 
+  it("serves concurrent stale shared entries while one background revalidation runs", async () => {
+    // Ported from Next.js: test/e2e/app-dir/use-cache-swr/use-cache-swr.test.ts
+    // https://github.com/vercel/next.js/blob/a6223ac95d5e5a2f542d9bb76bd41e7451a21c73/test/e2e/app-dir/use-cache-swr/use-cache-swr.test.ts
+    const { registerCachedFunction } =
+      await import("../packages/vinext/src/shims/cache-runtime.js");
+    const { setCacheHandler, MemoryCacheHandler, cacheLife } =
+      await import("../packages/vinext/src/shims/cache.js");
+    const { addCollectedRequestTags, getCurrentFetchSoftTags } =
+      await import("../packages/vinext/src/shims/fetch-cache.js");
+    const { draftMode, headersContextFromRequest } =
+      await import("../packages/vinext/src/shims/headers.js");
+    const { getRootParam } = await import("../packages/vinext/src/shims/root-params.js");
+    const { createRequestContext, getRequestContext, runWithRequestContext } =
+      await import("../packages/vinext/src/shims/unified-request-context.js");
+
+    const staleEntry = {
+      lastModified: Date.now() - 2_000,
+      cacheState: "stale",
+      cacheControl: { revalidate: 3_600, expire: 7_200 },
+      value: {
+        kind: "FETCH",
+        data: {
+          headers: {},
+          body: JSON.stringify({ version: "stale" }),
+          url: "use-cache:test:stale-swr",
+        },
+        tags: ["stale-entry-tag"],
+        revalidate: 3_600,
+      },
+    } satisfies CacheHandlerValue;
+    const setEntry = vi.fn<CacheHandler["set"]>(async () => {});
+    setCacheHandler({
+      async get() {
+        return staleEntry;
+      },
+      set: setEntry,
+      async revalidateTag() {},
+    });
+
+    let markRevalidationStarted = () => {};
+    const revalidationStarted = new Promise<void>((resolve) => {
+      markRevalidationStarted = resolve;
+    });
+    let releaseRevalidation = () => {};
+    const revalidationGate = new Promise<void>((resolve) => {
+      releaseRevalidation = resolve;
+    });
+    const firstWaitUntilCalls: Promise<unknown>[] = [];
+    const secondWaitUntilCalls: Promise<unknown>[] = [];
+    const staleCalls: Promise<{ version: string }>[] = [];
+    const firstRequestContext = createRequestContext({
+      currentFetchSoftTags: ["implicit-route-tag"],
+      headersContext: headersContextFromRequest(
+        new Request("https://example.com/first", {
+          headers: { cookie: "__prerender_bypass=test-secret" },
+        }),
+        { draftModeSecret: "test-secret" },
+      ),
+      isFetchDedupeActive: true,
+      rootParams: { lang: "en" },
+      executionContext: {
+        waitUntil(promise) {
+          firstWaitUntilCalls.push(promise);
+        },
+      },
+    });
+    const secondRequestContext = createRequestContext({
+      currentFetchSoftTags: ["implicit-route-tag"],
+      headersContext: headersContextFromRequest(
+        new Request("https://example.com/second", {
+          headers: { cookie: "__prerender_bypass=test-secret" },
+        }),
+        { draftModeSecret: "test-secret" },
+      ),
+      isFetchDedupeActive: true,
+      rootParams: { lang: "en" },
+      executionContext: {
+        waitUntil(promise) {
+          secondWaitUntilCalls.push(promise);
+        },
+      },
+    });
+    let revalidationCalls = 0;
+    let refreshSoftTags: string[] = [];
+    let refreshRootParam: string | string[] | undefined;
+    let refreshDraftModeEnabled = false;
+    let refreshFetchDedupeActive = false;
+    let refreshFetchDedupeEntries: unknown;
+
+    const cached = registerCachedFunction(async () => {
+      revalidationCalls++;
+      refreshSoftTags = getCurrentFetchSoftTags();
+      refreshRootParam = await getRootParam("lang");
+      refreshDraftModeEnabled = (await draftMode()).isEnabled;
+      refreshFetchDedupeActive = getRequestContext().isFetchDedupeActive;
+      refreshFetchDedupeEntries = getRequestContext().currentFetchDedupeEntries;
+      cacheLife({ stale: 1, revalidate: 1, expire: 60 });
+      addCollectedRequestTags(["refresh-fetch-tag"]);
+      // These are the exact request-state slices updated by cached and
+      // uncached fetch observations during a real refresh.
+      getRequestContext().cacheableFetchUrls.add("https://example.com/refresh-cacheable");
+      getRequestContext().dynamicFetchUrls.add("https://example.com/refresh-dynamic");
+      markRevalidationStarted();
+      await revalidationGate;
+      return { version: "fresh" };
+    }, "test:stale-swr");
+
+    try {
+      staleCalls.push(
+        runWithRequestContext(firstRequestContext, () => cached()),
+        runWithRequestContext(secondRequestContext, () => cached()),
+      );
+      await revalidationStarted;
+
+      const outcome = await Promise.race([
+        Promise.all(staleCalls).then((values) => ({ status: "returned" as const, values })),
+        new Promise<{ status: "blocked" }>((resolve) => {
+          setImmediate(() => resolve({ status: "blocked" }));
+        }),
+      ]);
+
+      expect(outcome).toEqual({
+        status: "returned",
+        values: [{ version: "stale" }, { version: "stale" }],
+      });
+      expect(
+        [firstWaitUntilCalls.length, secondWaitUntilCalls.length].sort((a, b) => a - b),
+      ).toEqual([0, 1]);
+      expect(revalidationCalls).toBe(1);
+      expect(refreshSoftTags).toEqual(["implicit-route-tag"]);
+      expect(refreshRootParam).toBe("en");
+      expect(refreshDraftModeEnabled).toBe(true);
+      expect(refreshFetchDedupeActive).toBe(true);
+      expect(refreshFetchDedupeEntries).not.toBe(firstRequestContext.currentFetchDedupeEntries);
+      expect(refreshFetchDedupeEntries).not.toBe(secondRequestContext.currentFetchDedupeEntries);
+    } finally {
+      releaseRevalidation();
+      await Promise.allSettled([...staleCalls, ...firstWaitUntilCalls, ...secondWaitUntilCalls]);
+      setCacheHandler(new MemoryCacheHandler());
+    }
+
+    expect(setEntry).toHaveBeenCalledOnce();
+    for (const requestContext of [firstRequestContext, secondRequestContext]) {
+      expect(requestContext.requestScopedCacheLife).toEqual({
+        revalidate: 3_600,
+        expire: 7_200,
+      });
+      expect(requestContext.currentRequestTags).toEqual(["stale-entry-tag"]);
+      expect(requestContext.cacheableFetchUrls).toEqual(new Set());
+      expect(requestContext.dynamicFetchUrls).toEqual(new Set());
+    }
+  });
+
+  it("logs failed background writes and retries stale entries without a request context", async () => {
+    const { registerCachedFunction } =
+      await import("../packages/vinext/src/shims/cache-runtime.js");
+    const { setCacheHandler, MemoryCacheHandler } =
+      await import("../packages/vinext/src/shims/cache.js");
+
+    let resolveFirstWrite = () => {};
+    const firstWrite = new Promise<void>((resolve) => {
+      resolveFirstWrite = resolve;
+    });
+    let resolveSecondWrite = () => {};
+    const secondWrite = new Promise<void>((resolve) => {
+      resolveSecondWrite = resolve;
+    });
+    let writeCalls = 0;
+    setCacheHandler({
+      async get() {
+        return {
+          lastModified: Date.now() - 2_000,
+          cacheState: "stale",
+          cacheControl: { revalidate: 1, expire: 60 },
+          value: {
+            kind: "FETCH",
+            data: {
+              headers: {},
+              body: JSON.stringify({ version: "stale" }),
+              url: "use-cache:test:stale-write-retry",
+            },
+            tags: [],
+            revalidate: 1,
+          },
+        };
+      },
+      async set() {
+        writeCalls++;
+        if (writeCalls === 1) {
+          resolveFirstWrite();
+          throw new Error("cache backend unavailable");
+        }
+        resolveSecondWrite();
+      },
+      async revalidateTag() {},
+    });
+
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    let revalidationCalls = 0;
+    const cached = registerCachedFunction(async () => {
+      revalidationCalls++;
+      return { version: "fresh" };
+    }, "test:stale-write-retry");
+
+    try {
+      await expect(cached()).resolves.toEqual({ version: "stale" });
+      await firstWrite;
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(consoleError).toHaveBeenCalledWith(
+        "[vinext] use cache background revalidation cache write failed:",
+        expect.objectContaining({ message: "cache backend unavailable" }),
+      );
+
+      await expect(cached()).resolves.toEqual({ version: "stale" });
+      await secondWrite;
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    } finally {
+      consoleError.mockRestore();
+      setCacheHandler(new MemoryCacheHandler());
+    }
+
+    expect(revalidationCalls).toBe(2);
+    expect(writeCalls).toBe(2);
+  });
+
+  it("refreshes stale shared entries in the foreground during prerendering", async () => {
+    const { registerCachedFunction } =
+      await import("../packages/vinext/src/shims/cache-runtime.js");
+    const { setCacheHandler, MemoryCacheHandler } =
+      await import("../packages/vinext/src/shims/cache.js");
+
+    const setEntry = vi.fn<CacheHandler["set"]>(async () => {});
+    setCacheHandler({
+      async get() {
+        return {
+          lastModified: Date.now() - 2_000,
+          cacheState: "stale",
+          cacheControl: { revalidate: 1, expire: 60 },
+          value: {
+            kind: "FETCH",
+            data: {
+              headers: {},
+              body: JSON.stringify({ version: "stale" }),
+              url: "use-cache:test:stale-prerender",
+            },
+            tags: [],
+            revalidate: 1,
+          },
+        };
+      },
+      set: setEntry,
+      async revalidateTag() {},
+    });
+
+    let callCount = 0;
+    const cached = registerCachedFunction(async () => {
+      callCount++;
+      return { version: "fresh" };
+    }, "test:stale-prerender");
+    const previousPrerender = process.env.VINEXT_PRERENDER;
+
+    try {
+      process.env.VINEXT_PRERENDER = "1";
+      await expect(cached()).resolves.toEqual({ version: "fresh" });
+      expect(callCount).toBe(1);
+      expect(setEntry).toHaveBeenCalledOnce();
+    } finally {
+      if (previousPrerender === undefined) {
+        delete process.env.VINEXT_PRERENDER;
+      } else {
+        process.env.VINEXT_PRERENDER = previousPrerender;
+      }
+      setCacheHandler(new MemoryCacheHandler());
+    }
+  });
+
   it("registerCachedFunction collects cacheTag", async () => {
     const { registerCachedFunction } =
       await import("../packages/vinext/src/shims/cache-runtime.js");

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -6191,7 +6191,7 @@ describe("next/cache shim", () => {
     // pending revalidate and return the stale response immediately.
     // Source: https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/spec-extension/unstable-cache.ts
     const requestContext = createRequestContext({
-      unstableCacheRevalidation: "background",
+      cacheRevalidationMode: "background",
       executionContext: {
         waitUntil(promise) {
           waitUntilPromises.push(promise);
@@ -6261,7 +6261,7 @@ describe("next/cache shim", () => {
     // regenerating a static/ISR page so the regenerated page stores fresh data.
     // Source test: https://github.com/vercel/next.js/blob/canary/test/production/app-dir/unstable-cache-foreground-revalidate/unstable-cache-foreground-revalidate.test.ts
     const requestContext = createRequestContext({
-      unstableCacheRevalidation: "foreground",
+      cacheRevalidationMode: "foreground",
     });
 
     try {
@@ -6557,6 +6557,7 @@ describe('"use cache" runtime', () => {
     const secondWaitUntilCalls: Promise<unknown>[] = [];
     const staleCalls: Promise<{ version: string }>[] = [];
     const firstRequestContext = createRequestContext({
+      cacheRevalidationMode: "background",
       currentFetchSoftTags: ["implicit-route-tag"],
       headersContext: headersContextFromRequest(
         new Request("https://example.com/first", {
@@ -6573,6 +6574,7 @@ describe('"use cache" runtime', () => {
       },
     });
     const secondRequestContext = createRequestContext({
+      cacheRevalidationMode: "background",
       currentFetchSoftTags: ["implicit-route-tag"],
       headersContext: headersContextFromRequest(
         new Request("https://example.com/second", {
@@ -6659,11 +6661,13 @@ describe('"use cache" runtime', () => {
     }
   });
 
-  it("logs failed background writes and retries stale entries without a request context", async () => {
+  it("logs failed background writes and retries stale entries without waitUntil", async () => {
     const { registerCachedFunction } =
       await import("../packages/vinext/src/shims/cache-runtime.js");
     const { setCacheHandler, MemoryCacheHandler } =
       await import("../packages/vinext/src/shims/cache.js");
+    const { createRequestContext, runWithRequestContext } =
+      await import("../packages/vinext/src/shims/unified-request-context.js");
 
     let resolveFirstWrite = () => {};
     const firstWrite = new Promise<void>((resolve) => {
@@ -6709,9 +6713,15 @@ describe('"use cache" runtime', () => {
       revalidationCalls++;
       return { version: "fresh" };
     }, "test:stale-write-retry");
+    const requestContext = createRequestContext({
+      cacheRevalidationMode: "background",
+      executionContext: null,
+    });
 
     try {
-      await expect(cached()).resolves.toEqual({ version: "stale" });
+      await expect(runWithRequestContext(requestContext, () => cached())).resolves.toEqual({
+        version: "stale",
+      });
       await firstWrite;
       await new Promise<void>((resolve) => setImmediate(resolve));
 
@@ -6720,7 +6730,9 @@ describe('"use cache" runtime', () => {
         expect.objectContaining({ message: "cache backend unavailable" }),
       );
 
-      await expect(cached()).resolves.toEqual({ version: "stale" });
+      await expect(runWithRequestContext(requestContext, () => cached())).resolves.toEqual({
+        version: "stale",
+      });
       await secondWrite;
       await new Promise<void>((resolve) => setImmediate(resolve));
     } finally {
@@ -6730,6 +6742,92 @@ describe('"use cache" runtime', () => {
 
     expect(revalidationCalls).toBe(2);
     expect(writeCalls).toBe(2);
+  });
+
+  it("refreshes stale shared entries in foreground runtime revalidation contexts", async () => {
+    const { registerCachedFunction } =
+      await import("../packages/vinext/src/shims/cache-runtime.js");
+    const { setCacheHandler, MemoryCacheHandler } =
+      await import("../packages/vinext/src/shims/cache.js");
+    const { createRequestContext, runWithRequestContext } =
+      await import("../packages/vinext/src/shims/unified-request-context.js");
+
+    const setEntry = vi.fn<CacheHandler["set"]>(async () => {});
+    setCacheHandler({
+      async get() {
+        return {
+          lastModified: Date.now() - 2_000,
+          cacheState: "stale",
+          cacheControl: { revalidate: 1, expire: 60 },
+          value: {
+            kind: "FETCH",
+            data: {
+              headers: {},
+              body: JSON.stringify({ version: "stale" }),
+              url: "use-cache:test:stale-runtime-isr",
+            },
+            tags: [],
+            revalidate: 1,
+          },
+        };
+      },
+      set: setEntry,
+      async revalidateTag() {},
+    });
+
+    let markRefreshStarted = () => {};
+    const refreshStarted = new Promise<void>((resolve) => {
+      markRefreshStarted = resolve;
+    });
+    let releaseRefresh = () => {};
+    const refreshGate = new Promise<void>((resolve) => {
+      releaseRefresh = resolve;
+    });
+    const waitUntilCalls: Promise<unknown>[] = [];
+    const requestContext = createRequestContext({
+      cacheRevalidationMode: "foreground",
+      executionContext: {
+        waitUntil(promise) {
+          waitUntilCalls.push(promise);
+        },
+      },
+    });
+    const cached = registerCachedFunction(async () => {
+      markRefreshStarted();
+      await refreshGate;
+      return { version: "fresh" };
+    }, "test:stale-runtime-isr");
+    const resultPromise = runWithRequestContext(requestContext, () => cached());
+
+    try {
+      await refreshStarted;
+      const outcome = await Promise.race([
+        resultPromise.then((value) => ({ status: "returned" as const, value })),
+        new Promise<{ status: "blocked" }>((resolve) => {
+          setImmediate(() => resolve({ status: "blocked" }));
+        }),
+      ]);
+
+      expect(outcome).toEqual({ status: "blocked" });
+      expect(waitUntilCalls).toHaveLength(0);
+    } finally {
+      releaseRefresh();
+    }
+
+    try {
+      await expect(resultPromise).resolves.toEqual({ version: "fresh" });
+      expect(setEntry).toHaveBeenCalledOnce();
+      expect(setEntry).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          kind: "FETCH",
+          data: expect.objectContaining({ body: JSON.stringify({ version: "fresh" }) }),
+        }),
+        expect.any(Object),
+      );
+    } finally {
+      setCacheHandler(new MemoryCacheHandler());
+    }
   });
 
   it("refreshes stale shared entries in the foreground during prerendering", async () => {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -6515,8 +6515,6 @@ describe('"use cache" runtime', () => {
       await import("../packages/vinext/src/shims/cache.js");
     const { addCollectedRequestTags, getCurrentFetchSoftTags } =
       await import("../packages/vinext/src/shims/fetch-cache.js");
-    const { draftMode, headersContextFromRequest } =
-      await import("../packages/vinext/src/shims/headers.js");
     const { getRootParam } = await import("../packages/vinext/src/shims/root-params.js");
     const { createRequestContext, getRequestContext, runWithRequestContext } =
       await import("../packages/vinext/src/shims/unified-request-context.js");
@@ -6559,12 +6557,10 @@ describe('"use cache" runtime', () => {
     const firstRequestContext = createRequestContext({
       cacheRevalidationMode: "background",
       currentFetchSoftTags: ["implicit-route-tag"],
-      headersContext: headersContextFromRequest(
-        new Request("https://example.com/first", {
-          headers: { cookie: "__prerender_bypass=test-secret" },
-        }),
-        { draftModeSecret: "test-secret" },
-      ),
+      headersContext: {
+        headers: new Headers({ "x-request-only": "first" }),
+        cookies: new Map([["request-only", "first"]]),
+      },
       isFetchDedupeActive: true,
       rootParams: { lang: "en" },
       executionContext: {
@@ -6576,12 +6572,10 @@ describe('"use cache" runtime', () => {
     const secondRequestContext = createRequestContext({
       cacheRevalidationMode: "background",
       currentFetchSoftTags: ["implicit-route-tag"],
-      headersContext: headersContextFromRequest(
-        new Request("https://example.com/second", {
-          headers: { cookie: "__prerender_bypass=test-secret" },
-        }),
-        { draftModeSecret: "test-secret" },
-      ),
+      headersContext: {
+        headers: new Headers({ "x-request-only": "second" }),
+        cookies: new Map([["request-only", "second"]]),
+      },
       isFetchDedupeActive: true,
       rootParams: { lang: "en" },
       executionContext: {
@@ -6593,7 +6587,7 @@ describe('"use cache" runtime', () => {
     let revalidationCalls = 0;
     let refreshSoftTags: string[] = [];
     let refreshRootParam: string | string[] | undefined;
-    let refreshDraftModeEnabled = false;
+    let refreshHeadersContext: unknown;
     let refreshFetchDedupeActive = false;
     let refreshFetchDedupeEntries: unknown;
 
@@ -6601,7 +6595,7 @@ describe('"use cache" runtime', () => {
       revalidationCalls++;
       refreshSoftTags = getCurrentFetchSoftTags();
       refreshRootParam = await getRootParam("lang");
-      refreshDraftModeEnabled = (await draftMode()).isEnabled;
+      refreshHeadersContext = getRequestContext().headersContext;
       refreshFetchDedupeActive = getRequestContext().isFetchDedupeActive;
       refreshFetchDedupeEntries = getRequestContext().currentFetchDedupeEntries;
       cacheLife({ stale: 1, revalidate: 1, expire: 60 });
@@ -6639,7 +6633,7 @@ describe('"use cache" runtime', () => {
       expect(revalidationCalls).toBe(1);
       expect(refreshSoftTags).toEqual(["implicit-route-tag"]);
       expect(refreshRootParam).toBe("en");
-      expect(refreshDraftModeEnabled).toBe(true);
+      expect(refreshHeadersContext).toBeNull();
       expect(refreshFetchDedupeActive).toBe(true);
       expect(refreshFetchDedupeEntries).not.toBe(firstRequestContext.currentFetchDedupeEntries);
       expect(refreshFetchDedupeEntries).not.toBe(secondRequestContext.currentFetchDedupeEntries);
@@ -6658,6 +6652,80 @@ describe('"use cache" runtime', () => {
       expect(requestContext.currentRequestTags).toEqual(["stale-entry-tag"]);
       expect(requestContext.cacheableFetchUrls).toEqual(new Set());
       expect(requestContext.dynamicFetchUrls).toEqual(new Set());
+    }
+  });
+
+  it("bypasses persistent shared cache while draft mode is enabled", async () => {
+    const { registerCachedFunction } =
+      await import("../packages/vinext/src/shims/cache-runtime.js");
+    const { setCacheHandler, MemoryCacheHandler, cacheLife } =
+      await import("../packages/vinext/src/shims/cache.js");
+    const { draftMode, headersContextFromRequest } =
+      await import("../packages/vinext/src/shims/headers.js");
+    const { createRequestContext, runWithRequestContext } =
+      await import("../packages/vinext/src/shims/unified-request-context.js");
+
+    const getEntry = vi.fn<CacheHandler["get"]>(async () => ({
+      lastModified: Date.now() - 2_000,
+      cacheState: "stale",
+      cacheControl: { revalidate: 1, expire: 60 },
+      value: {
+        kind: "FETCH",
+        data: {
+          headers: {},
+          body: JSON.stringify({ version: "published-stale" }),
+          url: "use-cache:test:draft-mode-bypass",
+        },
+        tags: [],
+        revalidate: 1,
+      },
+    }));
+    const setEntry = vi.fn<CacheHandler["set"]>(async () => {});
+    setCacheHandler({
+      get: getEntry,
+      set: setEntry,
+      async revalidateTag() {},
+    });
+
+    const waitUntilCalls: Promise<unknown>[] = [];
+    const requestContext = createRequestContext({
+      cacheRevalidationMode: "background",
+      headersContext: headersContextFromRequest(
+        new Request("https://example.com/preview", {
+          headers: { cookie: "__prerender_bypass=test-secret" },
+        }),
+        { draftModeSecret: "test-secret" },
+      ),
+      executionContext: {
+        waitUntil(promise) {
+          waitUntilCalls.push(promise);
+        },
+      },
+    });
+    let calls = 0;
+    let observedDraftMode = false;
+    const cached = registerCachedFunction(async () => {
+      calls++;
+      observedDraftMode = (await draftMode()).isEnabled;
+      cacheLife({ revalidate: 5, expire: 60 });
+      return { version: "preview-fresh" };
+    }, "test:draft-mode-bypass");
+
+    try {
+      await expect(runWithRequestContext(requestContext, () => cached())).resolves.toEqual({
+        version: "preview-fresh",
+      });
+      expect(calls).toBe(1);
+      expect(observedDraftMode).toBe(true);
+      expect(getEntry).not.toHaveBeenCalled();
+      expect(setEntry).not.toHaveBeenCalled();
+      expect(waitUntilCalls).toHaveLength(0);
+      expect(requestContext.requestScopedCacheLife).toEqual({
+        revalidate: 5,
+        expire: 60,
+      });
+    } finally {
+      setCacheHandler(new MemoryCacheHandler());
     }
   });
 

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -6140,6 +6140,16 @@ describe("next/cache shim", () => {
     setCacheHandler(new MemoryCacheHandler());
   });
 
+  it("decideCacheRead distinguishes fresh, stale, and unusable cache states", async () => {
+    const { decideCacheRead } = await import("../packages/vinext/src/shims/cache-request-state.js");
+
+    expect(decideCacheRead(undefined, "background")).toBe("serve");
+    expect(decideCacheRead("stale", "background")).toBe("serve-and-revalidate");
+    expect(decideCacheRead("stale", "foreground")).toBe("revalidate");
+    expect(decideCacheRead("expired", "background")).toBe("revalidate");
+    expect(decideCacheRead("unknown", "background")).toBe("revalidate");
+  });
+
   it("unstable_cache serves stale entries and refreshes them in the background during App Router requests", async () => {
     const { unstable_cache, setCacheHandler, MemoryCacheHandler } =
       await import("../packages/vinext/src/shims/cache.js");
@@ -6213,6 +6223,65 @@ describe("next/cache shim", () => {
       await Promise.all(waitUntilPromises);
 
       expect(setBodies).toEqual([JSON.stringify({ v: "fresh-value" })]);
+    } finally {
+      setCacheHandler(new MemoryCacheHandler());
+    }
+  });
+
+  it("unstable_cache revalidates expired entries in the foreground", async () => {
+    const { unstable_cache, setCacheHandler, MemoryCacheHandler } =
+      await import("../packages/vinext/src/shims/cache.js");
+    const { createRequestContext, runWithRequestContext } =
+      await import("../packages/vinext/src/shims/unified-request-context.js");
+
+    const setEntry = vi.fn<CacheHandler["set"]>(async () => {});
+    setCacheHandler({
+      async get() {
+        return {
+          lastModified: Date.now() - 60_000,
+          cacheState: "expired",
+          value: {
+            kind: "FETCH",
+            data: {
+              headers: {},
+              body: JSON.stringify({ v: "expired-value" }),
+              url: "unstable_cache:expired-test:[]",
+            },
+            tags: ["expired"],
+            revalidate: 1,
+          },
+        };
+      },
+      set: setEntry,
+      async revalidateTag() {},
+    });
+
+    const waitUntilCalls: Promise<unknown>[] = [];
+    const requestContext = createRequestContext({
+      cacheRevalidationMode: "background",
+      executionContext: {
+        waitUntil(promise) {
+          waitUntilCalls.push(promise);
+        },
+      },
+    });
+    let callCount = 0;
+    const cached = unstable_cache(
+      async () => {
+        callCount++;
+        return "fresh-value";
+      },
+      ["expired-test"],
+      { tags: ["expired"], revalidate: 1 },
+    );
+
+    try {
+      await expect(runWithRequestContext(requestContext, () => cached())).resolves.toBe(
+        "fresh-value",
+      );
+      expect(callCount).toBe(1);
+      expect(waitUntilCalls).toHaveLength(0);
+      expect(setEntry).toHaveBeenCalledOnce();
     } finally {
       setCacheHandler(new MemoryCacheHandler());
     }
@@ -6668,6 +6737,63 @@ describe('"use cache" runtime', () => {
       expect(requestContext.currentRequestTags).toEqual(["stale-entry-tag"]);
       expect(requestContext.cacheableFetchUrls).toEqual(new Set());
       expect(requestContext.dynamicFetchUrls).toEqual(new Set());
+    }
+  });
+
+  it('"use cache" revalidates expired shared entries in the foreground', async () => {
+    const { registerCachedFunction } =
+      await import("../packages/vinext/src/shims/cache-runtime.js");
+    const { setCacheHandler, MemoryCacheHandler } =
+      await import("../packages/vinext/src/shims/cache.js");
+    const { createRequestContext, runWithRequestContext } =
+      await import("../packages/vinext/src/shims/unified-request-context.js");
+
+    const setEntry = vi.fn<CacheHandler["set"]>(async () => {});
+    setCacheHandler({
+      async get() {
+        return {
+          lastModified: Date.now() - 60_000,
+          cacheState: "expired",
+          value: {
+            kind: "FETCH",
+            data: {
+              headers: {},
+              body: JSON.stringify({ version: "expired" }),
+              url: "use-cache:test:expired",
+            },
+            tags: [],
+            revalidate: 1,
+          },
+        };
+      },
+      set: setEntry,
+      async revalidateTag() {},
+    });
+
+    const waitUntilCalls: Promise<unknown>[] = [];
+    const requestContext = createRequestContext({
+      cacheRevalidationMode: "background",
+      executionContext: {
+        waitUntil(promise) {
+          waitUntilCalls.push(promise);
+        },
+      },
+    });
+    let callCount = 0;
+    const cached = registerCachedFunction(async () => {
+      callCount++;
+      return { version: "fresh" };
+    }, "test:expired");
+
+    try {
+      await expect(runWithRequestContext(requestContext, () => cached())).resolves.toEqual({
+        version: "fresh",
+      });
+      expect(callCount).toBe(1);
+      expect(waitUntilCalls).toHaveLength(0);
+      expect(setEntry).toHaveBeenCalledOnce();
+    } finally {
+      setCacheHandler(new MemoryCacheHandler());
     }
   });
 

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -6515,6 +6515,7 @@ describe('"use cache" runtime', () => {
       await import("../packages/vinext/src/shims/cache.js");
     const { addCollectedRequestTags, getCurrentFetchSoftTags } =
       await import("../packages/vinext/src/shims/fetch-cache.js");
+    const { draftMode } = await import("../packages/vinext/src/shims/headers.js");
     const { getRootParam } = await import("../packages/vinext/src/shims/root-params.js");
     const { createRequestContext, getRequestContext, runWithRequestContext } =
       await import("../packages/vinext/src/shims/unified-request-context.js");
@@ -6560,6 +6561,7 @@ describe('"use cache" runtime', () => {
       headersContext: {
         headers: new Headers({ "x-request-only": "first" }),
         cookies: new Map([["request-only", "first"]]),
+        draftModeSecret: "test-secret",
       },
       isFetchDedupeActive: true,
       rootParams: { lang: "en" },
@@ -6575,6 +6577,7 @@ describe('"use cache" runtime', () => {
       headersContext: {
         headers: new Headers({ "x-request-only": "second" }),
         cookies: new Map([["request-only", "second"]]),
+        draftModeSecret: "test-secret",
       },
       isFetchDedupeActive: true,
       rootParams: { lang: "en" },
@@ -6587,24 +6590,34 @@ describe('"use cache" runtime', () => {
     let revalidationCalls = 0;
     let refreshSoftTags: string[] = [];
     let refreshRootParam: string | string[] | undefined;
-    let refreshHeadersContext: unknown;
+    let refreshDraftModeEnabled: boolean | undefined;
+    let refreshRequestHeader: string | null | undefined;
+    let refreshRequestCookie: string | undefined;
+    let refreshDraftModeSecret: string | undefined;
     let refreshFetchDedupeActive = false;
     let refreshFetchDedupeEntries: unknown;
 
     const cached = registerCachedFunction(async () => {
       revalidationCalls++;
-      refreshSoftTags = getCurrentFetchSoftTags();
-      refreshRootParam = await getRootParam("lang");
-      refreshHeadersContext = getRequestContext().headersContext;
-      refreshFetchDedupeActive = getRequestContext().isFetchDedupeActive;
-      refreshFetchDedupeEntries = getRequestContext().currentFetchDedupeEntries;
-      cacheLife({ stale: 1, revalidate: 1, expire: 60 });
-      addCollectedRequestTags(["refresh-fetch-tag"]);
-      // These are the exact request-state slices updated by cached and
-      // uncached fetch observations during a real refresh.
-      getRequestContext().cacheableFetchUrls.add("https://example.com/refresh-cacheable");
-      getRequestContext().dynamicFetchUrls.add("https://example.com/refresh-dynamic");
-      markRevalidationStarted();
+      try {
+        refreshSoftTags = getCurrentFetchSoftTags();
+        refreshRootParam = await getRootParam("lang");
+        refreshDraftModeEnabled = (await draftMode()).isEnabled;
+        const refreshHeadersContext = getRequestContext().headersContext;
+        refreshRequestHeader = refreshHeadersContext?.headers.get("x-request-only");
+        refreshRequestCookie = refreshHeadersContext?.cookies.get("request-only");
+        refreshDraftModeSecret = refreshHeadersContext?.draftModeSecret;
+        refreshFetchDedupeActive = getRequestContext().isFetchDedupeActive;
+        refreshFetchDedupeEntries = getRequestContext().currentFetchDedupeEntries;
+        cacheLife({ stale: 1, revalidate: 1, expire: 60 });
+        addCollectedRequestTags(["refresh-fetch-tag"]);
+        // These are the exact request-state slices updated by cached and
+        // uncached fetch observations during a real refresh.
+        getRequestContext().cacheableFetchUrls.add("https://example.com/refresh-cacheable");
+        getRequestContext().dynamicFetchUrls.add("https://example.com/refresh-dynamic");
+      } finally {
+        markRevalidationStarted();
+      }
       await revalidationGate;
       return { version: "fresh" };
     }, "test:stale-swr");
@@ -6633,7 +6646,10 @@ describe('"use cache" runtime', () => {
       expect(revalidationCalls).toBe(1);
       expect(refreshSoftTags).toEqual(["implicit-route-tag"]);
       expect(refreshRootParam).toBe("en");
-      expect(refreshHeadersContext).toBeNull();
+      expect(refreshDraftModeEnabled).toBe(false);
+      expect(refreshRequestHeader).toBeNull();
+      expect(refreshRequestCookie).toBeUndefined();
+      expect(refreshDraftModeSecret).toBe("test-secret");
       expect(refreshFetchDedupeActive).toBe(true);
       expect(refreshFetchDedupeEntries).not.toBe(firstRequestContext.currentFetchDedupeEntries);
       expect(refreshFetchDedupeEntries).not.toBe(secondRequestContext.currentFetchDedupeEntries);


### PR DESCRIPTION
Fixes #2672

## Summary

| goal | core change | expected impact |
| --- | --- | --- |
| Match `use cache` stale-while-revalidate semantics | Serve valid stale entries during ordinary App Router requests and coordinate one background refresh per logical cache key | Dynamic requests no longer wait for regeneration after the `revalidate` window |
| Reject unusable cache values | Choose an explicit read action from the handler state and request policy | Expired or unrecognized entries regenerate in the foreground and are never returned |
| Keep ISR artifacts fresh | Use the request-scoped cache revalidation policy for both `unstable_cache` and `use cache` | Page and route-handler ISR regeneration await fresh data instead of storing an artifact with a stale dependency |
| Isolate draft previews | Bypass persistent shared-cache reads and writes while retaining the normal `"use cache"` execution scope | Preview requests return fresh preview data and cannot replace published cache entries |
| Preserve cache-scope APIs during refresh | Give detached refreshes a disabled draft-mode provider with empty headers and cookies | Cached callbacks can read `draftMode().isEnabled` without inheriting request data |
| Coordinate background work | Share one per-key scheduler across both cache APIs | Deduplication, cleanup, error handling, and `waitUntil` attachment have one owner |

## Why

A cache value is usable only when both its stored state and its consumer allow it. An ordinary dynamic request may return a stale value immediately and refresh it in the background. A page or route-handler ISR regeneration must await that refresh so the new full-route artifact contains fresh data. An expired value is no longer usable in either context and must regenerate before the caller continues.

The request boundary owns this distinction because a cached function cannot know whether it is answering a user request or constructing a persistent artifact. Both function/data-cache APIs now consume the same decision:

| handler state | background request | foreground regeneration |
| --- | --- | --- |
| fresh (`cacheState` absent) | serve | serve |
| stale | serve and revalidate | revalidate |
| expired or unrecognized | revalidate | revalidate |

Draft mode is a separate cache boundary. Preview data can differ from published data, so a draft request executes the callback without reading or populating the persistent shared cache.

Non-draft background refreshes still need the request APIs supported inside public cache scopes. `draftMode().isEnabled` must return `false`; it must not fail because the detached context omitted its provider. The refresh receives a disabled provider with empty header and cookie stores. The draft-mode secret is retained, but no request data is copied.

## What changed

| scenario | before | after |
| --- | --- | --- |
| Ordinary App Router request | Stale `use cache` data blocked on regeneration | Returns the deserialized stale value and schedules one isolated refresh |
| Build-time or runtime ISR regeneration | Runtime ISR could detach the refresh and store stale data in the regenerated artifact | Both paths await the refresh under `cacheRevalidationMode: "foreground"` |
| Expired handler value | Any state other than `"stale"` was accepted as a hit, so the memory handler could return an expired value indefinitely | Both cache APIs skip the stored value, execute in the foreground, and write the fresh result |
| Draft-mode request | Could return stale published data and write preview output into shared storage | Executes inside the cache scope with no persistent `get`, `set`, or background refresh |
| Background callback using `draftMode()` | The detached context had no provider, so regeneration threw | Reads `isEnabled: false` from a minimal provider and completes the cache write |
| Background cache lifecycle | `unstable_cache` and `use cache` owned separate pending maps and cleanup logic | Both use one isolate-wide per-key scheduler |
| Refresh request state | The initial implementation copied full headers and cookies into regeneration | A named helper retains supported cache inputs, provides empty headers and cookies, and creates fresh response-output and fetch-deduplication containers |

Stored tags and cache-control metadata are applied to a stale response only after successful deserialization. Refresh-time metadata stays in the isolated context.

## Validation

- Added [explicit state-decision and expired-entry regressions](https://github.com/NathanDrake2406/vinext/blob/53812f3c0d70fb47d6d204cb3adcd329ec827240/tests/shims.test.ts#L6143-L6288) for `unstable_cache` and [`use cache`](https://github.com/NathanDrake2406/vinext/blob/53812f3c0d70fb47d6d204cb3adcd329ec827240/tests/shims.test.ts#L6743-L6798). Both behavior tests failed against the previous implementation by returning the stored expired value.
- Existing regression coverage verifies non-blocking stale reads, cross-request deduplication, `waitUntil` ownership, metadata isolation, disabled draft-mode access without request-data inheritance, draft-mode bypass, write-failure retry, missing `waitUntil`, build-time foreground refresh, and runtime ISR foreground refresh.
- Corrected the App Router page-builder test mock so the CI shard supplies the new `isDraftModeEnabled()` shim export.
- Passed 1,557 targeted tests across cache shims, unified request contexts, RSC handling, page construction, page dispatch, and route-handler execution.
- Passed the repository-wide format, lint, and type check across 2,649 formatted files and 1,143 checked files.
- Passed the vinext production build.
- The pre-commit hook passed its full check, staged unit and integration tests, and Knip.

<details>
<summary>Commands</summary>

```text
vp test run tests/shims.test.ts
vp test run tests/app-page-element-builder.test.ts tests/unified-request-context.test.ts tests/app-page-dispatch.test.ts tests/app-route-handler-execution.test.ts tests/app-rsc-handler.test.ts
vp check
vp run vinext#build
git diff --check
```

</details>

## Risk

Moderate. The behavior change is confined to persistent function/data-cache entries. Draft requests now match `unstable_cache` by bypassing persistent storage; request-local `"use cache: private"` remains available. Fresh published hits, misses, invalidated entries, the development bypass, and cache serialization retain their existing behavior. Unknown handler states fail closed by regenerating, so a custom handler that labels fresh values instead of leaving `cacheState` absent will lose a cache hit rather than serve a potentially unusable value.

The request policy does not govern patched `fetch()` response caching. That path retains its response-stream, refetch-map, and timeout lifecycle.

A refresh that never settles remains deduplicated for the isolate lifetime. This preserves the existing `unstable_cache` lifecycle behavior and does not introduce a new timeout policy.

## References

| reference | why it matters |
| --- | --- |
| [Vinext issue #2672](https://github.com/cloudflare/vinext/issues/2672) | Report and expected stale-while-revalidate behavior |
| [Next.js issue #74882](https://github.com/vercel/next.js/issues/74882) | Upstream bug report |
| [Next.js PR #92636](https://github.com/vercel/next.js/pull/92636) | Upstream `use cache` stale-while-revalidate fix |
| [Next.js stale refresh implementation](https://github.com/vercel/next.js/blob/a6223ac95d5e5a2f542d9bb76bd41e7451a21c73/packages/next/src/server/use-cache/use-cache-wrapper.ts#L2626-L2679) | Returns stale data during dynamic rendering, skips outer metadata propagation, and tracks background work |
| [Next.js expired-entry handling](https://github.com/vercel/next.js/blob/89c94877667f1692ae979cc553bf86c763b0a6b0/packages/next/src/server/use-cache/use-cache-wrapper.ts#L3019-L3063) | Treats an entry past `expire` as a miss and regenerates before use |
| [Next.js empty draft-mode behavior](https://github.com/vercel/next.js/blob/89c94877667f1692ae979cc553bf86c763b0a6b0/packages/next/src/server/request/draft-mode.ts#L54-L75) | Returns a disabled draft-mode object inside cache and prerender scopes when no enabled provider exists |
| [Next.js draft-mode write guard](https://github.com/vercel/next.js/blob/a6223ac95d5e5a2f542d9bb76bd41e7451a21c73/packages/next/src/server/use-cache/use-cache-wrapper.ts#L2512-L2529) | Avoids saving generated `"use cache"` entries while draft mode is enabled |
| [Next.js `use cache` SWR tests](https://github.com/vercel/next.js/blob/a6223ac95d5e5a2f542d9bb76bd41e7451a21c73/test/e2e/app-dir/use-cache-swr/use-cache-swr.test.ts#L60-L162) | Non-blocking response and cross-request deduplication behavior ported to Vinext's harness |
| [Next.js foreground ISR regression](https://github.com/vercel/next.js/blob/a6223ac95d5e5a2f542d9bb76bd41e7451a21c73/test/production/app-dir/unstable-cache-foreground-revalidate/unstable-cache-foreground-revalidate.test.ts#L13-L71) | Establishes that ISR must await fresh cache data before completing the regenerated page |
| [Next.js `cacheLife` documentation](https://github.com/vercel/next.js/blob/89c94877667f1692ae979cc553bf86c763b0a6b0/docs/01-app/03-api-reference/04-functions/cacheLife.mdx#L107-L115) | Documents immediate stale serving and background regeneration |
| [Vinext cache-read policy](https://github.com/NathanDrake2406/vinext/blob/53812f3c0d70fb47d6d204cb3adcd329ec827240/packages/vinext/src/shims/cache-request-state.ts#L44-L49) | Defines the function/data-cache policy boundary and explicit read actions |
| [Vinext cache-read decision](https://github.com/NathanDrake2406/vinext/blob/53812f3c0d70fb47d6d204cb3adcd329ec827240/packages/vinext/src/shims/cache-request-state.ts#L253-L270) | Maps fresh, stale, expired, and unrecognized states to serve or revalidate behavior |
| [Vinext memory-handler expiration](https://github.com/NathanDrake2406/vinext/blob/53812f3c0d70fb47d6d204cb3adcd329ec827240/packages/vinext/src/shims/cache-handler.ts#L249-L258) | Returns expired entries with `cacheState: "expired"`, which exposed the previous negative-state test |
| [Vinext `use cache` read path](https://github.com/NathanDrake2406/vinext/blob/53812f3c0d70fb47d6d204cb3adcd329ec827240/packages/vinext/src/shims/cache-runtime.ts#L478-L625) | Applies draft bypass, explicit cache disposition, metadata propagation, and isolated background refresh |
| [Vinext `unstable_cache` read path](https://github.com/NathanDrake2406/vinext/blob/53812f3c0d70fb47d6d204cb3adcd329ec827240/packages/vinext/src/shims/cache.ts#L586-L630) | Uses the same cache disposition for persistent function-cache reads |
| [Vinext minimal refresh context](https://github.com/NathanDrake2406/vinext/blob/53812f3c0d70fb47d6d204cb3adcd329ec827240/packages/vinext/src/shims/unified-request-context.ts#L143-L184) | Provides disabled draft mode and retains supported cache inputs without copying request headers or cookies |
| [Vinext shared scheduler](https://github.com/NathanDrake2406/vinext/blob/53812f3c0d70fb47d6d204cb3adcd329ec827240/packages/vinext/src/shims/internal/cache-revalidation.ts#L1-L51) | Owns isolate-wide deduplication, cleanup, rejection handling, and runtime lifetime attachment |
