### PR TITLE
test: add Vite ecosystem CI entry points

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "test:unit": "vp test run --project unit",
     "test:integration": "vp test run --project integration",
     "test:watch": "vp test",
+    "vite-ecosystem-ci:build": "vp run vinext#build",
+    "vite-ecosystem-ci:test": "vp test run --project unit tests/build-optimization.test.ts tests/client-assets-build.test.ts && vp test run --project integration tests/app-router-rsc-plugin.test.ts tests/app-router-production-build.test.ts tests/vite-hmr-websocket.test.ts",
     "sync:next-types": "node scripts/sync-next-types.mjs",
     "check:next-types": "node scripts/sync-next-types.mjs --check && node scripts/check-shim-types.mjs",
     "check:shim-types": "node scripts/check-shim-types.mjs",


### PR DESCRIPTION
## Summary

- add a Vite ecosystem CI build entry point scoped to the vinext package
- add a focused Vite compatibility test entry point covering plugin configuration, multi-environment builds, RSC dev integration, production builds, preview serving, and HMR
- avoid the full vinext test and Playwright suites so ecosystem CI stays fast

## Validation

- pnpm run vite-ecosystem-ci:build
- pnpm run vite-ecosystem-ci:test (173 passed, 2 skipped; about 38 seconds locally)
- pnpm run fmt:check -- package.json

Reference: https://github.com/vitejs/vite-ecosystem-ci/pull/434