### PR TITLE
fix(create-vinext-app): generate next env on first run

### DIFF
--- a/benchmarks/vinext/tsconfig.json
+++ b/benchmarks/vinext/tsconfig.json
@@ -11,6 +11,7 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "types": ["vinext/types"],
     "paths": {
       "@/*": ["./*"]
     }

--- a/examples/app-router-cloudflare/tsconfig.json
+++ b/examples/app-router-cloudflare/tsconfig.json
@@ -7,7 +7,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "types": ["@cloudflare/workers-types"]
+    "types": ["vinext/types", "@cloudflare/workers-types"]
   },
   "include": ["app", "worker", "*.ts"],
 }

--- a/examples/app-router-nitro/.gitignore
+++ b/examples/app-router-nitro/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .output
 .vercel
+next-env.d.ts

--- a/examples/app-router-nitro/tsconfig.json
+++ b/examples/app-router-nitro/tsconfig.json
@@ -7,7 +7,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "types": []
+    "types": ["vinext/types"]
   },
   "include": ["app", "worker"]
 }

--- a/examples/app-router-playground/.gitignore
+++ b/examples/app-router-playground/.gitignore
@@ -35,4 +35,5 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+next-env.d.ts
 .env*.local

--- a/examples/app-router-playground/tsconfig.json
+++ b/examples/app-router-playground/tsconfig.json
@@ -14,6 +14,7 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "incremental": true,
+    "types": ["vinext/types", "node"],
     "baseUrl": ".",
     "paths": { "#/*": ["./*"] },
     "plugins": [{ "name": "next" }]

--- a/examples/benchmarks/tsconfig.json
+++ b/examples/benchmarks/tsconfig.json
@@ -11,7 +11,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "types": ["@cloudflare/workers-types"]
+    "types": ["vinext/types", "@cloudflare/workers-types"]
   },
   "include": ["app", "worker"]
 }

--- a/examples/hackernews/tsconfig.json
+++ b/examples/hackernews/tsconfig.json
@@ -10,9 +10,7 @@
     "allowJs": true,
     "baseUrl": ".",
     "noEmit": true,
-    "types": [
-      "@cloudflare/workers-types"
-    ]
+    "types": ["vinext/types", "@cloudflare/workers-types"]
   },
   "include": [
     "app",

--- a/examples/nextra-docs-template/tsconfig.json
+++ b/examples/nextra-docs-template/tsconfig.json
@@ -12,7 +12,8 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "types": ["vinext/types", "node"]
   },
   "include": ["**/*.ts", "**/*.tsx", "**/*.mdx"],
   "exclude": ["node_modules"]

--- a/examples/pages-router-cloudflare/tsconfig.json
+++ b/examples/pages-router-cloudflare/tsconfig.json
@@ -7,7 +7,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "types": ["@cloudflare/workers-types"]
+    "types": ["vinext/types", "@cloudflare/workers-types"]
   },
   "include": ["next-env.d.ts", "pages", "components", "worker"]
 }

--- a/examples/realworld-api-rest/tsconfig.json
+++ b/examples/realworld-api-rest/tsconfig.json
@@ -12,7 +12,8 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "types": ["vinext/types", "node"]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]

--- a/examples/tpr-demo/tsconfig.json
+++ b/examples/tpr-demo/tsconfig.json
@@ -9,7 +9,8 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "types": ["vinext/types", "node"]
   },
   "include": ["app/**/*", "scripts/**/*"],
   "exclude": ["node_modules"]

--- a/examples/workers-cache/tsconfig.json
+++ b/examples/workers-cache/tsconfig.json
@@ -7,7 +7,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "types": ["@cloudflare/workers-types"]
+    "types": ["vinext/types", "@cloudflare/workers-types"]
   },
   "include": ["app", "worker", "*.ts"]
 }

--- a/packages/create-vinext-app/src/index.ts
+++ b/packages/create-vinext-app/src/index.ts
@@ -6,7 +6,6 @@ import type { Readable, Writable } from "node:stream";
 // Runtime imports use source paths so the create package bundles the shared init implementation.
 import { init } from "../../vinext/src/init";
 import { resolveInitOptions } from "../../vinext/src/init-platform";
-import { nextEnvFileContent } from "../../vinext/src/typegen";
 
 type PackageManagerName = "npm" | "pnpm" | "yarn" | "bun";
 type InitPlatform = "cloudflare" | "node";
@@ -208,8 +207,8 @@ export default function Home() {
     ".gitignore": `node_modules
 .env*
 .next
+next-env.d.ts
 `,
-    "next-env.d.ts": nextEnvFileContent(false, true),
     "next.config.ts": `import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {};
@@ -250,6 +249,7 @@ ${isCloudflare ? "- `pnpm run deploy` deploys the Cloudflare Worker.\n" : ""}
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    "types": ["vinext/types", "node"],
     "paths": {
       "@/*": ["./*"]
     }
@@ -444,36 +444,6 @@ function tryGitInit(root: string): boolean {
   return result.status === 0;
 }
 
-async function runTypegen(
-  root: string,
-  packageManager: PackageManagerName,
-  exec?: CreateVinextAppOptions["_exec"],
-): Promise<void> {
-  const [command, args] = (() => {
-    switch (packageManager) {
-      case "npm":
-        return ["npm", ["exec", "--", "vinext", "typegen"]] as const;
-      case "bun":
-        return ["bun", ["run", "vinext", "typegen"]] as const;
-      case "pnpm":
-      case "yarn":
-        return [packageManager, ["exec", "vinext", "typegen"]] as const;
-      default:
-        return [packageManager, ["exec", "vinext", "typegen"]] as const;
-    }
-  })();
-
-  if (exec) {
-    await exec([command, ...args].join(" "), { cwd: root, stdio: "inherit" });
-    return;
-  }
-
-  const result = spawnSync(command, args, { cwd: root, stdio: "inherit" });
-  if (result.status !== 0) {
-    throw new Error(`vinext typegen exited with code ${result.status ?? "unknown"}`);
-  }
-}
-
 export async function createVinextApp(options: CreateVinextAppOptions): Promise<void> {
   const root = path.resolve(options.appPath);
   const appName = path.basename(root);
@@ -498,14 +468,6 @@ export async function createVinextApp(options: CreateVinextAppOptions): Promise<
     ...options.initOptions,
     scriptNames: "standard",
   });
-
-  if (options.install ?? true) {
-    try {
-      await runTypegen(root, options.packageManager, options._exec);
-    } catch (error) {
-      console.error("Error running typegen:", error);
-    }
-  }
 
   if (options.git === false) {
     console.log("Skipping git initialization.\n");

--- a/packages/vinext/src/typegen.ts
+++ b/packages/vinext/src/typegen.ts
@@ -23,7 +23,7 @@ export type GenerateRouteTypesResult = {
 
 type ParamShape = Map<string, "string" | "string[]" | "string[]?">;
 
-export function nextEnvFileContent(hasNext: boolean, hasAppDir: boolean, eol = "\n"): string {
+function nextEnvFileContent(hasNext: boolean, hasAppDir: boolean, eol = "\n"): string {
   const typeReference = hasNext
     ? `/// <reference types="next" />
 /// <reference types="next/image-types/global" />

--- a/tests/create-vinext-app.test.ts
+++ b/tests/create-vinext-app.test.ts
@@ -1,8 +1,13 @@
+import { createServer, type ViteDevServer } from "vite-plus";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vite-plus/test";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
+import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { createVinextApp, runCreateVinextAppCli } from "../packages/create-vinext-app/src/index.js";
+import vinext from "../packages/vinext/src/index.js";
 import type { ResolvedInitOptions } from "../packages/vinext/src/init-platform.js";
 
 let tmpDir: string;
@@ -22,6 +27,44 @@ function readPkg(dir: string): {
   packageManager?: string;
 } {
   return JSON.parse(readFile(dir, "package.json"));
+}
+
+function linkInstalledPackage(root: string, packageName: string): void {
+  const vinextRequire = createRequire(new URL("../packages/vinext/package.json", import.meta.url));
+  let packageRoot =
+    packageName === "vinext" || packageName === "@vinext/types"
+      ? fileURLToPath(
+          new URL(
+            packageName === "vinext" ? "../packages/vinext" : "../packages/types",
+            import.meta.url,
+          ),
+        )
+      : packageName === "@vitejs/plugin-react"
+        ? path.dirname(vinextRequire.resolve(packageName))
+        : path.dirname(fileURLToPath(import.meta.resolve(`${packageName}/package.json`)));
+  while (!fs.existsSync(path.join(packageRoot, "package.json"))) {
+    const parent = path.dirname(packageRoot);
+    if (parent === packageRoot) throw new Error(`Could not find package root for ${packageName}`);
+    packageRoot = parent;
+  }
+  const linkPath = path.join(root, "node_modules", packageName);
+  fs.mkdirSync(path.dirname(linkPath), { recursive: true });
+  fs.symlinkSync(packageRoot, linkPath, process.platform === "win32" ? "junction" : "dir");
+}
+
+async function eventually(run: () => Promise<void>, timeoutMs = 3_000): Promise<void> {
+  const start = Date.now();
+  let lastError: unknown;
+  while (Date.now() - start < timeoutMs) {
+    try {
+      await run();
+      return;
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  }
+  throw lastError;
 }
 
 const cloudflareInitOptions: ResolvedInitOptions = {
@@ -92,6 +135,13 @@ describe("createVinextApp", () => {
     expect(readFile(appPath, "vite.config.ts")).toContain("@cloudflare/vite-plugin");
     expect(readFile(appPath, "wrangler.jsonc")).toContain('"main": "vinext/server/fetch-handler"');
     expect(readFile(appPath, ".gitignore")).toContain(".wrangler/");
+    expect(readFile(appPath, ".gitignore")).toContain("next-env.d.ts");
+    expect(fs.existsSync(path.join(appPath, "next-env.d.ts"))).toBe(false);
+
+    const tsconfig = JSON.parse(readFile(appPath, "tsconfig.json")) as {
+      compilerOptions: { types: string[] };
+    };
+    expect(tsconfig.compilerOptions.types).toEqual(["vinext/types", "node"]);
 
     const pkg = readPkg(appPath);
     expect(pkg.scripts).toEqual({
@@ -108,8 +158,6 @@ describe("createVinextApp", () => {
       "@vinext/cloudflare": "latest",
     });
     expect(pkg.dependencies).not.toHaveProperty("next");
-    expect(readFile(appPath, "next-env.d.ts")).toContain('import "vinext/types";');
-    expect(readFile(appPath, "next-env.d.ts")).toContain('import "./.next/types/routes.d.ts";');
     expect(readFile(appPath, "tsconfig.json")).not.toContain('"name": "next"');
     expect(pkg.scripts).not.toHaveProperty("postinstall");
     expect(pkg.devDependencies).toMatchObject({
@@ -142,7 +190,7 @@ describe("createVinextApp", () => {
     expect(pkg.scripts?.deploy).toBe("vinext-cloudflare deploy --config dist/server/wrangler.json");
   });
 
-  it("uses the selected package manager through the shared init install path", async () => {
+  it("uses the selected package manager without installing Next.js", async () => {
     const appPath = path.join(tmpDir, "install-app");
     const calls: string[] = [];
 
@@ -164,52 +212,86 @@ describe("createVinextApp", () => {
     expect(calls).toContain(
       "pnpm add -D vite @vitejs/plugin-react @vitejs/plugin-rsc @cloudflare/vite-plugin wrangler",
     );
-    expect(calls).toContain("pnpm exec vinext typegen");
+    expect(calls.some((command) => command.split(/\s+/).includes("next"))).toBe(false);
+    expect(calls.some((command) => command.includes("typegen"))).toBe(false);
   });
 
-  it.each([
-    ["npm", "npm exec -- vinext typegen"],
-    ["pnpm", "pnpm exec vinext typegen"],
-    ["yarn", "yarn exec vinext typegen"],
-    ["bun", "bun run vinext typegen"],
-  ] as const)("runs typegen through the %s binary runner", async (packageManager, expected) => {
-    const appPath = path.join(tmpDir, `${packageManager}-app`);
-    const calls: string[] = [];
+  it("type-checks a Next-less generated app before vinext first runs", async () => {
+    const appPath = path.join(tmpDir, "typecheck-app");
 
     await withQuietConsole(() =>
       createVinextApp({
         appPath,
-        packageManager,
-        install: true,
+        packageManager: "npm",
+        install: false,
         git: false,
         initOptions: nodeInitOptions,
-        _exec: (cmd) => {
-          calls.push(cmd);
-        },
       }),
     );
 
-    expect(calls).toContain(expected);
+    expect(fs.existsSync(path.join(appPath, "next-env.d.ts"))).toBe(false);
+    for (const packageName of [
+      "vinext",
+      "@vinext/types",
+      "@types/node",
+      "@types/react",
+      "@types/react-dom",
+      "@vitejs/plugin-react",
+      "@vitejs/plugin-rsc",
+      "react",
+      "react-dom",
+      "vite",
+    ]) {
+      linkInstalledPackage(appPath, packageName);
+    }
+
+    const tscPath = fileURLToPath(
+      new URL("bin/tsc", import.meta.resolve("typescript/package.json")),
+    );
+    const result = spawnSync(process.execPath, [tscPath, "--project", "tsconfig.json"], {
+      cwd: appPath,
+      encoding: "utf-8",
+    });
+    if (result.error) throw result.error;
+
+    expect(`${result.stdout ?? ""}${result.stderr ?? ""}`).toBe("");
+    expect(result.status).toBe(0);
+    expect(fs.existsSync(path.join(appPath, "node_modules/next"))).toBe(false);
+    expect(fs.existsSync(path.join(appPath, "next-env.d.ts"))).toBe(false);
   });
 
-  it("falls back to separator-free exec for an unknown package manager", async () => {
-    const appPath = path.join(tmpDir, "future-pm-app");
-    const calls: string[] = [];
+  // Next.js regenerates next-env.d.ts when the dev server starts:
+  // test/development/typescript-app-type-declarations/typescript-app-type-declarations.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/development/typescript-app-type-declarations/typescript-app-type-declarations.test.ts
+  it("generates next-env.d.ts when vinext starts", async () => {
+    const appPath = path.join(tmpDir, "dev-app");
+    let server: ViteDevServer | null = null;
 
     await withQuietConsole(() =>
       createVinextApp({
         appPath,
-        packageManager: "future-pm" as never,
-        install: true,
+        packageManager: "npm",
+        install: false,
         git: false,
         initOptions: nodeInitOptions,
-        _exec: (cmd) => {
-          calls.push(cmd);
-        },
       }),
     );
+    expect(fs.existsSync(path.join(appPath, "next-env.d.ts"))).toBe(false);
 
-    expect(calls).toContain("future-pm exec vinext typegen");
+    try {
+      server = await createServer({
+        root: appPath,
+        configFile: false,
+        logLevel: "silent",
+        plugins: [vinext({ appDir: appPath, rsc: false })],
+      });
+      await eventually(async () => {
+        expect(readFile(appPath, "next-env.d.ts")).toContain('import "vinext/types";');
+      });
+      expect(readFile(appPath, "next-env.d.ts")).toContain('import "./.next/types/routes.d.ts";');
+    } finally {
+      await server?.close();
+    }
   });
 
   it("does not include Cloudflare Workers copy for the Node target", async () => {


### PR DESCRIPTION
## Summary

- omit generated `next-env.d.ts` from the scaffold and ignore it until vinext dev/build creates it
- load `vinext/types` before first run while preserving Node and platform type entries
- update existing Next-less apps and add regression coverage for typechecking, generation, and dependency installation

## Testing

- `vp check --fix`
- `vp test run tests/create-vinext-app.test.ts tests/typegen.test.ts tests/init.test.ts`
- `vp run create-vinext-app#build`