### PR TITLE
fix(pages): preserve live Set-Cookie header arrays

### DIFF
--- a/packages/vinext/src/server/pages-node-compat.ts
+++ b/packages/vinext/src/server/pages-node-compat.ts
@@ -287,7 +287,7 @@ class PagesResponseStream extends Writable {
     this.resStatusCode = code;
     if (headers) {
       for (const [key, value] of Object.entries(headers)) {
-        this.setHeaderValue(key, value, { replaceSetCookie: false });
+        this.setHeaderValue(key, value, { replaceSetCookie: true });
       }
     }
     return this as PagesReqResResponse;

--- a/packages/vinext/src/server/pages-node-compat.ts
+++ b/packages/vinext/src/server/pages-node-compat.ts
@@ -451,14 +451,13 @@ class PagesResponseStream extends Writable {
     options: { replaceSetCookie: boolean },
   ): void {
     if (name.toLowerCase() === "set-cookie") {
+      // getHeader() exposes this array like Node's ServerResponse. Snapshot it
+      // before replacement so passing that live value back does not clear it.
+      const values = Array.isArray(value) ? value.map(String) : [String(value)];
       if (options.replaceSetCookie) {
         this.setCookieHeaders.length = 0;
       }
-      if (Array.isArray(value)) {
-        this.setCookieHeaders.push(...value.map(String));
-      } else {
-        this.setCookieHeaders.push(String(value));
-      }
+      this.setCookieHeaders.push(...values);
       return;
     }
 

--- a/tests/pages-api-route.test.ts
+++ b/tests/pages-api-route.test.ts
@@ -382,6 +382,32 @@ describe("pages api route", () => {
     expect(cookies).toEqual(["session=xyz"]);
   });
 
+  it("preserves Set-Cookie values when a caller mutates and resets the getHeader array", async () => {
+    const response = await handlePagesApiRoute({
+      match: createMatch((_req, res) => {
+        // Matches next-auth v4's setCookie helper:
+        // https://github.com/nextauthjs/next-auth/blob/next-auth%404.24.13/packages/next-auth/src/next/utils.ts#L5-L15
+        const appendCookie = (cookie: string) => {
+          let cookies = res.getHeader("Set-Cookie") ?? [];
+          if (!Array.isArray(cookies)) {
+            cookies = [String(cookies)];
+          }
+          cookies.push(cookie);
+          res.setHeader("Set-Cookie", cookies);
+        };
+
+        appendCookie("a=1; Path=/");
+        appendCookie("b=2; Path=/");
+        res.end();
+      }),
+      request: new Request("https://example.com/api/cookie"),
+      url: "/api/cookie",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.getSetCookie()).toEqual(["a=1; Path=/", "b=2; Path=/"]);
+  });
+
   it("calls edge API route handlers with a Fetch Request and returns their Response", async () => {
     // Ported from Next.js: test/e2e/edge-async-local-storage/index.test.ts
     // https://github.com/vercel/next.js/blob/canary/test/e2e/edge-async-local-storage/index.test.ts

--- a/tests/pages-api-route.test.ts
+++ b/tests/pages-api-route.test.ts
@@ -350,6 +350,23 @@ describe("pages api route", () => {
     expect(response.headers.get("x-multi")).toBe("a, b");
   });
 
+  it("res.writeHead() replaces previously set Set-Cookie headers (Node.js parity)", async () => {
+    const response = await handlePagesApiRoute({
+      match: createMatch((_req, res) => {
+        res.setHeader("Set-Cookie", "existing=1");
+        res.writeHead(200, {
+          "Set-Cookie": ["replacement=2", "replacement-extra=3"],
+        });
+        res.end();
+      }),
+      request: new Request("https://example.com/api/cookie"),
+      url: "/api/cookie",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.getSetCookie()).toEqual(["replacement=2", "replacement-extra=3"]);
+  });
+
   it("res.setHeader and res.getHeader round-trip correctly", async () => {
     const response = await handlePagesApiRoute({
       match: createMatch((_req, res) => {


### PR DESCRIPTION
## Summary

- preserve Node.js-compatible live `Set-Cookie` arrays in the Pages response adapter
- snapshot replacement values before clearing the internal cookie accumulator
- cover the exact append-and-reset pattern used by next-auth v4 through the Pages API route handler
- make `writeHead()` cookie values replace earlier `setHeader()` values like Node.js

## Root cause

`getHeader("Set-Cookie")` exposes the adapter's internal array, matching Node's live header-array behavior. When that same array was passed back to `setHeader`, vinext cleared the internal accumulator before reading the replacement values, which also emptied the aliased input.

The same adapter also treated `writeHead()` cookie values as additive even though Node gives explicit `writeHead()` headers precedence over values previously supplied through `setHeader()`.

## Validation

- `vp test run tests/pages-api-route.test.ts tests/pages-node-compat.test.ts tests/pages-preview.test.ts`
- `vp test run tests/pages-page-handler.test.ts`
- `vp check packages/vinext/src/server/pages-node-compat.ts tests/pages-api-route.test.ts`
- `vp run vinext#build`

Closes #2688
