### PR TITLE
fix(app-router): prefetch root-param segment trees

### DIFF
--- a/packages/vinext/src/client/vinext-next-data.ts
+++ b/packages/vinext/src/client/vinext-next-data.ts
@@ -14,6 +14,12 @@ export type VinextLinkPrefetchRoute = {
   isDynamic: boolean;
   patternParts: string[];
   requiresDynamicNavigationRequest?: boolean;
+  /**
+   * Root-layout params must be hydrated from the concrete pathname before the
+   * client derives segment request keys. Start these automatic prefetches with
+   * the route tree even when generic prefetch inlining is disabled.
+   */
+  requiresRouteTreePrefetch?: true;
 };
 
 /**

--- a/packages/vinext/src/client/vinext-next-data.ts
+++ b/packages/vinext/src/client/vinext-next-data.ts
@@ -14,12 +14,8 @@ export type VinextLinkPrefetchRoute = {
   isDynamic: boolean;
   patternParts: string[];
   requiresDynamicNavigationRequest?: boolean;
-  /**
-   * Root-layout params must be hydrated from the concrete pathname before the
-   * client derives segment request keys. Start these automatic prefetches with
-   * the route tree even when generic prefetch inlining is disabled.
-   */
-  requiresRouteTreePrefetch?: true;
+  /** The route has dynamic params above its root layout. */
+  hasRootParams?: true;
 };
 
 /**

--- a/packages/vinext/src/entries/app-browser-entry.ts
+++ b/packages/vinext/src/entries/app-browser-entry.ts
@@ -118,7 +118,7 @@ export function toLinkPrefetchRoute(
     patternParts: [...route.patternParts],
     isDynamic: route.isDynamic,
     ...(requiresDynamicNavigationRequest(route) ? { requiresDynamicNavigationRequest: true } : {}),
-    ...((route.rootParamNames?.length ?? 0) > 0 ? { requiresRouteTreePrefetch: true } : {}),
+    ...((route.rootParamNames?.length ?? 0) > 0 ? { hasRootParams: true } : {}),
   };
 }
 

--- a/packages/vinext/src/entries/app-browser-entry.ts
+++ b/packages/vinext/src/entries/app-browser-entry.ts
@@ -118,6 +118,7 @@ export function toLinkPrefetchRoute(
     patternParts: [...route.patternParts],
     isDynamic: route.isDynamic,
     ...(requiresDynamicNavigationRequest(route) ? { requiresDynamicNavigationRequest: true } : {}),
+    ...((route.rootParamNames?.length ?? 0) > 0 ? { requiresRouteTreePrefetch: true } : {}),
   };
 }
 

--- a/packages/vinext/src/shims/internal/app-route-prefetch-policy.ts
+++ b/packages/vinext/src/shims/internal/app-route-prefetch-policy.ts
@@ -90,7 +90,8 @@ export function resolveAutoAppRoutePrefetch(href: string): AppRoutePrefetchPolic
   if (!match) return NO_APP_ROUTE_PREFETCH;
 
   const route = match.route;
-  const requiresRouteTreePrefetch = route.requiresRouteTreePrefetch === true;
+  const requiresRouteTreePrefetch =
+    String(process.env.__NEXT_CACHE_COMPONENTS) === "true" && route.hasRootParams === true;
   // A search-param href renders query-specific output, so its payload can only
   // ever be a shell — never reusable by a navigation to the same route.
   const hasSearchParams = new URL(routeHref, "http://vinext.local").search !== "";

--- a/packages/vinext/src/shims/internal/app-route-prefetch-policy.ts
+++ b/packages/vinext/src/shims/internal/app-route-prefetch-policy.ts
@@ -44,6 +44,8 @@ export type AppRoutePrefetchPolicy = {
    */
   honorDynamicStaleTime: boolean;
   prefetchShellFirst: boolean;
+  /** Fetch the route tree before the concrete page segment. */
+  requiresRouteTreePrefetch?: true;
   shouldPrefetch: boolean;
 };
 
@@ -88,6 +90,7 @@ export function resolveAutoAppRoutePrefetch(href: string): AppRoutePrefetchPolic
   if (!match) return NO_APP_ROUTE_PREFETCH;
 
   const route = match.route;
+  const requiresRouteTreePrefetch = route.requiresRouteTreePrefetch === true;
   // A search-param href renders query-specific output, so its payload can only
   // ever be a shell — never reusable by a navigation to the same route.
   const hasSearchParams = new URL(routeHref, "http://vinext.local").search !== "";
@@ -99,11 +102,12 @@ export function resolveAutoAppRoutePrefetch(href: string): AppRoutePrefetchPolic
     // branches must be derived from the click-time target tree.
     cacheForNavigation:
       !hasSearchParams &&
-      !route.canPrefetchLoadingShell &&
-      route.requiresDynamicNavigationRequest !== true,
+      (requiresRouteTreePrefetch ||
+        (!route.canPrefetchLoadingShell && route.requiresDynamicNavigationRequest !== true)),
     fallbackTtl: "static",
     honorDynamicStaleTime: true,
-    prefetchShellFirst: hasSearchParams || !route.isDynamic,
+    prefetchShellFirst: requiresRouteTreePrefetch || hasSearchParams || !route.isDynamic,
+    ...(requiresRouteTreePrefetch ? { requiresRouteTreePrefetch: true } : {}),
     shouldPrefetch: true,
   };
 }

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -441,6 +441,7 @@ function prefetchUrl(
         const {
           getPrefetchInterceptionContext,
           getPrefetchCache,
+          getFreshPrefetchCacheEntry,
           getPrefetchedUrls,
           getMountedSlotsHeader,
           createAppPrefetchRequestHeaders,
@@ -686,8 +687,7 @@ function prefetchUrl(
                   shellRscUrl,
                   interceptionContext,
                 );
-                const shellCache = getPrefetchCache();
-                let shellEntry = shellCache.get(shellCacheKey);
+                let shellEntry = getFreshPrefetchCacheEntry(shellCacheKey);
                 if (shellEntry === undefined) {
                   getPrefetchedUrls().add(shellCacheKey);
                   prefetchRscResponse(
@@ -713,9 +713,10 @@ function prefetchUrl(
                       prefetchKind: "route-tree",
                     },
                   );
-                  shellEntry = shellCache.get(shellCacheKey);
+                  shellEntry = getFreshPrefetchCacheEntry(shellCacheKey);
                 }
                 await shellEntry?.pending?.catch(() => {});
+                shellEntry = getFreshPrefetchCacheEntry(shellCacheKey);
                 const renderedPathAndSearch = shellEntry?.snapshot?.renderedPathAndSearch;
                 if (renderedPathAndSearch) {
                   const renderedRscUrl = await createRscRequestUrl(renderedPathAndSearch, headers);

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -441,18 +441,16 @@ function prefetchUrl(
         const {
           getPrefetchInterceptionContext,
           getPrefetchCache,
-          getFreshPrefetchCacheEntry,
           getPrefetchedUrls,
           getMountedSlotsHeader,
           createAppPrefetchRequestHeaders,
           discardLearningOnlyPrefetchCacheEntry,
+          fetchRouteTreeGatedPrefetch,
           hasSearchAgnosticPrefetchShellForRoute,
           hasPrefetchCacheEntryForNavigation,
-          peekPrefetchResponseForNavigation,
           prefetchRscResponse,
           prepareNavigationPrefetchSnapshot,
           DYNAMIC_NAVIGATION_CACHE_TTL,
-          restoreRscResponse,
           PREFETCH_CACHE_TTL,
         } = navigation;
         const { createRscRequestUrl } = rscCacheBusting;
@@ -672,30 +670,13 @@ function prefetchUrl(
                   await fetchLoadingShellForReuse();
                   return fetchFullRscPayload();
                 }
-                const shellHeaders = createAppPrefetchRequestHeaders({
-                  interceptionContext,
-                  fetchPriority: priority,
-                  renderMode: undefined,
-                });
-                shellHeaders.set(NEXT_ROUTER_PREFETCH_HEADER, "1");
-                shellHeaders.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "/_tree");
-                if (mountedSlotsHeader) {
-                  shellHeaders.set(VINEXT_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
-                }
-                const shellRscUrl = await createRscRequestUrl(fullHref, shellHeaders);
-                const shellCacheKey = AppElementsWire.encodeCacheKey(
-                  shellRscUrl,
-                  interceptionContext,
-                );
-                let shellEntry = getFreshPrefetchCacheEntry(shellCacheKey);
-                if (shellEntry === undefined) {
-                  getPrefetchedUrls().add(shellCacheKey);
-                  prefetchRscResponse(
-                    shellRscUrl,
+                return fetchRouteTreeGatedPrefetch({
+                  fetchFullRscPayload,
+                  fetchRouteTree: (routeTreeRscUrl, routeTreeHeaders) =>
                     scheduleAppPrefetchFetch(
                       (signal) =>
-                        fetch(shellRscUrl, {
-                          headers: shellHeaders,
+                        fetch(routeTreeRscUrl, {
+                          headers: routeTreeHeaders,
                           credentials: "include",
                           priority,
                           signal,
@@ -704,43 +685,11 @@ function prefetchUrl(
                         }),
                       priority,
                     ),
-                    interceptionContext,
-                    mountedSlotsHeader,
-                    undefined,
-                    {
-                      cacheForNavigation: false,
-                      optimisticRouteShell: false,
-                      prefetchKind: "route-tree",
-                    },
-                  );
-                  shellEntry = getFreshPrefetchCacheEntry(shellCacheKey);
-                }
-                await shellEntry?.pending?.catch(() => {});
-                shellEntry = getFreshPrefetchCacheEntry(shellCacheKey);
-                const renderedPathAndSearch = shellEntry?.snapshot?.renderedPathAndSearch;
-                if (renderedPathAndSearch) {
-                  const renderedRscUrl = await createRscRequestUrl(renderedPathAndSearch, headers);
-                  const cachedRenderedResponse = peekPrefetchResponseForNavigation(
-                    renderedRscUrl,
-                    interceptionContext,
-                    mountedSlotsHeader,
-                  );
-                  if (cachedRenderedResponse) {
-                    return restoreRscResponse(cachedRenderedResponse);
-                  }
-                }
-                return scheduleAppPrefetchFetch(
-                  (signal) =>
-                    fetch(rscUrl, {
-                      headers,
-                      credentials: "include",
-                      priority,
-                      signal,
-                      // @ts-expect-error — purpose is a valid fetch option in some browsers
-                      purpose: "prefetch",
-                    }),
-                  priority,
-                );
+                  fullHref,
+                  headers,
+                  interceptionContext,
+                  mountedSlotsHeader,
+                });
               })()
             : fetchFullRscPayload();
         if (

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -512,7 +512,12 @@ function prefetchUrl(
           headers.set(VINEXT_MOUNTED_SLOTS_HEADER, mountedSlotsHeader);
         }
         const shouldSendSegmentPrefetchHeaders = isOptimisticRouteShellPrefetch || mode === "auto";
-        if (__prefetchInlining && mode === "auto" && autoPrefetch.cacheForNavigation) {
+        const requiresRouteTreePrefetch = autoPrefetch.requiresRouteTreePrefetch === true;
+        if (
+          (__prefetchInlining || requiresRouteTreePrefetch) &&
+          mode === "auto" &&
+          autoPrefetch.cacheForNavigation
+        ) {
           headers.set(NEXT_ROUTER_PREFETCH_HEADER, "1");
           headers.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "/__PAGE__");
         } else if (shouldSendSegmentPrefetchHeaders) {
@@ -648,7 +653,9 @@ function prefetchUrl(
         // timing so duplicate visible links see the full payload as already
         // pending while tests/userland can still observe the later data fetch.
         const gateViaRouteTree =
-          __prefetchInlining && mode === "auto" && autoPrefetch.prefetchShellFirst;
+          (__prefetchInlining || requiresRouteTreePrefetch) &&
+          mode === "auto" &&
+          autoPrefetch.prefetchShellFirst;
         const gateViaExplicitSearchShell =
           mode === "full" &&
           hasSearchParams &&

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -2713,6 +2713,7 @@ const _appRouter: AppRouterInstance = {
           ? resolveFullAppRoutePrefetch()
           : resolveAutoAppRoutePrefetch(rewrittenPrefetchHref ?? fullHref);
       const reusable = policy.shouldPrefetch && policy.cacheForNavigation;
+      const requiresRouteTreePrefetch = policy.requiresRouteTreePrefetch === true;
       // The call-time header snapshot defaults to AUTO/learning semantics.
       // A full reusable prefetch is the one policy that suppresses this header.
       if (reusable && kind === "full") {
@@ -2720,7 +2721,10 @@ const _appRouter: AppRouterInstance = {
       }
       if (reusable && kind === "auto") {
         headers.set(NEXT_ROUTER_PREFETCH_HEADER, "1");
-        headers.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, __prefetchInlining ? "/__PAGE__" : "1");
+        headers.set(
+          NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
+          __prefetchInlining || requiresRouteTreePrefetch ? "/__PAGE__" : "1",
+        );
       }
       // Both derive from the same headers and neither feeds the other, so the
       // rewrite variant is generated alongside rather than after.
@@ -2759,8 +2763,7 @@ const _appRouter: AppRouterInstance = {
         return;
       }
       prefetched.add(cacheKey);
-      prefetchRscResponse(
-        rscUrl,
+      const fetchFullRscPayload = () =>
         scheduleAppPrefetchFetch(
           (signal) =>
             fetch(rscUrl, {
@@ -2770,7 +2773,52 @@ const _appRouter: AppRouterInstance = {
               signal,
             }),
           "low",
-        ),
+        );
+      const fetchPromise =
+        reusable && kind === "auto" && requiresRouteTreePrefetch
+          ? (async () => {
+              const routeTreeHeaders = new Headers(headers);
+              routeTreeHeaders.set(NEXT_ROUTER_PREFETCH_HEADER, "1");
+              routeTreeHeaders.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "/_tree");
+              const routeTreeRscUrl = await createRscRequestUrl(fullHref, routeTreeHeaders);
+              const routeTreeCacheKey = AppElementsWire.encodeCacheKey(
+                routeTreeRscUrl,
+                interceptionContext,
+              );
+              const cache = getPrefetchCache();
+              let routeTreeEntry = cache.get(routeTreeCacheKey);
+              if (routeTreeEntry === undefined) {
+                prefetched.add(routeTreeCacheKey);
+                prefetchRscResponse(
+                  routeTreeRscUrl,
+                  scheduleAppPrefetchFetch(
+                    (signal) =>
+                      fetch(routeTreeRscUrl, {
+                        headers: routeTreeHeaders,
+                        credentials: "include",
+                        priority: "low" as RequestInit["priority"],
+                        signal,
+                      }),
+                    "low",
+                  ),
+                  interceptionContext,
+                  mountedSlotsHeader,
+                  undefined,
+                  {
+                    cacheForNavigation: false,
+                    optimisticRouteShell: false,
+                    prefetchKind: "route-tree",
+                  },
+                );
+                routeTreeEntry = cache.get(routeTreeCacheKey);
+              }
+              await routeTreeEntry?.pending?.catch(() => {});
+              return fetchFullRscPayload();
+            })()
+          : fetchFullRscPayload();
+      prefetchRscResponse(
+        rscUrl,
+        fetchPromise,
         interceptionContext,
         mountedSlotsHeader,
         options,

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -407,6 +407,21 @@ export function getPrefetchCache(): Map<string, PrefetchCacheEntry> {
 }
 
 /**
+ * Read an exact prefetch entry without allowing a settled stale value to
+ * steer a later request. Timers are an eviction optimization, not a freshness
+ * guarantee: background throttling can leave an expired route-tree entry in
+ * the Map until the next foreground read.
+ */
+export function getFreshPrefetchCacheEntry(cacheKey: string): PrefetchCacheEntry | undefined {
+  const cache = getPrefetchCache();
+  const entry = cache.get(cacheKey);
+  if (entry === undefined || entry.pending) return entry;
+  if (resolvePrefetchCacheEntryExpiresAt(entry) > Date.now()) return entry;
+  deletePrefetchCacheEntry(cache, getPrefetchedUrls(), cacheKey, entry, true);
+  return undefined;
+}
+
+/**
  * Get or create the shared set of already-prefetched RSC URLs on window.
  * Keyed by interception-aware cache key so distinct source routes do not alias.
  */
@@ -1230,11 +1245,15 @@ function parseRenderedPathAndSearchHeader(value: string | null): string | null {
  */
 export async function snapshotRscResponse(response: Response): Promise<CachedRscResponse> {
   try {
-    return createCachedRscResponseSnapshot(response, await response.arrayBuffer());
+    const snapshot = createCachedRscResponseSnapshot(response, await response.arrayBuffer());
+    const expiresAt = restoredRscResponseExpiresAt.get(response);
+    return expiresAt === undefined ? snapshot : { ...snapshot, expiresAt };
   } finally {
     releaseAppPrefetchFetchSlot(response);
   }
 }
+
+const restoredRscResponseExpiresAt = new WeakMap<Response, number>();
 
 /**
  * Reconstruct a Response from a cached RSC snapshot.
@@ -1280,10 +1299,14 @@ export function restoreRscResponse(cached: CachedRscResponse, copy = true): Resp
     );
   }
 
-  return new Response(copy ? cached.buffer.slice(0) : cached.buffer, {
+  const response = new Response(copy ? cached.buffer.slice(0) : cached.buffer, {
     status: 200,
     headers,
   });
+  if (isCacheExpiresAt(cached.expiresAt)) {
+    restoredRscResponseExpiresAt.set(response, cached.expiresAt);
+  }
+  return response;
 }
 
 /**
@@ -2785,8 +2808,7 @@ const _appRouter: AppRouterInstance = {
                 routeTreeRscUrl,
                 interceptionContext,
               );
-              const cache = getPrefetchCache();
-              let routeTreeEntry = cache.get(routeTreeCacheKey);
+              let routeTreeEntry = getFreshPrefetchCacheEntry(routeTreeCacheKey);
               if (routeTreeEntry === undefined) {
                 prefetched.add(routeTreeCacheKey);
                 prefetchRscResponse(
@@ -2810,9 +2832,22 @@ const _appRouter: AppRouterInstance = {
                     prefetchKind: "route-tree",
                   },
                 );
-                routeTreeEntry = cache.get(routeTreeCacheKey);
+                routeTreeEntry = getFreshPrefetchCacheEntry(routeTreeCacheKey);
               }
               await routeTreeEntry?.pending?.catch(() => {});
+              routeTreeEntry = getFreshPrefetchCacheEntry(routeTreeCacheKey);
+              const renderedPathAndSearch = routeTreeEntry?.snapshot?.renderedPathAndSearch;
+              if (renderedPathAndSearch) {
+                const renderedRscUrl = await createRscRequestUrl(renderedPathAndSearch, headers);
+                const cachedRenderedResponse = peekPrefetchResponseForNavigation(
+                  renderedRscUrl,
+                  interceptionContext,
+                  mountedSlotsHeader,
+                );
+                if (cachedRenderedResponse) {
+                  return restoreRscResponse(cachedRenderedResponse);
+                }
+              }
               return fetchFullRscPayload();
             })()
           : fetchFullRscPayload();

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -1326,6 +1326,67 @@ export async function prepareNavigationPrefetchSnapshot(
 }
 
 /**
+ * Gate a navigation-reusable prefetch behind the route-tree request shared by
+ * `<Link>` and `router.prefetch()`. Callers retain control of fetch scheduling
+ * and request-only options while freshness, deduplication, and alias reuse stay
+ * identical across both entry points.
+ */
+export async function fetchRouteTreeGatedPrefetch(options: {
+  fetchFullRscPayload: () => Promise<Response>;
+  fetchRouteTree: (rscUrl: string, headers: Headers) => Promise<Response>;
+  fullHref: string;
+  headers: Headers;
+  interceptionContext: string | null;
+  mountedSlotsHeader: string | null;
+}): Promise<Response> {
+  const {
+    fetchFullRscPayload,
+    fetchRouteTree,
+    fullHref,
+    headers,
+    interceptionContext,
+    mountedSlotsHeader,
+  } = options;
+  const routeTreeHeaders = new Headers(headers);
+  routeTreeHeaders.set(NEXT_ROUTER_PREFETCH_HEADER, "1");
+  routeTreeHeaders.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "/_tree");
+  const routeTreeRscUrl = await createRscRequestUrl(fullHref, routeTreeHeaders);
+  const routeTreeCacheKey = AppElementsWire.encodeCacheKey(routeTreeRscUrl, interceptionContext);
+  let routeTreeEntry = getFreshPrefetchCacheEntry(routeTreeCacheKey);
+  if (routeTreeEntry === undefined) {
+    getPrefetchedUrls().add(routeTreeCacheKey);
+    prefetchRscResponse(
+      routeTreeRscUrl,
+      fetchRouteTree(routeTreeRscUrl, routeTreeHeaders),
+      interceptionContext,
+      mountedSlotsHeader,
+      undefined,
+      {
+        cacheForNavigation: false,
+        optimisticRouteShell: false,
+        prefetchKind: "route-tree",
+      },
+    );
+    routeTreeEntry = getFreshPrefetchCacheEntry(routeTreeCacheKey);
+  }
+  await routeTreeEntry?.pending?.catch(() => {});
+  routeTreeEntry = getFreshPrefetchCacheEntry(routeTreeCacheKey);
+  const renderedPathAndSearch = routeTreeEntry?.snapshot?.renderedPathAndSearch;
+  if (renderedPathAndSearch) {
+    const renderedRscUrl = await createRscRequestUrl(renderedPathAndSearch, headers);
+    const cachedRenderedResponse = peekPrefetchResponseForNavigation(
+      renderedRscUrl,
+      interceptionContext,
+      mountedSlotsHeader,
+    );
+    if (cachedRenderedResponse) {
+      return restoreRscResponse(cachedRenderedResponse);
+    }
+  }
+  return fetchFullRscPayload();
+}
+
+/**
  * Prefetch an RSC response and snapshot it for later consumption.
  * Stores the in-flight promise so immediate clicks can await it instead
  * of firing a duplicate fetch.
@@ -2799,57 +2860,24 @@ const _appRouter: AppRouterInstance = {
         );
       const fetchPromise =
         reusable && kind === "auto" && requiresRouteTreePrefetch
-          ? (async () => {
-              const routeTreeHeaders = new Headers(headers);
-              routeTreeHeaders.set(NEXT_ROUTER_PREFETCH_HEADER, "1");
-              routeTreeHeaders.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "/_tree");
-              const routeTreeRscUrl = await createRscRequestUrl(fullHref, routeTreeHeaders);
-              const routeTreeCacheKey = AppElementsWire.encodeCacheKey(
-                routeTreeRscUrl,
-                interceptionContext,
-              );
-              let routeTreeEntry = getFreshPrefetchCacheEntry(routeTreeCacheKey);
-              if (routeTreeEntry === undefined) {
-                prefetched.add(routeTreeCacheKey);
-                prefetchRscResponse(
-                  routeTreeRscUrl,
-                  scheduleAppPrefetchFetch(
-                    (signal) =>
-                      fetch(routeTreeRscUrl, {
-                        headers: routeTreeHeaders,
-                        credentials: "include",
-                        priority: "low" as RequestInit["priority"],
-                        signal,
-                      }),
-                    "low",
-                  ),
-                  interceptionContext,
-                  mountedSlotsHeader,
-                  undefined,
-                  {
-                    cacheForNavigation: false,
-                    optimisticRouteShell: false,
-                    prefetchKind: "route-tree",
-                  },
-                );
-                routeTreeEntry = getFreshPrefetchCacheEntry(routeTreeCacheKey);
-              }
-              await routeTreeEntry?.pending?.catch(() => {});
-              routeTreeEntry = getFreshPrefetchCacheEntry(routeTreeCacheKey);
-              const renderedPathAndSearch = routeTreeEntry?.snapshot?.renderedPathAndSearch;
-              if (renderedPathAndSearch) {
-                const renderedRscUrl = await createRscRequestUrl(renderedPathAndSearch, headers);
-                const cachedRenderedResponse = peekPrefetchResponseForNavigation(
-                  renderedRscUrl,
-                  interceptionContext,
-                  mountedSlotsHeader,
-                );
-                if (cachedRenderedResponse) {
-                  return restoreRscResponse(cachedRenderedResponse);
-                }
-              }
-              return fetchFullRscPayload();
-            })()
+          ? fetchRouteTreeGatedPrefetch({
+              fetchFullRscPayload,
+              fetchRouteTree: (routeTreeRscUrl, routeTreeHeaders) =>
+                scheduleAppPrefetchFetch(
+                  (signal) =>
+                    fetch(routeTreeRscUrl, {
+                      headers: routeTreeHeaders,
+                      credentials: "include",
+                      priority: "low" as RequestInit["priority"],
+                      signal,
+                    }),
+                  "low",
+                ),
+              fullHref,
+              headers,
+              interceptionContext,
+              mountedSlotsHeader,
+            })
           : fetchFullRscPayload();
       prefetchRscResponse(
         rscUrl,

--- a/tests/e2e/app-router/nextjs-compat/root-params-segment-prefetch.browser.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/root-params-segment-prefetch.browser.spec.ts
@@ -1,0 +1,259 @@
+import fs from "node:fs/promises";
+import type { Server } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { expect, test, type Page, type Response } from "@playwright/test";
+import { waitForAppRouterHydration } from "../../helpers";
+
+type ProductionApp = {
+  baseUrl: string;
+  fixtureRoot: string;
+  server: Server;
+};
+
+type SegmentPrefetchResponse = {
+  body: string;
+  segment: string;
+};
+
+async function closeServer(server: Server): Promise<void> {
+  const closed = new Promise<void>((resolve) => server.close(() => resolve()));
+  server.closeIdleConnections();
+  server.closeAllConnections();
+  await closed;
+}
+
+async function linkFixtureNodeModules(fixtureRoot: string): Promise<void> {
+  const sourceNodeModules = path.resolve(process.cwd(), "tests/fixtures/app-basic/node_modules");
+  const targetNodeModules = path.join(fixtureRoot, "node_modules");
+  await fs.mkdir(targetNodeModules, { recursive: true });
+
+  for (const entry of await fs.readdir(sourceNodeModules, { withFileTypes: true })) {
+    if (entry.name === ".vite" || entry.name === ".vite-temp") continue;
+    await fs.symlink(
+      path.join(sourceNodeModules, entry.name),
+      path.join(targetNodeModules, entry.name),
+      entry.isDirectory() ? "junction" : "file",
+    );
+  }
+}
+
+async function writeFixture(fixtureRoot: string): Promise<void> {
+  const appDir = path.join(fixtureRoot, "app");
+  await fs.mkdir(path.join(appDir, "(main)", "root-params"), { recursive: true });
+  await fs.mkdir(path.join(appDir, "[rootParam]"), { recursive: true });
+  await fs.mkdir(path.join(fixtureRoot, "components"), { recursive: true });
+  await linkFixtureNodeModules(fixtureRoot);
+
+  await fs.writeFile(
+    path.join(fixtureRoot, "package.json"),
+    `${JSON.stringify({ type: "module", dependencies: {} }, null, 2)}\n`,
+  );
+  await fs.writeFile(
+    path.join(fixtureRoot, "next.config.ts"),
+    `const nextConfig = {
+  cacheComponents: true,
+  experimental: {
+    optimisticRouting: true,
+    varyParams: true,
+  },
+};
+
+export default nextConfig;
+`,
+  );
+  await fs.writeFile(
+    path.join(fixtureRoot, "components", "link-accordion.tsx"),
+    `"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+
+export function LinkAccordion({ href, children }: { href: string; children: React.ReactNode }) {
+  const [isVisible, setIsVisible] = useState(false);
+  return <>
+    <input
+      type="checkbox"
+      checked={isVisible}
+      onChange={() => setIsVisible(!isVisible)}
+      data-link-accordion={href}
+    />
+    {isVisible ? <Link href={href}>{children}</Link> : <>{children} (link is hidden)</>}
+  </>;
+}
+`,
+  );
+  await fs.writeFile(
+    path.join(appDir, "(main)", "layout.tsx"),
+    `import type { ReactNode } from "react";
+
+export default function MainLayout({ children }: { children: ReactNode }) {
+  return <html><body>{children}</body></html>;
+}
+`,
+  );
+  await fs.writeFile(
+    path.join(appDir, "(main)", "root-params", "page.tsx"),
+    `import { LinkAccordion } from "../../../components/link-accordion";
+
+export default function RootParamsIndexPage() {
+  return <main id="root-params-index">
+    <LinkAccordion href="/aaa">Root Param: aaa</LinkAccordion>
+    <LinkAccordion href="/bbb">Root Param: bbb</LinkAccordion>
+  </main>;
+}
+`,
+  );
+  await fs.writeFile(
+    path.join(appDir, "[rootParam]", "loading.tsx"),
+    `export default function Loading() {
+  return <div data-root-param-loading="true">Loading root param...</div>;
+}
+`,
+  );
+  await fs.writeFile(
+    path.join(appDir, "[rootParam]", "layout.tsx"),
+    `import { rootParam } from "next/root-params";
+import type { ReactNode } from "react";
+
+export function generateStaticParams() {
+  return [{ rootParam: "aaa" }, { rootParam: "bbb" }];
+}
+
+export default async function RootParamsLayout({ children }: { children: ReactNode }) {
+  const param = await rootParam();
+  return <html><body>
+    <div data-root-param={param}>{\`Root param layout - param: \${param}\`}</div>
+    {children}
+  </body></html>;
+}
+`,
+  );
+  await fs.writeFile(
+    path.join(appDir, "[rootParam]", "page.tsx"),
+    `import { rootParam } from "next/root-params";
+
+export default async function RootParamsPage() {
+  const param = await rootParam();
+  return <div id="root-params-page">{\`Root param page content - param: \${param}\`}</div>;
+}
+`,
+  );
+
+  const vinextSource = path.resolve(process.cwd(), "packages/vinext/src/index.ts");
+  await fs.writeFile(
+    path.join(fixtureRoot, "vite.config.ts"),
+    `import { defineConfig } from "vite";
+import vinext from ${JSON.stringify(pathToFileURL(vinextSource).href)};
+
+export default defineConfig({ plugins: [vinext({ appDir: import.meta.dirname })] });
+`,
+  );
+}
+
+async function buildAndServeFixture(): Promise<ProductionApp> {
+  const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-root-params-prefetch-"));
+  await writeFixture(fixtureRoot);
+
+  const { createBuilder } = await import("vite");
+  const builder = await createBuilder({
+    root: fixtureRoot,
+    configFile: path.join(fixtureRoot, "vite.config.ts"),
+    logLevel: "silent",
+  });
+  await builder.buildApp();
+
+  const { runPrerender } = await import(
+    pathToFileURL(path.resolve(process.cwd(), "packages/vinext/dist/build/run-prerender.js")).href
+  );
+  await runPrerender({ root: fixtureRoot });
+
+  const { startProdServer } = await import(
+    pathToFileURL(path.resolve(process.cwd(), "packages/vinext/dist/server/prod-server.js")).href
+  );
+  const started = await startProdServer({
+    host: "127.0.0.1",
+    port: 0,
+    outDir: path.join(fixtureRoot, "dist"),
+    noCompression: true,
+  });
+
+  return {
+    baseUrl: `http://127.0.0.1:${started.port}`,
+    fixtureRoot,
+    server: started.server,
+  };
+}
+
+async function revealAndReadSegmentPrefetches(
+  page: Page,
+  href: string,
+  expectedContent: string,
+): Promise<SegmentPrefetchResponse[]> {
+  const responseBodies: Array<Promise<SegmentPrefetchResponse>> = [];
+  const onResponse = (response: Response) => {
+    const segment = response.request().headers()["next-router-segment-prefetch"];
+    if (segment === undefined) return;
+    responseBodies.push(response.text().then((body) => ({ body, segment })));
+  };
+  page.on("response", onResponse);
+
+  try {
+    await page.locator(`input[data-link-accordion="${href}"]`).click();
+    await expect
+      .poll(async () => {
+        const settled = await Promise.all(responseBodies);
+        return settled.some(({ body }) => body.includes(expectedContent));
+      })
+      .toBe(true);
+    return Promise.all(responseBodies);
+  } finally {
+    page.off("response", onResponse);
+  }
+}
+
+test.setTimeout(90_000);
+
+// Ported from Next.js:
+// test/e2e/app-dir/segment-cache/vary-params/root-params-segment-prefetch.test.ts
+// https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/vary-params/root-params-segment-prefetch.test.ts
+test("root-param Link prefetches use concrete segment request keys", async ({ page }) => {
+  const app = await buildAndServeFixture();
+
+  try {
+    await page.goto(`${app.baseUrl}/root-params`);
+    await waitForAppRouterHydration(page);
+
+    const prefetchRoutes = await page.evaluate(() => window.__VINEXT_LINK_PREFETCH_ROUTES__ ?? []);
+    expect(prefetchRoutes).toContainEqual(
+      expect.objectContaining({
+        patternParts: [":rootParam"],
+        requiresRouteTreePrefetch: true,
+      }),
+    );
+
+    const aaaResponses = await revealAndReadSegmentPrefetches(
+      page,
+      "/aaa",
+      "Root param page content - param: aaa",
+    );
+    expect(aaaResponses.map(({ segment }) => segment)).toEqual(
+      expect.arrayContaining(["/_tree", "/__PAGE__"]),
+    );
+    expect(aaaResponses.every(({ body }) => !body.includes("%5BrootParam%5D"))).toBe(true);
+
+    const bbbResponses = await revealAndReadSegmentPrefetches(
+      page,
+      "/bbb",
+      "Root param page content - param: bbb",
+    );
+    expect(bbbResponses.map(({ segment }) => segment)).toEqual(
+      expect.arrayContaining(["/_tree", "/__PAGE__"]),
+    );
+    expect(bbbResponses.every(({ body }) => !body.includes("%5BrootParam%5D"))).toBe(true);
+  } finally {
+    await closeServer(app.server);
+    await fs.rm(app.fixtureRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/e2e/app-router/nextjs-compat/root-params-segment-prefetch.browser.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/root-params-segment-prefetch.browser.spec.ts
@@ -229,7 +229,7 @@ test("root-param Link prefetches use concrete segment request keys", async ({ pa
     expect(prefetchRoutes).toContainEqual(
       expect.objectContaining({
         patternParts: [":rootParam"],
-        requiresRouteTreePrefetch: true,
+        hasRootParams: true,
       }),
     );
 

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -460,6 +460,29 @@ describe("App Router generated manifest construction", () => {
     expect(toLinkPrefetchRoute(route).canPrefetchLoadingShell).toBe(true);
   });
 
+  it("marks root-param routes for concrete route-tree prefetching", () => {
+    // Ported from Next.js:
+    // test/e2e/app-dir/segment-cache/vary-params/root-params-segment-prefetch.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/vary-params/root-params-segment-prefetch.test.ts
+    const route = {
+      ...minimalAppRoutes[0],
+      pattern: "/:rootParam",
+      patternParts: [":rootParam"],
+      routeSegments: [":rootParam"],
+      isDynamic: true,
+      params: ["rootParam"],
+      rootParamNames: ["rootParam"],
+      loadingPath: "/tmp/test/app/[rootParam]/loading.tsx",
+    } satisfies AppRoute;
+
+    expect(toLinkPrefetchRoute(route)).toEqual(
+      expect.objectContaining({
+        canPrefetchLoadingShell: true,
+        requiresRouteTreePrefetch: true,
+      }),
+    );
+  });
+
   it("advertises sibling-intercept loading only on the target route", () => {
     const sourceRoute = {
       ...minimalAppRoutes[0],

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -478,7 +478,7 @@ describe("App Router generated manifest construction", () => {
     expect(toLinkPrefetchRoute(route)).toEqual(
       expect.objectContaining({
         canPrefetchLoadingShell: true,
-        requiresRouteTreePrefetch: true,
+        hasRootParams: true,
       }),
     );
   });

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -2670,6 +2670,7 @@ describe("Link prefetch scheduling", () => {
     // Ported from Next.js:
     // test/e2e/app-dir/segment-cache/vary-params/root-params-segment-prefetch.test.ts
     // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/vary-params/root-params-segment-prefetch.test.ts
+    vi.stubEnv("__NEXT_CACHE_COMPONENTS", "true");
     const observer = stubIntersectionObserver();
     const result = await renderIsolatedLink({
       href: "/root-param/aaa",
@@ -2680,7 +2681,7 @@ describe("Link prefetch scheduling", () => {
             canPrefetchLoadingShell: true,
             patternParts: ["root-param", ":value"],
             isDynamic: true,
-            requiresRouteTreePrefetch: true,
+            hasRootParams: true,
           },
         ],
       },

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -2666,6 +2666,70 @@ describe("Link prefetch scheduling", () => {
     }
   });
 
+  it("prefetches root-param routes through a concrete route tree before the page segment", async () => {
+    // Ported from Next.js:
+    // test/e2e/app-dir/segment-cache/vary-params/root-params-segment-prefetch.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/vary-params/root-params-segment-prefetch.test.ts
+    const observer = stubIntersectionObserver();
+    const result = await renderIsolatedLink({
+      href: "/root-param/aaa",
+      nodeEnv: "production",
+      windowOverrides: {
+        __VINEXT_LINK_PREFETCH_ROUTES__: [
+          {
+            canPrefetchLoadingShell: true,
+            patternParts: ["root-param", ":value"],
+            isDynamic: true,
+            requiresRouteTreePrefetch: true,
+          },
+        ],
+      },
+    });
+
+    try {
+      let releaseRouteTree: ((response: Response) => void) | undefined;
+      const routeTreeResponse = new Promise<Response>((resolve) => {
+        releaseRouteTree = resolve;
+      });
+      result.fetch
+        .mockImplementationOnce(() => routeTreeResponse)
+        .mockImplementation(() => Promise.resolve(new Response("concrete root-param page")));
+
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+
+      const routeTreeInit = result.fetch.mock.calls[0]?.[1] as RequestInit | undefined;
+      const routeTreeHeaders = routeTreeInit?.headers as Headers | undefined;
+      expect(routeTreeHeaders?.get(NEXT_ROUTER_PREFETCH_HEADER)).toBe("1");
+      expect(routeTreeHeaders?.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER)).toBe("/_tree");
+
+      releaseRouteTree?.(new Response(""));
+      await waitForFetchCalls(result.fetch, 2);
+
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[1],
+        "/root-param/aaa",
+        expect.objectContaining({ credentials: "include", priority: "low" }),
+      );
+      const pageInit = result.fetch.mock.calls[1]?.[1] as RequestInit | undefined;
+      const pageHeaders = pageInit?.headers as Headers | undefined;
+      expect(pageHeaders?.get(NEXT_ROUTER_PREFETCH_HEADER)).toBe("1");
+      expect(pageHeaders?.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER)).toBe("/__PAGE__");
+      const pageRequestUrl = result.fetch.mock.calls[1]?.[0];
+      expect(typeof pageRequestUrl).toBe("string");
+      expect(pageRequestUrl as string).not.toContain("%5Bvalue%5D");
+
+      const { getPrefetchCache } = await import("../packages/vinext/src/shims/navigation.js");
+      const navigationEntry = Array.from(getPrefetchCache().values()).find(
+        (entry) => entry.prefetchKind === "navigation",
+      );
+      expect(navigationEntry?.cacheForNavigation).toBe(true);
+    } finally {
+      await flushPrefetchTasks();
+      result.restoreNodeEnv();
+    }
+  });
+
   it("upgrades automatic dynamic links to full prefetch on unstable_dynamicOnHover intent", async () => {
     const observer = stubIntersectionObserver();
     const result = await renderIsolatedLink({

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -329,7 +329,7 @@ describe("Link App Router prefetch mode", () => {
           canPrefetchLoadingShell: true,
           patternParts: ["root-param", ":value"],
           isDynamic: true,
-          requiresRouteTreePrefetch: true,
+          hasRootParams: true,
         },
         {
           canPrefetchLoadingShell: false,
@@ -341,6 +341,7 @@ describe("Link App Router prefetch mode", () => {
       ],
     };
 
+    vi.stubEnv("__NEXT_CACHE_COMPONENTS", "true");
     try {
       expect(resolveAutoAppRoutePrefetch("/about")).toEqual({
         cacheForNavigation: true,
@@ -416,6 +417,43 @@ describe("Link App Router prefetch mode", () => {
       } else {
         (globalThis as any).window = originalWindow;
       }
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("keeps root-param loading routes shell-only without Cache Components", () => {
+    const originalWindow = globalThis.window;
+    vi.stubEnv("__NEXT_CACHE_COMPONENTS", "false");
+    (globalThis as any).window = {
+      location: {
+        href: "http://localhost/root-params",
+        origin: "http://localhost",
+      },
+      __VINEXT_LINK_PREFETCH_ROUTES__: [
+        {
+          canPrefetchLoadingShell: true,
+          patternParts: ["root-param", ":value"],
+          isDynamic: true,
+          hasRootParams: true,
+        },
+      ],
+    };
+
+    try {
+      expect(resolveAutoAppRoutePrefetch("/root-param/aaa")).toEqual({
+        cacheForNavigation: false,
+        fallbackTtl: "static",
+        honorDynamicStaleTime: true,
+        prefetchShellFirst: false,
+        shouldPrefetch: true,
+      });
+    } finally {
+      if (originalWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = originalWindow;
+      }
+      vi.unstubAllEnvs();
     }
   });
 });

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -326,6 +326,12 @@ describe("Link App Router prefetch mode", () => {
         { canPrefetchLoadingShell: false, patternParts: ["products", ":id"], isDynamic: true },
         { canPrefetchLoadingShell: false, patternParts: ["clothing", ":product"], isDynamic: true },
         {
+          canPrefetchLoadingShell: true,
+          patternParts: ["root-param", ":value"],
+          isDynamic: true,
+          requiresRouteTreePrefetch: true,
+        },
+        {
           canPrefetchLoadingShell: false,
           patternParts: ["teams", ":team", "dashboard"],
           isDynamic: true,
@@ -372,6 +378,22 @@ describe("Link App Router prefetch mode", () => {
         fallbackTtl: "static",
         honorDynamicStaleTime: true,
         prefetchShellFirst: false,
+        shouldPrefetch: true,
+      });
+      expect(resolveAutoAppRoutePrefetch("/root-param/aaa")).toEqual({
+        cacheForNavigation: true,
+        fallbackTtl: "static",
+        honorDynamicStaleTime: true,
+        prefetchShellFirst: true,
+        requiresRouteTreePrefetch: true,
+        shouldPrefetch: true,
+      });
+      expect(resolveAutoAppRoutePrefetch("/root-param/aaa?q=1")).toEqual({
+        cacheForNavigation: false,
+        fallbackTtl: "static",
+        honorDynamicStaleTime: true,
+        prefetchShellFirst: true,
+        requiresRouteTreePrefetch: true,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/teams/vercel/dashboard")).toEqual({

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -11,8 +11,13 @@
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vite-plus/test";
 import { AppElementsWire } from "../packages/vinext/src/server/app-elements.js";
-import { VINEXT_RSC_COMPATIBILITY_ID_HEADER } from "../packages/vinext/src/server/app-rsc-cache-busting.js";
 import {
+  createRscRequestUrl,
+  VINEXT_RSC_COMPATIBILITY_ID_HEADER,
+} from "../packages/vinext/src/server/app-rsc-cache-busting.js";
+import {
+  NEXT_ROUTER_PREFETCH_HEADER,
+  NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
   NEXT_ROUTER_STALE_TIME_HEADER,
   VINEXT_DYNAMIC_STALE_TIME_HEADER,
   VINEXT_RSC_COMPLETION_METADATA_HEADER,
@@ -21,6 +26,7 @@ import {
   VINEXT_RENDERED_PATH_AND_SEARCH_HEADER,
 } from "../packages/vinext/src/server/headers.js";
 import { appendRscCompletionMetadata } from "../packages/vinext/src/server/rsc-completion-metadata.js";
+import type { PrefetchCacheEntry } from "../packages/vinext/src/shims/navigation.js";
 
 type Navigation = typeof import("../packages/vinext/src/shims/navigation.js");
 let storePrefetchResponse: Navigation["storePrefetchResponse"];
@@ -42,6 +48,7 @@ let peekPrefetchResponseForNavigation: Navigation["peekPrefetchResponseForNaviga
 let appRouterInstance: Navigation["appRouterInstance"];
 let consumePrefetchResponseForNavigation: Navigation["consumePrefetchResponseForNavigation"];
 let seedPrefetchResponseSnapshot: Navigation["seedPrefetchResponseSnapshot"];
+let createAppPrefetchRequestHeaders: Navigation["createAppPrefetchRequestHeaders"];
 
 beforeEach(async () => {
   // Set window BEFORE importing so isServer evaluates to false
@@ -81,6 +88,7 @@ beforeEach(async () => {
   appRouterInstance = nav.appRouterInstance;
   consumePrefetchResponseForNavigation = nav.consumePrefetchResponseForNavigation;
   seedPrefetchResponseSnapshot = nav.seedPrefetchResponseSnapshot;
+  createAppPrefetchRequestHeaders = nav.createAppPrefetchRequestHeaders;
 });
 
 afterEach(() => {
@@ -725,6 +733,178 @@ describe("prefetch cache eviction", () => {
     );
     expect(navigationEntry?.cacheForNavigation).toBe(true);
     await settlePrefetchSetup();
+  });
+
+  it("reuses a rendered-path prefetch after the root-param route-tree gate", async () => {
+    let now = 1_000_000;
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    vi.stubEnv("__NEXT_CACHE_COMPONENTS", "true");
+    (globalThis as any).window.__VINEXT_LINK_PREFETCH_ROUTES__ = [
+      {
+        canPrefetchLoadingShell: true,
+        patternParts: [":rootParam"],
+        isDynamic: true,
+        hasRootParams: true,
+      },
+    ];
+    const renderedPathAndSearch = "/rendered-aaa";
+    const sourceExpiresAt = now + 100;
+    seedPrefetchResponseSnapshot(
+      `${renderedPathAndSearch}?_rsc=existing`,
+      {
+        buffer: new TextEncoder().encode("cached rendered page").buffer,
+        contentType: "text/x-component",
+        expiresAt: sourceExpiresAt,
+        mountedSlotsHeader: null,
+        paramsHeader: null,
+        renderedPathAndSearch: null,
+        url: `${renderedPathAndSearch}?_rsc=existing`,
+      },
+      null,
+      null,
+    );
+    const seededRenderedEntry = Array.from(getPrefetchCache().values()).find(
+      (entry) => entry.outcome === "cache-seeded",
+    );
+    expect(seededRenderedEntry).toBeDefined();
+
+    const fetch = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(() =>
+      Promise.resolve(
+        new Response("tree", {
+          headers: {
+            "content-type": "text/x-component",
+            [VINEXT_RENDERED_PATH_AND_SEARCH_HEADER]: encodeURIComponent(renderedPathAndSearch),
+          },
+        }),
+      ),
+    );
+    (globalThis as any).fetch = fetch;
+
+    appRouterInstance.prefetch("/aaa");
+    await waitForPrefetchSetup(() => fetch.mock.calls.length === 1);
+    await waitForPrefetchSetup(() =>
+      Array.from(getPrefetchCache().values()).some(
+        (entry) =>
+          entry !== seededRenderedEntry &&
+          entry.prefetchKind === "navigation" &&
+          entry.outcome === "cache-seeded",
+      ),
+    );
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const routeTreeHeaders = fetch.mock.calls[0]?.[1]?.headers as Headers | undefined;
+    expect(routeTreeHeaders?.get("Next-Router-Segment-Prefetch")).toBe("/_tree");
+    const navigationEntry = Array.from(getPrefetchCache().values()).find(
+      (entry) => entry !== seededRenderedEntry && entry.prefetchKind === "navigation",
+    );
+    expect(navigationEntry?.expiresAt).toBe(sourceExpiresAt);
+    if (navigationEntry?.snapshot) {
+      await expect(restoreRscResponse(navigationEntry.snapshot).text()).resolves.toBe(
+        "cached rendered page",
+      );
+    }
+    const navigationCacheKey = Array.from(navigationEntry?.cacheKeys ?? [])[0];
+    expect(navigationCacheKey).toBeDefined();
+    now = sourceExpiresAt + 1;
+    expect(peekPrefetchResponseForNavigation(navigationCacheKey!, null, null)).toBeNull();
+  });
+
+  it("refetches an expired root-param route tree before selecting its rendered path", async () => {
+    const now = 1_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    vi.stubEnv("__NEXT_CACHE_COMPONENTS", "true");
+    (globalThis as any).window.__VINEXT_LINK_PREFETCH_ROUTES__ = [
+      {
+        canPrefetchLoadingShell: true,
+        patternParts: [":rootParam"],
+        isDynamic: true,
+        hasRootParams: true,
+      },
+    ];
+
+    const oldRenderedPath = "/old-rendered-bbb";
+    const newRenderedPath = "/new-rendered-bbb";
+    const seedRenderedAlias = (pathAndSearch: string, body: string) =>
+      seedPrefetchResponseSnapshot(
+        `${pathAndSearch}?_rsc=existing`,
+        {
+          buffer: new TextEncoder().encode(body).buffer,
+          contentType: "text/x-component",
+          expiresAt: now + 10_000,
+          mountedSlotsHeader: null,
+          paramsHeader: null,
+          renderedPathAndSearch: null,
+          url: `${pathAndSearch}?_rsc=existing`,
+        },
+        null,
+        null,
+      );
+    seedRenderedAlias(oldRenderedPath, "stale rendered page");
+    seedRenderedAlias(newRenderedPath, "fresh rendered page");
+
+    const routeTreeHeaders = createAppPrefetchRequestHeaders({
+      fetchPriority: "low",
+      interceptionContext: null,
+      mountedSlotsHeader: null,
+    });
+    routeTreeHeaders.set(NEXT_ROUTER_PREFETCH_HEADER, "1");
+    routeTreeHeaders.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "/_tree");
+    const routeTreeRscUrl = await createRscRequestUrl("/bbb", routeTreeHeaders);
+    const routeTreeCacheKey = AppElementsWire.encodeCacheKey(routeTreeRscUrl, null);
+    const expiredRouteTreeEntry: PrefetchCacheEntry = {
+      cacheForNavigation: false,
+      cacheKeys: new Set([routeTreeCacheKey]),
+      expiresAt: now - 1,
+      mountedSlotsHeader: null,
+      outcome: "cache-seeded",
+      prefetchKind: "route-tree",
+      snapshot: {
+        buffer: new TextEncoder().encode("expired tree").buffer,
+        contentType: "text/x-component",
+        mountedSlotsHeader: null,
+        paramsHeader: null,
+        renderedPathAndSearch: oldRenderedPath,
+        url: routeTreeRscUrl,
+      },
+      timestamp: now - PREFETCH_CACHE_TTL,
+    };
+    getPrefetchCache().set(routeTreeCacheKey, expiredRouteTreeEntry);
+    getPrefetchedUrls().add(routeTreeCacheKey);
+
+    const fetch = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(() =>
+      Promise.resolve(
+        new Response("fresh tree", {
+          headers: {
+            "content-type": "text/x-component",
+            [VINEXT_RENDERED_PATH_AND_SEARCH_HEADER]: encodeURIComponent(newRenderedPath),
+          },
+        }),
+      ),
+    );
+    (globalThis as any).fetch = fetch;
+
+    appRouterInstance.prefetch("/bbb");
+    await waitForPrefetchSetup(() => fetch.mock.calls.length === 1);
+    await waitForPrefetchSetup(() =>
+      Array.from(getPrefetchCache().values()).some(
+        (entry) => entry.prefetchKind === "navigation" && entry.outcome === "cache-seeded",
+      ),
+    );
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(getPrefetchCache().get(routeTreeCacheKey)).not.toBe(expiredRouteTreeEntry);
+    expect(getPrefetchCache().get(routeTreeCacheKey)?.snapshot?.renderedPathAndSearch).toBe(
+      newRenderedPath,
+    );
+    const navigationEntry = Array.from(getPrefetchCache().values()).find(
+      (entry) => entry.prefetchKind === "navigation",
+    );
+    expect(navigationEntry?.snapshot).toBeDefined();
+    if (navigationEntry?.snapshot) {
+      await expect(restoreRscResponse(navigationEntry.snapshot).text()).resolves.toBe(
+        "fresh rendered page",
+      );
+    }
   });
 
   it("shares an in-flight router.prefetch with navigation instead of refetching (#2707)", async () => {

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -85,6 +85,7 @@ beforeEach(async () => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllEnvs();
   delete (globalThis as any).window;
   delete (globalThis as any).fetch;
 });
@@ -660,13 +661,70 @@ describe("prefetch cache eviction", () => {
     // A second programmatic prefetch while the entry is fresh must not issue
     // another request.
     appRouterInstance.prefetch("/dashboard");
-    await waitForPrefetchSetup();
+    await settlePrefetchSetup();
     expect(fetch).toHaveBeenCalledTimes(1);
 
     const consumed = consumePrefetchResponse(fetchedUrl, null, null);
     expect(consumed).not.toBeNull();
     if (consumed === null) return;
     await expect(restoreRscResponse(consumed).text()).resolves.toBe("flight");
+  });
+
+  it("gates Cache Components root-param router.prefetch behind the route tree", async () => {
+    // Ported from Next.js:
+    // test/e2e/app-dir/segment-cache/vary-params/root-params-segment-prefetch.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/vary-params/root-params-segment-prefetch.test.ts
+    vi.stubEnv("__NEXT_CACHE_COMPONENTS", "true");
+    (globalThis as any).window.__VINEXT_LINK_PREFETCH_ROUTES__ = [
+      {
+        canPrefetchLoadingShell: true,
+        patternParts: [":rootParam"],
+        isDynamic: true,
+        hasRootParams: true,
+      },
+    ];
+    const { resolveAutoAppRoutePrefetch } =
+      await import("../packages/vinext/src/shims/internal/app-route-prefetch-policy.js");
+    expect(resolveAutoAppRoutePrefetch("/aaa").requiresRouteTreePrefetch).toBe(true);
+    const routeTree = createDeferredResponse();
+    const fetch = vi
+      .fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>()
+      .mockImplementationOnce(() => routeTree.promise)
+      .mockImplementation(() =>
+        Promise.resolve(
+          new Response("concrete root-param page", {
+            headers: { "content-type": "text/x-component" },
+          }),
+        ),
+      );
+    (globalThis as any).fetch = fetch;
+
+    appRouterInstance.prefetch("/aaa");
+    await waitForPrefetchSetup(() => fetch.mock.calls.length === 1);
+
+    const routeTreeHeaders = fetch.mock.calls[0]?.[1]?.headers as Headers | undefined;
+    expect(routeTreeHeaders?.get("Next-Router-Prefetch")).toBe("1");
+    expect(routeTreeHeaders?.get("Next-Router-Segment-Prefetch")).toBe("/_tree");
+
+    routeTree.resolve(new Response("tree", { headers: { "content-type": "text/x-component" } }));
+    await waitForPrefetchSetup(() => fetch.mock.calls.length === 2);
+
+    const pageUrl = toRscUrlString(fetch.mock.calls[1]![0]);
+    const pageHeaders = fetch.mock.calls[1]?.[1]?.headers as Headers | undefined;
+    expect(pageHeaders?.get("Next-Router-Prefetch")).toBe("1");
+    expect(pageHeaders?.get("Next-Router-Segment-Prefetch")).toBe("/__PAGE__");
+    expect(pageUrl).not.toContain("%5BrootParam%5D");
+
+    const pageCacheKey = AppElementsWire.encodeCacheKey(pageUrl, null);
+    await waitForPrefetchSetup(
+      () => getPrefetchCache().get(pageCacheKey)?.outcome === "cache-seeded",
+    );
+
+    const navigationEntry = Array.from(getPrefetchCache().values()).find(
+      (entry) => entry.prefetchKind === "navigation",
+    );
+    expect(navigationEntry?.cacheForNavigation).toBe(true);
+    await settlePrefetchSetup();
   });
 
   it("shares an in-flight router.prefetch with navigation instead of refetching (#2707)", async () => {


### PR DESCRIPTION
## Summary

- mark routes with dynamic params above their root layout in the client prefetch manifest
- under Cache Components, gate automatic root-param prefetches through `/_tree` before requesting the concrete `/__PAGE__` payload
- apply the same sequence to both `<Link>` and imperative `router.prefetch()`, while preserving loading-shell behavior when Cache Components is disabled
- port the upstream root-param segment-prefetch regression into the vinext browser suite

## Current-main evidence

Fresh baseline on `99623542d` failed 0/1 at the first `/aaa` prefetch because the response never contained `Root param page content - param: aaa`.

PR #2463 was inspected only for historical context. Its July 1 head is conflicting and substantially behind current main, with no current exact-target proof, so this implementation was rebuilt against the current route-tree and prefetch-cache architecture rather than reviving or stacking that branch.

## Validation

- `REPO=\"$(pwd)\" NEXTJS_DIR=\"/Users/jamesanderson/Developer/vinext/.nextjs-ref\" ./scripts/run-targeted-nextjs-e2e.sh test/e2e/app-dir/segment-cache/vary-params/root-params-segment-prefetch.test.ts` — 1/1 passed
- `PLAYWRIGHT_PROJECT=app-router-chrome-browser-specific pnpm run test:e2e -- tests/e2e/app-router/nextjs-compat/root-params-segment-prefetch.browser.spec.ts` — 1/1 passed
- `vp test run tests/entry-templates.test.ts tests/link.test.ts tests/link-navigation.test.ts tests/prefetch-cache.test.ts tests/app-route-tree-prefetch.test.ts` — 339/339 passed
- `vp check` — passed

Two independent review findings were addressed before opening: Cache Components disabled-mode gating and `router.prefetch()` parity. Final rereview found no remaining issues.