### PR TITLE
fix(app-router): reject Route Handlers as interception source routes

### DIFF
--- a/packages/vinext/src/server/app-rsc-route-matching.ts
+++ b/packages/vinext/src/server/app-rsc-route-matching.ts
@@ -284,17 +284,30 @@ export function createAppRscRouteMatcher<Route extends AppRscRouteForMatching>(
         if (params === null) continue;
         canonicalizeAppPageParams(params);
 
-        const concreteSourceRouteIndex =
-          matchedSourceRoute && entry.sourceMatchPatternParts !== null
-            ? (routeIndexes.get(matchedSourceRoute.route) ?? entry.sourceRouteIndex)
-            : entry.sourceRouteIndex;
+        // Resolving the claimed source pathname to its concrete descendant
+        // route (#2042) keeps dynamic source params intact, but the source
+        // pathname is an unauthenticated client header and the resolved route
+        // becomes the route that renders or dispatches. A Route Handler has no
+        // page, layouts, or parallel slots, so it can never own or sit inside
+        // an interception source tree; promoting one only lets a crafted
+        // interception context execute a `route.ts` that happens to live under
+        // the intercepting route. Fall back to the slot owner instead, which is
+        // the fixed destination Next.js' generated interception rewrite uses.
+        const concreteSourceRoute =
+          matchedSourceRoute &&
+          entry.sourceMatchPatternParts !== null &&
+          !isAppRouteHandlerRoute(matchedSourceRoute.route)
+            ? matchedSourceRoute
+            : null;
+        const concreteSourceRouteIndex = concreteSourceRoute
+          ? (routeIndexes.get(concreteSourceRoute.route) ?? entry.sourceRouteIndex)
+          : entry.sourceRouteIndex;
         const sourceRoute = routes[concreteSourceRouteIndex];
-        const matchedSourceParams =
-          matchedSourceRoute && entry.sourceMatchPatternParts !== null
-            ? matchedSourceRoute.params
-            : sourceRoute
-              ? matchRoutePatternRaw(sourceParts, sourceRoute.patternParts)
-              : null;
+        const matchedSourceParams = concreteSourceRoute
+          ? concreteSourceRoute.params
+          : sourceRoute
+            ? matchRoutePatternRaw(sourceParts, sourceRoute.patternParts)
+            : null;
 
         // Secondary gate (from #1249): when the entry has no
         // `sourceMatchPatternParts` declared (older manifest shapes), reject

--- a/packages/vinext/src/server/app-rsc-route-matching.ts
+++ b/packages/vinext/src/server/app-rsc-route-matching.ts
@@ -306,7 +306,11 @@ export function createAppRscRouteMatcher<Route extends AppRscRouteForMatching>(
         const matchedSourceParams = concreteSourceRoute
           ? concreteSourceRoute.params
           : sourceRoute
-            ? matchRoutePatternRaw(sourceParts, sourceRoute.patternParts)
+            ? matchSlotOwnerSourceParams(
+                sourceParts,
+                sourceRoute.patternParts,
+                entry.sourceMatchPatternParts !== null,
+              )
             : null;
 
         // Secondary gate (from #1249): when the entry has no
@@ -336,6 +340,28 @@ export function createAppRscRouteMatcher<Route extends AppRscRouteForMatching>(
       return null;
     },
   };
+}
+
+/**
+ * Params for the slot owner when interception falls back to it instead of a
+ * concrete descendant source route. The owner is what renders, and
+ * `matchInterceptRoute` reads the promoted route's params solely from these,
+ * so dropping them would render a dynamic owner without its segments.
+ *
+ * An exact match covers a source that names the owner itself. It cannot
+ * succeed when the source names a deeper descendant — a rejected Route
+ * Handler, or a path with no concrete route — so once the descendants-allowed
+ * gate has approved the source, take the owner's params from that prefix.
+ */
+function matchSlotOwnerSourceParams(
+  sourceParts: readonly string[],
+  patternParts: readonly string[],
+  descendantsAllowed: boolean,
+): AppRscRouteParams | null {
+  const exact = matchRoutePatternRaw(sourceParts, patternParts);
+  if (exact !== null) return exact;
+  if (!descendantsAllowed || !matchRoutePatternPrefix(sourceParts, patternParts)) return null;
+  return extractRawParamsForMatchedRoute(patternParts, sourceParts);
 }
 
 /**

--- a/packages/vinext/src/server/app-rsc-route-matching.ts
+++ b/packages/vinext/src/server/app-rsc-route-matching.ts
@@ -303,6 +303,13 @@ export function createAppRscRouteMatcher<Route extends AppRscRouteForMatching>(
           ? (routeIndexes.get(concreteSourceRoute.route) ?? entry.sourceRouteIndex)
           : entry.sourceRouteIndex;
         const sourceRoute = routes[concreteSourceRouteIndex];
+        // The fallback owner can itself be a Route Handler. The route graph
+        // retains slots discovered beside `route.ts`, so rejecting only a
+        // concrete descendant handler is insufficient: promoting that owner
+        // would reach the same handler dispatch branch. A handler cannot be a
+        // renderable interception source, so let another matching intercept
+        // win or reject this interception entirely.
+        if (sourceRoute && isAppRouteHandlerRoute(sourceRoute)) continue;
         const matchedSourceParams = concreteSourceRoute
           ? concreteSourceRoute.params
           : sourceRoute

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -9,6 +9,7 @@ import {
   VINEXT_RSC_VARY_HEADER,
 } from "../packages/vinext/src/server/app-rsc-cache-busting.js";
 import { createAppRscHandler } from "../packages/vinext/src/server/app-rsc-handler.js";
+import { createAppRscRouteMatcher } from "../packages/vinext/src/server/app-rsc-route-matching.js";
 import type { AppRouteTreePrefetchRoute } from "../packages/vinext/src/server/app-route-tree-prefetch.js";
 import { createArtifactCompatibilityEnvelope } from "../packages/vinext/src/server/artifact-compatibility.js";
 import {
@@ -590,6 +591,69 @@ describe("createAppRscHandler", () => {
         route: sourceRoute,
       }),
     );
+  });
+
+  it("does not promote a Route Handler slot owner for interception-only RSC targets", async () => {
+    // A `route.ts` record can retain parallel slots discovered beside it. A
+    // client-controlled interception context may gate the modal rewrite, but
+    // Next.js never dispatches the owning handler as its source route.
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/generate-interception-routes-rewrites.ts
+    const matcher = createAppRscRouteMatcher([
+      {
+        pattern: "/feed",
+        patternParts: ["feed"],
+        __loadRouteHandler: async () => ({}),
+        slots: {
+          modal: {
+            intercepts: [
+              {
+                sourceMatchPattern: "/feed",
+                targetPattern: "/feed/hidden",
+                interceptLayouts: ["layout"],
+                page: "modal-page",
+                params: [],
+              },
+            ],
+          },
+        },
+      },
+    ]);
+    const handlerOwner = createPageRoute({
+      __loadPage: undefined,
+      __loadRouteHandler() {},
+      page: null,
+      pattern: "/feed",
+      routeHandler: { GET: () => new Response("secret handler") },
+      routeSegments: ["feed"],
+    });
+    const dispatchMatchedPage = vi.fn(async () => new Response("page"));
+    const dispatchMatchedRouteHandler = vi.fn(async () => new Response("secret handler"));
+    const handler = createHandler({
+      configHeaders: [],
+      dispatchMatchedPage,
+      dispatchMatchedRouteHandler,
+      matchInterceptRoute(pathname, sourcePathname) {
+        const intercept = matcher.findIntercept(pathname, sourcePathname);
+        return intercept ? { route: handlerOwner, params: {} } : null;
+      },
+      matchRoute: (pathname) => (pathname === "/feed" ? { route: handlerOwner, params: {} } : null),
+    });
+
+    // Direct requests still reach the Route Handler.
+    const directResponse = await handler(new Request("https://example.test/docs/feed"), null);
+    expect(await directResponse.text()).toBe("secret handler");
+    expect(dispatchMatchedRouteHandler).toHaveBeenCalledOnce();
+    dispatchMatchedRouteHandler.mockClear();
+
+    // The same handler must not be promoted for a forged interception-only
+    // target whose middleware/routing path was `/feed/hidden`.
+    const headers = createRscRequestHeaders({ interceptionContext: "/feed" });
+    const rscUrl = await createRscRequestUrl("/docs/feed/hidden", headers);
+    const response = await handler(new Request(`https://example.test${rscUrl}`, { headers }), null);
+
+    expect(response.status).toBe(404);
+    expect(dispatchMatchedRouteHandler).not.toHaveBeenCalled();
+    expect(dispatchMatchedPage).not.toHaveBeenCalled();
   });
 
   it("uses the request pathname consistently for encoded interception targets", async () => {

--- a/tests/app-rsc-route-matching.test.ts
+++ b/tests/app-rsc-route-matching.test.ts
@@ -710,6 +710,46 @@ describe("App RSC route matching", () => {
       });
     });
 
+    it("keeps the slot owner's dynamic params when falling back from a descendant", () => {
+      // The slot owner is what renders once a descendant source is rejected, and
+      // `matchInterceptRoute` reads the promoted route's params solely from
+      // `sourceMatchedParams`. An exact pattern match against the owner cannot
+      // succeed here — the approved source carries extra segments by definition —
+      // so the owner's params come from the prefix the source gate already
+      // approved. Otherwise `/:locale/feed` would render with no `locale`.
+      const matcher = createAppRscRouteMatcher([
+        route("/:locale/feed", [":locale", "feed"], {
+          modal: {
+            intercepts: [
+              {
+                sourceMatchPattern: "/:locale/feed",
+                targetPattern: "/:locale/hidden",
+                interceptLayouts: ["layout"],
+                page: "modal-hidden",
+                params: ["locale"],
+              },
+            ],
+          },
+        }),
+        { ...route("/:locale/feed/admin", [":locale", "feed", "admin"]), routeHandler: {} },
+      ]);
+
+      expect(matcher.findIntercept("/en/hidden", "/en/feed/admin")).toMatchObject({
+        sourceRouteIndex: 0,
+        sourceMatchedParams: { locale: "en" },
+      });
+      // A descendant with no concrete route at all takes the same fallback.
+      expect(matcher.findIntercept("/en/hidden", "/en/feed/unknown/deep")).toMatchObject({
+        sourceRouteIndex: 0,
+        sourceMatchedParams: { locale: "en" },
+      });
+      // An exact source still matches the owner directly.
+      expect(matcher.findIntercept("/en/hidden", "/en/feed")).toMatchObject({
+        sourceRouteIndex: 0,
+        sourceMatchedParams: { locale: "en" },
+      });
+    });
+
     it("treats a sourceMatchPattern of `/` as matching any source", () => {
       // Slot at root (`/@modal/(.)groups/[id]/new`) yields intercepting route `/`,
       // which Next.js implements as `^/.*$` — i.e. any source.

--- a/tests/app-rsc-route-matching.test.ts
+++ b/tests/app-rsc-route-matching.test.ts
@@ -710,6 +710,65 @@ describe("App RSC route matching", () => {
       });
     });
 
+    it.each([
+      {
+        ownerPattern: "/feed",
+        ownerParts: ["feed"],
+        sourcePathname: "/feed",
+        targetPattern: "/feed/hidden",
+        targetPathname: "/feed/hidden",
+      },
+      {
+        ownerPattern: "/:locale/feed",
+        ownerParts: [":locale", "feed"],
+        sourcePathname: "/en/feed",
+        targetPattern: "/:locale/feed/hidden",
+        targetPathname: "/en/feed/hidden",
+      },
+      {
+        ownerPattern: "/docs/:slug+",
+        ownerParts: ["docs", ":slug+"],
+        sourcePathname: "/docs/a/b",
+        targetPattern: "/hidden",
+        targetPathname: "/hidden",
+      },
+      {
+        ownerPattern: "/:locale*",
+        ownerParts: [":locale*"],
+        sourcePathname: "/en/us",
+        targetPattern: "/hidden",
+        targetPathname: "/hidden",
+      },
+    ])(
+      "never promotes a Route Handler slot owner for $ownerPattern",
+      ({ ownerParts, ownerPattern, sourcePathname, targetPathname, targetPattern }) => {
+        // The route graph retains parallel slots discovered beside `route.ts`.
+        // Next.js accepts this filesystem shape and rewrites the intercepted
+        // target to the modal page; it never executes the owning handler.
+        // https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/generate-interception-routes-rewrites.ts
+        const matcher = createAppRscRouteMatcher([
+          {
+            ...route(ownerPattern, ownerParts, {
+              modal: {
+                intercepts: [
+                  {
+                    sourceMatchPattern: ownerPattern,
+                    targetPattern,
+                    interceptLayouts: ["layout"],
+                    page: "modal-page",
+                    params: [],
+                  },
+                ],
+              },
+            }),
+            __loadRouteHandler: async () => ({}),
+          },
+        ]);
+
+        expect(matcher.findIntercept(targetPathname, sourcePathname)).toBeNull();
+      },
+    );
+
     it("keeps the slot owner's dynamic params when falling back from a descendant", () => {
       // The slot owner is what renders once a descendant source is rejected, and
       // `matchInterceptRoute` reads the promoted route's params solely from

--- a/tests/app-rsc-route-matching.test.ts
+++ b/tests/app-rsc-route-matching.test.ts
@@ -651,6 +651,65 @@ describe("App RSC route matching", () => {
       });
     });
 
+    it("never promotes a Route Handler as the concrete interception source", () => {
+      // The source pathname arrives as an unauthenticated client header
+      // (X-Vinext-Interception-Context / Next-URL), and the resolved source
+      // route is what later renders or dispatches. A `route.ts` has no page,
+      // layouts, or slots, so it can never own an interception source tree;
+      // resolving one would let a crafted context execute a Route Handler that
+      // merely lives under the intercepting route. Next.js rewrites the
+      // intercepted target to a fixed destination (the intercepting route), so
+      // falling back to the slot owner is also the parity-correct choice.
+      // https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/generate-interception-routes-rewrites.ts
+      const matcher = createAppRscRouteMatcher([
+        route("/feed", ["feed"], {
+          modal: {
+            intercepts: [
+              {
+                sourceMatchPattern: "/feed",
+                targetPattern: "/hidden",
+                interceptLayouts: ["layout"],
+                page: "modal-hidden",
+                params: [],
+              },
+            ],
+          },
+        }),
+        { ...route("/feed/admin", ["feed", "admin"]), routeHandler: {} },
+        route("/feed/:tab", ["feed", ":tab"]),
+      ]);
+
+      // A Route Handler descendant falls back to the slot owner (index 0).
+      expect(matcher.findIntercept("/hidden", "/feed/admin")).toMatchObject({
+        sourceRouteIndex: 0,
+      });
+      // A lazy Route Handler is classified the same before its first load.
+      const lazyMatcher = createAppRscRouteMatcher([
+        route("/feed", ["feed"], {
+          modal: {
+            intercepts: [
+              {
+                sourceMatchPattern: "/feed",
+                targetPattern: "/hidden",
+                interceptLayouts: ["layout"],
+                page: "modal-hidden",
+                params: [],
+              },
+            ],
+          },
+        }),
+        { ...route("/feed/admin", ["feed", "admin"]), __loadRouteHandler: async () => ({}) },
+      ]);
+      expect(lazyMatcher.findIntercept("/hidden", "/feed/admin")).toMatchObject({
+        sourceRouteIndex: 0,
+      });
+      // Page descendants still resolve concretely, preserving their params.
+      expect(matcher.findIntercept("/hidden", "/feed/recent")).toMatchObject({
+        sourceRouteIndex: 2,
+        sourceMatchedParams: { tab: "recent" },
+      });
+    });
+
     it("treats a sourceMatchPattern of `/` as matching any source", () => {
       // Slot at root (`/@modal/(.)groups/[id]/new`) yields intercepting route `/`,
       // which Next.js implements as `^/.*$` — i.e. any source.


### PR DESCRIPTION
> [!WARNING]
> **This is a high severity security fix.** It closes an authorization bypass in the App Router RSC request path that lets an unauthenticated remote client execute a Route Handler which middleware path checks were intended to protect. Please treat this as release-blocking.

## Overview

| | |
| --- | --- |
| Goal | Stop a client-supplied interception context from selecting a Route Handler as the route that gets dispatched |
| Core change | `findIntercept` rejects Route Handler concrete sources and validates the final fallback owner before promotion; page owners and descendants remain unchanged |
| Key boundary | The interception source pathname is an unauthenticated request header, so it may select *which slot owner renders*, never *which arbitrary route executes* |
| Expected impact | Route Handlers become unreachable through interception promotion. Descendant page routes and their dynamic source params are unchanged |

## Why

Route interception is gated on a client header. vinext reads `x-vinext-interception-context`; Next.js reads `Next-URL`. Neither is authenticated, and neither can be, because it is just the browser reporting its current pathname. That makes the header safe to use as a *gate* on an intercept the developer already declared, and unsafe to use as a *selector* for which route the server dispatches.

Next.js keeps to that distinction. `generateInterceptionRoutesRewrites` emits a rewrite whose `destination` is fixed at build time to the intercepting route's app path, gated by a `has` condition matching `Next-URL` against `^<interceptingRoute>(?:/.*)?$`. Source params come from matching the header against the *intercepting route pattern*. Next.js never resolves `Next-URL` to a concrete route and never dispatches whatever it lands on.

vinext's `findIntercept` does resolve it. After the source pathname passes the descendants-allowed pattern gate, the matcher re-resolves it through the route trie and returns whichever concrete route it hits as `sourceRouteIndex` (added in #2042 so dynamic descendant source params survive). Since #2256, an RSC request whose path has no direct App route match promotes that resolved route into the request's `match`, which then flows into the normal dispatch branches.

Those two behaviours compose into a route confusion. Middleware has already run, for the *requested target* path. A request naming a target that has no direct route, plus a header naming a descendant of the intercepting route, promotes that descendant. When the descendant is a Route Handler, dispatch executes it. An application that authorizes route handlers with middleware path checks never sees the protected path, so the guard does not fire and the handler runs.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| Interception source resolution | An unauthenticated header may gate a declared intercept, not choose an arbitrary dispatch target | Route Handler matches are skipped; a Route Handler fallback owner is rejected rather than dispatched |
| Route Handler reachability | A `route.ts` is not a renderable interception source, although the route graph may retain slots discovered beside it | Route Handlers are no longer promotable as interception sources |
| Next.js parity | The interception rewrite destination is the intercepting route, fixed at build time | Falling back to the slot owner matches the upstream destination |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| RSC request to an interception-only target, header names a descendant Route Handler | Handler is promoted and executed, having only run middleware for the target path | Promotion resolves to the slot owner; the handler is unreachable |
| Header names a descendant *page* route | Concrete descendant promoted, source params preserved | Unchanged |
| Header names a page slot owner exactly | Slot owner promoted | Unchanged |
| Header names a Route Handler slot owner | Handler could be promoted and executed | Interception is rejected; direct handler requests are unchanged |
| Header names a non-descendant, or is absent | No intercept | Unchanged |
| Lazy Route Handler whose module has not loaded yet | Classified as a page, so promotable | Classified as a handler via `__loadRouteHandler`, consistently before and after first load |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/server/app-rsc-route-matching.ts` — `findIntercept`'s `concreteSourceRoute` resolution. This is the whole behavioural change and the ownership decision: the guard sits in the shared matcher so every caller inherits it rather than each dispatch site guarding separately.
2. `tests/app-rsc-route-matching.test.ts` — regression proof, including the lazy-handler classification case and the preserved page-descendant behaviour.

</details>

<details>
<summary>Validation</summary>

- Added regression coverage for descendant and fallback-owner Route Handlers, including lazy, static, dynamic, catch-all, and optional-catch-all shapes; descendant page routes still resolve concretely with their source params.
- Confirmed the pre-fix behaviour by driving the real `createAppRscRouteMatcher` through `createAppRscHandler`: a request to an interception-only target with a header naming a middleware-protected Route Handler returned that handler's response, while a direct request to the same path was denied by middleware. After the change the handler is never dispatched. A full matcher-to-handler regression also proves a Route Handler slot owner remains directly reachable while forged interception promotion is rejected.
- Ran the interception-adjacent suites: `app-rsc-route-matching`, `app-rsc-handler`, `app-server-action-execution`, `app-page-request`, `app-page-dispatch`. 364 tests pass.
- Ran `pnpm run check` (format, lint, types, Next.js type sync, shim types) clean.
- No e2e fixture places a `route.ts` beneath an intercepting route, so no existing covered behaviour changes.

<details>
<summary>Commands</summary>

```text
pnpm test tests/app-rsc-route-matching.test.ts tests/app-rsc-handler.test.ts \
  tests/app-server-action-execution.test.ts tests/app-page-request.test.ts \
  tests/app-page-dispatch.test.ts
  Test Files  5 passed (5)
       Tests  364 passed (364)

pnpm run check
  pass: All 2681 files are correctly formatted
  pass: Found no warnings, lint errors, or type errors in 1162 files
  Next.js types are in sync with next@16.2.7 (347 files)
  Public shim values match their vendored types (24 modules)
```

</details>
</details>

<details>
<summary>Risk / compatibility</summary>

Low risk, and the reason is that the removed capability has no legitimate use. Interception renders a page into a parallel slot, so a Route Handler could never have been a working interception source. Any request that previously reached a handler this way was already a route confusion.

- Public API: unchanged. No signature, manifest, or config change.
- Behaviour: narrows one branch of interception source resolution. Page descendants, exact slot-owner sources, dynamic source params, sibling intercepts, and the non-intercept paths are untouched.
- Build output: unchanged. The manifest shape is the same; only request-time resolution differs.
- Deliberate divergence: none introduced. This moves closer to the upstream rewrite semantics.

</details>

<details>
<summary>Non-goals</summary>

- **Descendant page promotion is left as is.** A header naming a middleware-guarded *page* under the intercepting route can still promote it, and slot intercepts render the source route's own page as `children`. Closing that means deciding whether the concrete descendant resolution from #2042 should exist at all, versus always dispatching the slot owner and taking source params from the intercepting-route pattern as Next.js does. That is a behavioural change to a shipped fix with e2e fixtures behind it and belongs in its own PR.
- **Re-running middleware for the claimed source path is deliberately not done.** Next.js does not re-run middleware for `Next-URL`, and doing so would execute user middleware twice per interception navigation, duplicating side effects such as `Set-Cookie`, session rotation, and rate limiting.
- No changeset is included; add one if this should ship in the next release.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [`generate-interception-routes-rewrites.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/generate-interception-routes-rewrites.ts) | Upstream interception rewrite: fixed destination, `Next-URL` used only as a `has` gate |
| #2256 | Introduced interception-only RSC target promotion, which put the resolved source route into the dispatch path |
| #2042 | Introduced concrete descendant source resolution so dynamic source params survive |
