### PR TITLE
test(typegen): retry temporary directory cleanup

### DIFF
--- a/tests/typegen.test.ts
+++ b/tests/typegen.test.ts
@@ -18,7 +18,7 @@ async function withTempProject<T>(run: (root: string) => Promise<T>): Promise<T>
   try {
     return await run(root);
   } finally {
-    await rm(root, { recursive: true, force: true });
+    await rm(root, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
   }
 }
 


### PR DESCRIPTION
## Summary

- retry recursive removal of typegen temporary projects when Node reports transient ENOTEMPTY cleanup races
- keep persistent cleanup failures visible instead of swallowing them

Fixes the flaky cleanup failure seen in https://github.com/cloudflare/vinext/actions/runs/30305858505.

## Validation

- vp test run tests/typegen.test.ts
- exact watcher test passed 20 consecutive targeted runs
- vp check tests/typegen.test.ts