### PR TITLE
fix(app-router): preserve full prefetch stale windows

### DIFF
--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -495,9 +495,9 @@ function resolvePrefetchedRscResponseExpiresAt(
   // Next's runtime-prefetch stale time comes from the completed cacheLife
   // claim. `staleTimes.dynamic` independently bounds visited/BFCache reuse and
   // is only the prefetch fallback when the render made no cacheLife claim.
-  // A full prefetch uses the static window while a provisional cacheLife
-  // claim is unresolved. If the render completes with a real cacheLife value,
-  // completion metadata replaces this marker with a resolved bound below.
+  // A full prefetch uses the static window while a provisional cacheLife claim
+  // is unresolved. If the render completes with a real cacheLife or dynamic
+  // bound, completion metadata replaces the provisional marker below.
   const serverSeconds =
     cached.serverStaleTime?.kind === "pending" && !honorDynamicStaleTime
       ? undefined
@@ -516,12 +516,15 @@ function resolvePrefetchedRscResponseExpiresAt(
   // An automatic prefetch takes a dynamic render's bound verbatim, including
   // below the 30s floor: Next's `computeDynamicStaleAt` never floors it, so a
   // `0` must expire the entry now rather than license 30s of credentialed
-  // reuse. `prefetch={true}` uses Next's Full fetch strategy, whose dynamic
-  // payloads remain reusable for STATIC_STALETIME_MS. The configured static
-  // fallback therefore replaces (rather than merely floors) the dynamic bound.
+  // reuse. `prefetch={true}` uses Next's Full fetch strategy, so a config
+  // dynamic bound of zero selects STATIC_STALETIME_MS. Nonzero completed
+  // dynamic bounds keep their existing per-page expiry.
   return honorDynamicStaleTime
     ? timestamp + seconds * 1000
-    : timestamp + Math.max(fallbackTtlMs, MIN_PREFETCH_STALE_TIME_MS);
+    : timestamp +
+        (seconds === 0
+          ? Math.max(fallbackTtlMs, MIN_PREFETCH_STALE_TIME_MS)
+          : Math.max(seconds * 1000, MIN_PREFETCH_STALE_TIME_MS));
 }
 
 function resolvePrefetchCacheEntryExpiresAt(entry: PrefetchCacheEntry): number {

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -495,7 +495,13 @@ function resolvePrefetchedRscResponseExpiresAt(
   // Next's runtime-prefetch stale time comes from the completed cacheLife
   // claim. `staleTimes.dynamic` independently bounds visited/BFCache reuse and
   // is only the prefetch fallback when the render made no cacheLife claim.
-  const serverSeconds = serverStaleTimeSeconds(cached.serverStaleTime);
+  // A full prefetch uses the static window while a provisional cacheLife
+  // claim is unresolved. If the render completes with a real cacheLife value,
+  // completion metadata replaces this marker with a resolved bound below.
+  const serverSeconds =
+    cached.serverStaleTime?.kind === "pending" && !honorDynamicStaleTime
+      ? undefined
+      : serverStaleTimeSeconds(cached.serverStaleTime);
   if (serverSeconds !== undefined) {
     return timestamp + serverSeconds * 1000;
   }
@@ -510,12 +516,12 @@ function resolvePrefetchedRscResponseExpiresAt(
   // An automatic prefetch takes a dynamic render's bound verbatim, including
   // below the 30s floor: Next's `computeDynamicStaleAt` never floors it, so a
   // `0` must expire the entry now rather than license 30s of credentialed
-  // reuse. `prefetch={true}` is an explicit opt-in to caching dynamic content,
-  // and Next reuses a `full` prefetch for the floored static window, so it
-  // keeps the floor.
+  // reuse. `prefetch={true}` uses Next's Full fetch strategy, whose dynamic
+  // payloads remain reusable for STATIC_STALETIME_MS. The configured static
+  // fallback therefore replaces (rather than merely floors) the dynamic bound.
   return honorDynamicStaleTime
     ? timestamp + seconds * 1000
-    : timestamp + Math.max(seconds * 1000, MIN_PREFETCH_STALE_TIME_MS);
+    : timestamp + Math.max(fallbackTtlMs, MIN_PREFETCH_STALE_TIME_MS);
 }
 
 function resolvePrefetchCacheEntryExpiresAt(entry: PrefetchCacheEntry): number {

--- a/tests/e2e/app-router/nextjs-compat/client-cache.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/client-cache.spec.ts
@@ -268,6 +268,52 @@ test.describe("Next.js compat: client cache", () => {
     expect(requestsFor(requests, `${ROOT}/0`)).toEqual([]);
   });
 
+  test("prefetch=true with search params reuses a zero-dynamic-stale page", async ({ page }) => {
+    // Ported from Next.js:
+    // test/e2e/app-dir/app-client-cache/client-cache.experimental.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app-client-cache/client-cache.experimental.test.ts
+    const home = "/nextjs-compat/client-cache-search";
+    const target = `${home}/0`;
+    const requests = trackRscRequests(page);
+    await page.goto(home);
+    await waitForAppRouterHydration(page);
+    await expect(page.locator("#client-cache-search-home")).toBeVisible();
+    await expect
+      .poll(() => requestsFor(requests, target).some((request) => !request.partial))
+      .toBe(true);
+
+    requests.length = 0;
+    await page.click(`a[href="${target}?timeout=0"]`);
+    await expect(page.locator("#client-cache-search-id")).toHaveText("0");
+    const initial = await page.locator("#client-cache-search-random").innerText();
+    expect(requestsFor(requests, target)).toEqual([]);
+
+    await page.click(`a[href="${home}"]`);
+    await expect(page.locator("#client-cache-search-home")).toBeVisible();
+    requests.length = 0;
+    await page.click(`a[href="${target}?timeout=0"]`);
+    await expect(page.locator("#client-cache-search-id")).toHaveText("0");
+    expect(await page.locator("#client-cache-search-random").innerText()).toBe(initial);
+    expect(requestsFor(requests, target)).toEqual([]);
+
+    await page.click(`a[href="${home}"]`);
+    await expect(page.locator("#client-cache-search-home")).toBeVisible();
+    await advanceTime(page, 30_000);
+    requests.length = 0;
+    await page.click(`a[href="${target}?timeout=0"]`);
+    await expect(page.locator("#client-cache-search-id")).toHaveText("0");
+    expect(await page.locator("#client-cache-search-random").innerText()).toBe(initial);
+    expect(requestsFor(requests, target)).toEqual([]);
+
+    await page.click(`a[href="${home}"]`);
+    await expect(page.locator("#client-cache-search-home")).toBeVisible();
+    await advanceTime(page, 270_000);
+    requests.length = 0;
+    await page.click(`a[href="${target}?timeout=0"]`);
+    await expect(page.locator("#client-cache-search-id")).toHaveText("0");
+    expect(await page.locator("#client-cache-search-random").innerText()).not.toBe(initial);
+  });
+
   test("parallel-slot page state resets between dynamic siblings", async ({ page }) => {
     await openHome(page);
     await navigateTo(page, "#client-cache-full", "0");

--- a/tests/fixtures/app-basic/app/nextjs-compat/client-cache-search/[id]/loading.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/client-cache-search/[id]/loading.tsx
@@ -1,0 +1,3 @@
+export default function ClientCacheSearchLoading() {
+  return <div id="client-cache-search-loading">Loading</div>;
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/client-cache-search/[id]/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/client-cache-search/[id]/page.tsx
@@ -1,0 +1,20 @@
+import Link from "next/link";
+
+export default async function ClientCacheSearchTarget({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<{ timeout?: string }>;
+}) {
+  const [{ id }, { timeout }] = await Promise.all([params, searchParams]);
+  await new Promise((resolve) => setTimeout(resolve, Number.parseInt(timeout ?? "0", 10)));
+
+  return (
+    <main>
+      <Link href="/nextjs-compat/client-cache-search">Back to client cache search home</Link>
+      <div id="client-cache-search-id">{id}</div>
+      <div id="client-cache-search-random">{Math.random()}</div>
+    </main>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/client-cache-search/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/client-cache-search/page.tsx
@@ -1,0 +1,15 @@
+import Link from "next/link";
+
+export default function ClientCacheSearchHome() {
+  return (
+    <main>
+      <h1 id="client-cache-search-home">Client cache search home</h1>
+      <Link href="/nextjs-compat/client-cache-search/0?timeout=0" prefetch={true}>
+        Full prefetch with search params
+      </Link>
+      <Link href="/nextjs-compat/client-cache-search/0?timeout=1000" prefetch={true}>
+        Slow full prefetch with search params
+      </Link>
+    </main>
+  );
+}

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -1367,7 +1367,6 @@ describe("prefetch cache eviction", () => {
         new Response("flight", {
           headers: {
             "content-type": "text/x-component",
-            [VINEXT_DYNAMIC_STALE_TIME_HEADER]: "0",
             [VINEXT_STALE_TIME_PENDING_HEADER]: "1",
           },
         }),
@@ -1380,6 +1379,31 @@ describe("prefetch cache eviction", () => {
     await getPrefetchCache().get(rscUrl)?.pending;
 
     expect(getPrefetchCache().get(rscUrl)?.expiresAt).toBe(now + staticStaleTimeMs);
+  });
+
+  it("keeps a nonzero completed dynamic bound for an explicit full prefetch", async () => {
+    const now = 1_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const rscUrl = "/full-prefetch-dynamic-override.rsc";
+
+    prefetchRscResponse(
+      rscUrl,
+      Promise.resolve(
+        new Response("flight", {
+          headers: {
+            "content-type": "text/x-component",
+            [VINEXT_DYNAMIC_STALE_TIME_HEADER]: "60",
+          },
+        }),
+      ),
+      null,
+      null,
+      undefined,
+      { fallbackTtlMs: 300_000, honorDynamicStaleTime: false },
+    );
+    await getPrefetchCache().get(rscUrl)?.pending;
+
+    expect(getPrefetchCache().get(rscUrl)?.expiresAt).toBe(now + 60_000);
   });
 
   it("uses completed cacheLife for prefetch expiry without changing the dynamic BFCache bound", async () => {

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -1349,7 +1349,7 @@ describe("prefetch cache eviction", () => {
     expect(consumePrefetchResponse(rscUrl, null, null)).toBeNull();
   });
 
-  it("keeps the prefetch floor for an explicit full prefetch of dynamic content", async () => {
+  it("keeps the configured static window for an explicit full prefetch of dynamic content", async () => {
     // Ported from Next.js:
     // test/e2e/app-dir/segment-cache/metadata/segment-cache-metadata.test.ts
     // "Because the link is prefetched with prefetch={true}, we should be able
@@ -1360,6 +1360,7 @@ describe("prefetch cache eviction", () => {
     vi.spyOn(Date, "now").mockReturnValue(now);
     const rscUrl = "/full-prefetch-dynamic.rsc";
 
+    const staticStaleTimeMs = 180_000;
     prefetchRscResponse(
       rscUrl,
       Promise.resolve(
@@ -1367,17 +1368,18 @@ describe("prefetch cache eviction", () => {
           headers: {
             "content-type": "text/x-component",
             [VINEXT_DYNAMIC_STALE_TIME_HEADER]: "0",
+            [VINEXT_STALE_TIME_PENDING_HEADER]: "1",
           },
         }),
       ),
       null,
       null,
       undefined,
-      { fallbackTtlMs: PREFETCH_CACHE_TTL, honorDynamicStaleTime: false },
+      { fallbackTtlMs: staticStaleTimeMs, honorDynamicStaleTime: false },
     );
     await getPrefetchCache().get(rscUrl)?.pending;
 
-    expect(getPrefetchCache().get(rscUrl)?.expiresAt).toBe(now + 30_000);
+    expect(getPrefetchCache().get(rscUrl)?.expiresAt).toBe(now + staticStaleTimeMs);
   });
 
   it("uses completed cacheLife for prefetch expiry without changing the dynamic BFCache bound", async () => {


### PR DESCRIPTION
## Summary

- keep explicit `prefetch={true}` payloads reusable for the configured static stale window while a cacheLife claim is still provisional
- continue honoring completed cacheLife bounds and automatic-prefetch dynamic stale times, including a late-dynamic case caught by CI and corrected before the final head
- add a production client-cache regression covering search params, dynamic stale time zero, 30-second reuse, and 5-minute expiry

Failure source: [Next.js Deploy Suite run 31290819291](https://github.com/cloudflare/vinext/actions/runs/31290819291), `test/e2e/app-dir/app-client-cache/client-cache.experimental.test.ts`.

## Validation

- targeted Next.js E2E baseline on current main: 6 passed / 2 failed / 1 skipped
- targeted Next.js E2E at this head: 8 passed / 0 failed / 1 skipped
- `pnpm exec playwright test --project=app-router-client-cache tests/e2e/app-router/nextjs-compat/client-cache.spec.ts -g "prefetch=true with search params"` — 1 passed
- `vp test run tests/prefetch-cache.test.ts` — 72 passed
- scoped `vp check` — clean
- independent review of commit `6b550c3ec`: no findings
