### PR TITLE
fix(ci): pin Next.js tracker OpenCode version

### DIFF
--- a/.github/workflows/nextjs-tracker.yml
+++ b/.github/workflows/nextjs-tracker.yml
@@ -130,7 +130,8 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          model: "cloudflare-ai-gateway/anthropic/claude-opus-4-7"
+          model: "cloudflare-ai-gateway/anthropic/claude-opus-4-8"
+          variant: "high"
           permissions: write
           opencode_dev: false
           opencode_version: 1.15.13

--- a/.github/workflows/nextjs-tracker.yml
+++ b/.github/workflows/nextjs-tracker.yml
@@ -133,6 +133,7 @@ jobs:
           model: "cloudflare-ai-gateway/anthropic/claude-opus-4-7"
           permissions: write
           opencode_dev: false
+          opencode_version: 1.15.13
           agent: nextjs-tracker
           prompt: ${{ steps.build_prompt.outputs.prompt }}
 

--- a/.opencode/agents/nextjs-tracker.md
+++ b/.opencode/agents/nextjs-tracker.md
@@ -1,7 +1,7 @@
 ---
 description: Monitors Next.js canary commits and opens tracking issues for changes relevant to vinext
 mode: primary
-model: anthropic/claude-opus-4-7
+model: anthropic/claude-opus-4-8
 temperature: 0.2
 permission:
   bash:


### PR DESCRIPTION
## Summary

- pin the Next.js Tracker to OpenCode 1.15.13, matching the known-good Big Bonk runtime
- align the tracker with Big Bonk's Opus 4.8 high model configuration
- keep the workflow override and nextjs-tracker agent default consistent

## Root cause

Run https://github.com/cloudflare/vinext/actions/runs/30799708017 fetched two Next.js commits, installed the floating latest OpenCode 1.18.11, and then failed its first Anthropic request with a 401 Invalid Anthropic API Key.

The last tracker run that actually invoked the model successfully was June 17 (run 27679508081) on OpenCode 1.17.7. The first failure was June 18 (run 27749970885) after latest advanced to 1.17.8. That OpenCode release changed the Cloudflare AI Gateway unified client to pass CLOUDFLARE_API_TOKEN as its API key. For BYOK Anthropic requests, that Authorization value overrides the Gateway's stored Anthropic credential, so Anthropic receives the Cloudflare token and rejects it as an invalid Anthropic key.

Pinning the same 1.15.13 runtime already used by Big Bonk restores the pre-regression Gateway behavior and prevents future latest-version drift. Using Big Bonk's already-proven Opus 4.8 high configuration also removes the tracker's stale model difference.

## Validation

- actionlint .github/workflows/nextjs-tracker.yml
- vp fmt --check .github/workflows/nextjs-tracker.yml .opencode/agents/nextjs-tracker.md
- git diff --check
