### PR TITLE
fix(server): transfer request bodies into NextRequest instead of teeing

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -1236,7 +1236,7 @@ export default createAppRscHandler({
   },
   ${
     middlewarePath
-      ? `runMiddleware({ cleanPathname, context, hadBasePath, isDataRequest, request }) {
+      ? `runMiddleware({ cleanPathname, context, hadBasePath, isDataRequest, middlewareRequest, request }) {
     return __applyAppMiddleware({
       basePath: __basePath,
       cleanPathname,
@@ -1246,6 +1246,7 @@ export default createAppRscHandler({
       i18nConfig: __i18nConfig,
       isDataRequest,
       isProxy: ${JSON.stringify(isProxyFile(middlewarePath))},
+      middlewareRequest,
       module: middlewareModule,
       request,
       trailingSlash: __trailingSlash,

--- a/packages/vinext/src/server/app-middleware.ts
+++ b/packages/vinext/src/server/app-middleware.ts
@@ -5,7 +5,11 @@ import { setNavigationContext } from "vinext/shims/navigation";
 import { FLIGHT_HEADERS, VINEXT_MW_CTX_HEADER } from "./headers.js";
 import { buildRequestHeadersFromMiddlewareResponse } from "../utils/middleware-request-headers.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
-import { executeMiddleware, type MiddlewareModule } from "./middleware-runtime.js";
+import {
+  executeMiddleware,
+  type MiddlewareModule,
+  type MiddlewareResult,
+} from "./middleware-runtime.js";
 import { cloneRequestWithHeaders, processMiddlewareHeaders } from "./request-pipeline.js";
 import { internalServerErrorResponse } from "./http-error-responses.js";
 
@@ -28,6 +32,8 @@ export type ApplyAppMiddlewareOptions = {
   isDataRequest?: boolean;
   filePath?: string;
   isProxy: boolean;
+  /** An App Router-created body branch dedicated to middleware. */
+  middlewareRequest?: Request;
   module: MiddlewareModule;
   request: Request;
   /**
@@ -66,7 +72,7 @@ function isForwardedMiddlewareContext(value: unknown): value is ForwardedMiddlew
   return !!value && typeof value === "object";
 }
 
-function requestWithoutFlightHeaders(request: Request): Request {
+function requestWithoutFlightHeaders(request: Request, isolateBody = false): Request {
   let hasFlightHeader = false;
   const headers = new Headers();
 
@@ -78,9 +84,15 @@ function requestWithoutFlightHeaders(request: Request): Request {
     }
   }
 
-  if (!hasFlightHeader) return request;
-  const source = request.body ? request.clone() : request;
+  const source = isolateBody && request.body && !request.bodyUsed ? request.clone() : request;
+  if (!hasFlightHeader) return source;
   return cloneRequestWithHeaders(source, headers);
+}
+
+function cancelRequestBody(request: Request): void {
+  if (request.body && !request.body.locked) {
+    void request.body.cancel().catch(() => {});
+  }
 }
 
 function appendForwardedHeader(headers: Headers, value: unknown): void {
@@ -211,24 +223,25 @@ export async function applyAppMiddleware(
   options: ApplyAppMiddlewareOptions,
 ): Promise<ApplyAppMiddlewareResult> {
   const forwarded = applyForwardedMiddlewareContext(options.request, options.context);
-  const middlewareRequest = requestWithoutFlightHeaders(options.request);
   let cleanPathname = options.cleanPathname;
   let rewritten = false;
   let search: string | null = null;
 
   if (forwarded.rewriteUrl) {
     try {
-      if (isExternalMiddlewareRewrite(forwarded.rewriteUrl, middlewareRequest)) {
+      if (isExternalMiddlewareRewrite(forwarded.rewriteUrl, options.request)) {
+        if (options.middlewareRequest) cancelRequestBody(options.middlewareRequest);
+        const externalRequest = requestWithoutFlightHeaders(options.request);
         return {
           kind: "response",
           response: await proxyExternalMiddlewareRewrite(
-            middlewareRequest,
+            externalRequest,
             forwarded.rewriteUrl,
             options.context,
           ),
         };
       }
-      const rewriteParsed = new URL(forwarded.rewriteUrl, middlewareRequest.url);
+      const rewriteParsed = new URL(forwarded.rewriteUrl, options.request.url);
       cleanPathname = rewriteParsed.pathname;
       rewritten = true;
       search = rewriteParsed.search;
@@ -239,20 +252,37 @@ export async function applyAppMiddleware(
   }
 
   if (!forwarded.applied) {
-    const result = await executeMiddleware({
-      basePath: options.basePath,
-      hadBasePath: options.hadBasePath ?? true,
-      filePath: options.filePath,
-      i18nConfig: options.i18nConfig,
-      isDataRequest: options.isDataRequest,
-      isProxy: options.isProxy,
-      module: options.module,
-      normalizedPathname: cleanPathname,
-      request: middlewareRequest,
-      trailingSlash: options.trailingSlash,
-    });
+    // App Router may have created the one genuine middleware/downstream branch
+    // before URL normalization. Other callers branch here. Either way,
+    // executeMiddleware takes ownership instead of teeing a second time.
+    const middlewareRequest = requestWithoutFlightHeaders(
+      options.middlewareRequest ?? options.request,
+      options.middlewareRequest === undefined,
+    );
+    let result: MiddlewareResult;
+    try {
+      result = await executeMiddleware({
+        basePath: options.basePath,
+        hadBasePath: options.hadBasePath ?? true,
+        filePath: options.filePath,
+        i18nConfig: options.i18nConfig,
+        isDataRequest: options.isDataRequest,
+        isProxy: options.isProxy,
+        module: options.module,
+        normalizedPathname: cleanPathname,
+        requestBodyAlreadyIsolated: true,
+        request: middlewareRequest,
+        trailingSlash: options.trailingSlash,
+      });
+    } finally {
+      // Matcher misses and validation failures return before executeMiddleware
+      // transfers this branch into NextRequest. Once transferred it is locked,
+      // so this is a no-op and executeMiddleware owns the cancellation instead.
+      cancelRequestBody(middlewareRequest);
+    }
 
     if (!result.continue) {
+      cancelRequestBody(options.request);
       if (result.redirectUrl) {
         return { kind: "response", response: responseFromMiddlewareRedirect(result) };
       }
@@ -275,10 +305,11 @@ export async function applyAppMiddleware(
         options.context.status = result.rewriteStatus;
       }
       if (isExternalUrl(result.rewriteUrl)) {
+        const externalRequest = requestWithoutFlightHeaders(options.request);
         return {
           kind: "response",
           response: await proxyExternalMiddlewareRewrite(
-            middlewareRequest,
+            externalRequest,
             result.rewriteUrl,
             options.context,
           ),
@@ -289,6 +320,10 @@ export async function applyAppMiddleware(
       rewritten = true;
       search = rewriteParsed.search;
     }
+  }
+
+  if (forwarded.applied && options.middlewareRequest) {
+    cancelRequestBody(options.middlewareRequest);
   }
 
   if (options.context.headers) {

--- a/packages/vinext/src/server/app-route-handler-runtime.ts
+++ b/packages/vinext/src/server/app-route-handler-runtime.ts
@@ -301,9 +301,10 @@ export function createTrackedAppRouteRequest(
       const prefixedPathname = addBasePathToPathname(inputUrl.pathname, options.basePath);
       if (prefixedPathname !== inputUrl.pathname) {
         inputUrl.pathname = prefixedPathname;
-        // Branch the body so the caller-owned request stays readable.
-        const bodySource = rawInput.body && !rawInput.bodyUsed ? rawInput.clone() : rawInput;
-        input = new Request(inputUrl, bodySource);
+        // Transfer the body instead of cloning: `rawInput` is replaced here and
+        // its body is never read again, so a tee would just leave an unread
+        // branch buffering the whole request in memory.
+        input = new Request(inputUrl, rawInput);
       }
     }
     const requestHeaders = options.middlewareHeaders

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -113,6 +113,7 @@ type RunAppMiddlewareOptions = {
   context: AppRscMiddlewareContext;
   hadBasePath: boolean;
   isDataRequest: boolean;
+  middlewareRequest?: Request;
   request: Request;
 };
 
@@ -490,12 +491,11 @@ function requestWithoutRscCacheBustingSearchParam(request: Request): Request {
   if (!hasRscCacheBustingSearchParam(url)) return request;
 
   stripRscCacheBustingSearchParam(url);
-  // Clone when a body is present so the original request stays usable, then
-  // reconstruct via `cloneRequestWithUrl` rather than a bare `new Request` so
-  // the Workers `cf` metadata is preserved (user middleware reads it directly)
-  // and `duplex: "half"` is set for streaming bodies.
-  const source = request.body ? request.clone() : request;
-  return cloneRequestWithUrl(source, url.toString());
+  // URL normalization does not create a second body consumer. Reconstructing
+  // from the request shares/transfers its stream into the replacement request;
+  // App middleware creates the one explicit tee when it genuinely needs an
+  // isolated branch.
+  return cloneRequestWithUrl(request, url.toString());
 }
 
 function requestWithoutRscSuffix(request: Request): Request {
@@ -504,8 +504,7 @@ function requestWithoutRscSuffix(request: Request): Request {
   if (pathname === url.pathname) return request;
 
   url.pathname = pathname;
-  const source = request.body ? request.clone() : request;
-  return cloneRequestWithUrl(source, url.toString());
+  return cloneRequestWithUrl(request, url.toString());
 }
 
 async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
@@ -642,11 +641,25 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     : null;
   if (rscCacheBustingRedirect) return rscCacheBustingRedirect;
 
+  const runMiddleware = isOnDemandRevalidateRequest(
+    request.headers.get(PRERENDER_REVALIDATE_HEADER),
+  )
+    ? undefined
+    : options.runMiddleware;
+  // Branch the exact downstream body owner before creating URL aliases. URL
+  // reconstruction shares a stream; cloning an alias would lock the body still
+  // referenced by `request` and break the subsequent action/route-handler read.
+  const isolatedMiddlewareSource =
+    runMiddleware && request.body && !request.bodyUsed ? request.clone() : null;
+
   // Keep cache-busting validation on the real request above, then hide the
   // internal `_rsc` transport query from userland middleware and post-middleware
   // has/missing matching. This mirrors Next.js' navigation middleware fixture.
   const normalizedUserlandRequest = requestWithoutRscSuffix(request);
   const userlandRequest = requestWithoutRscCacheBustingSearchParam(normalizedUserlandRequest);
+  const isolatedMiddlewareRequest = isolatedMiddlewareSource
+    ? requestWithoutRscCacheBustingSearchParam(requestWithoutRscSuffix(isolatedMiddlewareSource))
+    : undefined;
   const middlewareContext: AppRscMiddlewareContext = {
     headers: null,
     requestHeaders: null,
@@ -654,11 +667,6 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
   };
   let didMiddlewareRewrite = false;
   let didMiddlewareRewritePathname = false;
-  const runMiddleware = isOnDemandRevalidateRequest(
-    request.headers.get(PRERENDER_REVALIDATE_HEADER),
-  )
-    ? undefined
-    : options.runMiddleware;
 
   if (runMiddleware) {
     const middlewareResult = await runMiddleware({
@@ -666,9 +674,13 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
       context: middlewareContext,
       hadBasePath,
       isDataRequest: isMiddlewareDataRequest,
+      middlewareRequest: isolatedMiddlewareRequest,
       request: userlandRequest,
     });
     if (middlewareResult.kind === "response") {
+      if (request.body && !request.body.locked) {
+        void request.body.cancel().catch(() => {});
+      }
       return applyConfigHeadersToMiddlewareRedirect(middlewareResult.response, {
         basePathState,
         configHeaders: options.configHeaders,

--- a/packages/vinext/src/server/middleware-runtime.ts
+++ b/packages/vinext/src/server/middleware-runtime.ts
@@ -75,6 +75,12 @@ type ExecuteMiddlewareOptions = {
   isProxy: boolean;
   module: MiddlewareModule;
   normalizedPathname?: string;
+  /**
+   * The caller already created an isolated body branch for middleware. This
+   * lets App Router normalize that branch's URL and headers without adding a
+   * second tee whose preserved side would never be consumed.
+   */
+  requestBodyAlreadyIsolated?: boolean;
   request: Request;
   /**
    * The user's `trailingSlash` config. Plumbed into the NextRequest's NextURL
@@ -228,11 +234,13 @@ function createNextRequest(
   basePath?: string,
   trailingSlash?: boolean,
   hadBasePath?: boolean,
+  requestBodyAlreadyIsolated = false,
 ): NextRequest {
   const url = new URL(request.url);
   // Middleware gets an isolated body branch; downstream routing keeps owning
   // the original request body.
-  let mwRequest = request.body && !request.bodyUsed ? request.clone() : request;
+  let mwRequest =
+    !requestBodyAlreadyIsolated && request.body && !request.bodyUsed ? request.clone() : request;
   // NextURL._stripBasePath only recognises basePath when the request URL's
   // pathname actually starts with the configured prefix. Dev requests may
   // arrive after Vite has stripped that prefix, so restore it for requests
@@ -316,6 +324,7 @@ export async function executeMiddleware(
     options.basePath,
     options.trailingSlash,
     hadBasePath,
+    options.requestBodyAlreadyIsolated,
   );
   if (options.isDataRequest) {
     Object.defineProperty(nextRequest, "__isData", {
@@ -340,7 +349,7 @@ export async function executeMiddleware(
       waitUntilPromises,
     };
   } finally {
-    if (process.env.NODE_ENV !== "development" && nextRequest.body) {
+    if (nextRequest.body) {
       void nextRequest.body.cancel().catch(() => {});
     }
   }

--- a/packages/vinext/src/server/middleware-runtime.ts
+++ b/packages/vinext/src/server/middleware-runtime.ts
@@ -349,7 +349,10 @@ export async function executeMiddleware(
       waitUntilPromises,
     };
   } finally {
-    if (nextRequest.body) {
+    // Middleware may transfer its request stream directly into the response.
+    // In that case the response owns consumption; cancelling here would
+    // disturb the body before the server can send it.
+    if (nextRequest.body && response?.body !== nextRequest.body) {
       void nextRequest.body.cancel().catch(() => {});
     }
   }

--- a/packages/vinext/src/shims/server.ts
+++ b/packages/vinext/src/shims/server.ts
@@ -132,11 +132,12 @@ export class NextRequest extends Request {
     // not a valid RequestInit property.
     const { nextConfig: _nextConfig, ...requestInit } = init ?? {};
     if (input instanceof Request) {
-      // Keep caller-owned request bodies readable after wrapping. Middleware and
-      // route-handler plumbing may need the source Request after this wrapper runs.
-      const requestInput =
-        requestInit.body === undefined && input.body && !input.bodyUsed ? input.clone() : input;
-      super(requestInput, requestInit);
+      // Transfer the body like Next.js does (`super(input, init)`). Cloning here
+      // would tee the stream, and the branch left on `input` buffers the entire
+      // body in memory because nothing reads or cancels it. Callers that need
+      // the source request to stay readable must branch it themselves and
+      // cancel the branch they do not consume.
+      super(input, requestInit);
       const cf = Reflect.get(input, "cf");
       if (cf !== undefined) {
         Object.defineProperty(this, "cf", {

--- a/tests/app-route-handler-runtime.test.ts
+++ b/tests/app-route-handler-runtime.test.ts
@@ -220,6 +220,22 @@ describe("app route handler runtime helpers", () => {
     expect(tracked.request.url).toBe("https://example.com/base/fr/demo?ping=from-url");
   });
 
+  it("transfers the request body when re-adding basePath instead of teeing it", async () => {
+    const request = new Request("https://example.com/demo", {
+      body: JSON.stringify({ ok: true }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+
+    const tracked = createTrackedAppRouteRequest(request, { basePath: "/base" });
+
+    await expect(tracked.request.json()).resolves.toEqual({ ok: true });
+    // Cloning to re-add the prefix would tee the body, and the branch left on
+    // the incoming request buffers the whole upload in memory because nothing
+    // reads or cancels it.
+    expect(request.bodyUsed).toBe(true);
+  });
+
   it("tracks request.ip and request.geo access", () => {
     const accesses: string[] = [];
     const tracked = createTrackedAppRouteRequest(

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -3241,6 +3241,124 @@ describe("createAppRscHandler", () => {
     expect(dispatchMatchedPage).not.toHaveBeenCalled();
   });
 
+  it("uses one isolated middleware branch for body-bearing RSC actions", async () => {
+    const rscHeaders = createRscRequestHeaders();
+    rscHeaders.set("content-type", "text/plain");
+    rscHeaders.set("next-action", "abc123");
+    const rscHash = await computeRscCacheBustingSearchParam(rscHeaders);
+    const cloneSpy = vi.spyOn(Request.prototype, "clone");
+    const handleServerActionRequest = vi.fn(async ({ request }: { request: Request }) => {
+      await expect(request.text()).resolves.toBe("streamed-action-body");
+      return new Response("action");
+    });
+    const middleware = vi.fn(async (request: Request) => {
+      await expect(request.text()).resolves.toBe("streamed-action-body");
+      return new Response(null, {
+        headers: { "x-middleware-next": "1" },
+      });
+    });
+    const handler = createHandler({
+      configHeaders: [],
+      handleServerActionRequest,
+      middlewareModule: {
+        default: middleware,
+      },
+    });
+
+    try {
+      const response = await handler(
+        new Request(`https://example.test/docs/about.rsc?_rsc=${rscHash}`, {
+          body: "streamed-action-body",
+          headers: rscHeaders,
+          method: "POST",
+        }),
+        null,
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe("action");
+      expect(middleware).toHaveBeenCalledOnce();
+      expect(handleServerActionRequest).toHaveBeenCalledOnce();
+      // URL/query/header normalization shares the downstream body owner. The
+      // only tee is the real middleware/downstream boundary, and middleware's
+      // branch is transferred into NextRequest rather than abandoned.
+      expect(cloneSpy).toHaveBeenCalledTimes(1);
+      expect((cloneSpy.mock.results[0]!.value as Request).bodyUsed).toBe(true);
+    } finally {
+      cloneSpy.mockRestore();
+    }
+  });
+
+  it("does not tee body-bearing RSC actions when middleware is absent", async () => {
+    const rscHeaders = createRscRequestHeaders();
+    rscHeaders.set("content-type", "text/plain");
+    rscHeaders.set("next-action", "abc123");
+    const rscHash = await computeRscCacheBustingSearchParam(rscHeaders);
+    const cloneSpy = vi.spyOn(Request.prototype, "clone");
+    const handleServerActionRequest = vi.fn(async ({ request }: { request: Request }) => {
+      await expect(request.text()).resolves.toBe("streamed-action-body");
+      return new Response("action");
+    });
+    const handler = createHandler({ configHeaders: [], handleServerActionRequest });
+
+    try {
+      const response = await handler(
+        new Request(`https://example.test/docs/about.rsc?_rsc=${rscHash}`, {
+          body: "streamed-action-body",
+          headers: rscHeaders,
+          method: "POST",
+        }),
+        null,
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe("action");
+      expect(cloneSpy).not.toHaveBeenCalled();
+    } finally {
+      cloneSpy.mockRestore();
+    }
+  });
+
+  it("cancels the isolated RSC body branch when middleware does not match", async () => {
+    const rscHeaders = createRscRequestHeaders();
+    rscHeaders.set("content-type", "text/plain");
+    rscHeaders.set("next-action", "abc123");
+    const rscHash = await computeRscCacheBustingSearchParam(rscHeaders);
+    const cloneSpy = vi.spyOn(Request.prototype, "clone");
+    const middleware = vi.fn(() => new Response("unexpected"));
+    const handleServerActionRequest = vi.fn(async ({ request }: { request: Request }) => {
+      await expect(request.text()).resolves.toBe("streamed-action-body");
+      return new Response("action");
+    });
+    const handler = createHandler({
+      configHeaders: [],
+      handleServerActionRequest,
+      middlewareModule: {
+        config: { matcher: "/middleware-only" },
+        default: middleware,
+      },
+    });
+
+    try {
+      const response = await handler(
+        new Request(`https://example.test/docs/about.rsc?_rsc=${rscHash}`, {
+          body: "streamed-action-body",
+          headers: rscHeaders,
+          method: "POST",
+        }),
+        null,
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe("action");
+      expect(middleware).not.toHaveBeenCalled();
+      expect(cloneSpy).toHaveBeenCalledTimes(1);
+      expect((cloneSpy.mock.results[0]!.value as Request).bodyUsed).toBe(true);
+    } finally {
+      cloneSpy.mockRestore();
+    }
+  });
+
   it("accepts the vinext action header name for server actions", async () => {
     const handleServerActionRequest = vi.fn(async () => new Response("action", { status: 200 }));
     const handler = createHandler({ handleServerActionRequest });

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -1148,6 +1148,7 @@ describe("App Router entry templates", () => {
     expect(withMiddleware).toContain("runMiddleware({ cleanPathname, context, hadBasePath");
     expect(withMiddleware).toContain("return __applyAppMiddleware({");
     expect(withMiddleware).toContain("hadBasePath,");
+    expect(withMiddleware).toContain("middlewareRequest,");
   });
 
   it("generateRscEntry only includes the PPR runtime when Cache Components is enabled", () => {

--- a/tests/middleware-runtime.test.ts
+++ b/tests/middleware-runtime.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vite-plus/test";
+import { describe, expect, it, vi } from "vite-plus/test";
 import { executeMiddleware } from "../packages/vinext/src/server/middleware-runtime.js";
 import type { NextRequest } from "../packages/vinext/src/shims/server.js";
 
@@ -12,6 +12,33 @@ import type { NextRequest } from "../packages/vinext/src/shims/server.js";
 // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/adapter.ts
 
 describe("middleware redirect protocol", () => {
+  it.each(["development", "production"])(
+    "preserves a request body transferred into the middleware response in %s",
+    async (nodeEnv) => {
+      vi.stubEnv("NODE_ENV", nodeEnv);
+      const request = new Request("http://localhost:3000/echo", {
+        body: "streamed-response",
+        method: "POST",
+      });
+
+      try {
+        const result = await executeMiddleware({
+          isProxy: false,
+          module: {
+            default: (request: Request) => new Response(request.body),
+          },
+          request,
+        });
+
+        expect(result.continue).toBe(false);
+        await expect(result.response?.text()).resolves.toBe("streamed-response");
+        await request.body?.cancel();
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    },
+  );
+
   it("exposes trusted data-request state to middleware", async () => {
     let capturedRequest: NextRequest | undefined;
     const module = {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -4829,7 +4829,7 @@ describe("next/server shim", () => {
     expect(req.cookies.has("missing")).toBe(false);
   });
 
-  it("NextRequest copies a Request body without disturbing the source request", async () => {
+  it("NextRequest transfers a Request body instead of teeing it", async () => {
     const { NextRequest } = await import("../packages/vinext/src/shims/server.js");
     const source = new Request("https://example.com/api/echo", {
       body: JSON.stringify({ ok: true }),
@@ -4840,8 +4840,10 @@ describe("next/server shim", () => {
     const req = new NextRequest(source);
 
     await expect(req.json()).resolves.toEqual({ ok: true });
-    expect(source.bodyUsed).toBe(false);
-    await expect(source.json()).resolves.toEqual({ ok: true });
+    // Next.js parity (`super(input, init)`), and the reason it matters: cloning
+    // here would tee the body, and the branch left on `source` would buffer the
+    // whole request in memory because nothing reads or cancels it.
+    expect(source.bodyUsed).toBe(true);
   });
 
   it("NextResponse.json() creates a JSON response", async () => {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -9521,6 +9521,63 @@ describe("double-encoded path handling in middleware", () => {
     await expect(request.json()).resolves.toEqual({ message: "hello" });
   });
 
+  it("App Router middleware cancels its unread body branch in development", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    try {
+      const { applyAppMiddleware } =
+        await import("../packages/vinext/src/server/app-middleware.js");
+      const request = new Request("http://localhost:3000/actions", {
+        body: "action-payload",
+        method: "POST",
+      });
+      let middlewareRequest: Request | undefined;
+
+      const result = await applyAppMiddleware({
+        cleanPathname: "/actions",
+        context: { headers: null, requestHeaders: null, status: null },
+        isProxy: false,
+        module: {
+          default: (request: Request) => {
+            middlewareRequest = request;
+            return new Response(null, { headers: { "x-middleware-next": "1" } });
+          },
+        },
+        request,
+      });
+
+      expect(result.kind).toBe("continue");
+      await vi.waitFor(() => expect(middlewareRequest?.bodyUsed).toBe(true));
+      await expect(request.text()).resolves.toBe("action-payload");
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("App Router middleware cancels the downstream body branch when it returns a response", async () => {
+    const { applyAppMiddleware } = await import("../packages/vinext/src/server/app-middleware.js");
+    const sourceCancel = vi.fn();
+    const request = new Request("http://localhost:3000/upload", {
+      body: new ReadableStream<Uint8Array>({
+        cancel: sourceCancel,
+      }),
+      duplex: "half",
+      method: "POST",
+    } as RequestInit & { duplex: "half" });
+
+    const result = await applyAppMiddleware({
+      cleanPathname: "/upload",
+      context: { headers: null, requestHeaders: null, status: null },
+      isProxy: false,
+      module: {
+        default: () => new Response("blocked", { status: 403 }),
+      },
+      request,
+    });
+
+    expect(result.kind).toBe("response");
+    await vi.waitFor(() => expect(sourceCancel).toHaveBeenCalledOnce());
+  });
+
   it("external middleware rewrite proxy strips upstream x-middleware headers without middleware context", async () => {
     const { proxyExternalMiddlewareRewrite } =
       await import("../packages/vinext/src/server/app-middleware.js");


### PR DESCRIPTION
## Overview

| | |
| --- | --- |
| Goal | Stop retaining whole request bodies in memory when the runtime wraps an incoming `Request` |
| Core change | `NextRequest` transfers the body (`super(input, init)`, matching Next.js) rather than `input.clone()` |
| Key boundary | Only code that genuinely needs two live branches clones, and it owns cancelling the branch it does not consume |
| Expected impact | Streaming route handlers stay O(1) memory; a remote unauthenticated client can no longer force full-body buffering |

## Why

`Request.clone()` is specified to `tee()` the body stream, and `tee` applies no backpressure to the slower branch: whenever one branch pulls a chunk from the source, that chunk is also enqueued into the other branch's queue. If a branch is never read, its queue grows to the full body size. Dropping the reference does not help, because the tee closure holds both branch controllers and stays reachable from the branch that *is* being read.

The `NextRequest` constructor cloned every body-bearing input. Ordinary App Router route handling wraps the incoming request through `createTrackedAppRouteRequest`, so the branch left behind on the caller-owned request was never read and never cancelled. A handler that streams an upload straight to storage, which should hold no more than one chunk at a time, instead retained the entire body for the life of the request. That is remotely reachable, unauthenticated on any public body-bearing route, and repeatable until the process or Worker isolate runs out of memory.

The clone also disabled an existing mitigation. `executeMiddleware` already cancels the middleware body branch in a `finally` (added in #2026). The constructor's clone inserted a second tee between that cancel and the branch actually accumulating chunks, so the cancel released a branch nothing was filling while the real one kept growing one level up. Removing the clone reconnects that cancel to the stream it was written for.

Upstream Next.js does `super(input, init)` in the same constructor, so transferring is also the parity behaviour. The isolation added in #1132 is preserved: the callers that need the source request to stay readable already clone explicitly before wrapping.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| `NextRequest` constructor | A wrapper takes ownership of the body it wraps | Transfers the body instead of teeing it |
| `createTrackedAppRouteRequest` basePath re-prefix | Do not branch a stream whose source is discarded | Builds the prefixed request directly from the incoming one |
| `executeMiddleware` | The one place with two genuinely live branches cancels the one it does not consume | Unchanged; its existing cancel becomes effective again |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| Route handler streams a body-bearing request | Whole body retained on an unread tee branch | Streams through, nothing retained |
| Route handler under a configured `basePath` | Second dead tee added while re-adding the prefix | Body transferred into the prefixed request |
| Middleware matches and never reads the body | Full body buffered despite the `finally` cancel | Branch released, downstream streams normally |
| Middleware reads the body, then `NextResponse.next()` | Downstream still reads the body (#1132) | Unchanged |
| Userland `new NextRequest(sourceRequest)` | Source stayed readable, diverging from Next.js | Source body is transferred, matching Next.js |
| Userland `request.clone()` inside a handler | Standard `Request` tee semantics | Unchanged; branching stays the caller's choice |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/shims/server.ts` for the ownership decision in the constructor.
2. `packages/vinext/src/server/app-route-handler-runtime.ts` for the dead tee on the basePath path.
3. `packages/vinext/src/server/middleware-runtime.ts` (unchanged) for the clone that is genuinely needed and the `finally` that cancels it.
4. `tests/shims.test.ts` and `tests/app-route-handler-runtime.test.ts` for the regression proofs.

</details>

<details>
<summary>Validation</summary>

- Reproduced the leak against the built package with a 128 MiB streamed body, reading and discarding chunk by chunk, holding the source request alive across the measurement the way a real call frame does.
- Confirmed the same retention through `applyAppMiddleware` for middleware that does not touch the body.
- Updated `tests/shims.test.ts` to pin the constructor as transferring rather than teeing, and added coverage in `tests/app-route-handler-runtime.test.ts` for the basePath path. Both fail if a clone is reintroduced.
- The #1132 regression test (middleware reads the body, downstream still reads it) continues to pass unchanged.
- Ran `tests/shims.test.ts`, `tests/app-route-handler-runtime.test.ts`, `tests/app-router-middleware-next-request.test.ts`, `tests/middleware-runtime.test.ts`, `tests/app-server-action-execution.test.ts`, `tests/app-route-handler-execution.test.ts`, `tests/app-post-middleware-context.test.ts`, `tests/routing.test.ts`, `tests/pages-api-route.test.ts`, `tests/api-handler.test.ts`, `tests/app-route-handler-dispatch.test.ts`, `tests/app-route-handler-policy.test.ts`, `tests/app-router-production-server.test.ts`, plus `vp check` on the changed files.

<details>
<summary>Measurements</summary>

Node 26.5.0, 128 chunks of 1 MiB, `--expose-gc`, delta measured around a full streaming read.

```text
before
  baseline (no wrap)           read=128.0MiB  arrayBuffers +0.0MiB
  new NextRequest(source)      read=128.0MiB  arrayBuffers +128.0MiB

after
  baseline (no wrap)           read=128.0MiB  arrayBuffers +0.0MiB
  new NextRequest(source)      read=128.0MiB  arrayBuffers +0.0MiB
```

Through `applyAppMiddleware`, downstream draining the request body:

```text
before
  middleware ignores body   downstream=128.0MiB  arrayBuffers +128.0MiB
  middleware reads body     downstream=128.0MiB  arrayBuffers +0.0MiB

after
  middleware ignores body   downstream=128.0MiB  arrayBuffers +0.0MiB
  middleware reads body     downstream=128.0MiB  arrayBuffers +0.0MiB
```

A second symptom disappears with the fix. Because a tee only releases its source once every branch has cancelled, cancelling the downstream body while the middleware branch was still live returned a promise that never settled. After the fix it settles and the source stream's `cancel()` runs.

</details>
</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: `new NextRequest(request)` now disturbs the source request's body, which is what Next.js does. Code that wrapped a request and then read the original is relying on a vinext-only divergence and must clone explicitly. No in-tree caller does this.
- Runtime: no new allocation, no new async work. One tee removed from every body-bearing request, and a second from the basePath path.
- Middleware isolation from #1132 is unchanged, and is still covered by its original test.

</details>

<details>
<summary>Non-goals</summary>

- No framework-level request body size limit is introduced here. This PR removes the amplification the framework was adding; capping upload size remains a deployment and userland concern.

</details>

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js `NextRequest`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/spec-extension/request.ts) | Upstream does `super(input, init)`, the behaviour this restores |
| [Streams spec, `ReadableStreamTee`](https://streams.spec.whatwg.org/#abstract-opdef-readablestreamdefaulttee) | Defines the unbounded queueing on the unread branch, and that the source is only cancelled once every branch cancels |
| #1132 | Introduced the clone to isolate middleware body reads; that isolation is preserved |
| #2026 | Added the middleware branch cancel that the clone had been defeating |

