### PR TITLE
fix(pages): preload dev hydration modules

### DIFF
--- a/examples/pages-router-complex/README.md
+++ b/examples/pages-router-complex/README.md
@@ -98,14 +98,12 @@ PLAYWRIGHT_PROJECT=pages-router-complex pnpm run test:e2e
   degrades under it, so the `@atlas/*` alias is wired into both bundlers
   explicitly (webpack hook + Vite `resolve.alias`); tsconfig `paths` (without
   the removed `baseUrl`) stays authoritative for the type checker.
-- **vinext dev (Cloudflare plugin): 65/73 specs pass; the 8 known gaps are
-  marked `test.fixme` so the passing surface runs in CI.** Known gaps:
-  `generateBuildId` is invoked at dev startup (Next.js only calls it at build
-  time — the e2e server exports `RELEASE_TAG` to compensate), shallow routing
-  + `router.events` (including a hydration knock-on that breaks page
-  interactivity), the `next/image` custom-loader/`fill` path, the
-  `history.replaceState`-beside-the-router hybrid, and the purge endpoint's
-  unauthorized-POST response.
+- **vinext dev (Cloudflare plugin): 72/74 specs pass; the 2 known gaps are
+  marked `test.fixme` so the passing surface runs in CI.** Known gaps are the
+  `next/image` custom-loader/`fill` path and the purge endpoint's
+  unauthorized-POST response. `generateBuildId` is also invoked at dev startup
+  (Next.js only calls it at build time), so the e2e server exports `RELEASE_TAG`
+  to compensate.
 - The pinned workerd binary caps `compatibility_date` at 2026-04-08, so
   `wrangler.jsonc` pins 2026-04-01 rather than the scaffold's "today".
 

--- a/examples/pages-router-complex/pages/[zone]/diagnostics.page.tsx
+++ b/examples/pages-router-complex/pages/[zone]/diagnostics.page.tsx
@@ -39,6 +39,7 @@ export type DiagnosticsProps = {
 const Diagnostics = ({ settingsDump, memoStamp }: DiagnosticsProps) => {
   const [isPrimaryFlyoutOpen, setPrimaryFlyoutOpen] = useState(false);
   const [isSecondaryFlyoutOpen, setSecondaryFlyoutOpen] = useState(false);
+  const [hydrationProbeCount, setHydrationProbeCount] = useState(0);
 
   const launchTimerArm = useTrialArm(LAUNCH_TIMER_FLAG);
 
@@ -65,6 +66,13 @@ const Diagnostics = ({ settingsDump, memoStamp }: DiagnosticsProps) => {
       </ServerHtmlOnly>
 
       <h1>Atlas quick links</h1>
+      <button
+        type="button"
+        data-testid="hydration-readiness-probe"
+        onClick={() => setHydrationProbeCount((count) => count + 1)}
+      >
+        Hydration readiness: {hydrationProbeCount}
+      </button>
       <ul>
         <li>
           <Link href="/gallery/skies/clips" prefetch={false} legacyBehavior>

--- a/examples/pages-router-complex/pages/[zone]/gallery/[...facets].page.tsx
+++ b/examples/pages-router-complex/pages/[zone]/gallery/[...facets].page.tsx
@@ -43,7 +43,7 @@ export type GalleryWallProps = PageLiftedProps & {
 
 export type GalleryWallComponentProps = Omit<
   GalleryWallProps,
-  "lifted" | "graphSnapshot" | "edgeProbeData"
+  "graphSnapshot" | "edgeProbeData"
 >;
 
 const SORT_ORDERS = ["featured", "newest", "alpha"] as const;
@@ -62,7 +62,7 @@ const orderAssets = (assets: AssetCard[], sort: SortOrder): AssetCard[] => {
   }
 };
 
-const GalleryWall = ({ wallPath, startPage }: GalleryWallComponentProps) => {
+const GalleryWall = ({ wallPath, startPage, lifted }: GalleryWallComponentProps) => {
   const router = useRouter();
   const leaf = wallPath.split("/").filter(Boolean)[1] ?? "";
   const node = useGraphOp<TopicNode>("nodeByTrail", { trail: leaf });
@@ -109,6 +109,7 @@ const GalleryWall = ({ wallPath, startPage }: GalleryWallComponentProps) => {
         data-start-page={startPage}
         data-sort={sort}
         data-from-snapshot={node.fromSnapshot}
+        data-rendered-at-ms={lifted.renderedAtMs}
       >
         <h1>Wall: {node.data?.name ?? "…"}</h1>
         <label>

--- a/packages/vinext/src/entries/pages-client-entry.ts
+++ b/packages/vinext/src/entries/pages-client-entry.ts
@@ -251,7 +251,7 @@ async function hydrate() {
   }
 
   const initialModules = window.__VINEXT_INITIAL_PAGES_MODULES__;
-  const pageModule = initialModules?.[${hasApp ? 1 : 0}] ?? (await loader());
+  const pageModule = initialModules?.page ?? (await loader());
   const PageComponent = pageModule.default;
   if (!PageComponent) {
     console.error("[vinext] Page module has no default export");
@@ -263,7 +263,7 @@ async function hydrate() {
     hasApp
       ? `
   try {
-    const appModule = initialModules?.[0] ?? (await appLoader());
+    const appModule = initialModules?.app ?? (await appLoader());
     const AppComponent = appModule.default;
     window.__VINEXT_APP__ = AppComponent;
     element = React.createElement(AppComponent, {

--- a/packages/vinext/src/entries/pages-client-entry.ts
+++ b/packages/vinext/src/entries/pages-client-entry.ts
@@ -57,6 +57,7 @@ export async function generateClientEntry(
   fileMatcher: ReturnType<typeof createValidFileMatcher>,
   options: {
     appPrefetchRoutes?: readonly VinextLinkPrefetchRoute[];
+    devErrorOverlay?: boolean;
     instrumentationClientPath?: string | null;
     middlewareMatcher?: StaticMiddlewareMatcher | undefined;
     reactPreamble?: boolean;
@@ -92,6 +93,9 @@ export async function generateClientEntry(
     )
   ).filter((pattern): pattern is string => pattern !== null);
   const instrumentationClientPath = options.instrumentationClientPath ?? null;
+  const devErrorOverlayImport = options.devErrorOverlay
+    ? 'import * as devErrorOverlay from "vinext/dev-error-overlay";\n'
+    : "";
   const clientRewrites = toClientRewrites(nextConfig.rewrites);
 
   // Build a map of route pattern -> dynamic import.
@@ -142,7 +146,7 @@ export async function generateClientEntry(
   // Next.js's `process.env.__NEXT_STRICT_MODE` branch in `client/index.tsx`.
   const reactStrictModeEnabled = nextConfig.reactStrictMode === true;
 
-  return `${userInstrumentationImport}${reactPreambleImport}
+  return `${userInstrumentationImport}${reactPreambleImport}${devErrorOverlayImport}
 import "vinext/instrumentation-client";
 import React from "react";
 import { hydrateRoot } from "react-dom/client";
@@ -227,7 +231,7 @@ async function hydrate() {
 
   let hydrateRootOptions;
   if (import.meta.env.DEV) {
-    const overlay = await import("vinext/dev-error-overlay");
+    const overlay = ${options.devErrorOverlay ? "devErrorOverlay" : 'await import("vinext/dev-error-overlay")'};
     overlay.installDevErrorOverlay();
     overlay.installViteHmrErrorHandler(import.meta.hot);
     overlay.reportInitialDevServerErrors();
@@ -246,7 +250,8 @@ async function hydrate() {
     return;
   }
 
-  const pageModule = await loader();
+  const initialModules = window.__VINEXT_INITIAL_PAGES_MODULES__;
+  const pageModule = initialModules?.[${hasApp ? 1 : 0}] ?? (await loader());
   const PageComponent = pageModule.default;
   if (!PageComponent) {
     console.error("[vinext] Page module has no default export");
@@ -258,7 +263,7 @@ async function hydrate() {
     hasApp
       ? `
   try {
-    const appModule = await appLoader();
+    const appModule = initialModules?.[0] ?? (await appLoader());
     const AppComponent = appModule.default;
     window.__VINEXT_APP__ = AppComponent;
     element = React.createElement(AppComponent, {

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -45,6 +45,7 @@ import {
 import { installSocketErrorBackstop } from "./server/socket-error-backstop.js";
 import { shouldInvalidateAppRouteFile } from "./server/dev-route-files.js";
 import { createDirectRunner } from "./server/dev-module-runner.js";
+import { createPagesDevAssetUrl, createPagesDevModuleUrl } from "./server/pages-dev-module-url.js";
 import { generateRscEntry } from "./entries/app-rsc-entry.js";
 import { generateSsrEntry } from "./entries/app-ssr-entry.js";
 import {
@@ -283,6 +284,14 @@ const PAGES_CLOUDFLARE_WORKER_OPTIMIZE_DEPS_INCLUDE = Object.freeze([
   "use-sync-external-store/with-selector",
 ]);
 
+const CLIENT_FRAMEWORK_OPTIMIZE_DEPS_INCLUDE = Object.freeze([
+  "react",
+  "react-dom",
+  "react-dom/client",
+  "react/jsx-runtime",
+  "react/jsx-dev-runtime",
+]);
+
 const OPTIONAL_OPTIMIZE_DEPS_WARNING_RE =
   /Failed to resolve dependency: .*use-sync-external-store\/with-selector.*present in .* 'optimizeDeps\.include'/;
 const VINEXT_FILTERED_OPTIMIZE_DEPS_WARN = Symbol.for("vinext.filteredOptimizeDepsWarn");
@@ -512,6 +521,7 @@ function toRelativeFileEntry(root: string, absPath: string): string {
 }
 
 const DEV_PAGES_CLIENT_ENTRY = "/@id/__x00__virtual:vinext-client-entry";
+const DEV_REACT_PREAMBLE = "/@id/__x00__@vitejs/plugin-react/preamble";
 const STYLESHEET_IMPORT_RE = /\.(?:css|scss|sass)$/i;
 const STYLESHEET_FILE_RE = /\.(?:css|scss|sass)$/i;
 const SCRIPT_IMPORT_RE = /\.(?:[cm]?[jt]sx?)$/i;
@@ -1140,6 +1150,8 @@ function createStaticImageAsset(imagePath: string): { fileName: string; source: 
  */
 const _shimsDir = path.resolve(__dirname, "shims") + "/";
 const _serverDir = path.resolve(__dirname, "server");
+const _clientDir = path.resolve(__dirname, "client");
+const _devErrorOverlayPath = resolveShimModulePath(_clientDir, "dev-error-overlay");
 const _fontGoogleShimPath = resolveShimModulePath(_shimsDir, "font-google");
 const _appBrowserServerActionClientPath = resolveShimModulePath(
   _serverDir,
@@ -1557,6 +1569,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
       : [];
     return _generateClientEntry(pagesDir, nextConfig, fileMatcher, {
       appPrefetchRoutes,
+      devErrorOverlay: isServeCommand,
       instrumentationClientPath,
       middlewareMatcher: middlewarePath
         ? extractMiddlewareMatcherConfig(middlewarePath)
@@ -3090,7 +3103,16 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           exclude: mergeOptimizeDepsExclude(incomingExclude, VINEXT_OPTIMIZE_DEPS_EXCLUDE, [
             "@tailwindcss/oxide",
           ]),
-          ...(incomingInclude.length > 0 ? { include: incomingInclude } : {}),
+          ...(!hasAppDir && hasPagesDir
+            ? {
+                include: mergeStringArrayValues(
+                  incomingInclude,
+                  CLIENT_FRAMEWORK_OPTIMIZE_DEPS_INCLUDE,
+                ),
+              }
+            : incomingInclude.length > 0
+              ? { include: incomingInclude }
+              : {}),
           ...depOptimizeNodeEnvOptions,
           rolldownOptions: {
             ...depOptimizeNodeEnvOptions.rolldownOptions,
@@ -3278,14 +3300,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 // React packages aren't crawled from app/ source files,
                 // so must be pre-included to avoid late discovery (#25).
                 include: [
-                  ...new Set([
-                    ...incomingInclude,
-                    "react",
-                    "react-dom",
-                    "react-dom/client",
-                    "react/jsx-runtime",
-                    "react/jsx-dev-runtime",
-                  ]),
+                  ...new Set([...incomingInclude, ...CLIENT_FRAMEWORK_OPTIMIZE_DEPS_INCLUDE]),
                 ],
                 // The client scanner also crawls app/ source files, so it
                 // needs the same JSX-in-`.js` handling (moduleTypes/loader) as
@@ -3321,6 +3336,10 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               consumer: "client",
               optimizeDeps: {
                 ...(pagesOptimizeEntries.length > 0 ? { entries: pagesOptimizeEntries } : {}),
+                include: mergeStringArrayValues(
+                  incomingInclude,
+                  CLIENT_FRAMEWORK_OPTIMIZE_DEPS_INCLUDE,
+                ),
                 ...depOptimizeNodeEnvOptions,
               },
               build: {
@@ -3349,6 +3368,10 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               consumer: "client",
               optimizeDeps: {
                 ...(pagesOptimizeEntries.length > 0 ? { entries: pagesOptimizeEntries } : {}),
+                include: mergeStringArrayValues(
+                  incomingInclude,
+                  CLIENT_FRAMEWORK_OPTIMIZE_DEPS_INCLUDE,
+                ),
                 ...depOptimizeNodeEnvOptions,
               },
               build: {
@@ -3720,9 +3743,35 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           if (id === RESOLVED_PAGES_CLIENT_ASSETS) {
             const metadata: {
               clientEntry: string;
+              devErrorOverlay?: string;
+              devModuleUrls?: Record<string, string>;
+              instrumentationClient?: string;
+              reactPreamble?: string;
               ssrManifest?: Record<string, string[]>;
-            } = { clientEntry: DEV_PAGES_CLIENT_ENTRY };
+            } = {
+              clientEntry: createPagesDevAssetUrl(
+                DEV_PAGES_CLIENT_ENTRY,
+                this.environment.config.base,
+              ),
+              devErrorOverlay: createPagesDevModuleUrl(
+                root,
+                _devErrorOverlayPath,
+                this.environment.config.base,
+              ),
+              instrumentationClient: instrumentationClientPath
+                ? createPagesDevModuleUrl(
+                    root,
+                    instrumentationClientPath,
+                    this.environment.config.base,
+                  )
+                : undefined,
+              reactPreamble:
+                options.react === false
+                  ? undefined
+                  : createPagesDevAssetUrl(DEV_REACT_PREAMBLE, this.environment.config.base),
+            };
             const ssrManifest: Record<string, string[]> = {};
+            const devModuleUrls: Record<string, string> = {};
             const appFilePath = findFileWithExts(pagesDir, "_app", fileMatcher);
             const pagesRoutes = await pagesRouter(
               pagesDir,
@@ -3738,14 +3787,19 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               this.resolve.bind(this),
             );
             for (const moduleFilePath of moduleFilePaths) {
+              const moduleId = toSlash(moduleFilePath);
+              devModuleUrls[moduleId] = createPagesDevModuleUrl(
+                root,
+                moduleFilePath,
+                this.environment.config.base,
+              );
               const stylesheetAssets = await collectDevPagesAppStylesheetAssets(
                 moduleFilePath,
                 getModuleDependencies,
               );
-              if (stylesheetAssets.length > 0) {
-                ssrManifest[toSlash(moduleFilePath)] = stylesheetAssets;
-              }
+              if (stylesheetAssets.length > 0) ssrManifest[moduleId] = stylesheetAssets;
             }
+            metadata.devModuleUrls = devModuleUrls;
             if (Object.keys(ssrManifest).length > 0) metadata.ssrManifest = ssrManifest;
             return `export default ${JSON.stringify(metadata)};`;
           }

--- a/packages/vinext/src/server/pages-asset-tags.ts
+++ b/packages/vinext/src/server/pages-asset-tags.ts
@@ -9,7 +9,7 @@
  * template string.
  */
 
-import { createNonceAttribute } from "./html.js";
+import { createNonceAttribute, safeJsonStringify } from "./html.js";
 import { assetServingUrlFromBaseAnchored } from "../utils/manifest-paths.js";
 import { appendDeploymentIdQuery } from "../utils/deployment-id.js";
 import { getPagesClientAssets } from "./pages-client-assets.js";
@@ -158,23 +158,81 @@ export function collectAssetTags(options: CollectAssetTagsOptions): string {
     return value.endsWith(".js") ? url : appendDeploymentIdQuery(url, options.deploymentId);
   };
 
+  // In development the shared client entry discovers the current page at
+  // runtime, so its page/App imports are normally asynchronous. Install the
+  // error overlay first, then expose those exact modules through an ordered
+  // parser-visible module before the client entry runs. The entry consumes the
+  // exported namespaces synchronously, allowing hydrateRoot() to install
+  // React's delegated event handlers before the document load event exposes
+  // the page as interactive.
+  const runtimeAssets = getPagesClientAssets();
+  const clientEntry = runtimeAssets.clientEntry;
+  const devModuleUrls = runtimeAssets.devModuleUrls;
+  const isDevBootstrap = !!clientEntry && !!devModuleUrls && options.moduleIds.length > 0;
+  if (isDevBootstrap) {
+    if (runtimeAssets.devErrorOverlay) {
+      const overlayImports = [
+        runtimeAssets.instrumentationClient
+          ? `import ${safeJsonStringify(runtimeAssets.instrumentationClient)};`
+          : "",
+        runtimeAssets.reactPreamble
+          ? `import ${safeJsonStringify(runtimeAssets.reactPreamble)};`
+          : "",
+      ]
+        .filter(Boolean)
+        .join("\n");
+      const overlayImportPrefix = overlayImports ? `${overlayImports}\n` : "";
+      tags.push(`<script type="module"${nonceAttr}>${overlayImportPrefix}import * as devErrorOverlay from ${safeJsonStringify(runtimeAssets.devErrorOverlay)};
+devErrorOverlay.installDevErrorOverlay();
+devErrorOverlay.reportInitialDevServerErrors();</script>`);
+    }
+
+    const imports: string[] = [];
+    if (runtimeAssets.instrumentationClient && !runtimeAssets.devErrorOverlay) {
+      imports.push(`import ${safeJsonStringify(runtimeAssets.instrumentationClient)};`);
+    }
+    if (runtimeAssets.reactPreamble) {
+      imports.push(`import ${safeJsonStringify(runtimeAssets.reactPreamble)};`);
+    }
+    const moduleRefs: string[] = [];
+    for (let i = 0; i < options.moduleIds.length; i++) {
+      const moduleId = options.moduleIds[i];
+      const moduleUrl = moduleId ? devModuleUrls[moduleId] : undefined;
+      if (!moduleUrl) {
+        moduleRefs.push("null");
+        continue;
+      }
+      const ref = `initialModule${i}`;
+      imports.push(`import * as ${ref} from ${safeJsonStringify(moduleUrl)};`);
+      moduleRefs.push(ref);
+    }
+    imports.push(`const nextDataElement = document.getElementById("__NEXT_DATA__");
+if (nextDataElement?.textContent) {
+  window.__NEXT_DATA__ = JSON.parse(nextDataElement.textContent);
+  window.__VINEXT_LOCALE__ = window.__NEXT_DATA__.locale;
+  window.__VINEXT_LOCALES__ = window.__NEXT_DATA__.locales;
+  window.__VINEXT_DEFAULT_LOCALE__ = window.__NEXT_DATA__.defaultLocale;
+}`);
+    imports.push(`window.__VINEXT_INITIAL_PAGES_MODULES__ = [${moduleRefs.join(",")}];`);
+    tags.push(`<script type="module"${nonceAttr}>${imports.join("\n")}</script>`);
+  }
+
   // Load the set of lazy chunk filenames (only reachable via dynamic imports).
   // These should NOT get <link rel="modulepreload"> or <script type="module">
   // tags — they are fetched on demand when the dynamic import() executes.
-  const runtimeAssets = getPagesClientAssets();
   const lazyChunks = runtimeAssets.lazyChunks ?? null;
   const lazySet = lazyChunks && lazyChunks.length > 0 ? new Set(lazyChunks) : null;
 
   // Development adapters provide the Vite-served virtual entry explicitly.
   // Production builds use the client entry registered from the emitted sidecar.
-  const clientEntry = runtimeAssets.clientEntry;
   if (clientEntry) {
+    const clientEntryHref = isDevBootstrap ? clientEntry : href(clientEntry);
     seen.add(clientEntry);
     tags.push(
       '<link rel="modulepreload"' +
         nonceAttr +
         ' href="' +
-        href(clientEntry) +
+        clientEntryHref +
         '"' +
         preloadCrossOriginAttr +
         " />",
@@ -184,7 +242,7 @@ export function collectAssetTags(options: CollectAssetTagsOptions): string {
         deferAttr +
         nonceAttr +
         ' src="' +
-        href(clientEntry) +
+        clientEntryHref +
         '"' +
         scriptCrossOriginAttr +
         "></script>",

--- a/packages/vinext/src/server/pages-asset-tags.ts
+++ b/packages/vinext/src/server/pages-asset-tags.ts
@@ -92,6 +92,15 @@ type CollectAssetTagsOptions = {
    * all manifest assets are injected.
    */
   moduleIds: (string | null | undefined)[];
+  /**
+   * Named Pages modules consumed synchronously by the development client
+   * bootstrap. Kept separate from `moduleIds` so asset ordering cannot change
+   * which namespace is treated as `_app` or the matched page.
+   */
+  devInitialModules?: {
+    app: string | null | undefined;
+    page: string | null | undefined;
+  };
   /** Script nonce for CSP. */
   scriptNonce?: string;
   /**
@@ -168,7 +177,8 @@ export function collectAssetTags(options: CollectAssetTagsOptions): string {
   const runtimeAssets = getPagesClientAssets();
   const clientEntry = runtimeAssets.clientEntry;
   const devModuleUrls = runtimeAssets.devModuleUrls;
-  const isDevBootstrap = !!clientEntry && !!devModuleUrls && options.moduleIds.length > 0;
+  const initialModules = options.devInitialModules;
+  const isDevBootstrap = !!clientEntry && !!devModuleUrls && !!initialModules;
   if (isDevBootstrap) {
     if (runtimeAssets.devErrorOverlay) {
       const overlayImports = [
@@ -194,17 +204,17 @@ devErrorOverlay.reportInitialDevServerErrors();</script>`);
     if (runtimeAssets.reactPreamble) {
       imports.push(`import ${safeJsonStringify(runtimeAssets.reactPreamble)};`);
     }
-    const moduleRefs: string[] = [];
-    for (let i = 0; i < options.moduleIds.length; i++) {
-      const moduleId = options.moduleIds[i];
+    const moduleRefs = {
+      app: "null",
+      page: "null",
+    };
+    for (const role of ["app", "page"] as const) {
+      const moduleId = initialModules[role];
       const moduleUrl = moduleId ? devModuleUrls[moduleId] : undefined;
-      if (!moduleUrl) {
-        moduleRefs.push("null");
-        continue;
-      }
-      const ref = `initialModule${i}`;
+      if (!moduleUrl) continue;
+      const ref = `initial${role === "app" ? "App" : "Page"}Module`;
       imports.push(`import * as ${ref} from ${safeJsonStringify(moduleUrl)};`);
-      moduleRefs.push(ref);
+      moduleRefs[role] = ref;
     }
     imports.push(`const nextDataElement = document.getElementById("__NEXT_DATA__");
 if (nextDataElement?.textContent) {
@@ -213,7 +223,9 @@ if (nextDataElement?.textContent) {
   window.__VINEXT_LOCALES__ = window.__NEXT_DATA__.locales;
   window.__VINEXT_DEFAULT_LOCALE__ = window.__NEXT_DATA__.defaultLocale;
 }`);
-    imports.push(`window.__VINEXT_INITIAL_PAGES_MODULES__ = [${moduleRefs.join(",")}];`);
+    imports.push(
+      `window.__VINEXT_INITIAL_PAGES_MODULES__ = { app: ${moduleRefs.app}, page: ${moduleRefs.page} };`,
+    );
     tags.push(`<script type="module"${nonceAttr}>${imports.join("\n")}</script>`);
   }
 

--- a/packages/vinext/src/server/pages-client-assets.ts
+++ b/packages/vinext/src/server/pages-client-assets.ts
@@ -1,5 +1,9 @@
 export type PagesClientAssets = {
   clientEntry?: string;
+  devErrorOverlay?: string;
+  devModuleUrls?: Record<string, string>;
+  instrumentationClient?: string;
+  reactPreamble?: string;
   appBootstrapPreinitModules?: string[];
   ssrManifest?: Record<string, string[]>;
   lazyChunks?: string[];

--- a/packages/vinext/src/server/pages-dev-module-url.ts
+++ b/packages/vinext/src/server/pages-dev-module-url.ts
@@ -1,4 +1,4 @@
-import path from "pathslash";
+import path, { toSlash } from "pathslash";
 
 function normalizeBase(base: string): string {
   if (!base || base === "/") return "/";
@@ -13,9 +13,9 @@ function encodePagesDevModulePath(modulePath: string): string {
     .replace(/#/g, "%23");
 }
 
-export function createPagesDevAssetUrl(assetPath: string): string {
+export function createPagesDevAssetUrl(assetPath: string, viteBase = "/"): string {
   const normalizedAssetPath = assetPath.replace(/^\/+/, "");
-  return "/" + encodePagesDevModulePath(normalizedAssetPath);
+  return normalizeBase(viteBase) + encodePagesDevModulePath(normalizedAssetPath);
 }
 
 export function createPagesDevModuleUrl(
@@ -27,5 +27,12 @@ export function createPagesDevModuleUrl(
   // Windows shapes there); pathslash's win32 already emits "/" on any host.
   const pathImpl = /^[A-Za-z]:[\\/]/.test(viteRoot) ? path.win32 : path;
   const relativePath = pathImpl.relative(viteRoot, moduleFilePath);
+  if (
+    relativePath === ".." ||
+    relativePath.startsWith("../") ||
+    pathImpl.isAbsolute(relativePath)
+  ) {
+    return normalizeBase(viteBase) + "@fs/" + encodePagesDevModulePath(toSlash(moduleFilePath));
+  }
   return normalizeBase(viteBase) + encodePagesDevModulePath(relativePath);
 }

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -1050,6 +1050,10 @@ export function createPagesPageHandler(
         const assetTags = collectAssetTags({
           manifest,
           moduleIds: pageModuleIds,
+          devInitialModules: {
+            app: appAssetPath,
+            page: route.filePath,
+          },
           scriptNonce,
           disableOptimizedLoading: vinextConfig.disableOptimizedLoading,
           basePath: vinextConfig.basePath,

--- a/packages/vinext/src/shims/internal/pages-router-ssr-context.ts
+++ b/packages/vinext/src/shims/internal/pages-router-ssr-context.ts
@@ -1,0 +1,52 @@
+/**
+ * Lightweight bridge to the current Pages Router SSR context.
+ *
+ * The server-only router-state module registers an accessor backed by the
+ * request-scoped AsyncLocalStorage state. The well-known symbol keeps the
+ * bridge working when Vite evaluates `next/router` and `next/link` through
+ * separate module instances during Pages SSR.
+ */
+
+export type PagesRouterSSRContext = {
+  asPath: string;
+  locales?: readonly string[];
+};
+
+const PAGES_ROUTER_SSR_CONTEXT_ACCESSOR_KEY = Symbol.for(
+  "vinext.router.pagesRouterSSRContextAccessor",
+);
+
+type GlobalWithAccessor = typeof globalThis & {
+  [PAGES_ROUTER_SSR_CONTEXT_ACCESSOR_KEY]?: () => PagesRouterSSRContext | null;
+};
+
+/** @internal */
+export function registerPagesRouterSSRContextAccessor(
+  accessor: () => PagesRouterSSRContext | null,
+): () => void {
+  const globalObject = globalThis as GlobalWithAccessor;
+  const previous = globalObject[PAGES_ROUTER_SSR_CONTEXT_ACCESSOR_KEY];
+  globalObject[PAGES_ROUTER_SSR_CONTEXT_ACCESSOR_KEY] = accessor;
+
+  return () => {
+    if (globalObject[PAGES_ROUTER_SSR_CONTEXT_ACCESSOR_KEY] !== accessor) return;
+    if (previous) {
+      globalObject[PAGES_ROUTER_SSR_CONTEXT_ACCESSOR_KEY] = previous;
+    } else {
+      delete globalObject[PAGES_ROUTER_SSR_CONTEXT_ACCESSOR_KEY];
+    }
+  };
+}
+
+export function getPagesRouterSSRContext(): PagesRouterSSRContext | null {
+  if (typeof window !== "undefined") return null;
+
+  const accessor = (globalThis as GlobalWithAccessor)[PAGES_ROUTER_SSR_CONTEXT_ACCESSOR_KEY];
+  if (!accessor) return null;
+
+  try {
+    return accessor();
+  } catch {
+    return null;
+  }
+}

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -69,6 +69,7 @@ import {
   type PendingLinkSetter,
 } from "./internal/link-status-registry.js";
 import { getCurrentRoutePathnameForWarning } from "./internal/route-pattern-for-warning.js";
+import { getPagesRouterSSRContext } from "./internal/pages-router-ssr-context.js";
 import { scheduleAppPrefetchFetch } from "./internal/app-prefetch-fetch-queue.js";
 
 type NavigateEvent = {
@@ -220,25 +221,40 @@ function resolveHref(href: LinkProps["href"]): string {
   return url;
 }
 
-function resolvePagesQueryOnlyHref(href: string): string {
+function resolvePagesQueryOnlyHref(
+  href: string,
+  context?: { asPath?: string; locales?: readonly string[] },
+): string {
   if (!HAS_PAGES_ROUTER) return href;
-  if ((!href.startsWith("?") && !href.startsWith("#")) || typeof window === "undefined") {
+  if (!href.startsWith("?") && !href.startsWith("#")) {
     return href;
   }
 
-  const pagesRouter = window.next?.appDir === true ? undefined : window.next?.router;
+  const pagesRouter =
+    typeof window === "undefined" || window.next?.appDir === true ? undefined : window.next?.router;
+  const ssrContext = getPagesRouterSSRContext();
   const visibleHref =
-    pagesRouter &&
+    context?.asPath ??
+    ssrContext?.asPath ??
+    (pagesRouter &&
     "reload" in pagesRouter &&
     "asPath" in pagesRouter &&
     typeof pagesRouter.asPath === "string"
       ? pagesRouter.asPath
-      : undefined;
+      : undefined);
+  if (visibleHref === undefined && typeof window === "undefined") return href;
+
   return resolvePagesRouterQueryOnlyHref(href, {
     asPath: visibleHref,
     basePath: __basePath,
-    fallbackHref: window.location.href,
-    locales: window.__VINEXT_LOCALES__,
+    fallbackHref:
+      typeof window === "undefined"
+        ? `http://vinext.local${visibleHref ?? "/"}`
+        : window.location.href,
+    locales:
+      context?.locales ??
+      ssrContext?.locales ??
+      (typeof window === "undefined" ? getI18nContext()?.locales : window.__VINEXT_LOCALES__),
   });
 }
 
@@ -1150,7 +1166,10 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
     typeof unresolvedHref === "string" &&
     unresolvedHref.startsWith("#") &&
     !getNavigationRuntime()?.functions.navigate
-      ? resolvePagesQueryOnlyHref(unresolvedHref)
+      ? resolvePagesQueryOnlyHref(unresolvedHref, {
+          asPath: pagesRouter?.asPath,
+          locales: pagesRouter?.locales,
+        })
       : unresolvedHref;
   const concreteRouteHref = HAS_PAGES_ROUTER
     ? resolveConcreteRouteHref(
@@ -1489,11 +1508,14 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
       // Next.js only consumes onRouterTransitionStart in the App Router.
       // Pages Router still executes instrumentation-client side effects
       // during startup, but it does not invoke the named export on navigation.
-      // Pages Router: use the Router singleton
-      const Router = window.next?.appDir === true ? undefined : window.next?.router;
-      const pagesRouter = Router && "reload" in Router ? Router : undefined;
+      // Pages Router: prefer the mounted context, matching Next.js Link. The
+      // window singleton and lazy import are compatibility fallbacks for split
+      // client chunks that render outside the provider.
+      const Router =
+        pagesRouter ?? (window.next?.appDir === true ? undefined : window.next?.router);
+      const pagesRouterRuntime = Router && "reload" in Router ? Router : undefined;
       await navigatePagesRouterLinkWithFallback({
-        router: pagesRouter,
+        router: pagesRouterRuntime,
         loadRouter: async () => (await import("next/router")).default,
         navigation: {
           href: pagesHrefForLink,

--- a/packages/vinext/src/shims/router-state.ts
+++ b/packages/vinext/src/shims/router-state.ts
@@ -10,6 +10,7 @@
 
 import { _registerRouterStateAccessors } from "./router.js";
 import { registerRoutePatternForWarningAccessor } from "./internal/route-pattern-for-warning.js";
+import { registerPagesRouterSSRContextAccessor } from "./internal/pages-router-ssr-context.js";
 import { getOrCreateAls } from "./internal/als-registry.js";
 import {
   getRequestContext,
@@ -91,3 +92,4 @@ _registerRouterStateAccessors({
 // in its "in page: '...'" message without importing router.ts (which would
 // pull a browser-only `installWindowNext()` side effect into the Link bundle).
 registerRoutePatternForWarningAccessor(() => _getState().ssrContext?.pathname ?? null);
+registerPagesRouterSSRContextAccessor(() => _getState().ssrContext);

--- a/packages/vinext/src/shims/url-utils.ts
+++ b/packages/vinext/src/shims/url-utils.ts
@@ -230,7 +230,7 @@ export function isHashOnlyBrowserUrlChange(
 
     // Mirrors Next.js: navigating repeatedly to the same non-empty hash still
     // scrolls to it, while identical absent/empty hashes are no-ops.
-    if (nextHash) return currentHash === nextHash;
+    if (nextHash && currentHash === nextHash) return true;
     return currentHash !== nextHash;
   } catch {
     return false;

--- a/packages/vinext/src/shims/url-utils.ts
+++ b/packages/vinext/src/shims/url-utils.ts
@@ -216,7 +216,22 @@ export function isHashOnlyBrowserUrlChange(
     // Keep this raw comparison distinct from the App Router planner's parsed
     // search-param comparison until their separate navigation lifecycles are
     // deliberately unified.
-    return currentPathname === nextPathname && current.search === next.search && next.hash !== "";
+    if (currentPathname !== nextPathname || current.search !== next.search) return false;
+
+    // URL.hash cannot distinguish an absent fragment from an explicitly empty
+    // fragment (`/page` vs `/page#`), but Next.js's onlyAHashChange does. Keep
+    // the delimiter while comparing so `<Link href="#">` takes the hash-only
+    // history path instead of fetching and remounting the current page.
+    const currentHashIndex = currentHref.indexOf("#");
+    const nextHashIndex = next.href.indexOf("#");
+    const currentHash =
+      currentHashIndex === -1 ? undefined : currentHref.slice(currentHashIndex + 1);
+    const nextHash = nextHashIndex === -1 ? undefined : next.href.slice(nextHashIndex + 1);
+
+    // Mirrors Next.js: navigating repeatedly to the same non-empty hash still
+    // scrolls to it, while identical absent/empty hashes are no-ops.
+    if (nextHash) return currentHash === nextHash;
+    return currentHash !== nextHash;
   } catch {
     return false;
   }

--- a/tests/build-optimization.test.ts
+++ b/tests/build-optimization.test.ts
@@ -237,7 +237,10 @@ describe("optimizeDeps.exclude for vinext", () => {
         root: tmpDir,
         build: {},
         plugins: [],
-        optimizeDeps: { exclude: ["@lingui/macro"] },
+        optimizeDeps: {
+          exclude: ["@lingui/macro"],
+          include: ["some-pages-client-dep"],
+        },
       };
       const result = await (mainPlugin as any).config(mockConfig, {
         command: "build",
@@ -245,6 +248,26 @@ describe("optimizeDeps.exclude for vinext", () => {
 
       expect(result.optimizeDeps?.exclude).toContain("vinext");
       expect(result.optimizeDeps?.exclude).toContain("@vercel/og");
+      expect(result.optimizeDeps?.include).toEqual(
+        expect.arrayContaining([
+          "some-pages-client-dep",
+          "react",
+          "react-dom",
+          "react-dom/client",
+          "react/jsx-runtime",
+          "react/jsx-dev-runtime",
+        ]),
+      );
+      expect(result.environments.client.optimizeDeps?.include).toEqual(
+        expect.arrayContaining([
+          "some-pages-client-dep",
+          "react",
+          "react-dom",
+          "react-dom/client",
+          "react/jsx-runtime",
+          "react/jsx-dev-runtime",
+        ]),
+      );
       // Incoming excludes from other plugins must survive the merge
       expect(result.optimizeDeps?.exclude).toContain("@lingui/macro");
       // No duplicates
@@ -679,13 +702,25 @@ describe("optimizeDeps.exclude for vinext", () => {
     await fsp.writeFile(path.join(tmpDir, "next.config.mjs"), `export default {};`);
 
     try {
-      await (mainPlugin as any).config(
+      const result = await (mainPlugin as any).config(
         {
           root: tmpDir,
           build: {},
           plugins: [{ name: "vite-plugin-cloudflare" }],
+          optimizeDeps: { include: ["already-client-included"] },
         },
         { command: "serve" },
+      );
+
+      expect(result.environments.client.optimizeDeps?.include).toEqual(
+        expect.arrayContaining([
+          "already-client-included",
+          "react",
+          "react-dom",
+          "react-dom/client",
+          "react/jsx-runtime",
+          "react/jsx-dev-runtime",
+        ]),
       );
 
       const workerEnvConfig = {

--- a/tests/e2e/pages-router-complex/client-routing.spec.ts
+++ b/tests/e2e/pages-router-complex/client-routing.spec.ts
@@ -10,14 +10,24 @@ type BeaconWindow = Window & {
  * Client-side routing behaviours: shallow router.push with the internal
  * dynamic-route pattern, router.events subscriptions, and the trial-mark
  * reset hook built on next/compat/router.
+ *
+ * Next.js parity references:
+ * https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-rewrites/test/index.test.ts
+ * https://github.com/vercel/next.js/blob/canary/test/e2e/basepath/router-events.test.ts
  */
 test.describe("shallow routing and router events", () => {
-  test.fixme("changing sort shallow-navigates without re-running gSSP", async ({ page }) => {
+  test("changing sort shallow-navigates without re-running gSSP", async ({ page }) => {
     await page.goto("/gallery/skies/clips");
     await expect(page.locator('[data-testid="gallery-wall"]')).toHaveAttribute(
       "data-sort",
       "featured",
     );
+    const renderedAtMs = await page
+      .locator('[data-testid="gallery-wall"]')
+      .getAttribute("data-rendered-at-ms");
+    if (!renderedAtMs) {
+      throw new Error("gallery wall did not expose its gSSP render timestamp");
+    }
 
     // Plant a marker: a shallow transition must NOT be a full document load.
     await page.evaluate(() => {
@@ -31,6 +41,10 @@ test.describe("shallow routing and router events", () => {
       "data-sort",
       "alpha",
     );
+    await expect(page.locator('[data-testid="gallery-wall"]')).toHaveAttribute(
+      "data-rendered-at-ms",
+      renderedAtMs,
+    );
 
     const marker = await page.evaluate(() => (window as BeaconWindow).__nav_marker__);
     expect(marker).toBe(true);
@@ -40,7 +54,7 @@ test.describe("shallow routing and router events", () => {
     expect(titles).toEqual([...titles].sort((a, b) => a.localeCompare(b)));
   });
 
-  test.fixme("shallow transitions fire router events observed by the progress frame", async ({
+  test("shallow transitions fire router events observed by the progress frame", async ({
     page,
   }) => {
     await page.goto("/gallery/skies/clips");
@@ -60,7 +74,7 @@ test.describe("shallow routing and router events", () => {
     expect(phases.indexOf("start")).toBeLessThan(phases.indexOf("complete"));
   });
 
-  test.fixme("route changes reset the per-page trial marks", async ({ page }) => {
+  test("route changes reset the per-page trial marks", async ({ page }) => {
     await page.goto("/gallery/skies/clips");
     await page.evaluate(() => {
       (window as BeaconWindow).__ATLAS_TRIALS_ACTIVE__ = ["stale-flag"];

--- a/tests/e2e/pages-router-complex/dataless-page.spec.ts
+++ b/tests/e2e/pages-router-complex/dataless-page.spec.ts
@@ -13,7 +13,7 @@ test.describe("data-function-less page", () => {
     await expect(page.locator('[data-testid="frame-masthead"]')).toBeVisible();
   });
 
-  test.fixme("radio toggles pin and clear the backend cookie", async ({ page }) => {
+  test("radio toggles pin and clear the backend cookie", async ({ page }) => {
     await page.goto("/detail-tools/client-flags");
 
     await page.getByLabel("canary").check();

--- a/tests/e2e/pages-router-complex/hydration-extras.spec.ts
+++ b/tests/e2e/pages-router-complex/hydration-extras.spec.ts
@@ -44,10 +44,21 @@ test.describe("hydration boundaries", () => {
     expect(await stamp()).toBe(first);
   });
 
-  test.fixme("flyouts open and close client-side", async ({ page }) => {
+  test("flyouts open and close client-side", async ({ page }) => {
+    await page.addInitScript(() => {
+      window.addEventListener(
+        "load",
+        () => {
+          const trigger = [...document.querySelectorAll("a")].find(
+            (link) => link.textContent === "Primary flyout",
+          );
+          trigger?.addEventListener("click", (event) => event.preventDefault(), { once: true });
+          trigger?.click();
+        },
+        { once: true },
+      );
+    });
     await page.goto("/diagnostics");
-    await expect(page.locator('[data-testid="primary-flyout"]')).toHaveCount(0);
-    await page.getByText("Primary flyout", { exact: true }).click();
     await expect(page.locator('[data-testid="primary-flyout"]')).toBeVisible();
     await page.locator('[data-testid="primary-flyout"] button').click();
     await expect(page.locator('[data-testid="primary-flyout"]')).toHaveCount(0);

--- a/tests/e2e/pages-router-complex/hydration-extras.spec.ts
+++ b/tests/e2e/pages-router-complex/hydration-extras.spec.ts
@@ -44,24 +44,42 @@ test.describe("hydration boundaries", () => {
     expect(await stamp()).toBe(first);
   });
 
-  test("flyouts open and close client-side", async ({ page }) => {
+  test("flyouts open and close client-side", async ({ page, request }) => {
+    const html = await (await request.get("/diagnostics")).text();
+    expect(html).toContain('href="/diagnostics#"');
+
+    await page.goto("/diagnostics");
+    await expect(page.getByText("Primary flyout", { exact: true })).toHaveAttribute(
+      "href",
+      "/diagnostics#",
+    );
+    await page.evaluate(() => {
+      Object.assign(window, { __atlasFlyoutReloadMarker: true });
+    });
+    await expect(page.locator('[data-testid="primary-flyout"]')).toHaveCount(0);
+    await page.getByText("Primary flyout", { exact: true }).click();
+    await expect(page.locator('[data-testid="primary-flyout"]')).toBeVisible();
+    await expect(page).toHaveURL(/\/diagnostics#$/);
+    expect(await page.evaluate(() => "__atlasFlyoutReloadMarker" in window)).toBe(true);
+    await page.locator('[data-testid="primary-flyout"] button').click();
+    await expect(page.locator('[data-testid="primary-flyout"]')).toHaveCount(0);
+  });
+
+  test("client handlers are installed before the document load event", async ({ page }) => {
     await page.addInitScript(() => {
       window.addEventListener(
         "load",
-        () => {
-          const trigger = [...document.querySelectorAll("a")].find(
-            (link) => link.textContent === "Primary flyout",
-          );
-          trigger?.addEventListener("click", (event) => event.preventDefault(), { once: true });
-          trigger?.click();
-        },
+        () =>
+          document
+            .querySelector<HTMLButtonElement>('[data-testid="hydration-readiness-probe"]')
+            ?.click(),
         { once: true },
       );
     });
     await page.goto("/diagnostics");
-    await expect(page.locator('[data-testid="primary-flyout"]')).toBeVisible();
-    await page.locator('[data-testid="primary-flyout"] button').click();
-    await expect(page.locator('[data-testid="primary-flyout"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="hydration-readiness-probe"]')).toHaveText(
+      "Hydration readiness: 1",
+    );
   });
 
   test("the launch-timer trial arm renders its knob value", async ({ page }) => {

--- a/tests/e2e/pages-router-complex/navigation-hooks.spec.ts
+++ b/tests/e2e/pages-router-complex/navigation-hooks.spec.ts
@@ -25,7 +25,7 @@ test.describe("next/navigation hooks in the pages router", () => {
     );
   });
 
-  test.fixme("filter changes update the URL via history.replaceState without navigating", async ({
+  test("filter changes update the URL via history.replaceState without navigating", async ({
     page,
   }) => {
     await page.goto("/gallery/directory/a-z");

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -1912,16 +1912,20 @@ describe("Pages Router entry template", () => {
         pagesDir,
         await resolveNextConfig({}),
         createValidFileMatcher(),
+        { devErrorOverlay: true },
       );
 
-      const overlayImportIndex = code.indexOf('await import("vinext/dev-error-overlay")');
-      const pageLoadIndex = code.indexOf("const pageModule = await loader()");
+      const overlayImportIndex = code.indexOf(
+        'import * as devErrorOverlay from "vinext/dev-error-overlay"',
+      );
+      const pageLoadIndex = code.indexOf("const pageModule = initialModules?.[");
       const hydrateRootIndex = code.indexOf("hydrateRoot(container, element, hydrateRootOptions)");
 
       expect(overlayImportIndex).toBeGreaterThanOrEqual(0);
       expect(pageLoadIndex).toBeGreaterThanOrEqual(0);
       expect(hydrateRootIndex).toBeGreaterThanOrEqual(0);
       expect(code).toContain("overlay.installDevErrorOverlay()");
+      expect(code).toContain("const overlay = devErrorOverlay;");
       expect(code).toContain("overlay.installViteHmrErrorHandler(import.meta.hot)");
       expect(code).toContain("overlay.reportInitialDevServerErrors()");
       expect(code).toContain("onCaughtError: overlay.devOnCaughtError");

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -1907,6 +1907,10 @@ describe("Pages Router entry template", () => {
         path.join(pagesDir, "index.tsx"),
         "export default function Page() { return null; }",
       );
+      fs.writeFileSync(
+        path.join(pagesDir, "_app.tsx"),
+        "export default function App({ Component, pageProps }) { return <Component {...pageProps} />; }",
+      );
 
       const code = await generateClientEntry(
         pagesDir,
@@ -1918,12 +1922,14 @@ describe("Pages Router entry template", () => {
       const overlayImportIndex = code.indexOf(
         'import * as devErrorOverlay from "vinext/dev-error-overlay"',
       );
-      const pageLoadIndex = code.indexOf("const pageModule = initialModules?.[");
+      const pageLoadIndex = code.indexOf("const pageModule = initialModules?.page");
       const hydrateRootIndex = code.indexOf("hydrateRoot(container, element, hydrateRootOptions)");
 
       expect(overlayImportIndex).toBeGreaterThanOrEqual(0);
       expect(pageLoadIndex).toBeGreaterThanOrEqual(0);
       expect(hydrateRootIndex).toBeGreaterThanOrEqual(0);
+      expect(code).toContain("const appModule = initialModules?.app");
+      expect(code).not.toContain("initialModules?.[");
       expect(code).toContain("overlay.installDevErrorOverlay()");
       expect(code).toContain("const overlay = devErrorOverlay;");
       expect(code).toContain("overlay.installViteHmrErrorHandler(import.meta.hot)");

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -713,6 +713,9 @@ describe("isHashOnlyChange", () => {
     expect(
       isHashOnlyBrowserUrlChange("/diagnostics#details", "http://localhost/diagnostics#details"),
     ).toBe(true);
+    expect(
+      isHashOnlyBrowserUrlChange("/diagnostics#next", "http://localhost/diagnostics#details"),
+    ).toBe(true);
     expect(isHashOnlyBrowserUrlChange("/diagnostics", "http://localhost/diagnostics")).toBe(false);
   });
 });

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -22,6 +22,7 @@ import Link, {
   useLinkStatus,
 } from "../packages/vinext/src/shims/link.js";
 import { RouterContext } from "../packages/vinext/src/shims/internal/router-context.js";
+import { registerPagesRouterSSRContextAccessor } from "../packages/vinext/src/shims/internal/pages-router-ssr-context.js";
 import {
   navigatePagesRouterLink,
   navigatePagesRouterLinkWithFallback,
@@ -40,6 +41,7 @@ import { addLocalePrefix } from "../packages/vinext/src/utils/domain-locale.js";
 import {
   isAbsoluteOrProtocolRelativeUrl,
   isAbsoluteUrl,
+  isHashOnlyBrowserUrlChange,
   normalizePathTrailingSlash,
   resolveRelativeHref,
   toBrowserNavigationHref,
@@ -88,6 +90,33 @@ describe("Link rendering", () => {
       React.createElement(Link, { href: { query: { tab: "settings" } } }, "Settings"),
     );
     expect(html).toContain('href="?tab=settings"');
+  });
+
+  // Ported from Next.js: test/e2e/basepath/pages/hello.js and
+  // test/e2e/basepath/router-events.test.ts. Hash-only Pages Links render
+  // against the current asPath and navigate without a document reload.
+  it("renders hash-only Pages Links against router.asPath during SSR", () => {
+    const html = ReactDOMServer.renderToString(
+      React.createElement(
+        RouterContext.Provider,
+        { value: { asPath: "/diagnostics" } as never },
+        React.createElement(Link, { href: "#" }, "Flyout"),
+      ),
+    );
+
+    expect(html).toContain('href="/diagnostics#"');
+  });
+
+  it("renders hash-only Pages Links from request state when the router context is split", () => {
+    const restore = registerPagesRouterSSRContextAccessor(() => ({ asPath: "/diagnostics" }));
+    try {
+      const html = ReactDOMServer.renderToString(
+        React.createElement(Link, { href: "#" }, "Flyout"),
+      );
+      expect(html).toContain('href="/diagnostics#"');
+    } finally {
+      restore();
+    }
   });
 
   it("renders with as prop overriding href", () => {
@@ -625,6 +654,13 @@ describe("Link resolveHref", () => {
         locales: ["en", "fr"],
       }),
     ).toBe("/about?tab=details#newhash");
+    expect(
+      resolvePagesRouterQueryOnlyHref("#", {
+        asPath: "/diagnostics",
+        basePath: "",
+        fallbackHref: "http://localhost/diagnostics",
+      }),
+    ).toBe("/diagnostics#");
   });
 });
 
@@ -665,6 +701,19 @@ describe("isHashOnlyChange", () => {
   // Server-side (no window) — should return false for non-hash-only
   it("returns false for absolute paths on server", () => {
     expect(isHashOnlyChange("/other")).toBe(false);
+  });
+
+  // Ported from Next.js: packages/next/src/shared/lib/router/router.ts
+  // (`onlyAHashChange`). URL.hash alone cannot represent the empty delimiter.
+  it("distinguishes an empty hash from an absent hash on the same browser URL", () => {
+    expect(isHashOnlyBrowserUrlChange("/diagnostics#", "http://localhost/diagnostics")).toBe(true);
+    expect(isHashOnlyBrowserUrlChange("/diagnostics#", "http://localhost/diagnostics#")).toBe(
+      false,
+    );
+    expect(
+      isHashOnlyBrowserUrlChange("/diagnostics#details", "http://localhost/diagnostics#details"),
+    ).toBe(true);
+    expect(isHashOnlyBrowserUrlChange("/diagnostics", "http://localhost/diagnostics")).toBe(false);
   });
 });
 

--- a/tests/pages-asset-tags.test.ts
+++ b/tests/pages-asset-tags.test.ts
@@ -301,7 +301,12 @@ describe("collectAssetTags", () => {
     });
     const result = collectAssetTags({
       manifest: null,
-      moduleIds: ["/project/pages/_app.tsx", "/project/pages/index.tsx"],
+      // The bootstrap roles are named independently of asset-tag ordering.
+      moduleIds: ["/project/pages/index.tsx", "/project/pages/_app.tsx"],
+      devInitialModules: {
+        app: "/project/pages/_app.tsx",
+        page: "/project/pages/index.tsx",
+      },
       scriptNonce: "dev-nonce",
       disableOptimizedLoading: false,
     });
@@ -313,21 +318,21 @@ describe("collectAssetTags", () => {
       'import * as devErrorOverlay from "/packages/vinext/src/client/dev-error-overlay.tsx";',
     );
     expect(result).toContain("devErrorOverlay.installDevErrorOverlay();");
-    expect(result).toContain('import * as initialModule0 from "/pages/_app.tsx";');
-    expect(result).toContain('import * as initialModule1 from "/pages/index.tsx";');
+    expect(result).toContain('import * as initialAppModule from "/pages/_app.tsx";');
+    expect(result).toContain('import * as initialPageModule from "/pages/index.tsx";');
     expect(result).toContain(
-      "window.__VINEXT_INITIAL_PAGES_MODULES__ = [initialModule0,initialModule1]",
+      "window.__VINEXT_INITIAL_PAGES_MODULES__ = { app: initialAppModule, page: initialPageModule }",
     );
     expect(result).toContain('src="/@id/__x00__virtual:vinext-client-entry" crossorigin></script>');
     expect(result.indexOf("devErrorOverlay.installDevErrorOverlay();")).toBeLessThan(
-      result.indexOf('import * as initialModule0 from "/pages/_app.tsx"'),
+      result.indexOf('import * as initialAppModule from "/pages/_app.tsx"'),
     );
     expect(result.indexOf('import "/instrumentation-client.ts";')).toBeLessThan(
       result.indexOf(
         'import * as devErrorOverlay from "/packages/vinext/src/client/dev-error-overlay.tsx"',
       ),
     );
-    expect(result.indexOf('import * as initialModule0 from "/pages/_app.tsx"')).toBeLessThan(
+    expect(result.indexOf('import * as initialAppModule from "/pages/_app.tsx"')).toBeLessThan(
       result.indexOf('src="/@id/__x00__virtual:vinext-client-entry"'),
     );
     expect(result).not.toContain('src="/pages/');
@@ -346,6 +351,10 @@ describe("collectAssetTags", () => {
     const result = collectAssetTags({
       manifest: null,
       moduleIds: ["/project/pages/index.tsx"],
+      devInitialModules: {
+        app: null,
+        page: "/project/pages/index.tsx",
+      },
       disableOptimizedLoading: false,
       basePath: "/docs",
       assetPrefix: "https://cdn.example.com/assets",
@@ -353,7 +362,10 @@ describe("collectAssetTags", () => {
 
     expect(result).toContain('import "/docs/instrumentation-client.ts";');
     expect(result).toContain('import "/docs/@id/__x00__@vitejs/plugin-react/preamble";');
-    expect(result).toContain('import * as initialModule0 from "/docs/pages/index.tsx";');
+    expect(result).toContain('import * as initialPageModule from "/docs/pages/index.tsx";');
+    expect(result).toContain(
+      "window.__VINEXT_INITIAL_PAGES_MODULES__ = { app: null, page: initialPageModule }",
+    );
     expect(result).toContain(
       'src="/docs/@id/__x00__virtual:vinext-client-entry" crossorigin></script>',
     );

--- a/tests/pages-asset-tags.test.ts
+++ b/tests/pages-asset-tags.test.ts
@@ -267,7 +267,11 @@ describe("collectAssetTags", () => {
   });
 
   it("injects the registered development client entry without a manifest", () => {
-    setPagesClientAssets({ clientEntry: "/@id/__x00__virtual:vinext-client-entry" });
+    setPagesClientAssets({
+      clientEntry: "/@id/__x00__virtual:vinext-client-entry",
+      instrumentationClient: "/instrumentation-client.ts",
+      reactPreamble: "/@id/__x00__@vitejs/plugin-react/preamble",
+    });
     const result = collectAssetTags({
       manifest: null,
       moduleIds: [],
@@ -282,6 +286,78 @@ describe("collectAssetTags", () => {
     expect(result).toContain(
       '<script type="module" defer nonce="dev-nonce" src="/@id/__x00__virtual:vinext-client-entry" crossorigin></script>',
     );
+  });
+
+  it("primes development page modules before the shared client entry", () => {
+    setPagesClientAssets({
+      clientEntry: "/@id/__x00__virtual:vinext-client-entry",
+      devErrorOverlay: "/packages/vinext/src/client/dev-error-overlay.tsx",
+      devModuleUrls: {
+        "/project/pages/_app.tsx": "/pages/_app.tsx",
+        "/project/pages/index.tsx": "/pages/index.tsx",
+      },
+      instrumentationClient: "/instrumentation-client.ts",
+      reactPreamble: "/@id/__x00__@vitejs/plugin-react/preamble",
+    });
+    const result = collectAssetTags({
+      manifest: null,
+      moduleIds: ["/project/pages/_app.tsx", "/project/pages/index.tsx"],
+      scriptNonce: "dev-nonce",
+      disableOptimizedLoading: false,
+    });
+
+    expect(result).toContain('document.getElementById("__NEXT_DATA__")');
+    expect(result).toContain('import "/instrumentation-client.ts";');
+    expect(result).toContain('import "/@id/__x00__@vitejs/plugin-react/preamble";');
+    expect(result).toContain(
+      'import * as devErrorOverlay from "/packages/vinext/src/client/dev-error-overlay.tsx";',
+    );
+    expect(result).toContain("devErrorOverlay.installDevErrorOverlay();");
+    expect(result).toContain('import * as initialModule0 from "/pages/_app.tsx";');
+    expect(result).toContain('import * as initialModule1 from "/pages/index.tsx";');
+    expect(result).toContain(
+      "window.__VINEXT_INITIAL_PAGES_MODULES__ = [initialModule0,initialModule1]",
+    );
+    expect(result).toContain('src="/@id/__x00__virtual:vinext-client-entry" crossorigin></script>');
+    expect(result.indexOf("devErrorOverlay.installDevErrorOverlay();")).toBeLessThan(
+      result.indexOf('import * as initialModule0 from "/pages/_app.tsx"'),
+    );
+    expect(result.indexOf('import "/instrumentation-client.ts";')).toBeLessThan(
+      result.indexOf(
+        'import * as devErrorOverlay from "/packages/vinext/src/client/dev-error-overlay.tsx"',
+      ),
+    );
+    expect(result.indexOf('import * as initialModule0 from "/pages/_app.tsx"')).toBeLessThan(
+      result.indexOf('src="/@id/__x00__virtual:vinext-client-entry"'),
+    );
+    expect(result).not.toContain('src="/pages/');
+  });
+
+  it("keeps development modules on Vite's base instead of assetPrefix", () => {
+    setPagesClientAssets({
+      clientEntry: "/docs/@id/__x00__virtual:vinext-client-entry",
+      devErrorOverlay: "/docs/packages/vinext/src/client/dev-error-overlay.tsx",
+      devModuleUrls: {
+        "/project/pages/index.tsx": "/docs/pages/index.tsx",
+      },
+      instrumentationClient: "/docs/instrumentation-client.ts",
+      reactPreamble: "/docs/@id/__x00__@vitejs/plugin-react/preamble",
+    });
+    const result = collectAssetTags({
+      manifest: null,
+      moduleIds: ["/project/pages/index.tsx"],
+      disableOptimizedLoading: false,
+      basePath: "/docs",
+      assetPrefix: "https://cdn.example.com/assets",
+    });
+
+    expect(result).toContain('import "/docs/instrumentation-client.ts";');
+    expect(result).toContain('import "/docs/@id/__x00__@vitejs/plugin-react/preamble";');
+    expect(result).toContain('import * as initialModule0 from "/docs/pages/index.tsx";');
+    expect(result).toContain(
+      'src="/docs/@id/__x00__virtual:vinext-client-entry" crossorigin></script>',
+    );
+    expect(result).not.toContain("cdn.example.com");
   });
 
   it("includes shared framework- chunks", () => {

--- a/tests/pages-dev-module-url.test.ts
+++ b/tests/pages-dev-module-url.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vite-plus/test";
-import { createPagesDevModuleUrl } from "../packages/vinext/src/server/pages-dev-module-url.js";
+import path from "node:path";
+import {
+  createPagesDevAssetUrl,
+  createPagesDevModuleUrl,
+} from "../packages/vinext/src/server/pages-dev-module-url.js";
 
 describe("createPagesDevModuleUrl", () => {
   it("uses Vite's configured base without applying assetPrefix", () => {
@@ -11,6 +15,33 @@ describe("createPagesDevModuleUrl", () => {
   it("preserves root-base behavior", () => {
     expect(createPagesDevModuleUrl("/repo", "/repo/pages/about.tsx", "/")).toBe("/pages/about.tsx");
   });
+
+  it("prefixes virtual development assets with Vite's configured base", () => {
+    expect(createPagesDevAssetUrl("/@id/__x00__virtual:vinext-client-entry", "/docs/")).toBe(
+      "/docs/@id/__x00__virtual:vinext-client-entry",
+    );
+  });
+
+  it("uses Vite's filesystem URL for modules outside the app root", () => {
+    expect(
+      createPagesDevModuleUrl(
+        "/repo/examples/app",
+        "/repo/packages/vinext/src/client/dev-error-overlay.tsx",
+        "/docs/",
+      ),
+    ).toBe("/docs/@fs//repo/packages/vinext/src/client/dev-error-overlay.tsx");
+  });
+
+  it.runIf(process.platform === "win32")(
+    "uses Vite's filesystem URL for modules on another Windows drive",
+    () => {
+      const appRoot = path.resolve("D:\\repo\\app");
+      const modulePath = path.resolve("C:\\repo\\vinext\\dev-error-overlay.tsx");
+      expect(createPagesDevModuleUrl(appRoot, modulePath, "/docs/")).toBe(
+        "/docs/@fs/C:/repo/vinext/dev-error-overlay.tsx",
+      );
+    },
+  );
 
   it("normalizes Windows paths", () => {
     expect(createPagesDevModuleUrl("C:\\repo", "C:\\repo\\pages\\about.tsx", "/docs/")).toBe(


### PR DESCRIPTION
## Summary

- preload the initial `_app` and page modules through ordered parser-visible development scripts
- install the dev overlay before page evaluation while preserving instrumentation-client and React preamble ordering
- consume preloaded namespaces synchronously so React handlers exist by the document load event
- pre-include the Pages client React entrypoints to prevent cold-cache dependency optimizer races
- keep dev module URLs on Vite `base`/`/@fs/`, independent of production `assetPrefix`
- enable six pages-router-complex tests covering flyouts, cookie radios, `history.replaceState`, shallow routing, and router events

These six failures had one framework root cause: development hydration began after the document load event because the shared Pages client entry dynamically imported the initial modules. Router/history symptoms were knock-on effects of controls being exposed before hydration, not separate routing bugs.

This PR is temporarily stacked on #2775 because timely hydration exposes that PR's independent raw `/_next/data` middleware bug in an existing full-navigation assertion. Retarget to `main` after #2775 merges.

Next.js parity references:
- https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-rewrites/test/index.test.ts
- https://github.com/vercel/next.js/blob/canary/test/e2e/basepath/router-events.test.ts

## Validation

- cold optimizer cache, full pages-router-complex project, 7 workers: hydration six passed; no stale optimized-module errors
- warm optimizer cache, fresh server, full project: 65 passed / 7 skipped; the only failure was corrected in the load-event probe itself and now passes targeted
- load-event flyout probe after correction: passed
- focused asset/config/generated-entry suite: 59 passed
- four dev stylesheet metadata integration regressions: passed
- package build: passed