### PR TITLE
fix(app-router): let concrete Pages routes win middleware rewrites

### DIFF
--- a/packages/vinext/src/server/app-pages-bridge.ts
+++ b/packages/vinext/src/server/app-pages-bridge.ts
@@ -190,7 +190,10 @@ export async function renderPagesFallback(
         middlewareContext.requestHeaders,
       );
   if (pagesRes.status === 404 && pageMatch === null) return null;
-  return applyDraftModeCookie(pagesRes, getDraftModeCookieHeader());
+  return applyDraftModeCookie(
+    applyRouteHandlerMiddlewareContext(pagesRes, middlewareContext),
+    getDraftModeCookieHeader(),
+  );
 }
 
 /**

--- a/packages/vinext/src/server/app-pages-bridge.ts
+++ b/packages/vinext/src/server/app-pages-bridge.ts
@@ -3,6 +3,7 @@ import type { EdgeApiExecutionRuntime } from "./edge-api-runtime.js";
 import { getRequestExecutionContext } from "vinext/shims/request-context";
 import { pagesRouteHasPriorityOverAppRoute } from "./hybrid-route-priority.js";
 import { cloneRequestWithHeaders, cloneRequestWithUrl } from "./request-pipeline.js";
+import { mergeHeaders } from "./worker-utils.js";
 
 export type PagesEntry = {
   handleApiRoute?: (
@@ -79,6 +80,30 @@ type RenderPagesFallbackOptions = {
   request: Request;
   url: URL;
 };
+
+function applyPagesMiddlewareContext(
+  response: Response,
+  middlewareContext: AppMiddlewareContext,
+): Response {
+  if (!middlewareContext.headers && middlewareContext.status === null) {
+    return response;
+  }
+
+  const middlewareHeaders: Record<string, string | string[]> = {};
+  if (middlewareContext.headers) {
+    for (const [key, value] of middlewareContext.headers) {
+      if (key.toLowerCase() !== "set-cookie") {
+        middlewareHeaders[key] = value;
+      }
+    }
+    const cookies = middlewareContext.headers.getSetCookie();
+    if (cookies.length > 0) {
+      middlewareHeaders["set-cookie"] = cookies;
+    }
+  }
+
+  return mergeHeaders(response, middlewareHeaders, middlewareContext.status ?? undefined);
+}
 
 /**
  * Fallback handler to route App Router requests to the Pages Router when no App Router route matches.
@@ -191,7 +216,7 @@ export async function renderPagesFallback(
       );
   if (pagesRes.status === 404 && pageMatch === null) return null;
   return applyDraftModeCookie(
-    applyRouteHandlerMiddlewareContext(pagesRes, middlewareContext),
+    applyPagesMiddlewareContext(pagesRes, middlewareContext),
     getDraftModeCookieHeader(),
   );
 }

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -899,7 +899,18 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     setRootParams(pickRootParams(preActionMatch.params, preActionMatch.route.rootParamNames));
   }
 
-  if (pagesDataRequest && didMiddlewareRewritePathname && preActionMatch) {
+  // A Pages client navigating to a path that middleware rewrites into App
+  // territory needs `x-nextjs-rewrite` so it can hard-navigate; the body is an
+  // unused placeholder. Only take this shortcut when the App match definitively
+  // owns the rewrite target. A dynamic App match does not: a concrete Pages
+  // route outranks it, so those fall through to the arbitration below, which
+  // gives `renderPagesFallback` its chance to run getServerSideProps.
+  if (
+    pagesDataRequest &&
+    didMiddlewareRewritePathname &&
+    preActionMatch &&
+    !preActionMatch.route.isDynamic
+  ) {
     const headers = new Headers();
     mergeMiddlewareResponseHeaders(headers, middlewareContext.headers);
     headers.set("content-type", "application/json");
@@ -1124,6 +1135,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     ) {
       const response = buildNextDataNotFoundResponse();
       const headers = new Headers(response.headers);
+      mergeMiddlewareResponseHeaders(headers, middlewareContext.headers);
       headers.set("x-nextjs-matched-path", matchPathname(canonicalPathname));
       if (resolvedUrl !== originalResolvedUrl) {
         headers.set("x-nextjs-rewrite", resolvedUrl);

--- a/tests/app-pages-bridge.test.ts
+++ b/tests/app-pages-bridge.test.ts
@@ -5,6 +5,7 @@ import {
   type PagesEntry,
 } from "../packages/vinext/src/server/app-pages-bridge.js";
 import type { AppMiddlewareContext } from "../packages/vinext/src/server/app-middleware.js";
+import { applyRouteHandlerMiddlewareContext } from "../packages/vinext/src/server/app-route-handler-response.js";
 import { handlePagesApiRoute } from "../packages/vinext/src/server/pages-api-route.js";
 import {
   runWithExecutionContext,
@@ -294,6 +295,44 @@ describe("renderPagesFallback", () => {
 
     expect(renderedHeader).toBe("injected");
     expect(renderedCf).toBe(cf);
+  });
+
+  it("applies middleware response headers to Pages data renders", async () => {
+    const renderPage = vi.fn(
+      () =>
+        new Response('{"pageProps":{"ok":true}}', {
+          headers: [
+            ["content-type", "application/json"],
+            ["set-cookie", "page=1; Path=/"],
+          ],
+        }),
+    );
+    const request = new Request("http://localhost/pages-dir/search");
+
+    const response = await renderPagesFallback(
+      {
+        isDataRequest: true,
+        isRscRequest: false,
+        middlewareContext: {
+          headers: new Headers([
+            ["set-cookie", "middleware=1; Path=/"],
+            ["x-middleware-response", "present"],
+          ]),
+          requestHeaders: null,
+          status: null,
+        },
+        request,
+        url: new URL(request.url),
+      },
+      {
+        ...defaultDeps,
+        applyRouteHandlerMiddlewareContext,
+        loadPagesEntry: () => ({ renderPage }),
+      },
+    );
+
+    expect(response?.headers.get("x-middleware-response")).toBe("present");
+    expect(response?.headers.getSetCookie()).toEqual(["page=1; Path=/", "middleware=1; Path=/"]);
   });
 
   it("matches rewritten Pages data requests against the rewritten destination", async () => {

--- a/tests/app-pages-bridge.test.ts
+++ b/tests/app-pages-bridge.test.ts
@@ -5,7 +5,6 @@ import {
   type PagesEntry,
 } from "../packages/vinext/src/server/app-pages-bridge.js";
 import type { AppMiddlewareContext } from "../packages/vinext/src/server/app-middleware.js";
-import { applyRouteHandlerMiddlewareContext } from "../packages/vinext/src/server/app-route-handler-response.js";
 import { handlePagesApiRoute } from "../packages/vinext/src/server/pages-api-route.js";
 import {
   runWithExecutionContext,
@@ -302,8 +301,10 @@ describe("renderPagesFallback", () => {
       () =>
         new Response('{"pageProps":{"ok":true}}', {
           headers: [
+            ["cache-control", "private, no-cache, no-store, max-age=0, must-revalidate"],
+            ["content-length", "25"],
             ["content-type", "application/json"],
-            ["set-cookie", "page=1; Path=/"],
+            ["set-cookie", "session=fresh; Path=/"],
           ],
         }),
     );
@@ -315,7 +316,9 @@ describe("renderPagesFallback", () => {
         isRscRequest: false,
         middlewareContext: {
           headers: new Headers([
-            ["set-cookie", "middleware=1; Path=/"],
+            ["cache-control", "public, max-age=3600"],
+            ["content-length", "999"],
+            ["set-cookie", "session=stale; Path=/"],
             ["x-middleware-response", "present"],
           ]),
           requestHeaders: null,
@@ -326,14 +329,59 @@ describe("renderPagesFallback", () => {
       },
       {
         ...defaultDeps,
-        applyRouteHandlerMiddlewareContext,
         loadPagesEntry: () => ({ renderPage }),
       },
     );
 
     expect(response?.headers.get("x-middleware-response")).toBe("present");
-    expect(response?.headers.getSetCookie()).toEqual(["page=1; Path=/", "middleware=1; Path=/"]);
+    expect(response?.headers.get("cache-control")).toBe(
+      "private, no-cache, no-store, max-age=0, must-revalidate",
+    );
+    expect(response?.headers.get("content-length")).toBe("25");
+    expect(response?.headers.getSetCookie()).toEqual([
+      "session=stale; Path=/",
+      "session=fresh; Path=/",
+    ]);
   });
+
+  it.each([204, 205, 304])(
+    "drops the Pages response body when middleware overrides its status to %s",
+    async (status) => {
+      const renderPage = vi.fn(
+        () =>
+          new Response("page body", {
+            headers: {
+              "content-encoding": "gzip",
+              "content-length": "9",
+              "content-type": "text/plain",
+              "transfer-encoding": "chunked",
+            },
+          }),
+      );
+      const request = new Request("http://localhost/pages-dir/search");
+
+      const response = await renderPagesFallback(
+        {
+          isDataRequest: true,
+          isRscRequest: false,
+          middlewareContext: { headers: null, requestHeaders: null, status },
+          request,
+          url: new URL(request.url),
+        },
+        {
+          ...defaultDeps,
+          loadPagesEntry: () => ({ renderPage }),
+        },
+      );
+
+      expect(response?.status).toBe(status);
+      expect(await response?.text()).toBe("");
+      expect(response?.headers.get("content-encoding")).toBeNull();
+      expect(response?.headers.get("content-length")).toBeNull();
+      expect(response?.headers.get("content-type")).toBeNull();
+      expect(response?.headers.get("transfer-encoding")).toBeNull();
+    },
+  );
 
   it("matches rewritten Pages data requests against the rewritten destination", async () => {
     const matchPageRoute = vi.fn(() => ({

--- a/tests/app-router-production-server.test.ts
+++ b/tests/app-router-production-server.test.ts
@@ -1134,6 +1134,28 @@ describe("App Router Production server (startProdServer)", () => {
     expect(html).toContain('"cookie":null');
   });
 
+  it("lets a concrete Pages data route win a middleware rewrite over an App catch-all", async () => {
+    // Next.js merges Pages and App matchers before applying dynamic-route
+    // precedence, so this concrete Pages route wins over app/docs/[...slug].
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/route-matcher-managers/default-route-matcher-manager.ts
+    const buildId = fs.readFileSync(path.join(outDir, "server", "BUILD_ID"), "utf8").trim();
+    const res = await fetch(`${baseUrl}/_next/data/${buildId}/pages-data-rewrite-source.json`, {
+      headers: { "x-nextjs-data": "1" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("x-nextjs-rewrite")).toBe("/docs/pages-data-rewrite-target");
+    expect(res.headers.get("cache-control")).toContain("private");
+    expect(res.headers.getSetCookie()).toEqual([
+      "pages-rewrite-session=middleware; Path=/",
+      "pages-rewrite-session=gssp; Path=/",
+    ]);
+    expect(await res.json()).toEqual({
+      pageProps: { message: "concrete Pages GSSP" },
+      __N_SSP: true,
+    });
+  });
+
   it("serves Pages Router edge API ImageResponse routes in hybrid production", async () => {
     // Ported from Next.js: test/e2e/og-api/index.test.ts
     // https://github.com/vercel/next.js/blob/canary/test/e2e/og-api/index.test.ts

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -2717,6 +2717,99 @@ describe("createAppRscHandler", () => {
     expect(clearRequestContext).toHaveBeenCalled();
   });
 
+  it("lets a concrete Pages route win a middleware rewrite over a dynamic App match", async () => {
+    // A dynamic App match does not own the rewrite target: the Pages route is
+    // more specific, so its data (here a getServerSideProps redirect) must be
+    // rendered rather than short-circuited into an empty rewrite response.
+    const renderPagesFallback = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ pageProps: { __N_REDIRECT: "/login" } }), {
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    const handler = createHandler({
+      configHeaders: [],
+      matchRoute: (pathname: string) =>
+        pathname === "/protected"
+          ? {
+              params: { slug: ["protected"] },
+              route: createPageRoute({
+                isDynamic: true,
+                pattern: "/[...slug]",
+                routeSegments: ["[...slug]"],
+              }),
+            }
+          : null,
+      middlewareModule: {
+        default: (request: NextRequest) =>
+          request.nextUrl.pathname === "/source"
+            ? new Response(null, {
+                headers: { "x-middleware-rewrite": new URL("/protected", request.url).toString() },
+              })
+            : undefined,
+      },
+      renderPagesFallback,
+    });
+
+    const response = await handler(
+      new Request("https://example.test/docs/_next/data/build-id/source.json", {
+        headers: { "x-nextjs-data": "1" },
+      }),
+      null,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-nextjs-rewrite")).toBe("/protected");
+    expect(await response.json()).toEqual({ pageProps: { __N_REDIRECT: "/login" } });
+    expect(renderPagesFallback).toHaveBeenCalled();
+  });
+
+  it("keeps middleware response headers when a rewrite lands on a dynamic App route", async () => {
+    // No Pages route claims the target, so the App match legitimately owns it.
+    // The response still has to carry cookies the middleware set on the way.
+    const handler = createHandler({
+      configHeaders: [],
+      matchRoute: (pathname: string) =>
+        pathname === "/app-only"
+          ? {
+              params: { slug: ["app-only"] },
+              route: createPageRoute({
+                isDynamic: true,
+                pattern: "/[...slug]",
+                routeSegments: ["[...slug]"],
+              }),
+            }
+          : null,
+      middlewareModule: {
+        default: (request: NextRequest) =>
+          request.nextUrl.pathname === "/source"
+            ? new Response(null, {
+                headers: {
+                  "set-cookie": "probe=1; Path=/",
+                  "x-test-header": "middleware",
+                  "x-middleware-rewrite": new URL("/app-only", request.url).toString(),
+                },
+              })
+            : undefined,
+      },
+      renderPagesFallback: vi.fn(async () => null),
+    });
+
+    const response = await handler(
+      new Request("https://example.test/docs/_next/data/build-id/source.json", {
+        headers: { "x-nextjs-data": "1" },
+      }),
+      null,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-nextjs-rewrite")).toBe("/app-only");
+    expect(response.headers.get("set-cookie")).toBe("probe=1; Path=/");
+    expect(response.headers.get("x-test-header")).toBe("middleware");
+    expect(response.headers.get("x-middleware-rewrite")).toBeNull();
+    expect(await response.text()).toBe("{}");
+  });
+
   it.each([
     { convention: "middleware", isProxy: false },
     { convention: "proxy", isProxy: true },

--- a/tests/fixtures/app-basic/middleware.ts
+++ b/tests/fixtures/app-basic/middleware.ts
@@ -25,6 +25,16 @@ export async function middleware(request: NextRequest, event: NextFetchEvent) {
     return NextResponse.rewrite(new URL("/about", request.url));
   }
 
+  // A concrete Pages route owns this destination even though the App Router's
+  // /docs/[...slug] catch-all also matches it. The Pages data response must run
+  // GSSP instead of being replaced by the App rewrite placeholder.
+  if (pathname === "/pages-data-rewrite-source") {
+    const response = NextResponse.rewrite(new URL("/docs/pages-data-rewrite-target", request.url));
+    response.cookies.set("pages-rewrite-session", "middleware", { path: "/" });
+    response.headers.set("cache-control", "public, max-age=3600");
+    return response;
+  }
+
   // Ported from Next.js: test/e2e/middleware-general/app/middleware-node.js
   // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-general/app/middleware-node.js
   if (pathname === "/_next/static/middleware-rewrite.js") {
@@ -382,6 +392,7 @@ export const config = {
   matcher: [
     "/about",
     "/exists-but-not-routed",
+    "/pages-data-rewrite-source",
     "/middleware-redirect",
     "/middleware-rewrite",
     "/middleware-rewritten-use-pathname",

--- a/tests/fixtures/app-basic/pages/docs/pages-data-rewrite-target.tsx
+++ b/tests/fixtures/app-basic/pages/docs/pages-data-rewrite-target.tsx
@@ -1,0 +1,14 @@
+import type { GetServerSideProps } from "next";
+
+type Props = {
+  message: string;
+};
+
+export const getServerSideProps: GetServerSideProps<Props> = async ({ res }) => {
+  res.setHeader("Set-Cookie", "pages-rewrite-session=gssp; Path=/");
+  return { props: { message: "concrete Pages GSSP" } };
+};
+
+export default function PagesDataRewriteTarget({ message }: Props) {
+  return <p id="pages-data-rewrite-result">{message}</p>;
+}

--- a/tests/fixtures/app-basic/pages/pages-data-rewrite-source.tsx
+++ b/tests/fixtures/app-basic/pages/pages-data-rewrite-source.tsx
@@ -1,0 +1,3 @@
+export default function PagesDataRewriteSource() {
+  return <p>This source is replaced by middleware.</p>;
+}


### PR DESCRIPTION
## Summary

The Pages-data middleware rewrite shortcut added in #2468 treats *any* App route match as owning the rewrite target, including dynamic and catch-all matches. A concrete Pages route outranks a dynamic App match everywhere else in this handler, so the shortcut returned a synthetic `{}` before `renderPagesFallback` could run `getServerSideProps` for the target.

## Why

`handleAppRscRequest` encodes App-vs-Pages ownership as `match === null || match.route.isDynamic` in the two places that arbitrate it: `renderPagesForMatchKind` (`app-rsc-handler.ts:989`) and the afterFiles rewrite guard (`:1018`). A dynamic App match does not own a pathname, because a concrete Pages route is more specific.

The fast path at `:902` tested `preActionMatch` for truthiness alone, so a catch-all such as `app/[...slug]` was treated as the owner. That matters beyond the response body, because the Pages client reuses the response:

1. The router stores the middleware probe response plus `x-nextjs-rewrite` as a `MiddlewareDataEffect` (`shims/router.ts:1826`).
2. When the rewrite target resolves to a Pages route, that stored response is passed to `navigateClientData` as `prefetchedResponse` (`:2555`).
3. `navigateClientData` skips the real data fetch when given one (`:2126`), and `{}` becomes `props = {}` with no `__N_REDIRECT` marker (`:2205`).

So a client-side navigation whose middleware rewrite lands on a Pages route shadowed by a dynamic App route rendered the page with empty props, without the redirect or `notFound` result its `getServerSideProps` would have returned. Document requests were unaffected, since they never take this path.

Client-side ownership already agrees with the server rule: `resolveMatchedHybridClientRouteOwner` runs `compareHybridRoutePatterns`, which gives the concrete Pages pattern precedence. Only the server shortcut disagreed.

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| Rewrite target owned by a static App route | `{}` + `x-nextjs-rewrite`, middleware headers merged | Unchanged |
| Rewrite target has a dynamic App match and a concrete Pages route | `{}` + `x-nextjs-rewrite`, `getServerSideProps` skipped | Pages fallback renders; real data plus `x-nextjs-rewrite` |
| Rewrite target has a dynamic App match and no Pages route | `{}` + `x-nextjs-rewrite`, middleware headers merged | Unchanged in observable output, now produced by the tail response |

The second hunk is required by the first. Restricting the shortcut moves dynamic-match requests onto the tail Pages-data response, which built its headers from `buildNextDataNotFoundResponse()` alone and dropped whatever the middleware set. Without merging them there, gating the shortcut would trade this bug for a dropped `Set-Cookie` on every rewrite landing on a genuinely App-owned dynamic route.

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/server/app-rsc-handler.ts:902` for the ownership predicate, which now matches `:989` and `:1018`.
2. `packages/vinext/src/server/app-rsc-handler.ts:1138` for the header merge the fallthrough depends on.
3. `tests/app-rsc-handler.test.ts` for the two regression tests.

</details>

<details>
<summary>Validation</summary>

- Added a regression test asserting a concrete Pages route wins a middleware rewrite over a dynamic App match, returning its `getServerSideProps` redirect marker rather than `{}`.
- Added a regression test asserting middleware `Set-Cookie` and custom headers survive a rewrite that lands on a dynamic App route with no Pages route.
- Mutation-checked both tests against their own hunk. Removing the predicate fails with `expected {} to deeply equal { Object (pageProps) }`; removing the merge fails with `expected null to be 'probe=1; Path=/'`.
- The existing #2468 test still passes unchanged: a static App match still short-circuits.
- `tests/e2e/app-router/pages-to-app-routing.spec.ts` passes in full, including the two cases #2468 added for Pages-to-App navigation through a middleware rewrite.

<details>
<summary>Commands</summary>

```text
vitest run tests/app-rsc-handler.test.ts                     134 passed
vitest run tests/hybrid-route-priority.test.ts \
  tests/hybrid-client-route-owner.test.ts \
  tests/pages-router.test.ts tests/middleware-runtime.test.ts 434 passed
vitest run tests/routing.test.ts                             284 passed (with the above)
tsc --noEmit -p packages/vinext/tsconfig.json                 clean
PLAYWRIGHT_PROJECT=app-router playwright test \
  tests/e2e/app-router/pages-to-app-routing.spec.ts            5 passed
```

</details>
</details>

<details>
<summary>Risk / compatibility</summary>

- No public API, configuration, or wire format change.
- Narrows an early return added in #2468 so that fewer requests take it. Requests that no longer take it fall into the arbitration that already existed for every non-rewritten Pages data request, so the path is well covered.
- The only behavioural change for App-owned targets is that the response is now built by the tail branch. Header output is asserted equivalent by the second regression test.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [#2468](https://github.com/cloudflare/vinext/pull/2468) | Introduced the shortcut; its test pins the static-App-match behaviour this PR preserves |
| `packages/vinext/src/server/app-rsc-handler.ts:989` | The ownership predicate this PR aligns with |
</content>
</invoke>


## Maintainer review note

- Pages fallback responses deliberately use the existing Pages Router `mergeHeaders` order: staged middleware headers are applied first, then rendered Pages headers and cookies win. This matches `pages-request-pipeline.ts`; it intentionally differs from App route-handler response merging.
- The same merger now applies middleware status to Pages fallbacks. Its established no-body handling drops bodies and representation headers for 204, 205, and 304 responses; focused tests cover all three statuses.
- `Vary` behavior remains identical to the existing Pages pipeline. Changing that shared behavior is outside this PR.
