### PR TITLE
fix(create-vinext-app): pnpm output loses ansi colors when installing dependencies

### DIFF
--- a/packages/vinext/src/init.ts
+++ b/packages/vinext/src/init.ts
@@ -35,6 +35,7 @@ import {
 } from "./init-cloudflare.js";
 import type { CloudflareInitOptions, InitPlatform } from "./init-platform.js";
 import { getReactUpgradeDeps } from "./utils/react-version.js";
+import { stripVTControlCharacters } from "node:util";
 
 export { getReactUpgradeDeps } from "./utils/react-version.js";
 
@@ -62,26 +63,65 @@ function isApproveBuildsError(error: unknown): boolean {
   );
 }
 
-function hasAutomaticallyIgnoredBuilds(output: string): boolean {
-  const automaticallyIgnored = output.match(
-    /Automatically ignored builds during installation:\s*\n([\s\S]*?)(?:\n\s*\n|$)/i,
+type PnpmIgnoredBuildsState =
+  | { kind: "pending"; packages: string[] }
+  | { kind: "none" }
+  | { kind: "error"; reason: string };
+
+function parsePnpmIgnoredBuilds(output: string): PnpmIgnoredBuildsState {
+  const automaticallyIgnored = stripVTControlCharacters(output).match(
+    /Automatically ignored builds during installation:[^\S\r\n]*\r?\n([\s\S]*?)(?:\r?\n[^\S\r\n]*\r?\n|$)/i,
   )?.[1];
-  if (!automaticallyIgnored) return false;
-  return automaticallyIgnored
-    .split("\n")
-    .map((line) => line.trim())
-    .some(
+  if (automaticallyIgnored === undefined) {
+    return { kind: "error", reason: "pnpm ignored-builds returned an unrecognized response" };
+  }
+
+  const packages = automaticallyIgnored
+    .split(/\r?\n/)
+    .map((line) => line.trim().replace(/^[-*]\s+/, ""))
+    .filter(
       (line) => line.length > 0 && !/^none\.?$/i.test(line) && !/^cannot identify\b/i.test(line),
     );
+
+  return packages.length > 0
+    ? { kind: "pending", packages: [...new Set(packages)] }
+    : { kind: "none" };
 }
 
-function inspectPnpmIgnoredBuilds(root: string): string {
-  const result = spawnSync("pnpm", ["ignored-builds"], {
+function hasNewPnpmIgnoredBuilds(
+  before: PnpmIgnoredBuildsState | undefined,
+  after: PnpmIgnoredBuildsState | undefined,
+): boolean {
+  if (!before || after?.kind !== "pending") return false;
+  if (before.kind === "none") return true;
+  if (before.kind === "error") return false;
+
+  const previousPackages = new Set(before.packages);
+  return after.packages.some((packageName) => !previousPackages.has(packageName));
+}
+
+function inspectPnpmIgnoredBuilds(root: string): PnpmIgnoredBuildsState {
+  const { error, status, stdout, stderr } = spawnSync("pnpm", ["ignored-builds"], {
     cwd: root,
     encoding: "utf-8",
     stdio: ["ignore", "pipe", "pipe"],
   });
-  return `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
+
+  if (error) {
+    return {
+      kind: "error",
+      reason: error.message,
+    };
+  }
+
+  if (status !== 0) {
+    return {
+      kind: "error",
+      reason: `pnpm ignored-builds exited with code ${status}`,
+    };
+  }
+
+  return parsePnpmIgnoredBuilds(`${stdout ?? ""}\n${stderr ?? ""}`);
 }
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -108,7 +148,7 @@ export type InitOptions = {
   /** @internal — override exec for testing (avoids ESM spy issues) */
   _exec?: (
     cmd: string,
-    opts: { cwd: string; stdio: string },
+    opts: { cwd: string; stdio: "inherit" },
   ) => string | void | Promise<string | void>;
   /** @internal — override pnpm ignored-builds inspection for testing */
   _inspectPnpmIgnoredBuilds?: (root: string) => string;
@@ -342,7 +382,7 @@ async function installDeps(
   deps: string[],
   exec: (
     cmd: string,
-    opts: { cwd: string; stdio: string },
+    opts: { cwd: string; stdio: "inherit" },
   ) => string | void | Promise<string | void>,
   { dev = true }: { dev?: boolean } = {},
 ): Promise<string> {
@@ -464,32 +504,20 @@ export async function init(options: InitOptions): Promise<InitResult> {
   }
   const exec =
     options._exec ??
-    ((cmd: string, opts: { cwd: string; stdio: string }) =>
-      new Promise<string>((resolve, reject) => {
+    ((cmd: string, opts: { cwd: string; stdio: "inherit" }) =>
+      new Promise<void>((resolve, reject) => {
         const child = spawn(cmd, {
           cwd: opts.cwd,
           shell: true,
-          stdio: ["inherit", "pipe", "pipe"],
+          stdio: opts.stdio,
         });
-        let output = "";
-        child.stdout.on("data", (chunk: Buffer) => {
-          const text = chunk.toString();
-          output += text;
-          process.stdout.write(text);
-        });
-        child.stderr.on("data", (chunk: Buffer) => {
-          const text = chunk.toString();
-          output += text;
-          process.stderr.write(text);
-        });
-        child.on("error", (error) => reject(Object.assign(error, { output })));
+        child.on("error", reject);
         child.on("close", (status) => {
-          if (status === 0) resolve(output);
+          if (status === 0) resolve();
           else {
             reject(
               Object.assign(new Error(`Command failed with exit code ${status}: ${cmd}`), {
                 status,
-                output,
               }),
             );
           }
@@ -601,6 +629,45 @@ export async function init(options: InitOptions): Promise<InitResult> {
   let dependencyInstallNeedsApproval = false;
   const dependencyEntriesAdded: string[] = [];
   const devDependencyEntriesAdded: string[] = [];
+  const inspectIgnoredBuilds = (): PnpmIgnoredBuildsState | undefined => {
+    if (pmName !== "pnpm" || !shouldInstall) return undefined;
+    if (options._inspectPnpmIgnoredBuilds) {
+      try {
+        return parsePnpmIgnoredBuilds(options._inspectPnpmIgnoredBuilds(root));
+      } catch (error) {
+        return {
+          kind: "error",
+          reason: error instanceof Error ? error.message : String(error),
+        };
+      }
+    }
+    // A custom command executor should not cause tests or embedders to spawn pnpm.
+    return options._exec ? undefined : inspectPnpmIgnoredBuilds(root);
+  };
+  const installWithApprovalDetection = async (
+    deps: string[],
+    installOptions: { dev?: boolean } = {},
+  ): Promise<boolean> => {
+    const before = inspectIgnoredBuilds();
+    try {
+      const installOutput = await installDeps(root, deps, exec, installOptions);
+      const after = inspectIgnoredBuilds();
+      if (isApproveBuildsError(installOutput) || after?.kind === "pending") {
+        dependencyInstallNeedsApproval = true;
+      }
+      return true;
+    } catch (error) {
+      const after = inspectIgnoredBuilds();
+      if (
+        pmName !== "pnpm" ||
+        (!isApproveBuildsError(error) && !hasNewPnpmIgnoredBuilds(before, after))
+      ) {
+        throw error;
+      }
+      dependencyInstallNeedsApproval = true;
+      return false;
+    }
+  };
 
   // For App Router: react-server-dom-webpack requires react/react-dom versions
   // to match exactly (e.g. rsdw@19.2.6 needs react@^19.2.6). If the installed
@@ -616,17 +683,11 @@ export async function init(options: InitOptions): Promise<InitResult> {
           "    ",
         ),
       );
-      try {
-        if (shouldInstall) {
-          const installOutput = await installDeps(root, reactUpgrade, exec, { dev: false });
-          if (isApproveBuildsError(installOutput)) dependencyInstallNeedsApproval = true;
-        } else {
-          const added = addDependencyEntries(root, reactUpgrade, { dev: false });
-          dependencyEntriesAdded.push(...added);
-        }
-      } catch (error) {
-        if (pmName !== "pnpm" || !isApproveBuildsError(error)) throw error;
-        dependencyInstallNeedsApproval = true;
+      if (shouldInstall) {
+        await installWithApprovalDetection(reactUpgrade, { dev: false });
+      } else {
+        const added = addDependencyEntries(root, reactUpgrade, { dev: false });
+        dependencyEntriesAdded.push(...added);
       }
     }
   }
@@ -634,18 +695,13 @@ export async function init(options: InitOptions): Promise<InitResult> {
   if (missingDependencies.length > 0) {
     console.log(`  ${terminalStyle.cyan(terminalStyle.bold("Installing dependencies:"))}`);
     console.log(formatList(missingDependencies, "    "));
-    try {
-      if (shouldInstall) {
-        const installOutput = await installDeps(root, missingDependencies, exec, { dev: false });
+    if (shouldInstall) {
+      if (await installWithApprovalDetection(missingDependencies, { dev: false })) {
         dependencyEntriesAdded.push(...missingDependencies);
-        if (isApproveBuildsError(installOutput)) dependencyInstallNeedsApproval = true;
-      } else {
-        const added = addDependencyEntries(root, missingDependencies, { dev: false });
-        dependencyEntriesAdded.push(...added);
       }
-    } catch (error) {
-      if (pmName !== "pnpm" || !isApproveBuildsError(error)) throw error;
-      dependencyInstallNeedsApproval = true;
+    } else {
+      const added = addDependencyEntries(root, missingDependencies, { dev: false });
+      dependencyEntriesAdded.push(...added);
     }
     console.log();
   }
@@ -653,38 +709,15 @@ export async function init(options: InitOptions): Promise<InitResult> {
   if (missingDevDependencies.length > 0) {
     console.log(`  ${terminalStyle.cyan(terminalStyle.bold("Installing devDependencies:"))}`);
     console.log(formatList(missingDevDependencies, "    "));
-    try {
-      if (shouldInstall) {
-        const installOutput = await installDeps(root, missingDevDependencies, exec);
+    if (shouldInstall) {
+      if (await installWithApprovalDetection(missingDevDependencies)) {
         devDependencyEntriesAdded.push(...missingDevDependencies);
-        if (isApproveBuildsError(installOutput)) dependencyInstallNeedsApproval = true;
-      } else {
-        const added = addDependencyEntries(root, missingDevDependencies, { dev: true });
-        devDependencyEntriesAdded.push(...added);
       }
-    } catch (error) {
-      if (pmName !== "pnpm" || !isApproveBuildsError(error)) throw error;
-      dependencyInstallNeedsApproval = true;
+    } else {
+      const added = addDependencyEntries(root, missingDevDependencies, { dev: true });
+      devDependencyEntriesAdded.push(...added);
     }
     console.log();
-  }
-
-  if (
-    pmName === "pnpm" &&
-    shouldInstall &&
-    !dependencyInstallNeedsApproval &&
-    !options._exec &&
-    hasAutomaticallyIgnoredBuilds(inspectPnpmIgnoredBuilds(root))
-  ) {
-    dependencyInstallNeedsApproval = true;
-  } else if (
-    pmName === "pnpm" &&
-    shouldInstall &&
-    !dependencyInstallNeedsApproval &&
-    options._inspectPnpmIgnoredBuilds &&
-    hasAutomaticallyIgnoredBuilds(options._inspectPnpmIgnoredBuilds(root))
-  ) {
-    dependencyInstallNeedsApproval = true;
   }
 
   // ── Step 7: Print summary ──────────────────────────────────────────────

--- a/tests/init-command-exec.test.ts
+++ b/tests/init-command-exec.test.ts
@@ -1,0 +1,72 @@
+import { EventEmitter } from "node:events";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { PassThrough } from "node:stream";
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { init } from "../packages/vinext/src/init.js";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    spawn: spawnMock,
+  };
+});
+
+let tmpDir: string;
+
+function successfulChild(): ChildProcessWithoutNullStreams {
+  const child = Object.assign(new EventEmitter(), {
+    stdin: new PassThrough(),
+    stdout: new PassThrough(),
+    stderr: new PassThrough(),
+  }) as unknown as ChildProcessWithoutNullStreams;
+  queueMicrotask(() => child.emit("close", 0, null));
+  return child;
+}
+
+describe("init command execution", () => {
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-init-exec-test-"));
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ name: "test-project", version: "1.0.0" }),
+      "utf-8",
+    );
+    fs.mkdirSync(path.join(tmpDir, "pages"));
+    fs.writeFileSync(
+      path.join(tmpDir, "pages", "index.tsx"),
+      "export default function Home() { return <div>hi</div> }",
+      "utf-8",
+    );
+    spawnMock.mockReset();
+    spawnMock.mockImplementation(successfulChild);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("inherits stdio for dependency installs so package managers retain terminal capabilities", async () => {
+    await init({
+      root: tmpDir,
+      skipCheck: true,
+      platform: "node",
+    });
+
+    expect(spawnMock).toHaveBeenCalled();
+    for (const [, options] of spawnMock.mock.calls) {
+      expect(options).toEqual(
+        expect.objectContaining({
+          stdio: "inherit",
+        }),
+      );
+    }
+  });
+});

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -1116,6 +1116,54 @@ describe("init — dependency installation", () => {
     expect(output).toContain("Added dependencies to devDependencies:");
   });
 
+  it("detects newly blocked builds after pnpm exits without capturable output", async () => {
+    setupProject(tmpDir, { router: "pages" });
+    writeFile(tmpDir, "pnpm-lock.yaml", "lockfileVersion: '9.0'\n");
+    let installStarted = false;
+    let installAttempts = 0;
+    const inspectPnpmIgnoredBuilds = vi.fn(() =>
+      installStarted
+        ? "Automatically ignored builds during installation:\n  esbuild\n"
+        : "Automatically ignored builds during installation:\n  None\n",
+    );
+
+    const { output } = await runInit(tmpDir, {
+      _exec: () => {
+        installStarted = true;
+        installAttempts++;
+        if (installAttempts === 1) {
+          throw Object.assign(new Error("Command failed with exit code 1: pnpm add vinext"), {
+            status: 1,
+          });
+        }
+      },
+      _inspectPnpmIgnoredBuilds: inspectPnpmIgnoredBuilds,
+    });
+
+    expect(inspectPnpmIgnoredBuilds.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(output).toContain("Dependency installation is waiting for build-script approval");
+    expect(output).toContain("pnpm approve-builds");
+  });
+
+  it("does not hide a generic pnpm failure when pending builds did not change", async () => {
+    setupProject(tmpDir, { router: "pages" });
+    writeFile(tmpDir, "pnpm-lock.yaml", "lockfileVersion: '9.0'\n");
+    const inspectPnpmIgnoredBuilds = vi.fn(
+      () => "Automatically ignored builds during installation:\n  esbuild\n",
+    );
+
+    await expect(
+      runInit(tmpDir, {
+        _exec: () => {
+          throw Object.assign(new Error("pnpm registry request timed out"), { status: 1 });
+        },
+        _inspectPnpmIgnoredBuilds: inspectPnpmIgnoredBuilds,
+      }),
+    ).rejects.toThrow("pnpm registry request timed out");
+
+    expect(inspectPnpmIgnoredBuilds.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
   it("does not request approval when pnpm has no automatically ignored builds", async () => {
     setupProject(tmpDir, { router: "pages" });
     writeFile(tmpDir, "pnpm-lock.yaml", "lockfileVersion: '9.0'\n");


### PR DESCRIPTION
Closes #2863

## Overview

Dependency installation during vinext init should behave like running the package manager directly in the terminal, including preserving pnpm’s interactive output and ANSI colors.

This PR restores that terminal-native experience while retaining reliable detection of pnpm dependencies awaiting build-script approval. It also ensures unrelated installation failures remain visible instead of being misclassified as approval-related errors.

## What changed

The root cause of this issue is the hard-coded `pipe` at `packages/vinext/src/init.ts:472`, which is to get the raw output of `pnpm install` and resolve the ignored builds. However, it just broke the terminal-native experience and made pnpm lost its color.

Fortunately, pnpm has a builtin command to list all ignore builds: `pnpm ignored-builds`. This PR runs `pnpm ignored-builds`, gets its output and resolve the list.

In this way, the default `exec()` function doesn't need to pass `pipe` to stdio and doesn't need to collect exec output:
```diff
  const child = spawn(cmd, {
    cwd: opts.cwd,
    shell: true,
-   stdio: ["inherit", "pipe", "pipe"],
+   stdio: opts.stdio,
  });
- let output = "";
- child.stdout.on("data", (chunk: Buffer) => {
-   const text = chunk.toString();
-   output += text;
-   process.stdout.write(text);
- });
- child.stderr.on("data", (chunk: Buffer) => {
-   const text = chunk.toString();
-   output += text;
-   process.stderr.write(text);
- });
- child.on("error", (error) => reject(Object.assign(error, { output })));
+ child.on("error", reject);
  child.on("close", (status) => {
-   if (status === 0) resolve(output);
+   if (status === 0) resolve();
    else {
      reject(
        Object.assign(new Error(`Command failed with exit code ${status}: ${cmd}`), {
          status,
-         output,
        }),
      );
    }
  });
```

## Testing

- `pnpm test tests/init-command-exec.test.ts tests/init.test.ts`
