### PR TITLE
fix(app): keep client trace metadata out of shared HTML cache entries

### DIFF
--- a/packages/vinext/src/server/app-page-cache-finalizer.ts
+++ b/packages/vinext/src/server/app-page-cache-finalizer.ts
@@ -6,7 +6,6 @@ import {
   createEmptyAppPageRenderObservationState,
   type AppPageRenderObservationState,
 } from "./app-page-render-observation.js";
-import { stripClientTraceMetadataTags } from "./client-trace-metadata.js";
 import { buildAppPageCacheValue, isrCacheControl, type AppPageCacheSetter } from "./isr-cache.js";
 import type { CacheControlMetadata } from "vinext/shims/cache-handler";
 import type { RenderObservation } from "./cache-proof.js";
@@ -151,10 +150,14 @@ export function finalizeAppPageHtmlCacheResponse(
 
   const cachePromise = (async () => {
     try {
-      const cachedHtml = stripClientTraceMetadataTags(
-        await readStreamAsText(streamForCache),
-        options.clientTraceMetadata,
-      );
+      let cachedHtml = await readStreamAsText(streamForCache);
+
+      // Gate on the allow-list so the trace-metadata module stays out of the
+      // RSC server graph for the common case where the feature is unset.
+      if (options.clientTraceMetadata && options.clientTraceMetadata.length > 0) {
+        const { stripClientTraceMetadataTags } = await import("./client-trace-metadata.js");
+        cachedHtml = stripClientTraceMetadataTags(cachedHtml, options.clientTraceMetadata);
+      }
 
       if (
         options.capturedDynamicUsageBeforeContextCleanup?.() === true ||

--- a/packages/vinext/src/server/app-page-cache-finalizer.ts
+++ b/packages/vinext/src/server/app-page-cache-finalizer.ts
@@ -6,6 +6,7 @@ import {
   createEmptyAppPageRenderObservationState,
   type AppPageRenderObservationState,
 } from "./app-page-render-observation.js";
+import { stripClientTraceMetadataTags } from "./client-trace-metadata.js";
 import { buildAppPageCacheValue, isrCacheControl, type AppPageCacheSetter } from "./isr-cache.js";
 import type { CacheControlMetadata } from "vinext/shims/cache-handler";
 import type { RenderObservation } from "./cache-proof.js";
@@ -33,6 +34,12 @@ type FinalizeAppPageHtmlCacheResponseOptions = {
   capturedDynamicUsageBeforeContextCleanup?: () => boolean;
   capturedRscDataPromise: Promise<ArrayBuffer> | null;
   cleanPathname: string;
+  /**
+   * `experimental.clientTraceMetadata` allow-list. The rendered response keeps
+   * its request-scoped trace `<meta>` tags; the cached copy must not, or the
+   * generating request's trace context is replayed to every later cache HIT.
+   */
+  clientTraceMetadata?: readonly string[];
   consumeDynamicUsage: () => boolean;
   consumeRenderObservationState?: () => AppPageRenderObservationState;
   createHtmlRenderObservation?: BuildAppPageCacheRenderObservation;
@@ -144,7 +151,10 @@ export function finalizeAppPageHtmlCacheResponse(
 
   const cachePromise = (async () => {
     try {
-      const cachedHtml = await readStreamAsText(streamForCache);
+      const cachedHtml = stripClientTraceMetadataTags(
+        await readStreamAsText(streamForCache),
+        options.clientTraceMetadata,
+      );
 
       if (
         options.capturedDynamicUsageBeforeContextCleanup?.() === true ||

--- a/packages/vinext/src/server/app-page-cache-finalizer.ts
+++ b/packages/vinext/src/server/app-page-cache-finalizer.ts
@@ -33,12 +33,8 @@ type FinalizeAppPageHtmlCacheResponseOptions = {
   capturedDynamicUsageBeforeContextCleanup?: () => boolean;
   capturedRscDataPromise: Promise<ArrayBuffer> | null;
   cleanPathname: string;
-  /**
-   * `experimental.clientTraceMetadata` allow-list. The rendered response keeps
-   * its request-scoped trace `<meta>` tags; the cached copy must not, or the
-   * generating request's trace context is replayed to every later cache HIT.
-   */
-  clientTraceMetadata?: readonly string[];
+  /** Private marker surrounding this render's injected client trace metadata. */
+  clientTraceMetadataMarker?: string;
   consumeDynamicUsage: () => boolean;
   consumeRenderObservationState?: () => AppPageRenderObservationState;
   createHtmlRenderObservation?: BuildAppPageCacheRenderObservation;
@@ -152,11 +148,11 @@ export function finalizeAppPageHtmlCacheResponse(
     try {
       let cachedHtml = await readStreamAsText(streamForCache);
 
-      // Gate on the allow-list so the trace-metadata module stays out of the
+      // Gate on the marker so the trace-metadata module stays out of the
       // RSC server graph for the common case where the feature is unset.
-      if (options.clientTraceMetadata && options.clientTraceMetadata.length > 0) {
-        const { stripClientTraceMetadataTags } = await import("./client-trace-metadata.js");
-        cachedHtml = stripClientTraceMetadataTags(cachedHtml, options.clientTraceMetadata);
+      if (options.clientTraceMetadataMarker) {
+        const { stripClientTraceMetadataBlock } = await import("./client-trace-metadata.js");
+        cachedHtml = stripClientTraceMetadataBlock(cachedHtml, options.clientTraceMetadataMarker);
       }
 
       if (

--- a/packages/vinext/src/server/app-page-cache-finalizer.ts
+++ b/packages/vinext/src/server/app-page-cache-finalizer.ts
@@ -148,13 +148,6 @@ export function finalizeAppPageHtmlCacheResponse(
     try {
       let cachedHtml = await readStreamAsText(streamForCache);
 
-      // Gate on the marker so the trace-metadata module stays out of the
-      // RSC server graph for the common case where the feature is unset.
-      if (options.clientTraceMetadataMarker) {
-        const { stripClientTraceMetadataBlock } = await import("./client-trace-metadata.js");
-        cachedHtml = stripClientTraceMetadataBlock(cachedHtml, options.clientTraceMetadataMarker);
-      }
-
       if (
         options.capturedDynamicUsageBeforeContextCleanup?.() === true ||
         options.consumeDynamicUsage()
@@ -171,6 +164,14 @@ export function finalizeAppPageHtmlCacheResponse(
       if (!cacheControl) {
         options.isrDebug?.("HTML cache write skipped (no cache policy)", htmlKey);
         return;
+      }
+
+      // Gate on the marker so the trace-metadata module stays out of the
+      // RSC server graph for the common case where the feature is unset. Do
+      // this only after proving that a cache write will actually happen.
+      if (options.clientTraceMetadataMarker) {
+        const { stripClientTraceMetadataBlock } = await import("./client-trace-metadata.js");
+        cachedHtml = stripClientTraceMetadataBlock(cachedHtml, options.clientTraceMetadataMarker);
       }
 
       const pageTags = options.getPageTags();

--- a/packages/vinext/src/server/app-page-cache-render.ts
+++ b/packages/vinext/src/server/app-page-cache-render.ts
@@ -34,7 +34,6 @@ export type RenderAppPageCacheArtifactsOptions = {
   basePath?: string;
   captureRscData: boolean;
   cleanPathname: string;
-  clientTraceMetadata?: readonly string[];
   element: AppPageRenderableElement;
   getFontLinks: () => string[];
   getFontPreloads: () => AppPageFontPreload[];
@@ -90,7 +89,8 @@ export async function renderAppPageCacheArtifacts(
     },
     {
       basePath: options.basePath,
-      clientTraceMetadata: options.clientTraceMetadata,
+      // No clientTraceMetadata: this render exists to produce a shared cache
+      // artifact, so request-scoped trace context must never be baked into it.
       reactMaxHeadersLength: options.reactMaxHeadersLength,
       rootParams: options.rootParams,
       waitForAllReady: options.waitForAllReady,

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -809,7 +809,6 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
               basePath: options.basePath,
               captureRscData: true,
               cleanPathname: options.cleanPathname,
-              clientTraceMetadata: options.clientTraceMetadata,
               element: revalidatedElement,
               getFontLinks: options.getFontLinks,
               getFontPreloads: options.getFontPreloads,

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -997,26 +997,32 @@ export async function renderAppPageLifecycle(
   // is no separate cache copy to sanitize. Omit request trace metadata from
   // responses that can enter that shared cache. Known no-store responses keep
   // the feature because neither the edge nor the origin will persist them.
+  const middlewareMayControlSharedCaching =
+    options.middlewareContext.headers?.has("cache-control") === true ||
+    options.middlewareContext.headers?.has("cdn-cache-control") === true ||
+    options.middlewareContext.headers?.has("cloudflare-cdn-cache-control") === true;
   const hasKnownNoStoreHtmlPolicy =
-    !options.isProduction ||
-    options.isDraftMode ||
-    options.isForceDynamic ||
-    Boolean(options.scriptNonce) ||
-    options.isProgressiveActionRender === true ||
-    revalidateSeconds === 0 ||
-    (options.isEdgeRuntime &&
-      revalidateSeconds === null &&
-      !options.isForceStatic &&
-      !options.isDynamicError) ||
-    peekDynamicUsage();
+    !middlewareMayControlSharedCaching &&
+    (options.isDraftMode ||
+      options.isForceDynamic ||
+      Boolean(options.scriptNonce) ||
+      options.isProgressiveActionRender === true ||
+      revalidateSeconds === 0 ||
+      (options.isEdgeRuntime &&
+        revalidateSeconds === null &&
+        !options.isForceStatic &&
+        !options.isDynamicError) ||
+      peekDynamicUsage());
   const originOwnsSharedHtmlStore = getCdnCacheAdapter().ownsBackgroundRevalidation;
+  const canSanitizeSeparateOriginCacheCopy =
+    options.isProduction && originOwnsSharedHtmlStore && !middlewareMayControlSharedCaching;
   const clientTraceMetadata =
-    !hasKnownNoStoreHtmlPolicy && !originOwnsSharedHtmlStore
-      ? undefined
-      : options.clientTraceMetadata;
+    hasKnownNoStoreHtmlPolicy || canSanitizeSeparateOriginCacheCopy
+      ? options.clientTraceMetadata
+      : undefined;
   const clientTraceMetadataMarker =
     !hasKnownNoStoreHtmlPolicy &&
-    originOwnsSharedHtmlStore &&
+    canSanitizeSeparateOriginCacheCopy &&
     clientTraceMetadata &&
     clientTraceMetadata.length > 0
       ? crypto.randomUUID()

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -992,6 +992,10 @@ export async function renderAppPageLifecycle(
     getStyles: options.getFontStyles,
   });
   const fontLinkHeader = buildAppPageFontLinkHeader(fontData.preloads);
+  const clientTraceMetadataMarker =
+    options.clientTraceMetadata && options.clientTraceMetadata.length > 0
+      ? crypto.randomUUID()
+      : undefined;
   let requestCacheLifeForPrerender: AppPageRequestCacheLife | null = null;
   let dynamicUsedDuringHtmlRender = false;
   let renderEnd: number | undefined;
@@ -1064,6 +1068,7 @@ export async function renderAppPageLifecycle(
         navigationContext: options.getNavigationContext(),
         basePath: options.basePath,
         clientTraceMetadata: options.clientTraceMetadata,
+        clientTraceMetadataMarker,
         reactMaxHeadersLength: options.reactMaxHeadersLength,
         rootParams: options.rootParams,
         pprFallbackShellSignal: options.pprFallbackShellSignal,
@@ -1244,7 +1249,7 @@ export async function renderAppPageLifecycle(
       },
       capturedRscDataPromise: capturedRscDataRef.value,
       cleanPathname: options.cleanPathname,
-      clientTraceMetadata: options.clientTraceMetadata,
+      clientTraceMetadataMarker,
       consumeDynamicUsage: consumeRenderDynamicUsage,
       consumeRenderObservationState: options.consumeRenderObservationState,
       createHtmlRenderObservation(input) {

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -83,6 +83,7 @@ import type {
 } from "./app-layout-param-observation.js";
 import { getStaticLayoutObservationSkipRejection } from "./app-layout-param-observation.js";
 import { peekDynamicUsage } from "vinext/shims/headers";
+import { getCdnCacheAdapter } from "vinext/shims/cdn-cache";
 import { VINEXT_RSC_COMPLETION_METADATA_HEADER } from "./headers.js";
 import { appendRscCompletionMetadata } from "./rsc-completion-metadata.js";
 
@@ -992,8 +993,29 @@ export async function renderAppPageLifecycle(
     getStyles: options.getFontStyles,
   });
   const fontLinkHeader = buildAppPageFontLinkHeader(fontData.preloads);
+  // Edge-managed adapters cache the outgoing response stream itself, so there
+  // is no separate cache copy to sanitize. Omit request trace metadata from
+  // responses that can enter that shared cache. Known no-store responses keep
+  // the feature because neither the edge nor the origin will persist them.
+  const hasKnownNoStoreHtmlPolicy =
+    !options.isProduction ||
+    options.isDraftMode ||
+    options.isForceDynamic ||
+    Boolean(options.scriptNonce) ||
+    options.isProgressiveActionRender === true ||
+    revalidateSeconds === 0 ||
+    (options.isEdgeRuntime && revalidateSeconds === null) ||
+    peekDynamicUsage();
+  const originOwnsSharedHtmlStore = getCdnCacheAdapter().ownsBackgroundRevalidation;
+  const clientTraceMetadata =
+    !hasKnownNoStoreHtmlPolicy && !originOwnsSharedHtmlStore
+      ? undefined
+      : options.clientTraceMetadata;
   const clientTraceMetadataMarker =
-    options.clientTraceMetadata && options.clientTraceMetadata.length > 0
+    !hasKnownNoStoreHtmlPolicy &&
+    originOwnsSharedHtmlStore &&
+    clientTraceMetadata &&
+    clientTraceMetadata.length > 0
       ? crypto.randomUUID()
       : undefined;
   let requestCacheLifeForPrerender: AppPageRequestCacheLife | null = null;
@@ -1067,7 +1089,7 @@ export async function renderAppPageLifecycle(
         hasCustomGlobalError: options.hasCustomGlobalError,
         navigationContext: options.getNavigationContext(),
         basePath: options.basePath,
-        clientTraceMetadata: options.clientTraceMetadata,
+        clientTraceMetadata,
         clientTraceMetadataMarker,
         reactMaxHeadersLength: options.reactMaxHeadersLength,
         rootParams: options.rootParams,

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -1004,7 +1004,10 @@ export async function renderAppPageLifecycle(
     Boolean(options.scriptNonce) ||
     options.isProgressiveActionRender === true ||
     revalidateSeconds === 0 ||
-    (options.isEdgeRuntime && revalidateSeconds === null) ||
+    (options.isEdgeRuntime &&
+      revalidateSeconds === null &&
+      !options.isForceStatic &&
+      !options.isDynamicError) ||
     peekDynamicUsage();
   const originOwnsSharedHtmlStore = getCdnCacheAdapter().ownsBackgroundRevalidation;
   const clientTraceMetadata =

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -94,6 +94,13 @@ type AppPageBoundaryOnError = (
 ) => unknown;
 type AppPageDebugLogger = (event: string, detail: string) => void;
 
+const SHARED_CACHE_CONTROL_HEADER_NAMES = [
+  "cache-control",
+  "cdn-cache-control",
+  "cloudflare-cdn-cache-control",
+  "vercel-cdn-cache-control",
+] as const;
+
 type AppPageRequestCacheLife = {
   revalidate?: number;
   expire?: number;
@@ -997,36 +1004,35 @@ export async function renderAppPageLifecycle(
   // is no separate cache copy to sanitize. Omit request trace metadata from
   // responses that can enter that shared cache. Known no-store responses keep
   // the feature because neither the edge nor the origin will persist them.
-  const middlewareMayControlSharedCaching =
-    options.middlewareContext.headers?.has("cache-control") === true ||
-    options.middlewareContext.headers?.has("cdn-cache-control") === true ||
-    options.middlewareContext.headers?.has("cloudflare-cdn-cache-control") === true;
-  const hasKnownNoStoreHtmlPolicy =
-    !middlewareMayControlSharedCaching &&
-    (options.isDraftMode ||
-      options.isForceDynamic ||
-      Boolean(options.scriptNonce) ||
-      options.isProgressiveActionRender === true ||
-      revalidateSeconds === 0 ||
-      (options.isEdgeRuntime &&
-        revalidateSeconds === null &&
-        !options.isForceStatic &&
-        !options.isDynamicError) ||
-      peekDynamicUsage());
-  const originOwnsSharedHtmlStore = getCdnCacheAdapter().ownsBackgroundRevalidation;
-  const canSanitizeSeparateOriginCacheCopy =
-    options.isProduction && originOwnsSharedHtmlStore && !middlewareMayControlSharedCaching;
-  const clientTraceMetadata =
-    hasKnownNoStoreHtmlPolicy || canSanitizeSeparateOriginCacheCopy
-      ? options.clientTraceMetadata
-      : undefined;
-  const clientTraceMetadataMarker =
-    !hasKnownNoStoreHtmlPolicy &&
-    canSanitizeSeparateOriginCacheCopy &&
-    clientTraceMetadata &&
-    clientTraceMetadata.length > 0
-      ? crypto.randomUUID()
-      : undefined;
+  let clientTraceMetadata = options.clientTraceMetadata;
+  let clientTraceMetadataMarker: string | undefined;
+  if (clientTraceMetadata && clientTraceMetadata.length > 0) {
+    const middlewareMayControlSharedCaching = SHARED_CACHE_CONTROL_HEADER_NAMES.some(
+      (name) => options.middlewareContext.headers?.has(name) === true,
+    );
+    const hasKnownNoStoreHtmlPolicy =
+      !middlewareMayControlSharedCaching &&
+      (options.isDraftMode ||
+        options.isForceDynamic ||
+        Boolean(options.scriptNonce) ||
+        options.isProgressiveActionRender === true ||
+        revalidateSeconds === 0 ||
+        (options.isEdgeRuntime &&
+          revalidateSeconds === null &&
+          !options.isForceStatic &&
+          !options.isDynamicError) ||
+        peekDynamicUsage());
+    const canSanitizeSeparateOriginCacheCopy =
+      options.isProduction &&
+      getCdnCacheAdapter().ownsBackgroundRevalidation &&
+      !middlewareMayControlSharedCaching;
+
+    if (!hasKnownNoStoreHtmlPolicy && !canSanitizeSeparateOriginCacheCopy) {
+      clientTraceMetadata = undefined;
+    } else if (!hasKnownNoStoreHtmlPolicy && canSanitizeSeparateOriginCacheCopy) {
+      clientTraceMetadataMarker = crypto.randomUUID();
+    }
+  }
   let requestCacheLifeForPrerender: AppPageRequestCacheLife | null = null;
   let dynamicUsedDuringHtmlRender = false;
   let renderEnd: number | undefined;

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -1239,6 +1239,7 @@ export async function renderAppPageLifecycle(
       },
       capturedRscDataPromise: capturedRscDataRef.value,
       cleanPathname: options.cleanPathname,
+      clientTraceMetadata: options.clientTraceMetadata,
       consumeDynamicUsage: consumeRenderDynamicUsage,
       consumeRenderObservationState: options.consumeRenderObservationState,
       createHtmlRenderObservation(input) {

--- a/packages/vinext/src/server/app-page-stream.ts
+++ b/packages/vinext/src/server/app-page-stream.ts
@@ -126,6 +126,8 @@ export type AppPageSsrHandler = {
        * in the SSR head. Sourced from `experimental.clientTraceMetadata`.
        */
       clientTraceMetadata?: readonly string[];
+      /** Per-render marker used to identify only vinext-injected trace tags. */
+      clientTraceMetadataMarker?: string;
       /**
        * Maximum total length (in characters) of the preload `Link` header
        * emitted during SSR. `0` disables emission. From `reactMaxHeadersLength`
@@ -166,6 +168,8 @@ type RenderAppPageHtmlStreamOptions = {
    * the SSR head. Undefined or empty disables emission.
    */
   clientTraceMetadata?: readonly string[];
+  /** Per-render marker used to identify only vinext-injected trace tags. */
+  clientTraceMetadataMarker?: string;
   /**
    * Maximum total length (in characters) of the preload `Link` header emitted
    * during SSR. `0` disables emission. From `reactMaxHeadersLength` in
@@ -247,6 +251,7 @@ export async function renderAppPageHtmlStream(
     scriptNonce: options.scriptNonce,
     basePath: options.basePath,
     clientTraceMetadata: options.clientTraceMetadata,
+    clientTraceMetadataMarker: options.clientTraceMetadataMarker,
     reactMaxHeadersLength: options.reactMaxHeadersLength,
     rootParams: options.rootParams,
     sideStream: options.sideStream,

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -45,7 +45,10 @@ import type { AppSsrRenderResult } from "./app-page-stream.js";
 import { deferUntilStreamConsumed } from "./defer-until-stream-consumed.js";
 import { createSsrErrorMetaRenderer } from "./app-ssr-error-meta.js";
 import { createInitialDevServerErrorScript } from "./dev-initial-server-error.js";
-import { getClientTraceMetadataHTML } from "./client-trace-metadata.js";
+import {
+  getClientTraceMetadataHTML,
+  markClientTraceMetadataBlock,
+} from "./client-trace-metadata.js";
 import { AppElementsWire, type AppWireElements } from "./app-elements.js";
 import { createInitialBfcacheMaps } from "./app-bfcache-identity.js";
 import { BfcacheIdentityMapContext, ElementsContext, Slot } from "vinext/shims/slot";
@@ -381,6 +384,8 @@ export async function handleSsr(
      * SSR head. Undefined or empty disables emission entirely.
      */
     clientTraceMetadata?: readonly string[];
+    /** Per-render marker used to identify only vinext-injected trace tags. */
+    clientTraceMetadataMarker?: string;
     /**
      * Maximum total length (in characters) of the preload `Link` header React
      * emits during SSR. `0` disables emission. From `reactMaxHeadersLength` in
@@ -676,7 +681,10 @@ export async function handleSsr(
         let traceMetaHTML: string | null = null;
         const getTraceMetaHTML = (): string => {
           if (traceMetaHTML === null) {
-            traceMetaHTML = getClientTraceMetadataHTML(options?.clientTraceMetadata);
+            traceMetaHTML = markClientTraceMetadataBlock(
+              getClientTraceMetadataHTML(options?.clientTraceMetadata),
+              options?.clientTraceMetadataMarker,
+            );
           }
           return traceMetaHTML;
         };

--- a/packages/vinext/src/server/client-trace-metadata.ts
+++ b/packages/vinext/src/server/client-trace-metadata.ts
@@ -177,6 +177,27 @@ export function renderClientTraceMetadataTags(
 }
 
 /**
+ * Remove the `<meta>` tags `renderClientTraceMetadataTags` emits for the
+ * configured allow-list. App Router HTML cache entries are shared across users,
+ * so the generating request's traceparent/baggage must not survive into them —
+ * a later cache HIT has no request whose trace it could correlate anyway.
+ */
+export function stripClientTraceMetadataTags(
+  html: string,
+  allowList: readonly string[] | undefined,
+): string {
+  if (!allowList || allowList.length === 0) return html;
+  let stripped = html;
+  for (const key of allowList) {
+    // Match the rendered form: HTML-escape the key the same way, then escape
+    // regex metacharacters. Values are attribute-escaped, so `"` never appears.
+    const name = escapeHtmlAttr(key).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    stripped = stripped.replace(new RegExp(`<meta name="${name}" content="[^"]*"/>`, "g"), "");
+  }
+  return stripped;
+}
+
+/**
  * Convenience helper: read OTel propagation data, filter against the
  * configured allow-list, and render the resulting `<meta>` tags. Returns an
  * empty string when the allow-list is unset, OTel is not installed, or no

--- a/packages/vinext/src/server/client-trace-metadata.ts
+++ b/packages/vinext/src/server/client-trace-metadata.ts
@@ -176,25 +176,33 @@ export function renderClientTraceMetadataTags(
   return html;
 }
 
+function clientTraceMetadataBlockStart(marker: string): string {
+  return `<!--vinext-client-trace-metadata:${marker}:start-->`;
+}
+
+function clientTraceMetadataBlockEnd(marker: string): string {
+  return `<!--vinext-client-trace-metadata:${marker}:end-->`;
+}
+
 /**
- * Remove the `<meta>` tags `renderClientTraceMetadataTags` emits for the
- * configured allow-list. App Router HTML cache entries are shared across users,
- * so the generating request's traceparent/baggage must not survive into them —
- * a later cache HIT has no request whose trace it could correlate anyway.
+ * Mark the framework-injected trace metadata so a later cache write can remove
+ * exactly that block without matching application-authored `<meta>` tags.
  */
-export function stripClientTraceMetadataTags(
-  html: string,
-  allowList: readonly string[] | undefined,
-): string {
-  if (!allowList || allowList.length === 0) return html;
-  let stripped = html;
-  for (const key of allowList) {
-    // Match the rendered form: HTML-escape the key the same way, then escape
-    // regex metacharacters. Values are attribute-escaped, so `"` never appears.
-    const name = escapeHtmlAttr(key).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    stripped = stripped.replace(new RegExp(`<meta name="${name}" content="[^"]*"/>`, "g"), "");
-  }
-  return stripped;
+export function markClientTraceMetadataBlock(html: string, marker: string | undefined): string {
+  if (!html || !marker) return html;
+  return `${clientTraceMetadataBlockStart(marker)}${html}${clientTraceMetadataBlockEnd(marker)}`;
+}
+
+/** Remove only the trace metadata block carrying this render's private marker. */
+export function stripClientTraceMetadataBlock(html: string, marker: string | undefined): string {
+  if (!marker) return html;
+  const start = clientTraceMetadataBlockStart(marker);
+  const end = clientTraceMetadataBlockEnd(marker);
+  const startIndex = html.indexOf(start);
+  if (startIndex === -1) return html;
+  const endIndex = html.indexOf(end, startIndex + start.length);
+  if (endIndex === -1) return html;
+  return html.slice(0, startIndex) + html.slice(endIndex + end.length);
 }
 
 /**

--- a/tests/app-page-cache.test.ts
+++ b/tests/app-page-cache.test.ts
@@ -9,6 +9,7 @@ import {
   readAppPageFallbackShellCacheResponse,
   scheduleAppPageRscCacheWrite,
 } from "../packages/vinext/src/server/app-page-cache.js";
+import { renderClientTraceMetadataTags } from "../packages/vinext/src/server/client-trace-metadata.js";
 import type { ISRCacheEntry } from "../packages/vinext/src/server/isr-cache.js";
 import {
   VINEXT_RSC_COMPATIBILITY_ID_HEADER,
@@ -1178,6 +1179,55 @@ describe("app page cache helpers", () => {
       },
     ]);
     expect(debugCalls).toEqual([["HTML cache written", "html:/fresh"]]);
+  });
+
+  it("keeps request-scoped client trace metadata out of the stored HTML", async () => {
+    const pendingCacheWrites: Promise<void>[] = [];
+    const storedHtml: string[] = [];
+    // Rendered by the same helper App SSR injects into the head, so the test
+    // breaks if either the emitted or the stripped tag shape drifts.
+    const traceMetaHTML = renderClientTraceMetadataTags([
+      { key: "traceparent", value: "00-abc-def-01" },
+      { key: "baggage", value: "tenant=alice,user=alice-123" },
+    ]);
+    expect(traceMetaHTML).not.toBe("");
+
+    const response = finalizeAppPageHtmlCacheResponse(
+      new Response(`<head>${traceMetaHTML}</head><h1>page</h1>`, {
+        headers: { "Content-Type": "text/html; charset=utf-8" },
+      }),
+      {
+        capturedRscDataPromise: null,
+        cleanPathname: "/traced",
+        clientTraceMetadata: ["traceparent", "baggage"],
+        consumeDynamicUsage() {
+          return false;
+        },
+        getPageTags() {
+          return ["/traced"];
+        },
+        isrHtmlKey(pathname) {
+          return "html:" + pathname;
+        },
+        isrRscKey(pathname) {
+          return "rsc:" + pathname;
+        },
+        async isrSet(_key, data) {
+          storedHtml.push(data.html);
+        },
+        revalidateSeconds: 60,
+        waitUntil(promise) {
+          pendingCacheWrites.push(promise);
+        },
+      },
+    );
+
+    // The generating request still gets its own trace context...
+    await expect(response.text()).resolves.toContain("tenant=alice,user=alice-123");
+    await pendingCacheWrites[0];
+
+    // ...but the entry every later user is served from carries none of it.
+    expect(storedHtml).toEqual(["<head></head><h1>page</h1>"]);
   });
 
   it("skips HTML and RSC cache writes when dynamic usage appears during stream rendering", async () => {

--- a/tests/app-page-cache.test.ts
+++ b/tests/app-page-cache.test.ts
@@ -9,7 +9,10 @@ import {
   readAppPageFallbackShellCacheResponse,
   scheduleAppPageRscCacheWrite,
 } from "../packages/vinext/src/server/app-page-cache.js";
-import { renderClientTraceMetadataTags } from "../packages/vinext/src/server/client-trace-metadata.js";
+import {
+  markClientTraceMetadataBlock,
+  renderClientTraceMetadataTags,
+} from "../packages/vinext/src/server/client-trace-metadata.js";
 import type { ISRCacheEntry } from "../packages/vinext/src/server/isr-cache.js";
 import {
   VINEXT_RSC_COMPATIBILITY_ID_HEADER,
@@ -1190,16 +1193,21 @@ describe("app page cache helpers", () => {
       { key: "traceparent", value: "00-abc-def-01" },
       { key: "baggage", value: "tenant=alice,user=alice-123" },
     ]);
+    const traceMetadataMarker = "private-render-marker";
+    const markedTraceMetaHTML = markClientTraceMetadataBlock(traceMetaHTML, traceMetadataMarker);
     expect(traceMetaHTML).not.toBe("");
 
     const response = finalizeAppPageHtmlCacheResponse(
-      new Response(`<head>${traceMetaHTML}</head><h1>page</h1>`, {
-        headers: { "Content-Type": "text/html; charset=utf-8" },
-      }),
+      new Response(
+        `<head><meta name="baggage" content="application-policy"/>${markedTraceMetaHTML}</head><h1>page</h1>`,
+        {
+          headers: { "Content-Type": "text/html; charset=utf-8" },
+        },
+      ),
       {
         capturedRscDataPromise: null,
         cleanPathname: "/traced",
-        clientTraceMetadata: ["traceparent", "baggage"],
+        clientTraceMetadataMarker: traceMetadataMarker,
         consumeDynamicUsage() {
           return false;
         },
@@ -1227,7 +1235,9 @@ describe("app page cache helpers", () => {
     await pendingCacheWrites[0];
 
     // ...but the entry every later user is served from carries none of it.
-    expect(storedHtml).toEqual(["<head></head><h1>page</h1>"]);
+    expect(storedHtml).toEqual([
+      '<head><meta name="baggage" content="application-policy"/></head><h1>page</h1>',
+    ]);
   });
 
   it("skips HTML and RSC cache writes when dynamic usage appears during stream rendering", async () => {

--- a/tests/app-page-render.test.ts
+++ b/tests/app-page-render.test.ts
@@ -439,6 +439,39 @@ describe("client trace metadata with edge-managed HTML caching", () => {
       setCdnCacheAdapter(new DefaultCdnCacheAdapter());
     }
   });
+
+  it("treats force-static Edge Runtime responses as potentially shared", async () => {
+    setCdnCacheAdapter(new CloudflareCdnCacheAdapter());
+    const common = createCommonOptions();
+    let ssrOptions:
+      | { clientTraceMetadata?: readonly string[]; clientTraceMetadataMarker?: string }
+      | undefined;
+    try {
+      const response = await renderAppPageLifecycle({
+        ...common.options,
+        clientTraceMetadata: ["baggage"],
+        isEdgeRuntime: true,
+        isForceStatic: true,
+        isProduction: true,
+        revalidateSeconds: null,
+        loadSsrHandler: async () => ({
+          async handleSsr(_rscStream, _navigationContext, _fontData, options) {
+            ssrOptions = options;
+            void options?.sideStream?.cancel();
+            return createStream(["<html>page</html>"]);
+          },
+        }),
+      });
+
+      expect(ssrOptions?.clientTraceMetadata).toBeUndefined();
+      expect(ssrOptions?.clientTraceMetadataMarker).toBeUndefined();
+      expect(response.headers.get("cdn-cache-control")).toContain("max-age=31536000");
+      await expect(response.text()).resolves.toBe("<html>page</html>");
+      await Promise.all(common.waitUntilPromises);
+    } finally {
+      setCdnCacheAdapter(new DefaultCdnCacheAdapter());
+    }
+  });
 });
 
 describe("form state rendering", () => {

--- a/tests/app-page-render.test.ts
+++ b/tests/app-page-render.test.ts
@@ -469,39 +469,42 @@ describe("client trace metadata with edge-managed HTML caching", () => {
     }
   });
 
-  it("does not trust known no-store policy when middleware can promote shared caching", async () => {
-    setCdnCacheAdapter(new CloudflareCdnCacheAdapter());
-    const common = createCommonOptions();
-    let ssrOptions:
-      | { clientTraceMetadata?: readonly string[]; clientTraceMetadataMarker?: string }
-      | undefined;
-    try {
-      const response = await renderAppPageLifecycle({
-        ...common.options,
-        clientTraceMetadata: ["baggage"],
-        isForceDynamic: true,
-        isProduction: true,
-        middlewareContext: {
-          headers: new Headers({ "CDN-Cache-Control": "public, max-age=60" }),
-          status: null,
-        },
-        revalidateSeconds: 30,
-        loadSsrHandler: async () => ({
-          async handleSsr(_rscStream, _navigationContext, _fontData, options) {
-            ssrOptions = options;
-            return createStream(["<html>page</html>"]);
+  it.each(["CDN-Cache-Control", "Vercel-CDN-Cache-Control"])(
+    "does not trust known no-store policy when middleware sets %s",
+    async (cacheHeaderName) => {
+      setCdnCacheAdapter(new CloudflareCdnCacheAdapter());
+      const common = createCommonOptions();
+      let ssrOptions:
+        | { clientTraceMetadata?: readonly string[]; clientTraceMetadataMarker?: string }
+        | undefined;
+      try {
+        const response = await renderAppPageLifecycle({
+          ...common.options,
+          clientTraceMetadata: ["baggage"],
+          isForceDynamic: true,
+          isProduction: true,
+          middlewareContext: {
+            headers: new Headers({ [cacheHeaderName]: "public, max-age=60" }),
+            status: null,
           },
-        }),
-      });
+          revalidateSeconds: 30,
+          loadSsrHandler: async () => ({
+            async handleSsr(_rscStream, _navigationContext, _fontData, options) {
+              ssrOptions = options;
+              return createStream(["<html>page</html>"]);
+            },
+          }),
+        });
 
-      expect(ssrOptions?.clientTraceMetadata).toBeUndefined();
-      expect(ssrOptions?.clientTraceMetadataMarker).toBeUndefined();
-      expect(response.headers.get("cdn-cache-control")).toBe("public, max-age=60");
-      await expect(response.text()).resolves.toBe("<html>page</html>");
-    } finally {
-      setCdnCacheAdapter(new DefaultCdnCacheAdapter());
-    }
-  });
+        expect(ssrOptions?.clientTraceMetadata).toBeUndefined();
+        expect(ssrOptions?.clientTraceMetadataMarker).toBeUndefined();
+        expect(response.headers.get(cacheHeaderName)).toBe("public, max-age=60");
+        await expect(response.text()).resolves.toBe("<html>page</html>");
+      } finally {
+        setCdnCacheAdapter(new DefaultCdnCacheAdapter());
+      }
+    },
+  );
 
   it("treats force-static Edge Runtime responses as potentially shared", async () => {
     setCdnCacheAdapter(new CloudflareCdnCacheAdapter());

--- a/tests/app-page-render.test.ts
+++ b/tests/app-page-render.test.ts
@@ -440,6 +440,69 @@ describe("client trace metadata with edge-managed HTML caching", () => {
     }
   });
 
+  it("omits request trace metadata from cacheable development responses", async () => {
+    setCdnCacheAdapter(new CloudflareCdnCacheAdapter());
+    const common = createCommonOptions();
+    let ssrOptions:
+      | { clientTraceMetadata?: readonly string[]; clientTraceMetadataMarker?: string }
+      | undefined;
+    try {
+      const response = await renderAppPageLifecycle({
+        ...common.options,
+        clientTraceMetadata: ["baggage"],
+        isProduction: false,
+        revalidateSeconds: 30,
+        loadSsrHandler: async () => ({
+          async handleSsr(_rscStream, _navigationContext, _fontData, options) {
+            ssrOptions = options;
+            return createStream(["<html>page</html>"]);
+          },
+        }),
+      });
+
+      expect(ssrOptions?.clientTraceMetadata).toBeUndefined();
+      expect(ssrOptions?.clientTraceMetadataMarker).toBeUndefined();
+      expect(response.headers.get("cache-control")).toContain("s-maxage=30");
+      await expect(response.text()).resolves.toBe("<html>page</html>");
+    } finally {
+      setCdnCacheAdapter(new DefaultCdnCacheAdapter());
+    }
+  });
+
+  it("does not trust known no-store policy when middleware can promote shared caching", async () => {
+    setCdnCacheAdapter(new CloudflareCdnCacheAdapter());
+    const common = createCommonOptions();
+    let ssrOptions:
+      | { clientTraceMetadata?: readonly string[]; clientTraceMetadataMarker?: string }
+      | undefined;
+    try {
+      const response = await renderAppPageLifecycle({
+        ...common.options,
+        clientTraceMetadata: ["baggage"],
+        isForceDynamic: true,
+        isProduction: true,
+        middlewareContext: {
+          headers: new Headers({ "CDN-Cache-Control": "public, max-age=60" }),
+          status: null,
+        },
+        revalidateSeconds: 30,
+        loadSsrHandler: async () => ({
+          async handleSsr(_rscStream, _navigationContext, _fontData, options) {
+            ssrOptions = options;
+            return createStream(["<html>page</html>"]);
+          },
+        }),
+      });
+
+      expect(ssrOptions?.clientTraceMetadata).toBeUndefined();
+      expect(ssrOptions?.clientTraceMetadataMarker).toBeUndefined();
+      expect(response.headers.get("cdn-cache-control")).toBe("public, max-age=60");
+      await expect(response.text()).resolves.toBe("<html>page</html>");
+    } finally {
+      setCdnCacheAdapter(new DefaultCdnCacheAdapter());
+    }
+  });
+
   it("treats force-static Edge Runtime responses as potentially shared", async () => {
     setCdnCacheAdapter(new CloudflareCdnCacheAdapter());
     const common = createCommonOptions();

--- a/tests/app-page-render.test.ts
+++ b/tests/app-page-render.test.ts
@@ -377,6 +377,70 @@ describe("SSR shell error recovery", () => {
   });
 });
 
+describe("client trace metadata with edge-managed HTML caching", () => {
+  it("omits request trace metadata from potentially shared edge responses", async () => {
+    setCdnCacheAdapter(new CloudflareCdnCacheAdapter());
+    const common = createCommonOptions();
+    let ssrOptions:
+      | { clientTraceMetadata?: readonly string[]; clientTraceMetadataMarker?: string }
+      | undefined;
+    try {
+      const response = await renderAppPageLifecycle({
+        ...common.options,
+        clientTraceMetadata: ["traceparent", "baggage"],
+        isProduction: true,
+        revalidateSeconds: 30,
+        loadSsrHandler: async () => ({
+          async handleSsr(_rscStream, _navigationContext, _fontData, options) {
+            ssrOptions = options;
+            void options?.sideStream?.cancel();
+            return createStream(["<html>page</html>"]);
+          },
+        }),
+      });
+
+      expect(ssrOptions?.clientTraceMetadata).toBeUndefined();
+      expect(ssrOptions?.clientTraceMetadataMarker).toBeUndefined();
+      expect(response.headers.get("cdn-cache-control")).toContain("max-age=30");
+      await expect(response.text()).resolves.toBe("<html>page</html>");
+      await Promise.all(common.waitUntilPromises);
+    } finally {
+      setCdnCacheAdapter(new DefaultCdnCacheAdapter());
+    }
+  });
+
+  it("keeps request trace metadata on known no-store edge responses", async () => {
+    setCdnCacheAdapter(new CloudflareCdnCacheAdapter());
+    const common = createCommonOptions();
+    let ssrOptions:
+      | { clientTraceMetadata?: readonly string[]; clientTraceMetadataMarker?: string }
+      | undefined;
+    try {
+      const response = await renderAppPageLifecycle({
+        ...common.options,
+        clientTraceMetadata: ["traceparent", "baggage"],
+        isForceDynamic: true,
+        isProduction: true,
+        revalidateSeconds: 30,
+        loadSsrHandler: async () => ({
+          async handleSsr(_rscStream, _navigationContext, _fontData, options) {
+            ssrOptions = options;
+            return createStream(["<html>page</html>"]);
+          },
+        }),
+      });
+
+      expect(ssrOptions?.clientTraceMetadata).toEqual(["traceparent", "baggage"]);
+      expect(ssrOptions?.clientTraceMetadataMarker).toBeUndefined();
+      expect(response.headers.get("cache-control")).toContain("no-store");
+      expect(response.headers.get("cdn-cache-control")).toBeNull();
+      await expect(response.text()).resolves.toBe("<html>page</html>");
+    } finally {
+      setCdnCacheAdapter(new DefaultCdnCacheAdapter());
+    }
+  });
+});
+
 describe("form state rendering", () => {
   it("passes action form state to SSR and disables HTML cache writes", async () => {
     const common = createCommonOptions();

--- a/tests/client-trace-metadata.test.ts
+++ b/tests/client-trace-metadata.test.ts
@@ -10,6 +10,7 @@ import {
   filterClientTraceMetadata,
   getClientTraceMetadataHTML,
   renderClientTraceMetadataTags,
+  stripClientTraceMetadataTags,
   type ClientTraceDataEntry,
 } from "../packages/vinext/src/server/client-trace-metadata.js";
 
@@ -307,5 +308,27 @@ describe("client trace metadata: getClientTraceMetadataHTML", () => {
     });
 
     expect(getClientTraceMetadataHTML(["my-test-key-1"])).toBe("");
+  });
+});
+
+describe("stripClientTraceMetadataTags", () => {
+  it("removes exactly the tags the renderer emits, including escaped keys", () => {
+    const entries = [
+      { key: "traceparent", value: "00-abc-def-01" },
+      { key: 'weird"key', value: "a&b<c>" },
+    ];
+    const allowList = entries.map(({ key }) => key);
+    const html = `<head>${renderClientTraceMetadataTags(entries)}<title>x</title></head>`;
+
+    expect(stripClientTraceMetadataTags(html, allowList)).toBe("<head><title>x</title></head>");
+  });
+
+  it("leaves unrelated meta tags and unconfigured keys alone", () => {
+    const html =
+      '<meta name="description" content="hi"/>' +
+      renderClientTraceMetadataTags([{ key: "baggage", value: "tenant=alice" }]);
+
+    expect(stripClientTraceMetadataTags(html, ["traceparent"])).toBe(html);
+    expect(stripClientTraceMetadataTags(html, undefined)).toBe(html);
   });
 });

--- a/tests/client-trace-metadata.test.ts
+++ b/tests/client-trace-metadata.test.ts
@@ -9,8 +9,9 @@ import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import {
   filterClientTraceMetadata,
   getClientTraceMetadataHTML,
+  markClientTraceMetadataBlock,
   renderClientTraceMetadataTags,
-  stripClientTraceMetadataTags,
+  stripClientTraceMetadataBlock,
   type ClientTraceDataEntry,
 } from "../packages/vinext/src/server/client-trace-metadata.js";
 
@@ -311,24 +312,25 @@ describe("client trace metadata: getClientTraceMetadataHTML", () => {
   });
 });
 
-describe("stripClientTraceMetadataTags", () => {
-  it("removes exactly the tags the renderer emits, including escaped keys", () => {
+describe("client trace metadata cache markers", () => {
+  it("removes exactly the marked framework-injected block", () => {
     const entries = [
       { key: "traceparent", value: "00-abc-def-01" },
       { key: 'weird"key', value: "a&b<c>" },
     ];
-    const allowList = entries.map(({ key }) => key);
-    const html = `<head>${renderClientTraceMetadataTags(entries)}<title>x</title></head>`;
+    const marker = "private-render-marker";
+    const html = `<head>${markClientTraceMetadataBlock(
+      renderClientTraceMetadataTags(entries),
+      marker,
+    )}<title>x</title></head>`;
 
-    expect(stripClientTraceMetadataTags(html, allowList)).toBe("<head><title>x</title></head>");
+    expect(stripClientTraceMetadataBlock(html, marker)).toBe("<head><title>x</title></head>");
   });
 
-  it("leaves unrelated meta tags and unconfigured keys alone", () => {
-    const html =
-      '<meta name="description" content="hi"/>' +
-      renderClientTraceMetadataTags([{ key: "baggage", value: "tenant=alice" }]);
+  it("leaves application-authored tags with allow-listed names alone", () => {
+    const html = '<meta name="baggage" content="application-policy"/>';
 
-    expect(stripClientTraceMetadataTags(html, ["traceparent"])).toBe(html);
-    expect(stripClientTraceMetadataTags(html, undefined)).toBe(html);
+    expect(stripClientTraceMetadataBlock(html, "private-render-marker")).toBe(html);
+    expect(stripClientTraceMetadataBlock(html, undefined)).toBe(html);
   });
 });


### PR DESCRIPTION
## Problem

`experimental.clientTraceMetadata` renders request-scoped OpenTelemetry propagation entries (`traceparent`, `baggage`, …) as `<meta>` tags in the App Router SSR head. Runtime cacheable App Router responses are teed and stored as full HTML by `finalizeAppPageHtmlCacheResponse`, and reading the OTel propagation context is **not** recorded as dynamic request usage — so the cache-write skip never fires.

Result: on a cache miss, the generating request's trace context is baked into the stored HTML and replayed to every later cache HIT, until the entry expires or is revalidated. Where operators put tenant/user correlation data in baggage, that is cross-user leakage of one request's identifiers into unrelated users' pages; it is also a cache-poisoning vector, since the first requester can influence the injected `traceparent`/`baggage` via incoming headers.

Pages Router already gates emission on route staticness (`shouldEmitPagesClientTraceMetadata` returns `false` for `getStaticProps`). App Router had no equivalent gate.

## Triage evidence

- `client-trace-metadata.ts` suppresses emission only under `VINEXT_PRERENDER=1`; there is no runtime cache-generation suppression.
- `app-ssr-entry.ts` appends `getClientTraceMetadataHTML()` into the head injection.
- `app-page-render.ts` routes cacheable runtime HTML into `finalizeAppPageHtmlCacheResponse`, which reads the tee'd stream and stores it after only dynamic-usage and cache-policy checks.
- `app-page-cache-render.ts` (ISR revalidation / PPR fallback shell) also passed the allow-list into a render whose entire purpose is producing a shared cache artifact.
- Confirmed by an added regression test that fails on `main`: the stored entry contained `content="tenant=alice,user=alice-123"`.

Upstream comparison: Next.js v16.2.6 emits client trace metadata for dynamically server-rendered App and Pages routes, while its production static routes omit it. Vinext adds a separate runtime HTML-cache boundary: a live request response can later become a shared artifact. The vinext global-registry path also synthesizes a span when none is active, so cacheable HTML can contain a `traceparent` in setups where Next.js would emit nothing.

## Fix

Enforce the invariant *HTML stored in a shared cache contains no request-scoped trace metadata* at every App Router storage boundary:

1. For origin-managed ISR, `finalizeAppPageHtmlCacheResponse` removes only the per-render, privately marked vinext trace-metadata block from the cache copy. Application-authored `<meta>` tags with the same names are preserved. The live response the generating request receives is unchanged.
2. `renderAppPageCacheArtifacts` (ISR/PPR cache-fill render) no longer receives the allow-list at all — that render exists solely to produce a shared artifact.
3. Edge-managed adapters such as Cloudflare cache the outgoing response stream rather than a separate origin-store copy. Any outgoing response that may enter a shared cache — including cacheable development responses, force-static Edge Runtime routes, and responses whose cache headers middleware can promote — suppresses client trace metadata before rendering. Only responses with a framework no-store policy and no middleware cache-header ownership retain it. The gate covers generic, Cloudflare, and Vercel CDN cache-control headers.

`markClientTraceMetadataBlock` and `stripClientTraceMetadataBlock` live next to the renderer. For origin-managed ISR, a random marker carries injection provenance across the SSR stream/cache tee, so cleanup cannot confuse framework-injected tags with application metadata. The common unset path still avoids loading the feature module.

### Why strip rather than suppress emission

Origin-managed ISR has a separate cache tee, so stripping preserves trace metadata on the generating response while keeping stored HTML clean. Edge-managed adapters and cacheable development responses expose the outgoing bytes directly, so potentially shared responses suppress metadata before rendering. Known no-store responses keep the feature only when middleware cannot override or add shared-cache directives. This conservative split is necessary because final cacheability can resolve only after the stream drains.

## Verification

- `vp test run tests/client-trace-metadata.test.ts tests/app-page-cache.test.ts tests/app-page-cache-render.test.ts` — 60 passed.
- `vp test run tests/app-page-render.test.ts tests/app-page-dispatch.test.ts tests/app-page-stream.test.ts tests/app-page-response.test.ts tests/otel-tracer-extension.test.ts` — 200 passed. (One unhandled `client disconnect` rejection appears here; verified pre-existing on clean `upstream/main`.)
- `vp test run tests/cloudflare-cdn-cache.test.ts` — 16 passed.
- The finalizer regression verifies that request trace metadata is absent from the stored entry while an application-authored `<meta name="baggage">` remains intact.
- Full `vp check` plus the staged unit/integration suites and knip ran via the pre-commit hook and passed.
