### PR TITLE
fix(middleware): stop restoring credentials middleware deleted before external rewrites

### DIFF
--- a/packages/vinext/src/config/config-matchers.ts
+++ b/packages/vinext/src/config/config-matchers.ts
@@ -448,13 +448,8 @@ function shouldEvaluateRule(ruleBasePath: false | undefined, state: BasePathMatc
 export function applyMiddlewareRequestHeaders(
   middlewareHeaders: Record<string, string | string[]>,
   request: Request,
-  options: { preserveCredentialHeaders?: boolean } = {},
 ): { request: Request; postMwReqCtx: RequestContext } {
-  const nextHeaders = buildRequestHeadersFromMiddlewareResponse(
-    request.headers,
-    middlewareHeaders,
-    options,
-  );
+  const nextHeaders = buildRequestHeadersFromMiddlewareResponse(request.headers, middlewareHeaders);
 
   for (const key of Object.keys(middlewareHeaders)) {
     if (key.startsWith(MIDDLEWARE_HEADER_PREFIX) && key !== MIDDLEWARE_CACHE_HEADER) {

--- a/packages/vinext/src/server/app-middleware.ts
+++ b/packages/vinext/src/server/app-middleware.ts
@@ -120,9 +120,7 @@ function requestWithMiddlewareRequestHeaders(
   middlewareHeaders: Headers | null,
 ): Request {
   const nextHeaders = middlewareHeaders
-    ? buildRequestHeadersFromMiddlewareResponse(request.headers, middlewareHeaders, {
-        preserveCredentialHeaders: true,
-      })
+    ? buildRequestHeadersFromMiddlewareResponse(request.headers, middlewareHeaders)
     : null;
   if (!nextHeaders) return request;
 

--- a/packages/vinext/src/server/pages-request-pipeline.ts
+++ b/packages/vinext/src/server/pages-request-pipeline.ts
@@ -437,7 +437,6 @@ export async function runPagesRequest(
   const { postMwReqCtx, request: postMwReq } = applyMiddlewareRequestHeaders(
     middlewareHeaders,
     request,
-    { preserveCredentialHeaders: isExternalUrl(resolvedUrl) },
   );
   request = postMwReq;
   const pathnameForResolvedUrl = (value: string): string => value.split("#", 1)[0].split("?", 1)[0];

--- a/packages/vinext/src/utils/middleware-request-headers.ts
+++ b/packages/vinext/src/utils/middleware-request-headers.ts
@@ -4,13 +4,9 @@ import {
   MIDDLEWARE_REQUEST_HEADER_PREFIX,
   MIDDLEWARE_SET_COOKIE_HEADER,
 } from "./protocol-headers.js";
-const CREDENTIAL_REQUEST_HEADERS = ["authorization", "cookie"] as const;
 
 type MiddlewareHeaderValue = string | string[];
 type MiddlewareHeaderSource = Headers | Record<string, MiddlewareHeaderValue>;
-type BuildRequestHeadersOptions = {
-  preserveCredentialHeaders?: boolean;
-};
 
 function getMiddlewareHeaderValue(source: MiddlewareHeaderSource, key: string): string | null {
   if (source instanceof Headers) {
@@ -72,10 +68,15 @@ export function encodeMiddlewareRequestHeaders(
   }
 }
 
+/**
+ * `x-middleware-override-headers` lists the complete post-middleware header set,
+ * so any name absent from it was deleted by middleware. Never re-add absent
+ * headers from the base request — that would resurrect credentials the app
+ * explicitly stripped before an external rewrite.
+ */
 export function buildRequestHeadersFromMiddlewareResponse(
   baseHeaders: Headers,
   middlewareHeaders: MiddlewareHeaderSource,
-  options: BuildRequestHeadersOptions = {},
 ): Headers | null {
   const overrideHeaderNames = getOverrideHeaderNames(middlewareHeaders);
   const forwardedHeaders = getForwardedRequestHeaders(middlewareHeaders);
@@ -91,18 +92,6 @@ export function buildRequestHeadersFromMiddlewareResponse(
       nextHeaders.set(key, value);
     }
     return nextHeaders;
-  }
-
-  if (options.preserveCredentialHeaders) {
-    const overrideHeaderNameSet = new Set(overrideHeaderNames);
-    for (const key of CREDENTIAL_REQUEST_HEADERS) {
-      if (overrideHeaderNameSet.has(key)) continue;
-
-      const value = baseHeaders.get(key);
-      if (value !== null) {
-        nextHeaders.set(key, value);
-      }
-    }
   }
 
   for (const key of overrideHeaderNames) {

--- a/tests/app-router-external-rewrite.test.ts
+++ b/tests/app-router-external-rewrite.test.ts
@@ -140,6 +140,32 @@ describe("App Router external rewrite proxy credential forwarding", () => {
     expect(capturedHeaders!["x-vinext-mw-ctx"]).toBeUndefined();
   });
 
+  it("does not send credentials a middleware rewrite deleted to the external target", async () => {
+    // `x-middleware-override-headers` carries the complete post-middleware
+    // header set, so headers.delete("cookie") before NextResponse.rewrite must
+    // keep first-party credentials off the cross-origin request.
+    mockResponseMode = "plain";
+    capturedHeaders = null;
+
+    const response = await fetch(`${baseUrl}/middleware-external-rewrite`, {
+      headers: {
+        Cookie: "session=secret123",
+        Authorization: "Bearer tok_secret",
+        "x-from-test": "keep-me",
+        "x-middleware-test-rewrite-target": `http://localhost:${mockPort}`,
+        "x-middleware-test-request-override": "strip-credentials",
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(capturedHeaders).not.toBeNull();
+    expect(capturedHeaders!["cookie"]).toBeUndefined();
+    expect(capturedHeaders!["authorization"]).toBeUndefined();
+    // Headers the middleware kept still arrive.
+    expect(capturedHeaders!["x-from-test"]).toBe("keep-me");
+    expect(capturedHeaders!["x-hello-from-middleware1"]).toBe("hello");
+  });
+
   it("strips content-encoding and content-length for Node fetch auto-decompression", async () => {
     mockResponseMode = "gzipHeaderAndBody";
     const response = await fetch(`${baseUrl}/proxy-external-test/some-path`);

--- a/tests/fixtures/app-basic/middleware.ts
+++ b/tests/fixtures/app-basic/middleware.ts
@@ -115,10 +115,16 @@ export async function middleware(request: NextRequest, event: NextFetchEvent) {
     if (target) {
       const rewriteTarget = new URL("/middleware-external-target", target);
       rewriteTarget.search = request.nextUrl.search;
-      if (request.headers.get("x-middleware-test-request-override") === "1") {
+      const override = request.headers.get("x-middleware-test-request-override");
+      if (override === "1" || override === "strip-credentials") {
         const headers = new Headers(request.headers);
         headers.set("x-hello-from-middleware1", "hello");
         headers.set("x-hello-from-middleware2", "world");
+        // Credentials deleted here must not reach the external target (#1121 regression).
+        if (override === "strip-credentials") {
+          headers.delete("cookie");
+          headers.delete("authorization");
+        }
         return NextResponse.rewrite(rewriteTarget, { request: { headers } });
       }
       return NextResponse.rewrite(rewriteTarget);

--- a/tests/pages-request-pipeline.test.ts
+++ b/tests/pages-request-pipeline.test.ts
@@ -1802,11 +1802,11 @@ describe("deferred error page re-render on 404", () => {
   });
 });
 
-// 19. preserveCredentialHeaders: isExternalUrl(resolvedUrl) → passed to applyMiddlewareRequestHeaders
-describe("preserveCredentialHeaders", () => {
-  it("preserves credential headers when resolvedUrl is external", async () => {
-    // When middleware rewrites to an external URL, the Authorization header
-    // should be forwarded. We verify by ensuring the pipeline reaches external proxy.
+// 19. Credential headers on external rewrites follow the middleware override list
+describe("external rewrite credential headers", () => {
+  it("forwards credentials when middleware sends no override list", async () => {
+    // No `x-middleware-override-headers` means middleware left the request
+    // headers alone, so Authorization reaches the external upstream.
     const mockFetch = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(new Response("proxied", { status: 200 }));
@@ -1823,8 +1823,35 @@ describe("preserveCredentialHeaders", () => {
       }),
     );
     expect(result.type).toBe("response");
-    // Verify fetch was called (external proxy triggered)
-    expect(mockFetch).toHaveBeenCalled();
+    const init = mockFetch.mock.calls[0][1] as RequestInit;
+    expect(new Headers(init.headers).get("authorization")).toBe("Bearer token");
+    mockFetch.mockRestore();
+  });
+
+  it("does not forward credentials the middleware deleted from the override list", async () => {
+    const mockFetch = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response("proxied", { status: 200 }));
+
+    const req = makeRequest("/internal", { Authorization: "Bearer token", Cookie: "session=abc" });
+    const result = await runPagesRequest(
+      req,
+      baseDeps({
+        runMiddleware: makeMiddleware({
+          continue: true,
+          rewriteUrl: "https://external.com/api",
+          responseHeaders: [
+            ["x-middleware-override-headers", "x-added"],
+            ["x-middleware-request-x-added", "1"],
+          ],
+        }),
+      }),
+    );
+    expect(result.type).toBe("response");
+    const headers = new Headers((mockFetch.mock.calls[0][1] as RequestInit).headers);
+    expect(headers.get("authorization")).toBeNull();
+    expect(headers.get("cookie")).toBeNull();
+    expect(headers.get("x-added")).toBe("1");
     mockFetch.mockRestore();
   });
 });

--- a/tests/request-pipeline.test.ts
+++ b/tests/request-pipeline.test.ts
@@ -912,7 +912,10 @@ describe("filterInternalHeaders", () => {
 });
 
 describe("buildRequestHeadersFromMiddlewareResponse", () => {
-  it("preserves credential headers when applying partial middleware override headers", () => {
+  it("drops every header absent from the override list, credentials included", () => {
+    // Next.js treats the override list as the complete post-middleware header
+    // set (resolve-routes.ts deletes non-listed request headers), so an absent
+    // name means deleted — it must never be restored from the base request.
     const baseHeaders = new Headers({
       authorization: "Bearer token",
       cookie: "session=abc",
@@ -923,34 +926,30 @@ describe("buildRequestHeadersFromMiddlewareResponse", () => {
       "x-middleware-request-x-added": "1",
     });
 
-    const result = buildRequestHeadersFromMiddlewareResponse(baseHeaders, middlewareHeaders, {
-      preserveCredentialHeaders: true,
-    });
-
-    expect(result).not.toBeNull();
-    expect(result!.get("authorization")).toBe("Bearer token");
-    expect(result!.get("cookie")).toBe("session=abc");
-    expect(result!.get("x-added")).toBe("1");
-    expect(result!.get("x-keep")).toBeNull();
-  });
-
-  it("deletes credential headers when middleware explicitly omits their forwarded values", () => {
-    const baseHeaders = new Headers({
-      authorization: "Bearer token",
-      cookie: "session=abc",
-      "x-keep": "original",
-    });
-    const middlewareHeaders = new Headers({
-      "x-middleware-override-headers": "authorization,cookie,x-keep",
-      "x-middleware-request-x-keep": "updated",
-    });
-
     const result = buildRequestHeadersFromMiddlewareResponse(baseHeaders, middlewareHeaders);
 
     expect(result).not.toBeNull();
     expect(result!.get("authorization")).toBeNull();
     expect(result!.get("cookie")).toBeNull();
-    expect(result!.get("x-keep")).toBe("updated");
+    expect(result!.get("x-keep")).toBeNull();
+    expect(result!.get("x-added")).toBe("1");
+  });
+
+  it("keeps base headers when middleware sends no override list at all", () => {
+    // NextResponse.next() without `request` emits no override list; that is the
+    // "unchanged" signal, and only then are base headers carried through.
+    const baseHeaders = new Headers({
+      authorization: "Bearer token",
+      cookie: "session=abc",
+    });
+    const middlewareHeaders = new Headers({ "x-middleware-request-x-added": "1" });
+
+    const result = buildRequestHeadersFromMiddlewareResponse(baseHeaders, middlewareHeaders);
+
+    expect(result).not.toBeNull();
+    expect(result!.get("authorization")).toBe("Bearer token");
+    expect(result!.get("cookie")).toBe("session=abc");
+    expect(result!.get("x-added")).toBe("1");
   });
 });
 

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -9462,7 +9462,11 @@ describe("double-encoded path handling in middleware", () => {
     }
   });
 
-  it("external middleware rewrite proxy preserves credentials when applying partial request overrides", async () => {
+  it("external middleware rewrite proxy does not forward credentials the middleware deleted", async () => {
+    // `x-middleware-override-headers` is the complete post-middleware header set,
+    // so a name missing from it means "deleted" — never "unchanged". Restoring
+    // cookie/authorization here would leak first-party credentials cross-origin.
+    const { NextResponse } = await import("../packages/vinext/src/shims/server.js");
     const { proxyExternalMiddlewareRewrite } =
       await import("../packages/vinext/src/server/app-middleware.js");
     const http = await import("node:http");
@@ -9478,30 +9482,34 @@ describe("double-encoded path handling in middleware", () => {
       const address = server.address();
       expect(address && typeof address === "object").toBe(true);
       const port = address && typeof address === "object" ? address.port : 0;
-      const response = await proxyExternalMiddlewareRewrite(
-        new Request("http://localhost:3000/source", {
-          headers: {
-            authorization: "Bearer secret",
-            cookie: "session=abc",
-            "x-keep": "original",
-          },
-        }),
-        `http://127.0.0.1:${port}/target`,
-        {
-          headers: null,
-          requestHeaders: new Headers({
-            "x-middleware-override-headers": "x-added",
-            "x-middleware-request-x-added": "1",
-          }),
-          status: null,
+      const request = new Request("http://localhost:3000/source", {
+        headers: {
+          authorization: "Bearer secret",
+          cookie: "session=abc",
+          "x-keep": "original",
         },
+      });
+
+      // The documented deletion pattern: clone, delete, rewrite.
+      const headers = new Headers(request.headers);
+      headers.delete("cookie");
+      headers.delete("authorization");
+      headers.set("x-added", "1");
+      const middlewareResponse = NextResponse.rewrite(`http://127.0.0.1:${port}/target`, {
+        request: { headers },
+      });
+
+      const response = await proxyExternalMiddlewareRewrite(
+        request,
+        `http://127.0.0.1:${port}/target`,
+        { headers: null, requestHeaders: middlewareResponse.headers, status: null },
       );
 
       expect(response.status).toBe(200);
-      expect(capturedHeaders.authorization).toBe("Bearer secret");
-      expect(capturedHeaders.cookie).toBe("session=abc");
+      expect(capturedHeaders.authorization).toBeUndefined();
+      expect(capturedHeaders.cookie).toBeUndefined();
       expect(capturedHeaders["x-added"]).toBe("1");
-      expect(capturedHeaders["x-keep"]).toBeUndefined();
+      expect(capturedHeaders["x-keep"]).toBe("original");
     } finally {
       await new Promise<void>((resolve) => server.close(() => resolve()));
     }


### PR DESCRIPTION
## The decision boundary

`x-middleware-override-headers` is the **complete post-middleware header set, not a diff.**

- `NextResponse.next`/`rewrite` encode *every* key of the `Headers` object middleware passes ([`response.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/spec-extension/response.ts) — `handleMiddlewareField`).
- Next.js then **deletes any request header not in that list** ([`resolve-routes.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/router-utils/resolve-routes.ts)):

  ```js
  // Delete headers.
  for (const key of Object.keys(req.headers)) {
    if (!overriddenHeaders.has(key)) {
      delete req.headers[key]
    }
  }
  ```

There is no tombstone for a deleted header because none is needed. **Absence is the tombstone.**

## The bug

`preserveCredentialHeaders` (#1121) read a short override list as a *partial* override and copied the base request's `cookie`/`authorization` back in. But the documented deletion pattern produces exactly such a list:

```ts
const headers = new Headers(request.headers)
headers.delete('cookie')
return NextResponse.rewrite(externalUrl, { request: { headers } })
```

`cookie` is simply absent from the override list — so the option resurrected it. The option was enabled **only for external rewrites**, so `proxyExternalRequest` then forwarded first-party session cookies and bearer tokens to a cross-origin target, despite the app explicitly stripping them.

Same-origin restoration would have been merely a parity bug; gating it to cross-origin destinations turned it into a credential leak.

## Why removal, not a narrower guard

The "partial override" the option guarded against **cannot occur**. `encodeMiddlewareRequestHeaders` is the only producer of the override list in the codebase, and it always emits the full key set:

```ts
const overrideHeaderNames = [...requestHeaders.keys()];
targetHeaders.set(MIDDLEWARE_OVERRIDE_HEADERS, overrideHeaderNames.join(","));
```

#1121's own "explicit deletion" test passed a list naming `authorization,cookie` with no corresponding `x-middleware-request-*` values — an encoding the public API never emits — so it never exercised the real deletion path. Deleting the option restores Next.js-exact semantics and removes the parameter from three call sites.

## Scenario-level behavior

| Middleware does | Override list | Before | After |
|---|---|---|---|
| `NextResponse.next()` (no `request`) | *not sent* | credentials forwarded | credentials forwarded (unchanged) |
| clones headers, adds one | full set incl. `cookie` | credentials forwarded | credentials forwarded (unchanged) |
| clones headers, **deletes `cookie`** | full set minus `cookie` | 🔴 **`cookie` restored and sent cross-origin** | ✅ `cookie` dropped |

Only the third row changes.

## Validation

Both regression tests were confirmed **failing before the fix, passing after**:

- `tests/app-router-external-rewrite.test.ts` — end to end through the dev server; fixture middleware deletes `cookie`/`authorization` before an external rewrite, mock upstream asserts neither arrives. Pre-fix: `expected 'session=secret123' to be undefined`.
- `tests/shims.test.ts` — the `proxyExternalMiddlewareRewrite` boundary, driven through the real `NextResponse.rewrite` API against a live `node:http` upstream. Pre-fix: `expected 'Bearer secret' to be undefined`.
- `tests/pages-request-pipeline.test.ts` — Pages Router pipeline, both the no-override-list (credentials forwarded) and deleted-from-override-list (dropped) cases.
- `tests/request-pipeline.test.ts` — unit coverage for both override-list states, replacing the two #1121 tests that encoded the buggy expectation.

`pnpm run check` passes (format, lint, types, Next.js type sync, shim types).

## Risk / review path

Behavior change is confined to the one row above — restoring a header the app deleted. Any app relying on the old behavior was relying on a credential leak.

Suggested review order: `middleware-request-headers.ts` (the semantics), then the three call sites (mechanical parameter removal), then the tests.