### PR TITLE
test(actions): test case for server-reference value propagation beyond ESM import/export

### DIFF
--- a/tests/e2e/app-router/action-owner-production.browser.spec.ts
+++ b/tests/e2e/app-router/action-owner-production.browser.spec.ts
@@ -20,6 +20,7 @@ type ProductionApp = {
     cookieOwner: string;
     dynamicProtected: string;
     loop: string;
+    objectWrapped: string;
     protected: string;
     protectedClient: string;
     redirectTo: string;
@@ -103,6 +104,7 @@ async function buildAndServeFixture(): Promise<ProductionApp> {
       cookieOwner: findActionId(builtSource, "$$hoist_0_readForwardedCredentials"),
       dynamicProtected: findActionId(builtSource, "$$hoist_0_dynamicProtectedAction"),
       loop: findActionId(builtSource, "$$hoist_0_loopAction"),
+      objectWrapped: findActionId(builtSource, "objectWrappedAction"),
       protected: findActionId(builtSource, "protectedAction"),
       protectedClient: findActionId(builtSource, "protectedClientAction"),
       redirectTo: findActionId(builtSource, "redirectTo"),
@@ -402,6 +404,24 @@ test.describe("production server action ownership", () => {
       return response.status;
     });
     expect(status).toBe(404);
+  });
+
+  test("fails closed when a client module receives an action through an object", async ({
+    page,
+  }) => {
+    await page.goto(`${app.baseUrl}/ownership/object-wrapped`);
+    await waitForAppRouterHydration(page);
+
+    const responsePromise = page.waitForResponse(
+      (response) =>
+        response.request().method() === "POST" &&
+        response.request().headers()["next-action"] === app.actionIds.objectWrapped,
+    );
+    await page.getByTestId("object-wrapped").click();
+    const response = await responsePromise;
+
+    expect(response.status()).toBe(404);
+    expect(await response.text()).not.toContain("OBJECT_WRAPPED_OK");
   });
 
   test("does not grant ownership through side-effect-only imports", async ({ page }) => {

--- a/tests/fixtures/app-action-ownership/app/ownership/object-wrapped/action.js
+++ b/tests/fixtures/app-action-ownership/app/ownership/object-wrapped/action.js
@@ -1,0 +1,5 @@
+"use server";
+
+export async function objectWrappedAction() {
+  return "OBJECT_WRAPPED_OK";
+}

--- a/tests/fixtures/app-action-ownership/app/ownership/object-wrapped/client-form.jsx
+++ b/tests/fixtures/app-action-ownership/app/ownership/object-wrapped/client-form.jsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { commands } from "./commands";
+
+export function ClientForm() {
+  return (
+    <form action={commands.objectWrappedAction}>
+      <button data-testid="object-wrapped">Run object-wrapped action</button>
+    </form>
+  );
+}

--- a/tests/fixtures/app-action-ownership/app/ownership/object-wrapped/commands.js
+++ b/tests/fixtures/app-action-ownership/app/ownership/object-wrapped/commands.js
@@ -1,0 +1,3 @@
+import { objectWrappedAction } from "./action";
+
+export const commands = { objectWrappedAction };

--- a/tests/fixtures/app-action-ownership/app/ownership/object-wrapped/page.jsx
+++ b/tests/fixtures/app-action-ownership/app/ownership/object-wrapped/page.jsx
@@ -1,0 +1,5 @@
+import { ClientForm } from "./client-form";
+
+export default function Page() {
+  return <ClientForm />;
+}


### PR DESCRIPTION
- related https://github.com/vitejs/vite-plugin-react/issues/1337
- stacked on https://github.com/cloudflare/vinext/pull/2520

This is one counter example where import/export based server action reachability can misjudge.