### PR TITLE
fix(lint): transform filename from linter context to the absolute one for `prefer-import-alias` rule

### DIFF
--- a/oxlint-plugins/prefer-import-alias.js
+++ b/oxlint-plugins/prefer-import-alias.js
@@ -167,6 +167,30 @@ function loadAliasesForFile(filename) {
 }
 
 /**
+ * Get an absolute on-disk filename for filesystem and path comparisons.
+ *
+ * `context.filename` is not guaranteed to be absolute (notably when linting
+ * through an editor), while `physicalFilename` is the ESLint API intended for
+ * accessing the file on disk. Keep the fallback for Oxlint/ESLint callers that
+ * do not provide it, resolving relative filenames against the lint context's
+ * cwd rather than the JS plugin process's cwd.
+ */
+function getPhysicalFilename(context) {
+  const filename = context.physicalFilename ?? context.filename;
+  if (
+    typeof filename !== "string" ||
+    filename.length === 0 ||
+    (filename.startsWith("<") && filename.endsWith(">"))
+  ) {
+    return null;
+  }
+  // Resolve even an already-absolute filename so Windows paths supplied by
+  // the language server with `/` separators are normalized to the same native
+  // representation as alias targets built with `path.resolve()`.
+  return path.resolve(context.cwd ?? process.cwd(), filename);
+}
+
+/**
  * Reverse-map an absolute import path to a tsconfig-defined bare specifier.
  * Returns null if no alias exposes this file.
  */
@@ -220,9 +244,11 @@ const rule = {
       if (!source || typeof source.value !== "string") return;
       const importPath = source.value;
       if (!importPath.startsWith(".")) return;
-      const aliases = loadAliasesForFile(context.filename);
+      const filename = getPhysicalFilename(context);
+      if (!filename) return;
+      const aliases = loadAliasesForFile(filename);
       if (aliases.length === 0) return;
-      const importerDir = path.dirname(context.filename);
+      const importerDir = path.dirname(filename);
       const absoluteImport = path.resolve(importerDir, importPath);
       const aliased = tryReverseAlias(absoluteImport, importerDir, aliases);
       if (!aliased) return;


### PR DESCRIPTION
## Overview

`context.filename` provided by the linter is not guaranteed to be absolute, but `prefer-import-alias` just directly uses the `context.filename` to resolve the import paths, which causes unintended lint error in editor.

For example, in `packages/vinext/src/server/api-handler.ts`
```ts
import "./server-globals.js";
// Use alias 'vinext/internal/server/server-globals' instead of relative path './server-globals.js'. oxc(vinext-local(prefer-import-alias))
```

## What changed

I added a function `getPhysicalFilename(context)` to get absolute `filename` from the linter context. This function resolves `context.physicalFilename` (if there is not, fallback to `context.filename`) to absolute with cwd.

And this function is called during `createOnce()`:
```diff
+ const filename = getPhysicalFilename(context);
+ if (!filename) return;
- const aliases = loadAliasesForFile(context.filename);
+ const aliases = loadAliasesForFile(filename);
if (aliases.length === 0) return;
- const importerDir = path.dirname(context.filename);
+ const importerDir = path.dirname(filename);
```