### PR TITLE
fix(build): throw error if there is `_next` folder inside the public folder

### DIFF
--- a/packages/vinext/src/build/public-dir-conflict.ts
+++ b/packages/vinext/src/build/public-dir-conflict.ts
@@ -1,0 +1,45 @@
+import { existsSync } from "node:fs";
+import path from "pathslash";
+
+export type PublicDirConflictOptions = {
+  root: string;
+  publicDir: string | null;
+  assetsDir: string;
+};
+
+const PUBLIC_NEXT_CONFLICT_ERROR =
+  "You can not have a '_next' folder inside of your public folder. " +
+  "This conflicts with the internal '/_next' route. " +
+  "https://nextjs.org/docs/messages/public-next-folder-conflict";
+
+export function assertNoPublicDirAssetConflict({
+  root,
+  publicDir,
+  assetsDir,
+}: PublicDirConflictOptions): void {
+  if (!publicDir) return;
+
+  const resolvedPublicDir = path.resolve(root, publicDir);
+  const publicNextDir = path.join(resolvedPublicDir, "_next");
+
+  if (existsSync(publicNextDir)) {
+    throw new Error(PUBLIC_NEXT_CONFLICT_ERROR);
+  }
+
+  if (!assetsDir) return;
+
+  const publicAssetsDir = path.resolve(resolvedPublicDir, assetsDir);
+  const relativeAssetsDir = path.relative(resolvedPublicDir, publicAssetsDir);
+
+  const isInsidePublicDir =
+    relativeAssetsDir !== "" &&
+    !relativeAssetsDir.startsWith("../") &&
+    !path.isAbsolute(relativeAssetsDir);
+
+  if (isInsidePublicDir && existsSync(publicAssetsDir)) {
+    throw new Error(
+      `[vinext] The public directory contains a path reserved for build assets: ` +
+        `${relativeAssetsDir}`,
+    );
+  }
+}

--- a/packages/vinext/src/build/public-dir-conflict.ts
+++ b/packages/vinext/src/build/public-dir-conflict.ts
@@ -7,27 +7,63 @@ export type PublicDirConflictOptions = {
   assetsDir: string;
 };
 
+export type PublicNextRequestConflictOptions = Pick<
+  PublicDirConflictOptions,
+  "root" | "publicDir"
+> & {
+  basePath: string;
+  requestUrl: string;
+};
+
 const PUBLIC_NEXT_CONFLICT_ERROR =
   "You can not have a '_next' folder inside of your public folder. " +
   "This conflicts with the internal '/_next' route. " +
   "https://nextjs.org/docs/messages/public-next-folder-conflict";
+
+function assertNoPublicNextDir(root: string, publicDir: string | null): void {
+  if (!publicDir) return;
+
+  const publicNextDir = path.join(path.resolve(root, publicDir), "_next");
+  if (existsSync(publicNextDir)) {
+    throw new Error(PUBLIC_NEXT_CONFLICT_ERROR);
+  }
+}
+
+export function assertNoPublicNextRequestConflict({
+  root,
+  publicDir,
+  basePath,
+  requestUrl,
+}: PublicNextRequestConflictOptions): void {
+  const internalOrigin = "http://vinext.invalid";
+  // Concatenate origin-form targets so a leading `//` stays in the pathname
+  // instead of being interpreted as a scheme-relative host. Next handles that
+  // malformed shape through its repeated-slash redirect before this check.
+  const parseTarget = requestUrl.startsWith("/") ? internalOrigin + requestUrl : requestUrl;
+  let pathname = new URL(parseTarget, internalOrigin).pathname;
+  if (basePath && (pathname === basePath || pathname.startsWith(basePath + "/"))) {
+    pathname = pathname.slice(basePath.length) || "/";
+  }
+
+  if (pathname.startsWith("/_next")) {
+    assertNoPublicNextDir(root, publicDir);
+  }
+}
 
 export function assertNoPublicDirAssetConflict({
   root,
   publicDir,
   assetsDir,
 }: PublicDirConflictOptions): void {
-  if (!publicDir) return;
+  assertNoPublicNextDir(root, publicDir);
+  if (!publicDir || !assetsDir) return;
 
   const resolvedPublicDir = path.resolve(root, publicDir);
-  const publicNextDir = path.join(resolvedPublicDir, "_next");
 
-  if (existsSync(publicNextDir)) {
-    throw new Error(PUBLIC_NEXT_CONFLICT_ERROR);
-  }
-
-  if (!assetsDir) return;
-
+  // Next.js only reserves public/_next because it keeps emitted assets in
+  // .next/static. Vinext writes path-prefixed assets into the client output,
+  // where Vite also copies public files, so the configured output path must be
+  // reserved as well to prevent the same namespace collision.
   const publicAssetsDir = path.resolve(resolvedPublicDir, assetsDir);
   const relativeAssetsDir = path.relative(resolvedPublicDir, publicAssetsDir);
 

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -17,63 +17,60 @@ import {
   apiRouter,
   invalidateRouteCache,
   matchRoute,
-} from "vinext/internal/routing/pages-router";
-import { generateServerEntry as _generateServerEntry } from "vinext/internal/entries/pages-server-entry";
-import { generateClientEntry as _generateClientEntry } from "vinext/internal/entries/pages-client-entry";
+} from "./routing/pages-router.js";
+import { generateServerEntry as _generateServerEntry } from "./entries/pages-server-entry.js";
+import { generateClientEntry as _generateClientEntry } from "./entries/pages-client-entry.js";
 import {
   appRouteGraph,
   appRouter,
   invalidateAppRouteCache,
   matchAppRoute,
-} from "vinext/internal/routing/app-router";
-import type { NitroRouteRuleConfig } from "vinext/internal/build/nitro-route-rules";
+} from "./routing/app-router.js";
+import type { NitroRouteRuleConfig } from "./build/nitro-route-rules.js";
 import {
   buildViteResolveExtensions,
   normalizeViteResolveExtensions,
   createValidFileMatcher,
   findFileWithExts,
-} from "vinext/internal/routing/file-matcher";
-import { createSSRHandler } from "vinext/internal/server/dev-server";
-import { handleApiRoute } from "vinext/internal/server/api-handler";
+} from "./routing/file-matcher.js";
+import { createSSRHandler } from "./server/dev-server.js";
+import { handleApiRoute } from "./server/api-handler.js";
 import {
   DEFAULT_DEVICE_SIZES,
   DEFAULT_IMAGE_SIZES,
   isImageOptimizationPath,
   resolveDevImageRedirect,
-} from "vinext/internal/server/image-optimization";
+} from "./server/image-optimization.js";
 
-import { installSocketErrorBackstop } from "vinext/internal/server/socket-error-backstop";
-import { shouldInvalidateAppRouteFile } from "vinext/internal/server/dev-route-files";
-import { createDirectRunner } from "vinext/internal/server/dev-module-runner";
-import { generateRscEntry } from "vinext/internal/entries/app-rsc-entry";
-import { generateSsrEntry } from "vinext/internal/entries/app-ssr-entry";
+import { installSocketErrorBackstop } from "./server/socket-error-backstop.js";
+import { shouldInvalidateAppRouteFile } from "./server/dev-route-files.js";
+import { createDirectRunner } from "./server/dev-module-runner.js";
+import { generateRscEntry } from "./entries/app-rsc-entry.js";
+import { generateSsrEntry } from "./entries/app-ssr-entry.js";
 import {
   VIRTUAL_CACHE_ADAPTERS,
   generateCacheAdaptersModule,
   VINEXT_CACHE_CONFIG_PLUGIN_PROPERTY,
   type VinextCacheConfig,
-} from "vinext/internal/cache/cache-adapters-virtual";
+} from "./cache/cache-adapters-virtual.js";
 import {
   VIRTUAL_IMAGE_ADAPTERS,
   generateImageAdaptersModule,
   type VinextImageConfig,
-} from "vinext/internal/image/image-adapters-virtual";
-import {
-  generateBrowserEntry,
-  toLinkPrefetchRoutes,
-} from "vinext/internal/entries/app-browser-entry";
+} from "./image/image-adapters-virtual.js";
+import { generateBrowserEntry, toLinkPrefetchRoutes } from "./entries/app-browser-entry.js";
 import {
   collectRouteClassificationManifest,
   type RouteClassificationManifest,
-} from "vinext/internal/build/route-classification-manifest";
+} from "./build/route-classification-manifest.js";
 import {
   extractMiddlewareMatcherConfig,
   extractMiddlewareMatcherConfigValue,
   hasExportedName,
-} from "vinext/internal/build/report";
-import { planRouteClassificationInjection } from "vinext/internal/build/route-classification-injector";
-import { normalizePathnameForRouteMatchStrict } from "vinext/internal/routing/utils";
-import { hasBasePath, stripBasePath } from "vinext/internal/utils/base-path";
+} from "./build/report.js";
+import { planRouteClassificationInjection } from "./build/route-classification-injector.js";
+import { normalizePathnameForRouteMatchStrict } from "./routing/utils.js";
+import { hasBasePath, stripBasePath } from "./utils/base-path.js";
 import {
   createRscCompatibilityId,
   findNextConfigPath,
@@ -84,12 +81,12 @@ import {
   type NextConfig,
   type NextConfigInput,
   type ResolvedNextConfig,
-} from "vinext/internal/config/next-config";
-import { loadDotenv } from "vinext/internal/config/dotenv";
-import { mergeServerExternalPackages } from "vinext/internal/config/server-external-packages";
+} from "./config/next-config.js";
+import { loadDotenv } from "./config/dotenv.js";
+import { mergeServerExternalPackages } from "./config/server-external-packages.js";
 
-import { findMiddlewareFile, isProxyFile, runMiddleware } from "vinext/internal/server/middleware";
-import { validateMiddlewareMatcherPatterns } from "vinext/internal/server/middleware-matcher-pattern";
+import { findMiddlewareFile, isProxyFile, runMiddleware } from "./server/middleware.js";
+import { validateMiddlewareMatcherPatterns } from "./server/middleware-matcher-pattern.js";
 import {
   encodeUrlParserIgnoredCharacters,
   isNextDataPathname,
@@ -97,11 +94,8 @@ import {
   parseNextDataPathname,
   shouldAddTrailingSlashToPagesDataPath,
   urlParserCreatesPagesDataPath,
-} from "vinext/internal/server/pages-data-route";
-import {
-  resolvePagesI18nRequest,
-  stripI18nLocaleForApiRoute,
-} from "vinext/internal/server/pages-i18n";
+} from "./server/pages-data-route.js";
+import { resolvePagesI18nRequest, stripI18nLocaleForApiRoute } from "./server/pages-i18n.js";
 import {
   MIDDLEWARE_NEXT_HEADER,
   MIDDLEWARE_REWRITE_HEADER,
@@ -109,9 +103,9 @@ import {
   VINEXT_MW_CTX_HEADER,
   VINEXT_REVALIDATE_HOST_HEADER,
   VINEXT_TIMING_HEADER,
-} from "vinext/internal/server/headers";
-import { logRequest, now } from "vinext/internal/server/request-log";
-import { normalizePath } from "vinext/internal/server/normalize-path";
+} from "./server/headers.js";
+import { logRequest, now } from "./server/request-log.js";
+import { normalizePath } from "./server/normalize-path.js";
 import {
   canonicalizeRequestUrlPathname,
   filterInternalHeaders,
@@ -119,75 +113,70 @@ import {
   isOpenRedirectShaped,
   normalizeTrailingSlash,
   VINEXT_INTERNAL_HEADERS,
-} from "vinext/internal/server/request-pipeline";
+} from "./server/request-pipeline.js";
 import {
   findInstrumentationClientFile,
   findInstrumentationFile,
   runInstrumentation,
-} from "vinext/internal/server/instrumentation";
+} from "./server/instrumentation.js";
 import { PHASE_PRODUCTION_BUILD, PHASE_DEVELOPMENT_SERVER } from "vinext/shims/constants";
-import { precompressAssets } from "vinext/internal/build/precompress";
-import { ensureAssetsIgnore } from "vinext/internal/build/assets-ignore";
-import { emitNextClientRuntimeManifests } from "vinext/internal/build/next-client-runtime-manifests";
-import {
-  collectInlineCssManifest,
-  injectInlineCssManifestGlobal,
-} from "vinext/internal/build/inline-css";
-import { validateDevRequest } from "vinext/internal/server/dev-origin-check";
-import { readTrustedRevalidationHostname } from "vinext/internal/server/revalidation-host";
-import { installDevStackSourcemapMiddleware } from "vinext/internal/server/dev-stack-sourcemap";
+import { precompressAssets } from "./build/precompress.js";
+import { ensureAssetsIgnore } from "./build/assets-ignore.js";
+import { emitNextClientRuntimeManifests } from "./build/next-client-runtime-manifests.js";
+import { collectInlineCssManifest, injectInlineCssManifestGlobal } from "./build/inline-css.js";
+import { validateDevRequest } from "./server/dev-origin-check.js";
+import { readTrustedRevalidationHostname } from "./server/revalidation-host.js";
+import { installDevStackSourcemapMiddleware } from "./server/dev-stack-sourcemap.js";
 
-import {
-  invalidateMetadataFileCache,
-  scanMetadataFiles,
-} from "vinext/internal/server/metadata-routes";
+import { invalidateMetadataFileCache, scanMetadataFiles } from "./server/metadata-routes.js";
 
 import {
   runPagesRequest,
   type PagesPipelineDeps,
   type MiddlewareResult,
-} from "vinext/internal/server/pages-request-pipeline";
+} from "./server/pages-request-pipeline.js";
 import {
   pagesRouteHasPriorityOverAppRoute,
   validateHybridRouteConflicts,
-} from "vinext/internal/server/hybrid-route-priority";
-import { matchesRewriteSource, proxyExternalRequest } from "vinext/internal/config/config-matchers";
+} from "./server/hybrid-route-priority.js";
+import { matchesRewriteSource, proxyExternalRequest } from "./config/config-matchers.js";
 import {
   detectPackageManager,
   formatMissingCloudflarePluginError,
   hasWranglerConfig,
-} from "vinext/internal/utils/project";
-import { isUnknownRecord as isRecord } from "vinext/internal/utils/record";
-import { VIRTUAL_MODULE_ID_RE, VIRTUAL_PREFIX } from "vinext/internal/utils/virtual-module";
-import { ASSET_PREFIX_URL_DIR, resolveAssetsDir } from "vinext/internal/utils/asset-prefix";
-import { renderVinextBuiltUrl } from "vinext/internal/utils/built-asset-url";
-import { asyncHooksStubPlugin } from "vinext/internal/plugins/async-hooks-stub";
-import { clientReferenceDedupPlugin } from "vinext/internal/plugins/client-reference-dedup";
-import { dataUrlCssPlugin } from "vinext/internal/plugins/css-data-url";
-import { createCssModuleImportCompatibilityPlugin } from "vinext/internal/plugins/css-module-imports";
-import { createRscClientReferenceLoadersPlugin } from "vinext/internal/plugins/rsc-client-reference-loaders";
-import { createRscReferenceValidationNormalizerPlugin } from "vinext/internal/plugins/rsc-reference-validation-normalizer";
-import { createInstrumentationClientTransformPlugin } from "vinext/internal/plugins/instrumentation-client";
-import { createStyledJsxPlugin } from "vinext/internal/plugins/styled-jsx";
+} from "./utils/project.js";
+import { isUnknownRecord as isRecord } from "./utils/record.js";
+import { VIRTUAL_MODULE_ID_RE, VIRTUAL_PREFIX } from "./utils/virtual-module.js";
+import { ASSET_PREFIX_URL_DIR, resolveAssetsDir } from "./utils/asset-prefix.js";
+import {
+  assertNoPublicDirAssetConflict,
+  assertNoPublicNextRequestConflict,
+} from "./build/public-dir-conflict.js";
+import { renderVinextBuiltUrl } from "./utils/built-asset-url.js";
+import { asyncHooksStubPlugin } from "./plugins/async-hooks-stub.js";
+import { clientReferenceDedupPlugin } from "./plugins/client-reference-dedup.js";
+import { dataUrlCssPlugin } from "./plugins/css-data-url.js";
+import { createCssModuleImportCompatibilityPlugin } from "./plugins/css-module-imports.js";
+import { createRscClientReferenceLoadersPlugin } from "./plugins/rsc-client-reference-loaders.js";
+import { createRscReferenceValidationNormalizerPlugin } from "./plugins/rsc-reference-validation-normalizer.js";
+import { createInstrumentationClientTransformPlugin } from "./plugins/instrumentation-client.js";
+import { createStyledJsxPlugin } from "./plugins/styled-jsx.js";
 import {
   generateInstrumentationClientInjectModule,
   INSTRUMENTATION_CLIENT_EMPTY_MODULE,
-} from "vinext/internal/client/instrumentation-client-inject";
-import { createMiddlewareServerOnlyPlugin } from "vinext/internal/plugins/middleware-server-only";
-import { validateMiddlewareModuleExports } from "vinext/internal/plugins/middleware-export-validation";
-import { createOptimizeImportsPlugin } from "vinext/internal/plugins/optimize-imports";
-import { createDynamicPreloadMetadataPlugin } from "vinext/internal/plugins/dynamic-preload-metadata";
-import {
-  createOgInlineFetchAssetsPlugin,
-  createOgAssetsPlugin,
-} from "vinext/internal/plugins/og-assets";
-import { generateRouteTypes } from "vinext/internal/typegen";
+} from "./client/instrumentation-client-inject.js";
+import { createMiddlewareServerOnlyPlugin } from "./plugins/middleware-server-only.js";
+import { validateMiddlewareModuleExports } from "./plugins/middleware-export-validation.js";
+import { createOptimizeImportsPlugin } from "./plugins/optimize-imports.js";
+import { createDynamicPreloadMetadataPlugin } from "./plugins/dynamic-preload-metadata.js";
+import { createOgInlineFetchAssetsPlugin, createOgAssetsPlugin } from "./plugins/og-assets.js";
+import { generateRouteTypes } from "./typegen.js";
 import {
   mergeOptimizeDepsExclude,
   SSR_EXTERNAL_REACT_ENTRIES,
   VINEXT_OPTIMIZE_DEPS_EXCLUDE,
-} from "vinext/internal/plugins/rsc-client-shim-excludes";
-import { createServerExternalsManifestPlugin } from "vinext/internal/plugins/server-externals-manifest";
+} from "./plugins/rsc-client-shim-excludes.js";
+import { createServerExternalsManifestPlugin } from "./plugins/server-externals-manifest.js";
 // Keep this source-relative: resolving through vinext's package export can read
 // a stale built copy while developing or testing the source tree.
 // oxlint-disable-next-line vinext-local/prefer-import-alias
@@ -199,32 +188,32 @@ import {
   generateGoogleFontsVirtualModule,
   createGoogleFontsPlugin,
   createLocalFontsPlugin,
-} from "vinext/internal/plugins/fonts";
-import { computeClientRuntimeMetadata } from "vinext/internal/utils/client-runtime-metadata";
+} from "./plugins/fonts.js";
+import { computeClientRuntimeMetadata } from "./utils/client-runtime-metadata.js";
 import {
   VINEXT_CLIENT_ENTRY_MANIFEST,
   type ClientEntryManifest,
-} from "vinext/internal/utils/client-entry-manifest";
+} from "./utils/client-entry-manifest.js";
 import {
   PAGES_CLIENT_ASSETS_MODULE,
   buildPagesClientAssetsModule,
   setPagesClientAssetsBuildMetadata,
   takePagesClientAssetsBuildMetadata,
   writePagesClientAssetsModuleIfMissing,
-} from "vinext/internal/build/pages-client-assets-module";
+} from "./build/pages-client-assets-module.js";
 import {
   createPreviewBuildCredentials,
   getPreviewBuildCredentials,
   type PreviewBuildCredentials,
-} from "vinext/internal/build/preview-credentials";
-import { createModuleDependencyCache } from "vinext/internal/build/module-dependency-cache";
-import { resolvePostcssStringPlugins } from "vinext/internal/plugins/postcss";
+} from "./build/preview-credentials.js";
+import { createModuleDependencyCache } from "./build/module-dependency-cache.js";
+import { resolvePostcssStringPlugins } from "./plugins/postcss.js";
 import {
   buildSassPreprocessorOptions,
   createSassCssUrlAssetImporter,
   createSassTildeImporter,
   createSassAwareFileSystemLoader,
-} from "vinext/internal/plugins/sass";
+} from "./plugins/sass.js";
 import {
   createClientFileNameConfig,
   createClientManualChunks,
@@ -234,35 +223,32 @@ import {
   getClientTreeshakeConfig,
   getBuildBundlerOptions,
   withBuildBundlerOptions,
-} from "vinext/internal/build/client-build-config";
+} from "./build/client-build-config.js";
 import {
   markCssUrlAssetReferences,
   restoreDedupedCssAssetReferences,
-} from "vinext/internal/build/css-url-assets";
+} from "./build/css-url-assets.js";
 import {
   augmentSsrManifestFromBundle,
   tryRealpathSync,
   relativeWithinRoot,
   type BundleBackfillChunk,
-} from "vinext/internal/build/ssr-manifest";
+} from "./build/ssr-manifest.js";
 import {
   hasExportAllCandidate,
   stripServerExports,
   validatePageExports,
-} from "vinext/internal/plugins/strip-server-exports";
-import { removeConsoleCalls } from "vinext/internal/plugins/remove-console";
-import { createImportMetaUrlPlugin } from "vinext/internal/plugins/import-meta-url";
-import { createRequireContextPlugin } from "vinext/internal/plugins/require-context";
-import { createExtensionlessDynamicImportPlugin } from "vinext/internal/plugins/extensionless-dynamic-import";
-import { createWasmModuleImportPlugin } from "vinext/internal/plugins/wasm-module-import";
-import {
-  getTypeofWindowReplacement,
-  replaceTypeofWindow,
-} from "vinext/internal/plugins/typeof-window";
-import { hasMdxFiles } from "vinext/internal/utils/mdx-scan";
-import { scanPublicFileRoutes } from "vinext/internal/utils/public-routes";
-import { publicFilePathVariants } from "vinext/internal/utils/public-file-path";
-import { methodNotAllowedResponse } from "vinext/internal/server/http-error-responses";
+} from "./plugins/strip-server-exports.js";
+import { removeConsoleCalls } from "./plugins/remove-console.js";
+import { createImportMetaUrlPlugin } from "./plugins/import-meta-url.js";
+import { createRequireContextPlugin } from "./plugins/require-context.js";
+import { createExtensionlessDynamicImportPlugin } from "./plugins/extensionless-dynamic-import.js";
+import { createWasmModuleImportPlugin } from "./plugins/wasm-module-import.js";
+import { getTypeofWindowReplacement, replaceTypeofWindow } from "./plugins/typeof-window.js";
+import { hasMdxFiles } from "./utils/mdx-scan.js";
+import { scanPublicFileRoutes } from "./utils/public-routes.js";
+import { publicFilePathVariants } from "./utils/public-file-path.js";
+import { methodNotAllowedResponse } from "./server/http-error-responses.js";
 import type { Options as VitePluginReactOptions } from "@vitejs/plugin-react";
 import MagicString from "magic-string";
 import path, { toSlash } from "pathslash";
@@ -270,23 +256,22 @@ import { pathToFileURL } from "node:url";
 import { createRequire } from "node:module";
 import fs from "node:fs";
 import { createHash, randomBytes } from "node:crypto";
-import { getPagesPreviewModeId } from "vinext/internal/server/pages-preview";
+import { getPagesPreviewModeId } from "./server/pages-preview.js";
 import commonjs from "vite-plugin-commonjs";
-import { createIgnoreDynamicRequestsPlugin } from "vinext/internal/plugins/ignore-dynamic-requests";
-import { createTransformCache } from "vinext/internal/plugins/transform-cache";
-import { stripJsExtension, stripViteModuleQuery } from "vinext/internal/utils/path";
+import { createIgnoreDynamicRequestsPlugin } from "./plugins/ignore-dynamic-requests.js";
+import { createTransformCache } from "./plugins/transform-cache.js";
+import { stripJsExtension, stripViteModuleQuery } from "./utils/path.js";
 import {
   assertSupportedViteVersion,
   getDepOptimizeNodeEnvOptions,
   serializeViteDefine,
-} from "vinext/internal/utils/vite-version";
+} from "./utils/vite-version.js";
 import {
   normalizeVinextPrerenderConfig,
   VINEXT_PRERENDER_CONFIG_PLUGIN_PROPERTY,
   VINEXT_ROUTE_ROOT_CONFIG_PLUGIN_PROPERTY,
   type VinextPrerenderConfig,
-} from "vinext/internal/config/prerender";
-import { assertNoPublicDirAssetConflict } from "vinext/internal/build/public-dir-conflict";
+} from "./config/prerender.js";
 
 const PAGES_CLOUDFLARE_WORKER_OPTIMIZE_DEPS_EXCLUDE = Object.freeze([
   "vinext/server/fetch-handler",
@@ -1485,6 +1470,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
   // Production builds leave it null and scan the configured public directory
   // once while generating the RSC entry.
   let devPublicFileRoutes: Set<string> | null = null;
+  let publicDirConflictOptions: Parameters<typeof assertNoPublicDirAssetConflict>[0] | null = null;
   let rscCompatibilityId: string | undefined;
   let draftModeSecret = getPagesPreviewModeId();
   let previewBuildCredentials: PreviewBuildCredentials | undefined;
@@ -3470,18 +3456,6 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
       },
 
       async configResolved(config) {
-        const publicDir = config.publicDir === "" ? null : config.publicDir;
-        const assetsDir =
-          config.environments.client.build.assetsDir ??
-          config.build.assetsDir ??
-          resolveAssetsDir(nextConfig.assetPrefix ?? "");
-
-        assertNoPublicDirAssetConflict({
-          root: config.root,
-          publicDir,
-          assetsDir,
-        });
-
         if (isServeCommand && hasCloudflarePlugin && hasPagesDir && !hasAppDir) {
           suppressOptionalOptimizeDepsWarnings(config.logger);
         }
@@ -3512,6 +3486,18 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 sourcePath: path.relative(root, route.pagePath ?? route.routePath!),
               })),
           );
+        }
+
+        if (config.command === "build") {
+          publicDirConflictOptions = {
+            root: config.root,
+            publicDir: config.publicDir === "" ? null : config.publicDir,
+            assetsDir:
+              config.environments?.client?.build?.assetsDir ??
+              config.build?.assetsDir ??
+              resolveAssetsDir(nextConfig.assetPrefix ?? ""),
+          };
+          assertNoPublicDirAssetConflict(publicDirConflictOptions);
         }
 
         // When the user sets `ssr.external: true`, strip React entries from
@@ -3614,6 +3600,17 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             }),
           );
         }
+      },
+
+      // Vite copies publicDir during its prepare-out-dir renderStart hook.
+      // Re-check immediately beforehand so files generated during buildStart
+      // cannot appear after configResolved and bypass the namespace guard.
+      renderStart: {
+        order: "pre",
+        handler() {
+          if (this.environment?.name !== "client" || !publicDirConflictOptions) return;
+          assertNoPublicDirAssetConflict(publicDirConflictOptions);
+        },
       },
 
       resolveId: {
@@ -4314,6 +4311,24 @@ export const loadServerActionClient = ${
         server.middlewares.use((req, _res, next) => {
           req.__vinextOriginalEncodedUrl ??= req.url;
           next();
+        });
+
+        // Match Next.js dev behavior: allow the server to start, then reject
+        // /_next requests while public/_next exists. This runs before Vite's
+        // public-file middleware and re-checks the filesystem on every request,
+        // so creating the directory after startup cannot bypass the guard.
+        server.middlewares.use((req, _res, next) => {
+          try {
+            assertNoPublicNextRequestConflict({
+              root: server.config.root,
+              publicDir: server.config.publicDir === "" ? null : server.config.publicDir,
+              basePath: nextConfig.basePath ?? "",
+              requestUrl: req.url ?? "/",
+            });
+            next();
+          } catch (error) {
+            next(error);
+          }
         });
 
         // Watch route files for additions/removals to invalidate route cache.
@@ -6572,7 +6587,7 @@ export const loadServerActionClient = ${
           if (nitro.options.dev) return;
 
           const { collectNitroRouteRules, mergeNitroRouteRules } =
-            await import("vinext/internal/build/nitro-route-rules");
+            await import("./build/nitro-route-rules.js");
           const generatedRouteRules = await collectNitroRouteRules({
             appDir: hasAppDir ? appDir : null,
             pagesDir: hasPagesDir ? pagesDir : null,
@@ -7107,13 +7122,13 @@ async function writeWebResponseToNodeRes(
 }
 
 // Public exports for static export
-export { staticExportPages, staticExportApp } from "vinext/internal/build/static-export";
+export { staticExportPages, staticExportApp } from "./build/static-export.js";
 export type {
   StaticExportResult,
   StaticExportOptions,
   AppStaticExportOptions,
-} from "vinext/internal/build/static-export";
+} from "./build/static-export.js";
 
 // Export NextConfig type so next.config.ts files can import it from "vinext"
 // instead of "next".
-export type { NextConfig } from "vinext/internal/config/next-config";
+export type { NextConfig } from "./config/next-config.js";

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -17,60 +17,63 @@ import {
   apiRouter,
   invalidateRouteCache,
   matchRoute,
-} from "./routing/pages-router.js";
-import { generateServerEntry as _generateServerEntry } from "./entries/pages-server-entry.js";
-import { generateClientEntry as _generateClientEntry } from "./entries/pages-client-entry.js";
+} from "vinext/internal/routing/pages-router";
+import { generateServerEntry as _generateServerEntry } from "vinext/internal/entries/pages-server-entry";
+import { generateClientEntry as _generateClientEntry } from "vinext/internal/entries/pages-client-entry";
 import {
   appRouteGraph,
   appRouter,
   invalidateAppRouteCache,
   matchAppRoute,
-} from "./routing/app-router.js";
-import type { NitroRouteRuleConfig } from "./build/nitro-route-rules.js";
+} from "vinext/internal/routing/app-router";
+import type { NitroRouteRuleConfig } from "vinext/internal/build/nitro-route-rules";
 import {
   buildViteResolveExtensions,
   normalizeViteResolveExtensions,
   createValidFileMatcher,
   findFileWithExts,
-} from "./routing/file-matcher.js";
-import { createSSRHandler } from "./server/dev-server.js";
-import { handleApiRoute } from "./server/api-handler.js";
+} from "vinext/internal/routing/file-matcher";
+import { createSSRHandler } from "vinext/internal/server/dev-server";
+import { handleApiRoute } from "vinext/internal/server/api-handler";
 import {
   DEFAULT_DEVICE_SIZES,
   DEFAULT_IMAGE_SIZES,
   isImageOptimizationPath,
   resolveDevImageRedirect,
-} from "./server/image-optimization.js";
+} from "vinext/internal/server/image-optimization";
 
-import { installSocketErrorBackstop } from "./server/socket-error-backstop.js";
-import { shouldInvalidateAppRouteFile } from "./server/dev-route-files.js";
-import { createDirectRunner } from "./server/dev-module-runner.js";
-import { generateRscEntry } from "./entries/app-rsc-entry.js";
-import { generateSsrEntry } from "./entries/app-ssr-entry.js";
+import { installSocketErrorBackstop } from "vinext/internal/server/socket-error-backstop";
+import { shouldInvalidateAppRouteFile } from "vinext/internal/server/dev-route-files";
+import { createDirectRunner } from "vinext/internal/server/dev-module-runner";
+import { generateRscEntry } from "vinext/internal/entries/app-rsc-entry";
+import { generateSsrEntry } from "vinext/internal/entries/app-ssr-entry";
 import {
   VIRTUAL_CACHE_ADAPTERS,
   generateCacheAdaptersModule,
   VINEXT_CACHE_CONFIG_PLUGIN_PROPERTY,
   type VinextCacheConfig,
-} from "./cache/cache-adapters-virtual.js";
+} from "vinext/internal/cache/cache-adapters-virtual";
 import {
   VIRTUAL_IMAGE_ADAPTERS,
   generateImageAdaptersModule,
   type VinextImageConfig,
-} from "./image/image-adapters-virtual.js";
-import { generateBrowserEntry, toLinkPrefetchRoutes } from "./entries/app-browser-entry.js";
+} from "vinext/internal/image/image-adapters-virtual";
+import {
+  generateBrowserEntry,
+  toLinkPrefetchRoutes,
+} from "vinext/internal/entries/app-browser-entry";
 import {
   collectRouteClassificationManifest,
   type RouteClassificationManifest,
-} from "./build/route-classification-manifest.js";
+} from "vinext/internal/build/route-classification-manifest";
 import {
   extractMiddlewareMatcherConfig,
   extractMiddlewareMatcherConfigValue,
   hasExportedName,
-} from "./build/report.js";
-import { planRouteClassificationInjection } from "./build/route-classification-injector.js";
-import { normalizePathnameForRouteMatchStrict } from "./routing/utils.js";
-import { hasBasePath, stripBasePath } from "./utils/base-path.js";
+} from "vinext/internal/build/report";
+import { planRouteClassificationInjection } from "vinext/internal/build/route-classification-injector";
+import { normalizePathnameForRouteMatchStrict } from "vinext/internal/routing/utils";
+import { hasBasePath, stripBasePath } from "vinext/internal/utils/base-path";
 import {
   createRscCompatibilityId,
   findNextConfigPath,
@@ -81,12 +84,12 @@ import {
   type NextConfig,
   type NextConfigInput,
   type ResolvedNextConfig,
-} from "./config/next-config.js";
-import { loadDotenv } from "./config/dotenv.js";
-import { mergeServerExternalPackages } from "./config/server-external-packages.js";
+} from "vinext/internal/config/next-config";
+import { loadDotenv } from "vinext/internal/config/dotenv";
+import { mergeServerExternalPackages } from "vinext/internal/config/server-external-packages";
 
-import { findMiddlewareFile, isProxyFile, runMiddleware } from "./server/middleware.js";
-import { validateMiddlewareMatcherPatterns } from "./server/middleware-matcher-pattern.js";
+import { findMiddlewareFile, isProxyFile, runMiddleware } from "vinext/internal/server/middleware";
+import { validateMiddlewareMatcherPatterns } from "vinext/internal/server/middleware-matcher-pattern";
 import {
   encodeUrlParserIgnoredCharacters,
   isNextDataPathname,
@@ -94,8 +97,11 @@ import {
   parseNextDataPathname,
   shouldAddTrailingSlashToPagesDataPath,
   urlParserCreatesPagesDataPath,
-} from "./server/pages-data-route.js";
-import { resolvePagesI18nRequest, stripI18nLocaleForApiRoute } from "./server/pages-i18n.js";
+} from "vinext/internal/server/pages-data-route";
+import {
+  resolvePagesI18nRequest,
+  stripI18nLocaleForApiRoute,
+} from "vinext/internal/server/pages-i18n";
 import {
   MIDDLEWARE_NEXT_HEADER,
   MIDDLEWARE_REWRITE_HEADER,
@@ -103,9 +109,9 @@ import {
   VINEXT_MW_CTX_HEADER,
   VINEXT_REVALIDATE_HOST_HEADER,
   VINEXT_TIMING_HEADER,
-} from "./server/headers.js";
-import { logRequest, now } from "./server/request-log.js";
-import { normalizePath } from "./server/normalize-path.js";
+} from "vinext/internal/server/headers";
+import { logRequest, now } from "vinext/internal/server/request-log";
+import { normalizePath } from "vinext/internal/server/normalize-path";
 import {
   canonicalizeRequestUrlPathname,
   filterInternalHeaders,
@@ -113,66 +119,75 @@ import {
   isOpenRedirectShaped,
   normalizeTrailingSlash,
   VINEXT_INTERNAL_HEADERS,
-} from "./server/request-pipeline.js";
+} from "vinext/internal/server/request-pipeline";
 import {
   findInstrumentationClientFile,
   findInstrumentationFile,
   runInstrumentation,
-} from "./server/instrumentation.js";
+} from "vinext/internal/server/instrumentation";
 import { PHASE_PRODUCTION_BUILD, PHASE_DEVELOPMENT_SERVER } from "vinext/shims/constants";
-import { precompressAssets } from "./build/precompress.js";
-import { ensureAssetsIgnore } from "./build/assets-ignore.js";
-import { emitNextClientRuntimeManifests } from "./build/next-client-runtime-manifests.js";
-import { collectInlineCssManifest, injectInlineCssManifestGlobal } from "./build/inline-css.js";
-import { validateDevRequest } from "./server/dev-origin-check.js";
-import { readTrustedRevalidationHostname } from "./server/revalidation-host.js";
-import { installDevStackSourcemapMiddleware } from "./server/dev-stack-sourcemap.js";
+import { precompressAssets } from "vinext/internal/build/precompress";
+import { ensureAssetsIgnore } from "vinext/internal/build/assets-ignore";
+import { emitNextClientRuntimeManifests } from "vinext/internal/build/next-client-runtime-manifests";
+import {
+  collectInlineCssManifest,
+  injectInlineCssManifestGlobal,
+} from "vinext/internal/build/inline-css";
+import { validateDevRequest } from "vinext/internal/server/dev-origin-check";
+import { readTrustedRevalidationHostname } from "vinext/internal/server/revalidation-host";
+import { installDevStackSourcemapMiddleware } from "vinext/internal/server/dev-stack-sourcemap";
 
-import { invalidateMetadataFileCache, scanMetadataFiles } from "./server/metadata-routes.js";
+import {
+  invalidateMetadataFileCache,
+  scanMetadataFiles,
+} from "vinext/internal/server/metadata-routes";
 
 import {
   runPagesRequest,
   type PagesPipelineDeps,
   type MiddlewareResult,
-} from "./server/pages-request-pipeline.js";
+} from "vinext/internal/server/pages-request-pipeline";
 import {
   pagesRouteHasPriorityOverAppRoute,
   validateHybridRouteConflicts,
-} from "./server/hybrid-route-priority.js";
-import { matchesRewriteSource, proxyExternalRequest } from "./config/config-matchers.js";
+} from "vinext/internal/server/hybrid-route-priority";
+import { matchesRewriteSource, proxyExternalRequest } from "vinext/internal/config/config-matchers";
 import {
   detectPackageManager,
   formatMissingCloudflarePluginError,
   hasWranglerConfig,
-} from "./utils/project.js";
-import { isUnknownRecord as isRecord } from "./utils/record.js";
-import { VIRTUAL_MODULE_ID_RE, VIRTUAL_PREFIX } from "./utils/virtual-module.js";
-import { ASSET_PREFIX_URL_DIR, resolveAssetsDir } from "./utils/asset-prefix.js";
-import { renderVinextBuiltUrl } from "./utils/built-asset-url.js";
-import { asyncHooksStubPlugin } from "./plugins/async-hooks-stub.js";
-import { clientReferenceDedupPlugin } from "./plugins/client-reference-dedup.js";
-import { dataUrlCssPlugin } from "./plugins/css-data-url.js";
-import { createCssModuleImportCompatibilityPlugin } from "./plugins/css-module-imports.js";
-import { createRscClientReferenceLoadersPlugin } from "./plugins/rsc-client-reference-loaders.js";
-import { createRscReferenceValidationNormalizerPlugin } from "./plugins/rsc-reference-validation-normalizer.js";
-import { createInstrumentationClientTransformPlugin } from "./plugins/instrumentation-client.js";
-import { createStyledJsxPlugin } from "./plugins/styled-jsx.js";
+} from "vinext/internal/utils/project";
+import { isUnknownRecord as isRecord } from "vinext/internal/utils/record";
+import { VIRTUAL_MODULE_ID_RE, VIRTUAL_PREFIX } from "vinext/internal/utils/virtual-module";
+import { ASSET_PREFIX_URL_DIR, resolveAssetsDir } from "vinext/internal/utils/asset-prefix";
+import { renderVinextBuiltUrl } from "vinext/internal/utils/built-asset-url";
+import { asyncHooksStubPlugin } from "vinext/internal/plugins/async-hooks-stub";
+import { clientReferenceDedupPlugin } from "vinext/internal/plugins/client-reference-dedup";
+import { dataUrlCssPlugin } from "vinext/internal/plugins/css-data-url";
+import { createCssModuleImportCompatibilityPlugin } from "vinext/internal/plugins/css-module-imports";
+import { createRscClientReferenceLoadersPlugin } from "vinext/internal/plugins/rsc-client-reference-loaders";
+import { createRscReferenceValidationNormalizerPlugin } from "vinext/internal/plugins/rsc-reference-validation-normalizer";
+import { createInstrumentationClientTransformPlugin } from "vinext/internal/plugins/instrumentation-client";
+import { createStyledJsxPlugin } from "vinext/internal/plugins/styled-jsx";
 import {
   generateInstrumentationClientInjectModule,
   INSTRUMENTATION_CLIENT_EMPTY_MODULE,
-} from "./client/instrumentation-client-inject.js";
-import { createMiddlewareServerOnlyPlugin } from "./plugins/middleware-server-only.js";
-import { validateMiddlewareModuleExports } from "./plugins/middleware-export-validation.js";
-import { createOptimizeImportsPlugin } from "./plugins/optimize-imports.js";
-import { createDynamicPreloadMetadataPlugin } from "./plugins/dynamic-preload-metadata.js";
-import { createOgInlineFetchAssetsPlugin, createOgAssetsPlugin } from "./plugins/og-assets.js";
-import { generateRouteTypes } from "./typegen.js";
+} from "vinext/internal/client/instrumentation-client-inject";
+import { createMiddlewareServerOnlyPlugin } from "vinext/internal/plugins/middleware-server-only";
+import { validateMiddlewareModuleExports } from "vinext/internal/plugins/middleware-export-validation";
+import { createOptimizeImportsPlugin } from "vinext/internal/plugins/optimize-imports";
+import { createDynamicPreloadMetadataPlugin } from "vinext/internal/plugins/dynamic-preload-metadata";
+import {
+  createOgInlineFetchAssetsPlugin,
+  createOgAssetsPlugin,
+} from "vinext/internal/plugins/og-assets";
+import { generateRouteTypes } from "vinext/internal/typegen";
 import {
   mergeOptimizeDepsExclude,
   SSR_EXTERNAL_REACT_ENTRIES,
   VINEXT_OPTIMIZE_DEPS_EXCLUDE,
-} from "./plugins/rsc-client-shim-excludes.js";
-import { createServerExternalsManifestPlugin } from "./plugins/server-externals-manifest.js";
+} from "vinext/internal/plugins/rsc-client-shim-excludes";
+import { createServerExternalsManifestPlugin } from "vinext/internal/plugins/server-externals-manifest";
 // Keep this source-relative: resolving through vinext's package export can read
 // a stale built copy while developing or testing the source tree.
 // oxlint-disable-next-line vinext-local/prefer-import-alias
@@ -184,32 +199,32 @@ import {
   generateGoogleFontsVirtualModule,
   createGoogleFontsPlugin,
   createLocalFontsPlugin,
-} from "./plugins/fonts.js";
-import { computeClientRuntimeMetadata } from "./utils/client-runtime-metadata.js";
+} from "vinext/internal/plugins/fonts";
+import { computeClientRuntimeMetadata } from "vinext/internal/utils/client-runtime-metadata";
 import {
   VINEXT_CLIENT_ENTRY_MANIFEST,
   type ClientEntryManifest,
-} from "./utils/client-entry-manifest.js";
+} from "vinext/internal/utils/client-entry-manifest";
 import {
   PAGES_CLIENT_ASSETS_MODULE,
   buildPagesClientAssetsModule,
   setPagesClientAssetsBuildMetadata,
   takePagesClientAssetsBuildMetadata,
   writePagesClientAssetsModuleIfMissing,
-} from "./build/pages-client-assets-module.js";
+} from "vinext/internal/build/pages-client-assets-module";
 import {
   createPreviewBuildCredentials,
   getPreviewBuildCredentials,
   type PreviewBuildCredentials,
-} from "./build/preview-credentials.js";
-import { createModuleDependencyCache } from "./build/module-dependency-cache.js";
-import { resolvePostcssStringPlugins } from "./plugins/postcss.js";
+} from "vinext/internal/build/preview-credentials";
+import { createModuleDependencyCache } from "vinext/internal/build/module-dependency-cache";
+import { resolvePostcssStringPlugins } from "vinext/internal/plugins/postcss";
 import {
   buildSassPreprocessorOptions,
   createSassCssUrlAssetImporter,
   createSassTildeImporter,
   createSassAwareFileSystemLoader,
-} from "./plugins/sass.js";
+} from "vinext/internal/plugins/sass";
 import {
   createClientFileNameConfig,
   createClientManualChunks,
@@ -219,32 +234,35 @@ import {
   getClientTreeshakeConfig,
   getBuildBundlerOptions,
   withBuildBundlerOptions,
-} from "./build/client-build-config.js";
+} from "vinext/internal/build/client-build-config";
 import {
   markCssUrlAssetReferences,
   restoreDedupedCssAssetReferences,
-} from "./build/css-url-assets.js";
+} from "vinext/internal/build/css-url-assets";
 import {
   augmentSsrManifestFromBundle,
   tryRealpathSync,
   relativeWithinRoot,
   type BundleBackfillChunk,
-} from "./build/ssr-manifest.js";
+} from "vinext/internal/build/ssr-manifest";
 import {
   hasExportAllCandidate,
   stripServerExports,
   validatePageExports,
-} from "./plugins/strip-server-exports.js";
-import { removeConsoleCalls } from "./plugins/remove-console.js";
-import { createImportMetaUrlPlugin } from "./plugins/import-meta-url.js";
-import { createRequireContextPlugin } from "./plugins/require-context.js";
-import { createExtensionlessDynamicImportPlugin } from "./plugins/extensionless-dynamic-import.js";
-import { createWasmModuleImportPlugin } from "./plugins/wasm-module-import.js";
-import { getTypeofWindowReplacement, replaceTypeofWindow } from "./plugins/typeof-window.js";
-import { hasMdxFiles } from "./utils/mdx-scan.js";
-import { scanPublicFileRoutes } from "./utils/public-routes.js";
-import { publicFilePathVariants } from "./utils/public-file-path.js";
-import { methodNotAllowedResponse } from "./server/http-error-responses.js";
+} from "vinext/internal/plugins/strip-server-exports";
+import { removeConsoleCalls } from "vinext/internal/plugins/remove-console";
+import { createImportMetaUrlPlugin } from "vinext/internal/plugins/import-meta-url";
+import { createRequireContextPlugin } from "vinext/internal/plugins/require-context";
+import { createExtensionlessDynamicImportPlugin } from "vinext/internal/plugins/extensionless-dynamic-import";
+import { createWasmModuleImportPlugin } from "vinext/internal/plugins/wasm-module-import";
+import {
+  getTypeofWindowReplacement,
+  replaceTypeofWindow,
+} from "vinext/internal/plugins/typeof-window";
+import { hasMdxFiles } from "vinext/internal/utils/mdx-scan";
+import { scanPublicFileRoutes } from "vinext/internal/utils/public-routes";
+import { publicFilePathVariants } from "vinext/internal/utils/public-file-path";
+import { methodNotAllowedResponse } from "vinext/internal/server/http-error-responses";
 import type { Options as VitePluginReactOptions } from "@vitejs/plugin-react";
 import MagicString from "magic-string";
 import path, { toSlash } from "pathslash";
@@ -252,22 +270,23 @@ import { pathToFileURL } from "node:url";
 import { createRequire } from "node:module";
 import fs from "node:fs";
 import { createHash, randomBytes } from "node:crypto";
-import { getPagesPreviewModeId } from "./server/pages-preview.js";
+import { getPagesPreviewModeId } from "vinext/internal/server/pages-preview";
 import commonjs from "vite-plugin-commonjs";
-import { createIgnoreDynamicRequestsPlugin } from "./plugins/ignore-dynamic-requests.js";
-import { createTransformCache } from "./plugins/transform-cache.js";
-import { stripJsExtension, stripViteModuleQuery } from "./utils/path.js";
+import { createIgnoreDynamicRequestsPlugin } from "vinext/internal/plugins/ignore-dynamic-requests";
+import { createTransformCache } from "vinext/internal/plugins/transform-cache";
+import { stripJsExtension, stripViteModuleQuery } from "vinext/internal/utils/path";
 import {
   assertSupportedViteVersion,
   getDepOptimizeNodeEnvOptions,
   serializeViteDefine,
-} from "./utils/vite-version.js";
+} from "vinext/internal/utils/vite-version";
 import {
   normalizeVinextPrerenderConfig,
   VINEXT_PRERENDER_CONFIG_PLUGIN_PROPERTY,
   VINEXT_ROUTE_ROOT_CONFIG_PLUGIN_PROPERTY,
   type VinextPrerenderConfig,
-} from "./config/prerender.js";
+} from "vinext/internal/config/prerender";
+import { assertNoPublicDirAssetConflict } from "vinext/internal/build/public-dir-conflict";
 
 const PAGES_CLOUDFLARE_WORKER_OPTIMIZE_DEPS_EXCLUDE = Object.freeze([
   "vinext/server/fetch-handler",
@@ -3451,6 +3470,18 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
       },
 
       async configResolved(config) {
+        const publicDir = config.publicDir === "" ? null : config.publicDir;
+        const assetsDir =
+          config.environments.client.build.assetsDir ??
+          config.build.assetsDir ??
+          resolveAssetsDir(nextConfig.assetPrefix ?? "");
+
+        assertNoPublicDirAssetConflict({
+          root: config.root,
+          publicDir,
+          assetsDir,
+        });
+
         if (isServeCommand && hasCloudflarePlugin && hasPagesDir && !hasAppDir) {
           suppressOptionalOptimizeDepsWarnings(config.logger);
         }
@@ -6541,7 +6572,7 @@ export const loadServerActionClient = ${
           if (nitro.options.dev) return;
 
           const { collectNitroRouteRules, mergeNitroRouteRules } =
-            await import("./build/nitro-route-rules.js");
+            await import("vinext/internal/build/nitro-route-rules");
           const generatedRouteRules = await collectNitroRouteRules({
             appDir: hasAppDir ? appDir : null,
             pagesDir: hasPagesDir ? pagesDir : null,
@@ -7076,13 +7107,13 @@ async function writeWebResponseToNodeRes(
 }
 
 // Public exports for static export
-export { staticExportPages, staticExportApp } from "./build/static-export.js";
+export { staticExportPages, staticExportApp } from "vinext/internal/build/static-export";
 export type {
   StaticExportResult,
   StaticExportOptions,
   AppStaticExportOptions,
-} from "./build/static-export.js";
+} from "vinext/internal/build/static-export";
 
 // Export NextConfig type so next.config.ts files can import it from "vinext"
 // instead of "next".
-export type { NextConfig } from "./config/next-config.js";
+export type { NextConfig } from "vinext/internal/config/next-config";

--- a/tests/public-dir-conflict.test.ts
+++ b/tests/public-dir-conflict.test.ts
@@ -1,14 +1,22 @@
 import fs from "node:fs";
+import { createServer as createHttpServer } from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vite-plus/test";
-import { assertNoPublicDirAssetConflict } from "../packages/vinext/src/build/public-dir-conflict.js";
+import { createServer as createViteServer, resolveConfig } from "vite";
+import vinext from "../packages/vinext/src/index.js";
+import {
+  assertNoPublicDirAssetConflict,
+  assertNoPublicNextRequestConflict,
+} from "../packages/vinext/src/build/public-dir-conflict.js";
 
 // Regression for cloudflare/vinext#2778: Vite copies public files into the
 // client output, so public/_next would otherwise collide with vinext's internal
 // build-asset namespace and be served as a hashed asset ahead of middleware.
 // Next.js rejects the same public/_next namespace during build:
 // https://github.com/vercel/next.js/blob/canary/packages/next/src/build/index.ts
+// In dev it checks on each /_next request after stripping basePath:
+// https://github.com/vercel/next.js/blob/canary/packages/next/src/server/dev/next-dev-server.ts
 describe("assertNoPublicDirAssetConflict", () => {
   const tmpDirs: string[] = [];
 
@@ -136,5 +144,148 @@ describe("assertNoPublicDirAssetConflict", () => {
         assetsDir: "../outside-assets",
       }),
     ).not.toThrow();
+  });
+
+  it("checks public/_next only for dev requests in the internal namespace", () => {
+    const root = makeProject();
+    fs.mkdirSync(path.join(root, "public", "_next"), { recursive: true });
+
+    expect(() =>
+      assertNoPublicNextRequestConflict({
+        root,
+        publicDir: "public",
+        basePath: "",
+        requestUrl: "/ordinary-page",
+      }),
+    ).not.toThrow();
+    expect(() =>
+      assertNoPublicNextRequestConflict({
+        root,
+        publicDir: "public",
+        basePath: "",
+        requestUrl: "/_next/static/chunk.js?cache=1",
+      }),
+    ).toThrow("You can not have a '_next' folder inside of your public folder.");
+    expect(() =>
+      assertNoPublicNextRequestConflict({
+        root,
+        publicDir: "public",
+        basePath: "",
+        requestUrl: "//host/_next/static/chunk.js",
+      }),
+    ).not.toThrow();
+  });
+
+  it("strips basePath before checking dev /_next requests", () => {
+    const root = makeProject();
+    fs.mkdirSync(path.join(root, "public", "_next"), { recursive: true });
+
+    expect(() =>
+      assertNoPublicNextRequestConflict({
+        root,
+        publicDir: "public",
+        basePath: "/docs",
+        requestUrl: "/docs/_next/webpack-hmr",
+      }),
+    ).toThrow("This conflicts with the internal '/_next' route.");
+    expect(() =>
+      assertNoPublicNextRequestConflict({
+        root,
+        publicDir: "public",
+        basePath: "/docs",
+        requestUrl: "/_next/webpack-hmr",
+      }),
+    ).toThrow("This conflicts with the internal '/_next' route.");
+  });
+
+  it("rejects build configuration without preventing the dev server from starting", async () => {
+    const root = makeProject();
+    fs.mkdirSync(path.join(root, "public", "_next"), { recursive: true });
+    const config = {
+      root,
+      configFile: false as const,
+      logLevel: "silent" as const,
+    };
+
+    await expect(
+      resolveConfig(
+        {
+          ...config,
+          plugins: [vinext({ disableAppRouter: true })],
+        },
+        "build",
+      ),
+    ).rejects.toThrow("https://nextjs.org/docs/messages/public-next-folder-conflict");
+
+    await expect(
+      resolveConfig(
+        {
+          ...config,
+          plugins: [vinext({ disableAppRouter: true })],
+        },
+        "serve",
+      ),
+    ).resolves.toMatchObject({ command: "serve" });
+  });
+
+  it("rechecks before public files are copied when a build plugin creates a conflict", async () => {
+    const root = makeProject();
+    const resolved = await resolveConfig(
+      {
+        root,
+        configFile: false,
+        logLevel: "silent",
+        plugins: [vinext({ disableAppRouter: true })],
+      },
+      "build",
+    );
+    fs.mkdirSync(path.join(root, "public", "_next"), { recursive: true });
+
+    const configPlugin = resolved.plugins.find((plugin) => plugin.name === "vinext:config");
+    const renderStart = configPlugin?.renderStart;
+    const handler = typeof renderStart === "object" ? renderStart.handler : renderStart;
+    expect(handler).toBeTypeOf("function");
+    expect(() =>
+      handler!.call({ environment: { name: "client" } } as any, {} as any, {} as any),
+    ).toThrow("https://nextjs.org/docs/messages/public-next-folder-conflict");
+  });
+
+  it("runs the dev conflict guard before Vite serves public files", async () => {
+    const root = makeProject();
+    writeFile(root, "public/ordinary.txt");
+    writeFile(root, "public/_next/static/private.txt");
+
+    const viteServer = await createViteServer({
+      root,
+      configFile: false,
+      appType: "custom",
+      logLevel: "silent",
+      plugins: [vinext({ disableAppRouter: true })],
+      server: { middlewareMode: true },
+    });
+    const httpServer = createHttpServer(viteServer.middlewares);
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        httpServer.once("error", reject);
+        httpServer.listen(0, "127.0.0.1", resolve);
+      });
+      const address = httpServer.address();
+      if (!address || typeof address === "string") throw new Error("Expected a TCP address");
+      const origin = `http://127.0.0.1:${address.port}`;
+
+      const ordinaryResponse = await fetch(`${origin}/ordinary.txt`);
+      expect(ordinaryResponse.status).toBe(200);
+      expect(await ordinaryResponse.text()).toBe("test");
+
+      const conflictResponse = await fetch(`${origin}/_next/static/private.txt`);
+      expect(conflictResponse.status).not.toBe(200);
+      expect(await conflictResponse.text()).not.toContain("test");
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        httpServer.close((error) => (error ? reject(error) : resolve()));
+      });
+      await viteServer.close();
+    }
   });
 });

--- a/tests/public-dir-conflict.test.ts
+++ b/tests/public-dir-conflict.test.ts
@@ -1,0 +1,140 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { assertNoPublicDirAssetConflict } from "../packages/vinext/src/build/public-dir-conflict.js";
+
+// Regression for cloudflare/vinext#2778: Vite copies public files into the
+// client output, so public/_next would otherwise collide with vinext's internal
+// build-asset namespace and be served as a hashed asset ahead of middleware.
+// Next.js rejects the same public/_next namespace during build:
+// https://github.com/vercel/next.js/blob/canary/packages/next/src/build/index.ts
+describe("assertNoPublicDirAssetConflict", () => {
+  const tmpDirs: string[] = [];
+
+  function makeProject(): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-public-dir-conflict-"));
+    tmpDirs.push(dir);
+    return dir;
+  }
+
+  function writeFile(root: string, relativePath: string): void {
+    const filePath = path.join(root, relativePath);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, "test", "utf-8");
+  }
+
+  function assertDefaultProject(root: string): void {
+    assertNoPublicDirAssetConflict({
+      root,
+      publicDir: "public",
+      assetsDir: "_next/static",
+    });
+  }
+
+  afterEach(() => {
+    for (const dir of tmpDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("allows a missing public directory", () => {
+    const root = makeProject();
+
+    expect(() => assertDefaultProject(root)).not.toThrow();
+  });
+
+  it("allows ordinary files in the public directory", () => {
+    const root = makeProject();
+    writeFile(root, "public/private.txt");
+
+    expect(() => assertDefaultProject(root)).not.toThrow();
+  });
+
+  it("rejects an empty public/_next directory", () => {
+    const root = makeProject();
+    fs.mkdirSync(path.join(root, "public", "_next"), { recursive: true });
+
+    expect(() => assertDefaultProject(root)).toThrow(
+      "You can not have a '_next' folder inside of your public folder.",
+    );
+  });
+
+  it("rejects files under public/_next/static", () => {
+    const root = makeProject();
+    writeFile(root, "public/_next/static/private.txt");
+
+    expect(() => assertDefaultProject(root)).toThrow(
+      "https://nextjs.org/docs/messages/public-next-folder-conflict",
+    );
+  });
+
+  it("resolves a custom public directory relative to the project root", () => {
+    const root = makeProject();
+    writeFile(root, "custom-public/_next/file.txt");
+
+    expect(() =>
+      assertNoPublicDirAssetConflict({
+        root,
+        publicDir: "custom-public",
+        assetsDir: "_next/static",
+      }),
+    ).toThrow("This conflicts with the internal '/_next' route.");
+  });
+
+  it("supports an absolute public directory", () => {
+    const root = makeProject();
+    const publicDir = path.join(root, "custom-public");
+    writeFile(publicDir, "_next/file.txt");
+
+    expect(() =>
+      assertNoPublicDirAssetConflict({
+        root,
+        publicDir,
+        assetsDir: "_next/static",
+      }),
+    ).toThrow("You can not have a '_next' folder inside of your public folder.");
+  });
+
+  it("skips validation when the public directory is disabled", () => {
+    const root = makeProject();
+    writeFile(root, "public/_next/static/private.txt");
+
+    expect(() =>
+      assertNoPublicDirAssetConflict({
+        root,
+        publicDir: null,
+        assetsDir: "_next/static",
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects a public path that collides with a custom assets directory", () => {
+    const root = makeProject();
+    writeFile(root, "public/cdn/_next/static/private.txt");
+
+    expect(() =>
+      assertNoPublicDirAssetConflict({
+        root,
+        publicDir: "public",
+        assetsDir: "cdn/_next/static",
+      }),
+    ).toThrow(
+      "[vinext] The public directory contains a path reserved for build assets: " +
+        "cdn/_next/static",
+    );
+  });
+
+  it("does not inspect an assets directory outside the public directory", () => {
+    const root = makeProject();
+    writeFile(root, "outside-assets/file.txt");
+
+    expect(() =>
+      assertNoPublicDirAssetConflict({
+        root,
+        publicDir: "public",
+        assetsDir: "../outside-assets",
+      }),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
Closes #2778

## Root cause

In `packages/vinext/src/server/prod-server.ts:1441`, the function `resolveAppRouterAssetPath()` does not consider the case where the provided pathname that starts with `_next/static` is from public folder.
https://github.com/cloudflare/vinext/blob/255be4e2ab20f1f98a6b6fddf7a669a02335e2ed/packages/vinext/src/server/prod-server.ts#L1467-L1470

But in the upstream next.js source, it is not allowed to put a `_next` folder inside the public folder, or it will throw an error during `npm run build`.

## What changed

I created an assert function `assertNoPublicDirAssetConflict()`. This function checks the paths. Once it found there is any `_next` inside public folder, it will throw an error and interrupt the build.

This assert function is executed during `configResolved()` (in `packages/vinext/src/index.ts`):
```diff
async configResolved(config) {
+  const publicDir = config.publicDir === "" ? null : config.publicDir;
+  const assetsDir =
+    config.environments.client.build.assetsDir ??
+    config.build.assetsDir ??
+    resolveAssetsDir(nextConfig.assetPrefix ?? "");
+
+  assertNoPublicDirAssetConflict({
+    root: config.root,
+    publicDir,
+    assetsDir,
+  });

  // ...
```

The workaround is quite simple and is aligned with the behavior of upstream next.js.

## Testing

- `pnpm test tests/public-dir-conflict.test.ts`

## Notes

The error message is as following:
```ts
const PUBLIC_NEXT_CONFLICT_ERROR =
  "You can not have a '_next' folder inside of your public folder. " +
  "This conflicts with the internal '/_next' route. " +
  "https://nextjs.org/docs/messages/public-next-folder-conflict";
```
I'm not sure if the link should be replaced with vinext's one.

Thanks for reviewing!