### PR TITLE
fix(script): reject event attributes in hoisted HTML

### DIFF
--- a/packages/vinext/src/server/before-interactive-head.ts
+++ b/packages/vinext/src/server/before-interactive-head.ts
@@ -8,6 +8,11 @@ import { createNonceAttribute, escapeHtmlAttr } from "./html.js";
 // into the unquoted *name* position where escaping wouldn't help.
 const VALID_ATTR_NAME = /^[a-zA-Z][\w.-]*$/;
 
+// React does not serialize string-valued event props, but this renderer emits
+// raw HTML and therefore has to preserve that safety boundary itself. HTML
+// attribute names are case-insensitive, so reject every `on*` case variant.
+const EVENT_HANDLER_ATTR_NAME = /^on/i;
+
 /**
  * Render captured `<Script strategy="beforeInteractive">` scripts to HTML,
  * ready to splice immediately after `<head ...>` opens. Each entry has already
@@ -39,6 +44,7 @@ export function renderBeforeInteractiveInlineScripts(
         // can't be escaped — a malformed key would break the tag — so we
         // gate at the boundary instead of trying to neutralise it.
         if (!VALID_ATTR_NAME.test(key)) continue;
+        if (EVENT_HANDLER_ATTR_NAME.test(key)) continue;
         // We emit the `data-nscript` marker ourselves below; drop any
         // user-supplied one so the tag never carries a duplicate attribute.
         if (key === "data-nscript") continue;

--- a/tests/script.test.ts
+++ b/tests/script.test.ts
@@ -753,6 +753,31 @@ describe("Script beforeInteractive registry (#2016)", () => {
 });
 
 describe("renderBeforeInteractiveInlineScripts (#2016)", () => {
+  it("drops event-handler attributes from hoisted scripts", () => {
+    const captured: BeforeInteractiveInlineScript[] = [];
+    ReactDOMServer.renderToString(
+      React.createElement(
+        BeforeInteractiveContext.Provider,
+        { value: (script: BeforeInteractiveInlineScript) => captured.push(script) },
+        React.createElement(Script, {
+          strategy: "beforeInteractive",
+          onload: "globalThis.__onloadExecuted = true",
+          oNeRrOr: "globalThis.__onerrorExecuted = true",
+          "data-onload": "diagnostic",
+          dangerouslySetInnerHTML: {
+            __html: "globalThis.__beforeInteractiveExecuted = true",
+          },
+        } as ScriptProps),
+      ),
+    );
+
+    expect(captured).toHaveLength(1);
+    const html = renderBeforeInteractiveInlineScripts(captured);
+    expect(html).not.toMatch(/\sonload=/i);
+    expect(html).not.toMatch(/\sonerror=/i);
+    expect(html).toContain('data-onload="diagnostic"');
+  });
+
   it('marks every hoisted script with data-nscript="beforeInteractive"', () => {
     const html = renderBeforeInteractiveInlineScripts([{ id: "x", innerHTML: "console.log(1)" }]);
     expect(html).toContain('data-nscript="beforeInteractive"');


### PR DESCRIPTION
## Summary

- reject case-insensitive `on*` attributes when hoisted `beforeInteractive` scripts are serialized into raw HTML
- preserve legitimate passthrough attributes, including names such as `data-onload`
- cover the actual `Script` capture and hoisted-render pipeline with a regression test

## Why

App Router hoisting manually serializes `beforeInteractive` Script props so the tag can precede React resource hints. That path bypassed React DOM filtering for string-valued event handlers. If an application passed request-influenced props through to an inline Script, attributes such as `onload` or mixed-case variants could be emitted as executable inline handlers.

The raw HTML emitter is the ownership boundary for this invariant. Filtering there protects every captured script regardless of which registration path supplied it.

## Validation

- reproduced the vulnerable upstream behavior through the real Script shim, registration context, and renderer; the resulting HTML contained `onload`, while the React SSR control dropped it
- demonstrated the new regression test fails on upstream and passes with this change
- `vp test run tests/script.test.ts tests/script-head-ordering.test.ts tests/app-ssr-stream.test.ts`: 86 tests passed
- `vp check tests/script.test.ts packages/vinext/src/server/before-interactive-head.ts`: formatting, lint, and type checks passed
- `vp run vinext#build`: passed
- repository pre-commit full check, staged unit/integration tests, and knip: passed

## Risk

This intentionally stops forwarding custom script attributes whose names begin with `on`, case-insensitively. That matches the event-handler safety boundary React applies during normal SSR. Other passthrough attributes and script ordering remain unchanged.

Browser execution was not rerun; the vulnerable and corrected SSR HTML paths were exercised directly, and the existing head-ordering integration suite passed.