### PR TITLE
fix(cache): keep encoded dynamic prefetches learning-only

### DIFF
--- a/packages/vinext/src/shims/internal/app-route-prefetch-policy.ts
+++ b/packages/vinext/src/shims/internal/app-route-prefetch-policy.ts
@@ -26,6 +26,7 @@ declare global {
 const __basePath: string = process.env.__NEXT_ROUTER_BASEPATH ?? "";
 
 const linkPrefetchRouteTrieCache = createRouteTrieCache<VinextLinkPrefetchRoute>();
+const ENCODED_PATH_DELIMITER_RE = /%(?:2f|5c)/i;
 
 /**
  * How an App Router prefetch for a given href should behave: whether to issue
@@ -90,17 +91,24 @@ export function resolveAutoAppRoutePrefetch(href: string): AppRoutePrefetchPolic
   const route = match.route;
   // A search-param href renders query-specific output, so its payload can only
   // ever be a shell — never reusable by a navigation to the same route.
-  const hasSearchParams = new URL(routeHref, "http://vinext.local").search !== "";
-  // Cache Components automatic prefetches keep dynamic path segments in the
-  // learning-only Segment Cache. Navigation must fetch the dynamic page data,
-  // while a later Link mount can still reuse the learned route identity. This
-  // also keeps encoded delimiters such as `%2F` under the exact href key instead
-  // of publishing a decoded server payload as authoritative navigation data.
+  const routeUrl = new URL(routeHref, "http://vinext.local");
+  const hasSearchParams = routeUrl.search !== "";
+  // A Cache Components dynamic href with an encoded path delimiter must stay
+  // in the learning-only Segment Cache. The server decodes the param while the
+  // client cache key retains its encoded spelling; publishing that payload for
+  // navigation reuse would make the two segment identities disagree. A
+  // root-level dynamic route also stays learning-only: Next's unencoded control
+  // for this case still performs a dynamic request during navigation. Ordinary
+  // prefixed dynamic hrefs do not have either constraint and remain reusable.
   //
   // Next.js parity:
   // test/e2e/app-dir/segment-cache/encoded-slash-params/encoded-slash-params.test.ts
-  const isCacheComponentsDynamicRoute =
-    route.isDynamic && String(process.env.__NEXT_CACHE_COMPONENTS) === "true";
+  const isFullyDynamicRootRoute =
+    route.patternParts.length === 1 && route.patternParts[0]?.startsWith(":");
+  const hasCacheComponentsLearningOnlyDynamicPath =
+    route.isDynamic &&
+    String(process.env.__NEXT_CACHE_COMPONENTS) === "true" &&
+    (isFullyDynamicRootRoute || ENCODED_PATH_DELIMITER_RE.test(routeUrl.pathname));
   return {
     // Vinext does not yet have Next.js's per-segment runtime-prefetch hints.
     // Routes with loading boundaries prefetch a shell first so navigation can
@@ -110,7 +118,7 @@ export function resolveAutoAppRoutePrefetch(href: string): AppRoutePrefetchPolic
     cacheForNavigation:
       !hasSearchParams &&
       !route.canPrefetchLoadingShell &&
-      !isCacheComponentsDynamicRoute &&
+      !hasCacheComponentsLearningOnlyDynamicPath &&
       route.requiresDynamicNavigationRequest !== true,
     fallbackTtl: "static",
     honorDynamicStaleTime: true,

--- a/packages/vinext/src/shims/internal/app-route-prefetch-policy.ts
+++ b/packages/vinext/src/shims/internal/app-route-prefetch-policy.ts
@@ -91,6 +91,16 @@ export function resolveAutoAppRoutePrefetch(href: string): AppRoutePrefetchPolic
   // A search-param href renders query-specific output, so its payload can only
   // ever be a shell — never reusable by a navigation to the same route.
   const hasSearchParams = new URL(routeHref, "http://vinext.local").search !== "";
+  // Cache Components automatic prefetches keep dynamic path segments in the
+  // learning-only Segment Cache. Navigation must fetch the dynamic page data,
+  // while a later Link mount can still reuse the learned route identity. This
+  // also keeps encoded delimiters such as `%2F` under the exact href key instead
+  // of publishing a decoded server payload as authoritative navigation data.
+  //
+  // Next.js parity:
+  // test/e2e/app-dir/segment-cache/encoded-slash-params/encoded-slash-params.test.ts
+  const isCacheComponentsDynamicRoute =
+    route.isDynamic && String(process.env.__NEXT_CACHE_COMPONENTS) === "true";
   return {
     // Vinext does not yet have Next.js's per-segment runtime-prefetch hints.
     // Routes with loading boundaries prefetch a shell first so navigation can
@@ -100,6 +110,7 @@ export function resolveAutoAppRoutePrefetch(href: string): AppRoutePrefetchPolic
     cacheForNavigation:
       !hasSearchParams &&
       !route.canPrefetchLoadingShell &&
+      !isCacheComponentsDynamicRoute &&
       route.requiresDynamicNavigationRequest !== true,
     fallbackTtl: "static",
     honorDynamicStaleTime: true,

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -445,6 +445,7 @@ function prefetchUrl(
           getMountedSlotsHeader,
           createAppPrefetchRequestHeaders,
           discardLearningOnlyPrefetchCacheEntry,
+          hasFreshLearningOnlyPrefetchCacheEntry,
           hasSearchAgnosticPrefetchShellForRoute,
           hasPrefetchCacheEntryForNavigation,
           peekPrefetchResponseForNavigation,
@@ -531,10 +532,11 @@ function prefetchUrl(
         if (autoPrefetch.cacheForNavigation) {
           discardLearningOnlyPrefetchCacheEntry(rscUrl, interceptionContext);
         }
-        if (prefetched.has(cacheKey)) {
-          if (!autoPrefetch.cacheForNavigation) {
-            return;
-          }
+        if (
+          !autoPrefetch.cacheForNavigation &&
+          hasFreshLearningOnlyPrefetchCacheEntry(rscUrl, interceptionContext)
+        ) {
+          return;
         }
         const fetchFullRscPayload = () =>
           scheduleAppPrefetchFetch(

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -676,6 +676,29 @@ export function hasPrefetchCacheEntryForNavigation(
   return false;
 }
 
+/**
+ * Return whether the exact learning-only Link prefetch is still usable.
+ * Pending entries dedupe concurrent Links; settled entries only suppress a
+ * remount while their response-derived freshness window remains active.
+ */
+export function hasFreshLearningOnlyPrefetchCacheEntry(
+  rscUrl: string,
+  interceptionContext: string | null = null,
+): boolean {
+  const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
+  const cache = getPrefetchCache();
+  const entry = cache.get(cacheKey);
+  if (entry?.cacheForNavigation !== false) return false;
+
+  if (entry.pending !== undefined || resolvePrefetchCacheEntryExpiresAt(entry) > Date.now()) {
+    touchPrefetchCacheEntry(cache, cacheKey, entry);
+    return true;
+  }
+
+  deletePrefetchCacheEntry(cache, getPrefetchedUrls(), cacheKey, entry, true);
+  return false;
+}
+
 export function hasSearchAgnosticPrefetchShellForRoute(
   rscUrl: string,
   interceptionContext: string | null = null,

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -2786,7 +2786,7 @@ const _appRouter: AppRouterInstance = {
         ) {
           return;
         }
-      } else if (prefetched.has(cacheKey)) {
+      } else if (hasFreshLearningOnlyPrefetchCacheEntry(rscUrl, interceptionContext)) {
         attachPrefetchInvalidationCallback(cacheKey, options?.onInvalidate);
         return;
       }

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -2042,6 +2042,66 @@ describe("Link prefetch scheduling", () => {
     }
   });
 
+  it("keeps Cache Components encoded dynamic paths learning-only across Link re-prefetches", async () => {
+    // Ported from Next.js:
+    // test/e2e/app-dir/segment-cache/encoded-slash-params/encoded-slash-params.test.ts
+    // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/segment-cache/encoded-slash-params/encoded-slash-params.test.ts
+    vi.stubEnv("__NEXT_CACHE_COMPONENTS", "true");
+    const observer = stubIntersectionObserver();
+
+    const result = await renderIsolatedLink({
+      href: "/products/foo%2Fbar",
+      nodeEnv: "production",
+    });
+
+    try {
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+
+      expect(result.fetch).toHaveBeenCalledTimes(1);
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[0],
+        "/products/foo%2Fbar",
+        expect.objectContaining({
+          credentials: "include",
+          priority: "low",
+        }),
+      );
+      const fetchInit = result.fetch.mock.calls[0]?.[1] as RequestInit | undefined;
+      const headers = fetchInit?.headers as Headers | undefined;
+      expect(headers?.get(VINEXT_RSC_RENDER_MODE_HEADER)).toBe(
+        APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+      );
+      expect(headers?.get(NEXT_ROUTER_PREFETCH_HEADER)).toBe("1");
+      expect(headers?.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER)).toBe("1");
+
+      const { getPrefetchCache } = await import("../packages/vinext/src/shims/navigation.js");
+      const entry = Array.from(getPrefetchCache().values())[0];
+      expect(entry?.cacheForNavigation).toBe(false);
+      expect(entry?.optimisticRouteShell).toBe(true);
+
+      // A Link remount after back navigation asks to prefetch the same href
+      // again. Preserve the encoded pathname identity and reuse the existing
+      // learning-only route entry instead of issuing another route-tree fetch.
+      observer.dispatchIntersectingEntry(result.anchor);
+      await flushPrefetchTasks();
+      expect(result.fetch).toHaveBeenCalledTimes(1);
+
+      await entry?.pending;
+      expect(entry?.expiresAt).toEqual(expect.any(Number));
+      observer.dispatchIntersectingEntry(result.anchor);
+      await flushPrefetchTasks();
+      expect(result.fetch).toHaveBeenCalledTimes(1);
+
+      vi.spyOn(Date, "now").mockReturnValue((entry?.expiresAt ?? 0) + 1);
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 2);
+      expect(result.fetch).toHaveBeenCalledTimes(2);
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
   it("uses the static stale time for reusable automatic dynamic full prefetches", async () => {
     vi.stubEnv("__NEXT_CLIENT_ROUTER_DYNAMIC_STALETIME", "0");
     vi.stubEnv("__NEXT_CLIENT_ROUTER_STATIC_STALETIME", "300");

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -396,6 +396,47 @@ describe("Link App Router prefetch mode", () => {
       }
     }
   });
+
+  it("keeps Cache Components encoded delimiters and fully dynamic roots learning-only", () => {
+    const originalWindow = globalThis.window;
+    const originalCacheComponents = process.env.__NEXT_CACHE_COMPONENTS;
+    process.env.__NEXT_CACHE_COMPONENTS = "true";
+    (globalThis as any).window = {
+      location: {
+        href: "http://localhost/",
+        origin: "http://localhost",
+      },
+      __VINEXT_LINK_PREFETCH_ROUTES__: [
+        { canPrefetchLoadingShell: false, patternParts: [":slug"], isDynamic: true },
+        {
+          canPrefetchLoadingShell: false,
+          patternParts: ["products", ":slug"],
+          isDynamic: true,
+        },
+      ],
+    };
+
+    try {
+      // Ported from Next.js:
+      // test/e2e/app-dir/segment-cache/encoded-slash-params/encoded-slash-params.test.ts
+      // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/segment-cache/encoded-slash-params/encoded-slash-params.test.ts
+      expect(resolveAutoAppRoutePrefetch("/foo").cacheForNavigation).toBe(false);
+      expect(resolveAutoAppRoutePrefetch("/products/foo").cacheForNavigation).toBe(true);
+      expect(resolveAutoAppRoutePrefetch("/products/foo%2Fbar").cacheForNavigation).toBe(false);
+      expect(resolveAutoAppRoutePrefetch("/products/foo%5Cbar").cacheForNavigation).toBe(false);
+    } finally {
+      if (originalWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = originalWindow;
+      }
+      if (originalCacheComponents === undefined) {
+        delete process.env.__NEXT_CACHE_COMPONENTS;
+      } else {
+        process.env.__NEXT_CACHE_COMPONENTS = originalCacheComponents;
+      }
+    }
+  });
 });
 
 // ─── resolveHref (internal helper, tested via component output) ─────────

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -1047,7 +1047,7 @@ describe("prefetch cache eviction", () => {
     expect(consumePrefetchResponse(fetchedUrl, null, null)).toBeNull();
   });
 
-  it("dedupes pending and fresh Cache Components dynamic router.prefetch calls but refetches after expiry", async () => {
+  it("dedupes pending and fresh Cache Components encoded dynamic router.prefetch calls but refetches after expiry", async () => {
     // Ported from Next.js:
     // test/e2e/app-dir/segment-cache/encoded-slash-params/encoded-slash-params.test.ts
     // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/segment-cache/encoded-slash-params/encoded-slash-params.test.ts

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -1047,6 +1047,53 @@ describe("prefetch cache eviction", () => {
     expect(consumePrefetchResponse(fetchedUrl, null, null)).toBeNull();
   });
 
+  it("dedupes pending and fresh Cache Components dynamic router.prefetch calls but refetches after expiry", async () => {
+    // Ported from Next.js:
+    // test/e2e/app-dir/segment-cache/encoded-slash-params/encoded-slash-params.test.ts
+    // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/segment-cache/encoded-slash-params/encoded-slash-params.test.ts
+    vi.stubEnv("__NEXT_CACHE_COMPONENTS", "true");
+    (globalThis as any).window.__VINEXT_LINK_PREFETCH_ROUTES__ = [
+      { canPrefetchLoadingShell: false, patternParts: [":slug"], isDynamic: true },
+    ];
+    const firstResponse = createDeferredResponse();
+    const fetch = vi
+      .fn<(input: RequestInfo | URL) => Promise<Response>>()
+      .mockImplementationOnce(() => firstResponse.promise)
+      .mockResolvedValue(
+        new Response("flight", { headers: { "content-type": "text/x-component" } }),
+      );
+    (globalThis as any).fetch = fetch;
+
+    appRouterInstance.prefetch("/foo%2Fbar");
+    await waitForPrefetchSetup(() => fetch.mock.calls.length === 1);
+
+    // A concurrent call shares the exact pending learning-only entry.
+    appRouterInstance.prefetch("/foo%2Fbar");
+    await settlePrefetchSetup();
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    firstResponse.resolve(
+      new Response("flight", { headers: { "content-type": "text/x-component" } }),
+    );
+    await waitForPrefetchSetup(() => {
+      const entry = getPrefetchCache().values().next().value;
+      return entry?.outcome === "cache-seeded" && entry.pending === undefined;
+    });
+    const entry = getPrefetchCache().values().next().value;
+    expect(entry?.cacheForNavigation).toBe(false);
+    expect(entry?.expiresAt).toEqual(expect.any(Number));
+
+    // A settled but fresh learning-only entry still suppresses a duplicate.
+    appRouterInstance.prefetch("/foo%2Fbar");
+    await settlePrefetchSetup();
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    vi.spyOn(Date, "now").mockReturnValue((entry?.expiresAt ?? 0) + 1);
+    appRouterInstance.prefetch("/foo%2Fbar");
+    await waitForPrefetchSetup(() => fetch.mock.calls.length === 2);
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
   it("promotes a queued prefetch when navigation consumes it (#2722)", async () => {
     // Every route is navigation-reusable, so the queued 5th prefetch is one a
     // navigation will actually try to await.


### PR DESCRIPTION
## Summary

- keep Cache Components automatic dynamic-route prefetches learning-only so encoded path identity remains authoritative at navigation time
- dedupe pending and fresh learning-only Link prefetches, while evicting and refetching settled entries after expiry
- cover pending, settled-fresh, and expired Link remount behavior

## Original deploy-suite rows

Next.js v16.2.6 suite: test/e2e/app-dir/segment-cache/encoded-slash-params/encoded-slash-params.test.ts

- unencoded param > back navigation does not refetch the route tree
- encoded slash in param > back navigation does not refetch the route tree

## Verification

- exact upstream v16.2.6 baseline: 0/2 passed
- exact upstream v16.2.6 with this patch: 2/2 passed
- focused link/navigation units: 274/274 passed
- scoped format, lint, and type checks passed for all 4 changed files
- git diff --check passed

Draft pending CI, Big Bonk, and an exact-head deploy-suite audit.