### PR TITLE
fix(examples): declare complex purge secret

### DIFF
--- a/examples/pages-router-complex/README.md
+++ b/examples/pages-router-complex/README.md
@@ -98,7 +98,7 @@ PLAYWRIGHT_PROJECT=pages-router-complex pnpm run test:e2e
   degrades under it, so the `@atlas/*` alias is wired into both bundlers
   explicitly (webpack hook + Vite `resolve.alias`); tsconfig `paths` (without
   the removed `baseUrl`) stays authoritative for the type checker.
-- **vinext dev (Cloudflare plugin): 59/73 specs pass; the 14 known gaps are
+- **vinext dev (Cloudflare plugin): 60/73 specs pass; the 13 known gaps are
   marked `test.fixme` so the passing surface runs in CI.** Known gaps:
   `generateBuildId` is invoked at dev startup (Next.js only calls it at build
   time — the e2e server exports `RELEASE_TAG` to compensate), shallow routing
@@ -107,8 +107,7 @@ PLAYWRIGHT_PROJECT=pages-router-complex pnpm run test:e2e
   `/_next/data` interception and the `/_next/image` 403 middleware branches,
   the `history.replaceState`-beside-the-router hybrid, the gallery scrub
   redirect, cacheable-404 surrogate headers, the `afterFiles` type-ahead
-  rewrite, and the purge endpoint pair (possibly env vars not reaching the
-  workerd runtime).
+  rewrite, and the purge endpoint's unauthorized-POST response.
 - The pinned workerd binary caps `compatibility_date` at 2026-04-08, so
   `wrangler.jsonc` pins 2026-04-01 rather than the scaffold's "today".
 

--- a/examples/pages-router-complex/wrangler.jsonc
+++ b/examples/pages-router-complex/wrangler.jsonc
@@ -4,6 +4,11 @@
   "compatibility_date": "2026-04-01",
   "compatibility_flags": ["nodejs_compat"],
   "main": "vinext/server/fetch-handler",
+  // Load this one runtime secret from .dev.vars/.env/process.env during local
+  // development without exposing the rest of the host process environment.
+  "secrets": {
+    "required": ["ATLAS_PURGE_BEARER"]
+  },
   "assets": {
     "directory": "dist/client",
     "not_found_handling": "none",

--- a/tests/e2e/pages-router-complex/api-routes.spec.ts
+++ b/tests/e2e/pages-router-complex/api-routes.spec.ts
@@ -18,7 +18,7 @@ test.describe("service routes", () => {
     expect(unauthorised.status()).toBe(401);
   });
 
-  test.fixme("purge validates its payload and evicts by prefix", async ({ request }) => {
+  test("purge validates its payload and evicts by prefix", async ({ request }) => {
     const badPayload = await request.post("/api/purge", {
       headers: { authorization: PURGE_BEARER },
       data: { registry: "" },


### PR DESCRIPTION
## Summary

- declare `ATLAS_PURGE_BEARER` as the complex fixture's required Worker secret
- let Cloudflare local dev load only that named secret from `.dev.vars`, `.env`, or `process.env`
- enable the purge validation/eviction E2E now that the Worker sees the configured bearer

Cloudflare Vite plugin support for `secrets.required` comes from workers-sdk PR #12701. The separate unauthorized POST test remains fixme because a 401 response to a proxied POST currently surfaces as an outer dev-server `fetch failed`; this PR does not mask that separate transport behavior.

## Validation

- `PLAYWRIGHT_PROJECT=pages-router-complex vp exec playwright test tests/e2e/pages-router-complex/api-routes.spec.ts --grep "purge validates" --workers=1` (1 passed)
- `vp check examples/pages-router-complex/wrangler.jsonc tests/e2e/pages-router-complex/api-routes.spec.ts`
- manual Worker flow: invalid payload 400, unknown registry 404, scoped purge 200, memo timestamp changed