### PR TITLE
fix(middleware): preserve headers for empty override value

### DIFF
--- a/packages/vinext/src/config/config-matchers.ts
+++ b/packages/vinext/src/config/config-matchers.ts
@@ -15,6 +15,7 @@ import type {
 import {
   MIDDLEWARE_CACHE_HEADER,
   MIDDLEWARE_HEADER_PREFIX,
+  MIDDLEWARE_REQUEST_HEADER_PREFIX,
   PRERENDER_REVALIDATE_HEADER,
   PRERENDER_REVALIDATE_ONLY_GENERATED_HEADER,
   VINEXT_MW_CTX_HEADER,
@@ -22,7 +23,10 @@ import {
   VINEXT_PRERENDER_SECRET_HEADER,
   VINEXT_REVALIDATE_HOST_HEADER,
 } from "../utils/protocol-headers.js";
-import { buildRequestHeadersFromMiddlewareResponse } from "../utils/middleware-request-headers.js";
+import {
+  buildRequestHeadersFromMiddlewareResponse,
+  getUnconsumedMiddlewareRequestHeaders,
+} from "../utils/middleware-request-headers.js";
 import { analyzeRegexSafety } from "../utils/regex-safety.js";
 import { requestContextFromRequest, type RequestContext } from "./request-context.js";
 import { isExternalUrl } from "../utils/external-url.js";
@@ -450,9 +454,14 @@ export function applyMiddlewareRequestHeaders(
   request: Request,
 ): { request: Request; postMwReqCtx: RequestContext } {
   const nextHeaders = buildRequestHeadersFromMiddlewareResponse(request.headers, middlewareHeaders);
+  const unconsumedRequestHeaders = getUnconsumedMiddlewareRequestHeaders(middlewareHeaders);
 
   for (const key of Object.keys(middlewareHeaders)) {
-    if (key.startsWith(MIDDLEWARE_HEADER_PREFIX) && key !== MIDDLEWARE_CACHE_HEADER) {
+    if (
+      key.startsWith(MIDDLEWARE_HEADER_PREFIX) &&
+      key !== MIDDLEWARE_CACHE_HEADER &&
+      !unconsumedRequestHeaders.has(key)
+    ) {
       delete middlewareHeaders[key];
     }
   }
@@ -1276,9 +1285,15 @@ export async function proxyExternalRequest(
   // proxy and backend (defense-in-depth against request smuggling,
   // ref: CVE GHSA-ggv3-7p47-pfv8).
   stripHopByHopRequestHeaders(headers);
+  // Next.js forwards truthy x-middleware-request-* values that were not
+  // consumed by an override list under their literal names. Other middleware
+  // protocol controls must not escape to the external origin.
   const keysToDelete: string[] = [];
   for (const key of headers.keys()) {
-    if (key.startsWith(MIDDLEWARE_HEADER_PREFIX)) {
+    if (
+      key.startsWith(MIDDLEWARE_HEADER_PREFIX) &&
+      !key.startsWith(MIDDLEWARE_REQUEST_HEADER_PREFIX)
+    ) {
       keysToDelete.push(key);
     }
   }

--- a/packages/vinext/src/server/middleware-runtime.ts
+++ b/packages/vinext/src/server/middleware-runtime.ts
@@ -410,12 +410,9 @@ export async function executeMiddleware(
         };
       }
 
-      const responseHeaders = new Headers();
-      for (const [key, value] of response.headers) {
-        if (!key.startsWith(MIDDLEWARE_HEADER_PREFIX) && key.toLowerCase() !== "location") {
-          responseHeaders.append(key, value);
-        }
-      }
+      const responseHeaders = new Headers(response.headers);
+      responseHeaders.delete("location");
+      processMiddlewareHeaders(responseHeaders);
       // Rebuild the response with the relativized Location so consumers that
       // forward `result.response` (rather than `result.redirectUrl`) also send
       // the correct header.

--- a/packages/vinext/src/server/request-pipeline.ts
+++ b/packages/vinext/src/server/request-pipeline.ts
@@ -6,6 +6,7 @@ import {
   VINEXT_STATIC_FILE_HEADER,
 } from "./headers.js";
 import { MIDDLEWARE_CACHE_HEADER } from "../utils/protocol-headers.js";
+import { getUnconsumedMiddlewareRequestHeaders } from "../utils/middleware-request-headers.js";
 import {
   forbiddenResponse,
   methodNotAllowedResponse,
@@ -475,15 +476,22 @@ export function isOriginAllowed(origin: string, allowed: string[]): boolean {
  *
  * Middleware uses `x-middleware-*` headers as internal signals (e.g.
  * `x-middleware-next`, `x-middleware-rewrite`, `x-middleware-request-*`).
- * These must be removed before sending the response to the client.
+ * Consumed protocol headers must be removed before sending the response to the
+ * client. Next.js exposes truthy unconsumed `x-middleware-request-*` values as
+ * literal request and response headers, so those are intentionally preserved.
  *
  * @param headers - The Headers object to modify in place
  */
 export function processMiddlewareHeaders(headers: Headers): void {
   const keysToDelete: string[] = [];
+  const unconsumedRequestHeaders = getUnconsumedMiddlewareRequestHeaders(headers);
 
   for (const key of headers.keys()) {
-    if (key.startsWith(MIDDLEWARE_HEADER_PREFIX) && key !== MIDDLEWARE_CACHE_HEADER) {
+    if (
+      key.startsWith(MIDDLEWARE_HEADER_PREFIX) &&
+      key !== MIDDLEWARE_CACHE_HEADER &&
+      !unconsumedRequestHeaders.has(key)
+    ) {
       keysToDelete.push(key);
     }
   }

--- a/packages/vinext/src/utils/middleware-request-headers.ts
+++ b/packages/vinext/src/utils/middleware-request-headers.ts
@@ -46,6 +46,29 @@ function getForwardedRequestHeaders(source: MiddlewareHeaderSource): Map<string,
   return forwardedHeaders;
 }
 
+/**
+ * Return truthy forwarded values that Next.js does not consume through the
+ * override list. Its subsequent generic middleware-header merge exposes these
+ * under their literal protocol-header names on both the request and response.
+ */
+export function getUnconsumedMiddlewareRequestHeaders(
+  source: MiddlewareHeaderSource,
+): Map<string, string> {
+  const rawOverrideHeader = getMiddlewareHeaderValue(source, MIDDLEWARE_OVERRIDE_HEADERS);
+  const overriddenHeaders = rawOverrideHeader
+    ? new Set(parseOverrideHeaderNames(rawOverrideHeader))
+    : null;
+  const unconsumedHeaders = new Map<string, string>();
+
+  for (const [key, value] of getForwardedRequestHeaders(source)) {
+    if (value && !overriddenHeaders?.has(key)) {
+      unconsumedHeaders.set(`${MIDDLEWARE_REQUEST_HEADER_PREFIX}${key}`, value);
+    }
+  }
+
+  return unconsumedHeaders;
+}
+
 export function encodeMiddlewareRequestHeaders(
   targetHeaders: Headers,
   requestHeaders: Headers,
@@ -72,6 +95,7 @@ export function buildRequestHeadersFromMiddlewareResponse(
   middlewareHeaders: MiddlewareHeaderSource,
 ): Headers | null {
   const forwardedHeaders = getForwardedRequestHeaders(middlewareHeaders);
+  const unconsumedHeaders = getUnconsumedMiddlewareRequestHeaders(middlewareHeaders);
   const rawOverrideHeader = getMiddlewareHeaderValue(
     middlewareHeaders,
     MIDDLEWARE_OVERRIDE_HEADERS,
@@ -81,17 +105,16 @@ export function buildRequestHeadersFromMiddlewareResponse(
   // truthiness. Unconsumed x-middleware-request-* headers still pass through
   // its subsequent generic middleware-header merge under their literal names.
   if (!rawOverrideHeader) {
-    if (forwardedHeaders.size === 0) return null;
+    if (unconsumedHeaders.size === 0) return null;
 
     const nextHeaders = new Headers(baseHeaders);
-    for (const [key, value] of forwardedHeaders) {
-      nextHeaders.set(`${MIDDLEWARE_REQUEST_HEADER_PREFIX}${key}`, value);
+    for (const [key, value] of unconsumedHeaders) {
+      nextHeaders.set(key, value);
     }
     return nextHeaders;
   }
 
   const overrideHeaderNames = parseOverrideHeaderNames(rawOverrideHeader);
-  const overriddenHeaders = new Set(overrideHeaderNames);
   const nextHeaders = new Headers();
 
   for (const key of overrideHeaderNames) {
@@ -104,10 +127,8 @@ export function buildRequestHeadersFromMiddlewareResponse(
   // Values named by the override list were consumed above. Any stray values
   // remain ordinary middleware response headers in Next.js and are copied to
   // the request literally by resolve-routes.ts's generic merge.
-  for (const [key, value] of forwardedHeaders) {
-    if (!overriddenHeaders.has(key)) {
-      nextHeaders.set(`${MIDDLEWARE_REQUEST_HEADER_PREFIX}${key}`, value);
-    }
+  for (const [key, value] of unconsumedHeaders) {
+    nextHeaders.set(key, value);
   }
 
   return nextHeaders;

--- a/packages/vinext/src/utils/middleware-request-headers.ts
+++ b/packages/vinext/src/utils/middleware-request-headers.ts
@@ -18,8 +18,7 @@ function getMiddlewareHeaderValue(source: MiddlewareHeaderSource, key: string): 
   return Array.isArray(value) ? (value[0] ?? null) : value;
 }
 
-function parseOverrideHeaderNames(rawValue: string | null): string[] | null {
-  if (rawValue === null) return null;
+function parseOverrideHeaderNames(rawValue: string): string[] {
   return rawValue
     .split(",")
     .map((key) => key.trim())
@@ -47,14 +46,6 @@ function getForwardedRequestHeaders(source: MiddlewareHeaderSource): Map<string,
   return forwardedHeaders;
 }
 
-function cloneHeaders(source: Headers): Headers {
-  const cloned = new Headers();
-  for (const [key, value] of source.entries()) {
-    cloned.append(key, value);
-  }
-  return cloned;
-}
-
 export function encodeMiddlewareRequestHeaders(
   targetHeaders: Headers,
   requestHeaders: Headers,
@@ -76,33 +67,21 @@ export function encodeMiddlewareRequestHeaders(
  * override and leaves the request unchanged.
  */
 export function buildRequestHeadersFromMiddlewareResponse(
-  baseHeaders: Headers,
+  _baseHeaders: Headers,
   middlewareHeaders: MiddlewareHeaderSource,
 ): Headers | null {
   const rawOverrideHeader = getMiddlewareHeaderValue(
     middlewareHeaders,
     MIDDLEWARE_OVERRIDE_HEADERS,
   );
-  // Next.js guards the override block with this header's truthiness, so the
-  // empty value emitted for `new Headers()` ignores even stray forwarded
-  // headers from malformed combinations that our encoder cannot produce.
-  if (rawOverrideHeader === "") return null;
+  // Next.js guards the entire mutation block with this header's truthiness.
+  // Missing and empty values therefore ignore even stray forwarded headers
+  // from malformed combinations that our encoder cannot produce.
+  if (!rawOverrideHeader) return null;
 
   const overrideHeaderNames = parseOverrideHeaderNames(rawOverrideHeader);
   const forwardedHeaders = getForwardedRequestHeaders(middlewareHeaders);
-
-  if (overrideHeaderNames === null && forwardedHeaders.size === 0) {
-    return null;
-  }
-
-  const nextHeaders = overrideHeaderNames === null ? cloneHeaders(baseHeaders) : new Headers();
-
-  if (overrideHeaderNames === null) {
-    for (const [key, value] of forwardedHeaders) {
-      nextHeaders.set(key, value);
-    }
-    return nextHeaders;
-  }
+  const nextHeaders = new Headers();
 
   for (const key of overrideHeaderNames) {
     const value = forwardedHeaders.get(key);

--- a/packages/vinext/src/utils/middleware-request-headers.ts
+++ b/packages/vinext/src/utils/middleware-request-headers.ts
@@ -64,29 +64,49 @@ export function encodeMiddlewareRequestHeaders(
  * middleware. Never re-add absent headers from the base request — that would
  * resurrect credentials the app explicitly stripped before an external
  * rewrite. Next.js treats the empty value emitted for `new Headers()` as no
- * override and leaves the request unchanged.
+ * override. Any unconsumed `x-middleware-request-*` values are subsequently
+ * copied to the request under their literal protocol-header names.
  */
 export function buildRequestHeadersFromMiddlewareResponse(
-  _baseHeaders: Headers,
+  baseHeaders: Headers,
   middlewareHeaders: MiddlewareHeaderSource,
 ): Headers | null {
+  const forwardedHeaders = getForwardedRequestHeaders(middlewareHeaders);
   const rawOverrideHeader = getMiddlewareHeaderValue(
     middlewareHeaders,
     MIDDLEWARE_OVERRIDE_HEADERS,
   );
-  // Next.js guards the entire mutation block with this header's truthiness.
-  // Missing and empty values therefore ignore even stray forwarded headers
-  // from malformed combinations that our encoder cannot produce.
-  if (!rawOverrideHeader) return null;
+
+  // Next.js guards the override translation block with this header's
+  // truthiness. Unconsumed x-middleware-request-* headers still pass through
+  // its subsequent generic middleware-header merge under their literal names.
+  if (!rawOverrideHeader) {
+    if (forwardedHeaders.size === 0) return null;
+
+    const nextHeaders = new Headers(baseHeaders);
+    for (const [key, value] of forwardedHeaders) {
+      nextHeaders.set(`${MIDDLEWARE_REQUEST_HEADER_PREFIX}${key}`, value);
+    }
+    return nextHeaders;
+  }
 
   const overrideHeaderNames = parseOverrideHeaderNames(rawOverrideHeader);
-  const forwardedHeaders = getForwardedRequestHeaders(middlewareHeaders);
+  const overriddenHeaders = new Set(overrideHeaderNames);
   const nextHeaders = new Headers();
 
   for (const key of overrideHeaderNames) {
     const value = forwardedHeaders.get(key);
     if (value !== undefined) {
       nextHeaders.set(key, value);
+    }
+  }
+
+  // Values named by the override list were consumed above. Any stray values
+  // remain ordinary middleware response headers in Next.js and are copied to
+  // the request literally by resolve-routes.ts's generic merge.
+  for (const [key, value] of forwardedHeaders) {
+    if (!overriddenHeaders.has(key)) {
+      nextHeaders.set(`${MIDDLEWARE_REQUEST_HEADER_PREFIX}${key}`, value);
     }
   }
 

--- a/packages/vinext/src/utils/middleware-request-headers.ts
+++ b/packages/vinext/src/utils/middleware-request-headers.ts
@@ -18,12 +18,8 @@ function getMiddlewareHeaderValue(source: MiddlewareHeaderSource, key: string): 
   return Array.isArray(value) ? (value[0] ?? null) : value;
 }
 
-function getOverrideHeaderNames(source: MiddlewareHeaderSource): string[] | null {
-  const rawValue = getMiddlewareHeaderValue(source, MIDDLEWARE_OVERRIDE_HEADERS);
-  // Next.js guards the override block with the protocol header's truthiness.
-  // `NextResponse.next({ request: { headers: new Headers() } })` emits an
-  // empty value, so that case leaves the original request headers unchanged.
-  if (rawValue === null || rawValue === "") return null;
+function parseOverrideHeaderNames(rawValue: string | null): string[] | null {
+  if (rawValue === null) return null;
   return rawValue
     .split(",")
     .map((key) => key.trim())
@@ -83,7 +79,16 @@ export function buildRequestHeadersFromMiddlewareResponse(
   baseHeaders: Headers,
   middlewareHeaders: MiddlewareHeaderSource,
 ): Headers | null {
-  const overrideHeaderNames = getOverrideHeaderNames(middlewareHeaders);
+  const rawOverrideHeader = getMiddlewareHeaderValue(
+    middlewareHeaders,
+    MIDDLEWARE_OVERRIDE_HEADERS,
+  );
+  // Next.js guards the override block with this header's truthiness, so the
+  // empty value emitted for `new Headers()` ignores even stray forwarded
+  // headers from malformed combinations that our encoder cannot produce.
+  if (rawOverrideHeader === "") return null;
+
+  const overrideHeaderNames = parseOverrideHeaderNames(rawOverrideHeader);
   const forwardedHeaders = getForwardedRequestHeaders(middlewareHeaders);
 
   if (overrideHeaderNames === null && forwardedHeaders.size === 0) {

--- a/packages/vinext/src/utils/middleware-request-headers.ts
+++ b/packages/vinext/src/utils/middleware-request-headers.ts
@@ -20,7 +20,10 @@ function getMiddlewareHeaderValue(source: MiddlewareHeaderSource, key: string): 
 
 function getOverrideHeaderNames(source: MiddlewareHeaderSource): string[] | null {
   const rawValue = getMiddlewareHeaderValue(source, MIDDLEWARE_OVERRIDE_HEADERS);
-  if (rawValue === null) return null;
+  // Next.js guards the override block with the protocol header's truthiness.
+  // `NextResponse.next({ request: { headers: new Headers() } })` emits an
+  // empty value, so that case leaves the original request headers unchanged.
+  if (rawValue === null || rawValue === "") return null;
   return rawValue
     .split(",")
     .map((key) => key.trim())
@@ -69,10 +72,12 @@ export function encodeMiddlewareRequestHeaders(
 }
 
 /**
- * `x-middleware-override-headers` lists the complete post-middleware header set,
- * so any name absent from it was deleted by middleware. Never re-add absent
- * headers from the base request — that would resurrect credentials the app
- * explicitly stripped before an external rewrite.
+ * A non-empty `x-middleware-override-headers` value lists the complete
+ * post-middleware header set, so any name absent from it was deleted by
+ * middleware. Never re-add absent headers from the base request — that would
+ * resurrect credentials the app explicitly stripped before an external
+ * rewrite. Next.js treats the empty value emitted for `new Headers()` as no
+ * override and leaves the request unchanged.
  */
 export function buildRequestHeadersFromMiddlewareResponse(
   baseHeaders: Headers,

--- a/tests/app-router-external-rewrite.test.ts
+++ b/tests/app-router-external-rewrite.test.ts
@@ -166,9 +166,29 @@ describe("App Router external rewrite proxy credential forwarding", () => {
     expect(capturedHeaders!["x-hello-from-middleware1"]).toBe("hello");
   });
 
-  it("does not apply a forwarded middleware header without an override list", async () => {
+  it("applies request headers passed through NextResponse.rewrite", async () => {
+    // Users provide the desired request Headers. NextResponse serializes both
+    // parts of the internal override protocol, including the override list.
+    mockResponseMode = "plain";
+    capturedHeaders = null;
+
+    const response = await fetch(`${baseUrl}/middleware-external-rewrite`, {
+      headers: {
+        "x-added": "original",
+        "x-middleware-test-rewrite-target": `http://localhost:${mockPort}`,
+        "x-middleware-test-request-override": "1",
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(capturedHeaders).not.toBeNull();
+    expect(capturedHeaders!["x-added"]).toBe("from-middleware");
+  });
+
+  it("does not translate a manually forged internal request-header value", async () => {
     // Next.js only translates x-middleware-request-* values inside the truthy
-    // x-middleware-override-headers guard. A stray value is not a request override.
+    // x-middleware-override-headers guard. Setting only the internal value
+    // header is not the supported NextResponse request-header API.
     // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/router-utils/resolve-routes.ts
     mockResponseMode = "plain";
     capturedHeaders = null;

--- a/tests/app-router-external-rewrite.test.ts
+++ b/tests/app-router-external-rewrite.test.ts
@@ -185,29 +185,6 @@ describe("App Router external rewrite proxy credential forwarding", () => {
     expect(capturedHeaders!["x-added"]).toBe("from-middleware");
   });
 
-  it("does not translate a manually forged internal request-header value", async () => {
-    // Next.js only translates x-middleware-request-* values inside the truthy
-    // x-middleware-override-headers guard. Setting only the internal value
-    // header is not the supported NextResponse request-header API.
-    // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/router-utils/resolve-routes.ts
-    mockResponseMode = "plain";
-    capturedHeaders = null;
-
-    const response = await fetch(`${baseUrl}/middleware-external-rewrite`, {
-      headers: {
-        Authorization: "Bearer tok_secret",
-        "x-added": "original",
-        "x-middleware-test-rewrite-target": `http://localhost:${mockPort}`,
-        "x-middleware-test-request-override": "stray-forwarded-value",
-      },
-    });
-
-    expect(response.status).toBe(200);
-    expect(capturedHeaders).not.toBeNull();
-    expect(capturedHeaders!["authorization"]).toBe("Bearer tok_secret");
-    expect(capturedHeaders!["x-added"]).toBe("original");
-  });
-
   it("strips content-encoding and content-length for Node fetch auto-decompression", async () => {
     mockResponseMode = "gzipHeaderAndBody";
     const response = await fetch(`${baseUrl}/proxy-external-test/some-path`);

--- a/tests/app-router-external-rewrite.test.ts
+++ b/tests/app-router-external-rewrite.test.ts
@@ -166,6 +166,28 @@ describe("App Router external rewrite proxy credential forwarding", () => {
     expect(capturedHeaders!["x-hello-from-middleware1"]).toBe("hello");
   });
 
+  it("does not apply a forwarded middleware header without an override list", async () => {
+    // Next.js only translates x-middleware-request-* values inside the truthy
+    // x-middleware-override-headers guard. A stray value is not a request override.
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/router-utils/resolve-routes.ts
+    mockResponseMode = "plain";
+    capturedHeaders = null;
+
+    const response = await fetch(`${baseUrl}/middleware-external-rewrite`, {
+      headers: {
+        Authorization: "Bearer tok_secret",
+        "x-added": "original",
+        "x-middleware-test-rewrite-target": `http://localhost:${mockPort}`,
+        "x-middleware-test-request-override": "stray-forwarded-value",
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(capturedHeaders).not.toBeNull();
+    expect(capturedHeaders!["authorization"]).toBe("Bearer tok_secret");
+    expect(capturedHeaders!["x-added"]).toBe("original");
+  });
+
   it("strips content-encoding and content-length for Node fetch auto-decompression", async () => {
     mockResponseMode = "gzipHeaderAndBody";
     const response = await fetch(`${baseUrl}/proxy-external-test/some-path`);

--- a/tests/app-router-external-rewrite.test.ts
+++ b/tests/app-router-external-rewrite.test.ts
@@ -185,6 +185,24 @@ describe("App Router external rewrite proxy credential forwarding", () => {
     expect(capturedHeaders!["x-added"]).toBe("from-middleware");
   });
 
+  it("forwards an unconsumed middleware request header literally", async () => {
+    mockResponseMode = "plain";
+    capturedHeaders = null;
+
+    const response = await fetch(`${baseUrl}/middleware-external-rewrite`, {
+      headers: {
+        "x-added": "original",
+        "x-middleware-test-rewrite-target": `http://localhost:${mockPort}`,
+        "x-middleware-test-request-override": "stray-forwarded-value",
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(capturedHeaders).not.toBeNull();
+    expect(capturedHeaders!["x-added"]).toBe("original");
+    expect(capturedHeaders!["x-middleware-request-x-added"]).toBe("forged-by-middleware");
+  });
+
   it("strips content-encoding and content-length for Node fetch auto-decompression", async () => {
     mockResponseMode = "gzipHeaderAndBody";
     const response = await fetch(`${baseUrl}/proxy-external-test/some-path`);

--- a/tests/app-router-middleware-next-request.test.ts
+++ b/tests/app-router-middleware-next-request.test.ts
@@ -135,6 +135,28 @@ describe("App Router middleware with NextRequest", () => {
     });
   });
 
+  it("does not translate an unlisted middleware request header value", async () => {
+    // Next.js skips override translation without x-middleware-override-headers,
+    // then copies the unconsumed protocol header to the request literally.
+    // Confirmed against Next.js 16.2.7 and resolve-routes.ts:
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/router-utils/resolve-routes.ts
+    const res = await fetch(`${baseUrl}/api/header-override-stray`, {
+      headers: {
+        authorization: "Bearer secret",
+        "x-added": "original",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      authorization: "Bearer secret",
+      logical: "original",
+      logicalFromHeadersApi: "original",
+      raw: "forged-by-middleware",
+      rawFromHeadersApi: "forged-by-middleware",
+    });
+  });
+
   it("middleware request header overrides can delete credential headers before pages getServerSideProps in mixed projects", async () => {
     const { res, html } = await fetchHtml(baseUrl, "/pages-header-override-delete", {
       headers: {

--- a/tests/app-router-middleware-next-request.test.ts
+++ b/tests/app-router-middleware-next-request.test.ts
@@ -148,6 +148,7 @@ describe("App Router middleware with NextRequest", () => {
     });
 
     expect(res.status).toBe(200);
+    expect(res.headers.get("x-middleware-request-x-added")).toBe("forged-by-middleware");
     expect(await res.json()).toEqual({
       authorization: "Bearer secret",
       logical: "original",

--- a/tests/fixtures/app-basic/app/api/header-override-stray/route.ts
+++ b/tests/fixtures/app-basic/app/api/header-override-stray/route.ts
@@ -1,0 +1,12 @@
+import { headers } from "next/headers";
+
+export async function GET(request: Request) {
+  const requestHeaders = await headers();
+  return Response.json({
+    authorization: request.headers.get("authorization"),
+    logical: request.headers.get("x-added"),
+    logicalFromHeadersApi: requestHeaders.get("x-added"),
+    raw: request.headers.get("x-middleware-request-x-added"),
+    rawFromHeadersApi: requestHeaders.get("x-middleware-request-x-added"),
+  });
+}

--- a/tests/fixtures/app-basic/middleware.ts
+++ b/tests/fixtures/app-basic/middleware.ts
@@ -116,6 +116,11 @@ export async function middleware(request: NextRequest, event: NextFetchEvent) {
       const rewriteTarget = new URL("/middleware-external-target", target);
       rewriteTarget.search = request.nextUrl.search;
       const override = request.headers.get("x-middleware-test-request-override");
+      if (override === "stray-forwarded-value") {
+        const response = NextResponse.rewrite(rewriteTarget);
+        response.headers.set("x-middleware-request-x-added", "forged-by-middleware");
+        return response;
+      }
       if (override === "1" || override === "strip-credentials") {
         const headers = new Headers(request.headers);
         headers.set("x-added", "from-middleware");

--- a/tests/fixtures/app-basic/middleware.ts
+++ b/tests/fixtures/app-basic/middleware.ts
@@ -123,6 +123,7 @@ export async function middleware(request: NextRequest, event: NextFetchEvent) {
       }
       if (override === "1" || override === "strip-credentials") {
         const headers = new Headers(request.headers);
+        headers.set("x-added", "from-middleware");
         headers.set("x-hello-from-middleware1", "hello");
         headers.set("x-hello-from-middleware2", "world");
         // Credentials deleted here must not reach the external target (#1121 regression).

--- a/tests/fixtures/app-basic/middleware.ts
+++ b/tests/fixtures/app-basic/middleware.ts
@@ -116,6 +116,11 @@ export async function middleware(request: NextRequest, event: NextFetchEvent) {
       const rewriteTarget = new URL("/middleware-external-target", target);
       rewriteTarget.search = request.nextUrl.search;
       const override = request.headers.get("x-middleware-test-request-override");
+      if (override === "stray-forwarded-value") {
+        const response = NextResponse.rewrite(rewriteTarget);
+        response.headers.set("x-middleware-request-x-added", "forged-by-middleware");
+        return response;
+      }
       if (override === "1" || override === "strip-credentials") {
         const headers = new Headers(request.headers);
         headers.set("x-hello-from-middleware1", "hello");

--- a/tests/fixtures/app-basic/middleware.ts
+++ b/tests/fixtures/app-basic/middleware.ts
@@ -116,11 +116,6 @@ export async function middleware(request: NextRequest, event: NextFetchEvent) {
       const rewriteTarget = new URL("/middleware-external-target", target);
       rewriteTarget.search = request.nextUrl.search;
       const override = request.headers.get("x-middleware-test-request-override");
-      if (override === "stray-forwarded-value") {
-        const response = NextResponse.rewrite(rewriteTarget);
-        response.headers.set("x-middleware-request-x-added", "forged-by-middleware");
-        return response;
-      }
       if (override === "1" || override === "strip-credentials") {
         const headers = new Headers(request.headers);
         headers.set("x-added", "from-middleware");
@@ -258,6 +253,12 @@ export async function middleware(request: NextRequest, event: NextFetchEvent) {
     headers.delete("cookie");
     headers.set("x-from-middleware", "hello-from-middleware");
     return NextResponse.next({ request: { headers } });
+  }
+
+  if (pathname === "/api/header-override-stray") {
+    const response = NextResponse.next();
+    response.headers.set("x-middleware-request-x-added", "forged-by-middleware");
+    return response;
   }
 
   // Regression for a bug where a middleware that reads `next/headers` →
@@ -412,6 +413,7 @@ export const config = {
     "/headers/override-from-middleware",
     "/header-override-delete",
     "/api/header-override-delete",
+    "/api/header-override-stray",
     "/api/pages-og",
     "/header-override-after-prior-access",
     "/pages-header-override-delete",

--- a/tests/middleware-runtime.test.ts
+++ b/tests/middleware-runtime.test.ts
@@ -70,6 +70,32 @@ describe("middleware redirect protocol", () => {
     expect(result.response?.headers.get("Location")).toBe("/another");
   });
 
+  it("preserves unconsumed request-header values on redirects", async () => {
+    const module = {
+      default: (req: Request) =>
+        new Response(null, {
+          status: 307,
+          headers: {
+            location: new URL("/another", req.url).toString(),
+            "x-middleware-request-x-added": "forged-by-middleware",
+          },
+        }),
+    };
+
+    const result = await executeMiddleware({
+      isProxy: false,
+      module,
+      request: new Request("http://localhost:3000/start"),
+    });
+
+    expect(result.responseHeaders?.get("x-middleware-request-x-added")).toBe(
+      "forged-by-middleware",
+    );
+    expect(result.response?.headers.get("x-middleware-request-x-added")).toBe(
+      "forged-by-middleware",
+    );
+  });
+
   it("preserves the search string when relativizing the Location header", async () => {
     const module = {
       default: (req: Request) => {

--- a/tests/pages-request-pipeline.test.ts
+++ b/tests/pages-request-pipeline.test.ts
@@ -545,6 +545,28 @@ describe("middleware", () => {
     expect(result.response.status).toBe(307);
   });
 
+  it("preserves unconsumed request-header values on middleware redirects", async () => {
+    const result = await runPagesRequest(
+      makeRequest("/foo"),
+      baseDeps({
+        runMiddleware: makeMiddleware({
+          continue: false,
+          redirectUrl: "http://localhost/bar",
+          redirectStatus: 307,
+          responseHeaders: new Headers({
+            "x-middleware-request-x-added": "forged-by-middleware",
+          }),
+        }),
+      }),
+    );
+
+    expect(result.type).toBe("response");
+    if (result.type !== "response") return;
+    expect(result.response.headers.get("x-middleware-request-x-added")).toBe(
+      "forged-by-middleware",
+    );
+  });
+
   // Ported from Next.js: test/e2e/middleware-general/test/index.test.ts
   // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-general/test/index.test.ts
   it("does not classify a normal request as data from x-nextjs-data alone", async () => {

--- a/tests/request-pipeline.test.ts
+++ b/tests/request-pipeline.test.ts
@@ -982,9 +982,10 @@ describe("buildRequestHeadersFromMiddlewareResponse", () => {
     expect(result!.get("x-added")).toBe("1");
   });
 
-  it("keeps base headers when middleware sends no override list at all", () => {
+  it("ignores forwarded header values when middleware sends no override list", () => {
     // NextResponse.next() without `request` emits no override list; that is the
-    // "unchanged" signal, and only then are base headers carried through.
+    // "unchanged" signal. Next.js skips the complete mutation block, including
+    // any stray forwarded values that appear without their required list.
     const baseHeaders = new Headers({
       authorization: "Bearer token",
       cookie: "session=abc",
@@ -993,10 +994,7 @@ describe("buildRequestHeadersFromMiddlewareResponse", () => {
 
     const result = buildRequestHeadersFromMiddlewareResponse(baseHeaders, middlewareHeaders);
 
-    expect(result).not.toBeNull();
-    expect(result!.get("authorization")).toBe("Bearer token");
-    expect(result!.get("cookie")).toBe("session=abc");
-    expect(result!.get("x-added")).toBe("1");
+    expect(result).toBeNull();
   });
 });
 

--- a/tests/request-pipeline.test.ts
+++ b/tests/request-pipeline.test.ts
@@ -940,6 +940,22 @@ describe("filterInternalHeaders", () => {
 });
 
 describe("buildRequestHeadersFromMiddlewareResponse", () => {
+  it("treats an empty override header as no request-header override", () => {
+    // Next.js only applies middleware request-header overrides when this
+    // protocol header is truthy, so the empty string emitted for `new Headers()`
+    // leaves the original request unchanged.
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/router-utils/resolve-routes.ts
+    const baseHeaders = new Headers({
+      authorization: "Bearer token",
+      cookie: "session=abc",
+    });
+    const middlewareHeaders = new Headers({ "x-middleware-override-headers": "" });
+
+    const result = buildRequestHeadersFromMiddlewareResponse(baseHeaders, middlewareHeaders);
+
+    expect(result).toBeNull();
+  });
+
   it("drops every header absent from the override list, credentials included", () => {
     // Next.js treats the override list as the complete post-middleware header
     // set (resolve-routes.ts deletes non-listed request headers), so an absent

--- a/tests/request-pipeline.test.ts
+++ b/tests/request-pipeline.test.ts
@@ -949,7 +949,10 @@ describe("buildRequestHeadersFromMiddlewareResponse", () => {
       authorization: "Bearer token",
       cookie: "session=abc",
     });
-    const middlewareHeaders = new Headers({ "x-middleware-override-headers": "" });
+    const middlewareHeaders = new Headers({
+      "x-middleware-override-headers": "",
+      "x-middleware-request-x-added": "must-be-ignored",
+    });
 
     const result = buildRequestHeadersFromMiddlewareResponse(baseHeaders, middlewareHeaders);
 

--- a/tests/request-pipeline.test.ts
+++ b/tests/request-pipeline.test.ts
@@ -765,8 +765,9 @@ describe("processMiddlewareHeaders", () => {
     expect(headers.get("content-type")).toBe("text/html");
   });
 
-  it("strips x-middleware-request-* headers", () => {
+  it("strips x-middleware-request-* headers consumed by the override list", () => {
     const headers = new Headers({
+      "x-middleware-override-headers": "x-custom",
       "x-middleware-request-x-custom": "value",
       "x-middleware-rewrite": "/new-path",
       "content-type": "text/html",
@@ -775,6 +776,18 @@ describe("processMiddlewareHeaders", () => {
     expect(headers.has("x-middleware-request-x-custom")).toBe(false);
     expect(headers.has("x-middleware-rewrite")).toBe(false);
     expect(headers.get("content-type")).toBe("text/html");
+  });
+
+  it("preserves truthy unconsumed x-middleware-request-* response headers", () => {
+    const headers = new Headers({
+      "x-middleware-request-x-custom": "literal",
+      "x-middleware-request-x-empty": "",
+    });
+
+    processMiddlewareHeaders(headers);
+
+    expect(headers.get("x-middleware-request-x-custom")).toBe("literal");
+    expect(headers.has("x-middleware-request-x-empty")).toBe(false);
   });
 
   it("preserves x-middleware-cache response opt-outs", () => {
@@ -1018,6 +1031,19 @@ describe("buildRequestHeadersFromMiddlewareResponse", () => {
     expect(result!.get("x-added")).toBe("translated");
     expect(result!.get("x-middleware-request-x-added")).toBeNull();
     expect(result!.get("x-middleware-request-x-stray")).toBe("literal");
+  });
+
+  it("drops empty unlisted forwarded values", () => {
+    const middlewareHeaders = new Headers({
+      "x-middleware-request-x-empty": "",
+    });
+
+    const result = buildRequestHeadersFromMiddlewareResponse(
+      new Headers({ "x-original": "kept" }),
+      middlewareHeaders,
+    );
+
+    expect(result).toBeNull();
   });
 });
 

--- a/tests/request-pipeline.test.ts
+++ b/tests/request-pipeline.test.ts
@@ -940,10 +940,11 @@ describe("filterInternalHeaders", () => {
 });
 
 describe("buildRequestHeadersFromMiddlewareResponse", () => {
-  it("treats an empty override header as no request-header override", () => {
+  it("does not translate stray forwarded values when the override header is empty", () => {
     // Next.js only applies middleware request-header overrides when this
     // protocol header is truthy, so the empty string emitted for `new Headers()`
-    // leaves the original request unchanged.
+    // leaves the original logical request headers unchanged. The unconsumed
+    // protocol value is then copied under its literal header name.
     // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/router-utils/resolve-routes.ts
     const baseHeaders = new Headers({
       authorization: "Bearer token",
@@ -951,12 +952,16 @@ describe("buildRequestHeadersFromMiddlewareResponse", () => {
     });
     const middlewareHeaders = new Headers({
       "x-middleware-override-headers": "",
-      "x-middleware-request-x-added": "must-be-ignored",
+      "x-middleware-request-x-added": "literal",
     });
 
     const result = buildRequestHeadersFromMiddlewareResponse(baseHeaders, middlewareHeaders);
 
-    expect(result).toBeNull();
+    expect(result).not.toBeNull();
+    expect(result!.get("authorization")).toBe("Bearer token");
+    expect(result!.get("cookie")).toBe("session=abc");
+    expect(result!.get("x-added")).toBeNull();
+    expect(result!.get("x-middleware-request-x-added")).toBe("literal");
   });
 
   it("drops every header absent from the override list, credentials included", () => {
@@ -982,10 +987,9 @@ describe("buildRequestHeadersFromMiddlewareResponse", () => {
     expect(result!.get("x-added")).toBe("1");
   });
 
-  it("ignores forwarded header values when middleware sends no override list", () => {
-    // NextResponse.next() without `request` emits no override list; that is the
-    // "unchanged" signal. Next.js skips the complete mutation block, including
-    // any stray forwarded values that appear without their required list.
+  it("preserves forwarded header values literally when middleware sends no override list", () => {
+    // Next.js skips override translation without the list, then copies the
+    // unconsumed middleware header literally during its generic header merge.
     const baseHeaders = new Headers({
       authorization: "Bearer token",
       cookie: "session=abc",
@@ -994,7 +998,26 @@ describe("buildRequestHeadersFromMiddlewareResponse", () => {
 
     const result = buildRequestHeadersFromMiddlewareResponse(baseHeaders, middlewareHeaders);
 
-    expect(result).toBeNull();
+    expect(result).not.toBeNull();
+    expect(result!.get("authorization")).toBe("Bearer token");
+    expect(result!.get("cookie")).toBe("session=abc");
+    expect(result!.get("x-added")).toBeNull();
+    expect(result!.get("x-middleware-request-x-added")).toBe("1");
+  });
+
+  it("preserves unlisted forwarded values literally alongside valid overrides", () => {
+    const middlewareHeaders = new Headers({
+      "x-middleware-override-headers": "x-added",
+      "x-middleware-request-x-added": "translated",
+      "x-middleware-request-x-stray": "literal",
+    });
+
+    const result = buildRequestHeadersFromMiddlewareResponse(new Headers(), middlewareHeaders);
+
+    expect(result).not.toBeNull();
+    expect(result!.get("x-added")).toBe("translated");
+    expect(result!.get("x-middleware-request-x-added")).toBeNull();
+    expect(result!.get("x-middleware-request-x-stray")).toBe("literal");
   });
 });
 

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -11888,6 +11888,28 @@ describe("middleware request header overrides", () => {
 
     expect(nextRequest.headers.get("x-added")).toBe("original");
     expect(nextRequest.headers.get("x-middleware-request-x-added")).toBe("forged-by-middleware");
+    expect(middlewareHeaders).toEqual({
+      "x-middleware-request-x-added": "forged-by-middleware",
+    });
+  });
+
+  it("config-matchers drops empty unlisted request values", async () => {
+    const { applyMiddlewareRequestHeaders } =
+      await import("../packages/vinext/src/config/config-matchers.js");
+
+    const middlewareHeaders: Record<string, string> = {
+      "x-middleware-request-x-empty": "",
+      "x-middleware-next": "1",
+    };
+    const request = new Request("http://localhost/test", {
+      headers: { "x-original": "kept" },
+    });
+
+    const { request: nextRequest } = applyMiddlewareRequestHeaders(middlewareHeaders, request);
+
+    expect(nextRequest).toBe(request);
+    expect(nextRequest.headers.get("x-original")).toBe("kept");
+    expect(nextRequest.headers.has("x-middleware-request-x-empty")).toBe(false);
     expect(middlewareHeaders).toEqual({});
   });
 

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -11872,6 +11872,25 @@ describe("middleware request header overrides", () => {
     expect(middlewareHeaders).toEqual({});
   });
 
+  it("config-matchers preserves unlisted request values under their literal protocol names", async () => {
+    const { applyMiddlewareRequestHeaders } =
+      await import("../packages/vinext/src/config/config-matchers.js");
+
+    const middlewareHeaders: Record<string, string> = {
+      "x-middleware-request-x-added": "forged-by-middleware",
+      "x-middleware-next": "1",
+    };
+    const request = new Request("http://localhost/test", {
+      headers: { "x-added": "original" },
+    });
+
+    const { request: nextRequest } = applyMiddlewareRequestHeaders(middlewareHeaders, request);
+
+    expect(nextRequest.headers.get("x-added")).toBe("original");
+    expect(nextRequest.headers.get("x-middleware-request-x-added")).toBe("forged-by-middleware");
+    expect(middlewareHeaders).toEqual({});
+  });
+
   it("config-matchers applyMiddlewareRequestHeaders preserves middleware cache opt-out response header", async () => {
     const { applyMiddlewareRequestHeaders } =
       await import("../packages/vinext/src/config/config-matchers.js");

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -4107,6 +4107,7 @@ describe("next/headers shim", () => {
 
     // Simulate middleware updating the cookie header
     const middlewareResponseHeaders = new Headers({
+      "x-middleware-override-headers": "cookie",
       "x-middleware-request-cookie": "a=2; b=3",
     });
 
@@ -4133,6 +4134,7 @@ describe("next/headers shim", () => {
     await runWithHeadersContext(ctx, async () => {
       applyMiddlewareRequestHeaders(
         new Headers({
+          "x-middleware-override-headers": "cookie",
           "x-middleware-request-cookie": "a=1; a=2; b=4",
         }),
       );
@@ -4164,6 +4166,7 @@ describe("next/headers shim", () => {
     await runWithHeadersContext(ctx, async () => {
       applyMiddlewareRequestHeaders(
         new Headers({
+          "x-middleware-override-headers": "cookie",
           "x-middleware-request-cookie": "empty=; flag",
         }),
       );

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -9651,6 +9651,54 @@ describe("double-encoded path handling in middleware", () => {
     }
   });
 
+  it("external middleware rewrite proxy preserves headers for an empty override value", async () => {
+    // NextResponse emits an empty override value for `new Headers()`, and
+    // Next.js skips its request-header mutation block for that falsy value.
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/router-utils/resolve-routes.ts
+    const { NextResponse } = await import("../packages/vinext/src/shims/server.js");
+    const { proxyExternalMiddlewareRewrite } =
+      await import("../packages/vinext/src/server/app-middleware.js");
+    const http = await import("node:http");
+    let capturedHeaders: Record<string, string | string[] | undefined> = {};
+    const server = http.createServer((req, res) => {
+      capturedHeaders = req.headers;
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end("proxied");
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    try {
+      const address = server.address();
+      expect(address && typeof address === "object").toBe(true);
+      const port = address && typeof address === "object" ? address.port : 0;
+      const request = new Request("http://localhost:3000/source", {
+        headers: {
+          authorization: "Bearer secret",
+          cookie: "session=abc",
+          "x-keep": "original",
+        },
+      });
+      const middlewareResponse = NextResponse.rewrite(`http://127.0.0.1:${port}/target`, {
+        request: { headers: new Headers() },
+      });
+
+      expect(middlewareResponse.headers.get("x-middleware-override-headers")).toBe("");
+
+      const response = await proxyExternalMiddlewareRewrite(
+        request,
+        `http://127.0.0.1:${port}/target`,
+        { headers: null, requestHeaders: middlewareResponse.headers, status: null },
+      );
+
+      expect(response.status).toBe(200);
+      expect(capturedHeaders.authorization).toBe("Bearer secret");
+      expect(capturedHeaders.cookie).toBe("session=abc");
+      expect(capturedHeaders["x-keep"]).toBe("original");
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
   it("Pages Router runMiddleware preserves the encoded pathname for middleware", async () => {
     const { runMiddleware } = await import("../packages/vinext/src/server/middleware.js");
     // Create a mock Vite server that returns a middleware module


### PR DESCRIPTION
## Summary

- require a truthy `x-middleware-override-headers` value before translating middleware request-header overrides
- preserve the original logical request headers when the override value is missing or empty
- preserve truthy unconsumed `x-middleware-request-*` values under their literal names on downstream requests and responses; skip empty values
- retain complete-set deletion semantics for every non-empty override list

## Next.js parity

Next.js handles these headers in two stages. The override translation block runs only when `x-middleware-override-headers` is truthy. Its later generic middleware-header merge copies any truthy values that were not consumed by that list under their literal names.

This was confirmed both from source and with a black-box Next.js 16.2.7 App Route repro, which observed the original logical header alongside the literal unconsumed protocol header.

- Producer: https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/spec-extension/response.ts
- Consumer: https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/router-utils/resolve-routes.ts

## Validation

- focused helper, config-matcher, redirect, App Route, Pages, and external-rewrite tests pass
- `vp check` passes for every changed source and test file
- independent sub-agent review: no findings
- all 66 PR checks green