### PR TITLE
fix(ci): enable test instrumentation in deploy shards

### DIFF
--- a/.github/workflows/nextjs-deploy-suite.yml
+++ b/.github/workflows/nextjs-deploy-suite.yml
@@ -280,6 +280,11 @@ jobs:
         env:
           CI: true
           NEXT_TEST_MODE: deploy
+          # Next.js sets this private build variable for its own dev/start
+          # harnesses. The deploy fixture build needs the equivalent so
+          # test-only client request metadata (such as fetch priority) is
+          # compiled into the app under test.
+          __NEXT_TEST_MODE: e2e
           NEXT_E2E_TEST_TIMEOUT: "240000"
           NEXT_EXTERNAL_TESTS_FILTERS: ${{ github.workspace }}/nextjs-deploy-manifest.json
           VINEXT_DIR: ${{ github.workspace }}

--- a/tests/e2e-deploy-script.test.ts
+++ b/tests/e2e-deploy-script.test.ts
@@ -3,7 +3,21 @@ import path from "node:path";
 import { execFileSync } from "node:child_process";
 import { describe, expect, it } from "vite-plus/test";
 
-describe("Next.js deploy harness logging", () => {
+describe("Next.js deploy harness", () => {
+  it("enables Next.js test-only client instrumentation in deploy shards", () => {
+    const workflow = fs.readFileSync(
+      path.resolve(".github/workflows/nextjs-deploy-suite.yml"),
+      "utf8",
+    );
+    const deployShard = workflow.match(
+      /- name: Run deploy shard[\s\S]*?\n      - name: Upload test results/,
+    )?.[0];
+
+    expect(deployShard).toBeDefined();
+    expect(deployShard).toContain("NEXT_TEST_MODE: deploy");
+    expect(deployShard).toContain("__NEXT_TEST_MODE: e2e");
+  });
+
   it("does not recursively append failure diagnostics to deploy logs", () => {
     const script = fs.readFileSync(path.resolve("scripts/e2e-deploy.sh"), "utf8");
     const cleanup = script.match(


### PR DESCRIPTION
## Summary

- compile Next.js test-only client instrumentation into deploy-shard fixture builds
- keep the workflow's direct `run-tests.js` path aligned with `run-nextjs-deploy-suite.sh`
- guard the deploy-shard environment with focused harness coverage

## Failure and root cause

Run https://github.com/cloudflare/vinext/actions/runs/31439707085, job https://github.com/cloudflare/vinext/actions/runs/31439707085/job/93624401572 reported two failures in `test/e2e/app-dir/app-prefetch/prefetching.test.ts`:

- `should prefetch links in viewport with low priority`
- `should have an auto priority for all other fetch operations`

The App Router fetch-priority implementation is already present from #2318. The deploy workflow was the mismatch: test shards invoke Next.js `run-tests.js` directly, bypassing `scripts/run-nextjs-deploy-suite.sh`, but only exported `NEXT_TEST_MODE=deploy`. Without the private `__NEXT_TEST_MODE=e2e` build variable, Vite compiled the test-only `Next-Test-Fetch-Priority` request header out of each fixture. The browser assertions therefore saw RSC requests without the diagnostic priority header even though the real Fetch API priority was correct.

## Next.js parity reference

Next.js emits the diagnostic header only in test mode from `packages/next/src/client/components/router-reducer/fetch-server-response.ts`, and validates it in:

https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/app-prefetch/prefetching.test.ts

## Validation

- `vp test run tests/e2e-deploy-script.test.ts` — 8 passed
- `vp check tests/e2e-deploy-script.test.ts .github/workflows/nextjs-deploy-suite.yml` — clean
- `REPO="$(pwd)" NEXTJS_DIR="/Users/jamesanderson/Developer/vinext/.nextjs-ref" VINEXT_BUILD=0 ./scripts/run-targeted-nextjs-e2e.sh test/e2e/app-dir/app-prefetch/prefetching.test.ts` against Next.js v16.2.6 — 17 passed, 1 upstream headed-mode skip, including all 3 fetch-priority tests
- independent review — no findings
