### PR TITLE
fix(middleware): align encoded path matching

### DIFF
--- a/packages/vinext/src/server/middleware-matcher.ts
+++ b/packages/vinext/src/server/middleware-matcher.ts
@@ -13,6 +13,10 @@ import {
 
 export type MatcherConfig = string | Array<string | MiddlewareMatcherObject>;
 
+export type MiddlewareLocaleMatchContext =
+  | { kind: "defaulted"; defaultLocale: string }
+  | { kind: "literal" | "none" };
+
 const EMPTY_MIDDLEWARE_REQUEST_CONTEXT: RequestContext = {
   headers: new Headers(),
   cookies: {},
@@ -30,13 +34,14 @@ export function matchesMiddleware(
   matcher: MatcherConfig | undefined,
   request?: Request,
   i18nConfig?: NextI18nConfig | null,
+  localeContext?: MiddlewareLocaleMatchContext,
 ): boolean {
   if (!matcher) {
     return true;
   }
 
   if (typeof matcher === "string") {
-    return matchMatcherPattern(pathname, matcher, i18nConfig);
+    return matchMatcherPattern(pathname, matcher, i18nConfig, localeContext);
   }
   if (!Array.isArray(matcher)) {
     return true;
@@ -48,7 +53,7 @@ export function matchesMiddleware(
 
   for (const m of matcher) {
     if (typeof m === "string") {
-      if (matchMatcherPattern(pathname, m, i18nConfig)) {
+      if (matchMatcherPattern(pathname, m, i18nConfig, localeContext)) {
         return true;
       }
       continue;
@@ -57,7 +62,7 @@ export function matchesMiddleware(
     if (!isValidMiddlewareMatcherObjectConfig(m)) {
       return true;
     }
-    if (!matchObjectMatcher(pathname, m, i18nConfig)) {
+    if (!matchObjectMatcher(pathname, m, i18nConfig, localeContext)) {
       continue;
     }
 
@@ -75,8 +80,16 @@ function matchMatcherPattern(
   pathname: string,
   pattern: string,
   i18nConfig?: NextI18nConfig | null,
+  localeContext?: MiddlewareLocaleMatchContext,
 ): boolean {
   if (!i18nConfig) return matchPattern(pathname, pattern);
+
+  if (localeContext) {
+    return matchPattern(
+      localeContext.kind === "literal" ? stripFirstPathSegment(pathname) : pathname,
+      pattern,
+    );
+  }
 
   const localeStrippedPathname = stripLocalePrefix(pathname, i18nConfig);
   return matchPattern(localeStrippedPathname ?? pathname, pattern);
@@ -86,10 +99,17 @@ function matchObjectMatcher(
   pathname: string,
   matcher: MiddlewareMatcherObject,
   i18nConfig?: NextI18nConfig | null,
+  localeContext?: MiddlewareLocaleMatchContext,
 ): boolean {
-  return matcher.locale === false
-    ? matchPattern(pathname, matcher.source)
-    : matchMatcherPattern(pathname, matcher.source, i18nConfig);
+  if (matcher.locale !== false) {
+    return matchMatcherPattern(pathname, matcher.source, i18nConfig, localeContext);
+  }
+
+  const matchPathname =
+    localeContext?.kind === "defaulted"
+      ? `/${localeContext.defaultLocale}${pathname === "/" ? "" : pathname}`
+      : pathname;
+  return matchPattern(matchPathname, matcher.source);
 }
 
 function stripLocalePrefix(pathname: string, i18nConfig: NextI18nConfig): string | null {
@@ -97,11 +117,19 @@ function stripLocalePrefix(pathname: string, i18nConfig: NextI18nConfig): string
 
   const segments = pathname.split("/");
   const firstSegment = segments[1];
-  if (!firstSegment || !i18nConfig.locales.includes(firstSegment)) {
+  const lowerFirstSegment = firstSegment?.toLowerCase();
+  if (
+    !lowerFirstSegment ||
+    !i18nConfig.locales.some((locale) => locale.toLowerCase() === lowerFirstSegment)
+  ) {
     return null;
   }
 
-  return "/" + segments.slice(2).join("/");
+  return stripFirstPathSegment(pathname);
+}
+
+function stripFirstPathSegment(pathname: string): string {
+  return "/" + pathname.split("/").slice(2).join("/");
 }
 
 export function matchPattern(pathname: string, pattern: string): boolean {

--- a/packages/vinext/src/server/middleware-matcher.ts
+++ b/packages/vinext/src/server/middleware-matcher.ts
@@ -4,7 +4,6 @@ import {
   type RequestContext,
 } from "../config/config-matchers.js";
 import type { NextI18nConfig } from "../config/next-config.js";
-import { removeTrailingSlash } from "../utils/base-path.js";
 import {
   compileMiddlewareMatcherPattern,
   isValidMiddlewareMatcherObjectConfig,
@@ -134,19 +133,16 @@ function stripFirstPathSegment(pathname: string): string {
 }
 
 export function matchPattern(pathname: string, pattern: string): boolean {
-  const hasPatternSyntax = /[\\():*+?]/.test(pattern);
-  const normalizedPattern = hasPatternSyntax ? pattern : removeTrailingSlash(pattern);
-  if (normalizedPattern === "/" && (pathname === "//" || pathname === "/?" || pathname === "/#")) {
+  if (pattern === "/" && (pathname === "//" || pathname === "/?" || pathname === "/#")) {
     return false;
   }
-  let cached = _mwPatternCache.get(normalizedPattern);
+  let cached = _mwPatternCache.get(pattern);
   if (cached === undefined) {
-    cached = compileMatcherPattern(normalizedPattern);
-    _mwPatternCache.set(normalizedPattern, cached);
+    cached = compileMatcherPattern(pattern);
+    _mwPatternCache.set(pattern, cached);
   }
   if (cached === UNSAFE_MATCHER_PATTERN) return true;
-  if (cached.test(pathname)) return true;
-  return pathname.endsWith("/") && !pathname.endsWith("//") && cached.test(pathname.slice(0, -1));
+  return cached.test(pathname);
 }
 
 function compileMatcherPattern(pattern: string): CompiledMatcherPattern {

--- a/packages/vinext/src/server/middleware-matcher.ts
+++ b/packages/vinext/src/server/middleware-matcher.ts
@@ -15,7 +15,7 @@ export type MatcherConfig = string | Array<string | MiddlewareMatcherObject>;
 
 export type MiddlewareLocaleMatchContext =
   | { kind: "defaulted"; defaultLocale: string }
-  | { kind: "literal" | "none" };
+  | { kind: "internal" | "literal" };
 
 const EMPTY_MIDDLEWARE_REQUEST_CONTEXT: RequestContext = {
   headers: new Headers(),
@@ -85,6 +85,7 @@ function matchMatcherPattern(
   if (!i18nConfig) return matchPattern(pathname, pattern);
 
   if (localeContext) {
+    if (localeContext.kind === "internal") return false;
     return matchPattern(
       localeContext.kind === "literal" ? stripFirstPathSegment(pathname) : pathname,
       pattern,
@@ -135,6 +136,9 @@ function stripFirstPathSegment(pathname: string): string {
 export function matchPattern(pathname: string, pattern: string): boolean {
   const hasPatternSyntax = /[\\():*+?]/.test(pattern);
   const normalizedPattern = hasPatternSyntax ? pattern : removeTrailingSlash(pattern);
+  if (normalizedPattern === "/" && (pathname === "//" || pathname === "/?" || pathname === "/#")) {
+    return false;
+  }
   let cached = _mwPatternCache.get(normalizedPattern);
   if (cached === undefined) {
     cached = compileMatcherPattern(normalizedPattern);
@@ -142,7 +146,7 @@ export function matchPattern(pathname: string, pattern: string): boolean {
   }
   if (cached === UNSAFE_MATCHER_PATTERN) return true;
   if (cached.test(pathname)) return true;
-  return pathname.endsWith("/") && cached.test(removeTrailingSlash(pathname));
+  return pathname.endsWith("/") && !pathname.endsWith("//") && cached.test(pathname.slice(0, -1));
 }
 
 function compileMatcherPattern(pattern: string): CompiledMatcherPattern {

--- a/packages/vinext/src/server/middleware-runtime.ts
+++ b/packages/vinext/src/server/middleware-runtime.ts
@@ -1,5 +1,6 @@
 import "./server-globals.js";
 import type { NextI18nConfig } from "../config/next-config.js";
+import { normalizeHost } from "../config/request-context.js";
 import { normalizePathnameForRouteMatchStrict } from "../routing/utils.js";
 import path from "pathslash";
 import {
@@ -14,7 +15,11 @@ import {
   MIDDLEWARE_NEXT_HEADER,
   MIDDLEWARE_REWRITE_HEADER,
 } from "./headers.js";
-import { matchesMiddleware, type MatcherConfig } from "./middleware-matcher.js";
+import {
+  matchesMiddleware,
+  type MatcherConfig,
+  type MiddlewareLocaleMatchContext,
+} from "./middleware-matcher.js";
 import { shouldKeepMiddlewareHeader } from "../utils/middleware-request-headers.js";
 import { processMiddlewareHeaders } from "./request-pipeline.js";
 import { badRequestResponse, internalServerErrorResponse } from "./http-error-responses.js";
@@ -25,6 +30,7 @@ import {
   removeTrailingSlash,
   stripBasePath,
 } from "../utils/base-path.js";
+import { normalizeDefaultLocalePathname } from "./pages-i18n.js";
 
 export type MiddlewareModule = Record<string, unknown>;
 
@@ -320,6 +326,8 @@ export async function executeMiddleware(
   if (normalizedPathname instanceof Response) {
     return { continue: false, response: normalizedPathname };
   }
+  const requestUrl = new URL(options.request.url);
+  const requestPathname = requestUrl.pathname;
 
   // Default: derive in-basePath state from the request URL. The Pages
   // prod/deploy adapters pass the original URL — prefixed for in-basePath
@@ -327,8 +335,7 @@ export async function executeMiddleware(
   // source of truth. Callers that pass pre-stripped URLs (dev server, App
   // Router) override this with an explicit `hadBasePath: true`.
   const hadBasePath =
-    options.hadBasePath ??
-    (!options.basePath || hasBasePath(new URL(options.request.url).pathname, options.basePath));
+    options.hadBasePath ?? (!options.basePath || hasBasePath(requestPathname, options.basePath));
 
   // Matcher patterns use basePath-stripped paths (e.g. /about, not /root/about),
   // matching Next.js behavior where the matcher is evaluated against the path
@@ -341,15 +348,99 @@ export async function executeMiddleware(
     ? stripBasePath(normalizedPathname, options.basePath)
     : normalizedPathname;
   const matchPathname = basePathStrippedPathname;
+  // Next.js tests the normalized encoded pathname first, then retries after
+  // decoding the full path once. Testing only a segment-decoded form lets
+  // percent-encoded line terminators turn into characters that `.` cannot
+  // match, while preserving encoded delimiters misses matchers that Next.js
+  // evaluates against their decoded path structure.
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/next-server.ts
+  const encodedRequestPathname = normalizePath(requestPathname);
+  const matcher = middlewareMatcher(options.module);
+  const prepareMatcherPathname = (candidate: string): string | null => {
+    if (!options.basePath) return candidate;
+    if (hasBasePath(candidate, options.basePath)) {
+      return stripBasePath(candidate, options.basePath);
+    }
+    if (
+      candidate.length === options.basePath.length + 1 &&
+      candidate.startsWith(options.basePath) &&
+      (candidate.endsWith("?") || candidate.endsWith("#"))
+    ) {
+      return `/${candidate.at(-1)}`;
+    }
+    // App Router and Pages dev may pass a URL that the adapter already
+    // stripped after recording that it crossed the configured basePath.
+    if (options.hadBasePath === true) return candidate;
+    // Next.js prefixes configured matchers with basePath at build time. Keep
+    // default middleware eligible on absolute paths, but custom matchers must
+    // not apply outside the basePath.
+    return matcher === undefined ? candidate : null;
+  };
+  const encodedMatchPathname = prepareMatcherPathname(encodedRequestPathname);
+  let decodedMatchPathname = encodedMatchPathname;
+  try {
+    if (encodedMatchPathname !== null) {
+      decodedMatchPathname = decodeURIComponent(encodedMatchPathname);
+    } else if (!options.i18nConfig) {
+      // Without i18n, Next.js can discover an encoded basePath on the decoded
+      // matcher attempt. With i18n, default-locale insertion has already made
+      // that path ineligible for the compiled basePath-prefixed matcher.
+      decodedMatchPathname = prepareMatcherPathname(decodeURIComponent(encodedRequestPathname));
+    }
+  } catch {
+    // Match Next.js: malformed encoding is non-fatal for matcher eligibility.
+  }
 
-  if (
-    !matchesMiddleware(
-      matchPathname,
-      middlewareMatcher(options.module),
+  let localeContext: MiddlewareLocaleMatchContext | undefined;
+  if (options.i18nConfig && encodedMatchPathname !== null) {
+    const hostname = normalizeHost(options.request.headers.get("host"), requestUrl.hostname);
+    const firstSegment = encodedMatchPathname.split("/", 3)[1];
+    const hasLiteralLocale =
+      firstSegment !== undefined &&
+      options.i18nConfig.locales.some(
+        (locale) => locale.toLowerCase() === firstSegment.toLowerCase(),
+      );
+    if (hasLiteralLocale) {
+      localeContext = { kind: "literal" };
+    } else {
+      const localeDefaultedPathname = normalizeDefaultLocalePathname(
+        encodedMatchPathname,
+        options.i18nConfig,
+        { hostname },
+      );
+      localeContext =
+        localeDefaultedPathname === encodedMatchPathname
+          ? { kind: "none" }
+          : {
+              defaultLocale: normalizeDefaultLocalePathname("/", options.i18nConfig, {
+                hostname,
+              }).slice(1),
+              kind: "defaulted",
+            };
+    }
+  }
+  const encodedMatches =
+    encodedMatchPathname !== null &&
+    matchesMiddleware(
+      encodedMatchPathname,
+      matcher,
       options.request,
       options.i18nConfig,
-    )
-  ) {
+      localeContext,
+    );
+  const decodedMatches =
+    !encodedMatches &&
+    decodedMatchPathname !== null &&
+    decodedMatchPathname !== encodedMatchPathname &&
+    matchesMiddleware(
+      decodedMatchPathname,
+      matcher,
+      options.request,
+      options.i18nConfig,
+      localeContext,
+    );
+
+  if (!encodedMatches && !decodedMatches) {
     return { continue: true };
   }
 

--- a/packages/vinext/src/server/middleware-runtime.ts
+++ b/packages/vinext/src/server/middleware-runtime.ts
@@ -354,7 +354,12 @@ export async function executeMiddleware(
   // match, while preserving encoded delimiters misses matchers that Next.js
   // evaluates against their decoded path structure.
   // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/next-server.ts
-  const encodedRequestPathname = normalizePath(requestPathname);
+  // Next.js removes the request pathname's terminal slash before evaluating
+  // the compiled middleware matcher. The matcher compiler still appends its
+  // own optional terminal delimiter, so a source without a slash matches both
+  // request spellings while a source that includes a slash remains distinct.
+  // https://github.com/vercel/next.js/blob/v16.2.6/packages/next/src/server/next-server.ts
+  const encodedRequestPathname = removeTrailingSlash(normalizePath(requestPathname));
   const matcher = middlewareMatcher(options.module);
   const prepareMatcherPathname = (candidate: string): string | null => {
     if (!options.basePath) return candidate;

--- a/packages/vinext/src/server/middleware-runtime.ts
+++ b/packages/vinext/src/server/middleware-runtime.ts
@@ -366,7 +366,7 @@ export async function executeMiddleware(
       candidate.startsWith(options.basePath) &&
       (candidate.endsWith("?") || candidate.endsWith("#"))
     ) {
-      return `/${candidate.at(-1)}`;
+      return "/";
     }
     // App Router and Pages dev may pass a URL that the adapter already
     // stripped after recording that it crossed the configured basePath.
@@ -410,7 +410,7 @@ export async function executeMiddleware(
       );
       localeContext =
         localeDefaultedPathname === encodedMatchPathname
-          ? { kind: "none" }
+          ? { kind: "internal" }
           : {
               defaultLocale: normalizeDefaultLocalePathname("/", options.i18nConfig, {
                 hostname,

--- a/tests/fixtures/middleware-matcher-auth/app/[locale]/admin/[page]/page.tsx
+++ b/tests/fixtures/middleware-matcher-auth/app/[locale]/admin/[page]/page.tsx
@@ -1,0 +1,3 @@
+export default function LocalizedAdminPage() {
+  return <main>protected localized admin page</main>;
+}

--- a/tests/fixtures/middleware-matcher-auth/app/billing/invoices/[[...path]]/route.ts
+++ b/tests/fixtures/middleware-matcher-auth/app/billing/invoices/[[...path]]/route.ts
@@ -1,0 +1,3 @@
+export function GET() {
+  return new Response("protected invoice route handler");
+}

--- a/tests/fixtures/middleware-matcher-auth/middleware.ts
+++ b/tests/fixtures/middleware-matcher-auth/middleware.ts
@@ -33,5 +33,24 @@ export const config = {
       ],
       missing: [{ type: "query", key: "blocked", value: "1" }],
     },
+    {
+      // Matches the negative-lookahead shape recommended in the Next.js docs.
+      // The header keeps this broad matcher isolated to the encoded-path auth
+      // regression without changing the fixture's existing public routes.
+      source: "/((?!api|_next/static|_next/image|favicon.ico).*)",
+      has: [{ type: "header", key: "x-encoded-path-auth", value: "1" }],
+    },
+    {
+      source: "/orders/:id(\\d+)",
+      has: [{ type: "header", key: "x-encoded-delimiter-auth", value: "1" }],
+    },
+    {
+      source: "/xx/admin/dash/board",
+      has: [{ type: "header", key: "x-encoded-delimiter-auth", value: "1" }],
+    },
+    {
+      source: "/billing/invoices/current/q3",
+      has: [{ type: "header", key: "x-encoded-delimiter-auth", value: "1" }],
+    },
   ],
 };

--- a/tests/fixtures/middleware-matcher-auth/pages/orders/[id].tsx
+++ b/tests/fixtures/middleware-matcher-auth/pages/orders/[id].tsx
@@ -1,0 +1,3 @@
+export default function OrderPage() {
+  return <main>protected order page</main>;
+}

--- a/tests/middleware-matcher-auth.test.ts
+++ b/tests/middleware-matcher-auth.test.ts
@@ -42,6 +42,8 @@ const PROTECTED_PATHS = [
   "/bracket-shorthand/a1z9",
 ] as const;
 
+const ENCODED_LINE_TERMINATORS = ["%0A", "%0D", "%E2%80%A8", "%E2%80%A9"] as const;
+
 async function assertAuthGuard(baseUrl: string): Promise<void> {
   const protectedResponses = await Promise.all(
     PROTECTED_PATHS.map(async (pathname) => {
@@ -104,6 +106,111 @@ async function assertAuthGuard(baseUrl: string): Promise<void> {
   expect(wrongLastMissingBody).toContain("conditioned page");
 }
 
+async function assertEncodedPathAuthGuard(baseUrl: string): Promise<void> {
+  const headers = { "x-encoded-path-auth": "1" };
+  const targets = [
+    { body: "protected localized admin page", pathname: "/xx/admin/dashboard" },
+    { body: "protected order page", pathname: "/orders/42" },
+    { body: "protected invoice route handler", pathname: "/billing/invoices/current" },
+    ...ENCODED_LINE_TERMINATORS.flatMap((encoded) => [
+      { body: "protected localized admin page", pathname: `/xx${encoded}/admin/dashboard` },
+      { body: "protected order page", pathname: `/orders/42${encoded}` },
+      { body: "protected invoice route handler", pathname: `/billing/invoices/${encoded}` },
+    ]),
+  ];
+
+  const unguardedResults: Array<{
+    body: string;
+    expectedBody: string;
+    guard: string | null;
+    pathname: string;
+    status: number;
+  }> = [];
+  for (const target of targets) {
+    const response = await fetch(`${baseUrl}${target.pathname}`);
+    unguardedResults.push({
+      body: await response.text(),
+      expectedBody: target.body,
+      guard: response.headers.get("x-auth-guard"),
+      pathname: target.pathname,
+      status: response.status,
+    });
+  }
+  expect(unguardedResults.map(({ pathname, status }) => ({ pathname, status }))).toEqual(
+    targets.map(({ pathname }) => ({ pathname, status: 200 })),
+  );
+  for (const { body, expectedBody, guard, pathname } of unguardedResults) {
+    expect(guard, pathname).toBeNull();
+    expect(body, pathname).toContain(expectedBody);
+  }
+
+  const results: Array<{ body: string; guard: string | null; pathname: string; status: number }> =
+    [];
+  for (const target of targets) {
+    const response = await fetch(`${baseUrl}${target.pathname}`, { headers });
+    results.push({
+      body: await response.text(),
+      guard: response.headers.get("x-auth-guard"),
+      pathname: target.pathname,
+      status: response.status,
+    });
+  }
+
+  expect(results.map(({ pathname, status }) => ({ pathname, status }))).toEqual(
+    targets.map(({ pathname }) => ({ pathname, status: 403 })),
+  );
+  for (const { body, guard, pathname } of results) {
+    expect(guard, pathname).toBe("blocked");
+    expect(body, pathname).toBe("blocked by middleware");
+  }
+}
+
+async function assertEncodedDelimiterAuthGuard(baseUrl: string): Promise<void> {
+  const protectedTargets = [
+    { body: "protected order page", pathname: "/orders/42%2F" },
+    { body: "protected order page", pathname: "/orders/42%3F" },
+    { body: "protected order page", pathname: "/orders/42%23" },
+    { body: "protected localized admin page", pathname: "/xx/admin/dash%2Fboard" },
+    { body: "protected localized admin page", pathname: "/xx/admin/dash%2Fboard.rsc" },
+    {
+      body: "protected invoice route handler",
+      pathname: "/billing/invoices/current%2Fq3",
+    },
+  ];
+  const matcherMissPaths = ["/orders/42%5C", "/orders/42%252F", "/orders/42%20"];
+
+  for (const target of protectedTargets) {
+    const response = await fetch(`${baseUrl}${target.pathname}`);
+    const body = await response.text();
+    expect(response.status, target.pathname).toBe(200);
+    expect(response.headers.get("x-auth-guard"), target.pathname).toBeNull();
+    expect(body, target.pathname).toContain(target.body);
+  }
+  for (const pathname of matcherMissPaths) {
+    const response = await fetch(`${baseUrl}${pathname}`);
+    const body = await response.text();
+    expect(response.status, pathname).toBe(200);
+    expect(response.headers.get("x-auth-guard"), pathname).toBeNull();
+    expect(body, pathname).toContain("protected order page");
+  }
+
+  const headers = { "x-encoded-delimiter-auth": "1" };
+  for (const target of protectedTargets) {
+    const response = await fetch(`${baseUrl}${target.pathname}`, { headers });
+    const body = await response.text();
+    expect(response.status, target.pathname).toBe(403);
+    expect(response.headers.get("x-auth-guard"), target.pathname).toBe("blocked");
+    expect(body, target.pathname).toBe("blocked by middleware");
+  }
+  for (const pathname of matcherMissPaths) {
+    const response = await fetch(`${baseUrl}${pathname}`, { headers });
+    const body = await response.text();
+    expect(response.status, pathname).toBe(200);
+    expect(response.headers.get("x-auth-guard"), pathname).toBeNull();
+    expect(body, pathname).toContain("protected order page");
+  }
+}
+
 async function closeHttpServer(server: http.Server | undefined): Promise<void> {
   if (!server) return;
   await new Promise<void>((resolve, reject) => {
@@ -150,6 +257,14 @@ describe("valid middleware matcher auth guards", () => {
     it("blocks every path selected by group and constrained-repeat matchers", async () => {
       await assertAuthGuard(baseUrl);
     }, 30_000);
+
+    it("keeps encoded line terminators inside middleware auth scope", async () => {
+      await assertEncodedPathAuthGuard(baseUrl);
+    }, 30_000);
+
+    it("matches decoded path delimiters with constrained matcher parity", async () => {
+      await assertEncodedDelimiterAuthGuard(baseUrl);
+    }, 30_000);
   });
 
   describe("built Node production server", () => {
@@ -193,6 +308,14 @@ describe("valid middleware matcher auth guards", () => {
 
     it("blocks every path selected by group and constrained-repeat matchers", async () => {
       await assertAuthGuard(baseUrl);
+    });
+
+    it("keeps encoded line terminators inside middleware auth scope", async () => {
+      await assertEncodedPathAuthGuard(baseUrl);
+    });
+
+    it("matches decoded path delimiters with constrained matcher parity", async () => {
+      await assertEncodedDelimiterAuthGuard(baseUrl);
     });
   });
 
@@ -262,6 +385,14 @@ describe("valid middleware matcher auth guards", () => {
 
     it("blocks every path selected by group and constrained-repeat matchers", async () => {
       await assertAuthGuard(baseUrl);
+    });
+
+    it("keeps encoded line terminators inside middleware auth scope", async () => {
+      await assertEncodedPathAuthGuard(baseUrl);
+    });
+
+    it("matches decoded path delimiters with constrained matcher parity", async () => {
+      await assertEncodedDelimiterAuthGuard(baseUrl);
     });
   });
 });

--- a/tests/middleware-runtime-trailing-slash.test.ts
+++ b/tests/middleware-runtime-trailing-slash.test.ts
@@ -209,59 +209,51 @@ describe("executeMiddleware normalizes trailing slashes for matcher evaluation",
     expect(observedPathnames).toEqual(["/api/admin/"]);
   });
 
-  it("does not match a canonical API pathname when the matcher source requires a trailing slash", async () => {
-    const result = await executeMiddleware({
-      isProxy: false,
-      module: {
-        config: { matcher: ["/api/admin/"] },
-        middleware: () => new Response("unauthorized", { status: 401 }),
-      },
-      request: new Request("http://localhost/api/admin"),
-    });
+  it.each(["/api/admin", "/api/admin/"])(
+    "does not match %s when the matcher source has a trailing slash",
+    async (pathname) => {
+      const result = await executeMiddleware({
+        isProxy: false,
+        module: {
+          config: { matcher: ["/api/admin/"] },
+          middleware: () => new Response("unauthorized", { status: 401 }),
+        },
+        request: new Request(`http://localhost${pathname}`),
+      });
 
-    expect(result.continue).toBe(true);
-    expect(result.response).toBeUndefined();
-  });
+      expect(result).toEqual({ continue: true });
+    },
+  );
 
-  it("preserves an escaped terminal slash matcher", async () => {
-    const module = {
-      config: { matcher: ["/api/admin\\/"] },
-      middleware: () => new Response("unauthorized", { status: 401 }),
-    };
-    const matchingResult = await executeMiddleware({
-      isProxy: false,
-      module,
-      request: new Request("http://localhost/api/admin/"),
-    });
-    const nonMatchingResult = await executeMiddleware({
-      isProxy: false,
-      module,
-      request: new Request("http://localhost/api/admin"),
-    });
+  it.each(["/api/admin", "/api/admin/"])(
+    "does not match %s when the matcher source has an escaped terminal slash",
+    async (pathname) => {
+      const result = await executeMiddleware({
+        isProxy: false,
+        module: {
+          config: { matcher: ["/api/admin\\/"] },
+          middleware: () => new Response("unauthorized", { status: 401 }),
+        },
+        request: new Request(`http://localhost${pathname}`),
+      });
 
-    expect(matchingResult.continue).toBe(false);
-    expect(matchingResult.response?.status).toBe(401);
-    expect(nonMatchingResult).toEqual({ continue: true });
-  });
+      expect(result).toEqual({ continue: true });
+    },
+  );
 
-  it("preserves a custom constraint that requires a terminal slash", async () => {
-    const module = {
-      config: { matcher: ["/:path(.*\\/)"] },
-      middleware: () => new Response("unauthorized", { status: 401 }),
-    };
-    const matchingResult = await executeMiddleware({
-      isProxy: false,
-      module,
-      request: new Request("http://localhost/foo/"),
-    });
-    const nonMatchingResult = await executeMiddleware({
-      isProxy: false,
-      module,
-      request: new Request("http://localhost/foo"),
-    });
+  it.each(["/foo", "/foo/"])(
+    "does not match %s when a custom constraint requires a terminal slash",
+    async (pathname) => {
+      const result = await executeMiddleware({
+        isProxy: false,
+        module: {
+          config: { matcher: ["/:path(.*\\/)"] },
+          middleware: () => new Response("unauthorized", { status: 401 }),
+        },
+        request: new Request(`http://localhost${pathname}`),
+      });
 
-    expect(matchingResult.continue).toBe(false);
-    expect(matchingResult.response?.status).toBe(401);
-    expect(nonMatchingResult).toEqual({ continue: true });
-  });
+      expect(result).toEqual({ continue: true });
+    },
+  );
 });

--- a/tests/middleware-runtime-trailing-slash.test.ts
+++ b/tests/middleware-runtime-trailing-slash.test.ts
@@ -209,7 +209,7 @@ describe("executeMiddleware normalizes trailing slashes for matcher evaluation",
     expect(observedPathnames).toEqual(["/api/admin/"]);
   });
 
-  it("matches a canonical API pathname when the matcher source has a trailing slash", async () => {
+  it("does not match a canonical API pathname when the matcher source requires a trailing slash", async () => {
     const result = await executeMiddleware({
       isProxy: false,
       module: {
@@ -219,8 +219,8 @@ describe("executeMiddleware normalizes trailing slashes for matcher evaluation",
       request: new Request("http://localhost/api/admin"),
     });
 
-    expect(result.continue).toBe(false);
-    expect(result.response?.status).toBe(401);
+    expect(result.continue).toBe(true);
+    expect(result.response).toBeUndefined();
   });
 
   it("preserves an escaped terminal slash matcher", async () => {

--- a/tests/middleware-runtime.test.ts
+++ b/tests/middleware-runtime.test.ts
@@ -2,6 +2,204 @@ import { describe, expect, it, vi } from "vite-plus/test";
 import { executeMiddleware } from "../packages/vinext/src/server/middleware-runtime.js";
 import type { NextRequest } from "../packages/vinext/src/shims/server.js";
 
+describe("middleware pathname matching", () => {
+  const i18nConfig = {
+    defaultLocale: "en",
+    locales: ["en", "fr"],
+  };
+
+  async function middlewareWasInvoked(
+    pathname: string,
+    matcher: string | { locale: false; source: string },
+    options: { basePath?: string } = {},
+  ): Promise<boolean> {
+    let invoked = false;
+    await executeMiddleware({
+      ...options,
+      i18nConfig,
+      isProxy: false,
+      module: {
+        config: { matcher: typeof matcher === "string" ? matcher : [matcher] },
+        default() {
+          invoked = true;
+        },
+      },
+      request: new Request(`http://localhost:3000${pathname}`),
+    });
+    return invoked;
+  }
+
+  // Next.js determines locale provenance before decoding the pathname and
+  // reuses it for both matcher attempts. In particular, an encoded locale is
+  // not reclassified as a literal locale after decode.
+  // Ported from Next.js:
+  // packages/next/src/server/lib/router-utils/resolve-routes.ts
+  // packages/next/src/shared/lib/i18n/normalize-locale-path.ts
+  it.each([
+    ["normal /foo", "/foo", "/foo", true],
+    ["normal /foo", "/foo", "/en/foo", true],
+    ["normal /foo", "/foo", "/fr/foo", true],
+    ["normal /foo", "/foo", "/EN/foo", true],
+    ["normal /foo", "/foo", "/Fr/foo", true],
+    ["normal /foo", "/foo", "/%65n/foo", false],
+    ["normal /foo", "/foo", "/%66r/foo", false],
+    ["normal /foo", "/foo", "/zz/foo", false],
+    ["normal /foo", "/foo", "/fr/en/foo", false],
+    ["normal /en/foo", "/en/foo", "/foo", false],
+    ["normal /en/foo", "/en/foo", "/en/foo", false],
+    ["normal /en/foo", "/en/foo", "/fr/foo", false],
+    ["normal /en/foo", "/en/foo", "/%65n/foo", true],
+    ["normal /en/foo", "/en/foo", "/%66r/foo", false],
+    ["normal /en/foo", "/en/foo", "/zz/foo", false],
+    ["normal /en/foo", "/en/foo", "/fr/en/foo", true],
+    ["locale:false /en/foo", { locale: false, source: "/en/foo" }, "/foo", true],
+    ["locale:false /en/foo", { locale: false, source: "/en/foo" }, "/en/foo", true],
+    ["locale:false /en/foo", { locale: false, source: "/en/foo" }, "/fr/foo", false],
+    ["locale:false /en/foo", { locale: false, source: "/en/foo" }, "/%65n/foo", false],
+    ["locale:false /en/foo", { locale: false, source: "/en/foo" }, "/%66r/foo", false],
+    ["locale:false /en/foo", { locale: false, source: "/en/foo" }, "/zz/foo", false],
+    ["locale:false /en/foo", { locale: false, source: "/en/foo" }, "/fr/en/foo", false],
+    ["locale:false /foo", { locale: false, source: "/foo" }, "/foo", false],
+    ["locale:false /foo", { locale: false, source: "/foo" }, "/en/foo", false],
+    ["locale:false /foo", { locale: false, source: "/foo" }, "/fr/foo", false],
+    ["locale:false /foo", { locale: false, source: "/foo" }, "/%65n/foo", false],
+    ["locale:false /foo", { locale: false, source: "/foo" }, "/%66r/foo", false],
+    ["locale:false /foo", { locale: false, source: "/foo" }, "/zz/foo", false],
+    ["locale:false /foo", { locale: false, source: "/foo" }, "/fr/en/foo", false],
+  ] as const)(
+    "matches Next.js i18n ordering for %s with %j at %s",
+    async (_name, matcher, path, expected) => {
+      await expect(middlewareWasInvoked(path, matcher)).resolves.toBe(expected);
+    },
+  );
+
+  it("does not discover an encoded basePath after i18n default-locale insertion", async () => {
+    await expect(middlewareWasInvoked("/%64ocs/foo", "/foo", { basePath: "/docs" })).resolves.toBe(
+      false,
+    );
+  });
+
+  it("uses the request domain's default locale for locale:false matchers", async () => {
+    let invoked = false;
+    await executeMiddleware({
+      i18nConfig: {
+        defaultLocale: "en",
+        domains: [{ defaultLocale: "fr", domain: "fr.example.com" }],
+        locales: ["en", "fr"],
+      },
+      isProxy: false,
+      module: {
+        config: { matcher: [{ locale: false, source: "/fr/foo" }] },
+        default() {
+          invoked = true;
+        },
+      },
+      request: new Request("https://internal.example/foo", {
+        headers: { host: "fr.example.com" },
+      }),
+    });
+
+    expect(invoked).toBe(true);
+  });
+
+  it.each(["%0A", "%0D", "%E2%80%A8", "%E2%80%A9"])(
+    "matches the encoded request pathname before the decoded %s form",
+    async (encoded) => {
+      let observedPathname: string | undefined;
+      const requestPathname = `/xx${encoded}/admin/dashboard`;
+      const result = await executeMiddleware({
+        isProxy: false,
+        module: {
+          config: { matcher: "/((?!api|_next/static|_next/image|favicon.ico).*)" },
+          default(request: NextRequest) {
+            observedPathname = request.nextUrl.pathname;
+            return new Response("blocked", { status: 403 });
+          },
+        },
+        normalizedPathname: `/xx${decodeURIComponent(encoded)}/admin/dashboard`,
+        request: new Request(`http://localhost:3000${requestPathname}`),
+      });
+
+      expect(result.continue).toBe(false);
+      expect(result.response?.status).toBe(403);
+      expect(observedPathname).toBe(requestPathname);
+    },
+  );
+
+  it("does not widen a constrained matcher beyond Next.js semantics", async () => {
+    let invoked = false;
+    const result = await executeMiddleware({
+      isProxy: false,
+      module: {
+        config: { matcher: "/orders/:id(\\d+)" },
+        default() {
+          invoked = true;
+        },
+      },
+      normalizedPathname: "/orders/42 ",
+      request: new Request("http://localhost:3000/orders/42%20"),
+    });
+
+    expect(result.continue).toBe(true);
+    expect(invoked).toBe(false);
+  });
+
+  it("retries matcher eligibility with Next.js's decoded delimiter candidate", async () => {
+    let invoked = false;
+    const result = await executeMiddleware({
+      isProxy: false,
+      module: {
+        config: { matcher: "/foo/bar" },
+        default() {
+          invoked = true;
+          return new Response("blocked", { status: 403 });
+        },
+      },
+      normalizedPathname: "/foo%2Fbar",
+      request: new Request("http://localhost:3000/foo%2Fbar"),
+    });
+
+    expect(result.continue).toBe(false);
+    expect(result.response?.status).toBe(403);
+    expect(invoked).toBe(true);
+  });
+
+  it.each(["%2F", "%3F", "%23"])(
+    "matches a constrained route through Next.js's decoded %s suffix",
+    async (encoded) => {
+      const result = await executeMiddleware({
+        isProxy: false,
+        module: {
+          config: { matcher: "/orders/:id(\\d+)" },
+          default: () => new Response("blocked", { status: 403 }),
+        },
+        normalizedPathname: `/orders/42${encoded}`,
+        request: new Request(`http://localhost:3000/orders/42${encoded}`),
+      });
+
+      expect(result.continue).toBe(false);
+      expect(result.response?.status).toBe(403);
+    },
+  );
+
+  it.each(["%5C", "%252F"])(
+    "does not overmatch the constrained route through decoded %s",
+    async (encoded) => {
+      const result = await executeMiddleware({
+        isProxy: false,
+        module: {
+          config: { matcher: "/orders/:id(\\d+)" },
+          default: () => new Response("blocked", { status: 403 }),
+        },
+        normalizedPathname: `/orders/42${encoded}`,
+        request: new Request(`http://localhost:3000/orders/42${encoded}`),
+      });
+
+      expect(result.continue).toBe(true);
+    },
+  );
+});
+
 // Tests for the redirect protocol implemented in `executeMiddleware`. These
 // fixtures mirror the behaviour Next.js's edge adapter applies after a
 // middleware returns a redirect Response:
@@ -566,6 +764,53 @@ describe("middleware nextUrl basePath", () => {
     expect(captured.request?.nextUrl.basePath).toBe("/root");
     expect(captured.request?.nextUrl.pathname).toBe("/dashboard");
   });
+
+  // Ported from Next.js:
+  // test/e2e/middleware-custom-matchers-basepath/test/index.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-custom-matchers-basepath/test/index.test.ts
+  it("does not apply a custom matcher outside the configured basePath", async () => {
+    const { captured, module } = captureModule();
+
+    const result = await executeMiddleware({
+      basePath: "/docs",
+      isProxy: false,
+      module: { ...module, config: { matcher: "/hello" } },
+      request: new Request("http://localhost:3000/hello"),
+    });
+
+    expect(result.continue).toBe(true);
+    expect(captured.request).toBeUndefined();
+  });
+
+  it("matches a custom matcher after decoding its encoded basePath", async () => {
+    const { captured, module } = captureModule();
+
+    const result = await executeMiddleware({
+      basePath: "/docs",
+      isProxy: false,
+      module: { ...module, config: { matcher: "/hello" } },
+      request: new Request("http://localhost:3000/%64ocs/hello"),
+    });
+
+    expect(result.continue).toBe(true);
+    expect(captured.request?.nextUrl.pathname).toBe("/%64ocs/hello");
+  });
+
+  it.each(["%2F", "%3F", "%23"])(
+    "matches a basePath root matcher through decoded terminal %s",
+    async (encoded) => {
+      const { captured, module } = captureModule();
+
+      await executeMiddleware({
+        basePath: "/docs",
+        isProxy: false,
+        module: { ...module, config: { matcher: "/" } },
+        request: new Request(`http://localhost:3000/docs${encoded}`),
+      });
+
+      expect(captured.request?.nextUrl.pathname).toBe(`/docs${encoded}`);
+    },
+  );
 
   it("matches encoded aliases while exposing the raw pathname to middleware", async () => {
     // Next.js tries middleware matchers against both the request pathname and

--- a/tests/middleware-runtime.test.ts
+++ b/tests/middleware-runtime.test.ts
@@ -66,6 +66,13 @@ describe("middleware pathname matching", () => {
     ["locale:false /foo", { locale: false, source: "/foo" }, "/%66r/foo", false],
     ["locale:false /foo", { locale: false, source: "/foo" }, "/zz/foo", false],
     ["locale:false /foo", { locale: false, source: "/foo" }, "/fr/en/foo", false],
+    ["normal internal path", "/:path*", "/_next/static/chunk.js", false],
+    [
+      "locale:false internal path",
+      { locale: false, source: "/_next/:path*" },
+      "/_next/static/chunk.js",
+      true,
+    ],
   ] as const)(
     "matches Next.js i18n ordering for %s with %j at %s",
     async (_name, matcher, path, expected) => {
@@ -196,6 +203,27 @@ describe("middleware pathname matching", () => {
       });
 
       expect(result.continue).toBe(true);
+    },
+  );
+
+  it.each(["%2F", "%3F", "%23"])(
+    "does not overmatch a root matcher when decoded %s occupies its own segment",
+    async (encoded) => {
+      await expect(middlewareWasInvoked(`/${encoded}`, "/")).resolves.toBe(false);
+      await expect(
+        middlewareWasInvoked(`/docs/${encoded}`, "/", { basePath: "/docs" }),
+      ).resolves.toBe(false);
+    },
+  );
+
+  it.each([
+    ["/foo", "/foo%2F%2F"],
+    ["/foo", "/foo/%2F"],
+    ["/orders/:id(\\d+)", "/orders/42%2F%2F"],
+  ] as const)(
+    "does not collapse multiple decoded trailing slashes for %s",
+    async (matcher, path) => {
+      await expect(middlewareWasInvoked(path, matcher)).resolves.toBe(false);
     },
   );
 });

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -315,8 +315,15 @@ function writeEncodedSlashPagesFixture(rootDir: string): void {
   );
   fs.writeFileSync(
     path.join(rootDir, "middleware.ts"),
-    `export const config = { matcher: "/a/b" };
-export default function middleware() {
+    `import { NextResponse, type NextRequest } from "next/server";
+
+export const config = { matcher: "/a/b" };
+export default function middleware(request: NextRequest) {
+  if (request.nextUrl.pathname === "/a%2Fb") {
+    const response = NextResponse.next();
+    response.headers.set("x-encoded-slash-matcher", "matched");
+    return response;
+  }
   return new Response("nested blocked", { status: 418 });
 }
 `,
@@ -1174,6 +1181,7 @@ describe("Pages Router integration", () => {
 
       const encodedRes = await fetch(`${started.baseUrl}/a%2Fb`);
       expect(encodedRes.status).toBe(404);
+      expect(encodedRes.headers.get("x-encoded-slash-matcher")).toBe("matched");
       expect(await encodedRes.text()).not.toContain("nested blocked");
 
       const nestedRes = await fetch(`${started.baseUrl}/a/b`);
@@ -6808,6 +6816,7 @@ describe("Production server middleware (Pages Router)", () => {
 
       const encodedRes = await fetch(`${tempProdUrl}/a%2Fb`);
       expect(encodedRes.status).toBe(404);
+      expect(encodedRes.headers.get("x-encoded-slash-matcher")).toBe("matched");
       expect(await encodedRes.text()).not.toContain("nested blocked");
 
       const nestedRes = await fetch(`${tempProdUrl}/a/b`);

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -8905,6 +8905,9 @@ describe("middleware matcher patterns", () => {
     // Next.js compiles middleware sources with an optional terminal delimiter.
     // https://github.com/vercel/next.js/blob/canary/packages/next/src/build/analysis/get-page-static-info.ts
     expect(matchPattern("/api/admin/", "/api/admin/")).toBe(true);
+    expect(matchPattern("/api/admin//", "/api/admin")).toBe(false);
+    expect(matchPattern("/?", "/")).toBe(false);
+    expect(matchPattern("/#", "/")).toBe(false);
     expect(matchPattern("/api/admin/", "/api/admin\\/")).toBe(true);
     expect(matchPattern("/api/admin", "/api/admin\\/")).toBe(false);
     expect(matchPattern("/blog/post/", "/(.*)/")).toBe(true);

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -8898,7 +8898,7 @@ describe("middleware matcher patterns", () => {
     expect(matchesMiddleware("/other", matcher)).toBe(false);
   });
 
-  it("matchesMiddleware: trailing slashes in matcher sources are optional", async () => {
+  it("matchesMiddleware: preserves source slashes and allows one terminal delimiter", async () => {
     const { matchPattern, matchesMiddleware } =
       await import("../packages/vinext/src/server/middleware.js");
 
@@ -8906,6 +8906,9 @@ describe("middleware matcher patterns", () => {
     // https://github.com/vercel/next.js/blob/canary/packages/next/src/build/analysis/get-page-static-info.ts
     expect(matchPattern("/api/admin/", "/api/admin/")).toBe(true);
     expect(matchPattern("/api/admin//", "/api/admin")).toBe(false);
+    expect(matchPattern("/api/admin//", "/api/admin/")).toBe(true);
+    expect(matchPattern("/api/admin/?", "/api/admin/")).toBe(true);
+    expect(matchPattern("/api/admin/#", "/api/admin/")).toBe(true);
     expect(matchPattern("/?", "/")).toBe(false);
     expect(matchPattern("/#", "/")).toBe(false);
     expect(matchPattern("/api/admin/", "/api/admin\\/")).toBe(true);
@@ -8917,9 +8920,9 @@ describe("middleware matcher patterns", () => {
     expect(matchPattern("/api/123", "/api/:id/")).toBe(false);
     expect(matchPattern("/foo/", "/:path(.*\\/)")).toBe(true);
     expect(matchPattern("/foo", "/:path(.*\\/)")).toBe(false);
-    expect(matchesMiddleware("/api/admin", "/api/admin/")).toBe(true);
-    expect(matchesMiddleware("/api/admin", ["/api/admin/"])).toBe(true);
-    expect(matchesMiddleware("/api/admin", [{ source: "/api/admin/" }])).toBe(true);
+    expect(matchesMiddleware("/api/admin", "/api/admin/")).toBe(false);
+    expect(matchesMiddleware("/api/admin", ["/api/admin/"])).toBe(false);
+    expect(matchesMiddleware("/api/admin", [{ source: "/api/admin/" }])).toBe(false);
     expect(
       matchesMiddleware("/fr/api/admin/", "/api/admin\\/", undefined, {
         locales: ["en", "fr"],

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -8860,6 +8860,12 @@ describe("middleware matcher patterns", () => {
       }),
     ).toBe(true);
     expect(
+      matchesMiddleware("/FR/about", "/about", undefined, {
+        locales: ["en", "fr"],
+        defaultLocale: "en",
+      }),
+    ).toBe(true);
+    expect(
       matchesMiddleware("/", "/", undefined, {
         locales: ["en", "fr"],
         defaultLocale: "en",


### PR DESCRIPTION
## Summary

- evaluate middleware matchers against the encoded pathname before a single decoded fallback
- preserve Next.js basePath and i18n locale ordering, including domain locale selection
- cover App Router pages, route handlers, RSC requests, and Pages Router paths across supported runtimes

## Validation

- vp test run tests/middleware-runtime.test.ts tests/middleware-runtime-trailing-slash.test.ts tests/pages-data-route.test.ts tests/pages-data-url.test.ts
- vp test run tests/middleware-matcher-auth.test.ts
- vp test run tests/shims.test.ts -t matchesMiddleware
- vp check packages/vinext/src/server/middleware-runtime.ts packages/vinext/src/server/middleware-matcher.ts tests/middleware-runtime.test.ts tests/shims.test.ts