### PR TITLE
fix(app-router): preserve page result render ordering

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -22,7 +22,6 @@ import { notifyAppRouterTransitionStart } from "../client/instrumentation-client
 import {
   __basePath,
   appRouterInstance,
-  consumePrefetchResponse,
   commitClientNavigationState,
   consumePrefetchResponseForNavigation,
   createCachedRscResponseSnapshot,
@@ -170,6 +169,7 @@ import {
 } from "./app-rsc-cache-busting.js";
 import { blockDangerousStreamedRscRedirect } from "./app-browser-rsc-redirect.js";
 import {
+  peekSettledPrefetchResponseForNavigation,
   prepareConsumedPrefetchResponseForPublication,
   resolvePrefetchNavigationResponseUrl,
 } from "./app-browser-prefetch-response.js";
@@ -1793,18 +1793,17 @@ function bootstrapHydration(
             ? [rewrittenNavigationHref]
             : [];
         // A settled prefetch is already indexed by its rendered path/search, so
-        // consume it before recomputing the async RSC cache-busting digest. This
-        // keeps a click on a fully prefetched Link in the same browser task while
-        // the pending/missing paths retain the exact request-header digest below.
-        const settledPrefetchedResponse =
-          navigationKind === "navigate" && !shouldBypassNavigationCache
-            ? consumePrefetchResponse(
-                targetPathAndSearch,
-                requestInterceptionContext,
-                mountedSlotsHeader,
-                { additionalRscUrls: additionalPrefetchPathAndSearch },
-              )
-            : null;
+        // peek before recomputing the async RSC cache-busting digest. Ownership
+        // transfers only if the reuse planner chooses the prefetch; a visited
+        // response hit must leave it available to visible Links after back-nav.
+        const settledPrefetchedResponse = peekSettledPrefetchResponseForNavigation({
+          additionalRscUrls: additionalPrefetchPathAndSearch,
+          bypassNavigationCache: shouldBypassNavigationCache,
+          interceptionContext: requestInterceptionContext,
+          mountedSlotsHeader,
+          navigationKind,
+          targetPathAndSearch,
+        });
         const rscUrl = settledPrefetchedResponse
           ? resolvePrefetchNavigationResponseUrl({
               additionalRscUrls: additionalPrefetchPathAndSearch,
@@ -1973,17 +1972,15 @@ function bootstrapHydration(
         let prefetchedElements: AppElements | undefined;
         let fallbackReuseDecision = reuseDecision;
         if (reuseDecision.kind === "consumePrefetch") {
-          const prefetchedResponse =
-            settledPrefetchedResponse ??
-            (await consumePrefetchResponseForNavigation(
-              rscUrl,
-              requestInterceptionContext,
-              mountedSlotsHeader,
-              {
-                additionalRscUrls: additionalPrefetchRscUrls,
-                shouldConsume: () => browserNavigationController.isCurrentNavigation(navId),
-              },
-            ));
+          const prefetchedResponse = await consumePrefetchResponseForNavigation(
+            rscUrl,
+            requestInterceptionContext,
+            mountedSlotsHeader,
+            {
+              additionalRscUrls: additionalPrefetchRscUrls,
+              shouldConsume: () => browserNavigationController.isCurrentNavigation(navId),
+            },
+          );
           if (!browserNavigationController.isCurrentNavigation(navId)) return;
           if (prefetchedResponse) {
             navResponse = restoreRscResponse(prefetchedResponse, false);
@@ -2299,12 +2296,11 @@ function bootstrapHydration(
             // A navigation that consumes prefetched Flight data keeps that
             // prefetch freshness window when committed, matching Next's
             // segment-cache handoff instead of recomputing dynamic freshness.
-            // The exception is a response whose completion footer records
-            // dynamic request usage: its final dynamic bound is more precise
-            // than the provisional prefetch expiry.
-            ...(navResponseExpiresAt !== undefined && !completedResponseResolvedDynamic
-              ? { expiresAt: navResponseExpiresAt }
-              : {}),
+            // The consumed entry was buffered through completion before its
+            // expiry was calculated, so this is already the final freshness
+            // window. Keep its original deadline instead of restarting the
+            // clock when delayed cache publication eventually runs.
+            ...(navResponseExpiresAt !== undefined ? { expiresAt: navResponseExpiresAt } : {}),
             mountedSlotsHeader: getMountedSlotIdsHeader(renderedElements),
           };
           const interceptionContext = resolveVisitedResponseInterceptionContext(
@@ -2342,7 +2338,7 @@ function bootstrapHydration(
               DYNAMIC_NAVIGATION_CACHE_TTL,
               mountedSlotsHeader,
               committedElements,
-              !completedResponseResolvedDynamic,
+              true,
             );
           }
         } catch {

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -169,7 +169,10 @@ import {
   VINEXT_RSC_CONTENT_TYPE,
 } from "./app-rsc-cache-busting.js";
 import { blockDangerousStreamedRscRedirect } from "./app-browser-rsc-redirect.js";
-import { resolvePrefetchNavigationResponseUrl } from "./app-browser-prefetch-response.js";
+import {
+  prepareConsumedPrefetchResponseForPublication,
+  resolvePrefetchNavigationResponseUrl,
+} from "./app-browser-prefetch-response.js";
 import {
   createOptimisticRouteTemplate,
   getOptimisticPrefetchSourceKey,
@@ -1983,17 +1986,20 @@ function bootstrapHydration(
             ));
           if (!browserNavigationController.isCurrentNavigation(navId)) return;
           if (prefetchedResponse) {
-            const { preparedElements, ...responseSnapshot } = prefetchedResponse;
-            consumedPrefetchSnapshot = responseSnapshot;
-            prefetchedElements = preparedElements;
             navResponse = restoreRscResponse(prefetchedResponse, false);
-            navResponseExpiresAt = prefetchedResponse.expiresAt;
             navResponseUrl = resolvePrefetchNavigationResponseUrl({
               additionalRscUrls: additionalPrefetchRscUrls,
               origin: window.location.origin,
               responseUrl: prefetchedResponse.url,
               visibleRscUrl: rscUrl,
             });
+            const publication = prepareConsumedPrefetchResponseForPublication(
+              prefetchedResponse,
+              navResponseUrl,
+            );
+            consumedPrefetchSnapshot = publication.snapshot;
+            prefetchedElements = publication.preparedElements;
+            navResponseExpiresAt = publication.expiresAt;
           }
           if (!navResponse) {
             routeManifest = navigationKind === "navigate" ? getBrowserRouteManifest() : null;

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -1966,6 +1966,7 @@ function bootstrapHydration(
         let navResponse: Response | undefined;
         let navResponseExpiresAt: number | undefined;
         let navResponseUrl: string | null = null;
+        let consumedPrefetchSnapshot: CachedRscResponse | undefined;
         let prefetchedElements: AppElements | undefined;
         let fallbackReuseDecision = reuseDecision;
         if (reuseDecision.kind === "consumePrefetch") {
@@ -1982,7 +1983,9 @@ function bootstrapHydration(
             ));
           if (!browserNavigationController.isCurrentNavigation(navId)) return;
           if (prefetchedResponse) {
-            prefetchedElements = prefetchedResponse.preparedElements;
+            const { preparedElements, ...responseSnapshot } = prefetchedResponse;
+            consumedPrefetchSnapshot = responseSnapshot;
+            prefetchedElements = preparedElements;
             navResponse = restoreRscResponse(prefetchedResponse, false);
             navResponseExpiresAt = prefetchedResponse.expiresAt;
             navResponseUrl = resolvePrefetchNavigationResponseUrl({
@@ -2259,13 +2262,15 @@ function bootstrapHydration(
           const renderedElements = await rscPayload;
           if (navigationCacheGeneration !== clientNavigationCacheGeneration) return;
           const metadata = AppElementsWire.readMetadata(renderedElements);
-          const cacheBuffer = await cacheBufferPromise;
           if (navigationCacheGeneration !== clientNavigationCacheGeneration) return;
-          const responseSnapshot = createCachedRscResponseSnapshot(
-            navResponse,
-            cacheBuffer,
-            navResponseUrl,
-          );
+          // A consumed prefetch was fully buffered before navigation could take
+          // ownership of it. Reuse that snapshot instead of waiting for the
+          // redundant cache tee to drain: otherwise an immediate back
+          // navigation can expose a window where the committed destination is
+          // absent from both caches and an explicit prefetch refetches it.
+          const responseSnapshot =
+            consumedPrefetchSnapshot ??
+            createCachedRscResponseSnapshot(navResponse, await cacheBufferPromise, navResponseUrl);
           const completedResponseResolvedDynamic =
             responseSnapshot.completedDynamicStaleTimeSeconds !== undefined;
           const cacheRestorable =

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -23,6 +23,7 @@ import {
   __basePath,
   appRouterInstance,
   commitClientNavigationState,
+  consumePrefetchResponse,
   consumePrefetchResponseForNavigation,
   createCachedRscResponseSnapshot,
   createClientNavigationRenderSnapshot,
@@ -170,6 +171,7 @@ import {
 import { blockDangerousStreamedRscRedirect } from "./app-browser-rsc-redirect.js";
 import {
   peekSettledPrefetchResponseForNavigation,
+  preserveCommittedPrefetchExpiry,
   prepareConsumedPrefetchResponseForPublication,
   resolvePrefetchNavigationResponseUrl,
 } from "./app-browser-prefetch-response.js";
@@ -766,6 +768,7 @@ function storeVisitedResponseSnapshot(
   requestMountedSlotsHeader: string | null = snapshot.mountedSlotsHeader ?? null,
   elements?: AppElements,
   seedPrefetchCache: boolean = true,
+  prefetchSnapshot: CachedRscResponse = snapshot,
 ): () => void {
   const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
   visitedResponseCache.delete(cacheKey);
@@ -783,7 +786,7 @@ function storeVisitedResponseSnapshot(
   if (seedPrefetchCache) {
     seedPrefetchResponseSnapshot(
       rscUrl,
-      snapshot,
+      prefetchSnapshot,
       interceptionContext,
       requestMountedSlotsHeader,
       prefetchFallbackTtlMs,
@@ -794,7 +797,7 @@ function storeVisitedResponseSnapshot(
       visitedResponseCache.delete(cacheKey);
     }
     if (seedPrefetchCache) {
-      deletePrefetchResponseSnapshot(rscUrl, snapshot, interceptionContext);
+      deletePrefetchResponseSnapshot(rscUrl, prefetchSnapshot, interceptionContext);
     }
   };
 }
@@ -1972,15 +1975,22 @@ function bootstrapHydration(
         let prefetchedElements: AppElements | undefined;
         let fallbackReuseDecision = reuseDecision;
         if (reuseDecision.kind === "consumePrefetch") {
-          const prefetchedResponse = await consumePrefetchResponseForNavigation(
-            rscUrl,
-            requestInterceptionContext,
-            mountedSlotsHeader,
-            {
-              additionalRscUrls: additionalPrefetchRscUrls,
-              shouldConsume: () => browserNavigationController.isCurrentNavigation(navId),
-            },
-          );
+          const prefetchedResponse = settledPrefetchedResponse
+            ? consumePrefetchResponse(
+                targetPathAndSearch,
+                requestInterceptionContext,
+                mountedSlotsHeader,
+                { additionalRscUrls: additionalPrefetchPathAndSearch },
+              )
+            : await consumePrefetchResponseForNavigation(
+                rscUrl,
+                requestInterceptionContext,
+                mountedSlotsHeader,
+                {
+                  additionalRscUrls: additionalPrefetchRscUrls,
+                  shouldConsume: () => browserNavigationController.isCurrentNavigation(navId),
+                },
+              );
           if (!browserNavigationController.isCurrentNavigation(navId)) return;
           if (prefetchedResponse) {
             navResponse = restoreRscResponse(prefetchedResponse, false);
@@ -2293,16 +2303,12 @@ function bootstrapHydration(
                     ? { dynamicStaleTimeSeconds: metadata.dynamicStaleTimeSeconds }
                     : {}),
                 }),
-            // A navigation that consumes prefetched Flight data keeps that
-            // prefetch freshness window when committed, matching Next's
-            // segment-cache handoff instead of recomputing dynamic freshness.
-            // The consumed entry was buffered through completion before its
-            // expiry was calculated, so this is already the final freshness
-            // window. Keep its original deadline instead of restarting the
-            // clock when delayed cache publication eventually runs.
-            ...(navResponseExpiresAt !== undefined ? { expiresAt: navResponseExpiresAt } : {}),
             mountedSlotsHeader: getMountedSlotIdsHeader(renderedElements),
           };
+          // The prefetch retains the absolute deadline calculated when its
+          // response settled. The visited/BFCache snapshot must not inherit
+          // that deadline: it independently applies staleTimes.dynamic.
+          const prefetchSnapshot = preserveCommittedPrefetchExpiry(snapshot, navResponseExpiresAt);
           const interceptionContext = resolveVisitedResponseInterceptionContext(
             requestInterceptionContext,
             metadata.interceptionContext,
@@ -2316,6 +2322,9 @@ function bootstrapHydration(
               navParams,
               PREFETCH_CACHE_TTL,
               mountedSlotsHeader,
+              undefined,
+              true,
+              prefetchSnapshot,
             );
           } else {
             const state = committedState;
@@ -2339,6 +2348,7 @@ function bootstrapHydration(
               mountedSlotsHeader,
               committedElements,
               true,
+              prefetchSnapshot,
             );
           }
         } catch {

--- a/packages/vinext/src/server/app-browser-prefetch-response.ts
+++ b/packages/vinext/src/server/app-browser-prefetch-response.ts
@@ -1,4 +1,5 @@
 import { stripRscCacheBustingSearchParam } from "./app-rsc-cache-busting.js";
+import type { CachedRscResponse } from "vinext/shims/navigation";
 
 function normalizeBrowserRscUrlForReuse(
   url: string | null | undefined,
@@ -52,4 +53,20 @@ export function resolvePrefetchNavigationResponseUrl(options: {
   return matchedAlternate
     ? options.visibleRscUrl
     : canonicalizeBrowserRscResponseUrl(options.responseUrl, options.origin);
+}
+
+export function prepareConsumedPrefetchResponseForPublication(
+  response: CachedRscResponse,
+  responseUrl: string,
+): {
+  expiresAt: number | undefined;
+  preparedElements: CachedRscResponse["preparedElements"];
+  snapshot: CachedRscResponse;
+} {
+  const { expiresAt, preparedElements, ...snapshot } = response;
+  return {
+    expiresAt,
+    preparedElements,
+    snapshot: { ...snapshot, url: responseUrl },
+  };
 }

--- a/packages/vinext/src/server/app-browser-prefetch-response.ts
+++ b/packages/vinext/src/server/app-browser-prefetch-response.ts
@@ -90,3 +90,10 @@ export function prepareConsumedPrefetchResponseForPublication(
     snapshot: { ...snapshot, url: responseUrl },
   };
 }
+
+export function preserveCommittedPrefetchExpiry(
+  snapshot: CachedRscResponse,
+  expiresAt: number | undefined,
+): CachedRscResponse {
+  return expiresAt === undefined ? snapshot : { ...snapshot, expiresAt };
+}

--- a/packages/vinext/src/server/app-browser-prefetch-response.ts
+++ b/packages/vinext/src/server/app-browser-prefetch-response.ts
@@ -1,5 +1,25 @@
 import { stripRscCacheBustingSearchParam } from "./app-rsc-cache-busting.js";
-import type { CachedRscResponse } from "vinext/shims/navigation";
+import { peekPrefetchResponseForNavigation, type CachedRscResponse } from "vinext/shims/navigation";
+
+export function peekSettledPrefetchResponseForNavigation(options: {
+  additionalRscUrls: readonly string[];
+  bypassNavigationCache: boolean;
+  interceptionContext: string | null;
+  mountedSlotsHeader: string | null;
+  navigationKind: "navigate" | "refresh" | "traverse";
+  peek?: typeof peekPrefetchResponseForNavigation;
+  targetPathAndSearch: string;
+}): CachedRscResponse | null {
+  if (options.navigationKind !== "navigate" || options.bypassNavigationCache) {
+    return null;
+  }
+  return (options.peek ?? peekPrefetchResponseForNavigation)(
+    options.targetPathAndSearch,
+    options.interceptionContext,
+    options.mountedSlotsHeader,
+    { additionalRscUrls: options.additionalRscUrls },
+  );
+}
 
 function normalizeBrowserRscUrlForReuse(
   url: string | null | undefined,

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -2,10 +2,7 @@ import { type ReactNode } from "react";
 import type { ReactFormState } from "react-dom/client";
 import type { NavigationContext } from "vinext/shims/navigation";
 import type { ClassificationReason } from "../build/layout-classification-types.js";
-import {
-  _consumeRequestScopedCacheLife,
-  _peekRequestScopedCacheLife,
-} from "vinext/shims/cache-request-state";
+import { _captureRequestScopedCacheLifeAccessors } from "vinext/shims/cache-request-state";
 import type { RootParams } from "vinext/shims/root-params";
 import type { PprFallbackShellState } from "vinext/shims/ppr-fallback-shell";
 import {
@@ -1086,6 +1083,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
   const pprFallbackShellReactSignal = activeFallbackShellState?.reactAbortController.signal;
   const isSpeculativePrerender =
     isPrerender && options.request.headers.get(VINEXT_PRERENDER_SPECULATIVE_HEADER) === "1";
+  const requestCacheLife = _captureRequestScopedCacheLifeAccessors();
 
   return renderAppPageLifecycle({
     basePath: options.basePath,
@@ -1111,10 +1109,10 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
       return buildAppPageTags(options.cleanPathname, getCollectedFetchTags(), route.routeSegments);
     },
     getRequestCacheLife() {
-      return _consumeRequestScopedCacheLife();
+      return requestCacheLife.consume();
     },
     peekRequestCacheLife() {
-      return _peekRequestScopedCacheLife();
+      return requestCacheLife.peek();
     },
     handlerStart: options.handlerStart,
     hasLoadingBoundary: hasActiveLoadingBoundary,

--- a/packages/vinext/src/server/app-page-element-builder.ts
+++ b/packages/vinext/src/server/app-page-element-builder.ts
@@ -44,6 +44,7 @@ import { shouldServeStreamingMetadata } from "./streaming-metadata.js";
 import { resolveAppPageBranchParams, resolveAppPageSegmentParams } from "./app-page-params.js";
 import {
   createAppPageRenderDependency,
+  isAppRenderSuspension,
   renderAfterAppDependencies,
   type AppPageRenderDependency,
 } from "./app-render-dependency.js";
@@ -72,17 +73,6 @@ function isReactOwnedPageComponent(component: AppPageComponent): boolean {
   };
   return (
     candidate.$$typeof === REACT_CLIENT_REFERENCE || candidate.prototype?.isReactComponent != null
-  );
-}
-
-function isReactSuspension(error: unknown): boolean {
-  if (isPromiseLike(error)) {
-    return true;
-  }
-
-  return (
-    error instanceof Error &&
-    error.message.startsWith("Suspense Exception: This is not a real error!")
   );
 }
 
@@ -585,7 +575,7 @@ export async function buildPageElements<
             )
           : result;
       } catch (error) {
-        if (isReactSuspension(error)) {
+        if (isAppRenderSuspension(error)) {
           // React requires its internal use() suspension value to be rethrown
           // immediately. With loading UI, release from a microtask so the
           // page-entry Suspense boundary can serialize its fallback. Without

--- a/packages/vinext/src/server/app-page-element-builder.ts
+++ b/packages/vinext/src/server/app-page-element-builder.ts
@@ -42,7 +42,11 @@ import {
 } from "./app-page-search-params-observation.js";
 import { shouldServeStreamingMetadata } from "./streaming-metadata.js";
 import { resolveAppPageBranchParams, resolveAppPageSegmentParams } from "./app-page-params.js";
-import { createAppRenderDependency, type AppRenderDependency } from "./app-render-dependency.js";
+import {
+  createAppPageRenderDependency,
+  renderAfterAppDependencies,
+  type AppPageRenderDependency,
+} from "./app-render-dependency.js";
 import { isPromiseLike } from "../utils/promise.js";
 
 function resolveInterceptLayoutParams(
@@ -523,12 +527,12 @@ export async function buildPageElements<
       ) !== null);
   const pageRenderDependency =
     EffectivePageComponent && !isReactOwnedPageComponent(EffectivePageComponent)
-      ? createAppRenderDependency()
+      ? createAppPageRenderDependency()
       : null;
   const createPageElement = (
     PageComponent: AppPageComponent,
     props: Readonly<Record<string, unknown>>,
-    renderDependency?: AppRenderDependency | null,
+    renderDependency?: AppPageRenderDependency | null,
   ) => {
     if (isReactOwnedPageComponent(PageComponent)) {
       const invocationProps = { ...props };
@@ -557,27 +561,29 @@ export async function buildPageElements<
         const result = ServerPageComponent(invocationProps);
         if (isPromiseLike(result)) {
           if (renderDependency) {
-            if (hasPageLoadingBoundary) {
-              // A loading boundary needs the dependent route/layout entries to
-              // serialize while the page is still pending so its fallback can
-              // stream. Request state consumed by those entries must therefore
-              // be established in the page's first continuation; an async
-              // consumer gets its own continuation before reading that state.
-              void Promise.resolve().then(() => renderDependency.release());
-            } else {
-              // With no loading UI to stream, preserve the stronger ordering
-              // contract: even a synchronous layout cannot observe request
-              // state until the async page has finished initializing it.
-              void Promise.resolve(result).then(
-                () => renderDependency.release(),
-                () => renderDependency.release(),
-              );
-            }
+            // A declared-async page reaches its first continuation before this
+            // microtask. That is enough for the Next.js pattern where the page
+            // awaits params and establishes request-scoped state for a parent
+            // layout. Do not wait for the complete page result: doing so turns
+            // an ancestor Suspense boundary into a blocking render.
+            void Promise.resolve().then(() => renderDependency.release());
           }
-          return result;
+          return Promise.resolve(result).then((resolvedResult) =>
+            renderDependency
+              ? renderAfterAppDependencies(
+                  resolvedResult as React.ReactNode,
+                  renderDependency.resultDependencies,
+                )
+              : (resolvedResult as React.ReactNode),
+          );
         }
         renderDependency?.release();
-        return result;
+        return renderDependency
+          ? renderAfterAppDependencies(
+              result as React.ReactNode,
+              renderDependency.resultDependencies,
+            )
+          : result;
       } catch (error) {
         if (isReactSuspension(error)) {
           // React requires its internal use() suspension value to be rethrown

--- a/packages/vinext/src/server/app-page-element-builder.ts
+++ b/packages/vinext/src/server/app-page-element-builder.ts
@@ -44,7 +44,9 @@ import { shouldServeStreamingMetadata } from "./streaming-metadata.js";
 import { resolveAppPageBranchParams, resolveAppPageSegmentParams } from "./app-page-params.js";
 import {
   createAppPageRenderDependency,
+  invokeAppComponent,
   isAppRenderSuspension,
+  isReactOwnedAppComponent,
   renderAfterAppDependencies,
   type AppPageRenderDependency,
 } from "./app-render-dependency.js";
@@ -61,20 +63,6 @@ function resolveInterceptLayoutParams(
 export type { AppPageErrorModule, AppPageRouteWiringRoute } from "./app-page-route-wiring.js";
 
 type AppPageComponent = NonNullable<AppPageModule["default"]>;
-const REACT_CLIENT_REFERENCE = Symbol.for("react.client.reference");
-
-function isReactOwnedPageComponent(component: AppPageComponent): boolean {
-  if (typeof component !== "function") {
-    return true;
-  }
-  const candidate = component as AppPageComponent & {
-    $$typeof?: symbol;
-    prototype?: { isReactComponent?: unknown };
-  };
-  return (
-    candidate.$$typeof === REACT_CLIENT_REFERENCE || candidate.prototype?.isReactComponent != null
-  );
-}
 
 /**
  * Route shape passed from the generated entry. Extends the wiring route with
@@ -516,7 +504,7 @@ export async function buildPageElements<
         pageTreePosition,
       ) !== null);
   const pageRenderDependency =
-    EffectivePageComponent && !isReactOwnedPageComponent(EffectivePageComponent)
+    EffectivePageComponent && !isReactOwnedAppComponent(EffectivePageComponent)
       ? createAppPageRenderDependency()
       : null;
   const createPageElement = (
@@ -524,7 +512,7 @@ export async function buildPageElements<
     props: Readonly<Record<string, unknown>>,
     renderDependency?: AppPageRenderDependency | null,
   ) => {
-    if (isReactOwnedPageComponent(PageComponent)) {
+    if (isReactOwnedAppComponent(PageComponent)) {
       const invocationProps = { ...props };
       if (searchParams) {
         invocationProps.searchParams = observePageSearchParamsAccess
@@ -536,9 +524,6 @@ export async function buildPageElements<
       return createElement(PageComponent, invocationProps);
     }
 
-    const ServerPageComponent = PageComponent as unknown as (
-      props: Readonly<Record<string, unknown>>,
-    ) => ReturnType<typeof createElement> | Promise<unknown> | string | number | null;
     const PageInvoker = () => {
       const invocationProps = { ...props };
       if (searchParams) {
@@ -548,7 +533,7 @@ export async function buildPageElements<
       }
 
       try {
-        const result = ServerPageComponent(invocationProps);
+        const result = invokeAppComponent(PageComponent, invocationProps);
         if (isPromiseLike(result)) {
           if (renderDependency) {
             // A declared-async page reaches its first continuation before this

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -901,7 +901,6 @@ export async function renderAppPageLifecycle(
     const completionHeaders = new Headers(rscResponse.headers);
     completionHeaders.set(VINEXT_RSC_COMPLETION_METADATA_HEADER, "1");
     const completionResponse =
-      !shouldEmitDynamicStaleTime &&
       dynamicStaleTimeSeconds !== undefined &&
       options.isPrerender !== true &&
       !options.isForceStatic &&
@@ -912,6 +911,12 @@ export async function renderAppPageLifecycle(
               const completedServerStaleTimeSeconds = resolveClientStaleTimeSeconds(
                 options.peekRequestCacheLife?.(),
               );
+              // A known-dynamic response already carries its BFCache bound in
+              // the header. Add a footer only when it has a distinct completed
+              // cacheLife claim for runtime-prefetch expiry.
+              if (shouldEmitDynamicStaleTime && completedServerStaleTimeSeconds === undefined) {
+                return undefined;
+              }
               return {
                 dynamicStaleTimeSeconds,
                 serverStaleTimeSeconds:

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -41,7 +41,7 @@ import {
   createAppRenderDependency,
   registerAppElementRenderDependencies,
   renderAfterAppDependencies,
-  renderWithAppDependencyBarrier,
+  renderAppComponentWithDependencyBarrier,
   type AppPageRenderDependency,
   type AppRenderDependency,
 } from "./app-render-dependency.js";
@@ -1106,10 +1106,9 @@ export function buildAppPageElements<
     const TemplateComponent = templateComponent;
     const templateDependency = templateDependenciesById.get(templateEntry.id);
     let templateElement: ReactNode = templateDependency ? (
-      renderWithAppDependencyBarrier(
-        <TemplateComponent>
-          <Children />
-        </TemplateComponent>,
+      renderAppComponentWithDependencyBarrier(
+        TemplateComponent,
+        { children: <Children /> },
         templateDependency,
       )
     ) : (
@@ -1175,10 +1174,9 @@ export function buildAppPageElements<
     const LayoutComponent = layoutComponent;
     const layoutDependency = layoutDependenciesByIndex.get(index);
     let layoutElement: ReactNode = layoutDependency ? (
-      renderWithAppDependencyBarrier(
-        <LayoutComponent {...layoutProps}>
-          <Children />
-        </LayoutComponent>,
+      renderAppComponentWithDependencyBarrier(
+        LayoutComponent,
+        { ...layoutProps, children: <Children /> },
         layoutDependency,
       )
     ) : (

--- a/packages/vinext/src/server/app-page-route-wiring.tsx
+++ b/packages/vinext/src/server/app-page-route-wiring.tsx
@@ -42,6 +42,7 @@ import {
   registerAppElementRenderDependencies,
   renderAfterAppDependencies,
   renderWithAppDependencyBarrier,
+  type AppPageRenderDependency,
   type AppRenderDependency,
 } from "./app-render-dependency.js";
 import {
@@ -242,7 +243,7 @@ type BuildAppPageRouteElementOptions<
     component: AppPageComponent,
     props: Readonly<Record<string, unknown>>,
   ) => ReactNode;
-  pageRenderDependency?: AppRenderDependency | null;
+  pageRenderDependency?: AppPageRenderDependency | null;
   searchParams?: unknown;
   slotOverrides?: Readonly<Record<string, AppPageSlotOverride<TModule>>> | null;
 };
@@ -1054,6 +1055,8 @@ export function buildAppPageElements<
     templateDependenciesBeforeById.set(templateEntry.id, [...pageDependencies]);
     pageDependencies.push(templateDependency);
   }
+
+  pageRenderDependency?.setResultDependencies(pageDependencies);
 
   const routeLoadingComponent = getDefaultExport(options.route.loading);
   const prefetchLoadingComponent = getDefaultExport(prefetchLoadingEntry?.loadingModule);

--- a/packages/vinext/src/server/app-render-dependency.tsx
+++ b/packages/vinext/src/server/app-render-dependency.tsx
@@ -28,6 +28,52 @@ const REACT_FORWARD_REF = Symbol.for("react.forward_ref");
 const REACT_LAZY = Symbol.for("react.lazy");
 const REACT_MEMO = Symbol.for("react.memo");
 
+export function isReactOwnedAppComponent(component: unknown): boolean {
+  const candidate = component as AppDependencyComponent | null;
+
+  if (
+    candidate?.$$typeof === REACT_MEMO ||
+    candidate?.$$typeof === REACT_LAZY ||
+    candidate?.$$typeof === REACT_FORWARD_REF
+  ) {
+    return false;
+  }
+
+  return (
+    typeof candidate !== "function" ||
+    candidate.$$typeof === REACT_CLIENT_REFERENCE ||
+    candidate.prototype?.isReactComponent != null
+  );
+}
+
+export function invokeAppComponent(
+  component: ComponentType<Record<string, unknown>>,
+  props: Readonly<Record<string, unknown>>,
+): ReactNode | Promise<ReactNode> {
+  const candidate = component as AppDependencyComponent;
+
+  if (candidate.$$typeof === REACT_MEMO && candidate.type) {
+    return invokeAppComponent(candidate.type, props);
+  }
+
+  if (candidate.$$typeof === REACT_LAZY && candidate._init) {
+    return invokeAppComponent(candidate._init(candidate._payload), props);
+  }
+
+  if (candidate.$$typeof === REACT_FORWARD_REF && candidate.render) {
+    return candidate.render(props, undefined);
+  }
+
+  if (isReactOwnedAppComponent(candidate)) {
+    return createElement(candidate, props);
+  }
+
+  const ServerComponent = candidate as unknown as (
+    props: Readonly<Record<string, unknown>>,
+  ) => ReactNode | Promise<ReactNode>;
+  return ServerComponent(props);
+}
+
 const appElementRenderDependencies = new WeakMap<
   Readonly<Record<string, unknown>>,
   ReadonlyMap<string, AppRenderDependency>
@@ -124,36 +170,9 @@ export function renderAppComponentWithDependencyBarrier(
   // is suspended. Unwrap server-owned wrappers here so dependency release is
   // tied to their actual result; client references and classes remain owned by
   // React and only need their element to be produced synchronously.
-  function invokeComponent(candidate: AppDependencyComponent): ReactNode | Promise<ReactNode> {
-    if (candidate.$$typeof === REACT_MEMO && candidate.type) {
-      return invokeComponent(candidate.type);
-    }
-
-    if (candidate.$$typeof === REACT_LAZY && candidate._init && candidate._payload !== undefined) {
-      return invokeComponent(candidate._init(candidate._payload));
-    }
-
-    if (candidate.$$typeof === REACT_FORWARD_REF && candidate.render) {
-      return candidate.render(props, undefined);
-    }
-
-    if (
-      typeof candidate !== "function" ||
-      candidate.$$typeof === REACT_CLIENT_REFERENCE ||
-      candidate.prototype?.isReactComponent != null
-    ) {
-      return createElement(candidate, props);
-    }
-
-    const ServerComponent = candidate as unknown as (
-      props: Readonly<Record<string, unknown>>,
-    ) => ReactNode | Promise<ReactNode>;
-    return ServerComponent(props);
-  }
-
   function AppComponentDependencyBarrier() {
     try {
-      const result = invokeComponent(component as AppDependencyComponent);
+      const result = invokeAppComponent(component, props);
       if (isPromiseLike(result)) {
         return Promise.resolve(result).then(
           (resolvedResult) => {

--- a/packages/vinext/src/server/app-render-dependency.tsx
+++ b/packages/vinext/src/server/app-render-dependency.tsx
@@ -11,6 +11,20 @@ export type AppPageRenderDependency = AppRenderDependency & {
   setResultDependencies: (dependencies: readonly AppRenderDependency[]) => void;
 };
 
+type AppDependencyComponent = ComponentType<Record<string, unknown>> & {
+  $$typeof?: symbol;
+  _init?: (payload: unknown) => AppDependencyComponent;
+  _payload?: unknown;
+  prototype?: { isReactComponent?: unknown };
+  render?: (props: Readonly<Record<string, unknown>>, ref: null) => ReactNode | Promise<ReactNode>;
+  type?: AppDependencyComponent;
+};
+
+const REACT_CLIENT_REFERENCE = Symbol.for("react.client.reference");
+const REACT_FORWARD_REF = Symbol.for("react.forward_ref");
+const REACT_LAZY = Symbol.for("react.lazy");
+const REACT_MEMO = Symbol.for("react.memo");
+
 const appElementRenderDependencies = new WeakMap<
   Readonly<Record<string, unknown>>,
   ReadonlyMap<string, AppRenderDependency>
@@ -103,31 +117,40 @@ export function renderAppComponentWithDependencyBarrier(
   props: Readonly<Record<string, unknown>>,
   dependency: AppRenderDependency,
 ): ReactNode {
-  const candidate = component as ComponentType<Record<string, unknown>> & {
-    $$typeof?: symbol;
-    prototype?: { isReactComponent?: unknown };
-  };
-  const isReactOwnedComponent =
-    typeof candidate !== "function" ||
-    candidate.$$typeof === Symbol.for("react.client.reference") ||
-    candidate.prototype?.isReactComponent != null;
-
-  if (isReactOwnedComponent) {
-    function ReactOwnedComponentBarrier() {
-      dependency.release();
-      return createElement(component, props);
+  // Flight may continue serializing sibling entries while an exotic wrapper
+  // is suspended. Unwrap server-owned wrappers here so dependency release is
+  // tied to their actual result; client references and classes remain owned by
+  // React and only need their element to be produced synchronously.
+  function invokeComponent(candidate: AppDependencyComponent): ReactNode | Promise<ReactNode> {
+    if (candidate.$$typeof === REACT_MEMO && candidate.type) {
+      return invokeComponent(candidate.type);
     }
 
-    return createElement(ReactOwnedComponentBarrier);
-  }
+    if (candidate.$$typeof === REACT_LAZY && candidate._init && candidate._payload !== undefined) {
+      return invokeComponent(candidate._init(candidate._payload));
+    }
 
-  const ServerComponent = component as unknown as (
-    props: Readonly<Record<string, unknown>>,
-  ) => ReactNode | Promise<ReactNode>;
+    if (candidate.$$typeof === REACT_FORWARD_REF && candidate.render) {
+      return candidate.render(props, null);
+    }
+
+    if (
+      typeof candidate !== "function" ||
+      candidate.$$typeof === REACT_CLIENT_REFERENCE ||
+      candidate.prototype?.isReactComponent != null
+    ) {
+      return createElement(candidate, props);
+    }
+
+    const ServerComponent = candidate as unknown as (
+      props: Readonly<Record<string, unknown>>,
+    ) => ReactNode | Promise<ReactNode>;
+    return ServerComponent(props);
+  }
 
   function AppComponentDependencyBarrier() {
     try {
-      const result = ServerComponent(props);
+      const result = invokeComponent(component as AppDependencyComponent);
       if (isPromiseLike(result)) {
         return Promise.resolve(result).then(
           (resolvedResult) => {

--- a/packages/vinext/src/server/app-render-dependency.tsx
+++ b/packages/vinext/src/server/app-render-dependency.tsx
@@ -5,6 +5,11 @@ export type AppRenderDependency = {
   release: () => void;
 };
 
+export type AppPageRenderDependency = AppRenderDependency & {
+  resultDependencies: readonly AppRenderDependency[];
+  setResultDependencies: (dependencies: readonly AppRenderDependency[]) => void;
+};
+
 const appElementRenderDependencies = new WeakMap<
   Readonly<Record<string, unknown>>,
   ReadonlyMap<string, AppRenderDependency>
@@ -41,6 +46,21 @@ export function createAppRenderDependency(): AppRenderDependency {
       }
       released = true;
       resolve();
+    },
+  };
+}
+
+export function createAppPageRenderDependency(): AppPageRenderDependency {
+  const initialization = createAppRenderDependency();
+  let resultDependencies: readonly AppRenderDependency[] = [];
+
+  return {
+    ...initialization,
+    get resultDependencies() {
+      return resultDependencies;
+    },
+    setResultDependencies(dependencies) {
+      resultDependencies = dependencies;
     },
   };
 }

--- a/packages/vinext/src/server/app-render-dependency.tsx
+++ b/packages/vinext/src/server/app-render-dependency.tsx
@@ -1,4 +1,5 @@
-import { use, type ReactNode } from "react";
+import { createElement, use, type ComponentType, type ReactNode } from "react";
+import { isPromiseLike } from "../utils/promise.js";
 
 export type AppRenderDependency = {
   promise: Promise<void>;
@@ -65,6 +66,17 @@ export function createAppPageRenderDependency(): AppPageRenderDependency {
   };
 }
 
+export function isAppRenderSuspension(error: unknown): boolean {
+  if (isPromiseLike(error)) {
+    return true;
+  }
+
+  return (
+    error instanceof Error &&
+    error.message.startsWith("Suspense Exception: This is not a real error!")
+  );
+}
+
 export function renderAfterAppDependencies(
   children: ReactNode,
   dependencies: readonly AppRenderDependency[],
@@ -86,25 +98,63 @@ export function renderAfterAppDependencies(
   return <AwaitAppRenderDependencies />;
 }
 
-export function renderWithAppDependencyBarrier(
-  children: ReactNode,
+export function renderAppComponentWithDependencyBarrier(
+  component: ComponentType<Record<string, unknown>>,
+  props: Readonly<Record<string, unknown>>,
   dependency: AppRenderDependency,
 ): ReactNode {
-  function ReleaseAppRenderDependency() {
-    // This render-time release is intentional. The dependency barrier is only
-    // used inside the RSC render graph, where producing this leaf means the
-    // owning entry has reached the serialization point that downstream entries
-    // are allowed to observe. If Phase 2 adds AbortSignal-based render
-    // timeouts, this dependency will also need an abort/reject path so stuck
-    // async layouts do not suspend downstream entries forever.
-    dependency.release();
-    return null;
+  const candidate = component as ComponentType<Record<string, unknown>> & {
+    $$typeof?: symbol;
+    prototype?: { isReactComponent?: unknown };
+  };
+  const isReactOwnedComponent =
+    typeof candidate !== "function" ||
+    candidate.$$typeof === Symbol.for("react.client.reference") ||
+    candidate.prototype?.isReactComponent != null;
+
+  if (isReactOwnedComponent) {
+    function ReactOwnedComponentBarrier() {
+      dependency.release();
+      return createElement(component, props);
+    }
+
+    return createElement(ReactOwnedComponentBarrier);
   }
 
-  return (
-    <>
-      {children}
-      <ReleaseAppRenderDependency />
-    </>
-  );
+  const ServerComponent = component as unknown as (
+    props: Readonly<Record<string, unknown>>,
+  ) => ReactNode | Promise<ReactNode>;
+
+  function AppComponentDependencyBarrier() {
+    try {
+      const result = ServerComponent(props);
+      if (isPromiseLike(result)) {
+        return Promise.resolve(result).then(
+          (resolvedResult) => {
+            dependency.release();
+            return resolvedResult;
+          },
+          (error: unknown) => {
+            dependency.release();
+            throw error;
+          },
+        );
+      }
+
+      dependency.release();
+      return result;
+    } catch (error) {
+      // A thrown thenable is React-owned suspension. Releasing here would let
+      // dependent flat Flight entries run before this component's retry has
+      // produced its result. Ordinary errors cannot retry, so release them to
+      // avoid leaving sibling entries suspended forever while the error is
+      // serialized by the owning boundary.
+      if (!isAppRenderSuspension(error)) {
+        dependency.release();
+      }
+      throw error;
+    }
+  }
+
+  return createElement(AppComponentDependencyBarrier);
 }

--- a/packages/vinext/src/server/app-render-dependency.tsx
+++ b/packages/vinext/src/server/app-render-dependency.tsx
@@ -16,7 +16,10 @@ type AppDependencyComponent = ComponentType<Record<string, unknown>> & {
   _init?: (payload: unknown) => AppDependencyComponent;
   _payload?: unknown;
   prototype?: { isReactComponent?: unknown };
-  render?: (props: Readonly<Record<string, unknown>>, ref: null) => ReactNode | Promise<ReactNode>;
+  render?: (
+    props: Readonly<Record<string, unknown>>,
+    ref: undefined,
+  ) => ReactNode | Promise<ReactNode>;
   type?: AppDependencyComponent;
 };
 
@@ -131,7 +134,7 @@ export function renderAppComponentWithDependencyBarrier(
     }
 
     if (candidate.$$typeof === REACT_FORWARD_REF && candidate.render) {
-      return candidate.render(props, null);
+      return candidate.render(props, undefined);
     }
 
     if (

--- a/packages/vinext/src/shims/cache-request-state.ts
+++ b/packages/vinext/src/shims/cache-request-state.ts
@@ -235,6 +235,31 @@ export function _consumeRequestScopedCacheLife(): CacheLifeConfig | null {
   return config;
 }
 
+/**
+ * Capture access to the current request's cache-life slot for work that may
+ * finish after the AsyncLocalStorage request scope has returned. RSC response
+ * bodies are consumed by the server runtime later, so resolving the active
+ * store from a stream-finalization callback can otherwise read a detached
+ * context and lose cacheLife claims made while rendering the body.
+ */
+export function _captureRequestScopedCacheLifeAccessors(): {
+  consume: () => CacheLifeConfig | null;
+  peek: () => CacheLifeConfig | null;
+} {
+  const state = getCacheState();
+  return {
+    consume() {
+      const config = state.requestScopedCacheLife;
+      state.requestScopedCacheLife = null;
+      return config;
+    },
+    peek() {
+      const config = state.requestScopedCacheLife;
+      return config === null ? null : { ...config };
+    },
+  };
+}
+
 export function recordUnstableCacheObservation(observation: UnstableCacheObservation): void {
   getCacheState().unstableCacheObservations.set(observation.keyHash, observation);
 }

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -492,7 +492,15 @@ function resolvePrefetchedRscResponseExpiresAt(
   if (isCacheExpiresAt(cached.expiresAt)) {
     return cached.expiresAt;
   }
-  const seconds = resolveRscResponseStaleTimeSeconds(cached);
+  // Next's runtime-prefetch stale time comes from the completed cacheLife
+  // claim. `staleTimes.dynamic` independently bounds visited/BFCache reuse and
+  // is only the prefetch fallback when the render made no cacheLife claim.
+  const serverSeconds = serverStaleTimeSeconds(cached.serverStaleTime);
+  const seconds =
+    serverSeconds ??
+    (isStaleTimeSeconds(cached.dynamicStaleTimeSeconds)
+      ? cached.dynamicStaleTimeSeconds
+      : undefined);
   if (seconds === undefined) {
     return timestamp + Math.max(fallbackTtlMs, minimumTtlMs);
   }
@@ -1417,11 +1425,13 @@ export function peekPrefetchResponseForNavigation(
   rscUrl: string,
   interceptionContext: string | null = null,
   mountedSlotsHeader: string | null = null,
+  options?: { additionalRscUrls?: readonly string[] },
 ): CachedRscResponse | null {
   const match = findPrefetchCacheEntryForNavigation(
     rscUrl,
     interceptionContext,
     mountedSlotsHeader,
+    options?.additionalRscUrls,
   );
   if (!match) return null;
 

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -34,9 +34,11 @@ import {
 import { createAppBrowserNavigationController } from "../packages/vinext/src/server/app-browser-navigation-controller.js";
 import {
   peekSettledPrefetchResponseForNavigation,
+  preserveCommittedPrefetchExpiry,
   prepareConsumedPrefetchResponseForPublication,
   resolvePrefetchNavigationResponseUrl,
 } from "../packages/vinext/src/server/app-browser-prefetch-response.js";
+import { createVisitedResponseCacheEntry } from "../packages/vinext/src/server/app-visited-response-cache.js";
 import {
   createPopstateRestoreHandler,
   restoreSynchronousPopstateScrollPosition,
@@ -887,6 +889,37 @@ describe("app browser entry navigation scheduling", () => {
     expect(publication.snapshot).not.toHaveProperty("expiresAt");
     expect(publication.snapshot).not.toHaveProperty("preparedElements");
     expect(publication.snapshot.url).toBe("/rewrite?_rsc=visible-digest");
+  });
+
+  it("keeps runtime-prefetch and visited-cache deadlines independent after commit", () => {
+    const now = 1_000_000;
+    const publication = prepareConsumedPrefetchResponseForPublication(
+      {
+        buffer: new ArrayBuffer(0),
+        completedDynamicStaleTimeSeconds: 30,
+        contentType: "text/x-component",
+        dynamicStaleTimeSeconds: 30,
+        expiresAt: now + 240_000,
+        paramsHeader: null,
+        renderedPathAndSearch: null,
+        serverStaleTime: { kind: "resolved", seconds: 240 },
+        url: "/runtime-prefetch",
+      },
+      "/runtime-prefetch",
+    );
+    const prefetchSnapshot = preserveCommittedPrefetchExpiry(
+      publication.snapshot,
+      publication.expiresAt,
+    );
+    const visited = createVisitedResponseCacheEntry({
+      now,
+      params: {},
+      response: publication.snapshot,
+    });
+
+    expect(prefetchSnapshot.expiresAt).toBe(now + 240_000);
+    expect(publication.snapshot).not.toHaveProperty("expiresAt");
+    expect(visited.expiresAt).toBe(now + 30_000);
   });
 
   it("keeps the visible URL when a settled prefetch was found through a rewrite alias", () => {

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -33,6 +33,7 @@ import {
 } from "../packages/vinext/src/server/app-browser-hydration.js";
 import { createAppBrowserNavigationController } from "../packages/vinext/src/server/app-browser-navigation-controller.js";
 import {
+  peekSettledPrefetchResponseForNavigation,
   prepareConsumedPrefetchResponseForPublication,
   resolvePrefetchNavigationResponseUrl,
 } from "../packages/vinext/src/server/app-browser-prefetch-response.js";
@@ -836,6 +837,34 @@ describe("app browser entry inline CSS cleanup", () => {
 });
 
 describe("app browser entry navigation scheduling", () => {
+  it("peeks at a settled prefetch without transferring ownership before reuse planning", () => {
+    const snapshot = {
+      buffer: new ArrayBuffer(0),
+      contentType: "text/x-component",
+      expiresAt: 123,
+      mountedSlotsHeader: null,
+      paramsHeader: null,
+      renderedPathAndSearch: null,
+      url: "/source?_rsc=prefetch-digest",
+    };
+    const peek = vi.fn(() => snapshot);
+
+    expect(
+      peekSettledPrefetchResponseForNavigation({
+        additionalRscUrls: ["/source"],
+        bypassNavigationCache: false,
+        interceptionContext: "/parent",
+        mountedSlotsHeader: "slot:children:/target",
+        navigationKind: "navigate",
+        peek,
+        targetPathAndSearch: "/target",
+      }),
+    ).toBe(snapshot);
+    expect(peek).toHaveBeenCalledWith("/target", "/parent", "slot:children:/target", {
+      additionalRscUrls: ["/source"],
+    });
+  });
+
   it("normalizes consumed prefetch snapshots for committed-cache publication", () => {
     const preparedElements = { route: "prepared" } as unknown as AppElements;
     const publication = prepareConsumedPrefetchResponseForPublication(

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -32,7 +32,10 @@ import {
   hydrateRootInTransition,
 } from "../packages/vinext/src/server/app-browser-hydration.js";
 import { createAppBrowserNavigationController } from "../packages/vinext/src/server/app-browser-navigation-controller.js";
-import { resolvePrefetchNavigationResponseUrl } from "../packages/vinext/src/server/app-browser-prefetch-response.js";
+import {
+  prepareConsumedPrefetchResponseForPublication,
+  resolvePrefetchNavigationResponseUrl,
+} from "../packages/vinext/src/server/app-browser-prefetch-response.js";
 import {
   createPopstateRestoreHandler,
   restoreSynchronousPopstateScrollPosition,
@@ -833,6 +836,30 @@ describe("app browser entry inline CSS cleanup", () => {
 });
 
 describe("app browser entry navigation scheduling", () => {
+  it("normalizes consumed prefetch snapshots for committed-cache publication", () => {
+    const preparedElements = { route: "prepared" } as unknown as AppElements;
+    const publication = prepareConsumedPrefetchResponseForPublication(
+      {
+        buffer: new ArrayBuffer(0),
+        completedDynamicStaleTimeSeconds: 60,
+        contentType: "text/x-component",
+        dynamicStaleTimeSeconds: 300,
+        expiresAt: 123,
+        paramsHeader: null,
+        preparedElements,
+        renderedPathAndSearch: null,
+        url: "https://example.com/source?_rsc=prefetch-digest",
+      },
+      "/rewrite?_rsc=visible-digest",
+    );
+
+    expect(publication.expiresAt).toBe(123);
+    expect(publication.preparedElements).toBe(preparedElements);
+    expect(publication.snapshot).not.toHaveProperty("expiresAt");
+    expect(publication.snapshot).not.toHaveProperty("preparedElements");
+    expect(publication.snapshot.url).toBe("/rewrite?_rsc=visible-digest");
+  });
+
   it("keeps the visible URL when a settled prefetch was found through a rewrite alias", () => {
     expect(
       resolvePrefetchNavigationResponseUrl({

--- a/tests/app-page-element-builder.test.ts
+++ b/tests/app-page-element-builder.test.ts
@@ -253,8 +253,8 @@ describe("buildPageElements", () => {
 
     async function LocalePage({ params }: { params: Promise<{ locale: string }> }) {
       const { locale } = await params;
-      await new Promise<void>((resolve) => setTimeout(resolve, 0));
       requestLocale = locale;
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
       return React.createElement("main", null, `page:${requestLocale}`);
     }
 
@@ -283,6 +283,119 @@ describe("buildPageElements", () => {
     expect(html).toContain("layout:de");
     expect(html).toContain("page:de");
     expect(html).not.toContain("layout:en");
+  });
+
+  it("lets layouts stream after page initialization without waiting for page completion", async () => {
+    // Ported from Next.js:
+    // test/e2e/app-dir/metadata-streaming-static-generation/metadata-streaming-static-generation.test.ts
+    // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/metadata-streaming-static-generation/metadata-streaming-static-generation.test.ts
+    let requestLocale = "en";
+    let resolvePage!: () => void;
+    const pageCompletion = new Promise<void>((resolve) => {
+      resolvePage = resolve;
+    });
+    let markPageInitialized!: () => void;
+    const pageInitialized = new Promise<void>((resolve) => {
+      markPageInitialized = resolve;
+    });
+    let layoutLocaleBeforePageCompletion: string | null = null;
+
+    async function SuspensefulPage({ params }: { params: Promise<{ locale: string }> }) {
+      const { locale } = await params;
+      requestLocale = locale;
+      markPageInitialized();
+      await pageCompletion;
+      return React.createElement("main", null, `page:${requestLocale}`);
+    }
+
+    function LocaleLayout(props: Record<string, unknown>) {
+      layoutLocaleBeforePageCompletion = requestLocale;
+      return React.createElement(
+        "section",
+        null,
+        `layout:${requestLocale}`,
+        props.children as React.ReactNode,
+      );
+    }
+
+    const route = createSyntheticRoute({
+      page: createSyntheticPageModule(SuspensefulPage),
+      layouts: [createSyntheticPageModule(LocaleLayout)],
+      layoutTreePositions: [0],
+      routeSegments: ["[locale]"],
+      pattern: "/:locale",
+    });
+
+    const result = await buildPageElements(
+      createBaseOptions({ route, params: { locale: "de" }, routePath: "/de" }),
+    );
+    const htmlPromise = renderRouteEntry(result, result[APP_ROUTE_KEY] as string);
+
+    await pageInitialized;
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    const observedBeforeCompletion = layoutLocaleBeforePageCompletion;
+    resolvePage();
+    const html = await htmlPromise;
+
+    expect(observedBeforeCompletion).toBe("de");
+    expect(html).toContain("layout:de");
+    expect(html).toContain("page:de");
+  });
+
+  it("initializes a page before layouts but serializes its result after layout dependencies", async () => {
+    // This preserves the parent/child render order used by parallel-route
+    // refreshes and by completed cacheLife observation in runtime prefetches.
+    // Ported from Next.js:
+    // test/e2e/app-dir/parallel-routes-revalidation/parallel-routes-revalidation.test.ts
+    // test/e2e/app-dir/segment-cache/staleness/segment-cache-stale-time.test.ts
+    const events: string[] = [];
+    let markLayoutStarted!: () => void;
+    const layoutStarted = new Promise<void>((resolve) => {
+      markLayoutStarted = resolve;
+    });
+    let resolveLayout!: () => void;
+    const layoutCompletion = new Promise<void>((resolve) => {
+      resolveLayout = resolve;
+    });
+
+    function PageContent() {
+      events.push("page:content");
+      return React.createElement("main", null, "Page content");
+    }
+
+    function Page() {
+      events.push("page:init");
+      return React.createElement(PageContent);
+    }
+
+    async function AsyncLayout(props: Record<string, unknown>) {
+      events.push("layout:start");
+      markLayoutStarted();
+      await layoutCompletion;
+      events.push("layout:complete");
+      return React.createElement("section", null, props.children as React.ReactNode);
+    }
+
+    const route = createSyntheticRoute({
+      page: createSyntheticPageModule(Page),
+      layouts: [createSyntheticPageModule(AsyncLayout)],
+      layoutTreePositions: [0],
+      routeSegments: ["ordered"],
+      pattern: "/ordered",
+    });
+
+    const result = await buildPageElements(createBaseOptions({ route, routePath: "/ordered" }));
+    const htmlPromise = renderRouteEntry(result, result[APP_ROUTE_KEY] as string);
+
+    await layoutStarted;
+    const contentRenderedBeforeLayoutCompleted = events.includes("page:content");
+    resolveLayout();
+    const html = await htmlPromise;
+
+    expect(contentRenderedBeforeLayoutCompleted).toBe(false);
+    expect(events.indexOf("page:init")).toBeLessThan(events.indexOf("layout:complete"));
+    expect(events.indexOf("layout:complete")).toBeLessThan(events.indexOf("page:content"));
+    expect(html).toContain("Page content");
   });
 
   it("preserves page initialization when async syntax is lowered to a Promise return", async () => {

--- a/tests/app-page-element-builder.test.ts
+++ b/tests/app-page-element-builder.test.ts
@@ -245,45 +245,64 @@ describe("buildPageElements", () => {
     markRenderRequestApiUsageMock.mockClear();
   });
 
-  it("renders the page before layouts that consume page-initialized request state", async () => {
-    // Regression from nodejs.org's next-intl integration, where the page calls
-    // setRequestLocale() before the parent layout renders NextIntlClientProvider.
-    // https://github.com/nodejs/nodejs.org/commit/5eace3f956c10da92880be7ce16e942bbcb47ff7
-    let requestLocale = "en";
+  it.each(["plain", "memo", "lazy", "forwardRef"] as const)(
+    "renders a %s page before layouts that consume page-initialized request state",
+    async (pageKind) => {
+      // Regression from nodejs.org's next-intl integration, where the page calls
+      // setRequestLocale() before the parent layout renders NextIntlClientProvider.
+      // https://github.com/nodejs/nodejs.org/commit/5eace3f956c10da92880be7ce16e942bbcb47ff7
+      let requestLocale = "en";
 
-    async function LocalePage({ params }: { params: Promise<{ locale: string }> }) {
-      const { locale } = await params;
-      requestLocale = locale;
-      await new Promise<void>((resolve) => setTimeout(resolve, 0));
-      return React.createElement("main", null, `page:${requestLocale}`);
-    }
+      async function LocalePage({ params }: { params: Promise<{ locale: string }> }) {
+        const { locale } = await params;
+        requestLocale = locale;
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+        return React.createElement("main", null, `page:${requestLocale}`);
+      }
 
-    function LocaleLayout(props: Record<string, unknown>) {
-      return React.createElement(
-        "section",
-        null,
-        `layout:${requestLocale}`,
-        props.children as React.ReactNode,
+      function LocaleLayout(props: Record<string, unknown>) {
+        return React.createElement(
+          "section",
+          null,
+          `layout:${requestLocale}`,
+          props.children as React.ReactNode,
+        );
+      }
+
+      let observedForwardRef: unknown = "not-called";
+      const PageComponent =
+        pageKind === "memo"
+          ? React.memo(LocalePage)
+          : pageKind === "lazy"
+            ? React.lazy(async () => ({ default: LocalePage }))
+            : pageKind === "forwardRef"
+              ? React.forwardRef<unknown, { params: Promise<{ locale: string }> }>((props, ref) => {
+                  observedForwardRef = ref;
+                  return LocalePage(props);
+                })
+              : LocalePage;
+
+      const route = createSyntheticRoute({
+        page: createSyntheticPageModule(PageComponent),
+        layouts: [createSyntheticPageModule(LocaleLayout)],
+        layoutTreePositions: [1],
+        routeSegments: ["[locale]"],
+        pattern: "/:locale",
+      });
+
+      const result = await buildPageElements(
+        createBaseOptions({ route, params: { locale: "de" }, routePath: "/de" }),
       );
-    }
+      const html = await renderRouteEntry(result, result[APP_ROUTE_KEY] as string);
 
-    const route = createSyntheticRoute({
-      page: createSyntheticPageModule(LocalePage),
-      layouts: [createSyntheticPageModule(LocaleLayout)],
-      layoutTreePositions: [1],
-      routeSegments: ["[locale]"],
-      pattern: "/:locale",
-    });
-
-    const result = await buildPageElements(
-      createBaseOptions({ route, params: { locale: "de" }, routePath: "/de" }),
-    );
-    const html = await renderRouteEntry(result, result[APP_ROUTE_KEY] as string);
-
-    expect(html).toContain("layout:de");
-    expect(html).toContain("page:de");
-    expect(html).not.toContain("layout:en");
-  });
+      expect(html).toContain("layout:de");
+      expect(html).toContain("page:de");
+      expect(html).not.toContain("layout:en");
+      if (pageKind === "forwardRef") {
+        expect(observedForwardRef).toBeUndefined();
+      }
+    },
+  );
 
   it("lets layouts stream after page initialization without waiting for page completion", async () => {
     // Ported from Next.js:

--- a/tests/app-page-render.test.ts
+++ b/tests/app-page-render.test.ts
@@ -1322,16 +1322,25 @@ describe("app page render lifecycle", () => {
     expect(common.isrSet).not.toHaveBeenCalled();
   });
 
-  it("emits the dynamic stale time header on RSC responses during dynamic renders", async () => {
+  it("emits dynamic BFCache and completed runtime-prefetch stale times together", async () => {
     const common = createCommonOptions();
     const response = await renderAppPageLifecycle({
       ...common.options,
       consumeDynamicUsage: vi.fn(() => true),
       dynamicStaleTimeSeconds: 60,
       isRscRequest: true,
+      peekRequestCacheLife() {
+        return { stale: 240 };
+      },
     });
     expect(response.headers.get(VINEXT_DYNAMIC_STALE_TIME_HEADER)).toBe("60");
-    await expect(response.text()).resolves.toBe("flight-data");
+    expect(response.headers.get(VINEXT_RSC_COMPLETION_METADATA_HEADER)).toBe("1");
+    const completed = extractRscCompletionMetadata(await response.arrayBuffer());
+    expect(new TextDecoder().decode(completed.buffer)).toBe("flight-data");
+    expect(completed.metadata).toEqual({
+      dynamicStaleTimeSeconds: 60,
+      serverStaleTimeSeconds: 240,
+    });
   });
 
   it("omits the dynamic stale time header during prerender (isPrerender=true)", async () => {

--- a/tests/app-page-route-wiring.test.ts
+++ b/tests/app-page-route-wiring.test.ts
@@ -41,7 +41,7 @@ import {
 } from "../packages/vinext/src/server/app-page-element-builder.js";
 import { createNextBfcacheIdMap } from "../packages/vinext/src/server/app-bfcache-identity.js";
 import type { AppPageSemanticSegment } from "../packages/vinext/src/server/app-page-segment-state.js";
-import { createAppRenderDependency } from "../packages/vinext/src/server/app-render-dependency.js";
+import { createAppPageRenderDependency } from "../packages/vinext/src/server/app-render-dependency.js";
 
 /**
  * Build the resolved semantic branch the route matcher hands to slot overrides.
@@ -3566,7 +3566,7 @@ describe("app page route wiring helpers", () => {
 
   it("waits for page initialization before serializing parallel slot entries", async () => {
     let activeLocale = "en";
-    const pageRenderDependency = createAppRenderDependency();
+    const pageRenderDependency = createAppPageRenderDependency();
 
     function LocaleSlot() {
       return createElement("aside", null, `slot:${activeLocale}`);

--- a/tests/app-render-dependency.test.ts
+++ b/tests/app-render-dependency.test.ts
@@ -109,30 +109,42 @@ describe("app render dependency helpers", () => {
         } = await vite.ssrLoadModule(
           "/packages/vinext/src/server/app-render-dependency.tsx",
         );
-        const dependency = createAppRenderDependency();
         const events = [];
 
-        async function Layout() {
-          events.push("layout:start");
-          await new Promise((resolve) => setTimeout(resolve, 25));
-          events.push("layout:end");
-          return React.createElement("section", null, "layout");
+        function createLayout(name) {
+          return async function Layout() {
+            events.push(name + ":layout:start");
+            await new Promise((resolve) => setTimeout(resolve, 25));
+            events.push(name + ":layout:end");
+            return React.createElement("section", null, name + " layout");
+          };
         }
 
-        async function Page() {
-          await dependency.promise;
-          events.push("page");
-          return React.createElement("p", null, "page");
+        const layouts = {
+          plain: createLayout("plain"),
+          memo: React.memo(createLayout("memo")),
+          lazy: React.lazy(async () => ({ default: createLayout("lazy") })),
+          forwardRef: React.forwardRef(createLayout("forwardRef")),
+        };
+        const model = {};
+
+        for (const [name, Layout] of Object.entries(layouts)) {
+          const dependency = createAppRenderDependency();
+          model[name + ":layout"] = renderAppComponentWithDependencyBarrier(
+            Layout,
+            {},
+            dependency,
+          );
+          model[name + ":page"] = React.createElement(async function Page() {
+            await dependency.promise;
+            events.push(name + ":page");
+            return React.createElement("p", null, name + " page");
+          });
         }
 
-        const stream = renderToReadableStream(
-          {
-            layout: renderAppComponentWithDependencyBarrier(Layout, {}, dependency),
-            page: React.createElement(Page),
-          },
-          null,
-          { onError: () => "digest" },
-        );
+        const stream = renderToReadableStream(model, null, {
+          onError: () => "digest",
+        });
         const reader = stream.getReader();
         while (!(await reader.read()).done) {}
         process.stdout.write(JSON.stringify(events));
@@ -151,6 +163,12 @@ describe("app render dependency helpers", () => {
       },
     );
 
-    expect(JSON.parse(stdout)).toEqual(["layout:start", "layout:end", "page"]);
+    const events = JSON.parse(stdout) as string[];
+    for (const name of ["plain", "memo", "lazy", "forwardRef"]) {
+      expect(events.indexOf(`${name}:layout:start`)).toBeLessThan(
+        events.indexOf(`${name}:layout:end`),
+      );
+      expect(events.indexOf(`${name}:layout:end`)).toBeLessThan(events.indexOf(`${name}:page`));
+    }
   });
 });

--- a/tests/app-render-dependency.test.ts
+++ b/tests/app-render-dependency.test.ts
@@ -120,11 +120,15 @@ describe("app render dependency helpers", () => {
           };
         }
 
+        const forwardRefLayout = createLayout("forwardRef");
         const layouts = {
           plain: createLayout("plain"),
           memo: React.memo(createLayout("memo")),
           lazy: React.lazy(async () => ({ default: createLayout("lazy") })),
-          forwardRef: React.forwardRef(createLayout("forwardRef")),
+          forwardRef: React.forwardRef((props, ref) => {
+            events.push("forwardRef:ref:" + String(ref));
+            return forwardRefLayout(props);
+          }),
         };
         const model = {};
 
@@ -170,5 +174,7 @@ describe("app render dependency helpers", () => {
       );
       expect(events.indexOf(`${name}:layout:end`)).toBeLessThan(events.indexOf(`${name}:page`));
     }
+    expect(events).toContain("forwardRef:ref:undefined");
+    expect(events).not.toContain("forwardRef:ref:null");
   });
 });

--- a/tests/app-render-dependency.test.ts
+++ b/tests/app-render-dependency.test.ts
@@ -1,11 +1,15 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import { createElement } from "react";
 import { renderToReadableStream } from "react-dom/server.edge";
 import { describe, expect, it } from "vite-plus/test";
 import {
   createAppRenderDependency,
   renderAfterAppDependencies,
-  renderWithAppDependencyBarrier,
+  renderAppComponentWithDependencyBarrier,
 } from "../packages/vinext/src/server/app-render-dependency.js";
+
+const execFileAsync = promisify(execFile);
 
 async function readStream(stream: ReadableStream<Uint8Array>): Promise<string> {
   const reader = stream.getReader();
@@ -61,7 +65,7 @@ describe("app render dependency helpers", () => {
     async function LocaleLayout() {
       await Promise.resolve();
       activeLocale = "de";
-      return createElement("div", null, renderWithAppDependencyBarrier("layout", layoutDependency));
+      return createElement("div", null, "layout");
     }
 
     function LocalePage() {
@@ -72,12 +76,81 @@ describe("app render dependency helpers", () => {
       createElement(
         "div",
         null,
-        createElement(LocaleLayout),
+        renderAppComponentWithDependencyBarrier(LocaleLayout, {}, layoutDependency),
         renderAfterAppDependencies(createElement(LocalePage), [layoutDependency]),
       ),
     );
 
     expect(body).toContain("page:de");
     expect(body).not.toContain("page:en");
+  });
+
+  it("releases a dependency after an async component produces its Flight result", async () => {
+    // Run the real helper through React Flight in a react-server subprocess.
+    // React DOM schedules the old fragment-sibling barrier differently and did
+    // not expose the production ordering regression.
+    const script = String.raw`
+      import React from "react";
+      import { createServer } from "vite";
+      import { renderToReadableStream } from "./node_modules/@vitejs/plugin-rsc/dist/vendor/react-server-dom/server.edge.js";
+
+      const vite = await createServer({
+        appType: "custom",
+        configFile: false,
+        logLevel: "silent",
+        mode: "production",
+        server: { middlewareMode: true },
+      });
+
+      try {
+        const {
+          createAppRenderDependency,
+          renderAppComponentWithDependencyBarrier,
+        } = await vite.ssrLoadModule(
+          "/packages/vinext/src/server/app-render-dependency.tsx",
+        );
+        const dependency = createAppRenderDependency();
+        const events = [];
+
+        async function Layout() {
+          events.push("layout:start");
+          await new Promise((resolve) => setTimeout(resolve, 25));
+          events.push("layout:end");
+          return React.createElement("section", null, "layout");
+        }
+
+        async function Page() {
+          await dependency.promise;
+          events.push("page");
+          return React.createElement("p", null, "page");
+        }
+
+        const stream = renderToReadableStream(
+          {
+            layout: renderAppComponentWithDependencyBarrier(Layout, {}, dependency),
+            page: React.createElement(Page),
+          },
+          null,
+          { onError: () => "digest" },
+        );
+        const reader = stream.getReader();
+        while (!(await reader.read()).done) {}
+        process.stdout.write(JSON.stringify(events));
+      } finally {
+        await vite.close();
+      }
+    `;
+
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      ["--conditions", "react-server", "--input-type=module", "-e", script],
+      {
+        cwd: process.cwd(),
+        env: { ...process.env, NODE_ENV: "production" },
+        timeout: 10_000,
+      },
+    );
+
+    expect(JSON.parse(stdout)).toEqual(["layout:start", "layout:end", "page"]);
   });
 });

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -1288,10 +1288,11 @@ describe("prefetch cache eviction", () => {
     expect(consumed?.expiresAt).toBe(now + 30_000);
   });
 
-  it("takes the shorter of the staleTimes config and the resolved cacheLife stale time", async () => {
-    // A route whose `use cache` subtree declares cacheLife("seconds")
-    // (stale: 30) alongside a 300s experimental.staleTimes value. Both are
-    // min-wins lattices, so the shorter one bounds prefetch reuse.
+  it("uses completed cacheLife for prefetch expiry without changing the dynamic BFCache bound", async () => {
+    // Ported from Next.js:
+    // test/e2e/app-dir/segment-cache/staleness/segment-cache-stale-time.test.ts
+    // Runtime-prefetch freshness comes from cacheLife, while staleTimes.dynamic
+    // independently bounds visited/BFCache reuse.
     const now = 1_000_000;
     vi.spyOn(Date, "now").mockReturnValue(now);
     const rscUrl = "/cache-life-prefetch.rsc";
@@ -1299,13 +1300,24 @@ describe("prefetch cache eviction", () => {
     prefetchRscResponse(
       rscUrl,
       Promise.resolve(
-        new Response("flight", {
-          headers: {
-            "content-type": "text/x-component",
-            [VINEXT_DYNAMIC_STALE_TIME_HEADER]: "300",
-            [NEXT_ROUTER_STALE_TIME_HEADER]: "30",
+        new Response(
+          appendRscCompletionMetadata(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(new TextEncoder().encode("flight"));
+                controller.close();
+              },
+            }),
+            () => ({ dynamicStaleTimeSeconds: 30, serverStaleTimeSeconds: 240 }),
+          ),
+          {
+            headers: {
+              "content-type": "text/x-component",
+              [VINEXT_DYNAMIC_STALE_TIME_HEADER]: "30",
+              [VINEXT_RSC_COMPLETION_METADATA_HEADER]: "1",
+            },
           },
-        }),
+        ),
       ),
       null,
       null,
@@ -1314,7 +1326,10 @@ describe("prefetch cache eviction", () => {
     );
     await getPrefetchCache().get(rscUrl)?.pending;
 
-    expect(getPrefetchCache().get(rscUrl)?.expiresAt).toBe(now + 30_000);
+    const snapshot = getPrefetchCache().get(rscUrl)?.snapshot;
+    expect(getPrefetchCache().get(rscUrl)?.expiresAt).toBe(now + 240_000);
+    expect(snapshot?.serverStaleTime).toEqual({ kind: "resolved", seconds: 240 });
+    expect(resolveCachedRscResponseTtlMs(snapshot!, 300_000)).toBe(30_000);
   });
 
   it("floors a shorter-than-minimum cacheLife stale time for prefetch entries", async () => {

--- a/tests/unified-request-context.test.ts
+++ b/tests/unified-request-context.test.ts
@@ -14,6 +14,10 @@ import {
   getRequestExecutionContext,
   runWithExecutionContext,
 } from "../packages/vinext/src/shims/request-context.js";
+import {
+  _captureRequestScopedCacheLifeAccessors,
+  _setRequestScopedCacheLife,
+} from "../packages/vinext/src/shims/cache-request-state.js";
 
 describe("unified-request-context", () => {
   describe("isInsideUnifiedScope", () => {
@@ -122,6 +126,21 @@ describe("unified-request-context", () => {
       });
 
       expect(isInsideUnifiedScope()).toBe(false);
+    });
+
+    it("retains captured cache-life access after the request scope exits", async () => {
+      const ctx = createRequestContext();
+      const accessors = await runWithRequestContext(ctx, async () => {
+        const captured = _captureRequestScopedCacheLifeAccessors();
+        await Promise.resolve();
+        _setRequestScopedCacheLife({ stale: 240 });
+        return captured;
+      });
+
+      expect(isInsideUnifiedScope()).toBe(false);
+      expect(accessors.peek()).toEqual({ stale: 240 });
+      expect(accessors.consume()).toEqual({ stale: 240 });
+      expect(accessors.peek()).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary

- split App Router page initialization from page-result serialization so layouts and templates can observe state established by the page without blocking ancestor Suspense streaming
- preserve parent-before-child serialization across plain, memo, lazy, and forward-ref page/layout components
- restore segment-cache stale-window behavior by republishing consumed prefetches with their original absolute deadline
- keep runtime-prefetch `cacheLife` expiry independent from visited/BFCache `staleTimes.dynamic` expiry
- retain request-scoped `cacheLife` metadata until RSC stream completion, even after the request AsyncLocalStorage scope has exited
- add focused unit, browser, and upstream Next.js regression coverage

## Root causes

### Page render ordering

PR #2751 used one dependency for both page initialization and full async page completion. Layouts and parallel slots therefore waited too long, blocking ancestor Suspense streaming, while the returned page subtree bypassed the existing layout/template result barriers.

The page dependency now has two phases: an initialization barrier released after the page's first async continuation, and result dependencies applied to the returned subtree after layouts/templates have produced their elements.

### Per-page stale window

Navigation consumed and removed the prefetched Flight entry. Returning to the source page exposed no reusable prefetch, so a visible Link fetched a replacement and restarted the stale window. Committed navigations now republish the consumed snapshot while retaining its original absolute expiry.

### Runtime-prefetch expiry

Runtime prefetches and visited/BFCache entries were sharing one expiry calculation. Next.js uses the completed `cacheLife` claim for runtime-prefetch freshness, while visited reuse remains bounded by `staleTimes.dynamic`; the implementation now preserves those as independent snapshots and deadlines.

The full deploy-suite run also exposed a timing-dependent Linux failure: RSC completion metadata re-resolved request cache state after the request AsyncLocalStorage scope had exited, occasionally losing the completed `cacheLife` claim and falling back to 30 seconds. Dispatch now captures request-bound cache-life accessors before creating the stream, so footer finalization reads the correct request state.

## Validation

Final head: `81d08c16bdf0ad763ff6d72261f9c52a67b59e75`

- `vp check` over all changed files — format, lint, and types passed
- 7 focused Vitest files — **535/535 passed**
- `full-prefetch.browser.spec.ts` — **2/2 passed**
- Next.js `segment-cache-per-page-dynamic-stale-time.test.ts` — `reuses dynamic data within the per-page stale time window` passed
- Next.js `segment-cache-stale-time.test.ts` — `expires runtime prefetches when their stale time has elapsed` passed
- other targeted Next.js checks: `metadata-streaming-static-generation.test.ts` 7/7, `app-basepath/index.test.ts` 13/13, and `optimistic-routing.test.ts` 9/9; known unrelated baseline failures remain in broader files
- [PR CI](https://github.com/cloudflare/vinext/actions/runs/30578078979) — **66/66 checks passed**
- [BigBonk exact-head review](https://github.com/cloudflare/vinext/actions/runs/30578305514) — **no correctness blockers; safe to merge**
- [full Next.js deploy suite](https://github.com/cloudflare/vinext/actions/runs/30578302299), Next.js `v16.2.6`, `suite-filter=all` — 2,615 passed / 189 known parity failures / 631 skipped; both regression assertions above passed on their first invocation

All local Next.js checks used `scripts/run-targeted-nextjs-e2e.sh` against Next.js `v16.2.6` with concurrency 1.
