### PR TITLE
fix(css): load Sass partials from paths containing tildes

### DIFF
--- a/packages/vinext/src/plugins/sass.ts
+++ b/packages/vinext/src/plugins/sass.ts
@@ -179,7 +179,6 @@ export function createSassCssUrlAssetImporter(): {
 } {
   const markedStylesheets = new Map<string, SassLoadedStylesheet>();
   const importUrlPrefix = "vinext-css-url-asset:";
-  const stylesheetKey = (url: URL): string => toSlash(fileURLToPath(url));
 
   const prepareStylesheet = (
     filename: string,
@@ -235,7 +234,7 @@ export function createSassCssUrlAssetImporter(): {
     },
 
     load(canonicalUrl) {
-      return markedStylesheets.get(stylesheetKey(canonicalUrl)) ?? null;
+      return markedStylesheets.get(toSlash(fileURLToPath(canonicalUrl))) ?? null;
     },
 
     rewriteImports,

--- a/packages/vinext/src/plugins/sass.ts
+++ b/packages/vinext/src/plugins/sass.ts
@@ -217,8 +217,7 @@ export function createSassCssUrlAssetImporter(): {
           if (!fs.statSync(candidate, { throwIfNoEntry: false })?.isFile()) continue;
           const prepared = prepareStylesheet(candidate, entryDirectory);
           if (prepared === null) return match;
-          const canonicalUrl = pathToFileURL(candidate);
-          markedStylesheets.set(stylesheetKey(canonicalUrl), prepared);
+          markedStylesheets.set(candidate, prepared);
           const namespace =
             rule === "use" && !/\bas\s+(?:\*|[-\w]+)/.test(suffix)
               ? ` as ${deriveSassNamespace(importUrl)}`

--- a/packages/vinext/src/plugins/sass.ts
+++ b/packages/vinext/src/plugins/sass.ts
@@ -25,7 +25,7 @@
 import fs from "node:fs";
 import { createRequire } from "node:module";
 import path, { toSlash } from "pathslash";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { preprocessCSS, type PreprocessCSSResult, type ResolvedConfig } from "vite";
 import { markCssUrlAssetReferences, rebaseCssUrlAssetReferences } from "../build/css-url-assets.js";
 
@@ -179,6 +179,7 @@ export function createSassCssUrlAssetImporter(): {
 } {
   const markedStylesheets = new Map<string, SassLoadedStylesheet>();
   const importUrlPrefix = "vinext-css-url-asset:";
+  const stylesheetKey = (url: URL): string => toSlash(fileURLToPath(url));
 
   const prepareStylesheet = (
     filename: string,
@@ -217,7 +218,7 @@ export function createSassCssUrlAssetImporter(): {
           const prepared = prepareStylesheet(candidate, entryDirectory);
           if (prepared === null) return match;
           const canonicalUrl = pathToFileURL(candidate);
-          markedStylesheets.set(canonicalUrl.href, prepared);
+          markedStylesheets.set(stylesheetKey(canonicalUrl), prepared);
           const namespace =
             rule === "use" && !/\bas\s+(?:\*|[-\w]+)/.test(suffix)
               ? ` as ${deriveSassNamespace(importUrl)}`
@@ -235,7 +236,7 @@ export function createSassCssUrlAssetImporter(): {
     },
 
     load(canonicalUrl) {
-      return markedStylesheets.get(canonicalUrl.href) ?? null;
+      return markedStylesheets.get(stylesheetKey(canonicalUrl)) ?? null;
     },
 
     rewriteImports,

--- a/tests/sass-options.test.ts
+++ b/tests/sass-options.test.ts
@@ -225,34 +225,31 @@ describe("createSassCssUrlAssetImporter", () => {
     }
   });
 
-  it.runIf(process.platform === "win32")(
-    "loads partials when Sass normalizes Windows short-path URLs",
-    async () => {
-      const sass = await import("sass");
-      const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-sass-short-path-url-"));
-      const shortPathDir = path.join(tmpDir, "RUNNER~1");
-      const entryPath = path.join(shortPathDir, "entry.scss");
-      await fsp.mkdir(shortPathDir);
-      await fsp.writeFile(
-        path.join(shortPathDir, "_card.scss"),
-        `$fg: red;\n.card { background-image: url('./card.svg'); }`,
-      );
+  it("loads partials when Sass normalizes URLs with '~'", async () => {
+    const sass = await import("sass");
+    const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-sass-short-path-url-"));
+    const shortPathDir = path.join(tmpDir, "RUNNER~1");
+    const entryPath = path.join(shortPathDir, "entry.scss");
+    await fsp.mkdir(shortPathDir);
+    await fsp.writeFile(
+      path.join(shortPathDir, "_card.scss"),
+      `$fg: red;\n.card { background-image: url('./card.svg'); }`,
+    );
 
-      try {
-        const importer = createSassCssUrlAssetImporter();
-        const rewritten = importer.rewriteImports(
-          `@use "./card";\n.test { color: card.$fg; }`,
-          entryPath,
-        );
-        expect(rewritten).toContain("RUNNER~1");
-        expect(() =>
-          sass.compileString(rewritten, { importers: [importer], syntax: "scss" }),
-        ).not.toThrow();
-      } finally {
-        await fsp.rm(tmpDir, { recursive: true, force: true });
-      }
-    },
-  );
+    try {
+      const importer = createSassCssUrlAssetImporter();
+      const rewritten = importer.rewriteImports(
+        `@use "./card";\n.test { color: card.$fg; }`,
+        entryPath,
+      );
+      expect(rewritten).toContain("RUNNER~1");
+      expect(() =>
+        sass.compileString(rewritten, { importers: [importer], syntax: "scss" }),
+      ).not.toThrow();
+    } finally {
+      await fsp.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("createSassTildeImporter", () => {

--- a/tests/sass-options.test.ts
+++ b/tests/sass-options.test.ts
@@ -224,6 +224,35 @@ describe("createSassCssUrlAssetImporter", () => {
       await fsp.rm(tmpDir, { recursive: true, force: true });
     }
   });
+
+  it.runIf(process.platform === "win32")(
+    "loads partials when Sass normalizes Windows short-path URLs",
+    async () => {
+      const sass = await import("sass");
+      const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-sass-short-path-url-"));
+      const shortPathDir = path.join(tmpDir, "RUNNER~1");
+      const entryPath = path.join(shortPathDir, "entry.scss");
+      await fsp.mkdir(shortPathDir);
+      await fsp.writeFile(
+        path.join(shortPathDir, "_card.scss"),
+        `$fg: red;\n.card { background-image: url('./card.svg'); }`,
+      );
+
+      try {
+        const importer = createSassCssUrlAssetImporter();
+        const rewritten = importer.rewriteImports(
+          `@use "./card";\n.test { color: card.$fg; }`,
+          entryPath,
+        );
+        expect(rewritten).toContain("RUNNER~1");
+        expect(() =>
+          sass.compileString(rewritten, { importers: [importer], syntax: "scss" }),
+        ).not.toThrow();
+      } finally {
+        await fsp.rm(tmpDir, { recursive: true, force: true });
+      }
+    },
+  );
 });
 
 describe("createSassTildeImporter", () => {


### PR DESCRIPTION
## Summary

- key Sass importer stylesheets by normalized filesystem paths instead of serialized URL strings
- preserve stylesheet lookup when Sass normalizes equivalent file URLs
- add a focused regression test using a path containing `~`
- related to #1792
- fix #2690 

## Problem

The Sass CSS URL asset importer stored prepared stylesheets using `pathToFileURL(candidate).href`.

Node serializes a filesystem path containing `~` as `%7E`:

```text
file:///C:/Users/RUNNER%7E1/.../_card.scss
```

When the canonical URL passes through Sass's internal URI representation, Sass normalizes `%7E` back to the equivalent unreserved character `~` before calling `load()`:

```text
file:///C:/Users/RUNNER~1/.../_card.scss
```

Although these URLs identify the same file, comparing their serialized `href` strings caused the stylesheet map lookup to fail. Sass then reported:

```text
Can't find stylesheet to import.
```

`RUNNER~1` are a common way to encounter this problem, but the issue is not Windows-specific. A path containing `~` on Linux or macOS goes through the same URL normalization.

## Fix

Convert canonical file URLs back to filesystem paths with `fileURLToPath()` and normalize the resulting external path with `toSlash()` before using it as the stylesheet map key.

This makes the key independent of equivalent URL serialization forms such as `%7E` and `~`, while retaining vinext's canonical forward-slash path format.

## Testing

Added a regression test that:

1. creates a Sass partial under a path containing `~`
2. rewrites an `@use` rule through the CSS URL asset importer
3. compiles the rewritten stylesheet with Sass
4. verifies that the normalized canonical URL still resolves to the prepared
   stylesheet

An existing namespace test happened to expose this failure on GitHub Actions because that runner's temporary directory used the Windows short path `C:\Users\RUNNER~1\...`. However, that coverage depended on the runner's environment. The same test passed locally when `os.tmpdir()` returned a path without `~`, and it would stop covering this regression if the runner's
temporary directory changed.

The focused regression test constructs the tilde-containing path explicitly, making the coverage deterministic. It is kept separate from the existing namespace test because the two tests cover different behavior:

- the existing test verifies that underscores are preserved in Sass default namespaces
- the new test verifies stylesheet lookup across equivalent canonical URL serializations

Keeping these concerns separate also makes future failures easier to diagnose.

Commands run:

- `vp test run tests/sass-options.test.ts`
- `vp check tests/sass-options.test.ts packages/vinext/src/plugins/sass.ts`
- `vp test run tests/sass-options.test.ts -t "loads partials when Sass normalizes Windows short-path URLs"`

All checks pass.