### PR TITLE
fix(pages): support bodyless API responses

### DIFF
--- a/packages/vinext/src/server/pages-node-compat.ts
+++ b/packages/vinext/src/server/pages-node-compat.ts
@@ -14,6 +14,9 @@ import {
 } from "./pages-preview.js";
 
 const MAX_PAGES_API_BODY_SIZE = DEFAULT_PAGES_API_BODY_SIZE_LIMIT;
+// Next.js's Node sendData() strips bodies for 204/304. Fetch additionally
+// forbids a body for 205, so the Worker adapter must normalize that status too.
+const NO_BODY_RESPONSE_STATUSES = new Set([204, 205, 304]);
 
 /**
  * @deprecated Use PagesBodyParseError from pages-media-type.ts instead.
@@ -255,6 +258,7 @@ class PagesResponseStream extends Writable {
   private readonly bufferedChunks: Buffer[] = [];
   private streamEnded = false;
   private pendingWrite: ((error?: Error | null) => void) | null = null;
+  private discardBody = false;
 
   constructor(
     private readonly resolveResponse: (value: Response) => void,
@@ -395,6 +399,10 @@ class PagesResponseStream extends Writable {
     encoding: BufferEncoding,
     callback: (error?: Error | null) => void,
   ): void {
+    if (this.discardBody) {
+      callback();
+      return;
+    }
     const buffer = typeof chunk === "string" ? Buffer.from(chunk, encoding) : Buffer.from(chunk);
     if (this.controller && !this.streamEnded) {
       try {
@@ -502,6 +510,20 @@ class PagesResponseStream extends Writable {
     }
     for (const cookie of this.setCookieHeaders) {
       headers.append("set-cookie", cookie);
+    }
+
+    // Fetch rejects a Response that pairs 204/205/304 with any body, including
+    // an empty ReadableStream. Node's ServerResponse accepts `res.status(204).end()`,
+    // so preserve that API while matching Next.js's sendData() cleanup for
+    // bodyless statuses.
+    if (NO_BODY_RESPONSE_STATUSES.has(this.resStatusCode)) {
+      this.discardBody = true;
+      this.bufferedChunks.length = 0;
+      headers.delete("content-length");
+      headers.delete("content-type");
+      headers.delete("transfer-encoding");
+      this.resolveResponse(new Response(null, { status: this.resStatusCode, headers }));
+      return;
     }
 
     const stream = new ReadableStream({

--- a/tests/e2e/pages-router-complex/cache-policy.spec.ts
+++ b/tests/e2e/pages-router-complex/cache-policy.spec.ts
@@ -35,13 +35,13 @@ test.describe("surrogate cache policy", () => {
     expect(response.headers()["surrogate-control"]).toBe("no-store, delta=noop");
   });
 
-  test.fixme("type-ahead shim answers 204 with cache headers, including via the legacy rewrite", async ({
+  test("type-ahead shim answers 204 with cache headers, including via the legacy rewrite", async ({
     request,
   }) => {
     for (const path of ["/api/type-ahead", "/legacy/gateway/type-ahead"]) {
       const response = await request.get(path);
-      expect(response.status()).toBe(204);
-      expect(response.headers()["surrogate-control"]).toBe("max-age=14400s, delta=noop");
+      expect(response.status(), path).toBe(204);
+      expect(response.headers()["surrogate-control"], path).toBe("max-age=14400s, delta=noop");
     }
   });
 });

--- a/tests/pages-node-compat.test.ts
+++ b/tests/pages-node-compat.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vite-plus/test";
+import { once } from "node:events";
 import {
   createPagesReqRes,
   getPagesPreviewData,
@@ -67,6 +68,41 @@ void previewDataValues;
 void nextApiHandler;
 
 describe("Pages Node compat response", () => {
+  it.each([204, 205, 304])(
+    "creates a bodyless %i response while preserving custom headers",
+    async (status) => {
+      // Ported from Next.js: test/e2e/api-support/pages/api/status-204.js
+      // https://github.com/vercel/next.js/blob/canary/test/e2e/api-support/pages/api/status-204.js
+      const { res, responsePromise } = createPagesReqRes({
+        body: undefined,
+        query: {},
+        request: new Request("https://example.test/api/status-204"),
+        url: "/api/status-204",
+      });
+
+      res.setHeader("Surrogate-Control", "max-age=14400");
+      res.setHeader("Content-Type", "text/plain");
+      res.setHeader("Content-Length", "18");
+      res.setHeader("Transfer-Encoding", "chunked");
+      res.status(status);
+      const finished = once(res, "finish");
+      res.write("discard-one");
+      res.write("discard-two");
+      res.end("discard-three");
+
+      const response = await responsePromise;
+      expect(response.status).toBe(status);
+      expect(response.headers.get("surrogate-control")).toBe("max-age=14400");
+      expect(response.headers.get("content-type")).toBeNull();
+      expect(response.headers.get("content-length")).toBeNull();
+      expect(response.headers.get("transfer-encoding")).toBeNull();
+      expect(response.body).toBeNull();
+      await expect(response.text()).resolves.toBe("");
+      await finished;
+      expect((res as unknown as { bufferedChunks: Buffer[] }).bufferedChunks).toHaveLength(0);
+    },
+  );
+
   it("does not expose process environment variables on the request", () => {
     const previousValue = process.env.VINEXT_API_REQUEST_ENV_TEST;
     process.env.VINEXT_API_REQUEST_ENV_TEST = "secret";


### PR DESCRIPTION
## Summary

- construct bodyless Fetch responses for Pages API 204, 205, and 304 statuses
- discard all attempted body writes and strip body-only headers while preserving custom response headers
- enable the pages-router-complex 204 cache-policy coverage for direct and `afterFiles`-rewritten requests

## Next.js parity

Next.js strips the body and body-specific headers for 204/304 API responses in [`api-resolver.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/api-utils/node/api-resolver.ts), with upstream 204 coverage in [`test/e2e/api-support/pages/api/status-204.js`](https://github.com/vercel/next.js/blob/canary/test/e2e/api-support/pages/api/status-204.js). Fetch additionally forbids bodies on 205, so the Worker adapter normalizes that status too. The legacy rewrite assertion also matches upstream `afterFiles` routing coverage in [`test/e2e/custom-routes/custom-routes.test.ts`](https://github.com/vercel/next.js/blob/canary/test/e2e/custom-routes/custom-routes.test.ts).

## Validation

- `vp test run tests/pages-node-compat.test.ts tests/pages-api-route.test.ts` (54 passed)
- `vp check packages/vinext/src/server/pages-node-compat.ts tests/pages-node-compat.test.ts tests/e2e/pages-router-complex/cache-policy.spec.ts`
- isolated pages-router-complex type-ahead E2E against this worktree server (1 passed, direct + afterFiles rewrite)
- independent re-review: no findings