### PR TITLE
fix(pages-router): stream piped API responses with backpressure

### DIFF
--- a/packages/vinext/src/server/pages-api-route.ts
+++ b/packages/vinext/src/server/pages-api-route.ts
@@ -8,6 +8,7 @@ import {
 } from "../utils/query.js";
 import {
   createPagesReqRes,
+  markVinextStreamedApiResponse,
   parsePagesApiBody,
   type PagesRequestQuery,
   type PagesReqResRequest,
@@ -228,7 +229,15 @@ async function _handlePagesApiRoute(options: HandlePagesApiRouteOptions): Promis
     if (!externalResolver && !resWasPiped && !res.headersSent) {
       res.end();
     }
-    return await responsePromise;
+    const response = await responsePromise;
+    // The response resolves on the first write; if `end()` still has not been
+    // called by the time it settles, the body is a live stream (e.g. a piped
+    // proxy upstream). Mark it so buffering adapters forward it as a stream
+    // instead of holding the whole body in memory until the source closes.
+    if (!res.writableEnded) {
+      markVinextStreamedApiResponse(response);
+    }
+    return response;
   } catch (error) {
     if (error instanceof PagesApiBodyParseError) {
       return new Response(error.message, {

--- a/packages/vinext/src/server/pages-api-route.ts
+++ b/packages/vinext/src/server/pages-api-route.ts
@@ -23,7 +23,11 @@ import {
   isEdgeApiRuntime,
   type EdgeApiExecutionRuntime,
 } from "./edge-api-runtime.js";
-import { runWithExecutionContext, type ExecutionContextLike } from "vinext/shims/request-context";
+import {
+  getRequestExecutionContext,
+  runWithExecutionContext,
+  type ExecutionContextLike,
+} from "vinext/shims/request-context";
 import { NextRequest } from "vinext/shims/server";
 
 type PagesApiRouteConfig = {
@@ -270,9 +274,16 @@ async function _handlePagesApiRoute(options: HandlePagesApiRouteOptions): Promis
     // the handler to finish first.
     const firstSettled = await Promise.race([responseReady, handlerCompletion]);
     if (firstSettled.type === "response") {
-      void handlerCompletion.then(completeHandler, (error) => {
+      const handlerLifecycle = handlerCompletion.then(completeHandler, (error) => {
         void options.reportRequestError?.(error, route.pattern);
       });
+      // The body may already be complete (for example, res.end() followed by
+      // awaited cleanup), so keeping only a floating promise is not enough on
+      // Workers. Register the remaining handler lifecycle before returning;
+      // this also covers hybrid App/Pages requests, where the context is
+      // inherited from the surrounding App Router handler rather than passed
+      // through options.ctx.
+      getRequestExecutionContext()?.waitUntil(handlerLifecycle);
       return finalizeResponse(firstSettled.response);
     }
 

--- a/packages/vinext/src/server/pages-api-route.ts
+++ b/packages/vinext/src/server/pages-api-route.ts
@@ -180,6 +180,7 @@ async function _handlePagesApiRoute(options: HandlePagesApiRouteOptions): Promis
     if (!isNodeApiRouteModule(route.module)) {
       return new Response("API route does not export a default function", { status: 500 });
     }
+    const handler = route.module.default;
 
     const query = buildPagesApiQuery(options.url, params);
 
@@ -221,23 +222,62 @@ async function _handlePagesApiRoute(options: HandlePagesApiRouteOptions): Promis
     // (e.g. proxy middleware that attaches its pipe asynchronously) sends it.
     const externalResolver = route.module.config?.api?.externalResolver || false;
 
-    await route.module.default(req, res);
-    // Auto-end if no stream is in progress. Without this guard a handler
-    // that forgets to call res.end() would leave the request hanging.
-    // Skipped for `externalResolver: true` routes, which legitimately
-    // respond after the handler settles.
-    if (!externalResolver && !resWasPiped && !res.headersSent) {
-      res.end();
+    const completeHandler = () => {
+      // Auto-end if no stream is in progress. Without this guard a handler
+      // that forgets to call res.end() would leave the request hanging.
+      // Skipped for `externalResolver: true` routes, which legitimately
+      // respond after the handler settles.
+      if (!externalResolver && !resWasPiped && !res.headersSent) {
+        res.end();
+      }
+    };
+    const finalizeResponse = (response: Response) => {
+      // The response resolves on the first write; if `end()` still has not
+      // been called by the time it settles, the body is a live stream (e.g. a
+      // piped proxy upstream). Mark it so buffering adapters forward it as a
+      // stream instead of holding the whole body in memory until the source
+      // closes.
+      if (!res.writableEnded) {
+        markVinextStreamedApiResponse(response);
+      }
+      return response;
+    };
+    const destroyAfterHandlerError = (error: unknown): never => {
+      const normalizedError = error instanceof Error ? error : new Error(String(error));
+      // Once a handler has started writing, the Fetch Response may already be
+      // on its way to the client. Error the bridge so a parked write callback
+      // and the response consumer both settle instead of abandoning the
+      // stream while the error is reported below.
+      res.destroy(normalizedError);
+      throw normalizedError;
+    };
+
+    const responseReady = responsePromise.then((response) => ({
+      type: "response" as const,
+      response,
+    }));
+    // Schedule invocation after both sides of the race have rejection
+    // handlers attached. A synchronous throw may destroy the response bridge,
+    // which rejects responsePromise as well as the handler completion.
+    const handlerCompletion = Promise.resolve()
+      .then(() => handler(req, res))
+      .then(() => ({ type: "handler" as const }), destroyAfterHandlerError);
+
+    // A real Node ServerResponse is consumed by the socket while the API
+    // handler is still running. Mirror that concurrency at the Fetch boundary:
+    // a handler is allowed to await pipeline() or `drain`, so expose the body
+    // as soon as its first write commits the Response instead of waiting for
+    // the handler to finish first.
+    const firstSettled = await Promise.race([responseReady, handlerCompletion]);
+    if (firstSettled.type === "response") {
+      void handlerCompletion.then(completeHandler, (error) => {
+        void options.reportRequestError?.(error, route.pattern);
+      });
+      return finalizeResponse(firstSettled.response);
     }
-    const response = await responsePromise;
-    // The response resolves on the first write; if `end()` still has not been
-    // called by the time it settles, the body is a live stream (e.g. a piped
-    // proxy upstream). Mark it so buffering adapters forward it as a stream
-    // instead of holding the whole body in memory until the source closes.
-    if (!res.writableEnded) {
-      markVinextStreamedApiResponse(response);
-    }
-    return response;
+
+    completeHandler();
+    return finalizeResponse(await responsePromise);
   } catch (error) {
     if (error instanceof PagesApiBodyParseError) {
       return new Response(error.message, {

--- a/packages/vinext/src/server/pages-node-compat.ts
+++ b/packages/vinext/src/server/pages-node-compat.ts
@@ -254,7 +254,7 @@ class PagesResponseStream extends Writable {
   private controller: ReadableStreamDefaultController | null = null;
   private readonly bufferedChunks: Buffer[] = [];
   private streamEnded = false;
-  private pendingWrite: (() => void) | null = null;
+  private pendingWrite: ((error?: Error | null) => void) | null = null;
 
   constructor(
     private readonly resolveResponse: (value: Response) => void,
@@ -441,7 +441,7 @@ class PagesResponseStream extends Writable {
     this.streamEnded = true;
     // A write parked for backpressure would otherwise never complete; release
     // it so piped sources unwind instead of waiting on a dead stream.
-    this.releasePendingWrite();
+    this.releasePendingWrite(error);
     if (!this.resolved) {
       if (error) {
         this.resolved = true;
@@ -483,10 +483,10 @@ class PagesResponseStream extends Writable {
     this.resHeaders[name.toLowerCase()] = Array.isArray(value) ? value.join(", ") : value;
   }
 
-  private releasePendingWrite(): void {
+  private releasePendingWrite(error?: Error | null): void {
     const callback = this.pendingWrite;
     this.pendingWrite = null;
-    callback?.();
+    callback?.(error);
   }
 
   private resolveOnce(): void {

--- a/packages/vinext/src/server/pages-node-compat.ts
+++ b/packages/vinext/src/server/pages-node-compat.ts
@@ -410,8 +410,9 @@ class PagesResponseStream extends Writable {
     // body's queue is full, hold the write callback until the consumer pulls.
     // A held callback makes `write()` return false, which pauses any piped
     // source (e.g. a proxied upstream) instead of queueing chunks without
-    // bound. Writes issued by `end(data)` belong to a complete body — finish
-    // them immediately so `finish` is not gated on the first read.
+    // bound. `end(data)` writes can park here too because Node sets
+    // writableEnded after _write returns; the adapter's first body pull
+    // releases them, and the completed response remains on the buffered path.
     if (
       this.controller &&
       !this.streamEnded &&

--- a/packages/vinext/src/server/pages-node-compat.ts
+++ b/packages/vinext/src/server/pages-node-compat.ts
@@ -254,6 +254,7 @@ class PagesResponseStream extends Writable {
   private controller: ReadableStreamDefaultController | null = null;
   private readonly bufferedChunks: Buffer[] = [];
   private streamEnded = false;
+  private pendingWrite: (() => void) | null = null;
 
   constructor(
     private readonly resolveResponse: (value: Response) => void,
@@ -405,7 +406,22 @@ class PagesResponseStream extends Writable {
       this.bufferedChunks.push(buffer);
     }
     this.resolveOnce();
-    callback();
+    // Propagate consumer backpressure to the Node source: while the response
+    // body's queue is full, hold the write callback until the consumer pulls.
+    // A held callback makes `write()` return false, which pauses any piped
+    // source (e.g. a proxied upstream) instead of queueing chunks without
+    // bound. Writes issued by `end(data)` belong to a complete body — finish
+    // them immediately so `finish` is not gated on the first read.
+    if (
+      this.controller &&
+      !this.streamEnded &&
+      !this.writableEnded &&
+      (this.controller.desiredSize ?? 1) <= 0
+    ) {
+      this.pendingWrite = callback;
+    } else {
+      callback();
+    }
   }
 
   override _final(callback: (error?: Error | null) => void): void {
@@ -423,6 +439,9 @@ class PagesResponseStream extends Writable {
 
   override _destroy(error: Error | null, callback: (error?: Error | null) => void): void {
     this.streamEnded = true;
+    // A write parked for backpressure would otherwise never complete; release
+    // it so piped sources unwind instead of waiting on a dead stream.
+    this.releasePendingWrite();
     if (!this.resolved) {
       if (error) {
         this.resolved = true;
@@ -464,6 +483,12 @@ class PagesResponseStream extends Writable {
     this.resHeaders[name.toLowerCase()] = Array.isArray(value) ? value.join(", ") : value;
   }
 
+  private releasePendingWrite(): void {
+    const callback = this.pendingWrite;
+    this.pendingWrite = null;
+    callback?.();
+  }
+
   private resolveOnce(): void {
     if (this.resolved) {
       return;
@@ -497,6 +522,9 @@ class PagesResponseStream extends Writable {
           }
         }
       },
+      pull: () => {
+        this.releasePendingWrite();
+      },
       cancel: (reason) => {
         this.bufferedChunks.length = 0;
         this.destroy(reason instanceof Error ? reason : new Error("Response body cancelled"));
@@ -505,6 +533,26 @@ class PagesResponseStream extends Writable {
 
     this.resolveResponse(new Response(stream, { status: this.resStatusCode, headers }));
   }
+}
+
+type ResponseWithVinextStreamedApiBody = Response & {
+  __vinextStreamedApiResponse?: boolean;
+};
+
+/**
+ * Marks a Pages API Response whose body was still being written when the
+ * handler settled (streaming/piping), so Node adapters forward it as a stream.
+ * Buffering a live stream would defer delivery until the source closes and
+ * hold the whole body in memory. Complete bodies (`res.json`, `res.send`,
+ * `res.end(data)`) are not marked and keep the buffered path, which preserves
+ * Content-Length.
+ */
+export function markVinextStreamedApiResponse(response: Response): void {
+  (response as ResponseWithVinextStreamedApiBody).__vinextStreamedApiResponse = true;
+}
+
+export function isVinextStreamedApiResponse(response: Response): boolean {
+  return (response as ResponseWithVinextStreamedApiBody).__vinextStreamedApiResponse === true;
 }
 
 export function createPagesReqRes(options: CreatePagesReqResOptions): CreatePagesReqResResult {

--- a/packages/vinext/src/server/pages-request-pipeline.ts
+++ b/packages/vinext/src/server/pages-request-pipeline.ts
@@ -580,12 +580,21 @@ export async function runPagesRequest(
         apiRequest = cloneRequestWithUrl(request, apiRequestUrl.toString());
       }
       const response = await deps.handleApi(apiRequest, apiLookupUrl, deps.ctx ?? null);
+      const merged = mergeHeaders(response, middlewareHeaders, middlewareStatus);
+      // Preserve the streaming marker so the adapter can decide stream-vs-buffer.
+      // mergeHeaders may create a new Response object (losing non-standard
+      // properties), so copy the marker from the original API response.
+      if (merged !== response) {
+        (merged as { __vinextStreamedApiResponse?: boolean }).__vinextStreamedApiResponse = (
+          response as { __vinextStreamedApiResponse?: boolean }
+        ).__vinextStreamedApiResponse;
+      }
       return {
         type: "response",
         // API routes return arbitrary data; default a missing content-type to
         // application/octet-stream (not text/html) to avoid content sniffing.
         defaultContentType: "application/octet-stream",
-        response: mergeHeaders(response, middlewareHeaders, middlewareStatus),
+        response: merged,
       };
     }
     return {

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -2249,7 +2249,9 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
         // carry no defaultContentType — send them verbatim without injecting a
         // Content-Type, matching the pre-refactor behavior. Buffered render/api
         // responses below apply a Content-Type fallback; streamed API responses
-        // apply the same fallback here since they skip the buffered path.
+        // apply the same fallback here since they skip the buffered path. Live
+        // API bodies also cannot use the buffered path's size threshold without
+        // defeating streaming, so sendWebResponse chooses compression up front.
         if (shouldStream || !response.body || result.defaultContentType === undefined) {
           if (
             streamedApi &&

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -437,10 +437,19 @@ function cancelResponseBody(response: Response): void {
 
 type ResponseWithVinextStreamingMetadata = Response & {
   __vinextStreamedHtmlResponse?: boolean;
+  __vinextStreamedApiResponse?: boolean;
 };
 
 function isVinextStreamedHtmlResponse(response: Response): boolean {
   return (response as ResponseWithVinextStreamingMetadata).__vinextStreamedHtmlResponse === true;
+}
+
+// Set by the Pages API bridge (pages-node-compat.ts) when the Response was
+// resolved while the handler was still writing (streaming/piping). Buffering
+// such a body would defer delivery until the source closes and hold the whole
+// stream in memory.
+function isVinextStreamedApiResponse(response: Response): boolean {
+  return (response as ResponseWithVinextStreamingMetadata).__vinextStreamedApiResponse === true;
 }
 
 function logProdServerStarted(host: string, port: number, purpose: ProdServerOptions["purpose"]) {
@@ -2009,12 +2018,21 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
           res.end("Not Found");
           return;
         }
-        const shouldStream = isVinextStreamedHtmlResponse(response);
+        const streamedApi = isVinextStreamedApiResponse(response);
+        const shouldStream = isVinextStreamedHtmlResponse(response) || streamedApi;
         // Passthrough responses (middleware short-circuits, external proxies, redirects)
         // carry no defaultContentType — send them verbatim without injecting a
-        // Content-Type, matching the pre-refactor behavior. Only buffered render/api
-        // responses below apply a Content-Type fallback.
+        // Content-Type, matching the pre-refactor behavior. Buffered render/api
+        // responses below apply a Content-Type fallback; streamed API responses
+        // apply the same fallback here since they skip the buffered path.
         if (shouldStream || !response.body || result.defaultContentType === undefined) {
+          if (
+            streamedApi &&
+            result.defaultContentType !== undefined &&
+            !response.headers.has("content-type")
+          ) {
+            response.headers.set("content-type", result.defaultContentType);
+          }
           await sendWebResponse(response, req, res, compress);
           return;
         }

--- a/packages/vinext/src/shims/unified-request-context.ts
+++ b/packages/vinext/src/shims/unified-request-context.ts
@@ -324,6 +324,9 @@ export function closeAfterResponseWithBody(
   (wrapped as { __vinextStreamedHtmlResponse?: boolean }).__vinextStreamedHtmlResponse = (
     response as { __vinextStreamedHtmlResponse?: boolean }
   ).__vinextStreamedHtmlResponse;
+  (wrapped as { __vinextStreamedApiResponse?: boolean }).__vinextStreamedApiResponse = (
+    response as { __vinextStreamedApiResponse?: boolean }
+  ).__vinextStreamedApiResponse;
   return wrapped;
 }
 

--- a/tests/after-deploy.test.ts
+++ b/tests/after-deploy.test.ts
@@ -198,6 +198,55 @@ describe("after() in deploy mode — Pages Router API handler", () => {
     expect(observedCtx).toBe(ctx);
   });
 
+  it("keeps streaming handler completion alive through the active execution context", async () => {
+    const { handlePagesApiRoute } =
+      await import("../packages/vinext/src/server/pages-api-route.js");
+    const { runWithExecutionContext } =
+      await import("../packages/vinext/src/shims/request-context.js");
+
+    const ctx = createMockCtx();
+    let releaseHandler!: () => void;
+    const handlerGate = new Promise<void>((resolve) => {
+      releaseHandler = resolve;
+    });
+    let handlerSettled = false;
+
+    // The ambient form matches the hybrid App/Pages bridge, where the App
+    // Router owns the request scope and handlePagesApiRoute receives no ctx
+    // argument of its own.
+    const response = await runWithExecutionContext(ctx, () =>
+      handlePagesApiRoute({
+        match: {
+          params: {},
+          route: {
+            pattern: "/api/test",
+            module: {
+              async default(
+                _req: unknown,
+                res: { end: (body?: string) => void; statusCode: number },
+              ) {
+                res.statusCode = 200;
+                res.end("ok");
+                await handlerGate;
+                handlerSettled = true;
+              },
+            },
+          },
+        },
+        request: new Request("https://example.test/api/test"),
+        url: "/api/test",
+      }),
+    );
+
+    await expect(response.text()).resolves.toBe("ok");
+    expect(handlerSettled).toBe(false);
+    expect(ctx.promises).toHaveLength(1);
+
+    releaseHandler();
+    await ctx.promises[0];
+    expect(handlerSettled).toBe(true);
+  });
+
   it("handlePagesApiRoute works without ctx (Node dev parity)", async () => {
     const { handlePagesApiRoute } =
       await import("../packages/vinext/src/server/pages-api-route.js");

--- a/tests/pages-api-route.test.ts
+++ b/tests/pages-api-route.test.ts
@@ -1,7 +1,9 @@
 import { AsyncLocalStorage } from "node:async_hooks";
+import { once } from "node:events";
 import http from "node:http";
 import type { AddressInfo } from "node:net";
 import { PassThrough, Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
 import { gzipSync } from "node:zlib";
 import { describe, expect, it, vi } from "vite-plus/test";
 import {
@@ -981,6 +983,84 @@ describe("pages api route", () => {
     const body = await response.arrayBuffer();
     expect(body.byteLength).toBe(totalChunks * chunk.length);
     expect(produced).toBe(totalChunks);
+  });
+
+  it("streams while an API handler awaits a backpressured pipeline", async () => {
+    // Ported from Next.js's awaited Pages API pipeline pattern:
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/cancel-request/pages/api/node-api.ts
+    // The Node socket consumes `res` concurrently with the handler. The Fetch
+    // bridge must do the same or pipeline() waits for a pull that cannot begin
+    // until handlePagesApiRoute() returns.
+    const totalChunks = 20;
+    const chunk = Buffer.alloc(64 * 1024, "x");
+    let handlerSettled = false;
+
+    const response = await handlePagesApiRoute({
+      match: createMatch(async (_req, res) => {
+        await pipeline(
+          Readable.from(
+            (function* () {
+              for (let i = 0; i < totalChunks; i++) yield chunk;
+            })(),
+          ),
+          res,
+        );
+        handlerSettled = true;
+      }),
+      request: new Request("https://example.com/api/awaited-pipeline"),
+      url: "/api/awaited-pipeline",
+    });
+
+    expect(handlerSettled).toBe(false);
+    const body = await response.arrayBuffer();
+    expect(body.byteLength).toBe(totalChunks * chunk.length);
+    await vi.waitFor(() => expect(handlerSettled).toBe(true));
+  });
+
+  it("streams while an API handler awaits drain", async () => {
+    const totalChunks = 20;
+    const chunk = Buffer.alloc(64 * 1024, "x");
+    let handlerSettled = false;
+
+    const response = await handlePagesApiRoute({
+      match: createMatch(async (_req, res) => {
+        for (let i = 0; i < totalChunks; i++) {
+          if (!res.write(chunk)) await once(res, "drain");
+        }
+        res.end();
+        handlerSettled = true;
+      }),
+      request: new Request("https://example.com/api/awaited-drain"),
+      url: "/api/awaited-drain",
+    });
+
+    expect(handlerSettled).toBe(false);
+    const body = await response.arrayBuffer();
+    expect(body.byteLength).toBe(totalChunks * chunk.length);
+    await vi.waitFor(() => expect(handlerSettled).toBe(true));
+  });
+
+  it("unwinds a parked write when an active streaming handler rejects", async () => {
+    const reportRequestError = vi.fn();
+    const failure = new Error("handler failed after writing");
+    let writeSettled = false;
+
+    const response = await handlePagesApiRoute({
+      match: createMatch(async (_req, res) => {
+        res.write(Buffer.alloc(64 * 1024), () => {
+          writeSettled = true;
+        });
+        throw failure;
+      }),
+      reportRequestError,
+      request: new Request("https://example.com/api/reject-after-write"),
+      url: "/api/reject-after-write",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).rejects.toThrow(failure.message);
+    await vi.waitFor(() => expect(writeSettled).toBe(true));
+    expect(reportRequestError).toHaveBeenCalledWith(failure, "/api/test");
   });
 
   it("marks a response as streamed only while its handler is still writing", async () => {

--- a/tests/pages-api-route.test.ts
+++ b/tests/pages-api-route.test.ts
@@ -1,13 +1,14 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import http from "node:http";
 import type { AddressInfo } from "node:net";
-import { PassThrough } from "node:stream";
+import { PassThrough, Readable } from "node:stream";
 import { gzipSync } from "node:zlib";
 import { describe, expect, it, vi } from "vite-plus/test";
 import {
   handlePagesApiRoute,
   type PagesApiRouteMatch,
 } from "../packages/vinext/src/server/pages-api-route.js";
+import { isVinextStreamedApiResponse } from "../packages/vinext/src/server/pages-node-compat.js";
 
 type PagesApiRouteModule = PagesApiRouteMatch["route"]["module"];
 
@@ -938,6 +939,81 @@ describe("pages api route", () => {
 
     expect(response.status).toBe(200);
     await expect(response.text()).resolves.toBe(body);
+  });
+
+  it("pauses a piped source until the response body is consumed", async () => {
+    // Availability: a fast source (e.g. a proxied upstream) piped into `res`
+    // must pause when the client is not reading, instead of queueing the
+    // entire stream in memory. The write callback is held while the body's
+    // queue is full, so `write()` returns false and `pipe()` pauses the source.
+    const totalChunks = 20;
+    const chunk = Buffer.alloc(64 * 1024, "x");
+    let produced = 0;
+    const source = Readable.from(
+      (function* () {
+        for (let i = 0; i < totalChunks; i++) {
+          produced++;
+          yield chunk;
+        }
+      })(),
+    );
+
+    const response = await handlePagesApiRoute({
+      match: createMatch(
+        (_req, res) => {
+          source.pipe(res);
+        },
+        {},
+        { api: { bodyParser: false } },
+      ),
+      request: new Request("https://example.com/api/backpressure"),
+      url: "/api/backpressure",
+    });
+
+    // Let the pipe run as far as it can while nothing reads the body.
+    for (let i = 0; i < 10; i++) {
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+    // Without backpressure the source drains completely here even though no
+    // consumer has read a single byte.
+    expect(produced).toBeLessThan(totalChunks);
+
+    const body = await response.arrayBuffer();
+    expect(body.byteLength).toBe(totalChunks * chunk.length);
+    expect(produced).toBe(totalChunks);
+  });
+
+  it("marks a response as streamed only while its handler is still writing", async () => {
+    // Contract with Node adapters (prod-server): live streams must be
+    // forwarded as streams, while complete bodies stay on the buffered path
+    // that preserves Content-Length.
+    const upstream = new PassThrough();
+    upstream.write("data");
+    const streamed = await handlePagesApiRoute({
+      match: createMatch(
+        (_req, res) => {
+          // Proxy pattern: the upstream stays open past the handler's return.
+          upstream.pipe(res);
+        },
+        {},
+        { api: { bodyParser: false } },
+      ),
+      request: new Request("https://example.com/api/marker-streamed"),
+      url: "/api/marker-streamed",
+    });
+    expect(isVinextStreamedApiResponse(streamed)).toBe(true);
+    upstream.end("-more");
+    await expect(streamed.text()).resolves.toBe("data-more");
+
+    const buffered = await handlePagesApiRoute({
+      match: createMatch((_req, res) => {
+        res.json({ ok: true });
+      }),
+      request: new Request("https://example.com/api/marker-buffered"),
+      url: "/api/marker-buffered",
+    });
+    expect(isVinextStreamedApiResponse(buffered)).toBe(false);
+    await expect(buffered.json()).resolves.toEqual({ ok: true });
   });
 
   it("streams a piped request body through to the response", async () => {

--- a/tests/pages-api-route.test.ts
+++ b/tests/pages-api-route.test.ts
@@ -1043,12 +1043,12 @@ describe("pages api route", () => {
   it("unwinds a parked write when an active streaming handler rejects", async () => {
     const reportRequestError = vi.fn();
     const failure = new Error("handler failed after writing");
-    let writeSettled = false;
+    let writeError: Error | null | undefined;
 
     const response = await handlePagesApiRoute({
       match: createMatch(async (_req, res) => {
-        res.write(Buffer.alloc(64 * 1024), () => {
-          writeSettled = true;
+        res.write(Buffer.alloc(64 * 1024), (error: Error | null | undefined) => {
+          writeError = error;
         });
         throw failure;
       }),
@@ -1059,8 +1059,26 @@ describe("pages api route", () => {
 
     expect(response.status).toBe(200);
     await expect(response.text()).rejects.toThrow(failure.message);
-    await vi.waitFor(() => expect(writeSettled).toBe(true));
+    await vi.waitFor(() => expect(writeError).toBe(failure));
     expect(reportRequestError).toHaveBeenCalledWith(failure, "/api/test");
+  });
+
+  it("passes cancellation errors to a parked write callback", async () => {
+    const cancellation = new Error("client cancelled");
+    let writeError: Error | null | undefined;
+
+    const response = await handlePagesApiRoute({
+      match: createMatch((_req, res) => {
+        res.write(Buffer.alloc(64 * 1024), (error: Error | null | undefined) => {
+          writeError = error;
+        });
+      }),
+      request: new Request("https://example.com/api/cancel-parked-write"),
+      url: "/api/cancel-parked-write",
+    });
+
+    await response.body!.cancel(cancellation);
+    await vi.waitFor(() => expect(writeError).toBe(cancellation));
   });
 
   it("marks a response as streamed only while its handler is still writing", async () => {


### PR DESCRIPTION
## Overview

| | |
| --- | --- |
| Goal | Make piped Pages API responses (stream proxying, #1902) deliver incrementally with bounded memory |
| Core change | The response bridge holds write callbacks while the body's queue is full, and the Node production server streams live API bodies instead of buffering them |
| Key boundary | `PagesResponseStream` owns backpressure; `handlePagesApiRoute` owns the stream-vs-complete decision; adapters only consume it |
| Expected impact | A piped source pauses when the client reads slowly; proxied SSE/long-lived streams flush incrementally on Node prod. `res.json`/`res.send`/`res.end(data)` behaviour is unchanged |

## Why

Node streams propagate backpressure by withholding the `_write` callback: a held callback makes `write()` return `false`, which pauses any `pipe()` source. `PagesResponseStream._write` enqueued each chunk into the Web `ReadableStream` and invoked the callback synchronously, so the Writable looked infinitely fast. A fast source piped into `res` (the proxy pattern #1902 enabled) kept producing at full rate while a slow client consumed nothing, and every unread chunk accumulated in the stream's unbounded queue. On real Next.js this cannot happen because `res` is a genuine `ServerResponse` with socket backpressure; the bridge silently dropped that property.

Independently, the Node production server read API responses with `arrayBuffer()` before sending. That predates streaming API bodies and was harmless while every API response was complete at resolution time. Once a response can resolve mid-stream, buffering holds the whole body in memory and defers the first byte until the source closes, so a proxied SSE stream never flushes.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| `PagesResponseStream` | A Writable must not acknowledge writes faster than its consumer drains | Write callback is parked while `desiredSize <= 0` and released from the stream's `pull()` hook (or on destroy) |
| `handlePagesApiRoute` | Only the bridge layer can know whether a body is complete or live | Responses still being written when the handler settles are marked streamed |
| Node prod server | A live stream must be forwarded, not materialised | Marked responses take the existing `sendWebResponse` streaming path, with the same `application/octet-stream` content-type fallback the buffered path applied |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| `upstream.pipe(res)` with a slow client | Source drained at full rate; unread chunks queued without bound | Source pauses after roughly one queued chunk plus the Writable's 16 KB buffer, resumes per consumer read |
| Piped/streaming API response on Node prod | Fully buffered via `arrayBuffer()`; first byte only after the source closed | Streams through `sendWebResponse`; bytes flush as they are written |
| `res.json` / `res.send` / `res.end(data)` | Buffered send with Content-Length | Unchanged (complete bodies are not marked streamed and keep the buffered path) |
| Client cancels mid-stream | Writable destroyed | Unchanged, and a parked write callback is released so piped sources unwind |
| Middleware headers merged onto an API response | Marker n/a | Streamed marker survives the `mergeHeaders` rewrap (same propagation as the streamed-HTML marker) |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/server/pages-node-compat.ts` for the backpressure mechanism (`_write` parking, `pull()` release, `_destroy` release) and the marker helpers.
2. `packages/vinext/src/server/pages-api-route.ts` for the stream-vs-complete decision after the response settles.
3. `packages/vinext/src/server/prod-server.ts` for the stream-vs-buffer branch and content-type fallback.
4. `packages/vinext/src/server/pages-request-pipeline.ts` and `packages/vinext/src/shims/unified-request-context.ts` for marker propagation across Response rewraps.
5. `tests/pages-api-route.test.ts` for the regression proof.

</details>

<details>
<summary>Validation</summary>

- New regression test: a 20-chunk (64 KB each) piped source must not drain while nothing reads the body, and completes fully once the body is consumed.
- New contract test: a response settled mid-pipe is marked streamed; `res.json` is not.
- All 70 tests in `tests/pages-api-route.test.ts` and `tests/pages-bodyparser-config.test.ts` pass, including the existing #1902 streaming, cancellation, and destroy-mid-stream cases.
- `tests/pages-node-compat.test.ts`, `tests/pages-request-pipeline.test.ts`, `tests/unified-request-context.test.ts` pass (118 tests).
- `vp check` clean on all touched files; pre-commit full check, staged tests, and knip passed.

</details>

<details>
<summary>Risk / compatibility</summary>

- No public API change; the marker is a non-enumerable-style internal property consumed only by vinext adapters.
- Complete-body responses keep the buffered path, so Content-Length emission on Node prod (#2703 behaviour) is unchanged.
- Responses that stream then finish quickly now go chunked on Node prod instead of buffered with Content-Length. This matches Next.js, where `res.write()` implies chunked transfer.
- A handler that writes and never ends nor pipes still relies on the existing auto-end/cancellation paths; parked callbacks are always released on destroy, so no new hang path is introduced.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| #1902 | Introduced stream proxying for Pages API routes; this PR makes that pattern flow-controlled and actually incremental on Node prod |
| #2703 | Content-Length preservation for buffered responses, deliberately kept intact for complete bodies |
