### PR TITLE
fix(build): recognize Vite dist client aliases

### DIFF
--- a/packages/vinext/src/plugins/extensionless-dynamic-import.ts
+++ b/packages/vinext/src/plugins/extensionless-dynamic-import.ts
@@ -411,11 +411,14 @@ function aliasesMayMatch(aliases: readonly Alias[], requestPattern: string): boo
 function isViteInternalAlias(alias: Alias): boolean {
   if (!(alias.find instanceof RegExp)) return false;
   const replacement = toSlash(alias.replacement);
-  const source = replacement.endsWith("/vite/client/env.mjs")
-    ? "@vite/env"
-    : replacement.endsWith("/vite/client/client.mjs")
-      ? "@vite/client"
-      : null;
+  const source =
+    replacement.endsWith("/vite/client/env.mjs") ||
+    replacement.endsWith("/vite/dist/client/env.mjs")
+      ? "@vite/env"
+      : replacement.endsWith("/vite/client/client.mjs") ||
+          replacement.endsWith("/vite/dist/client/client.mjs")
+        ? "@vite/client"
+        : null;
   if (source === null) return false;
   alias.find.lastIndex = 0;
   const matches = alias.find.test(source);

--- a/tests/extensionless-dynamic-import.test.ts
+++ b/tests/extensionless-dynamic-import.test.ts
@@ -375,6 +375,38 @@ describe("vinext:extensionless-dynamic-import", () => {
     ).toBeNull();
   });
 
+  it.each([
+    { find: /^@vite\/env$/, filename: "env.mjs" },
+    { find: /^@vite\/client$/, filename: "client.mjs" },
+  ])("ignores Vite's dist client alias $find", ({ find, filename }) => {
+    const packageName = "vite-internal-alias-locales";
+    const { importer } = createPackageFixture(packageName, {
+      ".": "./index.js",
+      "./*": "./messages/*",
+    });
+    const plugin = createExtensionlessDynamicImportPlugin();
+    unwrapHook(plugin.configResolved).call(plugin, {
+      resolve: {
+        alias: [
+          {
+            find,
+            replacement: `/workspace/node_modules/vite/dist/client/${filename}`,
+          },
+        ],
+        conditions: [],
+        extensions: [".js", ".json"],
+      },
+    });
+
+    const result = unwrapHook(plugin.transform).call(
+      plugin,
+      "await import(`vite-internal-alias-locales/${locale}.json`)",
+      importer,
+    );
+
+    expect(result?.code).toContain("import.meta.glob");
+  });
+
   it("does not cross a nested package scope for package self-resolution", () => {
     const root = mkdtempSync(path.join(tmpdir(), "vinext-package-dynamic-import-"));
     tempDirs.push(root);


### PR DESCRIPTION
## Summary
- recognize Vite built-in @vite/env and @vite/client aliases when their replacements use the current vite/dist/client layout
- keep the legacy vite/client layout supported
- add focused regression coverage for both internal aliases

## Regression proof
The two new focused cases both failed before the implementation because the package import transform returned null after treating the Vite regex aliases as user aliases.

## Validation
- vp test run tests/extensionless-dynamic-import.test.ts (44 passed)
- vp check packages/vinext/src/plugins/extensionless-dynamic-import.ts tests/extensionless-dynamic-import.test.ts
- vp run vinext#build