### PR TITLE
test(app-router): isolate * param route-graph case from Windows

### DIFF
--- a/tests/app-route-graph.test.ts
+++ b/tests/app-route-graph.test.ts
@@ -1482,23 +1482,39 @@ describe("App Router route graph builder", () => {
     });
   });
 
-  it("skips routes whose param names end in + or * (would collide with internal modifiers)", async () => {
-    // Param names ending in + or * would map to :id+ / :id*, which the trie
-    // matcher interprets as catch-all / optional-catch-all. Skip these routes
-    // entirely to avoid ambiguity.
+  // Param names ending in + or * would map to :id+ / :id*, which the trie
+  // matcher interprets as catch-all / optional-catch-all. Skip these routes
+  // entirely to avoid ambiguity. The + and * cases are split because `*` is a
+  // reserved character in Windows filenames — a literal `[id*]` directory can't
+  // exist there, so that scenario is gated to POSIX (where it's reachable).
+  it("skips routes whose param names end in + (would collide with the catch-all modifier)", async () => {
     await withTempApp(async (appDir) => {
       await writeAppFile(appDir, "layout.tsx", EMPTY_LAYOUT);
       await writeAppFile(appDir, "[id+]/page.tsx", EMPTY_PAGE);
-      await writeAppFile(appDir, "[id*]/page.tsx", EMPTY_PAGE);
 
       const graph = await buildAppRouteGraph(appDir, createValidFileMatcher());
       const patterns = graph.routes.map((r) => r.pattern);
 
       expect(patterns).not.toContain("/:id+");
-      expect(patterns).not.toContain("/:id*");
       expect(patterns).toHaveLength(0);
     });
   });
+
+  it.runIf(process.platform !== "win32")(
+    "skips routes whose param names end in * (would collide with the optional-catch-all modifier)",
+    async () => {
+      await withTempApp(async (appDir) => {
+        await writeAppFile(appDir, "layout.tsx", EMPTY_LAYOUT);
+        await writeAppFile(appDir, "[id*]/page.tsx", EMPTY_PAGE);
+
+        const graph = await buildAppRouteGraph(appDir, createValidFileMatcher());
+        const patterns = graph.routes.map((r) => r.pattern);
+
+        expect(patterns).not.toContain("/:id*");
+        expect(patterns).toHaveLength(0);
+      });
+    },
+  );
 
   // Intercepting route source-pattern computation. Mirrors Next.js'
   // `extractInterceptionRouteInformation` which derives the intercepting


### PR DESCRIPTION
## Summary

Related to #1792

The App Router route-graph test "skips routes whose param names end in + or *" builds a temp fixture directory named `[id*]`. `*` is a **reserved character in Windows filenames**, so that directory can't be created on Windows — the test throws before it can assert, making `vp test run` unrunnable locally on Windows even though the source under test is fine.

This PR splits the test so the **valid-on-every-platform** case (`+`) keeps running everywhere, and the **POSIX-only** case (`*`) is gated with `it.runIf(process.platform !== "win32")`. No source/runtime code changes — this is a test-portability fix.

## Root cause

Windows filenames may not contain `< > : " / \ | ? *`. The App Router fixture uses `*`:

| Fixture path | Result on Windows | Effect |
| --- | --- | --- |
| `[id*]/page.tsx` | `mkdir` throws `ENOENT` / "The filename, directory name, or volume label syntax is incorrect" | test errors before asserting |

Crucially, this is an **unreachable scenario on Windows in production too**: a real Next.js app on Windows can't have an `[id*]` directory on disk, so `buildAppRouteGraph` will never encounter one there. Gating the fixture to POSIX loses **zero** real Windows coverage while keeping full coverage on CI (Linux).

## Changes

`tests/app-route-graph.test.ts`
- Split "skips routes whose param names end in + or *" into a `+` test (all platforms) and a `*` test gated to POSIX.

## Verification

Before (Windows):

```
FAIL tests/app-route-graph.test.ts > skips routes whose param names end in + or *
  Error: ENOENT: no such file or directory, mkdir '...\app\[id*]'
```

After (Windows):

```
vp test run --project unit tests/app-route-graph.test.ts
Test Files  1 passed (1)
     Tests  63 passed | 1 skipped (64)
```

The 1 skip is exactly the POSIX-only `*` case. On Linux/macOS it continues to run unchanged (the guard evaluates true). `vp check tests/app-route-graph.test.ts` passes (format, lint, type).

## Test plan

- [x] `vp test run --project unit tests/app-route-graph.test.ts` (Windows) — green
- [x] `vp check tests/app-route-graph.test.ts` — format/lint/type clean
- [x] CI (Linux) runs the full suite, exercising the POSIX-only `*` case
