### PR TITLE
fix(test): name hybrid i18n fixture package

### DIFF
--- a/tests/fixtures/hybrid-i18n-api-handoff/package.json
+++ b/tests/fixtures/hybrid-i18n-api-handoff/package.json
@@ -1,3 +1,4 @@
 {
+  "name": "hybrid-i18n-api-handoff-fixture",
   "type": "module"
 }


### PR DESCRIPTION
Fixes the workspace validation failure introduced by the new `hybrid-i18n-api-handoff` fixture.

Validation:
- `pnpm -r exec true` (workspace package discovery passes)
- `vp check tests/fixtures/hybrid-i18n-api-handoff/package.json` (formatting passes; lint has no applicable JSON files)