### PR TITLE
test: add Vite ecosystem CI setup entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test:unit": "vp test run --project unit",
     "test:integration": "vp test run --project integration",
     "test:watch": "vp test",
+    "vite-ecosystem-ci:before-install": "pnpm config set frozen-lockfile false --location project",
     "vite-ecosystem-ci:build": "vp run vinext#build",
     "vite-ecosystem-ci:test": "vp test run --project unit tests/build-optimization.test.ts tests/client-assets-build.test.ts && vp test run --project integration tests/app-router-rsc-plugin.test.ts tests/app-router-production-build.test.ts tests/vite-hmr-websocket.test.ts",
     "sync:next-types": "node scripts/sync-next-types.mjs",


### PR DESCRIPTION
## Summary

- add a project-owned `vite-ecosystem-ci:before-install` script
- disable the project-local frozen-lockfile setting for ecosystem CI, where dependency overrides intentionally differ from the committed lockfile
- keep future ecosystem CI setup changes self-contained in vinext

This will be consumed by vitejs/vite-ecosystem-ci#510.

## Validation

- `pnpm run fmt:check -- package.json`
- verified the script value from `package.json`
- `git diff --check`