### PR TITLE
fix(pages): preserve not-found response headers

### DIFF
--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -367,6 +367,11 @@ function writeGsspRedirect(
 /** Body placeholder used to split the document shell for streaming. */
 const STREAM_BODY_MARKER = "<!--VINEXT_STREAM_BODY-->";
 
+function stripDevPagesNotFoundFramingHeaders(res: ServerResponse): void {
+  res.removeHeader("Content-Length");
+  res.removeHeader("Transfer-Encoding");
+}
+
 /**
  * Stream a Pages Router page response using progressive SSR.
  *
@@ -422,6 +427,8 @@ async function streamPageToResponse(
     crossOrigin?: string;
     /** Buffer the body before writing headers so error-page fallback remains safe. */
     bufferBodyBeforeHeaders?: boolean;
+    /** Keep a response Content-Type set before rendering a notFound page. */
+    preserveExistingContentType?: boolean;
   },
 ): Promise<void> {
   const {
@@ -440,6 +447,7 @@ async function streamPageToResponse(
     setDocumentInitialHead,
     crossOrigin,
     bufferBodyBeforeHeaders = false,
+    preserveExistingContentType = false,
   } = options;
 
   // Custom `_document.getInitialProps()` may opt in to wrapping the page tree
@@ -595,10 +603,10 @@ async function streamPageToResponse(
   // Set array-valued headers (e.g. Set-Cookie from gSSP) via setHeader()
   // before writeHead(), since writeHead()'s headers object doesn't handle
   // arrays portably. Then writeHead() merges with any setHeader() calls.
-  const headers: Record<string, string> = {
-    "Content-Type": "text/html; charset=utf-8",
-    "Transfer-Encoding": "chunked",
-  };
+  const headers: Record<string, string> = { "Transfer-Encoding": "chunked" };
+  if (!preserveExistingContentType || !res.hasHeader("Content-Type")) {
+    headers["Content-Type"] = "text/html; charset=utf-8";
+  }
   if (extraHeaders) {
     for (const [key, val] of Object.entries(extraHeaders)) {
       if (Array.isArray(val)) {
@@ -1231,11 +1239,14 @@ export function createSSRHandler(
               // `_next/data` notFound exits for deployment-skew protection. Fixes #1829.
               const deploymentId =
                 process.env.__VINEXT_DEPLOYMENT_ID || process.env.NEXT_DEPLOYMENT_ID;
-              const notFoundHeaders: Record<string, string> = {
-                "Content-Type": "application/json",
-              };
-              if (deploymentId) notFoundHeaders[NEXTJS_DEPLOYMENT_ID_HEADER] = deploymentId;
-              res.writeHead(404, notFoundHeaders);
+              stripDevPagesNotFoundFramingHeaders(res);
+              if (!res.hasHeader("Content-Type")) {
+                res.setHeader("Content-Type", "application/json");
+              }
+              if (deploymentId && !res.hasHeader(NEXTJS_DEPLOYMENT_ID_HEADER)) {
+                res.setHeader(NEXTJS_DEPLOYMENT_ID_HEADER, deploymentId);
+              }
+              res.writeHead(404);
               res.end('{"notFound":true}');
               return;
             }
@@ -2060,6 +2071,7 @@ async function renderErrorPage(
         setPagePatternsFromNextData: true,
       });
       const errorScripts = `${errorNextDataScript}\n${errorHydrationScript}`;
+      if (statusCode === 404) stripDevPagesNotFoundFramingHeaders(res);
       if (DocumentComponent) {
         await streamPageToResponse(res, element, {
           url,
@@ -2095,6 +2107,7 @@ async function renderErrorPage(
               ? headShim.setDocumentInitialHead
               : undefined,
           crossOrigin: context.crossOrigin,
+          preserveExistingContentType: statusCode === 404,
         });
       } else {
         const bodyHtml = await renderToStringAsync(element);
@@ -2133,7 +2146,12 @@ async function renderErrorPage(
           ),
           protectedAssetMarker,
         );
-        res.writeHead(statusCode, { "Content-Type": "text/html; charset=utf-8" });
+        res.writeHead(
+          statusCode,
+          statusCode === 404 && res.hasHeader("Content-Type")
+            ? undefined
+            : { "Content-Type": "text/html; charset=utf-8" },
+        );
         res.end(transformedHtml);
       }
       return;

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -402,6 +402,8 @@ type ResolvePagesPageDataResponseResult = {
 
 type ResolvePagesPageDataNotFoundResult = {
   kind: "notFound";
+  /** Headers set by getServerSideProps before it returned notFound. */
+  responseHeaders?: Record<string, string | number | boolean | string[]>;
   /** Current getStaticProps cache lifetime, when this is an SSG result. */
   revalidateSeconds?: number | false;
   expireSeconds?: number;
@@ -433,15 +435,51 @@ function buildPagesNotFoundResult(
   revalidateSeconds?: number | false,
   cacheState?: "MISS" | "HIT" | "STALE",
   expireSeconds?: number,
+  responseHeaders?: Record<string, string | number | boolean | string[]>,
 ): ResolvePagesPageDataResponseResult | ResolvePagesPageDataNotFoundResult {
   if (options.isDataReq) {
     return {
       kind: "response",
-      response: buildPagesDataNotFoundResponse(options.deploymentId),
+      response: mergePagesNotFoundSourceHeaders(
+        buildPagesDataNotFoundResponse(options.deploymentId),
+        responseHeaders,
+      ),
     };
   }
 
-  return { kind: "notFound", revalidateSeconds, expireSeconds, cacheState };
+  return {
+    kind: "notFound",
+    revalidateSeconds,
+    expireSeconds,
+    cacheState,
+    responseHeaders,
+  };
+}
+
+export function mergePagesNotFoundSourceHeaders(
+  response: Response,
+  sourceHeaders: Record<string, string | number | boolean | string[]> | undefined,
+): Response {
+  if (!sourceHeaders) return response;
+
+  const headers = new Headers(response.headers);
+
+  for (const [name, value] of Object.entries(sourceHeaders)) {
+    const lowerName = name.toLowerCase();
+    if (lowerName === "set-cookie") {
+      headers.delete("set-cookie");
+      const cookies = Array.isArray(value) ? value : [value];
+      for (const cookie of cookies) headers.append("set-cookie", String(cookie));
+    } else {
+      headers.set(name, Array.isArray(value) ? value.join(", ") : String(value));
+    }
+  }
+
+  return new Response(response.body, {
+    headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
 }
 
 function applyPagesTerminalMissHeaders(
@@ -1323,7 +1361,14 @@ export async function resolvePagesPageData(
     }
 
     if (result?.notFound) {
-      return buildPagesNotFoundResult(options);
+      const responseHeaders = res.getHeaders();
+      return buildPagesNotFoundResult(
+        options,
+        undefined,
+        undefined,
+        undefined,
+        Object.keys(responseHeaders).length > 0 ? responseHeaders : undefined,
+      );
     }
 
     // Mirrors Next.js render.tsx's `isSerializableProps(pathname, "getServerSideProps", data.props)`

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -24,7 +24,7 @@ import {
   type PagesPreviewState,
 } from "./pages-preview.js";
 import { hasUserDocumentGetInitialProps } from "./document-initial-head.js";
-import { resolvePagesPageData } from "./pages-page-data.js";
+import { mergePagesNotFoundSourceHeaders, resolvePagesPageData } from "./pages-page-data.js";
 import type { PagesPageModule } from "./pages-page-data.js";
 import { resolvePagesPageMethodResponse } from "./pages-page-method.js";
 import { renderPagesPageResponse } from "./pages-page-response.js";
@@ -105,6 +105,20 @@ function withPagesCacheState(
   } else {
     setCacheStateHeaders(headers, state);
   }
+  return new Response(response.body, {
+    headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
+}
+
+function stripPagesNotFoundFramingHeaders(response: Response): Response {
+  if (!response.headers.has("Content-Length") && !response.headers.has("Transfer-Encoding")) {
+    return response;
+  }
+  const headers = new Headers(response.headers);
+  headers.delete("Content-Length");
+  headers.delete("Transfer-Encoding");
   return new Response(response.body, {
     headers,
     status: response.status,
@@ -318,6 +332,8 @@ type RenderPageOptions = {
   __notFoundExpireSeconds?: number;
   /** Source-page identity used for the outgoing notFound cache tag. */
   __notFoundCachePathname?: string;
+  /** Source gSSP headers that seed the recursively rendered notFound page. */
+  __notFoundSourceHeaders?: Record<string, string | number | boolean | string[]>;
   /** Internal recursion guard while a top-level on-demand request owns the batch. */
   __skipOnDemandCoalesce?: boolean;
   err?: unknown;
@@ -782,6 +798,11 @@ export function createPagesPageHandler(
           if (typeof renderStatusCode === "number") {
             reqRes.res.statusCode = renderStatusCode;
           }
+          if (options?.__notFoundSourceHeaders) {
+            for (const [name, value] of Object.entries(options.__notFoundSourceHeaders)) {
+              reqRes.res.setHeader(name, value);
+            }
+          }
           return reqRes;
         };
 
@@ -888,10 +909,15 @@ export function createPagesPageHandler(
               __notFoundRevalidateSeconds: pageDataResult.revalidateSeconds,
               __notFoundExpireSeconds: pageDataResult.expireSeconds,
               __notFoundCachePathname: isrCachePathname,
+              __notFoundSourceHeaders: pageDataResult.responseHeaders,
             });
           } else {
-            notFoundResponse = buildDefaultPagesNotFoundResponse();
+            notFoundResponse = mergePagesNotFoundSourceHeaders(
+              buildDefaultPagesNotFoundResponse(),
+              pageDataResult.responseHeaders,
+            );
           }
+          notFoundResponse = stripPagesNotFoundFramingHeaders(notFoundResponse);
 
           if (isOnDemandRevalidate) {
             notFoundResponse = withPagesCacheState(notFoundResponse, "REVALIDATED");
@@ -929,7 +955,7 @@ export function createPagesPageHandler(
         }
         const gsspRes = pageDataResult.gsspRes;
         const documentReqRes =
-          serializedPagesNextData.autoExport === true
+          serializedPagesNextData.autoExport === true && !options?.__notFoundSourceHeaders
             ? null
             : (pageDataResult.documentReqRes ?? createPageReqRes());
         // The error page keeps its own ISR policy and cache identity. A source

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -485,7 +485,9 @@ function applyGsspHeaders(
       headers.set(key, String(value));
     }
   }
-  headers.set("Content-Type", "text/html; charset=utf-8");
+  if (!headers.has("Content-Type")) {
+    headers.set("Content-Type", "text/html; charset=utf-8");
+  }
   return statusCode ?? gsspRes.statusCode;
 }
 

--- a/tests/e2e/pages-router-complex/cache-policy.spec.ts
+++ b/tests/e2e/pages-router-complex/cache-policy.spec.ts
@@ -19,7 +19,7 @@ test.describe("surrogate cache policy", () => {
     expect(standard.headers()["surrogate-control"]).toBe("max-age=10800s, delta=noop");
   });
 
-  test.fixme("unacceptable gallery queries produce a cacheable 404", async ({ request }) => {
+  test("unacceptable gallery queries produce a cacheable 404", async ({ request }) => {
     const response = await request.get("/gallery/tides?page=abc");
     expect(response.status()).toBe(404);
     expect(response.headers()["surrogate-control"]).toBe("max-age=600s, delta=noop");

--- a/tests/fixtures/pages-basic/pages/posts/missing.tsx
+++ b/tests/fixtures/pages-basic/pages/posts/missing.tsx
@@ -5,7 +5,18 @@ export default function MissingPost() {
   return <div>This should never render</div>;
 }
 
-export async function getServerSideProps() {
+export async function getServerSideProps({
+  res,
+}: {
+  res: { setHeader(name: string, value: string | string[]): void };
+}) {
+  // Next.js retains this ServerResponse while rendering the 404 page.
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/route-modules/pages/pages-handler.ts
+  res.setHeader("Content-Length", "1");
+  res.setHeader("Content-Type", "application/vnd.vinext.not-found+html");
+  res.setHeader("Set-Cookie", ["missing=one; Path=/", "missing=two; Path=/"]);
+  res.setHeader("Surrogate-Control", "max-age=600s, delta=noop");
+  res.setHeader("Transfer-Encoding", "identity");
   return {
     notFound: true,
   };

--- a/tests/pages-page-data.test.ts
+++ b/tests/pages-page-data.test.ts
@@ -695,6 +695,48 @@ describe("pages page data", () => {
     expect(result).toEqual({ kind: "notFound" });
   });
 
+  it("preserves getServerSideProps headers on a notFound data response", async () => {
+    const result = await resolvePagesPageData(
+      createOptions({
+        isDataReq: true,
+        createGsspReqRes() {
+          return {
+            req: {},
+            res: {
+              headersSent: false,
+              statusCode: 200,
+              getHeaders() {
+                return {
+                  "Content-Type": "application/vnd.atlas.not-found+json",
+                  "Set-Cookie": ["source=one; Path=/", "source=two; Path=/"],
+                  "Surrogate-Control": "max-age=600s, delta=noop",
+                };
+              },
+            },
+            responsePromise: Promise.resolve(new Response("short-circuit", { status: 202 })),
+          };
+        },
+        pageModule: {
+          async getServerSideProps() {
+            return { notFound: true };
+          },
+        },
+      }),
+    );
+
+    expect(result.kind).toBe("response");
+    if (result.kind !== "response") throw new Error("expected data response");
+    expect(result.response.status).toBe(404);
+    expect(result.response.headers.get("content-type")).toBe(
+      "application/vnd.atlas.not-found+json",
+    );
+    expect(result.response.headers.getSetCookie()).toEqual([
+      "source=one; Path=/",
+      "source=two; Path=/",
+    ]);
+    expect(result.response.headers.get("surrogate-control")).toBe("max-age=600s, delta=noop");
+  });
+
   it("returns JSON 404 envelope for data requests when getStaticPaths excludes a path", async () => {
     const result = await resolvePagesPageData(
       createOptions({

--- a/tests/pages-page-handler.test.ts
+++ b/tests/pages-page-handler.test.ts
@@ -607,6 +607,79 @@ describe("createPagesPageHandler — preview responses", () => {
     ]);
   });
 
+  it("preserves headers set by getServerSideProps before a notFound result", async () => {
+    // Next.js keeps one ServerResponse while rendering the source and 404
+    // pages, so headers set before `notFound: true` remain on the response.
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/route-modules/pages/pages-handler.ts
+    const pageRoute = makeRoute(
+      "/missing",
+      makePageModule({
+        getServerSideProps: async ({
+          res,
+        }: {
+          res: { setHeader(name: string, value: string | string[]): void };
+        }) => {
+          res.setHeader("Content-Length", "1");
+          res.setHeader("Content-Type", "application/vnd.atlas.not-found+html");
+          res.setHeader("Surrogate-Control", "max-age=600s, delta=noop");
+          res.setHeader("Transfer-Encoding", "chunked");
+          return { notFound: true };
+        },
+      }),
+    );
+    const notFoundRoute = makeRoute("/404");
+    const handler = createPagesPageHandler(makeOpts({ pageRoutes: [pageRoute, notFoundRoute] }));
+
+    const response = await handler(makeRequest("/missing"), "/missing", null, null, null);
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("content-length")).toBeNull();
+    expect(response.headers.get("surrogate-control")).toBe("max-age=600s, delta=noop");
+    expect(response.headers.get("content-type")).toBe("application/vnd.atlas.not-found+html");
+    expect(response.headers.get("transfer-encoding")).toBeNull();
+  });
+
+  it("lets recursively rendered notFound headers replace source gSSP headers", async () => {
+    let appInitialPropsCalls = 0;
+    const AppComponent = Object.assign(() => null, {
+      getInitialProps({
+        ctx,
+      }: {
+        ctx: { res: { setHeader(name: string, value: string | string[]): void } };
+      }) {
+        appInitialPropsCalls += 1;
+        ctx.res.setHeader("X-Response-Phase", `app-${appInitialPropsCalls}`);
+        ctx.res.setHeader("Set-Cookie", [`app-${appInitialPropsCalls}=1; Path=/`]);
+        return { pageProps: {} };
+      },
+    });
+    const pageRoute = makeRoute(
+      "/missing",
+      makePageModule({
+        getServerSideProps: async ({
+          res,
+        }: {
+          res: { setHeader(name: string, value: string | string[]): void };
+        }) => {
+          res.setHeader("X-Response-Phase", "source-gssp");
+          res.setHeader("Set-Cookie", ["source-gssp=1; Path=/"]);
+          return { notFound: true };
+        },
+      }),
+    );
+    const notFoundRoute = makeRoute("/404");
+    const handler = createPagesPageHandler(
+      makeOpts({ AppComponent, pageRoutes: [pageRoute, notFoundRoute] }),
+    );
+
+    const response = await handler(makeRequest("/missing"), "/missing", null, null, null);
+
+    expect(response.status).toBe(404);
+    expect(appInitialPropsCalls).toBe(2);
+    expect(response.headers.get("x-response-phase")).toBe("app-2");
+    expect(response.headers.getSetCookie()).toEqual(["app-2=1; Path=/"]);
+  });
+
   it("does not expose preview notFound responses to shared CDN caching", async () => {
     const pageRoute = makeRoute(
       "/missing",

--- a/tests/pages-page-response.test.ts
+++ b/tests/pages-page-response.test.ts
@@ -189,7 +189,7 @@ describe("pages page response", () => {
     });
 
     expect(response.status).toBe(201);
-    expect(response.headers.get("content-type")).toBe("text/html; charset=utf-8");
+    expect(response.headers.get("content-type")).toBe("application/json");
     expect(response.headers.get("x-test")).toBe("1");
     expect(response.headers.get("link")).toBe(
       "</font.woff2>; rel=preload; as=font; type=font/woff2; crossorigin",

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -980,11 +980,30 @@ describe("Pages Router integration", () => {
   it("getServerSideProps returning notFound renders custom 404 page", async () => {
     const res = await fetch(`${baseUrl}/posts/missing`);
     expect(res.status).toBe(404);
+    expect(res.headers.get("content-length")).toBeNull();
+    expect(res.headers.get("content-type")).toBe("application/vnd.vinext.not-found+html");
+    expect(res.headers.get("set-cookie")).toContain("missing=one; Path=/");
+    expect(res.headers.get("set-cookie")).toContain("missing=two; Path=/");
+    expect(res.headers.get("surrogate-control")).toBe("max-age=600s, delta=noop");
     const html = await res.text();
     // Should render the custom 404 page (pages/404.tsx), not plain text
     expect(html).toContain("Page Not Found");
     // Should be wrapped in the _app layout
     expect(html).toContain("app-wrapper");
+  });
+
+  it("preserves getServerSideProps headers on notFound data responses", async () => {
+    const res = await fetch(`${baseUrl}/_next/data/test-build-id/posts/missing.json`, {
+      headers: { Accept: "application/json", "x-nextjs-data": "1" },
+    });
+
+    expect(res.status).toBe(404);
+    expect(res.headers.get("content-length")).toBeNull();
+    expect(res.headers.get("content-type")).toBe("application/vnd.vinext.not-found+html");
+    expect(res.headers.get("set-cookie")).toContain("missing=one; Path=/");
+    expect(res.headers.get("set-cookie")).toContain("missing=two; Path=/");
+    expect(res.headers.get("surrogate-control")).toBe("max-age=600s, delta=noop");
+    await expect(res.json()).resolves.toEqual({ notFound: true });
   });
 
   // Regression for #1465: a getServerSideProps `{ redirect }` on an HTML


### PR DESCRIPTION
## Summary

- carry headers set by `getServerSideProps` through a subsequent `notFound: true` result
- preserve source headers on rendered and `_next/data` 404s while keeping chronological App/Document override semantics
- strip stale HTML response framing and enable the pages-router-complex cacheable-404 coverage

## Next.js parity

Next.js keeps the same Node `ServerResponse` when a Pages render returns `notFound` and then calls `render404()`, so user headers remain present and later 404/App/Document writes replace earlier values. The relevant flow is in [`pages-handler.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/route-modules/pages/pages-handler.ts). Vinext creates separate Fetch responses for these phases and now seeds the recursive response state explicitly.

## Validation

- `vp test run tests/pages-page-handler.test.ts tests/pages-page-data.test.ts tests/pages-page-response.test.ts` (169 passed)
- `vp test run tests/pages-router.test.ts` (377 passed)
- focused `vp check` across implementation and regression files
- isolated pages-router-complex cacheable-404 E2E against this worktree server (1 passed)
- independent re-review: no findings