### PR TITLE
fix(app-router): replay Back/Forward missed before hydration

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -138,6 +138,10 @@ import {
   restoreSynchronousPopstateScrollPosition,
 } from "./app-browser-popstate.js";
 import {
+  hasMissedInitialTraversal,
+  readBrowserNavigationEntryKeySource,
+} from "./app-browser-missed-traversal.js";
+import {
   DevRecoveryBoundary,
   GlobalErrorBoundary,
   RedirectBoundary,
@@ -1507,7 +1511,26 @@ function bootstrapHydration(
   devErrorOverlay: DevErrorOverlayModule | null,
   initialRscBootstrap: NavigationRuntimeRscBootstrap | undefined,
 ): void {
+  // Back/Forward pressed before the popstate listener exists (the awaits in
+  // main(), or the entry script still loading) is an instant same-document
+  // traversal that nobody handled: the browser now sits on a different history
+  // entry than the one this document was activated on. The initial payload
+  // describes the activation entry, so it must not seed the URL-keyed
+  // navigation caches and the initial history writes must not overwrite the
+  // traversed-to entry's metadata. The traversal is replayed once the listener
+  // is installed below.
+  const missedInitialTraversal = hasMissedInitialTraversal({
+    historyState: window.history.state,
+    navigation: readBrowserNavigationEntryKeySource(),
+  });
+  if (missedInitialTraversal) {
+    historyController.markMissedInitialTraversal();
+  }
+
   const hydrationCachePublication = createHydrationCachePublication();
+  if (missedInitialTraversal) {
+    hydrationCachePublication.invalidate();
+  }
   const cacheGeneration = clientNavigationCacheGeneration;
   const [reactBranch, cacheBranch] = rscStream.tee();
   const root = decodeAppElementsPromise(createFromReadableStream<AppWireElements>(reactBranch));
@@ -1521,6 +1544,8 @@ function bootstrapHydration(
   void Promise.all([root, initialCacheBuffer])
     .then(async ([elements, buffer]) => {
       if (cacheGeneration !== clientNavigationCacheGeneration) return;
+      // The payload belongs to the activation entry, not the live URL.
+      if (missedInitialTraversal) return;
       const metadata = AppElementsWire.readMetadata(elements);
       initialPrefetchRouterState = {
         pathAndSearch: initialPathAndSearch,
@@ -2446,7 +2471,7 @@ function bootstrapHydration(
     shouldSkipScrollRestore: (navId) => synchronousPopstateScrollRestoreNavigationId === navId,
   });
 
-  window.addEventListener("popstate", (event) => {
+  const handleAppRouterTraversal = (state: unknown): void => {
     // The browser has already applied the history entry by the time popstate
     // fires. App Router state does not include hashes, so matching the
     // committed pathname/search proves this traversal does not need a new RSC
@@ -2456,13 +2481,13 @@ function bootstrapHydration(
     const href = window.location.href;
     if (isSameAppRoutePopstateTarget(href)) {
       notifyAppRouterTransitionStart(href, "traverse");
-      historyController.commitTraversalIndexFromHistoryState(event.state);
-      restorePopstateScrollPosition(event.state);
+      historyController.commitTraversalIndexFromHistoryState(state);
+      restorePopstateScrollPosition(state);
       return;
     }
     const snapshotNavigationId = browserNavigationController.beginNavigation();
     if (
-      restoreHistoryStateSnapshot(event.state, snapshotNavigationId, () => {
+      restoreHistoryStateSnapshot(state, snapshotNavigationId, () => {
         abortSupersededNavigation();
         notifyAppRouterTransitionStart(href, "traverse");
       })
@@ -2477,14 +2502,31 @@ function bootstrapHydration(
           },
           restorePopstateScrollPosition,
         },
-        event.state,
+        state,
       );
       browserNavigationController.finalizeNavigation(snapshotNavigationId, null);
       return;
     }
     browserNavigationController.finalizeNavigation(snapshotNavigationId, null);
-    handlePopstate(event);
+    handlePopstate(state);
+  };
+
+  window.addEventListener("popstate", (event) => {
+    handleAppRouterTraversal(event.state);
   });
+
+  // Re-check instead of trusting the detection made before hydration started: a
+  // third-party history write in between moves the live entry off the
+  // traversed-to one, and replaying onto it would render the wrong route.
+  if (
+    missedInitialTraversal &&
+    hasMissedInitialTraversal({
+      historyState: window.history.state,
+      navigation: readBrowserNavigationEntryKeySource(),
+    })
+  ) {
+    handleAppRouterTraversal(window.history.state);
+  }
 
   if (import.meta.env.DEV && import.meta.hot) {
     const applyRscHmrUpdate = async (updateId: number): Promise<void> => {

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -34,6 +34,7 @@ import {
   getBfcacheIdMapContext,
   getMountedSlotsHeader,
   getPrefetchCache,
+  hasObservedExternalHistoryWrite,
   hasPrefetchCacheEntryForNavigation,
   invalidatePrefetchCache,
   preloadHybridClientRouteOwner,
@@ -1520,6 +1521,7 @@ function bootstrapHydration(
   // traversed-to entry's metadata. The traversal is replayed once the listener
   // is installed below.
   const missedInitialTraversal = hasMissedInitialTraversal({
+    externalHistoryWriteObserved: hasObservedExternalHistoryWrite(),
     historyState: window.history.state,
     navigation: readBrowserNavigationEntryKeySource(),
   });
@@ -2521,6 +2523,7 @@ function bootstrapHydration(
   if (
     missedInitialTraversal &&
     hasMissedInitialTraversal({
+      externalHistoryWriteObserved: hasObservedExternalHistoryWrite(),
       historyState: window.history.state,
       navigation: readBrowserNavigationEntryKeySource(),
     })

--- a/packages/vinext/src/server/app-browser-history-controller.ts
+++ b/packages/vinext/src/server/app-browser-history-controller.ts
@@ -110,6 +110,7 @@ export class AppBrowserHistoryController {
   // still continue from the highest known app history.
   #currentHistoryTraversalIndex: number | null;
   #nextHistoryTraversalIndex: number;
+  #missedInitialTraversal = false;
 
   constructor(deps: AppBrowserHistoryControllerDeps) {
     this.#readHistoryState = deps.readHistoryState;
@@ -348,8 +349,20 @@ export class AppBrowserHistoryController {
     );
   }
 
+  /**
+   * A Back/Forward landed before the popstate listener existed, so the live
+   * entry is the traversed-to one, not the entry this document was activated
+   * on. Its own metadata is authoritative; the initial writes below would
+   * overwrite it with the activation entry's. The replayed traversal owns every
+   * later write.
+   */
+  markMissedInitialTraversal(): void {
+    this.#missedInitialTraversal = true;
+  }
+
   /** Initial history write performed before hydration starts. */
   writeBootstrapHistoryMetadata(): void {
+    if (this.#missedInitialTraversal) return;
     this.#replaceHistoryState(
       createHistoryStateWithNavigationMetadata(this.#readHistoryState(), {
         previousNextUrl: null,
@@ -364,6 +377,7 @@ export class AppBrowserHistoryController {
     bfcacheIds: BfcacheIdMap;
     previousNextUrl: string | null;
   }): void {
+    if (this.#missedInitialTraversal) return;
     this.#replaceHistoryState(
       createHistoryStateWithNavigationMetadata(this.#readHistoryState(), {
         bfcacheIds: options.bfcacheIds,

--- a/packages/vinext/src/server/app-browser-missed-traversal.ts
+++ b/packages/vinext/src/server/app-browser-missed-traversal.ts
@@ -1,0 +1,34 @@
+import { readHistoryStateTraversalIndex } from "./app-history-state.js";
+
+/** The only Navigation API surface this check reads: activation/current entry keys. */
+export type NavigationEntryKeySource = {
+  activation?: { entry?: { key?: string } | null } | null;
+  currentEntry?: { key?: string } | null;
+};
+
+/**
+ * Reads `window.navigation`. Undefined outside Chromium, where the check no-ops
+ * and a traversal missed before hydration stays unhandled.
+ */
+export function readBrowserNavigationEntryKeySource(): NavigationEntryKeySource | undefined {
+  if (typeof window === "undefined") return undefined;
+  return (window as Window & { navigation?: NavigationEntryKeySource }).navigation;
+}
+
+/**
+ * True when Back/Forward landed before the App Router's popstate listener
+ * existed. The activation entry is fixed for the document's lifetime and entry
+ * keys survive `replaceState`, so a key mismatch means a traversal fired with
+ * nobody listening. Only vinext-written entries (they carry a traversal index)
+ * can be replayed; on any other entry the traversal is left unhandled.
+ */
+export function hasMissedInitialTraversal(options: {
+  historyState: unknown;
+  navigation: NavigationEntryKeySource | undefined;
+}): boolean {
+  const activationKey = options.navigation?.activation?.entry?.key;
+  const currentKey = options.navigation?.currentEntry?.key;
+  if (typeof activationKey !== "string" || typeof currentKey !== "string") return false;
+  if (activationKey === currentKey) return false;
+  return readHistoryStateTraversalIndex(options.historyState) !== null;
+}

--- a/packages/vinext/src/server/app-browser-missed-traversal.ts
+++ b/packages/vinext/src/server/app-browser-missed-traversal.ts
@@ -19,13 +19,19 @@ export function readBrowserNavigationEntryKeySource(): NavigationEntryKeySource 
  * True when Back/Forward landed before the App Router's popstate listener
  * existed. The activation entry is fixed for the document's lifetime and entry
  * keys survive `replaceState`, so a key mismatch means a traversal fired with
- * nobody listening. Only vinext-written entries (they carry a traversal index)
- * can be replayed; on any other entry the traversal is left unhandled.
+ * nobody listening.
+ *
+ * Only an entry the App Router owns can be replayed. A traversal index alone
+ * does not prove ownership: vinext's patched `history.pushState` copies that
+ * metadata onto entries raw callers create, so any external history write in
+ * this document disqualifies the check and the traversal is left unhandled.
  */
 export function hasMissedInitialTraversal(options: {
+  externalHistoryWriteObserved: boolean;
   historyState: unknown;
   navigation: NavigationEntryKeySource | undefined;
 }): boolean {
+  if (options.externalHistoryWriteObserved) return false;
   const activationKey = options.navigation?.activation?.entry?.key;
   const currentKey = options.navigation?.currentEntry?.key;
   if (typeof activationKey !== "string" || typeof currentKey !== "string") return false;

--- a/packages/vinext/src/server/app-browser-popstate.ts
+++ b/packages/vinext/src/server/app-browser-popstate.ts
@@ -61,10 +61,14 @@ function createPopstateTraversalIntent(historyState: unknown): HistoryTraversalI
   };
 }
 
+/**
+ * Handles a popstate history state — from the real event, or replayed with
+ * `window.history.state` for a traversal that fired before the listener existed.
+ */
 export function createPopstateRestoreHandler(
   deps: BrowserPopstateRestoreDeps,
-): (event: PopStateEvent) => void {
-  return (event) => {
+): (historyState: unknown) => void {
+  return (historyState) => {
     deps.notifyAppRouterTransitionStart(window.location.href);
     const navigate = deps.getNavigate();
     const pendingNavigation =
@@ -75,19 +79,19 @@ export function createPopstateRestoreHandler(
         undefined,
         undefined,
         false,
-        createPopstateTraversalIntent(event.state),
+        createPopstateTraversalIntent(historyState),
       ) ?? Promise.resolve();
     const popstateNavId = deps.getActiveNavigationId();
 
     deps.setPendingNavigation(pendingNavigation);
-    const shouldRestoreSavedScroll = hasSavedScrollPosition(event.state);
+    const shouldRestoreSavedScroll = hasSavedScrollPosition(historyState);
     const shouldRestoreScrollForNavigation = () =>
       deps.isCurrentNavigation(popstateNavId) && !deps.shouldSkipScrollRestore(popstateNavId);
 
     if (shouldRestoreSavedScroll) {
       scheduleAfterFrame(() => {
         if (shouldRestoreScrollForNavigation()) {
-          deps.restorePopstateScrollPosition(event.state, {
+          deps.restorePopstateScrollPosition(historyState, {
             shouldContinue: shouldRestoreScrollForNavigation,
           });
         }
@@ -96,7 +100,7 @@ export function createPopstateRestoreHandler(
 
     void pendingNavigation.finally(() => {
       if (shouldRestoreScrollForNavigation() && !shouldRestoreSavedScroll) {
-        deps.restorePopstateScrollPosition(event.state);
+        deps.restorePopstateScrollPosition(historyState);
       }
 
       if (deps.getPendingNavigation() === pendingNavigation) {

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -1627,6 +1627,7 @@ type ClientNavigationState = {
   originalPushState: typeof window.history.pushState;
   originalReplaceState: typeof window.history.replaceState;
   patchInstalled: boolean;
+  externalHistoryWriteObserved: boolean;
   hasPendingNavigationUpdate: boolean;
   suppressUrlNotifyCount: number;
   navigationSnapshotActiveCount: number;
@@ -1675,6 +1676,7 @@ export function getClientNavigationState(): ClientNavigationState | null {
     originalPushState: window.history.pushState.bind(window.history),
     originalReplaceState: window.history.replaceState.bind(window.history),
     patchInstalled: false,
+    externalHistoryWriteObserved: false,
     hasPendingNavigationUpdate: false,
     suppressUrlNotifyCount: 0,
     navigationSnapshotActiveCount: 0,
@@ -2204,6 +2206,17 @@ export function replaceHistoryStateWithoutNotify(
     const state = getClientNavigationState();
     state?.originalReplaceState.call(window.history, data, unused, url);
   });
+}
+
+/**
+ * True once raw `history.pushState`/`replaceState` ran in this document — third
+ * party code, or App Router shallow routing. The patched writers copy vinext's
+ * navigation metadata onto the caller's state, so the resulting entry carries a
+ * traversal index it does not own; readers that infer entry ownership from that
+ * metadata must consult this first.
+ */
+export function hasObservedExternalHistoryWrite(): boolean {
+  return getClientNavigationState()?.externalHistoryWriteObserved ?? false;
 }
 
 /**
@@ -3025,6 +3038,7 @@ if (!isServer) {
       unused: string,
       url?: string | URL | null,
     ): void {
+      state.externalHistoryWriteObserved = true;
       state.originalPushState.call(
         window.history,
         createExternalHistoryStatePreservingMetadata(data, window.history.state),
@@ -3045,6 +3059,7 @@ if (!isServer) {
       unused: string,
       url?: string | URL | null,
     ): void {
+      state.externalHistoryWriteObserved = true;
       state.originalReplaceState.call(
         window.history,
         createExternalHistoryStatePreservingMetadata(data, window.history.state),

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -7465,6 +7465,7 @@ describe("hasMissedInitialTraversal", () => {
   it("reports a traversal that moved off the activation entry", () => {
     expect(
       hasMissedInitialTraversal({
+        externalHistoryWriteObserved: false,
         historyState: vinextEntryState,
         navigation: navigationWithKeys("activation", "traversed"),
       }),
@@ -7474,6 +7475,7 @@ describe("hasMissedInitialTraversal", () => {
   it("reports nothing while the document sits on its activation entry", () => {
     expect(
       hasMissedInitialTraversal({
+        externalHistoryWriteObserved: false,
         historyState: vinextEntryState,
         navigation: navigationWithKeys("activation", "activation"),
       }),
@@ -7485,7 +7487,20 @@ describe("hasMissedInitialTraversal", () => {
     // entry carries no vinext traversal index, so there is nothing to replay.
     expect(
       hasMissedInitialTraversal({
+        externalHistoryWriteObserved: false,
         historyState: { thirdParty: true },
+        navigation: navigationWithKeys("activation", "third-party"),
+      }),
+    ).toBe(false);
+  });
+
+  it("leaves an entry whose traversal index was merely inherited unhandled", () => {
+    // The patched history.pushState copies vinext's navigation metadata onto a
+    // raw caller's state, so a traversal index on a new entry proves nothing.
+    expect(
+      hasMissedInitialTraversal({
+        externalHistoryWriteObserved: true,
+        historyState: { ...vinextEntryState, thirdParty: true },
         navigation: navigationWithKeys("activation", "third-party"),
       }),
     ).toBe(false);
@@ -7493,10 +7508,15 @@ describe("hasMissedInitialTraversal", () => {
 
   it("no-ops without the Navigation API", () => {
     expect(
-      hasMissedInitialTraversal({ historyState: vinextEntryState, navigation: undefined }),
+      hasMissedInitialTraversal({
+        externalHistoryWriteObserved: false,
+        historyState: vinextEntryState,
+        navigation: undefined,
+      }),
     ).toBe(false);
     expect(
       hasMissedInitialTraversal({
+        externalHistoryWriteObserved: false,
         historyState: vinextEntryState,
         navigation: { activation: null, currentEntry: { key: "current" } },
       }),

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -43,6 +43,7 @@ import {
   createPopstateRestoreHandler,
   restoreSynchronousPopstateScrollPosition,
 } from "../packages/vinext/src/server/app-browser-popstate.js";
+import { hasMissedInitialTraversal } from "../packages/vinext/src/server/app-browser-missed-traversal.js";
 import {
   VINEXT_RSC_COMPATIBILITY_ID_HEADER,
   resolveRscCompatibilityNavigationDecision,
@@ -7454,6 +7455,55 @@ describe("app browser entry bfcacheId helpers", () => {
   });
 });
 
+describe("hasMissedInitialTraversal", () => {
+  const vinextEntryState = { __vinext_historyIndex: 0 };
+  const navigationWithKeys = (activationKey: string, currentKey: string) => ({
+    activation: { entry: { key: activationKey } },
+    currentEntry: { key: currentKey },
+  });
+
+  it("reports a traversal that moved off the activation entry", () => {
+    expect(
+      hasMissedInitialTraversal({
+        historyState: vinextEntryState,
+        navigation: navigationWithKeys("activation", "traversed"),
+      }),
+    ).toBe(true);
+  });
+
+  it("reports nothing while the document sits on its activation entry", () => {
+    expect(
+      hasMissedInitialTraversal({
+        historyState: vinextEntryState,
+        navigation: navigationWithKeys("activation", "activation"),
+      }),
+    ).toBe(false);
+  });
+
+  it("leaves a third-party history entry unhandled", () => {
+    // e.g. analytics tooling calling pushState before the framework boots: the
+    // entry carries no vinext traversal index, so there is nothing to replay.
+    expect(
+      hasMissedInitialTraversal({
+        historyState: { thirdParty: true },
+        navigation: navigationWithKeys("activation", "third-party"),
+      }),
+    ).toBe(false);
+  });
+
+  it("no-ops without the Navigation API", () => {
+    expect(
+      hasMissedInitialTraversal({ historyState: vinextEntryState, navigation: undefined }),
+    ).toBe(false);
+    expect(
+      hasMissedInitialTraversal({
+        historyState: vinextEntryState,
+        navigation: { activation: null, currentEntry: { key: "current" } },
+      }),
+    ).toBe(false);
+  });
+});
+
 describe("createPopstateRestoreHandler", () => {
   it("guards synchronous popstate scroll retry to the active navigation", () => {
     const scrollState = { __vinext_scrollY: 10 };
@@ -7518,8 +7568,8 @@ describe("createPopstateRestoreHandler", () => {
       shouldSkipScrollRestore: () => false,
     });
 
-    handler({ state: { __vinext_scrollY: 10 } } as PopStateEvent);
-    handler({ state: { __vinext_scrollY: 20 } } as PopStateEvent);
+    handler({ __vinext_scrollY: 10 });
+    handler({ __vinext_scrollY: 20 });
 
     expect(window.__VINEXT_RSC_PENDING__).toBe(secondNavigation.promise);
 
@@ -7564,7 +7614,7 @@ describe("createPopstateRestoreHandler", () => {
       shouldSkipScrollRestore: () => false,
     });
 
-    handler({ state: { __vinext_scrollY: 10 } } as PopStateEvent);
+    handler({ __vinext_scrollY: 10 });
     expect(window.__VINEXT_RSC_PENDING__).toBe(navigation.promise);
 
     activeNavigationId = 2;
@@ -7603,7 +7653,7 @@ describe("createPopstateRestoreHandler", () => {
       shouldSkipScrollRestore: (navId) => synchronouslyRestoredNavigationId === navId,
     });
 
-    handler({ state: { __vinext_scrollY: 10 } } as PopStateEvent);
+    handler({ __vinext_scrollY: 10 });
     synchronouslyRestoredNavigationId = activeNavigationId;
     restoreCalls.push({ __vinext_scrollY: 10, source: "sync" });
 

--- a/tests/app-browser-history-controller.test.ts
+++ b/tests/app-browser-history-controller.test.ts
@@ -259,6 +259,29 @@ describe("AppBrowserHistoryController history metadata sync", () => {
     expect(store.replaced[0]?.href).toBeUndefined();
   });
 
+  it("leaves the traversed-to entry's metadata intact after a missed traversal", () => {
+    // The live entry belongs to a Back that landed before the popstate listener
+    // existed; its own index (0) must survive the activation entry's (1).
+    const traversedEntryState = createHistoryStateWithNavigationMetadata(null, {
+      previousNextUrl: "/previous",
+      traversalIndex: 0,
+    });
+    const { controller, store } = createController({
+      initialState: createHistoryStateWithNavigationMetadata(null, {
+        previousNextUrl: null,
+        traversalIndex: 1,
+      }),
+    });
+    store.setState(traversedEntryState);
+
+    controller.markMissedInitialTraversal();
+    controller.writeBootstrapHistoryMetadata();
+    controller.writeHydratedHistoryMetadata({ bfcacheIds: {}, previousNextUrl: null });
+
+    expect(store.replaced).toHaveLength(0);
+    expect(store.state).toBe(traversedEntryState);
+  });
+
   it("omits the URL from current-entry metadata synchronization", () => {
     const { controller, store } = createController();
 

--- a/tests/e2e/app-router/back-before-hydration.spec.ts
+++ b/tests/e2e/app-router/back-before-hydration.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect } from "@playwright/test";
+import type { Page } from "@playwright/test";
+import { waitForAppRouterHydration } from "../helpers";
+
+const BASE = "http://localhost:4174";
+
+// Back/Forward pressed after a reload commits but before the App Router's
+// popstate listener exists is an instant same-document traversal: the URL bar
+// moves, popstate fires, and nobody is listening. Chrome keeps the
+// same-document association across the reload, so the entries created by the
+// earlier client-side navigation are still same-document siblings.
+//
+// Scripts are stalled to make that window deterministic; releasing them lets
+// hydration run and the router must reconcile the URL with what it renders.
+async function stallScripts(page: Page): Promise<() => void> {
+  let stalling = true;
+  const stalled: Array<() => void> = [];
+  await page.route("**/*", async (route) => {
+    if (stalling && route.request().resourceType() === "script") {
+      await new Promise<void>((resolve) => {
+        stalled.push(resolve);
+      });
+    }
+    await route.continue();
+  });
+  return () => {
+    stalling = false;
+    for (const release of stalled) release();
+  };
+}
+
+test.describe("App Router Back before hydration", () => {
+  test("replays a traversal that landed before the popstate listener existed", async ({ page }) => {
+    await page.goto(`${BASE}/`);
+    await waitForAppRouterHydration(page);
+
+    await page.click('a[href="/about"]');
+    await expect(page.locator("h1")).toHaveText("About");
+
+    const releaseScripts = await stallScripts(page);
+    await page.reload({ waitUntil: "commit" });
+    await page.evaluate("window.__stayed = true");
+
+    await page.goBack({ waitUntil: "commit" });
+    expect(new URL(page.url()).pathname).toBe("/");
+
+    releaseScripts();
+
+    // The traversal must be replayed once the router is up: URL and content
+    // agree on "/", and hydration must not have reloaded the document.
+    await expect(page.locator("h1")).toHaveText("Welcome to App Router");
+    expect(new URL(page.url()).pathname).toBe("/");
+    expect(await page.evaluate("window.__stayed")).toBe(true);
+
+    // Traversal keeps working afterwards.
+    await page.goForward();
+    await expect(page.locator("h1")).toHaveText("About");
+    await page.goBack();
+    await expect(page.locator("h1")).toHaveText("Welcome to App Router");
+  });
+
+  test("adopts a third-party pushState that lands before hydration", async ({ page }) => {
+    const releaseScripts = await stallScripts(page);
+    await page.goto(`${BASE}/about`, { waitUntil: "commit" });
+    await page.waitForSelector("h1");
+    await page.evaluate("window.__stayed = true");
+
+    // e.g. analytics/consent tooling running before the framework. The entry is
+    // not vinext-written, so there is no traversal to replay and no recovery.
+    await page.evaluate("window.history.pushState({ thirdParty: true }, '', '/about?tp=1')");
+    releaseScripts();
+
+    await waitForAppRouterHydration(page);
+    await expect(page.locator("h1")).toHaveText("About");
+    expect(new URL(page.url()).search).toBe("?tp=1");
+    expect(await page.evaluate("window.__stayed")).toBe(true);
+
+    // The router still navigates from the adopted entry.
+    await page.click('a[href="/"]');
+    await expect(page.locator("h1")).toHaveText("Welcome to App Router");
+  });
+});

--- a/tests/e2e/app-router/back-before-hydration.spec.ts
+++ b/tests/e2e/app-router/back-before-hydration.spec.ts
@@ -29,6 +29,27 @@ async function stallScripts(page: Page): Promise<() => void> {
   };
 }
 
+// Stalls only the dev overlay module the browser entry awaits inside main().
+// The entry's static graph has evaluated by then — so vinext's history patch is
+// installed — while hydration has not started, which is the window where a raw
+// pushState inherits the current entry's vinext metadata.
+async function stallHydrationAfterHistoryPatch(page: Page): Promise<() => void> {
+  let stalling = true;
+  const stalled: Array<() => void> = [];
+  await page.route("**/*", async (route) => {
+    if (stalling && route.request().url().includes("dev-error-overlay")) {
+      await new Promise<void>((resolve) => {
+        stalled.push(resolve);
+      });
+    }
+    await route.continue();
+  });
+  return () => {
+    stalling = false;
+    for (const release of stalled) release();
+  };
+}
+
 test.describe("App Router Back before hydration", () => {
   test("replays a traversal that landed before the popstate listener existed", async ({ page }) => {
     await page.goto(`${BASE}/`);
@@ -76,6 +97,47 @@ test.describe("App Router Back before hydration", () => {
     expect(await page.evaluate("window.__stayed")).toBe(true);
 
     // The router still navigates from the adopted entry.
+    await page.click('a[href="/"]');
+    await expect(page.locator("h1")).toHaveText("Welcome to App Router");
+  });
+
+  test("adopts a third-party pushState that inherits the entry's traversal metadata", async ({
+    page,
+  }) => {
+    // The patched pushState copies __vinext_historyIndex onto the caller's
+    // state, so the new entry carries a traversal index it does not own. Only a
+    // real traversal may be replayed — this push must be adopted instead.
+    await page.goto(`${BASE}/`);
+    await waitForAppRouterHydration(page);
+    await page.click('a[href="/about"]');
+    await expect(page.locator("h1")).toHaveText("About");
+
+    const releaseHydration = await stallHydrationAfterHistoryPatch(page);
+    await page.reload({ waitUntil: "commit" });
+    await page.waitForSelector("h1");
+    await page.evaluate("window.__stayed = true");
+    await page.waitForFunction(() => /patchedPushState/.test(window.history.pushState.toString()));
+
+    await page.evaluate("window.history.pushState({ thirdParty: true }, '', '/about?tp=1')");
+    // The entry inherited the reloaded entry's traversal index.
+    expect(await page.evaluate(() => window.history.state?.__vinext_historyIndex)).not.toBe(
+      undefined,
+    );
+
+    const rscRequests: string[] = [];
+    page.on("request", (request) => {
+      if (new URL(request.url()).searchParams.has("_rsc")) rscRequests.push(request.url());
+    });
+    releaseHydration();
+
+    await waitForAppRouterHydration(page);
+    expect(new URL(page.url()).search).toBe("?tp=1");
+    await expect(page.locator("h1")).toHaveText("About");
+    expect(await page.evaluate("window.__stayed")).toBe(true);
+    // A misclassified traversal would replay the push as a traverse and fetch
+    // the RSC payload for the pushed URL.
+    expect(rscRequests.filter((url) => url.includes("tp%3D1") || url.includes("tp=1"))).toEqual([]);
+
     await page.click('a[href="/"]');
     await expect(page.locator("h1")).toHaveText("Welcome to App Router");
   });

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -789,6 +789,84 @@ describe("next/navigation shim", () => {
     }
   });
 
+  it("disqualifies missed-traversal detection once an external history call preserves metadata", async () => {
+    // The patched pushState copies the current entry's traversal index onto the
+    // caller's state, so that index cannot prove the new entry is App Router
+    // owned. A Back/Forward missed before hydration must not be inferred from it.
+    const previousWindow = (globalThis as any).window;
+    const historyTraversalIndexKey = "__vinext_historyIndex";
+    const win = {
+      location: {
+        pathname: "/photo/1",
+        search: "",
+        hash: "",
+        href: "http://localhost/photo/1",
+        origin: "http://localhost",
+      },
+      history: {
+        state: { [historyTraversalIndexKey]: 4 } as unknown,
+        pushState(data: unknown, _unused: string, url?: string | URL | null) {
+          this.state = data;
+          if (!url) return;
+          const parsed = new URL(url, win.location.href);
+          win.location.pathname = parsed.pathname;
+          win.location.search = parsed.search;
+          win.location.href = parsed.href;
+        },
+        replaceState(data: unknown) {
+          this.state = data;
+        },
+      },
+      addEventListener: vi.fn(),
+    };
+    (globalThis as any).window = win;
+
+    try {
+      vi.resetModules();
+      const navigation = await import("../packages/vinext/src/shims/navigation.js");
+      const { hasMissedInitialTraversal } =
+        await import("../packages/vinext/src/server/app-browser-missed-traversal.js");
+      // A Chromium-shaped Navigation API: the raw push created a new entry, so
+      // its key differs from the one the document was activated on.
+      const navigationApi = {
+        activation: { entry: { key: "activation" } },
+        currentEntry: { key: "third-party" },
+      };
+
+      expect(navigation.hasObservedExternalHistoryWrite()).toBe(false);
+
+      win.history.pushState({ thirdParty: true }, "", "/photo/1?tp=1");
+
+      expect(win.history.state).toEqual({
+        [historyTraversalIndexKey]: 4,
+        thirdParty: true,
+      });
+      expect(navigation.hasObservedExternalHistoryWrite()).toBe(true);
+      expect(
+        hasMissedInitialTraversal({
+          externalHistoryWriteObserved: navigation.hasObservedExternalHistoryWrite(),
+          historyState: win.history.state,
+          navigation: navigationApi,
+        }),
+      ).toBe(false);
+      // Without the external write the same entry shape would be replayed.
+      expect(
+        hasMissedInitialTraversal({
+          externalHistoryWriteObserved: false,
+          historyState: win.history.state,
+          navigation: navigationApi,
+        }),
+      ).toBe(true);
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+    }
+  });
+
   it("preserves App Router history metadata when external history calls provide caller state", async () => {
     // Matches Next.js' external History API wrapper behavior:
     // https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/app-router.tsx#L114-L127


### PR DESCRIPTION
Closes #2822. Ports [vercel/next.js#96252](https://github.com/vercel/next.js/pull/96252) (`0fd2e51`).

## Problem

Navigate client-side (`/` → `/about` via `Link`), then reload. Chrome preserves the same-document association across the reload, so the entry pushed before the reload is still a same-document sibling. Pressing Back while the new document has committed but not hydrated is therefore an *instant same-document traversal*: the URL bar moves to `/`, `popstate` fires, and nobody is listening — vinext installs its listener at the end of `bootstrapHydration()`, after the `await`s in `main()` and after the entry script itself has loaded.

Reproduced against `tests/fixtures/app-basic` before the fix (scripts stalled via Playwright routing to make the window deterministic):

```
Expected: "Welcome to App Router"
Received: "About"
```

The URL said `/`, the page rendered `/about`, and every later Back/Forward moved the URL bar without changing the content. Two mechanisms kept it wrong once hydration finished:

1. `writeBootstrapHistoryMetadata()` / `writeHydratedHistoryMetadata()` replaced the traversed-to entry's own metadata (its traversal index, bfcache ids) with the activation entry's.
2. The hydration cache publication seeded the visited-response cache with the reloaded `/about` payload keyed by `window.location.href` — which was already `/`. A traversal to `/` then resolved from that cache and rendered `/about` again.

Point 2 is vinext-specific: Next.js stores the router tree in the history entry and restores from it, while vinext refetches by URL, so the mis-keyed hydration payload had to be withheld too.

## Fix

- `packages/vinext/src/server/app-browser-missed-traversal.ts` (new): `hasMissedInitialTraversal()` compares `navigation.activation.entry.key` with `navigation.currentEntry.key`, gated on the live entry being one the App Router owns.
  Ownership needs more than a traversal index: vinext's patched `history.pushState`/`replaceState` install during module evaluation — before `main()`'s awaits — and `createExternalHistoryStatePreservingMetadata()` copies `__vinext_historyIndex` onto the caller's state, so a raw push inside that window mints a new Navigation API entry key carrying inherited vinext metadata. The patched writers now record an external-write flag on the shared client navigation state (`hasObservedExternalHistoryWrite()`), and any such write disqualifies the check. Without it, a shallow/third-party push was misread as a Back/Forward: the hydration payload was discarded and the push replayed as a traverse (verified: 3 RSC fetches for the pushed URL). vinext's own writes go through `originalPushState`/`originalReplaceState` and never set the flag. The activation entry is fixed for the document's lifetime and entry keys survive `replaceState`, so a mismatch before the listener exists *is* a missed traversal. No-ops where `window.navigation` is undefined (Firefox/Safari), matching Next.js.
- `AppBrowserHistoryController.markMissedInitialTraversal()` makes both initial metadata writes no-op, leaving the traversed-to entry authoritative; the replayed traversal owns every later write.
- `bootstrapHydration()` invalidates the hydration cache publication and skips `initialPrefetchRouterState` when a traversal was missed.
- The popstate listener body is extracted into `handleAppRouterTraversal(state)` (and `createPopstateRestoreHandler` now takes a history state instead of an event) so the replay runs the exact same path as a real `popstate`. The replay re-checks detection after installing the listener, so a third-party history write in between leaves the traversal unhandled instead of replaying onto the wrong entry.

## Verification

- `tests/e2e/app-router/back-before-hydration.spec.ts` (new): fails on `main` with the output above; passes here. Three cases — the replay (including Forward/Back afterwards, and that hydration did not reload the document); a third-party `pushState` landing before the entry script runs; and a third-party `pushState` landing *after* the history patch is installed but before hydration, which is the inherited-metadata case. That third test stalls only the dev-overlay module `main()` awaits, so the entry graph has evaluated (patch installed) while hydration has not started, and asserts no RSC fetch is issued for the pushed URL. It fails with the external-write guard removed.
- `vp test run tests/shims.test.ts tests/app-browser-entry.test.ts tests/app-browser-history-controller.test.ts tests/link-status-registry.test.ts tests/pages-router-i18n-sticky-locale.test.ts` — 1552 passed, including new coverage for the predicate (traversal / same entry / third-party entry / inherited index / no Navigation API), for the suppressed initial writes, and for the shim seam itself: a raw `pushState` preserves the traversal index, sets the external-write flag, and the predicate then declines the entry.
- `playwright --project=app-router navigation.spec.ts navigation-flows.spec.ts navigation-regressions.spec.ts scroll-restoration.spec.ts hydration.spec.ts` — 33 passed.
- `playwright --project=app-router-bfcache` — 7 passed.
- Repo pre-commit gate (full `vp check`, staged unit/integration tests, knip) passed.

## Caveats

- Detection depends on the Navigation API, so Firefox and Safari keep the current behavior (traversal left unhandled), as upstream does.
- Not ported: upstream's Suspense-boundary and `cacheComponents` variants of the scenario, and the search-param variant. The e2e here exercises the shared mechanism on the `app-basic` fixture rather than adding a dedicated fixture app.
