### PR TITLE
test(routing): isolate reserved-char param cases from Windows

### DIFF
--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -2111,15 +2111,32 @@ describe("pagesRouter - hyphenated param names", () => {
 });
 
 describe("pagesRouter - dotted/colon param names (Next.js parity)", () => {
-  it("discovers dynamic segments with dots and colons", async () => {
+  it("discovers dynamic segments with dots", async () => {
     await withTempDir("vinext-pages-dotted-param-", async (tmpDir) => {
       const pagesDir = path.join(tmpDir, "pages");
       await mkdir(path.join(pagesDir, "products"), { recursive: true });
-      await mkdir(path.join(pagesDir, "repos"), { recursive: true });
       await writeFile(
         path.join(pagesDir, "products", "[variant.id].tsx"),
         "export default function Page() { return null; }",
       );
+
+      invalidateRouteCache(pagesDir);
+      const routes = await pagesRouter(pagesDir);
+      const patterns = routes.map((r) => r.pattern);
+
+      expect(patterns).toContain("/products/:variant.id");
+      invalidateRouteCache(pagesDir);
+    });
+  });
+
+  // `:` is a reserved character in Windows filenames — it delimits an NTFS
+  // alternate data stream, so writing `[repo:name].tsx` there silently produces
+  // a `[repo` file instead. The scenario is unreachable on Windows, so gate it
+  // to POSIX and keep the assertion unconditional.
+  it.runIf(process.platform !== "win32")("discovers dynamic segments with colons", async () => {
+    await withTempDir("vinext-pages-colon-param-", async (tmpDir) => {
+      const pagesDir = path.join(tmpDir, "pages");
+      await mkdir(path.join(pagesDir, "repos"), { recursive: true });
       await writeFile(
         path.join(pagesDir, "repos", "[repo:name].tsx"),
         "export default function Page() { return null; }",
@@ -2129,7 +2146,6 @@ describe("pagesRouter - dotted/colon param names (Next.js parity)", () => {
       const routes = await pagesRouter(pagesDir);
       const patterns = routes.map((r) => r.pattern);
 
-      expect(patterns).toContain("/products/:variant.id");
       expect(patterns).toContain("/repos/:repo:name");
       invalidateRouteCache(pagesDir);
     });
@@ -2155,16 +2171,15 @@ describe("pagesRouter - dotted/colon param names (Next.js parity)", () => {
     });
   });
 
-  it("skips routes whose param names end in + or * (would collide with internal modifiers)", async () => {
+  // The + and * cases are split because `*` is a reserved character in Windows
+  // filenames — a literal `[id*].tsx` file can't exist there, so that scenario
+  // is gated to POSIX (where it's reachable).
+  it("skips routes whose param names end in + (would collide with internal modifiers)", async () => {
     await withTempDir("vinext-pages-skip-plus-", async (tmpDir) => {
       const pagesDir = path.join(tmpDir, "pages");
       await mkdir(pagesDir, { recursive: true });
       await writeFile(
         path.join(pagesDir, "[id+].tsx"),
-        "export default function Page() { return null; }",
-      );
-      await writeFile(
-        path.join(pagesDir, "[id*].tsx"),
         "export default function Page() { return null; }",
       );
 
@@ -2176,4 +2191,25 @@ describe("pagesRouter - dotted/colon param names (Next.js parity)", () => {
       invalidateRouteCache(pagesDir);
     });
   });
+
+  it.runIf(process.platform !== "win32")(
+    "skips routes whose param names end in * (would collide with internal modifiers)",
+    async () => {
+      await withTempDir("vinext-pages-skip-star-", async (tmpDir) => {
+        const pagesDir = path.join(tmpDir, "pages");
+        await mkdir(pagesDir, { recursive: true });
+        await writeFile(
+          path.join(pagesDir, "[id*].tsx"),
+          "export default function Page() { return null; }",
+        );
+
+        invalidateRouteCache(pagesDir);
+        const routes = await pagesRouter(pagesDir);
+
+        // Skipped entirely to avoid ambiguity with internal :name+ / :name* modifiers
+        expect(routes).toHaveLength(0);
+        invalidateRouteCache(pagesDir);
+      });
+    },
+  );
 });


### PR DESCRIPTION
## Summary

Related to #1792

Two Pages Router tests in `tests/routing.test.ts` build temp route fixtures whose param names contain characters that are **reserved in Windows filenames** (`:` and `*`). On Windows these fixtures either fail to create or silently create the wrong file, so the tests error out or assert against a route that was never discovered — making `vp test run` unrunnable locally on Windows even though the source under test is fine.

This PR splits each affected test so the **valid-on-every-platform** case (`.`, `+`) keeps running everywhere, and the **POSIX-only** case (`:`, `*`) is gated with `it.runIf(process.platform !== "win32")`. No source/runtime code changes — this is a test-portability fix.

## Root cause

Windows filenames may not contain `< > : " / \ | ? *`. Two of these show up in Pages Router route-param fixtures:

| Fixture path | Result on Windows | Effect |
| --- | --- | --- |
| `[id*].tsx` | `writeFile` throws `ENOENT` / "The filename, directory name, or volume label syntax is incorrect" | test errors before asserting |
| `[repo:name].tsx` | `:` delimits an NTFS **alternate data stream** — `writeFile` succeeds but the directory listing shows only `[repo`, and the ADS `name].tsx` is invisible to `readdir` | `pagesRouter` never discovers `/repos/:repo:name`, assertion fails |

## Changes

`tests/routing.test.ts`
- Split "discovers dynamic segments with dots and colons" into a dots test (all platforms) and a colons test gated to POSIX.
- Split "skips routes whose param names end in + or *" into a `+` test (all platforms) and a `*` test gated to POSIX.

## Verification

Before (Windows):

```
FAIL tests/routing.test.ts > discovers dynamic segments with dots and colons
  AssertionError: expected [ '/products/:variant.id' ] to include '/repos/:repo:name'
FAIL tests/routing.test.ts > skips routes whose param names end in + or *
  Error: ENOENT: no such file or directory, open '...\pages\[id*].tsx'
```

After (Windows):

```
vp test run --project unit tests/routing.test.ts
Test Files  1 passed (1)
     Tests  122 passed | 2 skipped (124)
```

## Test plan

- [x] `vp test run --project unit tests/routing.test.ts` (Windows) — green
- [x] `vp check tests/routing.test.ts` — format/lint/type clean
- [x] CI (Linux) runs the full suite, exercising the POSIX-only `:` and `*` cases
