### PR TITLE
fix(cache): bypass shared "use cache" entries in draft mode

### DIFF
--- a/packages/vinext/src/shims/cache-runtime.ts
+++ b/packages/vinext/src/shims/cache-runtime.ts
@@ -49,7 +49,7 @@ import {
   getRequestContext,
   runWithUnifiedStateMutation,
 } from "./unified-request-context.js";
-import { markDynamicUsage } from "./headers.js";
+import { isDraftModeEnabled, markDynamicUsage } from "./headers.js";
 import { trackPprFallbackShellCacheTask } from "./ppr-fallback-shell.js";
 import { isMarkedAppPagePropsObject } from "./internal/app-page-props-cache-key.js";
 
@@ -536,9 +536,11 @@ export function registerCachedFunction<TArgs extends unknown[], TResult>(
         return result;
       }
 
-      // In dev mode, always execute fresh — skip shared cache lookup/storage.
-      // This ensures HMR changes are reflected immediately.
-      if (isDev) {
+      // Draft mode joins dev in skipping shared cache lookup/storage: the key
+      // covers function id, build seed and arguments but not draft state, so a
+      // preview request would otherwise seed unpublished content into an entry
+      // later served to public requests. Mirrors Next.js's `isDraftMode` guard.
+      if (isDev || isDraftModeEnabled()) {
         return executeWithContext(fn, args, cacheVariant);
       }
 

--- a/tests/app-page-element-builder.test.ts
+++ b/tests/app-page-element-builder.test.ts
@@ -42,6 +42,9 @@ const { markDynamicUsageMock, markRenderRequestApiUsageMock } = vi.hoisted(() =>
 
 vi.mock("../packages/vinext/src/shims/headers.js", () => ({
   getHeadersAccessPhase: () => "render",
+  // These builder tests render outside a draft request, so the shared "use
+  // cache" path in cache-runtime.ts must see draft mode off.
+  isDraftModeEnabled: () => false,
   markDynamicUsage: markDynamicUsageMock,
   markRenderRequestApiUsage: markRenderRequestApiUsageMock,
   throwIfInsideCacheScope: vi.fn(),

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -6718,9 +6718,9 @@ describe('"use cache" runtime', () => {
       draftContent = true;
       expect(await cached()).toBe("DRAFT");
 
-      // The draft execution must not replace the public entry either.
+      // Leave the source in its draft state: seeing PUBLIC again proves the
+      // draft execution neither replaced nor invalidated the existing entry.
       enterRequest(false);
-      draftContent = false;
       expect(await cached()).toBe("PUBLIC");
     } finally {
       setHeadersContext(null);

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -6684,6 +6684,8 @@ describe('"use cache" runtime', () => {
     expect(callCount).toBe(2);
   });
 
+  // Ported from Next.js: test/e2e/app-dir/use-cache/use-cache.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/use-cache/use-cache.test.ts
   it("bypasses the shared cache in draft mode", async () => {
     const { registerCachedFunction } =
       await import("../packages/vinext/src/shims/cache-runtime.js");
@@ -6715,6 +6717,11 @@ describe('"use cache" runtime', () => {
       enterRequest(true);
       draftContent = true;
       expect(await cached()).toBe("DRAFT");
+
+      // The draft execution must not replace the public entry either.
+      enterRequest(false);
+      draftContent = false;
+      expect(await cached()).toBe("PUBLIC");
     } finally {
       setHeadersContext(null);
       setCacheHandler(new MemoryCacheHandler());

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -6684,6 +6684,43 @@ describe('"use cache" runtime', () => {
     expect(callCount).toBe(2);
   });
 
+  it("bypasses the shared cache in draft mode", async () => {
+    const { registerCachedFunction } =
+      await import("../packages/vinext/src/shims/cache-runtime.js");
+    const { setCacheHandler, MemoryCacheHandler } =
+      await import("../packages/vinext/src/shims/cache.js");
+    const { setHeadersContext } = await import("../packages/vinext/src/shims/headers.js");
+    setCacheHandler(new MemoryCacheHandler());
+
+    let draftContent = false;
+    const cached = registerCachedFunction(
+      async () => (draftContent ? "DRAFT" : "PUBLIC"),
+      "test:draft-bypass",
+    );
+    const enterRequest = (draftModeEnabled: boolean) => {
+      setHeadersContext({ headers: new Headers(), cookies: new Map(), draftModeEnabled });
+    };
+
+    try {
+      // A preview request must not seed the entry public requests read.
+      enterRequest(true);
+      draftContent = true;
+      expect(await cached()).toBe("DRAFT");
+
+      enterRequest(false);
+      draftContent = false;
+      expect(await cached()).toBe("PUBLIC");
+
+      // ...and must not read back the public entry either.
+      enterRequest(true);
+      draftContent = true;
+      expect(await cached()).toBe("DRAFT");
+    } finally {
+      setHeadersContext(null);
+      setCacheHandler(new MemoryCacheHandler());
+    }
+  });
+
   it("scopes shared cache entries by build ID", async () => {
     const { registerCachedFunction } =
       await import("../packages/vinext/src/shims/cache-runtime.js");


### PR DESCRIPTION
Draft-mode requests can currently poison shared `"use cache"` entries.

## The gap

`registerCachedFunction` builds its shared cache key from the function id, the build seed and the serialized arguments — never from draft-mode state. Since #1489 made `draftMode().isEnabled` readable inside cache scopes (correctly matching Next.js, which allows reads and only forbids `enable()`/`disable()` there), a cached function that branches on it becomes a request-dependent input to a key that does not vary by request:

```ts
async function getPost(slug: string) {
  "use cache";
  const { isEnabled } = await draftMode();
  return isEnabled ? cms.preview(slug) : cms.published(slug); // seeds one shared entry
}
```

An editor request stores the unpublished result; later public requests are served it from cache without re-executing. The reverse also holds — a public request can pin published content into the preview view.

`unstable_cache` received this guard in #2319. The public `"use cache"` path was left without it.

## Change

Skip the shared cache lookup and store when the request is in draft mode, alongside the existing dev-mode bypass, reusing the `isDraftModeEnabled()` helper #2319 added for exactly this purpose.

This mirrors Next.js, which guards the same two operations at request level rather than by widening the key:

- read — `use-cache-wrapper.ts` gates `cacheHandler.get` on `!shouldForceRevalidate(...)`, and `shouldForceRevalidate` returns `true` when `workStore.isDraftMode`
- write — `if (!workStore.isDraftMode)` around the cache-handler save, commented "When draft mode is enabled, we must not save the cache entry."

`"use cache: private"` is deliberately untouched: it is a per-request in-memory map that never crosses a request boundary, so it cannot leak across the draft/public split.

## Validation

`tests/shims.test.ts` — "bypasses the shared cache in draft mode": a draft request renders `DRAFT`, then a non-draft request for the same key must observe `PUBLIC`, then a second draft request must observe `DRAFT` again. Reverting the source change alone fails it at the second assertion with `expected 'DRAFT' to be 'PUBLIC'` — the leak the fix closes.

Also run green: `tests/shims.test.ts`, `tests/cache-proof.test.ts`, `tests/use-cache-transform.test.ts`, `tests/draft-secret-exposure.test.ts` (1310 tests), plus the repo pre-commit full check, staged tests and knip.

## Out of scope

`patchedFetch` in `shims/fetch-cache.ts` has no draft-mode bypass either, where Next.js falls straight through to the native fetch (`patch-fetch.ts`). That is a preview-freshness parity gap rather than the same leak: vinext's fetch cache key already covers URL, method, headers and body, so a draft request and a public request only share an entry when the outgoing request is byte-for-byte identical. Worth fixing separately.