### PR TITLE
fix(pages): apply fallback rewrites after API misses

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -5454,8 +5454,10 @@ export const loadServerActionClient = ${
                 configMatchPathname,
                 runMiddleware: devRunMiddlewareAdapter,
                 // Treat App route handlers as an API filesystem match too. The
-                // pipeline then emits an API intent and the adapter's existing
-                // hybrid precedence logic delegates it to the RSC plugin.
+                // pipeline may then emit an API intent instead of continuing
+                // through fallback rewrites. This only answers whether an API
+                // route exists; the adapter's precedence check below still
+                // decides whether Pages or App owns overlapping matches.
                 matchApiRoute: async (apiUrl) => {
                   const devApiRoutes = await getDevApiRoutes();
                   const pagesMatch = matchRoute(apiUrl, devApiRoutes);
@@ -5571,14 +5573,18 @@ export const loadServerActionClient = ${
 
               // For render/api intents: flush staged middleware headers and
               // apply request header mutations before calling SSR/API handlers.
-              const flushStagedHeaders = () => {
+              const forEachStagedHeader = (visit: (key: string, value: string) => void) => {
                 for (const [key, value] of Object.entries(pipelineResult.stagedHeaders)) {
                   if (Array.isArray(value)) {
-                    for (const v of value) res.appendHeader(key, v);
+                    for (const item of value) visit(key, item);
                   } else {
-                    res.appendHeader(key, value);
+                    visit(key, value);
                   }
                 }
+              };
+
+              const flushStagedHeaders = () => {
+                forEachStagedHeader((key, value) => res.appendHeader(key, value));
               };
 
               // Apply post-middleware request headers to req.headers so the
@@ -5589,13 +5595,7 @@ export const loadServerActionClient = ${
 
               const forwardInternalApiRewriteToApp = (apiUrl: string) => {
                 const responseHeaders: [string, string][] = [];
-                for (const [key, value] of Object.entries(pipelineResult.stagedHeaders)) {
-                  if (Array.isArray(value)) {
-                    for (const item of value) responseHeaders.push([key, item]);
-                  } else {
-                    responseHeaders.push([key, value]);
-                  }
-                }
+                forEachStagedHeader((key, value) => responseHeaders.push([key, value]));
                 const requestHeaders = new Headers();
                 encodeMiddlewareRequestHeaders(requestHeaders, pipelineResult.requestHeaders);
 
@@ -5660,7 +5660,10 @@ export const loadServerActionClient = ${
                 // No API route matched — if app dir exists, let the RSC plugin handle it
                 // (app/api/* route handlers live there). Otherwise hard-404.
                 if (hasAppDir) {
-                  if (pipelineResult.apiUrl !== routeUrl) {
+                  // Only a next.config rewrite should override App's route
+                  // resolution. Locale stripping is API lookup normalization,
+                  // not an internal rewrite to forward to the RSC plugin.
+                  if (pipelineResult.configRewriteFired) {
                     forwardInternalApiRewriteToApp(pipelineResult.apiUrl);
                   }
                   return next();

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -140,6 +140,7 @@ import {
   validateHybridRouteConflicts,
 } from "./server/hybrid-route-priority.js";
 import { matchesRewriteSource, proxyExternalRequest } from "./config/config-matchers.js";
+import { encodeMiddlewareRequestHeaders } from "./utils/middleware-request-headers.js";
 import {
   detectPackageManager,
   formatMissingCloudflarePluginError,
@@ -5397,6 +5398,19 @@ export const loadServerActionClient = ${
                 nextConfig?.pageExtensions,
                 fileMatcher,
               );
+              let devApiRoutesPromise: ReturnType<typeof apiRouter> | null = null;
+              const getDevApiRoutes = () =>
+                (devApiRoutesPromise ??= apiRouter(
+                  pagesDir,
+                  nextConfig?.pageExtensions,
+                  fileMatcher,
+                ));
+              let devAppRoutesPromise: ReturnType<typeof appRouter> | null = null;
+              const getDevAppRoutes = () =>
+                (devAppRoutesPromise ??=
+                  hasAppDir && appDir
+                    ? appRouter(appDir, nextConfig?.pageExtensions, fileMatcher)
+                    : Promise.resolve([]));
               const devPageRouteDataKinds = new Map<string, "static" | "server" | "none">();
               const classifyDevPageRoute = (
                 route: (typeof devPageRoutes)[number],
@@ -5439,6 +5453,16 @@ export const loadServerActionClient = ${
                 rawSearch: url.includes("?") ? url.slice(url.indexOf("?")) : "",
                 configMatchPathname,
                 runMiddleware: devRunMiddlewareAdapter,
+                // Treat App route handlers as an API filesystem match too. The
+                // pipeline then emits an API intent and the adapter's existing
+                // hybrid precedence logic delegates it to the RSC plugin.
+                matchApiRoute: async (apiUrl) => {
+                  const devApiRoutes = await getDevApiRoutes();
+                  const pagesMatch = matchRoute(apiUrl, devApiRoutes);
+                  if (pagesMatch) return pagesMatch;
+                  const devAppRoutes = await getDevAppRoutes();
+                  return matchAppRoute(apiUrl, devAppRoutes);
+                },
                 matchPageRoute: (resolvedPathname, request) => {
                   const routeUrl = nextConfig?.i18n
                     ? resolvePagesI18nRequest(
@@ -5563,12 +5587,35 @@ export const loadServerActionClient = ${
                 applyRequestHeadersToNodeRequest(pipelineResult.requestHeaders);
               };
 
+              const forwardInternalApiRewriteToApp = (apiUrl: string) => {
+                const responseHeaders: [string, string][] = [];
+                for (const [key, value] of Object.entries(pipelineResult.stagedHeaders)) {
+                  if (Array.isArray(value)) {
+                    for (const item of value) responseHeaders.push([key, item]);
+                  } else {
+                    responseHeaders.push([key, value]);
+                  }
+                }
+                const requestHeaders = new Headers();
+                encodeMiddlewareRequestHeaders(requestHeaders, pipelineResult.requestHeaders);
+
+                // The Pages pipeline already ran middleware and evaluated the
+                // fallback rule against its request-header overrides. Carry
+                // both pieces of state into the App RSC plugin: reapplying the
+                // rule from the original request can lose its has/missing
+                // match, while mutating req.url would lose the public URL that
+                // App route handlers expose through request.url.
+                flushRequestHeaders();
+                req.headers[VINEXT_MW_CTX_HEADER] = JSON.stringify({
+                  h: responseHeaders,
+                  q: [...requestHeaders],
+                  s: pipelineResult.middlewareStatus ?? null,
+                  r: apiUrl,
+                });
+              };
+
               if (pipelineResult.type === "api") {
-                const apiRoutes = await apiRouter(
-                  pagesDir,
-                  nextConfig?.pageExtensions,
-                  fileMatcher,
-                );
+                const devApiRoutes = await getDevApiRoutes();
                 // Only flush staged middleware headers / mutate req.headers when a
                 // pages API route actually matches — mirroring the original
                 // `if (apiMatch)` gate. On a miss we must NOT touch res or req.headers
@@ -5576,14 +5623,10 @@ export const loadServerActionClient = ${
                 // deletes all req.headers and repopulates them from the body-less pipeline
                 // request, wiping the hybrid app+pages middleware context
                 // (VINEXT_MW_CTX_HEADER, set on req.headers) that the app RSC plugin reads.
-                const apiMatch = matchRoute(pipelineResult.apiUrl, apiRoutes);
+                const apiMatch = matchRoute(pipelineResult.apiUrl, devApiRoutes);
                 if (apiMatch && hasAppDir && appDir) {
-                  const appRoutes = await appRouter(
-                    appDir,
-                    nextConfig?.pageExtensions,
-                    fileMatcher,
-                  );
-                  const appMatch = matchAppRoute(pipelineResult.apiUrl, appRoutes);
+                  const devAppRoutes = await getDevAppRoutes();
+                  const appMatch = matchAppRoute(pipelineResult.apiUrl, devAppRoutes);
                   if (
                     appMatch &&
                     !pagesRouteHasPriorityOverAppRoute(apiMatch.route, appMatch.route)
@@ -5603,7 +5646,7 @@ export const loadServerActionClient = ${
                   req,
                   res,
                   pipelineResult.apiUrl,
-                  apiRoutes,
+                  devApiRoutes,
                   {
                     basePath: nextConfig?.basePath,
                     i18n: nextConfig?.i18n,
@@ -5616,7 +5659,12 @@ export const loadServerActionClient = ${
 
                 // No API route matched — if app dir exists, let the RSC plugin handle it
                 // (app/api/* route handlers live there). Otherwise hard-404.
-                if (hasAppDir) return next();
+                if (hasAppDir) {
+                  if (pipelineResult.apiUrl !== routeUrl) {
+                    forwardInternalApiRewriteToApp(pipelineResult.apiUrl);
+                  }
+                  return next();
+                }
 
                 res.statusCode = 404;
                 res.end("404 - API route not found");

--- a/packages/vinext/src/server/app-middleware.ts
+++ b/packages/vinext/src/server/app-middleware.ts
@@ -62,6 +62,7 @@ export type ApplyAppMiddlewareResult =
 
 type ForwardedMiddlewareContext = {
   h?: unknown;
+  q?: unknown;
   r?: unknown;
   s?: unknown;
 };
@@ -246,6 +247,12 @@ function applyForwardedMiddlewareContext(
         appendForwardedHeader(context.headers, entry);
       }
     }
+    if (Array.isArray(data.q) && data.q.length > 0) {
+      context.requestHeaders = new Headers();
+      for (const entry of data.q) {
+        appendForwardedHeader(context.requestHeaders, entry);
+      }
+    }
     if (typeof data.s === "number") {
       context.status = data.s;
     }
@@ -381,9 +388,11 @@ export async function applyAppMiddleware(
     cancelRequestBody(options.middlewareRequest);
   }
 
+  if (options.context.headers || options.context.requestHeaders) {
+    options.context.requestHeaders ??= new Headers(options.context.headers!);
+    applyMiddlewareRequestHeaders(options.context.requestHeaders);
+  }
   if (options.context.headers) {
-    options.context.requestHeaders = new Headers(options.context.headers);
-    applyMiddlewareRequestHeaders(options.context.headers);
     processMiddlewareHeaders(options.context.headers);
   }
 

--- a/packages/vinext/src/server/pages-request-pipeline.ts
+++ b/packages/vinext/src/server/pages-request-pipeline.ts
@@ -256,6 +256,8 @@ export type PagesPipelineResult =
   | {
       type: "api";
       apiUrl: string;
+      /** True only when next.config rewrites changed API resolution. */
+      configRewriteFired: boolean;
       stagedHeaders: HeaderRecord;
       /** Post-middleware request headers — dev adapters apply these to req.headers before API handler. */
       requestHeaders: Headers;
@@ -662,6 +664,7 @@ export async function runPagesRequest(
     return {
       type: "api",
       apiUrl: apiLookupUrl,
+      configRewriteFired,
       stagedHeaders: middlewareHeaders,
       requestHeaders: request.headers,
       middlewareStatus,

--- a/packages/vinext/src/server/pages-request-pipeline.ts
+++ b/packages/vinext/src/server/pages-request-pipeline.ts
@@ -151,6 +151,15 @@ export type PagesPipelineDeps = {
 
   // Route + render/api callbacks (optional — if absent, emit intent instead of Response)
   matchPageRoute?: ((pathname: string, request: Request) => PageRouteMatch | null) | null;
+  /**
+   * Return the matching Pages (or hybrid App) API route, if one exists.
+   *
+   * When supplied, an `/api/*` filesystem miss continues through afterFiles and
+   * fallback rewrites instead of being committed to the API 404 response.
+   */
+  matchApiRoute?:
+    | ((url: string, request: Request) => PageRouteMatch | null | Promise<PageRouteMatch | null>)
+    | null;
   runMiddleware?:
     | ((
         request: Request,
@@ -618,6 +627,10 @@ export async function runPagesRequest(
     const apiLookupUrl = stripI18nLocaleForApiRoute(resolvedUrl, i18nConfig);
     const apiLookupPathname = apiLookupUrl.split("?")[0];
     if (!apiLookupPathname.startsWith("/api/") && apiLookupPathname !== "/api") return null;
+    // Next.js performs the API filesystem check before afterFiles/fallback
+    // rewrites. Only a real API match owns the request at this point; a miss
+    // must continue through the remaining custom-route phases.
+    if (deps.matchApiRoute && !(await deps.matchApiRoute(apiLookupUrl, request))) return null;
     if (typeof deps.handleApi === "function") {
       let apiRequest = request;
       // Prod re-adds basePath only when the original request carried it.

--- a/packages/vinext/src/server/pages-router-entry.ts
+++ b/packages/vinext/src/server/pages-router-entry.ts
@@ -66,6 +66,7 @@ const {
   authorizeOnDemandRevalidate,
   handleApiRoute,
   hasMiddleware,
+  matchApiRoute,
   matchPageRoute,
   normalizeDataRequest,
   publicFiles,
@@ -192,6 +193,7 @@ async function handleRequest(
       dataNotFoundResponse: vinextConfig?.skipProxyUrlNormalize ? dataNorm.notFoundResponse : null,
       authorizeOnDemandRevalidate:
         typeof authorizeOnDemandRevalidate === "function" ? authorizeOnDemandRevalidate : undefined,
+      matchApiRoute: typeof matchApiRoute === "function" ? matchApiRoute : null,
       matchPageRoute: typeof matchPageRoute === "function" ? matchPageRoute : null,
       runMiddleware:
         typeof runMiddleware === "function"

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -1913,6 +1913,8 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
   } = serverEntry;
   const matchPageRoute =
     typeof serverEntry.matchPageRoute === "function" ? serverEntry.matchPageRoute : undefined;
+  const matchApiRoute =
+    typeof serverEntry.matchApiRoute === "function" ? serverEntry.matchApiRoute : undefined;
   const hasMiddleware = serverEntry.hasMiddleware === true;
   const pageRoutes = readPagesServerEntryPageRoutes(serverEntry.pageRoutes);
 
@@ -2189,6 +2191,7 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
             : undefined,
         configMatchPathname,
         matchPageRoute: matchPageRoute ?? null,
+        matchApiRoute: matchApiRoute ?? null,
         // Pass the original (pre-basePath-stripping) URL to middleware so that
         // request.nextUrl.basePath reflects whether the URL actually had the
         // basePath prefix (see wrapMiddlewareWithBasePath).

--- a/tests/app-router-next-config-dev.test.ts
+++ b/tests/app-router-next-config-dev.test.ts
@@ -116,6 +116,26 @@ describe("App Router next.config.js features (dev server integration)", () => {
     expect(html).toContain('"page":"/pages-header-override-delete"');
   });
 
+  it("hands unmatched API fallback rewrites to App route handlers", async () => {
+    const res = await fetch(
+      `${baseUrl}/api/pages-fallback-to-app/session/login?client=vinext&mw-auth`,
+      {
+        headers: { "x-api-fallback-handoff": "preserved" },
+      },
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("x-custom-header")).toBe("vinext-app");
+    await expect(res.json()).resolves.toEqual({
+      body: null,
+      cookie: "mw-api-fallback-user=1",
+      header: "preserved",
+      pathname: "/api/pages-fallback-to-app/session/login",
+      query: { client: "vinext", from: "fallback", "mw-auth": "" },
+      slugs: ["session", "login"],
+    });
+  });
+
   it("applies custom headers from next.config.js on API routes", async () => {
     const res = await fetch(`${baseUrl}/api/hello`);
     expect(res.headers.get("x-custom-header")).toBe("vinext-app");

--- a/tests/app-router-production-server.test.ts
+++ b/tests/app-router-production-server.test.ts
@@ -1227,6 +1227,25 @@ describe("App Router Production server (startProdServer)", () => {
     expect(json).toHaveProperty("message");
   });
 
+  it("routes unmatched API paths through fallback rewrites to App route handlers", async () => {
+    const res = await fetch(
+      `${baseUrl}/api/pages-fallback-to-app/session/login?client=vinext&mw-auth`,
+      {
+        headers: { "x-api-fallback-handoff": "preserved" },
+      },
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      body: null,
+      cookie: "mw-api-fallback-user=1",
+      header: "preserved",
+      pathname: "/api/pages-fallback-to-app/session/login",
+      query: { client: "vinext", from: "fallback", "mw-auth": "" },
+      slugs: ["session", "login"],
+    });
+  });
+
   // Ported from Next.js: test/e2e/app-dir/app-static/app-static.test.ts
   // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/app-static/app-static.test.ts
   it("lets route handlers synchronously catch updateTag errors without crashing", async () => {

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -3455,43 +3455,47 @@ describe("createAppRscHandler", () => {
     },
   );
 
-  it("propagates rewritten query parameters to App route handlers", async () => {
-    const route = createPageRoute({
-      page: null,
-      pattern: "/api/static",
-      routeHandler: { GET: () => new Response("route") },
-      routeSegments: ["api", "static"],
-    });
-    const dispatchMatchedRouteHandler = vi.fn(
-      async (_options: Parameters<HandlerOptions["dispatchMatchedRouteHandler"]>[0]) =>
-        new Response("route"),
-    );
-    const handler = createHandler({
-      configHeaders: [],
-      configRewrites: {
-        beforeFiles: [{ source: "/legacy", destination: "/api/static?destination=2&same=new" }],
-        afterFiles: [],
-        fallback: [],
-      },
-      dispatchMatchedRouteHandler,
-      matchRoute: (pathname) => (pathname === "/api/static" ? { params: {}, route } : null),
-    });
+  it.each(["beforeFiles", "fallback"] as const)(
+    "propagates %s rewrite query parameters to App route handlers",
+    async (rewritePhase) => {
+      const route = createPageRoute({
+        page: null,
+        pattern: "/api/static",
+        routeHandler: { GET: () => new Response("route") },
+        routeSegments: ["api", "static"],
+      });
+      const dispatchMatchedRouteHandler = vi.fn(
+        async (_options: Parameters<HandlerOptions["dispatchMatchedRouteHandler"]>[0]) =>
+          new Response("route"),
+      );
+      const rewrite = { source: "/legacy", destination: "/api/static?destination=2&same=new" };
+      const handler = createHandler({
+        configHeaders: [],
+        configRewrites: {
+          beforeFiles: rewritePhase === "beforeFiles" ? [rewrite] : [],
+          afterFiles: [],
+          fallback: rewritePhase === "fallback" ? [rewrite] : [],
+        },
+        dispatchMatchedRouteHandler,
+        matchRoute: (pathname) => (pathname === "/api/static" ? { params: {}, route } : null),
+      });
 
-    await handler(new Request("https://example.test/docs/legacy?original=1&same=old"), null);
+      await handler(new Request("https://example.test/docs/legacy?original=1&same=old"), null);
 
-    const routeHandlerOptions = dispatchMatchedRouteHandler.mock.lastCall?.[0];
-    expect(Object.fromEntries(routeHandlerOptions!.searchParams)).toEqual({
-      destination: "2",
-      original: "1",
-      same: "new",
-    });
-    expect(new URL(routeHandlerOptions!.request.url).pathname).toBe("/docs/legacy");
-    expect(Object.fromEntries(new URL(routeHandlerOptions!.request.url).searchParams)).toEqual({
-      destination: "2",
-      original: "1",
-      same: "new",
-    });
-  });
+      const routeHandlerOptions = dispatchMatchedRouteHandler.mock.lastCall?.[0];
+      expect(Object.fromEntries(routeHandlerOptions!.searchParams)).toEqual({
+        destination: "2",
+        original: "1",
+        same: "new",
+      });
+      expect(new URL(routeHandlerOptions!.request.url).pathname).toBe("/docs/legacy");
+      expect(Object.fromEntries(new URL(routeHandlerOptions!.request.url).searchParams)).toEqual({
+        destination: "2",
+        original: "1",
+        same: "new",
+      });
+    },
+  );
 
   it("does not let afterFiles rewrites override non-dynamic app routes", async () => {
     const routes = {

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -1385,6 +1385,9 @@ describe("readPagesRouterEntrySource", () => {
     // Worker passes configRewrites dep with all three phases.
     expect(content).toContain("configRewrites,");
     expect(content).toContain(
+      'matchApiRoute: typeof matchApiRoute === "function" ? matchApiRoute : null',
+    );
+    expect(content).toContain(
       'matchPageRoute: typeof matchPageRoute === "function" ? matchPageRoute : null',
     );
     expect(content).toContain("runPagesRequest(request, deps)");

--- a/tests/fixtures/app-basic/app/api/fallback-rewrite-target/[...slugs]/route.ts
+++ b/tests/fixtures/app-basic/app/api/fallback-rewrite-target/[...slugs]/route.ts
@@ -1,0 +1,13 @@
+type RouteContext = { params: Promise<{ slugs: string[] }> };
+
+export async function GET(request: Request, { params }: RouteContext) {
+  const url = new URL(request.url);
+  return Response.json({
+    body: null,
+    cookie: request.headers.get("cookie"),
+    header: request.headers.get("x-api-fallback-handoff"),
+    pathname: url.pathname,
+    query: Object.fromEntries(url.searchParams),
+    slugs: (await params).slugs,
+  });
+}

--- a/tests/fixtures/app-basic/middleware.ts
+++ b/tests/fixtures/app-basic/middleware.ts
@@ -253,6 +253,22 @@ export async function middleware(request: NextRequest, event: NextFetchEvent) {
     return NextResponse.next({ request: { headers } });
   }
 
+  // Gate the hybrid Pages -> App API fallback rewrite on a request cookie
+  // injected by middleware. The Pages dev pipeline owns this middleware pass,
+  // so its App handoff must carry both the resolved target and request headers.
+  if (
+    pathname.startsWith("/api/pages-fallback-to-app/") &&
+    request.nextUrl.searchParams.has("mw-auth")
+  ) {
+    const headers = new Headers(request.headers);
+    const existing = headers.get("cookie") ?? "";
+    headers.set(
+      "cookie",
+      existing ? existing + "; mw-api-fallback-user=1" : "mw-api-fallback-user=1",
+    );
+    return NextResponse.next({ request: { headers } });
+  }
+
   // Middleware headers take precedence over next.config.js headers for the same key.
   // Middleware sets e2e-headers=middleware; config sets e2e-headers=next.config.js via /(.*).
   // Ref: opennextjs-cloudflare headers.test.ts — "Middleware headers override next.config.js headers"
@@ -437,6 +453,7 @@ export const config = {
     "/api/header-override-delete",
     "/api/header-override-stray",
     "/api/pages-og",
+    "/api/pages-fallback-to-app/:path*",
     "/header-override-after-prior-access",
     "/pages-header-override-delete",
     "/revalidate-test",

--- a/tests/fixtures/app-basic/next.config.ts
+++ b/tests/fixtures/app-basic/next.config.ts
@@ -189,6 +189,14 @@ const nextConfig: NextConfig = {
           has: [{ type: "cookie", key: "mw-pages-fallback-user" }],
           destination: "/pages-header-override-delete",
         },
+        // Used by hybrid App+Pages dev and production tests: the Pages
+        // pipeline sees the unmatched /api source first, then hands the
+        // internal fallback destination to the App route handler.
+        {
+          source: "/api/pages-fallback-to-app/:path*",
+          has: [{ type: "cookie", key: "mw-api-fallback-user" }],
+          destination: "/api/fallback-rewrite-target/:path*?from=fallback",
+        },
       ],
     };
   },

--- a/tests/fixtures/hybrid-i18n-api-handoff/app/api/direct/route.ts
+++ b/tests/fixtures/hybrid-i18n-api-handoff/app/api/direct/route.ts
@@ -1,0 +1,3 @@
+export function GET() {
+  return Response.json({ router: "app" });
+}

--- a/tests/fixtures/hybrid-i18n-api-handoff/app/layout.tsx
+++ b/tests/fixtures/hybrid-i18n-api-handoff/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/tests/fixtures/hybrid-i18n-api-handoff/next.config.mjs
+++ b/tests/fixtures/hybrid-i18n-api-handoff/next.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  i18n: {
+    locales: ["en", "fr"],
+    defaultLocale: "en",
+  },
+};

--- a/tests/fixtures/hybrid-i18n-api-handoff/package.json
+++ b/tests/fixtures/hybrid-i18n-api-handoff/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/tests/fixtures/hybrid-i18n-api-handoff/pages/_app.tsx
+++ b/tests/fixtures/hybrid-i18n-api-handoff/pages/_app.tsx
@@ -1,0 +1,5 @@
+import type { AppProps } from "next/app";
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/tests/fixtures/hybrid-i18n-api-handoff/pages/index.tsx
+++ b/tests/fixtures/hybrid-i18n-api-handoff/pages/index.tsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <main>Hybrid i18n API handoff fixture</main>;
+}

--- a/tests/fixtures/hybrid-i18n-api-handoff/proxy.ts
+++ b/tests/fixtures/hybrid-i18n-api-handoff/proxy.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+
+export function proxy() {
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/:locale/api/:path*", "/api/:path*"],
+};

--- a/tests/hybrid-i18n-api-handoff.test.ts
+++ b/tests/hybrid-i18n-api-handoff.test.ts
@@ -1,0 +1,71 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { createBuilder } from "vite";
+import { describe, expect, it } from "vite-plus/test";
+import vinext from "../packages/vinext/src/index.js";
+import { createIsolatedFixture, startFixtureServer } from "./helpers.js";
+
+const FIXTURE_DIR = path.resolve(import.meta.dirname, "fixtures/hybrid-i18n-api-handoff");
+
+describe("hybrid i18n API handoff", () => {
+  // Next.js treats locale normalization and config rewrites as separate routing
+  // events. A locale-prefixed API pathname does not claim the unprefixed route.
+  // Ported from Next.js: test/e2e/i18n-api-support/index.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/i18n-api-support/index.test.ts
+  it.each(["development", "production"] as const)(
+    "does not turn locale normalization into an App API rewrite in %s",
+    async (mode) => {
+      const fixtureRoot = await createIsolatedFixture(
+        FIXTURE_DIR,
+        `vinext-hybrid-i18n-api-handoff-${mode}-`,
+      );
+      let closeServer: (() => Promise<void>) | undefined;
+
+      try {
+        let baseUrl: string;
+        if (mode === "development") {
+          const started = await startFixtureServer(fixtureRoot, { appRouter: true });
+          closeServer = () => started.server.close();
+          baseUrl = started.baseUrl;
+        } else {
+          const builder = await createBuilder({
+            root: fixtureRoot,
+            configFile: false,
+            plugins: [vinext({ appDir: fixtureRoot })],
+            logLevel: "silent",
+          });
+          await builder.buildApp();
+
+          const { startProdServer } = await import("../packages/vinext/src/server/prod-server.js");
+          const started = await startProdServer({
+            port: 0,
+            host: "127.0.0.1",
+            outDir: path.join(fixtureRoot, "dist"),
+            noCompression: true,
+          });
+          const server = started.server;
+          closeServer = () =>
+            new Promise<void>((resolve, reject) => {
+              server.close((error) => (error ? reject(error) : resolve()));
+            });
+          const address = server.address();
+          if (!address || typeof address === "string") {
+            throw new Error("Hybrid i18n production fixture did not bind to a TCP port");
+          }
+          baseUrl = `http://127.0.0.1:${address.port}`;
+        }
+
+        const direct = await fetch(`${baseUrl}/api/direct`);
+        expect(direct.status).toBe(200);
+        await expect(direct.json()).resolves.toEqual({ router: "app" });
+
+        const localePrefixed = await fetch(`${baseUrl}/fr/api/direct`);
+        expect(localePrefixed.status).toBe(404);
+      } finally {
+        await closeServer?.();
+        await fs.rm(fixtureRoot, { recursive: true, force: true });
+      }
+    },
+    120000,
+  );
+});

--- a/tests/pages-request-pipeline.test.ts
+++ b/tests/pages-request-pipeline.test.ts
@@ -1198,6 +1198,68 @@ describe("API routes", () => {
     expect(result.defaultContentType).toBe("application/octet-stream");
   });
 
+  it("continues to fallback rewrites when an API path has no route match", async () => {
+    const matchApiRoute = vi.fn().mockReturnValue(null);
+    const proxyExternal = vi.fn(async () => new Response("upstream"));
+    const result = await runPagesRequest(
+      makeRequest("/api/session?client=vinext", { "x-use-fallback": "yes" }),
+      baseDeps({
+        configRewrites: {
+          beforeFiles: [],
+          afterFiles: [],
+          fallback: [
+            {
+              source: "/api/:path*",
+              has: [{ type: "header", key: "x-use-fallback", value: "yes" }],
+              destination: "https://upstream.example/auth/:path*?from=config",
+            },
+          ],
+        },
+        matchApiRoute,
+        proxyExternal,
+      }),
+    );
+
+    expect(result.type).toBe("response");
+    if (result.type !== "response") return;
+    await expect(result.response.text()).resolves.toBe("upstream");
+    expect(matchApiRoute).toHaveBeenCalledWith("/api/session?client=vinext", expect.any(Request));
+    expect(proxyExternal).toHaveBeenCalledWith(
+      expect.any(Request),
+      "https://upstream.example/auth/session?from=config",
+    );
+  });
+
+  it("does not apply fallback rewrites when an API route matches", async () => {
+    const matchApiRoute = vi.fn().mockReturnValue({
+      route: { isDynamic: false, pattern: "/api/session" },
+    });
+    const handleApi = vi.fn(async () => new Response("local api"));
+    const proxyExternal = vi.fn(async () => new Response("upstream"));
+    const result = await runPagesRequest(
+      makeRequest("/api/session"),
+      baseDeps({
+        configRewrites: {
+          beforeFiles: [],
+          afterFiles: [],
+          fallback: [
+            {
+              source: "/api/:path*",
+              destination: "https://upstream.example/:path*",
+            },
+          ],
+        },
+        handleApi,
+        matchApiRoute,
+        proxyExternal,
+      }),
+    );
+
+    expect(result.type).toBe("response");
+    expect(handleApi).toHaveBeenCalledOnce();
+    expect(proxyExternal).not.toHaveBeenCalled();
+  });
+
   it("tags page renders with a text/html content-type default", async () => {
     const req = makeRequest("/page");
     const result = await runPagesRequest(req, baseDeps({ renderPage: makeRenderPage(200) }));
@@ -1902,6 +1964,8 @@ describe("fallback rewrites on 404", () => {
         },
         serveFilesystemRoute,
         handleApi,
+        matchApiRoute: (url) =>
+          url === "/api/hello" ? { route: { isDynamic: false, pattern: "/api/hello" } } : null,
         renderPage: makeRenderPage(404),
       }),
     );

--- a/tests/pages-request-pipeline.test.ts
+++ b/tests/pages-request-pipeline.test.ts
@@ -1183,6 +1183,42 @@ describe("API routes", () => {
     expect(result.type).toBe("api");
     if (result.type !== "api") return;
     expect(result.apiUrl).toBe("/api/users");
+    expect(result.configRewriteFired).toBe(false);
+  });
+
+  it("distinguishes locale-normalized API lookup from a config rewrite", async () => {
+    const result = await runPagesRequest(
+      makeRequest("/fr/api/users"),
+      baseDeps({
+        i18nConfig: {
+          defaultLocale: "en",
+          locales: ["en", "fr"],
+        },
+      }),
+    );
+
+    expect(result.type).toBe("api");
+    if (result.type !== "api") return;
+    expect(result.apiUrl).toBe("/api/users");
+    expect(result.configRewriteFired).toBe(false);
+  });
+
+  it("marks API intents reached through config rewrites", async () => {
+    const result = await runPagesRequest(
+      makeRequest("/legacy/users"),
+      baseDeps({
+        configRewrites: {
+          beforeFiles: [{ source: "/legacy/:path*", destination: "/api/:path*" }],
+          afterFiles: [],
+          fallback: [],
+        },
+      }),
+    );
+
+    expect(result.type).toBe("api");
+    if (result.type !== "api") return;
+    expect(result.apiUrl).toBe("/api/users");
+    expect(result.configRewriteFired).toBe(true);
   });
 
   // 12. API route with handleApi present → {type:"response"}

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -3527,6 +3527,149 @@ describe("Pages Router allowedDevOrigins config", () => {
   });
 });
 
+// Ported from Next.js: test/e2e/i18n-api-support/index.test.ts
+// https://github.com/vercel/next.js/blob/canary/test/e2e/i18n-api-support/index.test.ts
+// Next.js resolves fallback rewrites after an API filesystem miss instead of
+// immediately returning "404 - API route not found".
+describe("Pages Router unmatched API fallback rewrites", () => {
+  it("proxies unmatched API requests with their method, query, headers, and body", async () => {
+    const { createServer: createHttpServer } = await import("node:http");
+    const upstream = createHttpServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk: Buffer) => chunks.push(chunk));
+      req.on("end", () => {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(
+          JSON.stringify({
+            body: Buffer.concat(chunks).toString("utf8"),
+            header: req.headers["x-proxy-regression"],
+            method: req.method,
+            url: req.url,
+          }),
+        );
+      });
+    });
+    const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-pages-api-fallback-"));
+    const outDir = path.join(tmpDir, "dist");
+    let devServer: ViteDevServer | undefined;
+    let prodServer: import("node:http").Server | undefined;
+
+    try {
+      await new Promise<void>((resolve) => upstream.listen(0, "127.0.0.1", resolve));
+      const upstreamAddress = upstream.address();
+      if (typeof upstreamAddress === "string" || upstreamAddress === null) {
+        throw new Error("Expected upstream port");
+      }
+
+      await fsp.symlink(
+        path.resolve(import.meta.dirname, "../node_modules"),
+        path.join(tmpDir, "node_modules"),
+        "junction",
+      );
+      await fsp.mkdir(path.join(tmpDir, "pages", "api"), { recursive: true });
+      await fsp.writeFile(path.join(tmpDir, "package.json"), JSON.stringify({ type: "module" }));
+      await fsp.writeFile(path.join(tmpDir, "pages", "_app.tsx"), PAGES_APP_COMPONENT);
+      await fsp.writeFile(
+        path.join(tmpDir, "pages", "index.tsx"),
+        `export default function Home() { return <main>API fallback fixture</main>; }\n`,
+      );
+      await fsp.writeFile(
+        path.join(tmpDir, "pages", "api", "local.ts"),
+        `export default function handler(_req, res) { res.status(200).json({ local: true }); }\n`,
+      );
+      await fsp.writeFile(
+        path.join(tmpDir, "next.config.mjs"),
+        `export default {
+  basePath: "/docs",
+  async rewrites() {
+    return {
+      beforeFiles: [],
+      afterFiles: [],
+      fallback: [{
+        source: "/api/:path*",
+        has: [{ type: "header", key: "x-use-api-fallback", value: "yes" }],
+        missing: [{ type: "header", key: "x-block-api-fallback" }],
+        destination: "http://127.0.0.1:${upstreamAddress.port}/auth/:path*?from=config",
+      }],
+    };
+  },
+};
+`,
+      );
+
+      const assertRequests = async (baseUrl: string) => {
+        const missingHasResponse = await fetch(`${baseUrl}/docs/api/session/gated`);
+        expect(missingHasResponse.status).toBe(404);
+
+        const blockedByMissingResponse = await fetch(`${baseUrl}/docs/api/session/gated`, {
+          headers: {
+            "x-block-api-fallback": "1",
+            "x-use-api-fallback": "yes",
+          },
+        });
+        expect(blockedByMissingResponse.status).toBe(404);
+
+        const localResponse = await fetch(`${baseUrl}/docs/api/local`, {
+          headers: { "x-use-api-fallback": "yes" },
+        });
+        expect(localResponse.status).toBe(200);
+        await expect(localResponse.json()).resolves.toEqual({ local: true });
+
+        const body = JSON.stringify({ grant: "fixture" });
+        const response = await fetch(`${baseUrl}/docs/api/session/login?client=vinext`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-proxy-regression": "preserved",
+            "x-use-api-fallback": "yes",
+          },
+          body,
+        });
+        expect(response.status).toBe(200);
+        const upstreamRequest = (await response.json()) as {
+          body: string;
+          header?: string;
+          method?: string;
+          url?: string;
+        };
+        expect(upstreamRequest.body).toBe(body);
+        expect(upstreamRequest.header).toBe("preserved");
+        expect(upstreamRequest.method).toBe("POST");
+        const upstreamUrl = new URL(upstreamRequest.url ?? "", "http://upstream.test");
+        expect(upstreamUrl.pathname).toBe("/auth/session/login");
+        expect(Object.fromEntries(upstreamUrl.searchParams)).toEqual({
+          client: "vinext",
+          from: "config",
+        });
+      };
+
+      const dev = await startFixtureServer(tmpDir);
+      devServer = dev.server;
+      await assertRequests(dev.baseUrl);
+      await devServer.close();
+      devServer = undefined;
+
+      await buildPagesFixtureToOutDir(tmpDir, outDir);
+      const { startProdServer } = await import("../packages/vinext/src/server/prod-server.js");
+      prodServer = unwrapStartedProdServer(
+        await startProdServer({ port: 0, host: "127.0.0.1", outDir }),
+      );
+      const prodAddress = prodServer.address();
+      if (typeof prodAddress === "string" || prodAddress === null) {
+        throw new Error("Expected production server port");
+      }
+      await assertRequests(`http://127.0.0.1:${prodAddress.port}`);
+    } finally {
+      await devServer?.close();
+      await new Promise<void>((resolve) =>
+        prodServer ? prodServer.close(() => resolve()) : resolve(),
+      );
+      await new Promise<void>((resolve) => upstream.close(() => resolve()));
+      await fsp.rm(tmpDir, { recursive: true, force: true });
+    }
+  }, 120000);
+});
+
 describe("Virtual server entry generation", () => {
   it("generates valid JavaScript for the server entry", async () => {
     // Create a minimal server just to access the plugin's virtual module


### PR DESCRIPTION
## Summary

- apply fallback rewrites only after no filesystem API route claims the request
- share route-claim logic across Pages dev, built Node production, and the generated Pages Worker
- preserve external proxy method, query, headers, and body
- hand internal fallback destinations to App route handlers with post-middleware request overrides and staged response metadata intact

## Regression coverage

- a real Pages fixture proxies an unmatched POST through a fallback rewrite to a local upstream in dev and production
- covers basePath, has/missing conditions, local Pages API precedence, merged query, headers, and JSON body
- a real hybrid Pages/App fixture rewrites an unmatched API path to an App catch-all route handler and verifies middleware cookie overrides, response headers, URL/query/body/params, and production parity
- the external fixture returns 404 and the hybrid fixture returns 500 before the fix

## Validation

- focused Pages fixture, hybrid dev, and built production tests
- pages request-pipeline, deploy/Worker wiring, and App RSC rewrite tests
- vinext build and touched-file `vp check`
- independent cumulative parity review: clean