### PR TITLE
fix(middleware): preserve safe origins for double-slash redirects

### DIFF
--- a/packages/vinext/src/server/middleware-runtime.ts
+++ b/packages/vinext/src/server/middleware-runtime.ts
@@ -18,6 +18,7 @@ import { matchesMiddleware, type MatcherConfig } from "./middleware-matcher.js";
 import { shouldKeepMiddlewareHeader } from "../utils/middleware-request-headers.js";
 import { processMiddlewareHeaders } from "./request-pipeline.js";
 import { badRequestResponse, internalServerErrorResponse } from "./http-error-responses.js";
+import { isOpenRedirectShaped } from "./open-redirect.js";
 import {
   addBasePathToPathname,
   hasBasePath,
@@ -155,8 +156,9 @@ function stripMiddlewareHeadersFromResponse(response: Response): Response {
 }
 
 /**
- * Make a same-host URL relative to the request origin. Cross-origin URLs are
- * returned unchanged. Mirrors Next.js's `getRelativeURL` behaviour:
+ * Make a same-host URL relative to the request origin unless removing the
+ * origin would create a protocol-relative redirect. Cross-origin URLs are
+ * returned unchanged. Based on Next.js's `getRelativeURL` behaviour:
  * https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/relativize-url.ts
  */
 function relativizeLocation(location: string, requestUrl: string): string {
@@ -168,6 +170,11 @@ function relativizeLocation(location: string, requestUrl: string): string {
   }
   const base = new URL(requestUrl);
   if (parsed.origin !== base.origin) return parsed.toString();
+  // A leading double slash is a valid same-origin pathname while the URL is
+  // absolute, but becomes a protocol-relative redirect if the origin is
+  // removed. Keep the absolute form for every shape covered by the shared
+  // redirect guard.
+  if (isOpenRedirectShaped(parsed.pathname)) return parsed.toString();
   return parsed.pathname + parsed.search + parsed.hash;
 }
 
@@ -389,7 +396,8 @@ export async function executeMiddleware(
               }
             }
             if (normalized !== null) {
-              normalizedLocation = normalized + loc.search + loc.hash;
+              loc.pathname = normalized;
+              normalizedLocation = relativizeLocation(loc.toString(), options.request.url);
             }
           }
         } catch {

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -1597,6 +1597,13 @@ function resolveLocalRedirectUrl(location: string): string | null {
   }
 
   if (appPath === null) return null;
+  // Stripping an origin or basePath can expose a leading `//` that the browser
+  // would reinterpret as a different authority. Keep the original same-origin
+  // target instead; absolute and basePath-prefixed forms are both safe inputs
+  // to history navigation.
+  if (appPath.startsWith("//")) {
+    return normalizePathTrailingSlash(location, __trailingSlash);
+  }
   return normalizePathTrailingSlash(
     toBrowserNavigationHref(
       stripLocalePrefixForApiRedirect(appPath),

--- a/tests/middleware-runtime.test.ts
+++ b/tests/middleware-runtime.test.ts
@@ -5,7 +5,7 @@ import type { NextRequest } from "../packages/vinext/src/shims/server.js";
 // Tests for the redirect protocol implemented in `executeMiddleware`. These
 // fixtures mirror the behaviour Next.js's edge adapter applies after a
 // middleware returns a redirect Response:
-//   - Same-host Location headers are made relative.
+//   - Same-host Location headers are made relative when the result is safe.
 //   - When the original request carries `x-nextjs-data: 1`, the redirect is
 //     translated into a 200 response with `x-nextjs-redirect`.
 // Reference: packages/next/src/server/web/adapter.ts (canary)
@@ -119,6 +119,22 @@ describe("middleware redirect protocol", () => {
     expect(result.response?.headers.get("Location")).toBe("https://example.vercel.sh/");
   });
 
+  it("keeps same-host double-slash Location headers absolute", async () => {
+    const target = "https://victim.example//evil.example/steal?token=secret#fragment";
+    const module = {
+      default: () => Response.redirect(target, 307),
+    };
+
+    const result = await executeMiddleware({
+      isProxy: false,
+      module,
+      request: new Request("https://victim.example/start"),
+    });
+
+    expect(result.redirectUrl).toBe(target);
+    expect(result.response?.headers.get("Location")).toBe(target);
+  });
+
   it("translates same-host redirects to x-nextjs-redirect for data requests", async () => {
     const module = {
       default: (req: Request) => Response.redirect(new URL("/new-home", req.url).toString(), 307),
@@ -140,6 +156,27 @@ describe("middleware redirect protocol", () => {
     // No HTTP redirect should be surfaced to upstream callers.
     expect(result.redirectUrl).toBeUndefined();
     expect(result.redirectStatus).toBeUndefined();
+  });
+
+  it("keeps same-host double-slash data redirects absolute when adding a trailing slash", async () => {
+    const module = {
+      default: () =>
+        Response.redirect("https://victim.example//evil.example/steal?token=secret#fragment", 307),
+    };
+
+    const result = await executeMiddleware({
+      isDataRequest: true,
+      isProxy: false,
+      module,
+      request: new Request("https://victim.example/start"),
+      trailingSlash: true,
+    });
+
+    expect(result.response?.status).toBe(200);
+    expect(result.response?.headers.get("x-nextjs-redirect")).toBe(
+      "https://victim.example//evil.example/steal/?token=secret#fragment",
+    );
+    expect(result.response?.headers.get("Location")).toBeNull();
   });
 
   it("preserves middleware cache opt-out when shaping data-request redirects", async () => {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -18727,6 +18727,57 @@ describe("Pages Router concurrent navigation", () => {
     }
   });
 
+  it("preserves the origin for same-host double-slash middleware data redirects", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const { win, replaceState, render } = createNavWindow();
+    const pageModuleUrl = fixtureModuleUrl("fixtures/client-navigation-page.tsx");
+    const target = "http://localhost//evil.example/steal?token=secret#fragment";
+    Object.assign(win.location, { origin: "http://localhost" });
+    Object.assign(win.__NEXT_DATA__, {
+      buildId: "build-1",
+      __vinext: { ...win.__NEXT_DATA__.__vinext, hasMiddleware: true },
+    });
+    (globalThis as any).window = win;
+
+    const fetch = vi.fn(async (url: RequestInfo | URL) => {
+      const href = getFetchHref(url);
+      if (href === "/_next/data/build-1/old-home.json") {
+        return new Response("{}", {
+          headers: { "x-nextjs-redirect": target },
+          status: 200,
+        });
+      }
+      if (href === target) {
+        return new Response(buildNavHtml("//evil.example/steal", pageModuleUrl));
+      }
+      throw new Error(`Unexpected fetch: ${href}`);
+    });
+    globalThis.fetch = fetch;
+
+    try {
+      vi.resetModules();
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      const Router = routerModule.default;
+
+      const result = await Router.push("/old-home");
+
+      expect(result).toBe(true);
+      expect(fetch).toHaveBeenNthCalledWith(2, target, expect.any(Object));
+      expect(replaceState).toHaveBeenLastCalledWith({}, "", target);
+      expect(win.location.href).toBe(target);
+      expect(render).toHaveBeenCalled();
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("hydrates middleware rewrites to fallback pages from the data response", async () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;


### PR DESCRIPTION
## Summary

- Keep same-origin middleware redirect targets absolute when relativizing them would create a protocol-relative URL.
- Preserve that invariant while adding or removing a configured trailing slash.
- Keep the preserved origin through Pages Router `_next/data` consumption, including History API mutation and the follow-up HTML fetch.

## Why

A safe absolute target such as `https://victim.example//evil.example/steal` has a pathname beginning with `//`. Removing the same origin turned it into `//evil.example/steal`, which browsers interpret as an external authority. The middleware runtime owns server emission, and the Pages Router owns client consumption, so both boundaries now refuse transformations that would change the authority.

## Validation

- Demonstrated the server regression tests fail before the runtime fix with protocol-relative `Location` and `x-nextjs-redirect` output.
- Demonstrated the Pages Router regression test fails before the client fix because the data redirect loses its origin.
- `vp test run tests/shims.test.ts`: 1,270 passed.
- `vp test run tests/middleware-runtime.test.ts tests/middleware-runtime-trailing-slash.test.ts tests/request-pipeline.test.ts`: 138 passed.
- `vp check packages/vinext/src/server/middleware-runtime.ts packages/vinext/src/shims/router.ts tests/middleware-runtime.test.ts tests/shims.test.ts`: formatting, lint, and types passed.
- `vp run vinext#build`: passed after both changes.
- Pre-commit full check, staged unit and integration tests, and knip: passed for both commits.

## Risk and compatibility

Ordinary same-origin redirect locations remain relative, and cross-origin locations remain absolute. The deliberate compatibility exception is limited to same-origin paths that match the existing open-redirect guard or become authority-shaped after client origin/basePath stripping. Those targets remain in their original safe form so their authority cannot change during server emission or client navigation.