### PR TITLE
fix(build): support dynamic package subpath imports

### DIFF
--- a/packages/vinext/src/plugins/extensionless-dynamic-import.ts
+++ b/packages/vinext/src/plugins/extensionless-dynamic-import.ts
@@ -1,5 +1,8 @@
 import MagicString from "magic-string";
-import { parseAst, type Plugin, type ResolvedConfig } from "vite";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path, { toSlash } from "pathslash";
+import { parseAst, type Plugin } from "vite";
 import {
   DYNAMIC_IMPORT_PRESCAN,
   forEachAstChild,
@@ -9,6 +12,8 @@ import {
   type AstRecord,
 } from "./ast-utils.js";
 import { createTransformCache } from "./transform-cache.js";
+import { isUnknownRecord } from "../utils/record.js";
+import { escapeRegExp } from "../utils/regex.js";
 
 const MODULE_EXTENSIONS = [".mjs", ".js", ".mts", ".ts", ".jsx", ".tsx", ".json"];
 const TRANSFORMABLE_EXTENSIONS = new Set([
@@ -27,21 +32,61 @@ type ExtensionlessImport = {
   end: number;
   sourceStart: number;
   sourceEnd: number;
+} & (
+  | {
+      kind: "relative";
+      globPattern: string | readonly string[];
+      moduleExtensions: readonly string[];
+    }
+  | {
+      kind: "package";
+      resolution: PackageImportResolution;
+    }
+);
+
+type PackageImportResolution = {
   globPattern: string | readonly string[];
+  packageName: string;
+  requestPrefix: string;
+  requestSuffix: string;
+  resolvedPrefix: string;
+  resolvedSuffix: string;
+};
+
+type PackageJson = {
+  name?: unknown;
+  exports?: unknown;
+};
+
+type TransformConfig = {
   moduleExtensions: readonly string[];
+  exportConditions: ReadonlySet<string>;
+};
+
+type TransformEnvironmentConfig = {
+  isProduction?: boolean;
+  resolve: {
+    conditions?: readonly string[];
+    extensions: readonly string[];
+  };
 };
 
 export function createExtensionlessDynamicImportPlugin(): Plugin {
-  let moduleExtensions = MODULE_EXTENSIONS;
-  // Keyed by the extensions array reference: configResolved replaces the array
-  // wholesale, so results computed under a previous config never leak forward.
-  const cached = createTransformCache<readonly string[], TransformResult>();
+  let transformConfig: TransformConfig = {
+    moduleExtensions: MODULE_EXTENSIONS,
+    exportConditions: new Set(["import", "module", "node", "development", "default"]),
+  };
+  const environmentConfigs = new WeakMap<object, TransformConfig>();
+  // Keyed by the config object reference: configResolved replaces the object
+  // wholesale, so results computed under previous extensions or conditions
+  // never leak forward.
+  const cached = createTransformCache<TransformConfig, TransformResult>();
 
   return {
     name: "vinext:extensionless-dynamic-import",
     enforce: "pre",
     configResolved(config) {
-      moduleExtensions = getModuleExtensions(config);
+      transformConfig = createTransformConfig(config);
     },
     transform: {
       filter: {
@@ -52,8 +97,17 @@ export function createExtensionlessDynamicImportPlugin(): Plugin {
         code: DYNAMIC_IMPORT_PRESCAN,
       },
       handler(code, id) {
-        return cached(id, code, moduleExtensions, () =>
-          transformExtensionlessImports(code, id, moduleExtensions),
+        const environmentConfig = this.environment?.config as
+          | TransformEnvironmentConfig
+          | undefined;
+        let activeConfig = transformConfig;
+        if (environmentConfig) {
+          activeConfig =
+            environmentConfigs.get(environmentConfig) ?? createTransformConfig(environmentConfig);
+          environmentConfigs.set(environmentConfig, activeConfig);
+        }
+        return cached(id, code, activeConfig, () =>
+          transformExtensionlessImports(code, id, activeConfig),
         );
       },
     },
@@ -68,7 +122,7 @@ type TransformResult = {
 function transformExtensionlessImports(
   code: string,
   id: string,
-  moduleExtensions: readonly string[],
+  config: TransformConfig,
 ): TransformResult {
   const lang = langForId(id)!;
 
@@ -79,7 +133,7 @@ function transformExtensionlessImports(
     return null;
   }
 
-  const imports = collectExtensionlessImports(ast, code, moduleExtensions);
+  const imports = collectExtensionlessImports(ast, code, config, id);
   if (imports.length === 0) return null;
 
   const output = new MagicString(code);
@@ -88,7 +142,9 @@ function transformExtensionlessImports(
     output.overwrite(
       dynamicImport.start,
       dynamicImport.end,
-      buildReplacement(source, dynamicImport.globPattern, dynamicImport.moduleExtensions),
+      dynamicImport.kind === "package"
+        ? buildPackageReplacement(source, dynamicImport.resolution)
+        : buildReplacement(source, dynamicImport.globPattern, dynamicImport.moduleExtensions),
     );
   }
 
@@ -112,13 +168,14 @@ function langForId(id: string): "js" | "jsx" | "ts" | "tsx" | null {
 function collectExtensionlessImports(
   ast: unknown,
   code: string,
-  moduleExtensions: readonly string[],
+  config: TransformConfig,
+  id: string,
 ): ExtensionlessImport[] {
   const imports: ExtensionlessImport[] = [];
 
   function visit(value: unknown): void {
     if (!isAstRecord(value)) return;
-    const parsed = parseExtensionlessImport(value, code, moduleExtensions);
+    const parsed = parseExtensionlessImport(value, code, config, id);
     if (parsed) {
       imports.push(parsed);
       return;
@@ -133,7 +190,8 @@ function collectExtensionlessImports(
 function parseExtensionlessImport(
   node: AstRecord,
   code: string,
-  moduleExtensions: readonly string[],
+  config: TransformConfig,
+  id: string,
 ): ExtensionlessImport | null {
   if (node.type !== "ImportExpression" || !hasRange(node)) return null;
   if (node.options != null) return null;
@@ -147,8 +205,20 @@ function parseExtensionlessImport(
   const texts = quasiTexts as string[];
   const first = texts[0];
   if (!isImportPrefix(code.slice(node.start, source.start))) return null;
-  if (!(first.startsWith("./") || first.startsWith("../"))) return null;
   if (texts.some((text) => /[*?[\]{}()!?#]/.test(text))) return null;
+  if (!(first.startsWith("./") || first.startsWith("../"))) {
+    const resolution = resolvePackageImport(first, texts, id, config.exportConditions);
+    return resolution
+      ? {
+          kind: "package",
+          start: node.start,
+          end: node.end,
+          sourceStart: source.start,
+          sourceEnd: source.end,
+          resolution,
+        }
+      : null;
+  }
   if (texts.slice(1).some((text) => text.includes("."))) return null;
 
   const directoryEnd = first.lastIndexOf("/") + 1;
@@ -157,13 +227,311 @@ function parseExtensionlessImport(
   if (filenamePrefix.includes(".")) return null;
 
   return {
+    kind: "relative",
     start: node.start,
     end: node.end,
     sourceStart: source.start,
     sourceEnd: source.end,
     globPattern: filenamePrefix.length > 0 ? [`${first}*`, `${first}*/**/*`] : `${directory}**/*`,
-    moduleExtensions,
+    moduleExtensions: config.moduleExtensions,
   };
+}
+
+function resolvePackageImport(
+  first: string,
+  texts: readonly string[],
+  id: string,
+  exportConditions: ReadonlySet<string>,
+): PackageImportResolution | null {
+  const packageName = parsePackageName(first);
+  if (packageName === null || first === packageName || !first.startsWith(`${packageName}/`)) {
+    return null;
+  }
+
+  const packageInfo = resolvePackageInfo(packageName, id);
+  if (packageInfo === null || !isUnknownRecord(packageInfo.packageJson.exports)) return null;
+
+  const requestPattern = `./${[first.slice(packageName.length + 1), ...texts.slice(1)].join("*")}`;
+  const matchedExport = findBestPackageExport(packageInfo.packageJson.exports, requestPattern);
+  if (matchedExport === null) return null;
+
+  const { keyMatch, exportValue } = matchedExport;
+  for (const target of resolveExportTargets(exportValue, exportConditions)) {
+    if (!target.startsWith("./")) continue;
+    const targetParts = splitSingleWildcard(target);
+    if (targetParts === null) continue;
+
+    const [targetPrefix, targetSuffix] = targetParts;
+    const absoluteGlob = path.resolve(
+      packageInfo.packageRoot,
+      `${targetPrefix.slice(2)}${keyMatch.capture}${targetSuffix}`,
+    );
+    const absolutePrefix = path.resolve(packageInfo.packageRoot, targetPrefix.slice(2));
+    if (
+      !isWithinPackage(packageInfo.packageRoot, absoluteGlob) ||
+      !isWithinPackage(packageInfo.packageRoot, absolutePrefix)
+    ) {
+      continue;
+    }
+
+    const importerDirectory = resolveImporterDirectory(id);
+    const globPath = toImporterPath(importerDirectory, absoluteGlob);
+    const resolvedPrefixPath = toImporterPath(importerDirectory, absolutePrefix);
+    if (globPath === null || resolvedPrefixPath === null) return null;
+    const resolvedPrefix =
+      resolvedPrefixPath.replace(/\/+$/, "") + (targetPrefix.endsWith("/") ? "/" : "");
+    const globPattern = buildPackageGlobPatterns(resolvedPrefix, keyMatch.capture, targetSuffix);
+    if (globPattern === null) return null;
+    return {
+      globPattern,
+      packageName,
+      requestPrefix: `${packageName}/${keyMatch.prefix.slice(2)}`,
+      requestSuffix: keyMatch.suffix,
+      resolvedPrefix,
+      resolvedSuffix: targetSuffix,
+    };
+  }
+
+  return null;
+}
+
+function findBestPackageExport(
+  exports: Record<string, unknown>,
+  requestPattern: string,
+): { keyMatch: WildcardMatch; exportValue: unknown } | null {
+  let best: { exportKey: string; keyMatch: WildcardMatch; exportValue: unknown } | null = null;
+  for (const [exportKey, exportValue] of Object.entries(exports)) {
+    const keyMatch = matchWildcardPattern(exportKey, requestPattern);
+    if (keyMatch === null) continue;
+    if (best === null || comparePatternKeys(exportKey, best.exportKey) < 0) {
+      best = { exportKey, keyMatch, exportValue };
+    }
+  }
+  if (
+    best === null ||
+    hasHigherPrecedenceExportIntersection(exports, requestPattern, best.exportKey)
+  ) {
+    return null;
+  }
+  return { keyMatch: best.keyMatch, exportValue: best.exportValue };
+}
+
+function hasHigherPrecedenceExportIntersection(
+  exports: Record<string, unknown>,
+  requestPattern: string,
+  selectedKey: string,
+): boolean {
+  for (const exportKey of Object.keys(exports)) {
+    if (exportKey === selectedKey || exportKey === ".") continue;
+    if (!exportKey.includes("*")) {
+      if (matchesTemplatePattern(requestPattern, exportKey)) return true;
+      continue;
+    }
+    if (
+      comparePatternKeys(exportKey, selectedKey) < 0 &&
+      wildcardPatternsMayIntersect(requestPattern, exportKey)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function matchesTemplatePattern(templatePattern: string, value: string): boolean {
+  const source = templatePattern.split("*").map(escapeRegExp).join(".*");
+  return new RegExp(`^${source}$`).test(value);
+}
+
+function wildcardPatternsMayIntersect(left: string, right: string): boolean {
+  const leftBounds = wildcardPatternBounds(left);
+  const rightBounds = wildcardPatternBounds(right);
+  return (
+    (leftBounds.prefix.startsWith(rightBounds.prefix) ||
+      rightBounds.prefix.startsWith(leftBounds.prefix)) &&
+    (leftBounds.suffix.endsWith(rightBounds.suffix) ||
+      rightBounds.suffix.endsWith(leftBounds.suffix))
+  );
+}
+
+function wildcardPatternBounds(pattern: string): { prefix: string; suffix: string } {
+  const firstWildcard = pattern.indexOf("*");
+  const lastWildcard = pattern.lastIndexOf("*");
+  return {
+    prefix: pattern.slice(0, firstWildcard),
+    suffix: pattern.slice(lastWildcard + 1),
+  };
+}
+
+// Matches Node's package exports pattern precedence: the longest base wins,
+// then the longest complete key. Object insertion order is not significant.
+function comparePatternKeys(left: string, right: string): number {
+  const leftBaseLength = left.indexOf("*") + 1;
+  const rightBaseLength = right.indexOf("*") + 1;
+  return rightBaseLength - leftBaseLength || right.length - left.length;
+}
+
+function parsePackageName(specifierPrefix: string): string | null {
+  const segments = specifierPrefix.split("/");
+  if (specifierPrefix.startsWith("@")) {
+    return segments.length >= 2 && segments[0] && segments[1]
+      ? `${segments[0]}/${segments[1]}`
+      : null;
+  }
+  return segments[0] || null;
+}
+
+function resolvePackageInfo(
+  packageName: string,
+  id: string,
+): { packageRoot: string; packageJson: PackageJson } | null {
+  const cleanId = id.split(/[?#]/, 1)[0];
+  const selfPackage = findPackageInfo(path.dirname(cleanId), packageName);
+  if (selfPackage !== null) return selfPackage;
+
+  let resolver: NodeRequire;
+  try {
+    resolver = createRequire(cleanId);
+  } catch {
+    return null;
+  }
+
+  try {
+    const entry = resolver.resolve(packageName);
+    const fromEntry = findPackageInfo(path.dirname(entry), packageName);
+    if (fromEntry !== null) return fromEntry;
+  } catch {
+    // Packages with only subpath exports do not have a resolvable root entry.
+  }
+
+  for (const lookupPath of resolver.resolve.paths(packageName) ?? []) {
+    const candidate = path.join(lookupPath, packageName, "package.json");
+    const packageJson = readPackageJson(candidate);
+    if (packageJson?.name === packageName) {
+      return { packageRoot: path.dirname(candidate), packageJson };
+    }
+  }
+
+  return null;
+}
+
+function findPackageInfo(
+  startDirectory: string,
+  packageName: string,
+): { packageRoot: string; packageJson: PackageJson } | null {
+  let directory = startDirectory;
+  while (true) {
+    const packageJson = readPackageJson(path.join(directory, "package.json"));
+    if (packageJson?.name === packageName) {
+      return { packageRoot: directory, packageJson };
+    }
+    const parent = path.dirname(directory);
+    if (parent === directory) return null;
+    directory = parent;
+  }
+}
+
+function readPackageJson(filename: string): PackageJson | null {
+  try {
+    return JSON.parse(fs.readFileSync(filename, "utf8")) as PackageJson;
+  } catch {
+    return null;
+  }
+}
+
+function resolveExportTargets(value: unknown, conditions: ReadonlySet<string>): string[] {
+  if (typeof value === "string") return [value];
+  if (Array.isArray(value)) {
+    // A valid first array target wins in Node even if vinext cannot express it
+    // as a glob. Never skip ahead to a later target with different semantics.
+    return value.length === 0 ? [] : resolveExportTargets(value[0], conditions);
+  }
+  if (!isUnknownRecord(value)) return [];
+
+  // Package export conditions are ordered from most specific to least
+  // specific, so select the first branch active in this Vite environment.
+  for (const [condition, target] of Object.entries(value)) {
+    if (condition === "default" || conditions.has(condition)) {
+      return resolveExportTargets(target, conditions);
+    }
+  }
+  return [];
+}
+
+type WildcardMatch = { prefix: string; suffix: string; capture: string };
+
+function matchWildcardPattern(pattern: string, value: string): WildcardMatch | null {
+  const parts = splitSingleWildcard(pattern);
+  if (parts === null) return null;
+  const [prefix, suffix] = parts;
+  if (!value.startsWith(prefix) || !value.endsWith(suffix)) return null;
+  return {
+    prefix,
+    suffix,
+    capture: value.slice(prefix.length, suffix.length === 0 ? undefined : -suffix.length),
+  };
+}
+
+function splitSingleWildcard(value: string): [prefix: string, suffix: string] | null {
+  const wildcard = value.indexOf("*");
+  if (wildcard < 0 || wildcard !== value.lastIndexOf("*")) return null;
+  return [value.slice(0, wildcard), value.slice(wildcard + 1)];
+}
+
+function isWithinPackage(packageRoot: string, target: string): boolean {
+  const relative = path.relative(packageRoot, target);
+  return relative !== ".." && !relative.startsWith("../") && !path.isAbsolute(relative);
+}
+
+function toImporterPath(importerDirectory: string, absolutePath: string): string | null {
+  const relative = path.relative(importerDirectory, absolutePath);
+  // Vite glob keys must be relative to the importer. There is no valid
+  // relative specifier between Windows drives, so leave that import untouched.
+  if (path.isAbsolute(relative)) return null;
+  return relative.startsWith(".") ? relative : `./${relative}`;
+}
+
+const POSIX_UNESCAPED_GLOB_SYMBOLS = /(?<!\\)([()[\]{}*?|]|^!|[!+@](?=\()|\\(?![()[\]{}!*+?@|]))/g;
+const WIN32_UNESCAPED_GLOB_SYMBOLS = /(?<!\\)([()[\]{}]|^!|[!+@](?=\())/g;
+
+function escapeGlobLiteral(value: string): string {
+  const pattern =
+    process.platform === "win32" ? WIN32_UNESCAPED_GLOB_SYMBOLS : POSIX_UNESCAPED_GLOB_SYMBOLS;
+  return value.replace(pattern, "\\$&");
+}
+
+function buildPackageGlobPatterns(
+  resolvedPrefix: string,
+  capturePattern: string,
+  resolvedSuffix: string,
+): string | readonly string[] | null {
+  const parts = capturePattern.split("*");
+  const wildcardCount = parts.length - 1;
+  // Each expression needs both a segment-local and a slash-crossing variant.
+  // Keep expansion bounded; unusually complex templates remain native imports.
+  if (wildcardCount === 0 || wildcardCount > 4) return null;
+
+  let captures = [escapeGlobLiteral(parts[0])];
+  for (let index = 0; index < wildcardCount; index++) {
+    const suffix = escapeGlobLiteral(parts[index + 1]);
+    captures = captures.flatMap((capture) => [`${capture}*${suffix}`, `${capture}*/**/*${suffix}`]);
+  }
+
+  const prefix = escapeGlobLiteral(resolvedPrefix);
+  const suffix = escapeGlobLiteral(resolvedSuffix);
+  const patterns = [
+    ...new Set(captures.map((capture) => `${prefix}${capture}${suffix}`)),
+    `!${prefix}**/node_modules/**`,
+  ];
+  return patterns.length === 1 ? patterns[0] : patterns;
+}
+
+function resolveImporterDirectory(id: string): string {
+  const directory = path.dirname(id.split(/[?#]/, 1)[0]);
+  try {
+    return toSlash(fs.realpathSync.native(directory));
+  } catch {
+    return directory;
+  }
 }
 
 function isImportPrefix(value: string): boolean {
@@ -206,8 +574,24 @@ function templateElementText(value: unknown): string | null {
   return typeof cooked === "string" ? cooked : null;
 }
 
-function getModuleExtensions(config: ResolvedConfig): string[] {
+function getModuleExtensions(config: TransformEnvironmentConfig): string[] {
   return config.resolve.extensions.filter((extension) => extension !== ".node");
+}
+
+function getExportConditions(config: TransformEnvironmentConfig): ReadonlySet<string> {
+  const productionCondition = config.isProduction ? "production" : "development";
+  const conditions = new Set(["import", "default", productionCondition]);
+  for (const condition of config.resolve.conditions ?? []) {
+    conditions.add(condition === "development|production" ? productionCondition : condition);
+  }
+  return conditions;
+}
+
+function createTransformConfig(config: TransformEnvironmentConfig): TransformConfig {
+  return {
+    moduleExtensions: getModuleExtensions(config),
+    exportConditions: getExportConditions(config),
+  };
 }
 
 function buildReplacement(
@@ -217,4 +601,12 @@ function buildReplacement(
 ): string {
   const extensions = JSON.stringify(moduleExtensions);
   return `((__vinextPath, __vinextModules = import.meta.glob(${JSON.stringify(globPattern)}), __vinextExtensions = ${extensions}) => { const __vinextLoader = __vinextModules[__vinextPath] ?? __vinextExtensions.map((__vinextExtension) => __vinextModules[__vinextPath + __vinextExtension]).find(Boolean) ?? __vinextExtensions.map((__vinextExtension) => __vinextModules[__vinextPath + "/index" + __vinextExtension]).find(Boolean); return __vinextLoader ? __vinextLoader() : Promise.reject(new Error("Cannot find module '" + __vinextPath + "'")); })(${source})`;
+}
+
+function buildPackageReplacement(source: string, resolution: PackageImportResolution): string {
+  const captureEnd = resolution.requestSuffix
+    ? `-${JSON.stringify(resolution.requestSuffix)}.length`
+    : "undefined";
+  const packageSubpathStart = resolution.packageName.length + 1;
+  return `((__vinextPath, __vinextModules = import.meta.glob(${JSON.stringify(resolution.globPattern)}, { exhaustive: true })) => { const __vinextInvalidSubpath = __vinextPath.slice(${packageSubpathStart}).split("/").some((__vinextSegment) => { if (!__vinextSegment) return true; try { const __vinextDecodedSegment = decodeURIComponent(__vinextSegment); return __vinextDecodedSegment === "." || __vinextDecodedSegment === ".." || __vinextDecodedSegment.toLowerCase() === "node_modules" || __vinextDecodedSegment.includes("/") || __vinextDecodedSegment.includes("\\\\"); } catch { return true; } }); if (__vinextInvalidSubpath) return Promise.reject(new Error("Cannot find module '" + __vinextPath + "'")); const __vinextCapture = __vinextPath.slice(${JSON.stringify(resolution.requestPrefix)}.length, ${captureEnd}); const __vinextResolvedPath = ${JSON.stringify(resolution.resolvedPrefix)} + __vinextCapture + ${JSON.stringify(resolution.resolvedSuffix)}; const __vinextLoader = __vinextModules[__vinextResolvedPath]; return __vinextLoader ? __vinextLoader() : Promise.reject(new Error("Cannot find module '" + __vinextPath + "'")); })(${source})`;
 }

--- a/packages/vinext/src/plugins/extensionless-dynamic-import.ts
+++ b/packages/vinext/src/plugins/extensionless-dynamic-import.ts
@@ -2,7 +2,7 @@ import MagicString from "magic-string";
 import fs from "node:fs";
 import { createRequire } from "node:module";
 import path, { toSlash } from "pathslash";
-import { parseAst, type Plugin } from "vite";
+import { parseAst, type Alias, type Plugin } from "vite";
 import {
   DYNAMIC_IMPORT_PRESCAN,
   forEachAstChild,
@@ -59,6 +59,7 @@ type PackageJson = {
 };
 
 type TransformConfig = {
+  aliases: readonly Alias[];
   moduleExtensions: readonly string[];
   exportConditions: ReadonlySet<string>;
 };
@@ -66,6 +67,7 @@ type TransformConfig = {
 type TransformEnvironmentConfig = {
   isProduction?: boolean;
   resolve: {
+    alias?: readonly Alias[];
     conditions?: readonly string[];
     extensions: readonly string[];
   };
@@ -73,6 +75,7 @@ type TransformEnvironmentConfig = {
 
 export function createExtensionlessDynamicImportPlugin(): Plugin {
   let transformConfig: TransformConfig = {
+    aliases: [],
     moduleExtensions: MODULE_EXTENSIONS,
     exportConditions: new Set(["import", "module", "node", "development", "default"]),
   };
@@ -207,7 +210,13 @@ function parseExtensionlessImport(
   if (!isImportPrefix(code.slice(node.start, source.start))) return null;
   if (texts.some((text) => /[*?[\]{}()!?#]/.test(text))) return null;
   if (!(first.startsWith("./") || first.startsWith("../"))) {
-    const resolution = resolvePackageImport(first, texts, id, config.exportConditions);
+    const resolution = resolvePackageImport(
+      first,
+      texts,
+      id,
+      config.exportConditions,
+      config.aliases,
+    );
     return resolution
       ? {
           kind: "package",
@@ -242,11 +251,16 @@ function resolvePackageImport(
   texts: readonly string[],
   id: string,
   exportConditions: ReadonlySet<string>,
+  aliases: readonly Alias[],
 ): PackageImportResolution | null {
   const packageName = parsePackageName(first);
   if (packageName === null || first === packageName || !first.startsWith(`${packageName}/`)) {
     return null;
   }
+  // Rewriting to the physical package would bypass Vite's configured alias.
+  // Leave any template that may intersect an alias to the normal resolver.
+  const requestSpecifierPattern = [first, ...texts.slice(1)].join("*");
+  if (aliasesMayMatch(aliases, requestSpecifierPattern)) return null;
 
   const packageInfo = resolvePackageInfo(packageName, id);
   if (packageInfo === null || !isUnknownRecord(packageInfo.packageJson.exports)) return null;
@@ -258,13 +272,15 @@ function resolvePackageImport(
   const { keyMatch, exportValue } = matchedExport;
   for (const target of resolveExportTargets(exportValue, exportConditions)) {
     if (!target.startsWith("./")) continue;
-    const targetParts = splitSingleWildcard(target);
+    const targetParts = decodePackageTarget(target);
     if (targetParts === null) continue;
 
     const [targetPrefix, targetSuffix] = targetParts;
+    const decodedCapture = decodeRequestCapturePattern(keyMatch.capture);
+    if (decodedCapture === null) continue;
     const absoluteGlob = path.resolve(
       packageInfo.packageRoot,
-      `${targetPrefix.slice(2)}${keyMatch.capture}${targetSuffix}`,
+      `${targetPrefix.slice(2)}${decodedCapture}${targetSuffix}`,
     );
     const absolutePrefix = path.resolve(packageInfo.packageRoot, targetPrefix.slice(2));
     if (
@@ -280,7 +296,7 @@ function resolvePackageImport(
     if (globPath === null || resolvedPrefixPath === null) return null;
     const resolvedPrefix =
       resolvedPrefixPath.replace(/\/+$/, "") + (targetPrefix.endsWith("/") ? "/" : "");
-    const globPattern = buildPackageGlobPatterns(resolvedPrefix, keyMatch.capture, targetSuffix);
+    const globPattern = buildPackageGlobPatterns(resolvedPrefix, decodedCapture, targetSuffix);
     if (globPattern === null) return null;
     return {
       globPattern,
@@ -380,12 +396,101 @@ function parsePackageName(specifierPrefix: string): string | null {
   return segments[0] || null;
 }
 
+function aliasesMayMatch(aliases: readonly Alias[], requestPattern: string): boolean {
+  const requestPrefix = requestPattern.slice(0, requestPattern.indexOf("*"));
+  return aliases.some((alias) => {
+    const { find } = alias;
+    // Arbitrary regular-expression/template intersection is not decidable.
+    if (find instanceof RegExp) return !isViteInternalAlias(alias);
+    if (matchesTemplatePattern(requestPattern, find)) return true;
+    const aliasPrefix = `${find}/`;
+    return requestPrefix.startsWith(aliasPrefix) || aliasPrefix.startsWith(requestPrefix);
+  });
+}
+
+function isViteInternalAlias(alias: Alias): boolean {
+  if (!(alias.find instanceof RegExp)) return false;
+  const replacement = toSlash(alias.replacement);
+  const source = replacement.endsWith("/vite/client/env.mjs")
+    ? "@vite/env"
+    : replacement.endsWith("/vite/client/client.mjs")
+      ? "@vite/client"
+      : null;
+  if (source === null) return false;
+  alias.find.lastIndex = 0;
+  const matches = alias.find.test(source);
+  alias.find.lastIndex = 0;
+  return matches;
+}
+
+function decodePackageTarget(target: string): [prefix: string, suffix: string] | null {
+  // Raw URL query/fragment delimiters are not filesystem characters in Node's
+  // package-target URL resolution. Their percent-encoded forms remain valid.
+  if (target.includes("?") || target.includes("#")) return null;
+  const targetParts = splitSingleWildcard(target);
+  if (targetParts === null) return null;
+  const [rawPrefix, rawSuffix] = targetParts;
+  // A percent escape can span the wildcard boundary. Supporting that would
+  // require a runtime-derived glob, so preserve the native import instead.
+  if (/%[\da-f]?$/i.test(rawPrefix) || /^[\da-f]/i.test(rawSuffix)) return null;
+  for (const segment of target.slice(2).split("/")) {
+    let decodedSegment: string;
+    try {
+      decodedSegment = decodeURIComponent(segment);
+    } catch {
+      return null;
+    }
+    if (
+      decodedSegment === "." ||
+      decodedSegment === ".." ||
+      decodedSegment.toLowerCase() === "node_modules" ||
+      decodedSegment.includes("/") ||
+      decodedSegment.includes("\\")
+    ) {
+      return null;
+    }
+  }
+  const wildcard = target.indexOf("*");
+  try {
+    return [
+      decodeURIComponent(target.slice(0, wildcard)),
+      decodeURIComponent(target.slice(wildcard + 1)),
+    ];
+  } catch {
+    return null;
+  }
+}
+
+function decodeRequestCapturePattern(pattern: string): string | null {
+  const parts = pattern.split("*");
+  for (let index = 0; index < parts.length - 1; index++) {
+    if (/%[\da-f]?$/i.test(parts[index]) || /^[\da-f]/i.test(parts[index + 1])) return null;
+  }
+
+  const decodedParts: string[] = [];
+  for (const part of parts) {
+    const decodedSegments: string[] = [];
+    for (const segment of part.split("/")) {
+      let decodedSegment: string;
+      try {
+        decodedSegment = decodeURIComponent(segment);
+      } catch {
+        return null;
+      }
+      if (decodedSegment.includes("/") || decodedSegment.includes("\\")) return null;
+      decodedSegments.push(decodedSegment);
+    }
+    decodedParts.push(decodedSegments.join("/"));
+  }
+  return decodedParts.join("*");
+}
+
 function resolvePackageInfo(
   packageName: string,
   id: string,
 ): { packageRoot: string; packageJson: PackageJson } | null {
   const cleanId = id.split(/[?#]/, 1)[0];
-  const selfPackage = findPackageInfo(path.dirname(cleanId), packageName);
+  const selfPackage = findNearestPackageInfo(path.dirname(cleanId), packageName);
   if (selfPackage !== null) return selfPackage;
 
   let resolver: NodeRequire;
@@ -412,6 +517,23 @@ function resolvePackageInfo(
   }
 
   return null;
+}
+
+function findNearestPackageInfo(
+  startDirectory: string,
+  packageName: string,
+): { packageRoot: string; packageJson: PackageJson } | null {
+  let directory = startDirectory;
+  while (true) {
+    const filename = path.join(directory, "package.json");
+    if (fs.existsSync(filename)) {
+      const packageJson = readPackageJson(filename);
+      return packageJson?.name === packageName ? { packageRoot: directory, packageJson } : null;
+    }
+    const parent = path.dirname(directory);
+    if (parent === directory) return null;
+    directory = parent;
+  }
 }
 
 function findPackageInfo(
@@ -589,9 +711,24 @@ function getExportConditions(config: TransformEnvironmentConfig): ReadonlySet<st
 
 function createTransformConfig(config: TransformEnvironmentConfig): TransformConfig {
   return {
+    aliases: config.resolve.alias ?? [],
     moduleExtensions: getModuleExtensions(config),
     exportConditions: getExportConditions(config),
   };
+}
+
+const JAVASCRIPT_STRING_ESCAPE_MAP: Readonly<Record<string, string>> = {
+  "<": "\\u003C",
+  ">": "\\u003E",
+  "\u2028": "\\u2028",
+  "\u2029": "\\u2029",
+};
+
+function serializeJavaScriptValue(value: unknown): string {
+  return JSON.stringify(value).replace(
+    /[<>\u2028\u2029]/g,
+    (character) => JAVASCRIPT_STRING_ESCAPE_MAP[character],
+  );
 }
 
 function buildReplacement(
@@ -599,14 +736,14 @@ function buildReplacement(
   globPattern: string | readonly string[],
   moduleExtensions: readonly string[],
 ): string {
-  const extensions = JSON.stringify(moduleExtensions);
-  return `((__vinextPath, __vinextModules = import.meta.glob(${JSON.stringify(globPattern)}), __vinextExtensions = ${extensions}) => { const __vinextLoader = __vinextModules[__vinextPath] ?? __vinextExtensions.map((__vinextExtension) => __vinextModules[__vinextPath + __vinextExtension]).find(Boolean) ?? __vinextExtensions.map((__vinextExtension) => __vinextModules[__vinextPath + "/index" + __vinextExtension]).find(Boolean); return __vinextLoader ? __vinextLoader() : Promise.reject(new Error("Cannot find module '" + __vinextPath + "'")); })(${source})`;
+  const extensions = serializeJavaScriptValue(moduleExtensions);
+  return `((__vinextPath, __vinextModules = import.meta.glob(${serializeJavaScriptValue(globPattern)}), __vinextExtensions = ${extensions}) => { const __vinextLoader = __vinextModules[__vinextPath] ?? __vinextExtensions.map((__vinextExtension) => __vinextModules[__vinextPath + __vinextExtension]).find(Boolean) ?? __vinextExtensions.map((__vinextExtension) => __vinextModules[__vinextPath + "/index" + __vinextExtension]).find(Boolean); return __vinextLoader ? __vinextLoader() : Promise.reject(new Error("Cannot find module '" + __vinextPath + "'")); })(${source})`;
 }
 
 function buildPackageReplacement(source: string, resolution: PackageImportResolution): string {
   const captureEnd = resolution.requestSuffix
-    ? `-${JSON.stringify(resolution.requestSuffix)}.length`
+    ? `-${serializeJavaScriptValue(resolution.requestSuffix)}.length`
     : "undefined";
   const packageSubpathStart = resolution.packageName.length + 1;
-  return `((__vinextPath, __vinextModules = import.meta.glob(${JSON.stringify(resolution.globPattern)}, { exhaustive: true })) => { const __vinextInvalidSubpath = __vinextPath.slice(${packageSubpathStart}).split("/").some((__vinextSegment) => { if (!__vinextSegment) return true; try { const __vinextDecodedSegment = decodeURIComponent(__vinextSegment); return __vinextDecodedSegment === "." || __vinextDecodedSegment === ".." || __vinextDecodedSegment.toLowerCase() === "node_modules" || __vinextDecodedSegment.includes("/") || __vinextDecodedSegment.includes("\\\\"); } catch { return true; } }); if (__vinextInvalidSubpath) return Promise.reject(new Error("Cannot find module '" + __vinextPath + "'")); const __vinextCapture = __vinextPath.slice(${JSON.stringify(resolution.requestPrefix)}.length, ${captureEnd}); const __vinextResolvedPath = ${JSON.stringify(resolution.resolvedPrefix)} + __vinextCapture + ${JSON.stringify(resolution.resolvedSuffix)}; const __vinextLoader = __vinextModules[__vinextResolvedPath]; return __vinextLoader ? __vinextLoader() : Promise.reject(new Error("Cannot find module '" + __vinextPath + "'")); })(${source})`;
+  return `((__vinextPath, __vinextModules = import.meta.glob(${serializeJavaScriptValue(resolution.globPattern)}, { exhaustive: true })) => { const __vinextSegments = __vinextPath.slice(${packageSubpathStart}).split("/"); let __vinextDecodedSegments, __vinextCapture; try { __vinextDecodedSegments = __vinextSegments.map((__vinextSegment) => decodeURIComponent(__vinextSegment)); __vinextCapture = __vinextPath.slice(${serializeJavaScriptValue(resolution.requestPrefix)}.length, ${captureEnd}).split("/").map((__vinextSegment) => decodeURIComponent(__vinextSegment)).join("/"); } catch { return Promise.reject(new Error("Cannot find module '" + __vinextPath + "'")); } const __vinextInvalidSubpath = __vinextPath.includes("?") || __vinextPath.includes("#") || __vinextDecodedSegments.some((__vinextSegment) => __vinextSegment === "." || __vinextSegment === ".." || __vinextSegment.toLowerCase() === "node_modules" || __vinextSegment.includes("/") || __vinextSegment.includes("\\\\")); if (__vinextInvalidSubpath) return Promise.reject(new Error("Cannot find module '" + __vinextPath + "'")); const __vinextResolvedPath = (${serializeJavaScriptValue(resolution.resolvedPrefix)} + __vinextCapture + ${serializeJavaScriptValue(resolution.resolvedSuffix)}).replace(/\\/+/g, "/"); const __vinextLoader = __vinextModules[__vinextResolvedPath]; return __vinextLoader ? __vinextLoader() : Promise.reject(new Error("Cannot find module '" + __vinextPath + "'")); })(${source})`;
 }

--- a/tests/ecosystem.test.ts
+++ b/tests/ecosystem.test.ts
@@ -178,6 +178,13 @@ describe("next-intl", () => {
 
   afterAll(() => stopFixtureDevServer(proc));
 
+  it("negotiates the root locale through middleware", async () => {
+    const { html, status } = await fetchPage("/");
+    expect(status).toBe(200);
+    expect(html).toContain('<html lang="en"');
+    expect(html).toContain("Hello World");
+  });
+
   it("renders English SSR content", async () => {
     const { html, status } = await fetchPage("/en");
     expect(status).toBe(200);
@@ -188,6 +195,8 @@ describe("next-intl", () => {
   });
 
   it("renders German SSR content", async () => {
+    // The fixture mirrors nodejs.org's wildcard package export:
+    // import(`@vinext-test/next-intl/locales/${locale}.json`).
     const { html, status } = await fetchPage("/de");
     expect(status).toBe(200);
     expect(html).toContain('<html lang="de"');

--- a/tests/extensionless-dynamic-import.test.ts
+++ b/tests/extensionless-dynamic-import.test.ts
@@ -1,5 +1,17 @@
-import { describe, expect, it } from "vite-plus/test";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { build } from "vite";
 import { createExtensionlessDynamicImportPlugin } from "../packages/vinext/src/plugins/extensionless-dynamic-import.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const tempDir of tempDirs.splice(0)) {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
 
 function unwrapHook(hook: any): Function {
   return typeof hook === "function" ? hook : hook?.handler;
@@ -11,6 +23,27 @@ function createTransform(extensions?: string[]): Function {
     unwrapHook(plugin.configResolved).call(plugin, { resolve: { extensions } });
   }
   return unwrapHook(plugin.transform).bind(plugin);
+}
+
+function createPackageFixture(
+  packageName: string,
+  exports: Record<string, unknown>,
+  files: Record<string, string> = { "index.js": "export {};\n" },
+) {
+  const root = mkdtempSync(path.join(tmpdir(), "vinext-package-dynamic-import-"));
+  tempDirs.push(root);
+  const packageRoot = path.join(root, "node_modules", ...packageName.split("/"));
+  mkdirSync(packageRoot, { recursive: true });
+  writeFileSync(
+    path.join(packageRoot, "package.json"),
+    JSON.stringify({ name: packageName, type: "module", exports }),
+  );
+  for (const [filename, contents] of Object.entries(files)) {
+    const target = path.join(packageRoot, filename);
+    mkdirSync(path.dirname(target), { recursive: true });
+    writeFileSync(target, contents);
+  }
+  return { root, packageRoot, importer: path.join(root, "entry.ts") };
 }
 
 describe("vinext:extensionless-dynamic-import", () => {
@@ -125,6 +158,209 @@ describe("vinext:extensionless-dynamic-import", () => {
     const result = transform("await import(`${packageName}`)", "/app/page.tsx");
 
     expect(result).toBeNull();
+  });
+
+  it("expands variable package subpath imports through wildcard exports", () => {
+    // Mirrors nodejs.org's workspace package and import:
+    // https://github.com/nodejs/nodejs.org/blob/main/packages/i18n/package.json
+    // https://github.com/nodejs/nodejs.org/blob/main/apps/site/i18n.tsx
+    const root = mkdtempSync(path.join(tmpdir(), "vinext-package-dynamic-import-"));
+    tempDirs.push(root);
+    const appRoot = path.join(root, "apps", "site");
+    const packageRoot = path.join(root, "packages", "i18n");
+    mkdirSync(path.join(packageRoot, "src", "locales"), { recursive: true });
+    writeFileSync(
+      path.join(packageRoot, "package.json"),
+      JSON.stringify({
+        name: "@node-core/website-i18n",
+        type: "module",
+        exports: {
+          "./*": ["./src/*", "./src/*.d.ts", "./src/*.mjs", "./src/*.json"],
+          ".": "./src/index.mjs",
+        },
+      }),
+    );
+    writeFileSync(path.join(packageRoot, "src", "index.mjs"), "export const locales = ['en'];\n");
+    const packageLink = path.join(appRoot, "node_modules", "@node-core", "website-i18n");
+    mkdirSync(path.dirname(packageLink), { recursive: true });
+    symlinkSync(packageRoot, packageLink, process.platform === "win32" ? "junction" : "dir");
+
+    const transform = createTransform();
+    const importer = path.join(appRoot, "i18n.tsx");
+    const result = transform(
+      "await import(`@node-core/website-i18n/locales/${locale}.json`)",
+      importer,
+    );
+
+    expect(result.code).toContain('"../../packages/i18n/src/locales/*.json"');
+    expect(result.code).toContain("{ exhaustive: true }");
+    expect(result.code).toContain('"@node-core/website-i18n/".length');
+    expect(result.code).toContain('"../../packages/i18n/src/" + __vinextCapture');
+  });
+
+  it("honors the most specific wildcard export and explicit null targets", () => {
+    const packageName = "private-locales";
+    const { importer } = createPackageFixture(packageName, {
+      ".": "./index.js",
+      "./*": "./src/*",
+      "./private/*": null,
+    });
+
+    const transform = createTransform();
+    expect(
+      transform("await import(`private-locales/private/${locale}.json`)", importer),
+    ).toBeNull();
+  });
+
+  it("does not let a variable cross into a more-specific null export", () => {
+    const packageName = "variable-private-locales";
+    const { importer } = createPackageFixture(packageName, {
+      ".": "./index.js",
+      "./*": "./src/*",
+      "./private/*": null,
+    });
+
+    const transform = createTransform();
+    expect(transform("await import(`variable-private-locales/${name}.json`)", importer)).toBeNull();
+  });
+
+  it("does not let a variable cross into an exact export", () => {
+    const packageName = "variable-exact-locales";
+    const { importer } = createPackageFixture(packageName, {
+      ".": "./index.js",
+      "./*": "./src/*",
+      "./special.json": "./special.js",
+    });
+
+    const transform = createTransform();
+    expect(transform("await import(`variable-exact-locales/${name}.json`)", importer)).toBeNull();
+  });
+
+  it("selects the most specific wildcard export independent of insertion order", () => {
+    const packageName = "specific-locales";
+    const { importer } = createPackageFixture(packageName, {
+      ".": "./index.js",
+      "./*": "./src/*",
+      "./locales/*": "./translations/*",
+    });
+
+    const result = createTransform()(
+      "await import(`specific-locales/locales/${locale}.json`)",
+      importer,
+    );
+    expect(result.code).toContain('"./node_modules/specific-locales/translations/*.json"');
+    expect(result.code).not.toContain("/src/");
+  });
+
+  it("does not skip a valid unsupported first exports-array target", () => {
+    const packageName = "array-locales";
+    const { importer } = createPackageFixture(packageName, {
+      ".": "./index.js",
+      "./*": ["./shared.js", "./src/*"],
+    });
+
+    expect(createTransform()("await import(`array-locales/${locale}.json`)", importer)).toBeNull();
+  });
+
+  it("uses each Vite environment's export conditions and production state", () => {
+    const packageName = "conditional-locales";
+    const { importer } = createPackageFixture(packageName, {
+      ".": "./index.js",
+      "./locales/*": {
+        "react-server": {
+          development: "./rsc-development/*",
+          production: "./rsc-production/*",
+        },
+        default: "./client/*",
+      },
+    });
+    const plugin = createExtensionlessDynamicImportPlugin();
+    const transform = unwrapHook(plugin.transform);
+    const source = "await import(`conditional-locales/locales/${locale}.json`)";
+    const extensions = [".js", ".json"];
+
+    const rsc = transform.call(
+      {
+        environment: {
+          config: {
+            isProduction: true,
+            resolve: {
+              extensions,
+              conditions: ["react-server", "node", "development|production"],
+            },
+          },
+        },
+      },
+      source,
+      importer,
+    );
+    const client = transform.call(
+      {
+        environment: {
+          config: {
+            isProduction: false,
+            resolve: { extensions, conditions: ["browser", "development|production"] },
+          },
+        },
+      },
+      source,
+      importer,
+    );
+
+    expect(rsc.code).toContain("/rsc-production/");
+    expect(client.code).toContain("/client/");
+    expect(client).not.toBe(rsc);
+  });
+
+  it("bundles wildcard exports from packages physically installed in node_modules", async () => {
+    const packageName = "installed-locales";
+    const { root, importer } = createPackageFixture(
+      packageName,
+      { "./*": "./messages[prod]/*" },
+      {
+        "messages[prod]/en.json": '{"message":"English installed package"}',
+        "messages[prod]/locales/de.json": '{"message":"German nested installed package"}',
+      },
+    );
+    writeFileSync(
+      importer,
+      `export async function load(subpath: string) {
+  return (await import(\`installed-locales/\${subpath}\`)).default;
+}\n`,
+    );
+
+    const result = await build({
+      root,
+      logLevel: "silent",
+      plugins: [createExtensionlessDynamicImportPlugin()],
+      build: {
+        lib: { entry: importer, formats: ["es"] },
+        write: false,
+      },
+    });
+    const outputs = (Array.isArray(result) ? result : [result]).flatMap((item) =>
+      "output" in item ? item.output : [],
+    );
+    const emittedCode = outputs
+      .filter((item) => item.type === "chunk")
+      .map((item) => item.code)
+      .join("\n");
+
+    expect(emittedCode).toContain("English installed package");
+    expect(emittedCode).toContain("German nested installed package");
+  });
+
+  it("rejects Node-forbidden runtime package subpath segments", () => {
+    const packageName = "validated-locales";
+    const { importer } = createPackageFixture(packageName, {
+      ".": "./index.js",
+      "./*": "./src/*",
+    });
+
+    const result = createTransform()("await import(`validated-locales/${subpath}`)", importer);
+    expect(result.code).toContain("decodeURIComponent(__vinextSegment)");
+    expect(result.code).toContain('__vinextDecodedSegment.toLowerCase() === "node_modules"');
+    expect(result.code).toContain("!./node_modules/validated-locales/src/**/node_modules/**");
   });
 
   it("filters out dependency imports before invoking the handler", () => {

--- a/tests/extensionless-dynamic-import.test.ts
+++ b/tests/extensionless-dynamic-import.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "vite-plus/test";
 import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { build } from "vite";
 import { createExtensionlessDynamicImportPlugin } from "../packages/vinext/src/plugins/extensionless-dynamic-import.js";
 
@@ -312,6 +313,87 @@ describe("vinext:extensionless-dynamic-import", () => {
     expect(client).not.toBe(rsc);
   });
 
+  it("does not bypass Vite aliases when resolving package imports", () => {
+    const packageName = "aliased-locales";
+    const { root, importer } = createPackageFixture(packageName, {
+      ".": "./index.js",
+      "./*": "./physical-a/*",
+    });
+    const aliasedPackageRoot = path.join(root, "node_modules", "replacement-locales");
+    mkdirSync(aliasedPackageRoot, { recursive: true });
+    writeFileSync(
+      path.join(aliasedPackageRoot, "package.json"),
+      JSON.stringify({
+        name: "replacement-locales",
+        type: "module",
+        exports: { ".": "./index.js", "./*": "./physical-b/*" },
+      }),
+    );
+    writeFileSync(path.join(aliasedPackageRoot, "index.js"), "export {};\n");
+
+    const plugin = createExtensionlessDynamicImportPlugin();
+    unwrapHook(plugin.configResolved).call(plugin, {
+      resolve: {
+        alias: [{ find: packageName, replacement: "replacement-locales" }],
+        conditions: [],
+        extensions: [".js", ".json"],
+      },
+    });
+    const result = unwrapHook(plugin.transform).call(
+      plugin,
+      "await import(`aliased-locales/${locale}.json`)",
+      importer,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it.each([
+    { find: "aliased-locales/special.json", replacement: "replacement-locales/special.json" },
+    { find: /^aliased-locales\/.+/, replacement: "replacement-locales/$&" },
+  ])("does not let a variable package import cross alias $find", (alias) => {
+    const packageName = "aliased-locales";
+    const { importer } = createPackageFixture(packageName, {
+      ".": "./index.js",
+      "./*": "./physical/*",
+    });
+    const plugin = createExtensionlessDynamicImportPlugin();
+    unwrapHook(plugin.configResolved).call(plugin, {
+      resolve: {
+        alias: [alias],
+        conditions: [],
+        extensions: [".js", ".json"],
+      },
+    });
+
+    expect(
+      unwrapHook(plugin.transform).call(
+        plugin,
+        "await import(`aliased-locales/${locale}.json`)",
+        importer,
+      ),
+    ).toBeNull();
+  });
+
+  it("does not cross a nested package scope for package self-resolution", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "vinext-package-dynamic-import-"));
+    tempDirs.push(root);
+    writeFileSync(
+      path.join(root, "package.json"),
+      JSON.stringify({ name: "root-locales", exports: { "./*": "./messages/*" } }),
+    );
+    const appRoot = path.join(root, "apps", "site");
+    mkdirSync(appRoot, { recursive: true });
+    writeFileSync(path.join(appRoot, "package.json"), JSON.stringify({ name: "site" }));
+
+    const result = createTransform()(
+      "await import(`root-locales/${locale}.json`)",
+      path.join(appRoot, "entry.ts"),
+    );
+
+    expect(result).toBeNull();
+  });
+
   it("bundles wildcard exports from packages physically installed in node_modules", async () => {
     const packageName = "installed-locales";
     const { root, importer } = createPackageFixture(
@@ -350,6 +432,46 @@ describe("vinext:extensionless-dynamic-import", () => {
     expect(emittedCode).toContain("German nested installed package");
   });
 
+  it("decodes package export targets and runtime captures like Node", async () => {
+    const packageName = "encoded-locales";
+    const { root, importer } = createPackageFixture(
+      packageName,
+      { "./*": "./messages%20files/*" },
+      {
+        "messages files/hello world.js": 'export default "decoded package import";\n',
+        "messages files/hash#file.js": 'export default "decoded hash import";\n',
+        "messages files/foo/bar.js": 'export default "normalized slash import";\n',
+      },
+    );
+    writeFileSync(
+      importer,
+      `export async function load(subpath) {
+  return (await import(\`encoded-locales/\${subpath}\`)).default;
+}
+export async function loadStaticPrefix(name) {
+  return (await import(\`encoded-locales/hello%20\${name}.js\`)).default;
+}\n`,
+    );
+
+    await build({
+      root,
+      logLevel: "silent",
+      plugins: [createExtensionlessDynamicImportPlugin()],
+      build: {
+        lib: { entry: importer, formats: ["es"], fileName: () => "entry.mjs" },
+        outDir: "dist",
+      },
+    });
+    const output = await import(pathToFileURL(path.join(root, "dist", "entry.mjs")).href);
+
+    await expect(output.load("hello%20world.js")).resolves.toBe("decoded package import");
+    await expect(output.loadStaticPrefix("world")).resolves.toBe("decoded package import");
+    await expect(output.load("hash%23file.js")).resolves.toBe("decoded hash import");
+    await expect(output.load("hash#file.js")).rejects.toThrow("Cannot find module");
+    await expect(output.load("foo//bar.js")).resolves.toBe("normalized slash import");
+    await expect(output.load("/foo/bar.js")).resolves.toBe("normalized slash import");
+  });
+
   it("rejects Node-forbidden runtime package subpath segments", () => {
     const packageName = "validated-locales";
     const { importer } = createPackageFixture(packageName, {
@@ -359,8 +481,40 @@ describe("vinext:extensionless-dynamic-import", () => {
 
     const result = createTransform()("await import(`validated-locales/${subpath}`)", importer);
     expect(result.code).toContain("decodeURIComponent(__vinextSegment)");
-    expect(result.code).toContain('__vinextDecodedSegment.toLowerCase() === "node_modules"');
+    expect(result.code).toContain('__vinextSegment.toLowerCase() === "node_modules"');
     expect(result.code).toContain("!./node_modules/validated-locales/src/**/node_modules/**");
+  });
+
+  it.each([
+    "./src/../private/*",
+    "./src/%2e%2e/private/*",
+    "./src/node_modules/*",
+    "./src#fragment/*",
+    "./src?query/*",
+  ])("leaves Node-invalid package export target %s unchanged", (target) => {
+    const packageName = "invalid-target-locales";
+    const { importer } = createPackageFixture(packageName, {
+      ".": "./index.js",
+      "./*": target,
+    });
+
+    expect(
+      createTransform()(`await import(\`invalid-target-locales/\${locale}.json\`)`, importer),
+    ).toBeNull();
+  });
+
+  it("escapes package export metadata embedded in generated JavaScript", () => {
+    const packageName = "escaped-locales";
+    const { importer } = createPackageFixture(packageName, {
+      ".": "./index.js",
+      "./prefix</script>/*</script>": "./messages</script>/*</script>",
+    });
+
+    const importSource = "`escaped-locales/prefix</script>/${locale}</script>`";
+    const result = createTransform()(`await import(${importSource})`, importer);
+
+    expect(result.code.replace(importSource, "")).not.toContain("</script>");
+    expect(result.code).toContain("\\u003C/script\\u003E");
   });
 
   it("filters out dependency imports before invoking the handler", () => {
@@ -381,6 +535,18 @@ describe("vinext:extensionless-dynamic-import", () => {
     );
 
     expect(result).toBeNull();
+  });
+
+  it("preserves native imports when percent escapes can span an export wildcard", () => {
+    const packageName = "split-escape-locales";
+    const { importer } = createPackageFixture(packageName, {
+      ".": "./index.js",
+      "./foo*0bar": "./src/*0file.js",
+    });
+
+    expect(
+      createTransform()(`await import(\`split-escape-locales/foo\${value}0bar\`)`, importer),
+    ).toBeNull();
   });
 
   it.each([

--- a/tests/fixtures/ecosystem/next-intl/app/[locale]/layout.tsx
+++ b/tests/fixtures/ecosystem/next-intl/app/[locale]/layout.tsx
@@ -16,6 +16,9 @@ export default async function LocaleLayout({
     notFound();
   }
 
+  // Middleware only negotiates the root redirect in this fixture. Locale
+  // routes use next-intl's public request-scoped API instead of a private
+  // X-NEXT-INTL-LOCALE header.
   setRequestLocale(locale);
   const messages = await getMessages();
 

--- a/tests/fixtures/ecosystem/next-intl/i18n/request.ts
+++ b/tests/fixtures/ecosystem/next-intl/i18n/request.ts
@@ -8,6 +8,6 @@ export default getRequestConfig(async ({ requestLocale }) => {
   const resolvedLocale = hasLocale(locales, requested) ? requested : "en";
   return {
     locale: resolvedLocale,
-    messages: (await import(`../messages/${resolvedLocale}.json`)).default,
+    messages: (await import(`@vinext-test/next-intl/locales/${resolvedLocale}.json`)).default,
   };
 });

--- a/tests/fixtures/ecosystem/next-intl/middleware.ts
+++ b/tests/fixtures/ecosystem/next-intl/middleware.ts
@@ -1,0 +1,11 @@
+import createMiddleware from "next-intl/middleware";
+
+export default createMiddleware({
+  locales: ["en", "de"],
+  defaultLocale: "en",
+  localePrefix: "always",
+});
+
+// Match nodejs.org's routing: middleware negotiates the root redirect, while
+// the locale layout supplies setRequestLocale() for locale-prefixed pages.
+export const config = { matcher: ["/"] };

--- a/tests/fixtures/ecosystem/next-intl/package-entry.ts
+++ b/tests/fixtures/ecosystem/next-intl/package-entry.ts
@@ -1,0 +1,1 @@
+export const locales = ["en", "de"] as const;

--- a/tests/fixtures/ecosystem/next-intl/package.json
+++ b/tests/fixtures/ecosystem/next-intl/package.json
@@ -1,7 +1,11 @@
 {
-  "name": "ecosystem-next-intl",
+  "name": "@vinext-test/next-intl",
   "private": true,
   "type": "module",
+  "exports": {
+    ".": "./package-entry.ts",
+    "./locales/*": ["./messages/*", "./messages/*.json"]
+  },
   "dependencies": {
     "react": "catalog:",
     "react-dom": "catalog:",


### PR DESCRIPTION
## Summary

- transform variable bare-package imports through wildcard `package.json` exports while preserving Node export precedence, conditions, invalid-subpath rules, and array semantics
- generate Vite glob maps that support workspace packages, physical `node_modules` packages, nested captures, and literal glob metacharacters
- mirror nodejs.org's next-intl dynamic locale-package pattern in the ecosystem fixture while using next-intl's public `setRequestLocale` API

Downstream reproduction: https://github.com/nodejs/nodejs.org/compare/main...james-elicx:nodejs.org:james/vinext?expand=1

## Validation

- `vp check packages/vinext/src/plugins/extensionless-dynamic-import.ts tests/extensionless-dynamic-import.test.ts tests/ecosystem.test.ts tests/fixtures/ecosystem/next-intl`
- `vp test run tests/extensionless-dynamic-import.test.ts` (30 tests)
- `vp run vinext#build`
- `vp test run tests/ecosystem.test.ts -t next-intl`
- `npx --no-install vinext build` in the next-intl fixture
- independent review loop: clean after all findings were addressed