### PR TITLE
fix(router): minimize client rewrite manifests

### DIFF
--- a/packages/vinext/src/build/next-client-runtime-manifests.ts
+++ b/packages/vinext/src/build/next-client-runtime-manifests.ts
@@ -1,21 +1,10 @@
 import fs from "node:fs";
 import path from "pathslash";
-import type { NextRewrite, ResolvedNextConfig } from "../config/next-config.js";
-
-type ClientRuntimeRewrite = {
-  source: string;
-  destination?: string;
-  has?: NextRewrite["has"];
-};
-
-type ClientRuntimeRewrites = {
-  beforeFiles: ClientRuntimeRewrite[];
-  afterFiles: ClientRuntimeRewrite[];
-  fallback: ClientRuntimeRewrite[];
-};
+import { toClientRewrites, type ClientRewrites } from "../client/client-rewrites.js";
+import type { ResolvedNextConfig } from "../config/next-config.js";
 
 type ClientRuntimeBuildManifest = {
-  __rewrites: ClientRuntimeRewrites;
+  __rewrites: ClientRewrites;
   sortedPages: string[];
 };
 
@@ -26,29 +15,11 @@ type EmitNextClientRuntimeManifestsOptions = {
   rewrites: ResolvedNextConfig["rewrites"];
 };
 
-function normalizeRewriteForClientManifest(rewrite: NextRewrite): ClientRuntimeRewrite {
-  if (rewrite.destination.startsWith("/")) {
-    return { has: rewrite.has, source: rewrite.source, destination: rewrite.destination };
-  }
-
-  return { has: rewrite.has, source: rewrite.source };
-}
-
-function normalizeRewritesForClientManifest(
-  rewrites: ResolvedNextConfig["rewrites"],
-): ClientRuntimeRewrites {
-  return {
-    beforeFiles: rewrites.beforeFiles.map(normalizeRewriteForClientManifest),
-    afterFiles: rewrites.afterFiles.map(normalizeRewriteForClientManifest),
-    fallback: rewrites.fallback.map(normalizeRewriteForClientManifest),
-  };
-}
-
 export function buildNextClientBuildManifestContent(
   rewrites: ResolvedNextConfig["rewrites"],
 ): string {
   const manifest: ClientRuntimeBuildManifest = {
-    __rewrites: normalizeRewritesForClientManifest(rewrites),
+    __rewrites: toClientRewrites(rewrites),
     sortedPages: [],
   };
   return `self.__BUILD_MANIFEST = ${JSON.stringify(manifest)};self.__BUILD_MANIFEST_CB && self.__BUILD_MANIFEST_CB()`;

--- a/packages/vinext/src/client/client-rewrite-matcher.ts
+++ b/packages/vinext/src/client/client-rewrite-matcher.ts
@@ -18,7 +18,7 @@ export function matchClientRewrite(
       {
         source: rewrite.source,
         // Server-evaluated rules use a harmless local destination only to
-        // determine whether their public source/has fields match.
+        // determine whether their client-safe source/has fields match.
         destination: rewrite.destination ?? "/",
         has: rewrite.has,
         locale: rewrite.locale,

--- a/packages/vinext/src/client/client-rewrite-matcher.ts
+++ b/packages/vinext/src/client/client-rewrite-matcher.ts
@@ -1,0 +1,36 @@
+import {
+  matchRewrite,
+  type BasePathMatchState,
+  type RequestContext,
+} from "../config/config-matchers.js";
+import { isExternalUrl } from "../utils/external-url.js";
+import type { ClientRewrite } from "./client-rewrites.js";
+
+export function matchClientRewrite(
+  pathname: string,
+  rewrite: ClientRewrite,
+  context: RequestContext,
+  basePathState: BasePathMatchState,
+): { kind: "rewrite"; destination: string } | { kind: "server" } | null {
+  const destination = matchRewrite(
+    pathname,
+    [
+      {
+        source: rewrite.source,
+        // Server-evaluated rules use a harmless local destination only to
+        // determine whether their public source/has fields match.
+        destination: rewrite.destination ?? "/",
+        has: rewrite.has,
+        locale: rewrite.locale,
+        basePath: rewrite.basePath,
+      },
+    ],
+    context,
+    basePathState,
+  );
+  if (destination === null) return null;
+  if (rewrite.requiresServerEvaluation || isExternalUrl(destination)) {
+    return { kind: "server" };
+  }
+  return { kind: "rewrite", destination };
+}

--- a/packages/vinext/src/client/client-rewrites.ts
+++ b/packages/vinext/src/client/client-rewrites.ts
@@ -1,0 +1,59 @@
+import type { NextRewrite, ResolvedNextConfig } from "../config/next-config.js";
+import { isExternalUrl } from "../utils/external-url.js";
+
+type ClientRewriteFields = Pick<NextRewrite, "basePath" | "has" | "locale" | "source">;
+
+/**
+ * Rewrite data that is safe to publish in a browser bundle.
+ *
+ * Rules that require server-only data deliberately omit both the destination
+ * and the data that made server evaluation necessary. The client can still
+ * match their public source/has fields, then hand the navigation to the server.
+ */
+export type ClientRewrite =
+  | (ClientRewriteFields & {
+      destination: string;
+      requiresServerEvaluation?: never;
+    })
+  | (ClientRewriteFields & {
+      destination?: never;
+      requiresServerEvaluation: true;
+    });
+
+export type ClientRewrites = {
+  afterFiles: ClientRewrite[];
+  beforeFiles: ClientRewrite[];
+  fallback: ClientRewrite[];
+};
+
+function toClientRewrite(rewrite: NextRewrite): ClientRewrite {
+  const common = {
+    source: rewrite.source,
+    has: rewrite.has,
+    locale: rewrite.locale,
+    basePath: rewrite.basePath,
+  };
+
+  if (isExternalUrl(rewrite.destination) || (rewrite.missing?.length ?? 0) > 0) {
+    return {
+      ...common,
+      requiresServerEvaluation: true,
+    };
+  }
+
+  return {
+    source: rewrite.source,
+    destination: rewrite.destination,
+    has: rewrite.has,
+    locale: rewrite.locale,
+    basePath: rewrite.basePath,
+  };
+}
+
+export function toClientRewrites(rewrites: ResolvedNextConfig["rewrites"]): ClientRewrites {
+  return {
+    beforeFiles: rewrites.beforeFiles.map(toClientRewrite),
+    afterFiles: rewrites.afterFiles.map(toClientRewrite),
+    fallback: rewrites.fallback.map(toClientRewrite),
+  };
+}

--- a/packages/vinext/src/client/client-rewrites.ts
+++ b/packages/vinext/src/client/client-rewrites.ts
@@ -1,14 +1,21 @@
-import type { NextRewrite, ResolvedNextConfig } from "../config/next-config.js";
+import type { HasCondition, NextRewrite, ResolvedNextConfig } from "../config/next-config.js";
 import { isExternalUrl } from "../utils/external-url.js";
 
-type ClientRewriteFields = Pick<NextRewrite, "basePath" | "has" | "locale" | "source">;
+type ClientHasCondition = Omit<HasCondition, "type"> & {
+  type: "host" | "query";
+};
+
+type ClientRewriteFields = Pick<NextRewrite, "basePath" | "locale" | "source"> & {
+  has?: ClientHasCondition[];
+};
 
 /**
  * Rewrite data that is safe to publish in a browser bundle.
  *
  * Rules that require server-only data deliberately omit both the destination
  * and the data that made server evaluation necessary. The client can still
- * match their public source/has fields, then hand the navigation to the server.
+ * use browser-authoritative conditions as a prefilter before handing the
+ * navigation to the server.
  */
 export type ClientRewrite =
   | (ClientRewriteFields & {
@@ -26,15 +33,39 @@ export type ClientRewrites = {
   fallback: ClientRewrite[];
 };
 
+function isClientHasCondition(condition: HasCondition): condition is ClientHasCondition {
+  switch (condition.type) {
+    case "host":
+    case "query":
+      return true;
+    case "cookie":
+    case "header":
+      // Headers may be added or changed by an intermediary, and HttpOnly
+      // cookies are intentionally unavailable to browser JavaScript.
+      return false;
+    default:
+      // Runtime config is an external boundary. Keep unknown future condition
+      // types server-owned even before the public TypeScript type learns them.
+      return false;
+  }
+}
+
 function toClientRewrite(rewrite: NextRewrite): ClientRewrite {
+  const clientHas = rewrite.has?.filter(isClientHasCondition);
+  const hasServerOnlyCondition =
+    rewrite.has?.some((condition) => !isClientHasCondition(condition)) ?? false;
   const common = {
     source: rewrite.source,
-    has: rewrite.has,
+    has: clientHas?.length ? clientHas : undefined,
     locale: rewrite.locale,
     basePath: rewrite.basePath,
   };
 
-  if (isExternalUrl(rewrite.destination) || (rewrite.missing?.length ?? 0) > 0) {
+  if (
+    isExternalUrl(rewrite.destination) ||
+    (rewrite.missing?.length ?? 0) > 0 ||
+    hasServerOnlyCondition
+  ) {
     return {
       ...common,
       requiresServerEvaluation: true,
@@ -44,7 +75,7 @@ function toClientRewrite(rewrite: NextRewrite): ClientRewrite {
   return {
     source: rewrite.source,
     destination: rewrite.destination,
-    has: rewrite.has,
+    has: common.has,
     locale: rewrite.locale,
     basePath: rewrite.basePath,
   };

--- a/packages/vinext/src/entries/app-browser-entry.ts
+++ b/packages/vinext/src/entries/app-browser-entry.ts
@@ -3,6 +3,7 @@ import type {
   VinextLinkPrefetchRoute,
   VinextPagesLinkPrefetchRoute,
 } from "../client/vinext-next-data.js";
+import { toClientRewrites } from "../client/client-rewrites.js";
 import type { AppRoute } from "../routing/app-router.js";
 import { patternsStructurallyEquivalent, type RouteManifest } from "../routing/app-route-graph.js";
 import type { NextRewrite } from "../config/next-config.js";
@@ -27,6 +28,7 @@ export function generateBrowserEntry(
   const entryPath = resolveRuntimeEntryModule("app-browser-entry");
   const navigationRuntimePath = resolveClientRuntimeModule("navigation-runtime");
   const prefetchRoutes = toLinkPrefetchRoutes(routes);
+  const clientRewrites = toClientRewrites(rewrites);
 
   return `import { registerNavigationRuntimeBootstrap } from ${JSON.stringify(navigationRuntimePath)};
 
@@ -36,7 +38,7 @@ window.__VINEXT_LINK_PREFETCH_ROUTES__ = ${JSON.stringify(prefetchRoutes)};
 // entry must also expose the Pages manifest (the Pages client entry does
 // the same — whichever entry runs first emits both globals).
 window.__VINEXT_PAGES_LINK_PREFETCH_ROUTES__ = ${JSON.stringify(pagesPrefetchRoutes)};
-window.__VINEXT_CLIENT_REWRITES__ = ${JSON.stringify(rewrites)};
+window.__VINEXT_CLIENT_REWRITES__ = ${JSON.stringify(clientRewrites)};
 registerNavigationRuntimeBootstrap({
     routeManifest: ${buildRouteManifestExpression(routeManifest)}
 });

--- a/packages/vinext/src/entries/pages-client-entry.ts
+++ b/packages/vinext/src/entries/pages-client-entry.ts
@@ -22,6 +22,7 @@ import type {
   VinextLinkPrefetchRoute,
   VinextPagesLinkPrefetchRoute,
 } from "../client/vinext-next-data.js";
+import { toClientRewrites } from "../client/client-rewrites.js";
 import { findFileWithExts } from "./pages-entry-helpers.js";
 import { toSlash } from "pathslash";
 import { hasExportedName, type StaticMiddlewareMatcher } from "../build/report.js";
@@ -91,6 +92,7 @@ export async function generateClientEntry(
     )
   ).filter((pattern): pattern is string => pattern !== null);
   const instrumentationClientPath = options.instrumentationClientPath ?? null;
+  const clientRewrites = toClientRewrites(nextConfig.rewrites);
 
   // Build a map of route pattern -> dynamic import.
   // Keys must use Next.js bracket format (e.g. "/user/[id]") to match
@@ -204,7 +206,7 @@ window.__VINEXT_LINK_PREFETCH_ROUTES__ = ${JSON.stringify(appPrefetchRoutes)};
 // so whichever entry runs first emits the Pages manifest.
 window.__VINEXT_PAGES_LINK_PREFETCH_ROUTES__ = ${JSON.stringify(pagesPrefetchRoutes)};
 window.__VINEXT_CLIENT_REDIRECTS__ = ${JSON.stringify(nextConfig.redirects)};
-window.__VINEXT_CLIENT_REWRITES__ = ${JSON.stringify(nextConfig.rewrites)};
+window.__VINEXT_CLIENT_REWRITES__ = ${JSON.stringify(clientRewrites)};
 
 const nextDataElement = document.getElementById("__NEXT_DATA__");
 if (nextDataElement?.textContent) {

--- a/packages/vinext/src/global.d.ts
+++ b/packages/vinext/src/global.d.ts
@@ -20,7 +20,8 @@ import type { Root } from "react-dom/client";
 import type { OnRequestErrorHandler } from "./server/instrumentation";
 import type { InitialDevServerErrorPayload } from "./server/dev-initial-server-error";
 import type { CachedRscResponse, PrefetchCacheEntry } from "vinext/shims/navigation";
-import type { NextRedirect, NextRewrite } from "./config/next-config";
+import type { NextRedirect } from "./config/next-config";
+import type { ClientRewrites } from "./client/client-rewrites";
 
 // `window.next` is declared inline in `./client/window-next.ts` (mirroring
 // Next.js's own pattern in `packages/next/src/client/next.ts`), not here, so
@@ -118,13 +119,7 @@ declare global {
     __VINEXT_CLIENT_REDIRECTS__: NextRedirect[] | undefined;
 
     /** Resolved client-safe rewrites from next.config.js. */
-    __VINEXT_CLIENT_REWRITES__:
-      | {
-          beforeFiles: NextRewrite[];
-          afterFiles: NextRewrite[];
-          fallback: NextRewrite[];
-        }
-      | undefined;
+    __VINEXT_CLIENT_REWRITES__: ClientRewrites | undefined;
 
     /**
      * Static `middleware/proxy` matcher config embedded for client-side Pages

--- a/packages/vinext/src/shims/internal/hybrid-client-route-owner.ts
+++ b/packages/vinext/src/shims/internal/hybrid-client-route-owner.ts
@@ -14,13 +14,9 @@
  * `entries/pages-client-entry.ts`). Hybrid builds expose both globals; a
  * single-router build only sets its own.
  */
-import {
-  isExternalUrl,
-  matchRewrite,
-  parseCookies,
-  type RequestContext,
-} from "../../config/config-matchers.js";
-import type { NextRewrite } from "../../config/next-config.js";
+import { parseCookies, type RequestContext } from "../../config/config-matchers.js";
+import { matchClientRewrite } from "../../client/client-rewrite-matcher.js";
+import type { ClientRewrite } from "../../client/client-rewrites.js";
 import { mergeRewriteQuery } from "../../utils/query.js";
 import {
   matchDirectHybridClientRoutes,
@@ -34,7 +30,7 @@ export type { HybridClientOwner } from "./hybrid-client-route-owner-direct.js";
 function resolveClientRewrite(
   href: string,
   basePath: string,
-  rewrites: readonly NextRewrite[],
+  rewrites: readonly ClientRewrite[],
   continueAfterMatch = false,
 ): { kind: "document" } | { href: string; kind: "rewrite" } | null {
   const initialUrl = new URL(href, window.location.href);
@@ -58,10 +54,10 @@ function resolveClientRewrite(
       host: url.hostname,
       query: url.searchParams,
     };
-    const rewritten = matchRewrite(pathname, [rewrite], context, basePathState);
-    if (rewritten === null) continue;
-    if (isExternalUrl(rewritten)) return { kind: "document" };
-    currentHref = mergeRewriteQuery(currentHref, rewritten);
+    const result = matchClientRewrite(pathname, rewrite, context, basePathState);
+    if (result === null) continue;
+    if (result.kind === "server") return { kind: "document" };
+    currentHref = mergeRewriteQuery(currentHref, result.destination);
     matched = true;
     if (!continueAfterMatch) break;
   }

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -100,7 +100,7 @@ import { interpolateDynamicRouteHref } from "./internal/interpolate-as.js";
 import { getCurrentBrowserLocale } from "./client-locale.js";
 import { getDeploymentId, NEXT_DEPLOYMENT_ID_HEADER } from "../utils/deployment-id.js";
 import type { RequestContext } from "../config/config-matchers.js";
-import type { NextRewrite } from "../config/next-config.js";
+import type { ClientRewrite } from "../client/client-rewrites.js";
 
 /** basePath from next.config.js, injected by the plugin at build time */
 const __basePath: string = process.env.__NEXT_ROUTER_BASEPATH ?? "";
@@ -1686,21 +1686,21 @@ async function resolveClientConfigRedirect(href: string): Promise<string | null>
 
 async function applyClientConfigRewrite(
   href: string,
-  rewrite: NextRewrite,
+  rewrite: ClientRewrite,
 ): Promise<{ href: string; kind: "rewrite" } | { kind: "document" } | null> {
   const routeContext = getClientConfigRouteContext(href);
   if (!routeContext) return null;
 
-  const { matchRewrite } = await import("../config/config-matchers.js");
-  const rewritten = matchRewrite(
+  const { matchClientRewrite } = await import("../client/client-rewrite-matcher.js");
+  const result = matchClientRewrite(
     routeContext.pathname,
-    [rewrite],
+    rewrite,
     routeContext.context,
     routeContext.basePathState,
   );
-  if (rewritten === null) return null;
-  if (isExternalUrl(rewritten)) return { kind: "document" };
-  return { href: mergeRewriteQuery(href, rewritten), kind: "rewrite" };
+  if (result === null) return null;
+  if (result.kind === "server") return { kind: "document" };
+  return { href: mergeRewriteQuery(href, result.destination), kind: "rewrite" };
 }
 
 type ClientConfigRewriteResolution =
@@ -1821,7 +1821,7 @@ function resolveClientConfigRewriteSync(href: string): ClientConfigRewriteResolu
     if (!simpleClientConfigSourceCouldMatch(routeContext.pathname, rewrite.source)) {
       continue;
     }
-    if (rewrite.has || rewrite.missing) return undefined;
+    if (rewrite.has || rewrite.requiresServerEvaluation) return undefined;
 
     const params = matchSimpleClientConfigPattern(routeContext.pathname, rewrite.source);
     if (params === undefined) return undefined;

--- a/tests/client-build-manifest.test.ts
+++ b/tests/client-build-manifest.test.ts
@@ -14,6 +14,7 @@ import {
   buildNextClientSsgManifestContent,
   emitNextClientRuntimeManifests,
 } from "../packages/vinext/src/build/next-client-runtime-manifests.js";
+import type { ClientRewrites } from "../packages/vinext/src/client/client-rewrites.js";
 import {
   findClientEntryFileFromVinextManifest,
   findPagesClientEntryFileFromVinextManifest,
@@ -21,6 +22,7 @@ import {
   VINEXT_CLIENT_ENTRY_MANIFEST,
 } from "../packages/vinext/src/utils/client-entry-manifest.js";
 import { computeClientRuntimeMetadata } from "../packages/vinext/src/utils/client-runtime-metadata.js";
+import type { HasCondition } from "../packages/vinext/src/config/next-config.js";
 
 describe("client build manifest helpers", () => {
   let tmpDir: string;
@@ -187,7 +189,22 @@ describe("client build manifest helpers", () => {
       clientDir,
       assetsSubdir: "base/_next/static",
       buildId: "build-123",
-      rewrites: { beforeFiles: [], afterFiles: [], fallback: [] },
+      rewrites: {
+        beforeFiles: [
+          {
+            source: "/header",
+            destination: "/emitted-header-target-canary",
+            has: [{ type: "header", key: "x-origin-auth", value: "emitted-header-secret-canary" }],
+          },
+        ],
+        afterFiles: [
+          {
+            source: "/external",
+            destination: "//example.com/emitted-protocol-relative-canary",
+          },
+        ],
+        fallback: [],
+      },
     });
 
     const buildManifest = await fsp.readFile(
@@ -196,6 +213,10 @@ describe("client build manifest helpers", () => {
     );
     expect(buildManifest).toContain("self.__BUILD_MANIFEST = ");
     expect(buildManifest).toContain("__BUILD_MANIFEST_CB");
+    expect(buildManifest).toContain('"requiresServerEvaluation":true');
+    expect(buildManifest).not.toContain("emitted-header-target-canary");
+    expect(buildManifest).not.toContain("emitted-header-secret-canary");
+    expect(buildManifest).not.toContain("emitted-protocol-relative-canary");
 
     const ssgManifest = await fsp.readFile(
       path.join(clientDir, "base", "_next", "static", "build-123", "_ssgManifest.js"),
@@ -204,19 +225,45 @@ describe("client build manifest helpers", () => {
     expect(ssgManifest).toBe(buildNextClientSsgManifestContent());
   });
 
-  it("normalizes rewrites in the Next.js runtime build manifest", () => {
+  it("publishes only client-safe rewrites in the Next.js runtime build manifest", () => {
     const content = buildNextClientBuildManifestContent({
       beforeFiles: [
         {
-          source: "/internal/:path*",
+          source: "/query/:path*",
           destination: "/rewritten/:path*",
-          has: [{ type: "header", key: "x-test", value: "1" }],
+          has: [{ type: "query", key: "preview", value: "1" }],
+        },
+        {
+          source: "/header",
+          destination: "/header-target-canary",
+          has: [{ type: "header", key: "x-origin-auth", value: "header-secret-canary" }],
+        },
+        {
+          source: "/host",
+          destination: "/host-target",
+          has: [{ type: "host", key: "host", value: "example.com" }],
         },
       ],
       afterFiles: [
         {
+          source: "/cookie",
+          destination: "/cookie-target-canary",
+          has: [{ type: "cookie", key: "internal-access", value: "cookie-secret-canary" }],
+        },
+        {
           source: "/external",
-          destination: "https://example.com/external",
+          destination: "//example.com/protocol-relative-destination-canary",
+        },
+        {
+          source: "/future-condition",
+          destination: "/future-target-canary",
+          has: [
+            {
+              type: "future-condition",
+              key: "future-key",
+              value: "future-secret-canary",
+            } as unknown as HasCondition,
+          ],
         },
       ],
       fallback: [
@@ -228,11 +275,46 @@ describe("client build manifest helpers", () => {
       ],
     });
 
-    expect(content).toContain('"source":"/internal/:path*"');
-    expect(content).toContain('"destination":"/rewritten/:path*"');
-    expect(content).toContain('"source":"/external"');
-    expect(content).not.toContain("https://example.com/external");
-    expect(content).toContain('"sortedPages":[]');
+    const serializedManifest = content.slice(
+      "self.__BUILD_MANIFEST = ".length,
+      content.indexOf(";self.__BUILD_MANIFEST_CB"),
+    );
+    const manifest = JSON.parse(serializedManifest) as {
+      __rewrites: ClientRewrites;
+      sortedPages: string[];
+    };
+
+    expect(manifest).toEqual({
+      __rewrites: {
+        beforeFiles: [
+          {
+            source: "/query/:path*",
+            destination: "/rewritten/:path*",
+            has: [{ type: "query", key: "preview", value: "1" }],
+          },
+          { source: "/header", requiresServerEvaluation: true },
+          {
+            source: "/host",
+            destination: "/host-target",
+            has: [{ type: "host", key: "host", value: "example.com" }],
+          },
+        ],
+        afterFiles: [
+          { source: "/cookie", requiresServerEvaluation: true },
+          { source: "/external", requiresServerEvaluation: true },
+          { source: "/future-condition", requiresServerEvaluation: true },
+        ],
+        fallback: [{ source: "/only-without-cookie", requiresServerEvaluation: true }],
+      },
+      sortedPages: [],
+    });
+    expect(content).not.toContain("header-target-canary");
+    expect(content).not.toContain("header-secret-canary");
+    expect(content).not.toContain("cookie-target-canary");
+    expect(content).not.toContain("cookie-secret-canary");
+    expect(content).not.toContain("protocol-relative-destination-canary");
+    expect(content).not.toContain("future-target-canary");
+    expect(content).not.toContain("future-secret-canary");
     expect(content).not.toContain('"missing"');
   });
 

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -128,15 +128,36 @@ const minimalAppRoutes: AppRoute[] = [
 // ── App Router manifest construction ─────────────────────────────────
 
 describe("App Router generated manifest construction", () => {
-  it("embeds client rewrite rules in the App browser entry", () => {
+  it("embeds only client-safe rewrite data in the App browser entry", () => {
     const code = generateBrowserEntry([], null, [], {
-      afterFiles: [],
-      beforeFiles: [{ source: "/legacy", destination: "/about" }],
-      fallback: [],
+      afterFiles: [
+        {
+          source: "/conditional",
+          destination: "/about",
+          has: [{ type: "query", key: "preview", value: "1" }],
+        },
+      ],
+      beforeFiles: [
+        {
+          source: "/external",
+          destination: "https://internal.example/proxy?token=external-destination-canary",
+        },
+      ],
+      fallback: [
+        {
+          source: "/missing-cookie",
+          destination: "/about",
+          missing: [{ type: "cookie", key: "session", value: "missing-condition-canary" }],
+        },
+      ],
     });
 
-    expect(code).toContain('window.__VINEXT_CLIENT_REWRITES__ = {"afterFiles":[],"beforeFiles"');
-    expect(code).toContain('"source":"/legacy","destination":"/about"');
+    expect(code).toContain('"source":"/conditional","destination":"/about"');
+    expect(code).toContain('"has":[{"type":"query","key":"preview","value":"1"}]');
+    expect(code).toContain('"requiresServerEvaluation":true');
+    expect(code).not.toContain("internal.example");
+    expect(code).not.toContain("external-destination-canary");
+    expect(code).not.toContain("missing-condition-canary");
   });
 
   it("embeds the Link auto-prefetch route manifest in the browser entry", () => {
@@ -1344,6 +1365,57 @@ describe("App Router entry templates", () => {
 // ── Pages Router entry template runtime bootstrap ─────────────────────
 
 describe("Pages Router entry template", () => {
+  it("embeds only client-safe rewrite data in the Pages browser entry", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-client-rewrites-"));
+    const pagesDir = path.join(tmpDir, "pages");
+
+    try {
+      fs.mkdirSync(pagesDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(pagesDir, "index.tsx"),
+        "export default function Page() { return null; }",
+      );
+
+      const code = await generateClientEntry(
+        pagesDir,
+        await resolveNextConfig({
+          rewrites: async () => ({
+            afterFiles: [
+              {
+                source: "/conditional",
+                destination: "/about",
+                has: [{ type: "query", key: "preview", value: "1" }],
+              },
+            ],
+            beforeFiles: [
+              {
+                source: "/external",
+                destination: "https://internal.example/proxy?token=external-destination-canary",
+              },
+            ],
+            fallback: [
+              {
+                source: "/missing-cookie",
+                destination: "/about",
+                missing: [{ type: "cookie", key: "session", value: "missing-condition-canary" }],
+              },
+            ],
+          }),
+        }),
+        createValidFileMatcher(),
+      );
+
+      expect(code).toContain('"source":"/conditional","destination":"/about"');
+      expect(code).toContain('"has":[{"type":"query","key":"preview","value":"1"}]');
+      expect(code).toContain('"requiresServerEvaluation":true');
+      expect(code).not.toContain("internal.example");
+      expect(code).not.toContain("external-destination-canary");
+      expect(code).not.toContain("missing-condition-canary");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("reports trusted _next/data classification from URL normalization", async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-pages-data-entry-"));
     const pagesDir = path.join(tmpDir, "pages");

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -142,12 +142,22 @@ describe("App Router generated manifest construction", () => {
           source: "/external",
           destination: "https://internal.example/proxy?token=external-destination-canary",
         },
+        {
+          source: "/header",
+          destination: "/header-target-canary",
+          has: [{ type: "header", key: "x-origin-auth", value: "header-secret-canary" }],
+        },
       ],
       fallback: [
         {
           source: "/missing-cookie",
           destination: "/about",
           missing: [{ type: "cookie", key: "session", value: "missing-condition-canary" }],
+        },
+        {
+          source: "/cookie",
+          destination: "/cookie-target-canary",
+          has: [{ type: "cookie", key: "internal-access", value: "cookie-secret-canary" }],
         },
       ],
     });
@@ -158,6 +168,10 @@ describe("App Router generated manifest construction", () => {
     expect(code).not.toContain("internal.example");
     expect(code).not.toContain("external-destination-canary");
     expect(code).not.toContain("missing-condition-canary");
+    expect(code).not.toContain("header-target-canary");
+    expect(code).not.toContain("header-secret-canary");
+    expect(code).not.toContain("cookie-target-canary");
+    expect(code).not.toContain("cookie-secret-canary");
   });
 
   it("embeds the Link auto-prefetch route manifest in the browser entry", () => {
@@ -1392,12 +1406,22 @@ describe("Pages Router entry template", () => {
                 source: "/external",
                 destination: "https://internal.example/proxy?token=external-destination-canary",
               },
+              {
+                source: "/header",
+                destination: "/header-target-canary",
+                has: [{ type: "header", key: "x-origin-auth", value: "header-secret-canary" }],
+              },
             ],
             fallback: [
               {
                 source: "/missing-cookie",
                 destination: "/about",
                 missing: [{ type: "cookie", key: "session", value: "missing-condition-canary" }],
+              },
+              {
+                source: "/cookie",
+                destination: "/cookie-target-canary",
+                has: [{ type: "cookie", key: "internal-access", value: "cookie-secret-canary" }],
               },
             ],
           }),
@@ -1411,6 +1435,10 @@ describe("Pages Router entry template", () => {
       expect(code).not.toContain("internal.example");
       expect(code).not.toContain("external-destination-canary");
       expect(code).not.toContain("missing-condition-canary");
+      expect(code).not.toContain("header-target-canary");
+      expect(code).not.toContain("header-secret-canary");
+      expect(code).not.toContain("cookie-target-canary");
+      expect(code).not.toContain("cookie-secret-canary");
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/tests/hybrid-client-route-owner.test.ts
+++ b/tests/hybrid-client-route-owner.test.ts
@@ -22,7 +22,7 @@ import type {
   VinextLinkPrefetchRoute,
   VinextPagesLinkPrefetchRoute,
 } from "../packages/vinext/src/client/vinext-next-data.js";
-import type { NextRewrite } from "../packages/vinext/src/config/next-config.js";
+import type { ClientRewrites } from "../packages/vinext/src/client/client-rewrites.js";
 import {
   resolveHybridClientRewriteHref,
   resolveHybridClientRouteOwner,
@@ -33,11 +33,7 @@ const APP_BASE = "http://localhost/";
 type WindowState = {
   app: VinextLinkPrefetchRoute[];
   pages: VinextPagesLinkPrefetchRoute[];
-  rewrites?: {
-    afterFiles: NextRewrite[];
-    beforeFiles: NextRewrite[];
-    fallback: NextRewrite[];
-  };
+  rewrites?: ClientRewrites;
 };
 
 function installWindow({ app, pages, rewrites }: WindowState): void {
@@ -209,6 +205,42 @@ describe("resolveHybridClientRouteOwner", () => {
 
     expect(resolveHybridClientRouteOwner("/source", "")).toBeNull();
     expect(resolveHybridClientRouteOwner("/source?preview=1", "")).toBe("app");
+  });
+
+  it("hands server-evaluated rewrites back to the document request", () => {
+    installWindow({
+      app: [appRoute(["app-destination"], false)],
+      pages: [],
+      rewrites: {
+        afterFiles: [],
+        beforeFiles: [{ source: "/source", requiresServerEvaluation: true }],
+        fallback: [],
+      },
+    });
+
+    expect(resolveHybridClientRewriteHref("/source", "")).toBeNull();
+    expect(resolveHybridClientRouteOwner("/source", "")).toBe("document");
+  });
+
+  it("checks public has conditions before handing a rewrite to the server", () => {
+    installWindow({
+      app: [appRoute(["app-destination"], false)],
+      pages: [],
+      rewrites: {
+        afterFiles: [],
+        beforeFiles: [
+          {
+            source: "/source",
+            has: [{ type: "query", key: "preview", value: "1" }],
+            requiresServerEvaluation: true,
+          },
+        ],
+        fallback: [],
+      },
+    });
+
+    expect(resolveHybridClientRouteOwner("/source", "")).toBeNull();
+    expect(resolveHybridClientRouteOwner("/source?preview=1", "")).toBe("document");
   });
 
   it("applies every beforeFiles rewrite before choosing ownership", () => {

--- a/tests/hybrid-client-route-owner.test.ts
+++ b/tests/hybrid-client-route-owner.test.ts
@@ -22,7 +22,10 @@ import type {
   VinextLinkPrefetchRoute,
   VinextPagesLinkPrefetchRoute,
 } from "../packages/vinext/src/client/vinext-next-data.js";
-import type { ClientRewrites } from "../packages/vinext/src/client/client-rewrites.js";
+import {
+  toClientRewrites,
+  type ClientRewrites,
+} from "../packages/vinext/src/client/client-rewrites.js";
 import {
   resolveHybridClientRewriteHref,
   resolveHybridClientRouteOwner,
@@ -207,36 +210,52 @@ describe("resolveHybridClientRouteOwner", () => {
     expect(resolveHybridClientRouteOwner("/source?preview=1", "")).toBe("app");
   });
 
-  it("hands server-evaluated rewrites back to the document request", () => {
+  it("hands rewrites with browser-invisible conditions back to the document request", () => {
     installWindow({
       app: [appRoute(["app-destination"], false)],
       pages: [],
-      rewrites: {
+      rewrites: toClientRewrites({
         afterFiles: [],
-        beforeFiles: [{ source: "/source", requiresServerEvaluation: true }],
+        beforeFiles: [
+          {
+            source: "/cookie-source",
+            destination: "/app-destination",
+            has: [{ type: "cookie", key: "internal-access", value: "cookie-secret" }],
+          },
+          {
+            source: "/header-source",
+            destination: "/app-destination",
+            has: [{ type: "header", key: "x-origin-auth", value: "header-secret" }],
+          },
+        ],
         fallback: [],
-      },
+      }),
     });
 
-    expect(resolveHybridClientRewriteHref("/source", "")).toBeNull();
-    expect(resolveHybridClientRouteOwner("/source", "")).toBe("document");
+    expect(resolveHybridClientRewriteHref("/cookie-source", "")).toBeNull();
+    expect(resolveHybridClientRouteOwner("/cookie-source", "")).toBe("document");
+    expect(resolveHybridClientRewriteHref("/header-source", "")).toBeNull();
+    expect(resolveHybridClientRouteOwner("/header-source", "")).toBe("document");
   });
 
-  it("checks public has conditions before handing a rewrite to the server", () => {
+  it("uses browser-authoritative conditions as a server handoff prefilter", () => {
     installWindow({
       app: [appRoute(["app-destination"], false)],
       pages: [],
-      rewrites: {
+      rewrites: toClientRewrites({
         afterFiles: [],
         beforeFiles: [
           {
             source: "/source",
-            has: [{ type: "query", key: "preview", value: "1" }],
-            requiresServerEvaluation: true,
+            destination: "/app-destination",
+            has: [
+              { type: "query", key: "preview", value: "1" },
+              { type: "cookie", key: "internal-access", value: "cookie-secret" },
+            ],
           },
         ],
         fallback: [],
-      },
+      }),
     });
 
     expect(resolveHybridClientRouteOwner("/source", "")).toBeNull();

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -20751,6 +20751,48 @@ describe("Pages Router _next/data client navigation", () => {
     }
   });
 
+  it("hands server-evaluated rewrites to a document navigation", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+
+    const destinationLoader = vi.fn(async () => makePageModule("destination"));
+    const { win } = createDataNavWindow({
+      loaders: {
+        "/": vi.fn(async () => makePageModule("home")),
+        "/conditional": destinationLoader,
+      },
+      ssgPatterns: [],
+      sspPatterns: [],
+    });
+    const hrefAssignments = trackHrefAssignmentsLocal(win);
+    (win as any).__VINEXT_CLIENT_REWRITES__ = {
+      beforeFiles: [{ source: "/conditional", requiresServerEvaluation: true }],
+      afterFiles: [],
+      fallback: [],
+    };
+    (globalThis as any).window = win;
+    vi.resetModules();
+
+    const fetchMock = vi.fn(async () => new Response("{}"));
+    globalThis.fetch = fetchMock as any;
+
+    try {
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      const Router = routerModule.default;
+      const result = await Router.push("/conditional");
+
+      expect(result).toBe(false);
+      expect(hrefAssignments).toContain("/conditional");
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(destinationLoader).not.toHaveBeenCalled();
+    } finally {
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+      vi.resetModules();
+    }
+  });
+
   it("preserves the visible pathname for query-only beforeFiles rewrite navigations", async () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -8,6 +8,7 @@ import { fileURLToPath } from "node:url";
 import { PAGES_FIXTURE_DIR, aliasEntriesToRecord } from "./helpers.js";
 import { isExternalUrl, isHashOnlyChange } from "../packages/vinext/src/shims/router.js";
 import { extractVinextNextDataJson } from "../packages/vinext/src/client/vinext-next-data.js";
+import { toClientRewrites } from "../packages/vinext/src/client/client-rewrites.js";
 import { isValidModulePath } from "../packages/vinext/src/client/validate-module-path.js";
 import vinext from "../packages/vinext/src/index.js";
 import { safeJsonStringify } from "../packages/vinext/src/server/html.js";
@@ -20751,7 +20752,16 @@ describe("Pages Router _next/data client navigation", () => {
     }
   });
 
-  it("hands server-evaluated rewrites to a document navigation", async () => {
+  it.each([
+    [
+      "an HttpOnly cookie",
+      { type: "cookie", key: "internal-access", value: "cookie-secret" } as const,
+    ],
+    [
+      "a server-added header",
+      { type: "header", key: "x-origin-auth", value: "header-secret" } as const,
+    ],
+  ])("hands a rewrite requiring %s to a document navigation", async (_label, condition) => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;
 
@@ -20765,11 +20775,11 @@ describe("Pages Router _next/data client navigation", () => {
       sspPatterns: [],
     });
     const hrefAssignments = trackHrefAssignmentsLocal(win);
-    (win as any).__VINEXT_CLIENT_REWRITES__ = {
-      beforeFiles: [{ source: "/conditional", requiresServerEvaluation: true }],
+    (win as any).__VINEXT_CLIENT_REWRITES__ = toClientRewrites({
+      beforeFiles: [{ source: "/conditional", destination: "/private", has: [condition] }],
       afterFiles: [],
       fallback: [],
-    };
+    });
     (globalThis as any).window = win;
     vi.resetModules();
 


### PR DESCRIPTION
## Overview

| | |
| --- | --- |
| Goal | Publish only rewrite data the browser can evaluate authoritatively |
| Core change | Project resolved rewrites into a client-specific discriminated manifest |
| Key boundary | Only internal destinations with query or host conditions remain client-resolvable |
| Expected impact | Client-safe rewrites keep SPA navigation; every other rule returns to the server |

## Why

Client routing is correct only when every input to a rewrite decision is authoritative in the browser. Query and host conditions meet that requirement. Cookie conditions may depend on HttpOnly values, arbitrary headers may be added by the server or an intermediary, and `missing` conditions require complete request context.

The client projection therefore fails closed. Rules with external destinations, `missing` conditions, cookie or header `has` conditions, or unknown future condition types omit both the destination and server-only condition data. The source and any safe query or host preconditions remain available so the router can conservatively hand matching navigations back to the server.

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| Internal rewrite with query or host conditions | Full rule serialized and resolved on the client | Minimal rule serialized and resolved on the client |
| Rewrite with cookie or header conditions | Condition and destination serialized; browser matching could false-negative | Server-only values omitted; matching source returns to the server |
| External or `missing` rewrite | Server-only data could be present in client output | Destination and server-only conditions omitted |
| `_buildManifest.js` | Used a separate rewrite normalizer | Uses the same projection as App and Pages entries |
| Unknown future condition type | No explicit policy | Defaults to server evaluation |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/client/client-rewrites.ts` defines the allow-list and discriminated client manifest.
2. `packages/vinext/src/build/next-client-runtime-manifests.ts` applies that projection to `_buildManifest.js`.
3. `packages/vinext/src/client/client-rewrite-matcher.ts` performs client resolution or server handoff.
4. `tests/client-build-manifest.test.ts` verifies the emitted file and serialized projection.
5. `tests/hybrid-client-route-owner.test.ts` and `tests/shims.test.ts` verify App/Link and Pages Router behavior from raw rewrite config.

</details>

## Validation

- App and Pages generated entries omit external, missing, cookie, and header canaries.
- The emitted `_buildManifest.js` uses the same projection and omits protocol-relative destinations.
- HttpOnly-cookie and server-added-header rules perform document navigation through both client consumers.
- Query and host conditions remain client-resolvable; mixed safe and server-only conditions retain only a safe prefilter.

<details>
<summary>Commands and results</summary>

- `vp check`: passed across 1,164 checked files.
- `vp test run tests/client-build-manifest.test.ts tests/entry-templates.test.ts tests/hybrid-client-route-owner.test.ts tests/shims.test.ts`: 1,372 tests passed.
- `vp run vinext#build`: passed.
- Pre-commit full check, staged unit and integration tests, and knip: passed.

</details>

## Risk / compatibility

- Public API: unchanged.
- Internal rewrites using only query or host conditions retain soft navigation.
- Rules requiring server-only inputs may perform a full document navigation even when the hidden condition ultimately does not match. This is deliberate because the server is the first authoritative evaluation boundary.
- The client manifest gains an internal `requiresServerEvaluation` discriminator; destination-less entries remain compatible with the existing server-handoff behavior.
