### PR TITLE
fix(rsc): handle Windows paths in client reference dedup

### DIFF
--- a/packages/vinext/src/plugins/client-reference-dedup.ts
+++ b/packages/vinext/src/plugins/client-reference-dedup.ts
@@ -1,4 +1,5 @@
 import { readFile as readFileFromFs } from "node:fs/promises";
+import path, { toSlash } from "pathslash";
 import type { Plugin } from "vite";
 import { isUnknownRecord as isRecord } from "../utils/record.js";
 
@@ -244,18 +245,19 @@ export function clientReferenceDedupPlugin(options: ClientReferenceDedupOptions 
         if (!importer || !importer.includes(PROXY_MARKER)) return;
 
         // Only handle absolute paths through node_modules
-        if (!id.startsWith("/") || !id.includes("/node_modules/")) return;
+        const normalizedId = toSlash(id);
+        if (!path.isAbsolute(normalizedId) || !normalizedId.includes("/node_modules/")) return;
 
-        const packageName = extractPackageName(id);
+        const packageName = extractPackageName(normalizedId);
         if (!packageName) return;
 
         // Respect user's optimizeDeps.exclude
         if (excludeSet.has(packageName)) return;
 
-        let packageImportPromise = packageImportCache.get(id);
+        let packageImportPromise = packageImportCache.get(normalizedId);
         if (!packageImportPromise) {
-          packageImportPromise = extractPackageImportSpecifier(id, readPackageJson);
-          packageImportCache.set(id, packageImportPromise);
+          packageImportPromise = extractPackageImportSpecifier(normalizedId, readPackageJson);
+          packageImportCache.set(normalizedId, packageImportPromise);
         }
 
         const packageImport = await packageImportPromise;

--- a/tests/client-reference-dedup.test.ts
+++ b/tests/client-reference-dedup.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { describe, it, expect } from "vite-plus/test";
 import type { Plugin } from "vite";
 import vinext from "../packages/vinext/src/index.js";
@@ -198,6 +199,27 @@ describe("clientReferenceDedupPlugin", () => {
       );
       expect(result).toBe("\0vinext:dedup/@mantine/core");
     });
+
+    it.runIf(process.platform === "win32")(
+      "redirects Vite-normalized Windows drive paths from proxy modules",
+      async () => {
+        const ctx = createContext("client");
+        const viteId = path.join(
+          "C:\\project",
+          "node_modules",
+          "@testmodule",
+          "core",
+          "esm",
+          "test.mjs",
+        );
+        const result = await resolveId.call(
+          ctx,
+          viteId,
+          "\0virtual:vite-rsc/client-in-server-package-proxy/abc123",
+        );
+        expect(result).toBe("\0vinext:dedup/@testmodule/core");
+      },
+    );
 
     it("preserves package subpaths when package exports map them", async () => {
       const subpathPlugin = clientReferenceDedupPlugin({


### PR DESCRIPTION
## Summary

- normalize incoming module IDs in the client reference dedup plugin
- replace the POSIX-only absolute-path check with a platform-aware check
- add coverage for native Windows `node_modules` paths
- related to #1605 

## Test plans

Added a Windows-only regression case.
tests/client-reference-dedup.test.ts all green.
