### PR TITLE
fix(server): evaluate lazy route modules outside the request context

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -427,7 +427,7 @@ import { clearAppRequestContext as __clearRequestContext, setAppNavigationContex
 
 __configureMemoryCacheHandler({ cacheMaxMemorySize: ${JSON.stringify(cacheMaxMemorySize)} });
 import { createAppPrerenderStaticParamsResolver as __createAppPrerenderStaticParamsResolver } from ${JSON.stringify(appPrerenderStaticParamsPath)};
-import { ensureAppRouteModulesLoaded as __ensureRouteLoaded } from ${JSON.stringify(appRouteModuleLoaderPath)};
+import { ensureAppRouteModulesLoaded as __ensureRouteLoaded, loadAppInterceptPage as __loadAppInterceptPage } from ${JSON.stringify(appRouteModuleLoaderPath)};
 import {
   getRenderedConcreteUrlPathsForRoute as __getRenderedConcreteUrlPathsForRoute,
   initPregeneratedPathsFromGlobals as __initPregeneratedPathsFromGlobals,
@@ -897,12 +897,11 @@ export default createAppRscHandler({
         // The intercepting-route page module is lazy (page: null + __pageLoader).
         // Resolve it before probing so buildAppPageProbes inspects the real page
         // component for dynamic bailout — matching the render path, which also
-        // awaits __pageLoader (resolveAppPageInterceptState). Without this the
-        // intercept probe branch silently inspects an undefined component and
-        // never observes the page's searchParams/headers access.
-        if (__probeIntercept && __probeIntercept.__pageLoader && __probeIntercept.page == null) {
-          __probeIntercept.page = await __probeIntercept.__pageLoader();
-        }
+        // hydrates it (resolveAppPageInterceptState). Without this the intercept
+        // probe branch silently inspects an undefined component and never
+        // observes the page's searchParams/headers access. Shared loader, so
+        // the import is isolated from the request context here too.
+        if (__probeIntercept) await __loadAppInterceptPage(__probeIntercept);
         return Promise.all(__buildAppPageProbes({
           route,
           pageComponent: PageComponent,

--- a/packages/vinext/src/server/app-fallback-renderer.ts
+++ b/packages/vinext/src/server/app-fallback-renderer.ts
@@ -17,6 +17,7 @@ import type { AppElements } from "./app-elements.js";
 import type { ApplyAppPageFileBasedMetadata } from "./app-page-head.js";
 import type { AppPageInterceptOptions } from "./app-page-element-builder.js";
 import { shouldServeStreamingMetadata } from "./streaming-metadata.js";
+import { runOutsideRequestContext } from "vinext/shims/unified-request-context";
 
 // oxlint-disable-next-line @typescript-eslint/no-explicit-any
 type AppPageComponent = import("react").ComponentType<any>;
@@ -206,11 +207,20 @@ export function createAppFallbackRenderer<TModule extends AppPageModule>(
   // 404s in the same worker hit a warm import instead of re-resolving the
   // dynamic chunk. The loader itself is invoked at most once per worker;
   // failures are surfaced on every call so they don't get swallowed.
+  //
+  // That once-per-worker import happens while the 404-triggering request's
+  // context is active, and `import()` propagates AsyncLocalStorage into module
+  // evaluation — so `runOutsideRequestContext` keeps global-not-found.tsx's
+  // module scope from binding to that first request and serving it to everyone
+  // after. Same contract as the route-module loader; see
+  // `app-route-module-loader.ts`.
   let globalNotFoundModulePromise: Promise<TModule | null | undefined> | null = null;
   function resolveGlobalNotFoundModule(): Promise<TModule | null | undefined> | null {
     if (!loadGlobalNotFoundModule) return null;
     if (globalNotFoundModulePromise === null) {
-      globalNotFoundModulePromise = Promise.resolve().then(loadGlobalNotFoundModule);
+      globalNotFoundModulePromise = runOutsideRequestContext(() =>
+        Promise.resolve().then(loadGlobalNotFoundModule),
+      );
     }
     return globalNotFoundModulePromise;
   }

--- a/packages/vinext/src/server/app-fallback-renderer.ts
+++ b/packages/vinext/src/server/app-fallback-renderer.ts
@@ -17,7 +17,7 @@ import type { AppElements } from "./app-elements.js";
 import type { ApplyAppPageFileBasedMetadata } from "./app-page-head.js";
 import type { AppPageInterceptOptions } from "./app-page-element-builder.js";
 import { shouldServeStreamingMetadata } from "./streaming-metadata.js";
-import { runOutsideRequestContext } from "vinext/shims/unified-request-context";
+import { runOutsideRequestScopes } from "vinext/shims/internal/als-registry";
 
 // oxlint-disable-next-line @typescript-eslint/no-explicit-any
 type AppPageComponent = import("react").ComponentType<any>;
@@ -209,8 +209,8 @@ export function createAppFallbackRenderer<TModule extends AppPageModule>(
   // failures are surfaced on every call so they don't get swallowed.
   //
   // That once-per-worker import happens while the 404-triggering request's
-  // context is active, and `import()` propagates AsyncLocalStorage into module
-  // evaluation — so `runOutsideRequestContext` keeps global-not-found.tsx's
+  // scopes are active, and `import()` propagates AsyncLocalStorage into module
+  // evaluation — so `runOutsideRequestScopes` keeps global-not-found.tsx's
   // module scope from binding to that first request and serving it to everyone
   // after. Same contract as the route-module loader; see
   // `app-route-module-loader.ts`.
@@ -218,7 +218,7 @@ export function createAppFallbackRenderer<TModule extends AppPageModule>(
   function resolveGlobalNotFoundModule(): Promise<TModule | null | undefined> | null {
     if (!loadGlobalNotFoundModule) return null;
     if (globalNotFoundModulePromise === null) {
-      globalNotFoundModulePromise = runOutsideRequestContext(() =>
+      globalNotFoundModulePromise = runOutsideRequestScopes(() =>
         Promise.resolve().then(loadGlobalNotFoundModule),
       );
     }

--- a/packages/vinext/src/server/app-page-request.ts
+++ b/packages/vinext/src/server/app-page-request.ts
@@ -4,7 +4,11 @@ import { getAppPageSegmentParamName } from "./app-page-params.js";
 import { matchRoutePattern } from "../routing/route-pattern.js";
 import { notFoundResponse } from "./http-error-responses.js";
 import type { AppLayoutParamAccessTracker } from "./app-layout-param-observation.js";
-import { loadAppInterceptLayouts } from "./app-route-module-loader.js";
+import {
+  loadAppInterceptLayouts,
+  loadAppInterceptNotFound,
+  loadAppInterceptPage,
+} from "./app-route-module-loader.js";
 
 type AppPageParams = Record<string, string | string[]>;
 type GenerateStaticParams = (args: { params: AppPageParams }) => unknown;
@@ -667,49 +671,8 @@ async function resolveAppPageInterceptState<TRoute, TPage, TInterceptOpts>(
     return { kind: "none" };
   }
 
-  const loadState = intercept.__loadState;
-  if (loadState?.page != null) intercept.page = loadState.page;
-  if (intercept.__pageLoader && intercept.page == null) {
-    const loading =
-      loadState?.pageLoading ??
-      intercept
-        .__pageLoader()
-        .then((page) => {
-          intercept.page = page;
-          if (loadState) {
-            loadState.page = page;
-            loadState.pageLoading = null;
-          }
-          return page;
-        })
-        .catch((error: unknown) => {
-          if (loadState) loadState.pageLoading = null;
-          throw error;
-        });
-    if (loadState) loadState.pageLoading = loading;
-    await loading;
-  }
-  if (loadState?.notFound != null) intercept.notFound = loadState.notFound;
-  if (intercept.__loadNotFound && intercept.notFound == null) {
-    const loading =
-      loadState?.notFoundLoading ??
-      intercept
-        .__loadNotFound()
-        .then((notFound) => {
-          intercept.notFound = notFound;
-          if (loadState) {
-            loadState.notFound = notFound;
-            loadState.notFoundLoading = null;
-          }
-          return notFound;
-        })
-        .catch((error: unknown) => {
-          if (loadState) loadState.notFoundLoading = null;
-          throw error;
-        });
-    if (loadState) loadState.notFoundLoading = loading;
-    await loading;
-  }
+  await loadAppInterceptPage(intercept);
+  await loadAppInterceptNotFound(intercept);
   if (intercept.__loadInterceptLayouts || intercept.__loadInterceptLoadings) {
     await loadAppInterceptLayouts(intercept);
   }

--- a/packages/vinext/src/server/app-route-module-loader.ts
+++ b/packages/vinext/src/server/app-route-module-loader.ts
@@ -190,7 +190,11 @@ async function hydrateInterceptModule(
         throw error;
       });
   if (loadState) loadState[loadingField] = loading;
-  await loading;
+  // Each matched interception is a request-local clone that shares only
+  // `__loadState`. A concurrent caller can therefore observe the in-flight
+  // promise above without being the clone assigned by its `.then()` callback.
+  // Publish the resolved namespace onto every caller's clone before returning.
+  intercept[field] = await loading;
 }
 
 /** Hydrate an intercepting route's page module onto `intercept.page`. */

--- a/packages/vinext/src/server/app-route-module-loader.ts
+++ b/packages/vinext/src/server/app-route-module-loader.ts
@@ -22,17 +22,17 @@
  * (segment config, fetch-cache mode, runtime resolution, dispatch branch,
  * element building, etc.).
  *
- * Every thunk is invoked via `runOutsideRequestContext`. Hydration runs inside
- * the matched request's scope, and a dynamic `import()` propagates
+ * Every thunk is invoked via `runOutsideRequestScopes`. Hydration runs inside
+ * the matched request's scopes, and a dynamic `import()` propagates
  * AsyncLocalStorage into the imported module's top-level evaluation — so
- * without that guard, module-scope `headers()`/`cookies()` would bind to
- * whichever request happened to be first. Since a module evaluates once per
+ * without that guard, module-scope `headers()`/`cookies()`/`after()` would bind
+ * to whichever request happened to be first. Since a module evaluates once per
  * isolate and its namespace is cached here, that first request's data would
  * then be served to every later one. Matching Next.js, which loads components
  * before entering the request store, module scope simply sees no request.
  */
 
-import { runOutsideRequestContext } from "vinext/shims/unified-request-context";
+import { runOutsideRequestScopes } from "vinext/shims/internal/als-registry";
 
 type LazyModuleThunk = () => Promise<unknown>;
 type LazyModuleLoaderArray = readonly (LazyModuleThunk | null | undefined)[];
@@ -117,7 +117,7 @@ function pushFieldLoad(
 ): void {
   if (!loader || target[field] != null) return;
   loads.push(
-    runOutsideRequestContext(loader).then((module) => {
+    runOutsideRequestScopes(loader).then((module) => {
       target[field] = module;
     }),
   );
@@ -139,7 +139,7 @@ function pushArrayLoads(
   for (const [index, loader] of loaders.entries()) {
     if (index >= slots.length || !loader || slots[index] != null) continue;
     loads.push(
-      runOutsideRequestContext(loader).then((module) => {
+      runOutsideRequestScopes(loader).then((module) => {
         slots[index] = module;
       }),
     );

--- a/packages/vinext/src/server/app-route-module-loader.ts
+++ b/packages/vinext/src/server/app-route-module-loader.ts
@@ -38,11 +38,19 @@ type LazyModuleThunk = () => Promise<unknown>;
 type LazyModuleLoaderArray = readonly (LazyModuleThunk | null | undefined)[];
 
 type LazyLoadableIntercept = {
+  page?: unknown;
+  __pageLoader?: LazyModuleThunk | null;
+  notFound?: unknown;
+  __loadNotFound?: LazyModuleThunk | null;
   interceptLayouts?: readonly unknown[] | null;
   __loadInterceptLayouts?: LazyModuleLoaderArray | null;
   interceptLoadings?: readonly unknown[] | null;
   __loadInterceptLoadings?: LazyModuleLoaderArray | null;
   __loadState?: {
+    page?: unknown;
+    pageLoading?: Promise<unknown> | null;
+    notFound?: unknown;
+    notFoundLoading?: Promise<unknown> | null;
     interceptLayoutsLoading: Promise<readonly unknown[]> | null;
   };
 };
@@ -144,6 +152,55 @@ function pushArrayLoads(
       }),
     );
   }
+}
+
+/**
+ * Hydrate one lazily-imported intercept module onto the intercept, dedup'd
+ * through `__loadState` so concurrent navigations share a single import.
+ *
+ * The intercept's page and not-found modules were loaded inline at their call
+ * sites, which meant they missed the isolation every other route module gets.
+ * They are user modules cached for the isolate's lifetime just like the rest,
+ * so they belong on this path.
+ */
+async function hydrateInterceptModule(
+  intercept: LazyLoadableIntercept,
+  loader: LazyModuleThunk | null | undefined,
+  field: "page" | "notFound",
+  loadingField: "pageLoading" | "notFoundLoading",
+): Promise<void> {
+  const loadState = intercept.__loadState;
+  const cached = loadState?.[field];
+  if (cached != null) intercept[field] = cached;
+  if (!loader || intercept[field] != null) return;
+
+  const loading =
+    loadState?.[loadingField] ??
+    runOutsideRequestScopes(loader)
+      .then((module) => {
+        intercept[field] = module;
+        if (loadState) {
+          loadState[field] = module;
+          loadState[loadingField] = null;
+        }
+        return module;
+      })
+      .catch((error: unknown) => {
+        if (loadState) loadState[loadingField] = null;
+        throw error;
+      });
+  if (loadState) loadState[loadingField] = loading;
+  await loading;
+}
+
+/** Hydrate an intercepting route's page module onto `intercept.page`. */
+export function loadAppInterceptPage(intercept: LazyLoadableIntercept): Promise<void> {
+  return hydrateInterceptModule(intercept, intercept.__pageLoader, "page", "pageLoading");
+}
+
+/** Hydrate an intercepting route's not-found boundary onto `intercept.notFound`. */
+export function loadAppInterceptNotFound(intercept: LazyLoadableIntercept): Promise<void> {
+  return hydrateInterceptModule(intercept, intercept.__loadNotFound, "notFound", "notFoundLoading");
 }
 
 export function loadAppInterceptLayouts(

--- a/packages/vinext/src/server/app-route-module-loader.ts
+++ b/packages/vinext/src/server/app-route-module-loader.ts
@@ -21,7 +21,18 @@
  * Callers must `await` it before any synchronous read of route modules
  * (segment config, fetch-cache mode, runtime resolution, dispatch branch,
  * element building, etc.).
+ *
+ * Every thunk is invoked via `runOutsideRequestContext`. Hydration runs inside
+ * the matched request's scope, and a dynamic `import()` propagates
+ * AsyncLocalStorage into the imported module's top-level evaluation — so
+ * without that guard, module-scope `headers()`/`cookies()` would bind to
+ * whichever request happened to be first. Since a module evaluates once per
+ * isolate and its namespace is cached here, that first request's data would
+ * then be served to every later one. Matching Next.js, which loads components
+ * before entering the request store, module scope simply sees no request.
  */
+
+import { runOutsideRequestContext } from "vinext/shims/unified-request-context";
 
 type LazyModuleThunk = () => Promise<unknown>;
 type LazyModuleLoaderArray = readonly (LazyModuleThunk | null | undefined)[];
@@ -106,7 +117,7 @@ function pushFieldLoad(
 ): void {
   if (!loader || target[field] != null) return;
   loads.push(
-    loader().then((module) => {
+    runOutsideRequestContext(loader).then((module) => {
       target[field] = module;
     }),
   );
@@ -128,7 +139,7 @@ function pushArrayLoads(
   for (const [index, loader] of loaders.entries()) {
     if (index >= slots.length || !loader || slots[index] != null) continue;
     loads.push(
-      loader().then((module) => {
+      runOutsideRequestContext(loader).then((module) => {
         slots[index] = module;
       }),
     );

--- a/packages/vinext/src/shims/internal/als-registry.ts
+++ b/packages/vinext/src/shims/internal/als-registry.ts
@@ -40,6 +40,14 @@ import { AsyncLocalStorage } from "node:async_hooks";
 const _g = globalThis as unknown as Record<PropertyKey, unknown>;
 
 /**
+ * Every ALS handed out by `getOrCreateAls`, so `runOutsideRequestScopes` can
+ * exit all of them without an enumeration that goes stale as shims are added.
+ * Shares the `globalThis` slot for the same cross-module-instance reason.
+ */
+const _REGISTRY_KEY = Symbol.for("vinext.als.registry");
+const _registry = (_g[_REGISTRY_KEY] ??= new Set()) as Set<AsyncLocalStorage<unknown>>;
+
+/**
  * No-op AsyncLocalStorage used when the runtime does not provide a usable
  * `AsyncLocalStorage` constructor.
  *
@@ -79,8 +87,51 @@ class NoopAsyncLocalStorage<T> {
  */
 export function getOrCreateAls<T>(key: string): AsyncLocalStorage<T> {
   const sym = Symbol.for(key);
-  return (_g[sym] ??=
+  const als = (_g[sym] ??=
     typeof AsyncLocalStorage === "function"
       ? new AsyncLocalStorage<T>()
       : new NoopAsyncLocalStorage<T>()) as AsyncLocalStorage<T>;
+  _registry.add(als as AsyncLocalStorage<unknown>);
+  return als;
+}
+
+/**
+ * Enrol an ALS that is *not* created through `getOrCreateAls` into the
+ * scope-exit set. For stores that must stay module-local for identity reasons
+ * (`workUnitAsyncStorage` is a Next.js-compat external module third parties
+ * resolve by specifier) but still hold per-request state.
+ *
+ * Callers register themselves rather than being imported here, so this module
+ * keeps importing nothing but `node:async_hooks` and stays safe to evaluate in
+ * client bundles where that resolves to a constructor-less stub.
+ */
+export function registerAlsForScopeExit(als: AsyncLocalStorage<never>): void {
+  _registry.add(als as unknown as AsyncLocalStorage<unknown>);
+}
+
+/**
+ * Run `fn` — and every async continuation it starts — outside every
+ * request-scoped AsyncLocalStorage vinext installs, so the callback observes no
+ * request at all.
+ *
+ * For one-time module evaluation whose result is cached for the isolate's
+ * lifetime: a dynamic `import()` propagates ALS into the imported module's
+ * top-level evaluation, so without this the first request to reach a route
+ * leaks into module scope and stays there for every request after it.
+ *
+ * Exiting a single store is not enough. The stores are entered at different
+ * depths — the Cloudflare entry enters the standalone execution-context ALS
+ * *outside* the unified request context, and prerendering enters the work-unit
+ * store *inside* it — so anything left entered stays visible. `after()` in
+ * particular takes its `getRequestExecutionContext()` fallback precisely when
+ * the unified store is absent, so a partial exit would enable that path rather
+ * than close it.
+ */
+export function runOutsideRequestScopes<T>(fn: () => T): T {
+  let run = fn;
+  for (const als of _registry) {
+    const inner = run;
+    run = () => als.exit(inner);
+  }
+  return run();
 }

--- a/packages/vinext/src/shims/internal/work-unit-async-storage.ts
+++ b/packages/vinext/src/shims/internal/work-unit-async-storage.ts
@@ -10,6 +10,7 @@
  * io() for hanging-promise behavior during prerendering.
  */
 import { AsyncLocalStorage } from "node:async_hooks";
+import { registerAlsForScopeExit } from "./als-registry.js";
 
 // ── WorkUnitStore discriminated union ───────────────────────────────────
 
@@ -51,6 +52,10 @@ export type WorkUnitStore =
 export type WorkUnitAsyncStorage = AsyncLocalStorage<WorkUnitStore>;
 
 export const workUnitAsyncStorage: WorkUnitAsyncStorage = new AsyncLocalStorage();
+
+// Stays module-local (Sentry resolves this module by specifier), so enrol it
+// for scope exit explicitly instead of creating it via `getOrCreateAls`.
+registerAlsForScopeExit(workUnitAsyncStorage as unknown as AsyncLocalStorage<never>);
 
 // Legacy name (Next 13.x–14.x)
 export const requestAsyncStorage = workUnitAsyncStorage;

--- a/packages/vinext/src/shims/unified-request-context.ts
+++ b/packages/vinext/src/shims/unified-request-context.ts
@@ -348,20 +348,6 @@ export function runWithRequestContext<T>(
 }
 
 /**
- * Run `fn` — and every async continuation it starts — outside any request
- * context, so `isInsideUnifiedScope()` is false and the shims fall back to
- * their no-request behaviour.
- *
- * Used for work that must not observe the request that happened to trigger it,
- * most notably one-time module evaluation whose result is cached for the
- * isolate's lifetime. `exit()` is one of the `AsyncLocalStorage` methods
- * workerd implements (unlike `enterWith()`/`disable()`).
- */
-export function runOutsideRequestContext<T>(fn: () => T): T {
-  return _als.exit(fn);
-}
-
-/**
  * Run `fn` in a nested unified scope derived from the current request context.
  * Used by legacy runWith* wrappers to reset or override one sub-state while
  * preserving proper async isolation for continuations created inside `fn`.

--- a/packages/vinext/src/shims/unified-request-context.ts
+++ b/packages/vinext/src/shims/unified-request-context.ts
@@ -348,6 +348,20 @@ export function runWithRequestContext<T>(
 }
 
 /**
+ * Run `fn` — and every async continuation it starts — outside any request
+ * context, so `isInsideUnifiedScope()` is false and the shims fall back to
+ * their no-request behaviour.
+ *
+ * Used for work that must not observe the request that happened to trigger it,
+ * most notably one-time module evaluation whose result is cached for the
+ * isolate's lifetime. `exit()` is one of the `AsyncLocalStorage` methods
+ * workerd implements (unlike `enterWith()`/`disable()`).
+ */
+export function runOutsideRequestContext<T>(fn: () => T): T {
+  return _als.exit(fn);
+}
+
+/**
  * Run `fn` in a nested unified scope derived from the current request context.
  * Used by legacy runWith* wrappers to reset or override one sub-state while
  * preserving proper async isolation for continuations created inside `fn`.

--- a/tests/app-fallback-renderer.test.ts
+++ b/tests/app-fallback-renderer.test.ts
@@ -3,6 +3,11 @@ import React from "react";
 import ReactDOMServer from "react-dom/server";
 import { createAppFallbackRenderer } from "../packages/vinext/src/server/app-fallback-renderer.js";
 import type { AppElements } from "../packages/vinext/src/server/app-elements.js";
+import { cookies, headersContextFromRequest } from "../packages/vinext/src/shims/headers.js";
+import {
+  createRequestContext,
+  runWithRequestContext,
+} from "../packages/vinext/src/shims/unified-request-context.js";
 
 function createStreamFromMarkup(markup: string): ReadableStream<Uint8Array> {
   return new ReadableStream({
@@ -36,6 +41,8 @@ function createRenderer(overrides?: {
   sanitizeErrorForClient?: (error: Error) => Error;
   globalNotFoundModule?: { default: React.ComponentType<any> } | null;
   globalNotFoundEnabled?: boolean;
+  /** Takes precedence over `globalNotFoundModule`, for observing the loader call itself. */
+  globalNotFoundLoader?: () => Promise<{ default: React.ComponentType<any> } | null>;
   rootLayoutModules?: readonly ({ default: React.ComponentType<any> } | null | undefined)[];
   rootNotFoundModule?: { default: React.ComponentType<any> } | null;
   rscRenderer?: (
@@ -78,9 +85,11 @@ function createRenderer(overrides?: {
       globalErrorModule: null,
       globalNotFoundEnabled:
         overrides?.globalNotFoundEnabled ?? overrides?.globalNotFoundModule != null,
-      loadGlobalNotFoundModule: overrides?.globalNotFoundModule
-        ? async () => overrides.globalNotFoundModule ?? null
-        : null,
+      loadGlobalNotFoundModule:
+        overrides?.globalNotFoundLoader ??
+        (overrides?.globalNotFoundModule
+          ? async () => overrides.globalNotFoundModule ?? null
+          : null),
       makeThenableParams<T>(params: T) {
         return params;
       },
@@ -654,6 +663,44 @@ describe("app fallback renderer with globalNotFoundModule", () => {
     expect(html).toContain("global-not-found");
     // Root layout was NOT applied — it would have rendered <html lang="en">.
     expect(html).not.toContain('lang="en"');
+  });
+
+  it("loads global-not-found outside the request context that triggered the 404", async () => {
+    // The module is imported once per worker and cached, so if its top-level
+    // scope could read the 404-triggering request, that first visitor's data
+    // would be baked in for everyone after them.
+    let moduleScopeCookieAccess = "loader-not-called";
+    const { renderer } = createRenderer({
+      globalNotFoundEnabled: true,
+      globalNotFoundLoader: async () => {
+        moduleScopeCookieAccess = await cookies().then(
+          (jar) => `read:${jar.get("session")?.value ?? "none"}`,
+          () => "rejected-no-request-context",
+        );
+        return globalNotFoundModule;
+      },
+      rootLayoutModules: [rootLayoutModule],
+    });
+    const request = new Request("https://example.com/does-not-exist", {
+      headers: { cookie: "session=victim-secret" },
+    });
+    const requestContext = createRequestContext({
+      headersContext: headersContextFromRequest(request),
+    });
+
+    const liveCookie = await runWithRequestContext(requestContext, async () => {
+      // Read first: proves the request context really is active around the
+      // 404 render, so the assertion below is isolation, not an absent context.
+      const live = (await cookies()).get("session")?.value;
+      await renderer.renderNotFound(null, false, request, undefined, undefined, {
+        headers: null,
+        status: null,
+      });
+      return live;
+    });
+
+    expect(liveCookie).toBe("victim-secret");
+    expect(moduleScopeCookieAccess).toBe("rejected-no-request-context");
   });
 
   it("uses the route's not-found.tsx boundary when notFound() is called from a page", async () => {

--- a/tests/app-page-request.test.ts
+++ b/tests/app-page-request.test.ts
@@ -8,6 +8,11 @@ import {
   resolveAppPageGenerateStaticParamsSources,
   validateAppPageDynamicParams,
 } from "../packages/vinext/src/server/app-page-request.js";
+import { cookies, headersContextFromRequest } from "../packages/vinext/src/shims/headers.js";
+import {
+  createRequestContext,
+  runWithRequestContext,
+} from "../packages/vinext/src/shims/unified-request-context.js";
 
 describe("app page request helpers", () => {
   it("returns 404 when dynamicParams=false receives unknown params", async () => {
@@ -806,6 +811,58 @@ describe("resolveAppPageInterceptMatch", () => {
     expect(__loadInterceptLayout).toHaveBeenCalledTimes(1);
     expect(sharedLoadState.page).toBe(interceptPage);
     expect(intercept.interceptLayouts).toEqual([interceptLayout]);
+  });
+
+  it("evaluates intercept page and not-found modules outside the request context", async () => {
+    // Intercept modules are cached on the intercept for the isolate's lifetime
+    // just like route modules, so the first navigation that matches an
+    // intercept must not be able to leak into their module scope.
+    const reads: Record<string, string> = {};
+    const readCookieAtModuleScope = (label: string) => async () => {
+      reads[label] = await cookies().then(
+        (jar) => `read:${jar.get("session")?.value ?? "none"}`,
+        () => "rejected-no-request-context",
+      );
+      return { default: label };
+    };
+    const intercept = {
+      interceptLayouts: [null],
+      __loadInterceptLayouts: [readCookieAtModuleScope("layout")],
+      matchedParams: { id: "123" },
+      page: null,
+      __pageLoader: readCookieAtModuleScope("page"),
+      notFound: null,
+      __loadNotFound: readCookieAtModuleScope("notFound"),
+      slotKey: "modal@app/feed/@modal",
+      sourceRouteIndex: 0,
+    };
+    const request = new Request("https://example.com/photos/123", {
+      headers: { cookie: "session=victim-secret" },
+    });
+    const requestContext = createRequestContext({
+      headersContext: headersContextFromRequest(request),
+    });
+
+    const liveCookie = await runWithRequestContext(requestContext, async () => {
+      const live = (await cookies()).get("session")?.value;
+      await resolveAppPageInterceptMatch({
+        cleanPathname: "/photos/123",
+        currentRoute,
+        findIntercept: () => intercept,
+        getRouteParamNames: (route: { params: string[] }) => route.params,
+        getSourceRoute: () => sourceRoute,
+        isRscRequest: true,
+        toInterceptOpts,
+      });
+      return live;
+    });
+
+    expect(liveCookie).toBe("victim-secret");
+    expect(reads).toEqual({
+      page: "rejected-no-request-context",
+      notFound: "rejected-no-request-context",
+      layout: "rejected-no-request-context",
+    });
   });
 
   it("slices source params down to the source route's declared params", async () => {

--- a/tests/app-route-module-loader.test.ts
+++ b/tests/app-route-module-loader.test.ts
@@ -9,6 +9,11 @@ import {
   createRequestContext,
   runWithRequestContext,
 } from "../packages/vinext/src/shims/unified-request-context.js";
+import {
+  getRequestExecutionContext,
+  runWithExecutionContext,
+} from "../packages/vinext/src/shims/request-context.js";
+import { after } from "../packages/vinext/src/shims/server.js";
 
 describe("ensureAppRouteModulesLoaded", () => {
   it("returns the route synchronously when there are no lazy thunks (eager route)", () => {
@@ -264,5 +269,46 @@ describe("lazy hydration request-context isolation", () => {
     expect((route.page as { moduleScopeCookieAccess: string }).moduleScopeCookieAccess).toBe(
       "rejected-no-request-context",
     );
+  });
+
+  it("also escapes the execution-context scope the Cloudflare entry enters outside the request context", async () => {
+    // app-router-entry.ts wraps the whole handler in runWithExecutionContext()
+    // before app-rsc-handler.ts opens the unified request context, so the two
+    // stores nest at different depths. Exiting only the unified one would leave
+    // the worker's ExecutionContext visible — and after() takes its
+    // getRequestExecutionContext() fallback precisely when the unified store is
+    // absent, so a partial exit enables that path instead of closing it.
+    const waitUntil = vi.fn();
+    const executionContext = { waitUntil, passThroughOnException() {} };
+    let moduleScopeExecutionContext: unknown = "loader-not-called";
+    let moduleScopeAfter = "loader-not-called";
+
+    const route: LazyLoadableRoute = {
+      page: null,
+      __loadPage: async () => {
+        moduleScopeExecutionContext = getRequestExecutionContext();
+        try {
+          after(() => {});
+          moduleScopeAfter = "registered";
+        } catch (error) {
+          moduleScopeAfter = (error as Error).message;
+        }
+        return { default: () => null };
+      },
+    };
+
+    const requestContext = createRequestContext({
+      headersContext: headersContextFromRequest(new Request("https://example.com/dashboard")),
+      executionContext,
+    });
+
+    await runWithExecutionContext(executionContext, () =>
+      runWithRequestContext(requestContext, () => ensureAppRouteModulesLoaded(route)),
+    );
+
+    expect(moduleScopeExecutionContext).toBeNull();
+    expect(moduleScopeAfter).toBe("`after()` was called outside a request scope");
+    // Nothing was attached to the first request's lifecycle.
+    expect(waitUntil).not.toHaveBeenCalled();
   });
 });

--- a/tests/app-route-module-loader.test.ts
+++ b/tests/app-route-module-loader.test.ts
@@ -4,6 +4,11 @@ import {
   loadAppInterceptLayouts,
   type LazyLoadableRoute,
 } from "../packages/vinext/src/server/app-route-module-loader.js";
+import { cookies, headersContextFromRequest } from "../packages/vinext/src/shims/headers.js";
+import {
+  createRequestContext,
+  runWithRequestContext,
+} from "../packages/vinext/src/shims/unified-request-context.js";
 
 describe("ensureAppRouteModulesLoaded", () => {
   it("returns the route synchronously when there are no lazy thunks (eager route)", () => {
@@ -227,5 +232,37 @@ describe("loadAppInterceptLayouts", () => {
 
     // No loaders → returns a resolved promise wrapping the same array, no imports.
     return expect(loadAppInterceptLayouts(intercept)).resolves.toBe(intercept.interceptLayouts);
+  });
+});
+
+describe("lazy hydration request-context isolation", () => {
+  it("evaluates a lazy module outside the request context that triggered hydration", async () => {
+    const request = new Request("https://example.com/dashboard", {
+      headers: { cookie: "session=victim-secret" },
+    });
+    const requestContext = createRequestContext({
+      headersContext: headersContextFromRequest(request),
+    });
+    const route: LazyLoadableRoute = {
+      page: null,
+      __loadPage: () => import("./fixtures/module-scope-request-capture.js"),
+    };
+
+    const liveCookie = await runWithRequestContext(requestContext, async () => {
+      // Read first: proves the request context really is active at the
+      // hydration call site, so the assertion below is isolation rather than
+      // an absent context.
+      const live = (await cookies()).get("session")?.value;
+      await ensureAppRouteModulesLoaded(route);
+      return live;
+    });
+
+    expect(liveCookie).toBe("victim-secret");
+    // Module scope must see no request at all — matching Next.js, which loads
+    // components before entering the request store. Anything else would be
+    // cached on `route.page` and reused for every later visitor.
+    expect((route.page as { moduleScopeCookieAccess: string }).moduleScopeCookieAccess).toBe(
+      "rejected-no-request-context",
+    );
   });
 });

--- a/tests/app-route-module-loader.test.ts
+++ b/tests/app-route-module-loader.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 import {
   ensureAppRouteModulesLoaded,
+  loadAppInterceptNotFound,
+  loadAppInterceptPage,
   loadAppInterceptLayouts,
   type LazyLoadableRoute,
 } from "../packages/vinext/src/server/app-route-module-loader.js";
@@ -237,6 +239,52 @@ describe("loadAppInterceptLayouts", () => {
 
     // No loaders → returns a resolved promise wrapping the same array, no imports.
     return expect(loadAppInterceptLayouts(intercept)).resolves.toBe(intercept.interceptLayouts);
+  });
+});
+
+describe.each([
+  ["page", "__pageLoader", "pageLoading", loadAppInterceptPage],
+  ["notFound", "__loadNotFound", "notFoundLoading", loadAppInterceptNotFound],
+] as const)("loadAppIntercept%s", (field, loaderField, loadingField, load) => {
+  it("publishes a shared concurrent load onto every request-local intercept clone", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const module = { default: () => null };
+    const loader = vi.fn(async () => {
+      await gate;
+      return module;
+    });
+    const loadState = {
+      page: null,
+      pageLoading: null,
+      notFound: null,
+      notFoundLoading: null,
+      interceptLayoutsLoading: null,
+    };
+    const first = {
+      [field]: null,
+      [loaderField]: loader,
+      __loadState: loadState,
+    };
+    const second = {
+      [field]: null,
+      [loaderField]: loader,
+      __loadState: loadState,
+    };
+
+    const firstLoad = load(first);
+    const secondLoad = load(second);
+    expect(loadState[loadingField]).not.toBeNull();
+    release();
+    await Promise.all([firstLoad, secondLoad]);
+
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(first[field]).toBe(module);
+    expect(second[field]).toBe(module);
+    expect(loadState[field]).toBe(module);
+    expect(loadState[loadingField]).toBeNull();
   });
 });
 

--- a/tests/fixtures/module-scope-request-capture.ts
+++ b/tests/fixtures/module-scope-request-capture.ts
@@ -1,0 +1,12 @@
+/**
+ * Stands in for a route module that reads request APIs at module scope — the
+ * app pattern that turns lazy `import()` hydration into a cross-request leak.
+ * ESM evaluates this once per process, so whatever it captures here is what
+ * every later request to the route would be served.
+ */
+import { cookies } from "../../packages/vinext/src/shims/headers.js";
+
+export const moduleScopeCookieAccess: string = await cookies().then(
+  (jar) => `read:${jar.get("session")?.value ?? "none"}`,
+  () => "rejected-no-request-context",
+);


### PR DESCRIPTION
## The decision boundary

**A route module's top-level scope must not be able to observe a request.** It is evaluated exactly once per isolate and its namespace is cached forever, so anything it captures from a request becomes shared state for every user that follows.

That contract held for free while route modules were eagerly imported at RSC-entry evaluation — there was no request in scope to capture. Making them lazy quietly removed it.

## The bug

`app-rsc-manifest.ts` emits page/route-handler modules as `() => import(...)` thunks, and `ensureAppRouteModulesLoaded` resolves them from `app-rsc-handler.ts:1167` — which is inside the `runWithRequestContext(...)` scope opened at `app-rsc-handler.ts:1438`.

A dynamic `import()` propagates AsyncLocalStorage into the imported module's *top-level evaluation*, not just into the calling frame:

```js
await als.run({ secret: 'victim-cookie' }, () => import('./mod.mjs'));
// mod.mjs, at module scope:  als.getStore() -> { secret: 'victim-cookie' }
```

So for an app with module-scope request-API use:

```ts
// app/dashboard/page.tsx
const session = (await cookies()).get('session')?.value  // module scope
export default function Page() { return <Dash session={session} /> }
```

…the first request to reach `/dashboard` binds `session` to *its own* cookie. `ensureAppRouteModulesLoaded` then caches the namespace on `route.page` and sets `__loaded = true`, so every subsequent request in that isolate skips the import and reads the first visitor's session.

Before the lazy change this same code threw `cookies() can only be called from a Server Component, Route Handler, or Server Action` at startup — loud, and correct. Next.js behaves the same way: `findPageComponents`/`loadComponents` runs in `base-server.ts` **before** `app-render.tsx` enters the request store via `workUnitAsyncStorage.run`, so module scope never sees a request there either.

## The fix

`runOutsideRequestScopes` composes `AsyncLocalStorage.exit()` over **every ALS handed out by `getOrCreateAls`**. `exit()` is one of the methods [workerd implements](https://developers.cloudflare.com/workers/runtime-apis/nodejs/asynclocalstorage/) (unlike `enterWith()`/`disable()`), and the registry's `NoopAsyncLocalStorage` already provides it for runtimes without `node:async_hooks`.

Exiting *one* store is not enough, and that mistake is not fail-safe. vinext's request stores nest at different depths: the Cloudflare entry (`app-router-entry.ts:173`) enters the standalone execution-context ALS **outside** the unified request context, and prerendering enters the work-unit store **inside** it. Worse, `after()` takes its `getRequestExecutionContext()` fallback *precisely when the unified store is absent* — so a unified-only exit would have **enabled** top-level `after()` to attach to the first request's `waitUntil` rather than closing it. Registry-wide exit is also future-proof by construction: new shims enrol themselves as they are created, with no enumeration to keep in sync.

**Commit 1 — route modules.** One guard at the single place every lazy thunk is invoked. `pushFieldLoad` and `pushArrayLoads` in `app-route-module-loader.ts` are the only call sites, so all nine `ensureRouteLoaded` callers (RSC handler, page dispatch, route-handler dispatch, server actions, intercept layouts) are covered by two lines:

```ts
runOutsideRequestScopes(loader).then((module) => { target[field] = module })
```

**Commit 2 — global-not-found.** `resolveGlobalNotFoundModule` in `app-fallback-renderer.ts` is a sibling call path with the identical mechanism: it imports the user's `app/global-not-found.tsx` on the first route-miss 404, from inside that request's context, and memoizes the promise for the worker's lifetime. Not introduced by the lazy-route change, but the same class of bug on user-authored code, so it is fixed here rather than left behind.

In both cases the guard wraps only the import — the `.then` that assigns the resolved module still runs in the request's context, so nothing downstream changes.

## Scenario-level behavior

| Route module top-level code | Before lazy imports | On `main` | After |
|---|---|---|---|
| no request-API use (the norm) | works | works | works (unchanged) |
| `cookies()` / `headers()` at module scope | throws at startup | 🔴 **captures request #1, serves it to #2..N** | throws, as before |
| `after()` at module scope | throws at startup | binds to request #1's `waitUntil` | throws, as before |
| `getRequestExecutionContext()` at module scope | `null` | caches request #1's worker context | `null`, as before |

Only apps in rows 2–3 change, and they change back to the pre-lazy behavior.

## Validation

`tests/app-route-module-loader.test.ts` — new case driven through a **real dynamic `import()`** of `tests/fixtures/module-scope-request-capture.ts`, which reads `cookies()` at module scope exactly as a vulnerable app would. The test reads the live cookie inside the same `runWithRequestContext` scope first, so a pass proves isolation rather than a merely absent context:

```
expect(liveCookie).toBe("victim-secret")                    // context IS active at the call site
expect(page.moduleScopeCookieAccess).toBe("rejected-no-request-context")
```

Confirmed failing before the fix, passing after — pre-fix: `expected 'read:victim-secret' to be 'rejected-no-request-context'`.

`tests/app-fallback-renderer.test.ts` — the same shape for global-not-found, driven through `renderer.renderNotFound(null, ...)` (the route-miss path) inside a live request context. Also confirmed failing before, passing after, with the same pre-fix message.

`tests/app-route-module-loader.test.ts` — a second case for the nesting, built through the real `runWithExecutionContext` → `runWithRequestContext` → hydration chain: module scope must see `getRequestExecutionContext() === null`, `after()` must throw ``after() was called outside a request scope``, and `waitUntil` must never be called. Confirmed failing against a unified-only exit.

`tests/als-registry.test.ts` (pre-existing) earned its keep here: an earlier draft imported `work-unit-async-storage` *into* the registry, and this test caught that it would crash client bundles where `node:async_hooks` resolves to a constructor-less stub. Hence the self-registration direction.

Also green: `app-rsc-handler`, `app-page-route-wiring`, `app-page-dispatch`, `app-route-handler-dispatch`, `app-page-request`, `app-server-action-execution`, `app-rsc-route-matching` (516 tests), plus the pre-commit full `vp check` and knip on both commits.

## Review path

1. `packages/vinext/src/shims/internal/als-registry.ts` — the `runOutsideRequestScopes` primitive and the registry that feeds it.
2. `packages/vinext/src/server/app-route-module-loader.ts` — the two call sites it wraps; worth confirming these are still the only places a thunk is invoked.
3. `packages/vinext/src/server/app-fallback-renderer.ts` — the sibling global-not-found path.
4. `tests/app-route-module-loader.test.ts` + fixture, `tests/app-fallback-renderer.test.ts` — the regression tests.
