### PR TITLE
fix(test): lock hybrid i18n fixture workspace

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1624,6 +1624,8 @@ importers:
         specifier: 'catalog:'
         version: 0.2.6(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-istanbul@4.1.10(vitest@4.1.10))(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(esbuild@0.27.3)(jiti@2.7.0)(msw@2.14.6(@types/node@25.9.2)(typescript@7.0.2))(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0)
 
+  tests/fixtures/hybrid-i18n-api-handoff: {}
+
   tests/fixtures/middleware-matcher-auth: {}
 
   tests/fixtures/og-font-package: {}


### PR DESCRIPTION
Adds the lockfile importer generated for the newly named `hybrid-i18n-api-handoff` workspace fixture.

The package manifest fix landed in #2837; this follow-up keeps a fresh pnpm install from dirtying the lockfile.