### PR TITLE
fix(cache): bypass fetch cache in draft mode

### DIFF
--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -930,6 +930,10 @@ export function createSSRHandler(
             })
           : ({ data: false, shouldClear: false } satisfies PagesPreviewState);
         const requestPreviewData = requestPreview.data;
+        // Pages preview cookies are decoded by this router rather than
+        // next/headers. Publish the result to cache shims before any page data
+        // function runs so preview fetches cannot use shared entries.
+        requestContext.draftModeEnabled = requestPreviewData !== false;
         // Try to load _app.tsx if it exists. This happens before the readiness
         // predicate so app-level getInitialProps participates in the same
         // initial Pages Router state as the client __NEXT_DATA__ payload.

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -646,6 +646,10 @@ export function createPagesPageHandler(
             })
           : ({ data: false, shouldClear: false } satisfies PagesPreviewState);
         const previewData = preview.data;
+        // Pages preview cookies are decoded by this router rather than
+        // next/headers. Publish the result to cache shims before any page data
+        // function runs so preview fetches cannot use shared entries.
+        uCtx.draftModeEnabled = previewData !== false;
         const pagesNextData = {
           ...buildPagesReadinessNextData({
             pageModule,

--- a/packages/vinext/src/shims/fetch-cache.ts
+++ b/packages/vinext/src/shims/fetch-cache.ts
@@ -22,7 +22,7 @@
 import { getDataCacheHandler, type CachedFetchValue, type CacheHandler } from "./cache-handler.js";
 import { encodeCacheTags } from "../utils/encode-cache-tag.js";
 import { getOrCreateAls } from "./internal/als-registry.js";
-import { markDynamicUsage } from "./headers.js";
+import { isDraftModeEnabled, markDynamicUsage } from "./headers.js";
 import { _hasPendingRevalidatedTag, _setRequestScopedCacheLife } from "./cache-request-state.js";
 import { getRequestExecutionContext } from "./request-context.js";
 import {
@@ -1026,6 +1026,12 @@ function createPatchedFetch(): typeof globalThis.fetch {
     input: string | URL | Request,
     init?: RequestInit,
   ): Promise<Response> {
+    // Draft renders are not static generations. Bypass both shared fetch-cache
+    // reads and writes, matching Next.js's `workStore.isDraftMode` guard.
+    if (isDraftModeEnabled()) {
+      return originalFetch(input, init);
+    }
+
     const nextOpts = (init as ExtendedRequestInit | undefined)?.next as
       | NextFetchOptions
       | undefined;

--- a/packages/vinext/src/shims/fetch-cache.ts
+++ b/packages/vinext/src/shims/fetch-cache.ts
@@ -872,8 +872,16 @@ function createFetchDedupeCandidate(
     return null;
   }
 
-  const request =
-    typeof input === "string" || input instanceof URL ? new Request(input, init) : input;
+  // Request bodies are deliberately excluded from dedupe. Keep that early
+  // exit before constructing an effective Request so POST and consumed-body
+  // inputs retain their existing pass-through behavior.
+  if (input instanceof Request && input.method !== "GET" && input.method !== "HEAD") {
+    return null;
+  }
+
+  // Construct the effective Request so init overrides (especially headers)
+  // participate in the per-render dedupe key for GET/HEAD Request inputs.
+  const request = new Request(input, init);
 
   if ((request.method !== "GET" && request.method !== "HEAD") || request.keepalive) {
     return null;
@@ -1029,6 +1037,9 @@ function createPatchedFetch(): typeof globalThis.fetch {
     // Draft renders are not static generations. Bypass both shared fetch-cache
     // reads and writes, matching Next.js's `workStore.isDraftMode` guard.
     if (isDraftModeEnabled()) {
+      // Draft fetches are fresh dependencies for layout-reuse observation even
+      // though they still use request-scoped memoization below.
+      recordDynamicFetchObservation(input);
       // Keep request-scoped fetch memoization active while skipping the
       // persistent cache. This is the same path used by other uncached
       // fetches in this shim.

--- a/packages/vinext/src/shims/fetch-cache.ts
+++ b/packages/vinext/src/shims/fetch-cache.ts
@@ -1029,7 +1029,10 @@ function createPatchedFetch(): typeof globalThis.fetch {
     // Draft renders are not static generations. Bypass both shared fetch-cache
     // reads and writes, matching Next.js's `workStore.isDraftMode` guard.
     if (isDraftModeEnabled()) {
-      return originalFetch(input, init);
+      // Keep request-scoped fetch memoization active while skipping the
+      // persistent cache. This is the same path used by other uncached
+      // fetches in this shim.
+      return dedupeFetch(input, init);
     }
 
     const nextOpts = (init as ExtendedRequestInit | undefined)?.next as

--- a/packages/vinext/src/shims/headers.ts
+++ b/packages/vinext/src/shims/headers.ts
@@ -1118,8 +1118,14 @@ export function isDraftModeRequest(request: Request, draftModeSecret: string): b
  * callers fall back to an explicitly supplied request when needed.
  */
 export function getActiveDraftModeState(): boolean | null {
-  const context = _getState().headersContext;
-  if (!context) return null;
+  const state = _getState();
+  const context = state.headersContext;
+  if (!context) {
+    // Pages Router preview state is decoded by the router rather than by a
+    // next/headers context. Read that state from the unified request pipeline
+    // so cache shims can apply the same draft-mode guard to Pages renders.
+    return isInsideUnifiedScope() ? getRequestContext().draftModeEnabled : null;
+  }
   if (context.draftModeEnabled !== undefined) return context.draftModeEnabled;
   const secret = context.draftModeSecret;
   if (secret === undefined) return false;

--- a/packages/vinext/src/shims/unified-request-context.ts
+++ b/packages/vinext/src/shims/unified-request-context.ts
@@ -41,6 +41,10 @@ export type UnifiedRequestContext = {
   /** Cloudflare Workers ExecutionContext, or null on Node.js dev. */
   executionContext: ExecutionContextLike | null;
 
+  // ── request pipeline ────────────────────────────────────────────────
+  /** Active request-level draft/preview state when supplied by a router. */
+  draftModeEnabled: boolean | null;
+
   // ── cache-for-request.ts ──────────────────────────────────────────
   /** Per-request cache for cacheForRequest(). Keyed by factory function reference. */
   // oxlint-disable-next-line @typescript-eslint/no-explicit-any
@@ -124,6 +128,7 @@ export function createRequestContext(opts?: Partial<UnifiedRequestContext>): Uni
     refreshStaleFetchesInForeground: false,
     isFetchDedupeActive: false,
     currentFetchDedupeEntries: new Map(),
+    draftModeEnabled: null,
     executionContext: _getInheritedExecutionContext(), // inherits from standalone ALS if present
     requestCache: new WeakMap(),
     afterContext: {

--- a/tests/app-layout-param-observation.test.ts
+++ b/tests/app-layout-param-observation.test.ts
@@ -273,4 +273,23 @@ describe("app layout param observation", () => {
       completeness: "complete",
     });
   });
+
+  it("observes draft fetches as dynamic layout dependencies", () => {
+    ensureFetchPatch();
+    const tracker = createAppLayoutParamAccessTracker();
+
+    void runWithRequestContext(createRequestContext({ draftModeEnabled: true }), () => {
+      tracker.runLayoutProbe("layout:/draft", () => {
+        void fetch("data:application/json,%7B%22draft%22%3Atrue%7D", {
+          next: { revalidate: 60 },
+        }).catch(() => {});
+      });
+    });
+
+    expect(tracker.getLayoutObservation("layout:/draft")).toMatchObject({
+      cacheableFetchCount: 0,
+      dynamicFetchCount: 1,
+      completeness: "complete",
+    });
+  });
 });

--- a/tests/fetch-cache.test.ts
+++ b/tests/fetch-cache.test.ts
@@ -56,7 +56,8 @@ const {
 } = await import("../packages/vinext/src/shims/fetch-cache.js");
 const { getCacheHandler, revalidatePath, revalidateTag, MemoryCacheHandler, setCacheHandler } =
   await import("../packages/vinext/src/shims/cache.js");
-const { consumeDynamicUsage } = await import("../packages/vinext/src/shims/headers.js");
+const { consumeDynamicUsage, setHeadersContext } =
+  await import("../packages/vinext/src/shims/headers.js");
 const { runWithExecutionContext } = await import("../packages/vinext/src/shims/request-context.js");
 const { createRequestContext, runWithRequestContext } =
   await import("../packages/vinext/src/shims/unified-request-context.js");
@@ -105,6 +106,38 @@ describe("fetch cache shim", () => {
     const data2 = await res2.json();
     expect(data2.count).toBe(1); // Same count = cached
     expect(fetchMock).toHaveBeenCalledTimes(1); // Only one real fetch
+  });
+
+  it("bypasses the shared fetch cache in draft mode", async () => {
+    const url = "https://api.example.com/draft-mode";
+    const fetchOptions = { next: { revalidate: 3600 } };
+    const enterRequest = (draftModeEnabled: boolean) => {
+      setHeadersContext({
+        headers: new Headers(),
+        cookies: new Map(),
+        draftModeEnabled,
+      });
+    };
+
+    try {
+      // Seed the shared entry with published content.
+      enterRequest(false);
+      const published = await fetch(url, fetchOptions);
+      expect((await published.json()).count).toBe(1);
+
+      // Draft mode must bypass both the shared read and the shared write.
+      enterRequest(true);
+      const draft = await fetch(url, fetchOptions);
+      expect((await draft.json()).count).toBe(2);
+
+      // The draft response must not replace the published shared entry.
+      enterRequest(false);
+      const cachedPublished = await fetch(url, fetchOptions);
+      expect((await cachedPublished.json()).count).toBe(1);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    } finally {
+      setHeadersContext(null);
+    }
   });
 
   it("cache: 'force-cache' caches indefinitely", async () => {

--- a/tests/fetch-cache.test.ts
+++ b/tests/fetch-cache.test.ts
@@ -156,14 +156,52 @@ describe("fetch cache shim", () => {
           fetch(url, { next: { revalidate: 3600 } }),
           fetch(url, { next: { revalidate: 3600 } }),
         ]);
+        return {
+          results: await Promise.all([first.json(), second.json()]),
+          dynamicFetches: peekDynamicFetchObservations(),
+        };
+      });
+
+      expect(results.results).toEqual([
+        { url, count: 1 },
+        { url, count: 1 },
+      ]);
+      expect(results.dynamicFetches).toEqual([url]);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      setHeadersContext(null);
+    }
+  });
+
+  it("includes Request init overrides in draft dedupe keys", async () => {
+    const url = "https://api.example.com/draft-mode-request-overrides";
+    const request = new Request(url);
+    setHeadersContext({
+      headers: new Headers(),
+      cookies: new Map(),
+      draftModeEnabled: true,
+    });
+
+    try {
+      const results = await runWithFetchCache(async () => {
+        const [first, second] = await Promise.all([
+          fetch(request, {
+            headers: { Authorization: "Bearer first" },
+            next: { revalidate: 3600 },
+          }),
+          fetch(request, {
+            headers: { Authorization: "Bearer second" },
+            next: { revalidate: 3600 },
+          }),
+        ]);
         return Promise.all([first.json(), second.json()]);
       });
 
       expect(results).toEqual([
         { url, count: 1 },
-        { url, count: 1 },
+        { url, count: 2 },
       ]);
-      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
     } finally {
       setHeadersContext(null);
     }

--- a/tests/fetch-cache.test.ts
+++ b/tests/fetch-cache.test.ts
@@ -120,21 +120,50 @@ describe("fetch cache shim", () => {
     };
 
     try {
+      const fetchInRequest = async (draftModeEnabled: boolean) => {
+        enterRequest(draftModeEnabled);
+        return runWithFetchCache(() => fetch(url, fetchOptions));
+      };
+
       // Seed the shared entry with published content.
-      enterRequest(false);
-      const published = await fetch(url, fetchOptions);
+      const published = await fetchInRequest(false);
       expect((await published.json()).count).toBe(1);
 
       // Draft mode must bypass both the shared read and the shared write.
-      enterRequest(true);
-      const draft = await fetch(url, fetchOptions);
+      const draft = await fetchInRequest(true);
       expect((await draft.json()).count).toBe(2);
 
       // The draft response must not replace the published shared entry.
-      enterRequest(false);
-      const cachedPublished = await fetch(url, fetchOptions);
+      const cachedPublished = await fetchInRequest(false);
       expect((await cachedPublished.json()).count).toBe(1);
       expect(fetchMock).toHaveBeenCalledTimes(2);
+    } finally {
+      setHeadersContext(null);
+    }
+  });
+
+  it("dedupes draft fetches within a render scope without persisting them", async () => {
+    const url = "https://api.example.com/draft-mode-dedupe";
+    setHeadersContext({
+      headers: new Headers(),
+      cookies: new Map(),
+      draftModeEnabled: true,
+    });
+
+    try {
+      const results = await runWithFetchCache(async () => {
+        const [first, second] = await Promise.all([
+          fetch(url, { next: { revalidate: 3600 } }),
+          fetch(url, { next: { revalidate: 3600 } }),
+        ]);
+        return Promise.all([first.json(), second.json()]);
+      });
+
+      expect(results).toEqual([
+        { url, count: 1 },
+        { url, count: 1 },
+      ]);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
     } finally {
       setHeadersContext(null);
     }

--- a/tests/pages-page-handler.test.ts
+++ b/tests/pages-page-handler.test.ts
@@ -24,6 +24,7 @@ import {
   getRevalidateSecret,
   PRERENDER_REVALIDATE_HEADER,
 } from "../packages/vinext/src/server/isr-cache.js";
+import { isDraftModeEnabled } from "../packages/vinext/src/shims/headers.js";
 import { after } from "../packages/vinext/src/shims/server.js";
 
 // ---------------------------------------------------------------------------
@@ -470,12 +471,18 @@ describe("createPagesPageHandler — preview responses", () => {
 
   it("activates preview on pages with server props", async () => {
     const setSSRContext = vi.fn();
+    let draftModeEnabled = false;
     const handler = createPagesPageHandler(
       makeOpts({
         pageRoutes: [
           makeRoute(
             "/",
-            makePageModule({ getServerSideProps: async () => ({ props: { preview: true } }) }),
+            makePageModule({
+              getServerSideProps: async () => {
+                draftModeEnabled = isDraftModeEnabled();
+                return { props: { preview: true } };
+              },
+            }),
           ),
         ],
         setSSRContext,
@@ -489,6 +496,7 @@ describe("createPagesPageHandler — preview responses", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("cache-control")).toBe(PAGES_PREVIEW_CACHE_CONTROL);
+    expect(draftModeEnabled).toBe(true);
     expect(setSSRContext).toHaveBeenCalledWith(
       expect.objectContaining({
         isPreview: true,

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -3043,6 +3043,17 @@ export default function PreviewPage({ preview }) {
 }\n`,
     );
     await fsp.writeFile(
+      path.join(fixtureRoot, "pages", "preview-cache.tsx"),
+      `import { isDraftModeEnabled } from "vinext/shims/headers";
+
+export function getServerSideProps() {
+  return { props: { draftModeEnabled: isDraftModeEnabled() } };
+}
+export default function PreviewCachePage({ draftModeEnabled }) {
+  return <p id="draft-mode-enabled">{String(draftModeEnabled)}</p>;
+}\n`,
+    );
+    await fsp.writeFile(
       path.join(fixtureRoot, "pages", "gssp-not-found.tsx"),
       `export function getServerSideProps() { return { notFound: true }; }
 export default function Page() { return null; }\n`,
@@ -3110,6 +3121,24 @@ export default function Page(props) {
         "private, no-cache, no-store, max-age=0, must-revalidate",
       );
     }
+  });
+
+  it("propagates Pages preview state to request-scoped cache guards", async () => {
+    const readDraftModeFlag = async (cookie?: string): Promise<boolean> => {
+      const response = await fetch(`${previewBaseUrl}/preview-cache`, {
+        headers: cookie ? { cookie } : undefined,
+      });
+      expect(response.status).toBe(200);
+      const html = await response.text();
+      const nextDataMatch = html.match(
+        /<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/,
+      );
+      expect(nextDataMatch).toBeTruthy();
+      return JSON.parse(nextDataMatch![1]!).props.pageProps.draftModeEnabled;
+    };
+
+    expect(await readDraftModeFlag()).toBe(false);
+    expect(await readDraftModeFlag(await enablePreview())).toBe(true);
   });
 
   it("renders unlisted fallback false and fallback true paths with real preview props", async () => {


### PR DESCRIPTION
## Overview

Fix draft-mode data isolation for both App Router and Pages Router fetches. Draft renders now bypass persistent fetch-cache reads and writes while retaining render-scoped memoization, so editors receive current origin data without changing published cache entries.

## What changed

- Added the draft guard to `createPatchedFetch`.
- Route draft fetches through `dedupeFetch` so repeated GET and HEAD requests remain memoized within a render.
- Record draft fetches as dynamic dependencies for App Router layout-reuse observation.
- Propagate Pages preview state through the unified request context in both production and dev handlers.
- Build dedupe keys from effective GET and HEAD Requests so `init` header overrides cannot share a response across variants.
- Preserve existing pass-through behavior for POST and consumed-body Requests.

## Behavior

| Scenario | Result |
| --- | --- |
| Normal cached fetch | Existing shared cache behavior is unchanged |
| App Router draft fetch | Fresh origin fetch, no persistent read or write, render-scoped dedupe retained |
| Pages Router preview fetch | Fresh origin fetch in both production and dev |
| Public fetch after draft render | Existing published entry remains intact |
| Draft layout probe | Fetch dependency is recorded as dynamic, preventing unsafe layout reuse |

## Validation

- `vp test run tests/fetch-cache.test.ts`: 129 passed
- `vp test run tests/pages-page-handler.test.ts`: 37 passed
- `vp test run tests/pages-router.test.ts`: 378 passed
- App layout, page dispatch, execution, and render tests: 174 passed
- `vp test run tests/shims.test.ts`: 1,278 passed
- `vp check`: 1,175 files checked with no warnings or errors
- `vp run vinext#build`: passed
- Required PR CI and performance checks: green

## References

- Next.js draft-mode guard: https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/patch-fetch.ts#L375-L379
- Existing vinext shared-cache draft-mode fix: https://github.com/cloudflare/vinext/commit/fd35d9d14