### PR TITLE
fix(config): reject invalid action body limits

### DIFF
--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -36,7 +36,7 @@ export function parseBodySizeLimit(value: unknown): number {
   }
   if (typeof value !== "string") throwInvalidServerActionsBodySizeLimit();
   const trimmed = value.trim();
-  const match = trimmed.match(/^(\d+(?:\.\d+)?)\s*(b|kb|mb|gb|tb|pb)?$/i);
+  const match = trimmed.match(/^(\+?\d+(?:\.\d+)?)\s*(b|kb|mb|gb|tb|pb)?$/i);
   if (!match) throwInvalidServerActionsBodySizeLimit();
   const num = parseFloat(match[1]);
   const unit = (match[2] ?? "b").toLowerCase();

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -21,10 +21,20 @@ import { loadTsconfigResolutionForRoot } from "./tsconfig-paths.js";
 import { loadCommonJsModule, shouldRetryAsCommonJs } from "../utils/commonjs-loader.js";
 export const VINEXT_NEXT_CONFIG_PLUGIN_PROPERTY = "__vinextNextConfig";
 
+const BODY_SIZE_UNITS = {
+  b: 1,
+  kb: 1 << 10,
+  mb: 1 << 20,
+  gb: 1 << 30,
+  tb: 1024 ** 4,
+  pb: 1024 ** 5,
+} as const;
+const BODY_SIZE_PATTERN = /^([+-]?\d+(?:\.\d+)?) *(kb|mb|gb|tb|pb)$/i;
+
 /**
  * Parse a body size limit value (string or number) into bytes.
- * Accepts Next.js-style strings like "1mb", "500kb", "10mb", bare number strings like "1048576" (bytes),
- * and numeric values. Supports b, kb, mb, gb, tb, pb units.
+ * Mirrors Next.js's vendored bytes.parse() behavior for strings and passes
+ * numeric values through directly.
  * Returns the default 1MB if the value is not provided.
  * Throws Next.js's canonical config error if the value is invalid or less than 1 byte.
  */
@@ -35,34 +45,10 @@ export function parseBodySizeLimit(value: unknown): number {
     return value;
   }
   if (typeof value !== "string") throwInvalidServerActionsBodySizeLimit();
-  const trimmed = value.trim();
-  const match = trimmed.match(/^(\+?\d+(?:\.\d+)?)\s*(b|kb|mb|gb|tb|pb)?$/i);
-  if (!match) throwInvalidServerActionsBodySizeLimit();
-  const num = parseFloat(match[1]);
-  const unit = (match[2] ?? "b").toLowerCase();
-  let bytes: number;
-  switch (unit) {
-    case "b":
-      bytes = Math.floor(num);
-      break;
-    case "kb":
-      bytes = Math.floor(num * 1024);
-      break;
-    case "mb":
-      bytes = Math.floor(num * 1024 * 1024);
-      break;
-    case "gb":
-      bytes = Math.floor(num * 1024 * 1024 * 1024);
-      break;
-    case "tb":
-      bytes = Math.floor(num * 1024 * 1024 * 1024 * 1024);
-      break;
-    case "pb":
-      bytes = Math.floor(num * 1024 * 1024 * 1024 * 1024 * 1024);
-      break;
-    default:
-      throwInvalidServerActionsBodySizeLimit();
-  }
+  const match = BODY_SIZE_PATTERN.exec(value);
+  const amount = match ? Number.parseFloat(match[1]) : Number.parseInt(value, 10);
+  const unit = (match ? match[2].toLowerCase() : "b") as keyof typeof BODY_SIZE_UNITS;
+  const bytes = Math.floor(BODY_SIZE_UNITS[unit] * amount);
   if (Number.isNaN(bytes) || bytes < 1) throwInvalidServerActionsBodySizeLimit();
   return bytes;
 }

--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -25,23 +25,19 @@ export const VINEXT_NEXT_CONFIG_PLUGIN_PROPERTY = "__vinextNextConfig";
  * Parse a body size limit value (string or number) into bytes.
  * Accepts Next.js-style strings like "1mb", "500kb", "10mb", bare number strings like "1048576" (bytes),
  * and numeric values. Supports b, kb, mb, gb, tb, pb units.
- * Returns the default 1MB if the value is not provided or invalid.
- * Throws if the parsed value is less than 1.
+ * Returns the default 1MB if the value is not provided.
+ * Throws Next.js's canonical config error if the value is invalid or less than 1 byte.
  */
-export function parseBodySizeLimit(value: string | number | undefined | null): number {
-  if (value === undefined || value === null) return 1 * 1024 * 1024;
+export function parseBodySizeLimit(value: unknown): number {
+  if (value === undefined) return 1 * 1024 * 1024;
   if (typeof value === "number") {
-    if (value < 1) throw new Error(`Body size limit must be a positive number, got ${value}`);
+    if (Number.isNaN(value) || value < 1) throwInvalidServerActionsBodySizeLimit();
     return value;
   }
+  if (typeof value !== "string") throwInvalidServerActionsBodySizeLimit();
   const trimmed = value.trim();
   const match = trimmed.match(/^(\d+(?:\.\d+)?)\s*(b|kb|mb|gb|tb|pb)?$/i);
-  if (!match) {
-    console.warn(
-      `[vinext] Invalid bodySizeLimit value: "${value}". Expected a number or a string like "1mb", "500kb". Falling back to 1MB.`,
-    );
-    return 1 * 1024 * 1024;
-  }
+  if (!match) throwInvalidServerActionsBodySizeLimit();
   const num = parseFloat(match[1]);
   const unit = (match[2] ?? "b").toLowerCase();
   let bytes: number;
@@ -65,10 +61,17 @@ export function parseBodySizeLimit(value: string | number | undefined | null): n
       bytes = Math.floor(num * 1024 * 1024 * 1024 * 1024 * 1024);
       break;
     default:
-      return 1 * 1024 * 1024;
+      throwInvalidServerActionsBodySizeLimit();
   }
-  if (bytes < 1) throw new Error(`Body size limit must be a positive number, got ${bytes}`);
+  if (Number.isNaN(bytes) || bytes < 1) throwInvalidServerActionsBodySizeLimit();
   return bytes;
+}
+
+function throwInvalidServerActionsBodySizeLimit(): never {
+  throw new Error(
+    "Server Actions Size Limit must be a valid number or filesize format larger than 1MB: " +
+      "https://nextjs.org/docs/app/api-reference/next-config-js/serverActions#bodysizelimit",
+  );
 }
 
 export type HasCondition = {
@@ -1268,10 +1271,6 @@ function readOptionalString(value: unknown): string | undefined {
   return typeof value === "string" ? value : undefined;
 }
 
-function readOptionalBodySizeLimit(value: unknown): string | number | undefined {
-  return typeof value === "string" || typeof value === "number" ? value : undefined;
-}
-
 function readStringArray(value: unknown): string[] {
   return Array.isArray(value)
     ? value.filter((item): item is string => typeof item === "string")
@@ -1706,9 +1705,14 @@ export async function resolveNextConfig(
   const experimental = readOptionalRecord(config.experimental);
   const serverActionsConfig = readOptionalRecord(experimental?.serverActions);
   const serverActionsAllowedOrigins = readStringArray(serverActionsConfig?.allowedOrigins);
-  const serverActionsBodySizeLimitConfig = readOptionalBodySizeLimit(
-    serverActionsConfig?.bodySizeLimit,
-  );
+  const serverActionsBodySizeLimitConfig = serverActionsConfig?.bodySizeLimit;
+  if (
+    serverActionsBodySizeLimitConfig !== undefined &&
+    typeof serverActionsBodySizeLimitConfig !== "string" &&
+    typeof serverActionsBodySizeLimitConfig !== "number"
+  ) {
+    throwInvalidServerActionsBodySizeLimit();
+  }
   const serverActionsBodySizeLimit = parseBodySizeLimit(serverActionsBodySizeLimitConfig);
   // Preserve the verbatim config value (e.g. "2mb") for the "Body exceeded
   // {limit} limit" error message. Next.js surfaces the original string rather

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -1409,6 +1409,14 @@ describe("parseBodySizeLimit", () => {
     expect(parseBodySizeLimit("1.5mb")).toBe(Math.floor(1.5 * 1024 * 1024));
   });
 
+  // Next.js delegates to bytes.parse(), whose filesize grammar accepts an
+  // explicit positive sign.
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/compiled/bytes/index.js
+  it("accepts explicitly positive filesize strings", () => {
+    expect(parseBodySizeLimit("+2mb")).toBe(2 * 1024 * 1024);
+    expect(parseBodySizeLimit("+1048576")).toBe(1048576);
+  });
+
   it("returns default 1MB for undefined", () => {
     expect(parseBodySizeLimit(undefined)).toBe(1 * 1024 * 1024);
   });

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -1417,6 +1417,19 @@ describe("parseBodySizeLimit", () => {
     expect(parseBodySizeLimit("+1048576")).toBe(1048576);
   });
 
+  // Next.js delegates to bytes.parse(), which falls back to parseInt(value, 10)
+  // whenever the complete filesize grammar does not match. These surprising
+  // results are compatibility behavior, not additional validation rules.
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/compiled/bytes/index.js
+  it("matches bytes.parse fallback semantics for non-filesize strings", () => {
+    expect(parseBodySizeLimit("1mb ")).toBe(1);
+    expect(parseBodySizeLimit(" 1mb")).toBe(1);
+    expect(parseBodySizeLimit("1\tmb")).toBe(1);
+    expect(parseBodySizeLimit("2wat")).toBe(2);
+    expect(parseBodySizeLimit("1e3")).toBe(1);
+    expect(parseBodySizeLimit("1.5")).toBe(1);
+  });
+
   it("returns default 1MB for undefined", () => {
     expect(parseBodySizeLimit(undefined)).toBe(1 * 1024 * 1024);
   });

--- a/tests/next-config.test.ts
+++ b/tests/next-config.test.ts
@@ -1376,6 +1376,9 @@ module.exports = withPlugin({ basePath: "/wrapped" });`,
 });
 
 describe("parseBodySizeLimit", () => {
+  const configError =
+    "Server Actions Size Limit must be a valid number or filesize format larger than 1MB";
+
   it("parses megabyte strings", () => {
     expect(parseBodySizeLimit("10mb")).toBe(10 * 1024 * 1024);
     expect(parseBodySizeLimit("1mb")).toBe(1 * 1024 * 1024);
@@ -1410,26 +1413,13 @@ describe("parseBodySizeLimit", () => {
     expect(parseBodySizeLimit(undefined)).toBe(1 * 1024 * 1024);
   });
 
-  it("returns default 1MB for null", () => {
-    expect(parseBodySizeLimit(null)).toBe(1 * 1024 * 1024);
-  });
-
-  it("returns default 1MB and warns for invalid strings", () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    // In Vitest 4, spyOn on an already-intercepted console returns the same mock,
-    // which may have accumulated calls from earlier tests. Clear before asserting.
-    warn.mockClear();
-    expect(parseBodySizeLimit("invalid")).toBe(1 * 1024 * 1024);
-    expect(parseBodySizeLimit("10mbb")).toBe(1 * 1024 * 1024);
-    expect(warn).toHaveBeenCalledTimes(2);
-    expect(warn.mock.calls[0][0]).toContain("Invalid bodySizeLimit");
-    warn.mockRestore();
-    // empty string also falls through to the regex (no match), so it warns too
-    const warn2 = vi.spyOn(console, "warn").mockImplementation(() => {});
-    warn2.mockClear();
-    expect(parseBodySizeLimit("")).toBe(1 * 1024 * 1024);
-    expect(warn2).toHaveBeenCalledTimes(1);
-    warn2.mockRestore();
+  // Ported from Next.js:
+  // test/e2e/app-dir/actions/app-action-size-limit-invalid.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/actions/app-action-size-limit-invalid.test.ts
+  it("rejects invalid and negative filesize strings", () => {
+    expect(() => parseBodySizeLimit("testmb")).toThrow(configError);
+    expect(() => parseBodySizeLimit("-3000mb")).toThrow(configError);
+    expect(() => parseBodySizeLimit("")).toThrow(configError);
   });
 
   it("parses terabyte strings", () => {
@@ -1445,9 +1435,16 @@ describe("parseBodySizeLimit", () => {
     expect(parseBodySizeLimit("2097152")).toBe(2097152);
   });
 
-  it("throws for zero or negative numeric values", () => {
-    expect(() => parseBodySizeLimit(0)).toThrow();
-    expect(() => parseBodySizeLimit(-1)).toThrow();
+  it("throws the canonical error for invalid numeric values", () => {
+    expect(() => parseBodySizeLimit(0)).toThrow(configError);
+    expect(() => parseBodySizeLimit(-1)).toThrow(configError);
+    expect(() => parseBodySizeLimit(Number.NaN)).toThrow(configError);
+  });
+
+  it("rejects configured values outside Next.js's string-or-number schema", () => {
+    expect(() => parseBodySizeLimit(null)).toThrow(configError);
+    expect(() => parseBodySizeLimit(true)).toThrow(configError);
+    expect(() => parseBodySizeLimit({ value: "2mb" })).toThrow(configError);
   });
 });
 
@@ -1576,6 +1573,21 @@ describe("resolveNextConfig serverActionsBodySizeLimit", () => {
     expect(resolved.serverActionsBodySizeLimit).toBe(5242880);
   });
 
+  it.each([-3000, "testmb", "-3000mb", null, true])(
+    "rejects invalid bodySizeLimit config %j",
+    async (bodySizeLimit) => {
+      await expect(
+        resolveNextConfig({
+          experimental: {
+            serverActions: { bodySizeLimit: bodySizeLimit as string | number },
+          },
+        }),
+      ).rejects.toThrow(
+        "Server Actions Size Limit must be a valid number or filesize format larger than 1MB",
+      );
+    },
+  );
+
   // The verbatim config string drives the "Body exceeded {limit} limit" error
   // message (matching Next.js), so it must be preserved alongside the parsed
   // byte count rather than reconstructed from it.
@@ -1622,17 +1634,22 @@ describe("resolveNextConfig crossOrigin", () => {
 
   it("warns about unsupported crossOrigin values", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const resolved = await resolveNextConfig({ crossOrigin: "invalid" as "anonymous" });
+    warn.mockClear();
+    try {
+      const resolved = await resolveNextConfig({ crossOrigin: "invalid" as "anonymous" });
 
-    expect(resolved.crossOrigin).toBeUndefined();
-    expect(warn).toHaveBeenCalledOnce();
-    expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining("Invalid next.config options detected"),
-    );
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('"crossOrigin"'));
-    expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining("https://nextjs.org/docs/messages/invalid-next-config"),
-    );
+      expect(resolved.crossOrigin).toBeUndefined();
+      expect(warn).toHaveBeenCalledOnce();
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("Invalid next.config options detected"),
+      );
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('"crossOrigin"'));
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("https://nextjs.org/docs/messages/invalid-next-config"),
+      );
+    } finally {
+      warn.mockRestore();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- reject genuinely invalid `experimental.serverActions.bodySizeLimit` values during config resolution instead of silently substituting 1 MB
- use Next.js's canonical error and documentation link
- mirror Next.js's vendored `bytes.parse()` grammar and fallback exactly, including explicit `+` signs and its unusual `parseInt` fallback
- preserve the original configured label used by runtime body-limit errors

## User impact and reproduction

With:

```js
export default {
  experimental: {
    serverActions: { bodySizeLimit: "testmb" },
  },
}
```

Next.js refuses to start or build. Vinext previously warned, silently changed the value to 1 MB, and continued. That hides configuration mistakes until a Server Action later fails at a limit the developer never selected. Negative strings behaved the same way, negative numbers used a vinext-specific error, and wrong-type values were treated as omitted.

Strict parity also matters for accepted strings. Next's vendored parser accepts `"+2mb"`, but for strings outside its complete filesize grammar it falls back to `parseInt(value, 10)`: for example, `"2wat"` is 2 bytes, `"1e3"` is 1 byte, and `"1mb "` is 1 byte. This PR preserves those surprising but authoritative semantics instead of inventing stricter validation.

## Expected Next.js behavior

Next validates `bodySizeLimit` during config resolution. Numbers pass through directly; strings go through its vendored `bytes.parse()`; null, `NaN`, and results below one byte throw the canonical config error.

- [config validation](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/config.ts)
- [accepted schema](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/config-schema.ts)
- [vendored bytes parser](https://github.com/vercel/next.js/blob/canary/packages/next/src/compiled/bytes/index.js)
- [invalid-config E2E](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/actions/app-action-size-limit-invalid.test.ts)
- [bodySizeLimit documentation](https://nextjs.org/docs/app/api-reference/config/next-config-js/serverActions#bodysizelimit)

## Execution paths

`resolveNextConfig` is the shared configuration boundary for:

- App Router development, production, and prerendering
- CLI and Cloudflare Worker builds
- Pages Router development/production config loading

Server Actions are an App Router feature; Pages paths do not consume the runtime action limit, but they share the same config validation just as Next validates the option globally.

## Tests and verification

Tests were added first. The fallback-parity test failed against the previous implementation (`"1mb "` returned 1 MiB rather than 1 byte), then passed after the parser change.

Coverage includes malformed/negative strings, zero/`NaN`, wrong types, omitted defaults, valid numeric and unit values, `+2mb`, and fallback cases `"1mb "`, `" 1mb"`, tab-separated units, `"2wat"`, `"1e3"`, and `"1.5"`.

- `pnpm test tests/next-config.test.ts` — 223 passed
- `pnpm exec vp check packages/vinext/src/config/next-config.ts tests/next-config.test.ts` — passed
- `pnpm run build` — passed (only the repository's expected virtual-module external warnings)

## Self-review

Automated review correctly identified missing explicit-positive-sign support; commit `debb4e1a` added it. The final review then found a broader issue: the hand-written parser was still stricter than Next's vendored parser. Commit `004f4aa0` replaces it with the same grammar, unit multipliers, flooring, and `parseInt` fallback while keeping valid error cases strict.

I also tested removing the apparent duplicate type guard in config resolution. It is retained because it narrows the original value before preserving the runtime error label, avoiding an unsafe cast or object stringification.