### PR TITLE
fix(app-router): keep usePathname in sync across back/forward around shallow routing

### DIFF
--- a/.changeset/shallow-history-entry-identity.md
+++ b/.changeset/shallow-history-entry-identity.md
@@ -1,5 +1,0 @@
----
-"vinext": patch
----
-
-App Router: `usePathname()`/`useSearchParams()` no longer freeze on a stale URL after Back/Forward around shallow routing. Externally written history entries (app-called `history.pushState`/`replaceState`) now get their own traversal index instead of inheriting the current entry's, so a traversal can no longer restore the aliased entry's router snapshot; and the same-route popstate fast path resyncs the navigation shim's cached URL state from the restored location (#1541).

--- a/.changeset/shallow-history-entry-identity.md
+++ b/.changeset/shallow-history-entry-identity.md
@@ -1,0 +1,5 @@
+---
+"vinext": patch
+---
+
+App Router: `usePathname()`/`useSearchParams()` no longer freeze on a stale URL after Back/Forward around shallow routing. Externally written history entries (app-called `history.pushState`/`replaceState`) now get their own traversal index instead of inheriting the current entry's, so a traversal can no longer restore the aliased entry's router snapshot; and the same-route popstate fast path resyncs the navigation shim's cached URL state from the restored location (#1541).

--- a/packages/vinext/src/client/navigation-runtime.ts
+++ b/packages/vinext/src/client/navigation-runtime.ts
@@ -55,15 +55,21 @@ export type NavigationRuntimeNavigate = (
 
 export type NavigationRuntimeFunctions = {
   /**
-   * Allocates and commits a traversal index for a history entry created or
-   * rewritten by an app-called `history.pushState`/`history.replaceState`
-   * (shallow routing). Registered by the App Router browser entry, wired to
-   * `AppBrowserHistoryController`. The patched history methods in
-   * shims/navigation.ts call this so an externally-written entry gets its own
-   * identity instead of inheriting the current entry's traversal index, which
-   * would alias two entries onto one restorable-snapshot slot (#1541).
+   * Allocates (without committing) a traversal index for a history entry
+   * created or rewritten by an app-called `history.pushState`/
+   * `history.replaceState` (shallow routing). Registered by the App Router
+   * browser entry, wired to `AppBrowserHistoryController`. The patched history
+   * methods in shims/navigation.ts call this so an externally-written entry
+   * gets its own identity instead of inheriting the current entry's traversal
+   * index, which would alias two entries onto one restorable-snapshot slot
+   * (#1541). Allocation is a pure peek; the caller commits through
+   * `commitExternalHistoryTraversalIndex` only after the native history write
+   * succeeds, so a throwing pushState/replaceState (cross-origin URL,
+   * uncloneable state) leaves the traversal bookkeeping untouched.
    */
   allocateExternalHistoryTraversalIndex?: () => number | null;
+  /** Commits an index from `allocateExternalHistoryTraversalIndex` after the native write succeeded. */
+  commitExternalHistoryTraversalIndex?: (index: number) => void;
   clearNavigationCaches?: () => void;
   commitHashNavigation?: (
     href: string,
@@ -135,6 +141,7 @@ function isNavigationRuntimeFunctions(value: unknown): value is NavigationRuntim
   if (!isUnknownRecord(value)) return false;
   return (
     isOptionalRuntimeFunction(Reflect.get(value, "allocateExternalHistoryTraversalIndex")) &&
+    isOptionalRuntimeFunction(Reflect.get(value, "commitExternalHistoryTraversalIndex")) &&
     isOptionalRuntimeFunction(Reflect.get(value, "clearNavigationCaches")) &&
     isOptionalRuntimeFunction(Reflect.get(value, "commitHashNavigation")) &&
     isOptionalRuntimeFunction(Reflect.get(value, "navigateExternal")) &&

--- a/packages/vinext/src/client/navigation-runtime.ts
+++ b/packages/vinext/src/client/navigation-runtime.ts
@@ -54,6 +54,16 @@ export type NavigationRuntimeNavigate = (
 ) => Promise<void>;
 
 export type NavigationRuntimeFunctions = {
+  /**
+   * Allocates and commits a traversal index for a history entry created or
+   * rewritten by an app-called `history.pushState`/`history.replaceState`
+   * (shallow routing). Registered by the App Router browser entry, wired to
+   * `AppBrowserHistoryController`. The patched history methods in
+   * shims/navigation.ts call this so an externally-written entry gets its own
+   * identity instead of inheriting the current entry's traversal index, which
+   * would alias two entries onto one restorable-snapshot slot (#1541).
+   */
+  allocateExternalHistoryTraversalIndex?: () => number | null;
   clearNavigationCaches?: () => void;
   commitHashNavigation?: (
     href: string,
@@ -124,6 +134,7 @@ function readRuntimeWindow(): Window | null {
 function isNavigationRuntimeFunctions(value: unknown): value is NavigationRuntimeFunctions {
   if (!isUnknownRecord(value)) return false;
   return (
+    isOptionalRuntimeFunction(Reflect.get(value, "allocateExternalHistoryTraversalIndex")) &&
     isOptionalRuntimeFunction(Reflect.get(value, "clearNavigationCaches")) &&
     isOptionalRuntimeFunction(Reflect.get(value, "commitHashNavigation")) &&
     isOptionalRuntimeFunction(Reflect.get(value, "navigateExternal")) &&

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -2387,18 +2387,19 @@ function bootstrapHydration(
   // Exposed through one typed runtime seam so next/navigation, Link, Form, and
   // the browser entry share a single App Router capability contract.
   registerNavigationRuntimeFunctions({
-    allocateExternalHistoryTraversalIndex: () => {
-      // An app-called history.pushState/replaceState creates (or rewrites the
-      // URL of) an entry the router did not commit. Give it its own traversal
-      // index: inheriting the current entry's index would alias two distinct
-      // entries onto one restorable-snapshot slot, and a later traversal
-      // would restore the other entry's router state (#1541). Replace gets a
-      // fresh index too — its URL no longer matches the snapshot remembered
-      // under the old index.
-      const index = historyController.allocateNavigationHistoryTraversalIndex("push");
-      historyController.commitHistoryTraversalIndex(index);
-      return index;
-    },
+    // An app-called history.pushState/replaceState creates (or rewrites the
+    // URL of) an entry the router did not commit. Give it its own traversal
+    // index: inheriting the current entry's index would alias two distinct
+    // entries onto one restorable-snapshot slot, and a later traversal would
+    // restore the other entry's router state (#1541). A URL-changing replace
+    // gets a fresh index too — its URL no longer matches the snapshot
+    // remembered under the old index. Allocation is a pure peek; the shim
+    // commits only after the native write succeeds, so a throwing
+    // pushState/replaceState leaves the traversal bookkeeping untouched.
+    allocateExternalHistoryTraversalIndex: () =>
+      historyController.allocateNavigationHistoryTraversalIndex("push"),
+    commitExternalHistoryTraversalIndex: (index) =>
+      historyController.commitHistoryTraversalIndex(index),
     clearNavigationCaches: clearClientNavigationCaches,
     commitHashNavigation: (href, historyUpdateMode, scroll) =>
       historyController.commitHashOnlyNavigation(href, historyUpdateMode, scroll),

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -2387,6 +2387,18 @@ function bootstrapHydration(
   // Exposed through one typed runtime seam so next/navigation, Link, Form, and
   // the browser entry share a single App Router capability contract.
   registerNavigationRuntimeFunctions({
+    allocateExternalHistoryTraversalIndex: () => {
+      // An app-called history.pushState/replaceState creates (or rewrites the
+      // URL of) an entry the router did not commit. Give it its own traversal
+      // index: inheriting the current entry's index would alias two distinct
+      // entries onto one restorable-snapshot slot, and a later traversal
+      // would restore the other entry's router state (#1541). Replace gets a
+      // fresh index too — its URL no longer matches the snapshot remembered
+      // under the old index.
+      const index = historyController.allocateNavigationHistoryTraversalIndex("push");
+      historyController.commitHistoryTraversalIndex(index);
+      return index;
+    },
     clearNavigationCaches: clearClientNavigationCaches,
     commitHashNavigation: (href, historyUpdateMode, scroll) =>
       historyController.commitHashOnlyNavigation(href, historyUpdateMode, scroll),
@@ -2457,6 +2469,12 @@ function bootstrapHydration(
     if (isSameAppRoutePopstateTarget(href)) {
       notifyAppRouterTransitionStart(href, "traverse");
       historyController.commitTraversalIndexFromHistoryState(event.state);
+      // The committed router tree already matches the target, but the shim's
+      // cached URL state may not: an app-called shallow pushState/replaceState
+      // moves usePathname/useSearchParams without touching the router tree, so
+      // traversing back to the tree-matching entry must still resync them from
+      // the restored location (#1541).
+      commitClientNavigationState();
       restorePopstateScrollPosition(event.state);
       return;
     }

--- a/packages/vinext/src/server/app-history-state.ts
+++ b/packages/vinext/src/server/app-history-state.ts
@@ -243,12 +243,29 @@ export function createHistoryStateWithNavigationMetadata(
   return Object.keys(nextState).length > 0 ? nextState : null;
 }
 
+/**
+ * Builds the history state for an app-called (external) `history.pushState` /
+ * `history.replaceState`, preserving vinext's navigation metadata alongside the
+ * caller's own state.
+ *
+ * `allocatedTraversalIndex` is the entry's OWN traversal index, allocated by
+ * the App Router runtime. When it is undefined (no App Router runtime — Pages
+ * Router or pre-hydration), the current entry's index is carried over as
+ * before. With the runtime present the caller must pass a fresh index: copying
+ * the current entry's index onto a NEW entry keys two distinct entries to one
+ * restorable-snapshot slot, so a later Back/Forward restores the OTHER entry's
+ * router state and `usePathname()` freezes on a stale pathname (#1541).
+ */
 export function createExternalHistoryStatePreservingMetadata(
   callerState: unknown,
   currentHistoryState: unknown,
+  allocatedTraversalIndex?: number | null,
 ): unknown {
   const previousNextUrl = readHistoryStatePreviousNextUrl(currentHistoryState);
-  const traversalIndex = readHistoryStateTraversalIndex(currentHistoryState);
+  const traversalIndex =
+    allocatedTraversalIndex !== undefined
+      ? allocatedTraversalIndex
+      : readHistoryStateTraversalIndex(currentHistoryState);
   const bfcacheIds = readHistoryStateBfcacheIds(currentHistoryState);
   const bfcacheVersion = readHistoryStateBfcacheVersion(currentHistoryState);
 

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -3020,6 +3020,16 @@ if (!isServer) {
       }
     });
 
+    // An externally-written entry needs its OWN traversal index (allocated by
+    // the App Router runtime when present) — inheriting the current entry's
+    // index aliases two entries onto one restorable-snapshot slot, so a later
+    // Back/Forward restores the other entry's router state (#1541). Suppressed
+    // (vinext-internal) writes manage their own metadata and never allocate.
+    const allocateExternalHistoryTraversalIndex = (): number | null | undefined => {
+      if (state.suppressUrlNotifyCount !== 0) return undefined;
+      return getNavigationRuntime()?.functions.allocateExternalHistoryTraversalIndex?.();
+    };
+
     window.history.pushState = function patchedPushState(
       data: unknown,
       unused: string,
@@ -3027,7 +3037,11 @@ if (!isServer) {
     ): void {
       state.originalPushState.call(
         window.history,
-        createExternalHistoryStatePreservingMetadata(data, window.history.state),
+        createExternalHistoryStatePreservingMetadata(
+          data,
+          window.history.state,
+          allocateExternalHistoryTraversalIndex(),
+        ),
         unused,
         url,
       );
@@ -3047,7 +3061,11 @@ if (!isServer) {
     ): void {
       state.originalReplaceState.call(
         window.history,
-        createExternalHistoryStatePreservingMetadata(data, window.history.state),
+        createExternalHistoryStatePreservingMetadata(
+          data,
+          window.history.state,
+          allocateExternalHistoryTraversalIndex(),
+        ),
         unused,
         url,
       );

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -3025,9 +3025,35 @@ if (!isServer) {
     // index aliases two entries onto one restorable-snapshot slot, so a later
     // Back/Forward restores the other entry's router state (#1541). Suppressed
     // (vinext-internal) writes manage their own metadata and never allocate.
+    // Allocation is a pure peek; the index is committed only after the native
+    // write succeeds, so a throwing pushState/replaceState (cross-origin URL,
+    // uncloneable state) leaves the traversal bookkeeping untouched.
     const allocateExternalHistoryTraversalIndex = (): number | null | undefined => {
       if (state.suppressUrlNotifyCount !== 0) return undefined;
       return getNavigationRuntime()?.functions.allocateExternalHistoryTraversalIndex?.();
+    };
+
+    const commitExternalHistoryTraversalIndex = (index: number | null | undefined): void => {
+      if (typeof index !== "number") return;
+      getNavigationRuntime()?.functions.commitExternalHistoryTraversalIndex?.(index);
+    };
+
+    // A state-only or hash-only replaceState keeps the entry's URL identity, so
+    // the entry keeps its traversal index and its remembered snapshot stays
+    // representative. App Router state does not include hashes, so only a
+    // pathname/search change makes the old snapshot unrepresentative.
+    const externalReplaceChangesAppRouteUrl = (url?: string | URL | null): boolean => {
+      if (url === null || url === undefined || url === "") return false;
+      try {
+        const target = new URL(String(url), window.location.href);
+        return (
+          target.pathname !== window.location.pathname || target.search !== window.location.search
+        );
+      } catch {
+        // The native replaceState will throw on this URL; the commit is gated
+        // on that write succeeding either way.
+        return true;
+      }
     };
 
     window.history.pushState = function patchedPushState(
@@ -3035,16 +3061,18 @@ if (!isServer) {
       unused: string,
       url?: string | URL | null,
     ): void {
+      const allocatedTraversalIndex = allocateExternalHistoryTraversalIndex();
       state.originalPushState.call(
         window.history,
         createExternalHistoryStatePreservingMetadata(
           data,
           window.history.state,
-          allocateExternalHistoryTraversalIndex(),
+          allocatedTraversalIndex,
         ),
         unused,
         url,
       );
+      commitExternalHistoryTraversalIndex(allocatedTraversalIndex);
       if (state.suppressUrlNotifyCount === 0) {
         // A raw history.pushState (shallow routing) supersedes a pending link,
         // but changes browser state only — it issues no RSC request, so it must
@@ -3059,16 +3087,20 @@ if (!isServer) {
       unused: string,
       url?: string | URL | null,
     ): void {
+      const allocatedTraversalIndex = externalReplaceChangesAppRouteUrl(url)
+        ? allocateExternalHistoryTraversalIndex()
+        : undefined;
       state.originalReplaceState.call(
         window.history,
         createExternalHistoryStatePreservingMetadata(
           data,
           window.history.state,
-          allocateExternalHistoryTraversalIndex(),
+          allocatedTraversalIndex,
         ),
         unused,
         url,
       );
+      commitExternalHistoryTraversalIndex(allocatedTraversalIndex);
       if (state.suppressUrlNotifyCount === 0) {
         resetStaleLinkStatus();
         commitClientNavigationState();

--- a/tests/app-browser-history-controller.test.ts
+++ b/tests/app-browser-history-controller.test.ts
@@ -9,6 +9,7 @@ import {
   createSnapshotPathAndSearch,
 } from "../packages/vinext/src/server/app-browser-navigation-controller.js";
 import {
+  createExternalHistoryStatePreservingMetadata,
   createHistoryStateWithNavigationMetadata,
   readHistoryStateTraversalIndex,
 } from "../packages/vinext/src/server/app-history-state.js";
@@ -448,5 +449,81 @@ describe("history snapshot target normalization shared with same-route popstate 
 
     expect(plannerCurrentUrl.searchParams.toString()).toBe(snapshot.searchParams.toString());
     expect([...plannerCurrentUrl.searchParams]).toEqual([...snapshot.searchParams]);
+  });
+});
+
+describe("externally written history entries (shallow routing)", () => {
+  it("carries the current entry's traversal index over when no index was allocated", () => {
+    const currentEntryState = createHistoryStateWithNavigationMetadata(null, {
+      previousNextUrl: null,
+      traversalIndex: 3,
+    });
+
+    const entryState = createExternalHistoryStatePreservingMetadata(
+      { app: true },
+      currentEntryState,
+    );
+
+    expect(readHistoryStateTraversalIndex(entryState)).toBe(3);
+  });
+
+  it("stamps the allocated traversal index instead of copying the current entry's", () => {
+    const currentEntryState = createHistoryStateWithNavigationMetadata(null, {
+      previousNextUrl: null,
+      traversalIndex: 3,
+    });
+
+    const entryState = createExternalHistoryStatePreservingMetadata(null, currentEntryState, 4);
+
+    expect(readHistoryStateTraversalIndex(entryState)).toBe(4);
+  });
+
+  it("stamps the allocated traversal index even when the current entry carries no metadata", () => {
+    const entryState = createExternalHistoryStatePreservingMetadata(null, null, 4);
+
+    expect(readHistoryStateTraversalIndex(entryState)).toBe(4);
+  });
+
+  it("gives an externally pushed entry its own snapshot slot so a traversal restore cannot alias (#1541)", () => {
+    const { controller } = createController();
+    const homeState = createRouterState({
+      navigationSnapshot: createClientNavigationRenderSnapshot("https://example.com/", {}),
+      routeId: "route:/",
+    });
+    controller.commitHistoryTraversalIndex(0);
+    controller.rememberHistoryStateSnapshot(homeState);
+
+    // Mirrors the allocateExternalHistoryTraversalIndex runtime function the
+    // patched history.pushState calls: the app-written entry gets a fresh
+    // index rather than inheriting index 0 from the entry it was pushed from.
+    const externalIndex = controller.allocateNavigationHistoryTraversalIndex("push");
+    controller.commitHistoryTraversalIndex(externalIndex);
+    expect(externalIndex).not.toBe(0);
+
+    const shallowState = createRouterState({
+      navigationSnapshot: createClientNavigationRenderSnapshot("https://example.com/a", {}),
+      routeId: "route:/",
+    });
+    controller.rememberHistoryStateSnapshot(shallowState);
+
+    // Traversing back to the original entry restores the original state — with
+    // a copied index both entries share one slot and this restore would serve
+    // the state remembered while on the externally pushed entry.
+    const approveVisibleRestore = vi.fn((candidate: RestorableSnapshotCandidate) => {
+      candidate.beforeCommit();
+      return true;
+    });
+    const restored = controller.restoreHistorySnapshot({
+      historyState: createHistoryStateWithNavigationMetadata(null, {
+        previousNextUrl: null,
+        traversalIndex: 0,
+      }),
+      stageClientParams: vi.fn(),
+      approveVisibleRestore,
+    });
+
+    expect(restored).toBe(true);
+    expect(approveVisibleRestore.mock.calls[0]?.[0].state).toBe(homeState);
+    expect(controller.currentHistoryTraversalIndex).toBe(0);
   });
 });

--- a/tests/e2e/app-router/advanced.spec.ts
+++ b/tests/e2e/app-router/advanced.spec.ts
@@ -669,6 +669,65 @@ test.describe("Shallow Routing (history.pushState/replaceState)", () => {
     );
   });
 
+  // Regression test for #1541: a pushState performed after a Back/Forward
+  // traversal used to inherit the traversed-to entry's traversal index, so the
+  // next Back restored the aliased entry's router snapshot and usePathname()
+  // froze on a stale pathname while the URL moved on.
+  test("usePathname stays in sync with the URL through back/forward around interleaved pushState", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}/shallow-test`);
+
+    await page.waitForFunction(
+      () => typeof (window as any).__VINEXT_RSC_ROOT__ !== "undefined",
+      null,
+      { timeout: 10000 },
+    );
+
+    // Two shallow pushes: /shallow-test -> /shallow-test/sub -> ?filter=active
+    await page.locator('[data-testid="push-path"]').click({ noWaitAfter: true });
+    await expect(page.locator('[data-testid="pathname"]')).toHaveText(
+      "pathname: /shallow-test/sub",
+      { timeout: 10_000 },
+    );
+    await page.locator('[data-testid="push-filter"]').click({ noWaitAfter: true });
+    await expect(page.locator('[data-testid="pathname"]')).toHaveText("pathname: /shallow-test", {
+      timeout: 10_000,
+    });
+    await expect(page.locator('[data-testid="search"]')).toHaveText("search: filter=active");
+
+    // Traverse back, then push again from the restored entry.
+    await page.goBack();
+    await expect(page.locator('[data-testid="pathname"]')).toHaveText(
+      "pathname: /shallow-test/sub",
+      { timeout: 10_000 },
+    );
+    await page.locator('[data-testid="push-filter"]').click({ noWaitAfter: true });
+    await expect(page.locator('[data-testid="pathname"]')).toHaveText("pathname: /shallow-test", {
+      timeout: 10_000,
+    });
+
+    // The Back after a post-traversal pushState is the aliasing case.
+    await page.goBack();
+    await expect
+      .poll(() => new URL(page.url()).pathname, { timeout: 10_000 })
+      .toBe("/shallow-test/sub");
+    await expect(page.locator('[data-testid="pathname"]')).toHaveText(
+      "pathname: /shallow-test/sub",
+      { timeout: 10_000 },
+    );
+    await expect(page.locator('[data-testid="search"]')).toHaveText("search: ");
+
+    await page.goForward();
+    await expect
+      .poll(() => new URL(page.url()).pathname, { timeout: 10_000 })
+      .toBe("/shallow-test");
+    await expect(page.locator('[data-testid="pathname"]')).toHaveText("pathname: /shallow-test", {
+      timeout: 10_000,
+    });
+    await expect(page.locator('[data-testid="search"]')).toHaveText("search: filter=active");
+  });
+
   test.fixme("multiple pushState calls update search params correctly", async ({ page }) => {
     await page.goto(`${BASE}/shallow-test`);
 

--- a/tests/fixtures/app-basic/app/shallow-test/sub/page.tsx
+++ b/tests/fixtures/app-basic/app/shallow-test/sub/page.tsx
@@ -1,0 +1,4 @@
+// The /shallow-test page shallow-pushes this pathname. It must exist as a real
+// route so a Back/Forward traversal that falls back to an RSC navigation (no
+// restorable snapshot for the entry) resolves instead of 404ing.
+export { default } from "../page";


### PR DESCRIPTION
Fixes #1541.

## Problem

`usePathname()`/`useSearchParams()` freeze on a stale value after Back/Forward when the app uses shallow routing (native `history.pushState`/`replaceState`, per the [Next.js SPA guide](https://nextjs.org/docs/app/guides/single-page-applications#shallow-routing-on-the-client)). Minimal repro and a vinext-vs-`next dev` step table are in [this comment on #1541](https://github.com/cloudflare/vinext/issues/1541#issuecomment-5219915377): the desync needs a pushState performed **after** a traversal, and then it's the second Back that loses sync — the URL moves while the hooks stay put.

## Root cause — two defects

**1. Externally written entries inherited the current entry's traversal index.** The patched `history.pushState`/`replaceState` built the new entry's state with `createExternalHistoryStatePreservingMetadata`, which copied `__vinext_historyIndex` from the entry being pushed from. Two distinct history entries then shared one slot in the index-keyed restorable-snapshot cache (`HistoryStateSnapshotCache`), so a later traversal could resolve a "restore" against the *other* entry's remembered router state — committing a router tree whose `navigationSnapshot` carries the wrong URL, and short-circuiting the full traverse navigation that would have synced from `location`.

**2. The same-route popstate fast path skipped the URL-state resync.** With distinct indices in place, a second defect surfaced: when a traversal target's pathname+search already matches the *committed router tree* (`isSameAppRoutePopstateTarget`), the popstate handler returned after committing the traversal index — but an interleaved shallow pushState had moved the navigation shim's cached URL state elsewhere, and nothing brought it back. The tree matched; the hooks didn't.

## Fix

- `shims/navigation.ts`: the patched `pushState`/`replaceState` allocate a fresh traversal index for the externally written entry through a new `allocateExternalHistoryTraversalIndex` runtime function (skipped for vinext-internal suppressed writes, and absent-runtime callers — Pages Router, pre-hydration — keep the previous copy behavior). `replaceState` allocates too: its URL rewrite makes the snapshot remembered under the old index unrepresentative of the entry it now describes.
- `client/navigation-runtime.ts`: the new optional runtime function, registered by the App Router browser entry and wired to `AppBrowserHistoryController` (`allocateNavigationHistoryTraversalIndex("push")` + `commitHistoryTraversalIndex`).
- `server/app-browser-entry.ts`: the same-route popstate fast path now runs `commitClientNavigationState()` so `usePathname()`/`useSearchParams()` resync from the restored location.
- `server/app-history-state.ts`: `createExternalHistoryStatePreservingMetadata` accepts the allocated index; `undefined` preserves the legacy copy.

## Tests

- **e2e** (`tests/e2e/app-router/advanced.spec.ts`): drives the aliasing sequence — push `/shallow-test/sub`, push `?filter=active`, Back, push again, Back, Forward — asserting `usePathname`/`useSearchParams` match the URL at every settle point. Fails on `main` (frozen pathname at the second Back), passes with the fix. The fixture gains a real `/shallow-test/sub` route so the traverse-fallback RSC navigation resolves instead of 404ing (that page's pathname was already being shallow-pushed by the existing fixture buttons).
- **unit** (`tests/app-browser-history-controller.test.ts`): allocated index is stamped (including onto metadata-less entries), legacy copy preserved without allocation, and the aliasing scenario at the controller level — an externally pushed entry gets its own snapshot slot, so restoring the original entry yields the original state.

`pnpm test`, `PLAYWRIGHT_PROJECT=app-router pnpm run test:e2e -- tests/e2e/app-router/advanced.spec.ts` (38/38), and `pnpm run check` are green.

---

Found while root-causing a glyph-soup animation bug in a production app whose account tabs shallow-route with native pushState; the frozen `usePathname` compounds with cacheComponents' hidden-Activity keep-alive (stale state keeps morphing offscreen). Happy to iterate on review feedback.

https://claude.ai/code/session_01Y4w3KwfeSpsDQWFeLnZMXd
