### PR TITLE
fix(app-router): respect scroll padding top as viewport boundary during navigation

### DIFF
--- a/packages/vinext/src/shims/app-router-scroll.tsx
+++ b/packages/vinext/src/shims/app-router-scroll.tsx
@@ -43,7 +43,20 @@ function shouldSkipElement(element: HTMLElement): boolean {
   return rectProperties.every((property) => rect[property] === 0);
 }
 
-function topOfElementInViewport(element: HTMLElement, viewportHeight: number): boolean {
+function getScrollPaddingTopPx(element: HTMLElement, viewportHeight: number): number {
+  const scrollPaddingTop = getComputedStyle(element).scrollPaddingTop;
+  const value = Number.parseFloat(scrollPaddingTop);
+  if (!Number.isFinite(value) || value < 0) return 0;
+  if (scrollPaddingTop.endsWith("px")) return value;
+  if (scrollPaddingTop.endsWith("%")) return (value / 100) * viewportHeight;
+  return 0;
+}
+
+function topOfElementInViewport(
+  element: HTMLElement,
+  viewportHeight: number,
+  getCurrentScrollPaddingTop: () => number,
+): boolean {
   const rects = element.getClientRects();
   if (rects.length === 0) {
     return false;
@@ -56,7 +69,7 @@ function topOfElementInViewport(element: HTMLElement, viewportHeight: number): b
     }
   }
 
-  return elementTop >= 0 && elementTop <= viewportHeight;
+  return elementTop >= getCurrentScrollPaddingTop() && elementTop <= viewportHeight;
 }
 
 function getHashFragmentDomNode(hash: string): Element | null {
@@ -103,14 +116,24 @@ function scrollToElement(target: HTMLElement, hash: string | null): void {
 
   const htmlElement = document.documentElement;
   const viewportHeight = htmlElement.clientHeight;
+  let scrollPaddingTop: number | null = null;
 
-  if (topOfElementInViewport(target, viewportHeight)) {
+  // Lazily get current scroll padding top inside `topOfElementInViewport()`
+  // to ensure `getComputedStyle()` is called after checking rect !== null
+  const getCurrentScrollPaddingTop = () => {
+    if (scrollPaddingTop === null) {
+      scrollPaddingTop = getScrollPaddingTopPx(htmlElement, viewportHeight);
+    }
+    return scrollPaddingTop;
+  };
+
+  if (topOfElementInViewport(target, viewportHeight, getCurrentScrollPaddingTop)) {
     return;
   }
 
   htmlElement.scrollTop = 0;
 
-  if (!topOfElementInViewport(target, viewportHeight)) {
+  if (!topOfElementInViewport(target, viewportHeight, getCurrentScrollPaddingTop)) {
     target.scrollIntoView({ behavior: "auto", block: "start", inline: "nearest" });
   }
 }

--- a/tests/e2e/app-router/nextjs-compat/router-autoscroll.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/router-autoscroll.spec.ts
@@ -81,6 +81,14 @@ async function expectScroll(page: Page, position: { x: number; y: number }) {
     .toEqual(position);
 }
 
+async function setScrollPaddingTop(page: Page, scrollPaddingTop: string) {
+  await page.evaluate((padding) => {
+    const sheet = new CSSStyleSheet();
+    sheet.replaceSync(`html { scroll-padding-top: ${padding}; }`);
+    document.adoptedStyleSheets = [...document.adoptedStyleSheets, sheet];
+  }, scrollPaddingTop);
+}
+
 async function readElementDocumentTop(page: Page, selector: string) {
   return page
     .locator(selector)
@@ -192,6 +200,40 @@ test.describe("Next.js compat: App Router autoscroll", () => {
     await push(page, "/nextjs-compat/router-autoscroll/10/100/100/1000/page2");
     await expect(page.locator("#page")).toHaveText("page2");
     await expectScroll(page, { x: 0, y: 50 });
+  });
+
+  // Ported from Next.js:
+  // test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts
+  for (const scrollPaddingTop of ["100px", "50%"] as const) {
+    test(`scrolls when the page top is obscured by ${scrollPaddingTop} scroll padding`, async ({
+      page,
+    }) => {
+      await page.goto(`${ROUTE_BASE}/10/100/100/1000/page1`);
+      await waitForControls(page);
+      await setScrollPaddingTop(page, scrollPaddingTop);
+
+      await scrollTo(page, { x: 0, y: 50 });
+      await push(page, "/nextjs-compat/router-autoscroll/10/100/100/1000/page2");
+      await expect(page.locator("#page")).toHaveText("page2");
+      await expectScroll(page, { x: 0, y: 0 });
+    });
+  }
+
+  // Ported from Next.js:
+  // test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts
+  test("keeps the scroll position when the page top is below the scroll padding boundary", async ({
+    page,
+  }) => {
+    await page.goto(`${ROUTE_BASE}/10/1000/100/1000/page1`);
+    await waitForControls(page);
+    await setScrollPaddingTop(page, "100px");
+
+    await scrollTo(page, { x: 0, y: 800 });
+    await push(page, "/nextjs-compat/router-autoscroll/10/1000/100/1000/page2");
+    await expect(page.locator("#page")).toHaveText("page2");
+    await expectScroll(page, { x: 0, y: 800 });
   });
 
   // Ported from Next.js:


### PR DESCRIPTION
Closes #2810. Ports https://github.com/vercel/next.js/pull/96308 (https://github.com/vercel/next.js/commit/da90782311ff578bb950f7ca6d98e7e9fbed5f41)

## Overview

Align App Router navigation scrolling with Next.js when applications reserve space for sticky headers using root-level `scroll-padding-top`.

This ensures navigation targets that are visually obscured within the reserved top offset are treated as outside the usable viewport, while targets already visible below that boundary retain the current scroll position.

## What changed

Added a function `getScrollPaddingTopPx()` ported from Next.js.
```ts
function getScrollPaddingTopPx(element: HTMLElement, viewportHeight: number): number {
  const scrollPaddingTop = getComputedStyle(element).scrollPaddingTop;
  const value = Number.parseFloat(scrollPaddingTop);
  if (!Number.isFinite(value) || value < 0) return 0;
  if (scrollPaddingTop.endsWith("px")) return value;
  if (scrollPaddingTop.endsWith("%")) return (value / 100) * viewportHeight;
  return 0;
}
```

And this function is lazily called inside `topOfElementInViewport()` to ensure `getComputedStyle()` is called after checking `rect !== null`. (And this is also how Next.js does)

## Verification

- `playwright test --project=app-router tests/e2e/app-router/nextjs-compat/router-autoscroll.spec.ts`

This fix has been verified in my local repro project.