### PR TITLE
test(e2e): gate clicks that can land before hydration commits

### DIFF
--- a/tests/e2e/app-router/dev-error-overlay.spec.ts
+++ b/tests/e2e/app-router/dev-error-overlay.spec.ts
@@ -211,22 +211,12 @@ test.describe("Dev error overlay", () => {
     await expect(page.getByTestId("link-to-broken")).toBeVisible();
     // Wait for the Link's onClick handler to attach so the click drives a soft
     // RSC navigation (with historyUpdateMode = "push") instead of a full reload.
-    await page.waitForFunction(
-      () => {
-        const runtime = Reflect.get(window, Symbol.for("vinext.navigationRuntime"));
-        return (
-          typeof runtime === "object" &&
-          runtime !== null &&
-          "functions" in runtime &&
-          typeof runtime.functions === "object" &&
-          runtime.functions !== null &&
-          "navigate" in runtime.functions &&
-          typeof runtime.functions.navigate === "function"
-        );
-      },
-      undefined,
-      { timeout: 10_000 },
-    );
+    // The navigation runtime publishes `functions.navigate` before React commits
+    // the hydrated tree, so waiting on it alone lets a click land on an anchor
+    // with no listener yet — the browser then follows the href and the reload
+    // canary below is lost. `waitForAppRouterHydration` additionally requires
+    // `__VINEXT_HYDRATED_AT`, which App Router writes from a post-commit effect.
+    await waitForAppRouterHydration(page);
     await page.evaluate(() => {
       (window as unknown as { __vinextReloadCanary?: boolean }).__vinextReloadCanary = true;
     });

--- a/tests/e2e/use-params-app-pages/pages-form.spec.ts
+++ b/tests/e2e/use-params-app-pages/pages-form.spec.ts
@@ -2,6 +2,8 @@
 // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/next-form/default/pages-dir.test.ts
 import { expect, test } from "@playwright/test";
 
+import { waitForHydration } from "../helpers";
+
 async function installPageLoadCounter(page: import("@playwright/test").Page) {
   await page.addInitScript(() => {
     const count = Number(window.sessionStorage.getItem("form-page-loads") ?? "0") + 1;
@@ -13,6 +15,7 @@ test.describe("next/form on a hybrid Pages route", () => {
   test("soft-navigates a cross-route GSSP submission", async ({ page, baseURL }) => {
     await installPageLoadCounter(page);
     await page.goto(`${baseURL}/form-source`);
+    await waitForHydration(page);
     await page.locator("#basic-form button").click();
 
     await expect(page.locator("#search-query")).toHaveText("basic");
@@ -23,6 +26,7 @@ test.describe("next/form on a hybrid Pages route", () => {
   test("honors submitter formAction and name/value", async ({ page, baseURL }) => {
     await installPageLoadCounter(page);
     await page.goto(`${baseURL}/form-source`);
+    await waitForHydration(page);
     await page.locator("#submitter-form button").click();
 
     await expect(page.locator("#search-query")).toHaveText("submitter");
@@ -34,6 +38,7 @@ test.describe("next/form on a hybrid Pages route", () => {
   test("replace preserves history length", async ({ page, baseURL }) => {
     await installPageLoadCounter(page);
     await page.goto(`${baseURL}/form-source`);
+    await waitForHydration(page);
     const historyLength = await page.evaluate(() => history.length);
     await page.locator("#replace-form button").click();
 
@@ -44,6 +49,7 @@ test.describe("next/form on a hybrid Pages route", () => {
 
   test("scroll=false preserves scroll position", async ({ page, baseURL }) => {
     await page.goto(`${baseURL}/form-source`);
+    await waitForHydration(page);
     await page.evaluate(() => window.scrollTo(0, 900));
     expect(await page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
     await page.locator("#no-scroll-form button").click();
@@ -54,6 +60,7 @@ test.describe("next/form on a hybrid Pages route", () => {
 
   test("unsupported submitter attributes retain native semantics", async ({ page, baseURL }) => {
     await page.goto(`${baseURL}/form-source`);
+    await waitForHydration(page);
     const url = page.url();
     await page.locator("#native-form button").click();
 

--- a/tests/e2e/use-params-app-pages/use-params.spec.ts
+++ b/tests/e2e/use-params-app-pages/use-params.spec.ts
@@ -1,6 +1,9 @@
 // Ported from Next.js: test/e2e/app-dir/use-params/use-params.test.ts
 // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/use-params/use-params.test.ts
+import type { Request } from "@playwright/test";
 import { expect, test } from "@playwright/test";
+
+import { isAppRouterRscRequestForPath, waitForAppRouterHydration } from "../helpers";
 
 test.describe("use-params", () => {
   test("should work for single dynamic param", async ({ page, baseURL }) => {
@@ -24,12 +27,14 @@ test.describe("use-params", () => {
 
   test("should work for single dynamic param client navigating", async ({ page, baseURL }) => {
     await page.goto(`${baseURL}/`);
+    await waitForAppRouterHydration(page);
     await page.locator("#to-a").click();
     await expect(page.locator("#param-id")).toHaveText("a");
   });
 
   test("should work for nested dynamic params client navigating", async ({ page, baseURL }) => {
     await page.goto(`${baseURL}/`);
+    await waitForAppRouterHydration(page);
     await page.locator("#to-a-b").click();
     await expect(page.locator("#param-id")).toHaveText("a");
     await expect(page.locator("#param-id2")).toHaveText("b");
@@ -50,6 +55,7 @@ test.describe("use-params", () => {
     // render the catch-all's path array. Falls back to a document navigation
     // so the Pages handler renders the page.
     await page.goto(`${baseURL}/`);
+    await waitForAppRouterHydration(page);
     await page.locator("#to-pages").click();
     await expect(page).toHaveURL(/\/pages-dir\/foobar$/);
     await expect(page.locator("#params")).toHaveText('"foobar"');
@@ -63,6 +69,7 @@ test.describe("use-params", () => {
     // hard-navigate to the Pages document instead of sending an RSC
     // request that the App catch-all would otherwise answer.
     await page.goto(`${baseURL}/`);
+    await waitForAppRouterHydration(page);
     await page.locator("#router-push-pages").click();
     await expect(page).toHaveURL(/\/pages-dir\/foobar$/);
     await expect(page.locator("#params")).toHaveText('"foobar"');
@@ -75,6 +82,7 @@ test.describe("use-params", () => {
 
   test("earlier static App segment wins for Link navigation", async ({ page, baseURL }) => {
     await page.goto(`${baseURL}/`);
+    await waitForAppRouterHydration(page);
     await page.locator("#to-app-priority").click();
     await expect(page).toHaveURL(/\/account\/details$/);
     await expect(page.locator("#route-owner")).toHaveText("app");
@@ -82,6 +90,7 @@ test.describe("use-params", () => {
 
   test("earlier static App segment wins for router.push", async ({ page, baseURL }) => {
     await page.goto(`${baseURL}/`);
+    await waitForAppRouterHydration(page);
     await page.locator("#router-push-app-priority").click();
     await expect(page).toHaveURL(/\/account\/details$/);
     await expect(page.locator("#route-owner")).toHaveText("app");
@@ -96,15 +105,27 @@ test.describe("use-params", () => {
     // hit the App root catch-all's RSC handler and warm an unusable
     // cache entry, so the prefetch should be a no-op.
     await page.goto(`${baseURL}/`);
+    await waitForAppRouterHydration(page);
 
-    const rscRequests: string[] = [];
+    const requests: Request[] = [];
     page.on("request", (req) => {
-      if (req.url().includes(".rsc")) {
-        rscRequests.push(req.url());
-      }
+      requests.push(req);
     });
 
     await page.locator("#router-prefetch-pages").click();
+
+    // Positive control. A strict-zero assertion cannot tell "the hybrid
+    // check short-circuited the prefetch" apart from "the click landed
+    // before React committed, so the handler never ran and prefetch() was
+    // never called" — the second passes vacuously. The button's handler
+    // also prefetches /prefetch-control, which is App-owned and is not the
+    // target of any <Link> on this page, so nothing but this handler can
+    // produce an RSC request for it.
+    await expect
+      .poll(() => requests.some((req) => isAppRouterRscRequestForPath(req, "/prefetch-control")), {
+        message: "the prefetch handler never ran, so the assertion below would pass vacuously",
+      })
+      .toBe(true);
 
     // Give the network layer a chance to flush anything the resolver
     // accidentally started. The assertion is a strict zero RSC requests
@@ -113,13 +134,16 @@ test.describe("use-params", () => {
     // URL).
     await page.waitForTimeout(250);
     expect(
-      rscRequests.filter((u) => u.includes("/pages-dir/foobar")),
-      `unexpected RSC prefetch: ${rscRequests.join("\n")}`,
+      requests
+        .filter((req) => isAppRouterRscRequestForPath(req, "/pages-dir/foobar"))
+        .map((req) => req.url()),
+      `observed requests:\n${requests.map((req) => req.url()).join("\n")}`,
     ).toEqual([]);
   });
 
   test("shouldn't rerender host component when prefetching", async ({ page, baseURL }) => {
     await page.goto(`${baseURL}/rerenders/foobar`);
+    await waitForAppRouterHydration(page);
     const initialRandom = await page.locator("#random").textContent();
     await page.locator("a").hover();
     await expect(page.locator("#random")).toHaveText(initialRandom ?? "");

--- a/tests/fixtures/use-params-app-pages/app/page.tsx
+++ b/tests/fixtures/use-params-app-pages/app/page.tsx
@@ -35,7 +35,15 @@ export default function Page() {
         <button
           type="button"
           id="router-prefetch-pages"
-          onClick={() => router.prefetch("/pages-dir/foobar")}
+          onClick={() => {
+            router.prefetch("/pages-dir/foobar");
+            // Positive control for the e2e assertion. The subject prefetch
+            // above is expected to issue no request at all, which is
+            // indistinguishable from a click lost before hydration. This
+            // second target is App-owned and no <Link> on this page points
+            // at it, so its RSC request appears only when this handler runs.
+            router.prefetch("/prefetch-control");
+          }}
         >
           router.prefetch(/pages-dir/foobar)
         </button>


### PR DESCRIPTION
Closes #2716.

## The failure

`Dev error overlay › soft-nav to a broken route still updates the URL` intermittently fails `expect(canary).toBe(true)` with `Received: undefined`: the browser performed a document navigation and lost `window.__vinextReloadCanary` instead of the soft RSC navigation the test asserts on. Most recently on #2708 (https://github.com/cloudflare/vinext/actions/runs/30244321290/job/89907934259), failing both the initial attempt and retry #1. It is a recurrence of #1769 and the same race #2409 fixed for the `app-with-src` spec.

The test gated its click on an inline `waitForFunction` that only checked the navigation runtime exposes `functions.navigate`. That object is published before React commits the hydrated tree, so the predicate can pass while the anchor still has no click listener.

## I swept the rest of the suite before fixing it

A one-line guard swap is worth little if the shape is everywhere, so I audited all 200 E2E specs first. It is everywhere: 80 tests across 30 files click without a hydration gate, 29 of them high-exposure (click within `<=1` awaited step of `goto()`), 11 concentrated in `tests/e2e/use-params-app-pages/`. Method, measurements and the cleared false positives are in https://github.com/cloudflare/vinext/issues/2716#issuecomment-5088592502.

Polling at rAF cadence, counting ticks where the gate signal is observable but the post-commit marker is not:

| Gate | ticks early | click can land inside |
|---|---|---|
| App Router `navigationRuntime.functions.navigate` | 3–6 | yes |
| Pages Router `__VINEXT_ROOT__` (`waitForHydration`) | 0 | no |
| no gate at all | — | yes, both routers |

Hydration is finished neither when `goto()` resolves nor after one visibility assertion:

```
app-router:    hydratedAtGotoResolve=false  afterOneAssertion=false   (6/6 runs)
pages-router:  hydratedAtGotoResolve=false  afterOneAssertion=true    (3/4 runs)
```

Timing the dev-overlay page, recording when each signal first becomes observable:

```
navigate=2133.9ms  hydrated=2163.7ms  window=29.8ms
navigate=156.8ms   hydrated=173.4ms   window=16.6ms
navigate=150.3ms   hydrated=162.0ms   window=11.7ms
```

12–30ms, idle and local. Playwright's `click()` runs actionability checks and scrolling before dispatching, so on a loaded runner it lands inside that window — which is why the same shard also reported `error-interactive.spec.ts:51` flaky.

## What this fixes

**The confirmed failure.** `dev-error-overlay.spec.ts` now uses `waitForAppRouterHydration`, the guard its six other tests and the sibling `app-with-src/dev-overlay-recovery.spec.ts` already rely on. I checked the four other specs that reference `Symbol.for("vinext.navigationRuntime")` inline (`advanced`, `rsc-fetch-errors`, `build-id-navigation`, `hash-popstate-scroll`); all drive navigation programmatically rather than gating an anchor click, so this site was the only one.

**The cluster.** Every ungated click in `tests/e2e/use-params-app-pages/`, gated by whichever router owns the clicked element. The fixture is hybrid, so this is not a per-directory decision:

- `use-params.spec.ts` — 7 clicks and 1 hover on App pages (`app/page.tsx`, `app/rerenders/[dynamic]`) → `waitForAppRouterHydration`
- `pages-form.spec.ts` — 5 clicks on `/form-source`, which is `pages/form-source/index.tsx` → `waitForHydration`

That is 12 clicks, not the audit's 11; I enumerated this directory by hand rather than trusting the detector, which also misfiled the whole directory as Pages Router from its path string.

`waitForHydration` itself is untouched. It is theoretically weak — `__VINEXT_ROOT__` is assigned before `await hydrationCommitted` — but measures a 0-tick gap, so changing it would churn 95 call sites for nothing. Applying it where there was no gate at all is still worth it.

**A test that was never flaky, just vacuous.** `use-params.spec.ts:90` clicks `#router-prefetch-pages` and asserts zero RSC requests. A lost click means the handler never runs, `prefetch()` is never called, and the assertion passes for the wrong reason — quietly, indefinitely. A gate alone does not fix that, so the fixture's handler now also prefetches `/prefetch-control` and the test asserts that request **was** issued.

Picking that control target took some care. `/account/details` was the obvious choice and is wrong: it is already a `<Link>` on the page, and `link.tsx` runs a shared `IntersectionObserver` for viewport prefetching, so its RSC request appears after hydration whether or not anything is clicked. `/prefetch-control` is App-owned via the root catch-all `app/[...path]` and nothing links to it. Both prefetches sit in one handler invocation, so the control cannot pass while the subject call is skipped.

**A second vacuity in the same assertion, unrelated to the race.** Its filter was `req.url().includes(".rsc")` — a literal dot. This project emits query-param RSC URLs:

```
http://localhost:4186/prefetch-control?_rsc=4lsyqStKJzbXmimU
  rsc: 1, next-router-prefetch: 1, accept: text/x-component
```

`"...?_rsc=abc".includes(".rsc")` is `false`, so a real RSC prefetch to `/pages-dir/foobar` would have been filtered out before the assertion ever saw it. Now uses the existing `isAppRouterRscRequestForPath`, matching pathname + `_rsc` + `rsc: 1` — all three verified on a captured request.

## What this is not

No timeout bumps, no retry annotations, no new helper, no change to `waitForHydration`.

Not the rest of the audit. The other 18 high-exposure candidates span 9 files in 6 Playwright projects, several doing a full build, so validating them here would be slow and hard to review; #2716 tracks them. That list is a candidate list, not a defect list — of three I sampled, two must not be touched. `server-actions.spec.ts:64` and `:372` run with `javaScriptEnabled: false`, where a gate would hang until timeout, and `catch-error.spec.ts:52` is already correctly gated with `waitForHydration` because it clicks a Pages Router element.

## Validation

Measured:

- `vp check` clean.
- `tests/e2e/use-params-app-pages/` scoped to its own project, `--repeat-each=5`: 90 passed.
- The dev-overlay test in the `app-router` project, `--repeat-each=5`: 5 passed.
- The de-vacuuming, demonstrated rather than claimed. Green runs prove nothing here — the old test was green too. I stripped the `onClick` off `#router-prefetch-pages`, rebuilt the fixture, and ran both versions of the test against a button whose handler cannot fire:

| test version | against a dead button |
|---|---|
| `upstream/main` | **1 passed (3.9s)** — vacuous |
| this PR | **1 failed** — `the prefetch handler never ran, so the assertion below would pass vacuously` |

The fixture was restored before committing.

Reasoned, not measured:

- That any of the newly gated clicks would in fact have failed. The audit shows the window is open and that these clicks land in it; I did not force a failure. Exposed, not broken — except the prefetch test, measured above.
- The 12–30ms figures come from the dev `app-router` project. `use-params-app-pages` is a prod build and was not separately probed.

## Review path

Two commits: `76bdd20` is the one-line guard swap, `0432586` the cluster. Worth checking:

1. `__VINEXT_HYDRATED_AT` is written post-commit — the `useEffect` in `packages/vinext/src/server/app-browser-entry.ts` that also calls `hydrationCachePublication.complete()`.
2. Router ownership per gated test: `/` and `/rerenders/foobar` are `app/`, `/form-source` is `pages/`.
3. Nothing in `app/page.tsx` links to `/prefetch-control`. If a future edit adds one, the positive control goes soft.
