### PR TITLE
fix(actions): run middleware for server action redirect targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-node_modules/
+node_modules
 dist/
 !packages/types/next/upstream/dist/
 !packages/types/next/upstream/dist/**

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -1072,6 +1072,7 @@ export default createAppRscHandler({
     scriptNonce,
     routeMatch,
     routePathname,
+    runRedirectTargetMiddleware,
     searchParams,
   }) {
     const {
@@ -1173,6 +1174,7 @@ export default createAppRscHandler({
       },
       resolveRouteRuntime: __resolveRouteRuntime,
       request,
+      runRedirectTargetMiddleware,
       sanitizeErrorForClient(error) {
         return __sanitizeErrorForClient(error);
       },

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -1103,6 +1103,7 @@ export default createAppRscHandler({
         renderMode: actionRenderMode,
         observeMetadataSearchParamsAccess,
         observePageSearchParamsAccess,
+        scriptNonce: targetScriptNonce,
       }) {
         return buildPageElements(actionRoute, actionParams, actionCleanPathname, {
           opts: interceptOpts,
@@ -1113,7 +1114,7 @@ export default createAppRscHandler({
           renderMode: actionRenderMode,
           observeMetadataSearchParamsAccess: observeMetadataSearchParamsAccess === true,
           observePageSearchParamsAccess: observePageSearchParamsAccess === true,
-        }, undefined, actionCleanPathname, scriptNonce);
+        }, undefined, actionCleanPathname, targetScriptNonce ?? scriptNonce);
       },
       cleanPathname,
       clearRequestContext() {

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -1163,6 +1163,7 @@ export default createAppRscHandler({
       maxActionBodySize: __MAX_ACTION_BODY_SIZE,
       maxActionBodySizeLabel: __MAX_ACTION_BODY_SIZE_LABEL,
       middlewareHeaders: middlewareContext.headers,
+      middlewareRequestHeaders: middlewareContext.requestHeaders,
       middlewareStatus: middlewareContext.status,
       mountedSlotsHeader,
       readBodyWithLimit: __readBodyWithLimit,

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -1154,8 +1154,10 @@ export default createAppRscHandler({
       },
       isRscRequest,
       loadServerAction,
+      // Redirect targets are rendered as if the client had navigated to them,
+      // so they must route on the raw pathname a real request would use.
       matchRoute(pathnameToMatch) {
-        return matchRoute(pathnameToMatch);
+        return matchRequestRoute(pathnameToMatch);
       },
       maxActionBodySize: __MAX_ACTION_BODY_SIZE,
       maxActionBodySizeLabel: __MAX_ACTION_BODY_SIZE_LABEL,

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -71,6 +71,7 @@ import {
 } from "./image-optimization.js";
 import { runWithPrerenderWorkUnit } from "./prerender-work-unit-setup.js";
 import { buildPostMwRequestContext } from "./app-post-middleware-context.js";
+import type { ActionRedirectMiddlewareResult } from "./app-server-action-execution.js";
 import type { AppRscRenderMode } from "./app-rsc-render-mode.js";
 import type { AppPagePprFallbackCacheShell } from "./app-ppr-fallback-shell.js";
 import type { ClientReuseManifestParseResult } from "./client-reuse-manifest.js";
@@ -256,6 +257,10 @@ type HandleServerActionRequestOptions<TRoute> = {
   scriptNonce?: string;
   routeMatch: AppRscRouteMatch<TRoute> | null;
   routePathname: string;
+  runRedirectTargetMiddleware?: (options: {
+    cleanPathname: string;
+    request: Request;
+  }) => Promise<ActionRedirectMiddlewareResult>;
   searchParams: URLSearchParams;
 };
 
@@ -691,6 +696,38 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     resolvedUrl = cleanPathname + url.search;
   }
 
+  // A server action that redirects renders the target page inline instead of
+  // making the client re-request it, so the target's middleware has to be run
+  // here or it is skipped entirely. Only a clean pass-through can be rendered
+  // inline: a block, redirect, rewrite, or status override has to be resolved by
+  // a real navigation through the full request pipeline.
+  const runRedirectTargetMiddleware = runMiddleware
+    ? async (targetOptions: {
+        cleanPathname: string;
+        request: Request;
+      }): Promise<ActionRedirectMiddlewareResult> => {
+        const targetContext: AppRscMiddlewareContext = {
+          headers: null,
+          requestHeaders: null,
+          status: null,
+        };
+        const targetResult = await runMiddleware({
+          cleanPathname: targetOptions.cleanPathname,
+          context: targetContext,
+          hadBasePath,
+          isDataRequest: false,
+          request: targetOptions.request,
+        });
+        if (targetResult.kind === "response" || targetResult.rewritten) {
+          return { kind: "diverted" };
+        }
+        if (targetContext.status !== null && targetContext.status !== 200) {
+          return { kind: "diverted" };
+        }
+        return { kind: "continue", responseHeaders: targetContext.headers };
+      }
+    : undefined;
+
   const scriptNonce = getScriptNonceFromHeaderSources(request.headers, middlewareContext.headers);
   const postMiddlewareRequestContext = buildPostMwRequestContext(userlandRequest);
   let filesystemRouteEligible = hadBasePath || didMiddlewareRewrite;
@@ -972,6 +1009,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
           scriptNonce,
           routeMatch: preActionMatch,
           routePathname: preActionRoutePathname,
+          runRedirectTargetMiddleware,
           searchParams: getResolvedSearchParams(),
         })
       : null;

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -59,6 +59,7 @@ import {
   validateServerActionPayload,
 } from "./request-pipeline.js";
 import { readStreamAsTextWithLimit } from "../utils/text-stream.js";
+import { buildRequestHeadersFromMiddlewareResponse } from "../utils/middleware-request-headers.js";
 import {
   createServerActionNotFoundResponse,
   getServerActionNotFoundMessage,
@@ -311,6 +312,8 @@ export type HandleServerActionRscRequestOptions<
   /** Verbatim `serverActions.bodySizeLimit` config string (e.g. "2mb") for the body-exceeded error. */
   maxActionBodySizeLabel: string;
   middlewareHeaders: Headers | null;
+  /** Raw middleware response headers used to reconstruct request-header overrides. */
+  middlewareRequestHeaders: Headers | null;
   middlewareStatus: number | null | undefined;
   /**
    * Run userland middleware for an internal action-redirect target before that
@@ -398,11 +401,8 @@ const SERVER_ACTION_ARGS_LIMIT = 1000;
 const ACTION_DID_NOT_REVALIDATE = 0 satisfies ActionRevalidationKind;
 const ACTION_DID_REVALIDATE_STATIC_AND_DYNAMIC = 1 satisfies ActionRevalidationKind;
 const ACTION_REDIRECT_RENDER_STRIPPED_HEADERS = [
-  "accept",
   "content-length",
-  "content-type",
   "next-action",
-  "origin",
   "rsc",
   "x-action-forwarded",
   "x-rsc-action",
@@ -572,12 +572,23 @@ function cookiePathMatches(cookiePath: string, requestPath: string): boolean {
 
 function createActionRedirectRenderRequest(options: {
   actionMiddlewareHeaders: Headers | null;
+  actionMiddlewareRequestHeaders: Headers | null;
   pendingCookies: readonly string[];
   request: Request;
   url: URL;
 }): Request {
+  // App middleware request overrides are applied to headers()/cookies() through
+  // ALS, while the Request object remains the pre-middleware request. Next.js
+  // mutates req.headers before its internal target GET, so reconstruct that
+  // effective request here before forwarding ordinary response headers.
+  const effectiveRequestHeaders = options.actionMiddlewareRequestHeaders
+    ? (buildRequestHeadersFromMiddlewareResponse(
+        options.request.headers,
+        options.actionMiddlewareRequestHeaders,
+      ) ?? options.request.headers)
+    : options.request.headers;
   const headers = cloneActionRedirectHeaders(
-    options.request.headers,
+    effectiveRequestHeaders,
     options.actionMiddlewareHeaders,
   );
   // Like Next.js' internal action-redirect GET, this is necessarily a lossy
@@ -602,23 +613,6 @@ function createActionRedirectRenderRequest(options: {
   return attachRequestCfMetadata(
     new Request(options.url, { headers, method: "GET" }),
     options.request,
-  );
-}
-
-/**
- * Middleware matchers can gate on request headers (`has`/`missing`), so the
- * request middleware sees for a redirect target must carry what the navigation
- * the client would otherwise have made carries. The render request drops
- * `Accept` along with the action transport headers; put it back.
- */
-function createActionRedirectMiddlewareRequest(renderRequest: Request, accept: string | null) {
-  if (accept === null) return renderRequest;
-
-  const headers = new Headers(renderRequest.headers);
-  headers.set("accept", accept);
-  return attachRequestCfMetadata(
-    new Request(renderRequest.url, { headers, method: "GET" }),
-    renderRequest,
   );
 }
 
@@ -1504,6 +1498,7 @@ export async function handleServerActionRscRequest<
 
       const redirectRenderRequest = createActionRedirectRenderRequest({
         actionMiddlewareHeaders: options.middlewareHeaders,
+        actionMiddlewareRequestHeaders: options.middlewareRequestHeaders,
         // Project the action middleware's Set-Cookie mutations (session
         // rotation or deletion) into the internal target request first; the
         // action's own cookies().set() calls land after middleware and win for
@@ -1528,10 +1523,7 @@ export async function handleServerActionRscRequest<
       if (options.runRedirectTargetMiddleware) {
         const targetMiddleware = await options.runRedirectTargetMiddleware({
           cleanPathname: targetPathname,
-          request: createActionRedirectMiddlewareRequest(
-            redirectRenderRequest,
-            redirectRenderRequest.headers.get("accept") ?? options.request.headers.get("accept"),
-          ),
+          request: redirectRenderRequest,
         });
         // Diverting costs the target one extra middleware execution, since the
         // client's navigation runs it again. A pass-through — the common case —

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -491,15 +491,49 @@ function applySetCookieMutationsToRequestCookieHeader(
     : [...cookies].map(([name, value]) => `${name}=${value}`).join("; ");
 }
 
+/** RFC 6265 §5.1.4: the default cookie path is the request path's directory. */
+function defaultCookiePath(requestPathname: string): string {
+  if (!requestPathname.startsWith("/")) return "/";
+  const lastSlash = requestPathname.lastIndexOf("/");
+  return lastSlash <= 0 ? "/" : requestPathname.slice(0, lastSlash);
+}
+
+/** A missing or invalid Path attribute means the default path applies. */
+function readSetCookiePath(setCookie: string): string | null {
+  for (const part of setCookie.split(";").slice(1)) {
+    const equalsIndex = part.indexOf("=");
+    if (equalsIndex === -1) continue;
+    if (part.slice(0, equalsIndex).trim().toLowerCase() !== "path") continue;
+    const value = part.slice(equalsIndex + 1).trim();
+    return value.startsWith("/") ? value : null;
+  }
+  return null;
+}
+
+/** RFC 6265 §5.1.4 path-match. */
+function cookiePathMatches(cookiePath: string, requestPath: string): boolean {
+  if (cookiePath === requestPath) return true;
+  if (!requestPath.startsWith(cookiePath)) return false;
+  return cookiePath.endsWith("/") || requestPath[cookiePath.length] === "/";
+}
+
 function createActionRedirectRenderRequest(options: {
   pendingCookies: readonly string[];
   request: Request;
   url: URL;
 }): Request {
   const headers = cloneActionRedirectHeaders(options.request.headers);
+  // A browser only carries a Set-Cookie into the target navigation when the
+  // cookie's Path (or the default derived from the action URL) path-matches
+  // the target, so a mutation scoped elsewhere must not reach the target's
+  // middleware or render.
+  const actionDefaultPath = defaultCookiePath(new URL(options.request.url).pathname);
+  const applicableCookies = options.pendingCookies.filter((cookie) =>
+    cookiePathMatches(readSetCookiePath(cookie) ?? actionDefaultPath, options.url.pathname),
+  );
   const cookieHeader = applySetCookieMutationsToRequestCookieHeader(
     headers.get("cookie"),
-    options.pendingCookies,
+    applicableCookies,
   );
   if (cookieHeader === null) {
     headers.delete("cookie");
@@ -535,10 +569,12 @@ function createActionRedirectMiddlewareRequest(renderRequest: Request, accept: s
  * redirect wrapper: `Location` would give the (usually 303) wrapper genuine
  * HTTP-redirect semantics that fetch follows before the client reads the
  * control headers, a foreign `Content-Type` makes the client treat the Flight
- * body as non-RSC and hard-navigate, and the x-action-* headers steer the
- * client's navigation and cache invalidation.
+ * body as non-RSC and hard-navigate, a stale `Content-Length` misframes the
+ * generated Flight stream, and the x-action-* headers steer the client's
+ * navigation and cache invalidation.
  */
 const ACTION_REDIRECT_PROTECTED_HEADERS = [
+  "content-length",
   "content-type",
   "location",
   ACTION_REDIRECT_HEADER,

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -51,7 +51,11 @@ import {
   parseNextHttpErrorDigest,
   parseNextRedirectDigest,
 } from "./next-error-digest.js";
-import { validateCsrfOrigin, validateServerActionPayload } from "./request-pipeline.js";
+import {
+  attachRequestCfMetadata,
+  validateCsrfOrigin,
+  validateServerActionPayload,
+} from "./request-pipeline.js";
 import { readStreamAsTextWithLimit } from "../utils/text-stream.js";
 import {
   createServerActionNotFoundResponse,
@@ -102,6 +106,13 @@ type AppServerActionRoute = {
   pattern: string;
   rootParamNames?: readonly string[];
   routeHandler?: unknown;
+  /**
+   * Manifest lazy-module thunks (see app-route-module-loader.ts). Present when
+   * the route is lazy; `page`/`routeHandler` stay unset until hydration, so
+   * these are what identify the route's kind without importing its modules.
+   */
+  __loadPage?: unknown;
+  __loadRouteHandler?: unknown;
   routeSegments?: readonly string[];
   params?: readonly string[] | null;
   slots?: Readonly<
@@ -495,10 +506,10 @@ function createActionRedirectRenderRequest(options: {
     headers.set("cookie", cookieHeader);
   }
 
-  return new Request(options.url, {
-    headers,
-    method: "GET",
-  });
+  return attachRequestCfMetadata(
+    new Request(options.url, { headers, method: "GET" }),
+    options.request,
+  );
 }
 
 /**
@@ -512,7 +523,25 @@ function createActionRedirectMiddlewareRequest(renderRequest: Request, accept: s
 
   const headers = new Headers(renderRequest.headers);
   headers.set("accept", accept);
-  return new Request(renderRequest.url, { headers, method: "GET" });
+  return attachRequestCfMetadata(
+    new Request(renderRequest.url, { headers, method: "GET" }),
+    renderRequest,
+  );
+}
+
+/**
+ * Merge pass-through middleware response headers onto the action redirect
+ * wrapper, minus `Location`: the wrapper's real target travels in
+ * x-action-redirect and its status is usually 303, so a stray middleware
+ * `Location` would give it genuine HTTP-redirect semantics — fetch would
+ * follow it before the action client can read the control headers.
+ */
+function mergeActionRedirectMiddlewareHeaders(
+  target: Headers,
+  middlewareHeaders: Headers | null,
+): void {
+  mergeMiddlewareResponseHeaders(target, middlewareHeaders);
+  target.delete("location");
 }
 
 function withoutRscBodyHeaders(headers: Headers): Headers {
@@ -794,9 +823,15 @@ function shouldUseForwardedActionRedirectStatus<TRoute extends AppServerActionRo
   return currentRuntime !== targetRuntime;
 }
 
+/**
+ * Decided from lazy thunks as well as hydrated fields so it needs no
+ * `ensureRouteLoaded` first: a middleware-blocked target must never execute
+ * its modules' top-level code, so the route cannot be hydrated before
+ * middleware has cleared it.
+ */
 function canRenderActionRedirectTarget(route: AppServerActionRoute): boolean {
-  if ("routeHandler" in route && route.routeHandler) return false;
-  return route.page !== null && route.page !== undefined;
+  if (("routeHandler" in route && route.routeHandler) || route.__loadRouteHandler) return false;
+  return (route.page !== null && route.page !== undefined) || route.__loadPage != null;
 }
 
 function getActionHttpFallbackStatus(error: unknown): number | null {
@@ -1298,7 +1333,7 @@ export async function handleServerActionRscRequest<
         Vary: VINEXT_RSC_VARY_HEADER,
       });
       applyEdgeRuntimeHeader(redirectHeaders, options.isEdgeRuntime);
-      mergeMiddlewareResponseHeaders(redirectHeaders, options.middlewareHeaders);
+      mergeActionRedirectMiddlewareHeaders(redirectHeaders, options.middlewareHeaders);
       applyRscCompatibilityIdHeader(redirectHeaders);
       // Prefix basePath onto the redirect target. The client-side handler in
       // app-browser-entry reads ACTION_REDIRECT_HEADER and calls
@@ -1332,9 +1367,6 @@ export async function handleServerActionRscRequest<
 
       const targetPathname = stripBasePath(redirectTarget.pathname, options.basePath ?? "");
       const targetMatch = options.matchRoute(targetPathname);
-      // Hydrate the redirect target before reading its page/route-handler
-      // modules (canRenderActionRedirectTarget + fetch-cache-mode below).
-      if (targetMatch) await options.ensureRouteLoaded?.(targetMatch.route);
       if (!targetMatch || !canRenderActionRedirectTarget(targetMatch.route)) {
         options.clearRequestContext();
         return new Response(null, {
@@ -1342,9 +1374,6 @@ export async function handleServerActionRscRequest<
           headers: withoutRscBodyHeaders(redirectHeaders),
         });
       }
-      const currentMatch = options.currentRouteMatch;
-      // Hydrate the current route before resolving its runtime below.
-      if (currentMatch) await options.ensureRouteLoaded?.(currentMatch.route);
 
       const redirectRenderRequest = createActionRedirectRenderRequest({
         pendingCookies: [
@@ -1382,8 +1411,16 @@ export async function handleServerActionRscRequest<
             headers: withoutRscBodyHeaders(redirectHeaders),
           });
         }
-        mergeMiddlewareResponseHeaders(redirectHeaders, targetMiddleware.responseHeaders);
+        mergeActionRedirectMiddlewareHeaders(redirectHeaders, targetMiddleware.responseHeaders);
       }
+      // Hydrate the target only now that middleware has cleared it: importing
+      // its modules runs their top-level code, which a blocked target must
+      // never execute. The dynamic-config / fetch-cache reads below need the
+      // hydrated route.
+      await options.ensureRouteLoaded?.(targetMatch.route);
+      const currentMatch = options.currentRouteMatch;
+      // Hydrate the current route before resolving its runtime below.
+      if (currentMatch) await options.ensureRouteLoaded?.(currentMatch.route);
       const redirectDynamicConfig = options.resolveRouteDynamicConfig?.(targetMatch.route);
       const redirectSearchParams = prepareActionPageRerenderContext({
         draftModeCookie: actionDraftCookie,

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -428,10 +428,12 @@ const ACTION_REDIRECT_FORWARDED_FORBIDDEN_HEADERS = [
   "transfer-encoding",
 ];
 
-// Next.js explicitly removes its action header after merging the action
-// response into the target request. Do the same for both action protocols and
-// vinext's dev-only forwarded middleware context.
+// Headers that must not use ordinary response-over-request merging. Next.js
+// explicitly removes its action header, vinext also has its own action/dev
+// protocol headers, and Cookie is rebuilt separately from the original jar plus
+// Set-Cookie mutations.
 const ACTION_REDIRECT_FORWARDED_PROTOCOL_HEADERS = [
+  "cookie",
   "next-action",
   "rsc",
   "x-action-forwarded",
@@ -630,7 +632,10 @@ function createActionRedirectMiddlewareRequest(renderRequest: Request, accept: s
  * navigation and cache invalidation.
  */
 const ACTION_REDIRECT_PROTECTED_HEADERS = [
-  "content-length",
+  // Next.js does not copy these connection/framing headers from the internal
+  // target GET onto the action wrapper. Set-Cookie is the exception here: it
+  // carries middleware mutations back to the browser and is merged additively.
+  ...ACTION_REDIRECT_FORWARDED_FORBIDDEN_HEADERS.filter((name) => name !== "set-cookie"),
   "content-type",
   "location",
   ACTION_REDIRECT_HEADER,

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -198,6 +198,15 @@ type DecodeServerActionReplyOptions<TTemporaryReferences> = {
   temporaryReferences: TTemporaryReferences;
 };
 
+/**
+ * Outcome of running middleware for an action-redirect target. `diverted` means
+ * middleware blocked, redirected, or rewrote the target, so it cannot be
+ * rendered inline and has to be resolved by a real navigation.
+ */
+export type ActionRedirectMiddlewareResult =
+  | { kind: "continue"; responseHeaders: Headers | null }
+  | { kind: "diverted" };
+
 export type HandleProgressiveServerActionRequestOptions = {
   actionId: string | null;
   allowedOrigins: string[];
@@ -281,6 +290,17 @@ export type HandleServerActionRscRequestOptions<
   maxActionBodySizeLabel: string;
   middlewareHeaders: Headers | null;
   middlewareStatus: number | null | undefined;
+  /**
+   * Run userland middleware for an internal action-redirect target before that
+   * target is rendered inline. Middleware only ran for the action's own path,
+   * so without this the target's middleware — commonly the app's authorization
+   * boundary — would never see the request. Absent when the app has no
+   * middleware.
+   */
+  runRedirectTargetMiddleware?: (options: {
+    cleanPathname: string;
+    request: Request;
+  }) => Promise<ActionRedirectMiddlewareResult>;
   mountedSlotsHeader: string | null;
   readBodyWithLimit: ReadBodyWithLimit;
   readFormDataWithLimit: ReadFormDataWithLimit;
@@ -1312,6 +1332,24 @@ export async function handleServerActionRscRequest<
           draftModeSecret: options.draftModeSecret,
         }),
       );
+      // Middleware ran for the action's own path, not the target's. Run it here
+      // (against the headers context above, so request-header overrides land on
+      // the render) and hand anything it wants to change back to the client as a
+      // plain redirect it will re-request through the full pipeline.
+      if (options.runRedirectTargetMiddleware) {
+        const targetMiddleware = await options.runRedirectTargetMiddleware({
+          cleanPathname: targetPathname,
+          request: redirectRenderRequest,
+        });
+        if (targetMiddleware.kind === "diverted") {
+          options.clearRequestContext();
+          return new Response(null, {
+            status: 303,
+            headers: withoutRscBodyHeaders(redirectHeaders),
+          });
+        }
+        mergeMiddlewareResponseHeaders(redirectHeaders, targetMiddleware.responseHeaders);
+      }
       const redirectDynamicConfig = options.resolveRouteDynamicConfig?.(targetMatch.route);
       const redirectSearchParams = prepareActionPageRerenderContext({
         draftModeCookie: actionDraftCookie,

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -40,6 +40,7 @@ import {
   stripRscCacheBustingSearchParam,
 } from "./app-rsc-cache-busting.js";
 import { applyEdgeRuntimeHeader } from "./app-page-response.js";
+import { getScriptNonceFromHeaderSources } from "./csp.js";
 import { resolveAppPageActionRerenderTarget } from "./app-page-request.js";
 import { resolveAppPageNavigationParams } from "./app-page-element-builder.js";
 import { deferUntilStreamConsumed } from "./app-page-stream.js";
@@ -187,6 +188,7 @@ type BuildServerActionPageElementOptions<TRoute extends AppServerActionRoute, TI
   request: Request;
   route: TRoute;
   searchParams: URLSearchParams;
+  scriptNonce?: string;
   renderMode: AppRscRenderMode;
   observeMetadataSearchParamsAccess?: boolean;
   observePageSearchParamsAccess?: boolean;
@@ -1515,6 +1517,13 @@ export async function handleServerActionRscRequest<
       setCurrentFetchCacheMode(options.resolveRouteFetchCacheMode?.(targetMatch.route) ?? null);
       setCurrentForceDynamicFetchDefault(redirectDynamicConfig === "force-dynamic");
       setCurrentFetchSoftTags(buildServerActionPageTags(targetMatch.route, targetPathname));
+      // Target middleware can replace the action path's CSP with a freshly
+      // generated nonce. Build the inline target with the nonce on the final
+      // response it represents, not the stale action-path nonce.
+      const redirectScriptNonce = getScriptNonceFromHeaderSources(
+        redirectRenderRequest.headers,
+        redirectHeaders,
+      );
       const rscStream = await runWithRootParamsScope(
         pickRootParams(targetMatch.params, targetMatch.route.rootParamNames),
         () =>
@@ -1528,6 +1537,7 @@ export async function handleServerActionRscRequest<
               request: redirectRenderRequest,
               route: targetMatch.route,
               searchParams: redirectSearchParams,
+              scriptNonce: redirectScriptNonce,
               renderMode: APP_RSC_RENDER_MODE_NAVIGATION,
               observeMetadataSearchParamsAccess: redirectDynamicConfig !== "force-static",
               observePageSearchParamsAccess: redirectDynamicConfig !== "force-static",

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -1371,6 +1371,10 @@ export async function handleServerActionRscRequest<
             options.request.headers.get("accept"),
           ),
         });
+        // Diverting costs the target one extra middleware execution, since the
+        // client's navigation runs it again. A pass-through — the common case —
+        // runs it exactly once because no navigation follows, so the extra run
+        // buys a single round-trip redirect for every app that has middleware.
         if (targetMiddleware.kind === "diverted") {
           options.clearRequestContext();
           return new Response(null, {

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -31,6 +31,7 @@ import {
   ACTION_REDIRECT_STATUS_HEADER,
   ACTION_REDIRECT_TYPE_HEADER,
   ACTION_REVALIDATED_HEADER,
+  VINEXT_MW_CTX_HEADER,
 } from "./headers.js";
 import {
   VINEXT_RSC_CONTENT_TYPE,
@@ -284,6 +285,13 @@ export type HandleServerActionRscRequestOptions<
   isEdgeRuntime?: boolean;
   isRscRequest: boolean;
   loadServerAction: (actionId: string) => Promise<unknown>;
+  /**
+   * Match an action redirect target. Must use *request* route identity — the
+   * raw, undecoded pathname — because the target is rendered as if the client
+   * had navigated to it. A matcher that decodes would resolve an encoded alias
+   * like `/%61dmin` to `/admin` and render a page the navigation itself, and
+   * the middleware that just ran for `/%61dmin`, would never have reached.
+   */
   matchRoute: (pathname: string) => AppServerActionMatch<TRoute> | null;
   maxActionBodySize: number;
   /** Verbatim `serverActions.bodySizeLimit` config string (e.g. "2mb") for the body-exceeded error. */
@@ -384,6 +392,11 @@ const ACTION_REDIRECT_RENDER_STRIPPED_HEADERS = [
   "rsc",
   "x-action-forwarded",
   "x-rsc-action",
+  // Hybrid app+pages dev attaches the Pages handler's middleware result for the
+  // *action* path. Left on the redirect target's request it would make
+  // applyForwardedMiddlewareContext replay that result instead of executing
+  // middleware for the target.
+  VINEXT_MW_CTX_HEADER,
 ];
 
 function setActionRevalidatedHeader(headers: Headers, kind: ActionRevalidationKind): void {
@@ -486,6 +499,20 @@ function createActionRedirectRenderRequest(options: {
     headers,
     method: "GET",
   });
+}
+
+/**
+ * Middleware matchers can gate on request headers (`has`/`missing`), so the
+ * request middleware sees for a redirect target must carry what the navigation
+ * the client would otherwise have made carries. The render request drops
+ * `Accept` along with the action transport headers; put it back.
+ */
+function createActionRedirectMiddlewareRequest(renderRequest: Request, accept: string | null) {
+  if (accept === null) return renderRequest;
+
+  const headers = new Headers(renderRequest.headers);
+  headers.set("accept", accept);
+  return new Request(renderRequest.url, { headers, method: "GET" });
 }
 
 function withoutRscBodyHeaders(headers: Headers): Headers {
@@ -1339,7 +1366,10 @@ export async function handleServerActionRscRequest<
       if (options.runRedirectTargetMiddleware) {
         const targetMiddleware = await options.runRedirectTargetMiddleware({
           cleanPathname: targetPathname,
-          request: redirectRenderRequest,
+          request: createActionRedirectMiddlewareRequest(
+            redirectRenderRequest,
+            options.request.headers.get("accept"),
+          ),
         });
         if (targetMiddleware.kind === "diverted") {
           options.clearRequestContext();

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -413,6 +413,32 @@ const ACTION_REDIRECT_RENDER_STRIPPED_HEADERS = [
   VINEXT_MW_CTX_HEADER,
 ];
 
+// Matches Next.js' actionsForbiddenHeaders. These describe the action
+// response's framing/connection rather than the internal target GET and must
+// not be forwarded as request headers.
+const ACTION_REDIRECT_FORWARDED_FORBIDDEN_HEADERS = [
+  "accept-encoding",
+  "connection",
+  "content-encoding",
+  "content-length",
+  "expect",
+  "keep-alive",
+  "keepalive",
+  "set-cookie",
+  "transfer-encoding",
+];
+
+// Next.js explicitly removes its action header after merging the action
+// response into the target request. Do the same for both action protocols and
+// vinext's dev-only forwarded middleware context.
+const ACTION_REDIRECT_FORWARDED_PROTOCOL_HEADERS = [
+  "next-action",
+  "rsc",
+  "x-action-forwarded",
+  "x-rsc-action",
+  VINEXT_MW_CTX_HEADER,
+];
+
 function setActionRevalidatedHeader(headers: Headers, kind: ActionRevalidationKind): void {
   if (kind === ACTION_DID_NOT_REVALIDATE) return;
   headers.set(ACTION_REVALIDATED_HEADER, JSON.stringify(kind));
@@ -434,10 +460,33 @@ function clearRejectedActionSideEffects(getAndClearPendingCookies: () => string[
   getAndClearActionRevalidationKind();
 }
 
-function cloneActionRedirectHeaders(requestHeaders: Headers): Headers {
+function cloneActionRedirectHeaders(
+  requestHeaders: Headers,
+  actionMiddlewareHeaders: Headers | null,
+): Headers {
   const headers = new Headers(requestHeaders);
+  for (const header of ACTION_REDIRECT_FORWARDED_FORBIDDEN_HEADERS) {
+    headers.delete(header);
+  }
   for (const header of ACTION_REDIRECT_RENDER_STRIPPED_HEADERS) {
     headers.delete(header);
+  }
+
+  // Next.js' internal target GET merges ordinary action response headers over
+  // the request headers before running the target pipeline. Merge after
+  // stripping the action request's transport headers so a middleware-emitted
+  // value such as Accept or Content-Type remains an intentional target header.
+  if (actionMiddlewareHeaders) {
+    for (const [name, value] of actionMiddlewareHeaders) {
+      const normalizedName = name.toLowerCase();
+      if (
+        ACTION_REDIRECT_FORWARDED_FORBIDDEN_HEADERS.includes(normalizedName) ||
+        ACTION_REDIRECT_FORWARDED_PROTOCOL_HEADERS.includes(normalizedName)
+      ) {
+        continue;
+      }
+      headers.set(name, value);
+    }
   }
   return headers;
 }
@@ -520,11 +569,15 @@ function cookiePathMatches(cookiePath: string, requestPath: string): boolean {
 }
 
 function createActionRedirectRenderRequest(options: {
+  actionMiddlewareHeaders: Headers | null;
   pendingCookies: readonly string[];
   request: Request;
   url: URL;
 }): Request {
-  const headers = cloneActionRedirectHeaders(options.request.headers);
+  const headers = cloneActionRedirectHeaders(
+    options.request.headers,
+    options.actionMiddlewareHeaders,
+  );
   // Like Next.js' internal action-redirect GET, this is necessarily a lossy
   // cookie projection: the inbound Cookie header no longer carries the Path,
   // Domain, or acceptance metadata from the browser's jar. For newly emitted
@@ -1445,6 +1498,7 @@ export async function handleServerActionRscRequest<
       }
 
       const redirectRenderRequest = createActionRedirectRenderRequest({
+        actionMiddlewareHeaders: options.middlewareHeaders,
         // Project the action middleware's Set-Cookie mutations (session
         // rotation or deletion) into the internal target request first; the
         // action's own cookies().set() calls land after middleware and win for
@@ -1471,7 +1525,7 @@ export async function handleServerActionRscRequest<
           cleanPathname: targetPathname,
           request: createActionRedirectMiddlewareRequest(
             redirectRenderRequest,
-            options.request.headers.get("accept"),
+            redirectRenderRequest.headers.get("accept") ?? options.request.headers.get("accept"),
           ),
         });
         // Diverting costs the target one extra middleware execution, since the
@@ -1522,8 +1576,8 @@ export async function handleServerActionRscRequest<
       // generated nonce. Build the inline target with the nonce on the final
       // response it represents, not the stale action-path nonce.
       const redirectScriptNonce = getScriptNonceFromHeaderSources(
-        redirectRenderRequest.headers,
         redirectHeaders,
+        redirectRenderRequest.headers,
       );
       const rscStream = await runWithRootParamsScope(
         pickRootParams(targetMatch.params, targetMatch.route.rootParamNames),

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -37,6 +37,7 @@ import {
   VINEXT_RSC_CONTENT_TYPE,
   VINEXT_RSC_VARY_HEADER,
   applyRscCompatibilityIdHeader,
+  stripRscCacheBustingSearchParam,
 } from "./app-rsc-cache-busting.js";
 import { applyEdgeRuntimeHeader } from "./app-page-response.js";
 import { resolveAppPageActionRerenderTarget } from "./app-page-request.js";
@@ -530,18 +531,41 @@ function createActionRedirectMiddlewareRequest(renderRequest: Request, accept: s
 }
 
 /**
+ * Headers a pass-through middleware must not be able to change on the action
+ * redirect wrapper: `Location` would give the (usually 303) wrapper genuine
+ * HTTP-redirect semantics that fetch follows before the client reads the
+ * control headers, a foreign `Content-Type` makes the client treat the Flight
+ * body as non-RSC and hard-navigate, and the x-action-* headers steer the
+ * client's navigation and cache invalidation.
+ */
+const ACTION_REDIRECT_PROTECTED_HEADERS = [
+  "content-type",
+  "location",
+  ACTION_REDIRECT_HEADER,
+  ACTION_REDIRECT_TYPE_HEADER,
+  ACTION_REDIRECT_STATUS_HEADER,
+  ACTION_REVALIDATED_HEADER,
+];
+
+/**
  * Merge pass-through middleware response headers onto the action redirect
- * wrapper, minus `Location`: the wrapper's real target travels in
- * x-action-redirect and its status is usually 303, so a stray middleware
- * `Location` would give it genuine HTTP-redirect semantics — fetch would
- * follow it before the action client can read the control headers.
+ * wrapper, then restore the wrapper's own protocol headers — including their
+ * absence, so middleware can neither replace nor pre-inject them.
  */
 function mergeActionRedirectMiddlewareHeaders(
   target: Headers,
   middlewareHeaders: Headers | null,
 ): void {
+  if (!middlewareHeaders) return;
+
+  const protectedValues = ACTION_REDIRECT_PROTECTED_HEADERS.map(
+    (name) => [name, target.get(name)] as const,
+  );
   mergeMiddlewareResponseHeaders(target, middlewareHeaders);
-  target.delete("location");
+  for (const [name, value] of protectedValues) {
+    if (value === null) target.delete(name);
+    else target.set(name, value);
+  }
 }
 
 function withoutRscBodyHeaders(headers: Headers): Headers {
@@ -1365,6 +1389,12 @@ export async function handleServerActionRscRequest<
         });
       }
 
+      // The real request pipeline strips the internal `_rsc` transport param
+      // before middleware and rendering (app-rsc-handler); the synthetic target
+      // must match, or middleware matchers see a query no navigation carries.
+      // The x-action-redirect header above keeps the verbatim URL — a diverted
+      // client re-request goes through the pipeline's own `_rsc` validation.
+      stripRscCacheBustingSearchParam(redirectTarget);
       const targetPathname = stripBasePath(redirectTarget.pathname, options.basePath ?? "");
       const targetMatch = options.matchRoute(targetPathname);
       if (!targetMatch || !canRenderActionRedirectTarget(targetMatch.route)) {
@@ -1376,7 +1406,12 @@ export async function handleServerActionRscRequest<
       }
 
       const redirectRenderRequest = createActionRedirectRenderRequest({
+        // The action middleware's Set-Cookie mutations (session rotation or
+        // deletion) come first so the target sees the cookie jar the browser
+        // would carry into the navigation; the action's own cookies().set()
+        // calls land after middleware and win for the same name.
         pendingCookies: [
+          ...(options.middlewareHeaders?.getSetCookie() ?? []),
           ...actionPendingCookies,
           ...(actionDraftCookie ? [actionDraftCookie] : []),
         ],

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -525,10 +525,11 @@ function createActionRedirectRenderRequest(options: {
   url: URL;
 }): Request {
   const headers = cloneActionRedirectHeaders(options.request.headers);
-  // A browser only carries a Set-Cookie into the target navigation when the
-  // cookie's Path (or the default derived from the action URL) path-matches
-  // the target, so a mutation scoped elsewhere must not reach the target's
-  // middleware or render.
+  // Like Next.js' internal action-redirect GET, this is necessarily a lossy
+  // cookie projection: the inbound Cookie header no longer carries the Path,
+  // Domain, or acceptance metadata from the browser's jar. For newly emitted
+  // mutations the Path is still available, so avoid forwarding a known path
+  // mismatch even though older inbound cookies cannot be re-scoped here.
   const actionDefaultPath = defaultCookiePath(new URL(options.request.url).pathname);
   const applicableCookies = options.pendingCookies.filter((cookie) =>
     cookiePathMatches(readSetCookiePath(cookie) ?? actionDefaultPath, options.url.pathname),
@@ -1444,10 +1445,10 @@ export async function handleServerActionRscRequest<
       }
 
       const redirectRenderRequest = createActionRedirectRenderRequest({
-        // The action middleware's Set-Cookie mutations (session rotation or
-        // deletion) come first so the target sees the cookie jar the browser
-        // would carry into the navigation; the action's own cookies().set()
-        // calls land after middleware and win for the same name.
+        // Project the action middleware's Set-Cookie mutations (session
+        // rotation or deletion) into the internal target request first; the
+        // action's own cookies().set() calls land after middleware and win for
+        // the same name, matching Next.js' forwarded-cookie ordering.
         pendingCookies: [
           ...(options.middlewareHeaders?.getSetCookie() ?? []),
           ...actionPendingCookies,

--- a/packages/vinext/src/server/request-pipeline.ts
+++ b/packages/vinext/src/server/request-pipeline.ts
@@ -528,6 +528,24 @@ function getRequestCf(request: Request): unknown {
 }
 
 /**
+ * Re-attach the Workers-specific `cf` metadata from `source` onto a rebuilt
+ * Request. `new Request()` never copies it, and middleware/authorization code
+ * can key off `request.cf` (geo checks, bot scores), so every reconstruction
+ * must restore it explicitly.
+ */
+export function attachRequestCfMetadata(target: Request, source: Request): Request {
+  const cf = getRequestCf(source);
+  if (cf !== undefined) {
+    Object.defineProperty(target, "cf", {
+      value: cf,
+      enumerable: true,
+      configurable: true,
+    });
+  }
+  return target;
+}
+
+/**
  * Clone a Request while overriding headers, preserving metadata when possible.
  *
  * Some runtimes (Workers) allow `new Request(request, { headers })` which
@@ -559,16 +577,7 @@ export function cloneRequestWithHeaders(request: Request, headers: Headers): Req
     }
     cloned = new Request(request.url, init);
   }
-  const cf = getRequestCf(request);
-  if (cf !== undefined) {
-    // new Request() does not copy Workers-specific cf, so re-attach it.
-    Object.defineProperty(cloned, "cf", {
-      value: cf,
-      enumerable: true,
-      configurable: true,
-    });
-  }
-  return cloned;
+  return attachRequestCfMetadata(cloned, request);
 }
 
 /**
@@ -607,14 +616,5 @@ export function cloneRequestWithUrl(request: Request, url: string): Request {
     }
     cloned = new Request(url, init);
   }
-  const cf = getRequestCf(request);
-  if (cf !== undefined) {
-    // new Request() does not copy Workers-specific cf, so re-attach it.
-    Object.defineProperty(cloned, "cf", {
-      value: cf,
-      enumerable: true,
-      configurable: true,
-    });
-  }
-  return cloned;
+  return attachRequestCfMetadata(cloned, request);
 }

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -521,6 +521,52 @@ describe("createAppRscHandler", () => {
     expect(middlewareRequest!.nextUrl.pathname).toBe("/outside");
   });
 
+  // A redirecting Server Action renders the target page inline, so the target's
+  // middleware only runs if the handler hands the action dispatch a way to run
+  // it. Without this an action on a public path could return a middleware-gated
+  // page's Flight payload.
+  it("runs middleware for Server Action redirect targets", async () => {
+    const seenPathnames: string[] = [];
+    const middleware = vi.fn((request: NextRequest) => {
+      const { pathname } = new URL(request.url);
+      seenPathnames.push(pathname);
+      return pathname === "/docs/protected"
+        ? new Response("unauthorized", { status: 401 })
+        : new Response(null, { headers: { "x-middleware-next": "1" } });
+    });
+    let runRedirectTargetMiddleware:
+      | ((options: { cleanPathname: string; request: Request }) => Promise<{ kind: string }>)
+      | undefined;
+    const handler = createHandler({
+      configHeaders: [],
+      handleServerActionRequest: async (options) => {
+        runRedirectTargetMiddleware = options.runRedirectTargetMiddleware;
+        return new Response("action");
+      },
+      middlewareModule: { default: middleware },
+    });
+
+    const response = await handler(
+      new Request("https://example.test/docs/about", {
+        method: "POST",
+        headers: { "next-action": "action-id", "content-type": "text/plain" },
+      }),
+      null,
+    );
+
+    expect(response.status).toBe(200);
+    expect(seenPathnames).toEqual(["/docs/about"]);
+
+    expect(runRedirectTargetMiddleware).toBeDefined();
+    await expect(
+      runRedirectTargetMiddleware!({
+        cleanPathname: "/protected",
+        request: new Request("https://example.test/docs/protected"),
+      }),
+    ).resolves.toEqual({ kind: "diverted" });
+    expect(seenPathnames).toEqual(["/docs/about", "/docs/protected"]);
+  });
+
   it.each([
     "url=%2Fimg.jpg&w=640junk&q=75",
     "url=%2Fimg.jpg&w=640&q=75&extra=1",

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -2168,9 +2168,12 @@ describe("app server action execution helpers", () => {
         },
         middlewareHeaders: new Headers({
           accept: "application/action-middleware",
+          cookie: "forged=1",
           "content-length": "999",
+          "set-cookie": "session=rotated; Path=/",
           "x-action-auth-context": "member",
         }),
+        request: createFetchActionRequest({ cookie: "theme=dark" }),
         async runRedirectTargetMiddleware(targetOptions: { request: Request }) {
           middlewareRequest = targetOptions.request;
           return { kind: "continue", responseHeaders: null };
@@ -2182,10 +2185,12 @@ describe("app server action execution helpers", () => {
     expect(response?.headers.get("content-length")).toBeNull();
     expect(middlewareRequest).not.toBeNull();
     expect(middlewareRequest!.headers.get("accept")).toBe("application/action-middleware");
+    expect(middlewareRequest!.headers.get("cookie")).toBe("theme=dark; session=rotated");
     expect(middlewareRequest!.headers.get("content-length")).toBeNull();
     expect(middlewareRequest!.headers.get("x-action-auth-context")).toBe("member");
     expect(renderRequest).not.toBeNull();
     expect(renderRequest!.headers.get("accept")).toBe("application/action-middleware");
+    expect(renderRequest!.headers.get("cookie")).toBe("theme=dark; session=rotated");
     expect(renderRequest!.headers.get("content-length")).toBeNull();
     expect(renderRequest!.headers.get("x-action-auth-context")).toBe("member");
   });
@@ -2254,6 +2259,7 @@ describe("app server action execution helpers", () => {
           };
         },
         middlewareHeaders: new Headers({
+          "content-encoding": "br",
           location: "/mw-location",
           "content-type": "text/html",
           "x-action-redirect": "/mw-hijack",
@@ -2263,9 +2269,13 @@ describe("app server action execution helpers", () => {
           return {
             kind: "continue",
             responseHeaders: new Headers({
+              "accept-encoding": "gzip",
+              connection: "close",
+              "content-encoding": "gzip",
               location: "/target-mw-location",
               "content-type": "text/html",
               "content-length": "0",
+              "transfer-encoding": "chunked",
               "x-action-redirect": "/target-hijack",
               "x-target-mw": "1",
             }),
@@ -2284,7 +2294,11 @@ describe("app server action execution helpers", () => {
     expect(response?.headers.get("x-action-redirect")).toBe("/redirect-target");
     expect(response?.headers.get("location")).toBeNull();
     expect(response?.headers.get("content-type")).toContain("text/x-component");
+    expect(response?.headers.get("accept-encoding")).toBeNull();
+    expect(response?.headers.get("connection")).toBeNull();
+    expect(response?.headers.get("content-encoding")).toBeNull();
     expect(response?.headers.get("content-length")).toBeNull();
+    expect(response?.headers.get("transfer-encoding")).toBeNull();
     expect(response?.headers.get("x-action-mw")).toBe("1");
     expect(response?.headers.get("x-target-mw")).toBe("1");
   });

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -1983,6 +1983,87 @@ describe("app server action execution helpers", () => {
     expect(buildPageElement).not.toHaveBeenCalled();
   });
 
+  it("falls back to header-only redirects when target middleware diverts the request", async () => {
+    const buildPageElement = vi.fn(() => "should-not-render");
+    const runRedirectTargetMiddleware = vi.fn(async () => ({ kind: "diverted" }) as const);
+
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        buildPageElement,
+        loadServerAction() {
+          return Promise.resolve(() => redirect("/protected"));
+        },
+        matchRoute(pathname) {
+          if (pathname === "/protected") {
+            return {
+              params: {},
+              route: { id: "protected", page: {}, params: [], pattern: "/protected" },
+            };
+          }
+          return {
+            params: {},
+            route: { id: "dashboard", page: {}, params: [], pattern: "/dashboard" },
+          };
+        },
+        runRedirectTargetMiddleware,
+      }),
+    );
+
+    expect(response?.status).toBe(303);
+    expect(response?.headers.get("x-action-redirect")).toBe("/protected");
+    expect(response?.headers.get("content-type")).toBeNull();
+    expect(await response?.text()).toBe("");
+    expect(buildPageElement).not.toHaveBeenCalled();
+    expect(runRedirectTargetMiddleware).toHaveBeenCalledWith({
+      cleanPathname: "/protected",
+      request: expect.any(Request),
+    });
+  });
+
+  it("renders redirect targets that middleware passes through and keeps its response headers", async () => {
+    let middlewareRequest: Request | null = null;
+    const runRedirectTargetMiddleware = vi.fn(async (targetOptions: { request: Request }) => {
+      middlewareRequest = targetOptions.request;
+      return {
+        kind: "continue" as const,
+        responseHeaders: new Headers({ "x-from-target-middleware": "1" }),
+      };
+    });
+
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        loadServerAction() {
+          return Promise.resolve(() => redirect("/redirect-target"));
+        },
+        matchRoute(pathname) {
+          if (pathname === "/redirect-target") {
+            return {
+              params: {},
+              route: { id: "redirect-target", page: {}, params: [], pattern: "/redirect-target" },
+            };
+          }
+          return {
+            params: {},
+            route: { id: "dashboard", page: {}, params: [], pattern: "/dashboard" },
+          };
+        },
+        runRedirectTargetMiddleware,
+      }),
+    );
+
+    expect(response?.status).toBe(303);
+    expect(response?.headers.get("x-from-target-middleware")).toBe("1");
+    expect(JSON.parse(await response!.text())).toEqual({
+      root: "redirect-target:{}:none",
+      returnValue: { ok: true },
+    });
+
+    expect(middlewareRequest).not.toBeNull();
+    expect(middlewareRequest!.method).toBe("GET");
+    expect(middlewareRequest!.url).toBe("https://example.com/redirect-target");
+    expect(middlewareRequest!.headers.get("next-action")).toBeNull();
+  });
+
   it("does not emit x-action-revalidated when a fetch action revalidates a tag with a profile", async () => {
     const response = await handleServerActionRscRequest(
       createRscOptions({

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -2098,6 +2098,49 @@ describe("app server action execution helpers", () => {
     expect(Reflect.get(renderRequest!, "cf")).toEqual({ country: "AU" });
   });
 
+  it("builds an inline redirect target with target middleware's CSP nonce", async () => {
+    const buildPageElement = vi.fn(() => "redirect-target:{}:none");
+
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        buildPageElement,
+        loadServerAction() {
+          return Promise.resolve(() => redirect("/redirect-target"));
+        },
+        matchRoute(pathname) {
+          if (pathname === "/redirect-target") {
+            return {
+              params: {},
+              route: { id: "redirect-target", page: {}, params: [], pattern: "/redirect-target" },
+            };
+          }
+          return {
+            params: {},
+            route: { id: "dashboard", page: {}, params: [], pattern: "/dashboard" },
+          };
+        },
+        middlewareHeaders: new Headers({
+          "content-security-policy": "script-src 'nonce-action-path'",
+        }),
+        async runRedirectTargetMiddleware() {
+          return {
+            kind: "continue",
+            responseHeaders: new Headers({
+              "content-security-policy": "script-src 'nonce-redirect-target'",
+            }),
+          };
+        },
+      }),
+    );
+
+    expect(response?.headers.get("content-security-policy")).toBe(
+      "script-src 'nonce-redirect-target'",
+    );
+    expect(buildPageElement).toHaveBeenCalledWith(
+      expect.objectContaining({ scriptNonce: "redirect-target" }),
+    );
+  });
+
   it("runs target middleware before hydrating a lazy target route's modules", async () => {
     const events: string[] = [];
     const lazyRoute: TestRoute = {

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -2173,6 +2173,7 @@ describe("app server action execution helpers", () => {
             responseHeaders: new Headers({
               location: "/target-mw-location",
               "content-type": "text/html",
+              "content-length": "0",
               "x-action-redirect": "/target-hijack",
               "x-target-mw": "1",
             }),
@@ -2183,13 +2184,15 @@ describe("app server action execution helpers", () => {
 
     // The wrapper's protocol headers steer the action client: a Location on the
     // 303 would make fetch follow it before the client reads x-action-redirect,
-    // a foreign Content-Type flips the client to a hard navigation, and
+    // a foreign Content-Type flips the client to a hard navigation, a stale
+    // Content-Length misframes the generated Flight stream, and
     // x-action-redirect is the destination itself. Ordinary middleware headers
     // must still come through.
     expect(response?.status).toBe(303);
     expect(response?.headers.get("x-action-redirect")).toBe("/redirect-target");
     expect(response?.headers.get("location")).toBeNull();
     expect(response?.headers.get("content-type")).toContain("text/x-component");
+    expect(response?.headers.get("content-length")).toBeNull();
     expect(response?.headers.get("x-action-mw")).toBe("1");
     expect(response?.headers.get("x-target-mw")).toBe("1");
   });
@@ -2217,6 +2220,7 @@ describe("app server action execution helpers", () => {
         middlewareHeaders: new Headers([
           ["set-cookie", "session=; Max-Age=0"],
           ["set-cookie", "csrf=rotated"],
+          ["set-cookie", "admin=1; Path=/account"],
         ]),
         request: createFetchActionRequest({ cookie: "session=live; csrf=old; theme=dark" }),
         async runRedirectTargetMiddleware(targetOptions: { request: Request }) {
@@ -2229,7 +2233,9 @@ describe("app server action execution helpers", () => {
     // The action middleware deleted the session and rotated csrf. The browser
     // applies those before navigating to the redirect target, so target
     // middleware evaluating the pre-mutation jar would authorize on a
-    // credential the response is simultaneously revoking.
+    // credential the response is simultaneously revoking. The /account-scoped
+    // cookie is one a browser would never send to /redirect-target, so it must
+    // not appear either.
     expect(middlewareRequest).not.toBeNull();
     expect(middlewareRequest!.headers.get("cookie")).toBe("csrf=rotated; theme=dark");
   });

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -2022,6 +2022,7 @@ describe("app server action execution helpers", () => {
 
   it("renders redirect targets that middleware passes through and keeps its response headers", async () => {
     let middlewareRequest: Request | null = null;
+    let renderRequest: Request | null = null;
     const runRedirectTargetMiddleware = vi.fn(async (targetOptions: { request: Request }) => {
       middlewareRequest = targetOptions.request;
       return {
@@ -2032,9 +2033,17 @@ describe("app server action execution helpers", () => {
 
     const response = await handleServerActionRscRequest(
       createRscOptions({
+        buildPageElement({ route: matchedRoute, request }) {
+          renderRequest = request;
+          return `${matchedRoute.id}:{}:none`;
+        },
         loadServerAction() {
           return Promise.resolve(() => redirect("/redirect-target"));
         },
+        request: createFetchActionRequest({
+          accept: "text/x-component",
+          "x-vinext-mw-ctx": JSON.stringify({}),
+        }),
         matchRoute(pathname) {
           if (pathname === "/redirect-target") {
             return {
@@ -2058,10 +2067,20 @@ describe("app server action execution helpers", () => {
       returnValue: { ok: true },
     });
 
+    // Middleware must see the request the client would otherwise have sent:
+    // a GET for the target that still carries Accept, which object matchers can
+    // gate on. The forwarded-middleware-context header describes the *action*
+    // path's result and would make the target skip middleware entirely.
     expect(middlewareRequest).not.toBeNull();
     expect(middlewareRequest!.method).toBe("GET");
     expect(middlewareRequest!.url).toBe("https://example.com/redirect-target");
+    expect(middlewareRequest!.headers.get("accept")).toBe("text/x-component");
     expect(middlewareRequest!.headers.get("next-action")).toBeNull();
+    expect(middlewareRequest!.headers.get("x-vinext-mw-ctx")).toBeNull();
+
+    expect(renderRequest).not.toBeNull();
+    expect(renderRequest!.headers.get("accept")).toBeNull();
+    expect(renderRequest!.headers.get("x-vinext-mw-ctx")).toBeNull();
   });
 
   it("does not emit x-action-revalidated when a fetch action revalidates a tag with a profile", async () => {

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -2141,6 +2141,55 @@ describe("app server action execution helpers", () => {
     );
   });
 
+  it("forwards filtered action middleware response headers to the redirect target", async () => {
+    let middlewareRequest: Request | null = null;
+    let renderRequest: Request | null = null;
+
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        buildPageElement({ route: matchedRoute, request }) {
+          renderRequest = request;
+          return `${matchedRoute.id}:{}:none`;
+        },
+        loadServerAction() {
+          return Promise.resolve(() => redirect("/redirect-target"));
+        },
+        matchRoute(pathname) {
+          if (pathname === "/redirect-target") {
+            return {
+              params: {},
+              route: { id: "redirect-target", page: {}, params: [], pattern: "/redirect-target" },
+            };
+          }
+          return {
+            params: {},
+            route: { id: "dashboard", page: {}, params: [], pattern: "/dashboard" },
+          };
+        },
+        middlewareHeaders: new Headers({
+          accept: "application/action-middleware",
+          "content-length": "999",
+          "x-action-auth-context": "member",
+        }),
+        async runRedirectTargetMiddleware(targetOptions: { request: Request }) {
+          middlewareRequest = targetOptions.request;
+          return { kind: "continue", responseHeaders: null };
+        },
+      }),
+    );
+
+    expect(response?.status).toBe(303);
+    expect(response?.headers.get("content-length")).toBeNull();
+    expect(middlewareRequest).not.toBeNull();
+    expect(middlewareRequest!.headers.get("accept")).toBe("application/action-middleware");
+    expect(middlewareRequest!.headers.get("content-length")).toBeNull();
+    expect(middlewareRequest!.headers.get("x-action-auth-context")).toBe("member");
+    expect(renderRequest).not.toBeNull();
+    expect(renderRequest!.headers.get("accept")).toBe("application/action-middleware");
+    expect(renderRequest!.headers.get("content-length")).toBeNull();
+    expect(renderRequest!.headers.get("x-action-auth-context")).toBe("member");
+  });
+
   it("runs target middleware before hydrating a lazy target route's modules", async () => {
     const events: string[] = [];
     const lazyRoute: TestRoute = {

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -289,6 +289,7 @@ function createRscOptions(
     maxActionBodySize: 1024,
     maxActionBodySizeLabel: "1kb",
     middlewareHeaders: null,
+    middlewareRequestHeaders: null,
     middlewareStatus: null,
     mountedSlotsHeader: null,
     readBodyWithLimit() {
@@ -1740,7 +1741,7 @@ describe("app server action execution helpers", () => {
     }
   });
 
-  it("renders internal action redirects with a clean GET request and action cookies", async () => {
+  it("renders internal action redirects with a target GET and action context", async () => {
     // Ported from Next.js: test/e2e/app-dir/actions/app-action-node-middleware.test.ts
     // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/actions/app-action-node-middleware.test.ts
     const renderRequests: Request[] = [];
@@ -1789,8 +1790,9 @@ describe("app server action execution helpers", () => {
     expect(renderRequest.headers.get("next-action")).toBeNull();
     expect(renderRequest.headers.get("x-rsc-action")).toBeNull();
     expect(renderRequest.headers.get("rsc")).toBeNull();
-    expect(renderRequest.headers.get("content-type")).toBeNull();
-    expect(renderRequest.headers.get("origin")).toBeNull();
+    expect(renderRequest.headers.get("accept")).toBe("text/x-component");
+    expect(renderRequest.headers.get("content-type")).toBe("text/plain;charset=UTF-8");
+    expect(renderRequest.headers.get("origin")).toBe("https://example.com");
     expect(renderRequest.headers.get("cookie")).toBe(
       "session=1; __prerender_bypass=draft-secret; theme=dark",
     );
@@ -2077,19 +2079,23 @@ describe("app server action execution helpers", () => {
       returnValue: { ok: true },
     });
 
-    // Middleware must see the request the client would otherwise have sent:
-    // a GET for the target that still carries Accept, which object matchers can
-    // gate on. The forwarded-middleware-context header describes the *action*
-    // path's result and would make the target skip middleware entirely.
+    // Middleware sees the same effective headers as Next.js' internal target
+    // GET, including Accept. The forwarded-middleware-context header describes
+    // the *action* path's result and would make the target skip middleware
+    // entirely.
     expect(middlewareRequest).not.toBeNull();
     expect(middlewareRequest!.method).toBe("GET");
     expect(middlewareRequest!.url).toBe("https://example.com/redirect-target");
     expect(middlewareRequest!.headers.get("accept")).toBe("text/x-component");
+    expect(middlewareRequest!.headers.get("content-type")).toBe("text/plain;charset=UTF-8");
+    expect(middlewareRequest!.headers.get("origin")).toBe("https://example.com");
     expect(middlewareRequest!.headers.get("next-action")).toBeNull();
     expect(middlewareRequest!.headers.get("x-vinext-mw-ctx")).toBeNull();
 
     expect(renderRequest).not.toBeNull();
-    expect(renderRequest!.headers.get("accept")).toBeNull();
+    expect(renderRequest!.headers.get("accept")).toBe("text/x-component");
+    expect(renderRequest!.headers.get("content-type")).toBe("text/plain;charset=UTF-8");
+    expect(renderRequest!.headers.get("origin")).toBe("https://example.com");
     expect(renderRequest!.headers.get("x-vinext-mw-ctx")).toBeNull();
 
     // Middleware that authorizes on request.cf (geo checks) must not fail open
@@ -2193,6 +2199,54 @@ describe("app server action execution helpers", () => {
     expect(renderRequest!.headers.get("cookie")).toBe("theme=dark; session=rotated");
     expect(renderRequest!.headers.get("content-length")).toBeNull();
     expect(renderRequest!.headers.get("x-action-auth-context")).toBe("member");
+  });
+
+  it("starts redirect targets from action middleware's request-header overrides", async () => {
+    let middlewareRequest: Request | null = null;
+    let renderRequest: Request | null = null;
+
+    await handleServerActionRscRequest(
+      createRscOptions({
+        buildPageElement({ route: matchedRoute, request }) {
+          renderRequest = request;
+          return `${matchedRoute.id}:{}:none`;
+        },
+        loadServerAction() {
+          return Promise.resolve(() => redirect("/redirect-target"));
+        },
+        matchRoute(pathname) {
+          if (pathname === "/redirect-target") {
+            return {
+              params: {},
+              route: { id: "redirect-target", page: {}, params: [], pattern: "/redirect-target" },
+            };
+          }
+          return {
+            params: {},
+            route: { id: "dashboard", page: {}, params: [], pattern: "/dashboard" },
+          };
+        },
+        middlewareRequestHeaders: new Headers({
+          "x-middleware-override-headers": "x-auth-context",
+          "x-middleware-request-x-auth-context": "sanitized",
+        }),
+        request: createFetchActionRequest({
+          "x-attacker-controlled": "forged",
+          "x-auth-context": "untrusted",
+        }),
+        async runRedirectTargetMiddleware(targetOptions: { request: Request }) {
+          middlewareRequest = targetOptions.request;
+          return { kind: "continue", responseHeaders: null };
+        },
+      }),
+    );
+
+    expect(middlewareRequest).not.toBeNull();
+    expect(middlewareRequest!.headers.get("x-auth-context")).toBe("sanitized");
+    expect(middlewareRequest!.headers.get("x-attacker-controlled")).toBeNull();
+    expect(renderRequest).not.toBeNull();
+    expect(renderRequest!.headers.get("x-auth-context")).toBe("sanitized");
+    expect(renderRequest!.headers.get("x-attacker-controlled")).toBeNull();
   });
 
   it("runs target middleware before hydrating a lazy target route's modules", async () => {

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -2273,12 +2273,10 @@ describe("app server action execution helpers", () => {
       }),
     );
 
-    // The action middleware deleted the session and rotated csrf. The browser
-    // applies those before navigating to the redirect target, so target
-    // middleware evaluating the pre-mutation jar would authorize on a
-    // credential the response is simultaneously revoking. The /account-scoped
-    // cookie is one a browser would never send to /redirect-target, so it must
-    // not appear either.
+    // The action middleware deleted the session and rotated csrf, so target
+    // middleware must not authorize on the credential the response is
+    // simultaneously revoking. The newly emitted /account-scoped cookie still
+    // carries enough metadata to keep it out of /redirect-target as well.
     expect(middlewareRequest).not.toBeNull();
     expect(middlewareRequest!.headers.get("cookie")).toBe("csrf=rotated; theme=dark");
   });

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -58,6 +58,8 @@ type TestRoute = {
   routeHandler?: unknown;
   routeSegments?: readonly string[];
   runtime?: "edge" | "experimental-edge" | "nodejs" | null;
+  /** Manifest lazy-module thunk; set when the route's page is not yet hydrated. */
+  __loadPage?: unknown;
 };
 
 type TestInterceptOptions = {
@@ -1985,11 +1987,13 @@ describe("app server action execution helpers", () => {
 
   it("falls back to header-only redirects when target middleware diverts the request", async () => {
     const buildPageElement = vi.fn(() => "should-not-render");
+    const ensureRouteLoaded = vi.fn();
     const runRedirectTargetMiddleware = vi.fn(async () => ({ kind: "diverted" }) as const);
 
     const response = await handleServerActionRscRequest(
       createRscOptions({
         buildPageElement,
+        ensureRouteLoaded,
         loadServerAction() {
           return Promise.resolve(() => redirect("/protected"));
         },
@@ -2014,6 +2018,9 @@ describe("app server action execution helpers", () => {
     expect(response?.headers.get("content-type")).toBeNull();
     expect(await response?.text()).toBe("");
     expect(buildPageElement).not.toHaveBeenCalled();
+    // Hydrating a route imports its modules and runs their top-level code —
+    // a middleware-blocked target must never get that far.
+    expect(ensureRouteLoaded).not.toHaveBeenCalled();
     expect(runRedirectTargetMiddleware).toHaveBeenCalledWith({
       cleanPathname: "/protected",
       request: expect.any(Request),
@@ -2030,6 +2037,12 @@ describe("app server action execution helpers", () => {
         responseHeaders: new Headers({ "x-from-target-middleware": "1" }),
       };
     });
+    const actionRequest = createFetchActionRequest({
+      accept: "text/x-component",
+      "x-vinext-mw-ctx": JSON.stringify({}),
+    });
+    // Workers attach cf to the inbound request; new Request() never copies it.
+    Object.defineProperty(actionRequest, "cf", { value: { country: "AU" }, enumerable: true });
 
     const response = await handleServerActionRscRequest(
       createRscOptions({
@@ -2040,10 +2053,7 @@ describe("app server action execution helpers", () => {
         loadServerAction() {
           return Promise.resolve(() => redirect("/redirect-target"));
         },
-        request: createFetchActionRequest({
-          accept: "text/x-component",
-          "x-vinext-mw-ctx": JSON.stringify({}),
-        }),
+        request: actionRequest,
         matchRoute(pathname) {
           if (pathname === "/redirect-target") {
             return {
@@ -2081,6 +2091,93 @@ describe("app server action execution helpers", () => {
     expect(renderRequest).not.toBeNull();
     expect(renderRequest!.headers.get("accept")).toBeNull();
     expect(renderRequest!.headers.get("x-vinext-mw-ctx")).toBeNull();
+
+    // Middleware that authorizes on request.cf (geo checks) must not fail open
+    // on the reconstructed target requests.
+    expect(Reflect.get(middlewareRequest!, "cf")).toEqual({ country: "AU" });
+    expect(Reflect.get(renderRequest!, "cf")).toEqual({ country: "AU" });
+  });
+
+  it("runs target middleware before hydrating a lazy target route's modules", async () => {
+    const events: string[] = [];
+    const lazyRoute: TestRoute = {
+      id: "lazy-protected",
+      params: [],
+      pattern: "/lazy-protected",
+      __loadPage: () => Promise.resolve({}),
+    };
+
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        ensureRouteLoaded(route) {
+          events.push(`load:${route.id}`);
+          if (route === lazyRoute) route.page = {};
+        },
+        loadServerAction() {
+          return Promise.resolve(() => redirect("/lazy-protected"));
+        },
+        matchRoute(pathname) {
+          if (pathname === "/lazy-protected") {
+            return { params: {}, route: lazyRoute };
+          }
+          return {
+            params: {},
+            route: { id: "dashboard", page: {}, params: [], pattern: "/dashboard" },
+          };
+        },
+        async runRedirectTargetMiddleware() {
+          events.push("middleware");
+          return { kind: "continue", responseHeaders: null };
+        },
+      }),
+    );
+
+    // The unhydrated route only advertises its page via the lazy thunk, so it
+    // must still count as renderable, and middleware must run before the
+    // hydration that executes the page module's top-level code.
+    expect(events).toEqual(["middleware", "load:lazy-protected", "load:dashboard"]);
+    expect(response?.status).toBe(303);
+    expect(JSON.parse(await response!.text())).toEqual({
+      root: "lazy-protected:{}:none",
+      returnValue: { ok: true },
+    });
+  });
+
+  it("strips a middleware Location header from the action redirect response", async () => {
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        loadServerAction() {
+          return Promise.resolve(() => redirect("/redirect-target"));
+        },
+        matchRoute(pathname) {
+          if (pathname === "/redirect-target") {
+            return {
+              params: {},
+              route: { id: "redirect-target", page: {}, params: [], pattern: "/redirect-target" },
+            };
+          }
+          return {
+            params: {},
+            route: { id: "dashboard", page: {}, params: [], pattern: "/dashboard" },
+          };
+        },
+        middlewareHeaders: new Headers({ location: "/mw-location", "x-action-mw": "1" }),
+        async runRedirectTargetMiddleware() {
+          return {
+            kind: "continue",
+            responseHeaders: new Headers({ location: "/target-mw-location", "x-target-mw": "1" }),
+          };
+        },
+      }),
+    );
+
+    // The wrapper's real target travels in x-action-redirect; a Location header
+    // on the 303 would make fetch follow it before the client reads that.
+    expect(response?.status).toBe(303);
+    expect(response?.headers.get("x-action-redirect")).toBe("/redirect-target");
+    expect(response?.headers.get("location")).toBeNull();
+    expect(response?.headers.get("x-action-mw")).toBe("1");
+    expect(response?.headers.get("x-target-mw")).toBe("1");
   });
 
   it("does not emit x-action-revalidated when a fetch action revalidates a tag with a profile", async () => {

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -2143,7 +2143,7 @@ describe("app server action execution helpers", () => {
     });
   });
 
-  it("strips a middleware Location header from the action redirect response", async () => {
+  it("keeps the action protocol headers when merging middleware headers onto the redirect response", async () => {
     const response = await handleServerActionRscRequest(
       createRscOptions({
         loadServerAction() {
@@ -2161,23 +2161,115 @@ describe("app server action execution helpers", () => {
             route: { id: "dashboard", page: {}, params: [], pattern: "/dashboard" },
           };
         },
-        middlewareHeaders: new Headers({ location: "/mw-location", "x-action-mw": "1" }),
+        middlewareHeaders: new Headers({
+          location: "/mw-location",
+          "content-type": "text/html",
+          "x-action-redirect": "/mw-hijack",
+          "x-action-mw": "1",
+        }),
         async runRedirectTargetMiddleware() {
           return {
             kind: "continue",
-            responseHeaders: new Headers({ location: "/target-mw-location", "x-target-mw": "1" }),
+            responseHeaders: new Headers({
+              location: "/target-mw-location",
+              "content-type": "text/html",
+              "x-action-redirect": "/target-hijack",
+              "x-target-mw": "1",
+            }),
           };
         },
       }),
     );
 
-    // The wrapper's real target travels in x-action-redirect; a Location header
-    // on the 303 would make fetch follow it before the client reads that.
+    // The wrapper's protocol headers steer the action client: a Location on the
+    // 303 would make fetch follow it before the client reads x-action-redirect,
+    // a foreign Content-Type flips the client to a hard navigation, and
+    // x-action-redirect is the destination itself. Ordinary middleware headers
+    // must still come through.
     expect(response?.status).toBe(303);
     expect(response?.headers.get("x-action-redirect")).toBe("/redirect-target");
     expect(response?.headers.get("location")).toBeNull();
+    expect(response?.headers.get("content-type")).toContain("text/x-component");
     expect(response?.headers.get("x-action-mw")).toBe("1");
     expect(response?.headers.get("x-target-mw")).toBe("1");
+  });
+
+  it("applies the action middleware's cookie mutations to the redirect target request", async () => {
+    let middlewareRequest: Request | null = null;
+
+    await handleServerActionRscRequest(
+      createRscOptions({
+        loadServerAction() {
+          return Promise.resolve(() => redirect("/redirect-target"));
+        },
+        matchRoute(pathname) {
+          if (pathname === "/redirect-target") {
+            return {
+              params: {},
+              route: { id: "redirect-target", page: {}, params: [], pattern: "/redirect-target" },
+            };
+          }
+          return {
+            params: {},
+            route: { id: "dashboard", page: {}, params: [], pattern: "/dashboard" },
+          };
+        },
+        middlewareHeaders: new Headers([
+          ["set-cookie", "session=; Max-Age=0"],
+          ["set-cookie", "csrf=rotated"],
+        ]),
+        request: createFetchActionRequest({ cookie: "session=live; csrf=old; theme=dark" }),
+        async runRedirectTargetMiddleware(targetOptions: { request: Request }) {
+          middlewareRequest = targetOptions.request;
+          return { kind: "continue", responseHeaders: null };
+        },
+      }),
+    );
+
+    // The action middleware deleted the session and rotated csrf. The browser
+    // applies those before navigating to the redirect target, so target
+    // middleware evaluating the pre-mutation jar would authorize on a
+    // credential the response is simultaneously revoking.
+    expect(middlewareRequest).not.toBeNull();
+    expect(middlewareRequest!.headers.get("cookie")).toBe("csrf=rotated; theme=dark");
+  });
+
+  it("strips the internal _rsc param from the redirect target before middleware", async () => {
+    let middlewareRequest: Request | null = null;
+
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        loadServerAction() {
+          return Promise.resolve(() => redirect("/redirect-target?_rsc=abc123&tab=x"));
+        },
+        matchRoute(pathname) {
+          if (pathname === "/redirect-target") {
+            return {
+              params: {},
+              route: { id: "redirect-target", page: {}, params: [], pattern: "/redirect-target" },
+            };
+          }
+          return {
+            params: {},
+            route: { id: "dashboard", page: {}, params: [], pattern: "/dashboard" },
+          };
+        },
+        async runRedirectTargetMiddleware(targetOptions: { request: Request }) {
+          middlewareRequest = targetOptions.request;
+          return { kind: "continue", responseHeaders: null };
+        },
+      }),
+    );
+
+    // The real pipeline strips `_rsc` before middleware, so matchers keyed on
+    // it would branch differently for the synthetic request than for the
+    // navigation it stands in for. The client-facing redirect header keeps the
+    // verbatim URL — a diverted re-request goes through real validation.
+    expect(middlewareRequest).not.toBeNull();
+    const middlewareUrl = new URL(middlewareRequest!.url);
+    expect(middlewareUrl.searchParams.get("_rsc")).toBeNull();
+    expect(middlewareUrl.searchParams.get("tab")).toBe("x");
+    expect(response?.headers.get("x-action-redirect")).toBe("/redirect-target?_rsc=abc123&tab=x");
   });
 
   it("does not emit x-action-revalidated when a fetch action revalidates a tag with a profile", async () => {

--- a/tests/e2e/app-front-redirect-issue/fixture/node_modules
+++ b/tests/e2e/app-front-redirect-issue/fixture/node_modules
@@ -1,0 +1,1 @@
+../../../fixtures/app-basic/node_modules

--- a/tests/e2e/app-front-redirect-issue/fixture/node_modules
+++ b/tests/e2e/app-front-redirect-issue/fixture/node_modules
@@ -1,1 +1,0 @@
-../../../fixtures/app-basic/node_modules

--- a/tests/fixtures/app-basic/app/nextjs-compat/action-redirect-middleware/actions.ts
+++ b/tests/fixtures/app-basic/app/nextjs-compat/action-redirect-middleware/actions.ts
@@ -11,3 +11,14 @@ import { redirect } from "next/navigation";
 export async function redirectToBlockedPath(): Promise<void> {
   redirect("/admin");
 }
+
+/**
+ * Percent-encoded alias of the same blocked path. Route matching that decodes
+ * would resolve this to the `/admin` page, while middleware and a real
+ * navigation both see `/adm%69n`. Deliberately not `/%61dmin`, which this
+ * fixture's middleware rewrites — a rewrite already forces a real navigation,
+ * which would hide whether the target was matched with request identity.
+ */
+export async function redirectToEncodedBlockedPath(): Promise<void> {
+  redirect("/adm%69n");
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/action-redirect-middleware/actions.ts
+++ b/tests/fixtures/app-basic/app/nextjs-compat/action-redirect-middleware/actions.ts
@@ -1,0 +1,13 @@
+"use server";
+
+import { redirect } from "next/navigation";
+
+/**
+ * Redirects to `/admin`, which this fixture's middleware blocks with a 403.
+ * A redirecting action renders its target inline, so the target's middleware
+ * has to run before that render or the blocked page's payload leaks into the
+ * action response.
+ */
+export async function redirectToBlockedPath(): Promise<void> {
+  redirect("/admin");
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/action-redirect-middleware/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/action-redirect-middleware/page.tsx
@@ -1,0 +1,14 @@
+import { redirectToBlockedPath } from "./actions";
+
+export default function Page() {
+  return (
+    <main>
+      <h1>Action Redirect Middleware Test</h1>
+      <form action={redirectToBlockedPath}>
+        <button id="redirect-to-blocked" type="submit">
+          Redirect to blocked path
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/action-redirect-middleware/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/action-redirect-middleware/page.tsx
@@ -1,4 +1,4 @@
-import { redirectToBlockedPath } from "./actions";
+import { redirectToBlockedPath, redirectToEncodedBlockedPath } from "./actions";
 
 export default function Page() {
   return (
@@ -7,6 +7,11 @@ export default function Page() {
       <form action={redirectToBlockedPath}>
         <button id="redirect-to-blocked" type="submit">
           Redirect to blocked path
+        </button>
+      </form>
+      <form action={redirectToEncodedBlockedPath}>
+        <button id="redirect-to-encoded-blocked" type="submit">
+          Redirect to encoded blocked path
         </button>
       </form>
     </main>

--- a/tests/nextjs-compat/action-redirect-middleware.test.ts
+++ b/tests/nextjs-compat/action-redirect-middleware.test.ts
@@ -18,7 +18,22 @@ import type { ViteDevServer } from "vite-plus";
 import { APP_FIXTURE_DIR, startFixtureServer } from "../helpers.js";
 
 const ACTION_PATH = "/nextjs-compat/action-redirect-middleware";
-const ACTION_ID = "/app/nextjs-compat/action-redirect-middleware/actions.ts#redirectToBlockedPath";
+const ACTIONS = "/app/nextjs-compat/action-redirect-middleware/actions.ts";
+const ACTION_ID = `${ACTIONS}#redirectToBlockedPath`;
+const ENCODED_ACTION_ID = `${ACTIONS}#redirectToEncodedBlockedPath`;
+
+async function postAction(
+  baseUrl: string,
+  actionId: string,
+  extraHeaders: Record<string, string> = {},
+): Promise<{ res: Response; text: string }> {
+  const res = await fetch(`${baseUrl}${ACTION_PATH}.rsc`, {
+    method: "POST",
+    headers: { "Content-Type": "text/plain", "x-rsc-action": actionId, ...extraHeaders },
+    body: JSON.stringify([]),
+  });
+  return { res, text: await res.text() };
+}
 
 describe("Next.js compat: server action redirect targets run middleware", () => {
   let server: ViteDevServer;
@@ -40,21 +55,37 @@ describe("Next.js compat: server action redirect targets run middleware", () => 
   });
 
   it("does not return the blocked target's payload from the action response", async () => {
-    const res = await fetch(`${baseUrl}${ACTION_PATH}.rsc`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "text/plain",
-        "x-rsc-action": ACTION_ID,
-      },
-      body: JSON.stringify([]),
-    });
-    const text = await res.text();
+    const { res, text } = await postAction(baseUrl, ACTION_ID);
 
     expect(res.headers.get("x-action-redirect")).toBe("/admin");
     expect(text).not.toContain("Protected admin content");
     // A header-only redirect the client re-requests through the full pipeline,
     // where middleware gets to block it.
     expect(res.headers.get("content-type")).toBeNull();
+    expect(text).toBe("");
+  });
+
+  // The dev-only forwarded-middleware-context header carries the *action* path's
+  // middleware result. Replayed for the target it would skip middleware
+  // execution entirely, so it must not survive onto the target's request.
+  it("ignores a forwarded middleware context when evaluating the target", async () => {
+    const { res, text } = await postAction(baseUrl, ACTION_ID, {
+      "x-vinext-mw-ctx": JSON.stringify({ h: [["x-mw-ran", "true"]] }),
+    });
+
+    expect(res.headers.get("x-action-redirect")).toBe("/admin");
+    expect(text).not.toContain("Protected admin content");
+    expect(text).toBe("");
+  });
+
+  // Route matching that decodes resolves /adm%69n to the /admin page, but
+  // middleware and a real navigation both see /adm%69n. Rendering the decoded
+  // route inline would serve a page neither of them reached.
+  it("does not render a percent-encoded alias of the blocked target", async () => {
+    const { res, text } = await postAction(baseUrl, ENCODED_ACTION_ID);
+
+    expect(res.headers.get("x-action-redirect")).toBe("/adm%69n");
+    expect(text).not.toContain("Protected admin content");
     expect(text).toBe("");
   });
 });

--- a/tests/nextjs-compat/action-redirect-middleware.test.ts
+++ b/tests/nextjs-compat/action-redirect-middleware.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Next.js Compatibility Tests: middleware runs for server action redirect targets.
+ *
+ * A server action that throws `redirect()` renders the target page inline and
+ * returns its Flight payload with the action response, instead of making the
+ * client re-request the target. Middleware only ran for the action's own path,
+ * so the target's middleware — commonly the app's authorization boundary — has
+ * to be run before that render.
+ *
+ * In Next.js the client re-requests the target through the full pipeline, so a
+ * middleware-blocked target is never rendered from the action request. Here the
+ * fixture's middleware blocks `/admin` with a 403; the action response must fall
+ * back to a header-only redirect the client re-requests, carrying no payload.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vite-plus/test";
+import type { ViteDevServer } from "vite-plus";
+import { APP_FIXTURE_DIR, startFixtureServer } from "../helpers.js";
+
+const ACTION_PATH = "/nextjs-compat/action-redirect-middleware";
+const ACTION_ID = "/app/nextjs-compat/action-redirect-middleware/actions.ts#redirectToBlockedPath";
+
+describe("Next.js compat: server action redirect targets run middleware", () => {
+  let server: ViteDevServer;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    ({ server, baseUrl } = await startFixtureServer(APP_FIXTURE_DIR, { appRouter: true }));
+    await fetch(`${baseUrl}${ACTION_PATH}`).catch(() => {});
+  }, 60_000);
+
+  afterAll(async () => {
+    await server?.close();
+  });
+
+  it("blocks a direct request to the redirect target", async () => {
+    const res = await fetch(`${baseUrl}/admin`);
+    expect(res.status).toBe(403);
+    expect(await res.text()).not.toContain("Protected admin content");
+  });
+
+  it("does not return the blocked target's payload from the action response", async () => {
+    const res = await fetch(`${baseUrl}${ACTION_PATH}.rsc`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "text/plain",
+        "x-rsc-action": ACTION_ID,
+      },
+      body: JSON.stringify([]),
+    });
+    const text = await res.text();
+
+    expect(res.headers.get("x-action-redirect")).toBe("/admin");
+    expect(text).not.toContain("Protected admin content");
+    // A header-only redirect the client re-requests through the full pipeline,
+    // where middleware gets to block it.
+    expect(res.headers.get("content-type")).toBeNull();
+    expect(text).toBe("");
+  });
+});


### PR DESCRIPTION
## Problem

A server action that throws `redirect()` renders the target page inline and returns its Flight payload with the action response, saving the client a round-trip. Middleware only ran for the action's own path, so the target's middleware never saw the request.

That makes middleware unenforceable as an authorization boundary for any page reachable as an action redirect target. An action on a public path that redirects to a middleware-gated page — a `next`/callback URL pattern, or just a hardcoded destination — returns that page's server-rendered payload, and `app-browser-server-action-client.ts` decodes `result.root` and commits it as a navigation.

Next.js has no equivalent hole: it performs an internal GET for the target through the full request pipeline and streams that Flight response back with `x-action-redirect`; if that internal fetch cannot produce Flight, the client re-requests the target.

Reproduced against the `app-basic` fixture, whose middleware blocks `/admin` with a 403. Before this change, `GET /admin` returns 403 while a POST to an action that redirects there returns `"Protected admin content"` in the action response body.

## Change

`app-rsc-handler` already owns the middleware plumbing, so it hands the action dispatch a `runRedirectTargetMiddleware` callback. `handleServerActionRscRequest` calls it for internal redirect targets before rendering them.

- Middleware runs *after* `setHeadersContext(redirectRenderRequest)` so `NextResponse.next({ request: { headers } })` overrides land on the context the target page reads through `headers()`/`cookies()`.
- Middleware response headers merge into the action response.
- Only a clean pass-through is rendered inline. A block, redirect, rewrite, or status override diverts to the header-only 303 that already exists for non-App-route targets — the client then re-requests the target through the full request pipeline, where middleware gets to apply its real response.

## Scope

Apps with no middleware, and targets no middleware matcher matches, take the same path as before. Redirecting actions in middleware apps now run middleware twice per request (once for the action path, once for the target) — the same total as the two requests Next.js makes for the same flow.

Config-level `redirects`/`rewrites`/`headers` are still not applied to inline redirect targets. That is a separate parity gap, not an authorization boundary, and is left out of this change.

## Validation

- `tests/nextjs-compat/action-redirect-middleware.test.ts` — new integration test through the real generated RSC entry: direct `/admin` is 403, and the redirecting action's response carries no target payload. Fails on `main` with `"Protected admin content"` in the body.
- `tests/app-rsc-handler.test.ts` — the handler supplies the callback and it diverts when middleware blocks the target.
- `tests/app-server-action-execution.test.ts` — diverted targets produce a header-only 303 and never build the page element; pass-through targets render inline, keep the middleware response headers, and receive a clean GET with `next-action` stripped.

All three fail without the source change. `pnpm run check` passes.