### PR TITLE
test(pages): enable complex shallow routing coverage

### DIFF
--- a/examples/pages-router-complex/README.md
+++ b/examples/pages-router-complex/README.md
@@ -98,12 +98,11 @@ PLAYWRIGHT_PROJECT=pages-router-complex pnpm run test:e2e
   degrades under it, so the `@atlas/*` alias is wired into both bundlers
   explicitly (webpack hook + Vite `resolve.alias`); tsconfig `paths` (without
   the removed `baseUrl`) stays authoritative for the type checker.
-- **vinext dev (Cloudflare plugin): 59/73 specs pass; the 14 known gaps are
+- **vinext dev (Cloudflare plugin): 62/73 specs pass; the 11 known gaps are
   marked `test.fixme` so the passing surface runs in CI.** Known gaps:
   `generateBuildId` is invoked at dev startup (Next.js only calls it at build
-  time — the e2e server exports `RELEASE_TAG` to compensate), shallow routing
-  + `router.events` (including a hydration knock-on that breaks page
-  interactivity), the `next/image` custom-loader/`fill` path, raw
+  time — the e2e server exports `RELEASE_TAG` to compensate), the `next/image`
+  custom-loader/`fill` path, raw
   `/_next/data` interception and the `/_next/image` 403 middleware branches,
   the `history.replaceState`-beside-the-router hybrid, the gallery scrub
   redirect, cacheable-404 surrogate headers, the `afterFiles` type-ahead

--- a/examples/pages-router-complex/pages/[zone]/gallery/[...facets].page.tsx
+++ b/examples/pages-router-complex/pages/[zone]/gallery/[...facets].page.tsx
@@ -43,7 +43,7 @@ export type GalleryWallProps = PageLiftedProps & {
 
 export type GalleryWallComponentProps = Omit<
   GalleryWallProps,
-  "lifted" | "graphSnapshot" | "edgeProbeData"
+  "graphSnapshot" | "edgeProbeData"
 >;
 
 const SORT_ORDERS = ["featured", "newest", "alpha"] as const;
@@ -62,7 +62,7 @@ const orderAssets = (assets: AssetCard[], sort: SortOrder): AssetCard[] => {
   }
 };
 
-const GalleryWall = ({ wallPath, startPage }: GalleryWallComponentProps) => {
+const GalleryWall = ({ wallPath, startPage, lifted }: GalleryWallComponentProps) => {
   const router = useRouter();
   const leaf = wallPath.split("/").filter(Boolean)[1] ?? "";
   const node = useGraphOp<TopicNode>("nodeByTrail", { trail: leaf });
@@ -109,6 +109,7 @@ const GalleryWall = ({ wallPath, startPage }: GalleryWallComponentProps) => {
         data-start-page={startPage}
         data-sort={sort}
         data-from-snapshot={node.fromSnapshot}
+        data-rendered-at-ms={lifted.renderedAtMs}
       >
         <h1>Wall: {node.data?.name ?? "…"}</h1>
         <label>

--- a/tests/e2e/pages-router-complex/client-routing.spec.ts
+++ b/tests/e2e/pages-router-complex/client-routing.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 
 type BeaconWindow = Window & {
   __ATLAS_BEACONS__?: { name: string; attributes: Record<string, unknown> }[];
@@ -6,18 +6,26 @@ type BeaconWindow = Window & {
   __nav_marker__?: boolean;
 };
 
+const waitForHydration = (page: Page) =>
+  expect(page.locator('[data-testid="helper-dock"]')).toBeVisible();
+
 /**
  * Client-side routing behaviours: shallow router.push with the internal
  * dynamic-route pattern, router.events subscriptions, and the trial-mark
  * reset hook built on next/compat/router.
+ *
+ * Next.js parity references:
+ * https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-rewrites/test/index.test.ts
+ * https://github.com/vercel/next.js/blob/canary/test/e2e/basepath/router-events.test.ts
  */
 test.describe("shallow routing and router events", () => {
-  test.fixme("changing sort shallow-navigates without re-running gSSP", async ({ page }) => {
+  test("changing sort shallow-navigates without re-running gSSP", async ({ page }) => {
     await page.goto("/gallery/skies/clips");
     await expect(page.locator('[data-testid="gallery-wall"]')).toHaveAttribute(
       "data-sort",
       "featured",
     );
+    await waitForHydration(page);
 
     // Plant a marker: a shallow transition must NOT be a full document load.
     await page.evaluate(() => {
@@ -40,10 +48,11 @@ test.describe("shallow routing and router events", () => {
     expect(titles).toEqual([...titles].sort((a, b) => a.localeCompare(b)));
   });
 
-  test.fixme("shallow transitions fire router events observed by the progress frame", async ({
+  test("shallow transitions fire router events observed by the progress frame", async ({
     page,
   }) => {
     await page.goto("/gallery/skies/clips");
+    await waitForHydration(page);
     await expect(page.locator('[data-testid="route-progress"]')).toBeVisible();
 
     await page.locator('[data-testid="wall-sort"]').selectOption("newest");
@@ -60,8 +69,9 @@ test.describe("shallow routing and router events", () => {
     expect(phases.indexOf("start")).toBeLessThan(phases.indexOf("complete"));
   });
 
-  test.fixme("route changes reset the per-page trial marks", async ({ page }) => {
+  test("route changes reset the per-page trial marks", async ({ page }) => {
     await page.goto("/gallery/skies/clips");
+    await waitForHydration(page);
     await page.evaluate(() => {
       (window as BeaconWindow).__ATLAS_TRIALS_ACTIVE__ = ["stale-flag"];
     });

--- a/tests/e2e/pages-router-complex/client-routing.spec.ts
+++ b/tests/e2e/pages-router-complex/client-routing.spec.ts
@@ -26,6 +26,12 @@ test.describe("shallow routing and router events", () => {
       "featured",
     );
     await waitForHydration(page);
+    const renderedAtMs = await page
+      .locator('[data-testid="gallery-wall"]')
+      .getAttribute("data-rendered-at-ms");
+    if (!renderedAtMs) {
+      throw new Error("gallery wall did not expose its gSSP render timestamp");
+    }
 
     // Plant a marker: a shallow transition must NOT be a full document load.
     await page.evaluate(() => {
@@ -38,6 +44,10 @@ test.describe("shallow routing and router events", () => {
     await expect(page.locator('[data-testid="gallery-wall"]')).toHaveAttribute(
       "data-sort",
       "alpha",
+    );
+    await expect(page.locator('[data-testid="gallery-wall"]')).toHaveAttribute(
+      "data-rendered-at-ms",
+      renderedAtMs,
     );
 
     const marker = await page.evaluate(() => (window as BeaconWindow).__nav_marker__);


### PR DESCRIPTION
## Summary

- wait for the pages-router-complex client-only hydration sentinel before exercising controlled inputs
- enable the shallow routing, router event, and compat-router trial reset tests
- assert the gSSP-derived render timestamp stays stable across the shallow transition
- link the relevant Next.js parity tests and update the documented pass count

All three former fixmes shared one cause on current `main`: Playwright could change the server-rendered `<select>` before React attached its `onChange` handler. The shallow router behavior itself now matches Next.js.

## Validation

- `vp check tests/e2e/pages-router-complex/client-routing.spec.ts`
- negative control: changing the fixture call to `{ shallow: false }` fails on the render timestamp changing
- `PLAYWRIGHT_PROJECT=pages-router-complex pnpm exec playwright test tests/e2e/pages-router-complex/client-routing.spec.ts --retries=0 --reporter=line` (4 passed)
- `PLAYWRIGHT_PROJECT=pages-router-complex pnpm exec playwright test --retries=0 --reporter=line` (62 passed, 11 unrelated skipped)