### PR TITLE
feat(client): expose host React to Module Federation remotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,49 @@ export default defineConfig({
 > Adding an explicit `rsc()` call fails the build with `[vinext] Duplicate @vitejs/plugin-rsc detected`.
 > Pass `rsc: false` to `vinext()` only if you want to own that registration.
 
+#### Module Federation (client-side)
+
+For client-side Module Federation, configure React and React DOM as singleton shared modules in both the host and remotes:
+
+```ts
+import { federation } from "@module-federation/vite";
+import { defineConfig } from "vite";
+import vinext from "vinext";
+
+export default defineConfig({
+  plugins: [
+    federation({
+      name: "host",
+      shared: {
+        react: { singleton: true },
+        "react/": { singleton: true },
+        "react-dom": { singleton: true },
+        "react-dom/": { singleton: true },
+      },
+    }),
+    vinext(),
+  ],
+});
+```
+
+In a remote client component, use `getVinextReact()` before reading React hooks. vinext registers the host's browser React instance before application modules execute, and the first registration remains stable across remote evaluation and HMR:
+
+```tsx
+"use client";
+
+import * as React from "react";
+import { getVinextReact } from "vinext/client";
+
+const { useState } = getVinextReact(React);
+
+export function RemoteCounter() {
+  const [count, setCount] = useState(0);
+  return <button onClick={() => setCount((value) => value + 1)}>{count}</button>;
+}
+```
+
+This bridge is browser-only. It does not provide App Router Module Federation SSR or transparently replace React imports inside third-party packages; compatible React versions remain the responsibility of the Module Federation `shared` configuration.
+
 See the [examples](#live-examples) for complete working configurations.
 
 ### Other platforms (via Nitro)

--- a/knip.ts
+++ b/knip.ts
@@ -45,6 +45,7 @@ export default {
         "src/build/prerender-server-entry.ts",
         // Runtime helpers imported by generated virtual entries. The imports
         // are emitted as strings, so knip cannot trace them statically.
+        "src/client/react-instance-bootstrap.ts",
         "src/server/app-middleware.ts",
         "src/server/app-page-dispatch.ts",
         "src/server/app-page-head.ts",

--- a/packages/vinext/package.json
+++ b/packages/vinext/package.json
@@ -21,6 +21,10 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./client": {
+      "types": "./dist/client/index.d.ts",
+      "import": "./dist/client/index.js"
+    },
     "./cache": {
       "types": "./dist/cache.d.ts",
       "import": "./dist/cache.js"

--- a/packages/vinext/src/client/index.ts
+++ b/packages/vinext/src/client/index.ts
@@ -1,0 +1,1 @@
+export { getVinextReact } from "./react-instance.js";

--- a/packages/vinext/src/client/react-instance-bootstrap.ts
+++ b/packages/vinext/src/client/react-instance-bootstrap.ts
@@ -1,0 +1,6 @@
+"use client";
+
+import * as React from "react";
+import { getVinextReact } from "./react-instance.js";
+
+getVinextReact(React);

--- a/packages/vinext/src/client/react-instance.ts
+++ b/packages/vinext/src/client/react-instance.ts
@@ -1,0 +1,26 @@
+const VINEXT_CLIENT_REACT = Symbol.for("vinext.client.react");
+
+/**
+ * Return the React instance registered by the vinext browser entry.
+ *
+ * Module Federation remotes can call this with their local React namespace to
+ * reuse the host instance. The first browser registration wins so evaluating
+ * another copy of this module (for example after HMR) cannot replace it.
+ * Server and RSC environments always keep their condition-specific React
+ * instance local.
+ */
+export function getVinextReact(reactInstance: typeof import("react")): typeof import("react") {
+  if (typeof window === "undefined") {
+    return reactInstance;
+  }
+
+  const registeredReact = Reflect.get(globalThis, VINEXT_CLIENT_REACT) as
+    | typeof import("react")
+    | undefined;
+  if (registeredReact !== undefined) {
+    return registeredReact;
+  }
+
+  Reflect.set(globalThis, VINEXT_CLIENT_REACT, reactInstance);
+  return reactInstance;
+}

--- a/packages/vinext/src/entries/app-browser-entry.ts
+++ b/packages/vinext/src/entries/app-browser-entry.ts
@@ -26,11 +26,13 @@ export function generateBrowserEntry(
   },
 ): string {
   const entryPath = resolveRuntimeEntryModule("app-browser-entry");
+  const reactInstanceBootstrapPath = resolveClientRuntimeModule("react-instance-bootstrap");
   const navigationRuntimePath = resolveClientRuntimeModule("navigation-runtime");
   const prefetchRoutes = toLinkPrefetchRoutes(routes);
   const clientRewrites = toClientRewrites(rewrites);
 
-  return `import { registerNavigationRuntimeBootstrap } from ${JSON.stringify(navigationRuntimePath)};
+  return `import ${JSON.stringify(reactInstanceBootstrapPath)};
+import { registerNavigationRuntimeBootstrap } from ${JSON.stringify(navigationRuntimePath)};
 
 window.__VINEXT_LINK_PREFETCH_ROUTES__ = ${JSON.stringify(prefetchRoutes)};
 // Pages route manifest for hybrid ownership decisions. In a hybrid

--- a/packages/vinext/src/entries/pages-client-entry.ts
+++ b/packages/vinext/src/entries/pages-client-entry.ts
@@ -26,6 +26,7 @@ import { toClientRewrites } from "../client/client-rewrites.js";
 import { findFileWithExts } from "./pages-entry-helpers.js";
 import { toSlash } from "pathslash";
 import { hasExportedName, type StaticMiddlewareMatcher } from "../build/report.js";
+import { resolveClientRuntimeModule } from "./runtime-entry-module.js";
 
 /**
  * Project a Pages `Route` down to the public `VinextPagesLinkPrefetchRoute`
@@ -93,6 +94,7 @@ export async function generateClientEntry(
   ).filter((pattern): pattern is string => pattern !== null);
   const instrumentationClientPath = options.instrumentationClientPath ?? null;
   const clientRewrites = toClientRewrites(nextConfig.rewrites);
+  const reactInstanceBootstrapPath = resolveClientRuntimeModule("react-instance-bootstrap");
 
   // Build a map of route pattern -> dynamic import.
   // Keys must use Next.js bracket format (e.g. "/user/[id]") to match
@@ -114,9 +116,11 @@ export async function generateClientEntry(
   const appFileBase = appFilePath ?? undefined;
 
   // Refs #1474: Side-effect-import the user's `instrumentation-client.{ts,js}`
-  // (when present at project root or in `src/`) BEFORE any other module so its
-  // top-level statements run before `hydrateRoot()` is called. Mirrors
-  // Next.js's `page-bootstrap.ts`, which side-effect-imports
+  // (when present at project root or in `src/`) before the Pages application
+  // runtime so its top-level statements run before `hydrateRoot()` is called.
+  // The framework-owned React instance bootstrap is intentionally earlier so
+  // Module Federation remotes observe the host React from instrumentation too.
+  // This mirrors Next.js's `page-bootstrap.ts`, which side-effect-imports
   // `require-instrumentation-client` ahead of `initialize`/`hydrate`
   // (.nextjs-ref/packages/next/src/client/page-bootstrap.ts L1).
   //
@@ -142,7 +146,8 @@ export async function generateClientEntry(
   // Next.js's `process.env.__NEXT_STRICT_MODE` branch in `client/index.tsx`.
   const reactStrictModeEnabled = nextConfig.reactStrictMode === true;
 
-  return `${userInstrumentationImport}${reactPreambleImport}
+  return `import ${JSON.stringify(reactInstanceBootstrapPath)};
+${userInstrumentationImport}${reactPreambleImport}
 import "vinext/instrumentation-client";
 import React from "react";
 import { hydrateRoot } from "react-dom/client";

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2490,6 +2490,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             "vinext/head-state": path.join(shimsDir, "head-state"),
             "vinext/i18n-state": path.join(shimsDir, "i18n-state"),
             "vinext/i18n-context": path.join(shimsDir, "i18n-context"),
+            "vinext/client": path.resolve(__dirname, "client", "index"),
             "vinext/cache": path.resolve(__dirname, "cache"),
             "vinext/instrumentation": path.resolve(__dirname, "server", "instrumentation"),
             "vinext/instrumentation-client": path.resolve(

--- a/packages/vinext/src/server/pages-dev-hydration.ts
+++ b/packages/vinext/src/server/pages-dev-hydration.ts
@@ -1,4 +1,5 @@
 import { createNonceAttribute } from "./html.js";
+import { resolveClientRuntimeModule } from "../entries/runtime-entry-module.js";
 
 export type PagesDevHydrationOptions = {
   appModuleSource: string | null;
@@ -13,6 +14,7 @@ export type PagesDevHydrationOptions = {
 
 export function createPagesDevHydrationScript(options: PagesDevHydrationOptions): string {
   const nonceAttr = createNonceAttribute(options.scriptNonce);
+  const reactInstanceBootstrapPath = resolveClientRuntimeModule("react-instance-bootstrap");
   const initializeRouter = options.forceRouterReady
     ? "_initializePagesRouterReadyFromNextData(nextData, true);"
     : "_initializePagesRouterReadyFromNextData(nextData);";
@@ -47,6 +49,7 @@ export function createPagesDevHydrationScript(options: PagesDevHydrationOptions)
 
   return `
 <script type="module"${nonceAttr}>
+import ${JSON.stringify(reactInstanceBootstrapPath)};
 import "vinext/instrumentation-client";
 import React from "react";
 import { hydrateRoot } from "react-dom/client";

--- a/tests/client-react-bridge.test.ts
+++ b/tests/client-react-bridge.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { getVinextReact } from "../packages/vinext/src/client/index.js";
+
+type VinextReactInstance = typeof import("react");
+
+const VINEXT_CLIENT_REACT = Symbol.for("vinext.client.react");
+
+function reactInstance(name: string): VinextReactInstance {
+  return { version: name } as unknown as VinextReactInstance;
+}
+
+afterEach(() => {
+  Reflect.deleteProperty(globalThis, VINEXT_CLIENT_REACT);
+  vi.unstubAllGlobals();
+});
+
+describe("getVinextReact", () => {
+  it("returns the first React instance registered in the browser", () => {
+    vi.stubGlobal("window", globalThis);
+    const hostReact = reactInstance("host");
+    const remoteReact = reactInstance("remote");
+
+    expect(getVinextReact(hostReact)).toBe(hostReact);
+    expect(getVinextReact(remoteReact)).toBe(hostReact);
+    expect(Reflect.get(globalThis, Symbol.for("vinext.client.react"))).toBe(hostReact);
+  });
+
+  it("preserves an existing registration across duplicate or HMR module evaluation", () => {
+    vi.stubGlobal("window", globalThis);
+    const hostReact = reactInstance("host");
+    const hmrReact = reactInstance("hmr");
+    Reflect.set(globalThis, Symbol.for("vinext.client.react"), hostReact);
+
+    expect(getVinextReact(hmrReact)).toBe(hostReact);
+    expect(Reflect.get(globalThis, VINEXT_CLIENT_REACT)).toBe(hostReact);
+  });
+
+  it("returns the caller's React instance without creating server global state", () => {
+    vi.stubGlobal("window", undefined);
+    const serverReact = reactInstance("react-server");
+
+    expect(getVinextReact(serverReact)).toBe(serverReact);
+    expect(Reflect.has(globalThis, VINEXT_CLIENT_REACT)).toBe(false);
+  });
+});

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -1479,6 +1479,7 @@ describe("readPagesRouterEntrySource", () => {
 
   it("exports the built-in fetch handler and router-specific worker entries", () => {
     const exportsMap = readVinextPackageExports();
+    expect(hasPackageExport(exportsMap, "./client")).toBe(true);
     expect(hasPackageExport(exportsMap, "./server/fetch-handler")).toBe(true);
     expect(hasPackageExport(exportsMap, "./server/app-router-entry")).toBe(true);
     expect(hasPackageExport(exportsMap, "./server/pages-router-entry")).toBe(true);

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -23,6 +23,7 @@ import { buildAppRouteGraph } from "../packages/vinext/src/routing/app-route-gra
 import { createValidFileMatcher } from "../packages/vinext/src/routing/file-matcher.js";
 import type { AppRoute } from "../packages/vinext/src/routing/app-router.js";
 import type { MetadataFileRoute } from "../packages/vinext/src/server/metadata-routes.js";
+import { createPagesDevHydrationScript } from "../packages/vinext/src/server/pages-dev-hydration.js";
 
 // ── Minimal App Router route fixtures ─────────────────────────────────
 // Use stable absolute paths so tests don't depend on the machine.
@@ -128,6 +129,19 @@ const minimalAppRoutes: AppRoute[] = [
 // ── App Router manifest construction ─────────────────────────────────
 
 describe("App Router generated manifest construction", () => {
+  it("registers the host React instance before the App Router browser runtime", () => {
+    const code = generateBrowserEntry();
+    const reactBootstrapIndex = code.indexOf("react-instance-bootstrap");
+    const navigationRuntimeIndex = code.indexOf("navigation-runtime");
+    const browserRuntimeIndex = code.indexOf("app-browser-entry");
+
+    expect(reactBootstrapIndex).toBeGreaterThanOrEqual(0);
+    expect(navigationRuntimeIndex).toBeGreaterThanOrEqual(0);
+    expect(browserRuntimeIndex).toBeGreaterThanOrEqual(0);
+    expect(reactBootstrapIndex).toBeLessThan(navigationRuntimeIndex);
+    expect(reactBootstrapIndex).toBeLessThan(browserRuntimeIndex);
+  });
+
   it("embeds only client-safe rewrite data in the App browser entry", () => {
     const code = generateBrowserEntry([], null, [], {
       afterFiles: [
@@ -1681,14 +1695,37 @@ describe("Pages Router entry template", () => {
       // side-effect import (no `from`, no `as`) so its top-level statements
       // execute when the client entry module is evaluated.
       const userImportIndex = code.indexOf(`import ${JSON.stringify(instrumentationClientPath)}`);
+      const reactBootstrapIndex = code.indexOf("react-instance-bootstrap");
       const hydrateRootIndex = code.indexOf("hydrateRoot(");
 
+      expect(reactBootstrapIndex).toBeGreaterThanOrEqual(0);
       expect(userImportIndex).toBeGreaterThanOrEqual(0);
       expect(hydrateRootIndex).toBeGreaterThanOrEqual(0);
+      expect(reactBootstrapIndex).toBeLessThan(userImportIndex);
       expect(userImportIndex).toBeLessThan(hydrateRootIndex);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
+  });
+
+  it("registers the host React instance before Pages Router dev hydration", () => {
+    const code = createPagesDevHydrationScript({
+      appModuleSource: "/tmp/test/pages/_app.tsx",
+      pageModuleSource: "/tmp/test/pages/index.tsx",
+      reactStrictMode: false,
+    });
+    const reactBootstrapIndex = code.indexOf("react-instance-bootstrap");
+    const instrumentationIndex = code.indexOf('import "vinext/instrumentation-client"');
+    const pageImportIndex = code.indexOf('await import("/tmp/test/pages/index.tsx")');
+    const hydrateRootIndex = code.indexOf("hydrateRoot(");
+
+    expect(reactBootstrapIndex).toBeGreaterThanOrEqual(0);
+    expect(instrumentationIndex).toBeGreaterThanOrEqual(0);
+    expect(pageImportIndex).toBeGreaterThanOrEqual(0);
+    expect(hydrateRootIndex).toBeGreaterThanOrEqual(0);
+    expect(reactBootstrapIndex).toBeLessThan(instrumentationIndex);
+    expect(reactBootstrapIndex).toBeLessThan(pageImportIndex);
+    expect(reactBootstrapIndex).toBeLessThan(hydrateRootIndex);
   });
 
   it("omits the user instrumentation-client import when no file is present", async () => {


### PR DESCRIPTION
## Summary

- add a browser-only `vinext/client` entry point with `getVinextReact()` so Module Federation remotes can reuse the host React instance
- register the host React instance before App Router and Pages Router client runtimes, including Pages Router development hydration
- document the required singleton sharing configuration, usage, and browser-only limitations

## Why

Module Federation remotes can evaluate with a different React module instance from the vinext host. Components that read hooks from that copy can hit React dispatcher mismatches and fail with invalid hook call errors.

The client bridge stores the first browser React instance under a global symbol and returns it to remotes explicitly. First-registration semantics also keep the host instance stable when duplicate modules are evaluated or HMR reloads the bridge. Server and RSC environments continue to use their condition-specific React instances without global registration.

## User impact

Client-side Module Federation integrations can import `getVinextReact` from `vinext/client` and resolve hooks against the vinext host React instance. Consumers still need compatible singleton `react`, `react/`, `react-dom`, and `react-dom/` sharing configuration. This does not add App Router Module Federation SSR or rewrite React imports in third-party packages.

## Validation

- `pnpm test tests/client-react-bridge.test.ts tests/entry-templates.test.ts tests/deploy.test.ts` — 369 tests passed
- `pnpm run check` — formatting, lint, type checks, Next.js type sync, and public shim checks passed
