### PR TITLE
fix(prerender): expose the production build phase

### DIFF
--- a/packages/vinext/src/build/prerender-paths.ts
+++ b/packages/vinext/src/build/prerender-paths.ts
@@ -22,6 +22,7 @@ import { findDir } from "../utils/project.js";
 import { BLOCKED_PAGES, PHASE_PRODUCTION_BUILD } from "vinext/shims/constants";
 import { VINEXT_PRERENDER_SECRET_HEADER } from "../server/headers.js";
 import type { VinextRouteRootConfig } from "../config/prerender.js";
+import { enterPrerenderPhase } from "./prerender-phase.js";
 
 export type PrerenderPathManifest = {
   buildId?: string;
@@ -169,15 +170,13 @@ async function shouldStartPathDiscoveryServer(options: {
 }
 
 async function withPrerenderEndpoints<T>(fn: () => Promise<T>): Promise<T> {
-  const previousPrerenderFlag = process.env.VINEXT_PRERENDER;
+  const restorePrerenderPhase = enterPrerenderPhase();
   const previousPathDiscoveryFlag = process.env[PRERENDER_PATH_DISCOVERY_ENV];
-  process.env.VINEXT_PRERENDER = "1";
   process.env[PRERENDER_PATH_DISCOVERY_ENV] = "1";
   try {
     return await fn();
   } finally {
-    if (previousPrerenderFlag === undefined) delete process.env.VINEXT_PRERENDER;
-    else process.env.VINEXT_PRERENDER = previousPrerenderFlag;
+    restorePrerenderPhase();
     if (previousPathDiscoveryFlag === undefined) delete process.env[PRERENDER_PATH_DISCOVERY_ENV];
     else process.env[PRERENDER_PATH_DISCOVERY_ENV] = previousPathDiscoveryFlag;
   }

--- a/packages/vinext/src/build/prerender-phase.ts
+++ b/packages/vinext/src/build/prerender-phase.ts
@@ -1,0 +1,53 @@
+import { PHASE_PRODUCTION_BUILD } from "vinext/shims/constants";
+
+type PrerenderPhaseState = {
+  depth: number;
+  previousNextPhase: string | undefined;
+  previousPrerenderFlag: string | undefined;
+};
+
+type PrerenderPhaseEnv = {
+  NEXT_PHASE?: string;
+  NODE_ENV?: string;
+  VINEXT_PRERENDER?: string;
+};
+
+const activePrerenderPhases = new WeakMap<PrerenderPhaseEnv, PrerenderPhaseState>();
+
+/**
+ * Enter the same process environment phase that Next.js exposes while its
+ * static workers execute application code. The returned cleanup is nest-safe:
+ * direct prerender helpers can run inside the CLI's broader build scope without
+ * overwriting the caller's prior phase when they finish.
+ */
+export function enterPrerenderPhase(env: PrerenderPhaseEnv = process.env): () => void {
+  let state = activePrerenderPhases.get(env);
+  if (state) {
+    state.depth += 1;
+  } else {
+    state = {
+      depth: 1,
+      previousPrerenderFlag: env.VINEXT_PRERENDER,
+      previousNextPhase: env.NEXT_PHASE,
+    };
+    activePrerenderPhases.set(env, state);
+  }
+  let restored = false;
+
+  env.VINEXT_PRERENDER = "1";
+  env.NEXT_PHASE = PHASE_PRODUCTION_BUILD;
+
+  return () => {
+    if (restored) return;
+    restored = true;
+    state.depth -= 1;
+    if (state.depth > 0) return;
+    activePrerenderPhases.delete(env);
+
+    if (state.previousPrerenderFlag === undefined) delete env.VINEXT_PRERENDER;
+    else env.VINEXT_PRERENDER = state.previousPrerenderFlag;
+
+    if (state.previousNextPhase === undefined) delete env.NEXT_PHASE;
+    else env.NEXT_PHASE = state.previousNextPhase;
+  };
+}

--- a/packages/vinext/src/build/prerender-server-entry.ts
+++ b/packages/vinext/src/build/prerender-server-entry.ts
@@ -8,9 +8,9 @@
  * vinext production server on an ephemeral port and reports it to the parent
  * over IPC. The parent then load-balances per-route fetches across the pool.
  *
- * `VINEXT_PRERENDER` / `VINEXT_PRERENDER_OUTDIR` are passed via the fork env so
- * they are set before any module loads (some server modules read the flag at
- * import time).
+ * `VINEXT_PRERENDER` / `NEXT_PHASE` / `VINEXT_PRERENDER_OUTDIR` are passed via
+ * the fork env so they are set before any module loads (some server and user
+ * modules read the phase at import time).
  */
 import { startProdServer } from "../server/prod-server.js";
 import { NoOpCacheHandler, setCacheHandler } from "vinext/shims/cache-handler";

--- a/packages/vinext/src/build/prerender-server-pool.ts
+++ b/packages/vinext/src/build/prerender-server-pool.ts
@@ -18,6 +18,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "pathslash";
 import { fileURLToPath } from "node:url";
+import { PHASE_PRODUCTION_BUILD } from "vinext/shims/constants";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const WORKER_ENTRY = path.join(__dirname, "prerender-server-entry.js");
@@ -144,6 +145,7 @@ export async function startPrerenderServerPool(
         env: {
           ...process.env,
           VINEXT_PRERENDER: "1",
+          NEXT_PHASE: PHASE_PRODUCTION_BUILD,
           VINEXT_PRERENDER_OUTDIR: outDir,
         },
         // Inherit stdout/stderr so server-side errors surface; keep IPC.

--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -65,6 +65,7 @@ import {
   createAppPprFallbackShells,
   markAppPprDynamicFallbackShellHtml,
 } from "../server/app-ppr-fallback-shell.js";
+import { enterPrerenderPhase } from "./prerender-phase.js";
 export { readPrerenderSecret } from "./server-manifest.js";
 
 const EXPERIMENTAL_PPR_FALLBACK_SHELLS_ENV = "__VINEXT_EXPERIMENTAL_PPR_FALLBACK_SHELLS";
@@ -623,8 +624,7 @@ export async function prerenderPages({
 
   const previousHandler = getCacheHandler();
   setCacheHandler(new NoOpCacheHandler());
-  const previousPrerenderFlag = process.env.VINEXT_PRERENDER;
-  process.env.VINEXT_PRERENDER = "1";
+  const restorePrerenderPhase = enterPrerenderPhase();
   // ownedProdServerHandle: a prod server we started ourselves and must close in finally.
   // When the caller passes options._prodServer we use that and do NOT close it.
   let ownedProdServerHandle: { server: HttpServer; port: number } | null = null;
@@ -988,12 +988,14 @@ export async function prerenderPages({
 
     return { routes: results };
   } finally {
-    if (renderPool) await renderPool.close();
-    setCacheHandler(previousHandler);
-    if (previousPrerenderFlag === undefined) delete process.env.VINEXT_PRERENDER;
-    else process.env.VINEXT_PRERENDER = previousPrerenderFlag;
-    if (ownedProdServerHandle) {
-      await new Promise<void>((resolve) => ownedProdServerHandle!.server.close(() => resolve()));
+    try {
+      if (renderPool) await renderPool.close();
+      setCacheHandler(previousHandler);
+      if (ownedProdServerHandle) {
+        await new Promise<void>((resolve) => ownedProdServerHandle!.server.close(() => resolve()));
+      }
+    } finally {
+      restorePrerenderPhase();
     }
   }
 }
@@ -1035,13 +1037,11 @@ export async function prerenderApp({
   const previousHandler = getCacheHandler();
   setCacheHandler(new NoOpCacheHandler());
   // VINEXT_PRERENDER=1 tells the prod server to skip instrumentation.register()
-  // and enable prerender-only endpoints (/__vinext/prerender/*). It also makes
-  // the socket-error backstop (server/socket-error-backstop.ts) re-throw
-  // peer-disconnect errors during prerender. Save the prior value so callers
-  // that already set the flag (run-prerender.ts) aren't clobbered when this
-  // function's finally block restores.
-  const previousPrerenderFlag = process.env.VINEXT_PRERENDER;
-  process.env.VINEXT_PRERENDER = "1";
+  // and enable prerender-only endpoints (/__vinext/prerender/*), while
+  // NEXT_PHASE matches Next's static-worker contract for application code.
+  // The scope is nest-safe because run-prerender.ts also enters it around a
+  // shared hybrid server.
+  const restorePrerenderPhase = enterPrerenderPhase();
 
   const serverDir = path.dirname(rscBundlePath);
 
@@ -1683,12 +1683,14 @@ export async function prerenderApp({
       ...(outputFiles.length > 0 ? { outputFiles } : {}),
     };
   } finally {
-    if (renderPool) await renderPool.close();
-    setCacheHandler(previousHandler);
-    if (previousPrerenderFlag === undefined) delete process.env.VINEXT_PRERENDER;
-    else process.env.VINEXT_PRERENDER = previousPrerenderFlag;
-    if (ownedProdServerHandle) {
-      await new Promise<void>((resolve) => ownedProdServerHandle!.server.close(() => resolve()));
+    try {
+      if (renderPool) await renderPool.close();
+      setCacheHandler(previousHandler);
+      if (ownedProdServerHandle) {
+        await new Promise<void>((resolve) => ownedProdServerHandle!.server.close(() => resolve()));
+      }
+    } finally {
+      restorePrerenderPhase();
     }
   }
 }

--- a/packages/vinext/src/build/run-prerender.ts
+++ b/packages/vinext/src/build/run-prerender.ts
@@ -35,6 +35,7 @@ import { scanMetadataFiles } from "../server/metadata-routes.js";
 import { findDir } from "../utils/project.js";
 import { injectPregeneratedConcretePaths } from "./inject-pregenerated-paths.js";
 import { rememberCurrentServerEntryImportMtime, startProdServer } from "../server/prod-server.js";
+import { enterPrerenderPhase } from "./prerender-phase.js";
 
 // ─── Progress UI ──────────────────────────────────────────────────────────────
 
@@ -161,15 +162,6 @@ export async function runPrerender(options: RunPrerenderOptions): Promise<Preren
 
   if (!appDir && !pagesDir) return null;
 
-  // Mark the entire prerender orchestration so the socket-error backstop
-  // re-throws peer-disconnect errors during user fetch() calls instead of
-  // silently absorbing them and producing corrupt output. prerender.ts
-  // sets and clears this var around its own render passes, but we widen
-  // the scope here to cover startProdServer / shared-server setup that
-  // happens before those phases run. See server/socket-error-backstop.ts.
-  const previousPrerenderFlag = process.env.VINEXT_PRERENDER;
-  process.env.VINEXT_PRERENDER = "1";
-
   // The manifest lands in dist/server/ alongside the server bundle so it's
   // cleaned with the rest of vinext's build output on rebuild and co-located
   // with server artifacts.
@@ -226,6 +218,10 @@ export async function runPrerender(options: RunPrerenderOptions): Promise<Preren
   // and ensures both phases render against the same built bundle.
   let sharedProdServer: { server: HttpServer; port: number } | null = null;
   let sharedPrerenderSecret: string | undefined;
+  // Match Next's static-worker phase while user modules execute. This wider
+  // scope also covers shared-server startup; the nested router helpers restore
+  // back to this value and this cleanup restores the ordinary caller phase.
+  const restorePrerenderPhase = enterPrerenderPhase();
 
   try {
     if (appDir && pagesDir) {
@@ -319,12 +315,14 @@ export async function runPrerender(options: RunPrerenderOptions): Promise<Preren
       if (result.outputFiles) allOutputFiles.push(...result.outputFiles);
     }
   } finally {
-    // Close the shared prod server if we started one.
-    if (sharedProdServer) {
-      await new Promise<void>((resolve) => sharedProdServer!.server.close(() => resolve()));
+    try {
+      // Close the shared prod server if we started one.
+      if (sharedProdServer) {
+        await new Promise<void>((resolve) => sharedProdServer!.server.close(() => resolve()));
+      }
+    } finally {
+      restorePrerenderPhase();
     }
-    if (previousPrerenderFlag === undefined) delete process.env.VINEXT_PRERENDER;
-    else process.env.VINEXT_PRERENDER = previousPrerenderFlag;
   }
 
   if (allRoutes.length === 0) {

--- a/packages/vinext/src/build/run-prerender.ts
+++ b/packages/vinext/src/build/run-prerender.ts
@@ -36,6 +36,7 @@ import { findDir } from "../utils/project.js";
 import { injectPregeneratedConcretePaths } from "./inject-pregenerated-paths.js";
 import { rememberCurrentServerEntryImportMtime, startProdServer } from "../server/prod-server.js";
 import { enterPrerenderPhase } from "./prerender-phase.js";
+import { PHASE_PRODUCTION_BUILD } from "vinext/shims/constants";
 
 // ─── Progress UI ──────────────────────────────────────────────────────────────
 
@@ -171,7 +172,9 @@ export async function runPrerender(options: RunPrerenderOptions): Promise<Preren
 
   const config = options.nextConfig
     ? { ...options.nextConfig }
-    : { ...(await resolveNextConfig(await loadNextConfig(root), root)) };
+    : {
+        ...(await resolveNextConfig(await loadNextConfig(root, PHASE_PRODUCTION_BUILD), root)),
+      };
   // Prerender must reuse the exact BUILD_ID that `vinext build` wrote to disk
   // rather than re-resolving a fresh one. `config.buildId` is consumed when
   // computing prerendered-output identity (prerender.ts), so re-resolving here

--- a/tests/fixtures/app-basic/app/prerender-inline-server-action/form.tsx
+++ b/tests/fixtures/app-basic/app/prerender-inline-server-action/form.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { useActionState, type ReactNode } from "react";
+
+export function Form({ action }: { action: () => Promise<ReactNode> }) {
+  const [result, formAction] = useActionState(action, "initial");
+
+  return (
+    <form action={formAction}>
+      <button>Submit</button>
+      <p>{result}</p>
+    </form>
+  );
+}

--- a/tests/fixtures/app-basic/app/prerender-inline-server-action/page.tsx
+++ b/tests/fixtures/app-basic/app/prerender-inline-server-action/page.tsx
@@ -1,0 +1,34 @@
+import { PHASE_PRODUCTION_BUILD } from "next/constants";
+import { Form } from "./form";
+
+// Ported from Next.js:
+// test/e2e/app-dir/cache-components/cache-components.server-action.test.ts
+// https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/cache-components/cache-components.server-action.test.ts
+export default function Page() {
+  const simpleValue = "result";
+  const jsxValue = <span>and more</span>;
+  const timedValue = <HasTimingInfo />;
+
+  return (
+    <>
+      <Form
+        action={async () => {
+          "use server";
+          return (
+            <>
+              {simpleValue} {jsxValue} {timedValue}
+            </>
+          );
+        }}
+      />
+      <div id="phase">
+        {process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD ? "at buildtime" : "at runtime"}
+      </div>
+    </>
+  );
+}
+
+async function HasTimingInfo() {
+  await Promise.resolve();
+  return "and even more";
+}

--- a/tests/prerender-phase.test.ts
+++ b/tests/prerender-phase.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vite-plus/test";
+import { enterPrerenderPhase } from "../packages/vinext/src/build/prerender-phase.js";
+import { PHASE_PRODUCTION_BUILD } from "../packages/vinext/src/shims/constants.js";
+
+describe("prerender process phase", () => {
+  it("exposes the Next production-build phase and removes it afterward", () => {
+    const env: Record<string, string | undefined> = {};
+
+    const restore = enterPrerenderPhase(env);
+    expect(env).toMatchObject({
+      VINEXT_PRERENDER: "1",
+      NEXT_PHASE: PHASE_PRODUCTION_BUILD,
+    });
+
+    restore();
+    expect(env.VINEXT_PRERENDER).toBeUndefined();
+    expect(env.NEXT_PHASE).toBeUndefined();
+  });
+
+  it("restores an ordinary runtime phase after overlapping prerender scopes", () => {
+    const env: Record<string, string | undefined> = {
+      VINEXT_PRERENDER: "runtime-control",
+      NEXT_PHASE: "phase-production-server",
+    };
+
+    const restoreOuter = enterPrerenderPhase(env);
+    const restoreInner = enterPrerenderPhase(env);
+    restoreOuter();
+    expect(env.NEXT_PHASE).toBe(PHASE_PRODUCTION_BUILD);
+
+    restoreInner();
+    expect(env).toEqual({
+      VINEXT_PRERENDER: "runtime-control",
+      NEXT_PHASE: "phase-production-server",
+    });
+  });
+});

--- a/tests/prerender-server-pool.test.ts
+++ b/tests/prerender-server-pool.test.ts
@@ -72,6 +72,30 @@ describe("prerender server pool sizing", () => {
     }
   });
 
+  it("starts render workers in the Next production-build phase", async () => {
+    const { dir, entry } = writeWorkerEntry(`
+      if (
+        process.env.VINEXT_PRERENDER !== "1" ||
+        process.env.NEXT_PHASE !== "phase-production-build"
+      ) {
+        process.send({ type: "error", error: JSON.stringify({
+          VINEXT_PRERENDER: process.env.VINEXT_PRERENDER,
+          NEXT_PHASE: process.env.NEXT_PHASE,
+        }) });
+      } else {
+        process.send({ type: "ready", port: 4125 });
+      }
+      setInterval(() => {}, 1000);
+    `);
+
+    try {
+      const pool = await startPrerenderServerPool(dir, 1, entry);
+      await pool.close();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("fails assertHealthy immediately after a worker transport error", async () => {
     const { dir, entry } = writeWorkerEntry(`
       process.send({ type: "ready", port: 4124 });

--- a/tests/prerender.test.ts
+++ b/tests/prerender.test.ts
@@ -806,6 +806,7 @@ describe("prerenderPages — export mode (pages-basic)", () => {
 describe("prerenderApp — default mode (app-basic)", () => {
   let outDir: string;
   let results: PrerenderRouteResult[];
+  let nextPhaseAfterPrerender: string | undefined;
 
   beforeAll(async () => {
     const rscBundlePath = await buildAppFixture(APP_FIXTURE);
@@ -819,14 +820,22 @@ describe("prerenderApp — default mode (app-basic)", () => {
     const routes = await appRouter(appDir);
     const config = await resolveNextConfig({});
 
-    const prerenderResult = await prerenderApp({
-      mode: "default",
-      rscBundlePath,
-      routes,
-      outDir,
-      config,
-    });
-    results = prerenderResult.routes;
+    const previousNextPhase = process.env.NEXT_PHASE;
+    process.env.NEXT_PHASE = "phase-production-server";
+    try {
+      const prerenderResult = await prerenderApp({
+        mode: "default",
+        rscBundlePath,
+        routes,
+        outDir,
+        config,
+      });
+      results = prerenderResult.routes;
+      nextPhaseAfterPrerender = process.env.NEXT_PHASE;
+    } finally {
+      if (previousNextPhase === undefined) delete process.env.NEXT_PHASE;
+      else process.env.NEXT_PHASE = previousNextPhase;
+    }
   }, 120_000);
 
   afterAll(() => {
@@ -915,6 +924,18 @@ describe("prerenderApp — default mode (app-basic)", () => {
     const html = fs.readFileSync(path.join(outDir, "use-cache-test.html"), "utf-8");
     expect(html).toContain('"initialCacheKind":"static"');
     expect(html).toContain('"staleTimeSeconds":30');
+  });
+
+  it("renders inline server actions during the production build phase", () => {
+    const r = findRoute(results, "/prerender-inline-server-action");
+    expect(r).toMatchObject({
+      route: "/prerender-inline-server-action",
+      status: "rendered",
+    });
+
+    const html = fs.readFileSync(path.join(outDir, "prerender-inline-server-action.html"), "utf-8");
+    expect(html).toContain('<div id="phase">at buildtime</div>');
+    expect(nextPhaseAfterPrerender).toBe("phase-production-server");
   });
 
   it("records collected App Router cache tags for cache seeding", () => {

--- a/tests/run-prerender-concurrency.test.ts
+++ b/tests/run-prerender-concurrency.test.ts
@@ -69,4 +69,34 @@ describe("runPrerender concurrency", () => {
       fs.rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it("loads functional next config with the production-build phase", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-run-prerender-config-phase-"));
+    fs.mkdirSync(path.join(root, "app"));
+    fs.writeFileSync(
+      path.join(root, "next.config.mjs"),
+      `export default (phase) => ({ env: { OBSERVED_CONFIG_PHASE: phase } });\n`,
+    );
+
+    try {
+      const { runPrerender } = await import("../packages/vinext/src/build/run-prerender.js");
+
+      await runPrerender({
+        root,
+        rscBundlePath: path.join(root, "dist", "server", "index.js"),
+      });
+
+      expect(prerenderAppMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.objectContaining({
+            env: expect.objectContaining({
+              OBSERVED_CONFIG_PHASE: "phase-production-build",
+            }),
+          }),
+        }),
+      );
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- expose `NEXT_PHASE=phase-production-build` while prerender workers and in-process prerender servers execute application code
- preserve and restore the caller environment safely across nested and overlapping prerender scopes
- load omitted functional `next.config.*` values with the production-build phase
- add regression coverage for prerendering inline server actions that capture JSX and async component values

## Validation

- `REPO="$(pwd)" NEXTJS_DIR="/Users/jamesanderson/Developer/vinext/.nextjs-ref" ./scripts/run-targeted-nextjs-e2e.sh test/e2e/app-dir/cache-components/cache-components.server-action.test.ts` — 3/3 passed
- `vp test run tests/prerender-phase.test.ts tests/run-prerender-concurrency.test.ts tests/prerender-server-pool.test.ts` — 12/12 passed
- `vp test run tests/prerender.test.ts -t "renders inline server actions during the production build phase"` — passed
- focused `vp check` for all changed source and test files — passed

The targeted Next.js E2E is the primary acceptance check for this fix.