### PR TITLE
fix(dev): refresh Pages hydration after render errors

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -127,6 +127,7 @@ import { collectInlineCssManifest, injectInlineCssManifestGlobal } from "./build
 import { validateDevRequest } from "./server/dev-origin-check.js";
 import { readTrustedRevalidationHostname } from "./server/revalidation-host.js";
 import { installDevStackSourcemapMiddleware } from "./server/dev-stack-sourcemap.js";
+import { createPagesHtmlProxyCapturePlugin } from "./server/pages-html-proxy.js";
 
 import { invalidateMetadataFileCache, scanMetadataFiles } from "./server/metadata-routes.js";
 
@@ -1815,6 +1816,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
   >();
 
   const plugins: PluginOption[] = [
+    createPagesHtmlProxyCapturePlugin(),
     // Resolve tsconfig paths/baseUrl aliases so real-world Next.js repos
     // that use @/*, #/*, or baseUrl imports work out of the box.
     // Vite 8+ supports this natively via resolve.tsconfigPaths.

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -93,6 +93,7 @@ import {
   type PagesPreviewState,
 } from "./pages-preview.js";
 import { isBotUserAgent } from "../utils/html-limited-bots.js";
+import { transformPagesHtml } from "./pages-html-proxy.js";
 
 /**
  * Render a React element to a string using renderToReadableStream.
@@ -596,7 +597,7 @@ async function streamPageToResponse(
 
   // Apply Vite's HTML transforms (injects HMR client, etc.) on the full
   // shell template, then split at the body marker.
-  let transformedShell = await server.transformIndexHtml(url, shellTemplate);
+  let transformedShell = await transformPagesHtml(server, url, shellTemplate, scriptNonce);
   transformedShell = stripDocumentAssetPropsProtectionMarkers(
     applyDocumentAssetProps(transformedShell, documentAssetProps, {
       configuredCrossOrigin: crossOrigin,
@@ -2094,6 +2095,7 @@ async function renderErrorPage(
           scripts: errorScripts,
           DocumentComponent,
           statusCode,
+          scriptNonce,
           documentContext: {
             err,
             pathname: errorPage,
@@ -2150,7 +2152,7 @@ async function renderErrorPage(
 </html>`;
         const transformedHtml = stripDocumentAssetPropsProtectionMarkers(
           applyDocumentAssetProps(
-            await server.transformIndexHtml(url, html),
+            await transformPagesHtml(server, url, html, scriptNonce),
             {},
             {
               configuredCrossOrigin: context.crossOrigin,

--- a/packages/vinext/src/server/pages-html-proxy.ts
+++ b/packages/vinext/src/server/pages-html-proxy.ts
@@ -145,11 +145,11 @@ function applyProxyScriptNonce(tag: string, nonce?: string): string {
   );
 }
 
-function evictViteModule(server: ViteDevServer, resolvedId: string): void {
-  const graph: EvictableModuleGraph = server.environments.client.moduleGraph;
-  const module = graph.getModuleById(resolvedId);
-  if (!module) return;
-
+function removeViteModule(
+  graph: EvictableModuleGraph,
+  module: EnvironmentModuleNode,
+  resolvedId: string,
+): void {
   graph.invalidateModule(module);
   for (const imported of module.importedModules) imported.importers.delete(module);
   for (const importer of module.importers) {
@@ -176,6 +176,27 @@ function evictViteModule(server: ViteDevServer, resolvedId: string): void {
   // strong reference after the public graph maps above are cleared.
   for (const [url, candidate] of graph._unresolvedUrlToModuleMap ?? []) {
     if (candidate === module) graph._unresolvedUrlToModuleMap!.delete(url);
+  }
+}
+
+function evictViteModule(server: ViteDevServer, resolvedId: string, aliases: string[]): void {
+  const graph: EvictableModuleGraph = server.environments.client.moduleGraph;
+  const module = graph.getModuleById(resolvedId);
+  if (module) removeViteModule(graph, module, resolvedId);
+
+  const unresolved = graph._unresolvedUrlToModuleMap;
+  if (!unresolved) return;
+  const aliasSet = new Set(aliases);
+  for (const [url, candidate] of unresolved) {
+    if (!aliasSet.has(cleanUrl(url)) || !(candidate instanceof Promise)) continue;
+    void candidate.then(
+      (resolved) => {
+        if (resolved.id) removeViteModule(graph, resolved, resolved.id);
+      },
+      () => {
+        if (unresolved.get(url) === candidate) unresolved.delete(url);
+      },
+    );
   }
 }
 
@@ -222,7 +243,9 @@ function retainProxyModule(
     for (const alias of oldest.aliases) {
       if (publicToResolvedId.get(alias) === oldestId) publicToResolvedId.delete(alias);
     }
-    evictViteModule(server, oldestId);
+    // A browser still fetching HTML older than this bounded dev history may
+    // receive a 404, just as a stale tab can after an HMR invalidation.
+    evictViteModule(server, oldestId, oldest.aliases);
   }
 }
 

--- a/packages/vinext/src/server/pages-html-proxy.ts
+++ b/packages/vinext/src/server/pages-html-proxy.ts
@@ -1,4 +1,4 @@
-import type { Plugin, ViteDevServer } from "vite";
+import type { EnvironmentModuleGraph, EnvironmentModuleNode, Plugin, ViteDevServer } from "vite";
 import type { SourceDescription } from "vite/rolldown";
 import { AsyncLocalStorage } from "node:async_hooks";
 import { createHash } from "node:crypto";
@@ -16,10 +16,18 @@ type CapturedProxyModule = {
   map?: SourceDescription["map"];
   moduleSideEffects?: SourceDescription["moduleSideEffects"];
 };
+type RetainedProxyModule = {
+  aliases: string[];
+  module: CapturedProxyModule;
+};
+type EvictableModuleGraph = EnvironmentModuleGraph & {
+  _unresolvedUrlToModuleMap?: Map<string, EnvironmentModuleNode | Promise<EnvironmentModuleNode>>;
+};
 
 const HTML_PROXY_SCRIPT_RE =
   /<script\b[^>]*\bsrc="([^"]*[?&]html-proxy&index=(\d+)\.js)"[^>]*><\/script>/g;
 const CONTENT_MODULE_PREFIX = "__vinext_html_proxy_content_";
+const MAX_RETAINED_PROXY_VERSIONS = 8;
 const pagesHtmlTransformContext = new AsyncLocalStorage<PagesHtmlTransformContext>();
 const serverLocks = new WeakMap<ViteDevServer, Map<string, Promise<void>>>();
 
@@ -137,13 +145,97 @@ function applyProxyScriptNonce(tag: string, nonce?: string): string {
   );
 }
 
+function evictViteModule(server: ViteDevServer, resolvedId: string): void {
+  const graph: EvictableModuleGraph = server.environments.client.moduleGraph;
+  const module = graph.getModuleById(resolvedId);
+  if (!module) return;
+
+  graph.invalidateModule(module);
+  for (const imported of module.importedModules) imported.importers.delete(module);
+  for (const importer of module.importers) {
+    importer.importedModules.delete(module);
+    importer.acceptedHmrDeps.delete(module);
+  }
+  module.importedModules.clear();
+  module.importers.clear();
+  module.acceptedHmrDeps.clear();
+  graph.idToModuleMap.delete(resolvedId);
+  for (const [url, candidate] of graph.urlToModuleMap) {
+    if (candidate === module) graph.urlToModuleMap.delete(url);
+  }
+  for (const [etag, candidate] of graph.etagToModuleMap) {
+    if (candidate === module) graph.etagToModuleMap.delete(etag);
+  }
+  if (module.file) {
+    const fileModules = graph.fileToModulesMap.get(module.file);
+    fileModules?.delete(module);
+    if (fileModules?.size === 0) graph.fileToModulesMap.delete(module.file);
+  }
+
+  // Vite has no public module-removal API. Its unresolved lookup is the last
+  // strong reference after the public graph maps above are cleared.
+  for (const [url, candidate] of graph._unresolvedUrlToModuleMap ?? []) {
+    if (candidate === module) graph._unresolvedUrlToModuleMap!.delete(url);
+  }
+}
+
+function retainProxyModule(
+  server: ViteDevServer,
+  modules: Map<string, RetainedProxyModule>,
+  publicToResolvedId: Map<string, string>,
+  retainedByDocumentIndex: Map<string, Set<string>>,
+  documentIndex: string,
+  resolvedId: string,
+  publicUrl: string,
+  publicBase: string,
+  module: CapturedProxyModule,
+): void {
+  const aliases = Array.from(
+    new Set([cleanUrl(publicUrl), cleanUrl(stripBase(publicUrl, publicBase))]),
+  );
+  const previous = modules.get(resolvedId);
+  if (previous) {
+    modules.delete(resolvedId);
+    for (const alias of previous.aliases) {
+      if (publicToResolvedId.get(alias) === resolvedId) publicToResolvedId.delete(alias);
+    }
+  }
+
+  modules.set(resolvedId, { aliases, module });
+  for (const alias of aliases) publicToResolvedId.set(alias, resolvedId);
+
+  let retained = retainedByDocumentIndex.get(documentIndex);
+  if (!retained) {
+    retained = new Set();
+    retainedByDocumentIndex.set(documentIndex, retained);
+  }
+  retained.delete(resolvedId);
+  retained.add(resolvedId);
+
+  while (retained.size > MAX_RETAINED_PROXY_VERSIONS) {
+    const oldestId = retained.keys().next().value;
+    if (oldestId === undefined) break;
+    retained.delete(oldestId);
+    const oldest = modules.get(oldestId);
+    if (!oldest) continue;
+    modules.delete(oldestId);
+    for (const alias of oldest.aliases) {
+      if (publicToResolvedId.get(alias) === oldestId) publicToResolvedId.delete(alias);
+    }
+    evictViteModule(server, oldestId);
+  }
+}
+
 /** Capture Vite's exact proxy sources and rewrite them to immutable modules. */
 export function createPagesHtmlProxyCapturePlugin(): Plugin {
-  const modules = new Map<string, CapturedProxyModule>();
+  const modules = new Map<string, RetainedProxyModule>();
   const publicToResolvedId = new Map<string, string>();
+  const retainedByDocumentIndex = new Map<string, Set<string>>();
   return {
     name: "vinext:pages-html-proxy-capture",
     enforce: "pre",
+    // Keep this as a normal-order hook: Vite creates its html-proxy scripts in
+    // devHtmlHook before normal hooks run. An `order: "pre"` hook cannot see them.
     async transformIndexHtml(html) {
       const active = pagesHtmlTransformContext.getStore();
       if (!active) return;
@@ -169,13 +261,22 @@ export function createPagesHtmlProxyCapturePlugin(): Plugin {
           document: active.documentUrl,
           index,
           map: loaded.map ?? null,
+          moduleSideEffects: loaded.moduleSideEffects ?? null,
         });
         const hash = createHash("sha256").update(identity).digest("hex");
         const publicUrl = contentModuleUrl(active.documentUrl, hash, index, publicBase);
         const resolvedId = contentModuleId(server.config.root, publicUrl, publicBase);
-        modules.set(resolvedId, loaded);
-        publicToResolvedId.set(cleanUrl(publicUrl), resolvedId);
-        publicToResolvedId.set(cleanUrl(stripBase(publicUrl, publicBase)), resolvedId);
+        retainProxyModule(
+          server,
+          modules,
+          publicToResolvedId,
+          retainedByDocumentIndex,
+          `${active.documentUrl}\0${index}`,
+          resolvedId,
+          publicUrl,
+          publicBase,
+          loaded,
+        );
         replacements.push({
           end: match.index + match[0].length,
           start: match.index,
@@ -201,7 +302,7 @@ export function createPagesHtmlProxyCapturePlugin(): Plugin {
     load: {
       filter: { id: new RegExp(CONTENT_MODULE_PREFIX) },
       handler(id) {
-        const captured = modules.get(cleanUrl(id));
+        const captured = modules.get(cleanUrl(id))?.module;
         if (!captured) return;
         return {
           code: captured.code,

--- a/packages/vinext/src/server/pages-html-proxy.ts
+++ b/packages/vinext/src/server/pages-html-proxy.ts
@@ -1,0 +1,228 @@
+import type { Plugin, ViteDevServer } from "vite";
+import type { SourceDescription } from "vite/rolldown";
+import { AsyncLocalStorage } from "node:async_hooks";
+import { createHash } from "node:crypto";
+import path from "pathslash";
+import { createNonceAttribute } from "./html.js";
+
+type PagesHtmlTransformContext = {
+  documentUrl: string;
+  scriptNonce?: string;
+  server: ViteDevServer;
+  transformUrl: string;
+};
+type CapturedProxyModule = {
+  code: string;
+  map?: SourceDescription["map"];
+  moduleSideEffects?: SourceDescription["moduleSideEffects"];
+};
+
+const HTML_PROXY_SCRIPT_RE =
+  /<script\b[^>]*\bsrc="([^"]*[?&]html-proxy&index=(\d+)\.js)"[^>]*><\/script>/g;
+const CONTENT_MODULE_PREFIX = "__vinext_html_proxy_content_";
+const pagesHtmlTransformContext = new AsyncLocalStorage<PagesHtmlTransformContext>();
+const serverLocks = new WeakMap<ViteDevServer, Map<string, Promise<void>>>();
+
+function cleanUrl(url: string): string {
+  return url.replace(/[?#].*$/, "");
+}
+
+function documentDirectory(url: string): string {
+  const pathname = cleanUrl(url);
+  return pathname.endsWith("/") ? pathname : pathname.slice(0, pathname.lastIndexOf("/") + 1);
+}
+
+function htmlProxyDocumentId(url: string): string {
+  // Vite determines this before stripping the query string. Preserve that
+  // order so `/route/` maps to `index.html`, while `/route/?q=1` does not.
+  const trailingSlash = url.endsWith("/");
+  const pathname = decodeURI(cleanUrl(url));
+  return `\0${trailingSlash ? `${pathname}index.html` : pathname}`;
+}
+
+function stripBase(url: string, base: string): string {
+  if (base === "/" || !url.startsWith(base)) return url;
+  return `/${url.slice(base.length)}`;
+}
+
+function decodedBase(server: ViteDevServer): string {
+  return decodeURI(server.config.base);
+}
+
+function unwrapHtmlProxyUrl(url: string, base: string): string | null {
+  const withoutBase = stripBase(url, base);
+  const prefix = "/@id/__x00__";
+  return withoutBase.startsWith(prefix)
+    ? decodeURI(`\0${withoutBase.slice(prefix.length)}`)
+    : decodeURI(withoutBase);
+}
+
+function isActiveHtmlProxyDocument(id: string, url: string): boolean {
+  const documentPath = decodeURI(cleanUrl(url));
+  const proxyPath = cleanUrl(id);
+  return proxyPath === documentPath || proxyPath === htmlProxyDocumentId(url);
+}
+
+function contentModuleUrl(
+  markerUrl: string,
+  hash: string,
+  index: number,
+  publicBase: string,
+): string {
+  const documentUrl = `${documentDirectory(markerUrl)}${CONTENT_MODULE_PREFIX}${hash}_${index}.js`;
+  if (publicBase === "/") return documentUrl;
+  return `${publicBase}${documentUrl.slice(1)}`;
+}
+
+function contentModuleId(root: string, publicUrl: string, base: string): string {
+  // The content module stays in the document directory, so Vite's normal
+  // resolver preserves relative-import semantics without a virtual-importer
+  // remapping hook.
+  let decodedUrl: string;
+  try {
+    // Match Vite's URL-to-filesystem conversion: decode ordinary path bytes
+    // (including spaces) while leaving encoded separators such as %2F intact.
+    decodedUrl = decodeURI(stripBase(publicUrl, base));
+  } catch {
+    throw new Error(`[vinext] Invalid Pages HTML proxy URL ${publicUrl}`);
+  }
+  const id = path.resolve(root, `.${decodedUrl}`);
+  const relative = path.relative(root, id);
+  if (relative === ".." || relative.startsWith("../")) {
+    throw new Error(`[vinext] Pages HTML proxy URL escapes the Vite root: ${publicUrl}`);
+  }
+  return id;
+}
+
+async function withDocumentLock<T>(
+  server: ViteDevServer,
+  key: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  let locks = serverLocks.get(server);
+  if (!locks) {
+    locks = new Map();
+    serverLocks.set(server, locks);
+  }
+  const previous = locks.get(key) ?? Promise.resolve();
+  let release!: () => void;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  locks.set(key, current);
+  await previous;
+  try {
+    return await operation();
+  } finally {
+    release();
+    if (locks.get(key) === current) locks.delete(key);
+  }
+}
+
+function normalizeLoadedModule(loaded: string | SourceDescription): CapturedProxyModule {
+  if (typeof loaded === "string") return { code: loaded };
+  return {
+    code: loaded.code,
+    map: loaded.map,
+    moduleSideEffects: loaded.moduleSideEffects,
+  };
+}
+
+function applyProxyScriptNonce(tag: string, nonce?: string): string {
+  if (!nonce) return tag;
+  const withoutExistingNonce = tag.replace(/\snonce=(?:"[^"]*"|'[^']*'|[^\s>]+)/i, "");
+  return withoutExistingNonce.replace(
+    /^<script\b/i,
+    (open) => `${open}${createNonceAttribute(nonce)}`,
+  );
+}
+
+/** Capture Vite's exact proxy sources and rewrite them to immutable modules. */
+export function createPagesHtmlProxyCapturePlugin(): Plugin {
+  const modules = new Map<string, CapturedProxyModule>();
+  const publicToResolvedId = new Map<string, string>();
+  return {
+    name: "vinext:pages-html-proxy-capture",
+    enforce: "pre",
+    async transformIndexHtml(html) {
+      const active = pagesHtmlTransformContext.getStore();
+      if (!active) return;
+      const { server } = active;
+      const replacements: Array<{ end: number; start: number; value: string }> = [];
+      for (const match of html.matchAll(HTML_PROXY_SCRIPT_RE)) {
+        const proxyUrl = match[1]!;
+        const index = Number(match[2]);
+        const publicBase = server.config.base;
+        const proxyBase = decodedBase(server);
+        const originalId = unwrapHtmlProxyUrl(proxyUrl, proxyBase);
+        if (!originalId || !isActiveHtmlProxyDocument(originalId, active.transformUrl)) {
+          continue;
+        }
+        const container = server.environments.client.pluginContainer;
+        const resolved = await container.resolveId(originalId);
+        if (!resolved) throw new Error(`[vinext] Failed to resolve Pages HTML proxy ${proxyUrl}`);
+        const result = await container.load(resolved.id);
+        if (!result) throw new Error(`[vinext] Failed to load Pages HTML proxy ${proxyUrl}`);
+        const loaded = normalizeLoadedModule(result);
+        const identity = JSON.stringify({
+          code: loaded.code,
+          document: active.documentUrl,
+          index,
+          map: loaded.map ?? null,
+        });
+        const hash = createHash("sha256").update(identity).digest("hex");
+        const publicUrl = contentModuleUrl(active.documentUrl, hash, index, publicBase);
+        const resolvedId = contentModuleId(server.config.root, publicUrl, publicBase);
+        modules.set(resolvedId, loaded);
+        publicToResolvedId.set(cleanUrl(publicUrl), resolvedId);
+        publicToResolvedId.set(cleanUrl(stripBase(publicUrl, publicBase)), resolvedId);
+        replacements.push({
+          end: match.index + match[0].length,
+          start: match.index,
+          value: applyProxyScriptNonce(match[0].replace(proxyUrl, publicUrl), active.scriptNonce),
+        });
+      }
+      let transformedHtml = html;
+      for (let index = replacements.length - 1; index >= 0; index -= 1) {
+        const replacement = replacements[index]!;
+        transformedHtml =
+          transformedHtml.slice(0, replacement.start) +
+          replacement.value +
+          transformedHtml.slice(replacement.end);
+      }
+      return transformedHtml;
+    },
+    resolveId: {
+      filter: { id: new RegExp(CONTENT_MODULE_PREFIX) },
+      handler(source) {
+        return publicToResolvedId.get(cleanUrl(source));
+      },
+    },
+    load: {
+      filter: { id: new RegExp(CONTENT_MODULE_PREFIX) },
+      handler(id) {
+        const captured = modules.get(cleanUrl(id));
+        if (!captured) return;
+        return {
+          code: captured.code,
+          map: captured.map,
+          moduleSideEffects: captured.moduleSideEffects ?? true,
+        };
+      },
+    },
+  };
+}
+
+export function transformPagesHtml(
+  server: ViteDevServer,
+  url: string,
+  html: string,
+  scriptNonce?: string,
+): Promise<string> {
+  const documentUrl = cleanUrl(url);
+  return withDocumentLock(server, documentUrl, () =>
+    pagesHtmlTransformContext.run({ documentUrl, scriptNonce, server, transformUrl: url }, () =>
+      server.transformIndexHtml(url, html),
+    ),
+  );
+}

--- a/packages/vinext/src/server/pages-html-proxy.ts
+++ b/packages/vinext/src/server/pages-html-proxy.ts
@@ -27,6 +27,7 @@ type EvictableModuleGraph = EnvironmentModuleGraph & {
 const HTML_PROXY_SCRIPT_RE =
   /<script\b[^>]*\bsrc="([^"]*[?&]html-proxy&index=(\d+)\.js)"[^>]*><\/script>/g;
 const CONTENT_MODULE_PREFIX = "__vinext_html_proxy_content_";
+const MAX_RETAINED_PROXY_DOCUMENTS = 128;
 const MAX_RETAINED_PROXY_VERSIONS = 8;
 const pagesHtmlTransformContext = new AsyncLocalStorage<PagesHtmlTransformContext>();
 const serverLocks = new WeakMap<ViteDevServer, Map<string, Promise<void>>>();
@@ -200,12 +201,28 @@ function evictViteModule(server: ViteDevServer, resolvedId: string, aliases: str
   }
 }
 
+function evictRetainedProxyModule(
+  server: ViteDevServer,
+  modules: Map<string, RetainedProxyModule>,
+  publicToResolvedId: Map<string, string>,
+  resolvedId: string,
+): void {
+  const retained = modules.get(resolvedId);
+  if (!retained) return;
+  modules.delete(resolvedId);
+  for (const alias of retained.aliases) {
+    if (publicToResolvedId.get(alias) === resolvedId) publicToResolvedId.delete(alias);
+  }
+  evictViteModule(server, resolvedId, retained.aliases);
+}
+
 function retainProxyModule(
   server: ViteDevServer,
   modules: Map<string, RetainedProxyModule>,
   publicToResolvedId: Map<string, string>,
-  retainedByDocumentIndex: Map<string, Set<string>>,
-  documentIndex: string,
+  retainedByDocument: Map<string, Map<number, Set<string>>>,
+  documentUrl: string,
+  index: number,
   resolvedId: string,
   publicUrl: string,
   publicBase: string,
@@ -225,10 +242,18 @@ function retainProxyModule(
   modules.set(resolvedId, { aliases, module });
   for (const alias of aliases) publicToResolvedId.set(alias, resolvedId);
 
-  let retained = retainedByDocumentIndex.get(documentIndex);
+  let document = retainedByDocument.get(documentUrl);
+  if (document) {
+    retainedByDocument.delete(documentUrl);
+    retainedByDocument.set(documentUrl, document);
+  } else {
+    document = new Map();
+    retainedByDocument.set(documentUrl, document);
+  }
+  let retained = document.get(index);
   if (!retained) {
     retained = new Set();
-    retainedByDocumentIndex.set(documentIndex, retained);
+    document.set(index, retained);
   }
   retained.delete(resolvedId);
   retained.add(resolvedId);
@@ -237,15 +262,21 @@ function retainProxyModule(
     const oldestId = retained.keys().next().value;
     if (oldestId === undefined) break;
     retained.delete(oldestId);
-    const oldest = modules.get(oldestId);
-    if (!oldest) continue;
-    modules.delete(oldestId);
-    for (const alias of oldest.aliases) {
-      if (publicToResolvedId.get(alias) === oldestId) publicToResolvedId.delete(alias);
-    }
     // A browser still fetching HTML older than this bounded dev history may
     // receive a 404, just as a stale tab can after an HMR invalidation.
-    evictViteModule(server, oldestId, oldest.aliases);
+    evictRetainedProxyModule(server, modules, publicToResolvedId, oldestId);
+  }
+
+  while (retainedByDocument.size > MAX_RETAINED_PROXY_DOCUMENTS) {
+    const oldestDocumentUrl = retainedByDocument.keys().next().value;
+    if (oldestDocumentUrl === undefined) break;
+    const oldestDocument = retainedByDocument.get(oldestDocumentUrl)!;
+    retainedByDocument.delete(oldestDocumentUrl);
+    for (const versions of oldestDocument.values()) {
+      for (const oldId of versions) {
+        evictRetainedProxyModule(server, modules, publicToResolvedId, oldId);
+      }
+    }
   }
 }
 
@@ -253,7 +284,7 @@ function retainProxyModule(
 export function createPagesHtmlProxyCapturePlugin(): Plugin {
   const modules = new Map<string, RetainedProxyModule>();
   const publicToResolvedId = new Map<string, string>();
-  const retainedByDocumentIndex = new Map<string, Set<string>>();
+  const retainedByDocument = new Map<string, Map<number, Set<string>>>();
   return {
     name: "vinext:pages-html-proxy-capture",
     enforce: "pre",
@@ -293,8 +324,9 @@ export function createPagesHtmlProxyCapturePlugin(): Plugin {
           server,
           modules,
           publicToResolvedId,
-          retainedByDocumentIndex,
-          `${active.documentUrl}\0${index}`,
+          retainedByDocument,
+          active.documentUrl,
+          index,
           resolvedId,
           publicUrl,
           publicBase,
@@ -315,6 +347,12 @@ export function createPagesHtmlProxyCapturePlugin(): Plugin {
           transformedHtml.slice(replacement.end);
       }
       return transformedHtml;
+    },
+    hotUpdate({ server }) {
+      for (const resolvedId of Array.from(modules.keys())) {
+        evictRetainedProxyModule(server, modules, publicToResolvedId, resolvedId);
+      }
+      retainedByDocument.clear();
     },
     resolveId: {
       filter: { id: new RegExp(CONTENT_MODULE_PREFIX) },

--- a/tests/fixtures/pages-basic/html-proxy-race-state.ts
+++ b/tests/fixtures/pages-basic/html-proxy-race-state.ts
@@ -63,8 +63,12 @@ export function getHtmlProxyRaceStatus(id: string) {
 }
 
 export function releaseHtmlProxyRace(id: string): void {
-  const race = getRace(id);
+  const race = races.get(id);
+  if (!race) return;
   if (race.released) return;
   race.released = true;
   race.releaseFirstRequest();
+  queueMicrotask(() => {
+    if (races.get(id) === race) races.delete(id);
+  });
 }

--- a/tests/fixtures/pages-basic/html-proxy-race-state.ts
+++ b/tests/fixtures/pages-basic/html-proxy-race-state.ts
@@ -1,0 +1,70 @@
+type HtmlProxyRaceState = {
+  firstRequestStarted: boolean;
+  releaseFirstRequest: () => void;
+  released: boolean;
+  requestCount: number;
+  waitForRelease: Promise<void>;
+};
+
+const races = new Map<string, HtmlProxyRaceState>();
+
+function getRace(id: string): HtmlProxyRaceState {
+  let race = races.get(id);
+  if (race) return race;
+
+  let releaseFirstRequest!: () => void;
+  const waitForRelease = new Promise<void>((resolve) => {
+    releaseFirstRequest = resolve;
+  });
+  race = {
+    firstRequestStarted: false,
+    releaseFirstRequest,
+    released: false,
+    requestCount: 0,
+    waitForRelease,
+  };
+  races.set(id, race);
+  return race;
+}
+
+export async function enterHtmlProxyRace(id: string): Promise<"error" | "success"> {
+  const race = getRace(id);
+  race.requestCount += 1;
+  if (race.requestCount !== 1) return "success";
+
+  race.firstRequestStarted = true;
+  await race.waitForRelease;
+  return "error";
+}
+
+export async function enterInlineModuleRace(id: string): Promise<"first" | "second"> {
+  const race = getRace(id);
+  race.requestCount += 1;
+  if (race.requestCount !== 1) return "second";
+
+  race.firstRequestStarted = true;
+  await race.waitForRelease;
+  return "first";
+}
+
+export function getNonModuleVariant(id: string): "first-data" | "second-data" {
+  const race = getRace(id);
+  race.requestCount += 1;
+  return race.requestCount === 1 ? "first-data" : "second-data";
+}
+
+export function getHtmlProxyRaceStatus(id: string) {
+  const race = getRace(id);
+  return {
+    firstRequestStarted: race.firstRequestStarted,
+    released: race.released,
+    requestCount: race.requestCount,
+  };
+}
+
+export function releaseHtmlProxyRace(id: string): void {
+  const race = getRace(id);
+  if (race.released) return;
+  race.released = true;
+  race.releaseFirstRequest();
+}

--- a/tests/fixtures/pages-basic/html-proxy-relative.ts
+++ b/tests/fixtures/pages-basic/html-proxy-relative.ts
@@ -1,0 +1,1 @@
+export const htmlProxyRelativeValue = "relative import resolved";

--- a/tests/fixtures/pages-basic/pages/api/html-proxy-race-control.ts
+++ b/tests/fixtures/pages-basic/pages/api/html-proxy-race-control.ts
@@ -1,0 +1,14 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getHtmlProxyRaceStatus, releaseHtmlProxyRace } from "../../html-proxy-race-state";
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const id = Array.isArray(req.query.id) ? req.query.id[0] : req.query.id;
+  if (!id) {
+    res.status(400).json({ error: "missing race id" });
+    return;
+  }
+
+  const action = Array.isArray(req.query.action) ? req.query.action[0] : req.query.action;
+  if (action === "release") releaseHtmlProxyRace(id);
+  res.status(200).json(getHtmlProxyRaceStatus(id));
+}

--- a/tests/fixtures/pages-basic/pages/html-proxy-recovery.tsx
+++ b/tests/fixtures/pages-basic/pages/html-proxy-recovery.tsx
@@ -1,0 +1,60 @@
+import type { GetServerSidePropsContext } from "next";
+import Head from "next/head";
+import {
+  enterHtmlProxyRace,
+  enterInlineModuleRace,
+  getNonModuleVariant,
+} from "../html-proxy-race-state";
+
+export async function getServerSideProps({ query }: GetServerSidePropsContext) {
+  const raceId = Array.isArray(query.race) ? query.race[0] : query.race;
+  if (raceId && (await enterHtmlProxyRace(raceId)) === "error") {
+    throw new Error("intentional delayed render failure");
+  }
+
+  const inlineRaceId = Array.isArray(query.inlineRace) ? query.inlineRace[0] : query.inlineRace;
+  const inlineModuleVariant = inlineRaceId ? await enterInlineModuleRace(inlineRaceId) : null;
+  const preHookProxy = query.preHookProxy === "1";
+  const dataRaceId = Array.isArray(query.dataRace) ? query.dataRace[0] : query.dataRace;
+  const message = dataRaceId ? getNonModuleVariant(dataRaceId) : "route render recovered";
+
+  return { props: { inlineModuleVariant, message, preHookProxy } };
+}
+
+export default function HtmlProxyRecoveryPage({
+  inlineModuleVariant,
+  message,
+  preHookProxy,
+}: {
+  inlineModuleVariant: "first" | "second" | null;
+  message: string;
+  preHookProxy: boolean;
+}) {
+  return (
+    <>
+      {inlineModuleVariant ? (
+        <Head>
+          <script
+            type="module"
+            dangerouslySetInnerHTML={{
+              __html: `import { htmlProxyRelativeValue } from "./html-proxy-relative.ts";
+window.__HTML_PROXY_INLINE_VARIANT__ = ${JSON.stringify(inlineModuleVariant)} + ":" + htmlProxyRelativeValue;`,
+            }}
+          />
+        </Head>
+      ) : null}
+      {preHookProxy ? (
+        <Head>
+          <script
+            type="module"
+            dangerouslySetInnerHTML={{
+              __html:
+                'window.__HTML_PROXY_PRE_HOOK_SEQUENCE__ = "__VINEXT_HTML_PROXY_PRE_HOOK_SEQUENCE__";',
+            }}
+          />
+        </Head>
+      ) : null}
+      <p id="html-proxy-recovery">{message}</p>
+    </>
+  );
+}

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -11,7 +11,7 @@ import http, { type IncomingHttpHeaders } from "node:http";
 import fs from "node:fs/promises";
 import os from "node:os";
 import { pathToFileURL } from "node:url";
-import { createServer, build, type ViteDevServer } from "vite";
+import { createServer, build, type PluginOption, type ViteDevServer } from "vite";
 import vinext from "../packages/vinext/src/index.js";
 import path from "node:path";
 
@@ -57,6 +57,7 @@ export async function startFixtureServer(
     appRouter?: boolean;
     listen?: boolean;
     publicDir?: string | false;
+    plugins?: PluginOption[];
     server?: {
       host?: string;
       allowedHosts?: true | string[];
@@ -81,7 +82,7 @@ export async function startFixtureServer(
   } else {
     plugin = vinext({ appDir: opts?.appDir ?? fixtureDir });
   }
-  const plugins = [plugin];
+  const plugins = [...(opts?.plugins ?? []), plugin];
 
   const server = await createServer({
     root: fixtureDir,

--- a/tests/pages-html-proxy.test.ts
+++ b/tests/pages-html-proxy.test.ts
@@ -1,0 +1,319 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { Plugin, ViteDevServer } from "vite";
+import { createServer } from "vite-plus";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import {
+  createPagesHtmlProxyCapturePlugin,
+  transformPagesHtml,
+} from "../packages/vinext/src/server/pages-html-proxy.js";
+
+const CONTENT_MODULE_RE = /src="([^"]*__vinext_html_proxy_content_[^"]+\.js)"/g;
+
+function contentModuleUrls(html: string): string[] {
+  return Array.from(html.matchAll(CONTENT_MODULE_RE), (match) => match[1]!);
+}
+
+describe("Pages HTML proxy capture", () => {
+  const servers: ViteDevServer[] = [];
+  const roots: string[] = [];
+
+  async function createTestServer(
+    options: { base?: string; cspNonce?: string; plugins?: Plugin[] } = {},
+  ) {
+    const root = await mkdtemp(path.join(os.tmpdir(), "vinext-pages-html-proxy-"));
+    roots.push(root);
+    const server = await createServer({
+      appType: "custom",
+      base: options.base,
+      html: options.cspNonce ? { cspNonce: options.cspNonce } : undefined,
+      logLevel: "silent",
+      plugins: [createPagesHtmlProxyCapturePlugin(), ...(options.plugins ?? [])],
+      root,
+    });
+    servers.push(server);
+    return { root, server };
+  }
+
+  afterEach(async () => {
+    await Promise.all(servers.splice(0).map((server) => server.close()));
+    await Promise.all(roots.splice(0).map((root) => rm(root, { force: true, recursive: true })));
+  });
+
+  it("does not rewrite ordinary non-Pages HTML transforms", async () => {
+    const { server } = await createTestServer();
+    const transformed = await server.transformIndexHtml(
+      "/ordinary",
+      `<script type="module">ordinary()</script>`,
+    );
+
+    expect(transformed).toContain("html-proxy&index=0.js");
+    expect(transformed).not.toContain("__vinext_html_proxy_content_");
+  });
+
+  it("preserves user hook paths and captures trailing-slash document proxies", async () => {
+    const hookPaths: string[] = [];
+    const { server } = await createTestServer({
+      plugins: [
+        {
+          name: "test:observe-real-html-path",
+          transformIndexHtml: {
+            order: "pre",
+            handler(html, context) {
+              hookPaths.push(context.path);
+              return html;
+            },
+          },
+        },
+      ],
+    });
+    const root = await transformPagesHtml(
+      server,
+      "/",
+      `<script type="module">rootDocument()</script>`,
+    );
+    const nested = await transformPagesHtml(
+      server,
+      "/nested/",
+      `<script type="module">nestedDocument()</script>`,
+    );
+    const nestedWithQuery = await transformPagesHtml(
+      server,
+      "/nested/?q=1",
+      `<script type="module">nestedQueryDocument()</script>`,
+    );
+    const rootWithQuery = await transformPagesHtml(
+      server,
+      "/?q=1",
+      `<script type="module">rootQueryDocument()</script>`,
+    );
+
+    expect(hookPaths).toEqual(["/", "/nested/", "/nested/?q=1", "/?q=1"]);
+    expect(contentModuleUrls(root)).toHaveLength(1);
+    expect(contentModuleUrls(nested)).toHaveLength(1);
+    expect(contentModuleUrls(nestedWithQuery)).toHaveLength(1);
+    expect(contentModuleUrls(rootWithQuery)).toHaveLength(1);
+  });
+
+  it("captures Vite's filesystem-backed proxy form when a document path exists", async () => {
+    const { root, server } = await createTestServer();
+    await mkdir(path.join(root, "collision"));
+    const transformed = await transformPagesHtml(
+      server,
+      "/collision",
+      `<script type="module">collisionDocument()</script>`,
+    );
+    const [url] = contentModuleUrls(transformed);
+
+    expect(url).toBeDefined();
+    await expect(server.transformRequest(url!)).resolves.toMatchObject({
+      code: expect.stringContaining("collisionDocument()"),
+    });
+  });
+
+  it("reuses immutable modules when only non-module HTML changes", async () => {
+    const { server } = await createTestServer();
+    const first = await transformPagesHtml(
+      server,
+      "/page",
+      `<script type="module">sameModule()</script><p>first body</p>`,
+    );
+    const second = await transformPagesHtml(
+      server,
+      "/page",
+      `<script type="module">sameModule()</script><p>second body</p>`,
+    );
+
+    expect(contentModuleUrls(first)).toEqual(contentModuleUrls(second));
+    expect(first).toContain("first body");
+    expect(second).toContain("second body");
+  });
+
+  it("captures stateful pre-hook output instead of hashing its input", async () => {
+    let transformCount = 0;
+    const { server } = await createTestServer({
+      plugins: [
+        {
+          name: "test:stateful-html-pre-hook",
+          transformIndexHtml: {
+            order: "pre",
+            handler(html) {
+              transformCount += 1;
+              return html.replace("stateful()", `stateful(${transformCount})`);
+            },
+          },
+        },
+      ],
+    });
+    const input = `<script type="module">stateful()</script>`;
+    const first = await transformPagesHtml(server, "/page", input);
+    const second = await transformPagesHtml(server, "/page", input);
+    const [firstUrl] = contentModuleUrls(first);
+    const [secondUrl] = contentModuleUrls(second);
+
+    expect(firstUrl).not.toBe(secondUrl);
+    expect((await server.transformRequest(firstUrl!))?.code).toContain("stateful(1)");
+    expect((await server.transformRequest(secondUrl!))?.code).toContain("stateful(2)");
+  });
+
+  it("keeps duplicate modules and Vite proxy indices distinct", async () => {
+    const { server } = await createTestServer();
+    const transformed = await transformPagesHtml(
+      server,
+      "/page",
+      `<script type="module">duplicate()</script>
+       <div style="background: url('/asset.png')"></div>
+       <script type="module">duplicate()</script>`,
+    );
+    const urls = contentModuleUrls(transformed);
+
+    expect(urls).toHaveLength(2);
+    expect(urls[0]).not.toBe(urls[1]);
+    expect(urls[0]).toMatch(/_0\.js$/);
+    expect(urls[1]).toMatch(/_2\.js$/);
+    await expect(server.transformRequest(urls[0]!)).resolves.toMatchObject({
+      code: expect.stringContaining("duplicate()"),
+    });
+    await expect(server.transformRequest(urls[1]!)).resolves.toMatchObject({
+      code: expect.stringContaining("duplicate()"),
+    });
+  });
+
+  it("preserves base paths, encoded document directories, CSP nonces, and hook order", async () => {
+    let normalHtml = "";
+    let postHtml = "";
+    const { root, server } = await createTestServer({
+      base: "/base/",
+      plugins: [
+        {
+          name: "test:observe-normal-html",
+          transformIndexHtml(html) {
+            normalHtml = html;
+          },
+        },
+        {
+          name: "test:observe-post-html",
+          transformIndexHtml: {
+            order: "post",
+            handler(html) {
+              postHtml = html;
+            },
+          },
+        },
+      ],
+    });
+    await mkdir(path.join(root, "nested directory"), { recursive: true });
+    await writeFile(
+      path.join(root, "nested directory", "dep.js"),
+      `export const encodedDirectoryValue = "resolved";`,
+    );
+    const transformed = await transformPagesHtml(
+      server,
+      "/nested%20directory/page",
+      `<script type="module" nonce="test-nonce">
+        import { encodedDirectoryValue } from "./dep.js";
+        withNonce(encodedDirectoryValue);
+      </script>`,
+      "test-nonce",
+    );
+    const [url] = contentModuleUrls(transformed);
+
+    expect(url).toMatch(/^\/base\/nested%20directory\/__vinext_html_proxy_content_/);
+    expect(transformed).toContain('nonce="test-nonce"');
+    expect(normalHtml).toContain(url);
+    expect(postHtml).toContain(url);
+    await expect(server.transformRequest(url!)).resolves.toMatchObject({
+      code: expect.stringContaining("nested directory/dep.js"),
+    });
+
+    const percentEncoded = await transformPagesHtml(
+      server,
+      "/encoded%25directory/page",
+      `<script type="module">encodedPercent()</script>`,
+    );
+    const [percentUrl] = contentModuleUrls(percentEncoded);
+    expect(percentUrl).toContain("/base/encoded%25directory/");
+    await expect(server.transformRequest(percentUrl!)).resolves.toMatchObject({
+      code: expect.stringContaining("encodedPercent()"),
+    });
+  });
+
+  it("keeps an encoded public base separate from decoded filesystem paths", async () => {
+    const { root, server } = await createTestServer({
+      base: "/base%20directory/",
+      cspNonce: "static-nonce",
+    });
+    await mkdir(path.join(root, "nested directory"), { recursive: true });
+    await writeFile(
+      path.join(root, "nested directory", "dep.js"),
+      `export const encodedBaseValue = "resolved";`,
+    );
+    const transformed = await transformPagesHtml(
+      server,
+      "/nested%20directory/page",
+      `<script type="module">
+        import { encodedBaseValue } from "./dep.js";
+        useEncodedBase(encodedBaseValue);
+      </script>`,
+    );
+    const [url] = contentModuleUrls(transformed);
+
+    expect(url).toMatch(/^\/base%20directory\/nested%20directory\/__vinext_html_proxy_content_/);
+    expect(transformed).toContain('nonce="static-nonce"');
+    await expect(server.transformRequest(url!)).resolves.toMatchObject({
+      code: expect.stringContaining("nested directory/dep.js"),
+    });
+  });
+
+  it("resolves relative imports from the original nested document", async () => {
+    const { root, server } = await createTestServer();
+    await writeFile(path.join(root, "nested-relative.js"), `export const relativeValue = "ok";`);
+    const transformed = await transformPagesHtml(
+      server,
+      "/nested/page",
+      `<script type="module">
+        import { relativeValue } from "../nested-relative.js";
+        window.__relativeValue = relativeValue;
+      </script>`,
+    );
+    const [url] = contentModuleUrls(transformed);
+    const result = await server.transformRequest(url!);
+
+    expect(result?.code).toContain("/nested-relative.js");
+    expect(result?.code).toContain("window.__relativeValue = relativeValue");
+  });
+
+  it("releases the per-document lock when an HTML transform throws", async () => {
+    let shouldThrow = true;
+    const { server } = await createTestServer({
+      plugins: [
+        {
+          name: "test:throw-once",
+          transformIndexHtml: {
+            order: "post",
+            handler() {
+              if (!shouldThrow) return;
+              shouldThrow = false;
+              throw new Error("intentional transform failure");
+            },
+          },
+        },
+      ],
+    });
+
+    await expect(
+      transformPagesHtml(server, "/page", `<script type="module">first()</script>`),
+    ).rejects.toThrow("intentional transform failure");
+    const recovered = await transformPagesHtml(
+      server,
+      "/page",
+      `<script type="module">recovered()</script>`,
+    );
+
+    expect(contentModuleUrls(recovered)).toHaveLength(1);
+    await expect(server.transformRequest(contentModuleUrls(recovered)[0]!)).resolves.toMatchObject({
+      code: expect.stringContaining("recovered()"),
+    });
+  });
+});

--- a/tests/pages-html-proxy.test.ts
+++ b/tests/pages-html-proxy.test.ts
@@ -24,16 +24,17 @@ describe("Pages HTML proxy capture", () => {
   ) {
     const root = await mkdtemp(path.join(os.tmpdir(), "vinext-pages-html-proxy-"));
     roots.push(root);
+    const capturePlugin = createPagesHtmlProxyCapturePlugin();
     const server = await createServer({
       appType: "custom",
       base: options.base,
       html: options.cspNonce ? { cspNonce: options.cspNonce } : undefined,
       logLevel: "silent",
-      plugins: [createPagesHtmlProxyCapturePlugin(), ...(options.plugins ?? [])],
+      plugins: [capturePlugin, ...(options.plugins ?? [])],
       root,
     });
     servers.push(server);
-    return { root, server };
+    return { capturePlugin, root, server };
   }
 
   afterEach(async () => {
@@ -189,6 +190,51 @@ describe("Pages HTML proxy capture", () => {
     await expect(server.transformRequest(renderedUrls.at(-1)!)).resolves.toMatchObject({
       code: expect.stringContaining("renderVersion(299)"),
     });
+  });
+
+  it("bounds retained modules across distinct document URLs", async () => {
+    const { server } = await createTestServer();
+    const renderedUrls: string[] = [];
+
+    for (let index = 0; index < 160; index += 1) {
+      const transformed = await transformPagesHtml(
+        server,
+        `/docs/${index}`,
+        `<script type="module">documentVersion(${index})</script>`,
+      );
+      const url = contentModuleUrls(transformed)[0]!;
+      renderedUrls.push(url);
+      await server.transformRequest(url);
+    }
+
+    const graph = server.environments.client.moduleGraph;
+    const retainedGraphUrls = Array.from(graph.urlToModuleMap.keys()).filter((url) =>
+      url.includes("__vinext_html_proxy_content_"),
+    );
+    expect(retainedGraphUrls.length).toBeLessThanOrEqual(128);
+    await expect(server.transformRequest(renderedUrls[0]!)).rejects.toThrow();
+    await expect(server.transformRequest(renderedUrls.at(-1)!)).resolves.toMatchObject({
+      code: expect.stringContaining("documentVersion(159)"),
+    });
+  });
+
+  it("evicts retained proxies when the source graph updates", async () => {
+    const { capturePlugin, server } = await createTestServer();
+    const transformed = await transformPagesHtml(
+      server,
+      "/page",
+      `<script type="module">beforeUpdate()</script>`,
+    );
+    const url = contentModuleUrls(transformed)[0]!;
+    await expect(server.transformRequest(url)).resolves.toMatchObject({
+      code: expect.stringContaining("beforeUpdate()"),
+    });
+
+    const hotUpdate = capturePlugin.hotUpdate;
+    if (typeof hotUpdate !== "function") throw new Error("Expected a hotUpdate handler");
+    await hotUpdate.call(undefined as never, { server } as never);
+
+    await expect(server.transformRequest(url)).rejects.toThrow();
   });
 
   it("retains every current proxy index in a document", async () => {

--- a/tests/pages-html-proxy.test.ts
+++ b/tests/pages-html-proxy.test.ts
@@ -210,6 +210,46 @@ describe("Pages HTML proxy capture", () => {
     }
   });
 
+  it("finishes eviction when Vite module resolution is still pending", async () => {
+    const { server } = await createTestServer();
+    const first = await transformPagesHtml(
+      server,
+      "/page",
+      `<script type="module">pendingVersion(0)</script>`,
+    );
+    const firstUrl = contentModuleUrls(first)[0]!;
+    const graph = server.environments.client.moduleGraph;
+    const internals = graph as unknown as {
+      _resolveId: (url: string) => Promise<{ id: string } | null>;
+      _unresolvedUrlToModuleMap: Map<string, unknown>;
+    };
+    const originalResolveId = internals._resolveId.bind(graph);
+    let releaseResolution!: () => void;
+    const resolutionGate = new Promise<void>((resolve) => {
+      releaseResolution = resolve;
+    });
+    internals._resolveId = async (url) => {
+      if (url === firstUrl) await resolutionGate;
+      return originalResolveId(url);
+    };
+
+    const pendingModule = graph.ensureEntryFromUrl(firstUrl);
+    expect(internals._unresolvedUrlToModuleMap.get(firstUrl)).toBeInstanceOf(Promise);
+    for (let index = 1; index <= 8; index += 1) {
+      await transformPagesHtml(
+        server,
+        "/page",
+        `<script type="module">pendingVersion(${index})</script>`,
+      );
+    }
+
+    releaseResolution();
+    await pendingModule;
+    await Promise.resolve();
+    expect(graph.urlToModuleMap.has(firstUrl)).toBe(false);
+    expect(internals._unresolvedUrlToModuleMap.has(firstUrl)).toBe(false);
+  });
+
   it("keeps duplicate modules and Vite proxy indices distinct", async () => {
     const { server } = await createTestServer();
     const transformed = await transformPagesHtml(

--- a/tests/pages-html-proxy.test.ts
+++ b/tests/pages-html-proxy.test.ts
@@ -157,6 +157,59 @@ describe("Pages HTML proxy capture", () => {
     expect((await server.transformRequest(secondUrl!))?.code).toContain("stateful(2)");
   });
 
+  it("bounds retained request-dependent proxy modules", async () => {
+    const { server } = await createTestServer();
+    const renderedUrls: string[] = [];
+
+    for (let index = 0; index < 300; index += 1) {
+      const transformed = await transformPagesHtml(
+        server,
+        "/page",
+        `<script type="module">renderVersion(${index})</script>`,
+      );
+      const url = contentModuleUrls(transformed)[0]!;
+      renderedUrls.push(url);
+      await server.transformRequest(url);
+    }
+
+    const graph = server.environments.client.moduleGraph;
+    const retainedGraphUrls = Array.from(graph.urlToModuleMap.keys()).filter((url) =>
+      url.includes("__vinext_html_proxy_content_"),
+    );
+    const unresolvedUrls = Array.from(
+      (
+        graph as unknown as {
+          _unresolvedUrlToModuleMap: Map<string, unknown>;
+        }
+      )._unresolvedUrlToModuleMap.keys(),
+    ).filter((url) => url.includes("__vinext_html_proxy_content_"));
+    expect(retainedGraphUrls.length).toBeLessThanOrEqual(8);
+    expect(unresolvedUrls.length).toBeLessThanOrEqual(8);
+    await expect(server.transformRequest(renderedUrls[0]!)).rejects.toThrow();
+    await expect(server.transformRequest(renderedUrls.at(-1)!)).resolves.toMatchObject({
+      code: expect.stringContaining("renderVersion(299)"),
+    });
+  });
+
+  it("retains every current proxy index in a document", async () => {
+    const { server } = await createTestServer();
+    const transformed = await transformPagesHtml(
+      server,
+      "/page",
+      Array.from(
+        { length: 12 },
+        (_, index) => `<script type="module">currentModule(${index})</script>`,
+      ).join(""),
+    );
+    const urls = contentModuleUrls(transformed);
+
+    expect(urls).toHaveLength(12);
+    const results = await Promise.all(urls.map((url) => server.transformRequest(url)));
+    for (let index = 0; index < results.length; index += 1) {
+      expect(results[index]?.code).toContain(`currentModule(${index})`);
+    }
+  });
+
   it("keeps duplicate modules and Vite proxy indices distinct", async () => {
     const { server } = await createTestServer();
     const transformed = await transformPagesHtml(

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -152,6 +152,14 @@ function getStylesheetHrefs(html: string): string[] {
     .filter((href): href is string => href !== null);
 }
 
+function getImmutablePagesHtmlProxyPaths(html: string): string[] {
+  expect(html).not.toContain("?html-proxy&index=");
+  return Array.from(
+    html.matchAll(/src="([^"]*__vinext_html_proxy_content_[^"]*\.js)"/g),
+    (match) => match[1]!,
+  );
+}
+
 function writePagesAppGlobalCssFixture(rootDir: string): PagesAppGlobalCssFixture {
   const pagesDir = path.join(rootDir, "pages");
   const libDir = path.join(rootDir, "lib");
@@ -677,9 +685,32 @@ function findBuildManifestEntries(
 describe("Pages Router integration", () => {
   let server: ViteDevServer;
   let baseUrl: string;
+  let htmlProxyPreHookSequence = 0;
 
   beforeAll(async () => {
-    ({ server, baseUrl } = await startFixtureServer(FIXTURE_DIR));
+    ({ server, baseUrl } = await startFixtureServer(FIXTURE_DIR, {
+      plugins: [
+        {
+          name: "test:stateful-pages-html-pre-hook",
+          transformIndexHtml: {
+            order: "pre",
+            handler(html, context) {
+              if (
+                context.path.split(/[?#]/, 1)[0] !== "/html-proxy-recovery" ||
+                !html.includes("__VINEXT_HTML_PROXY_PRE_HOOK_SEQUENCE__")
+              ) {
+                return;
+              }
+              htmlProxyPreHookSequence += 1;
+              return html.replace(
+                "__VINEXT_HTML_PROXY_PRE_HOOK_SEQUENCE__",
+                String(htmlProxyPreHookSequence),
+              );
+            },
+          },
+        },
+      ],
+    }));
   });
 
   afterAll(async () => {
@@ -848,6 +879,11 @@ describe("Pages Router integration", () => {
     expect(html).toContain(
       '<script id="__NEXT_DATA__" type="application/json" nonce="pages-response">',
     );
+    const immutableProxyTags = html.match(
+      /<script\b[^>]*src="[^"]*__vinext_html_proxy_content_[^"]*"[^>]*><\/script>/g,
+    );
+    expect(immutableProxyTags).not.toBeNull();
+    expect(immutableProxyTags!.every((tag) => tag.includes('nonce="pages-response"'))).toBe(true);
   });
 
   it("renders Pages GSP HTML afresh for CSP nonce requests", async () => {
@@ -1077,6 +1113,153 @@ describe("Pages Router integration", () => {
     const html = await res.text();
     expect(html).toContain("custom pages/500");
     expect(html).not.toBe("Internal Server Error");
+  });
+
+  // Next.js Pages dev recovers in the same process after a render error:
+  // https://github.com/vercel/next.js/blob/canary/test/development/acceptance/error-recovery.test.ts
+  it("keeps overlapping success and error hydration modules isolated", async () => {
+    const raceId = `overlap-${Date.now()}`;
+    const requestUrl = `${baseUrl}/html-proxy-recovery?race=${raceId}`;
+    const controlUrl = `${baseUrl}/api/html-proxy-race-control?id=${raceId}`;
+    const delayedErrorResponse = fetch(requestUrl);
+
+    try {
+      await vi.waitFor(async () => {
+        const status = (await fetch(controlUrl).then((response) => response.json())) as {
+          firstRequestStarted: boolean;
+        };
+        expect(status.firstRequestStarted).toBe(true);
+      }, 5_000);
+
+      const successResponse = await fetch(requestUrl);
+      expect(successResponse.status).toBe(200);
+      const successHtml = await successResponse.text();
+      expect(successHtml).toContain("route render recovered");
+
+      await fetch(`${controlUrl}&action=release`);
+      const errorResponse = await delayedErrorResponse;
+      expect(errorResponse.status).toBe(500);
+      const errorHtml = await errorResponse.text();
+      expect(errorHtml).toContain("custom pages/500");
+
+      const getProxyPath = (html: string) => getImmutablePagesHtmlProxyPaths(html)[0];
+      const successProxyPath = getProxyPath(successHtml);
+      const errorProxyPath = getProxyPath(errorHtml);
+      expect(successProxyPath).toBeDefined();
+      expect(errorProxyPath).toBeDefined();
+      expect(successProxyPath).not.toBe(errorProxyPath);
+
+      const [successProxy, errorProxy] = await Promise.all(
+        [successProxyPath!, errorProxyPath!].map((proxyPath) =>
+          fetch(new URL(proxyPath, baseUrl)).then((response) => response.text()),
+        ),
+      );
+      expect(successProxy).toContain("/pages/html-proxy-recovery.tsx");
+      expect(successProxy).not.toContain("/pages/500.tsx");
+      expect(errorProxy).toContain("/pages/500.tsx");
+      expect(errorProxy).not.toContain("/pages/html-proxy-recovery.tsx");
+    } finally {
+      await fetch(`${controlUrl}&action=release`);
+    }
+  });
+
+  it("keeps request-dependent inline module proxies isolated", async () => {
+    const raceId = `inline-overlap-${Date.now()}`;
+    const requestUrl = `${baseUrl}/html-proxy-recovery?inlineRace=${raceId}`;
+    const controlUrl = `${baseUrl}/api/html-proxy-race-control?id=${raceId}`;
+    const delayedFirstResponse = fetch(requestUrl);
+
+    try {
+      await vi.waitFor(async () => {
+        const status = (await fetch(controlUrl).then((response) => response.json())) as {
+          firstRequestStarted: boolean;
+        };
+        expect(status.firstRequestStarted).toBe(true);
+      }, 5_000);
+
+      const secondResponse = await fetch(requestUrl);
+      expect(secondResponse.status).toBe(200);
+      const secondHtml = await secondResponse.text();
+
+      await fetch(`${controlUrl}&action=release`);
+      const firstResponse = await delayedFirstResponse;
+      expect(firstResponse.status).toBe(200);
+      const firstHtml = await firstResponse.text();
+
+      const getProxyPaths = getImmutablePagesHtmlProxyPaths;
+      const firstProxyPaths = getProxyPaths(firstHtml);
+      const secondProxyPaths = getProxyPaths(secondHtml);
+      expect(firstProxyPaths.length).toBeGreaterThanOrEqual(2);
+      expect(secondProxyPaths.length).toBe(firstProxyPaths.length);
+      expect(secondProxyPaths).not.toEqual(firstProxyPaths);
+
+      const [firstInlineModule, secondInlineModule] = await Promise.all([
+        fetch(new URL(firstProxyPaths[0]!, baseUrl)).then((response) => response.text()),
+        fetch(new URL(secondProxyPaths[0]!, baseUrl)).then((response) => response.text()),
+      ]);
+      expect(firstInlineModule).toContain('__HTML_PROXY_INLINE_VARIANT__ = "first"');
+      expect(firstInlineModule).not.toContain('__HTML_PROXY_INLINE_VARIANT__ = "second"');
+      expect(secondInlineModule).toContain('__HTML_PROXY_INLINE_VARIANT__ = "second"');
+      expect(secondInlineModule).not.toContain('__HTML_PROXY_INLINE_VARIANT__ = "first"');
+      expect(firstInlineModule).toContain('from "/html-proxy-relative.ts"');
+      const relativeModule = await fetch(`${baseUrl}/html-proxy-relative.ts`).then((response) =>
+        response.text(),
+      );
+      expect(relativeModule).toContain('htmlProxyRelativeValue = "relative import resolved"');
+    } finally {
+      await fetch(`${controlUrl}&action=release`);
+    }
+  });
+
+  it("captures stateful pre HTML hook output in immutable modules", async () => {
+    const requestUrl = `${baseUrl}/html-proxy-recovery?preHookProxy=1`;
+    const firstHtml = await fetch(requestUrl).then((response) => response.text());
+    const secondHtml = await fetch(requestUrl).then((response) => response.text());
+    const getProxyPaths = getImmutablePagesHtmlProxyPaths;
+    const firstProxyPaths = getProxyPaths(firstHtml);
+    const secondProxyPaths = getProxyPaths(secondHtml);
+    const loadPreHookModule = async (paths: string[]) => {
+      const sources = await Promise.all(
+        paths.map((proxyPath) =>
+          fetch(new URL(proxyPath, baseUrl)).then((response) => response.text()),
+        ),
+      );
+      return sources.find((source) => source.includes("__HTML_PROXY_PRE_HOOK_SEQUENCE__"));
+    };
+    const [firstModule, secondModule] = await Promise.all([
+      loadPreHookModule(firstProxyPaths),
+      loadPreHookModule(secondProxyPaths),
+    ]);
+    const sequence = (source: string | undefined) =>
+      source?.match(/__HTML_PROXY_PRE_HOOK_SEQUENCE__ = "(\d+)"/)?.[1];
+
+    expect(firstModule).toBeDefined();
+    expect(secondModule).toBeDefined();
+    expect(sequence(firstModule)).toBeDefined();
+    expect(sequence(secondModule)).toBeDefined();
+    expect(sequence(firstModule)).not.toBe(sequence(secondModule));
+  });
+
+  it("reuses hydration proxies when only non-module response data changes", async () => {
+    const raceId = `data-variant-${Date.now()}`;
+    const requestUrl = `${baseUrl}/html-proxy-recovery?dataRace=${raceId}`;
+
+    const firstResponse = await fetch(requestUrl);
+    expect(firstResponse.status).toBe(200);
+    const firstHtml = await firstResponse.text();
+    expect(firstHtml).toContain("first-data");
+
+    const secondResponse = await fetch(requestUrl);
+    expect(secondResponse.status).toBe(200);
+    const secondHtml = await secondResponse.text();
+    expect(secondHtml).toContain("second-data");
+    expect(secondHtml).not.toBe(firstHtml);
+
+    const getProxyPaths = getImmutablePagesHtmlProxyPaths;
+    const firstProxyPaths = getProxyPaths(firstHtml);
+    const secondProxyPaths = getProxyPaths(secondHtml);
+    expect(firstProxyPaths.length).toBeGreaterThan(0);
+    expect(secondProxyPaths).toEqual(firstProxyPaths);
   });
 
   it("renders dynamic routes with params", async () => {
@@ -1514,9 +1697,7 @@ export default function Page({ marker }: { marker: string }) {
   it("installs the vinext dev error overlay in the hydration script", async () => {
     const res = await fetch(`${baseUrl}/`);
     const html = await res.text();
-    const hydrationProxyPath = html.match(
-      /<script type="module" src="([^"]*html-proxy[^"]*)"><\/script>/,
-    )?.[1];
+    const hydrationProxyPath = getImmutablePagesHtmlProxyPaths(html)[0];
     expect(hydrationProxyPath).toBeDefined();
 
     const hydrationProxy = await fetch(new URL(hydrationProxyPath!, baseUrl)).then((response) =>
@@ -1614,9 +1795,7 @@ export default class CustomDocument extends Document {
         const nextData = JSON.parse(nextDataMatch![1]);
         expect(nextData.__vinext.appModuleUrl).toBe("/pages/_app.page.tsx");
 
-        const hydrationProxyPath = html.match(
-          /<script type="module" src="([^"]*html-proxy[^"]*)"><\/script>/,
-        )?.[1];
+        const hydrationProxyPath = getImmutablePagesHtmlProxyPaths(html)[0];
         expect(hydrationProxyPath).toBeDefined();
         const hydrationProxy = await fetch(new URL(hydrationProxyPath!, started.baseUrl)).then(
           (proxyResponse) => proxyResponse.text(),
@@ -1832,9 +2011,7 @@ export default class CustomDocument extends Document {
   it("includes hydration script for client-side rendering", async () => {
     const res = await fetch(`${baseUrl}/`);
     const html = await res.text();
-    // Vite extracts inline module scripts into html-proxy modules.
-    // The hydration script becomes a <script type="module" src="...html-proxy...">
-    expect(html).toMatch(/html-proxy.*\.js/);
+    expect(getImmutablePagesHtmlProxyPaths(html)).not.toHaveLength(0);
   });
 
   // --- Catch-all Routes ---
@@ -2557,10 +2734,10 @@ export default class CustomDocument extends Document {
     // and verify it contains our hydration code
     const res = await fetch(`${baseUrl}/`);
     const html = await res.text();
-    const proxyMatch = html.match(/src="([^"]*html-proxy[^"]*)"/);
-    expect(proxyMatch).toBeTruthy();
+    const proxyPath = getImmutablePagesHtmlProxyPaths(html)[0];
+    expect(proxyPath).toBeDefined();
 
-    const scriptRes = await fetch(`${baseUrl}${proxyMatch![1]}`);
+    const scriptRes = await fetch(`${baseUrl}${proxyPath}`);
     expect(scriptRes.status).toBe(200);
     const scriptContent = await scriptRes.text();
     // The proxy module should contain our hydration imports


### PR DESCRIPTION
## Summary

- serialize Pages HTML transforms per clean document URL, then let Vite run its supported pre hooks and parser before capture
- capture the exact Vite-generated inline JavaScript proxy sources inside a normal HTML hook and rewrite response tags to immutable content-addressed vinext modules
- preserve supported user hook context, request CSP nonces, base paths, encoded directories, relative imports, source maps, module side effects, HMR relationships, root/trailing/query paths, and filesystem-backed proxy IDs
- dedupe identical executable modules so changes limited to the SSR body or `__NEXT_DATA__` reuse the same immutable URLs

## Regression coverage

- real Pages fixture with an API-controlled barrier for overlapping same-URL success and error responses
- request-dependent user inline modules with a real relative TypeScript import
- stateful `order: pre` HTML hook output captured after Vite processing
- repeated responses with different body and `__NEXT_DATA__` values reuse proxy URLs
- request-derived middleware CSP nonce remains on immutable hydration scripts
- focused Vite server coverage for hook paths, root and trailing paths with queries, filesystem path collisions, static and dynamic CSP nonces, encoded public bases and directories, duplicate proxy indices, and lock recovery
- pre-fix source fails the overlap and mutable-URL assertions

Next.js recovery reference: https://github.com/vercel/next.js/blob/canary/test/development/acceptance/error-recovery.test.ts

Vite implementation reference: https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/middlewares/indexHtml.ts

## Validation

- `vp test run tests/pages-html-proxy.test.ts` — 10 passed
- affected real Pages fixture cases — 10 passed
- `vp test run tests/pages-router.test.ts` — 382 passed
- `PLAYWRIGHT_PROJECT=pages-router-basepath-dev vp run test:e2e` — 3 passed
- touched check and `vp run vinext#build` passed
- two independent exact-diff reviews — NO FINDINGS