### PR TITLE
fix(image): reject unrecognized deployment IDs

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -172,6 +172,8 @@ type AppRouterConfig = {
   /** Internationalization routing config for middleware matcher locale handling. */
   i18n?: NextI18nConfig | null;
   imageConfig?: ImageConfig;
+  /** Build-time deployment ID emitted in managed image URLs. */
+  deploymentId?: string;
   /**
    * Absolute path to `app/global-not-found.{tsx,ts,js,jsx}` when present.
    * When provided, route-miss 404s render this module standalone (it owns its
@@ -225,6 +227,7 @@ export function generateRscEntry(
   const htmlLimitedBots = config?.htmlLimitedBots;
   const clientTraceMetadata = config?.clientTraceMetadata;
   const assetPrefix = config?.assetPrefix ?? "";
+  const deploymentId = config?.deploymentId;
   const expireTime = config?.expireTime ?? DEFAULT_EXPIRE_TIME;
   const reactMaxHeadersLength = config?.reactMaxHeadersLength ?? DEFAULT_REACT_MAX_HEADERS_LENGTH;
   const cacheMaxMemorySize = config?.cacheMaxMemorySize;
@@ -669,6 +672,7 @@ const __reactMaxHeadersLength = ${JSON.stringify(reactMaxHeadersLength)};
 // mirrors the embedded \`__basePath\` pattern (and Pages Router's
 // \`vinextConfig\` export). Empty string when unset.
 export const __assetPrefix = ${JSON.stringify(assetPrefix)};
+export const __deploymentId = ${JSON.stringify(deploymentId)};
 export const __imageAllowedWidths = ${JSON.stringify(imageAllowedWidths)};
 export const __imageConfig = ${JSON.stringify(imageConfig)};
 export const __inlineCss = ${JSON.stringify(inlineCss)};
@@ -739,6 +743,7 @@ export default createAppRscHandler({
   }
   configRedirects: __configRedirects,
   configRewrites: __configRewrites,
+  deploymentId: __deploymentId,
   imageConfig: __runtimeImageConfig,
   isDev: process.env.NODE_ENV !== "production",
   draftModeSecret: __draftModeSecret,

--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -118,6 +118,7 @@ export async function generateServerEntry(
   const vinextConfigJson = JSON.stringify({
     basePath: nextConfig?.basePath ?? "",
     assetPrefix: nextConfig?.assetPrefix ?? "",
+    deploymentId: nextConfig?.deploymentId,
     trailingSlash: nextConfig?.trailingSlash ?? false,
     redirects: nextConfig?.redirects ?? [],
     rewrites: nextConfig?.rewrites ?? { beforeFiles: [], afterFiles: [], fallback: [] },

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -3790,6 +3790,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 htmlLimitedBots: nextConfig?.htmlLimitedBots,
                 clientTraceMetadata: nextConfig?.clientTraceMetadata,
                 assetPrefix: nextConfig?.assetPrefix,
+                deploymentId: nextConfig?.deploymentId,
                 expireTime: nextConfig?.expireTime,
                 reactMaxHeadersLength: nextConfig?.reactMaxHeadersLength,
                 cacheMaxMemorySize: nextConfig?.cacheMaxMemorySize,
@@ -5035,6 +5036,7 @@ export const loadServerActionClient = ${
                   imageRequestUrl,
                   allowedWidths,
                   nextConfig.images?.qualities,
+                  { isDev: true, deploymentId: nextConfig.deploymentId },
                 );
                 if (!encodedLocation) {
                   res.writeHead(400);

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -329,6 +329,7 @@ type CreateAppRscHandlerOptions<TRoute extends AppRscHandlerRoute> = {
     options: HandleServerActionRequestOptions<TRoute>,
   ) => Promise<Response | null>;
   i18nConfig: NextI18nConfig | null;
+  deploymentId?: string;
   imageConfig?: ImageConfig;
   isDev: boolean;
   loadPrerenderPagesRoutes?: () => Promise<unknown>;
@@ -815,7 +816,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
         ...(options.imageConfig?.imageSizes ?? DEFAULT_IMAGE_SIZES),
       ],
       options.imageConfig?.qualities,
-      { isDev: options.isDev },
+      { isDev: options.isDev, deploymentId: options.deploymentId },
     );
     if (!imageRedirect)
       return new Response("Invalid image optimization parameters", { status: 400 });

--- a/packages/vinext/src/server/image-optimization.ts
+++ b/packages/vinext/src/server/image-optimization.ts
@@ -18,6 +18,7 @@
  */
 
 import { badRequestResponse } from "./http-error-responses.js";
+import { getDeploymentId } from "../utils/deployment-id.js";
 
 /** The pathname that triggers image optimization (matches Next.js). */
 export const IMAGE_OPTIMIZATION_PATH = "/_next/image";
@@ -94,6 +95,8 @@ const DEV_BLUR_QUALITY = 70;
 
 export type ParseImageParamsOptions = {
   isDev?: boolean;
+  /** Deployment ID accepted by the optimizer. Defaults to the configured runtime value. */
+  deploymentId?: string;
 };
 
 export function resolveDevImageRedirect(
@@ -133,9 +136,27 @@ export function parseImageParams(
   // Intentional hardening divergence from Next.js: reject duplicate and unknown
   // parameters so semantically identical transforms cannot occupy distinct
   // cache keys and amplify image transformation work.
+  const rawParamSegments = url.search.slice(1).split("&");
+  if (rawParamSegments.some((segment) => segment.length === 0)) return null;
+
   const allowedParamNames = new Set(["url", "w", "q", "dpl"]);
   for (const name of url.searchParams.keys()) {
     if (!allowedParamNames.has(name) || url.searchParams.getAll(name).length !== 1) return null;
+  }
+
+  const deploymentId = url.searchParams.get("dpl");
+  if (deploymentId !== null) {
+    const expectedDeploymentId = options.deploymentId ?? getDeploymentId();
+    // The deployment ID affects platform routing before the optimizer runs. A
+    // different or percent-encoded value reaches the same local transform in
+    // vinext, so accept only the configured ID in its canonical emitted form.
+    if (
+      !expectedDeploymentId ||
+      deploymentId !== expectedDeploymentId ||
+      !rawParamSegments.includes(`dpl=${expectedDeploymentId}`)
+    ) {
+      return null;
+    }
   }
 
   const imageUrl = url.searchParams.get("url");

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -1563,6 +1563,8 @@ async function startAppRouterServer(options: AppRouterServerOptions) {
     typeof rscModule.__assetPrefix === "string" ? rscModule.__assetPrefix : "";
   const appRouterBasePath: string =
     typeof rscModule.__basePath === "string" ? rscModule.__basePath : "";
+  const appRouterDeploymentId: string | undefined =
+    typeof rscModule.__deploymentId === "string" ? rscModule.__deploymentId : undefined;
   const appRouterInlineCss = rscModule.__inlineCss === true;
   const appRouterHasPagesDir = rscModule.__hasPagesDir === true;
   const appRouterI18nConfig: NextI18nConfig | null = rscModule.__i18nConfig ?? null;
@@ -1706,7 +1708,9 @@ async function startAppRouterServer(options: AppRouterServerOptions) {
     // serves the original file with cache headers and security headers)
     if (isImageOptimizationPath(pathname)) {
       const parsedUrl = new URL(rawUrl, "http://localhost");
-      const params = parseImageParams(parsedUrl, appImageAllowedWidths, imageConfig?.qualities);
+      const params = parseImageParams(parsedUrl, appImageAllowedWidths, imageConfig?.qualities, {
+        deploymentId: appRouterDeploymentId,
+      });
       if (!params) {
         res.writeHead(400);
         res.end("Bad Request");
@@ -2059,7 +2063,9 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
     // ── Image optimization passthrough ──────────────────────────────
     if (isImageOptimizationPath(pathname) || isImageOptimizationPath(staticLookupPath)) {
       const parsedUrl = new URL(rawUrl, "http://localhost");
-      const params = parseImageParams(parsedUrl, allowedImageWidths, pagesImageConfig?.qualities);
+      const params = parseImageParams(parsedUrl, allowedImageWidths, pagesImageConfig?.qualities, {
+        deploymentId: vinextConfig?.deploymentId,
+      });
       if (!params) {
         res.writeHead(400);
         res.end("Bad Request");

--- a/tests/app-router-next-config-codegen.test.ts
+++ b/tests/app-router-next-config-codegen.test.ts
@@ -122,12 +122,15 @@ describe("App Router next.config.js features (generateRscEntry)", () => {
         imageSizes: [16],
         qualities: [60, 75],
       },
+      deploymentId: "deploy-1",
     });
     expect(code).toContain("const __runtimeImageConfig");
     expect(code).toContain("export const __imageConfig");
+    expect(code).toContain('export const __deploymentId = "deploy-1"');
     expect(code).toContain('"deviceSizes":[320,640]');
     expect(code).toContain('"qualities":[60,75]');
     expect(code).toContain("imageConfig: __runtimeImageConfig");
+    expect(code).toContain("deploymentId: __deploymentId");
     expect(code).toContain('isDev: process.env.NODE_ENV !== "production"');
   });
 

--- a/tests/image-optimization-parity.test.ts
+++ b/tests/image-optimization-parity.test.ts
@@ -166,7 +166,9 @@ describe("image deployment query parity", () => {
       "http://vinext.test/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.hash.png&w=828&q=85&dpl=deploy-1",
     );
 
-    expect(parseImageParams(requestUrl)).toEqual({
+    expect(
+      parseImageParams(requestUrl, undefined, undefined, { deploymentId: "deploy-1" }),
+    ).toEqual({
       imageUrl: "/_next/static/media/test.hash.png",
       width: 828,
       quality: 85,

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -22772,6 +22772,23 @@ describe("image optimization request parsing", () => {
     ).toBeNull();
   });
 
+  it("parseImageParams accepts only the canonical configured deployment ID", async () => {
+    const { parseImageParams } =
+      await import("../packages/vinext/src/server/image-optimization.js");
+    const request = (deploymentId: string) =>
+      new URL(`http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=75&dpl=${deploymentId}`);
+    const options = { deploymentId: "deploy-1" };
+
+    expect(parseImageParams(request("deploy-1"), undefined, undefined, options)).toEqual({
+      imageUrl: "/img.jpg",
+      width: 640,
+      quality: 75,
+    });
+    expect(parseImageParams(request("other-deploy"), undefined, undefined, options)).toBeNull();
+    expect(parseImageParams(request("%64eploy-1"), undefined, undefined, options)).toBeNull();
+    expect(parseImageParams(request("deploy-1&&"), undefined, undefined, options)).toBeNull();
+  });
+
   it("parseImageParams rejects source URLs longer than 3072 characters", async () => {
     const { parseImageParams } =
       await import("../packages/vinext/src/server/image-optimization.js");
@@ -23170,6 +23187,27 @@ describe("handleImageOptimization", () => {
     };
     const response = await handleImageOptimization(request, handlers);
     expect(response.status).toBe(400);
+  });
+
+  it("rejects unrecognized deployment IDs before fetching the source", async () => {
+    vi.stubEnv("__VINEXT_DEPLOYMENT_ID", "deploy-1");
+    try {
+      const { handleImageOptimization } =
+        await import("../packages/vinext/src/server/image-optimization.js");
+      const fetchAsset = vi.fn(async () => new Response("source"));
+
+      for (const deploymentId of ["other-deploy", "%64eploy-1"]) {
+        const request = new Request(
+          `http://localhost/_next/image?url=%2Fimg.jpg&w=640&q=75&dpl=${deploymentId}`,
+        );
+        const response = await handleImageOptimization(request, { fetchAsset });
+        expect(response.status).toBe(400);
+      }
+
+      expect(fetchAsset).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllEnvs();
+    }
   });
 
   it("returns 404 when fetchAsset fails", async () => {

--- a/tests/static-image-emission.test.ts
+++ b/tests/static-image-emission.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
 import { request, type IncomingHttpHeaders, type Server } from "node:http";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { build, createBuilder } from "vite";
+import { build, createBuilder, createServer } from "vite";
 import { afterAll, describe, expect, it } from "vite-plus/test";
 import vinext from "../packages/vinext/src/index.js";
 import { startProdServer } from "../packages/vinext/src/server/prod-server.js";
@@ -366,7 +366,8 @@ async function assertStaticImageProductionParity(
   servers.push(started.server);
   const address = started.server.address();
   if (!address || typeof address === "string") throw new Error("Production server did not bind");
-  const response = await fetch(`http://127.0.0.1:${address.port}${options.basePath ?? ""}/`);
+  const serverOrigin = `http://127.0.0.1:${address.port}`;
+  const response = await fetch(`${serverOrigin}${options.basePath ?? ""}/`);
   const html = await response.text();
   expect(response.status, html).toBe(200);
 
@@ -390,6 +391,10 @@ async function assertStaticImageProductionParity(
     expect(srcset).toContain(`url=${encodeURIComponent(managedUrl)}`);
     if (options.deploymentId) expect(srcset).toContain(`dpl=${options.deploymentId}`);
     expect(srcset).not.toContain("data%3Aimage");
+    if (options.deploymentId) {
+      const optimizedResponse = await fetch(new URL(src, serverOrigin));
+      expect(optimizedResponse.status, await optimizedResponse.text()).toBe(200);
+    }
   }
 
   expect(getAttribute(html, "ordinary-asset", "src")).toMatch(/^data:image\/png/);
@@ -399,7 +404,7 @@ async function assertStaticImageProductionParity(
   expect(getAttribute(html, "static-svg", "src")).toBe(managedSvgUrl);
   expect(getAttribute(html, "static-svg", "src")).not.toContain("/_next/image?");
   const assetResponse = await fetch(
-    `http://127.0.0.1:${address.port}${effectiveAssetPrefix}/_next/static/media/${emittedImage}`,
+    `${serverOrigin}${effectiveAssetPrefix}/_next/static/media/${emittedImage}`,
   );
   expect(assetResponse.status).toBe(200);
   expect(assetResponse.headers.get("cache-control")).toBe("public, max-age=31536000, immutable");
@@ -411,7 +416,7 @@ async function assertStaticImageProductionParity(
   // validators. Use the lower-level client so this exercises a plain
   // If-None-Match request; no-cache revalidation is covered separately.
   const conditionalResponse = await rawHttpRequest(
-    `http://127.0.0.1:${address.port}${effectiveAssetPrefix}/_next/static/media/${emittedImage}`,
+    `${serverOrigin}${effectiveAssetPrefix}/_next/static/media/${emittedImage}`,
     { "if-none-match": etag! },
   );
   expect(conditionalResponse.statusCode).toBe(304);
@@ -444,6 +449,48 @@ describe("static image import production emission", () => {
       deploymentId: "static-image-test",
     });
   }, 60_000);
+
+  it("serves Pages Router managed image URLs with a deployment ID", async () => {
+    await assertStaticImageProductionParity("pages", {
+      deploymentId: "static-pages-image-test",
+    });
+  }, 60_000);
+
+  it.each(["app", "pages"] as const)(
+    "accepts the configured deployment ID in the %s dev image optimizer",
+    async (router) => {
+      const deploymentId = `static-${router}-dev-image-test`;
+      const root = await createFixture(router);
+      const server = await createServer({
+        root,
+        configFile: false,
+        plugins: [
+          vinext({
+            appDir: router === "app" ? root : undefined,
+            nextConfig: () => ({ deploymentId }),
+          }),
+        ],
+        optimizeDeps: { holdUntilCrawlEnd: true },
+        server: { port: 0, cors: false },
+        logLevel: "silent",
+      });
+      await server.listen();
+
+      try {
+        const address = server.httpServer?.address();
+        if (!address || typeof address === "string") throw new Error("Dev server did not bind");
+        const response = await fetch(
+          `http://localhost:${address.port}/_next/image?url=%2Ftest.png&w=640&q=75&dpl=${deploymentId}`,
+          { redirect: "manual" },
+        );
+        expect(response.status).toBe(302);
+        expect(new URL(response.headers.get("location")!, response.url).pathname).toBe("/test.png");
+      } finally {
+        await server.close();
+      }
+    },
+    60_000,
+  );
 
   it("emits matching SSR and client image URLs in Cloudflare builds", async () => {
     const root = await createFixture("app");


### PR DESCRIPTION
## Overview

| | |
| --- | --- |
| Goal | Prevent deployment-ID query variants from amplifying equivalent image optimization work and cache entries. |
| Core change | Accept `dpl` only when it matches the configured deployment ID in the canonical emitted form. |
| Key boundary | Reject invalid optimizer query parameters before source asset fetches or transforms. |
| Expected impact | Arbitrary, percent-encoded, and empty-segment `dpl` aliases return 400 without consuming image backend work. |

## Why

The image loader emits deployment IDs as a top-level `dpl` parameter. The optimizer previously allowlisted that parameter but discarded it when constructing the source and transform tuple. An unauthenticated caller could therefore vary `dpl` across distinct request URLs while repeating the same fetch and image transform.

The parameter parser owns this decision because every dev, Node, App Router, Pages Router, and configured optimizer path crosses it before image I/O.

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| Canonical configured `dpl` | Accepted | Accepted |
| Different deployment ID | Accepted and transformed | Rejected before asset fetch |
| Percent-encoded alias of the configured ID | Accepted and transformed | Rejected before asset fetch |
| Empty raw query segments | Ignored by URL parsing | Rejected as non-canonical |
| Request without `dpl` | Accepted | Unchanged |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/server/image-optimization.ts` for the decoded identity and raw canonical-form checks.
2. `tests/shims.test.ts` for malicious parser inputs and the proof that asset I/O is not reached.
3. `tests/image-optimization-parity.test.ts` for preserved valid deployment-ID behavior.

</details>

## Validation

The regression tests were first run against the vulnerable implementation and failed while showing both attacker variants reached `fetchAsset`. They pass after the fix with zero asset calls.

- `vp test run tests/shims.test.ts`: 1,271 passed.
- `vp test run tests/image-component.test.ts`: 65 passed.
- `vp test run tests/image-optimization-parity.test.ts`: 7 passed across App and Pages Router fixtures.
- `vp test run tests/static-image-emission.test.ts -t "preserves managed image URLs under basePath and assetPrefix"`: passed.
- `vp check packages/vinext/src/server/image-optimization.ts tests/shims.test.ts tests/image-optimization-parity.test.ts`: format, lint, and types passed.
- `vp run vinext#build`: passed.
- Pre-commit full check, staged tests, and knip: passed.

<details>
<summary>Risk / compatibility</summary>

- Public API signatures remain compatible. Tests may inject an expected deployment ID through the existing parser options object.
- Generated URLs using the configured deployment ID remain accepted.
- Manually supplied or stale deployment IDs now fail closed with the existing 400 response used for invalid optimizer parameters.
- Query requests without `dpl` are unchanged.

</details>