### PR TITLE
fix(pnpm-workspace): disable global virtual store option

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ preferFrozenLockfile: true
 saveExact: true
 blockExoticSubdeps: true
 minimumReleaseAge: 1440
+enableGlobalVirtualStore: false
 
 packages:
   - apps/*


### PR DESCRIPTION
## Summary

Disable pnpm's global virtual store for this project.

When `enableGlobalVirtualStore` is enabled, Vite+ fails to resolve its native Rolldown binding and exits with the following error:

```text
Error: Cannot find native binding
Cannot find module 'vite-plus/binding'
Cannot find module './rolldown-binding.darwin-arm64.node'
```

Setting `enableGlobalVirtualStore` to `false` restores the project-local virtual store layout and allows Vite+ to resolve the native binding correctly.

## Changes

* Set `enableGlobalVirtualStore: false` in `pnpm-workspace.yaml`

## Verification

1. Removed the existing `node_modules` directory
2. Reinstalled dependencies with `pnpm install`
3. Ran the command that previously failed
4. Confirmed that Vite+ starts without the native binding error
