### PR TITLE
fix(actions): run redirect targets through full request pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-node_modules/
+node_modules
 dist/
 !packages/types/next/upstream/dist/
 !packages/types/next/upstream/dist/**

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -1072,6 +1072,7 @@ export default createAppRscHandler({
     scriptNonce,
     routeMatch,
     routePathname,
+    runRedirectTargetMiddleware,
     searchParams,
   }) {
     const {
@@ -1173,6 +1174,7 @@ export default createAppRscHandler({
       },
       resolveRouteRuntime: __resolveRouteRuntime,
       request,
+      runRedirectTargetMiddleware,
       sanitizeErrorForClient(error) {
         return __sanitizeErrorForClient(error);
       },

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -1103,6 +1103,7 @@ export default createAppRscHandler({
         renderMode: actionRenderMode,
         observeMetadataSearchParamsAccess,
         observePageSearchParamsAccess,
+        scriptNonce: targetScriptNonce,
       }) {
         return buildPageElements(actionRoute, actionParams, actionCleanPathname, {
           opts: interceptOpts,
@@ -1113,7 +1114,7 @@ export default createAppRscHandler({
           renderMode: actionRenderMode,
           observeMetadataSearchParamsAccess: observeMetadataSearchParamsAccess === true,
           observePageSearchParamsAccess: observePageSearchParamsAccess === true,
-        }, undefined, actionCleanPathname, scriptNonce);
+        }, undefined, actionCleanPathname, targetScriptNonce ?? scriptNonce);
       },
       cleanPathname,
       clearRequestContext() {

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -1163,6 +1163,7 @@ export default createAppRscHandler({
       maxActionBodySize: __MAX_ACTION_BODY_SIZE,
       maxActionBodySizeLabel: __MAX_ACTION_BODY_SIZE_LABEL,
       middlewareHeaders: middlewareContext.headers,
+      middlewareRequestHeaders: middlewareContext.requestHeaders,
       middlewareStatus: middlewareContext.status,
       mountedSlotsHeader,
       readBodyWithLimit: __readBodyWithLimit,

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -1154,8 +1154,10 @@ export default createAppRscHandler({
       },
       isRscRequest,
       loadServerAction,
+      // Redirect targets are rendered as if the client had navigated to them,
+      // so they must route on the raw pathname a real request would use.
       matchRoute(pathnameToMatch) {
-        return matchRoute(pathnameToMatch);
+        return matchRequestRoute(pathnameToMatch);
       },
       maxActionBodySize: __MAX_ACTION_BODY_SIZE,
       maxActionBodySizeLabel: __MAX_ACTION_BODY_SIZE_LABEL,

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -1072,7 +1072,8 @@ export default createAppRscHandler({
     scriptNonce,
     routeMatch,
     routePathname,
-    runRedirectTargetMiddleware,
+    dispatchRedirectTargetRequest,
+    sourceConfigHeaders,
     searchParams,
   }) {
     const {
@@ -1178,7 +1179,8 @@ export default createAppRscHandler({
       },
       resolveRouteRuntime: __resolveRouteRuntime,
       request,
-      runRedirectTargetMiddleware,
+      dispatchRedirectTargetRequest,
+      sourceConfigHeaders,
       sanitizeErrorForClient(error) {
         return __sanitizeErrorForClient(error);
       },

--- a/packages/vinext/src/server/app-browser-server-action-client.ts
+++ b/packages/vinext/src/server/app-browser-server-action-client.ts
@@ -219,9 +219,10 @@ export async function invokeClientServerAction(
   }
 
   if (actionRedirectTarget) {
-    if (isServerActionResult(result) && result.root !== undefined) {
+    const redirectRoot = isServerActionResult(result) ? result.root : result;
+    if (redirectRoot !== undefined) {
       deps.renderRedirectPayload(
-        AppElementsWire.decode(result.root),
+        AppElementsWire.decode(redirectRoot),
         actionRedirectTarget,
         actionInitiation,
         revalidation,

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -71,6 +71,7 @@ import {
 } from "./image-optimization.js";
 import { runWithPrerenderWorkUnit } from "./prerender-work-unit-setup.js";
 import { buildPostMwRequestContext } from "./app-post-middleware-context.js";
+import type { ActionRedirectMiddlewareResult } from "./app-server-action-execution.js";
 import type { AppRscRenderMode } from "./app-rsc-render-mode.js";
 import type { AppPagePprFallbackCacheShell } from "./app-ppr-fallback-shell.js";
 import type { ClientReuseManifestParseResult } from "./client-reuse-manifest.js";
@@ -256,6 +257,10 @@ type HandleServerActionRequestOptions<TRoute> = {
   scriptNonce?: string;
   routeMatch: AppRscRouteMatch<TRoute> | null;
   routePathname: string;
+  runRedirectTargetMiddleware?: (options: {
+    cleanPathname: string;
+    request: Request;
+  }) => Promise<ActionRedirectMiddlewareResult>;
   searchParams: URLSearchParams;
 };
 
@@ -691,6 +696,38 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     resolvedUrl = cleanPathname + url.search;
   }
 
+  // A server action that redirects renders the target page inline instead of
+  // making the client re-request it, so the target's middleware has to be run
+  // here or it is skipped entirely. Only a clean pass-through can be rendered
+  // inline: a block, redirect, rewrite, or status override has to be resolved by
+  // a real navigation through the full request pipeline.
+  const runRedirectTargetMiddleware = runMiddleware
+    ? async (targetOptions: {
+        cleanPathname: string;
+        request: Request;
+      }): Promise<ActionRedirectMiddlewareResult> => {
+        const targetContext: AppRscMiddlewareContext = {
+          headers: null,
+          requestHeaders: null,
+          status: null,
+        };
+        const targetResult = await runMiddleware({
+          cleanPathname: targetOptions.cleanPathname,
+          context: targetContext,
+          hadBasePath,
+          isDataRequest: false,
+          request: targetOptions.request,
+        });
+        if (targetResult.kind === "response" || targetResult.rewritten) {
+          return { kind: "diverted" };
+        }
+        if (targetContext.status !== null && targetContext.status !== 200) {
+          return { kind: "diverted" };
+        }
+        return { kind: "continue", responseHeaders: targetContext.headers };
+      }
+    : undefined;
+
   const scriptNonce = getScriptNonceFromHeaderSources(request.headers, middlewareContext.headers);
   const postMiddlewareRequestContext = buildPostMwRequestContext(userlandRequest);
   let filesystemRouteEligible = hadBasePath || didMiddlewareRewrite;
@@ -972,6 +1009,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
           scriptNonce,
           routeMatch: preActionMatch,
           routePathname: preActionRoutePathname,
+          runRedirectTargetMiddleware,
           searchParams: getResolvedSearchParams(),
         })
       : null;

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -52,7 +52,7 @@ import {
   stripRscSuffix,
   VINEXT_RSC_CACHE_BUSTING_SEARCH_PARAM,
 } from "./app-rsc-cache-busting.js";
-import { finalizeAppRscResponse } from "./app-rsc-response-finalizer.js";
+import { applyAppRscConfigHeaders, finalizeAppRscResponse } from "./app-rsc-response-finalizer.js";
 import { normalizeRscRequest } from "./app-rsc-request-normalization.js";
 import { buildNextDataNotFoundResponse, normalizePagesDataRequest } from "./pages-data-route.js";
 import { normalizeDefaultLocalePathname } from "./pages-i18n.js";
@@ -71,7 +71,6 @@ import {
 } from "./image-optimization.js";
 import { runWithPrerenderWorkUnit } from "./prerender-work-unit-setup.js";
 import { buildPostMwRequestContext } from "./app-post-middleware-context.js";
-import type { ActionRedirectMiddlewareResult } from "./app-server-action-execution.js";
 import type { AppRscRenderMode } from "./app-rsc-render-mode.js";
 import type { AppPagePprFallbackCacheShell } from "./app-ppr-fallback-shell.js";
 import type { ClientReuseManifestParseResult } from "./client-reuse-manifest.js";
@@ -257,10 +256,8 @@ type HandleServerActionRequestOptions<TRoute> = {
   scriptNonce?: string;
   routeMatch: AppRscRouteMatch<TRoute> | null;
   routePathname: string;
-  runRedirectTargetMiddleware?: (options: {
-    cleanPathname: string;
-    request: Request;
-  }) => Promise<ActionRedirectMiddlewareResult>;
+  dispatchRedirectTargetRequest: (request: Request) => Promise<Response>;
+  sourceConfigHeaders: Headers | null;
   searchParams: URLSearchParams;
 };
 
@@ -520,6 +517,8 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
   isDataRequest: boolean,
   isMiddlewareDataRequest: boolean,
   pagesDataRequest: Request | null,
+  dispatchInternalRequest: (request: Request) => Promise<Response>,
+  allowInternalRscDocumentFallback: boolean,
 ): Promise<Response> {
   const handlerStart = process.env.NODE_ENV !== "production" ? performance.now() : 0;
 
@@ -695,38 +694,6 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     }
     resolvedUrl = cleanPathname + url.search;
   }
-
-  // A server action that redirects renders the target page inline instead of
-  // making the client re-request it, so the target's middleware has to be run
-  // here or it is skipped entirely. Only a clean pass-through can be rendered
-  // inline: a block, redirect, rewrite, or status override has to be resolved by
-  // a real navigation through the full request pipeline.
-  const runRedirectTargetMiddleware = runMiddleware
-    ? async (targetOptions: {
-        cleanPathname: string;
-        request: Request;
-      }): Promise<ActionRedirectMiddlewareResult> => {
-        const targetContext: AppRscMiddlewareContext = {
-          headers: null,
-          requestHeaders: null,
-          status: null,
-        };
-        const targetResult = await runMiddleware({
-          cleanPathname: targetOptions.cleanPathname,
-          context: targetContext,
-          hadBasePath,
-          isDataRequest: false,
-          request: targetOptions.request,
-        });
-        if (targetResult.kind === "response" || targetResult.rewritten) {
-          return { kind: "diverted" };
-        }
-        if (targetContext.status !== null && targetContext.status !== 200) {
-          return { kind: "diverted" };
-        }
-        return { kind: "continue", responseHeaders: targetContext.headers };
-      }
-    : undefined;
 
   const scriptNonce = getScriptNonceFromHeaderSources(request.headers, middlewareContext.headers);
   const postMiddlewareRequestContext = buildPostMwRequestContext(userlandRequest);
@@ -995,6 +962,24 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     middlewareContext.status = 500;
   }
 
+  let sourceConfigHeaders: Headers | null = null;
+  if (filesystemRouteEligible && isPostRequest && actionId && options.handleServerActionRequest) {
+    sourceConfigHeaders = new Headers();
+    const sourceConfigUrl = new URL(request.url);
+    sourceConfigUrl.pathname = hadBasePath
+      ? addBasePathToPathname(requestCleanPathname, options.basePath)
+      : requestCleanPathname;
+    await applyAppRscConfigHeaders(
+      sourceConfigHeaders,
+      cloneRequestWithUrl(request, sourceConfigUrl.toString()),
+      {
+        basePath: options.basePath,
+        configHeaders: options.configHeaders,
+        i18nConfig: options.i18nConfig,
+        requestContext: preMiddlewareRequestContext,
+      },
+    );
+  }
   const serverActionResponse =
     filesystemRouteEligible && isPostRequest && actionId && options.handleServerActionRequest
       ? await options.handleServerActionRequest({
@@ -1009,7 +994,8 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
           scriptNonce,
           routeMatch: preActionMatch,
           routePathname: preActionRoutePathname,
-          runRedirectTargetMiddleware,
+          dispatchRedirectTargetRequest: dispatchInternalRequest,
+          sourceConfigHeaders,
           searchParams: getResolvedSearchParams(),
         })
       : null;
@@ -1027,7 +1013,8 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
       !isInterceptionMatch && (match === null || match.route.isDynamic)
         ? ((await options.renderPagesFallback?.({
             appRouteMatch: match ?? null,
-            allowRscDocumentFallback: didMiddlewareRewritePathname,
+            allowRscDocumentFallback:
+              didMiddlewareRewritePathname || allowInternalRscDocumentFallback,
             isDataRequest,
             isRscRequest,
             matchKind,
@@ -1378,7 +1365,7 @@ function applyProgressiveActionSideEffects(
 export function createAppRscHandler<TRoute extends AppRscHandlerRoute>(
   options: CreateAppRscHandlerOptions<TRoute>,
 ): (request: Request, ctx: unknown) => Promise<Response> {
-  return async function appRscHandler(rawRequest, ctx) {
+  return async function appRscHandler(rawRequest, ctx, allowInternalRscDocumentFallback = false) {
     // Register config-driven cache adapters before anything touches the cache.
     // On the Cloudflare worker the entry already registered them with `env` (this
     // guarded call is a no-op); on Node/dev this is where they get wired, with no
@@ -1488,6 +1475,8 @@ export function createAppRscHandler<TRoute extends AppRscHandlerRoute>(
               isPagesDataRequest,
               isPagesDataRequest,
               pagesDataRequest,
+              (internalRequest) => appRscHandler(internalRequest, ctx, true),
+              allowInternalRscDocumentFallback,
             );
           } catch (error) {
             if (process.env.NODE_ENV !== "production") {

--- a/packages/vinext/src/server/app-rsc-response-finalizer.ts
+++ b/packages/vinext/src/server/app-rsc-response-finalizer.ts
@@ -28,6 +28,38 @@ type FinalizeAppRscResponseOptions = {
 };
 
 const HAS_CONFIG_HEADERS = process.env.__VINEXT_HAS_CONFIG_HEADERS !== "false";
+const configHeadersAlreadyApplied = new WeakSet<Response>();
+
+/** Mark a response whose final target pipeline has already applied config headers. */
+export function markAppRscResponseConfigHeadersApplied(response: Response): Response {
+  configHeadersAlreadyApplied.add(response);
+  return response;
+}
+
+/** Apply only the matching next.config headers for an App Router request. */
+export async function applyAppRscConfigHeaders(
+  headers: Headers,
+  request: Request,
+  options: FinalizeAppRscResponseOptions,
+): Promise<void> {
+  if (!HAS_CONFIG_HEADERS || !options.configHeaders.length) return;
+
+  const url = new URL(request.url);
+  let pathname = url.pathname;
+  const hadBasePath = !options.basePath || hasBasePath(pathname, options.basePath);
+  pathname = stripBasePath(pathname, options.basePath);
+  const matchPathname = options.i18nConfig
+    ? normalizeDefaultLocalePathname(pathname, options.i18nConfig, { hostname: url.hostname })
+    : pathname;
+
+  const { applyConfigHeadersToResponse } = await import("./config-headers.js");
+  applyConfigHeadersToResponse(headers, {
+    configHeaders: options.configHeaders,
+    pathname: matchPathname,
+    requestContext: options.requestContext,
+    basePathState: { basePath: options.basePath, hadBasePath },
+  });
+}
 
 /**
  * Apply App Router response finalization that must happen outside individual
@@ -73,35 +105,10 @@ export async function finalizeAppRscResponse(
     applyCdnResponseHeaders(response.headers, { cacheControl: "" });
   }
 
-  if (!HAS_CONFIG_HEADERS || !options.configHeaders.length) {
+  if (configHeadersAlreadyApplied.has(response)) {
     return response;
   }
-
-  const url = new URL(request.url);
-  let pathname = url.pathname;
-
-  // Config header sources are defined without basePath prefix. Strip basePath
-  // at a segment boundary (not a string prefix) so /app2/page with basePath
-  // /app is not incorrectly treated as /app with suffix /2/page.
-  const hadBasePath = !options.basePath || hasBasePath(pathname, options.basePath);
-  pathname = stripBasePath(pathname, options.basePath);
-
-  // Default-locale path normalisation (issue #1336, item 4). Splice in the
-  // (domain-aware) default locale on unprefixed paths so locale-aware
-  // `has`/`missing` rules with `:locale` placeholders or `locale: false`
-  // overrides still match default-locale URLs. Mirrors the call sites in
-  // `prod-server.ts`, `deploy.ts`, and `app-rsc-handler.ts`.
-  const matchPathname = options.i18nConfig
-    ? normalizeDefaultLocalePathname(pathname, options.i18nConfig, { hostname: url.hostname })
-    : pathname;
-
-  const { applyConfigHeadersToResponse } = await import("./config-headers.js");
-  applyConfigHeadersToResponse(response.headers, {
-    configHeaders: options.configHeaders,
-    pathname: matchPathname,
-    requestContext: options.requestContext,
-    basePathState: { basePath: options.basePath, hadBasePath },
-  });
+  await applyAppRscConfigHeaders(response.headers, request, options);
 
   // Static-file 405 responses are synthesized before config headers run.
   // Reassert their body metadata afterward so a matching headers() rule cannot

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -59,6 +59,7 @@ import {
   validateServerActionPayload,
 } from "./request-pipeline.js";
 import { readStreamAsTextWithLimit } from "../utils/text-stream.js";
+import { buildRequestHeadersFromMiddlewareResponse } from "../utils/middleware-request-headers.js";
 import {
   createServerActionNotFoundResponse,
   getServerActionNotFoundMessage,
@@ -311,6 +312,8 @@ export type HandleServerActionRscRequestOptions<
   /** Verbatim `serverActions.bodySizeLimit` config string (e.g. "2mb") for the body-exceeded error. */
   maxActionBodySizeLabel: string;
   middlewareHeaders: Headers | null;
+  /** Raw middleware response headers used to reconstruct request-header overrides. */
+  middlewareRequestHeaders: Headers | null;
   middlewareStatus: number | null | undefined;
   /**
    * Run userland middleware for an internal action-redirect target before that
@@ -398,11 +401,8 @@ const SERVER_ACTION_ARGS_LIMIT = 1000;
 const ACTION_DID_NOT_REVALIDATE = 0 satisfies ActionRevalidationKind;
 const ACTION_DID_REVALIDATE_STATIC_AND_DYNAMIC = 1 satisfies ActionRevalidationKind;
 const ACTION_REDIRECT_RENDER_STRIPPED_HEADERS = [
-  "accept",
   "content-length",
-  "content-type",
   "next-action",
-  "origin",
   "rsc",
   "x-action-forwarded",
   "x-rsc-action",
@@ -572,12 +572,23 @@ function cookiePathMatches(cookiePath: string, requestPath: string): boolean {
 
 function createActionRedirectRenderRequest(options: {
   actionMiddlewareHeaders: Headers | null;
+  actionMiddlewareRequestHeaders: Headers | null;
   pendingCookies: readonly string[];
   request: Request;
   url: URL;
 }): Request {
+  // App middleware request overrides are applied to headers()/cookies() through
+  // ALS, while the Request object remains the pre-middleware request. Next.js
+  // mutates req.headers before its internal target GET, so reconstruct that
+  // effective request here before forwarding ordinary response headers.
+  const effectiveRequestHeaders = options.actionMiddlewareRequestHeaders
+    ? (buildRequestHeadersFromMiddlewareResponse(
+        options.request.headers,
+        options.actionMiddlewareRequestHeaders,
+      ) ?? options.request.headers)
+    : options.request.headers;
   const headers = cloneActionRedirectHeaders(
-    options.request.headers,
+    effectiveRequestHeaders,
     options.actionMiddlewareHeaders,
   );
   // Like Next.js' internal action-redirect GET, this is necessarily a lossy
@@ -602,23 +613,6 @@ function createActionRedirectRenderRequest(options: {
   return attachRequestCfMetadata(
     new Request(options.url, { headers, method: "GET" }),
     options.request,
-  );
-}
-
-/**
- * Middleware matchers can gate on request headers (`has`/`missing`), so the
- * request middleware sees for a redirect target must carry what the navigation
- * the client would otherwise have made carries. The render request drops
- * `Accept` along with the action transport headers; put it back.
- */
-function createActionRedirectMiddlewareRequest(renderRequest: Request, accept: string | null) {
-  if (accept === null) return renderRequest;
-
-  const headers = new Headers(renderRequest.headers);
-  headers.set("accept", accept);
-  return attachRequestCfMetadata(
-    new Request(renderRequest.url, { headers, method: "GET" }),
-    renderRequest,
   );
 }
 
@@ -1504,6 +1498,7 @@ export async function handleServerActionRscRequest<
 
       const redirectRenderRequest = createActionRedirectRenderRequest({
         actionMiddlewareHeaders: options.middlewareHeaders,
+        actionMiddlewareRequestHeaders: options.middlewareRequestHeaders,
         // Project the action middleware's Set-Cookie mutations (session
         // rotation or deletion) into the internal target request first; the
         // action's own cookies().set() calls land after middleware and win for
@@ -1528,10 +1523,7 @@ export async function handleServerActionRscRequest<
       if (options.runRedirectTargetMiddleware) {
         const targetMiddleware = await options.runRedirectTargetMiddleware({
           cleanPathname: targetPathname,
-          request: createActionRedirectMiddlewareRequest(
-            redirectRenderRequest,
-            redirectRenderRequest.headers.get("accept") ?? options.request.headers.get("accept"),
-          ),
+          request: redirectRenderRequest,
         });
         // Diverting costs the target one extra middleware execution, since the
         // client's navigation runs it again. A pass-through — the common case —

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -491,15 +491,49 @@ function applySetCookieMutationsToRequestCookieHeader(
     : [...cookies].map(([name, value]) => `${name}=${value}`).join("; ");
 }
 
+/** RFC 6265 §5.1.4: the default cookie path is the request path's directory. */
+function defaultCookiePath(requestPathname: string): string {
+  if (!requestPathname.startsWith("/")) return "/";
+  const lastSlash = requestPathname.lastIndexOf("/");
+  return lastSlash <= 0 ? "/" : requestPathname.slice(0, lastSlash);
+}
+
+/** A missing or invalid Path attribute means the default path applies. */
+function readSetCookiePath(setCookie: string): string | null {
+  for (const part of setCookie.split(";").slice(1)) {
+    const equalsIndex = part.indexOf("=");
+    if (equalsIndex === -1) continue;
+    if (part.slice(0, equalsIndex).trim().toLowerCase() !== "path") continue;
+    const value = part.slice(equalsIndex + 1).trim();
+    return value.startsWith("/") ? value : null;
+  }
+  return null;
+}
+
+/** RFC 6265 §5.1.4 path-match. */
+function cookiePathMatches(cookiePath: string, requestPath: string): boolean {
+  if (cookiePath === requestPath) return true;
+  if (!requestPath.startsWith(cookiePath)) return false;
+  return cookiePath.endsWith("/") || requestPath[cookiePath.length] === "/";
+}
+
 function createActionRedirectRenderRequest(options: {
   pendingCookies: readonly string[];
   request: Request;
   url: URL;
 }): Request {
   const headers = cloneActionRedirectHeaders(options.request.headers);
+  // A browser only carries a Set-Cookie into the target navigation when the
+  // cookie's Path (or the default derived from the action URL) path-matches
+  // the target, so a mutation scoped elsewhere must not reach the target's
+  // middleware or render.
+  const actionDefaultPath = defaultCookiePath(new URL(options.request.url).pathname);
+  const applicableCookies = options.pendingCookies.filter((cookie) =>
+    cookiePathMatches(readSetCookiePath(cookie) ?? actionDefaultPath, options.url.pathname),
+  );
   const cookieHeader = applySetCookieMutationsToRequestCookieHeader(
     headers.get("cookie"),
-    options.pendingCookies,
+    applicableCookies,
   );
   if (cookieHeader === null) {
     headers.delete("cookie");
@@ -535,10 +569,12 @@ function createActionRedirectMiddlewareRequest(renderRequest: Request, accept: s
  * redirect wrapper: `Location` would give the (usually 303) wrapper genuine
  * HTTP-redirect semantics that fetch follows before the client reads the
  * control headers, a foreign `Content-Type` makes the client treat the Flight
- * body as non-RSC and hard-navigate, and the x-action-* headers steer the
- * client's navigation and cache invalidation.
+ * body as non-RSC and hard-navigate, a stale `Content-Length` misframes the
+ * generated Flight stream, and the x-action-* headers steer the client's
+ * navigation and cache invalidation.
  */
 const ACTION_REDIRECT_PROTECTED_HEADERS = [
+  "content-length",
   "content-type",
   "location",
   ACTION_REDIRECT_HEADER,

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -51,7 +51,11 @@ import {
   parseNextHttpErrorDigest,
   parseNextRedirectDigest,
 } from "./next-error-digest.js";
-import { validateCsrfOrigin, validateServerActionPayload } from "./request-pipeline.js";
+import {
+  attachRequestCfMetadata,
+  validateCsrfOrigin,
+  validateServerActionPayload,
+} from "./request-pipeline.js";
 import { readStreamAsTextWithLimit } from "../utils/text-stream.js";
 import {
   createServerActionNotFoundResponse,
@@ -102,6 +106,13 @@ type AppServerActionRoute = {
   pattern: string;
   rootParamNames?: readonly string[];
   routeHandler?: unknown;
+  /**
+   * Manifest lazy-module thunks (see app-route-module-loader.ts). Present when
+   * the route is lazy; `page`/`routeHandler` stay unset until hydration, so
+   * these are what identify the route's kind without importing its modules.
+   */
+  __loadPage?: unknown;
+  __loadRouteHandler?: unknown;
   routeSegments?: readonly string[];
   params?: readonly string[] | null;
   slots?: Readonly<
@@ -495,10 +506,10 @@ function createActionRedirectRenderRequest(options: {
     headers.set("cookie", cookieHeader);
   }
 
-  return new Request(options.url, {
-    headers,
-    method: "GET",
-  });
+  return attachRequestCfMetadata(
+    new Request(options.url, { headers, method: "GET" }),
+    options.request,
+  );
 }
 
 /**
@@ -512,7 +523,25 @@ function createActionRedirectMiddlewareRequest(renderRequest: Request, accept: s
 
   const headers = new Headers(renderRequest.headers);
   headers.set("accept", accept);
-  return new Request(renderRequest.url, { headers, method: "GET" });
+  return attachRequestCfMetadata(
+    new Request(renderRequest.url, { headers, method: "GET" }),
+    renderRequest,
+  );
+}
+
+/**
+ * Merge pass-through middleware response headers onto the action redirect
+ * wrapper, minus `Location`: the wrapper's real target travels in
+ * x-action-redirect and its status is usually 303, so a stray middleware
+ * `Location` would give it genuine HTTP-redirect semantics — fetch would
+ * follow it before the action client can read the control headers.
+ */
+function mergeActionRedirectMiddlewareHeaders(
+  target: Headers,
+  middlewareHeaders: Headers | null,
+): void {
+  mergeMiddlewareResponseHeaders(target, middlewareHeaders);
+  target.delete("location");
 }
 
 function withoutRscBodyHeaders(headers: Headers): Headers {
@@ -794,9 +823,15 @@ function shouldUseForwardedActionRedirectStatus<TRoute extends AppServerActionRo
   return currentRuntime !== targetRuntime;
 }
 
+/**
+ * Decided from lazy thunks as well as hydrated fields so it needs no
+ * `ensureRouteLoaded` first: a middleware-blocked target must never execute
+ * its modules' top-level code, so the route cannot be hydrated before
+ * middleware has cleared it.
+ */
 function canRenderActionRedirectTarget(route: AppServerActionRoute): boolean {
-  if ("routeHandler" in route && route.routeHandler) return false;
-  return route.page !== null && route.page !== undefined;
+  if (("routeHandler" in route && route.routeHandler) || route.__loadRouteHandler) return false;
+  return (route.page !== null && route.page !== undefined) || route.__loadPage != null;
 }
 
 function getActionHttpFallbackStatus(error: unknown): number | null {
@@ -1298,7 +1333,7 @@ export async function handleServerActionRscRequest<
         Vary: VINEXT_RSC_VARY_HEADER,
       });
       applyEdgeRuntimeHeader(redirectHeaders, options.isEdgeRuntime);
-      mergeMiddlewareResponseHeaders(redirectHeaders, options.middlewareHeaders);
+      mergeActionRedirectMiddlewareHeaders(redirectHeaders, options.middlewareHeaders);
       applyRscCompatibilityIdHeader(redirectHeaders);
       // Prefix basePath onto the redirect target. The client-side handler in
       // app-browser-entry reads ACTION_REDIRECT_HEADER and calls
@@ -1332,9 +1367,6 @@ export async function handleServerActionRscRequest<
 
       const targetPathname = stripBasePath(redirectTarget.pathname, options.basePath ?? "");
       const targetMatch = options.matchRoute(targetPathname);
-      // Hydrate the redirect target before reading its page/route-handler
-      // modules (canRenderActionRedirectTarget + fetch-cache-mode below).
-      if (targetMatch) await options.ensureRouteLoaded?.(targetMatch.route);
       if (!targetMatch || !canRenderActionRedirectTarget(targetMatch.route)) {
         options.clearRequestContext();
         return new Response(null, {
@@ -1342,9 +1374,6 @@ export async function handleServerActionRscRequest<
           headers: withoutRscBodyHeaders(redirectHeaders),
         });
       }
-      const currentMatch = options.currentRouteMatch;
-      // Hydrate the current route before resolving its runtime below.
-      if (currentMatch) await options.ensureRouteLoaded?.(currentMatch.route);
 
       const redirectRenderRequest = createActionRedirectRenderRequest({
         pendingCookies: [
@@ -1382,8 +1411,16 @@ export async function handleServerActionRscRequest<
             headers: withoutRscBodyHeaders(redirectHeaders),
           });
         }
-        mergeMiddlewareResponseHeaders(redirectHeaders, targetMiddleware.responseHeaders);
+        mergeActionRedirectMiddlewareHeaders(redirectHeaders, targetMiddleware.responseHeaders);
       }
+      // Hydrate the target only now that middleware has cleared it: importing
+      // its modules runs their top-level code, which a blocked target must
+      // never execute. The dynamic-config / fetch-cache reads below need the
+      // hydrated route.
+      await options.ensureRouteLoaded?.(targetMatch.route);
+      const currentMatch = options.currentRouteMatch;
+      // Hydrate the current route before resolving its runtime below.
+      if (currentMatch) await options.ensureRouteLoaded?.(currentMatch.route);
       const redirectDynamicConfig = options.resolveRouteDynamicConfig?.(targetMatch.route);
       const redirectSearchParams = prepareActionPageRerenderContext({
         draftModeCookie: actionDraftCookie,

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -428,10 +428,12 @@ const ACTION_REDIRECT_FORWARDED_FORBIDDEN_HEADERS = [
   "transfer-encoding",
 ];
 
-// Next.js explicitly removes its action header after merging the action
-// response into the target request. Do the same for both action protocols and
-// vinext's dev-only forwarded middleware context.
+// Headers that must not use ordinary response-over-request merging. Next.js
+// explicitly removes its action header, vinext also has its own action/dev
+// protocol headers, and Cookie is rebuilt separately from the original jar plus
+// Set-Cookie mutations.
 const ACTION_REDIRECT_FORWARDED_PROTOCOL_HEADERS = [
+  "cookie",
   "next-action",
   "rsc",
   "x-action-forwarded",
@@ -630,7 +632,10 @@ function createActionRedirectMiddlewareRequest(renderRequest: Request, accept: s
  * navigation and cache invalidation.
  */
 const ACTION_REDIRECT_PROTECTED_HEADERS = [
-  "content-length",
+  // Next.js does not copy these connection/framing headers from the internal
+  // target GET onto the action wrapper. Set-Cookie is the exception here: it
+  // carries middleware mutations back to the browser and is merged additively.
+  ...ACTION_REDIRECT_FORWARDED_FORBIDDEN_HEADERS.filter((name) => name !== "set-cookie"),
   "content-type",
   "location",
   ACTION_REDIRECT_HEADER,

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -198,6 +198,15 @@ type DecodeServerActionReplyOptions<TTemporaryReferences> = {
   temporaryReferences: TTemporaryReferences;
 };
 
+/**
+ * Outcome of running middleware for an action-redirect target. `diverted` means
+ * middleware blocked, redirected, or rewrote the target, so it cannot be
+ * rendered inline and has to be resolved by a real navigation.
+ */
+export type ActionRedirectMiddlewareResult =
+  | { kind: "continue"; responseHeaders: Headers | null }
+  | { kind: "diverted" };
+
 export type HandleProgressiveServerActionRequestOptions = {
   actionId: string | null;
   allowedOrigins: string[];
@@ -281,6 +290,17 @@ export type HandleServerActionRscRequestOptions<
   maxActionBodySizeLabel: string;
   middlewareHeaders: Headers | null;
   middlewareStatus: number | null | undefined;
+  /**
+   * Run userland middleware for an internal action-redirect target before that
+   * target is rendered inline. Middleware only ran for the action's own path,
+   * so without this the target's middleware — commonly the app's authorization
+   * boundary — would never see the request. Absent when the app has no
+   * middleware.
+   */
+  runRedirectTargetMiddleware?: (options: {
+    cleanPathname: string;
+    request: Request;
+  }) => Promise<ActionRedirectMiddlewareResult>;
   mountedSlotsHeader: string | null;
   readBodyWithLimit: ReadBodyWithLimit;
   readFormDataWithLimit: ReadFormDataWithLimit;
@@ -1312,6 +1332,24 @@ export async function handleServerActionRscRequest<
           draftModeSecret: options.draftModeSecret,
         }),
       );
+      // Middleware ran for the action's own path, not the target's. Run it here
+      // (against the headers context above, so request-header overrides land on
+      // the render) and hand anything it wants to change back to the client as a
+      // plain redirect it will re-request through the full pipeline.
+      if (options.runRedirectTargetMiddleware) {
+        const targetMiddleware = await options.runRedirectTargetMiddleware({
+          cleanPathname: targetPathname,
+          request: redirectRenderRequest,
+        });
+        if (targetMiddleware.kind === "diverted") {
+          options.clearRequestContext();
+          return new Response(null, {
+            status: 303,
+            headers: withoutRscBodyHeaders(redirectHeaders),
+          });
+        }
+        mergeMiddlewareResponseHeaders(redirectHeaders, targetMiddleware.responseHeaders);
+      }
       const redirectDynamicConfig = options.resolveRouteDynamicConfig?.(targetMatch.route);
       const redirectSearchParams = prepareActionPageRerenderContext({
         draftModeCookie: actionDraftCookie,

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -40,6 +40,7 @@ import {
   stripRscCacheBustingSearchParam,
 } from "./app-rsc-cache-busting.js";
 import { applyEdgeRuntimeHeader } from "./app-page-response.js";
+import { getScriptNonceFromHeaderSources } from "./csp.js";
 import { resolveAppPageActionRerenderTarget } from "./app-page-request.js";
 import { resolveAppPageNavigationParams } from "./app-page-element-builder.js";
 import { deferUntilStreamConsumed } from "./app-page-stream.js";
@@ -187,6 +188,7 @@ type BuildServerActionPageElementOptions<TRoute extends AppServerActionRoute, TI
   request: Request;
   route: TRoute;
   searchParams: URLSearchParams;
+  scriptNonce?: string;
   renderMode: AppRscRenderMode;
   observeMetadataSearchParamsAccess?: boolean;
   observePageSearchParamsAccess?: boolean;
@@ -1515,6 +1517,13 @@ export async function handleServerActionRscRequest<
       setCurrentFetchCacheMode(options.resolveRouteFetchCacheMode?.(targetMatch.route) ?? null);
       setCurrentForceDynamicFetchDefault(redirectDynamicConfig === "force-dynamic");
       setCurrentFetchSoftTags(buildServerActionPageTags(targetMatch.route, targetPathname));
+      // Target middleware can replace the action path's CSP with a freshly
+      // generated nonce. Build the inline target with the nonce on the final
+      // response it represents, not the stale action-path nonce.
+      const redirectScriptNonce = getScriptNonceFromHeaderSources(
+        redirectRenderRequest.headers,
+        redirectHeaders,
+      );
       const rscStream = await runWithRootParamsScope(
         pickRootParams(targetMatch.params, targetMatch.route.rootParamNames),
         () =>
@@ -1528,6 +1537,7 @@ export async function handleServerActionRscRequest<
               request: redirectRenderRequest,
               route: targetMatch.route,
               searchParams: redirectSearchParams,
+              scriptNonce: redirectScriptNonce,
               renderMode: APP_RSC_RENDER_MODE_NAVIGATION,
               observeMetadataSearchParamsAccess: redirectDynamicConfig !== "force-static",
               observePageSearchParamsAccess: redirectDynamicConfig !== "force-static",

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -1371,6 +1371,10 @@ export async function handleServerActionRscRequest<
             options.request.headers.get("accept"),
           ),
         });
+        // Diverting costs the target one extra middleware execution, since the
+        // client's navigation runs it again. A pass-through — the common case —
+        // runs it exactly once because no navigation follows, so the extra run
+        // buys a single round-trip redirect for every app that has middleware.
         if (targetMiddleware.kind === "diverted") {
           options.clearRequestContext();
           return new Response(null, {

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -31,6 +31,7 @@ import {
   ACTION_REDIRECT_STATUS_HEADER,
   ACTION_REDIRECT_TYPE_HEADER,
   ACTION_REVALIDATED_HEADER,
+  VINEXT_MW_CTX_HEADER,
 } from "./headers.js";
 import {
   VINEXT_RSC_CONTENT_TYPE,
@@ -284,6 +285,13 @@ export type HandleServerActionRscRequestOptions<
   isEdgeRuntime?: boolean;
   isRscRequest: boolean;
   loadServerAction: (actionId: string) => Promise<unknown>;
+  /**
+   * Match an action redirect target. Must use *request* route identity — the
+   * raw, undecoded pathname — because the target is rendered as if the client
+   * had navigated to it. A matcher that decodes would resolve an encoded alias
+   * like `/%61dmin` to `/admin` and render a page the navigation itself, and
+   * the middleware that just ran for `/%61dmin`, would never have reached.
+   */
   matchRoute: (pathname: string) => AppServerActionMatch<TRoute> | null;
   maxActionBodySize: number;
   /** Verbatim `serverActions.bodySizeLimit` config string (e.g. "2mb") for the body-exceeded error. */
@@ -384,6 +392,11 @@ const ACTION_REDIRECT_RENDER_STRIPPED_HEADERS = [
   "rsc",
   "x-action-forwarded",
   "x-rsc-action",
+  // Hybrid app+pages dev attaches the Pages handler's middleware result for the
+  // *action* path. Left on the redirect target's request it would make
+  // applyForwardedMiddlewareContext replay that result instead of executing
+  // middleware for the target.
+  VINEXT_MW_CTX_HEADER,
 ];
 
 function setActionRevalidatedHeader(headers: Headers, kind: ActionRevalidationKind): void {
@@ -486,6 +499,20 @@ function createActionRedirectRenderRequest(options: {
     headers,
     method: "GET",
   });
+}
+
+/**
+ * Middleware matchers can gate on request headers (`has`/`missing`), so the
+ * request middleware sees for a redirect target must carry what the navigation
+ * the client would otherwise have made carries. The render request drops
+ * `Accept` along with the action transport headers; put it back.
+ */
+function createActionRedirectMiddlewareRequest(renderRequest: Request, accept: string | null) {
+  if (accept === null) return renderRequest;
+
+  const headers = new Headers(renderRequest.headers);
+  headers.set("accept", accept);
+  return new Request(renderRequest.url, { headers, method: "GET" });
 }
 
 function withoutRscBodyHeaders(headers: Headers): Headers {
@@ -1339,7 +1366,10 @@ export async function handleServerActionRscRequest<
       if (options.runRedirectTargetMiddleware) {
         const targetMiddleware = await options.runRedirectTargetMiddleware({
           cleanPathname: targetPathname,
-          request: redirectRenderRequest,
+          request: createActionRedirectMiddlewareRequest(
+            redirectRenderRequest,
+            options.request.headers.get("accept"),
+          ),
         });
         if (targetMiddleware.kind === "diverted") {
           options.clearRequestContext();

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -413,6 +413,32 @@ const ACTION_REDIRECT_RENDER_STRIPPED_HEADERS = [
   VINEXT_MW_CTX_HEADER,
 ];
 
+// Matches Next.js' actionsForbiddenHeaders. These describe the action
+// response's framing/connection rather than the internal target GET and must
+// not be forwarded as request headers.
+const ACTION_REDIRECT_FORWARDED_FORBIDDEN_HEADERS = [
+  "accept-encoding",
+  "connection",
+  "content-encoding",
+  "content-length",
+  "expect",
+  "keep-alive",
+  "keepalive",
+  "set-cookie",
+  "transfer-encoding",
+];
+
+// Next.js explicitly removes its action header after merging the action
+// response into the target request. Do the same for both action protocols and
+// vinext's dev-only forwarded middleware context.
+const ACTION_REDIRECT_FORWARDED_PROTOCOL_HEADERS = [
+  "next-action",
+  "rsc",
+  "x-action-forwarded",
+  "x-rsc-action",
+  VINEXT_MW_CTX_HEADER,
+];
+
 function setActionRevalidatedHeader(headers: Headers, kind: ActionRevalidationKind): void {
   if (kind === ACTION_DID_NOT_REVALIDATE) return;
   headers.set(ACTION_REVALIDATED_HEADER, JSON.stringify(kind));
@@ -434,10 +460,33 @@ function clearRejectedActionSideEffects(getAndClearPendingCookies: () => string[
   getAndClearActionRevalidationKind();
 }
 
-function cloneActionRedirectHeaders(requestHeaders: Headers): Headers {
+function cloneActionRedirectHeaders(
+  requestHeaders: Headers,
+  actionMiddlewareHeaders: Headers | null,
+): Headers {
   const headers = new Headers(requestHeaders);
+  for (const header of ACTION_REDIRECT_FORWARDED_FORBIDDEN_HEADERS) {
+    headers.delete(header);
+  }
   for (const header of ACTION_REDIRECT_RENDER_STRIPPED_HEADERS) {
     headers.delete(header);
+  }
+
+  // Next.js' internal target GET merges ordinary action response headers over
+  // the request headers before running the target pipeline. Merge after
+  // stripping the action request's transport headers so a middleware-emitted
+  // value such as Accept or Content-Type remains an intentional target header.
+  if (actionMiddlewareHeaders) {
+    for (const [name, value] of actionMiddlewareHeaders) {
+      const normalizedName = name.toLowerCase();
+      if (
+        ACTION_REDIRECT_FORWARDED_FORBIDDEN_HEADERS.includes(normalizedName) ||
+        ACTION_REDIRECT_FORWARDED_PROTOCOL_HEADERS.includes(normalizedName)
+      ) {
+        continue;
+      }
+      headers.set(name, value);
+    }
   }
   return headers;
 }
@@ -520,11 +569,15 @@ function cookiePathMatches(cookiePath: string, requestPath: string): boolean {
 }
 
 function createActionRedirectRenderRequest(options: {
+  actionMiddlewareHeaders: Headers | null;
   pendingCookies: readonly string[];
   request: Request;
   url: URL;
 }): Request {
-  const headers = cloneActionRedirectHeaders(options.request.headers);
+  const headers = cloneActionRedirectHeaders(
+    options.request.headers,
+    options.actionMiddlewareHeaders,
+  );
   // Like Next.js' internal action-redirect GET, this is necessarily a lossy
   // cookie projection: the inbound Cookie header no longer carries the Path,
   // Domain, or acceptance metadata from the browser's jar. For newly emitted
@@ -1445,6 +1498,7 @@ export async function handleServerActionRscRequest<
       }
 
       const redirectRenderRequest = createActionRedirectRenderRequest({
+        actionMiddlewareHeaders: options.middlewareHeaders,
         // Project the action middleware's Set-Cookie mutations (session
         // rotation or deletion) into the internal target request first; the
         // action's own cookies().set() calls land after middleware and win for
@@ -1471,7 +1525,7 @@ export async function handleServerActionRscRequest<
           cleanPathname: targetPathname,
           request: createActionRedirectMiddlewareRequest(
             redirectRenderRequest,
-            options.request.headers.get("accept"),
+            redirectRenderRequest.headers.get("accept") ?? options.request.headers.get("accept"),
           ),
         });
         // Diverting costs the target one extra middleware execution, since the
@@ -1522,8 +1576,8 @@ export async function handleServerActionRscRequest<
       // generated nonce. Build the inline target with the nonce on the final
       // response it represents, not the stale action-path nonce.
       const redirectScriptNonce = getScriptNonceFromHeaderSources(
-        redirectRenderRequest.headers,
         redirectHeaders,
+        redirectRenderRequest.headers,
       );
       const rscStream = await runWithRootParamsScope(
         pickRootParams(targetMatch.params, targetMatch.route.rootParamNames),

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -37,6 +37,7 @@ import {
   VINEXT_RSC_CONTENT_TYPE,
   VINEXT_RSC_VARY_HEADER,
   applyRscCompatibilityIdHeader,
+  stripRscCacheBustingSearchParam,
 } from "./app-rsc-cache-busting.js";
 import { applyEdgeRuntimeHeader } from "./app-page-response.js";
 import { resolveAppPageActionRerenderTarget } from "./app-page-request.js";
@@ -530,18 +531,41 @@ function createActionRedirectMiddlewareRequest(renderRequest: Request, accept: s
 }
 
 /**
+ * Headers a pass-through middleware must not be able to change on the action
+ * redirect wrapper: `Location` would give the (usually 303) wrapper genuine
+ * HTTP-redirect semantics that fetch follows before the client reads the
+ * control headers, a foreign `Content-Type` makes the client treat the Flight
+ * body as non-RSC and hard-navigate, and the x-action-* headers steer the
+ * client's navigation and cache invalidation.
+ */
+const ACTION_REDIRECT_PROTECTED_HEADERS = [
+  "content-type",
+  "location",
+  ACTION_REDIRECT_HEADER,
+  ACTION_REDIRECT_TYPE_HEADER,
+  ACTION_REDIRECT_STATUS_HEADER,
+  ACTION_REVALIDATED_HEADER,
+];
+
+/**
  * Merge pass-through middleware response headers onto the action redirect
- * wrapper, minus `Location`: the wrapper's real target travels in
- * x-action-redirect and its status is usually 303, so a stray middleware
- * `Location` would give it genuine HTTP-redirect semantics — fetch would
- * follow it before the action client can read the control headers.
+ * wrapper, then restore the wrapper's own protocol headers — including their
+ * absence, so middleware can neither replace nor pre-inject them.
  */
 function mergeActionRedirectMiddlewareHeaders(
   target: Headers,
   middlewareHeaders: Headers | null,
 ): void {
+  if (!middlewareHeaders) return;
+
+  const protectedValues = ACTION_REDIRECT_PROTECTED_HEADERS.map(
+    (name) => [name, target.get(name)] as const,
+  );
   mergeMiddlewareResponseHeaders(target, middlewareHeaders);
-  target.delete("location");
+  for (const [name, value] of protectedValues) {
+    if (value === null) target.delete(name);
+    else target.set(name, value);
+  }
 }
 
 function withoutRscBodyHeaders(headers: Headers): Headers {
@@ -1365,6 +1389,12 @@ export async function handleServerActionRscRequest<
         });
       }
 
+      // The real request pipeline strips the internal `_rsc` transport param
+      // before middleware and rendering (app-rsc-handler); the synthetic target
+      // must match, or middleware matchers see a query no navigation carries.
+      // The x-action-redirect header above keeps the verbatim URL — a diverted
+      // client re-request goes through the pipeline's own `_rsc` validation.
+      stripRscCacheBustingSearchParam(redirectTarget);
       const targetPathname = stripBasePath(redirectTarget.pathname, options.basePath ?? "");
       const targetMatch = options.matchRoute(targetPathname);
       if (!targetMatch || !canRenderActionRedirectTarget(targetMatch.route)) {
@@ -1376,7 +1406,12 @@ export async function handleServerActionRscRequest<
       }
 
       const redirectRenderRequest = createActionRedirectRenderRequest({
+        // The action middleware's Set-Cookie mutations (session rotation or
+        // deletion) come first so the target sees the cookie jar the browser
+        // would carry into the navigation; the action's own cookies().set()
+        // calls land after middleware and win for the same name.
         pendingCookies: [
+          ...(options.middlewareHeaders?.getSetCookie() ?? []),
           ...actionPendingCookies,
           ...(actionDraftCookie ? [actionDraftCookie] : []),
         ],

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -525,10 +525,11 @@ function createActionRedirectRenderRequest(options: {
   url: URL;
 }): Request {
   const headers = cloneActionRedirectHeaders(options.request.headers);
-  // A browser only carries a Set-Cookie into the target navigation when the
-  // cookie's Path (or the default derived from the action URL) path-matches
-  // the target, so a mutation scoped elsewhere must not reach the target's
-  // middleware or render.
+  // Like Next.js' internal action-redirect GET, this is necessarily a lossy
+  // cookie projection: the inbound Cookie header no longer carries the Path,
+  // Domain, or acceptance metadata from the browser's jar. For newly emitted
+  // mutations the Path is still available, so avoid forwarding a known path
+  // mismatch even though older inbound cookies cannot be re-scoped here.
   const actionDefaultPath = defaultCookiePath(new URL(options.request.url).pathname);
   const applicableCookies = options.pendingCookies.filter((cookie) =>
     cookiePathMatches(readSetCookiePath(cookie) ?? actionDefaultPath, options.url.pathname),
@@ -1444,10 +1445,10 @@ export async function handleServerActionRscRequest<
       }
 
       const redirectRenderRequest = createActionRedirectRenderRequest({
-        // The action middleware's Set-Cookie mutations (session rotation or
-        // deletion) come first so the target sees the cookie jar the browser
-        // would carry into the navigation; the action's own cookies().set()
-        // calls land after middleware and win for the same name.
+        // Project the action middleware's Set-Cookie mutations (session
+        // rotation or deletion) into the internal target request first; the
+        // action's own cookies().set() calls land after middleware and win for
+        // the same name, matching Next.js' forwarded-cookie ordering.
         pendingCookies: [
           ...(options.middlewareHeaders?.getSetCookie() ?? []),
           ...actionPendingCookies,

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -56,6 +56,7 @@ import {
 } from "./request-pipeline.js";
 import { readStreamAsTextWithLimit } from "../utils/text-stream.js";
 import { buildRequestHeadersFromMiddlewareResponse } from "../utils/middleware-request-headers.js";
+import { parseEdgeRequestCookieHeader } from "../utils/parse-cookie.js";
 import {
   createServerActionNotFoundResponse,
   getServerActionNotFoundMessage,
@@ -487,75 +488,36 @@ function readSetCookieNameValue(setCookie: string): { name: string; value: strin
 
   const name = setCookie.slice(0, equalsIndex).trim();
   const valueEnd = setCookie.indexOf(";", equalsIndex + 1);
-  const value = setCookie.slice(equalsIndex + 1, valueEnd === -1 ? undefined : valueEnd);
+  const encodedValue = setCookie.slice(equalsIndex + 1, valueEnd === -1 ? undefined : valueEnd);
+
+  let value: string;
+  try {
+    value = decodeURIComponent(encodedValue);
+  } catch {
+    return null;
+  }
 
   return { name, value };
-}
-
-function isExpiredSetCookie(setCookie: string): boolean {
-  return (
-    /(?:^|;\s*)max-age=0(?:;|$)/i.test(setCookie) ||
-    /(?:^|;\s*)expires=Thu,\s*0?1[\s-]+Jan[\s-]+1970/i.test(setCookie)
-  );
 }
 
 function applySetCookieMutationsToRequestCookieHeader(
   cookieHeader: string | null,
   setCookies: readonly string[],
 ): string | null {
-  const cookies = new Map<string, string>();
-  if (cookieHeader) {
-    for (const part of cookieHeader.split(";")) {
-      const trimmed = part.trim();
-      if (!trimmed) continue;
-      const equalsIndex = trimmed.indexOf("=");
-      if (equalsIndex <= 0) continue;
-      cookies.set(trimmed.slice(0, equalsIndex), trimmed.slice(equalsIndex + 1));
-    }
-  }
+  const cookies = parseEdgeRequestCookieHeader(cookieHeader ?? "");
 
   for (const setCookie of setCookies) {
     const entry = readSetCookieNameValue(setCookie);
     if (!entry) continue;
-    if (isExpiredSetCookie(setCookie)) {
-      cookies.delete(entry.name);
-    } else {
-      // Cookie header values are raw (not URL-encoded), and
-      // readSetCookieNameValue extracts the value verbatim from the
-      // Set-Cookie header, so store it as-is.
-      cookies.set(entry.name, entry.value);
-    }
+    // Match Next.js' ResponseCookies -> RequestCookies projection exactly:
+    // attributes such as Path and Max-Age are discarded, and a deletion is
+    // forwarded as an empty value rather than removing the cookie name.
+    cookies.set(entry.name, entry.value);
   }
 
   return cookies.size === 0
     ? null
-    : [...cookies].map(([name, value]) => `${name}=${value}`).join("; ");
-}
-
-/** RFC 6265 §5.1.4: the default cookie path is the request path's directory. */
-function defaultCookiePath(requestPathname: string): string {
-  if (!requestPathname.startsWith("/")) return "/";
-  const lastSlash = requestPathname.lastIndexOf("/");
-  return lastSlash <= 0 ? "/" : requestPathname.slice(0, lastSlash);
-}
-
-/** A missing or invalid Path attribute means the default path applies. */
-function readSetCookiePath(setCookie: string): string | null {
-  for (const part of setCookie.split(";").slice(1)) {
-    const equalsIndex = part.indexOf("=");
-    if (equalsIndex === -1) continue;
-    if (part.slice(0, equalsIndex).trim().toLowerCase() !== "path") continue;
-    const value = part.slice(equalsIndex + 1).trim();
-    return value.startsWith("/") ? value : null;
-  }
-  return null;
-}
-
-/** RFC 6265 §5.1.4 path-match. */
-function cookiePathMatches(cookiePath: string, requestPath: string): boolean {
-  if (cookiePath === requestPath) return true;
-  if (!requestPath.startsWith(cookiePath)) return false;
-  return cookiePath.endsWith("/") || requestPath[cookiePath.length] === "/";
+    : [...cookies].map(([name, value]) => `${name}=${encodeURIComponent(value)}`).join("; ");
 }
 
 async function createActionRedirectTargetRequest(options: {
@@ -581,18 +543,9 @@ async function createActionRedirectTargetRequest(options: {
     options.sourceConfigHeaders,
     options.actionMiddlewareHeaders,
   );
-  // Like Next.js' internal action-redirect GET, this is necessarily a lossy
-  // cookie projection: the inbound Cookie header no longer carries the Path,
-  // Domain, or acceptance metadata from the browser's jar. For newly emitted
-  // mutations the Path is still available, so avoid forwarding a known path
-  // mismatch even though older inbound cookies cannot be re-scoped here.
-  const actionDefaultPath = defaultCookiePath(new URL(options.request.url).pathname);
-  const applicableCookies = options.pendingCookies.filter((cookie) =>
-    cookiePathMatches(readSetCookiePath(cookie) ?? actionDefaultPath, options.url.pathname),
-  );
   const cookieHeader = applySetCookieMutationsToRequestCookieHeader(
     headers.get("cookie"),
-    applicableCookies,
+    options.pendingCookies,
   );
   if (cookieHeader === null) {
     headers.delete("cookie");
@@ -675,9 +628,10 @@ async function dispatchActionRedirectTarget(options: {
 /** Headers the internally dispatched target must not replace on the action wrapper. */
 const ACTION_REDIRECT_PROTECTED_HEADERS = [
   // Next.js does not copy these connection/framing headers from the internal
-  // target GET onto the action wrapper. Set-Cookie is the exception here: it
-  // carries middleware mutations back to the browser and is merged additively.
-  ...ACTION_REDIRECT_FORWARDED_FORBIDDEN_HEADERS.filter((name) => name !== "set-cookie"),
+  // target GET onto the action wrapper. This also protects the wrapper's
+  // source/action Set-Cookie values while preventing target cookies from being
+  // copied, matching actionsForbiddenHeaders in Next.js.
+  ...ACTION_REDIRECT_FORWARDED_FORBIDDEN_HEADERS,
   "content-type",
   "location",
   ACTION_REDIRECT_HEADER,
@@ -686,20 +640,34 @@ const ACTION_REDIRECT_PROTECTED_HEADERS = [
   ACTION_REVALIDATED_HEADER,
 ];
 
-/**
- * Merge the target response headers onto the action redirect wrapper, then
- * restore the wrapper's own protocol headers — including their absence.
- */
-function mergeActionRedirectTargetHeaders(target: Headers, responseHeaders: Headers | null): void {
+const ACTION_REDIRECT_SOURCE_PROTECTED_HEADERS = ACTION_REDIRECT_PROTECTED_HEADERS.filter(
+  (name) => name !== "set-cookie",
+);
+
+function mergeActionRedirectSourceHeaders(target: Headers, responseHeaders: Headers | null): void {
   if (!responseHeaders) return;
 
-  const protectedValues = ACTION_REDIRECT_PROTECTED_HEADERS.map(
+  const protectedValues = ACTION_REDIRECT_SOURCE_PROTECTED_HEADERS.map(
     (name) => [name, target.get(name)] as const,
   );
   mergeMiddlewareResponseHeaders(target, responseHeaders);
   for (const [name, value] of protectedValues) {
     if (value === null) target.delete(name);
     else target.set(name, value);
+  }
+}
+
+/**
+ * Copy ordinary target response headers onto the action redirect wrapper.
+ * Next.js uses setHeader here, so target values replace source values instead
+ * of using middleware-specific merge behavior such as unioning Vary.
+ */
+function mergeActionRedirectTargetHeaders(target: Headers, responseHeaders: Headers | null): void {
+  if (!responseHeaders) return;
+
+  for (const [name, value] of responseHeaders) {
+    if (ACTION_REDIRECT_PROTECTED_HEADERS.includes(name.toLowerCase())) continue;
+    target.set(name, value);
   }
 }
 
@@ -1480,8 +1448,8 @@ export async function handleServerActionRscRequest<
         Vary: VINEXT_RSC_VARY_HEADER,
       });
       applyEdgeRuntimeHeader(redirectHeaders, options.isEdgeRuntime);
-      mergeActionRedirectTargetHeaders(redirectHeaders, options.sourceConfigHeaders ?? null);
-      mergeActionRedirectTargetHeaders(redirectHeaders, options.middlewareHeaders);
+      mergeActionRedirectSourceHeaders(redirectHeaders, options.sourceConfigHeaders ?? null);
+      mergeActionRedirectSourceHeaders(redirectHeaders, options.middlewareHeaders);
       applyRscCompatibilityIdHeader(redirectHeaders);
       // Prefix basePath onto the redirect target. The client-side handler in
       // app-browser-entry reads ACTION_REDIRECT_HEADER and calls

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -511,15 +511,23 @@ function applySetCookieMutationsToRequestCookieHeader(
   setCookies: readonly string[],
 ): string | null {
   const cookies = parseEdgeRequestCookieHeader(cookieHeader ?? "");
+  const responseCookies = new Map<string, string | undefined>();
 
   for (const setCookie of setCookies) {
     const entry = readSetCookieNameValue(setCookie);
     if (!entry) continue;
+    // ResponseCookies stores response mutations in a name-keyed Map before
+    // getForwardedHeaders applies them. Repeated names therefore collapse to
+    // the last value without changing their first insertion order.
+    responseCookies.set(entry.name, entry.value);
+  }
+
+  for (const [name, value] of responseCookies) {
     // Match Next.js' ResponseCookies -> RequestCookies projection exactly:
     // attributes such as Path and Max-Age are discarded, while a compacted
     // empty value deletes the request cookie.
-    if (entry.value === undefined) cookies.delete(entry.name);
-    else cookies.set(entry.name, entry.value);
+    if (value === undefined) cookies.delete(name);
+    else cookies.set(name, value);
   }
 
   return cookies.size === 0

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -492,13 +492,23 @@ function readSetCookieNameValue(
   const valueEnd = setCookie.indexOf(";", equalsIndex + 1);
   const encodedValue = setCookie.slice(equalsIndex + 1, valueEnd === -1 ? undefined : valueEnd);
 
+  let onceDecodedValue = encodedValue;
+  try {
+    onceDecodedValue = decodeURIComponent(encodedValue);
+  } catch {
+    // Manually emitted/config Set-Cookie values need not be URI-encoded. Keep
+    // their raw value so the target cannot retain the stale inbound cookie.
+  }
+
   let value: string;
   try {
     // ResponseCookies parses the pair once, then parseSetCookie decodes the
     // extracted value again before RequestCookies serializes it.
-    value = decodeURIComponent(decodeURIComponent(encodedValue));
+    value = decodeURIComponent(onceDecodedValue);
   } catch {
-    return null;
+    // Next.js lets this second decode throw. Keep the valid first decode as a
+    // robustness exception so the target cannot retain a stale cookie value.
+    value = onceDecodedValue;
   }
 
   // @edge-runtime/cookies compacts an empty value out of the parsed response

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -482,7 +482,9 @@ function cloneActionRedirectHeaders(
   return headers;
 }
 
-function readSetCookieNameValue(setCookie: string): { name: string; value: string } | null {
+function readSetCookieNameValue(
+  setCookie: string,
+): { name: string; value: string | undefined } | null {
   const equalsIndex = setCookie.indexOf("=");
   if (equalsIndex <= 0) return null;
 
@@ -492,12 +494,16 @@ function readSetCookieNameValue(setCookie: string): { name: string; value: strin
 
   let value: string;
   try {
-    value = decodeURIComponent(encodedValue);
+    // ResponseCookies parses the pair once, then parseSetCookie decodes the
+    // extracted value again before RequestCookies serializes it.
+    value = decodeURIComponent(decodeURIComponent(encodedValue));
   } catch {
     return null;
   }
 
-  return { name, value };
+  // @edge-runtime/cookies compacts an empty value out of the parsed response
+  // cookie. getForwardedHeaders treats that undefined value as a deletion.
+  return { name, value: value === "" ? undefined : value };
 }
 
 function applySetCookieMutationsToRequestCookieHeader(
@@ -510,9 +516,10 @@ function applySetCookieMutationsToRequestCookieHeader(
     const entry = readSetCookieNameValue(setCookie);
     if (!entry) continue;
     // Match Next.js' ResponseCookies -> RequestCookies projection exactly:
-    // attributes such as Path and Max-Age are discarded, and a deletion is
-    // forwarded as an empty value rather than removing the cookie name.
-    cookies.set(entry.name, entry.value);
+    // attributes such as Path and Max-Age are discarded, while a compacted
+    // empty value deletes the request cookie.
+    if (entry.value === undefined) cookies.delete(entry.name);
+    else cookies.set(entry.name, entry.value);
   }
 
   return cookies.size === 0
@@ -547,11 +554,10 @@ async function createActionRedirectTargetRequest(options: {
     headers.get("cookie"),
     options.pendingCookies,
   );
-  if (cookieHeader === null) {
-    headers.delete("cookie");
-  } else {
-    headers.set("cookie", cookieHeader);
-  }
+  // Next.js unconditionally assigns RequestCookies.toString() to the internal
+  // target request, so an empty jar is represented as Cookie: rather than by
+  // omitting the header.
+  headers.set("cookie", cookieHeader ?? "");
 
   // Match Next.js' internal redirect fetch: it is a fresh full-tree RSC GET,
   // not another action request or a patch against the action route's tree.

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -4,7 +4,6 @@ import {
   type ActionRevalidationKind,
 } from "vinext/shims/cache-request-state";
 import {
-  headersContextFromRequest,
   isDraftModeRequest,
   setHeadersContext,
   type HeadersAccessPhase,
@@ -16,12 +15,7 @@ import {
   setCurrentForceDynamicFetchDefault,
 } from "vinext/shims/fetch-cache";
 import type { ReactFormState } from "react-dom/client";
-import {
-  createRootParamsUsageController,
-  pickRootParams,
-  runWithRootParamsScope,
-  runWithRootParamsUsage,
-} from "vinext/shims/root-params";
+import { createRootParamsUsageController, runWithRootParamsUsage } from "vinext/shims/root-params";
 import { isExternalUrl } from "../utils/external-url.js";
 import { splitPathSegments } from "../routing/utils.js";
 import { addBasePathToPathname, hasBasePath, stripBasePath } from "../utils/base-path.js";
@@ -31,16 +25,18 @@ import {
   ACTION_REDIRECT_STATUS_HEADER,
   ACTION_REDIRECT_TYPE_HEADER,
   ACTION_REVALIDATED_HEADER,
+  NEXT_ROUTER_STATE_TREE_HEADER,
+  RSC_HEADER,
   VINEXT_MW_CTX_HEADER,
 } from "./headers.js";
 import {
   VINEXT_RSC_CONTENT_TYPE,
   VINEXT_RSC_VARY_HEADER,
   applyRscCompatibilityIdHeader,
+  createRscRequestUrl,
   stripRscCacheBustingSearchParam,
 } from "./app-rsc-cache-busting.js";
 import { applyEdgeRuntimeHeader } from "./app-page-response.js";
-import { getScriptNonceFromHeaderSources } from "./csp.js";
 import { resolveAppPageActionRerenderTarget } from "./app-page-request.js";
 import { resolveAppPageNavigationParams } from "./app-page-element-builder.js";
 import { deferUntilStreamConsumed } from "./app-page-stream.js";
@@ -67,6 +63,7 @@ import {
 } from "./server-action-not-found.js";
 import { internalServerErrorResponse, payloadTooLargeResponse } from "./http-error-responses.js";
 import { createStaticGenerationHeadersContext } from "./app-static-generation.js";
+import { markAppRscResponseConfigHeadersApplied } from "./app-rsc-response-finalizer.js";
 
 type AppPageParams = Record<string, string | string[]>;
 
@@ -214,15 +211,6 @@ type DecodeServerActionReplyOptions<TTemporaryReferences> = {
   temporaryReferences: TTemporaryReferences;
 };
 
-/**
- * Outcome of running middleware for an action-redirect target. `diverted` means
- * middleware blocked, redirected, or rewrote the target, so it cannot be
- * rendered inline and has to be resolved by a real navigation.
- */
-export type ActionRedirectMiddlewareResult =
-  | { kind: "continue"; responseHeaders: Headers | null }
-  | { kind: "diverted" };
-
 export type HandleProgressiveServerActionRequestOptions = {
   actionId: string | null;
   allowedOrigins: string[];
@@ -316,16 +304,14 @@ export type HandleServerActionRscRequestOptions<
   middlewareRequestHeaders: Headers | null;
   middlewareStatus: number | null | undefined;
   /**
-   * Run userland middleware for an internal action-redirect target before that
-   * target is rendered inline. Middleware only ran for the action's own path,
-   * so without this the target's middleware — commonly the app's authorization
-   * boundary — would never see the request. Absent when the app has no
-   * middleware.
+   * Dispatch a synthetic redirect-target GET through the complete App Router
+   * request pipeline. The callback enters a fresh request context and returns
+   * the finalized response, including config rules, middleware, routing, and
+   * response headers.
    */
-  runRedirectTargetMiddleware?: (options: {
-    cleanPathname: string;
-    request: Request;
-  }) => Promise<ActionRedirectMiddlewareResult>;
+  dispatchRedirectTargetRequest: (request: Request) => Promise<Response>;
+  /** next.config headers matched on the action source path, before middleware. */
+  sourceConfigHeaders?: Headers | null;
   mountedSlotsHeader: string | null;
   readBodyWithLimit: ReadBodyWithLimit;
   readFormDataWithLimit: ReadFormDataWithLimit;
@@ -464,6 +450,7 @@ function clearRejectedActionSideEffects(getAndClearPendingCookies: () => string[
 
 function cloneActionRedirectHeaders(
   requestHeaders: Headers,
+  sourceConfigHeaders: Headers | null,
   actionMiddlewareHeaders: Headers | null,
 ): Headers {
   const headers = new Headers(requestHeaders);
@@ -478,8 +465,9 @@ function cloneActionRedirectHeaders(
   // the request headers before running the target pipeline. Merge after
   // stripping the action request's transport headers so a middleware-emitted
   // value such as Accept or Content-Type remains an intentional target header.
-  if (actionMiddlewareHeaders) {
-    for (const [name, value] of actionMiddlewareHeaders) {
+  for (const responseHeaders of [sourceConfigHeaders, actionMiddlewareHeaders]) {
+    if (!responseHeaders) continue;
+    for (const [name, value] of responseHeaders) {
       const normalizedName = name.toLowerCase();
       if (
         ACTION_REDIRECT_FORWARDED_FORBIDDEN_HEADERS.includes(normalizedName) ||
@@ -570,13 +558,14 @@ function cookiePathMatches(cookiePath: string, requestPath: string): boolean {
   return cookiePath.endsWith("/") || requestPath[cookiePath.length] === "/";
 }
 
-function createActionRedirectRenderRequest(options: {
+async function createActionRedirectTargetRequest(options: {
   actionMiddlewareHeaders: Headers | null;
   actionMiddlewareRequestHeaders: Headers | null;
   pendingCookies: readonly string[];
   request: Request;
+  sourceConfigHeaders: Headers | null;
   url: URL;
-}): Request {
+}): Promise<Request> {
   // App middleware request overrides are applied to headers()/cookies() through
   // ALS, while the Request object remains the pre-middleware request. Next.js
   // mutates req.headers before its internal target GET, so reconstruct that
@@ -589,6 +578,7 @@ function createActionRedirectRenderRequest(options: {
     : options.request.headers;
   const headers = cloneActionRedirectHeaders(
     effectiveRequestHeaders,
+    options.sourceConfigHeaders,
     options.actionMiddlewareHeaders,
   );
   // Like Next.js' internal action-redirect GET, this is necessarily a lossy
@@ -610,21 +600,79 @@ function createActionRedirectRenderRequest(options: {
     headers.set("cookie", cookieHeader);
   }
 
+  // Match Next.js' internal redirect fetch: it is a fresh full-tree RSC GET,
+  // not another action request or a patch against the action route's tree.
+  headers.set(RSC_HEADER, "1");
+  headers.delete(NEXT_ROUTER_STATE_TREE_HEADER);
+  stripRscCacheBustingSearchParam(options.url);
+  const requestPath = await createRscRequestUrl(
+    `${options.url.pathname}${options.url.search}`,
+    headers,
+  );
+  const requestUrl = new URL(requestPath, options.url.origin);
+
   return attachRequestCfMetadata(
-    new Request(options.url, { headers, method: "GET" }),
+    new Request(requestUrl, { headers, method: "GET" }),
     options.request,
   );
 }
 
+const ACTION_REDIRECT_MAX_INTERNAL_REDIRECTS = 20;
+const FOLLOWABLE_REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+async function createActionRedirectFollowRequest(request: Request, url: URL): Promise<Request> {
+  stripRscCacheBustingSearchParam(url);
+  const requestPath = await createRscRequestUrl(`${url.pathname}${url.search}`, request.headers);
+  return attachRequestCfMetadata(
+    new Request(new URL(requestPath, url.origin), {
+      headers: request.headers,
+      method: "GET",
+    }),
+    request,
+  );
+}
+
 /**
- * Headers a pass-through middleware must not be able to change on the action
- * redirect wrapper: `Location` would give the (usually 303) wrapper genuine
- * HTTP-redirect semantics that fetch follows before the client reads the
- * control headers, a foreign `Content-Type` makes the client treat the Flight
- * body as non-RSC and hard-navigate, a stale `Content-Length` misframes the
- * generated Flight stream, and the x-action-* headers steer the client's
- * navigation and cache invalidation.
+ * Resolve a same-origin redirect target through the real App request pipeline.
+ * This mirrors the redirect-following behavior of Next.js' internal fetch while
+ * avoiding a network round trip back into the current Worker/dev server.
  */
+async function dispatchActionRedirectTarget(options: {
+  basePath: string;
+  dispatch: (request: Request) => Promise<Response>;
+  request: Request;
+}): Promise<Response | null> {
+  let request = options.request;
+
+  for (
+    let redirectCount = 0;
+    redirectCount <= ACTION_REDIRECT_MAX_INTERNAL_REDIRECTS;
+    redirectCount++
+  ) {
+    const response = await options.dispatch(request);
+    const location = response.headers.get("location");
+    if (!location || !FOLLOWABLE_REDIRECT_STATUSES.has(response.status)) {
+      return response;
+    }
+
+    response.body?.cancel().catch(() => {});
+    if (redirectCount === ACTION_REDIRECT_MAX_INTERNAL_REDIRECTS) return null;
+
+    const nextUrl = new URL(location, request.url);
+    const currentUrl = new URL(request.url);
+    if (
+      nextUrl.origin !== currentUrl.origin ||
+      (options.basePath !== "" && !hasBasePath(nextUrl.pathname, options.basePath))
+    ) {
+      return null;
+    }
+    request = await createActionRedirectFollowRequest(request, nextUrl);
+  }
+
+  return null;
+}
+
+/** Headers the internally dispatched target must not replace on the action wrapper. */
 const ACTION_REDIRECT_PROTECTED_HEADERS = [
   // Next.js does not copy these connection/framing headers from the internal
   // target GET onto the action wrapper. Set-Cookie is the exception here: it
@@ -639,20 +687,16 @@ const ACTION_REDIRECT_PROTECTED_HEADERS = [
 ];
 
 /**
- * Merge pass-through middleware response headers onto the action redirect
- * wrapper, then restore the wrapper's own protocol headers — including their
- * absence, so middleware can neither replace nor pre-inject them.
+ * Merge the target response headers onto the action redirect wrapper, then
+ * restore the wrapper's own protocol headers — including their absence.
  */
-function mergeActionRedirectMiddlewareHeaders(
-  target: Headers,
-  middlewareHeaders: Headers | null,
-): void {
-  if (!middlewareHeaders) return;
+function mergeActionRedirectTargetHeaders(target: Headers, responseHeaders: Headers | null): void {
+  if (!responseHeaders) return;
 
   const protectedValues = ACTION_REDIRECT_PROTECTED_HEADERS.map(
     (name) => [name, target.get(name)] as const,
   );
-  mergeMiddlewareResponseHeaders(target, middlewareHeaders);
+  mergeMiddlewareResponseHeaders(target, responseHeaders);
   for (const [name, value] of protectedValues) {
     if (value === null) target.delete(name);
     else target.set(name, value);
@@ -861,25 +905,24 @@ function resolveInternalActionRedirectTarget(
   requestUrl: string,
   basePath: string,
 ): URL | null {
-  if (isExternalUrl(redirectUrl)) {
-    const requestOrigin = new URL(requestUrl).origin;
-    const parsed = new URL(redirectUrl);
-    if (parsed.origin !== requestOrigin) return null;
-    if (basePath && !hasBasePath(parsed.pathname, basePath)) return null;
-    return parsed;
-  }
-
-  let resolvedBase = requestUrl;
-  if (!redirectUrl.startsWith("/") && !/^[a-z]+:/i.test(redirectUrl)) {
+  try {
     const parsedRequestUrl = new URL(requestUrl);
-    let pathname = parsedRequestUrl.pathname;
-    if (!pathname.endsWith("/")) {
-      pathname = pathname + "/";
+    let resolvedBase = requestUrl;
+    if (!redirectUrl.startsWith("/") && !/^[a-z]+:/i.test(redirectUrl)) {
+      let pathname = parsedRequestUrl.pathname;
+      if (!pathname.endsWith("/")) {
+        pathname = pathname + "/";
+      }
+      resolvedBase = `${parsedRequestUrl.origin}${pathname}${parsedRequestUrl.search}`;
     }
-    resolvedBase = `${parsedRequestUrl.origin}${pathname}${parsedRequestUrl.search}`;
-  }
 
-  return new URL(redirectUrl, resolvedBase);
+    const resolved = new URL(redirectUrl, resolvedBase);
+    if (resolved.origin !== parsedRequestUrl.origin) return null;
+    if (basePath && !hasBasePath(resolved.pathname, basePath)) return null;
+    return resolved;
+  } catch {
+    return null;
+  }
 }
 
 function isAncestorRouteRedirect(targetPathname: string, currentPathname: string): boolean {
@@ -924,29 +967,18 @@ function shouldUseForwardedActionRedirectStatus<TRoute extends AppServerActionRo
   currentRoute: TRoute | null;
   resolveRouteRuntime?: (route: TRoute) => AppServerActionRouteRuntime;
   targetPathname: string;
-  targetRoute: TRoute;
+  targetRoute: TRoute | null;
 }): boolean {
   if (options.actionWasForwarded) return true;
   if (isAncestorRouteRedirect(options.targetPathname, options.currentPathname)) return true;
   if (isStaleChildSiblingRouteRedirect(options.targetPathname, options.currentPathname)) {
     return true;
   }
-  if (!options.currentRoute || !options.resolveRouteRuntime) return false;
+  if (!options.currentRoute || !options.targetRoute || !options.resolveRouteRuntime) return false;
 
   const currentRuntime = normalizeRuntime(options.resolveRouteRuntime(options.currentRoute));
   const targetRuntime = normalizeRuntime(options.resolveRouteRuntime(options.targetRoute));
   return currentRuntime !== targetRuntime;
-}
-
-/**
- * Decided from lazy thunks as well as hydrated fields so it needs no
- * `ensureRouteLoaded` first: a middleware-blocked target must never execute
- * its modules' top-level code, so the route cannot be hydrated before
- * middleware has cleared it.
- */
-function canRenderActionRedirectTarget(route: AppServerActionRoute): boolean {
-  if (("routeHandler" in route && route.routeHandler) || route.__loadRouteHandler) return false;
-  return (route.page !== null && route.page !== undefined) || route.__loadPage != null;
 }
 
 function getActionHttpFallbackStatus(error: unknown): number | null {
@@ -1448,7 +1480,8 @@ export async function handleServerActionRscRequest<
         Vary: VINEXT_RSC_VARY_HEADER,
       });
       applyEdgeRuntimeHeader(redirectHeaders, options.isEdgeRuntime);
-      mergeActionRedirectMiddlewareHeaders(redirectHeaders, options.middlewareHeaders);
+      mergeActionRedirectTargetHeaders(redirectHeaders, options.sourceConfigHeaders ?? null);
+      mergeActionRedirectTargetHeaders(redirectHeaders, options.middlewareHeaders);
       applyRscCompatibilityIdHeader(redirectHeaders);
       // Prefix basePath onto the redirect target. The client-side handler in
       // app-browser-entry reads ACTION_REDIRECT_HEADER and calls
@@ -1480,15 +1513,39 @@ export async function handleServerActionRscRequest<
         });
       }
 
-      // The real request pipeline strips the internal `_rsc` transport param
-      // before middleware and rendering (app-rsc-handler); the synthetic target
-      // must match, or middleware matchers see a query no navigation carries.
-      // The x-action-redirect header above keeps the verbatim URL — a diverted
-      // client re-request goes through the pipeline's own `_rsc` validation.
-      stripRscCacheBustingSearchParam(redirectTarget);
-      const targetPathname = stripBasePath(redirectTarget.pathname, options.basePath ?? "");
-      const targetMatch = options.matchRoute(targetPathname);
-      if (!targetMatch || !canRenderActionRedirectTarget(targetMatch.route)) {
+      let targetResponse: Response | null = null;
+      try {
+        const targetRequest = await createActionRedirectTargetRequest({
+          actionMiddlewareHeaders: options.middlewareHeaders,
+          actionMiddlewareRequestHeaders: options.middlewareRequestHeaders,
+          // Project the action middleware's Set-Cookie mutations (session
+          // rotation or deletion) into the internal target request first; the
+          // action's own cookies().set() calls land after middleware and win for
+          // the same name, matching Next.js' forwarded-cookie ordering.
+          pendingCookies: [
+            ...(options.sourceConfigHeaders?.getSetCookie() ?? []),
+            ...(options.middlewareHeaders?.getSetCookie() ?? []),
+            ...actionPendingCookies,
+            ...(actionDraftCookie ? [actionDraftCookie] : []),
+          ],
+          request: options.request,
+          sourceConfigHeaders: options.sourceConfigHeaders ?? null,
+          url: redirectTarget,
+        });
+        targetResponse = await dispatchActionRedirectTarget({
+          basePath: options.basePath ?? "",
+          dispatch: options.dispatchRedirectTargetRequest,
+          request: targetRequest,
+        });
+      } catch (error) {
+        console.error("[vinext] Failed to dispatch server action redirect target:", error);
+      }
+      if (
+        !targetResponse ||
+        !targetResponse.headers.get("content-type")?.startsWith(VINEXT_RSC_CONTENT_TYPE) ||
+        !targetResponse.body
+      ) {
+        targetResponse?.body?.cancel().catch(() => {});
         options.clearRequestContext();
         return new Response(null, {
           status: 303,
@@ -1496,130 +1553,27 @@ export async function handleServerActionRscRequest<
         });
       }
 
-      const redirectRenderRequest = createActionRedirectRenderRequest({
-        actionMiddlewareHeaders: options.middlewareHeaders,
-        actionMiddlewareRequestHeaders: options.middlewareRequestHeaders,
-        // Project the action middleware's Set-Cookie mutations (session
-        // rotation or deletion) into the internal target request first; the
-        // action's own cookies().set() calls land after middleware and win for
-        // the same name, matching Next.js' forwarded-cookie ordering.
-        pendingCookies: [
-          ...(options.middlewareHeaders?.getSetCookie() ?? []),
-          ...actionPendingCookies,
-          ...(actionDraftCookie ? [actionDraftCookie] : []),
-        ],
-        request: options.request,
-        url: redirectTarget,
-      });
-      setHeadersContext(
-        headersContextFromRequest(redirectRenderRequest, {
-          draftModeSecret: options.draftModeSecret,
-        }),
-      );
-      // Middleware ran for the action's own path, not the target's. Run it here
-      // (against the headers context above, so request-header overrides land on
-      // the render) and hand anything it wants to change back to the client as a
-      // plain redirect it will re-request through the full pipeline.
-      if (options.runRedirectTargetMiddleware) {
-        const targetMiddleware = await options.runRedirectTargetMiddleware({
-          cleanPathname: targetPathname,
-          request: redirectRenderRequest,
-        });
-        // Diverting costs the target one extra middleware execution, since the
-        // client's navigation runs it again. A pass-through — the common case —
-        // runs it exactly once because no navigation follows, so the extra run
-        // buys a single round-trip redirect for every app that has middleware.
-        if (targetMiddleware.kind === "diverted") {
-          options.clearRequestContext();
-          return new Response(null, {
-            status: 303,
-            headers: withoutRscBodyHeaders(redirectHeaders),
-          });
-        }
-        mergeActionRedirectMiddlewareHeaders(redirectHeaders, targetMiddleware.responseHeaders);
-      }
-      // Hydrate the target only now that middleware has cleared it: importing
-      // its modules runs their top-level code, which a blocked target must
-      // never execute. The dynamic-config / fetch-cache reads below need the
-      // hydrated route.
-      await options.ensureRouteLoaded?.(targetMatch.route);
+      mergeActionRedirectTargetHeaders(redirectHeaders, targetResponse.headers);
+      const targetPathname = stripBasePath(redirectTarget.pathname, options.basePath ?? "");
+      const targetMatch = options.matchRoute(targetPathname);
       const currentMatch = options.currentRouteMatch;
-      // Hydrate the current route before resolving its runtime below.
-      if (currentMatch) await options.ensureRouteLoaded?.(currentMatch.route);
-      const redirectDynamicConfig = options.resolveRouteDynamicConfig?.(targetMatch.route);
-      const redirectSearchParams = prepareActionPageRerenderContext({
-        draftModeCookie: actionDraftCookie,
-        draftModeSecret: options.draftModeSecret,
-        dynamicConfig: redirectDynamicConfig,
-        request: redirectRenderRequest,
-        routePattern: targetMatch.route.pattern,
-        searchParams: redirectTarget.searchParams,
-      });
-      const redirectNavigationParams = resolveAppPageNavigationParams(
-        targetMatch.route,
-        targetMatch.params,
-        targetPathname,
-        null,
-      );
-      options.setNavigationContext({
-        pathname: targetPathname,
-        searchParams: redirectSearchParams,
-        params: redirectNavigationParams,
-      });
-      setCurrentFetchCacheMode(options.resolveRouteFetchCacheMode?.(targetMatch.route) ?? null);
-      setCurrentForceDynamicFetchDefault(redirectDynamicConfig === "force-dynamic");
-      setCurrentFetchSoftTags(buildServerActionPageTags(targetMatch.route, targetPathname));
-      // Target middleware can replace the action path's CSP with a freshly
-      // generated nonce. Build the inline target with the nonce on the final
-      // response it represents, not the stale action-path nonce.
-      const redirectScriptNonce = getScriptNonceFromHeaderSources(
-        redirectHeaders,
-        redirectRenderRequest.headers,
-      );
-      const rscStream = await runWithRootParamsScope(
-        pickRootParams(targetMatch.params, targetMatch.route.rootParamNames),
-        () =>
-          runWithRootParamsUsage({ kind: "route" }, async () => {
-            const element = options.buildPageElement({
-              cleanPathname: targetPathname,
-              interceptOpts: undefined,
-              isRscRequest: true,
-              mountedSlotsHeader: null,
-              params: targetMatch.params,
-              request: redirectRenderRequest,
-              route: targetMatch.route,
-              searchParams: redirectSearchParams,
-              scriptNonce: redirectScriptNonce,
-              renderMode: APP_RSC_RENDER_MODE_NAVIGATION,
-              observeMetadataSearchParamsAccess: redirectDynamicConfig !== "force-static",
-              observePageSearchParamsAccess: redirectDynamicConfig !== "force-static",
-            });
-            const onRenderError = options.createRscOnErrorHandler(
-              redirectRenderRequest,
-              targetPathname,
-              targetMatch.route.pattern,
-            );
-            return options.renderToReadableStream(
-              { root: element, returnValue },
-              { temporaryReferences, onError: onRenderError },
-            );
-          }),
-      );
       const redirectResponseStatus = shouldUseForwardedActionRedirectStatus({
         actionWasForwarded,
         currentPathname: options.cleanPathname,
         currentRoute: currentMatch?.route ?? null,
         resolveRouteRuntime: options.resolveRouteRuntime,
         targetPathname,
-        targetRoute: targetMatch.route,
+        targetRoute: targetMatch?.route ?? null,
       })
         ? 200
         : 303;
 
-      return createServerActionRscResponse(
-        rscStream,
-        { status: redirectResponseStatus, headers: redirectHeaders },
-        options.clearRequestContext,
+      return markAppRscResponseConfigHeadersApplied(
+        createServerActionRscResponse(
+          targetResponse.body,
+          { status: redirectResponseStatus, headers: redirectHeaders },
+          options.clearRequestContext,
+        ),
       );
     }
 

--- a/packages/vinext/src/server/request-pipeline.ts
+++ b/packages/vinext/src/server/request-pipeline.ts
@@ -528,6 +528,24 @@ function getRequestCf(request: Request): unknown {
 }
 
 /**
+ * Re-attach the Workers-specific `cf` metadata from `source` onto a rebuilt
+ * Request. `new Request()` never copies it, and middleware/authorization code
+ * can key off `request.cf` (geo checks, bot scores), so every reconstruction
+ * must restore it explicitly.
+ */
+export function attachRequestCfMetadata(target: Request, source: Request): Request {
+  const cf = getRequestCf(source);
+  if (cf !== undefined) {
+    Object.defineProperty(target, "cf", {
+      value: cf,
+      enumerable: true,
+      configurable: true,
+    });
+  }
+  return target;
+}
+
+/**
  * Clone a Request while overriding headers, preserving metadata when possible.
  *
  * Some runtimes (Workers) allow `new Request(request, { headers })` which
@@ -559,16 +577,7 @@ export function cloneRequestWithHeaders(request: Request, headers: Headers): Req
     }
     cloned = new Request(request.url, init);
   }
-  const cf = getRequestCf(request);
-  if (cf !== undefined) {
-    // new Request() does not copy Workers-specific cf, so re-attach it.
-    Object.defineProperty(cloned, "cf", {
-      value: cf,
-      enumerable: true,
-      configurable: true,
-    });
-  }
-  return cloned;
+  return attachRequestCfMetadata(cloned, request);
 }
 
 /**
@@ -607,14 +616,5 @@ export function cloneRequestWithUrl(request: Request, url: string): Request {
     }
     cloned = new Request(url, init);
   }
-  const cf = getRequestCf(request);
-  if (cf !== undefined) {
-    // new Request() does not copy Workers-specific cf, so re-attach it.
-    Object.defineProperty(cloned, "cf", {
-      value: cf,
-      enumerable: true,
-      configurable: true,
-    });
-  }
-  return cloned;
+  return attachRequestCfMetadata(cloned, request);
 }

--- a/tests/app-browser-server-action-client.test.ts
+++ b/tests/app-browser-server-action-client.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { createFromFetch } from "@vitejs/plugin-rsc/browser";
 import { createClientNavigationRenderSnapshot } from "../packages/vinext/src/shims/navigation.js";
 import { createServerActionInitiationSnapshot } from "../packages/vinext/src/server/app-browser-action-result.js";
 import { invokeClientServerAction } from "../packages/vinext/src/server/app-browser-server-action-client.js";
@@ -21,6 +22,83 @@ afterEach(() => {
 });
 
 describe("app browser server action client", () => {
+  it("commits a raw full-tree Flight payload from an internal action redirect", async () => {
+    const wireElements = AppElementsWire.createMetadataEntries({
+      interception: null,
+      interceptionContext: null,
+      layoutIds: [AppElementsWire.encodeLayoutId("/")],
+      rootLayoutTreePath: "/",
+      routeId: AppElementsWire.encodeRouteId("/target", null),
+      slotBindings: [],
+    });
+    const elements = normalizeAppElements(wireElements);
+    const routerState: AppRouterState = {
+      activeOperation: null,
+      bfcacheIds: {},
+      elements,
+      interception: null,
+      interceptionContext: null,
+      layoutFlags: {},
+      layoutIds: [AppElementsWire.encodeLayoutId("/")],
+      navigationSnapshot: createClientNavigationRenderSnapshot("https://example.com/source", {}),
+      previousNextUrl: null,
+      renderId: 0,
+      rootLayoutTreePath: "/",
+      routeId: AppElementsWire.encodeRouteId("/source", null),
+      slotBindings: [],
+      visibleCommitVersion: 0,
+    };
+    vi.stubGlobal("window", {
+      location: { href: "https://example.com/source", origin: "https://example.com" },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response("flight", {
+          status: 303,
+          headers: {
+            [ACTION_REDIRECT_HEADER]: "/target",
+            "content-type": "text/x-component",
+          },
+        }),
+      ),
+    );
+    vi.mocked(createFromFetch).mockResolvedValueOnce(wireElements);
+    const renderRedirectPayload = vi.fn();
+    const performHardNavigation = vi.fn();
+
+    await expect(
+      invokeClientServerAction(
+        "action-id",
+        [],
+        createServerActionInitiationSnapshot({
+          href: "https://example.com/source",
+          navigationId: 1,
+          routerState,
+        }),
+        {
+          basePath: "",
+          clearClientNavigationCaches: vi.fn(),
+          clientRscCompatibilityId: null,
+          commitSameUrlNavigatePayload: vi.fn(),
+          navigationPlanner,
+          performHardNavigation,
+          renderRedirectPayload,
+          syncCurrentHistoryState: vi.fn(),
+          syncServerActionHttpFallbackHead: vi.fn(),
+        },
+      ),
+    ).rejects.toMatchObject({ handled: true });
+
+    expect(renderRedirectPayload).toHaveBeenCalledWith(
+      normalizeAppElements(wireElements),
+      expect.objectContaining({ href: "https://example.com/target" }),
+      expect.any(Object),
+      "none",
+    );
+    expect(performHardNavigation).not.toHaveBeenCalled();
+  });
+
   it("uses action state captured before the lazy client loads", async () => {
     const elements = normalizeAppElements(
       AppElementsWire.createMetadataEntries({

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -521,6 +521,52 @@ describe("createAppRscHandler", () => {
     expect(middlewareRequest!.nextUrl.pathname).toBe("/outside");
   });
 
+  // A redirecting Server Action renders the target page inline, so the target's
+  // middleware only runs if the handler hands the action dispatch a way to run
+  // it. Without this an action on a public path could return a middleware-gated
+  // page's Flight payload.
+  it("runs middleware for Server Action redirect targets", async () => {
+    const seenPathnames: string[] = [];
+    const middleware = vi.fn((request: NextRequest) => {
+      const { pathname } = new URL(request.url);
+      seenPathnames.push(pathname);
+      return pathname === "/docs/protected"
+        ? new Response("unauthorized", { status: 401 })
+        : new Response(null, { headers: { "x-middleware-next": "1" } });
+    });
+    let runRedirectTargetMiddleware:
+      | ((options: { cleanPathname: string; request: Request }) => Promise<{ kind: string }>)
+      | undefined;
+    const handler = createHandler({
+      configHeaders: [],
+      handleServerActionRequest: async (options) => {
+        runRedirectTargetMiddleware = options.runRedirectTargetMiddleware;
+        return new Response("action");
+      },
+      middlewareModule: { default: middleware },
+    });
+
+    const response = await handler(
+      new Request("https://example.test/docs/about", {
+        method: "POST",
+        headers: { "next-action": "action-id", "content-type": "text/plain" },
+      }),
+      null,
+    );
+
+    expect(response.status).toBe(200);
+    expect(seenPathnames).toEqual(["/docs/about"]);
+
+    expect(runRedirectTargetMiddleware).toBeDefined();
+    await expect(
+      runRedirectTargetMiddleware!({
+        cleanPathname: "/protected",
+        request: new Request("https://example.test/docs/protected"),
+      }),
+    ).resolves.toEqual({ kind: "diverted" });
+    expect(seenPathnames).toEqual(["/docs/about", "/docs/protected"]);
+  });
+
   it.each([
     "url=%2Fimg.jpg&w=640junk&q=75",
     "url=%2Fimg.jpg&w=640&q=75&extra=1",

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -219,6 +219,27 @@ describe("createAppRscHandler", () => {
     },
   );
 
+  it("passes source config headers into Server Action execution", async () => {
+    let sourceConfigHeader: string | null | undefined;
+    const handleServerActionRequest: NonNullable<
+      HandlerOptions["handleServerActionRequest"]
+    > = async (options) => {
+      sourceConfigHeader = options.sourceConfigHeaders?.get("x-test-header");
+      return new Response("action");
+    };
+    const handler = createHandler({ handleServerActionRequest });
+
+    await handler(
+      new Request("https://example.test/docs/about", {
+        method: "POST",
+        headers: { "next-action": "action-id", "content-type": "text/plain" },
+      }),
+      null,
+    );
+
+    expect(sourceConfigHeader).toBe("applied");
+  });
+
   it.each(["afterFiles", "fallback"] as const)(
     "allows out-of-basePath POST requests through %s rewrites to App route handlers",
     async (phase) => {
@@ -521,11 +542,7 @@ describe("createAppRscHandler", () => {
     expect(middlewareRequest!.nextUrl.pathname).toBe("/outside");
   });
 
-  // A redirecting Server Action renders the target page inline, so the target's
-  // middleware only runs if the handler hands the action dispatch a way to run
-  // it. Without this an action on a public path could return a middleware-gated
-  // page's Flight payload.
-  it("runs middleware for Server Action redirect targets", async () => {
+  it("dispatches Server Action redirect targets through the complete App pipeline", async () => {
     const seenPathnames: string[] = [];
     const middleware = vi.fn((request: NextRequest) => {
       const { pathname } = new URL(request.url);
@@ -534,13 +551,11 @@ describe("createAppRscHandler", () => {
         ? new Response("unauthorized", { status: 401 })
         : new Response(null, { headers: { "x-middleware-next": "1" } });
     });
-    let runRedirectTargetMiddleware:
-      | ((options: { cleanPathname: string; request: Request }) => Promise<{ kind: string }>)
-      | undefined;
+    let dispatchRedirectTargetRequest: ((request: Request) => Promise<Response>) | undefined;
     const handler = createHandler({
       configHeaders: [],
       handleServerActionRequest: async (options) => {
-        runRedirectTargetMiddleware = options.runRedirectTargetMiddleware;
+        dispatchRedirectTargetRequest = options.dispatchRedirectTargetRequest;
         return new Response("action");
       },
       middlewareModule: { default: middleware },
@@ -557,13 +572,12 @@ describe("createAppRscHandler", () => {
     expect(response.status).toBe(200);
     expect(seenPathnames).toEqual(["/docs/about"]);
 
-    expect(runRedirectTargetMiddleware).toBeDefined();
-    await expect(
-      runRedirectTargetMiddleware!({
-        cleanPathname: "/protected",
-        request: new Request("https://example.test/docs/protected"),
-      }),
-    ).resolves.toEqual({ kind: "diverted" });
+    expect(dispatchRedirectTargetRequest).toBeDefined();
+    const targetResponse = await dispatchRedirectTargetRequest!(
+      new Request("https://example.test/docs/protected"),
+    );
+    expect(targetResponse.status).toBe(401);
+    expect(await targetResponse.text()).toBe("unauthorized");
     expect(seenPathnames).toEqual(["/docs/about", "/docs/protected"]);
   });
 

--- a/tests/app-rsc-response-finalizer.test.ts
+++ b/tests/app-rsc-response-finalizer.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vite-plus/test";
 import { VINEXT_RSC_VARY_HEADER } from "../packages/vinext/src/server/app-rsc-cache-busting.js";
-import { finalizeAppRscResponse } from "../packages/vinext/src/server/app-rsc-response-finalizer.js";
+import {
+  finalizeAppRscResponse,
+  markAppRscResponseConfigHeadersApplied,
+} from "../packages/vinext/src/server/app-rsc-response-finalizer.js";
 import type { RequestContext } from "../packages/vinext/src/config/request-context.js";
 
 function makeRequestContext(headers: Headers = new Headers()): RequestContext {
@@ -29,6 +32,26 @@ describe("finalizeAppRscResponse — config header application", () => {
     });
 
     expect(response.headers.get("x-added")).toBe("config");
+  });
+
+  it("does not reapply source config headers to an internally dispatched target response", async () => {
+    const response = markAppRscResponseConfigHeadersApplied(
+      new Response("target flight", { headers: { "x-route-value": "target" } }),
+    );
+
+    await finalizeAppRscResponse(response, new Request("http://example.com/action-source"), {
+      basePath: "",
+      configHeaders: [
+        {
+          source: "/action-source",
+          headers: [{ key: "x-route-value", value: "source" }],
+        },
+      ],
+      i18nConfig: null,
+      requestContext: makeRequestContext(),
+    });
+
+    expect(response.headers.get("x-route-value")).toBe("target");
   });
 
   it("adds the App Router RSC vary header when no config headers are configured", async () => {

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -2168,9 +2168,12 @@ describe("app server action execution helpers", () => {
         },
         middlewareHeaders: new Headers({
           accept: "application/action-middleware",
+          cookie: "forged=1",
           "content-length": "999",
+          "set-cookie": "session=rotated; Path=/",
           "x-action-auth-context": "member",
         }),
+        request: createFetchActionRequest({ cookie: "theme=dark" }),
         async runRedirectTargetMiddleware(targetOptions: { request: Request }) {
           middlewareRequest = targetOptions.request;
           return { kind: "continue", responseHeaders: null };
@@ -2182,10 +2185,12 @@ describe("app server action execution helpers", () => {
     expect(response?.headers.get("content-length")).toBeNull();
     expect(middlewareRequest).not.toBeNull();
     expect(middlewareRequest!.headers.get("accept")).toBe("application/action-middleware");
+    expect(middlewareRequest!.headers.get("cookie")).toBe("theme=dark; session=rotated");
     expect(middlewareRequest!.headers.get("content-length")).toBeNull();
     expect(middlewareRequest!.headers.get("x-action-auth-context")).toBe("member");
     expect(renderRequest).not.toBeNull();
     expect(renderRequest!.headers.get("accept")).toBe("application/action-middleware");
+    expect(renderRequest!.headers.get("cookie")).toBe("theme=dark; session=rotated");
     expect(renderRequest!.headers.get("content-length")).toBeNull();
     expect(renderRequest!.headers.get("x-action-auth-context")).toBe("member");
   });
@@ -2254,6 +2259,7 @@ describe("app server action execution helpers", () => {
           };
         },
         middlewareHeaders: new Headers({
+          "content-encoding": "br",
           location: "/mw-location",
           "content-type": "text/html",
           "x-action-redirect": "/mw-hijack",
@@ -2263,9 +2269,13 @@ describe("app server action execution helpers", () => {
           return {
             kind: "continue",
             responseHeaders: new Headers({
+              "accept-encoding": "gzip",
+              connection: "close",
+              "content-encoding": "gzip",
               location: "/target-mw-location",
               "content-type": "text/html",
               "content-length": "0",
+              "transfer-encoding": "chunked",
               "x-action-redirect": "/target-hijack",
               "x-target-mw": "1",
             }),
@@ -2284,7 +2294,11 @@ describe("app server action execution helpers", () => {
     expect(response?.headers.get("x-action-redirect")).toBe("/redirect-target");
     expect(response?.headers.get("location")).toBeNull();
     expect(response?.headers.get("content-type")).toContain("text/x-component");
+    expect(response?.headers.get("accept-encoding")).toBeNull();
+    expect(response?.headers.get("connection")).toBeNull();
+    expect(response?.headers.get("content-encoding")).toBeNull();
     expect(response?.headers.get("content-length")).toBeNull();
+    expect(response?.headers.get("transfer-encoding")).toBeNull();
     expect(response?.headers.get("x-action-mw")).toBe("1");
     expect(response?.headers.get("x-target-mw")).toBe("1");
   });

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -1983,6 +1983,87 @@ describe("app server action execution helpers", () => {
     expect(buildPageElement).not.toHaveBeenCalled();
   });
 
+  it("falls back to header-only redirects when target middleware diverts the request", async () => {
+    const buildPageElement = vi.fn(() => "should-not-render");
+    const runRedirectTargetMiddleware = vi.fn(async () => ({ kind: "diverted" }) as const);
+
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        buildPageElement,
+        loadServerAction() {
+          return Promise.resolve(() => redirect("/protected"));
+        },
+        matchRoute(pathname) {
+          if (pathname === "/protected") {
+            return {
+              params: {},
+              route: { id: "protected", page: {}, params: [], pattern: "/protected" },
+            };
+          }
+          return {
+            params: {},
+            route: { id: "dashboard", page: {}, params: [], pattern: "/dashboard" },
+          };
+        },
+        runRedirectTargetMiddleware,
+      }),
+    );
+
+    expect(response?.status).toBe(303);
+    expect(response?.headers.get("x-action-redirect")).toBe("/protected");
+    expect(response?.headers.get("content-type")).toBeNull();
+    expect(await response?.text()).toBe("");
+    expect(buildPageElement).not.toHaveBeenCalled();
+    expect(runRedirectTargetMiddleware).toHaveBeenCalledWith({
+      cleanPathname: "/protected",
+      request: expect.any(Request),
+    });
+  });
+
+  it("renders redirect targets that middleware passes through and keeps its response headers", async () => {
+    let middlewareRequest: Request | null = null;
+    const runRedirectTargetMiddleware = vi.fn(async (targetOptions: { request: Request }) => {
+      middlewareRequest = targetOptions.request;
+      return {
+        kind: "continue" as const,
+        responseHeaders: new Headers({ "x-from-target-middleware": "1" }),
+      };
+    });
+
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        loadServerAction() {
+          return Promise.resolve(() => redirect("/redirect-target"));
+        },
+        matchRoute(pathname) {
+          if (pathname === "/redirect-target") {
+            return {
+              params: {},
+              route: { id: "redirect-target", page: {}, params: [], pattern: "/redirect-target" },
+            };
+          }
+          return {
+            params: {},
+            route: { id: "dashboard", page: {}, params: [], pattern: "/dashboard" },
+          };
+        },
+        runRedirectTargetMiddleware,
+      }),
+    );
+
+    expect(response?.status).toBe(303);
+    expect(response?.headers.get("x-from-target-middleware")).toBe("1");
+    expect(JSON.parse(await response!.text())).toEqual({
+      root: "redirect-target:{}:none",
+      returnValue: { ok: true },
+    });
+
+    expect(middlewareRequest).not.toBeNull();
+    expect(middlewareRequest!.method).toBe("GET");
+    expect(middlewareRequest!.url).toBe("https://example.com/redirect-target");
+    expect(middlewareRequest!.headers.get("next-action")).toBeNull();
+  });
+
   it("does not emit x-action-revalidated when a fetch action revalidates a tag with a profile", async () => {
     const response = await handleServerActionRscRequest(
       createRscOptions({

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -2098,6 +2098,49 @@ describe("app server action execution helpers", () => {
     expect(Reflect.get(renderRequest!, "cf")).toEqual({ country: "AU" });
   });
 
+  it("builds an inline redirect target with target middleware's CSP nonce", async () => {
+    const buildPageElement = vi.fn(() => "redirect-target:{}:none");
+
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        buildPageElement,
+        loadServerAction() {
+          return Promise.resolve(() => redirect("/redirect-target"));
+        },
+        matchRoute(pathname) {
+          if (pathname === "/redirect-target") {
+            return {
+              params: {},
+              route: { id: "redirect-target", page: {}, params: [], pattern: "/redirect-target" },
+            };
+          }
+          return {
+            params: {},
+            route: { id: "dashboard", page: {}, params: [], pattern: "/dashboard" },
+          };
+        },
+        middlewareHeaders: new Headers({
+          "content-security-policy": "script-src 'nonce-action-path'",
+        }),
+        async runRedirectTargetMiddleware() {
+          return {
+            kind: "continue",
+            responseHeaders: new Headers({
+              "content-security-policy": "script-src 'nonce-redirect-target'",
+            }),
+          };
+        },
+      }),
+    );
+
+    expect(response?.headers.get("content-security-policy")).toBe(
+      "script-src 'nonce-redirect-target'",
+    );
+    expect(buildPageElement).toHaveBeenCalledWith(
+      expect.objectContaining({ scriptNonce: "redirect-target" }),
+    );
+  });
+
   it("runs target middleware before hydrating a lazy target route's modules", async () => {
     const events: string[] = [];
     const lazyRoute: TestRoute = {

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -2173,6 +2173,7 @@ describe("app server action execution helpers", () => {
             responseHeaders: new Headers({
               location: "/target-mw-location",
               "content-type": "text/html",
+              "content-length": "0",
               "x-action-redirect": "/target-hijack",
               "x-target-mw": "1",
             }),
@@ -2183,13 +2184,15 @@ describe("app server action execution helpers", () => {
 
     // The wrapper's protocol headers steer the action client: a Location on the
     // 303 would make fetch follow it before the client reads x-action-redirect,
-    // a foreign Content-Type flips the client to a hard navigation, and
+    // a foreign Content-Type flips the client to a hard navigation, a stale
+    // Content-Length misframes the generated Flight stream, and
     // x-action-redirect is the destination itself. Ordinary middleware headers
     // must still come through.
     expect(response?.status).toBe(303);
     expect(response?.headers.get("x-action-redirect")).toBe("/redirect-target");
     expect(response?.headers.get("location")).toBeNull();
     expect(response?.headers.get("content-type")).toContain("text/x-component");
+    expect(response?.headers.get("content-length")).toBeNull();
     expect(response?.headers.get("x-action-mw")).toBe("1");
     expect(response?.headers.get("x-target-mw")).toBe("1");
   });
@@ -2217,6 +2220,7 @@ describe("app server action execution helpers", () => {
         middlewareHeaders: new Headers([
           ["set-cookie", "session=; Max-Age=0"],
           ["set-cookie", "csrf=rotated"],
+          ["set-cookie", "admin=1; Path=/account"],
         ]),
         request: createFetchActionRequest({ cookie: "session=live; csrf=old; theme=dark" }),
         async runRedirectTargetMiddleware(targetOptions: { request: Request }) {
@@ -2229,7 +2233,9 @@ describe("app server action execution helpers", () => {
     // The action middleware deleted the session and rotated csrf. The browser
     // applies those before navigating to the redirect target, so target
     // middleware evaluating the pre-mutation jar would authorize on a
-    // credential the response is simultaneously revoking.
+    // credential the response is simultaneously revoking. The /account-scoped
+    // cookie is one a browser would never send to /redirect-target, so it must
+    // not appear either.
     expect(middlewareRequest).not.toBeNull();
     expect(middlewareRequest!.headers.get("cookie")).toBe("csrf=rotated; theme=dark");
   });

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -2022,6 +2022,7 @@ describe("app server action execution helpers", () => {
 
   it("renders redirect targets that middleware passes through and keeps its response headers", async () => {
     let middlewareRequest: Request | null = null;
+    let renderRequest: Request | null = null;
     const runRedirectTargetMiddleware = vi.fn(async (targetOptions: { request: Request }) => {
       middlewareRequest = targetOptions.request;
       return {
@@ -2032,9 +2033,17 @@ describe("app server action execution helpers", () => {
 
     const response = await handleServerActionRscRequest(
       createRscOptions({
+        buildPageElement({ route: matchedRoute, request }) {
+          renderRequest = request;
+          return `${matchedRoute.id}:{}:none`;
+        },
         loadServerAction() {
           return Promise.resolve(() => redirect("/redirect-target"));
         },
+        request: createFetchActionRequest({
+          accept: "text/x-component",
+          "x-vinext-mw-ctx": JSON.stringify({}),
+        }),
         matchRoute(pathname) {
           if (pathname === "/redirect-target") {
             return {
@@ -2058,10 +2067,20 @@ describe("app server action execution helpers", () => {
       returnValue: { ok: true },
     });
 
+    // Middleware must see the request the client would otherwise have sent:
+    // a GET for the target that still carries Accept, which object matchers can
+    // gate on. The forwarded-middleware-context header describes the *action*
+    // path's result and would make the target skip middleware entirely.
     expect(middlewareRequest).not.toBeNull();
     expect(middlewareRequest!.method).toBe("GET");
     expect(middlewareRequest!.url).toBe("https://example.com/redirect-target");
+    expect(middlewareRequest!.headers.get("accept")).toBe("text/x-component");
     expect(middlewareRequest!.headers.get("next-action")).toBeNull();
+    expect(middlewareRequest!.headers.get("x-vinext-mw-ctx")).toBeNull();
+
+    expect(renderRequest).not.toBeNull();
+    expect(renderRequest!.headers.get("accept")).toBeNull();
+    expect(renderRequest!.headers.get("x-vinext-mw-ctx")).toBeNull();
   });
 
   it("does not emit x-action-revalidated when a fetch action revalidates a tag with a profile", async () => {

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -2141,6 +2141,55 @@ describe("app server action execution helpers", () => {
     );
   });
 
+  it("forwards filtered action middleware response headers to the redirect target", async () => {
+    let middlewareRequest: Request | null = null;
+    let renderRequest: Request | null = null;
+
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        buildPageElement({ route: matchedRoute, request }) {
+          renderRequest = request;
+          return `${matchedRoute.id}:{}:none`;
+        },
+        loadServerAction() {
+          return Promise.resolve(() => redirect("/redirect-target"));
+        },
+        matchRoute(pathname) {
+          if (pathname === "/redirect-target") {
+            return {
+              params: {},
+              route: { id: "redirect-target", page: {}, params: [], pattern: "/redirect-target" },
+            };
+          }
+          return {
+            params: {},
+            route: { id: "dashboard", page: {}, params: [], pattern: "/dashboard" },
+          };
+        },
+        middlewareHeaders: new Headers({
+          accept: "application/action-middleware",
+          "content-length": "999",
+          "x-action-auth-context": "member",
+        }),
+        async runRedirectTargetMiddleware(targetOptions: { request: Request }) {
+          middlewareRequest = targetOptions.request;
+          return { kind: "continue", responseHeaders: null };
+        },
+      }),
+    );
+
+    expect(response?.status).toBe(303);
+    expect(response?.headers.get("content-length")).toBeNull();
+    expect(middlewareRequest).not.toBeNull();
+    expect(middlewareRequest!.headers.get("accept")).toBe("application/action-middleware");
+    expect(middlewareRequest!.headers.get("content-length")).toBeNull();
+    expect(middlewareRequest!.headers.get("x-action-auth-context")).toBe("member");
+    expect(renderRequest).not.toBeNull();
+    expect(renderRequest!.headers.get("accept")).toBe("application/action-middleware");
+    expect(renderRequest!.headers.get("content-length")).toBeNull();
+    expect(renderRequest!.headers.get("x-action-auth-context")).toBe("member");
+  });
+
   it("runs target middleware before hydrating a lazy target route's modules", async () => {
     const events: string[] = [];
     const lazyRoute: TestRoute = {

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -289,6 +289,7 @@ function createRscOptions(
     maxActionBodySize: 1024,
     maxActionBodySizeLabel: "1kb",
     middlewareHeaders: null,
+    middlewareRequestHeaders: null,
     middlewareStatus: null,
     mountedSlotsHeader: null,
     readBodyWithLimit() {
@@ -1740,7 +1741,7 @@ describe("app server action execution helpers", () => {
     }
   });
 
-  it("renders internal action redirects with a clean GET request and action cookies", async () => {
+  it("renders internal action redirects with a target GET and action context", async () => {
     // Ported from Next.js: test/e2e/app-dir/actions/app-action-node-middleware.test.ts
     // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/actions/app-action-node-middleware.test.ts
     const renderRequests: Request[] = [];
@@ -1789,8 +1790,9 @@ describe("app server action execution helpers", () => {
     expect(renderRequest.headers.get("next-action")).toBeNull();
     expect(renderRequest.headers.get("x-rsc-action")).toBeNull();
     expect(renderRequest.headers.get("rsc")).toBeNull();
-    expect(renderRequest.headers.get("content-type")).toBeNull();
-    expect(renderRequest.headers.get("origin")).toBeNull();
+    expect(renderRequest.headers.get("accept")).toBe("text/x-component");
+    expect(renderRequest.headers.get("content-type")).toBe("text/plain;charset=UTF-8");
+    expect(renderRequest.headers.get("origin")).toBe("https://example.com");
     expect(renderRequest.headers.get("cookie")).toBe(
       "session=1; __prerender_bypass=draft-secret; theme=dark",
     );
@@ -2077,19 +2079,23 @@ describe("app server action execution helpers", () => {
       returnValue: { ok: true },
     });
 
-    // Middleware must see the request the client would otherwise have sent:
-    // a GET for the target that still carries Accept, which object matchers can
-    // gate on. The forwarded-middleware-context header describes the *action*
-    // path's result and would make the target skip middleware entirely.
+    // Middleware sees the same effective headers as Next.js' internal target
+    // GET, including Accept. The forwarded-middleware-context header describes
+    // the *action* path's result and would make the target skip middleware
+    // entirely.
     expect(middlewareRequest).not.toBeNull();
     expect(middlewareRequest!.method).toBe("GET");
     expect(middlewareRequest!.url).toBe("https://example.com/redirect-target");
     expect(middlewareRequest!.headers.get("accept")).toBe("text/x-component");
+    expect(middlewareRequest!.headers.get("content-type")).toBe("text/plain;charset=UTF-8");
+    expect(middlewareRequest!.headers.get("origin")).toBe("https://example.com");
     expect(middlewareRequest!.headers.get("next-action")).toBeNull();
     expect(middlewareRequest!.headers.get("x-vinext-mw-ctx")).toBeNull();
 
     expect(renderRequest).not.toBeNull();
-    expect(renderRequest!.headers.get("accept")).toBeNull();
+    expect(renderRequest!.headers.get("accept")).toBe("text/x-component");
+    expect(renderRequest!.headers.get("content-type")).toBe("text/plain;charset=UTF-8");
+    expect(renderRequest!.headers.get("origin")).toBe("https://example.com");
     expect(renderRequest!.headers.get("x-vinext-mw-ctx")).toBeNull();
 
     // Middleware that authorizes on request.cf (geo checks) must not fail open
@@ -2193,6 +2199,54 @@ describe("app server action execution helpers", () => {
     expect(renderRequest!.headers.get("cookie")).toBe("theme=dark; session=rotated");
     expect(renderRequest!.headers.get("content-length")).toBeNull();
     expect(renderRequest!.headers.get("x-action-auth-context")).toBe("member");
+  });
+
+  it("starts redirect targets from action middleware's request-header overrides", async () => {
+    let middlewareRequest: Request | null = null;
+    let renderRequest: Request | null = null;
+
+    await handleServerActionRscRequest(
+      createRscOptions({
+        buildPageElement({ route: matchedRoute, request }) {
+          renderRequest = request;
+          return `${matchedRoute.id}:{}:none`;
+        },
+        loadServerAction() {
+          return Promise.resolve(() => redirect("/redirect-target"));
+        },
+        matchRoute(pathname) {
+          if (pathname === "/redirect-target") {
+            return {
+              params: {},
+              route: { id: "redirect-target", page: {}, params: [], pattern: "/redirect-target" },
+            };
+          }
+          return {
+            params: {},
+            route: { id: "dashboard", page: {}, params: [], pattern: "/dashboard" },
+          };
+        },
+        middlewareRequestHeaders: new Headers({
+          "x-middleware-override-headers": "x-auth-context",
+          "x-middleware-request-x-auth-context": "sanitized",
+        }),
+        request: createFetchActionRequest({
+          "x-attacker-controlled": "forged",
+          "x-auth-context": "untrusted",
+        }),
+        async runRedirectTargetMiddleware(targetOptions: { request: Request }) {
+          middlewareRequest = targetOptions.request;
+          return { kind: "continue", responseHeaders: null };
+        },
+      }),
+    );
+
+    expect(middlewareRequest).not.toBeNull();
+    expect(middlewareRequest!.headers.get("x-auth-context")).toBe("sanitized");
+    expect(middlewareRequest!.headers.get("x-attacker-controlled")).toBeNull();
+    expect(renderRequest).not.toBeNull();
+    expect(renderRequest!.headers.get("x-auth-context")).toBe("sanitized");
+    expect(renderRequest!.headers.get("x-attacker-controlled")).toBeNull();
   });
 
   it("runs target middleware before hydrating a lazy target route's modules", async () => {

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -2273,12 +2273,10 @@ describe("app server action execution helpers", () => {
       }),
     );
 
-    // The action middleware deleted the session and rotated csrf. The browser
-    // applies those before navigating to the redirect target, so target
-    // middleware evaluating the pre-mutation jar would authorize on a
-    // credential the response is simultaneously revoking. The /account-scoped
-    // cookie is one a browser would never send to /redirect-target, so it must
-    // not appear either.
+    // The action middleware deleted the session and rotated csrf, so target
+    // middleware must not authorize on the credential the response is
+    // simultaneously revoking. The newly emitted /account-scoped cookie still
+    // carries enough metadata to keep it out of /redirect-target as well.
     expect(middlewareRequest).not.toBeNull();
     expect(middlewareRequest!.headers.get("cookie")).toBe("csrf=rotated; theme=dark");
   });

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -58,6 +58,8 @@ type TestRoute = {
   routeHandler?: unknown;
   routeSegments?: readonly string[];
   runtime?: "edge" | "experimental-edge" | "nodejs" | null;
+  /** Manifest lazy-module thunk; set when the route's page is not yet hydrated. */
+  __loadPage?: unknown;
 };
 
 type TestInterceptOptions = {
@@ -1985,11 +1987,13 @@ describe("app server action execution helpers", () => {
 
   it("falls back to header-only redirects when target middleware diverts the request", async () => {
     const buildPageElement = vi.fn(() => "should-not-render");
+    const ensureRouteLoaded = vi.fn();
     const runRedirectTargetMiddleware = vi.fn(async () => ({ kind: "diverted" }) as const);
 
     const response = await handleServerActionRscRequest(
       createRscOptions({
         buildPageElement,
+        ensureRouteLoaded,
         loadServerAction() {
           return Promise.resolve(() => redirect("/protected"));
         },
@@ -2014,6 +2018,9 @@ describe("app server action execution helpers", () => {
     expect(response?.headers.get("content-type")).toBeNull();
     expect(await response?.text()).toBe("");
     expect(buildPageElement).not.toHaveBeenCalled();
+    // Hydrating a route imports its modules and runs their top-level code —
+    // a middleware-blocked target must never get that far.
+    expect(ensureRouteLoaded).not.toHaveBeenCalled();
     expect(runRedirectTargetMiddleware).toHaveBeenCalledWith({
       cleanPathname: "/protected",
       request: expect.any(Request),
@@ -2030,6 +2037,12 @@ describe("app server action execution helpers", () => {
         responseHeaders: new Headers({ "x-from-target-middleware": "1" }),
       };
     });
+    const actionRequest = createFetchActionRequest({
+      accept: "text/x-component",
+      "x-vinext-mw-ctx": JSON.stringify({}),
+    });
+    // Workers attach cf to the inbound request; new Request() never copies it.
+    Object.defineProperty(actionRequest, "cf", { value: { country: "AU" }, enumerable: true });
 
     const response = await handleServerActionRscRequest(
       createRscOptions({
@@ -2040,10 +2053,7 @@ describe("app server action execution helpers", () => {
         loadServerAction() {
           return Promise.resolve(() => redirect("/redirect-target"));
         },
-        request: createFetchActionRequest({
-          accept: "text/x-component",
-          "x-vinext-mw-ctx": JSON.stringify({}),
-        }),
+        request: actionRequest,
         matchRoute(pathname) {
           if (pathname === "/redirect-target") {
             return {
@@ -2081,6 +2091,93 @@ describe("app server action execution helpers", () => {
     expect(renderRequest).not.toBeNull();
     expect(renderRequest!.headers.get("accept")).toBeNull();
     expect(renderRequest!.headers.get("x-vinext-mw-ctx")).toBeNull();
+
+    // Middleware that authorizes on request.cf (geo checks) must not fail open
+    // on the reconstructed target requests.
+    expect(Reflect.get(middlewareRequest!, "cf")).toEqual({ country: "AU" });
+    expect(Reflect.get(renderRequest!, "cf")).toEqual({ country: "AU" });
+  });
+
+  it("runs target middleware before hydrating a lazy target route's modules", async () => {
+    const events: string[] = [];
+    const lazyRoute: TestRoute = {
+      id: "lazy-protected",
+      params: [],
+      pattern: "/lazy-protected",
+      __loadPage: () => Promise.resolve({}),
+    };
+
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        ensureRouteLoaded(route) {
+          events.push(`load:${route.id}`);
+          if (route === lazyRoute) route.page = {};
+        },
+        loadServerAction() {
+          return Promise.resolve(() => redirect("/lazy-protected"));
+        },
+        matchRoute(pathname) {
+          if (pathname === "/lazy-protected") {
+            return { params: {}, route: lazyRoute };
+          }
+          return {
+            params: {},
+            route: { id: "dashboard", page: {}, params: [], pattern: "/dashboard" },
+          };
+        },
+        async runRedirectTargetMiddleware() {
+          events.push("middleware");
+          return { kind: "continue", responseHeaders: null };
+        },
+      }),
+    );
+
+    // The unhydrated route only advertises its page via the lazy thunk, so it
+    // must still count as renderable, and middleware must run before the
+    // hydration that executes the page module's top-level code.
+    expect(events).toEqual(["middleware", "load:lazy-protected", "load:dashboard"]);
+    expect(response?.status).toBe(303);
+    expect(JSON.parse(await response!.text())).toEqual({
+      root: "lazy-protected:{}:none",
+      returnValue: { ok: true },
+    });
+  });
+
+  it("strips a middleware Location header from the action redirect response", async () => {
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        loadServerAction() {
+          return Promise.resolve(() => redirect("/redirect-target"));
+        },
+        matchRoute(pathname) {
+          if (pathname === "/redirect-target") {
+            return {
+              params: {},
+              route: { id: "redirect-target", page: {}, params: [], pattern: "/redirect-target" },
+            };
+          }
+          return {
+            params: {},
+            route: { id: "dashboard", page: {}, params: [], pattern: "/dashboard" },
+          };
+        },
+        middlewareHeaders: new Headers({ location: "/mw-location", "x-action-mw": "1" }),
+        async runRedirectTargetMiddleware() {
+          return {
+            kind: "continue",
+            responseHeaders: new Headers({ location: "/target-mw-location", "x-target-mw": "1" }),
+          };
+        },
+      }),
+    );
+
+    // The wrapper's real target travels in x-action-redirect; a Location header
+    // on the 303 would make fetch follow it before the client reads that.
+    expect(response?.status).toBe(303);
+    expect(response?.headers.get("x-action-redirect")).toBe("/redirect-target");
+    expect(response?.headers.get("location")).toBeNull();
+    expect(response?.headers.get("x-action-mw")).toBe("1");
+    expect(response?.headers.get("x-target-mw")).toBe("1");
   });
 
   it("does not emit x-action-revalidated when a fetch action revalidates a tag with a profile", async () => {

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -2143,7 +2143,7 @@ describe("app server action execution helpers", () => {
     });
   });
 
-  it("strips a middleware Location header from the action redirect response", async () => {
+  it("keeps the action protocol headers when merging middleware headers onto the redirect response", async () => {
     const response = await handleServerActionRscRequest(
       createRscOptions({
         loadServerAction() {
@@ -2161,23 +2161,115 @@ describe("app server action execution helpers", () => {
             route: { id: "dashboard", page: {}, params: [], pattern: "/dashboard" },
           };
         },
-        middlewareHeaders: new Headers({ location: "/mw-location", "x-action-mw": "1" }),
+        middlewareHeaders: new Headers({
+          location: "/mw-location",
+          "content-type": "text/html",
+          "x-action-redirect": "/mw-hijack",
+          "x-action-mw": "1",
+        }),
         async runRedirectTargetMiddleware() {
           return {
             kind: "continue",
-            responseHeaders: new Headers({ location: "/target-mw-location", "x-target-mw": "1" }),
+            responseHeaders: new Headers({
+              location: "/target-mw-location",
+              "content-type": "text/html",
+              "x-action-redirect": "/target-hijack",
+              "x-target-mw": "1",
+            }),
           };
         },
       }),
     );
 
-    // The wrapper's real target travels in x-action-redirect; a Location header
-    // on the 303 would make fetch follow it before the client reads that.
+    // The wrapper's protocol headers steer the action client: a Location on the
+    // 303 would make fetch follow it before the client reads x-action-redirect,
+    // a foreign Content-Type flips the client to a hard navigation, and
+    // x-action-redirect is the destination itself. Ordinary middleware headers
+    // must still come through.
     expect(response?.status).toBe(303);
     expect(response?.headers.get("x-action-redirect")).toBe("/redirect-target");
     expect(response?.headers.get("location")).toBeNull();
+    expect(response?.headers.get("content-type")).toContain("text/x-component");
     expect(response?.headers.get("x-action-mw")).toBe("1");
     expect(response?.headers.get("x-target-mw")).toBe("1");
+  });
+
+  it("applies the action middleware's cookie mutations to the redirect target request", async () => {
+    let middlewareRequest: Request | null = null;
+
+    await handleServerActionRscRequest(
+      createRscOptions({
+        loadServerAction() {
+          return Promise.resolve(() => redirect("/redirect-target"));
+        },
+        matchRoute(pathname) {
+          if (pathname === "/redirect-target") {
+            return {
+              params: {},
+              route: { id: "redirect-target", page: {}, params: [], pattern: "/redirect-target" },
+            };
+          }
+          return {
+            params: {},
+            route: { id: "dashboard", page: {}, params: [], pattern: "/dashboard" },
+          };
+        },
+        middlewareHeaders: new Headers([
+          ["set-cookie", "session=; Max-Age=0"],
+          ["set-cookie", "csrf=rotated"],
+        ]),
+        request: createFetchActionRequest({ cookie: "session=live; csrf=old; theme=dark" }),
+        async runRedirectTargetMiddleware(targetOptions: { request: Request }) {
+          middlewareRequest = targetOptions.request;
+          return { kind: "continue", responseHeaders: null };
+        },
+      }),
+    );
+
+    // The action middleware deleted the session and rotated csrf. The browser
+    // applies those before navigating to the redirect target, so target
+    // middleware evaluating the pre-mutation jar would authorize on a
+    // credential the response is simultaneously revoking.
+    expect(middlewareRequest).not.toBeNull();
+    expect(middlewareRequest!.headers.get("cookie")).toBe("csrf=rotated; theme=dark");
+  });
+
+  it("strips the internal _rsc param from the redirect target before middleware", async () => {
+    let middlewareRequest: Request | null = null;
+
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        loadServerAction() {
+          return Promise.resolve(() => redirect("/redirect-target?_rsc=abc123&tab=x"));
+        },
+        matchRoute(pathname) {
+          if (pathname === "/redirect-target") {
+            return {
+              params: {},
+              route: { id: "redirect-target", page: {}, params: [], pattern: "/redirect-target" },
+            };
+          }
+          return {
+            params: {},
+            route: { id: "dashboard", page: {}, params: [], pattern: "/dashboard" },
+          };
+        },
+        async runRedirectTargetMiddleware(targetOptions: { request: Request }) {
+          middlewareRequest = targetOptions.request;
+          return { kind: "continue", responseHeaders: null };
+        },
+      }),
+    );
+
+    // The real pipeline strips `_rsc` before middleware, so matchers keyed on
+    // it would branch differently for the synthetic request than for the
+    // navigation it stands in for. The client-facing redirect header keeps the
+    // verbatim URL — a diverted re-request goes through real validation.
+    expect(middlewareRequest).not.toBeNull();
+    const middlewareUrl = new URL(middlewareRequest!.url);
+    expect(middlewareUrl.searchParams.get("_rsc")).toBeNull();
+    expect(middlewareUrl.searchParams.get("tab")).toBe("x");
+    expect(response?.headers.get("x-action-redirect")).toBe("/redirect-target?_rsc=abc123&tab=x");
   });
 
   it("does not emit x-action-revalidated when a fetch action revalidates a tag with a profile", async () => {

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -2132,6 +2132,29 @@ describe("app server action execution helpers", () => {
     expect(targetRequest!.headers.get("cookie")).toBe("a=1; foo=new; b=2");
   });
 
+  it("does not retain a stale cookie when the second response-cookie decode fails", async () => {
+    let targetRequest: Request | null = null;
+    await handleServerActionRscRequest(
+      createRscOptions({
+        async dispatchRedirectTargetRequest(request) {
+          targetRequest = request;
+          return new Response("flight", { headers: { "content-type": "text/x-component" } });
+        },
+        loadServerAction() {
+          return Promise.resolve(() => redirect("/redirect-target"));
+        },
+        middlewareHeaders: new Headers([
+          ["set-cookie", "session=%25bad; Path=/"],
+          ["set-cookie", "raw=%; Path=/"],
+        ]),
+        request: createFetchActionRequest({ cookie: "session=old; raw=old" }),
+      }),
+    );
+
+    expect(targetRequest).not.toBeNull();
+    expect(targetRequest!.headers.get("cookie")).toBe("session=%25bad; raw=%25");
+  });
+
   // Next.js follows same-origin redirects from its internal target fetch. The
   // in-process dispatcher must do the same so config and middleware redirects
   // can still produce a single action response containing the final Flight.

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -2109,6 +2109,29 @@ describe("app server action execution helpers", () => {
     expect(targetRequest!.headers.get("cookie")).toBe("");
   });
 
+  it("collapses repeated response cookies before forwarding the target request", async () => {
+    let targetRequest: Request | null = null;
+    await handleServerActionRscRequest(
+      createRscOptions({
+        async dispatchRedirectTargetRequest(request) {
+          targetRequest = request;
+          return new Response("flight", { headers: { "content-type": "text/x-component" } });
+        },
+        getAndClearPendingCookies() {
+          return ["foo=new; Path=/"];
+        },
+        loadServerAction() {
+          return Promise.resolve(() => redirect("/redirect-target"));
+        },
+        middlewareHeaders: new Headers({ "set-cookie": "foo=; Max-Age=0" }),
+        request: createFetchActionRequest({ cookie: "a=1; foo=old; b=2" }),
+      }),
+    );
+
+    expect(targetRequest).not.toBeNull();
+    expect(targetRequest!.headers.get("cookie")).toBe("a=1; foo=new; b=2");
+  });
+
   // Next.js follows same-origin redirects from its internal target fetch. The
   // in-process dispatcher must do the same so config and middleware redirects
   // can still produce a single action response containing the final Flight.

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -1782,7 +1782,7 @@ describe("app server action execution helpers", () => {
     expect(targetRequest!.headers.get("x-rsc-action")).toBeNull();
     expect(targetRequest!.headers.get("next-router-state-tree")).toBeNull();
     expect(targetRequest!.headers.get("x-vinext-mw-ctx")).toBeNull();
-    expect(targetRequest!.headers.get("cookie")).toBe("session=1; theme=dark");
+    expect(targetRequest!.headers.get("cookie")).toBe("session=1; deleted=; theme=dark");
     expect(Reflect.get(targetRequest!, "cf")).toEqual({ country: "AU" });
   });
 
@@ -2083,7 +2083,7 @@ describe("app server action execution helpers", () => {
     );
 
     expect(targetRequest).not.toBeNull();
-    expect(targetRequest!.headers.get("cookie")).toBe("csrf=rotated");
+    expect(targetRequest!.headers.get("cookie")).toBe("session=; csrf=rotated; admin=1");
     expect(targetRequest!.headers.get("x-auth-context")).toBe("sanitized");
     expect(targetRequest!.headers.get("x-attacker-controlled")).toBeNull();
     expect(targetRequest!.headers.get("x-action-auth-context")).toBe("member");
@@ -2140,6 +2140,8 @@ describe("app server action execution helpers", () => {
           "content-encoding": "br",
           location: "/mw-location",
           "content-type": "text/html",
+          "set-cookie": "source=1; Path=/",
+          vary: "x-source",
           "x-action-redirect": "/mw-hijack",
           "x-action-mw": "1",
         }),
@@ -2151,7 +2153,9 @@ describe("app server action execution helpers", () => {
               "content-encoding": "gzip",
               "content-type": "text/x-component",
               "content-length": "0",
+              "set-cookie": "target=1; Path=/",
               "transfer-encoding": "chunked",
+              vary: "x-target",
               "x-action-redirect": "/target-hijack",
               "x-target-mw": "1",
             },
@@ -2174,7 +2178,9 @@ describe("app server action execution helpers", () => {
     expect(response?.headers.get("connection")).toBeNull();
     expect(response?.headers.get("content-encoding")).toBeNull();
     expect(response?.headers.get("content-length")).toBeNull();
+    expect(response?.headers.getSetCookie()).toEqual(["source=1; Path=/"]);
     expect(response?.headers.get("transfer-encoding")).toBeNull();
+    expect(response?.headers.get("vary")).toBe("x-target");
     expect(response?.headers.get("x-action-mw")).toBe("1");
     expect(response?.headers.get("x-target-mw")).toBe("1");
   });

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -1782,7 +1782,7 @@ describe("app server action execution helpers", () => {
     expect(targetRequest!.headers.get("x-rsc-action")).toBeNull();
     expect(targetRequest!.headers.get("next-router-state-tree")).toBeNull();
     expect(targetRequest!.headers.get("x-vinext-mw-ctx")).toBeNull();
-    expect(targetRequest!.headers.get("cookie")).toBe("session=1; deleted=; theme=dark");
+    expect(targetRequest!.headers.get("cookie")).toBe("session=1; theme=dark");
     expect(Reflect.get(targetRequest!, "cf")).toEqual({ country: "AU" });
   });
 
@@ -2068,6 +2068,7 @@ describe("app server action execution helpers", () => {
           ["set-cookie", "session=; Max-Age=0"],
           ["set-cookie", "csrf=rotated"],
           ["set-cookie", "admin=1; Path=/account"],
+          ["set-cookie", "encoded=%2520; Path=/"],
           ["x-action-auth-context", "member"],
         ]),
         middlewareRequestHeaders: new Headers({
@@ -2083,10 +2084,29 @@ describe("app server action execution helpers", () => {
     );
 
     expect(targetRequest).not.toBeNull();
-    expect(targetRequest!.headers.get("cookie")).toBe("session=; csrf=rotated; admin=1");
+    expect(targetRequest!.headers.get("cookie")).toBe("csrf=rotated; admin=1; encoded=%20");
     expect(targetRequest!.headers.get("x-auth-context")).toBe("sanitized");
     expect(targetRequest!.headers.get("x-attacker-controlled")).toBeNull();
     expect(targetRequest!.headers.get("x-action-auth-context")).toBe("member");
+  });
+
+  it("forwards an empty Cookie header to the target pipeline", async () => {
+    let targetRequest: Request | null = null;
+    await handleServerActionRscRequest(
+      createRscOptions({
+        async dispatchRedirectTargetRequest(request) {
+          targetRequest = request;
+          return new Response("flight", { headers: { "content-type": "text/x-component" } });
+        },
+        loadServerAction() {
+          return Promise.resolve(() => redirect("/redirect-target"));
+        },
+      }),
+    );
+
+    expect(targetRequest).not.toBeNull();
+    expect(targetRequest!.headers.has("cookie")).toBe(true);
+    expect(targetRequest!.headers.get("cookie")).toBe("");
   });
 
   // Next.js follows same-origin redirects from its internal target fetch. The

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -40,10 +40,8 @@ import {
   runWithRequestContext,
 } from "../packages/vinext/src/shims/unified-request-context.js";
 import {
-  cookies,
   getHeadersContext,
   headersContextFromRequest,
-  isDraftModeEnabled,
   setHeadersAccessPhase,
   setHeadersContext,
 } from "../packages/vinext/src/shims/headers.js";
@@ -242,13 +240,15 @@ function createRscOptions(
       params: {},
       route,
     }));
+  const buildPageElement =
+    overrides.buildPageElement ??
+    (({ route: matchedRoute, params, interceptOpts }) =>
+      `${matchedRoute.id}:${JSON.stringify(params)}:${interceptOpts?.slot ?? "none"}`);
 
   return {
     actionId: "action-id",
     allowedOrigins: [],
-    buildPageElement({ route: matchedRoute, params, interceptOpts }) {
-      return `${matchedRoute.id}:${JSON.stringify(params)}:${interceptOpts?.slot ?? "none"}`;
-    },
+    buildPageElement,
     clearRequestContext() {},
     contentType: "text/plain;charset=UTF-8",
     createNotFoundElement(routeId) {
@@ -267,6 +267,35 @@ function createRscOptions(
       return Promise.resolve([]);
     },
     draftModeSecret: "draft-secret",
+    async dispatchRedirectTargetRequest(request) {
+      const url = new URL(request.url);
+      const matched = matchRoute(url.pathname);
+      if (
+        !matched ||
+        matched.route.routeHandler ||
+        (!matched.route.page && !matched.route.__loadPage)
+      ) {
+        return new Response("not-rsc", {
+          status: 404,
+          headers: { "content-type": "text/plain" },
+        });
+      }
+      await overrides.ensureRouteLoaded?.(matched.route);
+      const root = buildPageElement({
+        cleanPathname: url.pathname,
+        interceptOpts: undefined,
+        isRscRequest: true,
+        mountedSlotsHeader: null,
+        params: matched.params,
+        request,
+        route: matched.route,
+        searchParams: url.searchParams,
+        renderMode: "navigation",
+      });
+      return new Response(JSON.stringify({ root, returnValue: { ok: true } }), {
+        headers: { "content-type": "text/x-component" },
+      });
+    },
     findIntercept() {
       return null;
     },
@@ -1578,121 +1607,89 @@ describe("app server action execution helpers", () => {
     });
   });
 
-  it.each(["rerender", "redirect"] as const)(
-    "passes empty request APIs to force-static action %s targets",
-    async (kind) => {
-      const buildInputs: Array<{ query: string; header: string | null }> = [];
-      const targetRoute: TestRoute = {
-        id: kind === "redirect" ? "redirect-target" : "dashboard",
-        page: {},
-        params: [],
-        pattern: kind === "redirect" ? "/redirect-target" : "/dashboard",
-      };
-      const response = await handleServerActionRscRequest(
-        createRscOptions({
-          buildPageElement({ searchParams }) {
-            buildInputs.push({
-              query: searchParams.toString(),
-              header: getHeadersContext()?.headers.get("x-request-value") ?? null,
-            });
-            return "force-static-target";
-          },
-          loadServerAction() {
-            return Promise.resolve(
-              kind === "redirect"
-                ? () => redirect("/redirect-target?user=alice")
-                : async () => {
-                    await Promise.resolve(revalidatePath("/dashboard"));
-                    return "revalidated";
-                  },
-            );
-          },
-          matchRoute(pathname) {
-            if (kind === "redirect" && pathname === "/redirect-target") {
-              return { params: {}, route: targetRoute };
-            }
-            return {
-              params: {},
-              route:
-                kind === "rerender"
-                  ? targetRoute
-                  : { id: "dashboard", page: {}, params: [], pattern: "/dashboard" },
-            };
-          },
-          request: createFetchActionRequest({ "x-request-value": "present" }),
-          resolveRouteDynamicConfig(route) {
-            return route === targetRoute ? "force-static" : undefined;
-          },
-          searchParams: new URLSearchParams("user=alice"),
-        }),
-      );
+  it("passes empty request APIs to force-static action rerender targets", async () => {
+    const buildInputs: Array<{ query: string; header: string | null }> = [];
+    const targetRoute: TestRoute = {
+      id: "dashboard",
+      page: {},
+      params: [],
+      pattern: "/dashboard",
+    };
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        buildPageElement({ searchParams }) {
+          buildInputs.push({
+            query: searchParams.toString(),
+            header: getHeadersContext()?.headers.get("x-request-value") ?? null,
+          });
+          return "force-static-target";
+        },
+        loadServerAction() {
+          return Promise.resolve(async () => {
+            await Promise.resolve(revalidatePath("/dashboard"));
+            return "revalidated";
+          });
+        },
+        matchRoute() {
+          return { params: {}, route: targetRoute };
+        },
+        request: createFetchActionRequest({ "x-request-value": "present" }),
+        resolveRouteDynamicConfig() {
+          return "force-static";
+        },
+        searchParams: new URLSearchParams("user=alice"),
+      }),
+    );
 
-      expect(response?.status).toBe(kind === "redirect" ? 303 : 200);
-      expect(buildInputs).toEqual([{ query: "", header: null }]);
-    },
-  );
+    expect(response?.status).toBe(200);
+    expect(buildInputs).toEqual([{ query: "", header: null }]);
+  });
 
-  it.each(["rerender", "redirect"] as const)(
-    "observes searchParams access for dynamic-error action %s targets",
-    async (kind) => {
-      const buildInputs: Array<{
-        metadata: boolean | undefined;
-        page: boolean | undefined;
-        query: string;
-      }> = [];
-      const targetRoute: TestRoute = {
-        id: kind === "redirect" ? "redirect-target" : "dashboard",
-        page: {},
-        params: [],
-        pattern: kind === "redirect" ? "/redirect-target" : "/dashboard",
-      };
-      const response = await handleServerActionRscRequest(
-        createRscOptions({
-          buildPageElement({
-            observeMetadataSearchParamsAccess,
-            observePageSearchParamsAccess,
-            searchParams,
-          }) {
-            buildInputs.push({
-              metadata: observeMetadataSearchParamsAccess,
-              page: observePageSearchParamsAccess,
-              query: searchParams.toString(),
-            });
-            return "dynamic-error-target";
-          },
-          loadServerAction() {
-            return Promise.resolve(
-              kind === "redirect"
-                ? () => redirect("/redirect-target?user=alice")
-                : async () => {
-                    await Promise.resolve(revalidatePath("/dashboard"));
-                    return "revalidated";
-                  },
-            );
-          },
-          matchRoute(pathname) {
-            if (kind === "redirect" && pathname === "/redirect-target") {
-              return { params: {}, route: targetRoute };
-            }
-            return {
-              params: {},
-              route:
-                kind === "rerender"
-                  ? targetRoute
-                  : { id: "dashboard", page: {}, params: [], pattern: "/dashboard" },
-            };
-          },
-          resolveRouteDynamicConfig(route) {
-            return route === targetRoute ? "error" : undefined;
-          },
-          searchParams: new URLSearchParams("user=alice"),
-        }),
-      );
+  it("observes searchParams access for dynamic-error action rerender targets", async () => {
+    const buildInputs: Array<{
+      metadata: boolean | undefined;
+      page: boolean | undefined;
+      query: string;
+    }> = [];
+    const targetRoute: TestRoute = {
+      id: "dashboard",
+      page: {},
+      params: [],
+      pattern: "/dashboard",
+    };
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        buildPageElement({
+          observeMetadataSearchParamsAccess,
+          observePageSearchParamsAccess,
+          searchParams,
+        }) {
+          buildInputs.push({
+            metadata: observeMetadataSearchParamsAccess,
+            page: observePageSearchParamsAccess,
+            query: searchParams.toString(),
+          });
+          return "dynamic-error-target";
+        },
+        loadServerAction() {
+          return Promise.resolve(async () => {
+            await Promise.resolve(revalidatePath("/dashboard"));
+            return "revalidated";
+          });
+        },
+        matchRoute() {
+          return { params: {}, route: targetRoute };
+        },
+        resolveRouteDynamicConfig() {
+          return "error";
+        },
+        searchParams: new URLSearchParams("user=alice"),
+      }),
+    );
 
-      expect(response?.status).toBe(kind === "redirect" ? 303 : 200);
-      expect(buildInputs).toEqual([{ metadata: true, page: true, query: "user=alice" }]);
-    },
-  );
+    expect(response?.status).toBe(200);
+    expect(buildInputs).toEqual([{ metadata: true, page: true, query: "user=alice" }]);
+  });
 
   it("uses empty action request APIs for force-static targets in draft mode", async () => {
     const buildInputs: Array<{ query: string; header: string | null }> = [];
@@ -1741,17 +1738,25 @@ describe("app server action execution helpers", () => {
     }
   });
 
-  it("renders internal action redirects with a target GET and action context", async () => {
-    // Ported from Next.js: test/e2e/app-dir/actions/app-action-node-middleware.test.ts
-    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/actions/app-action-node-middleware.test.ts
-    const renderRequests: Request[] = [];
-    let redirectRenderDraftMode = false;
+  it("dispatches internal action redirects as full-tree RSC GET requests", async () => {
+    let targetRequest: Request | null = null;
+    const actionRequest = createFetchActionRequest({
+      cookie: "session=1; deleted=stale",
+      "next-action": "action-id",
+      "x-vinext-mw-ctx": "action-path-context",
+    });
+    Object.defineProperty(actionRequest, "cf", { value: { country: "AU" }, enumerable: true });
+
     const response = await handleServerActionRscRequest(
       createRscOptions({
-        buildPageElement({ request }) {
-          renderRequests.push(request);
-          redirectRenderDraftMode = isDraftModeEnabled();
-          return "redirect-target:{}:none";
+        async dispatchRedirectTargetRequest(request) {
+          targetRequest = request;
+          return new Response("target-flight", {
+            headers: {
+              "content-type": "text/x-component",
+              "x-target-pipeline": "1",
+            },
+          });
         },
         getAndClearPendingCookies() {
           return ["theme=dark; Path=/", "deleted=; Path=/; Max-Age=0"];
@@ -1759,137 +1764,174 @@ describe("app server action execution helpers", () => {
         loadServerAction() {
           return Promise.resolve(() => redirect("/redirect-target?from=action"));
         },
-        matchRoute(pathname) {
-          if (pathname === "/redirect-target") {
-            return {
-              params: {},
-              route: { id: "redirect-target", page: {}, params: [], pattern: "/redirect-target" },
-            };
-          }
-          return {
-            params: {},
-            route: { id: "dashboard", page: {}, params: [], pattern: "/dashboard" },
-          };
-        },
-        request: createFetchActionRequest({
-          accept: "text/x-component",
-          cookie: "session=1; deleted=stale; __prerender_bypass=draft-secret",
-          "next-action": "action-id",
-          rsc: "1",
-        }),
+        request: actionRequest,
       }),
     );
 
     expect(response?.status).toBe(303);
     expect(response?.headers.get("x-action-redirect")).toBe("/redirect-target?from=action");
-    const renderRequest = renderRequests[0];
-    if (!renderRequest) throw new Error("Expected redirect render request");
-
-    expect(renderRequest.method).toBe("GET");
-    expect(renderRequest.url).toBe("https://example.com/redirect-target?from=action");
-    expect(renderRequest.headers.get("next-action")).toBeNull();
-    expect(renderRequest.headers.get("x-rsc-action")).toBeNull();
-    expect(renderRequest.headers.get("rsc")).toBeNull();
-    expect(renderRequest.headers.get("accept")).toBe("text/x-component");
-    expect(renderRequest.headers.get("content-type")).toBe("text/plain;charset=UTF-8");
-    expect(renderRequest.headers.get("origin")).toBe("https://example.com");
-    expect(renderRequest.headers.get("cookie")).toBe(
-      "session=1; __prerender_bypass=draft-secret; theme=dark",
-    );
-    expect(redirectRenderDraftMode).toBe(true);
+    expect(response?.headers.get("x-target-pipeline")).toBe("1");
+    expect(await response?.text()).toBe("target-flight");
+    expect(targetRequest).not.toBeNull();
+    expect(targetRequest!.method).toBe("GET");
+    expect(new URL(targetRequest!.url).pathname).toBe("/redirect-target");
+    expect(new URL(targetRequest!.url).searchParams.get("from")).toBe("action");
+    expect(new URL(targetRequest!.url).searchParams.has("_rsc")).toBe(true);
+    expect(targetRequest!.headers.get("rsc")).toBe("1");
+    expect(targetRequest!.headers.get("next-action")).toBeNull();
+    expect(targetRequest!.headers.get("x-rsc-action")).toBeNull();
+    expect(targetRequest!.headers.get("next-router-state-tree")).toBeNull();
+    expect(targetRequest!.headers.get("x-vinext-mw-ctx")).toBeNull();
+    expect(targetRequest!.headers.get("cookie")).toBe("session=1; theme=dark");
+    expect(Reflect.get(targetRequest!, "cf")).toEqual({ country: "AU" });
   });
 
-  it("renders internal action redirects with the target route's root params", async () => {
-    let renderedRootParam: string | string[] | undefined;
-
-    await runWithRootParamsScope({ lang: "source" }, () =>
-      handleServerActionRscRequest(
-        createRscOptions({
-          async renderToReadableStream(model) {
-            renderedRootParam = await getRootParam("lang");
-            return new Response(JSON.stringify(model)).body;
-          },
-          loadServerAction() {
-            return Promise.resolve(() => redirect("/fr/target"));
-          },
-          matchRoute(pathname) {
-            if (pathname === "/fr/target") {
-              return {
-                params: { lang: "fr" },
-                route: {
-                  id: "redirect-target",
-                  page: {},
-                  params: ["lang"],
-                  pattern: "/[lang]/target",
-                  rootParamNames: ["lang"],
-                },
-              };
-            }
-            return {
-              params: { lang: "source" },
-              route: {
-                id: "dashboard",
-                page: {},
-                params: ["lang"],
-                pattern: "/[lang]/dashboard",
-                rootParamNames: ["lang"],
-              },
-            };
-          },
-        }),
-      ),
+  it("forwards source config headers before middleware and keeps target precedence", async () => {
+    let targetRequest: Request | null = null;
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        async dispatchRedirectTargetRequest(request) {
+          targetRequest = request;
+          return new Response("target-flight", {
+            headers: {
+              "content-type": "text/x-component",
+              "x-collision": "target",
+              "x-target-only": "yes",
+            },
+          });
+        },
+        loadServerAction() {
+          return Promise.resolve(() => redirect("/redirect-target"));
+        },
+        getAndClearPendingCookies() {
+          return ["source=action; Path=/", "action=1; Path=/"];
+        },
+        middlewareHeaders: new Headers({ accept: "application/custom" }),
+        sourceConfigHeaders: new Headers([
+          ["accept", "application/config"],
+          ["set-cookie", "config=1; Path=/"],
+          ["set-cookie", "source=config; Path=/"],
+          ["x-collision", "source"],
+          ["x-source-only", "yes"],
+        ]),
+      }),
     );
 
-    expect(renderedRootParam).toBe("fr");
+    expect(targetRequest).not.toBeNull();
+    expect(targetRequest!.headers.get("accept")).toBe("application/custom");
+    expect(targetRequest!.headers.get("cookie")).toBe("config=1; source=action; action=1");
+    expect(targetRequest!.headers.get("x-source-only")).toBe("yes");
+    expect(response?.headers.get("x-source-only")).toBe("yes");
+    expect(response?.headers.get("x-target-only")).toBe("yes");
+    expect(response?.headers.get("x-collision")).toBe("target");
   });
 
-  it("keeps redirected action render context alive until the Flight body is consumed", async () => {
-    // Ported from Next.js: test/e2e/app-dir/actions/app-action-node-middleware.test.ts
-    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/actions/app-action-node-middleware.test.ts
-    const clearRequestContext = vi.fn(() => setHeadersContext(null));
+  it("falls back to a header-only redirect when internal target dispatch throws", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    errorSpy.mockClear();
+    const clearRequestContext = vi.fn();
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        clearRequestContext,
+        dispatchRedirectTargetRequest() {
+          return Promise.reject(new Error("target unavailable"));
+        },
+        loadServerAction() {
+          return Promise.resolve(() => redirect("/redirect-target"));
+        },
+      }),
+    );
 
-    try {
+    expect(response?.status).toBe(303);
+    expect(response?.headers.get("x-action-redirect")).toBe("/redirect-target");
+    expect(response?.headers.get("content-type")).toBeNull();
+    expect(await response?.text()).toBe("");
+    expect(clearRequestContext).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledOnce();
+    errorSpy.mockRestore();
+  });
+
+  it("falls back to a header-only redirect for a malformed followed Location", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    errorSpy.mockClear();
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        dispatchRedirectTargetRequest() {
+          return Promise.resolve(
+            new Response(null, { status: 307, headers: { location: "http://[" } }),
+          );
+        },
+        loadServerAction() {
+          return Promise.resolve(() => redirect("/redirect-target"));
+        },
+      }),
+    );
+
+    expect(response?.status).toBe(303);
+    expect(response?.headers.get("x-action-redirect")).toBe("/redirect-target");
+    expect(response?.headers.get("content-type")).toBeNull();
+    expect(await response?.text()).toBe("");
+    expect(errorSpy).toHaveBeenCalledOnce();
+    errorSpy.mockRestore();
+  });
+
+  it.each(["../../admin", "/base/%2e%2e/admin", "https://example.com/admin"])(
+    "does not internally dispatch basePath escape %s",
+    async (target) => {
+      const dispatchRedirectTargetRequest = vi.fn(() =>
+        Promise.resolve(
+          new Response("should-not-dispatch", {
+            headers: { "content-type": "text/x-component" },
+          }),
+        ),
+      );
       const response = await handleServerActionRscRequest(
         createRscOptions({
-          clearRequestContext,
-          getAndClearPendingCookies() {
-            return ["theme=dark; Path=/"];
-          },
+          basePath: "/base",
+          dispatchRedirectTargetRequest,
           loadServerAction() {
-            return Promise.resolve(() => redirect("/redirect-target"));
+            return Promise.resolve(() => redirect(target));
           },
-          matchRoute(pathname) {
-            if (pathname === "/redirect-target") {
-              return {
-                params: {},
-                route: { id: "redirect-target", page: {}, params: [], pattern: "/redirect-target" },
-              };
-            }
-            return {
-              params: {},
-              route: { id: "dashboard", page: {}, params: [], pattern: "/dashboard" },
-            };
-          },
-          renderToReadableStream() {
-            return new ReadableStream<Uint8Array>({
-              async pull(controller) {
-                const cookieStore = await cookies();
-                controller.enqueue(
-                  new TextEncoder().encode(cookieStore.get("theme")?.value ?? "missing"),
-                );
-                controller.close();
-              },
-            });
-          },
+          request: new Request("https://example.com/base/account", {
+            body: "encoded-flight-body",
+            method: "POST",
+            headers: createFetchActionRequest().headers,
+          }),
         }),
       );
 
-      expect(clearRequestContext).not.toHaveBeenCalled();
-      expect(await response?.text()).toBe("dark");
-      expect(clearRequestContext).toHaveBeenCalledTimes(1);
-    } finally {
-      setHeadersContext(null);
-    }
+      expect(response?.status).toBe(303);
+      expect(response?.headers.get("x-action-redirect")).toBe(target);
+      expect(await response?.text()).toBe("");
+      expect(dispatchRedirectTargetRequest).not.toHaveBeenCalled();
+    },
+  );
+
+  it("keeps both request contexts alive until the dispatched Flight body is consumed", async () => {
+    const clearRequestContext = vi.fn();
+    const response = await handleServerActionRscRequest(
+      createRscOptions({
+        clearRequestContext,
+        async dispatchRedirectTargetRequest() {
+          return new Response(
+            new ReadableStream<Uint8Array>({
+              pull(controller) {
+                controller.enqueue(new TextEncoder().encode("streamed-target"));
+                controller.close();
+              },
+            }),
+            { headers: { "content-type": "text/x-component" } },
+          );
+        },
+        loadServerAction() {
+          return Promise.resolve(() => redirect("/redirect-target"));
+        },
+      }),
+    );
+
+    expect(clearRequestContext).not.toHaveBeenCalled();
+    expect(await response?.text()).toBe("streamed-target");
+    expect(clearRequestContext).toHaveBeenCalledTimes(1);
   });
 
   it("falls back to header-only redirects when the target is not an App route", async () => {
@@ -1987,31 +2029,20 @@ describe("app server action execution helpers", () => {
     expect(buildPageElement).not.toHaveBeenCalled();
   });
 
-  it("falls back to header-only redirects when target middleware diverts the request", async () => {
+  it("falls back to a header-only redirect when the target pipeline does not return Flight", async () => {
     const buildPageElement = vi.fn(() => "should-not-render");
-    const ensureRouteLoaded = vi.fn();
-    const runRedirectTargetMiddleware = vi.fn(async () => ({ kind: "diverted" }) as const);
-
     const response = await handleServerActionRscRequest(
       createRscOptions({
         buildPageElement,
-        ensureRouteLoaded,
+        async dispatchRedirectTargetRequest() {
+          return new Response("unauthorized", {
+            status: 401,
+            headers: { "content-type": "text/plain" },
+          });
+        },
         loadServerAction() {
           return Promise.resolve(() => redirect("/protected"));
         },
-        matchRoute(pathname) {
-          if (pathname === "/protected") {
-            return {
-              params: {},
-              route: { id: "protected", page: {}, params: [], pattern: "/protected" },
-            };
-          }
-          return {
-            params: {},
-            route: { id: "dashboard", page: {}, params: [], pattern: "/dashboard" },
-          };
-        },
-        runRedirectTargetMiddleware,
       }),
     );
 
@@ -2020,281 +2051,74 @@ describe("app server action execution helpers", () => {
     expect(response?.headers.get("content-type")).toBeNull();
     expect(await response?.text()).toBe("");
     expect(buildPageElement).not.toHaveBeenCalled();
-    // Hydrating a route imports its modules and runs their top-level code —
-    // a middleware-blocked target must never get that far.
-    expect(ensureRouteLoaded).not.toHaveBeenCalled();
-    expect(runRedirectTargetMiddleware).toHaveBeenCalledWith({
-      cleanPathname: "/protected",
-      request: expect.any(Request),
-    });
   });
 
-  it("renders redirect targets that middleware passes through and keeps its response headers", async () => {
-    let middlewareRequest: Request | null = null;
-    let renderRequest: Request | null = null;
-    const runRedirectTargetMiddleware = vi.fn(async (targetOptions: { request: Request }) => {
-      middlewareRequest = targetOptions.request;
-      return {
-        kind: "continue" as const,
-        responseHeaders: new Headers({ "x-from-target-middleware": "1" }),
-      };
-    });
-    const actionRequest = createFetchActionRequest({
-      accept: "text/x-component",
-      "x-vinext-mw-ctx": JSON.stringify({}),
-    });
-    // Workers attach cf to the inbound request; new Request() never copies it.
-    Object.defineProperty(actionRequest, "cf", { value: { country: "AU" }, enumerable: true });
-
-    const response = await handleServerActionRscRequest(
-      createRscOptions({
-        buildPageElement({ route: matchedRoute, request }) {
-          renderRequest = request;
-          return `${matchedRoute.id}:{}:none`;
-        },
-        loadServerAction() {
-          return Promise.resolve(() => redirect("/redirect-target"));
-        },
-        request: actionRequest,
-        matchRoute(pathname) {
-          if (pathname === "/redirect-target") {
-            return {
-              params: {},
-              route: { id: "redirect-target", page: {}, params: [], pattern: "/redirect-target" },
-            };
-          }
-          return {
-            params: {},
-            route: { id: "dashboard", page: {}, params: [], pattern: "/dashboard" },
-          };
-        },
-        runRedirectTargetMiddleware,
-      }),
-    );
-
-    expect(response?.status).toBe(303);
-    expect(response?.headers.get("x-from-target-middleware")).toBe("1");
-    expect(JSON.parse(await response!.text())).toEqual({
-      root: "redirect-target:{}:none",
-      returnValue: { ok: true },
-    });
-
-    // Middleware sees the same effective headers as Next.js' internal target
-    // GET, including Accept. The forwarded-middleware-context header describes
-    // the *action* path's result and would make the target skip middleware
-    // entirely.
-    expect(middlewareRequest).not.toBeNull();
-    expect(middlewareRequest!.method).toBe("GET");
-    expect(middlewareRequest!.url).toBe("https://example.com/redirect-target");
-    expect(middlewareRequest!.headers.get("accept")).toBe("text/x-component");
-    expect(middlewareRequest!.headers.get("content-type")).toBe("text/plain;charset=UTF-8");
-    expect(middlewareRequest!.headers.get("origin")).toBe("https://example.com");
-    expect(middlewareRequest!.headers.get("next-action")).toBeNull();
-    expect(middlewareRequest!.headers.get("x-vinext-mw-ctx")).toBeNull();
-
-    expect(renderRequest).not.toBeNull();
-    expect(renderRequest!.headers.get("accept")).toBe("text/x-component");
-    expect(renderRequest!.headers.get("content-type")).toBe("text/plain;charset=UTF-8");
-    expect(renderRequest!.headers.get("origin")).toBe("https://example.com");
-    expect(renderRequest!.headers.get("x-vinext-mw-ctx")).toBeNull();
-
-    // Middleware that authorizes on request.cf (geo checks) must not fail open
-    // on the reconstructed target requests.
-    expect(Reflect.get(middlewareRequest!, "cf")).toEqual({ country: "AU" });
-    expect(Reflect.get(renderRequest!, "cf")).toEqual({ country: "AU" });
-  });
-
-  it("builds an inline redirect target with target middleware's CSP nonce", async () => {
-    const buildPageElement = vi.fn(() => "redirect-target:{}:none");
-
-    const response = await handleServerActionRscRequest(
-      createRscOptions({
-        buildPageElement,
-        loadServerAction() {
-          return Promise.resolve(() => redirect("/redirect-target"));
-        },
-        matchRoute(pathname) {
-          if (pathname === "/redirect-target") {
-            return {
-              params: {},
-              route: { id: "redirect-target", page: {}, params: [], pattern: "/redirect-target" },
-            };
-          }
-          return {
-            params: {},
-            route: { id: "dashboard", page: {}, params: [], pattern: "/dashboard" },
-          };
-        },
-        middlewareHeaders: new Headers({
-          "content-security-policy": "script-src 'nonce-action-path'",
-        }),
-        async runRedirectTargetMiddleware() {
-          return {
-            kind: "continue",
-            responseHeaders: new Headers({
-              "content-security-policy": "script-src 'nonce-redirect-target'",
-            }),
-          };
-        },
-      }),
-    );
-
-    expect(response?.headers.get("content-security-policy")).toBe(
-      "script-src 'nonce-redirect-target'",
-    );
-    expect(buildPageElement).toHaveBeenCalledWith(
-      expect.objectContaining({ scriptNonce: "redirect-target" }),
-    );
-  });
-
-  it("forwards filtered action middleware response headers to the redirect target", async () => {
-    let middlewareRequest: Request | null = null;
-    let renderRequest: Request | null = null;
-
-    const response = await handleServerActionRscRequest(
-      createRscOptions({
-        buildPageElement({ route: matchedRoute, request }) {
-          renderRequest = request;
-          return `${matchedRoute.id}:{}:none`;
-        },
-        loadServerAction() {
-          return Promise.resolve(() => redirect("/redirect-target"));
-        },
-        matchRoute(pathname) {
-          if (pathname === "/redirect-target") {
-            return {
-              params: {},
-              route: { id: "redirect-target", page: {}, params: [], pattern: "/redirect-target" },
-            };
-          }
-          return {
-            params: {},
-            route: { id: "dashboard", page: {}, params: [], pattern: "/dashboard" },
-          };
-        },
-        middlewareHeaders: new Headers({
-          accept: "application/action-middleware",
-          cookie: "forged=1",
-          "content-length": "999",
-          "set-cookie": "session=rotated; Path=/",
-          "x-action-auth-context": "member",
-        }),
-        request: createFetchActionRequest({ cookie: "theme=dark" }),
-        async runRedirectTargetMiddleware(targetOptions: { request: Request }) {
-          middlewareRequest = targetOptions.request;
-          return { kind: "continue", responseHeaders: null };
-        },
-      }),
-    );
-
-    expect(response?.status).toBe(303);
-    expect(response?.headers.get("content-length")).toBeNull();
-    expect(middlewareRequest).not.toBeNull();
-    expect(middlewareRequest!.headers.get("accept")).toBe("application/action-middleware");
-    expect(middlewareRequest!.headers.get("cookie")).toBe("theme=dark; session=rotated");
-    expect(middlewareRequest!.headers.get("content-length")).toBeNull();
-    expect(middlewareRequest!.headers.get("x-action-auth-context")).toBe("member");
-    expect(renderRequest).not.toBeNull();
-    expect(renderRequest!.headers.get("accept")).toBe("application/action-middleware");
-    expect(renderRequest!.headers.get("cookie")).toBe("theme=dark; session=rotated");
-    expect(renderRequest!.headers.get("content-length")).toBeNull();
-    expect(renderRequest!.headers.get("x-action-auth-context")).toBe("member");
-  });
-
-  it("starts redirect targets from action middleware's request-header overrides", async () => {
-    let middlewareRequest: Request | null = null;
-    let renderRequest: Request | null = null;
-
+  it("forwards effective action headers and cookies to the target pipeline", async () => {
+    let targetRequest: Request | null = null;
     await handleServerActionRscRequest(
       createRscOptions({
-        buildPageElement({ route: matchedRoute, request }) {
-          renderRequest = request;
-          return `${matchedRoute.id}:{}:none`;
+        async dispatchRedirectTargetRequest(request) {
+          targetRequest = request;
+          return new Response("flight", { headers: { "content-type": "text/x-component" } });
         },
         loadServerAction() {
           return Promise.resolve(() => redirect("/redirect-target"));
         },
-        matchRoute(pathname) {
-          if (pathname === "/redirect-target") {
-            return {
-              params: {},
-              route: { id: "redirect-target", page: {}, params: [], pattern: "/redirect-target" },
-            };
-          }
-          return {
-            params: {},
-            route: { id: "dashboard", page: {}, params: [], pattern: "/dashboard" },
-          };
-        },
+        middlewareHeaders: new Headers([
+          ["set-cookie", "session=; Max-Age=0"],
+          ["set-cookie", "csrf=rotated"],
+          ["set-cookie", "admin=1; Path=/account"],
+          ["x-action-auth-context", "member"],
+        ]),
         middlewareRequestHeaders: new Headers({
           "x-middleware-override-headers": "x-auth-context",
           "x-middleware-request-x-auth-context": "sanitized",
         }),
         request: createFetchActionRequest({
+          cookie: "session=live; csrf=old; theme=dark",
           "x-attacker-controlled": "forged",
           "x-auth-context": "untrusted",
         }),
-        async runRedirectTargetMiddleware(targetOptions: { request: Request }) {
-          middlewareRequest = targetOptions.request;
-          return { kind: "continue", responseHeaders: null };
-        },
       }),
     );
 
-    expect(middlewareRequest).not.toBeNull();
-    expect(middlewareRequest!.headers.get("x-auth-context")).toBe("sanitized");
-    expect(middlewareRequest!.headers.get("x-attacker-controlled")).toBeNull();
-    expect(renderRequest).not.toBeNull();
-    expect(renderRequest!.headers.get("x-auth-context")).toBe("sanitized");
-    expect(renderRequest!.headers.get("x-attacker-controlled")).toBeNull();
+    expect(targetRequest).not.toBeNull();
+    expect(targetRequest!.headers.get("cookie")).toBe("csrf=rotated");
+    expect(targetRequest!.headers.get("x-auth-context")).toBe("sanitized");
+    expect(targetRequest!.headers.get("x-attacker-controlled")).toBeNull();
+    expect(targetRequest!.headers.get("x-action-auth-context")).toBe("member");
   });
 
-  it("runs target middleware before hydrating a lazy target route's modules", async () => {
-    const events: string[] = [];
-    const lazyRoute: TestRoute = {
-      id: "lazy-protected",
-      params: [],
-      pattern: "/lazy-protected",
-      __loadPage: () => Promise.resolve({}),
-    };
-
+  // Next.js follows same-origin redirects from its internal target fetch. The
+  // in-process dispatcher must do the same so config and middleware redirects
+  // can still produce a single action response containing the final Flight.
+  it("follows same-origin target redirects through the internal dispatcher", async () => {
+    const paths: string[] = [];
     const response = await handleServerActionRscRequest(
       createRscOptions({
-        ensureRouteLoaded(route) {
-          events.push(`load:${route.id}`);
-          if (route === lazyRoute) route.page = {};
+        async dispatchRedirectTargetRequest(request) {
+          const url = new URL(request.url);
+          paths.push(url.pathname);
+          if (url.pathname === "/redirect-source") {
+            return new Response(null, { status: 307, headers: { location: "/redirect-target" } });
+          }
+          return new Response("redirect-target-flight", {
+            headers: { "content-type": "text/x-component", "x-final-target": "1" },
+          });
         },
         loadServerAction() {
-          return Promise.resolve(() => redirect("/lazy-protected"));
-        },
-        matchRoute(pathname) {
-          if (pathname === "/lazy-protected") {
-            return { params: {}, route: lazyRoute };
-          }
-          return {
-            params: {},
-            route: { id: "dashboard", page: {}, params: [], pattern: "/dashboard" },
-          };
-        },
-        async runRedirectTargetMiddleware() {
-          events.push("middleware");
-          return { kind: "continue", responseHeaders: null };
+          return Promise.resolve(() => redirect("/redirect-source"));
         },
       }),
     );
 
-    // The unhydrated route only advertises its page via the lazy thunk, so it
-    // must still count as renderable, and middleware must run before the
-    // hydration that executes the page module's top-level code.
-    expect(events).toEqual(["middleware", "load:lazy-protected", "load:dashboard"]);
-    expect(response?.status).toBe(303);
-    expect(JSON.parse(await response!.text())).toEqual({
-      root: "lazy-protected:{}:none",
-      returnValue: { ok: true },
-    });
+    expect(paths).toEqual(["/redirect-source", "/redirect-target"]);
+    expect(response?.headers.get("x-action-redirect")).toBe("/redirect-source");
+    expect(response?.headers.get("x-final-target")).toBe("1");
+    expect(await response?.text()).toBe("redirect-target-flight");
   });
 
-  it("keeps the action protocol headers when merging middleware headers onto the redirect response", async () => {
+  it("keeps action protocol headers when merging target pipeline headers", async () => {
     const response = await handleServerActionRscRequest(
       createRscOptions({
         loadServerAction() {
@@ -2319,21 +2143,19 @@ describe("app server action execution helpers", () => {
           "x-action-redirect": "/mw-hijack",
           "x-action-mw": "1",
         }),
-        async runRedirectTargetMiddleware() {
-          return {
-            kind: "continue",
-            responseHeaders: new Headers({
+        async dispatchRedirectTargetRequest() {
+          return new Response("flight", {
+            headers: {
               "accept-encoding": "gzip",
               connection: "close",
               "content-encoding": "gzip",
-              location: "/target-mw-location",
-              "content-type": "text/html",
+              "content-type": "text/x-component",
               "content-length": "0",
               "transfer-encoding": "chunked",
               "x-action-redirect": "/target-hijack",
               "x-target-mw": "1",
-            }),
-          };
+            },
+          });
         },
       }),
     );
@@ -2357,49 +2179,8 @@ describe("app server action execution helpers", () => {
     expect(response?.headers.get("x-target-mw")).toBe("1");
   });
 
-  it("applies the action middleware's cookie mutations to the redirect target request", async () => {
-    let middlewareRequest: Request | null = null;
-
-    await handleServerActionRscRequest(
-      createRscOptions({
-        loadServerAction() {
-          return Promise.resolve(() => redirect("/redirect-target"));
-        },
-        matchRoute(pathname) {
-          if (pathname === "/redirect-target") {
-            return {
-              params: {},
-              route: { id: "redirect-target", page: {}, params: [], pattern: "/redirect-target" },
-            };
-          }
-          return {
-            params: {},
-            route: { id: "dashboard", page: {}, params: [], pattern: "/dashboard" },
-          };
-        },
-        middlewareHeaders: new Headers([
-          ["set-cookie", "session=; Max-Age=0"],
-          ["set-cookie", "csrf=rotated"],
-          ["set-cookie", "admin=1; Path=/account"],
-        ]),
-        request: createFetchActionRequest({ cookie: "session=live; csrf=old; theme=dark" }),
-        async runRedirectTargetMiddleware(targetOptions: { request: Request }) {
-          middlewareRequest = targetOptions.request;
-          return { kind: "continue", responseHeaders: null };
-        },
-      }),
-    );
-
-    // The action middleware deleted the session and rotated csrf, so target
-    // middleware must not authorize on the credential the response is
-    // simultaneously revoking. The newly emitted /account-scoped cookie still
-    // carries enough metadata to keep it out of /redirect-target as well.
-    expect(middlewareRequest).not.toBeNull();
-    expect(middlewareRequest!.headers.get("cookie")).toBe("csrf=rotated; theme=dark");
-  });
-
-  it("strips the internal _rsc param from the redirect target before middleware", async () => {
-    let middlewareRequest: Request | null = null;
+  it("replaces a redirect-supplied _rsc value before target dispatch", async () => {
+    let targetRequest: Request | null = null;
 
     const response = await handleServerActionRscRequest(
       createRscOptions({
@@ -2418,9 +2199,9 @@ describe("app server action execution helpers", () => {
             route: { id: "dashboard", page: {}, params: [], pattern: "/dashboard" },
           };
         },
-        async runRedirectTargetMiddleware(targetOptions: { request: Request }) {
-          middlewareRequest = targetOptions.request;
-          return { kind: "continue", responseHeaders: null };
+        async dispatchRedirectTargetRequest(request) {
+          targetRequest = request;
+          return new Response("flight", { headers: { "content-type": "text/x-component" } });
         },
       }),
     );
@@ -2429,10 +2210,10 @@ describe("app server action execution helpers", () => {
     // it would branch differently for the synthetic request than for the
     // navigation it stands in for. The client-facing redirect header keeps the
     // verbatim URL — a diverted re-request goes through real validation.
-    expect(middlewareRequest).not.toBeNull();
-    const middlewareUrl = new URL(middlewareRequest!.url);
-    expect(middlewareUrl.searchParams.get("_rsc")).toBeNull();
-    expect(middlewareUrl.searchParams.get("tab")).toBe("x");
+    expect(targetRequest).not.toBeNull();
+    const targetUrl = new URL(targetRequest!.url);
+    expect(targetUrl.searchParams.get("_rsc")).not.toBe("abc123");
+    expect(targetUrl.searchParams.get("tab")).toBe("x");
     expect(response?.headers.get("x-action-redirect")).toBe("/redirect-target?_rsc=abc123&tab=x");
   });
 
@@ -2873,7 +2654,7 @@ describe("app server action execution helpers", () => {
       returnValue: { ok: true },
     });
     expect(clearContext).toHaveBeenCalledTimes(1);
-    expect(renderToReadableStream).toHaveBeenCalledTimes(1);
+    expect(renderToReadableStream).not.toHaveBeenCalled();
   });
 
   it("emits x-action-revalidated when a redirecting fetch action revalidates a tag", async () => {
@@ -3327,49 +3108,6 @@ describe("app server action execution helpers", () => {
 
     expect(response?.status).toBe(200);
     expect(response?.headers.get("x-edge-runtime")).toBe("1");
-  });
-
-  it("resolves the redirect target route's dynamic config and fetch cache mode for force-dynamic fetch defaults", async () => {
-    const fetchCacheShims = await import("../packages/vinext/src/shims/fetch-cache.js");
-    const modeSpy = vi.spyOn(fetchCacheShims, "setCurrentFetchCacheMode");
-    const forceDynamicSpy = vi.spyOn(fetchCacheShims, "setCurrentForceDynamicFetchDefault");
-
-    const targetRoute: TestRoute = {
-      id: "redirect-target",
-      page: {},
-      params: [],
-      pattern: "/redirect-target",
-    };
-
-    const response = await handleServerActionRscRequest(
-      createRscOptions({
-        loadServerAction() {
-          return Promise.resolve(() => redirect("/redirect-target"));
-        },
-        matchRoute(pathname) {
-          if (pathname === "/redirect-target") {
-            return { params: {}, route: targetRoute };
-          }
-          return {
-            params: {},
-            route: { id: "dashboard", page: {}, params: [], pattern: "/dashboard" },
-          };
-        },
-        resolveRouteFetchCacheMode(route) {
-          return route === targetRoute ? "force-cache" : null;
-        },
-        resolveRouteDynamicConfig(route) {
-          return route === targetRoute ? "force-dynamic" : null;
-        },
-      }),
-    );
-
-    expect(response?.status).toBe(303);
-    expect(modeSpy).toHaveBeenCalledWith("force-cache");
-    expect(forceDynamicSpy).toHaveBeenCalledWith(true);
-
-    modeSpy.mockRestore();
-    forceDynamicSpy.mockRestore();
   });
 
   it("resolves the re-render target route's dynamic config and fetch cache mode for force-dynamic fetch defaults", async () => {

--- a/tests/e2e/app-front-redirect-issue/fixture/node_modules
+++ b/tests/e2e/app-front-redirect-issue/fixture/node_modules
@@ -1,0 +1,1 @@
+../../../fixtures/app-basic/node_modules

--- a/tests/e2e/app-front-redirect-issue/fixture/node_modules
+++ b/tests/e2e/app-front-redirect-issue/fixture/node_modules
@@ -1,1 +1,0 @@
-../../../fixtures/app-basic/node_modules

--- a/tests/e2e/app-router-encoded-basepath-i18n/encoded-path-routing.spec.ts
+++ b/tests/e2e/app-router-encoded-basepath-i18n/encoded-path-routing.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { request as httpRequest, type IncomingHttpHeaders } from "node:http";
+import { waitForAppRouterHydration } from "../helpers";
 
 function getRawPath(
   path: string,
@@ -121,4 +122,35 @@ test("preserves raw redirect captures behind basePath and i18n", async () => {
 
   expect(response.status).toBe(307);
   expect(response.location).toBe("/docs/blog/a%252Fb/a%252Fb");
+});
+
+test("runs an action redirect rewrite through the full pipeline behind basePath", async ({
+  page,
+}) => {
+  await page.goto("/docs/nextjs-compat/action-redirect-middleware");
+  await waitForAppRouterHydration(page);
+  await page.evaluate(() => {
+    Reflect.set(window, "__ACTION_REDIRECT_BASEPATH_DOCUMENT__", "preserved");
+  });
+
+  await page.click("#redirect-to-middleware-rewrite");
+
+  await expect(page).toHaveURL(/\/docs\/middleware-rewrite$/);
+  await expect(page.getByText("Welcome to App Router", { exact: true })).toBeVisible();
+  expect(
+    await page.evaluate(() => Reflect.get(window, "__ACTION_REDIRECT_BASEPATH_DOCUMENT__")),
+  ).toBe("preserved");
+
+  await page.goto("/docs/nextjs-compat/action-redirect-middleware");
+  await waitForAppRouterHydration(page);
+  await page.evaluate(() => {
+    Reflect.set(window, "__ACTION_REDIRECT_BASEPATH_DOCUMENT__", "preserved");
+  });
+  await page.click("#redirect-to-config-redirect");
+
+  await expect(page).toHaveURL(/\/docs\/redirect-test-config$/);
+  await expect(page.getByText("About", { exact: true })).toBeVisible();
+  expect(
+    await page.evaluate(() => Reflect.get(window, "__ACTION_REDIRECT_BASEPATH_DOCUMENT__")),
+  ).toBe("preserved");
 });

--- a/tests/e2e/app-router/action-redirect-pipeline.spec.ts
+++ b/tests/e2e/app-router/action-redirect-pipeline.spec.ts
@@ -1,0 +1,108 @@
+import { expect, test } from "@playwright/test";
+import { waitForAppRouterHydration } from "../helpers";
+
+const BASE = "http://localhost:4174";
+const ACTION_PATH = "/nextjs-compat/action-redirect-middleware";
+
+async function markCurrentDocument(page: import("@playwright/test").Page): Promise<void> {
+  await page.evaluate(() => {
+    Reflect.set(window, "__ACTION_REDIRECT_PIPELINE_DOCUMENT__", "preserved");
+  });
+}
+
+async function expectDocumentPreserved(page: import("@playwright/test").Page): Promise<void> {
+  await expect
+    .poll(() => page.evaluate(() => Reflect.get(window, "__ACTION_REDIRECT_PIPELINE_DOCUMENT__")))
+    .toBe("preserved");
+}
+
+test.describe("Server Action redirect target pipeline", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(`${BASE}${ACTION_PATH}`);
+    await waitForAppRouterHydration(page);
+    await markCurrentDocument(page);
+  });
+
+  // Ported from Next.js:
+  // test/e2e/app-dir/server-actions-redirect-middleware-rewrite/
+  // server-actions-redirect-middleware-rewrite.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/server-actions-redirect-middleware-rewrite/server-actions-redirect-middleware-rewrite.test.ts
+  test("resolves middleware rewrites inside the action response", async ({ page }) => {
+    await page.click("#redirect-to-middleware-rewrite");
+
+    await expect(page).toHaveURL(`${BASE}/middleware-rewrite`);
+    await expect(page.getByText("Welcome to App Router", { exact: true })).toBeVisible();
+    await expectDocumentPreserved(page);
+  });
+
+  test("resolves next.config rewrites inside the action response", async ({ page }) => {
+    await page.click("#redirect-to-config-rewrite");
+
+    await expect(page).toHaveURL(`${BASE}/config-rewrite`);
+    await expect(page.getByText("Welcome to App Router", { exact: true })).toBeVisible();
+    await expectDocumentPreserved(page);
+  });
+
+  test("follows middleware redirects before streaming the final Flight payload", async ({
+    page,
+  }) => {
+    await page.click("#redirect-to-middleware-redirect");
+
+    await expect(page).toHaveURL(`${BASE}/middleware-redirect`);
+    await expect(page.getByText("About", { exact: true })).toBeVisible();
+    await expectDocumentPreserved(page);
+  });
+
+  test("follows next.config redirects before streaming the final Flight payload", async ({
+    page,
+  }) => {
+    await page.click("#redirect-to-config-redirect");
+
+    await expect(page).toHaveURL(`${BASE}/redirect-test-config`);
+    await expect(page.getByText("About", { exact: true })).toBeVisible();
+    await expectDocumentPreserved(page);
+  });
+
+  test("carries target config headers on the action response", async ({ page }) => {
+    const actionResponse = page.waitForResponse(
+      (response) =>
+        response.request().method() === "POST" && new URL(response.url()).pathname === ACTION_PATH,
+    );
+    await page.click("#redirect-to-about");
+
+    const headers = (await actionResponse).headers();
+    expect(headers["x-page-header"]).toBe("about-page");
+    expect(headers["x-action-source-only"]).toBe("yes");
+    expect(headers["x-action-target-saw-source"]).toBe("yes");
+    expect(headers["x-action-header-collision"]).toBe("target");
+    await expect(page).toHaveURL(`${BASE}/about`);
+    await expectDocumentPreserved(page);
+  });
+
+  test("falls back to a hard navigation for a Pages Router target", async ({ page }) => {
+    await page.click("#redirect-to-pages-route");
+
+    await expect(page).toHaveURL(`${BASE}/old-school`);
+    await expect(page.getByText("Old School Pages Directory", { exact: true })).toBeVisible();
+    expect(
+      await page.evaluate(() => Reflect.get(window, "__ACTION_REDIRECT_PIPELINE_DOCUMENT__")),
+    ).toBeUndefined();
+  });
+
+  test("does not stream a middleware-blocked target", async ({ page }) => {
+    await page.click("#redirect-to-blocked");
+
+    await expect(page).toHaveURL(`${BASE}/admin`);
+    await expect(page.getByText("Protected admin content", { exact: true })).toHaveCount(0);
+    await expect(page.getByText("Blocked by middleware", { exact: false })).toBeVisible();
+  });
+
+  test("streams the safe 404 Flight response for an encoded static alias", async ({ page }) => {
+    await page.click("#redirect-to-encoded-blocked");
+
+    await expect(page).toHaveURL(`${BASE}/adm%69n`);
+    await expect(page.getByText("404 - Page Not Found", { exact: true })).toBeVisible();
+    await expect(page.getByText("Protected admin content", { exact: true })).toHaveCount(0);
+    await expectDocumentPreserved(page);
+  });
+});

--- a/tests/fixtures/app-basic/app/nextjs-compat/action-redirect-middleware/actions.ts
+++ b/tests/fixtures/app-basic/app/nextjs-compat/action-redirect-middleware/actions.ts
@@ -11,3 +11,14 @@ import { redirect } from "next/navigation";
 export async function redirectToBlockedPath(): Promise<void> {
   redirect("/admin");
 }
+
+/**
+ * Percent-encoded alias of the same blocked path. Route matching that decodes
+ * would resolve this to the `/admin` page, while middleware and a real
+ * navigation both see `/adm%69n`. Deliberately not `/%61dmin`, which this
+ * fixture's middleware rewrites — a rewrite already forces a real navigation,
+ * which would hide whether the target was matched with request identity.
+ */
+export async function redirectToEncodedBlockedPath(): Promise<void> {
+  redirect("/adm%69n");
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/action-redirect-middleware/actions.ts
+++ b/tests/fixtures/app-basic/app/nextjs-compat/action-redirect-middleware/actions.ts
@@ -1,0 +1,13 @@
+"use server";
+
+import { redirect } from "next/navigation";
+
+/**
+ * Redirects to `/admin`, which this fixture's middleware blocks with a 403.
+ * A redirecting action renders its target inline, so the target's middleware
+ * has to run before that render or the blocked page's payload leaks into the
+ * action response.
+ */
+export async function redirectToBlockedPath(): Promise<void> {
+  redirect("/admin");
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/action-redirect-middleware/actions.ts
+++ b/tests/fixtures/app-basic/app/nextjs-compat/action-redirect-middleware/actions.ts
@@ -22,3 +22,27 @@ export async function redirectToBlockedPath(): Promise<void> {
 export async function redirectToEncodedBlockedPath(): Promise<void> {
   redirect("/adm%69n");
 }
+
+export async function redirectToMiddlewareRewrite(): Promise<void> {
+  redirect("/middleware-rewrite");
+}
+
+export async function redirectToConfigRewrite(): Promise<void> {
+  redirect("/config-rewrite");
+}
+
+export async function redirectToMiddlewareRedirect(): Promise<void> {
+  redirect("/middleware-redirect");
+}
+
+export async function redirectToConfigRedirect(): Promise<void> {
+  redirect("/redirect-test-config");
+}
+
+export async function redirectToAbout(): Promise<void> {
+  redirect("/about");
+}
+
+export async function redirectToPagesRoute(): Promise<void> {
+  redirect("/old-school");
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/action-redirect-middleware/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/action-redirect-middleware/page.tsx
@@ -1,0 +1,14 @@
+import { redirectToBlockedPath } from "./actions";
+
+export default function Page() {
+  return (
+    <main>
+      <h1>Action Redirect Middleware Test</h1>
+      <form action={redirectToBlockedPath}>
+        <button id="redirect-to-blocked" type="submit">
+          Redirect to blocked path
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/action-redirect-middleware/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/action-redirect-middleware/page.tsx
@@ -1,4 +1,4 @@
-import { redirectToBlockedPath } from "./actions";
+import { redirectToBlockedPath, redirectToEncodedBlockedPath } from "./actions";
 
 export default function Page() {
   return (
@@ -7,6 +7,11 @@ export default function Page() {
       <form action={redirectToBlockedPath}>
         <button id="redirect-to-blocked" type="submit">
           Redirect to blocked path
+        </button>
+      </form>
+      <form action={redirectToEncodedBlockedPath}>
+        <button id="redirect-to-encoded-blocked" type="submit">
+          Redirect to encoded blocked path
         </button>
       </form>
     </main>

--- a/tests/fixtures/app-basic/app/nextjs-compat/action-redirect-middleware/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/action-redirect-middleware/page.tsx
@@ -1,4 +1,13 @@
-import { redirectToBlockedPath, redirectToEncodedBlockedPath } from "./actions";
+import {
+  redirectToBlockedPath,
+  redirectToAbout,
+  redirectToConfigRedirect,
+  redirectToConfigRewrite,
+  redirectToEncodedBlockedPath,
+  redirectToMiddlewareRedirect,
+  redirectToMiddlewareRewrite,
+  redirectToPagesRoute,
+} from "./actions";
 
 export default function Page() {
   return (
@@ -12,6 +21,36 @@ export default function Page() {
       <form action={redirectToEncodedBlockedPath}>
         <button id="redirect-to-encoded-blocked" type="submit">
           Redirect to encoded blocked path
+        </button>
+      </form>
+      <form action={redirectToMiddlewareRewrite}>
+        <button id="redirect-to-middleware-rewrite" type="submit">
+          Redirect through middleware rewrite
+        </button>
+      </form>
+      <form action={redirectToConfigRewrite}>
+        <button id="redirect-to-config-rewrite" type="submit">
+          Redirect through config rewrite
+        </button>
+      </form>
+      <form action={redirectToMiddlewareRedirect}>
+        <button id="redirect-to-middleware-redirect" type="submit">
+          Redirect through middleware redirect
+        </button>
+      </form>
+      <form action={redirectToConfigRedirect}>
+        <button id="redirect-to-config-redirect" type="submit">
+          Redirect through config redirect
+        </button>
+      </form>
+      <form action={redirectToAbout}>
+        <button id="redirect-to-about" type="submit">
+          Redirect to about
+        </button>
+      </form>
+      <form action={redirectToPagesRoute}>
+        <button id="redirect-to-pages-route" type="submit">
+          Redirect to Pages Router
         </button>
       </form>
     </main>

--- a/tests/fixtures/app-basic/middleware.ts
+++ b/tests/fixtures/app-basic/middleware.ts
@@ -362,6 +362,12 @@ export async function middleware(request: NextRequest, event: NextFetchEvent) {
   }
   r.headers.set("x-mw-pathname", pathname);
   r.headers.set("x-mw-ran", "true");
+  if (pathname === "/about") {
+    r.headers.set(
+      "x-action-target-saw-source",
+      request.headers.get("x-action-source-only") ?? "missing",
+    );
+  }
   if (sessionToken) {
     r.headers.set("x-mw-has-session", "true");
   }

--- a/tests/fixtures/app-basic/next.config.ts
+++ b/tests/fixtures/app-basic/next.config.ts
@@ -203,7 +203,19 @@ const nextConfig: NextConfig = {
       // Used by Vitest: app-router.test.ts
       {
         source: "/about",
-        headers: [{ key: "X-Page-Header", value: "about-page" }],
+        headers: [
+          { key: "X-Page-Header", value: "about-page" },
+          { key: "X-Action-Header-Collision", value: "target" },
+        ],
+      },
+      // Server-action redirect parity: source headers are forwarded into the
+      // internal target GET and retained unless the target replaces them.
+      {
+        source: "/nextjs-compat/action-redirect-middleware",
+        headers: [
+          { key: "X-Action-Source-Only", value: "yes" },
+          { key: "X-Action-Header-Collision", value: "source" },
+        ],
       },
       // Used by E2E: config-redirect.spec.ts — has/missing on headers rules
       {

--- a/tests/nextjs-compat/action-redirect-middleware.test.ts
+++ b/tests/nextjs-compat/action-redirect-middleware.test.ts
@@ -18,7 +18,22 @@ import type { ViteDevServer } from "vite-plus";
 import { APP_FIXTURE_DIR, startFixtureServer } from "../helpers.js";
 
 const ACTION_PATH = "/nextjs-compat/action-redirect-middleware";
-const ACTION_ID = "/app/nextjs-compat/action-redirect-middleware/actions.ts#redirectToBlockedPath";
+const ACTIONS = "/app/nextjs-compat/action-redirect-middleware/actions.ts";
+const ACTION_ID = `${ACTIONS}#redirectToBlockedPath`;
+const ENCODED_ACTION_ID = `${ACTIONS}#redirectToEncodedBlockedPath`;
+
+async function postAction(
+  baseUrl: string,
+  actionId: string,
+  extraHeaders: Record<string, string> = {},
+): Promise<{ res: Response; text: string }> {
+  const res = await fetch(`${baseUrl}${ACTION_PATH}.rsc`, {
+    method: "POST",
+    headers: { "Content-Type": "text/plain", "x-rsc-action": actionId, ...extraHeaders },
+    body: JSON.stringify([]),
+  });
+  return { res, text: await res.text() };
+}
 
 describe("Next.js compat: server action redirect targets run middleware", () => {
   let server: ViteDevServer;
@@ -40,21 +55,37 @@ describe("Next.js compat: server action redirect targets run middleware", () => 
   });
 
   it("does not return the blocked target's payload from the action response", async () => {
-    const res = await fetch(`${baseUrl}${ACTION_PATH}.rsc`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "text/plain",
-        "x-rsc-action": ACTION_ID,
-      },
-      body: JSON.stringify([]),
-    });
-    const text = await res.text();
+    const { res, text } = await postAction(baseUrl, ACTION_ID);
 
     expect(res.headers.get("x-action-redirect")).toBe("/admin");
     expect(text).not.toContain("Protected admin content");
     // A header-only redirect the client re-requests through the full pipeline,
     // where middleware gets to block it.
     expect(res.headers.get("content-type")).toBeNull();
+    expect(text).toBe("");
+  });
+
+  // The dev-only forwarded-middleware-context header carries the *action* path's
+  // middleware result. Replayed for the target it would skip middleware
+  // execution entirely, so it must not survive onto the target's request.
+  it("ignores a forwarded middleware context when evaluating the target", async () => {
+    const { res, text } = await postAction(baseUrl, ACTION_ID, {
+      "x-vinext-mw-ctx": JSON.stringify({ h: [["x-mw-ran", "true"]] }),
+    });
+
+    expect(res.headers.get("x-action-redirect")).toBe("/admin");
+    expect(text).not.toContain("Protected admin content");
+    expect(text).toBe("");
+  });
+
+  // Route matching that decodes resolves /adm%69n to the /admin page, but
+  // middleware and a real navigation both see /adm%69n. Rendering the decoded
+  // route inline would serve a page neither of them reached.
+  it("does not render a percent-encoded alias of the blocked target", async () => {
+    const { res, text } = await postAction(baseUrl, ENCODED_ACTION_ID);
+
+    expect(res.headers.get("x-action-redirect")).toBe("/adm%69n");
+    expect(text).not.toContain("Protected admin content");
     expect(text).toBe("");
   });
 });

--- a/tests/nextjs-compat/action-redirect-middleware.test.ts
+++ b/tests/nextjs-compat/action-redirect-middleware.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Next.js Compatibility Tests: middleware runs for server action redirect targets.
+ *
+ * A server action that throws `redirect()` renders the target page inline and
+ * returns its Flight payload with the action response, instead of making the
+ * client re-request the target. Middleware only ran for the action's own path,
+ * so the target's middleware — commonly the app's authorization boundary — has
+ * to be run before that render.
+ *
+ * In Next.js the client re-requests the target through the full pipeline, so a
+ * middleware-blocked target is never rendered from the action request. Here the
+ * fixture's middleware blocks `/admin` with a 403; the action response must fall
+ * back to a header-only redirect the client re-requests, carrying no payload.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vite-plus/test";
+import type { ViteDevServer } from "vite-plus";
+import { APP_FIXTURE_DIR, startFixtureServer } from "../helpers.js";
+
+const ACTION_PATH = "/nextjs-compat/action-redirect-middleware";
+const ACTION_ID = "/app/nextjs-compat/action-redirect-middleware/actions.ts#redirectToBlockedPath";
+
+describe("Next.js compat: server action redirect targets run middleware", () => {
+  let server: ViteDevServer;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    ({ server, baseUrl } = await startFixtureServer(APP_FIXTURE_DIR, { appRouter: true }));
+    await fetch(`${baseUrl}${ACTION_PATH}`).catch(() => {});
+  }, 60_000);
+
+  afterAll(async () => {
+    await server?.close();
+  });
+
+  it("blocks a direct request to the redirect target", async () => {
+    const res = await fetch(`${baseUrl}/admin`);
+    expect(res.status).toBe(403);
+    expect(await res.text()).not.toContain("Protected admin content");
+  });
+
+  it("does not return the blocked target's payload from the action response", async () => {
+    const res = await fetch(`${baseUrl}${ACTION_PATH}.rsc`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "text/plain",
+        "x-rsc-action": ACTION_ID,
+      },
+      body: JSON.stringify([]),
+    });
+    const text = await res.text();
+
+    expect(res.headers.get("x-action-redirect")).toBe("/admin");
+    expect(text).not.toContain("Protected admin content");
+    // A header-only redirect the client re-requests through the full pipeline,
+    // where middleware gets to block it.
+    expect(res.headers.get("content-type")).toBeNull();
+    expect(text).toBe("");
+  });
+});

--- a/tests/nextjs-compat/action-redirect-middleware.test.ts
+++ b/tests/nextjs-compat/action-redirect-middleware.test.ts
@@ -85,7 +85,8 @@ describe("Next.js compat: server action redirect targets run middleware", () => 
     const { res, text } = await postAction(baseUrl, ENCODED_ACTION_ID);
 
     expect(res.headers.get("x-action-redirect")).toBe("/adm%69n");
+    expect(res.headers.get("content-type")).toContain("text/x-component");
     expect(text).not.toContain("Protected admin content");
-    expect(text).toBe("");
+    expect(text).toContain("404 - Page Not Found");
   });
 });


### PR DESCRIPTION
## Problem

Server Actions that redirect can inline the target Flight payload in the action response. PR #2745 correctly identified that vinext rendered that target without running its middleware, which could expose middleware-protected server-rendered content.

The narrower middleware-only approximation still diverged from Next.js: Next.js internally dispatches a synthetic RSC GET through the normal request pipeline, including config headers, redirects, rewrites, middleware, route matching, and final response shaping.

Closes #2745

## Change

Replace the redirect-target render shortcut with recursive in-process App Router dispatch.

- Dispatch internal action redirect targets as full-tree RSC GET requests through the normal App Router pipeline.
- Follow internal config and middleware redirects before returning the final Flight payload.
- Preserve source response state while applying target header and cookie precedence.
- Fall back to the existing header-only redirect when internal dispatch cannot safely produce an App Router Flight response.
- Hard-navigate App-to-Pages targets instead of streaming an App Router 404.
- Reject normalized basePath escapes from internal dispatch.
- Accept raw full-tree Flight payloads in the action client.

This supersedes and expands #2745 while preserving its security fix.

## Next.js parity

Browser coverage is ported from Next.js `test/e2e/app-dir/server-actions-redirect-middleware-rewrite/server-actions-redirect-middleware-rewrite.test.ts` and extends it across middleware/config rewrites, middleware/config redirects, blocked targets, headers, cookies, Pages Router targets, encoded aliases, and basePath production behavior.

The target header and cookie projection follows Next.js semantics: target `Set-Cookie` is filtered, target ordinary headers replace source values, response-cookie mutations collapse by name before request projection, paths are ignored, deletions remove request cookies, values round-trip through the edge-runtime encoding model, and an empty jar remains an explicit `Cookie:` header. Malformed raw values use a safe fallback so the target cannot retain stale credentials.

## Validation

Exact final head: `6b6d60b97faeebc7c3896e9ff8f2a617bef6234e`

- `vp check`
- Focused unit/integration suite — 263 passed
- Dev browser pipeline E2E — 8 passed
- Production browser pipeline E2E — 8 passed
- Production encoded basePath/i18n E2E — 9 passed
- `vp run vinext#build`
- app-basic production build
- Independent exact-head parity, lifecycle, security, and test reviews — clean
- BigBonk — no blocking issues
- PR checks — 66 passing, none pending or failing
- Next.js deploy suite [run 30672313164](https://github.com/cloudflare/vinext/actions/runs/30672313164), Next.js `v16.2.6` — 2,615 passed / 189 known failures / 631 skipped; exact failure set matches nightly `main` run 30600469609 with zero new failures
