### PR TITLE
test(app-router): cover consumed prefetch cache handoff

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -1983,6 +1983,17 @@ function bootstrapHydration(
           if (!browserNavigationController.isCurrentNavigation(navId)) return;
           if (prefetchedResponse) {
             prefetchedElements = prefetchedResponse.preparedElements;
+            // Consuming a prefetch removes its cache entry, but the buffered
+            // snapshot remains valid while this navigation renders. Keep it
+            // discoverable until the committed visited-response publication
+            // replaces it, so a Link remount cannot start a duplicate request
+            // in the handoff window.
+            seedPrefetchResponseSnapshot(
+              rscUrl,
+              prefetchedResponse,
+              requestInterceptionContext,
+              mountedSlotsHeader,
+            );
             navResponse = restoreRscResponse(prefetchedResponse, false);
             navResponseExpiresAt = prefetchedResponse.expiresAt;
             navResponseUrl = resolvePrefetchNavigationResponseUrl({

--- a/tests/e2e/app-router/nextjs-compat/client-cache.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/client-cache.spec.ts
@@ -296,13 +296,17 @@ test.describe("Next.js compat: client cache", () => {
     // remain discoverable during that handoff so a Link remount cannot start a
     // duplicate request.
     await page.evaluate(() => {
+      const testWindow = window as ClientCacheTestWindow;
+      const state: DelayedNavigationCachePublicationState = {
+        releaseOldNavigationTail: null,
+      };
+      testWindow.__VINEXT_DELAYED_NAVIGATION_CACHE_PUBLICATION__ = state;
       const originalTee = Reflect.get(
         ReadableStream.prototype,
         "tee",
       ) as typeof ReadableStream.prototype.tee;
       ReadableStream.prototype.tee = function (this: ReadableStream<unknown>) {
         ReadableStream.prototype.tee = originalTee;
-        document.documentElement.dataset.vinextDelayedCacheTee = "pending";
         const [reactBranch, cacheBranch] = originalTee.call(this);
         const cacheReader = cacheBranch.getReader();
         const delayedCacheBranch = new ReadableStream({
@@ -312,8 +316,9 @@ test.describe("Next.js compat: client cache", () => {
               if (result.done) break;
               controller.enqueue(result.value);
             }
-            await new Promise((resolve) => setTimeout(resolve, 1_000));
-            document.documentElement.dataset.vinextDelayedCacheTee = "complete";
+            await new Promise<void>((resolve) => {
+              state.releaseOldNavigationTail = resolve;
+            });
             controller.close();
           },
           cancel(reason) {
@@ -327,7 +332,15 @@ test.describe("Next.js compat: client cache", () => {
     requests.length = 0;
     await targetLink.click();
     await expect(page.locator("#client-cache-id")).toHaveText("0");
-    await expect(page.locator("html")).toHaveAttribute("data-vinext-delayed-cache-tee", "pending");
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            typeof (window as ClientCacheTestWindow).__VINEXT_DELAYED_NAVIGATION_CACHE_PUBLICATION__
+              ?.releaseOldNavigationTail === "function",
+        ),
+      )
+      .toBe(true);
     const initial = await readRandom(page);
     expect(requestsFor(requests, `${ROOT}/0`)).toEqual([]);
 
@@ -343,6 +356,17 @@ test.describe("Next.js compat: client cache", () => {
     requests.length = 0;
     const cachedTargetLink = await revealAccordionLink(page, `${ROOT}/0`);
     expect(requestsFor(requests, `${ROOT}/0`)).toEqual([]);
+    await page.evaluate(() => {
+      const state = (window as ClientCacheTestWindow)
+        .__VINEXT_DELAYED_NAVIGATION_CACHE_PUBLICATION__;
+      if (
+        state?.releaseOldNavigationTail === null ||
+        state?.releaseOldNavigationTail === undefined
+      ) {
+        throw new Error("Consumed prefetch cache tail was not delayed");
+      }
+      state.releaseOldNavigationTail();
+    });
     await cachedTargetLink.click();
     await expect(page.locator("#client-cache-id")).toHaveText("0");
     expect(await readRandom(page)).toBe(initial);

--- a/tests/e2e/app-router/nextjs-compat/client-cache.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/client-cache.spec.ts
@@ -291,9 +291,10 @@ test.describe("Next.js compat: client cache", () => {
       .poll(() => requestsFor(requests, `${ROOT}/0`).some((request) => !request.partial))
       .toBe(true);
 
-    // Delay committed-cache publication after the prefetch is consumed. The
-    // consumed snapshot must remain discoverable during that handoff so a Link
-    // remount cannot start a duplicate request.
+    // Delay the redundant cache branch that formerly blocked committed-cache
+    // publication after the prefetch was consumed. The consumed snapshot must
+    // remain discoverable during that handoff so a Link remount cannot start a
+    // duplicate request.
     await page.evaluate(() => {
       const originalTee = Reflect.get(
         ReadableStream.prototype,
@@ -301,6 +302,7 @@ test.describe("Next.js compat: client cache", () => {
       ) as typeof ReadableStream.prototype.tee;
       ReadableStream.prototype.tee = function (this: ReadableStream<unknown>) {
         ReadableStream.prototype.tee = originalTee;
+        document.documentElement.dataset.vinextDelayedCacheTee = "pending";
         const [reactBranch, cacheBranch] = originalTee.call(this);
         const cacheReader = cacheBranch.getReader();
         const delayedCacheBranch = new ReadableStream({
@@ -311,6 +313,7 @@ test.describe("Next.js compat: client cache", () => {
               controller.enqueue(result.value);
             }
             await new Promise((resolve) => setTimeout(resolve, 1_000));
+            document.documentElement.dataset.vinextDelayedCacheTee = "complete";
             controller.close();
           },
           cancel(reason) {
@@ -324,6 +327,7 @@ test.describe("Next.js compat: client cache", () => {
     requests.length = 0;
     await targetLink.click();
     await expect(page.locator("#client-cache-id")).toHaveText("0");
+    await expect(page.locator("html")).toHaveAttribute("data-vinext-delayed-cache-tee", "pending");
     const initial = await readRandom(page);
     expect(requestsFor(requests, `${ROOT}/0`)).toEqual([]);
 

--- a/tests/e2e/app-router/nextjs-compat/client-cache.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/client-cache.spec.ts
@@ -356,6 +356,10 @@ test.describe("Next.js compat: client cache", () => {
     requests.length = 0;
     const cachedTargetLink = await revealAccordionLink(page, `${ROOT}/0`);
     expect(requestsFor(requests, `${ROOT}/0`)).toEqual([]);
+    await cachedTargetLink.click();
+    await expect(page.locator("#client-cache-id")).toHaveText("0");
+    expect(await readRandom(page)).toBe(initial);
+    expect(requestsFor(requests, `${ROOT}/0`)).toEqual([]);
     await page.evaluate(() => {
       const state = (window as ClientCacheTestWindow)
         .__VINEXT_DELAYED_NAVIGATION_CACHE_PUBLICATION__;
@@ -367,10 +371,6 @@ test.describe("Next.js compat: client cache", () => {
       }
       state.releaseOldNavigationTail();
     });
-    await cachedTargetLink.click();
-    await expect(page.locator("#client-cache-id")).toHaveText("0");
-    expect(await readRandom(page)).toBe(initial);
-    expect(requestsFor(requests, `${ROOT}/0`)).toEqual([]);
 
     const cachedHomeLink = await revealAccordionLink(page, ROOT);
     await cachedHomeLink.click();

--- a/tests/e2e/app-router/nextjs-compat/client-cache.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/client-cache.spec.ts
@@ -291,6 +291,36 @@ test.describe("Next.js compat: client cache", () => {
       .poll(() => requestsFor(requests, `${ROOT}/0`).some((request) => !request.partial))
       .toBe(true);
 
+    // Delay committed-cache publication after the prefetch is consumed. The
+    // consumed snapshot must remain discoverable during that handoff so a Link
+    // remount cannot start a duplicate request.
+    await page.evaluate(() => {
+      const originalTee = Reflect.get(
+        ReadableStream.prototype,
+        "tee",
+      ) as typeof ReadableStream.prototype.tee;
+      ReadableStream.prototype.tee = function (this: ReadableStream<unknown>) {
+        ReadableStream.prototype.tee = originalTee;
+        const [reactBranch, cacheBranch] = originalTee.call(this);
+        const cacheReader = cacheBranch.getReader();
+        const delayedCacheBranch = new ReadableStream({
+          async start(controller) {
+            while (true) {
+              const result = await cacheReader.read();
+              if (result.done) break;
+              controller.enqueue(result.value);
+            }
+            await new Promise((resolve) => setTimeout(resolve, 1_000));
+            controller.close();
+          },
+          cancel(reason) {
+            return cacheReader.cancel(reason);
+          },
+        });
+        return [reactBranch, delayedCacheBranch];
+      } as typeof ReadableStream.prototype.tee;
+    });
+
     requests.length = 0;
     await targetLink.click();
     await expect(page.locator("#client-cache-id")).toHaveText("0");
@@ -308,6 +338,7 @@ test.describe("Next.js compat: client cache", () => {
 
     requests.length = 0;
     const cachedTargetLink = await revealAccordionLink(page, `${ROOT}/0`);
+    expect(requestsFor(requests, `${ROOT}/0`)).toEqual([]);
     await cachedTargetLink.click();
     await expect(page.locator("#client-cache-id")).toHaveText("0");
     expect(await readRandom(page)).toBe(initial);


### PR DESCRIPTION
## Summary

- add a deterministic App Router browser regression for the consumed-prefetch to committed-cache handoff
- delay the redundant cache tee after a full prefetch is consumed and assert that remounting the destination Link does not issue a duplicate RSC request
- retain the existing upstream Next.js five-minute parallel-route reuse coverage

## Why

The original production fix on this branch was superseded by the broader cache-publication work merged in #2760. After merging current `main`, the conflict was resolved in favor of that newer implementation, leaving this PR as focused regression coverage for the same race.

The test remains useful because it deterministically delays the cache branch that previously created the false-miss window. Current `main` passes by publishing the already-buffered consumed-prefetch snapshot without waiting for that redundant branch to drain.

Upstream parity reference:

- `test/e2e/app-dir/app-client-cache/client-cache.parallel-routes.test.ts`
- https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app-client-cache/client-cache.parallel-routes.test.ts

Closes #2756.

## Validation

- `vp check tests/e2e/app-router/nextjs-compat/client-cache.spec.ts`
- targeted browser regression: 1/1 passed
- targeted browser regression repeated 10 times in parallel: 10/10 passed
