### PR TITLE
fix(app-router): render pages before consuming layouts

### DIFF
--- a/packages/vinext/src/server/app-page-element-builder.ts
+++ b/packages/vinext/src/server/app-page-element-builder.ts
@@ -70,8 +70,15 @@ function isReactOwnedPageComponent(component: AppPageComponent): boolean {
   );
 }
 
-function isDeclaredAsyncFunction(component: (...args: never[]) => unknown): boolean {
-  return component.constructor.name === "AsyncFunction";
+function isReactSuspension(error: unknown): boolean {
+  if (isPromiseLike(error)) {
+    return true;
+  }
+
+  return (
+    error instanceof Error &&
+    error.message.startsWith("Suspense Exception: This is not a real error!")
+  );
 }
 
 /**
@@ -533,15 +540,6 @@ export async function buildPageElements<
           : makeThenableParams(pageSearchParams);
       }
 
-      // Sync server components must remain owned by React so hooks such as
-      // use(promise) suspend inside the route's loading boundary. The
-      // request-state ordering guarantee is only needed for declared async
-      // pages, which can initialize state immediately after awaiting params.
-      if (!isDeclaredAsyncFunction(ServerPageComponent)) {
-        renderDependency?.release();
-        return createElement(ServerPageComponent as unknown as AppPageComponent, invocationProps);
-      }
-
       try {
         const result = ServerPageComponent(invocationProps);
         if (isPromiseLike(result)) {
@@ -560,6 +558,15 @@ export async function buildPageElements<
         renderDependency?.release();
         return result;
       } catch (error) {
+        if (isReactSuspension(error)) {
+          // React requires its internal use() suspension value to be rethrown
+          // immediately. Release from a microtask so the page-entry Suspense
+          // boundary can serialize its fallback and dependent entries can run.
+          if (renderDependency) {
+            void Promise.resolve().then(() => renderDependency.release());
+          }
+          throw error;
+        }
         renderDependency?.release();
         throw error;
       }

--- a/packages/vinext/src/server/app-page-element-builder.ts
+++ b/packages/vinext/src/server/app-page-element-builder.ts
@@ -70,15 +70,8 @@ function isReactOwnedPageComponent(component: AppPageComponent): boolean {
   );
 }
 
-function isReactSuspension(error: unknown): boolean {
-  if (isPromiseLike(error)) {
-    return true;
-  }
-
-  return (
-    error instanceof Error &&
-    error.message.startsWith("Suspense Exception: This is not a real error!")
-  );
+function isDeclaredAsyncFunction(component: (...args: never[]) => unknown): boolean {
+  return component.constructor.name === "AsyncFunction";
 }
 
 /**
@@ -539,14 +532,26 @@ export async function buildPageElements<
           ? makeObservedAppPageSearchParamsThenable(pageSearchParams)
           : makeThenableParams(pageSearchParams);
       }
+
+      // Sync server components must remain owned by React so hooks such as
+      // use(promise) suspend inside the route's loading boundary. The
+      // request-state ordering guarantee is only needed for declared async
+      // pages, which can initialize state immediately after awaiting params.
+      if (!isDeclaredAsyncFunction(ServerPageComponent)) {
+        renderDependency?.release();
+        return createElement(ServerPageComponent as unknown as AppPageComponent, invocationProps);
+      }
+
       try {
         const result = ServerPageComponent(invocationProps);
         if (isPromiseLike(result)) {
-          // Async components execute synchronously until their first await. Let
-          // one continuation run before layouts consume request state (for
-          // example `await params; setRequestLocale(locale)`), but do not wait
-          // for the whole page promise: loading.tsx must still be able to stream
-          // while the page performs slower data work.
+          // Consumers have already suspended on the dependency via use().
+          // Releasing it from a queued microtask schedules their replay behind
+          // the page's immediate post-params continuation (for example
+          // `await params; setRequestLocale(locale)`). Do not wait for the full
+          // page promise: loading.tsx must still stream during slower data work.
+          // Request state needed by a parent must therefore be established in
+          // that immediate continuation, before the page starts slower awaits.
           if (renderDependency) {
             void Promise.resolve().then(() => renderDependency.release());
           }
@@ -555,12 +560,6 @@ export async function buildPageElements<
         renderDependency?.release();
         return result;
       } catch (error) {
-        // React's use() implementation suspends by throwing an internal value.
-        // It must reach React unchanged and without releasing dependent layouts;
-        // React will retry this component after the thenable resolves.
-        if (isReactSuspension(error)) {
-          throw error;
-        }
         renderDependency?.release();
         throw error;
       }

--- a/packages/vinext/src/server/app-page-element-builder.ts
+++ b/packages/vinext/src/server/app-page-element-builder.ts
@@ -41,6 +41,8 @@ import {
 } from "./app-page-search-params-observation.js";
 import { shouldServeStreamingMetadata } from "./streaming-metadata.js";
 import { resolveAppPageBranchParams, resolveAppPageSegmentParams } from "./app-page-params.js";
+import { createAppRenderDependency, type AppRenderDependency } from "./app-render-dependency.js";
+import { isPromiseLike } from "../utils/promise.js";
 
 function resolveInterceptLayoutParams(
   branchSegments: readonly string[],
@@ -495,9 +497,14 @@ export async function buildPageElements<
 
   const pageProps: Record<string, unknown> = { params: makeThenableParams(effectiveParams) };
   const hasRequestSearchParams = Object.keys(pageSearchParams).length > 0;
+  const pageRenderDependency =
+    EffectivePageComponent && !isReactOwnedPageComponent(EffectivePageComponent)
+      ? createAppRenderDependency()
+      : null;
   const createPageElement = (
     PageComponent: AppPageComponent,
     props: Readonly<Record<string, unknown>>,
+    renderDependency?: AppRenderDependency | null,
   ) => {
     if (isReactOwnedPageComponent(PageComponent)) {
       const invocationProps = { ...props };
@@ -521,7 +528,17 @@ export async function buildPageElements<
           ? makeObservedAppPageSearchParamsThenable(pageSearchParams)
           : makeThenableParams(pageSearchParams);
       }
-      return ServerPageComponent(invocationProps);
+      try {
+        const result = ServerPageComponent(invocationProps);
+        if (isPromiseLike(result)) {
+          return Promise.resolve(result).finally(() => renderDependency?.release());
+        }
+        renderDependency?.release();
+        return result;
+      } catch (error) {
+        renderDependency?.release();
+        throw error;
+      }
     };
     return createElement(PageInvoker as unknown as AppPageComponent);
   };
@@ -538,7 +555,7 @@ export async function buildPageElements<
   // so a layout.tsx adjacent to the (.) / (..) / (...) marker dir is respected.
   let siblingInterceptElement: ReturnType<typeof createElement> | null =
     isSiblingIntercept && EffectivePageComponent
-      ? createPageElement(EffectivePageComponent, pageProps)
+      ? createPageElement(EffectivePageComponent, pageProps, pageRenderDependency)
       : null;
   if (isSiblingIntercept && siblingInterceptElement !== null) {
     const layoutIndexesByTreePosition = new Map<number, number[]>();
@@ -596,7 +613,7 @@ export async function buildPageElements<
     element: isSiblingIntercept
       ? siblingInterceptElement
       : EffectivePageComponent
-        ? createPageElement(EffectivePageComponent, pageProps)
+        ? createPageElement(EffectivePageComponent, pageProps, pageRenderDependency)
         : null,
     createPageElement,
     // Fall back to vinext's built-in default global error module so that
@@ -610,6 +627,7 @@ export async function buildPageElements<
     mountedSlotIds,
     makeThenableParams,
     matchedParams: params,
+    pageRenderDependency,
     metadataPlacement,
     resolvedMetadata,
     resolvedMetadataPathname: routePath,

--- a/packages/vinext/src/server/app-page-element-builder.ts
+++ b/packages/vinext/src/server/app-page-element-builder.ts
@@ -508,6 +508,22 @@ export async function buildPageElements<
 
   const pageProps: Record<string, unknown> = { params: makeThenableParams(effectiveParams) };
   const hasRequestSearchParams = Object.keys(pageSearchParams).length > 0;
+  const pageTreePosition = (sourcePageSegments ?? route.routeSegments ?? []).length;
+  const hasLoadingModuleAtOrAbovePage = (
+    modules: readonly (TModule | null | undefined)[] | null | undefined,
+    treePositions: readonly number[] | null | undefined,
+  ): boolean =>
+    (modules ?? []).some((module, index) => {
+      const treePosition = treePositions?.[index];
+      return (
+        Boolean(module?.default) && treePosition !== undefined && treePosition <= pageTreePosition
+      );
+    });
+  const hasPageLoadingBoundary =
+    Boolean(route.loading?.default) ||
+    hasLoadingModuleAtOrAbovePage(route.loadings, route.loadingTreePositions) ||
+    (isSiblingIntercept &&
+      hasLoadingModuleAtOrAbovePage(opts?.interceptLoadings, opts?.interceptLoadingTreePositions));
   const pageRenderDependency =
     EffectivePageComponent && !isReactOwnedPageComponent(EffectivePageComponent)
       ? createAppRenderDependency()
@@ -543,15 +559,23 @@ export async function buildPageElements<
       try {
         const result = ServerPageComponent(invocationProps);
         if (isPromiseLike(result)) {
-          // Consumers have already suspended on the dependency via use().
-          // Releasing it from a queued microtask schedules their replay behind
-          // the page's immediate post-params continuation (for example
-          // `await params; setRequestLocale(locale)`). Do not wait for the full
-          // page promise: loading.tsx must still stream during slower data work.
-          // Request state needed by a parent must therefore be established in
-          // that immediate continuation, before the page starts slower awaits.
           if (renderDependency) {
-            void Promise.resolve().then(() => renderDependency.release());
+            if (hasPageLoadingBoundary) {
+              // A loading boundary needs the dependent route/layout entries to
+              // serialize while the page is still pending so its fallback can
+              // stream. Request state consumed by those entries must therefore
+              // be established in the page's first continuation; an async
+              // consumer gets its own continuation before reading that state.
+              void Promise.resolve().then(() => renderDependency.release());
+            } else {
+              // With no loading UI to stream, preserve the stronger ordering
+              // contract: even a synchronous layout cannot observe request
+              // state until the async page has finished initializing it.
+              void Promise.resolve(result).then(
+                () => renderDependency.release(),
+                () => renderDependency.release(),
+              );
+            }
           }
           return result;
         }
@@ -560,9 +584,12 @@ export async function buildPageElements<
       } catch (error) {
         if (isReactSuspension(error)) {
           // React requires its internal use() suspension value to be rethrown
-          // immediately. Release from a microtask so the page-entry Suspense
-          // boundary can serialize its fallback and dependent entries can run.
-          if (renderDependency) {
+          // immediately. With loading UI, release from a microtask so the
+          // page-entry Suspense boundary can serialize its fallback. Without
+          // loading UI, the page retry releases the dependency after it can
+          // render, preserving the same page-before-layout ordering as an
+          // ordinary async return.
+          if (renderDependency && hasPageLoadingBoundary) {
             void Promise.resolve().then(() => renderDependency.release());
           }
           throw error;

--- a/packages/vinext/src/server/app-page-element-builder.ts
+++ b/packages/vinext/src/server/app-page-element-builder.ts
@@ -70,6 +70,17 @@ function isReactOwnedPageComponent(component: AppPageComponent): boolean {
   );
 }
 
+function isReactSuspension(error: unknown): boolean {
+  if (isPromiseLike(error)) {
+    return true;
+  }
+
+  return (
+    error instanceof Error &&
+    error.message.startsWith("Suspense Exception: This is not a real error!")
+  );
+}
+
 /**
  * Route shape passed from the generated entry. Extends the wiring route with
  * the page module reference (used to extract the default export for the page
@@ -531,11 +542,25 @@ export async function buildPageElements<
       try {
         const result = ServerPageComponent(invocationProps);
         if (isPromiseLike(result)) {
-          return Promise.resolve(result).finally(() => renderDependency?.release());
+          // Async components execute synchronously until their first await. Let
+          // one continuation run before layouts consume request state (for
+          // example `await params; setRequestLocale(locale)`), but do not wait
+          // for the whole page promise: loading.tsx must still be able to stream
+          // while the page performs slower data work.
+          if (renderDependency) {
+            void Promise.resolve().then(() => renderDependency.release());
+          }
+          return result;
         }
         renderDependency?.release();
         return result;
       } catch (error) {
+        // React's use() implementation suspends by throwing an internal value.
+        // It must reach React unchanged and without releasing dependent layouts;
+        // React will retry this component after the thenable resolves.
+        if (isReactSuspension(error)) {
+          throw error;
+        }
         renderDependency?.release();
         throw error;
       }

--- a/packages/vinext/src/server/app-page-element-builder.ts
+++ b/packages/vinext/src/server/app-page-element-builder.ts
@@ -14,6 +14,7 @@ import {
   buildAppPageElements,
   createAppPageSourcePage,
   createAppPageTreePath,
+  resolveAppPageLoadingModuleAtOrAbove,
   type AppPageErrorModule,
   type AppPageModule,
   type AppPageRouteWiringRoute,
@@ -509,21 +510,17 @@ export async function buildPageElements<
   const pageProps: Record<string, unknown> = { params: makeThenableParams(effectiveParams) };
   const hasRequestSearchParams = Object.keys(pageSearchParams).length > 0;
   const pageTreePosition = (sourcePageSegments ?? route.routeSegments ?? []).length;
-  const hasLoadingModuleAtOrAbovePage = (
-    modules: readonly (TModule | null | undefined)[] | null | undefined,
-    treePositions: readonly number[] | null | undefined,
-  ): boolean =>
-    (modules ?? []).some((module, index) => {
-      const treePosition = treePositions?.[index];
-      return (
-        Boolean(module?.default) && treePosition !== undefined && treePosition <= pageTreePosition
-      );
-    });
   const hasPageLoadingBoundary =
-    Boolean(route.loading?.default) ||
-    hasLoadingModuleAtOrAbovePage(route.loadings, route.loadingTreePositions) ||
+    resolveAppPageLoadingModuleAtOrAbove(route, pageTreePosition) !== null ||
     (isSiblingIntercept &&
-      hasLoadingModuleAtOrAbovePage(opts?.interceptLoadings, opts?.interceptLoadingTreePositions));
+      resolveAppPageLoadingModuleAtOrAbove(
+        {
+          loading: null,
+          loadings: opts?.interceptLoadings,
+          loadingTreePositions: opts?.interceptLoadingTreePositions,
+        },
+        pageTreePosition,
+      ) !== null);
   const pageRenderDependency =
     EffectivePageComponent && !isReactOwnedPageComponent(EffectivePageComponent)
       ? createAppRenderDependency()

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -242,6 +242,7 @@ type BuildAppPageRouteElementOptions<
     component: AppPageComponent,
     props: Readonly<Record<string, unknown>>,
   ) => ReactNode;
+  pageRenderDependency?: AppRenderDependency | null;
   searchParams?: unknown;
   slotOverrides?: Readonly<Record<string, AppPageSlotOverride<TModule>>> | null;
 };
@@ -833,6 +834,9 @@ export function buildAppPageElements<
   };
   const isPrefetchEmpty = renderMode === APP_RSC_RENDER_MODE_PREFETCH_EMPTY;
   const isPrefetchLoadingShell = renderMode === APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL;
+  // Loading-shell prefetches intentionally omit the page, so they cannot wait
+  // on a dependency that only the page invocation can release.
+  const pageRenderDependency = isPrefetchLoadingShell ? null : options.pageRenderDependency;
   const prefetchLoadingEntry = isPrefetchLoadingShell
     ? getPrefetchLoadingEntry(options.route)
     : null;
@@ -1045,7 +1049,9 @@ export function buildAppPageElements<
 
   elements[pageElementId] = isPrefetchLoadingShell
     ? null
-    : renderAfterAppDependencies(options.element, pageDependencies);
+    : pageRenderDependency
+      ? options.element
+      : renderAfterAppDependencies(options.element, pageDependencies);
 
   for (const templateEntry of templateEntries) {
     if (isPrefetchLoadingShell && !includesPrefetchTreePosition(templateEntry.treePosition)) {
@@ -1080,10 +1086,10 @@ export function buildAppPageElements<
         </Suspense>
       );
     }
-    elements[templateEntry.id] = renderAfterAppDependencies(
-      templateElement,
-      templateDependenciesBeforeById.get(templateEntry.id) ?? [],
-    );
+    elements[templateEntry.id] = renderAfterAppDependencies(templateElement, [
+      ...(pageRenderDependency ? [pageRenderDependency] : []),
+      ...(templateDependenciesBeforeById.get(templateEntry.id) ?? []),
+    ]);
   }
 
   for (let index = 0; index < layoutEntries.length; index++) {
@@ -1149,10 +1155,10 @@ export function buildAppPageElements<
         </Suspense>
       );
     }
-    elements[layoutEntry.id] = renderAfterAppDependencies(
-      layoutElement,
-      layoutDependenciesBefore[index] ?? [],
-    );
+    elements[layoutEntry.id] = renderAfterAppDependencies(layoutElement, [
+      ...(pageRenderDependency ? [pageRenderDependency] : []),
+      ...(layoutDependenciesBefore[index] ?? []),
+    ]);
   }
 
   for (const slotPlan of segmentPlan.slots) {
@@ -1710,7 +1716,7 @@ export function buildAppPageElements<
     </GlobalErrorBoundary>
   );
 
-  elements[routeId] = (
+  const routeElement = (
     <>
       {createAppPageRouteHead(
         options.resolvedMetadata,
@@ -1730,6 +1736,9 @@ export function buildAppPageElements<
       {createAppPageStreamingMetadataBody(streamingMetadataBodyId)}
     </>
   );
+  elements[routeId] = pageRenderDependency
+    ? renderAfterAppDependencies(routeElement, [pageRenderDependency])
+    : routeElement;
 
   // Merge only after rendering is complete so metadata never participates in
   // element construction, without copying the rendered element map on return.

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -1416,10 +1416,10 @@ export function buildAppPageElements<
       );
     }
 
-    elements[slotId] = renderAfterAppDependencies(
-      slotElement,
-      targetIndex >= 0 ? (slotDependenciesByLayoutIndex[targetIndex] ?? []) : [],
-    );
+    elements[slotId] = renderAfterAppDependencies(slotElement, [
+      ...(pageRenderDependency ? [pageRenderDependency] : []),
+      ...(targetIndex >= 0 ? (slotDependenciesByLayoutIndex[targetIndex] ?? []) : []),
+    ]);
   }
 
   let routeChildren: ReactNode = (

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -1047,11 +1047,22 @@ export function buildAppPageElements<
     elements[APP_PREFETCH_LOADING_SHELL_MARKER_KEY] = "LoadingBoundary";
   }
 
+  const pageLoadingEntry = findNearestLoadingEntryAtOrAbove(routeSegments.length);
+  const PageLoadingComponent = pageRenderDependency
+    ? (getDefaultExport(pageLoadingEntry?.loadingModule) ?? routeLoadingComponent)
+    : null;
+  const pageElement = PageLoadingComponent ? (
+    <Suspense key={routeResetKey} fallback={<PageLoadingComponent />}>
+      {options.element}
+    </Suspense>
+  ) : (
+    options.element
+  );
   elements[pageElementId] = isPrefetchLoadingShell
     ? null
     : pageRenderDependency
-      ? options.element
-      : renderAfterAppDependencies(options.element, pageDependencies);
+      ? pageElement
+      : renderAfterAppDependencies(pageElement, pageDependencies);
 
   for (const templateEntry of templateEntries) {
     if (isPrefetchLoadingShell && !includesPrefetchTreePosition(templateEntry.treePosition)) {

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -1048,6 +1048,12 @@ export function buildAppPageElements<
   }
 
   const pageLoadingEntry = findNearestLoadingEntryAtOrAbove(routeSegments.length);
+  // The page and route are sibling values in vinext's flat Flight record. The
+  // route-level Suspense below cannot catch the page value suspending while the
+  // record itself is serialized, so the page entry needs its own boundary to
+  // expose the fallback. Once <Slot> reconnects the entries this is nested
+  // inside the route boundary; that duplication is an intentional transport
+  // artifact, not two independently selected loading conventions.
   const PageLoadingComponent = pageRenderDependency
     ? (getDefaultExport(pageLoadingEntry?.loadingModule) ?? routeLoadingComponent)
     : null;

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -471,6 +471,27 @@ function createAppPageLoadingEntries<TModule extends AppPageModule>(
   });
 }
 
+export function resolveAppPageLoadingModuleAtOrAbove<TModule extends AppPageModule>(
+  route: Pick<AppPageRouteWiringRoute<TModule>, "loading" | "loadings" | "loadingTreePositions">,
+  treePosition: number,
+): TModule | null {
+  let nearest: AppPageLoadingEntry<TModule> | null = null;
+  for (const entry of createAppPageLoadingEntries(route)) {
+    if (
+      entry.treePosition <= treePosition &&
+      getDefaultExport(entry.loadingModule) !== null &&
+      (nearest === null || entry.treePosition > nearest.treePosition)
+    ) {
+      nearest = entry;
+    }
+  }
+
+  if (nearest?.loadingModule) {
+    return nearest.loadingModule;
+  }
+  return getDefaultExport(route.loading) === null ? null : (route.loading ?? null);
+}
+
 function getPrefetchLoadingEntry<TModule extends AppPageModule>(
   route: Pick<
     AppPageRouteWiringRoute<TModule>,
@@ -1047,16 +1068,17 @@ export function buildAppPageElements<
     elements[APP_PREFETCH_LOADING_SHELL_MARKER_KEY] = "LoadingBoundary";
   }
 
-  const pageLoadingEntry = findNearestLoadingEntryAtOrAbove(routeSegments.length);
+  const pageLoadingModule = resolveAppPageLoadingModuleAtOrAbove(
+    options.route,
+    routeSegments.length,
+  );
   // The page and route are sibling values in vinext's flat Flight record. The
   // route-level Suspense below cannot catch the page value suspending while the
   // record itself is serialized, so the page entry needs its own boundary to
   // expose the fallback. Once <Slot> reconnects the entries this is nested
   // inside the route boundary; that duplication is an intentional transport
   // artifact, not two independently selected loading conventions.
-  const PageLoadingComponent = pageRenderDependency
-    ? (getDefaultExport(pageLoadingEntry?.loadingModule) ?? routeLoadingComponent)
-    : null;
+  const PageLoadingComponent = pageRenderDependency ? getDefaultExport(pageLoadingModule) : null;
   const pageElement = PageLoadingComponent ? (
     <Suspense key={routeResetKey} fallback={<PageLoadingComponent />}>
       {options.element}

--- a/packages/vinext/src/server/app-render-dependency.tsx
+++ b/packages/vinext/src/server/app-render-dependency.tsx
@@ -53,6 +53,9 @@ export function renderAfterAppDependencies(
     return children;
   }
 
+  // AppRenderDependency promises are resolve-only by construction. If an
+  // abort/reject path is added later, use() will deliberately surface that
+  // rejection through the render error-boundary path.
   const pendingDependencies = Promise.all(dependencies.map((dependency) => dependency.promise));
 
   function AwaitAppRenderDependencies() {

--- a/packages/vinext/src/server/app-render-dependency.tsx
+++ b/packages/vinext/src/server/app-render-dependency.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from "react";
+import { use, type ReactNode } from "react";
 
 export type AppRenderDependency = {
   promise: Promise<void>;
@@ -53,8 +53,10 @@ export function renderAfterAppDependencies(
     return children;
   }
 
-  async function AwaitAppRenderDependencies() {
-    await Promise.all(dependencies.map((dependency) => dependency.promise));
+  const pendingDependencies = Promise.all(dependencies.map((dependency) => dependency.promise));
+
+  function AwaitAppRenderDependencies() {
+    use(pendingDependencies);
     return children;
   }
 

--- a/tests/app-page-dispatch.test.ts
+++ b/tests/app-page-dispatch.test.ts
@@ -175,7 +175,11 @@ async function renderReactNodeText(node: unknown): Promise<string> {
   }
   if (!React.isValidElement<{ children?: unknown }>(node)) return "";
 
-  if (node.type === React.Fragment || typeof node.type === "string") {
+  if (
+    node.type === React.Fragment ||
+    node.type === React.Suspense ||
+    typeof node.type === "string"
+  ) {
     return renderReactNodeText(node.props.children);
   }
   if (typeof node.type === "function") {

--- a/tests/app-page-element-builder.test.ts
+++ b/tests/app-page-element-builder.test.ts
@@ -322,6 +322,46 @@ describe("buildPageElements", () => {
     expect(html).not.toContain("layout:en");
   });
 
+  it("waits for a sync use() page before a synchronous layout without loading UI", async () => {
+    let resolveLocale!: (locale: string) => void;
+    const localePromise = new Promise<string>((resolve) => {
+      resolveLocale = resolve;
+    });
+    let requestLocale = "en";
+
+    function LocalePage() {
+      requestLocale = React.use(localePromise);
+      return React.createElement("main", null, `page:${requestLocale}`);
+    }
+
+    function LocaleLayout(props: Record<string, unknown>) {
+      return React.createElement(
+        "section",
+        null,
+        `layout:${requestLocale}`,
+        props.children as React.ReactNode,
+      );
+    }
+
+    const route = createSyntheticRoute({
+      page: createSyntheticPageModule(LocalePage),
+      layouts: [createSyntheticPageModule(LocaleLayout)],
+      layoutTreePositions: [0],
+      routeSegments: ["sync-use"],
+      pattern: "/sync-use",
+    });
+
+    const result = await buildPageElements(createBaseOptions({ route, routePath: "/sync-use" }));
+    const htmlPromise = renderRouteEntry(result, result[APP_ROUTE_KEY] as string);
+    await Promise.resolve();
+    resolveLocale("de");
+    const html = await htmlPromise;
+
+    expect(html).toContain("layout:de");
+    expect(html).toContain("page:de");
+    expect(html).not.toContain("layout:en");
+  });
+
   it("does not wait for an omitted page during loading-shell prefetches", async () => {
     const Page = vi.fn(() => React.createElement("main", null, "Page content"));
     const route = createSyntheticRoute({

--- a/tests/app-page-element-builder.test.ts
+++ b/tests/app-page-element-builder.test.ts
@@ -235,7 +235,6 @@ describe("buildPageElements", () => {
 
     async function LocalePage({ params }: { params: Promise<{ locale: string }> }) {
       const { locale } = await params;
-      await Promise.resolve();
       requestLocale = locale;
       return React.createElement("main", null, `page:${requestLocale}`);
     }
@@ -262,6 +261,48 @@ describe("buildPageElements", () => {
       createBaseOptions({ route, params: { locale: "de" }, routePath: "/de" }),
     );
     const html = await renderRouteEntry(result, result[APP_ROUTE_KEY] as string);
+
+    expect(html).toContain("layout:de");
+    expect(html).toContain("page:de");
+    expect(html).not.toContain("layout:en");
+  });
+
+  it("keeps layouts suspended when a sync page suspends before initializing request state", async () => {
+    let resolveLocale!: (locale: string) => void;
+    const pendingLocale = new Promise<string>((resolve) => {
+      resolveLocale = resolve;
+    });
+    let requestLocale = "en";
+
+    function LocalePage() {
+      requestLocale = React.use(pendingLocale);
+      return React.createElement("main", null, `page:${requestLocale}`);
+    }
+
+    function LocaleLayout(props: Record<string, unknown>) {
+      return React.createElement(
+        "section",
+        null,
+        `layout:${requestLocale}`,
+        props.children as React.ReactNode,
+      );
+    }
+
+    const route = createSyntheticRoute({
+      page: createSyntheticPageModule(LocalePage),
+      layouts: [createSyntheticPageModule(LocaleLayout)],
+      layoutTreePositions: [0],
+      routeSegments: ["suspended-locale"],
+      pattern: "/suspended-locale",
+    });
+
+    const result = await buildPageElements(
+      createBaseOptions({ route, routePath: "/suspended-locale" }),
+    );
+    const htmlPromise = renderRouteEntry(result, result[APP_ROUTE_KEY] as string);
+    await Promise.resolve();
+    resolveLocale("de");
+    const html = await htmlPromise;
 
     expect(html).toContain("layout:de");
     expect(html).toContain("page:de");

--- a/tests/app-page-element-builder.test.ts
+++ b/tests/app-page-element-builder.test.ts
@@ -174,6 +174,24 @@ async function renderRouteEntry(elements: AppElements, routeId: string): Promise
   );
 }
 
+async function renderElementEntry(elements: AppElements, elementId: string): Promise<string> {
+  const record = elements as Record<string, React.ReactNode>;
+  const element = record[elementId];
+  if (!React.isValidElement(element)) {
+    throw new Error(`Expected React element for ${elementId}`);
+  }
+
+  if (elementId.startsWith("page:")) {
+    return renderNode(element);
+  }
+
+  // Production Flight serialization starts every flat entry concurrently.
+  // Rendering the primary page beside a dependent slot lets its invocation
+  // release the page-initialization barrier just as production does.
+  const pageEntry = Object.entries(record).find(([key]) => key.startsWith("page:"))?.[1];
+  return renderNode(React.createElement(React.Fragment, null, pageEntry, element));
+}
+
 async function buildAndRenderElement(
   route: AppPageBuildRoute,
   elementId: string,
@@ -195,7 +213,7 @@ async function buildAndRenderElement(
 
   markDynamicUsageMock.mockClear();
   markRenderRequestApiUsageMock.mockClear();
-  return renderNode(element);
+  return renderElementEntry(result, elementId);
 }
 
 function expectNoSearchParamsObservation(): void {
@@ -267,16 +285,14 @@ describe("buildPageElements", () => {
     expect(html).not.toContain("layout:en");
   });
 
-  it("keeps layouts suspended when a sync page suspends before initializing request state", async () => {
-    let resolveLocale!: (locale: string) => void;
-    const pendingLocale = new Promise<string>((resolve) => {
-      resolveLocale = resolve;
-    });
+  it("preserves page initialization when async syntax is lowered to a Promise return", async () => {
     let requestLocale = "en";
 
-    function LocalePage() {
-      requestLocale = React.use(pendingLocale);
-      return React.createElement("main", null, `page:${requestLocale}`);
+    function LoweredLocalePage({ params }: { params: Promise<{ locale: string }> }) {
+      return params.then(({ locale }) => {
+        requestLocale = locale;
+        return React.createElement("main", null, `page:${requestLocale}`);
+      });
     }
 
     function LocaleLayout(props: Record<string, unknown>) {
@@ -289,20 +305,17 @@ describe("buildPageElements", () => {
     }
 
     const route = createSyntheticRoute({
-      page: createSyntheticPageModule(LocalePage),
+      page: createSyntheticPageModule(LoweredLocalePage),
       layouts: [createSyntheticPageModule(LocaleLayout)],
       layoutTreePositions: [0],
-      routeSegments: ["suspended-locale"],
-      pattern: "/suspended-locale",
+      routeSegments: ["[locale]"],
+      pattern: "/:locale",
     });
 
     const result = await buildPageElements(
-      createBaseOptions({ route, routePath: "/suspended-locale" }),
+      createBaseOptions({ route, params: { locale: "de" }, routePath: "/de" }),
     );
-    const htmlPromise = renderRouteEntry(result, result[APP_ROUTE_KEY] as string);
-    await Promise.resolve();
-    resolveLocale("de");
-    const html = await htmlPromise;
+    const html = await renderRouteEntry(result, result[APP_ROUTE_KEY] as string);
 
     expect(html).toContain("layout:de");
     expect(html).toContain("page:de");
@@ -757,9 +770,7 @@ describe("buildPageElements", () => {
 
     const result = await buildPageElements(createBaseOptions({ route, routePath: "/exotic-slot" }));
 
-    await expect(
-      renderNode((result as Record<string, React.ReactNode>)["slot:modal:/"]),
-    ).resolves.toContain("memo slot");
+    await expect(renderElementEntry(result, "slot:modal:/")).resolves.toContain("memo slot");
   });
 
   it("records serialized queryless searchParams without marking client pages dynamic", async () => {
@@ -1464,7 +1475,7 @@ describe("buildPageElements", () => {
 
       markDynamicUsageMock.mockClear();
       markRenderRequestApiUsageMock.mockClear();
-      return renderNode(element);
+      return renderElementEntry(result, "slot:modal:/");
     };
 
     await expectCachedRenderIgnoresQuery({
@@ -1596,7 +1607,7 @@ describe("buildPageElements", () => {
     const record = result as Record<string, unknown>;
     const slotElement = record["slot:modal:/"] as React.ReactNode;
     expect(slotElement).toBeDefined();
-    await renderNode(slotElement);
+    await renderElementEntry(result, "slot:modal:/");
     await expect(capturedSearchParams).resolves.toEqual({ search: "hello" });
   });
 
@@ -1642,7 +1653,7 @@ describe("buildPageElements", () => {
     const record = result as Record<string, unknown>;
     const slotElement = record["slot:modal:/"] as React.ReactNode;
     expect(slotElement).toBeDefined();
-    await renderNode(slotElement);
+    await renderElementEntry(result, "slot:modal:/");
     await expect(capturedSearchParams).resolves.toEqual({ search: "hello" });
   });
 
@@ -1698,7 +1709,7 @@ describe("buildPageElements", () => {
     const record = result as Record<string, unknown>;
     const slotElement = record["slot:bc:/"] as React.ReactNode;
     expect(slotElement).toBeDefined();
-    await renderNode(slotElement);
+    await renderElementEntry(result, "slot:bc:/");
     const slotParams = await capturedParams;
     // Without the fix, urlParts would be ["base","distinct","alice"], the
     // pattern match would fail, and slotParams would silently fall back to

--- a/tests/app-page-element-builder.test.ts
+++ b/tests/app-page-element-builder.test.ts
@@ -30,6 +30,7 @@ import {
 } from "../packages/vinext/src/server/app-page-element-builder.js";
 import { probeAppPage } from "../packages/vinext/src/server/app-page-probe.js";
 import { SIBLING_PAGE_INTERCEPT_SLOT_KEY } from "../packages/vinext/src/server/app-rsc-route-matching.js";
+import { APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL } from "../packages/vinext/src/server/app-rsc-render-mode.js";
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -155,11 +156,20 @@ async function renderNode(node: React.ReactNode): Promise<string> {
 
 async function renderRouteEntry(elements: AppElements, routeId: string): Promise<string> {
   const { ElementsContext, Slot } = await import("../packages/vinext/src/shims/slot.js");
+  // Production Flight serialization starts every entry in the flat payload.
+  // Include the page entry beside the route so page/layout ordering tests use
+  // the same concurrent render shape instead of creating a route-only cycle.
+  const pageEntry = Object.entries(elements).find(([key]) => key.startsWith("page:"))?.[1];
   return renderNode(
     React.createElement(
       ElementsContext.Provider,
       { value: elements },
-      React.createElement(Slot, { id: routeId }),
+      React.createElement(
+        React.Fragment,
+        null,
+        pageEntry as React.ReactNode,
+        React.createElement(Slot, { id: routeId }),
+      ),
     ),
   );
 }
@@ -215,6 +225,77 @@ describe("buildPageElements", () => {
   beforeEach(() => {
     markDynamicUsageMock.mockClear();
     markRenderRequestApiUsageMock.mockClear();
+  });
+
+  it("renders the page before layouts that consume page-initialized request state", async () => {
+    // Regression from nodejs.org's next-intl integration, where the page calls
+    // setRequestLocale() before the parent layout renders NextIntlClientProvider.
+    // https://github.com/nodejs/nodejs.org/commit/5eace3f956c10da92880be7ce16e942bbcb47ff7
+    let requestLocale = "en";
+
+    async function LocalePage({ params }: { params: Promise<{ locale: string }> }) {
+      const { locale } = await params;
+      await Promise.resolve();
+      requestLocale = locale;
+      return React.createElement("main", null, `page:${requestLocale}`);
+    }
+
+    async function LocaleLayout(props: Record<string, unknown>) {
+      await Promise.resolve();
+      return React.createElement(
+        "section",
+        null,
+        `layout:${requestLocale}`,
+        props.children as React.ReactNode,
+      );
+    }
+
+    const route = createSyntheticRoute({
+      page: createSyntheticPageModule(LocalePage),
+      layouts: [createSyntheticPageModule(LocaleLayout)],
+      layoutTreePositions: [1],
+      routeSegments: ["[locale]"],
+      pattern: "/:locale",
+    });
+
+    const result = await buildPageElements(
+      createBaseOptions({ route, params: { locale: "de" }, routePath: "/de" }),
+    );
+    const html = await renderRouteEntry(result, result[APP_ROUTE_KEY] as string);
+
+    expect(html).toContain("layout:de");
+    expect(html).toContain("page:de");
+    expect(html).not.toContain("layout:en");
+  });
+
+  it("does not wait for an omitted page during loading-shell prefetches", async () => {
+    const Page = vi.fn(() => React.createElement("main", null, "Page content"));
+    const route = createSyntheticRoute({
+      page: createSyntheticPageModule(Page),
+      layouts: [
+        createSyntheticPageModule((props: { children?: React.ReactNode }) =>
+          React.createElement("section", null, props.children),
+        ),
+      ],
+      layoutTreePositions: [0],
+      loading: createSyntheticPageModule(() => React.createElement("p", null, "Loading shell")),
+      routeSegments: ["slow"],
+      pattern: "/slow",
+    });
+    const options = createBaseOptions({ route, routePath: "/slow" });
+
+    const result = await buildPageElements({
+      ...options,
+      pageRequest: {
+        ...options.pageRequest,
+        renderMode: APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+      },
+    });
+    const html = await renderRouteEntry(result, result[APP_ROUTE_KEY] as string);
+
+    expect(html).toContain("Loading shell");
+    expect(html).not.toContain("Page content");
+    expect(Page).not.toHaveBeenCalled();
   });
 
   it("returns an error element record when a page module has no default export", async () => {

--- a/tests/app-page-element-builder.test.ts
+++ b/tests/app-page-element-builder.test.ts
@@ -253,12 +253,12 @@ describe("buildPageElements", () => {
 
     async function LocalePage({ params }: { params: Promise<{ locale: string }> }) {
       const { locale } = await params;
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
       requestLocale = locale;
       return React.createElement("main", null, `page:${requestLocale}`);
     }
 
-    async function LocaleLayout(props: Record<string, unknown>) {
-      await Promise.resolve();
+    function LocaleLayout(props: Record<string, unknown>) {
       return React.createElement(
         "section",
         null,

--- a/tests/app-page-route-wiring.test.ts
+++ b/tests/app-page-route-wiring.test.ts
@@ -40,6 +40,7 @@ import {
 } from "../packages/vinext/src/server/app-page-element-builder.js";
 import { createNextBfcacheIdMap } from "../packages/vinext/src/server/app-bfcache-identity.js";
 import type { AppPageSemanticSegment } from "../packages/vinext/src/server/app-page-segment-state.js";
+import { createAppRenderDependency } from "../packages/vinext/src/server/app-render-dependency.js";
 
 /**
  * Build the resolved semantic branch the route matcher hands to slot overrides.
@@ -3533,6 +3534,69 @@ describe("app page route wiring helpers", () => {
 
     expect(body).toContain("page:de");
     expect(body).not.toContain("page:en");
+  });
+
+  it("waits for page initialization before serializing parallel slot entries", async () => {
+    let activeLocale = "en";
+    const pageRenderDependency = createAppRenderDependency();
+
+    function LocaleSlot() {
+      return createElement("aside", null, `slot:${activeLocale}`);
+    }
+
+    const elements = buildAppPageElements({
+      element: createElement("main", null, "Page content"),
+      makeThenableParams(params) {
+        return Promise.resolve(params);
+      },
+      matchedParams: {},
+      pageRenderDependency,
+      resolvedMetadata: null,
+      resolvedViewport: {},
+      route: {
+        error: null,
+        errors: [],
+        layoutTreePositions: [],
+        layouts: [],
+        loading: null,
+        notFound: null,
+        notFounds: [],
+        routeSegments: ["dashboard"],
+        slots: {
+          sidebar: {
+            default: null,
+            error: null,
+            layout: null,
+            layoutIndex: -1,
+            loading: null,
+            name: "sidebar",
+            page: { default: LocaleSlot },
+            routeSegments: [],
+          },
+        },
+        templateTreePositions: [],
+        templates: [],
+      },
+      routePath: "/dashboard",
+      rootNotFoundModule: null,
+    });
+
+    const slotId = AppElementsWire.encodeSlotId("sidebar", "/");
+    let slotRenderSettled = false;
+    const slotHtmlPromise = renderHtml(readChildren(elements[slotId])).then((html) => {
+      slotRenderSettled = true;
+      return html;
+    });
+
+    await Promise.resolve();
+    expect(slotRenderSettled).toBe(false);
+
+    activeLocale = "de";
+    pageRenderDependency.release();
+    const html = await withTimeout(slotHtmlPromise, 1_000);
+
+    expect(html).toContain("slot:de");
+    expect(html).not.toContain("slot:en");
   });
 
   it("preserves parent-before-child execution under an ancestor loading boundary", async () => {

--- a/tests/app-page-route-wiring.test.ts
+++ b/tests/app-page-route-wiring.test.ts
@@ -22,6 +22,7 @@ import {
   createAppPageLayoutEntries,
   probeAppPageLayoutWithTracking,
   resolveAppPageChildSegments,
+  resolveAppPageLoadingModuleAtOrAbove,
 } from "../packages/vinext/src/server/app-page-route-wiring.js";
 import { createAppLayoutParamAccessTracker } from "../packages/vinext/src/server/app-layout-param-observation.js";
 import {
@@ -447,6 +448,33 @@ function LayoutWithoutChildren() {
 }
 
 describe("app page route wiring helpers", () => {
+  it("selects the nearest positioned loading module with a default export", () => {
+    const legacyLoading = { default: () => null };
+    const rootLoading = { default: () => null };
+    const leafWithoutDefault = { generateMetadata: () => null };
+
+    expect(
+      resolveAppPageLoadingModuleAtOrAbove(
+        {
+          loading: legacyLoading,
+          loadings: [rootLoading, leafWithoutDefault],
+          loadingTreePositions: [0, 2],
+        },
+        2,
+      ),
+    ).toBe(rootLoading);
+    expect(
+      resolveAppPageLoadingModuleAtOrAbove(
+        {
+          loading: legacyLoading,
+          loadings: [rootLoading],
+          loadingTreePositions: [],
+        },
+        2,
+      ),
+    ).toBe(legacyLoading);
+  });
+
   it("probes returned layout children with param and revalidate tracking", async () => {
     const calls: string[] = [];
     const layoutParamAccess = createAppLayoutParamAccessTracker();

--- a/tests/app-page-route-wiring.test.ts
+++ b/tests/app-page-route-wiring.test.ts
@@ -246,6 +246,9 @@ async function renderRouteEntry(elements: AppElements, routeId: string): Promise
 
 async function renderRouteDocument(elements: AppElements, routeId: string): Promise<string> {
   const { ElementsContext, Slot } = await import("../packages/vinext/src/shims/slot.js");
+  // Match production Flight serialization, which starts the flat page and
+  // route entries concurrently before the decoded route tree is rendered.
+  const pageEntry = Object.entries(elements).find(([key]) => key.startsWith("page:"))?.[1];
   return renderHtml(
     createElement(
       "html",
@@ -257,7 +260,12 @@ async function renderRouteDocument(elements: AppElements, routeId: string): Prom
         createElement(
           ElementsContext.Provider,
           { value: elements },
-          createElement(Slot, { id: routeId }),
+          createElement(
+            Fragment,
+            null,
+            pageEntry as ReactNode,
+            createElement(Slot, { id: routeId }),
+          ),
         ),
       ),
     ),

--- a/tests/e2e/app-router/loading.spec.ts
+++ b/tests/e2e/app-router/loading.spec.ts
@@ -58,6 +58,15 @@ test.describe("Loading boundaries (loading.tsx)", () => {
     });
   });
 
+  test("ancestor loading boundary streams for a nested sync use() page", async ({ page }) => {
+    void page.goto(`${BASE}/slow-use-ancestor/child`);
+
+    await expect(page.locator("#loading-use-ancestor-fallback")).toBeVisible({ timeout: 5_000 });
+    await expect(page.locator("h1")).toHaveText("Nested slow use() Page", {
+      timeout: 10_000,
+    });
+  });
+
   // Ported from Next.js: test/e2e/app-dir/app/index.test.ts
   // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app/index.test.ts
   test("slow nested layout streams its ancestor loading fallback before resolving", async () => {

--- a/tests/e2e/app-router/loading.spec.ts
+++ b/tests/e2e/app-router/loading.spec.ts
@@ -49,6 +49,17 @@ test.describe("Loading boundaries (loading.tsx)", () => {
 
   // Ported from Next.js: test/e2e/app-dir/app/index.test.ts
   // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app/index.test.ts
+  test("loading boundary streams when a sync server page suspends with use()", async ({ page }) => {
+    void page.goto(`${BASE}/slow-use`);
+
+    await expect(page.locator("#loading-use-fallback")).toBeVisible({ timeout: 5_000 });
+    await expect(page.locator("h1")).toHaveText("Slow use() Page", {
+      timeout: 10_000,
+    });
+  });
+
+  // Ported from Next.js: test/e2e/app-dir/app/index.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app/index.test.ts
   test("slow nested layout streams its ancestor loading fallback before resolving", async () => {
     const streamFallback = async () => {
       const response = await fetch(`${BASE}/slow-layout-with-loading/slow`);

--- a/tests/fixtures/app-basic/app/slow-use-ancestor/child/page.tsx
+++ b/tests/fixtures/app-basic/app/slow-use-ancestor/child/page.tsx
@@ -1,12 +1,14 @@
-import { use } from "react";
+import { cache, use } from "react";
 
 async function getData() {
   await new Promise((resolve) => setTimeout(resolve, 2000));
   return "ready";
 }
 
+const getCachedData = cache(getData);
+
 export default function SlowUseChildPage() {
-  use(getData());
+  use(getCachedData());
 
   return <h1>Nested slow use() Page</h1>;
 }

--- a/tests/fixtures/app-basic/app/slow-use-ancestor/child/page.tsx
+++ b/tests/fixtures/app-basic/app/slow-use-ancestor/child/page.tsx
@@ -1,0 +1,12 @@
+import { use } from "react";
+
+async function getData() {
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+  return "ready";
+}
+
+export default function SlowUseChildPage() {
+  use(getData());
+
+  return <h1>Nested slow use() Page</h1>;
+}

--- a/tests/fixtures/app-basic/app/slow-use-ancestor/loading.tsx
+++ b/tests/fixtures/app-basic/app/slow-use-ancestor/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div id="loading-use-ancestor-fallback">Loading ancestor use() page...</div>;
+}

--- a/tests/fixtures/app-basic/app/slow-use/loading.tsx
+++ b/tests/fixtures/app-basic/app/slow-use/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div id="loading-use-fallback">Loading use() page...</div>;
+}

--- a/tests/fixtures/app-basic/app/slow-use/page.tsx
+++ b/tests/fixtures/app-basic/app/slow-use/page.tsx
@@ -1,14 +1,16 @@
-import { use } from "react";
+import { cache, use } from "react";
 
 async function getData() {
   await new Promise((resolve) => setTimeout(resolve, 2000));
   return "ready";
 }
 
+const getCachedData = cache(getData);
+
 // Ported from Next.js: test/e2e/app-dir/app/app/slow-page-with-loading/page.js
 // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app/app/slow-page-with-loading/page.js
 export default function SlowUsePage() {
-  use(getData());
+  use(getCachedData());
 
   return (
     <main>

--- a/tests/fixtures/app-basic/app/slow-use/page.tsx
+++ b/tests/fixtures/app-basic/app/slow-use/page.tsx
@@ -1,0 +1,19 @@
+import { use } from "react";
+
+async function getData() {
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+  return "ready";
+}
+
+// Ported from Next.js: test/e2e/app-dir/app/app/slow-page-with-loading/page.js
+// https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app/app/slow-page-with-loading/page.js
+export default function SlowUsePage() {
+  use(getData());
+
+  return (
+    <main>
+      <h1>Slow use() Page</h1>
+      <p>This synchronous page suspends with React.use().</p>
+    </main>
+  );
+}

--- a/tests/fixtures/ecosystem/next-intl/app/[locale]/layout.tsx
+++ b/tests/fixtures/ecosystem/next-intl/app/[locale]/layout.tsx
@@ -1,5 +1,5 @@
 import { hasLocale, NextIntlClientProvider } from "next-intl";
-import { getMessages, setRequestLocale } from "next-intl/server";
+import { getMessages } from "next-intl/server";
 import { notFound } from "next/navigation";
 
 const locales = ["en", "de"] as const;
@@ -16,10 +16,6 @@ export default async function LocaleLayout({
     notFound();
   }
 
-  // Middleware only negotiates the root redirect in this fixture. Locale
-  // routes use next-intl's public request-scoped API instead of a private
-  // X-NEXT-INTL-LOCALE header.
-  setRequestLocale(locale);
   const messages = await getMessages();
 
   return (

--- a/tests/fixtures/ecosystem/next-intl/app/[locale]/page.tsx
+++ b/tests/fixtures/ecosystem/next-intl/app/[locale]/page.tsx
@@ -1,7 +1,17 @@
-import { useTranslations } from "next-intl";
+import { getTranslations, setRequestLocale } from "next-intl/server";
 
-export default function HomePage() {
-  const t = useTranslations("HomePage");
+export default async function HomePage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+
+  // Mirrors nodejs.org: the page establishes next-intl's request locale and
+  // the parent layout consumes it while resolving the provider messages.
+  // https://github.com/nodejs/nodejs.org/commit/5eace3f956c10da92880be7ce16e942bbcb47ff7
+  setRequestLocale(locale);
+  const t = await getTranslations("HomePage");
 
   return (
     <div>


### PR DESCRIPTION
## Summary

- start declared-async page entries independently of layout/template/slot barriers so page-initialized request state is available to parents
- preserve React ownership for synchronous server pages, including `use(promise)` suspension and `loading.tsx` streaming
- gate layouts, templates, route entries, and parallel slots on the page-initialization dependency
- keep loading-shell prefetches independent from omitted page entries
- update the real `next-intl` fixture to match nodejs.org's page-level `setRequestLocale()` pattern

## Root cause

vinext serializes App Router pages, layouts, templates, and slots as a flat Flight element record. Its existing dependency graph made the page wait for layouts and templates. In nodejs.org, the page calls `setRequestLocale(locale)` while the parent layout's `NextIntlClientProvider` consumes that request-scoped configuration. The reversed ordering caused `/de` to serialize English messages even though the route params and `<html lang>` were German.

Next.js builds the child page branch before returning the parent layout seed data. This change gives vinext's flat record the equivalent initialization dependency. Declared-async pages receive one post-params continuation to establish request state, while synchronous server pages remain React-owned so hooks and Suspense retain normal semantics. The dependency is released before slower async page work, preserving loading streaming.

## Regression proof

Before the implementation:

- the focused builder test rendered `layout:en` followed by `page:de`
- the real next-intl fixture returned HTTP 200 for `/de`, but rendered `Hello World` and English provider messages
- the first implementation blocked the existing declared-async `loading.tsx` timing test
- a synchronous server page using `use(promise)` also failed to stream its loading boundary

After the implementation:

- 138 focused dependency/element/wiring unit tests pass
- next-intl ecosystem fixture: 3/3 pass
- full loading-boundary Playwright file: 12/12 pass, covering both declared-async and sync-`use()` pages
- client-cache regression: 10/10 isolated repetitions pass
- targeted format, lint, and type checks pass
- package build passes
- production next-intl preview `/de`: HTTP 200 with `Hallo Welt` and the German description
- independent exact-tree review: clean after all findings

Next.js loading reference: https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app/app/slow-page-with-loading/page.js

Downstream reference: https://github.com/james-elicx/nodejs.org/commit/5eace3f956c10da92880be7ce16e942bbcb47ff7
