### PR TITLE
ci(bonk): bump BigBonk to Opus 5 medium

### DIFF
--- a/.github/workflows/bigbonk.yml
+++ b/.github/workflows/bigbonk.yml
@@ -43,9 +43,9 @@ jobs:
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
-          model: "cloudflare-ai-gateway/anthropic/claude-opus-4-8"
+          model: "cloudflare-ai-gateway/anthropic/claude-opus-5"
           mentions: "/bigbonk"
-          variant: "high"
+          variant: "medium"
           permissions: write
           opencode_dev: false
           opencode_version: 1.15.13

--- a/.opencode/agents/viguy.md
+++ b/.opencode/agents/viguy.md
@@ -1,7 +1,7 @@
 ---
 description: Vite, Next.js, TypeScript and JS build systems expert for vinext
 mode: primary
-model: anthropic/claude-opus-4-8
+model: anthropic/claude-opus-5
 temperature: 0.2
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ vinext was born from an experiment in pushing AI to its limits. Almost every lin
 
 ## Recommended setup
 
-We use [OpenCode](https://opencode.ai) with Opus 4.8 at high reasoning effort for BigBonk reviews, and GPT-5.5 at high reasoning effort for regular Bonk review passes. This is the same setup that built the project.
+We use [OpenCode](https://opencode.ai) with Opus 5 at medium reasoning effort for BigBonk reviews, and GPT-5.5 at high reasoning effort for regular Bonk review passes. This is the same setup that built the project.
 
 ## Before you open a PR
 
@@ -15,7 +15,7 @@ We use [OpenCode](https://opencode.ai) with Opus 4.8 at high reasoning effort fo
 
 ## AI code review
 
-Every PR goes through AI code review. When you open a PR, a contributor with write access will request a review from **BigBonk** (Opus 4.8, high reasoning effort). For lighter review passes, maintainers can use **Bonk** (GPT-5.5, high reasoning effort). External contributors can't trigger this directly.
+Every PR goes through AI code review. When you open a PR, a contributor with write access will request a review from **BigBonk** (Opus 5, medium reasoning effort). For lighter review passes, maintainers can use **Bonk** (GPT-5.5, high reasoning effort). External contributors can't trigger this directly.
 
 Our process is to iterate on BigBonk's feedback until there are no unresolved comments. That doesn't mean you have to accept every suggestion verbatim, but we've found it to be very good at finding real problems and very useful for debugging this codebase. Expect multiple review rounds on larger PRs.
 


### PR DESCRIPTION
Cloudflare AI Gateway now lists `claude-opus-5` (anomalyco/models.dev#3736).

Medium, not high — DeepSWE bench numbers:

| model | effort | score | cost | tokens | duration |
|---|---|---|---|---|---|
| claude-opus-5 | high | 73%±2% | $6.08 | 64k | 73 |
| claude-opus-5 | medium | 69%±1% | $3.29 | 37k | 52 |
| claude-opus-4.8 | high | 52%±5% | $4.28 | 50k | 73 |

`claude-opus-5 [medium]` already beats `claude-opus-4.8 [high]` (69% vs 52%) at lower cost ($3.29 vs $4.28) and less time (52 vs 73). Bumping to `[high]` only buys 4 more points for nearly 2x the cost and higher latency — not worth the extra wait for BigBonk review turnaround.