### PR TITLE
fix(next/font/local): omit font-weight descriptor when no weight is specified

### DIFF
--- a/packages/vinext/src/shims/font-local.ts
+++ b/packages/vinext/src/shims/font-local.ts
@@ -117,7 +117,13 @@ function generateFontFaceCSS(
   const rules: string[] = [];
 
   for (const src of sources) {
-    const weight = sanitizeFontDescriptorValue(src.weight ?? options.weight ?? "400") ?? "400";
+    // Only emit a font-weight descriptor when a weight was actually
+    // specified. Next.js does the same (see loader.ts / stylesheet.rs) -
+    // defaulting to "400" here would clamp variable fonts with a `wght`
+    // axis to the regular instance even when the caller never asked for a
+    // fixed weight.
+    const rawWeight = src.weight ?? options.weight;
+    const weight = rawWeight !== undefined ? sanitizeFontDescriptorValue(rawWeight) : undefined;
     const style = sanitizeFontDescriptorValue(src.style ?? options.style ?? "normal") ?? "normal";
     const format = src.path.endsWith(".woff2")
       ? "woff2"
@@ -132,8 +138,7 @@ function generateFontFaceCSS(
     rules.push(`@font-face {
   font-family: '${escapeCSSString(family)}';
   src: url('${escapeCSSString(src.path)}') format('${format}');
-  font-weight: ${weight};
-  font-style: ${style};
+${weight !== undefined ? `  font-weight: ${weight};\n` : ""}  font-style: ${style};
   font-display: ${display};
 }`);
   }

--- a/tests/font-local-transform.test.ts
+++ b/tests/font-local-transform.test.ts
@@ -568,6 +568,37 @@ describe("vinext:local-fonts plugin", () => {
     expect(addedStyles).toContain("font-style: italic");
   });
 
+  it("omits the font-weight descriptor when no weight is specified (issue #2793)", () => {
+    // Next.js only emits `font-weight` in the generated @font-face rule when
+    // `weight` (or `defaultWeight`) was provided. For variable fonts with a
+    // `wght` axis, inventing a `font-weight: 400` descriptor clamps the font
+    // face to the regular instance even though no fixed weight was requested.
+    // See:
+    // https://github.com/vercel/next.js/blob/canary/packages/font/src/local/loader.ts
+    const beforeCount = getSSRFontStyles().length;
+    const result = localFont({
+      src: "./variable-font.woff2",
+    });
+
+    expect(result.style.fontWeight).toBeUndefined();
+
+    const addedStyles = getSSRFontStyles().slice(beforeCount).join("\n");
+    expect(addedStyles).not.toContain("font-weight");
+    // font-style still defaults to "normal"
+    expect(addedStyles).toContain("font-style: normal");
+  });
+
+  it("still emits font-weight when a weight is specified on a single non-object source options", () => {
+    const beforeCount = getSSRFontStyles().length;
+    localFont({
+      src: "./font.woff2",
+      weight: "600",
+    });
+
+    const addedStyles = getSSRFontStyles().slice(beforeCount).join("\n");
+    expect(addedStyles).toContain("font-weight: 600");
+  });
+
   it("sanitizes declaration props to prevent injection", () => {
     const beforeCount = getSSRFontStyles().length;
     const result = localFont({


### PR DESCRIPTION
Fixes #2793

## Problem

The `next/font/local` shim's generated `@font-face` rule always defaulted to `font-weight: 400` whenever neither the source nor the top-level options specified a weight:

```ts
const weight = sanitizeFontDescriptorValue(src.weight ?? options.weight ?? "400") ?? "400";
```

For variable fonts with a `wght` axis, this clamps the font face to the regular (400) instance. Elements styled with e.g. `font-weight: 600` still compute to 600 in the CSSOM, but the browser renders the 400 instance of the variable font instead of interpolating to 600, because the `@font-face` rule pins the descriptor.

## Fix

`packages/vinext/src/shims/font-local.ts`: only emit the `font-weight` descriptor when a weight was actually specified on the source or top-level options. `font-style` keeps its existing `"normal"` default, matching the expected output in the issue.

This matches Next.js, which only emits `font-weight` in the generated CSS when `weight`/`defaultWeight` is provided (see `packages/font/src/local/loader.ts` and the Turbopack `next_font/local/stylesheet.rs` implementation, both linked from the issue).

## Test plan

- Added two tests to `tests/font-local-transform.test.ts`:
  - `omits the font-weight descriptor when no weight is specified (issue #2793)` — asserts no `font-weight` in the generated CSS and that `result.style.fontWeight` is `undefined` when no weight is given.
  - `still emits font-weight when a weight is specified on a single non-object source options` — regression guard for the existing explicit-weight path.
- Verified RED: reverted only the source fix (kept the new test) and confirmed the new test fails against the old code with `font-weight: 400` present.
- Verified GREEN: `pnpm test tests/font-local-transform.test.ts` — all 43 tests pass.
- `pnpm test tests/shims.test.ts -t "font"` — all font-related tests in the broader shims suite pass (19 passed, rest unrelated/skipped).
- `vp check` (format + lint + typecheck) passes on the changed files.

Scope note: this only touches `font-local.ts` — I checked `font-google-base.ts` for the same pattern and it doesn't hardcode a `font-weight` default, so it isn't affected.