### PR TITLE
fix(server): honor static freshness validators

### DIFF
--- a/packages/vinext/src/server/app-router-entry.ts
+++ b/packages/vinext/src/server/app-router-entry.ts
@@ -39,7 +39,11 @@ import {
   handleConfiguredImageOptimization,
   isImageOptimizationPath,
 } from "./image-optimization.js";
-import { finalizeMissingStaticAssetResponse, resolveStaticAssetSignal } from "./worker-utils.js";
+import {
+  createStaticAssetRequest,
+  finalizeMissingStaticAssetResponse,
+  resolveStaticAssetSignal,
+} from "./worker-utils.js";
 import {
   cloneRequestWithHeaders,
   filterInternalHeaders,
@@ -178,7 +182,7 @@ async function handleRequest(
       const assetFetcher = env.ASSETS;
       const assetResponse = await resolveStaticAssetSignal(response, {
         fetchAsset: (path) =>
-          Promise.resolve(assetFetcher.fetch(new Request(new URL(path, request.url)))),
+          Promise.resolve(assetFetcher.fetch(createStaticAssetRequest(path, request))),
       });
       if (assetResponse) response = assetResponse;
     }

--- a/packages/vinext/src/server/http-conditional.ts
+++ b/packages/vinext/src/server/http-conditional.ts
@@ -1,3 +1,5 @@
+import { parseHttpDate } from "./http-date.js";
+
 /**
  * Test an If-None-Match field value against a current entity tag.
  *
@@ -39,7 +41,46 @@ export function matchesIfNoneMatch(ifNoneMatch: string | undefined, etag: string
   return sawTag && matched;
 }
 
+/** Test an If-Match field using RFC 9110's strong entity-tag comparison. */
+export function matchesIfMatch(ifMatch: string | undefined, etag: string | undefined): boolean {
+  if (!ifMatch) return false;
+
+  let index = skipOptionalWhitespace(ifMatch, 0);
+  if (ifMatch[index] === "*") {
+    return skipOptionalWhitespace(ifMatch, index + 1) === ifMatch.length;
+  }
+
+  if (!etag) return false;
+  const current = parseEntityTag(etag, 0);
+  if (!current || current.end !== etag.length || current.weak) return false;
+  const currentOpaqueTag = etag.slice(current.opaqueStart, current.opaqueEnd);
+
+  let matched = false;
+  let sawTag = false;
+  while (index < ifMatch.length) {
+    if (ifMatch[index] === ",") {
+      index = skipOptionalWhitespace(ifMatch, index + 1);
+      continue;
+    }
+
+    const candidate = parseEntityTag(ifMatch, index);
+    if (!candidate) return false;
+    sawTag = true;
+    matched ||=
+      !candidate.weak &&
+      ifMatch.slice(candidate.opaqueStart, candidate.opaqueEnd) === currentOpaqueTag;
+
+    index = skipOptionalWhitespace(ifMatch, candidate.end);
+    if (index === ifMatch.length) break;
+    if (ifMatch[index] !== ",") return false;
+    index = skipOptionalWhitespace(ifMatch, index + 1);
+  }
+
+  return sawTag && matched;
+}
+
 type ParsedEntityTag = {
+  weak: boolean;
   opaqueStart: number;
   opaqueEnd: number;
   end: number;
@@ -47,7 +88,8 @@ type ParsedEntityTag = {
 
 function parseEntityTag(value: string, start: number): ParsedEntityTag | null {
   let index = start;
-  if (value.startsWith("W/", index)) index += 2;
+  const weak = value.startsWith("W/", index);
+  if (weak) index += 2;
   if (value[index] !== '"') return null;
 
   const opaqueStart = ++index;
@@ -62,11 +104,77 @@ function parseEntityTag(value: string, start: number): ParsedEntityTag | null {
   }
   if (value[index] !== '"') return null;
 
-  return { opaqueStart, opaqueEnd: index, end: index + 1 };
+  return { weak, opaqueStart, opaqueEnd: index, end: index + 1 };
 }
 
 function skipOptionalWhitespace(value: string, start: number): number {
   let index = start;
   while (value[index] === " " || value[index] === "\t") index++;
   return index;
+}
+
+type StaticConditionalHeaders = {
+  cacheControl?: string | string[];
+  ifMatch?: string | string[];
+  ifUnmodifiedSince?: string | string[];
+  ifNoneMatch?: string | string[];
+  ifModifiedSince?: string | string[];
+};
+
+export type StaticPreconditionResult = "proceed" | "not-modified" | "precondition-failed";
+
+/** Evaluate static representation preconditions in RFC 9110 section 13.2.2 order. */
+export function evaluateStaticPreconditions(
+  headers: StaticConditionalHeaders,
+  method: string | undefined,
+  etag: string | undefined,
+  mtimeMs: number,
+): StaticPreconditionResult {
+  const ifMatch = joinHeader(headers.ifMatch);
+  if (ifMatch !== undefined) {
+    if (!matchesIfMatch(ifMatch, etag)) return "precondition-failed";
+  } else {
+    const ifUnmodifiedSince = joinHeader(headers.ifUnmodifiedSince);
+    if (ifUnmodifiedSince) {
+      const unmodifiedSinceMs = parseHttpDate(ifUnmodifiedSince);
+      if (
+        Number.isFinite(unmodifiedSinceMs) &&
+        Number.isFinite(mtimeMs) &&
+        Math.floor(mtimeMs / 1000) > Math.floor(unmodifiedSinceMs / 1000)
+      ) {
+        return "precondition-failed";
+      }
+    }
+  }
+
+  const ifNoneMatch = joinHeader(headers.ifNoneMatch);
+  if (ifNoneMatch !== undefined) {
+    const matches =
+      ifNoneMatch.trim() === "*" || (etag !== undefined && matchesIfNoneMatch(ifNoneMatch, etag));
+    if (!matches) return "proceed";
+    if (method !== "GET" && method !== "HEAD") return "precondition-failed";
+
+    const cacheControl = joinHeader(headers.cacheControl);
+    return cacheControl && /(?:^|,)\s*no-cache\s*(?:,|$)/i.test(cacheControl)
+      ? "proceed"
+      : "not-modified";
+  }
+
+  if (method !== "GET" && method !== "HEAD") return "proceed";
+
+  const cacheControl = joinHeader(headers.cacheControl);
+  if (cacheControl && /(?:^|,)\s*no-cache\s*(?:,|$)/i.test(cacheControl)) return "proceed";
+
+  const ifModifiedSince = joinHeader(headers.ifModifiedSince);
+  if (!ifModifiedSince) return "proceed";
+  const modifiedSinceMs = parseHttpDate(ifModifiedSince);
+  if (!Number.isFinite(modifiedSinceMs)) return "proceed";
+  return Number.isFinite(mtimeMs) &&
+    Math.floor(mtimeMs / 1000) <= Math.floor(modifiedSinceMs / 1000)
+    ? "not-modified"
+    : "proceed";
+}
+
+function joinHeader(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value.join(", ") : value;
 }

--- a/packages/vinext/src/server/http-conditional.ts
+++ b/packages/vinext/src/server/http-conditional.ts
@@ -41,7 +41,7 @@ export function matchesIfNoneMatch(ifNoneMatch: string | undefined, etag: string
   return sawTag && matched;
 }
 
-/** Test an If-Match field using RFC 9110's strong entity-tag comparison. */
+/** Test an If-Match field using Next.js's weak/strong-equivalent comparison. */
 export function matchesIfMatch(ifMatch: string | undefined, etag: string | undefined): boolean {
   if (!ifMatch) return false;
 
@@ -52,7 +52,7 @@ export function matchesIfMatch(ifMatch: string | undefined, etag: string | undef
 
   if (!etag) return false;
   const current = parseEntityTag(etag, 0);
-  if (!current || current.end !== etag.length || current.weak) return false;
+  if (!current || current.end !== etag.length) return false;
   const currentOpaqueTag = etag.slice(current.opaqueStart, current.opaqueEnd);
 
   let matched = false;
@@ -66,9 +66,7 @@ export function matchesIfMatch(ifMatch: string | undefined, etag: string | undef
     const candidate = parseEntityTag(ifMatch, index);
     if (!candidate) return false;
     sawTag = true;
-    matched ||=
-      !candidate.weak &&
-      ifMatch.slice(candidate.opaqueStart, candidate.opaqueEnd) === currentOpaqueTag;
+    matched ||= ifMatch.slice(candidate.opaqueStart, candidate.opaqueEnd) === currentOpaqueTag;
 
     index = skipOptionalWhitespace(ifMatch, candidate.end);
     if (index === ifMatch.length) break;

--- a/packages/vinext/src/server/http-date.ts
+++ b/packages/vinext/src/server/http-date.ts
@@ -1,0 +1,120 @@
+const IMF_FIXDATE_RE =
+  /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), (\d{2}) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (\d{4}) (\d{2}):(\d{2}):(\d{2}) GMT$/;
+const RFC850_DATE_RE =
+  /^(Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday), (\d{2})-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-(\d{2}) (\d{2}):(\d{2}):(\d{2}) GMT$/;
+const ASCTIME_DATE_RE =
+  /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (?: (\d)|(\d{2})) (\d{2}):(\d{2}):(\d{2}) (\d{4})$/;
+
+const WEEKDAY_INDEX: Record<string, number> = {
+  Sun: 0,
+  Sunday: 0,
+  Mon: 1,
+  Monday: 1,
+  Tue: 2,
+  Tuesday: 2,
+  Wed: 3,
+  Wednesday: 3,
+  Thu: 4,
+  Thursday: 4,
+  Fri: 5,
+  Friday: 5,
+  Sat: 6,
+  Saturday: 6,
+};
+const MONTH_INDEX: Record<string, number> = {
+  Jan: 0,
+  Feb: 1,
+  Mar: 2,
+  Apr: 3,
+  May: 4,
+  Jun: 5,
+  Jul: 6,
+  Aug: 7,
+  Sep: 8,
+  Oct: 9,
+  Nov: 10,
+  Dec: 11,
+};
+
+/** Parse only the three HTTP-date wire formats accepted by RFC 9110. */
+export function parseHttpDate(value: string): number {
+  const imf = IMF_FIXDATE_RE.exec(value);
+  if (imf) {
+    return timestampFromHttpDateParts(imf[1], imf[2], imf[3], imf[4], imf[5], imf[6], imf[7]);
+  }
+
+  const rfc850 = RFC850_DATE_RE.exec(value);
+  if (rfc850) {
+    const now = new Date();
+    let year = now.getUTCFullYear() - (now.getUTCFullYear() % 100) + Number(rfc850[4]);
+    const candidateTimestamp = timestampFromHttpDateParts(
+      undefined,
+      rfc850[2],
+      rfc850[3],
+      String(year),
+      rfc850[5],
+      rfc850[6],
+      rfc850[7],
+    );
+    const fiftyYearsFromNow = new Date(now);
+    fiftyYearsFromNow.setUTCFullYear(now.getUTCFullYear() + 50);
+    if (candidateTimestamp > fiftyYearsFromNow.getTime()) year -= 100;
+    return timestampFromHttpDateParts(
+      rfc850[1],
+      rfc850[2],
+      rfc850[3],
+      String(year),
+      rfc850[5],
+      rfc850[6],
+      rfc850[7],
+    );
+  }
+
+  const asctime = ASCTIME_DATE_RE.exec(value);
+  if (asctime) {
+    return timestampFromHttpDateParts(
+      asctime[1],
+      asctime[3] || asctime[4],
+      asctime[2],
+      asctime[8],
+      asctime[5],
+      asctime[6],
+      asctime[7],
+    );
+  }
+
+  return Number.NaN;
+}
+
+function timestampFromHttpDateParts(
+  weekday: string | undefined,
+  dayValue: string,
+  monthValue: string,
+  yearValue: string,
+  hourValue: string,
+  minuteValue: string,
+  secondValue: string,
+): number {
+  const day = Number(dayValue);
+  const month = MONTH_INDEX[monthValue];
+  const year = Number(yearValue);
+  const hour = Number(hourValue);
+  const minute = Number(minuteValue);
+  const second = Number(secondValue);
+
+  const date = new Date(0);
+  date.setUTCFullYear(year, month, day);
+  date.setUTCHours(hour, minute, second, 0);
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month ||
+    date.getUTCDate() !== day ||
+    date.getUTCHours() !== hour ||
+    date.getUTCMinutes() !== minute ||
+    date.getUTCSeconds() !== second ||
+    (weekday !== undefined && date.getUTCDay() !== WEEKDAY_INDEX[weekday])
+  ) {
+    return Number.NaN;
+  }
+  return date.getTime();
+}

--- a/packages/vinext/src/server/http-date.ts
+++ b/packages/vinext/src/server/http-date.ts
@@ -47,8 +47,7 @@ export function parseHttpDate(value: string): number {
   if (rfc850) {
     const now = new Date();
     let year = now.getUTCFullYear() - (now.getUTCFullYear() % 100) + Number(rfc850[4]);
-    const candidateTimestamp = timestampFromHttpDateParts(
-      undefined,
+    const candidateTimestamp = timestampForRfc850YearWindow(
       rfc850[2],
       rfc850[3],
       String(year),
@@ -84,6 +83,22 @@ export function parseHttpDate(value: string): number {
   }
 
   return Number.NaN;
+}
+
+function timestampForRfc850YearWindow(
+  dayValue: string,
+  monthValue: string,
+  yearValue: string,
+  hourValue: string,
+  minuteValue: string,
+  secondValue: string,
+): number {
+  // Normalize solely for the 50-year comparison. Final calendar and weekday
+  // validation happens after the RFC 850 century adjustment.
+  const date = new Date(0);
+  date.setUTCFullYear(Number(yearValue), MONTH_INDEX[monthValue], Number(dayValue));
+  date.setUTCHours(Number(hourValue), Number(minuteValue), Number(secondValue), 0);
+  return date.getTime();
 }
 
 function timestampFromHttpDateParts(

--- a/packages/vinext/src/server/http-range.ts
+++ b/packages/vinext/src/server/http-range.ts
@@ -54,6 +54,8 @@ export function parseByteRange(value: string | undefined, size: number): ByteRan
 /**
  * If-Range requires strong entity-tag comparison. Date validators are matched
  * at HTTP-date (whole-second) precision because filesystem mtimes are finer.
+ * Vinext's static ETags are currently weak, so its emitted Last-Modified value
+ * is the validator that can enable a range response on a later request.
  */
 export function ifRangeAllowsRange(
   value: string | undefined,

--- a/packages/vinext/src/server/http-range.ts
+++ b/packages/vinext/src/server/http-range.ts
@@ -53,7 +53,8 @@ export function parseByteRange(value: string | undefined, size: number): ByteRan
 
 /**
  * If-Range requires strong entity-tag comparison. Date validators are matched
- * at HTTP-date (whole-second) precision because filesystem mtimes are finer.
+ * at HTTP-date (whole-second) precision because filesystem mtimes are finer,
+ * and allow a range when the representation has not changed since that date.
  * Vinext's static ETags are currently weak, so its emitted Last-Modified value
  * is the validator that can enable a range response on a later request.
  */
@@ -70,7 +71,7 @@ export function ifRangeAllowsRange(
   }
 
   const timestamp = parseHttpDate(trimmed);
-  return Number.isFinite(timestamp) && Math.floor(mtimeMs / 1000) * 1000 === timestamp;
+  return Number.isFinite(timestamp) && Math.floor(mtimeMs / 1000) * 1000 <= timestamp;
 }
 
 function parseDecimalInteger(value: string): number | "overflow" {

--- a/packages/vinext/src/server/http-range.ts
+++ b/packages/vinext/src/server/http-range.ts
@@ -1,0 +1,77 @@
+import { parseHttpDate } from "./http-date.js";
+
+export type ByteRange =
+  | { kind: "ignore" }
+  | { kind: "unsatisfiable" }
+  | { kind: "range"; start: number; end: number };
+
+/**
+ * Parse a single bytes range. Unsupported range units, malformed values, and
+ * multipart ranges are ignored, which RFC 9110 permits servers to do.
+ */
+export function parseByteRange(value: string | undefined, size: number): ByteRange {
+  if (!value || value.slice(0, 6).toLowerCase() !== "bytes=") return { kind: "ignore" };
+
+  const spec = value.slice("bytes=".length).trim();
+  if (spec.includes(",")) return { kind: "ignore" };
+
+  const match = /^(\d*)-(\d*)$/.exec(spec);
+  if (!match || (!match[1] && !match[2])) return { kind: "ignore" };
+
+  if (!match[1]) {
+    const suffixLength = parseDecimalInteger(match[2]);
+    if (suffixLength === "overflow") {
+      if (size === 0) return { kind: "unsatisfiable" };
+      return { kind: "range", start: 0, end: size - 1 };
+    }
+    if (suffixLength === 0 || size === 0) return { kind: "unsatisfiable" };
+    return {
+      kind: "range",
+      start: Math.max(size - suffixLength, 0),
+      end: size - 1,
+    };
+  }
+
+  const start = parseDecimalInteger(match[1]);
+  const requestedEnd = match[2] ? parseDecimalInteger(match[2]) : size - 1;
+  // The wire grammar has no JavaScript-safe-integer limit. A start beyond
+  // that limit is necessarily beyond any file size Node can address, while an
+  // overflowing end still denotes the remainder of the representation.
+  if (start === "overflow") return { kind: "unsatisfiable" };
+  if (requestedEnd === "overflow") {
+    if (start >= size) return { kind: "unsatisfiable" };
+    return { kind: "range", start, end: size - 1 };
+  }
+  if (start >= size || requestedEnd < start) return { kind: "unsatisfiable" };
+
+  return {
+    kind: "range",
+    start,
+    end: Math.min(requestedEnd, size - 1),
+  };
+}
+
+/**
+ * If-Range requires strong entity-tag comparison. Date validators are matched
+ * at HTTP-date (whole-second) precision because filesystem mtimes are finer.
+ */
+export function ifRangeAllowsRange(
+  value: string | undefined,
+  etag: string,
+  mtimeMs: number,
+): boolean {
+  if (!value) return true;
+
+  const trimmed = value.trim();
+  if (trimmed.startsWith('"') || trimmed.startsWith("W/")) {
+    return !trimmed.startsWith("W/") && !etag.startsWith("W/") && trimmed === etag;
+  }
+
+  const timestamp = parseHttpDate(trimmed);
+  return Number.isFinite(timestamp) && Math.floor(mtimeMs / 1000) * 1000 === timestamp;
+}
+
+function parseDecimalInteger(value: string): number | "overflow" {
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? parsed : "overflow";
+}

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -677,6 +677,8 @@ async function tryServeStatic(
     }
 
     if (range.kind === "range") {
+      // Byte ranges always address the identity representation, regardless of
+      // the content encoding negotiated for a full response.
       const length = range.end - range.start + 1;
       const rangeHeaders = {
         ...entry.original.headers,

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -92,7 +92,9 @@ import {
   parseAcceptedEncodings,
   selectContentEncoding,
 } from "./accept-encoding.js";
-import { matchesIfNoneMatch } from "./http-conditional.js";
+import { ifRangeAllowsRange, parseByteRange, type ByteRange } from "./http-range.js";
+import { evaluateStaticPreconditions } from "./http-conditional.js";
+import { parseHttpDate } from "./http-date.js";
 import type { NextI18nConfig } from "../config/next-config.js";
 import { readTrustedRevalidationHostname } from "./revalidation-host.js";
 
@@ -568,6 +570,11 @@ async function tryServeStatic(
   if (pathname === "/") return false;
   const responseStatus = statusCode ?? 200;
   const omitBody = isNoBodyResponseStatus(responseStatus);
+  // RFC 9110 defines Range for GET. A Range field on HEAD or another method
+  // must not change the selected response status or representation metadata.
+  const requestRange = req.method === "GET" ? req.headers.range : undefined;
+  const rawIfRange = req.headers["if-range"];
+  const ifRange = typeof rawIfRange === "string" ? rawIfRange : undefined;
 
   // ── Fast path: pre-computed headers, minimal per-request work ──
   // When a cache is provided, all path validation happened at startup.
@@ -621,12 +628,24 @@ async function tryServeStatic(
             ? entry.gz!
             : entry.original;
 
-    const ifNoneMatch = req.headers["if-none-match"];
-    if (
-      responseStatus === 200 &&
-      typeof ifNoneMatch === "string" &&
-      matchesIfNoneMatch(ifNoneMatch, entry.etag)
-    ) {
+    const validators = extraHeaders
+      ? resolveStaticValidators(entry.etag, entry.mtimeMs, extraHeaders)
+      : undefined;
+    const effectiveEtag = validators ? validators.etag : entry.etag;
+    const effectiveMtimeMs = validators ? validators.mtimeMs : entry.mtimeMs;
+
+    const preconditionResult =
+      responseStatus === 200
+        ? evaluateRequestPreconditions(req, effectiveEtag, effectiveMtimeMs)
+        : "proceed";
+
+    if (preconditionResult === "precondition-failed") {
+      res.writeHead(412, { ...entry.notModifiedHeaders, ...extraHeaders });
+      res.end();
+      return true;
+    }
+
+    if (preconditionResult === "not-modified") {
       const notModifiedHeaders = variesByEncoding
         ? mergeVaryHeader({ ...entry.notModifiedHeaders, ...extraHeaders }, "Accept-Encoding")
         : { ...entry.notModifiedHeaders, ...extraHeaders };
@@ -636,7 +655,52 @@ async function tryServeStatic(
       return true;
     }
 
-    const responseHeaders = { ...variant.headers, ...extraHeaders };
+    const range = resolveRequestedRange(
+      requestRange,
+      ifRange,
+      entry.original.size,
+      effectiveEtag ?? "",
+      effectiveMtimeMs,
+      responseStatus,
+    );
+
+    if (range.kind === "unsatisfiable") {
+      res.writeHead(416, {
+        ...entry.notModifiedHeaders,
+        ...extraHeaders,
+        "Accept-Ranges": "bytes",
+        "Content-Range": `bytes */${entry.original.size}`,
+      });
+      res.end();
+      return true;
+    }
+
+    if (range.kind === "range") {
+      const length = range.end - range.start + 1;
+      const rangeHeaders = {
+        ...entry.original.headers,
+        ...extraHeaders,
+        "Accept-Ranges": "bytes",
+        "Content-Length": String(length),
+        "Content-Range": `bytes ${range.start}-${range.end}/${entry.original.size}`,
+      };
+      res.writeHead(
+        206,
+        variesByEncoding ? mergeVaryHeader(rangeHeaders, "Accept-Encoding") : rangeHeaders,
+      );
+      if (entry.original.buffer) {
+        res.end(entry.original.buffer.subarray(range.start, range.end + 1));
+      } else {
+        pipeStaticFileRange(entry.original.path, range, res);
+      }
+      return true;
+    }
+
+    const responseHeaders = {
+      ...variant.headers,
+      ...extraHeaders,
+      "Accept-Ranges": "bytes",
+    };
     res.writeHead(
       responseStatus,
       variesByEncoding ? mergeVaryHeader(responseHeaders, "Accept-Encoding") : responseHeaders,
@@ -704,58 +768,91 @@ async function tryServeStatic(
     "Content-Type": ct,
     "Cache-Control": cacheControl,
     ETag: etag,
+    "Last-Modified": new Date(resolved.mtimeMs).toUTCString(),
+    "Accept-Ranges": "bytes",
     ...extraHeaders,
   };
 
-  if (isCompressible) {
-    const encoding = negotiateEncoding(req);
-    const ifNoneMatch = req.headers["if-none-match"];
-    if (
-      responseStatus === 200 &&
-      typeof ifNoneMatch === "string" &&
-      matchesIfNoneMatch(ifNoneMatch, etag)
-    ) {
-      const notModifiedHeaders = mergeVaryHeader(baseHeaders, "Accept-Encoding");
-      if (encoding !== "identity") notModifiedHeaders["Content-Encoding"] = encoding;
-      res.writeHead(304, notModifiedHeaders);
+  const encoding = isCompressible ? negotiateEncoding(req) : "identity";
+  const validators = extraHeaders
+    ? resolveStaticValidators(etag, resolved.mtimeMs, extraHeaders)
+    : undefined;
+  const effectiveEtag = validators ? validators.etag : etag;
+  const effectiveMtimeMs = validators ? validators.mtimeMs : resolved.mtimeMs;
+  const preconditionResult =
+    responseStatus === 200
+      ? evaluateRequestPreconditions(req, effectiveEtag, effectiveMtimeMs)
+      : "proceed";
+
+  if (preconditionResult === "precondition-failed") {
+    res.writeHead(412, baseHeaders);
+    res.end();
+    return true;
+  }
+
+  if (preconditionResult === "not-modified") {
+    const notModifiedHeaders = isCompressible
+      ? mergeVaryHeader(baseHeaders, "Accept-Encoding")
+      : baseHeaders;
+    if (encoding !== "identity") notModifiedHeaders["Content-Encoding"] = encoding;
+    res.writeHead(304, notModifiedHeaders);
+    res.end();
+    return true;
+  }
+
+  const range = resolveRequestedRange(
+    requestRange,
+    ifRange,
+    resolved.size,
+    effectiveEtag ?? "",
+    effectiveMtimeMs,
+    responseStatus,
+  );
+
+  if (range.kind === "unsatisfiable") {
+    res.writeHead(416, {
+      ...baseHeaders,
+      "Content-Range": `bytes */${resolved.size}`,
+    });
+    res.end();
+    return true;
+  }
+
+  if (range.kind === "range") {
+    const length = range.end - range.start + 1;
+    const rangeHeaders = {
+      ...baseHeaders,
+      "Content-Length": String(length),
+      "Content-Range": `bytes ${range.start}-${range.end}/${resolved.size}`,
+    };
+    res.writeHead(
+      206,
+      isCompressible ? mergeVaryHeader(rangeHeaders, "Accept-Encoding") : rangeHeaders,
+    );
+    pipeStaticFileRange(resolved.path, range, res);
+    return true;
+  }
+
+  if (isCompressible && encoding !== "identity") {
+    // Content-Length omitted intentionally: compressed size isn't known
+    // ahead of time, so Node.js uses chunked transfer encoding.
+    res.writeHead(
+      responseStatus,
+      mergeVaryHeader({ ...baseHeaders, "Content-Encoding": encoding }, "Accept-Encoding"),
+    );
+    if (omitBody || req.method === "HEAD") {
       res.end();
       return true;
     }
-    if (encoding !== "identity") {
-      // Content-Length omitted intentionally: compressed size isn't known
-      // ahead of time, so Node.js uses chunked transfer encoding.
-      res.writeHead(
-        responseStatus,
-        mergeVaryHeader({ ...baseHeaders, "Content-Encoding": encoding }, "Accept-Encoding"),
-      );
-      if (omitBody || req.method === "HEAD") {
-        res.end();
-        return true;
+    const compressor = createCompressor(encoding);
+    pipeline(fs.createReadStream(resolved.path), compressor, res, (err) => {
+      if (err) {
+        // Headers already sent — can't write a 500. Destroy the connection
+        // so the client sees a reset instead of a truncated response.
+        console.warn(`[vinext] Static file stream error for ${resolved.path}:`, err.message);
+        res.destroy(err);
       }
-      const compressor = createCompressor(encoding);
-      pipeline(fs.createReadStream(resolved.path), compressor, res, (err) => {
-        if (err) {
-          // Headers already sent — can't write a 500. Destroy the connection
-          // so the client sees a reset instead of a truncated response.
-          console.warn(`[vinext] Static file stream error for ${resolved.path}:`, err.message);
-          res.destroy(err);
-        }
-      });
-      return true;
-    }
-  }
-
-  const ifNoneMatch = req.headers["if-none-match"];
-  if (
-    responseStatus === 200 &&
-    typeof ifNoneMatch === "string" &&
-    matchesIfNoneMatch(ifNoneMatch, etag)
-  ) {
-    res.writeHead(
-      304,
-      isCompressible ? mergeVaryHeader(baseHeaders, "Accept-Encoding") : baseHeaders,
-    );
-    res.end();
+    });
     return true;
   }
 
@@ -780,6 +877,80 @@ async function tryServeStatic(
     }
   });
   return true;
+}
+
+function resolveStaticValidators(
+  etag: string,
+  mtimeMs: number,
+  extraHeaders: Record<string, string | string[]>,
+): { etag: string | undefined; mtimeMs: number } {
+  let effectiveEtag: string | undefined = etag;
+  let effectiveMtimeMs = mtimeMs;
+  for (const [name, value] of Object.entries(extraHeaders)) {
+    const lowerName = name.toLowerCase();
+    if (lowerName === "etag") {
+      effectiveEtag = typeof value === "string" ? value : undefined;
+    } else if (lowerName === "last-modified") {
+      effectiveMtimeMs = typeof value === "string" ? parseHttpDate(value) : Number.NaN;
+    }
+  }
+  return { etag: effectiveEtag, mtimeMs: effectiveMtimeMs };
+}
+
+function evaluateRequestPreconditions(
+  req: IncomingMessage,
+  etag: string | undefined,
+  mtimeMs: number,
+) {
+  const headers = req.headers;
+  if (
+    headers["if-match"] === undefined &&
+    headers["if-unmodified-since"] === undefined &&
+    headers["if-none-match"] === undefined &&
+    headers["if-modified-since"] === undefined
+  ) {
+    return "proceed";
+  }
+
+  return evaluateStaticPreconditions(
+    {
+      cacheControl: headers["cache-control"],
+      ifMatch: headers["if-match"],
+      ifUnmodifiedSince: headers["if-unmodified-since"],
+      ifNoneMatch: headers["if-none-match"],
+      ifModifiedSince: headers["if-modified-since"],
+    },
+    req.method,
+    etag,
+    mtimeMs,
+  );
+}
+
+function resolveRequestedRange(
+  rangeHeader: string | undefined,
+  ifRangeHeader: string | undefined,
+  size: number,
+  etag: string,
+  mtimeMs: number,
+  responseStatus: number,
+): ByteRange {
+  if (responseStatus !== 200 || !ifRangeAllowsRange(ifRangeHeader, etag, mtimeMs)) {
+    return { kind: "ignore" };
+  }
+  return parseByteRange(rangeHeader, size);
+}
+
+function pipeStaticFileRange(
+  filePath: string,
+  range: Extract<ByteRange, { kind: "range" }>,
+  res: ServerResponse,
+): void {
+  pipeline(fs.createReadStream(filePath, { start: range.start, end: range.end }), res, (err) => {
+    if (err) {
+      console.warn(`[vinext] Static file range stream error for ${filePath}:`, err.message);
+      res.destroy(err);
+    }
+  });
 }
 
 type ResolvedFile = {

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -799,9 +799,15 @@ async function tryServeStatic(
   }
 
   if (preconditionResult === "not-modified") {
+    const notModifiedBaseHeaders: Record<string, string | string[]> = {
+      "Cache-Control": cacheControl,
+      ETag: etag,
+      "Last-Modified": new Date(resolved.mtimeMs).toUTCString(),
+      ...extraHeaders,
+    };
     const notModifiedHeaders = isCompressible
-      ? mergeVaryHeader(baseHeaders, "Accept-Encoding")
-      : baseHeaders;
+      ? mergeVaryHeader(notModifiedBaseHeaders, "Accept-Encoding")
+      : notModifiedBaseHeaders;
     if (encoding !== "identity") notModifiedHeaders["Content-Encoding"] = encoding;
     res.writeHead(304, notModifiedHeaders);
     res.end();

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -640,7 +640,12 @@ async function tryServeStatic(
         : "proceed";
 
     if (preconditionResult === "precondition-failed") {
-      res.writeHead(412, { ...entry.notModifiedHeaders, ...extraHeaders });
+      res.writeHead(412, {
+        ...entry.notModifiedHeaders,
+        ...extraHeaders,
+        "Content-Type": entry.original.headers["Content-Type"],
+        "Accept-Ranges": "bytes",
+      });
       res.end();
       return true;
     }

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -570,9 +570,10 @@ async function tryServeStatic(
   if (pathname === "/") return false;
   const responseStatus = statusCode ?? 200;
   const omitBody = isNoBodyResponseStatus(responseStatus);
-  // RFC 9110 defines Range for GET. A Range field on HEAD or another method
-  // must not change the selected response status or representation metadata.
-  const requestRange = req.method === "GET" ? req.headers.range : undefined;
+  // Match Next.js's `send` behavior: HEAD evaluates Range like GET, then omits
+  // the selected representation body.
+  const requestRange =
+    req.method === "GET" || req.method === "HEAD" ? req.headers.range : undefined;
   const rawIfRange = req.headers["if-range"];
   const ifRange = typeof rawIfRange === "string" ? rawIfRange : undefined;
 
@@ -598,6 +599,10 @@ async function tryServeStatic(
 
     const entry = cache.lookup(lookupPath);
     if (!entry) return false;
+    if (req.method !== "GET" && req.method !== "HEAD") {
+      sendStaticMethodNotAllowed(res, extraHeaders);
+      return true;
+    }
 
     // Pick the best precompressed variant: zstd → br → gzip → original.
     // Each variant has pre-computed headers — zero string building.
@@ -696,6 +701,10 @@ async function tryServeStatic(
         206,
         variesByEncoding ? mergeVaryHeader(rangeHeaders, "Accept-Encoding") : rangeHeaders,
       );
+      if (req.method === "HEAD") {
+        res.end();
+        return true;
+      }
       if (entry.original.buffer) {
         res.end(entry.original.buffer.subarray(range.start, range.end + 1));
       } else {
@@ -752,6 +761,10 @@ async function tryServeStatic(
 
   const resolved = await resolveStaticFile(staticFile);
   if (!resolved) return false;
+  if (req.method !== "GET" && req.method !== "HEAD") {
+    sendStaticMethodNotAllowed(res, extraHeaders);
+    return true;
+  }
 
   const ext = path.extname(resolved.path);
   const ct = contentTypeForPath(resolved.path);
@@ -843,6 +856,10 @@ async function tryServeStatic(
       206,
       isCompressible ? mergeVaryHeader(rangeHeaders, "Accept-Encoding") : rangeHeaders,
     );
+    if (req.method === "HEAD") {
+      res.end();
+      return true;
+    }
     pipeStaticFileRange(resolved.path, range, res);
     return true;
   }
@@ -891,6 +908,20 @@ async function tryServeStatic(
     }
   });
   return true;
+}
+
+function sendStaticMethodNotAllowed(
+  res: ServerResponse,
+  extraHeaders?: Record<string, string | string[]>,
+): void {
+  const body = "Method Not Allowed";
+  res.writeHead(405, {
+    ...extraHeaders,
+    Allow: "GET, HEAD",
+    "Content-Type": "text/plain; charset=utf-8",
+    "Content-Length": String(Buffer.byteLength(body)),
+  });
+  res.end(body);
 }
 
 function resolveStaticValidators(

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -668,6 +668,7 @@ async function tryServeStatic(
       res.writeHead(416, {
         ...entry.notModifiedHeaders,
         ...extraHeaders,
+        "Content-Type": entry.original.headers["Content-Type"],
         "Accept-Ranges": "bytes",
         "Content-Range": `bytes */${entry.original.size}`,
       });

--- a/packages/vinext/src/server/static-file-cache.ts
+++ b/packages/vinext/src/server/static-file-cache.ts
@@ -79,6 +79,8 @@ type FileVariant = {
 type StaticFileEntry = {
   /** Weak ETag for conditional request matching. */
   etag: string;
+  /** Original file modification time for If-Range date validation. */
+  mtimeMs: number;
   /** Pre-computed headers for 304 Not Modified response. */
   notModifiedHeaders: Record<string, string>;
   /** Original file variant (uncompressed). */
@@ -160,10 +162,12 @@ export class StaticFileCache {
         `W/"${fileInfo.size}-${Math.floor(fileInfo.mtimeMs / 1000)}"`;
 
       // Base headers shared by all variants (Content-Type, Cache-Control, ETag)
+      const lastModified = new Date(fileInfo.mtimeMs).toUTCString();
       const baseHeaders = {
         "Content-Type": contentType,
         "Cache-Control": cacheControl,
         ETag: etag,
+        "Last-Modified": lastModified,
       };
 
       // Pre-compute original variant headers
@@ -175,7 +179,12 @@ export class StaticFileCache {
 
       const entry: StaticFileEntry = {
         etag,
-        notModifiedHeaders: { ETag: etag, "Cache-Control": cacheControl },
+        mtimeMs: fileInfo.mtimeMs,
+        notModifiedHeaders: {
+          ETag: etag,
+          "Cache-Control": cacheControl,
+          "Last-Modified": lastModified,
+        },
         original,
       };
 

--- a/packages/vinext/src/server/worker-utils.ts
+++ b/packages/vinext/src/server/worker-utils.ts
@@ -146,9 +146,12 @@ export async function resolveStaticAssetSignal(
   const assetResponse = await options.fetchAsset(assetPath);
   // Only preserve the middleware/status-layer override when we actually got a
   // real asset response back. If the asset lookup misses (404/other non-ok),
-  // keep that filesystem result instead of masking it with the signal status.
+  // or returns a partial response, keep that filesystem result instead of
+  // masking its status while retaining mismatched range headers and body.
   const statusOverride =
-    assetResponse.ok && signalResponse.status !== 200 ? signalResponse.status : undefined;
+    assetResponse.ok && assetResponse.status !== 206 && signalResponse.status !== 200
+      ? signalResponse.status
+      : undefined;
   return mergeHeaders(assetResponse, extraHeaders, statusOverride);
 }
 

--- a/packages/vinext/src/server/worker-utils.ts
+++ b/packages/vinext/src/server/worker-utils.ts
@@ -151,3 +151,15 @@ export async function resolveStaticAssetSignal(
     assetResponse.ok && signalResponse.status !== 200 ? signalResponse.status : undefined;
   return mergeHeaders(assetResponse, extraHeaders, statusOverride);
 }
+
+/** Retarget a Worker asset request without dropping its conditional/range fields. */
+export function createStaticAssetRequest(assetPath: string, sourceRequest: Request): Request {
+  const assetUrl = new URL(assetPath, sourceRequest.url);
+  if (sourceRequest.method === "GET" || sourceRequest.method === "HEAD") {
+    return new Request(assetUrl, sourceRequest);
+  }
+  return new Request(assetUrl, {
+    method: sourceRequest.method,
+    headers: sourceRequest.headers,
+  });
+}

--- a/tests/app-router-production-server.test.ts
+++ b/tests/app-router-production-server.test.ts
@@ -451,6 +451,13 @@ describe("App Router Production server (startProdServer)", () => {
     expect(failed.headers["content-range"]).toBeUndefined();
     expect(failed.body).toHaveLength(0);
 
+    expect(etag).toMatch(/^W\//);
+    const matchingIfMatch = await rawHttpRequest(assetUrl, {
+      headers: { "If-Match": etag },
+    });
+    expect(matchingIfMatch.status).toBe(200);
+    expect(matchingIfMatch.body).toEqual(full.body);
+
     const range = await rawHttpRequest(assetUrl, {
       headers: {
         "If-Match": "*",

--- a/tests/app-router-production-server.test.ts
+++ b/tests/app-router-production-server.test.ts
@@ -74,6 +74,27 @@ function getInlineStyleText(html: string): string {
   return styles.join("\n");
 }
 
+async function rawHttpRequest(
+  url: URL,
+  options: { method?: string; headers?: Record<string, string> } = {},
+): Promise<{ status: number; headers: http.IncomingHttpHeaders; body: Buffer }> {
+  return new Promise((resolve, reject) => {
+    const request = http.request(url, options, (response) => {
+      const chunks: Buffer[] = [];
+      response.on("data", (chunk: Buffer) => chunks.push(chunk));
+      response.on("end", () => {
+        resolve({
+          status: response.statusCode ?? 0,
+          headers: response.headers,
+          body: Buffer.concat(chunks),
+        });
+      });
+    });
+    request.on("error", reject);
+    request.end();
+  });
+}
+
 async function withCountingFetchTarget<T>(
   fn: (targetUrl: string, getRequestCount: () => number) => Promise<T>,
 ): Promise<T> {
@@ -328,6 +349,139 @@ describe("App Router Production server (startProdServer)", () => {
     const html = await res.text();
     expect(html).toContain("Welcome to App Router");
     expect(html).toContain("<script");
+  });
+
+  it("serves static asset byte ranges from the identity representation", async () => {
+    const html = await (await fetch(`${baseUrl}/`)).text();
+    const href = html.match(/["'](\/_next\/static\/[^"']+\.(?:js|css))["']/)?.[1];
+    if (!href) throw new Error("Expected the production HTML to reference a static asset");
+
+    const assetUrl = new URL(href, baseUrl);
+    const full = await fetch(assetUrl);
+    const fullBody = new Uint8Array(await full.arrayBuffer());
+    expect(fullBody.byteLength).toBeGreaterThan(10);
+    expect(full.headers.get("accept-ranges")).toBe("bytes");
+    expect(full.headers.get("last-modified")).not.toBeNull();
+
+    const partial = await fetch(assetUrl, {
+      headers: { Range: "bytes=2-9", "Accept-Encoding": "br, gzip" },
+    });
+    expect(partial.status).toBe(206);
+    expect(partial.headers.get("content-range")).toBe(`bytes 2-9/${fullBody.byteLength}`);
+    expect(partial.headers.get("content-length")).toBe("8");
+    expect(partial.headers.get("content-encoding")).toBeNull();
+    expect(new Uint8Array(await partial.arrayBuffer())).toEqual(fullBody.subarray(2, 10));
+
+    const hugeEnd = await fetch(assetUrl, {
+      headers: { Range: "bytes=2-9007199254740992" },
+    });
+    expect(hugeEnd.status).toBe(206);
+    expect(hugeEnd.headers.get("content-range")).toBe(
+      `bytes 2-${fullBody.length - 1}/${fullBody.length}`,
+    );
+    expect(new Uint8Array(await hugeEnd.arrayBuffer())).toEqual(fullBody.subarray(2));
+
+    const matchingIfRange = await fetch(assetUrl, {
+      headers: {
+        Range: "bytes=2-9",
+        "If-Range": full.headers.get("last-modified")!,
+      },
+    });
+    expect(matchingIfRange.status).toBe(206);
+    expect(new Uint8Array(await matchingIfRange.arrayBuffer())).toEqual(fullBody.subarray(2, 10));
+
+    const futureIfRange = await fetch(assetUrl, {
+      headers: {
+        Range: "bytes=2-9",
+        "If-Range": "Thu, 01 Jan 2099 00:00:00 GMT",
+      },
+    });
+    expect(futureIfRange.status).toBe(200);
+    expect(futureIfRange.headers.get("content-range")).toBeNull();
+    expect(new Uint8Array(await futureIfRange.arrayBuffer())).toEqual(fullBody);
+
+    const invalidIfRange = await fetch(assetUrl, {
+      headers: {
+        Range: "bytes=2-9",
+        "If-Range": "Sun, 31 Feb 2099 00:00:00 GMT",
+      },
+    });
+    expect(invalidIfRange.status).toBe(200);
+    expect(invalidIfRange.headers.get("content-range")).toBeNull();
+    expect(new Uint8Array(await invalidIfRange.arrayBuffer())).toEqual(fullBody);
+
+    const unsatisfiable = await fetch(assetUrl, {
+      headers: { Range: "bytes=9007199254740992-" },
+    });
+    expect(unsatisfiable.status).toBe(416);
+    expect(unsatisfiable.headers.get("content-range")).toBe(`bytes */${fullBody.byteLength}`);
+
+    const head = await fetch(assetUrl, {
+      method: "HEAD",
+      headers: { Range: "bytes=2-9" },
+    });
+    expect(head.status).toBe(200);
+    expect(head.headers.get("content-length")).toBe(String(fullBody.byteLength));
+  });
+
+  it("evaluates static asset preconditions before byte ranges", async () => {
+    const html = await (await fetch(`${baseUrl}/`)).text();
+    const href = html.match(/["'](\/_next\/static\/[^"']+\.(?:js|css))["']/)?.[1];
+    if (!href) throw new Error("Expected the production HTML to reference a static asset");
+
+    const assetUrl = new URL(href, baseUrl);
+    const full = await rawHttpRequest(assetUrl);
+    const etag = full.headers.etag;
+    const lastModified = full.headers["last-modified"];
+    if (!etag || !lastModified) throw new Error("Expected static validators");
+
+    const notModified = await rawHttpRequest(assetUrl, {
+      headers: { "If-None-Match": etag, Range: "bytes=0-2" },
+    });
+    expect(notModified.status).toBe(304);
+    expect(notModified.headers["content-range"]).toBeUndefined();
+    expect(notModified.body).toHaveLength(0);
+
+    const failed = await rawHttpRequest(assetUrl, {
+      headers: { "If-Match": '"different"', Range: "bytes=0-2" },
+    });
+    expect(failed.status).toBe(412);
+    expect(failed.headers["content-range"]).toBeUndefined();
+    expect(failed.body).toHaveLength(0);
+
+    const range = await rawHttpRequest(assetUrl, {
+      headers: {
+        "If-Match": "*",
+        "If-Unmodified-Since": "Thu, 01 Jan 1970 00:00:00 GMT",
+        Range: "bytes=0-2",
+      },
+    });
+    expect(range.status).toBe(206);
+    expect(range.body).toEqual(full.body.subarray(0, 3));
+
+    const head = await rawHttpRequest(assetUrl, {
+      method: "HEAD",
+      headers: { "If-Modified-Since": lastModified },
+    });
+    expect(head.status).toBe(304);
+    expect(head.body).toHaveLength(0);
+
+    const unsafe = await rawHttpRequest(assetUrl, {
+      method: "POST",
+      headers: { "If-None-Match": etag },
+    });
+    expect(unsafe.status).toBe(412);
+    expect(unsafe.body).toHaveLength(0);
+
+    const forcedRange = await rawHttpRequest(assetUrl, {
+      headers: {
+        "Cache-Control": "no-cache",
+        "If-None-Match": etag,
+        Range: "bytes=0-2",
+      },
+    });
+    expect(forcedRange.status).toBe(206);
+    expect(forcedRange.body).toEqual(full.body.subarray(0, 3));
   });
 
   // Ported from Next.js: test/e2e/app-dir/app-static/app-static.test.ts

--- a/tests/app-router-production-server.test.ts
+++ b/tests/app-router-production-server.test.ts
@@ -396,9 +396,9 @@ describe("App Router Production server (startProdServer)", () => {
         "If-Range": "Thu, 01 Jan 2099 00:00:00 GMT",
       },
     });
-    expect(futureIfRange.status).toBe(200);
-    expect(futureIfRange.headers.get("content-range")).toBeNull();
-    expect(new Uint8Array(await futureIfRange.arrayBuffer())).toEqual(fullBody);
+    expect(futureIfRange.status).toBe(206);
+    expect(futureIfRange.headers.get("content-range")).toBe(`bytes 2-9/${fullBody.byteLength}`);
+    expect(new Uint8Array(await futureIfRange.arrayBuffer())).toEqual(fullBody.subarray(2, 10));
 
     const invalidIfRange = await fetch(assetUrl, {
       headers: {
@@ -420,8 +420,10 @@ describe("App Router Production server (startProdServer)", () => {
       method: "HEAD",
       headers: { Range: "bytes=2-9" },
     });
-    expect(head.status).toBe(200);
-    expect(head.headers.get("content-length")).toBe(String(fullBody.byteLength));
+    expect(head.status).toBe(206);
+    expect(head.headers.get("content-range")).toBe(`bytes 2-9/${fullBody.byteLength}`);
+    expect(head.headers.get("content-length")).toBe("8");
+    expect((await head.arrayBuffer()).byteLength).toBe(0);
   });
 
   it("evaluates static asset preconditions before byte ranges", async () => {
@@ -466,12 +468,16 @@ describe("App Router Production server (startProdServer)", () => {
     expect(head.status).toBe(304);
     expect(head.body).toHaveLength(0);
 
-    const unsafe = await rawHttpRequest(assetUrl, {
+    const unsafe = await rawHttpRequest(assetUrl, { method: "POST" });
+    expect(unsafe.status).toBe(405);
+    expect(unsafe.headers.allow).toBe("GET, HEAD");
+
+    const unsafeConditional = await rawHttpRequest(assetUrl, {
       method: "POST",
       headers: { "If-None-Match": etag },
     });
-    expect(unsafe.status).toBe(412);
-    expect(unsafe.body).toHaveLength(0);
+    expect(unsafeConditional.status).toBe(405);
+    expect(unsafeConditional.headers.allow).toBe("GET, HEAD");
 
     const forcedRange = await rawHttpRequest(assetUrl, {
       headers: {

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -1695,6 +1695,34 @@ describe("readPagesRouterEntrySource", () => {
     expect(await resolved!.text()).toBe("<svg />");
   });
 
+  it("preserves partial asset status over a middleware status override", async () => {
+    const signalResponse = new Response(null, {
+      status: 403,
+      headers: {
+        "x-vinext-static-file": encodeURIComponent("/asset.txt"),
+        "x-middleware": "blocked",
+      },
+    });
+
+    const resolved = await resolveStaticAssetSignal(signalResponse, {
+      fetchAsset: async () =>
+        new Response("par", {
+          status: 206,
+          headers: {
+            "content-length": "3",
+            "content-range": "bytes 0-2/7",
+          },
+        }),
+    });
+
+    expect(resolved).not.toBeNull();
+    expect(resolved!.status).toBe(206);
+    expect(resolved!.headers.get("content-length")).toBe("3");
+    expect(resolved!.headers.get("content-range")).toBe("bytes 0-2/7");
+    expect(resolved!.headers.get("x-middleware")).toBe("blocked");
+    expect(await resolved!.text()).toBe("par");
+  });
+
   it("retargets Worker assets without dropping conditional and range fields", () => {
     const source = new Request("https://example.com/rewrite", {
       method: "HEAD",

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -58,6 +58,7 @@ import {
 } from "../packages/vinext/src/build/pages-client-assets-module.js";
 import { fetchWorkerFilesystemRoute } from "../packages/vinext/src/server/pages-request-pipeline.js";
 import {
+  createStaticAssetRequest,
   finalizeMissingStaticAssetResponse,
   mergeHeaders,
   resolveStaticAssetSignal,
@@ -1692,6 +1693,24 @@ describe("readPagesRouterEntrySource", () => {
     expect(resolved!.headers.get("x-middleware")).toBe("blocked");
     expect(resolved!.headers.get("x-asset-path")).toBe("/logo/logo.svg");
     expect(await resolved!.text()).toBe("<svg />");
+  });
+
+  it("retargets Worker assets without dropping conditional and range fields", () => {
+    const source = new Request("https://example.com/rewrite", {
+      method: "HEAD",
+      headers: {
+        "cache-control": "no-cache",
+        "if-none-match": 'W/"asset"',
+        "if-modified-since": "Sun, 26 Jul 2026 12:34:56 GMT",
+        "if-range": '"asset"',
+        range: "bytes=0-2",
+      },
+    });
+
+    const assetRequest = createStaticAssetRequest("/asset.txt", source);
+    expect(assetRequest.url).toBe("https://example.com/asset.txt");
+    expect(assetRequest.method).toBe("HEAD");
+    expect(Object.fromEntries(assetRequest.headers)).toEqual(Object.fromEntries(source.headers));
   });
 
   it("preserves x-middleware-request-* headers for prod request override handling", () => {

--- a/tests/e2e/pages-router-prod/production.spec.ts
+++ b/tests/e2e/pages-router-prod/production.spec.ts
@@ -146,6 +146,16 @@ test.describe("Pages Router Production Build", () => {
     expect(jsRes.status()).toBe(200);
     expect(jsRes.headers()["content-type"]).toContain("javascript");
     expect(jsRes.headers()["cache-control"]).toContain("immutable");
+
+    const unsupported = await request.post(`${BASE}${jsPath}`);
+    expect(unsupported.status()).toBe(405);
+    expect(unsupported.headers()["allow"]).toBe("GET, HEAD");
+
+    const unsupportedConditional = await request.post(`${BASE}${jsPath}`, {
+      headers: { "If-None-Match": jsRes.headers()["etag"] ?? "*" },
+    });
+    expect(unsupportedConditional.status()).toBe(405);
+    expect(unsupportedConditional.headers()["allow"]).toBe("GET, HEAD");
   });
 
   test("large responses include compression headers", async ({ request }) => {

--- a/tests/http-conditional.test.ts
+++ b/tests/http-conditional.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { matchesIfNoneMatch } from "../packages/vinext/src/server/http-conditional.js";
+import {
+  evaluateStaticPreconditions,
+  matchesIfMatch,
+  matchesIfNoneMatch,
+} from "../packages/vinext/src/server/http-conditional.js";
 
 describe("matchesIfNoneMatch", () => {
   it("matches an identical entity tag", () => {
@@ -65,5 +69,157 @@ describe("matchesIfNoneMatch", () => {
   it("rejects an absent or empty field value", () => {
     expect(matchesIfNoneMatch(undefined, '"asset"')).toBe(false);
     expect(matchesIfNoneMatch("", '"asset"')).toBe(false);
+  });
+});
+
+describe("matchesIfMatch", () => {
+  it("uses strong comparison for entity tags", () => {
+    expect(matchesIfMatch('"asset"', '"asset"')).toBe(true);
+    expect(matchesIfMatch('W/"asset"', '"asset"')).toBe(false);
+    expect(matchesIfMatch('"asset"', 'W/"asset"')).toBe(false);
+  });
+
+  it("matches strong tags containing commas inside a list", () => {
+    expect(matchesIfMatch('"other", "asset,part"', '"asset,part"')).toBe(true);
+  });
+
+  it("matches a standalone wildcard when the representation exists", () => {
+    expect(matchesIfMatch(" \t * \t ", undefined)).toBe(true);
+    expect(matchesIfMatch('*, "asset"', '"asset"')).toBe(false);
+  });
+
+  it("rejects malformed entity-tag lists", () => {
+    expect(matchesIfMatch('asset, "match"', '"match"')).toBe(false);
+    expect(matchesIfMatch('"unterminated', '"unterminated"')).toBe(false);
+  });
+});
+
+describe("evaluateStaticPreconditions", () => {
+  const mtimeMs = Date.parse("2026-07-26T12:34:56.789Z");
+
+  it("uses If-None-Match before If-Modified-Since", () => {
+    expect(
+      evaluateStaticPreconditions(
+        {
+          ifNoneMatch: '"different"',
+          ifModifiedSince: "Mon, 27 Jul 2026 12:34:56 GMT",
+        },
+        "GET",
+        '"asset"',
+        mtimeMs,
+      ),
+    ).toBe("proceed");
+  });
+
+  it("matches If-Modified-Since at whole-second precision", () => {
+    expect(
+      evaluateStaticPreconditions(
+        { ifModifiedSince: "Sun, 26 Jul 2026 12:34:56 GMT" },
+        "GET",
+        '"asset"',
+        mtimeMs,
+      ),
+    ).toBe("not-modified");
+    expect(
+      evaluateStaticPreconditions(
+        { ifModifiedSince: "Sun, 26 Jul 2026 12:34:55 GMT" },
+        "GET",
+        '"asset"',
+        mtimeMs,
+      ),
+    ).toBe("proceed");
+  });
+
+  it("ignores malformed and normalized-invalid modification dates", () => {
+    expect(
+      evaluateStaticPreconditions({ ifModifiedSince: "not a date" }, "GET", '"asset"', mtimeMs),
+    ).toBe("proceed");
+    expect(
+      evaluateStaticPreconditions(
+        { ifModifiedSince: "Tue, 31 Feb 2026 12:34:56 GMT" },
+        "GET",
+        '"asset"',
+        mtimeMs,
+      ),
+    ).toBe("proceed");
+    expect(
+      evaluateStaticPreconditions(
+        { ifModifiedSince: "Mon, 26 Jul 2026 12:34:56 GMT" },
+        "GET",
+        '"asset"',
+        mtimeMs,
+      ),
+    ).toBe("proceed");
+  });
+
+  it("honors Cache-Control: no-cache despite matching freshness validators", () => {
+    expect(
+      evaluateStaticPreconditions(
+        {
+          cacheControl: "max-age=0, No-Cache",
+          ifNoneMatch: 'W/"asset"',
+          ifModifiedSince: "Mon, 27 Jul 2026 12:34:56 GMT",
+        },
+        "GET",
+        '"asset"',
+        mtimeMs,
+      ),
+    ).toBe("proceed");
+  });
+
+  it("evaluates If-Match before If-Unmodified-Since", () => {
+    expect(
+      evaluateStaticPreconditions(
+        {
+          ifMatch: '"asset"',
+          ifUnmodifiedSince: "Sat, 25 Jul 2026 12:34:56 GMT",
+        },
+        "GET",
+        '"asset"',
+        mtimeMs,
+      ),
+    ).toBe("proceed");
+    expect(evaluateStaticPreconditions({ ifMatch: '"different"' }, "GET", '"asset"', mtimeMs)).toBe(
+      "precondition-failed",
+    );
+  });
+
+  it("fails If-Unmodified-Since when the representation changed later", () => {
+    expect(
+      evaluateStaticPreconditions(
+        { ifUnmodifiedSince: "Sun, 26 Jul 2026 12:34:55 GMT" },
+        "GET",
+        '"asset"',
+        mtimeMs,
+      ),
+    ).toBe("precondition-failed");
+  });
+
+  it("ignores an invalid If-Unmodified-Since date", () => {
+    expect(
+      evaluateStaticPreconditions(
+        { ifUnmodifiedSince: "Tue, 31 Feb 2026 12:34:56 GMT" },
+        "GET",
+        '"asset"',
+        mtimeMs,
+      ),
+    ).toBe("proceed");
+  });
+
+  it("ignores If-Unmodified-Since without a valid current modification date", () => {
+    expect(
+      evaluateStaticPreconditions(
+        { ifUnmodifiedSince: "Thu, 01 Jan 1970 00:00:00 GMT" },
+        "GET",
+        '"asset"',
+        Number.NaN,
+      ),
+    ).toBe("proceed");
+  });
+
+  it("uses 412 rather than 304 for matching If-None-Match on unsafe methods", () => {
+    expect(
+      evaluateStaticPreconditions({ ifNoneMatch: 'W/"asset"' }, "POST", '"asset"', mtimeMs),
+    ).toBe("precondition-failed");
   });
 });

--- a/tests/http-conditional.test.ts
+++ b/tests/http-conditional.test.ts
@@ -73,10 +73,12 @@ describe("matchesIfNoneMatch", () => {
 });
 
 describe("matchesIfMatch", () => {
-  it("uses strong comparison for entity tags", () => {
+  it("matches weak and strong variants like Next.js static serving", () => {
     expect(matchesIfMatch('"asset"', '"asset"')).toBe(true);
-    expect(matchesIfMatch('W/"asset"', '"asset"')).toBe(false);
-    expect(matchesIfMatch('"asset"', 'W/"asset"')).toBe(false);
+    expect(matchesIfMatch('W/"asset"', '"asset"')).toBe(true);
+    expect(matchesIfMatch('"asset"', 'W/"asset"')).toBe(true);
+    expect(matchesIfMatch('W/"asset"', 'W/"asset"')).toBe(true);
+    expect(matchesIfMatch('W/"other"', 'W/"asset"')).toBe(false);
   });
 
   it("matches strong tags containing commas inside a list", () => {

--- a/tests/http-date.test.ts
+++ b/tests/http-date.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+import { parseHttpDate } from "../packages/vinext/src/server/http-date.js";
+
+describe("parseHttpDate", () => {
+  const timestamp = Date.parse("2026-01-01T00:00:00Z");
+
+  it("parses all three RFC 9110 HTTP-date formats", () => {
+    expect(parseHttpDate("Thu, 01 Jan 2026 00:00:00 GMT")).toBe(timestamp);
+    expect(parseHttpDate("Thursday, 01-Jan-26 00:00:00 GMT")).toBe(timestamp);
+    expect(parseHttpDate("Thu Jan  1 00:00:00 2026")).toBe(timestamp);
+  });
+
+  it("rejects non-HTTP dates and normalized calendar or weekday mistakes", () => {
+    expect(parseHttpDate("2026-01-01T00:00:00Z")).toBeNaN();
+    expect(parseHttpDate("Sun, 31 Feb 2099 00:00:00 GMT")).toBeNaN();
+    expect(parseHttpDate("Fri, 01 Jan 2026 00:00:00 GMT")).toBeNaN();
+  });
+
+  it("resolves an RFC 850 year using the full 50-year timestamp boundary", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime("2026-07-27T12:00:00Z");
+    try {
+      expect(parseHttpDate("Thursday, 31-Dec-76 00:00:00 GMT")).toBeNaN();
+      expect(parseHttpDate("Friday, 31-Dec-76 00:00:00 GMT")).toBe(
+        Date.parse("1976-12-31T00:00:00Z"),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/tests/http-date.test.ts
+++ b/tests/http-date.test.ts
@@ -28,4 +28,16 @@ describe("parseHttpDate", () => {
       vi.useRealTimers();
     }
   });
+
+  it("adjusts an RFC 850 leap day before validating the inferred century", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime("2026-07-27T12:00:00Z");
+    try {
+      expect(parseHttpDate("Tuesday, 29-Feb-00 00:00:00 GMT")).toBe(
+        Date.parse("2000-02-29T00:00:00Z"),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/tests/http-range.test.ts
+++ b/tests/http-range.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from "vitest";
+import { ifRangeAllowsRange, parseByteRange } from "../packages/vinext/src/server/http-range.js";
+
+describe("parseByteRange", () => {
+  it("parses bounded and open-ended ranges", () => {
+    expect(parseByteRange("bytes=2-5", 10)).toEqual({ kind: "range", start: 2, end: 5 });
+    expect(parseByteRange("bytes=7-", 10)).toEqual({ kind: "range", start: 7, end: 9 });
+  });
+
+  it("parses suffix ranges and clamps them to the representation", () => {
+    expect(parseByteRange("bytes=-3", 10)).toEqual({ kind: "range", start: 7, end: 9 });
+    expect(parseByteRange("bytes=-20", 10)).toEqual({ kind: "range", start: 0, end: 9 });
+  });
+
+  it("parses case-insensitive range units and clamps an oversized end", () => {
+    expect(parseByteRange("BYTES=8-99", 10)).toEqual({ kind: "range", start: 8, end: 9 });
+  });
+
+  it("marks valid but impossible ranges unsatisfiable", () => {
+    expect(parseByteRange("bytes=10-", 10)).toEqual({ kind: "unsatisfiable" });
+    expect(parseByteRange("bytes=7-3", 10)).toEqual({ kind: "unsatisfiable" });
+    expect(parseByteRange("bytes=-0", 10)).toEqual({ kind: "unsatisfiable" });
+    expect(parseByteRange("bytes=0-", 0)).toEqual({ kind: "unsatisfiable" });
+  });
+
+  it("ignores malformed, unsupported, and multipart ranges", () => {
+    expect(parseByteRange(undefined, 10)).toEqual({ kind: "ignore" });
+    expect(parseByteRange("items=0-2", 10)).toEqual({ kind: "ignore" });
+    expect(parseByteRange("bytes=abc", 10)).toEqual({ kind: "ignore" });
+    expect(parseByteRange("bytes=0-1,4-5", 10)).toEqual({ kind: "ignore" });
+  });
+
+  it("preserves valid range semantics above Number.MAX_SAFE_INTEGER", () => {
+    expect(parseByteRange("bytes=9007199254740992-", 10)).toEqual({ kind: "unsatisfiable" });
+    expect(parseByteRange("bytes=2-9007199254740992", 10)).toEqual({
+      kind: "range",
+      start: 2,
+      end: 9,
+    });
+    expect(parseByteRange("bytes=-9007199254740992", 10)).toEqual({
+      kind: "range",
+      start: 0,
+      end: 9,
+    });
+    expect(parseByteRange("bytes=-9007199254740992", 0)).toEqual({ kind: "unsatisfiable" });
+  });
+});
+
+describe("ifRangeAllowsRange", () => {
+  const mtimeMs = Date.parse("2026-01-01T00:00:00.500Z");
+
+  it("accepts an absent validator and an identical strong ETag", () => {
+    expect(ifRangeAllowsRange(undefined, '"asset"', mtimeMs)).toBe(true);
+    expect(ifRangeAllowsRange('"asset"', '"asset"', mtimeMs)).toBe(true);
+  });
+
+  it("rejects weak or different entity tags", () => {
+    expect(ifRangeAllowsRange('W/"asset"', '"asset"', mtimeMs)).toBe(false);
+    expect(ifRangeAllowsRange('"asset"', 'W/"asset"', mtimeMs)).toBe(false);
+    expect(ifRangeAllowsRange('"other"', '"asset"', mtimeMs)).toBe(false);
+  });
+
+  it("accepts only an exact whole-second Last-Modified date", () => {
+    expect(ifRangeAllowsRange("Thu, 01 Jan 2026 00:00:00 GMT", '"asset"', mtimeMs)).toBe(true);
+    expect(ifRangeAllowsRange("Thu, 01 Jan 2026 00:00:01 GMT", '"asset"', mtimeMs)).toBe(false);
+  });
+
+  it("rejects stale or invalid dates", () => {
+    expect(ifRangeAllowsRange("Wed, 31 Dec 2025 23:59:59 GMT", '"asset"', mtimeMs)).toBe(false);
+    expect(ifRangeAllowsRange("not-a-date", '"asset"', mtimeMs)).toBe(false);
+    expect(ifRangeAllowsRange("12/31/2099", '"asset"', mtimeMs)).toBe(false);
+    expect(ifRangeAllowsRange("2099-12-31", '"asset"', mtimeMs)).toBe(false);
+    expect(ifRangeAllowsRange("Sun, 31 Feb 2099 00:00:00 GMT", '"asset"', mtimeMs)).toBe(false);
+    expect(ifRangeAllowsRange("Fri, 01 Jan 2026 00:00:00 GMT", '"asset"', mtimeMs)).toBe(false);
+  });
+
+  it("accepts obsolete HTTP-date formats required for recipients", () => {
+    expect(ifRangeAllowsRange("Thursday, 01-Jan-26 00:00:00 GMT", '"asset"', mtimeMs)).toBe(true);
+    expect(ifRangeAllowsRange("Thu Jan  1 00:00:00 2026", '"asset"', mtimeMs)).toBe(true);
+  });
+
+  it("resolves an RFC 850 year from the full 50-year timestamp boundary", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime("2026-07-27T12:00:00Z");
+    try {
+      expect(
+        ifRangeAllowsRange(
+          "Thursday, 31-Dec-76 00:00:00 GMT",
+          '"asset"',
+          Date.parse("2076-12-31T00:00:00Z"),
+        ),
+      ).toBe(false);
+      expect(
+        ifRangeAllowsRange(
+          "Friday, 31-Dec-76 00:00:00 GMT",
+          '"asset"',
+          Date.parse("1976-12-31T00:00:00Z"),
+        ),
+      ).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/tests/http-range.test.ts
+++ b/tests/http-range.test.ts
@@ -60,9 +60,9 @@ describe("ifRangeAllowsRange", () => {
     expect(ifRangeAllowsRange('"other"', '"asset"', mtimeMs)).toBe(false);
   });
 
-  it("accepts only an exact whole-second Last-Modified date", () => {
+  it("accepts an equal or future If-Range date", () => {
     expect(ifRangeAllowsRange("Thu, 01 Jan 2026 00:00:00 GMT", '"asset"', mtimeMs)).toBe(true);
-    expect(ifRangeAllowsRange("Thu, 01 Jan 2026 00:00:01 GMT", '"asset"', mtimeMs)).toBe(false);
+    expect(ifRangeAllowsRange("Thu, 01 Jan 2026 00:00:01 GMT", '"asset"', mtimeMs)).toBe(true);
   });
 
   it("rejects stale or invalid dates", () => {

--- a/tests/serve-static.test.ts
+++ b/tests/serve-static.test.ts
@@ -1277,6 +1277,8 @@ describe("tryServeStatic (with StaticFileCache)", () => {
     await captured.ended;
     expect(captured.status).toBe(304);
     expect(captured.headers["Vary"]).toBe("Accept-Encoding");
+    expect(captured.headers["Content-Type"]).toBeUndefined();
+    expect(captured.headers["Accept-Ranges"]).toBeUndefined();
   });
 
   it("returns slow-path 304 via identity fallback when codings are refused", async () => {

--- a/tests/serve-static.test.ts
+++ b/tests/serve-static.test.ts
@@ -496,7 +496,7 @@ describe("tryServeStatic (with StaticFileCache)", () => {
     expect(captured.body).toHaveLength(0);
   });
 
-  it("returns 412 for matching If-None-Match on an unsafe cached request", async () => {
+  it("returns 405 before evaluating conditions on an unsupported cached request", async () => {
     await writeFile(clientDir, "unsafe-conditional.txt", "cached content");
     const cache = await StaticFileCache.create(clientDir);
     const entry = cache.lookup("/unsafe-conditional.txt")!;
@@ -506,8 +506,9 @@ describe("tryServeStatic (with StaticFileCache)", () => {
     await tryServeStatic(req, res, clientDir, "/unsafe-conditional.txt", true, cache);
     await captured.ended;
 
-    expect(captured.status).toBe(412);
-    expect(captured.body).toHaveLength(0);
+    expect(captured.status).toBe(405);
+    expect(captured.headers.Allow).toBe("GET, HEAD");
+    expect(captured.body.toString()).toBe("Method Not Allowed");
   });
 
   it("evaluates conditions against validators overridden by response headers", async () => {
@@ -884,6 +885,15 @@ describe("tryServeStatic (with StaticFileCache)", () => {
     expect(unsatisfiable.headers["Content-Type"]).toBe("application/javascript; charset=utf-8");
     expect(unsatisfiable.headers["Content-Range"]).toBe("bytes */10");
     expect(unsatisfiable.body).toHaveLength(0);
+
+    const headReq = mockReq(undefined, { range: "bytes=2-5" }, "HEAD");
+    const { res: headRes, captured: head } = mockRes();
+    await tryServeStatic(headReq, headRes, clientDir, `/${relativePath}`, true, cache);
+    await head.ended;
+    expect(head.status).toBe(206);
+    expect(head.headers["Content-Range"]).toBe("bytes 2-5/10");
+    expect(head.headers["Content-Length"]).toBe("4");
+    expect(head.body).toHaveLength(0);
   });
 
   // ── Slow path (no cache) ───────────────────────────────────────
@@ -939,6 +949,28 @@ describe("tryServeStatic (with StaticFileCache)", () => {
     expect(range.headers.Vary).toBe("Accept-Encoding");
     expect(range.headers["Content-Encoding"]).toBeUndefined();
     expect(range.body.toString()).toBe("2345");
+
+    const headReq = mockReq(undefined, { range: "bytes=2-5" }, "HEAD");
+    const { res: headRes, captured: head } = mockRes();
+    await tryServeStatic(headReq, headRes, clientDir, "/if-range.txt", true);
+    await head.ended;
+    expect(head.status).toBe(206);
+    expect(head.headers["Content-Range"]).toBe("bytes 2-5/10");
+    expect(head.headers["Content-Length"]).toBe("4");
+    expect(head.body).toHaveLength(0);
+  });
+
+  it("returns 405 before evaluating conditions on an unsupported slow request", async () => {
+    await writeFile(clientDir, "unsafe-slow.txt", "slow content");
+    const req = mockReq(undefined, { "if-none-match": "*" }, "POST");
+    const { res, captured } = mockRes();
+
+    await tryServeStatic(req, res, clientDir, "/unsafe-slow.txt", true);
+    await captured.ended;
+
+    expect(captured.status).toBe(405);
+    expect(captured.headers.Allow).toBe("GET, HEAD");
+    expect(captured.body.toString()).toBe("Method Not Allowed");
   });
 
   it("slow path does not vary non-compressible files", async () => {

--- a/tests/serve-static.test.ts
+++ b/tests/serve-static.test.ts
@@ -490,6 +490,8 @@ describe("tryServeStatic (with StaticFileCache)", () => {
     await captured.ended;
 
     expect(captured.status).toBe(412);
+    expect(captured.headers["Content-Type"]).toBe("text/plain; charset=utf-8");
+    expect(captured.headers["Accept-Ranges"]).toBe("bytes");
     expect(captured.headers["Content-Range"]).toBeUndefined();
     expect(captured.body).toHaveLength(0);
   });
@@ -1352,6 +1354,8 @@ describe("tryServeStatic (with StaticFileCache)", () => {
     await captured.ended;
 
     expect(captured.status).toBe(412);
+    expect(captured.headers["Content-Type"]).toBe("text/plain; charset=utf-8");
+    expect(captured.headers["Accept-Ranges"]).toBe("bytes");
     expect(captured.headers["Content-Range"]).toBeUndefined();
     expect(captured.body).toHaveLength(0);
   });

--- a/tests/serve-static.test.ts
+++ b/tests/serve-static.test.ts
@@ -879,6 +879,7 @@ describe("tryServeStatic (with StaticFileCache)", () => {
     );
     await unsatisfiable.ended;
     expect(unsatisfiable.status).toBe(416);
+    expect(unsatisfiable.headers["Content-Type"]).toBe("application/javascript; charset=utf-8");
     expect(unsatisfiable.headers["Content-Range"]).toBe("bytes */10");
     expect(unsatisfiable.body).toHaveLength(0);
   });
@@ -913,6 +914,7 @@ describe("tryServeStatic (with StaticFileCache)", () => {
     await tryServeStatic(emptyReq, emptyRes, clientDir, "/empty.txt", false);
     await empty.ended;
     expect(empty.status).toBe(416);
+    expect(empty.headers["Content-Type"]).toBe("text/plain; charset=utf-8");
     expect(empty.headers["Content-Range"]).toBe("bytes */0");
 
     await writeFile(clientDir, "if-range.txt", "0123456789");

--- a/tests/serve-static.test.ts
+++ b/tests/serve-static.test.ts
@@ -426,6 +426,121 @@ describe("tryServeStatic (with StaticFileCache)", () => {
     expect(captured.status).toBe(200);
   });
 
+  it("returns 304 when a cached asset has not changed since If-Modified-Since", async () => {
+    await writeFile(clientDir, "conditional.txt", "cached content");
+    const cache = await StaticFileCache.create(clientDir);
+    const entry = cache.lookup("/conditional.txt")!;
+    const req = mockReq(undefined, {
+      "if-modified-since": entry.original.headers["Last-Modified"],
+    });
+    const { res, captured } = mockRes();
+
+    await tryServeStatic(req, res, clientDir, "/conditional.txt", true, cache);
+    await captured.ended;
+
+    expect(captured.status).toBe(304);
+    expect(captured.headers["Last-Modified"]).toBe(entry.original.headers["Last-Modified"]);
+  });
+
+  it("honors Cache-Control: no-cache when a cached asset ETag matches", async () => {
+    await writeFile(clientDir, "forced-revalidation.txt", "cached content");
+    const cache = await StaticFileCache.create(clientDir);
+    const entry = cache.lookup("/forced-revalidation.txt")!;
+    const req = mockReq(undefined, {
+      "cache-control": "no-cache",
+      "if-none-match": entry.etag,
+    });
+    const { res, captured } = mockRes();
+
+    await tryServeStatic(req, res, clientDir, "/forced-revalidation.txt", true, cache);
+    await captured.ended;
+
+    expect(captured.status).toBe(200);
+    expect(captured.body.toString()).toBe("cached content");
+  });
+
+  it("evaluates cached preconditions before Range", async () => {
+    await writeFile(clientDir, "conditional-range.txt", "0123456789");
+    const cache = await StaticFileCache.create(clientDir);
+    const entry = cache.lookup("/conditional-range.txt")!;
+    const req = mockReq(undefined, {
+      "if-none-match": entry.etag,
+      range: "bytes=0-2",
+    });
+    const { res, captured } = mockRes();
+
+    await tryServeStatic(req, res, clientDir, "/conditional-range.txt", true, cache);
+    await captured.ended;
+
+    expect(captured.status).toBe(304);
+    expect(captured.headers["Content-Range"]).toBeUndefined();
+    expect(captured.body).toHaveLength(0);
+  });
+
+  it("returns 412 before evaluating a cached Range when If-Match fails", async () => {
+    await writeFile(clientDir, "if-match-range.txt", "0123456789");
+    const cache = await StaticFileCache.create(clientDir);
+    const req = mockReq(undefined, {
+      "if-match": '"different"',
+      range: "bytes=0-2",
+    });
+    const { res, captured } = mockRes();
+
+    await tryServeStatic(req, res, clientDir, "/if-match-range.txt", true, cache);
+    await captured.ended;
+
+    expect(captured.status).toBe(412);
+    expect(captured.headers["Content-Range"]).toBeUndefined();
+    expect(captured.body).toHaveLength(0);
+  });
+
+  it("returns 412 for matching If-None-Match on an unsafe cached request", async () => {
+    await writeFile(clientDir, "unsafe-conditional.txt", "cached content");
+    const cache = await StaticFileCache.create(clientDir);
+    const entry = cache.lookup("/unsafe-conditional.txt")!;
+    const req = mockReq(undefined, { "if-none-match": entry.etag }, "POST");
+    const { res, captured } = mockRes();
+
+    await tryServeStatic(req, res, clientDir, "/unsafe-conditional.txt", true, cache);
+    await captured.ended;
+
+    expect(captured.status).toBe(412);
+    expect(captured.body).toHaveLength(0);
+  });
+
+  it("evaluates conditions against validators overridden by response headers", async () => {
+    await writeFile(clientDir, "custom-validator.txt", "cached content");
+    const cache = await StaticFileCache.create(clientDir);
+    const req = mockReq(undefined, { "if-none-match": '"custom"' });
+    const { res, captured } = mockRes();
+
+    await tryServeStatic(req, res, clientDir, "/custom-validator.txt", true, cache, {
+      etag: '"custom"',
+    });
+    await captured.ended;
+
+    expect(captured.status).toBe(304);
+    expect(captured.headers.etag).toBe('"custom"');
+    expect(captured.body).toHaveLength(0);
+  });
+
+  it("ignores If-Unmodified-Since when a cached response overrides Last-Modified invalidly", async () => {
+    await writeFile(clientDir, "invalid-last-modified.txt", "cached content");
+    const cache = await StaticFileCache.create(clientDir);
+    const req = mockReq(undefined, {
+      "if-unmodified-since": "Thu, 01 Jan 1970 00:00:00 GMT",
+    });
+    const { res, captured } = mockRes();
+
+    await tryServeStatic(req, res, clientDir, "/invalid-last-modified.txt", true, cache, {
+      "Last-Modified": "not-a-date",
+    });
+    await captured.ended;
+
+    expect(captured.status).toBe(200);
+    expect(captured.body.toString()).toBe("cached content");
+  });
+
   it("304 response excludes Content-Type per RFC 9110", async () => {
     await writeFile(clientDir, "_next/static/rfc-aaa111.js", "rfc content");
 
@@ -712,6 +827,62 @@ describe("tryServeStatic (with StaticFileCache)", () => {
     expect(captured.headers.Vary).toBeUndefined();
   });
 
+  it("serves cached ranges with conditional precedence and lossless large integers", async () => {
+    const relativePath = "_next/static/range-aaa111.js";
+    const content = "0123456789";
+    await writeFile(clientDir, relativePath, content);
+    await writeFile(clientDir, `${relativePath}.br`, zlib.brotliCompressSync(content));
+    const cache = await StaticFileCache.create(clientDir);
+
+    const initialReq = mockReq();
+    const { res: initialRes, captured: initial } = mockRes();
+    await tryServeStatic(initialReq, initialRes, clientDir, `/${relativePath}`, true, cache);
+    await initial.ended;
+
+    const conditionalReq = mockReq(undefined, {
+      range: "bytes=2-9007199254740992",
+      "if-none-match": initial.headers.ETag as string,
+    });
+    const { res: conditionalRes, captured: conditional } = mockRes();
+    await tryServeStatic(
+      conditionalReq,
+      conditionalRes,
+      clientDir,
+      `/${relativePath}`,
+      true,
+      cache,
+    );
+    await conditional.ended;
+    expect(conditional.status).toBe(304);
+    expect(conditional.body).toHaveLength(0);
+
+    const rangeReq = mockReq("br, gzip", { range: "bytes=2-9007199254740992" });
+    const { res: rangeRes, captured: range } = mockRes();
+    await tryServeStatic(rangeReq, rangeRes, clientDir, `/${relativePath}`, true, cache);
+    await range.ended;
+    expect(range.status).toBe(206);
+    expect(range.headers["Content-Range"]).toBe("bytes 2-9/10");
+    expect(range.headers["Content-Length"]).toBe("8");
+    expect(range.headers["Content-Encoding"]).toBeUndefined();
+    expect(range.headers.Vary).toBe("Accept-Encoding");
+    expect(range.body.toString()).toBe("23456789");
+
+    const unsatisfiableReq = mockReq(undefined, { range: "bytes=9007199254740992-" });
+    const { res: unsatisfiableRes, captured: unsatisfiable } = mockRes();
+    await tryServeStatic(
+      unsatisfiableReq,
+      unsatisfiableRes,
+      clientDir,
+      `/${relativePath}`,
+      true,
+      cache,
+    );
+    await unsatisfiable.ended;
+    expect(unsatisfiable.status).toBe(416);
+    expect(unsatisfiable.headers["Content-Range"]).toBe("bytes */10");
+    expect(unsatisfiable.body).toHaveLength(0);
+  });
+
   // ── Slow path (no cache) ───────────────────────────────────────
 
   it("slow path serves static file without cache", async () => {
@@ -733,6 +904,37 @@ describe("tryServeStatic (with StaticFileCache)", () => {
     expect(captured.status).toBe(200);
     expect(captured.headers["Content-Type"]).toBe("application/javascript; charset=utf-8");
     expect(captured.body.toString()).toBe("slow path content");
+  });
+
+  it("slow path rejects ranges for empty files and ignores invalid If-Range dates", async () => {
+    await writeFile(clientDir, "empty.txt", "");
+    const emptyReq = mockReq(undefined, { range: "bytes=-9007199254740992" });
+    const { res: emptyRes, captured: empty } = mockRes();
+    await tryServeStatic(emptyReq, emptyRes, clientDir, "/empty.txt", false);
+    await empty.ended;
+    expect(empty.status).toBe(416);
+    expect(empty.headers["Content-Range"]).toBe("bytes */0");
+
+    await writeFile(clientDir, "if-range.txt", "0123456789");
+    const invalidDateReq = mockReq(undefined, {
+      range: "bytes=2-5",
+      "if-range": "Sun, 31 Feb 2099 00:00:00 GMT",
+    });
+    const { res: invalidDateRes, captured: invalidDate } = mockRes();
+    await tryServeStatic(invalidDateReq, invalidDateRes, clientDir, "/if-range.txt", false);
+    await invalidDate.ended;
+    expect(invalidDate.status).toBe(200);
+    expect(invalidDate.headers["Content-Range"]).toBeUndefined();
+    expect(invalidDate.body.toString()).toBe("0123456789");
+
+    const rangeReq = mockReq("br", { range: "bytes=2-5" });
+    const { res: rangeRes, captured: range } = mockRes();
+    await tryServeStatic(rangeReq, rangeRes, clientDir, "/if-range.txt", true);
+    await range.ended;
+    expect(range.status).toBe(206);
+    expect(range.headers.Vary).toBe("Accept-Encoding");
+    expect(range.headers["Content-Encoding"]).toBeUndefined();
+    expect(range.body.toString()).toBe("2345");
   });
 
   it("slow path does not vary non-compressible files", async () => {
@@ -1083,6 +1285,90 @@ describe("tryServeStatic (with StaticFileCache)", () => {
     await captured.ended;
     expect(captured.status).toBe(304);
     expect(captured.headers.Vary).toBe("Accept-Encoding");
+  });
+
+  it("supports If-Modified-Since on the slow path", async () => {
+    await writeFile(clientDir, "conditional-slow.txt", "slow content");
+    const stat = await fsp.stat(path.join(clientDir, "conditional-slow.txt"));
+    const req = mockReq(undefined, {
+      "if-modified-since": new Date(stat.mtimeMs).toUTCString(),
+    });
+    const { res, captured } = mockRes();
+
+    await tryServeStatic(req, res, clientDir, "/conditional-slow.txt", true);
+    await captured.ended;
+
+    expect(captured.status).toBe(304);
+    expect(captured.headers["Last-Modified"]).toBe(new Date(stat.mtimeMs).toUTCString());
+  });
+
+  it("honors Cache-Control: no-cache on the slow path", async () => {
+    await writeFile(clientDir, "_next/static/no-cache-slow-abc123.js", "slow content");
+    const req = mockReq(undefined, {
+      "cache-control": "no-cache",
+      "if-none-match": 'W/"abc123"',
+    });
+    const { res, captured } = mockRes();
+
+    await tryServeStatic(req, res, clientDir, "/_next/static/no-cache-slow-abc123.js", true);
+    await captured.ended;
+
+    expect(captured.status).toBe(200);
+    expect(captured.body.toString()).toBe("slow content");
+  });
+
+  it("evaluates slow-path preconditions before Range", async () => {
+    const relativePath = "conditional-range-slow.txt";
+    await writeFile(clientDir, relativePath, "0123456789");
+    const stat = await fsp.stat(path.join(clientDir, relativePath));
+    const etag = `W/"${stat.size}-${Math.floor(stat.mtimeMs / 1000)}"`;
+    const req = mockReq(undefined, {
+      "if-none-match": etag,
+      range: "bytes=0-2",
+    });
+    const { res, captured } = mockRes();
+
+    await tryServeStatic(req, res, clientDir, `/${relativePath}`, true);
+    await captured.ended;
+
+    expect(captured.status).toBe(304);
+    expect(captured.headers["Content-Range"]).toBeUndefined();
+    expect(captured.body).toHaveLength(0);
+  });
+
+  it("returns 412 before evaluating a slow-path Range when If-Unmodified-Since fails", async () => {
+    const relativePath = "if-unmodified-since-slow.txt";
+    await writeFile(clientDir, relativePath, "0123456789");
+    const stat = await fsp.stat(path.join(clientDir, relativePath));
+    const req = mockReq(undefined, {
+      "if-unmodified-since": new Date(stat.mtimeMs - 2_000).toUTCString(),
+      range: "bytes=0-2",
+    });
+    const { res, captured } = mockRes();
+
+    await tryServeStatic(req, res, clientDir, `/${relativePath}`, true);
+    await captured.ended;
+
+    expect(captured.status).toBe(412);
+    expect(captured.headers["Content-Range"]).toBeUndefined();
+    expect(captured.body).toHaveLength(0);
+  });
+
+  it("ignores If-Unmodified-Since when a slow response overrides Last-Modified invalidly", async () => {
+    const relativePath = "invalid-last-modified-slow.txt";
+    await writeFile(clientDir, relativePath, "slow content");
+    const req = mockReq(undefined, {
+      "if-unmodified-since": "Thu, 01 Jan 1970 00:00:00 GMT",
+    });
+    const { res, captured } = mockRes();
+
+    await tryServeStatic(req, res, clientDir, `/${relativePath}`, true, undefined, {
+      "Last-Modified": "not-a-date",
+    });
+    await captured.ended;
+
+    expect(captured.status).toBe(200);
+    expect(captured.body.toString()).toBe("slow content");
   });
 
   it("slow path 304 omits Vary for non-compressible content (compress=false)", async () => {

--- a/tests/static-file-cache.test.ts
+++ b/tests/static-file-cache.test.ts
@@ -76,6 +76,7 @@ describe("StaticFileCache", () => {
     expect(entry).toBeDefined();
     expect(entry!.original.headers["Content-Type"]).toBe("application/javascript; charset=utf-8");
     expect(entry!.original.headers["Content-Length"]).toBe("12"); // "const x = 1;"
+    expect(Date.parse(entry!.original.headers["Last-Modified"])).not.toBeNaN();
     expect(entry!.original.path).toBe(
       toSlash(path.join(clientDir, "_next/static/index-abc123.js")),
     );

--- a/tests/static-image-emission.test.ts
+++ b/tests/static-image-emission.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
-import type { Server } from "node:http";
+import { request, type IncomingHttpHeaders, type Server } from "node:http";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { build, createBuilder } from "vite";
@@ -24,6 +24,27 @@ const cloudflarePluginPath = path.resolve(
 const workerEntryPath = path
   .resolve(import.meta.dirname, "../packages/vinext/src/server/app-router-entry.ts")
   .replaceAll("\\", "/");
+
+async function rawHttpRequest(
+  url: string,
+  headers: Record<string, string>,
+): Promise<{ statusCode: number; headers: IncomingHttpHeaders; body: Buffer }> {
+  return new Promise((resolve, reject) => {
+    const req = request(url, { headers }, (res) => {
+      const chunks: Buffer[] = [];
+      res.on("data", (chunk: Buffer) => chunks.push(chunk));
+      res.on("end", () => {
+        resolve({
+          statusCode: res.statusCode ?? 0,
+          headers: res.headers,
+          body: Buffer.concat(chunks),
+        });
+      });
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
 
 type CloudflarePluginFactory = (options?: {
   viteEnvironment?: { name: string; childEnvironments?: string[] };
@@ -386,13 +407,16 @@ async function assertStaticImageProductionParity(
   expect(etag).toMatch(/^W\/"[0-9a-f]{8}"$/);
   expect(Buffer.from(await assetResponse.arrayBuffer())).toEqual(PNG_1X1);
 
-  const conditionalResponse = await fetch(
+  // Node's fetch adds Cache-Control: no-cache to requests with explicit
+  // validators. Use the lower-level client so this exercises a plain
+  // If-None-Match request; no-cache revalidation is covered separately.
+  const conditionalResponse = await rawHttpRequest(
     `http://127.0.0.1:${address.port}${effectiveAssetPrefix}/_next/static/media/${emittedImage}`,
-    { headers: { "if-none-match": etag! } },
+    { "if-none-match": etag! },
   );
-  expect(conditionalResponse.status).toBe(304);
-  expect(conditionalResponse.headers.get("etag")).toBe(etag);
-  expect(await conditionalResponse.text()).toBe("");
+  expect(conditionalResponse.statusCode).toBe(304);
+  expect(conditionalResponse.headers.etag).toBe(etag);
+  expect(conditionalResponse.body).toHaveLength(0);
 }
 
 describe("static image import production emission", () => {


### PR DESCRIPTION
## Summary

- build on the merged #2710 entity-tag parser and extend static serving to the full RFC precondition order
- support strong `If-Match`, `If-Unmodified-Since`, weak `If-None-Match`, and strict HTTP-date handling
- evaluate preconditions before byte ranges and honor `Cache-Control: no-cache`
- support single `bytes` ranges with correct `206` and `416` responses
- ignore unusable effective modification dates instead of incorrectly failing `If-Unmodified-Since`
- preserve conditional and range request headers when forwarding Worker asset requests
- cover both startup-cache and filesystem-fallback production paths

## Branch refresh

Rebuilt directly on current `main` at `c9a4a843c`, which contains the final merged #2710 implementation. The stale #2710 merge ancestry and the discarded dev public-file ETag index are gone. The range behavior previously stacked from #2711 is included in this single clean commit.

## Next.js parity

Next.js static serving delegates freshness and range evaluation to its send/fresh stack. This change matches the observable validator precedence and freshness behavior while preserving vinext byte-range and multi-runtime behavior.

## Validation

- 437 targeted tests passed across conditional parsing, HTTP dates, ranges, static serving/cache, Worker forwarding, static image emission, and App Router production serving
- all 15 changed files pass scoped format, lint, and type checks
- `vp run vinext#build` passed
- exact-head CI and re-review pending on the refreshed branch
