### PR TITLE
fix(app-router): preserve valued RSC queries through routing

### DIFF
--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -1785,6 +1785,12 @@ function bootstrapHydration(
           fetchPriority: "auto",
           interceptionContext: requestInterceptionContext,
           mountedSlotsHeader,
+          routerState: {
+            pathAndSearch: createSnapshotPathAndSearch(
+              navigationInitiationState.navigationSnapshot,
+            ),
+            routeId: navigationInitiationState.routeId,
+          },
         });
         const rewrittenNavigationHref =
           navigationKind === "navigate" && HAS_CLIENT_REWRITES

--- a/packages/vinext/src/server/app-rsc-cache-busting.ts
+++ b/packages/vinext/src/server/app-rsc-cache-busting.ts
@@ -1,5 +1,9 @@
 import { fnv1a64 } from "../utils/hash.js";
 import {
+  createAppRscStateFingerprint,
+  type AppRscStateFingerprintInput,
+} from "./app-rsc-state-fingerprint.js";
+import {
   APP_RSC_RENDER_MODE_NAVIGATION,
   parseAppRscRenderMode,
   type AppRscRenderMode,
@@ -15,6 +19,7 @@ import {
   VINEXT_MOUNTED_SLOTS_HEADER,
   NEXTJS_DEPLOYMENT_ID_HEADER,
   VINEXT_RSC_RENDER_MODE_HEADER,
+  VINEXT_RSC_STATE_FINGERPRINT_HEADER,
 } from "./headers.js";
 import { applyDeploymentIdHeader, getDeploymentId } from "../utils/deployment-id.js";
 
@@ -40,6 +45,7 @@ export const VINEXT_RSC_VARY_HEADER = [
   VINEXT_INTERCEPTION_CONTEXT_HEADER,
   VINEXT_MOUNTED_SLOTS_HEADER,
   VINEXT_RSC_RENDER_MODE_HEADER,
+  VINEXT_RSC_STATE_FINGERPRINT_HEADER,
 ].join(", ");
 
 const CACHE_BUSTING_DIGEST_BYTES = 12;
@@ -57,6 +63,7 @@ type CreateRscRequestHeadersOptions = {
     pathAndSearch: string;
     routeId: string;
   } | null;
+  routerState?: AppRscStateFingerprintInput | null;
 };
 
 type ResolveInvalidRscCacheBustingRequestOptions = {
@@ -175,6 +182,7 @@ function normalizeRenderModeHeaderValue(value: string | null): string | null {
 
 type CreateCacheBustingInputOptions = {
   includeRenderModeHeader?: boolean;
+  includeStateFingerprintHeader?: boolean;
 };
 
 function createCacheBustingInput(
@@ -194,6 +202,10 @@ function createCacheBustingInput(
       ? []
       : [normalizeRenderModeHeaderValue(headers.get(VINEXT_RSC_RENDER_MODE_HEADER))]),
   ];
+  const stateFingerprint = headers.get(VINEXT_RSC_STATE_FINGERPRINT_HEADER);
+  if (options.includeStateFingerprintHeader !== false && stateFingerprint !== null) {
+    values.push(stateFingerprint);
+  }
 
   if (values.every((value) => value === null)) {
     return null;
@@ -210,20 +222,6 @@ async function sha256CacheBustingHash(input: string): Promise<string> {
 function computeLegacyRscCacheBustingSearchParam(headers: Headers): string {
   const input = createCacheBustingInput(headers);
   return input === null ? "" : fnv1a64(input);
-}
-
-async function computePreviousRscCacheBustingSearchParam(headers: Headers): Promise<string | null> {
-  const input = createCacheBustingInput(headers, { includeRenderModeHeader: false });
-  if (input === null) {
-    return null;
-  }
-
-  return sha256CacheBustingHash(input);
-}
-
-function computePreviousLegacyRscCacheBustingSearchParam(headers: Headers): string | null {
-  const input = createCacheBustingInput(headers, { includeRenderModeHeader: false });
-  return input === null ? null : fnv1a64(input);
 }
 
 function getSearchPairsWithoutRscCacheBusting(url: URL): string[] {
@@ -306,6 +304,11 @@ export function createRscRequestHeaders(options: CreateRscRequestHeadersOptions 
       NEXT_ROUTER_STATE_TREE_HEADER,
       encodeURIComponent(JSON.stringify(options.prefetchRouterState)),
     );
+  }
+
+  const routerState = options.routerState ?? options.prefetchRouterState;
+  if (routerState) {
+    headers.set(VINEXT_RSC_STATE_FINGERPRINT_HEADER, createAppRscStateFingerprint(routerState));
   }
 
   if (options.nextUrl) {
@@ -398,16 +401,31 @@ export async function resolveInvalidRscCacheBustingRequest(
   const acceptedHashes = new Set<string>([expectedHash]);
   if (actualHash !== null && actualHash !== expectedHash) {
     acceptedHashes.add(computeLegacyRscCacheBustingSearchParam(options.request.headers));
-    if (
+    const compatibilityInputs: CreateCacheBustingInputOptions[] = [];
+    const hasStateFingerprint = options.request.headers.has(VINEXT_RSC_STATE_FINGERPRINT_HEADER);
+    const hasNormalRenderMode =
       normalizeRenderModeHeaderValue(options.request.headers.get(VINEXT_RSC_RENDER_MODE_HEADER)) ===
-      null
-    ) {
-      const previousHash = await computePreviousRscCacheBustingSearchParam(options.request.headers);
-      const previousLegacyHash = computePreviousLegacyRscCacheBustingSearchParam(
-        options.request.headers,
-      );
-      if (previousHash !== null) acceptedHashes.add(previousHash);
-      if (previousLegacyHash !== null) acceptedHashes.add(previousLegacyHash);
+      null;
+    if (hasStateFingerprint) {
+      compatibilityInputs.push({ includeStateFingerprintHeader: false });
+    }
+    if (hasNormalRenderMode) {
+      compatibilityInputs.push({ includeRenderModeHeader: false });
+    }
+    if (hasStateFingerprint && hasNormalRenderMode) {
+      compatibilityInputs.push({
+        includeRenderModeHeader: false,
+        includeStateFingerprintHeader: false,
+      });
+    }
+    for (const compatibilityOptions of compatibilityInputs) {
+      const input = createCacheBustingInput(options.request.headers, compatibilityOptions);
+      if (input === null) {
+        acceptedHashes.add("");
+      } else {
+        acceptedHashes.add(await sha256CacheBustingHash(input));
+        acceptedHashes.add(fnv1a64(input));
+      }
     }
   }
 

--- a/packages/vinext/src/server/app-rsc-state-fingerprint.ts
+++ b/packages/vinext/src/server/app-rsc-state-fingerprint.ts
@@ -1,0 +1,16 @@
+import { fnv1a64 } from "../utils/hash.js";
+
+export type AppRscStateFingerprintInput = {
+  pathAndSearch: string;
+  routeId: string;
+};
+
+/**
+ * Compact identity for the visible App Router state that produced an RSC
+ * request. This is deliberately separate from Next-Router-State-Tree: vinext
+ * does not emit Next.js' Flight router-tree wire format, so reusing that header
+ * would give it incorrect routing semantics.
+ */
+export function createAppRscStateFingerprint(input: AppRscStateFingerprintInput): string {
+  return fnv1a64(JSON.stringify([input.pathAndSearch, input.routeId]));
+}

--- a/packages/vinext/src/server/headers.ts
+++ b/packages/vinext/src/server/headers.ts
@@ -87,6 +87,9 @@ export const VINEXT_INTERCEPTION_CONTEXT_HEADER = "X-Vinext-Interception-Context
 /** RSC render mode (e.g. "navigation", "prefetch"). */
 export const VINEXT_RSC_RENDER_MODE_HEADER = "X-Vinext-Rsc-Render-Mode";
 
+/** Stable visible-router-state variant for RSC cache busting. */
+export const VINEXT_RSC_STATE_FINGERPRINT_HEADER = "X-Vinext-Rsc-State-Fingerprint";
+
 /** Disabled-by-default client hint describing already-held App Router payload entries. */
 export const VINEXT_CLIENT_REUSE_MANIFEST_HEADER = "X-Vinext-Client-Reuse-Manifest";
 
@@ -205,6 +208,7 @@ export const FLIGHT_HEADERS: readonly string[] = [
   "next-router-prefetch",
   "next-hmr-refresh",
   "next-router-segment-prefetch",
+  "x-vinext-rsc-state-fingerprint",
 ];
 
 // ---------------------------------------------------------------------------

--- a/tests/app-rsc-cache-busting.test.ts
+++ b/tests/app-rsc-cache-busting.test.ts
@@ -16,7 +16,11 @@ import {
   VINEXT_RSC_VARY_HEADER,
 } from "../packages/vinext/src/server/app-rsc-cache-busting.js";
 import { APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL } from "../packages/vinext/src/server/app-rsc-render-mode.js";
-import { VINEXT_CLIENT_REUSE_MANIFEST_HEADER } from "../packages/vinext/src/server/headers.js";
+import {
+  FLIGHT_HEADERS,
+  VINEXT_CLIENT_REUSE_MANIFEST_HEADER,
+  VINEXT_RSC_STATE_FINGERPRINT_HEADER,
+} from "../packages/vinext/src/server/headers.js";
 import { fnv1a64 } from "../packages/vinext/src/utils/hash.js";
 import { withEnvVar } from "./env-test-helpers.js";
 
@@ -104,6 +108,29 @@ describe("App Router RSC cache-busting", () => {
     expect(hash).not.toBe("");
     await expect(createRscRequestUrl("/photos/42", headers)).resolves.toBe(
       `/photos/42?${VINEXT_RSC_CACHE_BUSTING_SEARCH_PARAM}=${hash}`,
+    );
+  });
+
+  it("adds a valued _rsc query for visible App Router state", async () => {
+    const headers = createRscRequestHeaders({
+      routerState: { pathAndSearch: "/current", routeId: "route:/current" },
+    });
+    const hash = await computeRscCacheBustingSearchParam(headers);
+
+    expect(headers.get(VINEXT_RSC_STATE_FINGERPRINT_HEADER)).toMatch(/^[0-9a-f]{16}$/);
+    expect(hash).not.toBe("");
+    await expect(createRscRequestUrl("/destination", headers)).resolves.toBe(
+      `/destination?_rsc=${hash}`,
+    );
+  });
+
+  it("derives the same state fingerprint for reusable prefetch requests", () => {
+    const routerState = { pathAndSearch: "/current", routeId: "route:/current" };
+    const navigationHeaders = createRscRequestHeaders({ routerState });
+    const prefetchHeaders = createRscRequestHeaders({ prefetchRouterState: routerState });
+
+    expect(prefetchHeaders.get(VINEXT_RSC_STATE_FINGERPRINT_HEADER)).toBe(
+      navigationHeaders.get(VINEXT_RSC_STATE_FINGERPRINT_HEADER),
     );
   });
 
@@ -292,6 +319,17 @@ describe("App Router RSC cache-busting", () => {
     ).resolves.toBeNull();
   });
 
+  it("accepts the prior bare navigation query after adding the state fingerprint", async () => {
+    const headers = createRscRequestHeaders({
+      routerState: { pathAndSearch: "/current", routeId: "route:/current" },
+    });
+    const request = new Request("https://example.com/photos/42?_rsc", { headers });
+
+    await expect(
+      resolveInvalidRscCacheBustingRequest({ isRscRequest: true, request }),
+    ).resolves.toBeNull();
+  });
+
   it("ignores non-RSC and mutating requests", async () => {
     const headers = createRscRequestHeaders({ interceptionContext: "/feed" });
 
@@ -313,9 +351,10 @@ describe("App Router RSC cache-busting", () => {
     // Mirrors Next.js App Router's base Vary header:
     // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/route-modules/app-page/module.ts
     expect(VINEXT_RSC_VARY_HEADER).toBe(
-      "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch, Next-Url, X-Vinext-Interception-Context, X-Vinext-Mounted-Slots, X-Vinext-Rsc-Render-Mode",
+      "RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch, Next-Url, X-Vinext-Interception-Context, X-Vinext-Mounted-Slots, X-Vinext-Rsc-Render-Mode, X-Vinext-Rsc-State-Fingerprint",
     );
     expect(VINEXT_RSC_VARY_HEADER.split(", ")).not.toContain("Accept");
+    expect(FLIGHT_HEADERS).toContain(VINEXT_RSC_STATE_FINGERPRINT_HEADER.toLowerCase());
   });
 
   it("applies the current compatibility ID to RSC response headers when available", () => {

--- a/tests/e2e/app-router/nextjs-compat/rsc-query-routing.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/rsc-query-routing.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "@playwright/test";
+import { waitForAppRouterHydration } from "../../helpers";
+
+const BASE = process.env.VINEXT_RSC_QUERY_TEST_BASE_URL ?? "http://localhost:4174";
+const ROOT = "/nextjs-compat/rsc-query-routing";
+
+// Ported from Next.js v16.2.6:
+// test/e2e/app-dir/rsc-query-routing/rsc-query-routing.test.ts
+// https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/rsc-query-routing/rsc-query-routing.test.ts
+test.describe("Next.js compat: RSC query routing", () => {
+  test("preserves a valued RSC query through a config redirect", async ({ page }) => {
+    await page.goto(`${BASE}${ROOT}/redirect`);
+    await waitForAppRouterHydration(page);
+
+    const rscRequestUrls: URL[] = [];
+    page.on("request", (request) => {
+      const url = new URL(request.url());
+      if (url.searchParams.get("_rsc")) rscRequestUrls.push(url);
+    });
+
+    await page.getByRole("link", { name: "Redirect Link" }).click();
+    await expect(page.getByRole("heading", { name: "Redirect Dest" })).toBeVisible();
+
+    expect(rscRequestUrls[0]?.pathname).toBe(`${ROOT}/redirect/source`);
+    expect(rscRequestUrls[1]?.pathname).toBe(`${ROOT}/redirect/dest`);
+  });
+
+  test("preserves a valued RSC query through a config rewrite", async ({ page }) => {
+    await page.goto(`${BASE}${ROOT}/rewrite`);
+    await waitForAppRouterHydration(page);
+
+    const rscRequestUrls: URL[] = [];
+    page.on("request", (request) => {
+      const url = new URL(request.url());
+      if (url.searchParams.get("_rsc")) rscRequestUrls.push(url);
+    });
+
+    await page.getByRole("link", { name: "Rewrite Link" }).click();
+    await expect(page.getByRole("heading", { name: "Rewrite Dest" })).toBeVisible();
+
+    expect(rscRequestUrls[0]?.pathname).toBe(`${ROOT}/rewrite/source`);
+  });
+});

--- a/tests/fixtures/app-basic/app/nextjs-compat/rsc-query-routing/redirect/dest/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/rsc-query-routing/redirect/dest/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Redirect Dest</h1>;
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/rsc-query-routing/redirect/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/rsc-query-routing/redirect/page.tsx
@@ -1,0 +1,9 @@
+import Link from "next/link";
+
+export default function Page() {
+  return (
+    <Link prefetch={false} href="/nextjs-compat/rsc-query-routing/redirect/source">
+      Redirect Link
+    </Link>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/rsc-query-routing/rewrite/dest/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/rsc-query-routing/rewrite/dest/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Rewrite Dest</h1>;
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/rsc-query-routing/rewrite/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/rsc-query-routing/rewrite/page.tsx
@@ -1,0 +1,9 @@
+import Link from "next/link";
+
+export default function Page() {
+  return (
+    <Link prefetch={false} href="/nextjs-compat/rsc-query-routing/rewrite/source">
+      Rewrite Link
+    </Link>
+  );
+}

--- a/tests/fixtures/app-basic/next.config.ts
+++ b/tests/fixtures/app-basic/next.config.ts
@@ -90,6 +90,13 @@ const nextConfig: NextConfig = {
         destination: "/about",
         permanent: false,
       },
+      // Ported from Next.js v16.2.6:
+      // test/e2e/app-dir/rsc-query-routing/next.config.js
+      {
+        source: "/nextjs-compat/rsc-query-routing/redirect/source",
+        destination: "/nextjs-compat/rsc-query-routing/redirect/dest",
+        permanent: true,
+      },
     ];
   },
 
@@ -170,6 +177,12 @@ const nextConfig: NextConfig = {
         {
           source: "/rewritten-use-pathname",
           destination: "/nextjs-compat/hooks-search",
+        },
+        // Ported from Next.js v16.2.6:
+        // test/e2e/app-dir/rsc-query-routing/next.config.js
+        {
+          source: "/nextjs-compat/rsc-query-routing/rewrite/source",
+          destination: "/nextjs-compat/rsc-query-routing/rewrite/dest",
         },
       ],
       fallback: [

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -9633,6 +9633,7 @@ describe("double-encoded path handling in middleware", () => {
           "next-router-prefetch": "1",
           "next-router-segment-prefetch": "/dashboard",
           "next-hmr-refresh": "1",
+          "x-vinext-rsc-state-fingerprint": "state-a",
           "x-user-visible": "keep",
         },
       }),
@@ -9643,6 +9644,7 @@ describe("double-encoded path handling in middleware", () => {
     expect(capturedHeaders?.get("next-router-state-tree")).toBeNull();
     expect(capturedHeaders?.get("next-router-prefetch")).toBeNull();
     expect(capturedHeaders?.get("next-router-segment-prefetch")).toBeNull();
+    expect(capturedHeaders?.get("x-vinext-rsc-state-fingerprint")).toBeNull();
     expect(capturedHeaders?.get("next-hmr-refresh")).toBeNull();
     expect(capturedHeaders?.get("x-user-visible")).toBe("keep");
   });


### PR DESCRIPTION
## Summary

- vary App Router RSC navigation URLs by a stable visible-state fingerprint
- preserve valued `_rsc=` requests through config redirects and rewrites
- retain compatibility with prior SHA, FNV, and bare `_rsc` request variants
- port the Next.js v16.2.6 redirect/rewrite regression to vinext

## Backlog failures

Fixes both non-cache failures from [run 31439707085, job 93624401572](https://github.com/cloudflare/vinext/actions/runs/31439707085/job/93624401572) in `test/e2e/app-dir/rsc-query-routing/rsc-query-routing.test.ts`:

- RSC query preserved on config redirect
- RSC query preserved on config rewrite

## Validation

- exact Next.js v16.2.6 targeted deploy suite: 2/2 passed
- vinext Playwright regression: 2/2 passed
- focused cache-busting, browser navigation, Link, and RSC handler tests: 520/520 passed
- focused middleware flight-header test passed
- `vp check`
- `vp run vinext#build`
- `vp run knip`

Refs the two `rsc-query-routing` failures in run 31439707085.