### PR TITLE
fix(document): HTML-escape NextScript.getInlineScriptSource output

### DIFF
--- a/packages/vinext/src/shims/document.tsx
+++ b/packages/vinext/src/shims/document.tsx
@@ -12,6 +12,7 @@ import type {
   DocumentProps,
 } from "@vinext/types/next/upstream/dist/shared/lib/utils";
 import type { HtmlProps } from "@vinext/types/next/upstream/dist/shared/lib/html-context.shared-runtime";
+import { safeJsonStringify } from "../server/html";
 
 const documentAssetMarkerAttributes = {
   headNonce: "data-vinext-head-nonce",
@@ -126,7 +127,9 @@ export class NextScript extends React.Component<OriginProps> {
   }
 
   static getInlineScriptSource(context: Readonly<HtmlProps>): string {
-    return JSON.stringify(context.__NEXT_DATA__);
+    // Matches Next.js: the returned string is embedded in an inline <script>,
+    // so it must be HTML-escaped like the framework's own __NEXT_DATA__ tag.
+    return safeJsonStringify(context.__NEXT_DATA__);
   }
 
   render(): React.ReactElement {

--- a/packages/vinext/src/shims/document.tsx
+++ b/packages/vinext/src/shims/document.tsx
@@ -12,7 +12,7 @@ import type {
   DocumentProps,
 } from "@vinext/types/next/upstream/dist/shared/lib/utils";
 import type { HtmlProps } from "@vinext/types/next/upstream/dist/shared/lib/html-context.shared-runtime";
-import { safeJsonStringify } from "../server/html";
+import { safeJsonStringify } from "../server/html.js";
 
 const documentAssetMarkerAttributes = {
   headNonce: "data-vinext-head-nonce",

--- a/tests/document.test.ts
+++ b/tests/document.test.ts
@@ -37,6 +37,19 @@ describe("NextScript", () => {
     expect(html).toContain('data-vinext-script-nonce="test-nonce"');
     expect(html).toContain('data-vinext-script-cross-origin="anonymous"');
   });
+
+  it("HTML-escapes getInlineScriptSource output so page data cannot break out of the script tag", () => {
+    // Custom _document implementations embed this string in an inline
+    // <script>; an unescaped "</script>" in page data would end the tag.
+    const source = NextScript.getInlineScriptSource({
+      __NEXT_DATA__: { props: { evil: "</script><script>alert(1)</script>" } },
+    } as unknown as Parameters<typeof NextScript.getInlineScriptSource>[0]);
+    expect(source).not.toContain("</script>");
+    expect(source).toContain("\\u003c/script\\u003e");
+    expect(JSON.parse(source)).toEqual({
+      props: { evil: "</script><script>alert(1)</script>" },
+    });
+  });
 });
 
 describe("Head", () => {

--- a/tests/document.test.ts
+++ b/tests/document.test.ts
@@ -38,17 +38,30 @@ describe("NextScript", () => {
     expect(html).toContain('data-vinext-script-cross-origin="anonymous"');
   });
 
-  it("HTML-escapes getInlineScriptSource output so page data cannot break out of the script tag", () => {
+  // Ported from Next.js: test/unit/htmlescape.test.ts and
+  // packages/next/src/pages/_document.tsx (NextScript.getInlineScriptSource).
+  // https://github.com/vercel/next.js/blob/canary/test/unit/htmlescape.test.ts
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/pages/_document.tsx
+  it("HTML-escapes getInlineScriptSource output and preserves its JSON value", () => {
     // Custom _document implementations embed this string in an inline
     // <script>; an unescaped "</script>" in page data would end the tag.
+    const pageData = {
+      props: {
+        evil: "</script><script>alert(1)</script>",
+        html: "<>&",
+        separators: "\u2028\u2029",
+      },
+    };
     const source = NextScript.getInlineScriptSource({
-      __NEXT_DATA__: { props: { evil: "</script><script>alert(1)</script>" } },
+      __NEXT_DATA__: pageData,
     } as unknown as Parameters<typeof NextScript.getInlineScriptSource>[0]);
+
     expect(source).not.toContain("</script>");
+    expect(source).not.toMatch(/[<>&\u2028\u2029]/u);
     expect(source).toContain("\\u003c/script\\u003e");
-    expect(JSON.parse(source)).toEqual({
-      props: { evil: "</script><script>alert(1)</script>" },
-    });
+    expect(source).toContain("\\u0026");
+    expect(source).toContain("\\u2028\\u2029");
+    expect(JSON.parse(source)).toEqual(pageData);
   });
 });
 


### PR DESCRIPTION
## Problem

`NextScript.getInlineScriptSource()` in the `next/document` shim returned raw `JSON.stringify(context.__NEXT_DATA__)`:

```ts
static getInlineScriptSource(context: Readonly<HtmlProps>): string {
  return JSON.stringify(context.__NEXT_DATA__);
}
```

`JSON.stringify` does not escape characters the HTML parser treats as significant. A string value containing `</script>` terminates the inline script the result is embedded in, and everything after it is parsed as HTML rather than as script content. The same applies to `<`, `>`, `&`, U+2028 and U+2029.

## Why it matters

This method exists so a custom `_document` can place `__NEXT_DATA__` into its own inline `<script>`. Next.js returns `htmlEscapeJsonString(data)` from **every** return path of the equivalent method (`packages/next/src/pages/_document.tsx`), so an app that relied on that escaping silently lost it here — page props or query-derived values become script injection on the app's origin.

The default renderer was never affected: `pages-page-response.ts` already builds its `__NEXT_DATA__` tag with `safeJsonStringify`. Only the custom-`_document` path diverged.

## Fix

Call `safeJsonStringify` — the escaper already used for the framework-generated tag — so both paths emit identical output. `server/html.ts` has no imports, so pulling it into the shim adds no dependency weight.

## Testing

- New test in `tests/document.test.ts` asserts the output contains no literal `</script>`, contains the escaped form, and still round-trips through `JSON.parse` to the original value.
- Verified the test fails against the previous implementation and passes with the fix.
- `tests/document.test.ts` + `tests/safe-json.test.ts`: 45 passing. Repo pre-commit full check, unit/integration suites and knip all passed.

No behavior change for apps using the default document.