### PR TITLE
fix(cache): vary use cache entries by root params

### DIFF
--- a/packages/vinext/src/shims/cache-request-state.ts
+++ b/packages/vinext/src/shims/cache-request-state.ts
@@ -26,6 +26,7 @@ type CacheContextLike = {
   tags: string[];
   lifeConfigs: CacheLifeConfig[];
   variant: string;
+  readRootParamNames?: Set<string>;
   hasExplicitRevalidate: boolean;
   hasExplicitExpire: boolean;
   dynamicNestedCacheError: Error | undefined;
@@ -39,6 +40,14 @@ export function _registerCacheContextAccessor(fn: () => CacheContextLike | null)
 
 export function getRegisteredCacheContext(): CacheContextLike | null {
   return getCacheContext?.() ?? null;
+}
+
+/** Record a root-param dependency on the active public `"use cache"` scope. */
+export function _recordUseCacheRootParamRead(name: string): void {
+  const context = getRegisteredCacheContext();
+  if (context && context.variant !== "private") {
+    context.readRootParamNames?.add(name);
+  }
 }
 
 export type UnstableCacheRevalidationMode = "foreground" | "background";

--- a/packages/vinext/src/shims/cache-runtime.ts
+++ b/packages/vinext/src/shims/cache-runtime.ts
@@ -52,6 +52,7 @@ import {
 import { isDraftModeEnabled, markDynamicUsage } from "./headers.js";
 import { trackPprFallbackShellCacheTask } from "./ppr-fallback-shell.js";
 import { isMarkedAppPagePropsObject } from "./internal/app-page-props-cache-key.js";
+import { getCurrentRootParams, type RootParams } from "./root-params.js";
 
 export { markAppPagePropsForUseCache } from "./internal/app-page-props-cache-key.js";
 
@@ -129,6 +130,8 @@ export type CacheContext = {
   lifeConfigs: CacheLifeConfig[];
   /** Cache variant: "default" | "remote" | "private" */
   variant: string;
+  /** Root params observed while producing this public cache entry. */
+  readRootParamNames?: Set<string>;
   /** Whether cacheLife() was called with an explicit revalidate value */
   hasExplicitRevalidate: boolean;
   /** Whether cacheLife() was called with an explicit expire value */
@@ -428,6 +431,63 @@ export function clearPrivateCache(): void {
 }
 
 // ---------------------------------------------------------------------------
+// Root-param-aware shared cache keys
+// ---------------------------------------------------------------------------
+
+const ROOT_PARAM_REDIRECT_HEADER = "x-vinext-use-cache-root-params";
+const ROOT_PARAM_TAG_PREFIX = "__vinext_use_cache_root_param__:";
+const _KNOWN_ROOT_PARAMS_KEY = Symbol.for("vinext.cacheRuntime.knownRootParamsByFunctionId");
+
+const knownRootParamsByFunctionId = (_g[_KNOWN_ROOT_PARAMS_KEY] ??= new Map<
+  string,
+  Set<string>
+>()) as Map<string, Set<string>>;
+
+function addKnownRootParamNames(id: string, names: ReadonlySet<string>): Set<string> {
+  const known = knownRootParamsByFunctionId.get(id);
+  if (known) {
+    for (const name of names) known.add(name);
+    return known;
+  }
+  const created = new Set(names);
+  knownRootParamsByFunctionId.set(id, created);
+  return created;
+}
+
+function computeRootParamsCacheKeySuffix(
+  rootParams: RootParams,
+  paramNames: ReadonlySet<string>,
+): string {
+  if (paramNames.size === 0) return "";
+  return `:root-params:${JSON.stringify(
+    [...paramNames].sort().map((name) => [name, rootParams[name]]),
+  )}`;
+}
+
+function rootParamNamesFromTags(tags: readonly string[] | undefined): Set<string> {
+  const names = new Set<string>();
+  for (const tag of tags ?? []) {
+    if (tag.startsWith(ROOT_PARAM_TAG_PREFIX)) {
+      names.add(tag.slice(ROOT_PARAM_TAG_PREFIX.length));
+    }
+  }
+  return names;
+}
+
+function isRootParamRedirect(entry: CacheHandlerValue | null): boolean {
+  return (
+    entry?.value?.kind === "FETCH" && entry.value.data.headers[ROOT_PARAM_REDIRECT_HEADER] === "1"
+  );
+}
+
+function propagateRootParamNamesToParent(names: ReadonlySet<string> | undefined): void {
+  if (!names || names.size === 0) return;
+  const parent = cacheContextStorage.getStore();
+  if (!parent || parent.variant === "private") return;
+  for (const name of names) parent.readRootParamNames?.add(name);
+}
+
+// ---------------------------------------------------------------------------
 // Core runtime: registerCachedFunction
 // ---------------------------------------------------------------------------
 
@@ -565,6 +625,12 @@ export function registerCachedFunction<TArgs extends unknown[], TResult>(
 
       // Shared cache ("use cache" / "use cache: remote")
       const handler = getDataCacheHandler();
+      const rootParams = getCurrentRootParams();
+      const knownRootParamNames = knownRootParamsByFunctionId.get(id);
+      const coarseCacheKey = cacheKey;
+      if (knownRootParamNames && rootParams) {
+        cacheKey += computeRootParamsCacheKeySuffix(rootParams, knownRootParamNames);
+      }
 
       // Check cache — deserialize via RSC stream when available, JSON otherwise.
       // Pass soft tags so that revalidatePath() / revalidateTag() invalidation
@@ -585,6 +651,24 @@ export function registerCachedFunction<TArgs extends unknown[], TResult>(
           console.error("[vinext] use cache: handler.get failed; treating as a cache miss:", error);
         }
       }
+      const redirectValue = existing?.value;
+      if (
+        isRootParamRedirect(existing) &&
+        existing?.cacheState !== "stale" &&
+        rootParams &&
+        redirectValue?.kind === "FETCH" &&
+        !_hasPendingRevalidatedTag([...(redirectValue.tags ?? []), ...softTags])
+      ) {
+        const redirectNames = rootParamNamesFromTags(redirectValue.tags);
+        const combinedNames = addKnownRootParamNames(id, redirectNames);
+        cacheKey = coarseCacheKey + computeRootParamsCacheKeySuffix(rootParams, combinedNames);
+        try {
+          existing = await handler.get(cacheKey, { kind: "FETCH", softTags });
+        } catch (error) {
+          console.error("[vinext] use cache: handler.get failed; treating as a cache miss:", error);
+          existing = null;
+        }
+      }
       if (
         existing?.value &&
         existing.value.kind === "FETCH" &&
@@ -592,6 +676,7 @@ export function registerCachedFunction<TArgs extends unknown[], TResult>(
         !_hasPendingRevalidatedTag([...(existing.value.tags ?? []), ...softTags])
       ) {
         try {
+          propagateRootParamNamesToParent(knownRootParamsByFunctionId.get(id));
           // Surface the cached entry's tags to the surrounding request so the
           // enclosing page / route-handler ISR entry carries them even on a data
           // cache HIT — otherwise `revalidateTag()` could not evict the rendered
@@ -624,6 +709,11 @@ export function registerCachedFunction<TArgs extends unknown[], TResult>(
         callArgs,
         cacheVariant,
       );
+
+      const rootParamNames =
+        ctx.readRootParamNames && ctx.readRootParamNames.size > 0
+          ? addKnownRootParamNames(id, ctx.readRootParamNames)
+          : knownRootParamsByFunctionId.get(id);
 
       recordRequestScopedCacheLife(effectiveLife);
       // Bubble the cache scope's tags up to the surrounding request so the
@@ -664,8 +754,7 @@ export function registerCachedFunction<TArgs extends unknown[], TResult>(
           tags: ctx.tags,
           revalidate: revalidateSeconds,
         } satisfies CachedFetchValue;
-
-        await handler.set(cacheKey, cacheValue, {
+        const cacheContext = {
           fetchCache: true,
           tags: ctx.tags,
           cacheControl: {
@@ -675,7 +764,35 @@ export function registerCachedFunction<TArgs extends unknown[], TResult>(
             // the enclosing render's minimum depends on cache temperature.
             stale: effectiveLife.stale,
           },
-        });
+        };
+
+        if (rootParamNames && rootParamNames.size > 0 && rootParams) {
+          const specificCacheKey =
+            coarseCacheKey + computeRootParamsCacheKeySuffix(rootParams, rootParamNames);
+          cacheValue.data.url = specificCacheKey;
+          await handler.set(specificCacheKey, cacheValue, cacheContext);
+
+          const redirectTags = [
+            ...ctx.tags,
+            ...[...rootParamNames].map((name) => ROOT_PARAM_TAG_PREFIX + name),
+          ];
+          await handler.set(
+            coarseCacheKey,
+            {
+              kind: "FETCH",
+              data: {
+                headers: { [ROOT_PARAM_REDIRECT_HEADER]: "1" },
+                body: "",
+                url: coarseCacheKey,
+              },
+              tags: redirectTags,
+              revalidate: revalidateSeconds,
+            },
+            { ...cacheContext, tags: redirectTags },
+          );
+        } else {
+          await handler.set(cacheKey, cacheValue, cacheContext);
+        }
       } catch {
         // Result not serializable — skip caching, still return the result
       }
@@ -885,6 +1002,7 @@ async function runCachedFunctionWithContext<T extends (...args: any[]) => Promis
     tags: [],
     lifeConfigs: [],
     variant: variant || "default",
+    readRootParamNames: new Set(),
     hasExplicitRevalidate: false,
     hasExplicitExpire: false,
     dynamicNestedCacheError: undefined,
@@ -940,6 +1058,11 @@ async function runCachedFunctionWithContext<T extends (...args: any[]) => Promis
     for (const tag of ctx.tags) {
       if (!parentCtx.tags.includes(tag)) {
         parentCtx.tags.push(tag);
+      }
+    }
+    if (parentCtx.variant !== "private") {
+      for (const name of ctx.readRootParamNames ?? []) {
+        parentCtx.readRootParamNames?.add(name);
       }
     }
   }

--- a/packages/vinext/src/shims/cache-runtime.ts
+++ b/packages/vinext/src/shims/cache-runtime.ts
@@ -188,6 +188,11 @@ type RscModule = {
   decodeReply: (body: string | FormData, options?: unknown) => Promise<unknown[]>;
 };
 
+type SerializedCacheResult = {
+  body: string;
+  headers: Record<string, string>;
+};
+
 function getUseCacheDeploymentIdDefine(): string | undefined {
   try {
     // Keep this direct reference so Vite's define transform can inline it for
@@ -289,6 +294,30 @@ function uint8ToStream(bytes: Uint8Array): ReadableStream<Uint8Array> {
       controller.close();
     },
   });
+}
+
+async function serializeCacheResult(
+  result: unknown,
+  rsc: RscModule | null,
+): Promise<SerializedCacheResult | null> {
+  try {
+    if (rsc) {
+      // Draining the stream is part of cache entry generation: lazy Server
+      // Components may execute here and contribute tags, cache life, or root
+      // param dependencies to the active cache scope.
+      const stream = rsc.renderToReadableStream(result);
+      const bytes = await collectStream(stream);
+      return {
+        body: uint8ToBase64(bytes),
+        headers: { [VINEXT_RSC_MARKER_HEADER]: "1" },
+      };
+    }
+
+    const body = JSON.stringify(result);
+    return body === undefined ? null : { body, headers: {} };
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -704,10 +733,11 @@ export function registerCachedFunction<TArgs extends unknown[], TResult>(
       }
 
       // Cache miss (or stale) — execute with context
-      const { result, ctx, effectiveLife } = await runCachedFunctionWithContext(
+      const { result, ctx, effectiveLife, collectedResult } = await runCachedFunctionWithContext(
         fn,
         callArgs,
         cacheVariant,
+        (value) => serializeCacheResult(value, rsc),
       );
 
       const rootParamNames =
@@ -724,77 +754,63 @@ export function registerCachedFunction<TArgs extends unknown[], TResult>(
       const revalidateSeconds =
         effectiveLife.revalidate ?? cacheLifeProfiles.default.revalidate ?? 900;
 
-      // Store in cache — use RSC stream serialization when available (handles
-      // React elements, client refs, Promises, etc.), JSON otherwise.
-      try {
-        let body: string;
-        const headers: Record<string, string> = {};
-
-        if (rsc) {
-          // RSC serialization: result → stream → bytes → base64.
-          // No temporaryReferences — cached values must be self-contained
-          // since they're persisted across requests.
-          const stream = rsc.renderToReadableStream(result);
-          const bytes = await collectStream(stream);
-          body = uint8ToBase64(bytes);
-          headers[VINEXT_RSC_MARKER_HEADER] = "1";
-        } else {
-          // JSON fallback
-          body = JSON.stringify(result);
-          if (body === undefined) return result;
-        }
-
-        const cacheValue = {
-          kind: "FETCH",
-          data: {
-            headers,
-            body,
-            url: cacheKey,
-          },
-          tags: ctx.tags,
-          revalidate: revalidateSeconds,
-        } satisfies CachedFetchValue;
-        const cacheContext = {
-          fetchCache: true,
-          tags: ctx.tags,
-          cacheControl: {
-            revalidate: revalidateSeconds,
-            expire: effectiveLife.expire,
-            // Persisted so a later hit re-registers the same claim; otherwise
-            // the enclosing render's minimum depends on cache temperature.
-            stale: effectiveLife.stale,
-          },
-        };
-
-        if (rootParamNames && rootParamNames.size > 0 && rootParams) {
-          const specificCacheKey =
-            coarseCacheKey + computeRootParamsCacheKeySuffix(rootParams, rootParamNames);
-          cacheValue.data.url = specificCacheKey;
-          await handler.set(specificCacheKey, cacheValue, cacheContext);
-
-          const redirectTags = [
-            ...ctx.tags,
-            ...[...rootParamNames].map((name) => ROOT_PARAM_TAG_PREFIX + name),
-          ];
-          await handler.set(
-            coarseCacheKey,
-            {
-              kind: "FETCH",
-              data: {
-                headers: { [ROOT_PARAM_REDIRECT_HEADER]: "1" },
-                body: "",
-                url: coarseCacheKey,
-              },
-              tags: redirectTags,
-              revalidate: revalidateSeconds,
+      // Serialization ran while the cache ALS was active so lazy Server
+      // Component work is reflected in `ctx` before selecting the final key.
+      if (collectedResult) {
+        try {
+          const cacheValue = {
+            kind: "FETCH",
+            data: {
+              headers: collectedResult.headers,
+              body: collectedResult.body,
+              url: cacheKey,
             },
-            { ...cacheContext, tags: redirectTags },
-          );
-        } else {
-          await handler.set(cacheKey, cacheValue, cacheContext);
+            tags: ctx.tags,
+            revalidate: revalidateSeconds,
+          } satisfies CachedFetchValue;
+          const cacheContext = {
+            fetchCache: true,
+            tags: ctx.tags,
+            cacheControl: {
+              revalidate: revalidateSeconds,
+              expire: effectiveLife.expire,
+              // Persisted so a later hit re-registers the same claim; otherwise
+              // the enclosing render's minimum depends on cache temperature.
+              stale: effectiveLife.stale,
+            },
+          };
+
+          if (rootParamNames && rootParamNames.size > 0 && rootParams) {
+            const specificCacheKey =
+              coarseCacheKey + computeRootParamsCacheKeySuffix(rootParams, rootParamNames);
+            const redirectTags = [
+              ...ctx.tags,
+              ...[...rootParamNames].map((name) => ROOT_PARAM_TAG_PREFIX + name),
+            ];
+            await handler.set(
+              coarseCacheKey,
+              {
+                kind: "FETCH",
+                data: {
+                  headers: { [ROOT_PARAM_REDIRECT_HEADER]: "1" },
+                  body: "",
+                  url: coarseCacheKey,
+                },
+                tags: redirectTags,
+                revalidate: revalidateSeconds,
+              },
+              { ...cacheContext, tags: redirectTags },
+            );
+            // Write the useful entry last. A bounded LRU that can retain only
+            // one of the pair must keep the specific value, not the redirect.
+            cacheValue.data.url = specificCacheKey;
+            await handler.set(specificCacheKey, cacheValue, cacheContext);
+          } else {
+            await handler.set(cacheKey, cacheValue, cacheContext);
+          }
+        } catch {
+          // A handler failure skips caching but must not fail the render.
         }
-      } catch {
-        // Result not serializable — skip caching, still return the result
       }
 
       return result;
@@ -957,19 +973,24 @@ async function executeWithContext<T extends (...args: any[]) => Promise<any>>(
  * inner-vs-outer recording does not affect correctness — the final request
  * stale/revalidate/expire is the min across all caches encountered.
  */
-type CachedFunctionResult<T> = {
+type CachedFunctionResult<T, TCollected> = {
   result: T;
   ctx: CacheContext;
   effectiveLife: CacheLifeConfig;
+  collectedResult: TCollected | undefined;
 };
 
-// oxlint-disable-next-line @typescript-eslint/no-explicit-any
-async function runCachedFunctionWithContext<T extends (...args: any[]) => Promise<any>>(
+async function runCachedFunctionWithContext<
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+  T extends (...args: any[]) => Promise<any>,
+  TCollected = never,
+>(
   fn: T,
   // oxlint-disable-next-line @typescript-eslint/no-explicit-any
   args: any[],
   variant: string,
-): Promise<CachedFunctionResult<Awaited<ReturnType<T>>>> {
+  collectResult?: (result: Awaited<ReturnType<T>>, context: CacheContext) => Promise<TCollected>,
+): Promise<CachedFunctionResult<Awaited<ReturnType<T>>, TCollected>> {
   const parentCtx = cacheContextStorage.getStore();
 
   // Eagerly capture an error at the call site if we're inside a public cache.
@@ -1009,7 +1030,14 @@ async function runCachedFunctionWithContext<T extends (...args: any[]) => Promis
     invalidDynamicUsageError: undefined,
   };
 
-  const result = await cacheContextStorage.run(ctx, () => fn(...args));
+  let collectedResult: TCollected | undefined;
+  const result = await cacheContextStorage.run(ctx, async () => {
+    const value = await fn(...args);
+    if (collectResult) {
+      collectedResult = await collectResult(value, ctx);
+    }
+    return value;
+  });
 
   if (ctx.invalidDynamicUsageError) {
     throw ctx.invalidDynamicUsageError;
@@ -1155,7 +1183,7 @@ async function runCachedFunctionWithContext<T extends (...args: any[]) => Promis
     }
   }
 
-  return { result, ctx, effectiveLife };
+  return { result, ctx, effectiveLife, collectedResult };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/vinext/src/shims/root-params.ts
+++ b/packages/vinext/src/shims/root-params.ts
@@ -1,4 +1,5 @@
 import { getOrCreateAls } from "./internal/als-registry.js";
+import { _recordUseCacheRootParamRead } from "./cache-request-state.js";
 import {
   getRequestContext,
   isInsideUnifiedScope,
@@ -71,7 +72,13 @@ export function getRootParam(name: string): Promise<string | string[] | undefine
       `Route ${usage.routePattern} used \`import('next/root-params').${name}()\` inside a Route Handler. Support for this API in Route Handlers is planned for a future version of Next.js.`,
     );
   }
+  _recordUseCacheRootParamRead(name);
   return Promise.resolve(getState().rootParams?.[name]);
+}
+
+/** @internal Current route root params for `"use cache"` key derivation. */
+export function getCurrentRootParams(): RootParams | null {
+  return getState().rootParams;
 }
 
 export function runWithRootParamsUsage<T>(

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -6690,6 +6690,82 @@ describe('"use cache" runtime', () => {
     expect(callCount).toBe(2);
   });
 
+  // Ported from Next.js: test/e2e/app-dir/app-root-params-getters/use-cache.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app-root-params-getters/use-cache.test.ts
+  it("varies shared cache entries by root params read by the cached function", async () => {
+    const { registerCachedFunction } =
+      await import("../packages/vinext/src/shims/cache-runtime.js");
+    const { setCacheHandler, MemoryCacheHandler } =
+      await import("../packages/vinext/src/shims/cache.js");
+    const { getRootParam, runWithRootParamsScope } =
+      await import("../packages/vinext/src/shims/root-params.js");
+    setCacheHandler(new MemoryCacheHandler());
+
+    let callCount = 0;
+    const cached = registerCachedFunction(async () => {
+      callCount++;
+      return {
+        lang: await getRootParam("lang"),
+        countryCode: await getRootParam("countryCode"),
+        callCount,
+      };
+    }, "test:root-param-key");
+    const invoke = (lang: string, countryCode: string) =>
+      runWithRootParamsScope({ lang, countryCode }, () => cached());
+
+    await expect(invoke("en", "us")).resolves.toEqual({
+      lang: "en",
+      countryCode: "us",
+      callCount: 1,
+    });
+    await expect(invoke("fr", "ca")).resolves.toEqual({
+      lang: "fr",
+      countryCode: "ca",
+      callCount: 2,
+    });
+
+    // A fresh isolate has no in-memory dependency map. The coarse redirect
+    // entry must recover the param names from the shared handler.
+    const knownRootParams = Reflect.get(
+      globalThis,
+      Symbol.for("vinext.cacheRuntime.knownRootParamsByFunctionId"),
+    ) as Map<string, Set<string>>;
+    knownRootParams.clear();
+
+    await expect(invoke("en", "us")).resolves.toEqual({
+      lang: "en",
+      countryCode: "us",
+      callCount: 1,
+    });
+    expect(callCount).toBe(2);
+  });
+
+  it("propagates nested cache root-param reads into the outer cache key", async () => {
+    const { registerCachedFunction } =
+      await import("../packages/vinext/src/shims/cache-runtime.js");
+    const { setCacheHandler, MemoryCacheHandler } =
+      await import("../packages/vinext/src/shims/cache.js");
+    const { getRootParam, runWithRootParamsScope } =
+      await import("../packages/vinext/src/shims/root-params.js");
+    setCacheHandler(new MemoryCacheHandler());
+
+    let outerCalls = 0;
+    const inner = registerCachedFunction(
+      async () => ({ countryCode: await getRootParam("countryCode") }),
+      "test:nested-root-param-inner",
+    );
+    const outer = registerCachedFunction(async () => {
+      outerCalls++;
+      return { ...(await inner()), outerCalls };
+    }, "test:nested-root-param-outer");
+    const invoke = (countryCode: string) => runWithRootParamsScope({ countryCode }, () => outer());
+
+    await expect(invoke("us")).resolves.toEqual({ countryCode: "us", outerCalls: 1 });
+    await expect(invoke("gb")).resolves.toEqual({ countryCode: "gb", outerCalls: 2 });
+    await expect(invoke("us")).resolves.toEqual({ countryCode: "us", outerCalls: 1 });
+    expect(outerCalls).toBe(2);
+  });
+
   // Ported from Next.js: test/e2e/app-dir/use-cache/use-cache.test.ts
   // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/use-cache/use-cache.test.ts
   it("bypasses the shared cache in draft mode", async () => {

--- a/tests/use-cache-root-params.test.ts
+++ b/tests/use-cache-root-params.test.ts
@@ -1,0 +1,123 @@
+import { createElement } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@vitejs/plugin-rsc/react/rsc", () => {
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+
+  async function materialize(value: unknown): Promise<unknown> {
+    if (Array.isArray(value)) return Promise.all(value.map(materialize));
+    if (!value || typeof value !== "object") return value;
+
+    const element = value as {
+      type?: string | ((props: Record<string, unknown>) => unknown);
+      props?: Record<string, unknown>;
+    };
+    if (typeof element.type === "function") {
+      return materialize(await element.type(element.props ?? {}));
+    }
+    if (typeof element.type === "string") {
+      return {
+        type: element.type,
+        children: await materialize(element.props?.children),
+      };
+    }
+    return value;
+  }
+
+  async function readStream(stream: ReadableStream<Uint8Array>): Promise<string> {
+    const reader = stream.getReader();
+    const chunks: Uint8Array[] = [];
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+    }
+    const length = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+    const bytes = new Uint8Array(length);
+    let offset = 0;
+    for (const chunk of chunks) {
+      bytes.set(chunk, offset);
+      offset += chunk.length;
+    }
+    return decoder.decode(bytes);
+  }
+
+  return {
+    createClientTemporaryReferenceSet: () => ({}),
+    createTemporaryReferenceSet: () => ({}),
+    decodeReply: async (body: string) => JSON.parse(body),
+    encodeReply: async (value: unknown) => JSON.stringify(value),
+    renderToReadableStream: (value: unknown) =>
+      new ReadableStream<Uint8Array>({
+        async start(controller) {
+          controller.enqueue(encoder.encode(JSON.stringify(await materialize(value))));
+          controller.close();
+        },
+      }),
+    createFromReadableStream: async (stream: ReadableStream<Uint8Array>) =>
+      JSON.parse(await readStream(stream)),
+  };
+});
+
+describe('"use cache" root-param entry generation', () => {
+  beforeEach(async () => {
+    const { setCacheHandler, MemoryCacheHandler } =
+      await import("../packages/vinext/src/shims/cache.js");
+    setCacheHandler(new MemoryCacheHandler());
+    const knownRootParams = Reflect.get(
+      globalThis,
+      Symbol.for("vinext.cacheRuntime.knownRootParamsByFunctionId"),
+    ) as Map<string, Set<string>> | undefined;
+    knownRootParams?.clear();
+  });
+
+  // Ported from Next.js: test/e2e/app-dir/app-root-params-getters/use-cache.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app-root-params-getters/use-cache.test.ts
+  it("tracks root params read by a returned lazy Server Component", async () => {
+    const { registerCachedFunction } =
+      await import("../packages/vinext/src/shims/cache-runtime.js");
+    const { getRootParam, runWithRootParamsScope } =
+      await import("../packages/vinext/src/shims/root-params.js");
+
+    async function LazyChild() {
+      return createElement("span", null, await getRootParam("lang"));
+    }
+
+    let calls = 0;
+    const cached = registerCachedFunction(async () => {
+      calls++;
+      return createElement(LazyChild);
+    }, "test:lazy-root-param-child");
+    const invoke = (lang: string) => runWithRootParamsScope({ lang }, () => cached());
+
+    await invoke("en");
+    await invoke("fr");
+    expect(calls).toBe(2);
+
+    await expect(invoke("en")).resolves.toEqual({ type: "span", children: "en" });
+    await expect(invoke("fr")).resolves.toEqual({ type: "span", children: "fr" });
+    expect(calls).toBe(2);
+  });
+
+  it("retains the specific entry when the handler can hold only one entry", async () => {
+    const { registerCachedFunction } =
+      await import("../packages/vinext/src/shims/cache-runtime.js");
+    const { setCacheHandler, MemoryCacheHandler } =
+      await import("../packages/vinext/src/shims/cache.js");
+    const { getRootParam, runWithRootParamsScope } =
+      await import("../packages/vinext/src/shims/root-params.js");
+    setCacheHandler(new MemoryCacheHandler({ cacheMaxMemorySize: 300 }));
+
+    let calls = 0;
+    const cached = registerCachedFunction(async () => {
+      calls++;
+      return getRootParam("lang");
+    }, "test:bounded-root-param-cache");
+    const invoke = () => runWithRootParamsScope({ lang: "en" }, () => cached());
+
+    await expect(invoke()).resolves.toBe("en");
+    await expect(invoke()).resolves.toBe("en");
+    expect(calls).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- track the root params read while producing shared `"use cache"` entries and include their values in the persistent cache key
- persist a coarse-key redirect so cold isolates can recover the root-param dependency set
- propagate root-param dependencies through nested cache scopes and cache hits
- collect lazy RSC output while the cache ALS is active so lazy Server Components contribute dependencies, tags, and cache life before final key selection
- write the specific entry after the redirect so bounded LRU handlers retain the useful cached value

## Next.js targeted E2E

`test/e2e/app-dir/app-root-params-getters/use-cache.test.ts`

- baseline: **5 passed / 3 failed**
- final exact head: **8 passed / 0 failed**

This covers separate entries across roots, resume-data consistency, conditional root-param reads, reads introduced after revalidation, private cache behavior, and build-time use.

## Additional validation

- `vp test run tests/use-cache-root-params.test.ts tests/root-params.test.ts tests/shims.test.ts -t "root param|root-param|retains the specific entry"` — 15 passed
- focused `vp check` for all changed source and test files — passed
- independent exact-head review — no findings

The review regressions specifically exercise lazy Server Component serialization inside the cache context and a handler constrained to retain one entry.