### PR TITLE
fix(pages): refresh next/head tags when regenerating ISR HTML

### DIFF
--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -284,7 +284,7 @@ async function _renderToStringAsync(element) {
   return new Response(stream).text();
 }
 
-async function _renderIsrPassToStringAsync(element) {
+async function _renderIsrPassToStringAsync(element, onHeadReady) {
   // The cache-fill render is a second render pass for the same request.
   // Reset render-scoped state so it cannot leak from the streamed response
   // render or affect async work that is still draining from that stream.
@@ -293,7 +293,17 @@ async function _renderIsrPassToStringAsync(element) {
   return await runWithServerInsertedHTMLState(() =>
     runWithHeadState(() =>
       _runWithCacheState(() =>
-        runWithPrivateCache(() => runWithFetchCache(async () => _renderToStringAsync(element))),
+        runWithPrivateCache(() =>
+          runWithFetchCache(async () => {
+            const html = await _renderToStringAsync(element);
+            // next/head tags are collected as a side effect of the render
+            // above and live in this ALS scope only, so a caller that wants
+            // the regenerated head has to read it here — after the render,
+            // before the scope unwinds.
+            await onHeadReady?.();
+            return html;
+          }),
+        ),
       ),
     ),
   );

--- a/packages/vinext/src/server/document-initial-head.ts
+++ b/packages/vinext/src/server/document-initial-head.ts
@@ -44,23 +44,34 @@ type DocumentLike = {
   getInitialProps?: (ctx: DocumentContext) => Promise<{ head?: unknown } | undefined>;
 };
 
+/**
+ * True when `_document` supplies its own `getInitialProps`, rather than
+ * exposing none or inheriting the shim's default. Comparing against the
+ * captured `DEFAULT_GET_INITIAL_PROPS` reference is what distinguishes a user
+ * override from the default — extending the shim's `Document` without
+ * overriding inherits the same static function.
+ *
+ * Callers use this to decide whether the render pipeline owes `_document` the
+ * full `getInitialProps` contract, since only an override can observe it.
+ */
+export function hasUserDocumentGetInitialProps(
+  DocumentComponent: React.ComponentType | null | undefined,
+): boolean {
+  if (!DocumentComponent) return false;
+  const getInitialProps = (DocumentComponent as unknown as DocumentLike).getInitialProps;
+  return typeof getInitialProps === "function" && getInitialProps !== DEFAULT_GET_INITIAL_PROPS;
+}
+
 export async function callDocumentGetInitialProps(
   DocumentComponent: React.ComponentType | null | undefined,
   setDocumentInitialHead: ((head: React.ReactNode[]) => void) | undefined,
 ): Promise<void> {
   if (!DocumentComponent || !setDocumentInitialHead) return;
 
-  const DocCtor = DocumentComponent as unknown as DocumentLike;
-  const getInitialProps = DocCtor.getInitialProps;
-
-  // Skip when the component does not expose `getInitialProps` at all, or
-  // when it still resolves to the default inherited from vinext's shim.
-  // Comparing against the captured `DEFAULT_GET_INITIAL_PROPS` reference is
-  // what distinguishes a user override from the default — extending the
-  // shim's `Document` without overriding inherits the same static function.
-  if (typeof getInitialProps !== "function" || getInitialProps === DEFAULT_GET_INITIAL_PROPS) {
-    return;
-  }
+  // Nothing to merge when the user did not override the shim's default, which
+  // always resolves `head` to `undefined`.
+  const getInitialProps = (DocumentComponent as unknown as DocumentLike).getInitialProps;
+  if (!getInitialProps || !hasUserDocumentGetInitialProps(DocumentComponent)) return;
 
   try {
     const context = {

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -225,7 +225,7 @@ export type PagesPageModule = {
 type RenderPagesIsrHtmlOptions = {
   buildId: string | null;
   cachedHtml: string;
-  collectIsrHeadHTML?: (() => Promise<string>) | undefined;
+  collectIsrHeadHTML?: (() => string) | undefined;
   createPageElement: (props: Record<string, unknown>) => ReactNode;
   i18n: PagesI18nRenderContext;
   pageProps: Record<string, unknown>;
@@ -347,7 +347,7 @@ export type ResolvePagesPageDataOptions = {
    * inside that render's head scope so the regenerated shell can pick up
    * `next/head` output derived from the refreshed `getStaticProps` data.
    */
-  collectIsrHeadHTML?: (() => Promise<string>) | undefined;
+  collectIsrHeadHTML?: (() => string) | undefined;
   vinext?: VinextNextData["__vinext"];
   nextData?: PagesNextDataExtras;
   /**
@@ -1012,6 +1012,14 @@ const SSR_HEAD_TAG_PATTERN =
   /<(title|meta|link|style|script|base|noscript)\b[^>]*?\sdata-next-head=""[^>]*?(?:\/>|>[\s\S]*?<\/\1>)/g;
 
 /**
+ * Matches a whole `<script>`/`<style>` element. Their bodies are raw text, so
+ * markup-looking strings inside them are not markup — and `headChildToHTML()`
+ * only escapes `</script`/`</style`, so an inline script from `next/head` may
+ * legitimately carry a literal `</head>`.
+ */
+const RAW_TEXT_ELEMENT_PATTERN = /<(script|style)\b[^>]*>[\s\S]*?<\/\1>/gi;
+
+/**
  * Replace the `next/head` region of a cached shell with a freshly collected
  * one.
  *
@@ -1036,7 +1044,14 @@ function refreshCachedHeadTags(cachedHtml: string, freshHead: string): string {
   // cached head alone rather than deleting the tags we do have.
   if (!freshHead) return cachedHtml;
 
-  const headEnd = cachedHtml.indexOf("</head>");
+  // Blank out raw-text bodies before locating the boundary so a `</head>`
+  // string inside an inline script is not mistaken for the closing tag —
+  // that would truncate the scan and leave stale tags behind the fresh head.
+  // The replacement is length-preserving, so the index still maps onto
+  // `cachedHtml`.
+  const headEnd = cachedHtml
+    .replace(RAW_TEXT_ELEMENT_PATTERN, (element) => " ".repeat(element.length))
+    .indexOf("</head>");
   if (headEnd < 0) return cachedHtml;
 
   const matches = [...cachedHtml.slice(0, headEnd).matchAll(SSR_HEAD_TAG_PATTERN)];
@@ -1092,7 +1107,7 @@ export async function renderPagesIsrHtml(options: RenderPagesIsrHtmlOptions): Pr
     options.createPageElement(renderProps),
     collectHead &&
       (async () => {
-        freshHead = await collectHead();
+        freshHead = collectHead();
       }),
   );
   const nextDataScript = buildPagesNextDataScript({

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -1015,12 +1015,14 @@ const SSR_HEAD_TAG_PATTERN =
   /<(title|meta|link|style|script|base|noscript)\b[^>]*?\sdata-next-head=""[^>]*?(?:\/>|>[\s\S]*?<\/\1>)/g;
 
 /**
- * Matches a whole `<script>`/`<style>` element. Their bodies are raw text, so
- * markup-looking strings inside them are not markup — and `headChildToHTML()`
- * only escapes `</script`/`</style`, so an inline script from `next/head` may
- * legitimately carry a literal `</head>`.
+ * Matches a whole head element whose body may contain markup-looking text.
+ * Script/style are raw-text elements, title is RCDATA, and noscript is raw
+ * text while scripting is enabled. In all four, a literal `</head>` does not
+ * close the document head. `headChildToHTML()` only escapes the element's own
+ * closing sequence for script/style, while `dangerouslySetInnerHTML` may leave
+ * `</head>` intact in any of them.
  */
-const RAW_TEXT_ELEMENT_PATTERN = /<(script|style)\b[^>]*>[\s\S]*?<\/\1>/gi;
+const HEAD_TEXT_ELEMENT_PATTERN = /<(script|style|title|noscript)\b[^>]*>[\s\S]*?<\/\1>/gi;
 
 /**
  * Replace the `next/head` region of a cached shell with a freshly collected
@@ -1047,13 +1049,13 @@ function refreshCachedHeadTags(cachedHtml: string, freshHead: string): string {
   // cached head alone rather than deleting the tags we do have.
   if (!freshHead) return cachedHtml;
 
-  // Blank out raw-text bodies before locating the boundary so a `</head>`
-  // string inside an inline script is not mistaken for the closing tag —
-  // that would truncate the scan and leave stale tags behind the fresh head.
-  // The replacement is length-preserving, so the index still maps onto
+  // Blank out raw-text/RCDATA elements before locating the boundary so a
+  // `</head>` string inside one is not mistaken for the closing tag — that
+  // would truncate the scan and leave stale tags behind the fresh head. The
+  // replacement is length-preserving, so the index still maps onto
   // `cachedHtml`.
   const headEnd = cachedHtml
-    .replace(RAW_TEXT_ELEMENT_PATTERN, (element) => " ".repeat(element.length))
+    .replace(HEAD_TEXT_ELEMENT_PATTERN, (element) => " ".repeat(element.length))
     .indexOf("</head>");
   if (headEnd < 0) return cachedHtml;
 

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -225,12 +225,16 @@ export type PagesPageModule = {
 type RenderPagesIsrHtmlOptions = {
   buildId: string | null;
   cachedHtml: string;
+  collectIsrHeadHTML?: (() => Promise<string>) | undefined;
   createPageElement: (props: Record<string, unknown>) => ReactNode;
   i18n: PagesI18nRenderContext;
   pageProps: Record<string, unknown>;
   props?: Record<string, unknown>;
   params: Record<string, unknown>;
-  renderIsrPassToStringAsync: (element: ReactNode) => Promise<string>;
+  renderIsrPassToStringAsync: (
+    element: ReactNode,
+    onHeadReady?: () => Promise<void>,
+  ) => Promise<string>;
   routePattern: string;
   safeJsonStringify: (value: unknown) => string;
   vinext?: VinextNextData["__vinext"];
@@ -334,7 +338,16 @@ export type ResolvePagesPageDataOptions = {
     renderFn: () => Promise<void>,
     errorContext?: { routerKind: "Pages Router"; routePath: string; routeType: "render" },
   ) => void;
-  renderIsrPassToStringAsync: (element: ReactNode) => Promise<string>;
+  renderIsrPassToStringAsync: (
+    element: ReactNode,
+    onHeadReady?: () => Promise<void>,
+  ) => Promise<string>;
+  /**
+   * Serializes the `<head>` collected by an ISR regeneration render. Called
+   * inside that render's head scope so the regenerated shell can pick up
+   * `next/head` output derived from the refreshed `getStaticProps` data.
+   */
+  collectIsrHeadHTML?: (() => Promise<string>) | undefined;
   vinext?: VinextNextData["__vinext"];
   nextData?: PagesNextDataExtras;
   /**
@@ -985,6 +998,59 @@ function applyBotETagAndCheck(
   return null;
 }
 
+/**
+ * Matches one serialized `next/head` tag. `getSSRHeadHTML()` stamps every tag
+ * it emits with `data-next-head=""` (see `shims/head.ts`), which is the same
+ * marker Next.js uses to reconcile the head on the client — so it is a stable
+ * anchor for finding the collector's output inside an already-rendered shell.
+ *
+ * Raw-content tags are safe to match non-greedily: `headChildToHTML()` escapes
+ * closing-tag sequences in `<style>`/`<script>` bodies, so the first `</style>`
+ * encountered is always the real terminator.
+ */
+const SSR_HEAD_TAG_PATTERN =
+  /<(title|meta|link|style|script|base|noscript)\b[^>]*?\sdata-next-head=""[^>]*?(?:\/>|>[\s\S]*?<\/\1>)/g;
+
+/**
+ * Replace the `next/head` region of a cached shell with a freshly collected
+ * one.
+ *
+ * ISR regeneration re-renders the page body but reuses the cached shell, so
+ * without this the `<head>` stays frozen at whatever the first cache-filling
+ * render produced — a page whose `<title>`/meta derive from `getStaticProps`
+ * data would serve an updated body under permanently stale metadata.
+ *
+ * The collector emits its tags as one contiguous run (`ssrHeadHTML` is
+ * concatenated ahead of trace meta and `_document` styles in
+ * `buildPagesShellHtml`), so replacing first-match-start through
+ * last-match-end swaps exactly that run and leaves `_document`-owned head
+ * markup either side of it untouched.
+ *
+ * Only the `next/head` run refreshes. `_document`-rendered head children and
+ * CSS-in-JS `styles` still come from the cached shell, because regeneration
+ * never re-renders `_document` — refreshing those means running the full
+ * document pipeline on regeneration the way Next.js does.
+ */
+function refreshCachedHeadTags(cachedHtml: string, freshHead: string): string {
+  // An empty collection means the render produced no head at all; leave the
+  // cached head alone rather than deleting the tags we do have.
+  if (!freshHead) return cachedHtml;
+
+  const headEnd = cachedHtml.indexOf("</head>");
+  if (headEnd < 0) return cachedHtml;
+
+  const matches = [...cachedHtml.slice(0, headEnd).matchAll(SSR_HEAD_TAG_PATTERN)];
+  const first = matches[0];
+  const last = matches[matches.length - 1];
+  if (!first || !last || first.index === undefined || last.index === undefined) {
+    return cachedHtml;
+  }
+
+  return (
+    cachedHtml.slice(0, first.index) + freshHead + cachedHtml.slice(last.index + last[0].length)
+  );
+}
+
 function rewritePagesCachedHtml(
   cachedHtml: string,
   freshBody: string,
@@ -1020,8 +1086,14 @@ function rewritePagesCachedHtml(
 
 export async function renderPagesIsrHtml(options: RenderPagesIsrHtmlOptions): Promise<string> {
   const renderProps = options.props ?? { pageProps: options.pageProps };
+  const collectHead = options.collectIsrHeadHTML;
+  let freshHead = "";
   const freshBody = await options.renderIsrPassToStringAsync(
     options.createPageElement(renderProps),
+    collectHead &&
+      (async () => {
+        freshHead = await collectHead();
+      }),
   );
   const nextDataScript = buildPagesNextDataScript({
     buildId: options.buildId,
@@ -1038,7 +1110,11 @@ export async function renderPagesIsrHtml(options: RenderPagesIsrHtmlOptions): Pr
     vinext: options.vinext,
   });
 
-  return rewritePagesCachedHtml(options.cachedHtml, freshBody, nextDataScript);
+  return rewritePagesCachedHtml(
+    refreshCachedHeadTags(options.cachedHtml, freshHead),
+    freshBody,
+    nextDataScript,
+  );
 }
 
 export async function resolvePagesPageData(
@@ -1331,6 +1407,7 @@ export async function resolvePagesPageData(
                 props: freshRenderProps,
                 params: options.params,
                 renderIsrPassToStringAsync: options.renderIsrPassToStringAsync,
+                collectIsrHeadHTML: options.collectIsrHeadHTML,
                 routePattern: options.routePattern,
                 safeJsonStringify: options.safeJsonStringify,
                 nextData: options.nextData,

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -23,6 +23,7 @@ import {
   PAGES_PREVIEW_CACHE_CONTROL,
   type PagesPreviewState,
 } from "./pages-preview.js";
+import { callDocumentGetInitialProps } from "./document-initial-head.js";
 import { resolvePagesPageData } from "./pages-page-data.js";
 import type { PagesPageModule } from "./pages-page-data.js";
 import { resolvePagesPageMethodResponse } from "./pages-page-method.js";
@@ -270,8 +271,15 @@ export type CreatePagesPageHandlerOptions = {
   getFontPreloads: () => Array<{ href: string; type: string }>;
   /** `renderToReadableStream` from `react-dom/server.edge`. */
   renderToReadableStream: (element: ReactNode) => Promise<ReadableStream<Uint8Array>>;
-  /** Render a second ISR pass to a string (wraps renderToReadableStream). */
-  renderIsrPassToStringAsync: (element: ReactNode) => Promise<string>;
+  /**
+   * Render a second ISR pass to a string (wraps renderToReadableStream).
+   * `onHeadReady` runs inside the pass's head scope, after the render and
+   * before the scope unwinds, so callers can read the collected `<head>`.
+   */
+  renderIsrPassToStringAsync: (
+    element: ReactNode,
+    onHeadReady?: () => Promise<void>,
+  ) => Promise<string>;
   /** `safeJsonStringify` from `vinext/html`. */
   safeJsonStringify: (value: unknown) => string;
   /** `sanitizeDestination` from the config-matchers module. */
@@ -824,6 +832,17 @@ export function createPagesPageHandler(
           asPath: routerAsPath,
           resolvedUrl: pagesResolvedUrl,
           renderIsrPassToStringAsync,
+          // Regeneration re-renders the page but reuses the cached shell, so
+          // the refreshed `next/head` output has to be read out of the render
+          // pass explicitly. `_document.getInitialProps` runs here too because
+          // its `head` tags share the same collector — omitting it would drop
+          // them from the regenerated shell.
+          collectIsrHeadHTML: getSSRHeadHTML
+            ? async () => {
+                await callDocumentGetInitialProps(DocumentComponent, setDocumentInitialHead);
+                return getSSRHeadHTML();
+              }
+            : undefined,
           route: { isDynamic: route.isDynamic },
           routePattern,
           routeUrl: renderRouteUrl,

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -23,7 +23,7 @@ import {
   PAGES_PREVIEW_CACHE_CONTROL,
   type PagesPreviewState,
 } from "./pages-preview.js";
-import { callDocumentGetInitialProps } from "./document-initial-head.js";
+import { hasUserDocumentGetInitialProps } from "./document-initial-head.js";
 import { resolvePagesPageData } from "./pages-page-data.js";
 import type { PagesPageModule } from "./pages-page-data.js";
 import { resolvePagesPageMethodResponse } from "./pages-page-method.js";
@@ -834,15 +834,19 @@ export function createPagesPageHandler(
           renderIsrPassToStringAsync,
           // Regeneration re-renders the page but reuses the cached shell, so
           // the refreshed `next/head` output has to be read out of the render
-          // pass explicitly. `_document.getInitialProps` runs here too because
-          // its `head` tags share the same collector — omitting it would drop
-          // them from the regenerated shell.
-          collectIsrHeadHTML: getSSRHeadHTML
-            ? async () => {
-                await callDocumentGetInitialProps(DocumentComponent, setDocumentInitialHead);
-                return getSSRHeadHTML();
-              }
-            : undefined,
+          // pass explicitly.
+          //
+          // Skipped when `_document` overrides `getInitialProps`: those apps
+          // resolve their head through `runDocumentRenderPage`, which supplies
+          // a real `renderPage` plus the request context (`req`/`res`/
+          // pathname/query/asPath) that regeneration cannot reproduce without
+          // running the whole document pipeline again. Collecting a head
+          // without them would swap a complete cached head for a degraded one,
+          // so those entries keep serving the cached head as before.
+          collectIsrHeadHTML:
+            getSSRHeadHTML && !hasUserDocumentGetInitialProps(DocumentComponent)
+              ? getSSRHeadHTML
+              : undefined,
           route: { isDynamic: route.isDynamic },
           routePattern,
           routeUrl: renderRouteUrl,

--- a/tests/fixtures/pages-basic/pages/isr-second-render-state.tsx
+++ b/tests/fixtures/pages-basic/pages/isr-second-render-state.tsx
@@ -21,7 +21,7 @@ export default function ISRSecondRenderStatePage({ timestamp }: ISRSecondRenderS
   return (
     <>
       <Head>
-        <title>ISR Second Render State</title>
+        <title>ISR Second Render State {timestamp}</title>
       </Head>
       <h1>ISR Second Render State</h1>
       <p data-testid="head-before">{headBefore}</p>

--- a/tests/pages-page-data.test.ts
+++ b/tests/pages-page-data.test.ts
@@ -158,6 +158,78 @@ describe("pages page data", () => {
     expect(html).toContain('"__vinext":{"hasMiddleware":true}');
   });
 
+  it("refreshes next/head tags in the regenerated shell without disturbing document markup", async () => {
+    // The collector only yields tags once the page has rendered, so the
+    // regenerated head must come from the callback the render pass invokes
+    // rather than from anything captured beforehand.
+    const collectIsrHeadHTML = vi.fn(async () => '<title data-next-head="">fresh</title>');
+
+    const html = await renderPagesIsrHtml({
+      buildId: "build-123",
+      cachedHtml:
+        '<!DOCTYPE html><html><head><meta charSet="utf-8" data-next-head="" /><title data-next-head="">stale</title><style data-vinext-doc="">.a{}</style></head><body><div id="__next"><div>stale-body</div></div><script>window.__NEXT_DATA__ = {"old":1}</script></body></html>',
+      collectIsrHeadHTML,
+      createPageElement(_pageProps: Record<string, unknown>) {
+        return "page";
+      },
+      i18n: {
+        locale: "en",
+        locales: ["en"],
+        defaultLocale: "en",
+        domainLocales: [],
+      },
+      pageProps: { title: "fresh" },
+      params: { slug: "post" },
+      renderIsrPassToStringAsync: vi.fn(async (_element, onHeadReady) => {
+        await onHeadReady?.();
+        return "<div>fresh-body</div>";
+      }),
+      routePattern: "/posts/[slug]",
+      safeJsonStringify(value: unknown) {
+        return JSON.stringify(value);
+      },
+    });
+
+    expect(collectIsrHeadHTML).toHaveBeenCalled();
+    expect(html).toContain('<title data-next-head="">fresh</title>');
+    expect(html).not.toContain("stale");
+    // Head markup outside the collector's run belongs to _document and is not
+    // regenerated, so the swap must leave it in place.
+    expect(html).toContain('<style data-vinext-doc="">.a{}</style>');
+    expect(html).toContain("<div>fresh-body</div>");
+  });
+
+  it("leaves the cached head alone when the regeneration collects no head", async () => {
+    const cachedHead = '<title data-next-head="">cached</title>';
+    const html = await renderPagesIsrHtml({
+      buildId: "build-123",
+      cachedHtml: `<!DOCTYPE html><html><head>${cachedHead}</head><body><div id="__next"><div>stale-body</div></div><script>window.__NEXT_DATA__ = {"old":1}</script></body></html>`,
+      collectIsrHeadHTML: vi.fn(async () => ""),
+      createPageElement(_pageProps: Record<string, unknown>) {
+        return "page";
+      },
+      i18n: {
+        locale: "en",
+        locales: ["en"],
+        defaultLocale: "en",
+        domainLocales: [],
+      },
+      pageProps: {},
+      params: {},
+      renderIsrPassToStringAsync: vi.fn(async (_element, onHeadReady) => {
+        await onHeadReady?.();
+        return "<div>fresh-body</div>";
+      }),
+      routePattern: "/posts/[slug]",
+      safeJsonStringify(value: unknown) {
+        return JSON.stringify(value);
+      },
+    });
+
+    expect(html).toContain(cachedHead);
+    expect(html).toContain("<div>fresh-body</div>");
+  });
+
   it("preserves custom app props in fallback shells", async () => {
     const AppComponent = Object.assign(function App() {}, {
       getInitialProps() {

--- a/tests/pages-page-data.test.ts
+++ b/tests/pages-page-data.test.ts
@@ -162,7 +162,7 @@ describe("pages page data", () => {
     // The collector only yields tags once the page has rendered, so the
     // regenerated head must come from the callback the render pass invokes
     // rather than from anything captured beforehand.
-    const collectIsrHeadHTML = vi.fn(async () => '<title data-next-head="">fresh</title>');
+    const collectIsrHeadHTML = vi.fn(() => '<title data-next-head="">fresh</title>');
 
     const html = await renderPagesIsrHtml({
       buildId: "build-123",
@@ -204,7 +204,7 @@ describe("pages page data", () => {
     const html = await renderPagesIsrHtml({
       buildId: "build-123",
       cachedHtml: `<!DOCTYPE html><html><head>${cachedHead}</head><body><div id="__next"><div>stale-body</div></div><script>window.__NEXT_DATA__ = {"old":1}</script></body></html>`,
-      collectIsrHeadHTML: vi.fn(async () => ""),
+      collectIsrHeadHTML: vi.fn(() => ""),
       createPageElement(_pageProps: Record<string, unknown>) {
         return "page";
       },
@@ -228,6 +228,41 @@ describe("pages page data", () => {
 
     expect(html).toContain(cachedHead);
     expect(html).toContain("<div>fresh-body</div>");
+  });
+
+  it("swaps the whole head run when an inline script body contains a literal </head>", async () => {
+    // A `<script>` body is raw text, and the head serializer only escapes
+    // `</script` — so this string is legal page content, not the closing head
+    // tag. Reading it as markup would end the scan early and leave every tag
+    // after it stale while the fresh head was inserted before it.
+    const inlineScript = '<script data-next-head="">var marker = "</head>";</script>';
+    const html = await renderPagesIsrHtml({
+      buildId: "build-123",
+      cachedHtml:
+        `<!DOCTYPE html><html><head>${inlineScript}<title data-next-head="">stale</title></head>` +
+        `<body><div id="__next"><div>stale-body</div></div><script>window.__NEXT_DATA__ = {"old":1}</script></body></html>`,
+      collectIsrHeadHTML: vi.fn(() => '<title data-next-head="">fresh</title>'),
+      createPageElement(_pageProps: Record<string, unknown>) {
+        return "page";
+      },
+      i18n: { locale: "en", locales: ["en"], defaultLocale: "en", domainLocales: [] },
+      pageProps: {},
+      params: {},
+      renderIsrPassToStringAsync: vi.fn(async (_element, onHeadReady) => {
+        await onHeadReady?.();
+        return "<div>fresh-body</div>";
+      }),
+      routePattern: "/posts/[slug]",
+      safeJsonStringify(value: unknown) {
+        return JSON.stringify(value);
+      },
+    });
+
+    expect(html).toContain('<title data-next-head="">fresh</title>');
+    expect(html).not.toContain("stale");
+    // The stale script belongs to the same collector run, so the swap replaces
+    // it rather than leaving a duplicate behind the fresh head.
+    expect(html).not.toContain("var marker");
   });
 
   it("preserves custom app props in fallback shells", async () => {

--- a/tests/pages-page-data.test.ts
+++ b/tests/pages-page-data.test.ts
@@ -265,6 +265,40 @@ describe("pages page data", () => {
     expect(html).not.toContain("var marker");
   });
 
+  it("swaps the whole head run when title RCDATA contains a literal </head>", async () => {
+    // `title` is an RCDATA element: only its own `</title>` end tag closes it,
+    // so `</head>` here is text rather than the document-head boundary.
+    const titleWithMarkupText =
+      '<title data-next-head="">stale prefix </head> stale suffix</title>';
+    const html = await renderPagesIsrHtml({
+      buildId: "build-123",
+      cachedHtml:
+        '<!DOCTYPE html><html><head><meta charset="utf-8" data-next-head="" />' +
+        `${titleWithMarkupText}</head>` +
+        '<body><div id="__next"><div>stale-body</div></div>' +
+        '<script>window.__NEXT_DATA__ = {"old":1}</script></body></html>',
+      collectIsrHeadHTML: vi.fn(() => '<title data-next-head="">fresh</title>'),
+      createPageElement(_pageProps: Record<string, unknown>) {
+        return "page";
+      },
+      i18n: { locale: "en", locales: ["en"], defaultLocale: "en", domainLocales: [] },
+      pageProps: {},
+      params: {},
+      renderIsrPassToStringAsync: vi.fn(async (_element, onHeadReady) => {
+        await onHeadReady?.();
+        return "<div>fresh-body</div>";
+      }),
+      routePattern: "/posts/[slug]",
+      safeJsonStringify(value: unknown) {
+        return JSON.stringify(value);
+      },
+    });
+
+    expect(html).toContain('<title data-next-head="">fresh</title>');
+    expect(html).not.toContain("stale prefix");
+    expect(html.match(/<title data-next-head="">/g)).toHaveLength(1);
+  });
+
   it("preserves custom app props in fallback shells", async () => {
     const AppComponent = Object.assign(function App() {}, {
       getInitialProps() {

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -6212,6 +6212,11 @@ export default function CounterPage() {
       expect(isrFirstHtml).toContain('data-testid="head-before">0<');
       expect(isrFirstHtml).toContain('data-testid="private-cache-before">0<');
       expect(isrFirstHtml).toContain('data-testid="inserted-html-before">0<');
+      const firstTimestamp = isrFirstHtml.match(/data-testid="timestamp">(\d+)</)?.[1];
+      expect(firstTimestamp).toBeDefined();
+      expect(isrFirstHtml).toContain(
+        `<title data-next-head="">ISR Second Render State ${firstTimestamp}</title>`,
+      );
 
       const isrSecondRes = await fetch(`${prodUrl}/isr-second-render-state`);
       expect(isrSecondRes.status).toBe(200);
@@ -6220,6 +6225,27 @@ export default function CounterPage() {
       expect(isrSecondHtml).toContain('data-testid="head-before">0<');
       expect(isrSecondHtml).toContain('data-testid="private-cache-before">0<');
       expect(isrSecondHtml).toContain('data-testid="inserted-html-before">0<');
+
+      // Ported from Next.js's full-render ISR contract: a regeneration reruns
+      // the complete Pages render, so metadata derived from getStaticProps
+      // must advance with the body rather than remaining in the cached shell.
+      // Next.js source: packages/next/src/server/render.tsx
+      const revalidateRes = await fetch(
+        `${prodUrl}/api/revalidate-reason?path=${encodeURIComponent("/isr-second-render-state")}`,
+      );
+      expect(revalidateRes.status).toBe(200);
+      expect(await revalidateRes.json()).toEqual({ revalidated: true });
+
+      const isrRegeneratedRes = await fetch(`${prodUrl}/isr-second-render-state`);
+      expect(isrRegeneratedRes.status).toBe(200);
+      expect(isrRegeneratedRes.headers.get("x-vinext-cache")).toBe("HIT");
+      const isrRegeneratedHtml = await isrRegeneratedRes.text();
+      const regeneratedTimestamp = isrRegeneratedHtml.match(/data-testid="timestamp">(\d+)</)?.[1];
+      expect(regeneratedTimestamp).toBeDefined();
+      expect(regeneratedTimestamp).not.toBe(firstTimestamp);
+      expect(isrRegeneratedHtml).toContain(
+        `<title data-next-head="">ISR Second Render State ${regeneratedTimestamp}</title>`,
+      );
 
       // Test: SSR page with getServerSideProps
       const ssrRes = await fetch(`${prodUrl}/ssr`);

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -6226,21 +6226,31 @@ export default function CounterPage() {
       expect(isrSecondHtml).toContain('data-testid="private-cache-before">0<');
       expect(isrSecondHtml).toContain('data-testid="inserted-html-before">0<');
 
-      // Ported from Next.js's full-render ISR contract: a regeneration reruns
-      // the complete Pages render, so metadata derived from getStaticProps
-      // must advance with the body rather than remaining in the cached shell.
-      // Next.js source: packages/next/src/server/render.tsx
-      const revalidateRes = await fetch(
-        `${prodUrl}/api/revalidate-reason?path=${encodeURIComponent("/isr-second-render-state")}`,
-      );
-      expect(revalidateRes.status).toBe(200);
-      expect(await revalidateRes.json()).toEqual({ revalidated: true });
+      // Next.js regenerates stale Pages entries with a full render, so
+      // metadata derived from getStaticProps must advance with the body rather
+      // than remaining in the cached shell. Exercise vinext's natural stale
+      // background path here: on-demand revalidation uses a different
+      // foreground-render path and would not cover renderPagesIsrHtml().
+      await new Promise((resolve) => setTimeout(resolve, 1_100));
+      const staleRes = await fetch(`${prodUrl}/isr-second-render-state`);
+      expect(staleRes.status).toBe(200);
+      expect(staleRes.headers.get("x-vinext-cache")).toBe("STALE");
+      expect(await staleRes.text()).toContain(`data-testid="timestamp">${firstTimestamp}<`);
 
-      const isrRegeneratedRes = await fetch(`${prodUrl}/isr-second-render-state`);
-      expect(isrRegeneratedRes.status).toBe(200);
-      expect(isrRegeneratedRes.headers.get("x-vinext-cache")).toBe("HIT");
-      const isrRegeneratedHtml = await isrRegeneratedRes.text();
-      const regeneratedTimestamp = isrRegeneratedHtml.match(/data-testid="timestamp">(\d+)</)?.[1];
+      let regeneratedTimestamp: string | undefined;
+      let isrRegeneratedHtml = "";
+      for (let attempt = 0; attempt < 40; attempt++) {
+        const regeneratedRes = await fetch(`${prodUrl}/isr-second-render-state`);
+        isrRegeneratedHtml = await regeneratedRes.text();
+        regeneratedTimestamp = isrRegeneratedHtml.match(/data-testid="timestamp">(\d+)</)?.[1];
+        if (
+          regeneratedRes.headers.get("x-vinext-cache") === "HIT" &&
+          regeneratedTimestamp !== firstTimestamp
+        ) {
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
       expect(regeneratedTimestamp).toBeDefined();
       expect(regeneratedTimestamp).not.toBe(firstTimestamp);
       expect(isrRegeneratedHtml).toContain(


### PR DESCRIPTION
## Overview

| | |
| --- | --- |
| Goal | Keep `next/head` output in sync with the data an ISR regeneration renders |
| Core change | Read the regenerated head inside the ISR render pass and swap it into the cached shell |
| Key boundary | `next/head` tags only; `_document`-owned shell markup stays cached |
| Expected impact | ISR pages with data-derived `<title>`/meta stop serving permanently stale metadata |

## Why

ISR regeneration re-renders the page body but reuses the cached shell verbatim. `renderPagesIsrHtml()` rewrites the body region and the `__NEXT_DATA__` script, and everything before `<div id="__next">` (the entire `<head>`) is carried over from the previously cached HTML.

That freezes the head at whatever the first cache-filling render produced. For a page whose metadata derives from `getStaticProps`:

```jsx
export async function getStaticProps() { /* ... revalidate: 60 */ }

export default function Product({ product }) {
  return (
    <>
      <Head><title>{product.name}</title></Head>
      <h1>{product.name}</h1>
    </>
  )
}
```

renaming the product updates the `<h1>` on the next revalidation but not the `<title>`. Body and metadata drift apart and never reconverge for the lifetime of the entry. Next.js re-runs the whole render, including the document, on every background revalidate, so the head rotates with the data there.

The reason the head was dropped rather than deliberately excluded: `next/head` tags are not returned by the render, they accumulate as a side effect of it into an AsyncLocalStorage scope (`runWithHeadState`) that closes when the pass returns. By the time `renderPagesIsrHtml()` has the fresh body string, the collected head is already out of reach. Reading it requires a hook inside the pass.

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| ISR regeneration, page with data-derived `next/head` tags | Head frozen at first cache-fill render | Head reflects the regenerated data |
| ISR regeneration, app whose `_document` overrides `getInitialProps` | Head frozen at first cache-fill render | Unchanged — refresh deliberately skipped, see below |
| ISR regeneration, `_document`-rendered head children / CSS-in-JS `styles` | From cached shell | Unchanged, still from cached shell |
| Regeneration collecting an empty head | n/a | Cached head left intact rather than emptied |
| Cache entries written before this change | n/a | Refreshed normally; the anchor attribute already exists in them |
| Foreground render, non-ISR paths | Unchanged | Unchanged |

The collector's tags are located in the cached shell via the `data-next-head` attribute that `getSSRHeadHTML()` stamps on everything it emits, which is also what Next.js uses to reconcile the head on the client. Because `ssrHeadHTML` is concatenated ahead of trace meta and `_document` styles in `buildPagesShellHtml()`, the tags form one contiguous run, and replacing first-match-start through last-match-end swaps exactly that run.

### Why `_document.getInitialProps` apps opt out

`enhancePageElement` is non-optional in `createPagesPageHandler`, so in production a user `_document.getInitialProps` override always resolves its head through `runDocumentRenderPage()` — with a real `ctx.renderPage` plus the request-scoped `req`, `res`, `pathname`, `query` and `asPath`. `pages-page-response.ts` only falls back to the bare `callDocumentGetInitialProps()` on the `skipped` branch, which by definition means there is no override.

Regeneration cannot reproduce that context without running the whole document pipeline again, which is out of scope here. Collecting a head anyway would mean swapping a complete cached head for one built from a `_document` that threw on `ctx.req` (swallowed) or emitted fallback tags. So those apps keep the cached head — their pre-PR behaviour — and everyone else gets the refresh. For every app that does refresh, the `_document` helper was a no-op regardless, since it early-returns on the unmodified shim default.

### Locating the closing `</head>`

`headChildToHTML()` escapes `</script` and `</style` in inline bodies but not `</head>`, so a `next/head` inline script may legitimately contain that string. Raw-text and RCDATA elements (`<script>`, `<style>`, `<title>`, and `<noscript>`) are therefore blanked (length-preservingly, so indices still map onto the original shell) before the boundary lookup, rather than reading the first `</head>` substring as markup.

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/entries/pages-server-entry.ts` for the `onHeadReady` hook and why it sits inside the ALS scope.
2. `packages/vinext/src/server/pages-page-data.ts` for `refreshCachedHeadTags()`, the swap boundary, and the raw-text-aware `</head>` lookup.
3. `packages/vinext/src/server/pages-page-handler.ts` for `collectIsrHeadHTML` and the `_document.getInitialProps` opt-out.
4. `packages/vinext/src/server/document-initial-head.ts` for `hasUserDocumentGetInitialProps()`, which keeps the shim-default identity check in one place.
5. `tests/pages-page-data.test.ts` for the regression proof.

</details>

<details>
<summary>Validation</summary>

- Regression coverage in `tests/pages-page-data.test.ts`: the regenerated shell carries the fresh `next/head` tags while leaving `_document`-owned head markup in place; an empty collection does not delete the cached head; a cached shell whose inline script or title body contains a literal `</head>` still swaps the whole run; and a generated production entry advances the cached title with the refreshed body through the natural stale/background-regeneration path.
- Confirmed the head-swap test fails without the fix by reverting the `refreshCachedHeadTags()` call, and confirmed the `</head>`-in-script test fails against the previous plain `indexOf()` boundary. Restored after each.
- Ran `vp test run` over `pages-page-data`, `pages-page-handler`, `pages-page-response`, `pages-isr-query-context`, `isr-cache`, `document`, `head`, and `script-head-ordering`.
- Ran `vp check` repo-wide: no formatting, lint, or type errors.
- Pre-commit hook regenerated entry template snapshots and ran the full check, staged tests, and knip; all passed.

Full local suite and e2e were not run; leaving those to CI.

</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: unchanged. `onHeadReady` and `collectIsrHeadHTML` are optional internal parameters; omitting them preserves the previous behaviour exactly.
- Cached data: no cache schema change. Existing entries already carry `data-next-head`, so they refresh without invalidation.
- Failure mode is conservative: if the anchor is not found, the closing `</head>` is missing, the app overrides `_document.getInitialProps`, or the regeneration collects no head, the cached head is returned untouched.

</details>

<details>
<summary>Non-goals</summary>

- Refreshing `_document`-rendered head children, CSS-in-JS `styles`, or the head of apps that override `_document.getInitialProps`. All require running the full document pipeline on the regeneration path, which is a larger change than this one.

</details>
