### PR TITLE
fix(app-router): keep mounted-slot RSC responses no-store

### DIFF
--- a/packages/vinext/src/server/app-page-cache-finalizer.ts
+++ b/packages/vinext/src/server/app-page-cache-finalizer.ts
@@ -226,10 +226,13 @@ export function finalizeAppPageRscCacheResponse(
   response: Response,
   options: ScheduleAppPageRscCacheWriteOptions,
 ): Response {
-  const didSchedule = scheduleAppPageRscCacheWrite(options);
-  if (!didSchedule) {
-    return response;
-  }
+  // Persisting to the ISR store and finalizing the client-facing headers are
+  // independent decisions. Mounted-slot variants are deliberately never stored
+  // (their RSC key is slot-blind), but a fresh MISS stream can still reach a
+  // dynamic API after the cache policy was chosen, so shared caches must not
+  // keep it either way. Gate on preserveClientResponseHeaders alone, matching
+  // finalizeAppPageHtmlCacheResponse.
+  scheduleAppPageRscCacheWrite(options);
 
   if (options.preserveClientResponseHeaders === true) {
     return response;

--- a/packages/vinext/src/server/app-page-cache-finalizer.ts
+++ b/packages/vinext/src/server/app-page-cache-finalizer.ts
@@ -78,39 +78,49 @@ function applyPendingDynamicCdnHeaders(
   tags?: readonly string[],
   options: { omitCacheState?: boolean } = {},
 ): void {
+  clearSharedCacheOverrides(headers);
   const cacheable = headers.get("Cache-Control") ?? "";
   applyCdnResponseHeaders(headers, { cacheControl: cacheable, pendingDynamicCheck: true, tags });
-  if (options.omitCacheState === true) {
-    headers.delete(VINEXT_CACHE_HEADER);
-    headers.delete(NEXTJS_CACHE_HEADER);
-    return;
-  }
-  setCacheStateHeaders(headers, "MISS");
+  finalizePendingCacheStateHeaders(headers, options);
 }
 
 function applyMountedSlotRscNoStoreHeaders(
   headers: Headers,
   options: { omitCacheState?: boolean } = {},
 ): void {
-  const hadCacheState = headers.has(VINEXT_CACHE_HEADER) || headers.has(NEXTJS_CACHE_HEADER);
   // Mounted-slot RSC payloads deliberately bypass the slot-blind persistent
   // cache. Make that same bypass explicit to every CDN adapter: an edge-managed
   // adapter may intentionally cache pending-dynamic responses, so the generic
   // pendingDynamicCheck signal is not strong enough for this variant.
-  // Middleware owns ordinary response headers, but it must not be able to keep
-  // a provider-specific shared-cache override on a payload whose cache identity
-  // the server deliberately cannot prove. Clear the built-in CDN adapter's
-  // recognized override headers even when another adapter is active. This hard
-  // override is slot-specific because these variants have no persistent
-  // admission path at all; ordinary pending renders are handled by the separate
-  // completion-and-write flow.
+  // Middleware owns ordinary response headers, but provider-specific shared-
+  // cache overrides are cleared before both pending-response adapter calls so
+  // they cannot defeat the adapter's policy. This branch additionally forces
+  // no-store because mounted variants have no persistent admission path at all.
+  clearSharedCacheOverrides(headers);
+  applyCdnResponseHeaders(headers, { cacheControl: NO_STORE_CACHE_CONTROL });
+  // Dynamic and draft responses intentionally have no cache state. Do not
+  // manufacture a MISS solely because the request carried mounted slots.
+  finalizePendingCacheStateHeaders(headers, {
+    ...options,
+    preserveMissingCacheState: true,
+  });
+}
+
+function clearSharedCacheOverrides(headers: Headers): void {
   headers.delete("CDN-Cache-Control");
   headers.delete("Cloudflare-CDN-Cache-Control");
   headers.delete("Cache-Tag");
-  applyCdnResponseHeaders(headers, { cacheControl: NO_STORE_CACHE_CONTROL });
-  if (options.omitCacheState === true || !hadCacheState) {
-    // Dynamic and draft responses intentionally have no cache state. Do not
-    // manufacture a MISS solely because the request carried mounted slots.
+}
+
+function finalizePendingCacheStateHeaders(
+  headers: Headers,
+  options: { omitCacheState?: boolean; preserveMissingCacheState?: boolean } = {},
+): void {
+  const hadCacheState = headers.has(VINEXT_CACHE_HEADER) || headers.has(NEXTJS_CACHE_HEADER);
+  if (
+    options.omitCacheState === true ||
+    (options.preserveMissingCacheState === true && !hadCacheState)
+  ) {
     headers.delete(VINEXT_CACHE_HEADER);
     headers.delete(NEXTJS_CACHE_HEADER);
     return;

--- a/packages/vinext/src/server/app-page-cache-finalizer.ts
+++ b/packages/vinext/src/server/app-page-cache-finalizer.ts
@@ -117,6 +117,8 @@ function finalizePendingCacheStateHeaders(
   options: { omitCacheState?: boolean; preserveMissingCacheState?: boolean } = {},
 ): void {
   const hadCacheState = headers.has(VINEXT_CACHE_HEADER) || headers.has(NEXTJS_CACHE_HEADER);
+  // Either an explicitly omitted provisional state or an intentionally absent
+  // mounted dynamic/draft state must remain headerless.
   if (
     options.omitCacheState === true ||
     (options.preserveMissingCacheState === true && !hadCacheState)

--- a/packages/vinext/src/server/app-page-cache-finalizer.ts
+++ b/packages/vinext/src/server/app-page-cache-finalizer.ts
@@ -97,6 +97,13 @@ function applyMountedSlotRscNoStoreHeaders(
   // cache. Make that same bypass explicit to every CDN adapter: an edge-managed
   // adapter may intentionally cache pending-dynamic responses, so the generic
   // pendingDynamicCheck signal is not strong enough for this variant.
+  // Middleware owns ordinary response headers, but it must not be able to keep
+  // a provider-specific shared-cache override on a payload whose cache identity
+  // the server deliberately cannot prove. Clear the built-in CDN adapter's
+  // recognized override headers even when another adapter is active.
+  headers.delete("CDN-Cache-Control");
+  headers.delete("Cloudflare-CDN-Cache-Control");
+  headers.delete("Cache-Tag");
   applyCdnResponseHeaders(headers, { cacheControl: NO_STORE_CACHE_CONTROL });
   if (options.omitCacheState === true || !hadCacheState) {
     headers.delete(VINEXT_CACHE_HEADER);

--- a/packages/vinext/src/server/app-page-cache-finalizer.ts
+++ b/packages/vinext/src/server/app-page-cache-finalizer.ts
@@ -1,5 +1,5 @@
 import type { AppRscRenderMode } from "./app-rsc-render-mode.js";
-import { applyCdnResponseHeaders } from "./cache-control.js";
+import { applyCdnResponseHeaders, NO_STORE_CACHE_CONTROL } from "./cache-control.js";
 import { setCacheStateHeaders } from "./cache-headers.js";
 import { NEXTJS_CACHE_HEADER, VINEXT_CACHE_HEADER } from "./headers.js";
 import {
@@ -81,6 +81,24 @@ function applyPendingDynamicCdnHeaders(
   const cacheable = headers.get("Cache-Control") ?? "";
   applyCdnResponseHeaders(headers, { cacheControl: cacheable, pendingDynamicCheck: true, tags });
   if (options.omitCacheState === true) {
+    headers.delete(VINEXT_CACHE_HEADER);
+    headers.delete(NEXTJS_CACHE_HEADER);
+    return;
+  }
+  setCacheStateHeaders(headers, "MISS");
+}
+
+function applyMountedSlotRscNoStoreHeaders(
+  headers: Headers,
+  options: { omitCacheState?: boolean } = {},
+): void {
+  const hadCacheState = headers.has(VINEXT_CACHE_HEADER) || headers.has(NEXTJS_CACHE_HEADER);
+  // Mounted-slot RSC payloads deliberately bypass the slot-blind persistent
+  // cache. Make that same bypass explicit to every CDN adapter: an edge-managed
+  // adapter may intentionally cache pending-dynamic responses, so the generic
+  // pendingDynamicCheck signal is not strong enough for this variant.
+  applyCdnResponseHeaders(headers, { cacheControl: NO_STORE_CACHE_CONTROL });
+  if (options.omitCacheState === true || !hadCacheState) {
     headers.delete(VINEXT_CACHE_HEADER);
     headers.delete(NEXTJS_CACHE_HEADER);
     return;
@@ -225,18 +243,25 @@ export function finalizeAppPageRscCacheResponse(
   // independent decisions. Mounted-slot variants are deliberately never stored
   // (their RSC key is slot-blind), but a fresh MISS stream can still reach a
   // dynamic API after the cache policy was chosen, so shared caches must not
-  // keep it either way. Gate on preserveClientResponseHeaders alone, matching
-  // finalizeAppPageHtmlCacheResponse.
+  // keep it either way. An explicit no-store policy is required for mounted
+  // slots because edge-managed adapters may cache pending-dynamic responses.
   scheduleAppPageRscCacheWrite(options);
 
-  if (options.preserveClientResponseHeaders === true) {
+  const isMountedSlotVariant = Boolean(options.mountedSlotsHeader);
+  if (options.preserveClientResponseHeaders === true && !isMountedSlotVariant) {
     return response;
   }
 
   const clientHeaders = new Headers(response.headers);
-  applyPendingDynamicCdnHeaders(clientHeaders, options.getPageTags(), {
-    omitCacheState: options.omitPendingDynamicCacheState === true,
-  });
+  if (isMountedSlotVariant) {
+    applyMountedSlotRscNoStoreHeaders(clientHeaders, {
+      omitCacheState: options.omitPendingDynamicCacheState === true,
+    });
+  } else {
+    applyPendingDynamicCdnHeaders(clientHeaders, options.getPageTags(), {
+      omitCacheState: options.omitPendingDynamicCacheState === true,
+    });
+  }
 
   return new Response(response.body, {
     status: response.status,

--- a/packages/vinext/src/server/app-page-cache-finalizer.ts
+++ b/packages/vinext/src/server/app-page-cache-finalizer.ts
@@ -100,12 +100,17 @@ function applyMountedSlotRscNoStoreHeaders(
   // Middleware owns ordinary response headers, but it must not be able to keep
   // a provider-specific shared-cache override on a payload whose cache identity
   // the server deliberately cannot prove. Clear the built-in CDN adapter's
-  // recognized override headers even when another adapter is active.
+  // recognized override headers even when another adapter is active. This hard
+  // override is slot-specific because these variants have no persistent
+  // admission path at all; ordinary pending renders are handled by the separate
+  // completion-and-write flow.
   headers.delete("CDN-Cache-Control");
   headers.delete("Cloudflare-CDN-Cache-Control");
   headers.delete("Cache-Tag");
   applyCdnResponseHeaders(headers, { cacheControl: NO_STORE_CACHE_CONTROL });
   if (options.omitCacheState === true || !hadCacheState) {
+    // Dynamic and draft responses intentionally have no cache state. Do not
+    // manufacture a MISS solely because the request carried mounted slots.
     headers.delete(VINEXT_CACHE_HEADER);
     headers.delete(NEXTJS_CACHE_HEADER);
     return;

--- a/packages/vinext/src/server/cache-control.ts
+++ b/packages/vinext/src/server/cache-control.ts
@@ -28,8 +28,9 @@ function isSharedCacheControl(cacheControl: string): boolean {
  *
  * We only clear `Cache-Control` — the one header vinext stamps internally — so
  * a stale vinext value never lingers if an adapter chooses not to emit one. The
- * adapter's own headers are applied via `set()`, which overrides any prior value
- * for the same name, so there's no need to pre-clear adapter-specific headers.
+ * adapter's own headers are applied via `set()`, which overrides prior values
+ * for names it emits. Callers that must also discard provider-specific headers
+ * before the adapter recomputes policy clear those explicitly.
  */
 export function applyCdnResponseHeaders(headers: Headers, input: CdnCacheableHeaderInput): void {
   headers.delete("Cache-Control");

--- a/tests/app-page-cache.test.ts
+++ b/tests/app-page-cache.test.ts
@@ -1214,6 +1214,9 @@ describe("app page cache helpers", () => {
         headers: {
           "Content-Type": "text/html; charset=utf-8",
           "Cache-Control": "s-maxage=60, stale-while-revalidate",
+          "Cache-Tag": "/dynamic-html",
+          "CDN-Cache-Control": "public, max-age=60",
+          "Cloudflare-CDN-Cache-Control": "public, max-age=60",
           Vary: "RSC, Accept",
           "X-Vinext-Cache": "MISS",
         },
@@ -1222,6 +1225,9 @@ describe("app page cache helpers", () => {
     );
 
     expect(response.headers.get("Cache-Control")).toBe("no-store, must-revalidate");
+    expect(response.headers.get("CDN-Cache-Control")).toBeNull();
+    expect(response.headers.get("Cloudflare-CDN-Cache-Control")).toBeNull();
+    expect(response.headers.get("Cache-Tag")).toBeNull();
     expect(response.headers.get("X-Vinext-Cache")).toBe("MISS");
     await expect(response.text()).resolves.toBe("<h1>personalized</h1>");
     expect(pendingCacheWrites).toHaveLength(1);

--- a/tests/app-page-cache.test.ts
+++ b/tests/app-page-cache.test.ts
@@ -1316,6 +1316,50 @@ describe("app page cache helpers", () => {
     expect(isrSet).not.toHaveBeenCalled();
   });
 
+  it("marks mounted-slot RSC cache MISS responses no-store without persisting them", async () => {
+    const pendingCacheWrites: Promise<void>[] = [];
+    const isrRscKey = vi.fn();
+    const isrSet = vi.fn();
+
+    const response = finalizeAppPageRscCacheResponse(
+      new Response("flight", {
+        headers: {
+          "Content-Type": "text/x-component",
+          "Cache-Control": "s-maxage=60, stale-while-revalidate",
+          "X-Vinext-Cache": "MISS",
+        },
+      }),
+      {
+        capturedRscDataPromise: Promise.resolve(new TextEncoder().encode("flight").buffer),
+        cleanPathname: "/fresh-rsc",
+        consumeDynamicUsage() {
+          return false;
+        },
+        dynamicUsedDuringBuild: false,
+        getPageTags() {
+          return ["/fresh-rsc"];
+        },
+        isrRscKey,
+        isrSet,
+        mountedSlotsHeader: "slot:auth:/",
+        preserveClientResponseHeaders: false,
+        revalidateSeconds: 60,
+        waitUntil(promise) {
+          pendingCacheWrites.push(promise);
+        },
+      },
+    );
+
+    // The slot variant is never written to the ISR store, but the fresh MISS
+    // still has to leave the origin uncacheable by shared caches.
+    expect(response.headers.get("Cache-Control")).toBe("no-store, must-revalidate");
+    expect(response.headers.get("X-Vinext-Cache")).toBe("MISS");
+    await expect(response.text()).resolves.toBe("flight");
+    expect(pendingCacheWrites).toEqual([]);
+    expect(isrRscKey).not.toHaveBeenCalled();
+    expect(isrSet).not.toHaveBeenCalled();
+  });
+
   it("marks client-facing RSC cache MISS responses no-store until the stream dynamic check finishes", async () => {
     const pendingCacheWrites: Promise<void>[] = [];
     const isrSetCalls: string[] = [];

--- a/tests/cloudflare-cdn-cache.test.ts
+++ b/tests/cloudflare-cdn-cache.test.ts
@@ -16,6 +16,7 @@ import {
   DefaultCdnCacheAdapter,
 } from "../packages/vinext/src/shims/cdn-cache.js";
 import { runWithExecutionContext } from "../packages/vinext/src/shims/request-context.js";
+import { finalizeAppPageRscCacheResponse } from "../packages/vinext/src/server/app-page-cache-finalizer.js";
 
 const CDN_KEY = Symbol.for("vinext.cdnCacheAdapter");
 
@@ -105,6 +106,51 @@ describe("CloudflareCdnCacheAdapter", () => {
       });
     }
   });
+
+  it.each(["MISS", "STATIC"] as const)(
+    "keeps mounted-slot %s RSC responses out of the edge cache",
+    async (cacheState) => {
+      setCdnCacheAdapter(new CloudflareCdnCacheAdapter());
+      const isrSet = vi.fn();
+
+      const response = finalizeAppPageRscCacheResponse(
+        new Response("slot-specific-flight", {
+          headers: {
+            "Cache-Control": "s-maxage=60, stale-while-revalidate",
+            "Cache-Tag": "/dashboard",
+            "CDN-Cache-Control": "public, max-age=60",
+            "Content-Type": "text/x-component",
+            "X-Vinext-Cache": cacheState,
+          },
+        }),
+        {
+          capturedRscDataPromise: Promise.resolve(
+            new TextEncoder().encode("slot-specific-flight").buffer,
+          ),
+          cleanPathname: "/dashboard",
+          consumeDynamicUsage() {
+            return false;
+          },
+          dynamicUsedDuringBuild: false,
+          getPageTags() {
+            return ["/dashboard"];
+          },
+          isrRscKey: vi.fn(),
+          isrSet,
+          mountedSlotsHeader: "slot:auth:/",
+          preserveClientResponseHeaders: cacheState !== "MISS",
+          revalidateSeconds: 60,
+        },
+      );
+
+      expect(response.headers.get("Cache-Control")).toBe("no-store, must-revalidate");
+      expect(response.headers.get("CDN-Cache-Control")).toBeNull();
+      expect(response.headers.get("Cache-Tag")).toBeNull();
+      expect(response.headers.get("X-Vinext-Cache")).toBe("MISS");
+      await expect(response.text()).resolves.toBe("slot-specific-flight");
+      expect(isrSet).not.toHaveBeenCalled();
+    },
+  );
 
   it("revalidateTag purges the Workers Cache by tag via ctx.cache.purge", async () => {
     const purge = vi.fn(async () => {});

--- a/tests/cloudflare-cdn-cache.test.ts
+++ b/tests/cloudflare-cdn-cache.test.ts
@@ -152,6 +152,47 @@ describe("CloudflareCdnCacheAdapter", () => {
     },
   );
 
+  it("clears middleware CDN overrides for mounted slots with the default adapter", async () => {
+    setCdnCacheAdapter(new DefaultCdnCacheAdapter());
+
+    const response = finalizeAppPageRscCacheResponse(
+      new Response("slot-specific-flight", {
+        headers: {
+          "Cache-Control": "s-maxage=60",
+          "Cache-Tag": "/dashboard",
+          "CDN-Cache-Control": "public, max-age=60",
+          "Cloudflare-CDN-Cache-Control": "public, max-age=60",
+          "X-Vinext-Cache": "STATIC",
+        },
+      }),
+      {
+        capturedRscDataPromise: Promise.resolve(
+          new TextEncoder().encode("slot-specific-flight").buffer,
+        ),
+        cleanPathname: "/dashboard",
+        consumeDynamicUsage() {
+          return false;
+        },
+        dynamicUsedDuringBuild: false,
+        getPageTags() {
+          return ["/dashboard"];
+        },
+        isrRscKey: vi.fn(),
+        isrSet: vi.fn(),
+        mountedSlotsHeader: "slot:auth:/",
+        preserveClientResponseHeaders: true,
+        revalidateSeconds: 60,
+      },
+    );
+
+    expect(response.headers.get("Cache-Control")).toBe("no-store, must-revalidate");
+    expect(response.headers.get("CDN-Cache-Control")).toBeNull();
+    expect(response.headers.get("Cloudflare-CDN-Cache-Control")).toBeNull();
+    expect(response.headers.get("Cache-Tag")).toBeNull();
+    expect(response.headers.get("X-Vinext-Cache")).toBe("MISS");
+    await expect(response.text()).resolves.toBe("slot-specific-flight");
+  });
+
   it("revalidateTag purges the Workers Cache by tag via ctx.cache.purge", async () => {
     const purge = vi.fn(async () => {});
     await runWithExecutionContext({ waitUntil() {}, cache: { purge } }, async () => {

--- a/tests/cloudflare-cdn-cache.test.ts
+++ b/tests/cloudflare-cdn-cache.test.ts
@@ -193,6 +193,45 @@ describe("CloudflareCdnCacheAdapter", () => {
     await expect(response.text()).resolves.toBe("slot-specific-flight");
   });
 
+  it("keeps mounted dynamic responses headerless while clearing CDN overrides", async () => {
+    setCdnCacheAdapter(new DefaultCdnCacheAdapter());
+
+    const response = finalizeAppPageRscCacheResponse(
+      new Response("dynamic-slot-flight", {
+        headers: {
+          "Cache-Control": "no-store, must-revalidate",
+          "Cache-Tag": "/dashboard",
+          "CDN-Cache-Control": "public, max-age=60",
+          "Cloudflare-CDN-Cache-Control": "public, max-age=60",
+        },
+      }),
+      {
+        capturedRscDataPromise: null,
+        cleanPathname: "/dashboard",
+        consumeDynamicUsage() {
+          return true;
+        },
+        dynamicUsedDuringBuild: true,
+        getPageTags() {
+          return ["/dashboard"];
+        },
+        isrRscKey: vi.fn(),
+        isrSet: vi.fn(),
+        mountedSlotsHeader: "slot:auth:/",
+        preserveClientResponseHeaders: true,
+        revalidateSeconds: null,
+      },
+    );
+
+    expect(response.headers.get("Cache-Control")).toBe("no-store, must-revalidate");
+    expect(response.headers.get("CDN-Cache-Control")).toBeNull();
+    expect(response.headers.get("Cloudflare-CDN-Cache-Control")).toBeNull();
+    expect(response.headers.get("Cache-Tag")).toBeNull();
+    expect(response.headers.get("X-Vinext-Cache")).toBeNull();
+    expect(response.headers.get("X-Nextjs-Cache")).toBeNull();
+    await expect(response.text()).resolves.toBe("dynamic-slot-flight");
+  });
+
   it("clears middleware CDN overrides for pending dynamic misses", async () => {
     setCdnCacheAdapter(new DefaultCdnCacheAdapter());
 

--- a/tests/cloudflare-cdn-cache.test.ts
+++ b/tests/cloudflare-cdn-cache.test.ts
@@ -193,6 +193,44 @@ describe("CloudflareCdnCacheAdapter", () => {
     await expect(response.text()).resolves.toBe("slot-specific-flight");
   });
 
+  it("clears middleware CDN overrides for pending dynamic misses", async () => {
+    setCdnCacheAdapter(new DefaultCdnCacheAdapter());
+
+    const response = finalizeAppPageRscCacheResponse(
+      new Response("pending-dynamic-flight", {
+        headers: {
+          "Cache-Control": "s-maxage=60",
+          "Cache-Tag": "/dashboard",
+          "CDN-Cache-Control": "public, max-age=60",
+          "Cloudflare-CDN-Cache-Control": "public, max-age=60",
+          "X-Vinext-Cache": "MISS",
+        },
+      }),
+      {
+        capturedRscDataPromise: null,
+        cleanPathname: "/dashboard",
+        consumeDynamicUsage() {
+          return false;
+        },
+        dynamicUsedDuringBuild: false,
+        getPageTags() {
+          return ["/dashboard"];
+        },
+        isrRscKey: vi.fn(),
+        isrSet: vi.fn(),
+        preserveClientResponseHeaders: false,
+        revalidateSeconds: 60,
+      },
+    );
+
+    expect(response.headers.get("Cache-Control")).toBe("no-store, must-revalidate");
+    expect(response.headers.get("CDN-Cache-Control")).toBeNull();
+    expect(response.headers.get("Cloudflare-CDN-Cache-Control")).toBeNull();
+    expect(response.headers.get("Cache-Tag")).toBeNull();
+    expect(response.headers.get("X-Vinext-Cache")).toBe("MISS");
+    await expect(response.text()).resolves.toBe("pending-dynamic-flight");
+  });
+
   it("revalidateTag purges the Workers Cache by tag via ctx.cache.purge", async () => {
     const purge = vi.fn(async () => {});
     await runWithExecutionContext({ waitUntil() {}, cache: { purge } }, async () => {


### PR DESCRIPTION
## What

Mounted-slot RSC variants bypass persistent ISR reads and writes because their payload depends on `X-Vinext-Mounted-Slots` while the persistent RSC key is slot-blind. The response finalizer previously coupled that write decision to client-facing cache headers, allowing those fresh variants to retain shared-cacheable policy.

This change separates the decisions:

- mounted-slot RSC variants are still never persisted under the canonical key;
- every mounted-slot RSC response is explicitly `no-store`, including finite `MISS` and nominally `STATIC` responses;
- pending-response adapter calls clear stale `CDN-Cache-Control`, `Cloudflare-CDN-Cache-Control`, and `Cache-Tag` values before the active adapter recomputes its policy, so middleware cannot defeat a default-adapter `no-store` decision;
- Cloudflare remains free to issue its own edge-cache headers for canonical pending responses, while mounted-slot variants stay hard `no-store`.

Canonical responses retain their separate completion-and-write admission path once the render proves static.

## Why

The server cannot safely reuse or publish a slot-specific Flight payload under a slot-blind cache identity. A suspended component may also access `cookies()` or `headers()` after the initial cache policy is selected. Keeping the response private avoids replaying one slot/auth state to another request.

Provider-specific middleware overrides must not outlive the active adapter policy: under the default adapter, an otherwise `no-store` pending response could still carry a stale shared-cache directive. Clearing those values before adapter application preserves the adapter as the single source of truth.

## Verification

- `tests/app-page-cache.test.ts` verifies mounted-slot responses remain `no-store` without persistent writes and covers pending HTML override removal.
- `tests/cloudflare-cdn-cache.test.ts` covers `MISS`, `STATIC`, and headerless dynamic mounted responses plus middleware-shaped CDN overrides on canonical pending paths.
- 63 focused tests pass.
- Targeted format, lint, and type checks pass.
- Fresh independent nested review is clean.
- [Exact-head CI](https://github.com/cloudflare/vinext/actions/runs/30418159796) is green.
- [Final BigBonk](https://github.com/cloudflare/vinext/actions/runs/30418325094) found no blocking issues and marked the fix ready to land.
- [Next.js deploy suite](https://github.com/cloudflare/vinext/actions/runs/30418493968) was dispatched against the exact final head.