### PR TITLE
fix(server): prevent bot user-agent regex backtracking

### DIFF
--- a/packages/vinext/src/utils/html-limited-bots.ts
+++ b/packages/vinext/src/utils/html-limited-bots.ts
@@ -13,7 +13,9 @@
 // Next.js's list predates Meta's UA migration and still only carries the
 // legacy `facebookexternalhit`. Users can still override via the
 // `htmlLimitedBots` config, which replaces this default entirely.
-const HTML_LIMITED_BOT_UA_RE_STRING = String.raw`[\w-]+-Google|Google-[\w-]+|Chrome-Lighthouse|Slurp|DuckDuckBot|baiduspider|yandex|sogou|bitlybot|tumblr|vkShare|quora link preview|redditbot|ia_archiver|Bingbot|BingPreview|applebot|facebookexternalhit|facebookcatalog|meta-externalagent|meta-externalfetcher|Twitterbot|LinkedInBot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|Yeti|googleweblight`;
+// The leading token boundary keeps the broad `*-Google` contract without
+// retrying the greedy token match at every character of a non-matching UA.
+const HTML_LIMITED_BOT_UA_RE_STRING = String.raw`(?:^|[^\w-])[\w-]+-Google|Google-[\w-]+|Chrome-Lighthouse|Slurp|DuckDuckBot|baiduspider|yandex|sogou|bitlybot|tumblr|vkShare|quora link preview|redditbot|ia_archiver|Bingbot|BingPreview|applebot|facebookexternalhit|facebookcatalog|meta-externalagent|meta-externalfetcher|Twitterbot|LinkedInBot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|Yeti|googleweblight`;
 
 // Headless browser bot (executes JS). Mirrors Next.js
 // `HEADLESS_BROWSER_BOT_UA_RE` in

--- a/tests/pages-page-response.test.ts
+++ b/tests/pages-page-response.test.ts
@@ -151,6 +151,20 @@ describe("isPagesStreamingBot", () => {
     ).toBe(true);
   });
 
+  it("detects Google crawlers with the -Google suffix", () => {
+    expect(isPagesStreamingBot("Mediapartners-Google/2.1")).toBe(true);
+    expect(isPagesStreamingBot("AdsBot-Google (+http://www.google.com/adsbot.html)")).toBe(true);
+    expect(isPagesStreamingBot("Mozilla/5.0 Storebot-Google/1.0")).toBe(true);
+  });
+
+  it(
+    "handles long non-matching User-Agents without quadratic backtracking",
+    { timeout: 500 },
+    () => {
+      expect(isPagesStreamingBot("a".repeat(64_000))).toBe(false);
+    },
+  );
+
   it("detects other known HTML-limited bots", () => {
     expect(isPagesStreamingBot("Bingbot/2.0")).toBe(true);
     expect(isPagesStreamingBot("facebookexternalhit/1.1")).toBe(true);


### PR DESCRIPTION
## Overview

| | |
| --- | --- |
| Goal | Keep attacker-controlled User-Agent matching linear for the default bot detector |
| Core change | Anchor the broad `*-Google` branch at the start of each word/hyphen token |
| Key boundary | Shared `html-limited-bots` utility used by Pages rendering and metadata bot gates |
| Expected impact | Long non-matching User-Agent values no longer cause quadratic request-time CPU work |

## Why

The default bot pattern included an unanchored greedy `[\w-]+-Google` branch. On a long word-only value without the suffix, the JavaScript regex engine retried that scan at every character. The detector runs on request User-Agent headers, so matching work must scale with input length.

Requiring either the start of the string or a non-token delimiter before the greedy token preserves the broad Google crawler contract while preventing overlapping retries.

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| Long non-matching User-Agent | Greedy suffix branch performed quadratic backtracking | Each token is considered from one boundary |
| `Mediapartners-Google`, `AdsBot-Google`, `Storebot-Google` | Detected | Still detected |
| `Google-*` and fixed crawler tokens | Detected | Unchanged |
| Custom `htmlLimitedBots` configuration | Evaluated as the configured regular expression | Unchanged |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/utils/html-limited-bots.ts` for the token-boundary decision.
2. `tests/pages-page-response.test.ts` for suffix compatibility and the long-input regression.

</details>

## Validation

- The Pages response, Pages data, and streaming metadata suites pass: 134 assertions.
- Targeted format, lint, and type checks pass.
- The vinext package build passes.
- The repository pre-commit gate passes full check, staged unit/integration tests, and knip.
- Built-output timing scales linearly through a 128,000-character non-match.

<details>
<summary>Commands</summary>

```text
vp test run tests/pages-page-response.test.ts
vp test run tests/streaming-metadata.test.ts tests/pages-page-data.test.ts
vp check packages/vinext/src/utils/html-limited-bots.ts tests/pages-page-response.test.ts
vp run vinext#build
```

</details>

## Risk / compatibility

The production change is limited to the default suffix branch and preserves boolean matches for word/hyphen crawler tokens ending in `-Google`. The configured-regex path and public configuration shape are unchanged. The new timeout-backed regression has substantial headroom: the fixed 64,000-character case completes in well under the 500 ms limit locally.

## References

| Reference | Why it matters |
| --- | --- |
| [Next.js default HTML-limited bot pattern](https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/html-bots.ts) | Defines the broad Google crawler compatibility contract mirrored by vinext |
