### PR TITLE
fix(dev): adopt initial Pages stylesheets in Vite

### DIFF
--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -23,12 +23,7 @@ import {
 // These modules must be imported before any rendering occurs.
 import "vinext/shims/router-state";
 import { withScriptNonce } from "vinext/shims/script-nonce-context";
-import {
-  createInlineScriptTag,
-  createNonceAttribute,
-  escapeHtmlAttr,
-  safeJsonStringify,
-} from "./html.js";
+import { createInlineScriptTag, createNonceAttribute, safeJsonStringify } from "./html.js";
 import {
   applyDocumentAssetProps,
   extractDocumentAssetProps,
@@ -69,9 +64,9 @@ import {
   type PagesStaticPathsEntry,
 } from "./pages-page-data.js";
 import { sanitizeDestination } from "../config/config-matchers.js";
-import { createPagesDevAssetUrl, createPagesDevModuleUrl } from "./pages-dev-module-url.js";
+import { collectPagesDevInitialStylesheetHeadHTML } from "./pages-dev-stylesheets.js";
+import { createPagesDevModuleUrl } from "./pages-dev-module-url.js";
 import { createPagesDevHydrationScript } from "./pages-dev-hydration.js";
-import { getManifestFilesForModule } from "./pages-asset-tags.js";
 import { isSerializableProps } from "./pages-serializable-props.js";
 import { isDangerousScheme } from "vinext/shims/url-safety";
 import {
@@ -163,133 +158,6 @@ function buildDevPagesTerminalCacheControl(
   // stale-while-revalidate without an expire value in this case.
   if (revalidateSeconds === false) return `s-maxage=${PAGES_CACHE_ONE_YEAR_SECONDS}`;
   return buildMissIsrCacheControl(revalidateSeconds, expireSeconds);
-}
-
-const DEV_STYLESHEET_ASSET_RE = /\.(?:css|scss|sass)$/i;
-
-type PagesClientAssetsModule = {
-  default?: {
-    ssrManifest?: Record<string, string[]>;
-  };
-};
-
-const transformedStylesheetAssetsCache = new WeakMap<ViteDevServer, Map<string, string[]>>();
-const transformedStylesheetAssetsWatchers = new WeakSet<ViteDevServer>();
-
-function createDevInitialStylesheetHeadHTML(options: {
-  ssrManifest: Record<string, string[]> | null | undefined;
-  moduleIds: (string | null | undefined)[];
-  nonceAttr: string;
-}): string {
-  const { ssrManifest, moduleIds, nonceAttr } = options;
-  if (!ssrManifest || moduleIds.length === 0) return "";
-
-  const seen = new Set<string>();
-  let html = "";
-  for (const moduleId of moduleIds) {
-    const files = getManifestFilesForModule(ssrManifest, moduleId);
-    if (!files) continue;
-    for (const file of files) {
-      if (!DEV_STYLESHEET_ASSET_RE.test(file) || seen.has(file)) continue;
-      seen.add(file);
-      const href = createPagesDevAssetUrl(file);
-      html += `<link rel="stylesheet"${nonceAttr} href="${escapeHtmlAttr(href)}" />\n  `;
-    }
-  }
-  return html;
-}
-
-async function collectTransformedStylesheetAssets(
-  server: ViteDevServer,
-  moduleIds: (string | null | undefined)[],
-): Promise<string[]> {
-  const clientEnvironment = server.environments.client;
-  if (!clientEnvironment) return [];
-
-  const cachedServerAssets = transformedStylesheetAssetsCache.get(server);
-  const cache = cachedServerAssets ?? new Map<string, string[]>();
-  if (!cachedServerAssets) transformedStylesheetAssetsCache.set(server, cache);
-  if (!transformedStylesheetAssetsWatchers.has(server)) {
-    transformedStylesheetAssetsWatchers.add(server);
-    const clearCache = () => cache.clear();
-    server.watcher.on("add", clearCache);
-    server.watcher.on("change", clearCache);
-    server.watcher.on("unlink", clearCache);
-  }
-
-  const cacheKey = moduleIds.filter((moduleId): moduleId is string => Boolean(moduleId)).join("\0");
-  const cachedAssets = cache.get(cacheKey);
-  if (cachedAssets) return cachedAssets;
-
-  const assets = new Set<string>();
-  const seenModules = new Set<string>();
-  async function visitModule(moduleUrl: string): Promise<void> {
-    if (seenModules.has(moduleUrl)) return;
-    seenModules.add(moduleUrl);
-    try {
-      await clientEnvironment.transformRequest(moduleUrl);
-      const moduleNode = await clientEnvironment.moduleGraph.getModuleByUrl(moduleUrl);
-      if (!moduleNode) return;
-      for (const importedModule of moduleNode.importedModules) {
-        if (
-          importedModule.type === "css" ||
-          /\.(?:css|scss|sass)(?:$|[?#])/i.test(importedModule.url)
-        ) {
-          if (importedModule.url.startsWith("//")) continue;
-          const assetUrl = importedModule.url.startsWith("\0")
-            ? `/@id/__x00__${importedModule.url.slice(1)}${importedModule.url.includes("?") ? "&" : "?"}direct`
-            : importedModule.url;
-          assets.add(assetUrl);
-        } else if (importedModule.type === "js") {
-          await visitModule(importedModule.url);
-        }
-      }
-    } catch {
-      // Preserve the source-manifest fallback when a third-party client
-      // transform fails while the server render itself remains valid.
-    }
-  }
-
-  for (const moduleId of moduleIds) {
-    if (!moduleId) continue;
-    await visitModule(createPagesDevModuleUrl(server.config.root, moduleId, "/"));
-  }
-  const result = [...assets];
-  cache.set(cacheKey, result);
-  return result;
-}
-
-async function collectDevInitialStylesheetHeadHTML(
-  server: ViteDevServer,
-  runner: ModuleImporter,
-  moduleIds: (string | null | undefined)[],
-  nonceAttr: string,
-): Promise<string> {
-  let manifestHTML = "";
-  try {
-    const pagesClientAssets = (await runner.import(
-      "virtual:vinext-pages-client-assets",
-    )) as PagesClientAssetsModule;
-    manifestHTML = createDevInitialStylesheetHeadHTML({
-      ssrManifest: pagesClientAssets.default?.ssrManifest,
-      moduleIds,
-      nonceAttr,
-    });
-  } catch {
-    // If dev asset metadata is unavailable, keep the existing client-graph
-    // CSS behavior instead of failing the page render.
-  }
-
-  const transformedAssets = await collectTransformedStylesheetAssets(server, moduleIds);
-  if (transformedAssets.length === 0) return manifestHTML;
-
-  let html = manifestHTML;
-  for (const asset of transformedAssets) {
-    const href = asset.startsWith("/") ? asset : createPagesDevAssetUrl(asset);
-    if (html.includes(`href="${escapeHtmlAttr(href)}"`)) continue;
-    html += `<link rel="stylesheet"${nonceAttr} href="${escapeHtmlAttr(href)}" />\n  `;
-  }
-  return html;
 }
 
 /**
@@ -1573,7 +1441,7 @@ export function createSSRHandler(
         // Collect SSR font links (Google Fonts <link> tags) and font class styles
         let fontHeadHTML = "";
         const appAssetPath = AppComponent ? appFilePath : null;
-        const assetHeadHTML = await collectDevInitialStylesheetHeadHTML(
+        const assetHeadHTML = await collectPagesDevInitialStylesheetHeadHTML(
           server,
           runner,
           [appAssetPath, route.filePath],
@@ -2053,7 +1921,7 @@ async function renderErrorPage(
       const responseHeaders = typeof res.getHeaders === "function" ? res.getHeaders() : undefined;
       const scriptNonce = getScriptNonceFromNodeHeaderSources(req.headers, responseHeaders);
       const nonceAttr = createNonceAttribute(scriptNonce);
-      const assetHeadHTML = await collectDevInitialStylesheetHeadHTML(
+      const assetHeadHTML = await collectPagesDevInitialStylesheetHeadHTML(
         server,
         runner,
         [appAssetPath, errorAssetPath],

--- a/packages/vinext/src/server/pages-dev-stylesheets.ts
+++ b/packages/vinext/src/server/pages-dev-stylesheets.ts
@@ -8,7 +8,9 @@ const DEV_STYLESHEET_ASSET_RE = /\.(?:css|scss|sass)$/i;
 const DEV_STYLESHEET_MODULE_RE = /\.(?:css|scss|sass)(?:$|[?#])/i;
 // These Vite query modes replace the imported module instead of executing it
 // in the current document. `inline` and `direct` only have that meaning for
-// stylesheets; plain JavaScript carrying those queries still executes.
+// stylesheets; plain JavaScript carrying those queries still executes. Vite's
+// asset and worker loaders require these to be bare flags, so values such as
+// `?raw=false` do not activate the loader and the JavaScript still executes.
 const NON_EXECUTING_MODULE_QUERY_RE = /[?&](?:raw|url|worker|sharedworker)(?:&|$)/;
 const NON_INJECTING_STYLESHEET_QUERY_RE = /[?&](?:raw|url|worker|sharedworker|inline|direct)\b/;
 
@@ -133,7 +135,8 @@ async function collectTransformedStylesheetAssets(
   const cachedAssets = cache.get(cacheKey);
   if (cachedAssets) return cachedAssets;
 
-  const assets = new Map<string, PagesDevStylesheetAsset>();
+  const assets: PagesDevStylesheetAsset[] = [];
+  const assetKeyIndexes = new Map<string, number>();
   const seenModules = new Set<string>();
   async function addStylesheet(moduleNode: EnvironmentModuleNode): Promise<void> {
     const href = moduleNode.url.startsWith("\0")
@@ -144,7 +147,7 @@ async function collectTransformedStylesheetAssets(
       moduleNode.url,
       moduleNode.id,
     );
-    assets.set(viteDevId ? `id:${viteDevId}` : `url:${canonicalStylesheetUrl(href)}`, {
+    appendStylesheetAsset(assets, assetKeyIndexes, {
       href,
       viteDevId,
     });
@@ -178,7 +181,7 @@ async function collectTransformedStylesheetAssets(
     if (!moduleId) continue;
     await visitModule(createPagesDevModuleUrl(server.config.root, moduleId, "/"));
   }
-  const result = [...assets.values()];
+  const result = assets;
   cache.set(cacheKey, result);
   return result;
 }
@@ -192,8 +195,35 @@ function canonicalStylesheetUrl(url: string): string {
   }
 }
 
-function stylesheetAssetKey(asset: PagesDevStylesheetAsset): string {
-  return asset.viteDevId ? `id:${asset.viteDevId}` : `url:${canonicalStylesheetUrl(asset.href)}`;
+function stylesheetAssetKeys(asset: PagesDevStylesheetAsset): string[] {
+  const keys = [`url:${canonicalStylesheetUrl(asset.href)}`];
+  if (asset.viteDevId) keys.unshift(`id:${asset.viteDevId}`);
+  return keys;
+}
+
+function appendStylesheetAsset(
+  assets: PagesDevStylesheetAsset[],
+  keyIndexes: Map<string, number>,
+  asset: PagesDevStylesheetAsset,
+): void {
+  const keys = stylesheetAssetKeys(asset);
+  const existingIndex = keys
+    .map((key) => keyIndexes.get(key))
+    .find((index): index is number => index !== undefined);
+
+  if (existingIndex !== undefined) {
+    // A manifest-only resolution can fail before transforming the client
+    // graph. Prefer the later graph asset so Vite can adopt the emitted link.
+    if (!assets[existingIndex].viteDevId && asset.viteDevId) {
+      assets[existingIndex] = asset;
+    }
+    for (const key of keys) keyIndexes.set(key, existingIndex);
+    return;
+  }
+
+  const index = assets.length;
+  assets.push(asset);
+  for (const key of keys) keyIndexes.set(key, index);
 }
 
 export async function collectPagesDevInitialStylesheetHeadHTML(
@@ -204,14 +234,14 @@ export async function collectPagesDevInitialStylesheetHeadHTML(
 ): Promise<string> {
   const manifestAssets = await collectManifestStylesheetAssets(server, runner, moduleIds);
   const transformedAssets = await collectTransformedStylesheetAssets(server, moduleIds);
-  const assets = new Map<string, PagesDevStylesheetAsset>();
+  const assets: PagesDevStylesheetAsset[] = [];
+  const assetKeyIndexes = new Map<string, number>();
   for (const asset of [...manifestAssets, ...transformedAssets]) {
-    const key = stylesheetAssetKey(asset);
-    if (!assets.has(key)) assets.set(key, asset);
+    appendStylesheetAsset(assets, assetKeyIndexes, asset);
   }
 
   let html = "";
-  for (const { href: rawHref, viteDevId } of assets.values()) {
+  for (const { href: rawHref, viteDevId } of assets) {
     const href = rawHref.startsWith("/") ? rawHref : createPagesDevAssetUrl(rawHref);
     const viteDevIdAttr = viteDevId ? ` data-vite-dev-id="${escapeHtmlAttr(viteDevId)}"` : "";
     html += `<link rel="stylesheet"${nonceAttr}${viteDevIdAttr} href="${escapeHtmlAttr(href)}" />\n  `;

--- a/packages/vinext/src/server/pages-dev-stylesheets.ts
+++ b/packages/vinext/src/server/pages-dev-stylesheets.ts
@@ -1,0 +1,220 @@
+import type { EnvironmentModuleGraph, EnvironmentModuleNode, ViteDevServer } from "vite";
+import type { ModuleImporter } from "./instrumentation.js";
+import { escapeHtmlAttr } from "./html.js";
+import { getManifestFilesForModule } from "./pages-asset-tags.js";
+import { createPagesDevAssetUrl, createPagesDevModuleUrl } from "./pages-dev-module-url.js";
+
+const DEV_STYLESHEET_ASSET_RE = /\.(?:css|scss|sass)$/i;
+const DEV_STYLESHEET_MODULE_RE = /\.(?:css|scss|sass)(?:$|[?#])/i;
+// These Vite query modes replace the imported module instead of executing it
+// in the current document. `inline` and `direct` only have that meaning for
+// stylesheets; plain JavaScript carrying those queries still executes.
+const NON_EXECUTING_MODULE_QUERY_RE = /[?&](?:raw|url|worker|sharedworker)(?:&|$)/;
+const NON_INJECTING_STYLESHEET_QUERY_RE = /[?&](?:raw|url|worker|sharedworker|inline|direct)\b/;
+
+type PagesClientAssetsModule = {
+  default?: {
+    ssrManifest?: Record<string, string[]>;
+  };
+};
+
+type PagesDevStylesheetAsset = {
+  href: string;
+  viteDevId: string | null;
+};
+
+export function isViteStylesheetGraphTraversalBoundary(
+  moduleNode: Pick<EnvironmentModuleNode, "url">,
+): boolean {
+  return (
+    NON_EXECUTING_MODULE_QUERY_RE.test(moduleNode.url) ||
+    (DEV_STYLESHEET_MODULE_RE.test(moduleNode.url) &&
+      NON_INJECTING_STYLESHEET_QUERY_RE.test(moduleNode.url))
+  );
+}
+
+export function isViteInjectedStylesheetModule(
+  moduleNode: Pick<EnvironmentModuleNode, "type" | "url">,
+): boolean {
+  return (
+    !isViteStylesheetGraphTraversalBoundary(moduleNode) &&
+    (moduleNode.type === "css" || DEV_STYLESHEET_MODULE_RE.test(moduleNode.url))
+  );
+}
+
+const transformedStylesheetAssetsCache = new WeakMap<
+  ViteDevServer,
+  Map<string, readonly PagesDevStylesheetAsset[]>
+>();
+const transformedStylesheetAssetsWatchers = new WeakSet<ViteDevServer>();
+
+function adoptableViteDevId(id: string | null | undefined): string | null {
+  // Vite passes its resolved transform id, including any query, straight to
+  // updateStyle(). A null byte cannot survive HTML parsing, so virtual ids
+  // using Rollup's \0 convention cannot be adopted by a server-rendered tag.
+  return id && !id.includes("\0") ? id : null;
+}
+
+/** Resolve the exact id Vite's CSS transform passes to updateStyle(). */
+export async function resolvePagesDevStylesheetId(
+  moduleGraph: Pick<EnvironmentModuleGraph, "resolveUrl">,
+  url: string,
+  resolvedId?: string | null,
+): Promise<string | null> {
+  const knownId = adoptableViteDevId(resolvedId);
+  if (knownId) return knownId;
+  if (resolvedId?.includes("\0")) return null;
+
+  try {
+    // Vite's transform middleware decodes the request URL before handing it
+    // to the module graph. Do the same for manifest-only assets that have not
+    // passed through transformRequest yet.
+    const [, id] = await moduleGraph.resolveUrl(decodeURI(url));
+    return adoptableViteDevId(id);
+  } catch {
+    return null;
+  }
+}
+
+async function collectManifestStylesheetAssets(
+  server: ViteDevServer,
+  runner: ModuleImporter,
+  moduleIds: (string | null | undefined)[],
+): Promise<PagesDevStylesheetAsset[]> {
+  let ssrManifest: Record<string, string[]> | undefined;
+  try {
+    const pagesClientAssets = (await runner.import(
+      "virtual:vinext-pages-client-assets",
+    )) as PagesClientAssetsModule;
+    ssrManifest = pagesClientAssets.default?.ssrManifest;
+  } catch {
+    return [];
+  }
+  if (!ssrManifest || moduleIds.length === 0) return [];
+
+  const moduleGraph = server.environments.client?.moduleGraph;
+  const seen = new Set<string>();
+  const assets: PagesDevStylesheetAsset[] = [];
+  for (const moduleId of moduleIds) {
+    const files = getManifestFilesForModule(ssrManifest, moduleId);
+    if (!files) continue;
+    for (const file of files) {
+      if (!DEV_STYLESHEET_ASSET_RE.test(file) || seen.has(file)) continue;
+      seen.add(file);
+      const href = createPagesDevAssetUrl(file);
+      assets.push({
+        href,
+        viteDevId: moduleGraph ? await resolvePagesDevStylesheetId(moduleGraph, href) : null,
+      });
+    }
+  }
+  return assets;
+}
+
+async function collectTransformedStylesheetAssets(
+  server: ViteDevServer,
+  moduleIds: (string | null | undefined)[],
+): Promise<readonly PagesDevStylesheetAsset[]> {
+  const clientEnvironment = server.environments.client;
+  if (!clientEnvironment) return [];
+
+  const cachedServerAssets = transformedStylesheetAssetsCache.get(server);
+  const cache = cachedServerAssets ?? new Map<string, readonly PagesDevStylesheetAsset[]>();
+  if (!cachedServerAssets) transformedStylesheetAssetsCache.set(server, cache);
+  if (!transformedStylesheetAssetsWatchers.has(server)) {
+    transformedStylesheetAssetsWatchers.add(server);
+    const clearCache = () => cache.clear();
+    server.watcher.on("add", clearCache);
+    server.watcher.on("change", clearCache);
+    server.watcher.on("unlink", clearCache);
+  }
+
+  const cacheKey = moduleIds.filter((moduleId): moduleId is string => Boolean(moduleId)).join("\0");
+  const cachedAssets = cache.get(cacheKey);
+  if (cachedAssets) return cachedAssets;
+
+  const assets = new Map<string, PagesDevStylesheetAsset>();
+  const seenModules = new Set<string>();
+  async function addStylesheet(moduleNode: EnvironmentModuleNode): Promise<void> {
+    const href = moduleNode.url.startsWith("\0")
+      ? `/@id/__x00__${moduleNode.url.slice(1)}${moduleNode.url.includes("?") ? "&" : "?"}direct`
+      : moduleNode.url;
+    const viteDevId = await resolvePagesDevStylesheetId(
+      clientEnvironment.moduleGraph,
+      moduleNode.url,
+      moduleNode.id,
+    );
+    assets.set(viteDevId ? `id:${viteDevId}` : `url:${canonicalStylesheetUrl(href)}`, {
+      href,
+      viteDevId,
+    });
+  }
+  async function visitModule(moduleUrl: string): Promise<void> {
+    if (seenModules.has(moduleUrl)) return;
+    seenModules.add(moduleUrl);
+    try {
+      await clientEnvironment.transformRequest(moduleUrl);
+      const moduleNode = await clientEnvironment.moduleGraph.getModuleByUrl(moduleUrl);
+      if (!moduleNode) return;
+      for (const importedModule of moduleNode.importedModules) {
+        // Vite can retain the underlying CSS file as a graph dependency of a
+        // special-query wrapper (for example, `style.css?raw` points at
+        // `style.css`). The browser does not execute that file as a stylesheet,
+        // so the wrapper is also a traversal boundary.
+        if (isViteStylesheetGraphTraversalBoundary(importedModule)) continue;
+        if (isViteInjectedStylesheetModule(importedModule)) {
+          if (!importedModule.url.startsWith("//")) await addStylesheet(importedModule);
+        } else if (importedModule.type === "js") {
+          await visitModule(importedModule.url);
+        }
+      }
+    } catch {
+      // Preserve the source-manifest fallback when a third-party client
+      // transform fails while the server render itself remains valid.
+    }
+  }
+
+  for (const moduleId of moduleIds) {
+    if (!moduleId) continue;
+    await visitModule(createPagesDevModuleUrl(server.config.root, moduleId, "/"));
+  }
+  const result = [...assets.values()];
+  cache.set(cacheKey, result);
+  return result;
+}
+
+function canonicalStylesheetUrl(url: string): string {
+  try {
+    // decodeURI normalizes spaces while preserving encoded path separators.
+    return decodeURI(url);
+  } catch {
+    return url;
+  }
+}
+
+function stylesheetAssetKey(asset: PagesDevStylesheetAsset): string {
+  return asset.viteDevId ? `id:${asset.viteDevId}` : `url:${canonicalStylesheetUrl(asset.href)}`;
+}
+
+export async function collectPagesDevInitialStylesheetHeadHTML(
+  server: ViteDevServer,
+  runner: ModuleImporter,
+  moduleIds: (string | null | undefined)[],
+  nonceAttr: string,
+): Promise<string> {
+  const manifestAssets = await collectManifestStylesheetAssets(server, runner, moduleIds);
+  const transformedAssets = await collectTransformedStylesheetAssets(server, moduleIds);
+  const assets = new Map<string, PagesDevStylesheetAsset>();
+  for (const asset of [...manifestAssets, ...transformedAssets]) {
+    const key = stylesheetAssetKey(asset);
+    if (!assets.has(key)) assets.set(key, asset);
+  }
+
+  let html = "";
+  for (const { href: rawHref, viteDevId } of assets.values()) {
+    const href = rawHref.startsWith("/") ? rawHref : createPagesDevAssetUrl(rawHref);
+    const viteDevIdAttr = viteDevId ? ` data-vite-dev-id="${escapeHtmlAttr(viteDevId)}"` : "";
+    html += `<link rel="stylesheet"${nonceAttr}${viteDevIdAttr} href="${escapeHtmlAttr(href)}" />\n  `;
+  }
+  return html;
+}

--- a/packages/vinext/src/server/pages-dev-stylesheets.ts
+++ b/packages/vinext/src/server/pages-dev-stylesheets.ts
@@ -9,8 +9,9 @@ const DEV_STYLESHEET_MODULE_RE = /\.(?:css|scss|sass)(?:$|[?#])/i;
 // These Vite query modes replace the imported module instead of executing it
 // in the current document. `inline` and `direct` only have that meaning for
 // stylesheets; plain JavaScript carrying those queries still executes. Vite's
-// asset and worker loaders require these to be bare flags, so values such as
-// `?raw=false` do not activate the loader and the JavaScript still executes.
+// asset and worker loader matchers require bare flags. Its broader
+// SPECIAL_QUERY_RE uses `\b` only to filter unrelated plugin hooks; it does
+// not define loader behavior. Thus `?raw=false` still executes as JavaScript.
 const NON_EXECUTING_MODULE_QUERY_RE = /[?&](?:raw|url|worker|sharedworker)(?:&|$)/;
 const NON_INJECTING_STYLESHEET_QUERY_RE = /[?&](?:raw|url|worker|sharedworker|inline|direct)\b/;
 
@@ -139,9 +140,7 @@ async function collectTransformedStylesheetAssets(
   const assetKeyIndexes = new Map<string, number>();
   const seenModules = new Set<string>();
   async function addStylesheet(moduleNode: EnvironmentModuleNode): Promise<void> {
-    const href = moduleNode.url.startsWith("\0")
-      ? `/@id/__x00__${moduleNode.url.slice(1)}${moduleNode.url.includes("?") ? "&" : "?"}direct`
-      : moduleNode.url;
+    const href = createViteStylesheetHref(moduleNode.url);
     const viteDevId = await resolvePagesDevStylesheetId(
       clientEnvironment.moduleGraph,
       moduleNode.url,
@@ -184,6 +183,17 @@ async function collectTransformedStylesheetAssets(
   const result = assets;
   cache.set(cacheKey, result);
   return result;
+}
+
+function createViteStylesheetHref(moduleUrl: string): string {
+  if (moduleUrl.startsWith("/")) return moduleUrl;
+
+  // This mirrors Vite's wrapId(). Custom and null-byte virtual ids are not
+  // browser URLs, so request their CSS through /@id/ in direct mode. Null-byte
+  // ids still cannot be adopted because HTML parsing cannot preserve the id;
+  // the link nevertheless provides the initial server-rendered stylesheet.
+  const wrappedId = `/@id/${moduleUrl.replace("\0", "__x00__")}`;
+  return `${wrappedId}${moduleUrl.includes("?") ? "&" : "?"}direct`;
 }
 
 function canonicalStylesheetUrl(url: string): string {
@@ -241,8 +251,7 @@ export async function collectPagesDevInitialStylesheetHeadHTML(
   }
 
   let html = "";
-  for (const { href: rawHref, viteDevId } of assets) {
-    const href = rawHref.startsWith("/") ? rawHref : createPagesDevAssetUrl(rawHref);
+  for (const { href, viteDevId } of assets) {
     const viteDevIdAttr = viteDevId ? ` data-vite-dev-id="${escapeHtmlAttr(viteDevId)}"` : "";
     html += `<link rel="stylesheet"${nonceAttr}${viteDevIdAttr} href="${escapeHtmlAttr(href)}" />\n  `;
   }

--- a/tests/e2e/pages-router/css-adoption.spec.ts
+++ b/tests/e2e/pages-router/css-adoption.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "@playwright/test";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { createServer, type ViteDevServer } from "vite-plus";
+import { waitForHydration } from "../helpers";
+
+const fixtureSource = path.resolve(process.cwd(), "tests/fixtures/pages-css-adoption");
+let fixtureRoot: string;
+let server: ViteDevServer;
+let baseUrl: string;
+
+test.beforeAll(async () => {
+  fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-pages-css-adoption-"));
+  await fs.cp(fixtureSource, fixtureRoot, { recursive: true });
+  await fs.symlink(
+    path.resolve(process.cwd(), "tests/fixtures/pages-basic/node_modules"),
+    path.join(fixtureRoot, "node_modules"),
+    "junction",
+  );
+  server = await createServer({
+    root: fixtureRoot,
+    logLevel: "silent",
+    server: { host: "127.0.0.1", port: 0 },
+  });
+  await server.listen();
+  const address = server.httpServer?.address();
+  if (!address || typeof address === "string") throw new Error("Expected dev server address");
+  baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+test.afterAll(async () => {
+  await server?.close();
+  if (fixtureRoot) await fs.rm(fixtureRoot, { recursive: true, force: true });
+});
+
+// Ported from Next.js's Pages Router CSS ordering coverage:
+// test/integration/css/test/css-modules.test.ts
+// https://github.com/vercel/next.js/blob/canary/test/integration/css/test/css-modules.test.ts
+test("initial Pages stylesheets are adopted by Vite instead of injected twice", async ({
+  page,
+  request,
+}) => {
+  const nonceResponse = await request.get(`${baseUrl}/?nonce=css-adoption`);
+  const initialHtml = await nonceResponse.text();
+  const initialStyleTags = Array.from(
+    initialHtml.matchAll(/<link\b[^>]*>/g),
+    ([tag]) => tag,
+  ).filter((tag) => /\srel="stylesheet"/.test(tag));
+
+  expect(initialStyleTags).toHaveLength(2);
+  expect(initialStyleTags.every((tag) => tag.includes("data-vite-dev-id="))).toBe(true);
+  expect(initialStyleTags.every((tag) => tag.includes('nonce="css-adoption"'))).toBe(true);
+
+  await page.goto(baseUrl);
+  await waitForHydration(page);
+  await expect(page.getByTestId("css-adoption-target")).toHaveCSS("color", "rgb(0, 128, 0)");
+
+  const stylesheetState = await page.evaluate(() => {
+    const links = Array.from(document.querySelectorAll<HTMLLinkElement>('link[rel="stylesheet"]'));
+    const ids = links.map((link) => link.dataset.viteDevId);
+    return {
+      ids,
+      duplicateStyleIds: Array.from(
+        document.querySelectorAll<HTMLStyleElement>("style[data-vite-dev-id]"),
+      )
+        .map((style) => style.dataset.viteDevId)
+        .filter((id) => id && ids.includes(id)),
+    };
+  });
+
+  expect(stylesheetState.ids).toHaveLength(2);
+  expect(stylesheetState.ids.every(Boolean)).toBe(true);
+  expect(stylesheetState.duplicateStyleIds).toEqual([]);
+});

--- a/tests/fixtures/pages-css-adoption/middleware.ts
+++ b/tests/fixtures/pages-css-adoption/middleware.ts
@@ -1,0 +1,13 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+export default function middleware(request: NextRequest) {
+  const response = NextResponse.next();
+  const nonce = request.nextUrl.searchParams.get("nonce");
+  if (nonce) {
+    response.headers.set(
+      "content-security-policy",
+      `script-src 'nonce-${nonce}' 'strict-dynamic';`,
+    );
+  }
+  return response;
+}

--- a/tests/fixtures/pages-css-adoption/pages/_app.tsx
+++ b/tests/fixtures/pages-css-adoption/pages/_app.tsx
@@ -1,0 +1,7 @@
+import type { AppProps } from "next/app";
+import "../styles/dev css adoption.css";
+import "../styles/dev-css-adoption-override.css";
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/tests/fixtures/pages-css-adoption/pages/index.tsx
+++ b/tests/fixtures/pages-css-adoption/pages/index.tsx
@@ -1,0 +1,7 @@
+export default function CssAdoptionPage() {
+  return (
+    <p className="dev-css-adoption-target" data-testid="css-adoption-target">
+      Pages dev CSS adoption
+    </p>
+  );
+}

--- a/tests/fixtures/pages-css-adoption/styles/dev css adoption.css
+++ b/tests/fixtures/pages-css-adoption/styles/dev css adoption.css
@@ -1,0 +1,3 @@
+.dev-css-adoption-target {
+  color: rgb(255, 0, 0);
+}

--- a/tests/fixtures/pages-css-adoption/styles/dev-css-adoption-override.css
+++ b/tests/fixtures/pages-css-adoption/styles/dev-css-adoption-override.css
@@ -1,0 +1,3 @@
+.dev-css-adoption-target {
+  color: rgb(0, 128, 0);
+}

--- a/tests/fixtures/pages-css-adoption/vite.config.mts
+++ b/tests/fixtures/pages-css-adoption/vite.config.mts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite-plus";
+import vinext from "vinext";
+
+export default defineConfig({
+  plugins: [vinext()],
+});

--- a/tests/pages-dev-stylesheets.test.ts
+++ b/tests/pages-dev-stylesheets.test.ts
@@ -82,7 +82,13 @@ describe("Pages dev stylesheet Vite ids", () => {
           name: "test:stylesheet-id",
           resolveId(id) {
             if (id === "virtual:safe-style.css") return "virtual:safe-style.css?resolved";
+            if (id.startsWith("virtual:safe-style.css?resolved")) return id;
             if (id === "virtual:null-style.css") return "\0virtual:null-style.css";
+          },
+          load(id) {
+            if (id.startsWith("virtual:safe-style.css?resolved")) {
+              return ".safe-virtual { color: green; }\n";
+            }
           },
         },
       ],
@@ -119,6 +125,26 @@ describe("Pages dev stylesheet Vite ids", () => {
       [entryPath],
       "",
     );
+
+    const rawFalseTransform = await server.environments.client.transformRequest(
+      "/raw-value-wrapper.js?raw=false",
+    );
+    const rawTransform = await server.environments.client.transformRequest(
+      "/raw-value-wrapper.js?raw",
+    );
+    expect(rawFalseTransform?.code).toContain('import "/raw-value-wrapper.css"');
+    expect(rawTransform?.code).toContain('export default "import \\"./raw-value-wrapper.css\\"');
+
+    const rawFalseModule = await server.environments.client.moduleGraph.getModuleByUrl(
+      "/raw-value-wrapper.js?raw=false",
+    );
+    const rawModule = await server.environments.client.moduleGraph.getModuleByUrl(
+      "/raw-value-wrapper.js?raw",
+    );
+    expect([...rawFalseModule!.importedModules].map((moduleNode) => moduleNode.url)).toContain(
+      "/raw-value-wrapper.css",
+    );
+    expect([...rawModule!.importedModules]).toEqual([]);
 
     for (const file of ["inline-wrapper.css", "raw-value-wrapper.css"]) {
       expect(html).toContain(`href="/${file}"`);
@@ -197,5 +223,32 @@ describe("Pages dev stylesheet Vite ids", () => {
         "/resolved.css?query=kept",
       ),
     ).toBe("/resolved.css?query=kept");
+  });
+
+  it("serves non-null custom virtual stylesheets through Vite's wrapped id URL", async () => {
+    const entryPath = path.join(root, "safe-virtual-entry.js");
+    fs.writeFileSync(entryPath, 'import "virtual:safe-style.css";\n');
+
+    const html = await collectPagesDevInitialStylesheetHeadHTML(
+      server,
+      {
+        async import() {
+          throw new Error("No Pages manifest in this focused Vite fixture");
+        },
+      },
+      [entryPath],
+      "",
+    );
+
+    expect(html).toContain('data-vite-dev-id="virtual:safe-style.css?resolved"');
+    const href = html.match(/href="([^"]+)"/)?.[1];
+    expect(href).toBe("/@id/virtual:safe-style.css?resolved&amp;direct");
+
+    const baseUrl = server.resolvedUrls?.local[0];
+    expect(baseUrl).toBeDefined();
+    const response = await fetch(new URL(href!.replaceAll("&amp;", "&"), baseUrl));
+    expect(response.ok).toBe(true);
+    expect(response.headers.get("content-type")).toContain("text/css");
+    expect(await response.text()).toContain(".safe-virtual");
   });
 });

--- a/tests/pages-dev-stylesheets.test.ts
+++ b/tests/pages-dev-stylesheets.test.ts
@@ -1,0 +1,164 @@
+import { afterAll, beforeAll, describe, expect, it } from "vite-plus/test";
+import { createServer, type ViteDevServer } from "vite-plus";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { toSlash } from "pathslash";
+import {
+  collectPagesDevInitialStylesheetHeadHTML,
+  isViteInjectedStylesheetModule,
+  isViteStylesheetGraphTraversalBoundary,
+  resolvePagesDevStylesheetId,
+} from "../packages/vinext/src/server/pages-dev-stylesheets.js";
+
+describe("Pages dev stylesheet discovery", () => {
+  it("only adopts CSS requests whose Vite transform calls updateStyle", () => {
+    for (const url of [
+      "/style.css",
+      "/style.module.scss?theme=dark",
+      "/style.sass?theme=raw",
+      "/style.css?redirect=false",
+      "/style.css?RAW",
+    ]) {
+      expect(isViteInjectedStylesheetModule({ type: "css", url }), url).toBe(true);
+    }
+
+    for (const query of ["raw", "url", "worker", "sharedworker", "inline", "direct"]) {
+      expect(
+        isViteInjectedStylesheetModule({ type: "css", url: `/style.css?${query}` }),
+        query,
+      ).toBe(false);
+      expect(
+        isViteInjectedStylesheetModule({
+          type: "css",
+          url: `/style.css?theme=dark&${query}=false`,
+        }),
+        `${query}=false`,
+      ).toBe(false);
+    }
+
+    expect(isViteInjectedStylesheetModule({ type: "js", url: "/not-css.js" })).toBe(false);
+  });
+
+  it("traverses executable JavaScript query wrappers", () => {
+    for (const query of ["inline", "direct"]) {
+      expect(isViteStylesheetGraphTraversalBoundary({ url: `/component.js?${query}` }), query).toBe(
+        false,
+      );
+      expect(
+        isViteStylesheetGraphTraversalBoundary({ url: `/style.css?${query}` }),
+        `css?${query}`,
+      ).toBe(true);
+    }
+
+    for (const query of ["raw", "url", "worker", "sharedworker"]) {
+      expect(isViteStylesheetGraphTraversalBoundary({ url: `/component.js?${query}` }), query).toBe(
+        true,
+      );
+      expect(
+        isViteStylesheetGraphTraversalBoundary({ url: `/component.js?${query}=false` }),
+        `${query}=false`,
+      ).toBe(false);
+    }
+  });
+});
+
+describe("Pages dev stylesheet Vite ids", () => {
+  let root: string;
+  let server: ViteDevServer;
+  let stylesheetPath: string;
+
+  beforeAll(async () => {
+    root = fs.realpathSync.native(fs.mkdtempSync(path.join(os.tmpdir(), "vinext-dev-css-id-")));
+    stylesheetPath = path.join(root, "style sheet.css");
+    fs.writeFileSync(stylesheetPath, ".target { color: green; }\n");
+    server = await createServer({
+      root,
+      configFile: false,
+      logLevel: "silent",
+      server: { port: 0 },
+      plugins: [
+        {
+          name: "test:stylesheet-id",
+          resolveId(id) {
+            if (id === "virtual:safe-style.css") return "virtual:safe-style.css?resolved";
+            if (id === "virtual:null-style.css") return "\0virtual:null-style.css";
+          },
+        },
+      ],
+    });
+    await server.listen();
+  });
+
+  afterAll(async () => {
+    await server.close();
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("collects CSS imported through an executable JavaScript query wrapper", async () => {
+    const entryPath = path.join(root, "queried-entry.js");
+    fs.writeFileSync(
+      entryPath,
+      'import "./inline-wrapper.js?inline";\nimport "./raw-value-wrapper.js?raw=false";\n',
+    );
+    fs.writeFileSync(path.join(root, "inline-wrapper.js"), 'import "./inline-wrapper.css";\n');
+    fs.writeFileSync(
+      path.join(root, "raw-value-wrapper.js"),
+      'import "./raw-value-wrapper.css";\n',
+    );
+    fs.writeFileSync(path.join(root, "inline-wrapper.css"), ".inline { color: green; }\n");
+    fs.writeFileSync(path.join(root, "raw-value-wrapper.css"), ".raw-value { color: blue; }\n");
+
+    const html = await collectPagesDevInitialStylesheetHeadHTML(
+      server,
+      {
+        async import() {
+          throw new Error("No Pages manifest in this focused Vite fixture");
+        },
+      },
+      [entryPath],
+      "",
+    );
+
+    for (const file of ["inline-wrapper.css", "raw-value-wrapper.css"]) {
+      expect(html).toContain(`href="/${file}"`);
+      expect(html).toContain(`data-vite-dev-id="${toSlash(path.join(root, file))}"`);
+    }
+  });
+
+  it("uses Vite resolution for root URLs, encoded paths, /@fs/, queries, and manifest fallback", async () => {
+    const graph = server.environments.client.moduleGraph;
+    const encodedRootUrl = "/style%20sheet.css";
+
+    const canonicalStylesheetPath = toSlash(stylesheetPath);
+    expect(await resolvePagesDevStylesheetId(graph, encodedRootUrl)).toBe(canonicalStylesheetPath);
+    expect(await resolvePagesDevStylesheetId(graph, `${encodedRootUrl}?theme=dark`)).toBe(
+      `${canonicalStylesheetPath}?theme=dark`,
+    );
+    expect(
+      await resolvePagesDevStylesheetId(
+        graph,
+        `/@fs/${encodeURI(canonicalStylesheetPath)}?direct=false`,
+      ),
+    ).toBe(`${canonicalStylesheetPath}?direct=false`);
+
+    // Manifest assets are resolved before their CSS module has been transformed.
+    expect(graph.getModuleById(canonicalStylesheetPath)).toBeUndefined();
+  });
+
+  it("preserves safe virtual ids and omits null-byte ids that HTML cannot represent", async () => {
+    const graph = server.environments.client.moduleGraph;
+
+    expect(await resolvePagesDevStylesheetId(graph, "virtual:safe-style.css")).toBe(
+      "virtual:safe-style.css?resolved",
+    );
+    expect(await resolvePagesDevStylesheetId(graph, "virtual:null-style.css")).toBeNull();
+    expect(
+      await resolvePagesDevStylesheetId(
+        graph,
+        "/ignored.css?query=kept",
+        "/resolved.css?query=kept",
+      ),
+    ).toBe("/resolved.css?query=kept");
+  });
+});

--- a/tests/pages-dev-stylesheets.test.ts
+++ b/tests/pages-dev-stylesheets.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it } from "vite-plus/test";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vite-plus/test";
 import { createServer, type ViteDevServer } from "vite-plus";
 import fs from "node:fs";
 import os from "node:os";
@@ -144,6 +144,43 @@ describe("Pages dev stylesheet Vite ids", () => {
 
     // Manifest assets are resolved before their CSS module has been transformed.
     expect(graph.getModuleById(canonicalStylesheetPath)).toBeUndefined();
+  });
+
+  it("deduplicates a manifest fallback against the later resolved graph asset", async () => {
+    const entryPath = path.join(root, "manifest-transient-entry.js");
+    const cssPath = path.join(root, "manifest-transient.css");
+    fs.writeFileSync(entryPath, 'import "./manifest-transient.css";\n');
+    fs.writeFileSync(cssPath, ".manifest-transient { color: green; }\n");
+    const graph = server.environments.client.moduleGraph;
+    const resolveUrl = vi
+      .spyOn(graph, "resolveUrl")
+      .mockRejectedValueOnce(new Error("Simulated manifest-only resolution failure"));
+
+    let html: string;
+    try {
+      html = await collectPagesDevInitialStylesheetHeadHTML(
+        server,
+        {
+          async import() {
+            return {
+              default: {
+                ssrManifest: {
+                  [entryPath]: ["manifest-transient.css"],
+                },
+              },
+            };
+          },
+        },
+        [entryPath],
+        "",
+      );
+      expect(resolveUrl).toHaveBeenNthCalledWith(1, "/manifest-transient.css");
+    } finally {
+      resolveUrl.mockRestore();
+    }
+
+    expect(html.match(/href="\/manifest-transient\.css"/g)).toHaveLength(1);
+    expect(html).toContain(`data-vite-dev-id="${toSlash(cssPath)}"`);
   });
 
   it("preserves safe virtual ids and omits null-byte ids that HTML cannot represent", async () => {

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -7,6 +7,7 @@ import fsp from "node:fs/promises";
 import os from "node:os";
 import { Readable } from "node:stream";
 import { pathToFileURL } from "node:url";
+import { toSlash } from "pathslash";
 import zlib from "node:zlib";
 import vinext from "../packages/vinext/src/index.js";
 import { createModuleDependencyCache } from "../packages/vinext/src/build/module-dependency-cache.js";
@@ -150,6 +151,12 @@ function getStylesheetHrefs(html: string): string[] {
     .filter((tag) => getHtmlAttr(tag, "rel") === "stylesheet")
     .map((tag) => getHtmlAttr(tag, "href"))
     .filter((href): href is string => href !== null);
+}
+
+function getStylesheetTags(html: string): string[] {
+  return Array.from(html.matchAll(/<link\b[^>]*>/gi), (match) => match[0]).filter(
+    (tag) => getHtmlAttr(tag, "rel") === "stylesheet",
+  );
 }
 
 function writePagesAppGlobalCssFixture(rootDir: string): PagesAppGlobalCssFixture {
@@ -3618,8 +3625,17 @@ describe("Virtual server entry generation", () => {
       expect(res.status).toBe(200);
       expect(html).toContain("Global CSS Pages Test");
       const stylesheetHrefs = getStylesheetHrefs(html);
+      const stylesheetTags = getStylesheetTags(html);
+      expect(stylesheetHrefs).toHaveLength(fixture.devStylesheetHrefs.length);
+      expect(stylesheetHrefs).not.toContain("/styles/query.css?raw");
       for (const href of fixture.devStylesheetHrefs) {
         expect(stylesheetHrefs).toContain(href);
+        const tag = stylesheetTags.find((candidate) => getHtmlAttr(candidate, "href") === href);
+        expect(getHtmlAttr(tag ?? "", "data-vite-dev-id")).toBe(
+          toSlash(
+            fs.realpathSync.native(path.join(testServer.config.root, decodeURI(href).slice(1))),
+          ),
+        );
       }
       expect(html).not.toContain("type-only.module.css");
 


### PR DESCRIPTION
## Summary

- mark server-rendered Pages dev stylesheet links with the exact module IDs used by Vite
- let the Vite client adopt initial links instead of injecting duplicate style elements after hydration
- centralize stylesheet identity, deduplication, and URL handling in a focused helper while preserving CSP nonces

## Regression coverage

- adds a real Pages route with two CSS imports, middleware-provided CSP nonce, and cascade-sensitive rules
- live browser coverage asserts exactly two initial nonced links, no duplicate injected Vite styles, and stable cascade
- on unmodified `main`, the repro emits three links for two imports and injects two additional styles after hydration

## Validation

- focused stylesheet helper and Pages integration tests
- live Playwright regression
- vinext build and touched-file `vp check`
- independent Vite client-contract review: clean