### PR TITLE
fix(dev): report sane App Router compile times

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -103,7 +103,7 @@ import {
   VINEXT_REVALIDATE_HOST_HEADER,
   VINEXT_TIMING_HEADER,
 } from "./server/headers.js";
-import { logRequest, now } from "./server/request-log.js";
+import { logRequest, now, resolveAppPageDevRequestTiming } from "./server/request-log.js";
 import { normalizePath } from "./server/normalize-path.js";
 import {
   canonicalizeRequestUrlPathname,
@@ -4849,50 +4849,21 @@ export const loadServerActionClient = ${
                 return next();
               }
               const _reqStart = now();
-              let _compileMs: number | undefined;
-              let _renderMs: number | undefined;
+              let _workerRenderMs: unknown;
 
               // Intercept setHeader and writeHead so we can strip X-Vinext-Timing
               // before it reaches the client and capture the compile/render split.
               // The RSC plugin may set headers either way depending on its version.
-              // Parse the three-part X-Vinext-Timing header:
-              //   "handlerStart,inHandlerCompileMs,renderMs"
-              //
-              // True compile time = time the RSC plugin spent loading/transforming
-              // modules before our handler code ran, plus any in-handler work before
-              // renderToReadableStream. Concretely:
-              //   compileMs = (handlerStart - _reqStart) + inHandlerCompileMs
-              //   renderMs  = renderMs from header, or -1 for RSC-only (soft-nav)
-              //               responses where rendering is not measured in the handler.
-              //               In that case the middleware computes render time as
-              //               totalMs - compileMs.
-              //
-              // handlerStart is performance.now() recorded at the very top of
-              // _handleRequest in the generated RSC entry. _reqStart is recorded
-              // here in the Node middleware, one stack frame before the RSC plugin
-              // loads the module. The gap between them is exactly the Vite
-              // compile/transform cost.
-              function _parseTiming(raw: unknown) {
-                const [handlerStart, inHandlerCompileMs, renderMs] = String(raw)
-                  .split(",")
-                  .map((v) => Number(v));
-                if (
-                  !Number.isNaN(handlerStart) &&
-                  !Number.isNaN(inHandlerCompileMs) &&
-                  inHandlerCompileMs !== -1
-                ) {
-                  _compileMs =
-                    Math.max(0, Math.round(handlerStart - _reqStart)) + inHandlerCompileMs;
-                }
-                if (!Number.isNaN(renderMs) && renderMs !== -1) {
-                  _renderMs = renderMs;
-                }
-              }
+              // The Worker sends only its render duration. The Node middleware
+              // owns the total request duration, so it derives the remaining
+              // compile/module-loading time after the response finishes. Absolute
+              // timestamps cannot cross this boundary because Node and workerd use
+              // different performance.now() time origins.
 
               const _origSetHeader = res.setHeader.bind(res);
               res.setHeader = function (name, value) {
                 if (name.toLowerCase() === VINEXT_TIMING_HEADER) {
-                  _parseTiming(value);
+                  _workerRenderMs = value;
                   return res; // drop the header — don't forward to client
                 }
                 return _origSetHeader(name, value);
@@ -4916,7 +4887,7 @@ export const loadServerActionClient = ${
                     (k) => k.toLowerCase() === VINEXT_TIMING_HEADER,
                   );
                   if (timingKey) {
-                    _parseTiming(headers[timingKey]);
+                    _workerRenderMs = headers[timingKey];
                     delete headers[timingKey];
                   }
                 }
@@ -4929,25 +4900,18 @@ export const loadServerActionClient = ${
                 // not part of the actual page path the user navigated to.
                 const logUrl = url.replace(/\.rsc(\?|$)/, "$1");
                 const totalMs = now() - _reqStart;
-
-                // For RSC-only responses (soft nav), renderMs is -1 (sentinel meaning
-                // "not measured in the handler"). Compute it as totalMs - compileMs,
-                // which is how long the RSC stream took to fully flush to the client —
-                // matching what Next.js shows for soft navigations.
-                const resolvedRenderMs =
-                  _renderMs !== undefined
-                    ? _renderMs
-                    : _compileMs !== undefined
-                      ? Math.max(0, Math.round(totalMs - _compileMs))
-                      : undefined;
+                const { compileMs, renderMs } = resolveAppPageDevRequestTiming(
+                  totalMs,
+                  _workerRenderMs,
+                );
 
                 logRequest({
                   method: req.method ?? "GET",
                   url: logUrl,
                   status: res.statusCode,
                   totalMs,
-                  compileMs: _compileMs,
-                  renderMs: resolvedRenderMs,
+                  compileMs,
+                  renderMs,
                 });
               });
 

--- a/packages/vinext/src/server/app-page-response.ts
+++ b/packages/vinext/src/server/app-page-response.ts
@@ -104,9 +104,6 @@ function applyTimingHeader(headers: Headers, timing?: AppPageResponseTiming): vo
     return;
   }
 
-  const handlerStart = Math.round(timing.handlerStart);
-  const compileMs =
-    timing.compileEnd !== undefined ? Math.round(timing.compileEnd - timing.handlerStart) : -1;
   const renderMs =
     timing.responseKind === "html" &&
     timing.renderEnd !== undefined &&
@@ -114,7 +111,7 @@ function applyTimingHeader(headers: Headers, timing?: AppPageResponseTiming): vo
       ? Math.round(timing.renderEnd - timing.compileEnd)
       : -1;
 
-  headers.set(VINEXT_TIMING_HEADER, `${handlerStart},${compileMs},${renderMs}`);
+  headers.set(VINEXT_TIMING_HEADER, String(renderMs));
 }
 
 function applyDynamicStaleTimeHeader(headers: Headers, dynamicStaleTimeSeconds?: number): void {

--- a/packages/vinext/src/server/headers.ts
+++ b/packages/vinext/src/server/headers.ts
@@ -34,7 +34,7 @@ export const NEXT_CACHE_TAGS_HEADER = "x-next-cache-tags";
 /** Static file signal — value is URL-encoded pathname. */
 export const VINEXT_STATIC_FILE_HEADER = "x-vinext-static-file";
 
-/** Timing metrics: `handlerStart,compileMs,renderMs`. */
+/** Worker render duration in milliseconds, or `-1` when unavailable. */
 export const VINEXT_TIMING_HEADER = "x-vinext-timing";
 
 export {

--- a/packages/vinext/src/server/request-log.ts
+++ b/packages/vinext/src/server/request-log.ts
@@ -46,6 +46,40 @@ type RequestLogOptions = {
   renderMs?: number;
 };
 
+type AppPageDevRequestTiming = {
+  compileMs?: number;
+  renderMs?: number;
+};
+
+/**
+ * Resolve the App Router compile/render split without mixing timestamps from
+ * the Node dev server and the Worker runtime.
+ *
+ * The Worker sends only its measured render duration. The Node dev server
+ * measures the full request duration, so the remaining time is the Vite
+ * compile/module-loading portion.
+ */
+export function resolveAppPageDevRequestTiming(
+  totalMs: number,
+  rawRenderMs: unknown,
+): AppPageDevRequestTiming {
+  const renderMs = Number(String(rawRenderMs));
+  if (
+    !Number.isFinite(totalMs) ||
+    totalMs < 0 ||
+    !Number.isFinite(renderMs) ||
+    renderMs < 0 ||
+    renderMs > Math.ceil(totalMs)
+  ) {
+    return {};
+  }
+
+  return {
+    compileMs: Math.max(0, Math.round(totalMs - renderMs)),
+    renderMs,
+  };
+}
+
 /**
  * Print a single request log line to stdout.
  */

--- a/tests/app-page-response.test.ts
+++ b/tests/app-page-response.test.ts
@@ -441,7 +441,7 @@ describe("app page response helpers", () => {
     expect(response.headers.get("x-vinext-cache")).toBe("MISS");
     expect(response.headers.get("x-nextjs-cache")).toBe("MISS");
     expect(response.headers.get("vary")).toBe(VINEXT_RSC_VARY_HEADER);
-    expect(response.headers.get("x-vinext-timing")).toBe("10,5,-1");
+    expect(response.headers.get("x-vinext-timing")).toBe("-1");
     await expect(response.text()).resolves.toBe("flight");
   });
 
@@ -579,7 +579,7 @@ describe("app page response helpers", () => {
       "</font.woff2>; rel=preload; as=font; type=font/woff2; crossorigin",
     );
     expect(response.headers.get("x-extra")).toBe("present");
-    expect(response.headers.get("x-vinext-timing")).toBe("10,2,8");
+    expect(response.headers.get("x-vinext-timing")).toBe("8");
 
     const setCookies = response.headers.getSetCookie();
     expect(setCookies).toContain("__prerender_bypass=token; Path=/");

--- a/tests/request-log.test.ts
+++ b/tests/request-log.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vite-plus/test";
+import { resolveAppPageDevRequestTiming } from "../packages/vinext/src/server/request-log.js";
+
+describe("app page dev request timing", () => {
+  it("derives compile time from the Node-observed total and Worker render duration", () => {
+    expect(resolveAppPageDevRequestTiming(3100, "2900")).toEqual({
+      compileMs: 200,
+      renderMs: 2900,
+    });
+  });
+
+  it("omits the timing split when the Worker did not measure render duration", () => {
+    expect(resolveAppPageDevRequestTiming(100, "-1")).toEqual({});
+  });
+
+  it("omits invalid timing values instead of logging impossible durations", () => {
+    expect(resolveAppPageDevRequestTiming(100, "not-a-number")).toEqual({});
+    expect(resolveAppPageDevRequestTiming(100, "1000000000000")).toEqual({});
+  });
+});


### PR DESCRIPTION
Fixes #2721

## Summary

- send only the Worker's measured render duration through `x-vinext-timing`
- derive compile/module-loading time from the Node-observed total request duration
- omit the compile/render split when the timing value is unavailable or impossible
- add regression coverage for valid, unavailable, and invalid timing values

## Root cause

The Node dev middleware and workerd record `performance.now()` with different time origins. The previous implementation subtracted the Worker-side `handlerStart` timestamp from the Node-side request start timestamp, which produced epoch-scale compile durations of roughly 50 years even though the request completed normally.

This change keeps absolute timestamps inside their own runtimes. The Worker reports only a duration, and Node derives the remaining compile/module-loading duration from the total request time.

## Validation

- `vp test run tests/request-log.test.ts tests/app-page-response.test.ts` — 34 tests passed
- `vp fmt --check`
- `vp lint`
- `vp check`
- `vp run vinext#build`
- `examples/app-router-cloudflare` manual verification:
  - before: `compile: 1785393663.6s`
  - after, first request: `compile: 89ms, render: 2.8s`
  - after, warm request: `compile: 19ms, render: 25ms`

The full unit suite was also attempted locally, but it is not reported as passing: this Windows environment produced unrelated symlink permission, missing Unix `ln`, GitHub credential-fixture, and timeout failures. The targeted tests and the official Cloudflare example pass.