### PR TITLE
fix(app-router): preserve require export conditions

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -245,6 +245,7 @@ import {
 import { removeConsoleCalls } from "./plugins/remove-console.js";
 import { createImportMetaUrlPlugin } from "./plugins/import-meta-url.js";
 import { createRequireContextPlugin } from "./plugins/require-context.js";
+import { createRequireConditionPlugin } from "./plugins/require-condition.js";
 import { createExtensionlessDynamicImportPlugin } from "./plugins/extensionless-dynamic-import.js";
 import { createWasmModuleImportPlugin } from "./plugins/wasm-module-import.js";
 import { getTypeofWindowReplacement, replaceTypeofWindow } from "./plugins/typeof-window.js";
@@ -1894,6 +1895,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
     // Next.js ignores requests without any statically known path component
     // during graph analysis and leaves a deterministic runtime failure.
     createIgnoreDynamicRequestsPlugin(() => nextConfig?.turbopackTranspilePackages ?? []),
+    createRequireConditionPlugin(),
     // Transform CJS require()/module.exports to ESM before other plugins
     // analyze imports (RSC directive scanning, shim resolution, etc.)
     //

--- a/packages/vinext/src/plugins/require-condition.ts
+++ b/packages/vinext/src/plugins/require-condition.ts
@@ -1,0 +1,258 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import type { Plugin } from "vite";
+import { createIdResolver, parseAst } from "vite";
+import MagicString from "magic-string";
+import path from "pathslash";
+import { isUnknownRecord as isRecord } from "../utils/record.js";
+import { stripViteModuleQuery } from "../utils/path.js";
+
+const PUBLIC_REQUIRE_TARGET_PREFIX = "virtual:vinext/require-condition/";
+const BARE_IMPORT_RE = /^(?![a-zA-Z]:)[\w@](?!.*:\/\/)/;
+const SCRIPT_MODULE_RE = /\.[cm]?[jt]sx?$/i;
+
+type AstRecord = Record<string, unknown>;
+
+type StaticRequire = {
+  argumentEnd: number;
+  argumentStart: number;
+  specifier: string;
+};
+
+type RequireTarget = {
+  filePath: string;
+  resolved: {
+    external: boolean | "absolute";
+    id: string;
+    moduleSideEffects: boolean | "no-treeshake" | null;
+  };
+};
+
+function walkAst(value: unknown, visitor: (node: AstRecord) => void): void {
+  if (!isRecord(value)) return;
+  visitor(value);
+
+  for (const [key, child] of Object.entries(value)) {
+    if (key === "parent") continue;
+    if (Array.isArray(child)) {
+      for (const item of child) walkAst(item, visitor);
+    } else if (isRecord(child)) {
+      walkAst(child, visitor);
+    }
+  }
+}
+
+function collectStaticBareRequires(ast: unknown): StaticRequire[] {
+  const requires: StaticRequire[] = [];
+
+  walkAst(ast, (node) => {
+    if (node.type !== "CallExpression") return;
+    const callee = node.callee;
+    if (!isRecord(callee) || callee.type !== "Identifier" || callee.name !== "require") return;
+
+    const args = Array.isArray(node.arguments) ? node.arguments : [];
+    if (args.length !== 1 || !isRecord(args[0])) return;
+    const argument = args[0];
+    if (
+      argument.type !== "Literal" ||
+      typeof argument.value !== "string" ||
+      !BARE_IMPORT_RE.test(argument.value) ||
+      argument.value.startsWith(PUBLIC_REQUIRE_TARGET_PREFIX) ||
+      typeof argument.start !== "number" ||
+      typeof argument.end !== "number"
+    ) {
+      return;
+    }
+
+    requires.push({
+      argumentStart: argument.start,
+      argumentEnd: argument.end,
+      specifier: argument.value,
+    });
+  });
+
+  return requires;
+}
+
+function parserLanguage(id: string): "ts" | "tsx" {
+  return /\.[cm]?ts$/i.test(stripViteModuleQuery(id)) ? "ts" : "tsx";
+}
+
+function virtualExtension(id: string): string {
+  const extension = path.extname(stripViteModuleQuery(id)).toLowerCase();
+  if (extension === ".ts" || extension === ".cts" || extension === ".mts") return ".ts";
+  if (extension === ".tsx") return ".tsx";
+  if (extension === ".jsx") return ".jsx";
+  return ".js";
+}
+
+function virtualTargetId(resolvedId: string): string {
+  const hash = createHash("sha256").update(resolvedId).digest("hex").slice(0, 16);
+  return `${PUBLIC_REQUIRE_TARGET_PREFIX}${hash}${virtualExtension(resolvedId)}`;
+}
+
+/**
+ * Preserve per-call `require` export conditions before vite-plugin-commonjs
+ * rewrites static requires to ESM imports.
+ *
+ * Vite's resolver distinguishes `require-call` from `import-statement`, but
+ * that information is lost after the CommonJS transform. Only packages whose
+ * two resolutions differ are virtualized. The virtual JavaScript identity also
+ * lets the existing CommonJS and RSC transforms process require-selected `.cjs`
+ * client modules without Rolldown reparsing their generated ESM as CommonJS.
+ */
+export function createRequireConditionPlugin(): Plugin {
+  const targetsByPublicId = new Map<string, RequireTarget>();
+  const targetsByResolvedId = new Map<string, RequireTarget>();
+  let resolveDevImport: ReturnType<typeof createIdResolver> | undefined;
+  let resolveDevRequire: ReturnType<typeof createIdResolver> | undefined;
+
+  function targetForImporter(importer: string | undefined): RequireTarget | undefined {
+    if (!importer) return undefined;
+    return targetsByResolvedId.get(stripViteModuleQuery(importer));
+  }
+
+  return {
+    name: "vinext:require-condition",
+    enforce: "pre",
+
+    configResolved(config) {
+      resolveDevImport = createIdResolver(config, { isRequire: false, scan: true });
+      resolveDevRequire = createIdResolver(config, { isRequire: true, scan: true });
+    },
+
+    async resolveId(source, importer, options) {
+      const target = targetsByPublicId.get(source);
+      if (target) {
+        const id = `\0${source}`;
+        targetsByResolvedId.set(id, target);
+        return {
+          id,
+          moduleSideEffects: target.resolved.moduleSideEffects,
+        };
+      }
+
+      const importerTarget = targetForImporter(importer);
+      if (!importerTarget) return;
+      return this.resolve(source, importerTarget.resolved.id, {
+        kind: options.kind,
+        custom: options.custom,
+        isEntry: options.isEntry,
+        skipSelf: true,
+      });
+    },
+
+    load(id) {
+      const target = targetsByResolvedId.get(stripViteModuleQuery(id));
+      if (!target) return;
+      this.addWatchFile(target.filePath);
+      return fs.readFileSync(target.filePath, "utf8");
+    },
+
+    transform: {
+      filter: {
+        id: /\.[cm]?[jt]sx?(?:\?.*)?$/i,
+        code: "require(",
+      },
+      async handler(code, id) {
+        const importerTarget = targetForImporter(id);
+        const realImporter = importerTarget?.resolved.id ?? id;
+        const cleanId = stripViteModuleQuery(realImporter);
+        if (!importerTarget && cleanId.includes("/node_modules/")) return;
+
+        let ast: ReturnType<typeof parseAst>;
+        try {
+          ast = parseAst(code, { lang: parserLanguage(realImporter) });
+        } catch {
+          return;
+        }
+
+        const requires = collectStaticBareRequires(ast);
+        if (requires.length === 0) return;
+
+        const resolutions = await Promise.all(
+          requires.map(async ({ specifier }) => {
+            let [requireResolved, importResolved] = await Promise.all([
+              this.resolve(specifier, realImporter, {
+                kind: "require-call",
+                skipSelf: true,
+              }),
+              this.resolve(specifier, realImporter, {
+                kind: "import-statement",
+                skipSelf: true,
+              }),
+            ]);
+
+            // Dev dependency optimization is keyed by the bare specifier, so
+            // both calls above can point at the same pre-bundled import entry
+            // even when the unoptimized package exports differ. Compare with
+            // Vite's internal non-optimizer resolver in that case.
+            if (
+              this.environment.mode === "dev" &&
+              requireResolved?.id === importResolved?.id &&
+              resolveDevImport &&
+              resolveDevRequire
+            ) {
+              const [requireId, importId] = await Promise.all([
+                resolveDevRequire(this.environment, specifier, realImporter),
+                resolveDevImport(this.environment, specifier, realImporter),
+              ]);
+              if (requireId && importId && requireId !== importId) {
+                requireResolved = {
+                  external: false,
+                  id: requireId,
+                  meta: {},
+                  moduleSideEffects: null,
+                };
+                importResolved = {
+                  external: false,
+                  id: importId,
+                  meta: {},
+                  moduleSideEffects: null,
+                };
+              }
+            }
+
+            if (
+              !requireResolved ||
+              !importResolved ||
+              requireResolved.external ||
+              requireResolved.id === importResolved.id
+            ) {
+              return null;
+            }
+
+            const filePath = stripViteModuleQuery(requireResolved.id);
+            if (
+              filePath.startsWith("\0") ||
+              !path.isAbsolute(filePath) ||
+              !SCRIPT_MODULE_RE.test(filePath) ||
+              !fs.existsSync(filePath)
+            ) {
+              return null;
+            }
+
+            const publicId = virtualTargetId(requireResolved.id);
+            targetsByPublicId.set(publicId, { filePath, resolved: requireResolved });
+            return publicId;
+          }),
+        );
+
+        let output: MagicString | undefined;
+        for (let index = 0; index < requires.length; index++) {
+          const publicId = resolutions[index];
+          if (!publicId) continue;
+          output ??= new MagicString(code);
+          const request = requires[index];
+          output.overwrite(request.argumentStart, request.argumentEnd, JSON.stringify(publicId));
+        }
+
+        if (!output) return;
+        return {
+          code: output.toString(),
+          map: output.generateMap({ hires: "boundary" }),
+        };
+      },
+    },
+  };
+}

--- a/tests/client-module-package-type.test.ts
+++ b/tests/client-module-package-type.test.ts
@@ -1,0 +1,171 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { createBuilder, type ViteDevServer } from "vite";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import vinext from "../packages/vinext/src/index.js";
+import { startFixtureServer } from "./helpers.js";
+
+type BuiltHandler = (request: Request) => Promise<Response>;
+
+const EXPECTED_ROUTES = new Map([
+  ["/import-cjs", "lib-cjs: esm"],
+  ["/require-cjs", "lib-cjs: cjs"],
+  ["/import-esm", "lib-esm: esm"],
+  ["/require-esm", "lib-esm: cjs"],
+]);
+
+function writeFile(root: string, filePath: string, contents: string): void {
+  const absolutePath = path.join(root, filePath);
+  fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+  fs.writeFileSync(absolutePath, contents);
+}
+
+function linkWorkspaceDependencies(root: string): void {
+  const source = path.resolve(import.meta.dirname, "../node_modules");
+  const target = path.join(root, "node_modules");
+  fs.mkdirSync(target, { recursive: true });
+
+  for (const entry of fs.readdirSync(source, { withFileTypes: true })) {
+    if (entry.name === ".vite") continue;
+    const sourceEntry = path.join(source, entry.name);
+    fs.symlinkSync(
+      sourceEntry,
+      path.join(target, entry.name),
+      fs.statSync(sourceEntry).isDirectory() ? "junction" : "file",
+    );
+  }
+}
+
+function createFixture(): string {
+  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "vinext-package-type-")));
+  linkWorkspaceDependencies(root);
+  writeFile(root, "package.json", JSON.stringify({ private: true, type: "module" }));
+  writeFile(
+    root,
+    "app/layout.tsx",
+    `export default function Layout({ children }) {
+  return <html><body>{children}</body></html>;
+}`,
+  );
+
+  writeFile(
+    root,
+    "node_modules/lib-cjs/package.json",
+    JSON.stringify({
+      name: "lib-cjs",
+      type: "commonjs",
+      exports: { ".": { import: "./index.mjs", default: "./index.js" } },
+    }),
+  );
+  writeFile(
+    root,
+    "node_modules/lib-cjs/index.js",
+    `'use client';
+module.exports = () => 'cjs';`,
+  );
+  writeFile(
+    root,
+    "node_modules/lib-cjs/index.mjs",
+    `'use client';
+export default () => 'esm';`,
+  );
+
+  writeFile(
+    root,
+    "node_modules/lib-esm/package.json",
+    JSON.stringify({
+      name: "lib-esm",
+      type: "module",
+      exports: { ".": { require: "./index.cjs", default: "./index.js" } },
+    }),
+  );
+  writeFile(
+    root,
+    "node_modules/lib-esm/index.cjs",
+    `'use client';
+module.exports = () => 'cjs';`,
+  );
+  writeFile(
+    root,
+    "node_modules/lib-esm/index.js",
+    `'use client';
+export default () => 'esm';`,
+  );
+
+  writeFile(
+    root,
+    "app/import-cjs/page.tsx",
+    `import Component from "lib-cjs";
+export default function Page() { return <p>lib-cjs: <Component /></p>; }`,
+  );
+  writeFile(
+    root,
+    "app/require-cjs/page.tsx",
+    `const Component = require("lib-cjs");
+export default function Page() { return <p>lib-cjs: <Component /></p>; }`,
+  );
+  writeFile(
+    root,
+    "app/import-esm/page.tsx",
+    `import Component from "lib-esm";
+export default function Page() { return <p>lib-esm: <Component /></p>; }`,
+  );
+  writeFile(
+    root,
+    "app/require-esm/page.tsx",
+    `const Component = require("lib-esm");
+export default function Page() { return <p>lib-esm: <Component /></p>; }`,
+  );
+
+  return root;
+}
+
+describe("App Router client module package type resolution", () => {
+  let root = "";
+  let server: ViteDevServer | undefined;
+
+  afterEach(async () => {
+    await server?.close();
+    server = undefined;
+    if (root) fs.rmSync(root, { recursive: true, force: true });
+    root = "";
+  });
+
+  // Ported from Next.js:
+  // test/e2e/app-dir/client-module-with-package-type/index.test.ts
+  // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/client-module-with-package-type/index.test.ts
+  it("respects package type and conditional exports during development", async () => {
+    root = createFixture();
+    const started = await startFixtureServer(root, { appDir: root });
+    server = started.server;
+
+    for (const [pathname, text] of EXPECTED_ROUTES) {
+      const response = await fetch(`${started.baseUrl}${pathname}`);
+      expect(response.status).toBe(200);
+      expect((await response.text()).replaceAll("<!-- -->", "")).toContain(text);
+    }
+  }, 120_000);
+
+  it("respects package type and conditional exports in production", async () => {
+    root = createFixture();
+    const builder = await createBuilder({
+      root,
+      configFile: false,
+      plugins: [vinext({ appDir: root })],
+      logLevel: "silent",
+    });
+    await builder.buildApp();
+
+    const built = (await import(
+      `${pathToFileURL(path.join(root, "dist", "server", "index.js")).href}?t=${Date.now()}`
+    )) as { default: BuiltHandler };
+
+    for (const [pathname, text] of EXPECTED_ROUTES) {
+      const response = await built.default(new Request(`http://localhost${pathname}`));
+      expect(response.status).toBe(200);
+      expect((await response.text()).replaceAll("<!-- -->", "")).toContain(text);
+    }
+  }, 120_000);
+});


### PR DESCRIPTION
## Summary

- preserve Vite require-call package resolution before CommonJS conversion
- virtualize only require targets that differ from import targets so selected CJS client modules pass through the existing transforms
- port the upstream Next.js package-type fixture for development and production coverage

Fixes #1504

## Testing

- `pnpm test tests/client-module-package-type.test.ts tests/cjs.test.ts tests/dynamic-requests-build.test.ts tests/commonjs-loader.test.ts`
- `pnpm run check`
- `pnpm run build`
- `pnpm test` - 10,838 tests passed in the full run; the five assertions still failing after isolated reruns fail identically on untouched `origin/main`