### PR TITLE
fix(build): preserve transitive external versions

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1422,7 +1422,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
   let hasCloudflarePlugin = false;
   let warnedInlineNextConfigOverride = false;
   let hasNitroPlugin = false;
-  let nitroTraceDepsFromServerExternals: string[] = [];
+  let resolvedServerExternalPackages: string[] = [];
   let isServeCommand = false;
   let pagesOptimizeEntries: string[] = [];
   const pagesClientAssetsOutputDirs = new Set<string>();
@@ -2585,7 +2585,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           nextConfig?.serverExternalPackages,
           serverTranspilePackages,
         );
-        nitroTraceDepsFromServerExternals = nextServerExternal;
+        resolvedServerExternalPackages = nextServerExternal;
         // Detect if this is a multi-environment build (App Router or Cloudflare).
         // In multi-env builds, manualChunks must only be set per-environment
         // (on the client env), not globally — otherwise it leaks into RSC/SSR
@@ -6344,7 +6344,7 @@ export const loadServerActionClient = ${
     // when their importer and project-root resolutions differ.
     createTransitiveExternalsPlugin({
       getRoot: () => root,
-      getExternalPackages: () => nextConfig.serverExternalPackages,
+      getExternalPackages: () => resolvedServerExternalPackages,
     }),
     // Write image config JSON for the App Router production server.
     // The App Router RSC entry doesn't export vinextConfig (that's a Pages
@@ -6441,12 +6441,9 @@ export const loadServerActionClient = ${
           if (!nextConfig) return;
           if (!hasAppDir && !hasPagesDir) return;
 
-          if (nitroTraceDepsFromServerExternals.length > 0) {
+          if (resolvedServerExternalPackages.length > 0) {
             nitro.options.traceDeps = [
-              ...new Set([
-                ...(nitro.options.traceDeps ?? []),
-                ...nitroTraceDepsFromServerExternals,
-              ]),
+              ...new Set([...(nitro.options.traceDeps ?? []), ...resolvedServerExternalPackages]),
             ];
           }
 

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -179,6 +179,7 @@ import {
   VINEXT_OPTIMIZE_DEPS_EXCLUDE,
 } from "./plugins/rsc-client-shim-excludes.js";
 import { createServerExternalsManifestPlugin } from "./plugins/server-externals-manifest.js";
+import { createTransitiveExternalsPlugin } from "./plugins/transitive-externals.js";
 // Keep this source-relative: resolving through vinext's package export can read
 // a stale built copy while developing or testing the source tree.
 // oxlint-disable-next-line vinext-local/prefer-import-alias
@@ -6338,6 +6339,13 @@ export const loadServerActionClient = ${
     // standalone/node_modules/ — uses the bundler's own import graph instead of
     // fragile regex scanning of emitted files.
     createServerExternalsManifestPlugin(),
+    // Preserve importer-relative package identity for nested copies of
+    // serverExternalPackages. Next.js refuses to externalize these requests
+    // when their importer and project-root resolutions differ.
+    createTransitiveExternalsPlugin({
+      getRoot: () => root,
+      getExternalPackages: () => nextConfig.serverExternalPackages,
+    }),
     // Write image config JSON for the App Router production server.
     // The App Router RSC entry doesn't export vinextConfig (that's a Pages
     // Router pattern), so we write a separate JSON file at build time that

--- a/packages/vinext/src/plugins/transitive-externals.ts
+++ b/packages/vinext/src/plugins/transitive-externals.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import { createRequire } from "node:module";
 import path, { toSlash } from "pathslash";
 import { createIdResolver, type Plugin, type Rollup } from "vite";
+import { stripViteModuleQuery } from "../utils/path.js";
 
 type ExternalModuleMode = "import" | "require";
 
@@ -139,19 +140,19 @@ export function createTransitiveExternalsPlugin(options: {
 
         const packageName = packageNameFromSpecifier(source);
         if (!packageName || !externalPackages.has(packageName)) return null;
-        if (importer.startsWith("\0") || importer.includes("?") || !path.isAbsolute(importer)) {
-          return null;
-        }
+        if (importer.startsWith("\0")) return null;
+        const cleanImporter = stripViteModuleQuery(importer);
+        if (!path.isAbsolute(cleanImporter)) return null;
 
         const mode = moduleMode(resolveOptions.kind);
         const resolver = mode === "require" ? requireResolver : importResolver;
         return (async () => {
-          const importerResolution = await resolver(this.environment, source, importer);
+          const importerResolution = await resolver(this.environment, source, cleanImporter);
           if (!importerResolution || !path.isAbsolute(importerResolution)) {
             // Node's resolver models require() accurately, but must not be used
             // for ESM imports because doing so can select a require-only export.
             return mode === "require"
-              ? resolveTransitiveExternal(source, importer, rootResolver)
+              ? resolveTransitiveExternal(source, cleanImporter, rootResolver)
               : null;
           }
 

--- a/packages/vinext/src/plugins/transitive-externals.ts
+++ b/packages/vinext/src/plugins/transitive-externals.ts
@@ -1,0 +1,154 @@
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "pathslash";
+import { createIdResolver, type Plugin, type Rollup } from "vite";
+
+type ExternalModuleMode = "import" | "require";
+
+function realpath(resolvedPath: string): string {
+  try {
+    return fs.realpathSync(resolvedPath);
+  } catch {
+    return resolvedPath;
+  }
+}
+
+function packageNameFromSpecifier(specifier: string): string | null {
+  if (specifier.startsWith("@")) {
+    const parts = specifier.split("/");
+    return parts.length >= 2 ? `${parts[0]}/${parts[1]}` : null;
+  }
+  return specifier.split("/")[0] || null;
+}
+
+function moduleMode(kind: Rollup.ImportKind | undefined): ExternalModuleMode {
+  return kind === "require-call" ? "require" : "import";
+}
+
+/**
+ * Compare the package instance selected from an importer with the instance
+ * selected from the project root. A differing importer resolution must be
+ * bundled so relocating the server output cannot collapse both imports to the
+ * same root-level package.
+ */
+export function compareTransitiveExternalResolutions(
+  importerResolution: string,
+  rootResolution: string | null,
+): string | null {
+  const importerRealpath = realpath(importerResolution);
+  if (!rootResolution) return importerRealpath;
+  return importerRealpath === realpath(rootResolution) ? null : importerRealpath;
+}
+
+/**
+ * CommonJS fallback used when Vite cannot resolve a require-call with its
+ * conditions-aware resolver.
+ */
+export function resolveTransitiveExternal(
+  request: string,
+  importer: string,
+  rootResolver: NodeRequire,
+): string | null {
+  let importerResolution: string;
+  try {
+    importerResolution = createRequire(importer).resolve(request);
+  } catch {
+    return null;
+  }
+
+  let rootResolution: string | null = null;
+  try {
+    rootResolution = rootResolver.resolve(request);
+  } catch {
+    // The importer-only package must be bundled or it will not exist beside a
+    // relocated server bundle at runtime.
+  }
+
+  return compareTransitiveExternalResolutions(importerResolution, rootResolution);
+}
+
+/**
+ * Mirrors Next.js's `baseResolveCheck` for `serverExternalPackages`.
+ *
+ * A bare external imported by a dependency is only safe to leave external
+ * when resolving it from the dependency selects the same installed package as
+ * resolving it from the project root. Otherwise this hook returns the
+ * importer's absolute resolution, forcing Vite to bundle that nested copy.
+ *
+ * Reference: packages/next/src/build/handle-externals.ts in Next.js.
+ */
+export function createTransitiveExternalsPlugin(options: {
+  getRoot: () => string | undefined;
+  getExternalPackages: () => readonly string[];
+}): Plugin {
+  let externalPackages: Set<string> | undefined;
+  let rootImporter: string | undefined;
+  let rootResolver: NodeRequire | undefined;
+  let importResolver: ReturnType<typeof createIdResolver> | undefined;
+  let requireResolver: ReturnType<typeof createIdResolver> | undefined;
+
+  return {
+    name: "vinext:transitive-externals",
+    enforce: "pre",
+
+    configResolved(config) {
+      const root = options.getRoot();
+      if (!root) return;
+      externalPackages = new Set(options.getExternalPackages());
+      rootImporter = path.join(root, "package.json");
+      rootResolver = createRequire(rootImporter);
+      importResolver = createIdResolver(config, {
+        external: [],
+        isRequire: false,
+        noExternal: true,
+      });
+      requireResolver = createIdResolver(config, {
+        external: [],
+        isRequire: true,
+        noExternal: true,
+      });
+    },
+
+    resolveId(source, importer, resolveOptions) {
+      if (this.environment?.name === "client" || this.environment?.config.consumer === "client") {
+        return null;
+      }
+      if (
+        !importer ||
+        !externalPackages ||
+        externalPackages.size === 0 ||
+        !rootImporter ||
+        !rootResolver ||
+        !importResolver ||
+        !requireResolver
+      ) {
+        return null;
+      }
+
+      const packageName = packageNameFromSpecifier(source);
+      if (!packageName || !externalPackages.has(packageName)) return null;
+      if (importer.startsWith("\0") || importer.includes("?") || !path.isAbsolute(importer)) {
+        return null;
+      }
+
+      const mode = moduleMode(resolveOptions.kind);
+      const resolver = mode === "require" ? requireResolver : importResolver;
+      return (async () => {
+        const importerResolution = await resolver(this.environment, source, importer);
+        if (!importerResolution || !path.isAbsolute(importerResolution)) {
+          // Node's resolver models require() accurately, but must not be used
+          // for ESM imports because doing so can select a require-only export.
+          return mode === "require"
+            ? resolveTransitiveExternal(source, importer, rootResolver)
+            : null;
+        }
+
+        const rootResolution = await resolver(this.environment, source, rootImporter);
+        return compareTransitiveExternalResolutions(
+          importerResolution,
+          rootResolution && path.isAbsolute(rootResolution) ? rootResolution : null,
+        );
+      })();
+    },
+  };
+}

--- a/packages/vinext/src/plugins/transitive-externals.ts
+++ b/packages/vinext/src/plugins/transitive-externals.ts
@@ -98,6 +98,7 @@ export function createTransitiveExternalsPlugin(options: {
 
   return {
     name: "vinext:transitive-externals",
+    apply: "build",
     enforce: "pre",
     applyToEnvironment(environment) {
       return environment.name !== "client" && environment.config.consumer !== "client";

--- a/packages/vinext/src/plugins/transitive-externals.ts
+++ b/packages/vinext/src/plugins/transitive-externals.ts
@@ -34,7 +34,7 @@ function moduleMode(kind: Rollup.ImportKind | undefined): ExternalModuleMode {
  * bundled so relocating the server output cannot collapse both imports to the
  * same root-level package.
  */
-export function compareTransitiveExternalResolutions(
+function compareTransitiveExternalResolutions(
   importerResolution: string,
   rootResolution: string | null,
 ): string | null {
@@ -47,7 +47,7 @@ export function compareTransitiveExternalResolutions(
  * CommonJS fallback used when Vite cannot resolve a require-call with its
  * conditions-aware resolver.
  */
-export function resolveTransitiveExternal(
+function resolveTransitiveExternal(
   request: string,
   importer: string,
   rootResolver: NodeRequire,

--- a/packages/vinext/src/plugins/transitive-externals.ts
+++ b/packages/vinext/src/plugins/transitive-externals.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import { createRequire } from "node:module";
-import path from "pathslash";
+import path, { toSlash } from "pathslash";
 import { createIdResolver, type Plugin, type Rollup } from "vite";
 
 type ExternalModuleMode = "import" | "require";
@@ -10,9 +10,9 @@ const BARE_PACKAGE_SPECIFIER_RE =
 
 function realpath(resolvedPath: string): string {
   try {
-    return fs.realpathSync(resolvedPath);
+    return toSlash(fs.realpathSync.native(resolvedPath));
   } catch {
-    return resolvedPath;
+    return toSlash(resolvedPath);
   }
 }
 
@@ -71,12 +71,18 @@ function resolveTransitiveExternal(
 }
 
 /**
- * Mirrors Next.js's `baseResolveCheck` for `serverExternalPackages`.
+ * Mirrors the path-equality portion of Next.js's `baseResolveCheck` for
+ * `serverExternalPackages`.
  *
  * A bare external imported by a dependency is only safe to leave external
  * when resolving it from the dependency selects the same installed package as
  * resolving it from the project root. Otherwise this hook returns the
  * importer's absolute resolution, forcing Vite to bundle that nested copy.
+ *
+ * Next.js separately compares its resolver's CommonJS/ESM classification.
+ * Vite instead selects an import- or require-configured resolver up front;
+ * once both contexts select the same absolute file, its format follows that
+ * file and package scope rather than the importer context.
  *
  * Reference: packages/next/src/build/handle-externals.ts in Next.js.
  */

--- a/packages/vinext/src/plugins/transitive-externals.ts
+++ b/packages/vinext/src/plugins/transitive-externals.ts
@@ -5,6 +5,9 @@ import { createIdResolver, type Plugin, type Rollup } from "vite";
 
 type ExternalModuleMode = "import" | "require";
 
+const BARE_PACKAGE_SPECIFIER_RE =
+  /^(?:@[A-Za-z0-9._~-]+\/[A-Za-z0-9._~-]+|[A-Za-z0-9_~-][A-Za-z0-9._~-]*)(?:\/[^?#]*)?$/;
+
 function realpath(resolvedPath: string): string {
   try {
     return fs.realpathSync(resolvedPath);
@@ -90,6 +93,9 @@ export function createTransitiveExternalsPlugin(options: {
   return {
     name: "vinext:transitive-externals",
     enforce: "pre",
+    applyToEnvironment(environment) {
+      return environment.name !== "client" && environment.config.consumer !== "client";
+    },
 
     configResolved(config) {
       const root = options.getRoot();
@@ -109,46 +115,46 @@ export function createTransitiveExternalsPlugin(options: {
       });
     },
 
-    resolveId(source, importer, resolveOptions) {
-      if (this.environment?.name === "client" || this.environment?.config.consumer === "client") {
-        return null;
-      }
-      if (
-        !importer ||
-        !externalPackages ||
-        externalPackages.size === 0 ||
-        !rootImporter ||
-        !rootResolver ||
-        !importResolver ||
-        !requireResolver
-      ) {
-        return null;
-      }
-
-      const packageName = packageNameFromSpecifier(source);
-      if (!packageName || !externalPackages.has(packageName)) return null;
-      if (importer.startsWith("\0") || importer.includes("?") || !path.isAbsolute(importer)) {
-        return null;
-      }
-
-      const mode = moduleMode(resolveOptions.kind);
-      const resolver = mode === "require" ? requireResolver : importResolver;
-      return (async () => {
-        const importerResolution = await resolver(this.environment, source, importer);
-        if (!importerResolution || !path.isAbsolute(importerResolution)) {
-          // Node's resolver models require() accurately, but must not be used
-          // for ESM imports because doing so can select a require-only export.
-          return mode === "require"
-            ? resolveTransitiveExternal(source, importer, rootResolver)
-            : null;
+    resolveId: {
+      filter: { id: BARE_PACKAGE_SPECIFIER_RE },
+      handler(source, importer, resolveOptions) {
+        if (
+          !importer ||
+          !externalPackages ||
+          externalPackages.size === 0 ||
+          !rootImporter ||
+          !rootResolver ||
+          !importResolver ||
+          !requireResolver
+        ) {
+          return null;
         }
 
-        const rootResolution = await resolver(this.environment, source, rootImporter);
-        return compareTransitiveExternalResolutions(
-          importerResolution,
-          rootResolution && path.isAbsolute(rootResolution) ? rootResolution : null,
-        );
-      })();
+        const packageName = packageNameFromSpecifier(source);
+        if (!packageName || !externalPackages.has(packageName)) return null;
+        if (importer.startsWith("\0") || importer.includes("?") || !path.isAbsolute(importer)) {
+          return null;
+        }
+
+        const mode = moduleMode(resolveOptions.kind);
+        const resolver = mode === "require" ? requireResolver : importResolver;
+        return (async () => {
+          const importerResolution = await resolver(this.environment, source, importer);
+          if (!importerResolution || !path.isAbsolute(importerResolution)) {
+            // Node's resolver models require() accurately, but must not be used
+            // for ESM imports because doing so can select a require-only export.
+            return mode === "require"
+              ? resolveTransitiveExternal(source, importer, rootResolver)
+              : null;
+          }
+
+          const rootResolution = await resolver(this.environment, source, rootImporter);
+          return compareTransitiveExternalResolutions(
+            importerResolution,
+            rootResolution && path.isAbsolute(rootResolution) ? rootResolution : null,
+          );
+        })();
+      },
     },
   };
 }

--- a/tests/externals-transitive.test.ts
+++ b/tests/externals-transitive.test.ts
@@ -70,19 +70,24 @@ export default function Page() { return <p>{depA}, {depB}</p>; }\n`,
     "3.10.1",
     `export default "3.10.1";\n`,
   );
+  writePackage(root, "node_modules/pg", "pg", "8.0.0", `export default "8.0.0";\n`);
   writePackage(
     root,
     "packages/dep-a",
     "dep-a",
     "1.0.0",
-    `import version from "shared-version"; export default "depA:" + version;\n`,
+    `import version from "shared-version";
+import pgVersion from "pg";
+export default "depA:" + version + ":pg@" + pgVersion;\n`,
   );
   writePackage(
     root,
     "packages/dep-b",
     "dep-b",
     "1.0.0",
-    `import version from "shared-version"; export default "depB:" + version;\n`,
+    `import version from "shared-version";
+import pgVersion from "pg";
+export default "depB:" + version + ":pg@" + pgVersion;\n`,
   );
   writePackage(
     root,
@@ -91,6 +96,7 @@ export default function Page() { return <p>{depA}, {depB}</p>; }\n`,
     "4.17.21",
     `export default "4.17.21";\n`,
   );
+  writePackage(root, "packages/dep-b/node_modules/pg", "pg", "9.0.0", `export default "9.0.0";\n`);
   fs.mkdirSync(path.join(root, "node_modules"), { recursive: true });
   linkPackage(root, "dep-a");
   linkPackage(root, "dep-b");
@@ -141,6 +147,6 @@ describe("transitive server externals", () => {
     const response = await fetch(`http://127.0.0.1:${address.port}/`);
     const html = (await response.text()).replaceAll("<!-- -->", "");
     expect(response.status, html).toBe(200);
-    expect(html).toContain("depA:3.10.1, depB:4.17.21");
+    expect(html).toContain("depA:3.10.1:pg@8.0.0, depB:4.17.21:pg@9.0.0");
   }, 30_000);
 });

--- a/tests/externals-transitive.test.ts
+++ b/tests/externals-transitive.test.ts
@@ -59,7 +59,7 @@ async function createFixture(): Promise<string> {
     root,
     "app/page.tsx",
     `import depA from "dep-a";
-import depB from "dep-b";
+import depB from "../node_modules/dep-b/index.js?vinext-transitive";
 export default function Page() { return <p>{depA}, {depB}</p>; }\n`,
   );
 

--- a/tests/externals-transitive.test.ts
+++ b/tests/externals-transitive.test.ts
@@ -1,0 +1,146 @@
+import fs from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import type { Server } from "node:http";
+import path from "node:path";
+import { createBuilder } from "vite";
+import { afterAll, describe, expect, it } from "vite-plus/test";
+import vinext from "../packages/vinext/src/index.js";
+import { startProdServer } from "../packages/vinext/src/server/prod-server.js";
+
+const tempDirs: string[] = [];
+const servers: Server[] = [];
+
+function writeFile(root: string, relativePath: string, content: string): void {
+  const filePath = path.join(root, relativePath);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+function writePackage(
+  root: string,
+  relativePath: string,
+  name: string,
+  version: string,
+  source: string,
+): void {
+  writeFile(
+    root,
+    `${relativePath}/package.json`,
+    JSON.stringify({ name, version, type: "module", exports: "./index.js" }),
+  );
+  writeFile(root, `${relativePath}/index.js`, source);
+}
+
+function linkPackage(root: string, packageName: string): void {
+  fs.symlinkSync(
+    path.join(root, "packages", packageName),
+    path.join(root, "node_modules", packageName),
+    "junction",
+  );
+}
+
+async function createFixture(): Promise<string> {
+  const root = await mkdtemp(path.join(import.meta.dirname, ".tmp-externals-transitive-"));
+  tempDirs.push(root);
+  writeFile(root, "package.json", JSON.stringify({ private: true, type: "module" }));
+  writeFile(
+    root,
+    "next.config.mjs",
+    `export default { serverExternalPackages: ["shared-version"] };\n`,
+  );
+  writeFile(
+    root,
+    "app/layout.tsx",
+    `export default function Layout({ children }: { children: React.ReactNode }) {
+  return <html><body>{children}</body></html>;
+}\n`,
+  );
+  writeFile(
+    root,
+    "app/page.tsx",
+    `import depA from "dep-a";
+import depB from "dep-b";
+export default function Page() { return <p>{depA}, {depB}</p>; }\n`,
+  );
+
+  writePackage(
+    root,
+    "node_modules/shared-version",
+    "shared-version",
+    "3.10.1",
+    `export default "3.10.1";\n`,
+  );
+  writePackage(
+    root,
+    "packages/dep-a",
+    "dep-a",
+    "1.0.0",
+    `import version from "shared-version"; export default "depA:" + version;\n`,
+  );
+  writePackage(
+    root,
+    "packages/dep-b",
+    "dep-b",
+    "1.0.0",
+    `import version from "shared-version"; export default "depB:" + version;\n`,
+  );
+  writePackage(
+    root,
+    "packages/dep-b/node_modules/shared-version",
+    "shared-version",
+    "4.17.21",
+    `export default "4.17.21";\n`,
+  );
+  fs.mkdirSync(path.join(root, "node_modules"), { recursive: true });
+  linkPackage(root, "dep-a");
+  linkPackage(root, "dep-b");
+  return root;
+}
+
+afterAll(async () => {
+  await Promise.all(
+    servers.map(
+      (server) =>
+        new Promise<void>((resolve, reject) =>
+          server.close((error) => (error ? reject(error) : resolve())),
+        ),
+    ),
+  );
+  await Promise.all(tempDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("transitive server externals", () => {
+  // Ported from Next.js: test/e2e/externals-transitive/externals-transitive.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/externals-transitive/externals-transitive.test.ts
+  it("preserves the package version selected by each importing dependency", async () => {
+    const root = await createFixture();
+    const builder = await createBuilder({
+      root,
+      configFile: false,
+      logLevel: "silent",
+      plugins: [
+        vinext({
+          appDir: root,
+          rscOutDir: path.join(root, "dist/server"),
+          ssrOutDir: path.join(root, "dist/server/ssr"),
+          clientOutDir: path.join(root, "dist/client"),
+        }),
+      ],
+    });
+    await builder.buildApp();
+
+    const started = await startProdServer({
+      port: 0,
+      host: "127.0.0.1",
+      outDir: path.join(root, "dist"),
+    });
+    servers.push(started.server);
+    const address = started.server.address();
+    if (!address || typeof address === "string") throw new Error("Server did not bind");
+
+    const response = await fetch(`http://127.0.0.1:${address.port}/`);
+    const html = (await response.text()).replaceAll("<!-- -->", "");
+    expect(response.status, html).toBe(200);
+    expect(html).toContain("depA:3.10.1, depB:4.17.21");
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary

- mirrors Next.js baseResolveCheck behavior for serverExternalPackages by comparing importer-relative and project-root package resolution
- bundles nested package instances when relocation would otherwise collapse them to the root version
- applies the same merged default and explicit external set, including transpile-package exclusions
- limits the resolver to server environments and native-filtered bare package imports

## Failure mapping

Fixes the non-cache externals-transitive failure from Actions run 31439707085, job 93624401572:

- test/e2e/externals-transitive/externals-transitive.test.ts
- before: depB resolved lodash 3.10.1 instead of its nested 4.17.21
- after: exact Next.js v16.2.6 targeted deploy suite passes 1/1

## Validation

- exact Next.js targeted E2E: 1 suite, 1 test passed
- local production-build regression proves both an explicit external and default pg-style external preserve distinct root/nested versions
- adjacent external-package suites: 6/6 passed
- vp check on changed files
- vp run vinext#build
- independent review loop: no findings

Refs #1503.