### PR TITLE
fix(image): match Next.js 16 default image sizes

### DIFF
--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -222,7 +222,7 @@ export type NextConfig = {
     unoptimized?: boolean;
     /** Allowed device widths for image optimization. Defaults to Next.js defaults: [640, 750, 828, 1080, 1200, 1920, 2048, 3840] */
     deviceSizes?: number[];
-    /** Allowed image sizes for fixed-width images. Defaults to Next.js defaults: [16, 32, 48, 64, 96, 128, 256, 384] */
+    /** Allowed image sizes for fixed-width images. Defaults to Next.js defaults: [32, 48, 64, 96, 128, 256, 384] */
     imageSizes?: number[];
     /** Allowed image qualities. When unset, any quality from 1-100 is permitted (matches Next.js). */
     qualities?: number[];

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2267,7 +2267,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           const deviceSizes = nextConfig.images?.deviceSizes ?? [
             640, 750, 828, 1080, 1200, 1920, 2048, 3840,
           ];
-          const imageSizes = nextConfig.images?.imageSizes ?? [16, 32, 48, 64, 96, 128, 256, 384];
+          const imageSizes = nextConfig.images?.imageSizes ?? DEFAULT_IMAGE_SIZES;
           defines["process.env.__VINEXT_IMAGE_DEVICE_SIZES"] = JSON.stringify(
             JSON.stringify(deviceSizes),
           );

--- a/packages/vinext/src/server/image-optimization.ts
+++ b/packages/vinext/src/server/image-optimization.ts
@@ -88,7 +88,7 @@ export type ImageConfig = {
  * config is provided. Matches Next.js defaults exactly.
  */
 export const DEFAULT_DEVICE_SIZES = [640, 750, 828, 1080, 1200, 1920, 2048, 3840];
-export const DEFAULT_IMAGE_SIZES = [16, 32, 48, 64, 96, 128, 256, 384];
+export const DEFAULT_IMAGE_SIZES = [32, 48, 64, 96, 128, 256, 384];
 const DEV_BLUR_MAX_WIDTH = 8;
 const DEV_BLUR_QUALITY = 70;
 

--- a/packages/vinext/src/shims/image.tsx
+++ b/packages/vinext/src/shims/image.tsx
@@ -62,9 +62,9 @@ const __imageDeviceSizes: number[] = (() => {
 })();
 const __imageSizes: number[] = (() => {
   try {
-    return JSON.parse(process.env.__VINEXT_IMAGE_SIZES ?? "[16,32,48,64,96,128,256,384]");
+    return JSON.parse(process.env.__VINEXT_IMAGE_SIZES ?? "[32,48,64,96,128,256,384]");
   } catch {
-    return [16, 32, 48, 64, 96, 128, 256, 384];
+    return [32, 48, 64, 96, 128, 256, 384];
   }
 })();
 /**

--- a/tests/image-adapters-config.test.ts
+++ b/tests/image-adapters-config.test.ts
@@ -313,7 +313,7 @@ describe("registration is wired into the router/runtime entries", () => {
   it("App Router RSC entry falls back to Next.js default widths when images is unset", () => {
     const code = generateRscEntry("/tmp/test/app", minimalAppRoutes, null, [], null, "", false);
     // Next.js defaults: deviceSizes then imageSizes.
-    expect(code).toContain("[640,750,828,1080,1200,1920,2048,3840,16,32,48,64,96,128,256,384]");
+    expect(code).toContain("[640,750,828,1080,1200,1920,2048,3840,32,48,64,96,128,256,384]");
   });
 
   it("Pages Router worker entry registers the optimizer with env and uses the registry", () => {

--- a/tests/image-component.test.ts
+++ b/tests/image-component.test.ts
@@ -351,8 +351,10 @@ describe("Image srcSet generation", () => {
         height: 16,
       }),
     );
-    expect(html).toContain(`${optUrlHtml("/icon.png", 16)} 1x`);
-    expect(html).toContain(`${optUrlHtml("/icon.png", 32)} 2x`);
+    // Next.js 16 removed 16 from the defaults. Both the 1x and 2x targets
+    // therefore snap to 32 and collapse into one candidate.
+    expect(html).toContain(`${optUrlHtml("/icon.png", 32)} 1x`);
+    expect(html).not.toContain(optUrlHtml("/icon.png", 16));
   });
 
   it("does not generate srcSet for fill mode", () => {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -22596,11 +22596,11 @@ describe("image optimization request parsing", () => {
       16, 32, 48, 64, 96, 128, 256, 384, 640, 750, 828, 1080, 1200, 1920, 2048, 3840,
     ];
     const params = parseImageParams(
-      new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=64&q=75"),
+      new URL("http://localhost/_next/image?url=%2Fimg.jpg&w=16&q=75"),
       allowedWidths,
     );
     expect(params).not.toBeNull();
-    expect(params!.width).toBe(64);
+    expect(params!.width).toBe(16);
   });
 
   it("negotiateImageFormat prefers AVIF over WebP", async () => {
@@ -22648,11 +22648,15 @@ describe("image optimization request parsing", () => {
     expect(isImageOptimizationPath("/")).toBe(false);
   });
 
-  it("exports DEFAULT_DEVICE_SIZES and DEFAULT_IMAGE_SIZES matching Next.js defaults", async () => {
-    const { DEFAULT_DEVICE_SIZES, DEFAULT_IMAGE_SIZES } =
+  it("uses Next.js default widths for image optimization requests", async () => {
+    const { parseImageParams } =
       await import("../packages/vinext/src/server/image-optimization.js");
-    expect(DEFAULT_DEVICE_SIZES).toEqual([640, 750, 828, 1080, 1200, 1920, 2048, 3840]);
-    expect(DEFAULT_IMAGE_SIZES).toEqual([16, 32, 48, 64, 96, 128, 256, 384]);
+    const request = (width: number) =>
+      new URL(`http://localhost/_next/image?url=%2Fimg.jpg&w=${width}&q=75`);
+
+    expect(parseImageParams(request(16))).toBeNull();
+    expect(parseImageParams(request(32))?.width).toBe(32);
+    expect(parseImageParams(request(640))?.width).toBe(640);
   });
 });
 


### PR DESCRIPTION
## Summary

- Match Next.js 16's default `images.imageSizes` by removing `16`
- Reuse the shared server default when generating client image config
- Keep explicit `imageSizes` configurations containing `16` supported

## Why

vinext is pinned to Next.js 16.2.7, but still used the pre-v16 default:

```text
[16, 32, 48, 64, 96, 128, 256, 384]
```

Next.js 16 removed `16` because it is rarely requested and adds an unnecessary
candidate to responsive `srcset` output. The mismatch also meant vinext's image
optimizer accepted a default width that Next.js 16 no longer accepts.

## Behavior

| Scenario | Before | After |
| --- | --- | --- |
| Default 16px fixed image | Emits 16px and 32px candidates | Both targets snap to one 32px candidate |
| Default optimizer request for `w=16` | Accepted | Rejected |
| Explicit `images.imageSizes` containing `16` | Accepted | Unchanged |

## Validation

- `vp test run tests/image-component.test.ts tests/shims.test.ts`
  - 1,322 tests passed
- `vp check packages/vinext/src/config/next-config.ts packages/vinext/src/index.ts packages/vinext/src/server/image-optimization.ts packages/vinext/src/shims/image.tsx tests/image-component.test.ts tests/shims.test.ts`
  - Formatting, lint, and types passed for all six files
- `node scripts/check-shim-types.mjs`
  - 24 public shim modules matched their vendored types
- Pre-commit full check, staged tests, and knip passed

## Risk

This is an intentional Next.js 16 compatibility change for projects that rely
on the default image sizes. Projects that still require 16px optimization can
opt back in with `images.imageSizes`, matching Next.js's migration guidance.
Explicit configurations are otherwise unchanged.

## References

- [Next.js 16 image config default](https://github.com/vercel/next.js/blob/v16.2.7/packages/next/src/shared/lib/image-config.ts)
- [Next.js 16 upgrade guidance](https://github.com/vercel/next.js/blob/v16.2.7/docs/01-app/02-guides/upgrading/version-16.mdx#imagesizes-default-breaking-change)
- [vinext PR #2700 parity-gap note](https://github.com/cloudflare/vinext/pull/2700)
