### PR TITLE
fix(test): prevent recursive deploy log growth

### DIFF
--- a/scripts/e2e-deploy.sh
+++ b/scripts/e2e-deploy.sh
@@ -242,13 +242,17 @@ cleanup_on_error() {
     echo
     echo "=== vinext e2e deploy debug ==="
     if [ -f "${BUILD_LOG}" ]; then
+      local build_log_tail
+      build_log_tail="$(tail -80 "${BUILD_LOG}" 2>/dev/null || true)"
       echo "--- last 80 lines of ${BUILD_LOG} ---"
-      tail -80 "${BUILD_LOG}" 2>/dev/null || true
+      printf '%s\n' "${build_log_tail}"
       echo "--- end ${BUILD_LOG} (persisted to ${DEBUG_RUN_DIR}/${BUILD_LOG}) ---"
     fi
     if [ -f "${SERVER_LOG}" ]; then
+      local server_log_tail
+      server_log_tail="$(tail -40 "${SERVER_LOG}" 2>/dev/null || true)"
       echo "--- last 40 lines of ${SERVER_LOG} ---"
-      tail -40 "${SERVER_LOG}" 2>/dev/null || true
+      printf '%s\n' "${server_log_tail}"
       echo "--- end ${SERVER_LOG} (persisted to ${DEBUG_RUN_DIR}/${SERVER_LOG}) ---"
     fi
     echo "=== end vinext e2e deploy debug ==="

--- a/tests/e2e-deploy-script.test.ts
+++ b/tests/e2e-deploy-script.test.ts
@@ -4,6 +4,46 @@ import { execFileSync } from "node:child_process";
 import { describe, expect, it } from "vite-plus/test";
 
 describe("Next.js deploy harness logging", () => {
+  it("does not recursively append failure diagnostics to deploy logs", () => {
+    const script = fs.readFileSync(path.resolve("scripts/e2e-deploy.sh"), "utf8");
+    const cleanup = script.match(
+      /(cleanup_on_error\(\) \{[\s\S]*?\n\})\n\ntrap cleanup_on_error EXIT/,
+    )?.[1];
+    expect(cleanup).toBeDefined();
+
+    const tempRoot = fs.mkdtempSync(path.join(process.cwd(), ".e2e-deploy-cleanup-test-"));
+    try {
+      const buildLog = path.join(tempRoot, "build.log");
+      fs.writeFileSync(buildLog, "build failed\n");
+
+      const result = execFileSync(
+        "bash",
+        [
+          "-c",
+          [
+            "persist_debug_artifacts() { :; }",
+            cleanup!,
+            "DEPLOYMENT_READY=0 PID_FILE=missing.pid PORT_FILE=missing.port SERVER_LOG=missing.log DEBUG_RUN_DIR=debug",
+            'cleanup_on_error 2>> "${BUILD_LOG}"',
+          ].join("\n"),
+        ],
+        {
+          cwd: tempRoot,
+          env: { ...process.env, BUILD_LOG: buildLog },
+          timeout: 2_000,
+        },
+      );
+
+      expect(result).toHaveLength(0);
+      const output = fs.readFileSync(buildLog, "utf8");
+      expect(output.match(/build failed/g)).toHaveLength(2);
+      expect(output).toContain("=== vinext e2e deploy debug ===");
+      expect(Buffer.byteLength(output)).toBeLessThan(2_000);
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it("materializes workspace dependencies required by the local vinext package", () => {
     const repoRoot = path.resolve(".");
     const script = fs.readFileSync(path.join(repoRoot, "scripts/e2e-deploy.sh"), "utf8");


### PR DESCRIPTION
## Summary

- snapshot deploy and server log tails before writing failure diagnostics
- prevent the `EXIT` trap from reading a log while its stderr is redirected back into that same log
- retain the existing bounded failure diagnostics and persisted debug artifacts
- add regression coverage for the self-directed stderr case

## Validation

- `bash -n scripts/e2e-deploy.sh`
- `vp check scripts/e2e-deploy.sh tests/e2e-deploy-script.test.ts`
- `vp test run tests/e2e-deploy-script.test.ts`