### PR TITLE
fix(app-router): validate external RSC rewrites before proxying

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -1236,7 +1236,7 @@ export default createAppRscHandler({
   },
   ${
     middlewarePath
-      ? `runMiddleware({ cleanPathname, context, hadBasePath, isDataRequest, middlewareRequest, request }) {
+      ? `runMiddleware({ cleanPathname, context, hadBasePath, isDataRequest, middlewareRequest, request, validateExternalRewriteRequest }) {
     return __applyAppMiddleware({
       basePath: __basePath,
       cleanPathname,
@@ -1250,6 +1250,7 @@ export default createAppRscHandler({
       module: middlewareModule,
       request,
       trailingSlash: __trailingSlash,
+      validateExternalRewriteRequest,
     });
   },`
       : ""

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -1236,11 +1236,12 @@ export default createAppRscHandler({
   },
   ${
     middlewarePath
-      ? `runMiddleware({ cleanPathname, context, hadBasePath, isDataRequest, middlewareRequest, request, validateExternalRewriteRequest }) {
+      ? `runMiddleware({ cleanPathname, context, externalRewriteRequest, hadBasePath, isDataRequest, middlewareRequest, request, validateExternalRewriteRequest }) {
     return __applyAppMiddleware({
       basePath: __basePath,
       cleanPathname,
       context,
+      externalRewriteRequest,
       hadBasePath,
       filePath: ${JSON.stringify(middlewarePath ? toSlash(middlewarePath) : "")},
       i18nConfig: __i18nConfig,

--- a/packages/vinext/src/server/app-middleware.ts
+++ b/packages/vinext/src/server/app-middleware.ts
@@ -151,14 +151,34 @@ function requestWithMiddlewareRequestHeaders(
   return new Request(request.url, init);
 }
 
+function restoreFlightHeaders(request: Request, source: Request): Request {
+  const headers = new Headers(request.headers);
+  let changed = false;
+
+  for (const name of FLIGHT_HEADERS) {
+    const value = source.headers.get(name);
+    if (value === null) {
+      if (headers.has(name)) {
+        headers.delete(name);
+        changed = true;
+      }
+    } else if (headers.get(name) !== value) {
+      headers.set(name, value);
+      changed = true;
+    }
+  }
+
+  return changed ? cloneRequestWithHeaders(request, headers) : request;
+}
+
 export async function proxyExternalMiddlewareRewrite(
   request: Request,
   rewriteUrl: string,
   context: AppMiddlewareContext,
 ): Promise<Response> {
-  const proxyRequest = requestWithMiddlewareRequestHeaders(
+  const proxyRequest = restoreFlightHeaders(
+    requestWithMiddlewareRequestHeaders(request, context.requestHeaders ?? context.headers),
     request,
-    context.requestHeaders ?? context.headers,
   );
   setHeadersContext(null);
   setNavigationContext(null);
@@ -259,9 +279,7 @@ export async function applyAppMiddleware(
           };
         }
         if (options.middlewareRequest) cancelRequestBody(options.middlewareRequest);
-        const externalRequest = requestWithoutFlightHeaders(
-          options.externalRewriteRequest ?? options.request,
-        );
+        const externalRequest = options.externalRewriteRequest ?? options.request;
         return {
           kind: "response",
           response: await proxyExternalMiddlewareRewrite(
@@ -342,9 +360,7 @@ export async function applyAppMiddleware(
             response: validationResponseWithMiddlewareHeaders(validationResponse, options.context),
           };
         }
-        const externalRequest = requestWithoutFlightHeaders(
-          options.externalRewriteRequest ?? options.request,
-        );
+        const externalRequest = options.externalRewriteRequest ?? options.request;
         return {
           kind: "response",
           response: await proxyExternalMiddlewareRewrite(

--- a/packages/vinext/src/server/app-middleware.ts
+++ b/packages/vinext/src/server/app-middleware.ts
@@ -32,6 +32,8 @@ export type ApplyAppMiddlewareOptions = {
   isDataRequest?: boolean;
   filePath?: string;
   isProxy: boolean;
+  /** Request URL for external proxying, retaining internal transport query params. */
+  externalRewriteRequest?: Request;
   /** An App Router-created body branch dedicated to middleware. */
   middlewareRequest?: Request;
   module: MiddlewareModule;
@@ -184,6 +186,23 @@ export async function proxyExternalMiddlewareRewrite(
   });
 }
 
+function validationResponseWithMiddlewareHeaders(
+  response: Response,
+  context: AppMiddlewareContext,
+): Response {
+  if (!context.headers) return response;
+
+  const headers = new Headers(response.headers);
+  const middlewareHeaders = new Headers(context.headers);
+  processMiddlewareHeaders(middlewareHeaders);
+  mergeMiddlewareResponseHeaders(headers, middlewareHeaders);
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
 function applyForwardedMiddlewareContext(
   request: Request,
   context: AppMiddlewareContext,
@@ -232,10 +251,15 @@ export async function applyAppMiddleware(
         const validationResponse = await options.validateExternalRewriteRequest?.();
         if (validationResponse) {
           if (options.middlewareRequest) cancelRequestBody(options.middlewareRequest);
-          return { kind: "response", response: validationResponse };
+          return {
+            kind: "response",
+            response: validationResponseWithMiddlewareHeaders(validationResponse, options.context),
+          };
         }
         if (options.middlewareRequest) cancelRequestBody(options.middlewareRequest);
-        const externalRequest = requestWithoutFlightHeaders(options.request);
+        const externalRequest = requestWithoutFlightHeaders(
+          options.externalRewriteRequest ?? options.request,
+        );
         return {
           kind: "response",
           response: await proxyExternalMiddlewareRewrite(
@@ -310,8 +334,15 @@ export async function applyAppMiddleware(
       }
       if (isExternalUrl(result.rewriteUrl)) {
         const validationResponse = await options.validateExternalRewriteRequest?.();
-        if (validationResponse) return { kind: "response", response: validationResponse };
-        const externalRequest = requestWithoutFlightHeaders(options.request);
+        if (validationResponse) {
+          return {
+            kind: "response",
+            response: validationResponseWithMiddlewareHeaders(validationResponse, options.context),
+          };
+        }
+        const externalRequest = requestWithoutFlightHeaders(
+          options.externalRewriteRequest ?? options.request,
+        );
         return {
           kind: "response",
           response: await proxyExternalMiddlewareRewrite(

--- a/packages/vinext/src/server/app-middleware.ts
+++ b/packages/vinext/src/server/app-middleware.ts
@@ -193,9 +193,11 @@ function validationResponseWithMiddlewareHeaders(
   if (!context.headers) return response;
 
   const headers = new Headers(response.headers);
+  const location = headers.get("location");
   const middlewareHeaders = new Headers(context.headers);
   processMiddlewareHeaders(middlewareHeaders);
   mergeMiddlewareResponseHeaders(headers, middlewareHeaders);
+  if (location !== null) headers.set("location", location);
   return new Response(response.body, {
     status: response.status,
     statusText: response.statusText,

--- a/packages/vinext/src/server/app-middleware.ts
+++ b/packages/vinext/src/server/app-middleware.ts
@@ -36,6 +36,7 @@ export type ApplyAppMiddlewareOptions = {
   middlewareRequest?: Request;
   module: MiddlewareModule;
   request: Request;
+  validateExternalRewriteRequest?: () => Promise<Response | null>;
   /**
    * Forwarded to `executeMiddleware` so the NextRequest exposes a NextURL with
    * the configured trailingSlash policy. This is what makes
@@ -228,6 +229,11 @@ export async function applyAppMiddleware(
   if (forwarded.rewriteUrl) {
     try {
       if (isExternalMiddlewareRewrite(forwarded.rewriteUrl, options.request)) {
+        const validationResponse = await options.validateExternalRewriteRequest?.();
+        if (validationResponse) {
+          if (options.middlewareRequest) cancelRequestBody(options.middlewareRequest);
+          return { kind: "response", response: validationResponse };
+        }
         if (options.middlewareRequest) cancelRequestBody(options.middlewareRequest);
         const externalRequest = requestWithoutFlightHeaders(options.request);
         return {
@@ -303,6 +309,8 @@ export async function applyAppMiddleware(
         options.context.status = result.rewriteStatus;
       }
       if (isExternalUrl(result.rewriteUrl)) {
+        const validationResponse = await options.validateExternalRewriteRequest?.();
+        if (validationResponse) return { kind: "response", response: validationResponse };
         const externalRequest = requestWithoutFlightHeaders(options.request);
         return {
           kind: "response",

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -111,6 +111,7 @@ type AppRscMiddlewareContext = AppMiddlewareContext;
 type RunAppMiddlewareOptions = {
   cleanPathname: string;
   context: AppRscMiddlewareContext;
+  externalRewriteRequest: Request;
   hadBasePath: boolean;
   isDataRequest: boolean;
   middlewareRequest?: Request;
@@ -684,6 +685,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     const middlewareResult = await runMiddleware({
       cleanPathname,
       context: middlewareContext,
+      externalRewriteRequest: normalizedUserlandRequest,
       hadBasePath,
       isDataRequest: isMiddlewareDataRequest,
       middlewareRequest: isolatedMiddlewareRequest,

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -115,6 +115,7 @@ type RunAppMiddlewareOptions = {
   isDataRequest: boolean;
   middlewareRequest?: Request;
   request: Request;
+  validateExternalRewriteRequest: () => Promise<Response | null>;
 };
 
 type AppRscHandlerRoute = {
@@ -644,6 +645,14 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     : null;
   if (rscCacheBustingRedirect) return rscCacheBustingRedirect;
 
+  let filesystemRouteEligible = hadBasePath;
+  const validateClaimedOutsideBasePathRsc = async (
+    routeClaimed = filesystemRouteEligible,
+  ): Promise<Response | null> => {
+    if (hadBasePath || !routeClaimed) return null;
+    return resolveInvalidRscCacheBustingRequest({ isRscRequest, request });
+  };
+
   const runMiddleware = isOnDemandRevalidateRequest(
     request.headers.get(PRERENDER_REVALIDATE_HEADER),
   )
@@ -679,6 +688,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
       isDataRequest: isMiddlewareDataRequest,
       middlewareRequest: isolatedMiddlewareRequest,
       request: userlandRequest,
+      validateExternalRewriteRequest: () => validateClaimedOutsideBasePathRsc(true),
     });
     if (middlewareResult.kind === "response") {
       if (request.body && !request.body.locked) {
@@ -708,13 +718,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
 
   const scriptNonce = getScriptNonceFromHeaderSources(request.headers, middlewareContext.headers);
   const postMiddlewareRequestContext = buildPostMwRequestContext(userlandRequest);
-  let filesystemRouteEligible = hadBasePath || didMiddlewareRewrite;
-  const validateClaimedOutsideBasePathRsc = async (
-    routeClaimed = filesystemRouteEligible,
-  ): Promise<Response | null> => {
-    if (hadBasePath || !routeClaimed) return null;
-    return resolveInvalidRscCacheBustingRequest({ isRscRequest, request });
-  };
+  filesystemRouteEligible ||= didMiddlewareRewrite;
 
   // Rewrites (beforeFiles, afterFiles, fallback) use `matchPathname` from
   // above to splice in the default locale before matching. Route matching

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -401,6 +401,7 @@ async function applyRewrite(
     rewrites: NextRewrite[];
     /** Raw pathname identity used for config source matching and capture substitution. */
     paramsPathname?: string;
+    validateExternalRewriteRequest: () => Promise<Response | null>;
   },
   cleanPathname: string,
 ): Promise<Response | string | null> {
@@ -418,6 +419,8 @@ async function applyRewrite(
   if (!rewritten) return null;
 
   if (isExternalUrl(rewritten)) {
+    const validationResponse = await options.validateExternalRewriteRequest();
+    if (validationResponse) return validationResponse;
     options.clearRequestContext();
     return configMatchers.proxyExternalRequest(options.request, rewritten);
   }
@@ -694,8 +697,10 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
   const scriptNonce = getScriptNonceFromHeaderSources(request.headers, middlewareContext.headers);
   const postMiddlewareRequestContext = buildPostMwRequestContext(userlandRequest);
   let filesystemRouteEligible = hadBasePath || didMiddlewareRewrite;
-  const validateClaimedOutsideBasePathRsc = async (): Promise<Response | null> => {
-    if (hadBasePath || !filesystemRouteEligible) return null;
+  const validateClaimedOutsideBasePathRsc = async (
+    routeClaimed = filesystemRouteEligible,
+  ): Promise<Response | null> => {
+    if (hadBasePath || !routeClaimed) return null;
     return resolveInvalidRscCacheBustingRequest({ isRscRequest, request });
   };
 
@@ -721,6 +726,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
           cleanPathnameIsRequestPathname ? requestCleanPathname : cleanPathname,
         ),
         rewrites: [rewrite],
+        validateExternalRewriteRequest: () => validateClaimedOutsideBasePathRsc(true),
       },
       matchPathname(cleanPathname),
     );
@@ -760,6 +766,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
             cleanPathnameIsRequestPathname ? requestCleanPathname : cleanPathname,
           ),
           rewrites: [rewrite],
+          validateExternalRewriteRequest: () => validateClaimedOutsideBasePathRsc(true),
         },
         matchPathname(cleanPathname),
       );
@@ -788,6 +795,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
               cleanPathnameIsRequestPathname ? requestCleanPathname : cleanPathname,
             ),
             rewrites: [rewrite],
+            validateExternalRewriteRequest: () => validateClaimedOutsideBasePathRsc(true),
           },
           matchPathname(cleanPathname),
         );
@@ -1032,6 +1040,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
             cleanPathnameIsRequestPathname ? requestCleanPathname : cleanPathname,
           ),
           rewrites: [rewrite],
+          validateExternalRewriteRequest: () => validateClaimedOutsideBasePathRsc(true),
         },
         matchPathname(cleanPathname),
       );
@@ -1081,6 +1090,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
             cleanPathnameIsRequestPathname ? requestCleanPathname : cleanPathname,
           ),
           rewrites: [rewrite],
+          validateExternalRewriteRequest: () => validateClaimedOutsideBasePathRsc(true),
         },
         matchPathname(cleanPathname),
       );

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -1855,7 +1855,13 @@ describe("createAppRscHandler", () => {
         if (mode === "forwarded") {
           headers.set(
             VINEXT_MW_CTX_HEADER,
-            JSON.stringify({ h: [["set-cookie", "session=forwarded"]], r: upstreamUrl }),
+            JSON.stringify({
+              h: [
+                ["location", "/middleware-location"],
+                ["set-cookie", "session=forwarded"],
+              ],
+              r: upstreamUrl,
+            }),
           );
         }
         const handler = createHandler({
@@ -1864,6 +1870,7 @@ describe("createAppRscHandler", () => {
             default: () =>
               new Response(null, {
                 headers: {
+                  location: "/middleware-location",
                   "set-cookie": "session=middleware",
                   "x-middleware-rewrite": upstreamUrl,
                 },

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -20,6 +20,7 @@ import {
   NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
   RSC_HEADER,
   VINEXT_CLIENT_REUSE_MANIFEST_HEADER,
+  VINEXT_MW_CTX_HEADER,
 } from "../packages/vinext/src/server/headers.js";
 import { applyAppMiddleware } from "../packages/vinext/src/server/app-middleware.js";
 import type { NextRequest } from "../packages/vinext/src/shims/server.js";
@@ -1835,47 +1836,102 @@ describe("createAppRscHandler", () => {
     },
   );
 
-  it("validates out-of-basePath RSC requests before middleware external rewrite proxies", async () => {
-    const receivedUrls: string[] = [];
-    const server = createServer((req, res) => {
-      receivedUrls.push(req.url ?? "");
-      res.writeHead(200, { "content-type": "text/plain" });
-      res.end("upstream");
-    });
-    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
-    const address = server.address() as AddressInfo;
-    const upstreamUrl = `http://127.0.0.1:${address.port}/proxy`;
-
-    try {
-      const headers = createRscRequestHeaders({ mountedSlotsHeader: "slot:modal:/" });
-      const expectedHash = await computeRscCacheBustingSearchParam(headers);
-      const handler = createHandler({
-        configHeaders: [],
-        middlewareModule: {
-          default: () =>
-            new Response(null, {
-              headers: { "x-middleware-rewrite": upstreamUrl },
-            }),
-        },
-        matchRoute: () => null,
+  it.each(["middleware", "forwarded"] as const)(
+    "validates out-of-basePath RSC requests before %s external rewrite proxies",
+    async (mode) => {
+      const receivedUrls: string[] = [];
+      const server = createServer((req, res) => {
+        receivedUrls.push(req.url ?? "");
+        res.writeHead(200, { "content-type": "text/plain" });
+        res.end("upstream");
       });
+      await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+      const address = server.address() as AddressInfo;
+      const upstreamUrl = `http://127.0.0.1:${address.port}/proxy`;
 
-      for (const method of ["GET", "HEAD"] as const) {
+      try {
+        const headers = createRscRequestHeaders({ mountedSlotsHeader: "slot:modal:/" });
+        const expectedHash = await computeRscCacheBustingSearchParam(headers);
+        if (mode === "forwarded") {
+          headers.set(
+            VINEXT_MW_CTX_HEADER,
+            JSON.stringify({ h: [["set-cookie", "session=forwarded"]], r: upstreamUrl }),
+          );
+        }
+        const handler = createHandler({
+          configHeaders: [],
+          middlewareModule: {
+            default: () =>
+              new Response(null, {
+                headers: {
+                  "set-cookie": "session=middleware",
+                  "x-middleware-rewrite": upstreamUrl,
+                },
+              }),
+          },
+          matchRoute: () => null,
+        });
+
+        for (const method of ["GET", "HEAD"] as const) {
+          const response = await handler(
+            new Request("https://example.test/outside.rsc?tab=latest", { headers, method }),
+            null,
+          );
+
+          expect(response.status).toBe(307);
+          expect(response.headers.get("location")).toBe(
+            `/outside.rsc?tab=latest&_rsc=${expectedHash}`,
+          );
+          expect(response.headers.get("set-cookie")).toBe(`session=${mode}`);
+        }
+        expect(receivedUrls).toEqual([]);
+      } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+      }
+    },
+  );
+
+  it.each(["middleware", "forwarded"] as const)(
+    "forwards valid RSC cache-busting params to %s external rewrite proxies",
+    async (mode) => {
+      const receivedUrls: string[] = [];
+      const server = createServer((req, res) => {
+        receivedUrls.push(req.url ?? "");
+        res.writeHead(200, { "content-type": "text/plain" });
+        res.end("upstream");
+      });
+      await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+      const address = server.address() as AddressInfo;
+      const upstreamUrl = `http://127.0.0.1:${address.port}/proxy`;
+
+      try {
+        const headers = createRscRequestHeaders({ mountedSlotsHeader: "slot:modal:/" });
+        if (mode === "forwarded") {
+          headers.set(VINEXT_MW_CTX_HEADER, JSON.stringify({ r: upstreamUrl }));
+        }
+        const requestUrl = await createRscRequestUrl("/outside?tab=latest", headers);
+        const handler = createHandler({
+          configHeaders: [],
+          middlewareModule: {
+            default: () => new Response(null, { headers: { "x-middleware-rewrite": upstreamUrl } }),
+          },
+          matchRoute: () => null,
+        });
+
         const response = await handler(
-          new Request("https://example.test/outside.rsc?tab=latest", { headers, method }),
+          new Request(`https://example.test${requestUrl}`, { headers }),
           null,
         );
 
-        expect(response.status).toBe(307);
-        expect(response.headers.get("location")).toBe(
-          `/outside.rsc?tab=latest&_rsc=${expectedHash}`,
-        );
+        expect(response.status).toBe(200);
+        expect(receivedUrls).toHaveLength(1);
+        const forwardedUrl = new URL(`http://vinext.local${receivedUrls[0]}`);
+        expect(forwardedUrl.searchParams.has(VINEXT_RSC_CACHE_BUSTING_SEARCH_PARAM)).toBe(true);
+      } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
       }
-      expect(receivedUrls).toEqual([]);
-    } finally {
-      await new Promise<void>((resolve) => server.close(() => resolve()));
-    }
-  });
+    },
+  );
 
   it("applies basePath false rewrites before rejecting outside-basePath requests", async () => {
     // Ported from Next.js: test/e2e/app-dir/app-basepath/index.test.ts

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -1901,9 +1901,12 @@ describe("createAppRscHandler", () => {
   it.each(["middleware", "forwarded"] as const)(
     "forwards valid RSC cache-busting params to %s external rewrite proxies",
     async (mode) => {
-      const receivedUrls: string[] = [];
+      const receivedRequests: Array<{
+        headers: import("node:http").IncomingHttpHeaders;
+        url: string;
+      }> = [];
       const server = createServer((req, res) => {
-        receivedUrls.push(req.url ?? "");
+        receivedRequests.push({ headers: req.headers, url: req.url ?? "" });
         res.writeHead(200, { "content-type": "text/plain" });
         res.end("upstream");
       });
@@ -1912,15 +1915,44 @@ describe("createAppRscHandler", () => {
       const upstreamUrl = `http://127.0.0.1:${address.port}/proxy`;
 
       try {
-        const headers = createRscRequestHeaders({ mountedSlotsHeader: "slot:modal:/" });
+        const headers = createRscRequestHeaders({
+          mountedSlotsHeader: "slot:modal:/",
+          prefetchRouterState: { pathAndSearch: "/outside?tab=latest", routeId: "/outside" },
+        });
+        const routerState = headers.get("next-router-state-tree");
+        expect(routerState).not.toBeNull();
         if (mode === "forwarded") {
-          headers.set(VINEXT_MW_CTX_HEADER, JSON.stringify({ r: upstreamUrl }));
+          headers.set(
+            VINEXT_MW_CTX_HEADER,
+            JSON.stringify({
+              h: [
+                [
+                  "x-middleware-override-headers",
+                  "rsc,next-router-prefetch,next-router-state-tree",
+                ],
+                ["x-middleware-request-next-router-prefetch", "0"],
+                ["x-middleware-request-next-router-state-tree", "tampered"],
+                ["x-middleware-request-rsc", "0"],
+              ],
+              r: upstreamUrl,
+            }),
+          );
         }
         const requestUrl = await createRscRequestUrl("/outside?tab=latest", headers);
         const handler = createHandler({
           configHeaders: [],
           middlewareModule: {
-            default: () => new Response(null, { headers: { "x-middleware-rewrite": upstreamUrl } }),
+            default: () =>
+              new Response(null, {
+                headers: {
+                  "x-middleware-override-headers":
+                    "rsc,next-router-prefetch,next-router-state-tree",
+                  "x-middleware-request-next-router-prefetch": "0",
+                  "x-middleware-request-next-router-state-tree": "tampered",
+                  "x-middleware-request-rsc": "0",
+                  "x-middleware-rewrite": upstreamUrl,
+                },
+              }),
           },
           matchRoute: () => null,
         });
@@ -1931,9 +1963,13 @@ describe("createAppRscHandler", () => {
         );
 
         expect(response.status).toBe(200);
-        expect(receivedUrls).toHaveLength(1);
-        const forwardedUrl = new URL(`http://vinext.local${receivedUrls[0]}`);
+        expect(receivedRequests).toHaveLength(1);
+        const [received] = receivedRequests;
+        const forwardedUrl = new URL(`http://vinext.local${received.url}`);
         expect(forwardedUrl.searchParams.has(VINEXT_RSC_CACHE_BUSTING_SEARCH_PARAM)).toBe(true);
+        expect(received.headers[RSC_HEADER.toLowerCase()]).toBe("1");
+        expect(received.headers[NEXT_ROUTER_PREFETCH_HEADER.toLowerCase()]).toBe("1");
+        expect(received.headers["next-router-state-tree"]).toBe(routerState);
       } finally {
         await new Promise<void>((resolve) => server.close(() => resolve()));
       }

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -1786,6 +1786,55 @@ describe("createAppRscHandler", () => {
     }
   });
 
+  it.each(["beforeFiles", "afterFiles", "fallback"] as const)(
+    "validates out-of-basePath RSC requests before %s external rewrite proxies",
+    async (phase) => {
+      const receivedUrls: string[] = [];
+      const server = createServer((req, res) => {
+        receivedUrls.push(req.url ?? "");
+        res.writeHead(200, { "content-type": "text/plain" });
+        res.end("upstream");
+      });
+      await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+      const address = server.address() as AddressInfo;
+      const upstreamBase = `http://127.0.0.1:${address.port}`;
+
+      try {
+        const headers = createRscRequestHeaders({ mountedSlotsHeader: "slot:modal:/" });
+        const expectedHash = await computeRscCacheBustingSearchParam(headers);
+        const rewrite = {
+          source: "/outside",
+          destination: `${upstreamBase}/proxy`,
+          basePath: false as const,
+        };
+        const handler = createHandler({
+          configHeaders: [],
+          configRewrites: {
+            beforeFiles: phase === "beforeFiles" ? [rewrite] : [],
+            afterFiles: phase === "afterFiles" ? [rewrite] : [],
+            fallback: phase === "fallback" ? [rewrite] : [],
+          },
+          matchRoute: () => null,
+        });
+
+        for (const method of ["GET", "HEAD"] as const) {
+          const response = await handler(
+            new Request("https://example.test/outside.rsc?tab=latest", { headers, method }),
+            null,
+          );
+
+          expect(response.status).toBe(307);
+          expect(response.headers.get("location")).toBe(
+            `/outside.rsc?tab=latest&_rsc=${expectedHash}`,
+          );
+        }
+        expect(receivedUrls).toEqual([]);
+      } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+      }
+    },
+  );
+
   it("applies basePath false rewrites before rejecting outside-basePath requests", async () => {
     // Ported from Next.js: test/e2e/app-dir/app-basepath/index.test.ts
     // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/app-basepath/index.test.ts

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -1835,6 +1835,48 @@ describe("createAppRscHandler", () => {
     },
   );
 
+  it("validates out-of-basePath RSC requests before middleware external rewrite proxies", async () => {
+    const receivedUrls: string[] = [];
+    const server = createServer((req, res) => {
+      receivedUrls.push(req.url ?? "");
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end("upstream");
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address() as AddressInfo;
+    const upstreamUrl = `http://127.0.0.1:${address.port}/proxy`;
+
+    try {
+      const headers = createRscRequestHeaders({ mountedSlotsHeader: "slot:modal:/" });
+      const expectedHash = await computeRscCacheBustingSearchParam(headers);
+      const handler = createHandler({
+        configHeaders: [],
+        middlewareModule: {
+          default: () =>
+            new Response(null, {
+              headers: { "x-middleware-rewrite": upstreamUrl },
+            }),
+        },
+        matchRoute: () => null,
+      });
+
+      for (const method of ["GET", "HEAD"] as const) {
+        const response = await handler(
+          new Request("https://example.test/outside.rsc?tab=latest", { headers, method }),
+          null,
+        );
+
+        expect(response.status).toBe(307);
+        expect(response.headers.get("location")).toBe(
+          `/outside.rsc?tab=latest&_rsc=${expectedHash}`,
+        );
+      }
+      expect(receivedUrls).toEqual([]);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
   it("applies basePath false rewrites before rejecting outside-basePath requests", async () => {
     // Ported from Next.js: test/e2e/app-dir/app-basepath/index.test.ts
     // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/app-basepath/index.test.ts

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -1180,9 +1180,12 @@ describe("App Router entry templates", () => {
     expect(withoutMiddleware).not.toContain("app-middleware.js");
     expect(withoutMiddleware).not.toContain("runMiddleware(");
     expect(withMiddleware).toContain("app-middleware.js");
-    expect(withMiddleware).toContain("runMiddleware({ cleanPathname, context, hadBasePath");
+    expect(withMiddleware).toContain(
+      "runMiddleware({ cleanPathname, context, externalRewriteRequest, hadBasePath",
+    );
     expect(withMiddleware).toContain("return __applyAppMiddleware({");
     expect(withMiddleware).toContain("hadBasePath,");
+    expect(withMiddleware).toContain("externalRewriteRequest,");
     expect(withMiddleware).toContain("middlewareRequest,");
     expect(withMiddleware).toContain("validateExternalRewriteRequest,");
   });

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -1184,6 +1184,7 @@ describe("App Router entry templates", () => {
     expect(withMiddleware).toContain("return __applyAppMiddleware({");
     expect(withMiddleware).toContain("hadBasePath,");
     expect(withMiddleware).toContain("middlewareRequest,");
+    expect(withMiddleware).toContain("validateExternalRewriteRequest,");
   });
 
   it("generateRscEntry only includes the PPR runtime when Cache Components is enabled", () => {


### PR DESCRIPTION
## Overview

| | |
| --- | --- |
| Goal | Prevent invalid outside-basePath RSC requests from reaching external config or middleware rewrite destinations. |
| Core change | Validate cache-busting state at every external-proxy boundary, before proxy I/O begins. |
| Middleware parity | Keep internal Flight state hidden from user middleware, then restore the original authenticated `_rsc` and Flight headers for the external destination. |
| Expected impact | Missing or stale `_rsc` values receive the canonical 307 consistently; valid external RSC rewrites retain the state their destination needs to render and validate Flight. |

## Why

RSC cache-busting validation is delayed for requests outside the configured basePath until a `basePath: false` rule or middleware rewrite claims them. Internal rewrites reached a delayed validation checkpoint, but external config and middleware rewrites returned their proxy response immediately. That allowed invalid GET and HEAD requests to bypass canonicalization.

Middleware also receives a request with internal Flight state removed, as Next.js does. Before this change, vinext reused that stripped request for external proxying, so valid middleware rewrites dropped `_rsc` and the Flight headers at the destination. The proxy path now retains a separate downstream request and restores the original Flight headers after middleware request-header overrides, making those authenticated headers non-overridable.

This matches Next.js v16.2.6's middleware adapter and external-rewrite fixture:

- [Middleware adapter source](https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/server/web/adapter.ts)
- [External RSC middleware rewrite test](https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/middleware-rsc-external-rewrite/middleware-rsc-external-rewrite.test.ts)

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| Invalid outside-basePath RSC request claimed by a config external rewrite | Proxied without a validated `_rsc` token | Returns the canonical 307 before upstream contact |
| Invalid outside-basePath RSC request claimed by a middleware external rewrite | Proxied before the delayed checkpoint | Returns the canonical 307, preserving safe middleware response headers and the framework-owned `Location` |
| Valid middleware external RSC rewrite | `_rsc` and Flight headers were stripped with the middleware-facing request | Destination receives the original `_rsc`, `RSC`, router-state, and prefetch headers |
| Internal rewrite or unclaimed outside-basePath request | Existing delayed validation or plain 404 | Unchanged |
| POST/action traffic | Existing proxy behavior | Unchanged; validation remains GET/HEAD-only |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/server/app-rsc-handler.ts` for original-request validation and separate middleware/downstream requests.
2. `packages/vinext/src/server/app-middleware.ts` for the two pre-proxy gates, safe response-header merge, and non-overridable Flight-header restoration.
3. `packages/vinext/src/entries/app-rsc-entry.ts` for generated middleware wiring.
4. `tests/app-rsc-handler.test.ts` for config phases plus normal and forwarded middleware coverage.

</details>

<details>
<summary>Validation</summary>

- App RSC handler: 142 passed.
- RSC cache-busting: 37 passed.
- Entry template suite: 52 passed in BigBonk's checkout.
- Targeted format, lint, type, and diff checks passed.
- Exact-head CI: 47/47 jobs passed.
- Independent final review and BigBonk: clean/LGTM.

</details>

<details>
<summary>Risk / compatibility</summary>

- No public API or configuration shape changes.
- Validation runs only after an external rewrite claims an outside-basePath request.
- Middleware still cannot observe internal `_rsc` or Flight transport headers.
- Only the external downstream proxy receives the original authenticated Flight state, matching Next.js behavior.
- Middleware response cookies and custom headers survive a canonicalization response, but middleware cannot replace its framework-owned `Location`.

</details>
