### PR TITLE
fix(router): preserve basePath in Pages Router events

### DIFF
--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -1893,6 +1893,47 @@ function resolveClientConfigRewriteSync(href: string): ClientConfigRewriteResolu
   return matched ? { href: currentHref, kind: "rewrite" } : null;
 }
 
+/**
+ * Query-only navigations to the already-mounted destination of a beforeFiles
+ * rewrite can reuse the current route info. Next.js keeps that route info in
+ * `Router.components`, so its `beforeHistoryChange`/history commit happens in
+ * the click turn instead of waiting for another page-module load. Vinext does
+ * not keep the same route-info cache, but the generated loader manifest lets
+ * us prove the rewritten target is the page that is already mounted.
+ */
+function reusesMountedConfigRewritePage(href: string): boolean {
+  let current: URL;
+  let target: URL;
+  try {
+    current = new URL(window.location.href);
+    target = new URL(href, current);
+  } catch {
+    return false;
+  }
+
+  if (target.origin !== current.origin || target.pathname !== current.pathname) return false;
+  if (target.search === current.search) return false;
+  if (clientConfigRedirectCouldMatch(href)) return false;
+
+  const rewrite = resolveClientConfigRewriteSync(href);
+  if (rewrite?.kind !== "rewrite") return false;
+  const dataTarget = resolvePagesDataNavigationTarget(rewrite.href, __basePath);
+  const nextData = window.__NEXT_DATA__ as VinextNextData | undefined;
+  if (
+    dataTarget?.dataKind !== "none" ||
+    dataTarget.pattern !== nextData?.page ||
+    nextData.gip === true ||
+    nextData.appGip === true
+  ) {
+    return false;
+  }
+
+  // A middleware/proxy probe or page-data request can still redirect or fail,
+  // so those navigations must retain the normal post-resolution history
+  // commit. The eager path is only for a mounted, component-only page.
+  return getMiddlewarePagesDataFetchUrl(href, dataTarget) === null;
+}
+
 async function resolveClientConfigRewrite(
   href: string,
 ): Promise<{ href: string; kind: "rewrite" } | { kind: "document" } | null> {
@@ -3332,6 +3373,12 @@ async function performNavigation(
     updateHistory(mode, redirectBrowserHref ?? full, navState);
   };
   if (!shallow) {
+    // A query-only navigation through a beforeFiles rewrite can reuse the
+    // mounted page. Commit its visible URL before entering the asynchronous
+    // loader/render path, matching Next.js's cached-route behavior and keeping
+    // router.push/replace and <Link> observably synchronous for the address
+    // bar in this case.
+    if (reusesMountedConfigRewritePage(full)) emitBeforeHistoryChange();
     navigateOptions.beforeHistoryChange = emitBeforeHistoryChange;
     const result = await runNavigateClient(
       full,

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -1560,6 +1560,8 @@ type NavigateClientOptions = {
   mode?: "push" | "replace";
   scroll?: ScrollPosition | null;
   beforeHistoryChange?: () => void;
+  /** Validated same-origin browser URL for a redirect with a leading-`//` app path. */
+  redirectBrowserHref?: string;
 };
 
 /** Wire format of `/_next/data/<id>/<page>.json` response bodies. */
@@ -2365,7 +2367,7 @@ async function navigateClientHtml(
   assertStillCurrent: () => void,
   options: NavigateClientOptions = {},
 ): Promise<void> {
-  let browserUrl = url;
+  const browserUrl = options.redirectBrowserHref ?? url;
   const root = window.__VINEXT_ROOT__;
   if (!root) {
     // No React root yet — fall back to hard navigation
@@ -2782,7 +2784,7 @@ async function runNavigateClient(
     // throw HardNavigationScheduledError, and this guard skips those; only
     // unexpected failures (parse, import, render) need recovery here.
     if (typeof window !== "undefined" && !(err instanceof HardNavigationScheduledError)) {
-      window.location.href = fullUrl;
+      window.location.href = options.redirectBrowserHref ?? fullUrl;
     }
     return "failed";
   }
@@ -2963,10 +2965,10 @@ async function performNavigation(
   mode: "push" | "replace",
   onStateUpdate?: () => void,
   // A validated same-origin absolute redirect whose app pathname starts with
-  // `//` must stay absolute when written to history. Its app-relative form is
-  // still used for route state and fetching so the leading slashes remain a
-  // pathname rather than being reinterpreted as a protocol-relative host.
-  redirectHistoryHref?: string,
+  // `//` must stay absolute for browser-facing fetch/history operations. Its
+  // app-relative form remains the route/event state so the leading slashes
+  // cannot be reinterpreted as a protocol-relative host.
+  redirectBrowserHref?: string,
 ): Promise<boolean> {
   // SSR / prerender guard. Calling Router.push or Router.replace from a
   // Pages Router component during server rendering would otherwise crash
@@ -3169,6 +3171,9 @@ async function performNavigation(
         scroll: scrollTarget,
         isHydrationQueryUpdate: options?._h === 1,
       };
+  if (redirectBrowserHref !== undefined) {
+    navigateOptions.redirectBrowserHref = redirectBrowserHref;
+  }
 
   // Next.js push→replace coercion (narrowed): when the display URL (asPath)
   // doesn't change AND the route URL DOES change AND the locale doesn't
@@ -3262,8 +3267,8 @@ async function performNavigation(
   const hasAppRouteMarker =
     appPathEntry !== undefined && "__appRouter" in appPathEntry && appPathEntry.__appRouter;
   if (hasAppRouteMarker) {
-    if (mode === "push") window.location.assign(full);
-    else window.location.replace(full);
+    if (mode === "push") window.location.assign(redirectBrowserHref ?? full);
+    else window.location.replace(redirectBrowserHref ?? full);
     return new Promise<boolean>(() => {});
   }
   const rewrites = window.__VINEXT_CLIENT_REWRITES__;
@@ -3280,8 +3285,8 @@ async function performNavigation(
         )
       : resolveDirectHybridClientRouteOwner(resolved, __basePath);
   if (["app", "document"].includes(hybridOwner ?? "")) {
-    if (mode === "push") window.location.assign(full);
-    else window.location.replace(full);
+    if (mode === "push") window.location.assign(redirectBrowserHref ?? full);
+    else window.location.replace(redirectBrowserHref ?? full);
     return new Promise<boolean>(() => {});
   }
 
@@ -3302,14 +3307,14 @@ async function performNavigation(
     if (beforeHistoryChangeEmitted) return;
     beforeHistoryChangeEmitted = true;
     routerEvents.emit("beforeHistoryChange", full, { shallow });
-    updateHistory(mode, redirectHistoryHref ?? full, navState);
+    updateHistory(mode, redirectBrowserHref ?? full, navState);
   };
   if (!shallow) {
     navigateOptions.beforeHistoryChange = emitBeforeHistoryChange;
     const result = await runNavigateClient(
       full,
       full,
-      htmlFetchUrl,
+      redirectBrowserHref ?? htmlFetchUrl,
       navigateOptions,
       // When href and as differ, the data fetch must target the route URL
       // (the module that actually renders), not the masked display URL.

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -3792,6 +3792,25 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
       stateRouteUrl,
       eventContext,
     );
+    if (typeof result === "object") {
+      // Popstate enters the same redirect pipeline as push/replace, but the
+      // browser has already traversed to the source entry. Unwind that source
+      // event and replace it with the redirect destination so the source never
+      // commits or leaves a second history entry. This mirrors Next.js passing
+      // the popstate change() method (replaceState) through recursive redirects.
+      clearActiveNavigationEvent(eventContext);
+      await performNavigation(
+        result.redirectDestination,
+        undefined,
+        { locale: false },
+        "replace",
+        undefined,
+        isAbsoluteOrProtocolRelativeUrl(result.redirectDestination)
+          ? result.redirectDestination
+          : undefined,
+      );
+      return;
+    }
     if (result === "completed") {
       routerEvents.emit("routeChangeComplete", fullEventUrl, { shallow: false });
       clearActiveNavigationEvent(eventContext);

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -2342,10 +2342,10 @@ async function navigateClientData(
   // gSSP/gSP redirect marker. When getServerSideProps/getStaticProps returns
   // `{ redirect }`, the data endpoint replies 200 with `__N_REDIRECT` /
   // `__N_REDIRECT_STATUS` inside pageProps (rather than an HTTP redirect, which
-  // fetch would transparently follow to non-JSON HTML). Re-enter a fresh
-  // navigation to the destination — this increments the navigation id, which
-  // supersedes (cancels) the current navigation so the intermediate page is
-  // never committed. Mirrors Next.js's `pageProps.__N_REDIRECT` handling in
+  // fetch would transparently follow to non-JSON HTML). Throw an internal
+  // redirect signal so the caller unwinds this source navigation and
+  // re-dispatches the destination; only the destination commits history.
+  // Mirrors Next.js's `pageProps.__N_REDIRECT` handling in
   // packages/next/src/shared/lib/router/router.ts (`this.change(method, ...)`).
   const redirectDestination = pageProps.__N_REDIRECT;
   if (typeof redirectDestination === "string") {

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -408,7 +408,6 @@ type RouterEvents = {
 
 type PagesNavigationEventContext = {
   cancellationEmitted: boolean;
-  routeProps: { shallow: boolean };
   url: string;
 };
 
@@ -1486,7 +1485,7 @@ class NavigationCancelledError extends Error {
   }
 }
 
-function cancelActiveNavigationEvent(): void {
+function cancelActiveNavigationEvent(routeProps: { shallow: boolean }): void {
   const active = routerRuntimeState.activeNavigationEvent;
   if (active === null || active.cancellationEmitted) return;
 
@@ -1503,7 +1502,7 @@ function cancelActiveNavigationEvent(): void {
     "routeChangeError",
     new NavigationCancelledError(active.url),
     active.url,
-    active.routeProps,
+    routeProps,
   );
   if (routerRuntimeState.activeNavigationEvent === active) {
     routerRuntimeState.activeNavigationEvent = null;
@@ -1555,6 +1554,7 @@ type NavigateClientOptions = {
   mode?: "push" | "replace";
   scroll?: ScrollPosition | null;
   beforeHistoryChange?: () => void;
+  pendingRedirectHistoryUrl?: string;
 };
 
 /** Wire format of `/_next/data/<id>/<page>.json` response bodies. */
@@ -2283,10 +2283,15 @@ async function navigateClientData(
       scheduleHardNavigationAndThrow(softRedirect, "Navigation redirected externally");
     }
 
-    window.history.replaceState(window.history.state ?? {}, "", redirectedUrl);
-    routerRuntimeState.lastPathnameAndSearch = window.location.pathname + window.location.search;
-    routerRuntimeState.lastHash = window.location.hash;
-    await navigateClientHtml(redirectedUrl, redirectedUrl, controller, navId, assertStillCurrent);
+    options.pendingRedirectHistoryUrl = redirectedUrl;
+    await navigateClientHtml(
+      redirectedUrl,
+      redirectedUrl,
+      controller,
+      navId,
+      assertStillCurrent,
+      options,
+    );
     return;
   }
 
@@ -2371,7 +2376,9 @@ async function navigateClientHtml(
   options: NavigateClientOptions = {},
 ): Promise<void> {
   let browserUrl = url;
-  let pendingRedirectHistoryUrl: string | null = fetchUrl === url ? null : url;
+  if (options.pendingRedirectHistoryUrl === undefined && fetchUrl !== url) {
+    options.pendingRedirectHistoryUrl = url;
+  }
   const root = window.__VINEXT_ROOT__;
   if (!root) {
     // No React root yet — fall back to hard navigation
@@ -2399,7 +2406,7 @@ async function navigateClientHtml(
     const redirectedUrl = resolveSameOriginRedirectedUrl(res.url);
     if (redirectedUrl) {
       browserUrl = redirectedUrl;
-      pendingRedirectHistoryUrl = redirectedUrl;
+      options.pendingRedirectHistoryUrl = redirectedUrl;
     }
   }
 
@@ -2522,11 +2529,6 @@ async function navigateClientHtml(
   // stable Pages Router commit boundary before routeChangeComplete, matching
   // Next.js's client Root callback without remounting the page tree.
   options.beforeHistoryChange?.();
-  if (pendingRedirectHistoryUrl) {
-    window.history.replaceState(window.history.state ?? {}, "", pendingRedirectHistoryUrl);
-    routerRuntimeState.lastPathnameAndSearch = window.location.pathname + window.location.search;
-    routerRuntimeState.lastHash = window.location.hash;
-  }
   window.__NEXT_DATA__ = nextData;
   applyVinextLocaleGlobals(window, nextData);
   await renderPagesRouterElement(element, options.scroll);
@@ -2603,10 +2605,7 @@ async function navigateClient(
         if (!redirectedUrl) {
           scheduleHardNavigationAndThrow(configRedirect, "Navigation redirected externally");
         }
-        window.history.replaceState(window.history.state ?? {}, "", redirectedUrl);
-        routerRuntimeState.lastPathnameAndSearch =
-          window.location.pathname + window.location.search;
-        routerRuntimeState.lastHash = window.location.hash;
+        options.pendingRedirectHistoryUrl = redirectedUrl;
         browserUrl = redirectedUrl;
         htmlFetchUrl = redirectedUrl;
       }
@@ -2684,10 +2683,7 @@ async function navigateClient(
         if (!redirectedUrl) {
           scheduleHardNavigationAndThrow(redirectLocation, "Navigation redirected externally");
         }
-        window.history.replaceState(window.history.state ?? {}, "", redirectedUrl);
-        routerRuntimeState.lastPathnameAndSearch =
-          window.location.pathname + window.location.search;
-        routerRuntimeState.lastHash = window.location.hash;
+        options.pendingRedirectHistoryUrl = redirectedUrl;
         browserUrl = redirectedUrl;
         htmlFetchUrl = redirectedUrl;
       } else if (middlewareEffect) {
@@ -3228,7 +3224,7 @@ async function performNavigation(
     options: navStateOptions,
   };
 
-  if (options?._h !== 1) cancelActiveNavigationEvent();
+  if (options?._h !== 1) cancelActiveNavigationEvent({ shallow });
 
   // Hash-only change — no page fetch needed.
   // Guard: when the route URL differs from the display URL (i.e. href and as
@@ -3305,19 +3301,27 @@ async function performNavigation(
     ? undefined
     : {
         cancellationEmitted: false,
-        routeProps: { shallow },
         url: full,
       };
   if (eventContext) routerRuntimeState.activeNavigationEvent = eventContext;
   if (!isQueryUpdating) {
     routerEvents.emit("routeChangeStart", full, { shallow });
   }
-  updateHistory(mode, full, navState);
   let beforeHistoryChangeEmitted = false;
   const emitBeforeHistoryChange = () => {
     if (beforeHistoryChangeEmitted) return;
     beforeHistoryChangeEmitted = true;
     routerEvents.emit("beforeHistoryChange", full, { shallow });
+    updateHistory(mode, full, navState);
+    if (navigateOptions.pendingRedirectHistoryUrl !== undefined) {
+      window.history.replaceState(
+        window.history.state ?? {},
+        "",
+        navigateOptions.pendingRedirectHistoryUrl,
+      );
+      routerRuntimeState.lastPathnameAndSearch = window.location.pathname + window.location.search;
+      routerRuntimeState.lastHash = window.location.hash;
+    }
   };
   if (!shallow) {
     navigateOptions.beforeHistoryChange = emitBeforeHistoryChange;
@@ -3672,7 +3676,7 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
   // A history traversal is a new navigation just like push/replace. Cancel
   // the prior fetch/render before announcing this destination so the prior
   // routeChangeError is always observed before this routeChangeStart.
-  cancelActiveNavigationEvent();
+  cancelActiveNavigationEvent({ shallow: false });
 
   // Update trackers only after beforePopState confirms navigation proceeds.
   // If beforePopState cancels, the app stays on the previous history entry,
@@ -3714,7 +3718,6 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
   const fullEventUrl = browserUrl + window.location.hash;
   const eventContext: PagesNavigationEventContext = {
     cancellationEmitted: false,
-    routeProps: { shallow: false },
     url: fullEventUrl,
   };
   routerRuntimeState.activeNavigationEvent = eventContext;

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -1485,6 +1485,12 @@ class NavigationCancelledError extends Error {
   }
 }
 
+class InternalNavigationRedirect extends Error {
+  constructor(readonly destination: string) {
+    super("Internal navigation redirect");
+  }
+}
+
 function cancelActiveNavigationEvent(routeProps: { shallow: boolean }): void {
   const active = routerRuntimeState.activeNavigationEvent;
   if (active === null || active.cancellationEmitted) return;
@@ -1554,7 +1560,6 @@ type NavigateClientOptions = {
   mode?: "push" | "replace";
   scroll?: ScrollPosition | null;
   beforeHistoryChange?: () => void;
-  pendingRedirectHistoryUrl?: string;
 };
 
 /** Wire format of `/_next/data/<id>/<page>.json` response bodies. */
@@ -1640,14 +1645,10 @@ function resolveLocalRedirectUrl(location: string): string | null {
   if (appPath.startsWith("//")) {
     return normalizePathTrailingSlash(location, __trailingSlash);
   }
-  return normalizePathTrailingSlash(
-    toBrowserNavigationHref(
-      stripLocalePrefixForApiRedirect(appPath),
-      window.location.href,
-      __basePath,
-    ),
-    __trailingSlash,
-  );
+  // Internal redirects are re-dispatched through performNavigation(), whose
+  // input contract is app-relative. Keep basePath stripped here so the fresh
+  // navigation applies it exactly once when deriving its browser URL.
+  return normalizePathTrailingSlash(stripLocalePrefixForApiRedirect(appPath), __trailingSlash);
 }
 
 function hasClientRewriteRules(): boolean {
@@ -1977,19 +1978,15 @@ async function resolveMiddlewareDataEffect(
  * Internal destinations (absolute paths, unless the redirect opted out of
  * basePath via `__N_REDIRECT_BASE_PATH === false`) are followed with a fresh
  * client-side navigation that preserves the originating push/replace mode. The
- * fresh navigation increments the navigation id, so the navigation that
- * produced this redirect is superseded and never commits the intermediate
- * page. External (or non-absolute) destinations fall back to a hard navigation.
+ * caller unwinds the source navigation and re-dispatches the destination,
+ * so only the destination commits history state. External (or non-absolute)
+ * destinations fall back to a hard navigation.
  *
  * Ported from Next.js: packages/next/src/shared/lib/router/router.ts
  * (`pageProps.__N_REDIRECT` handling — internal `this.change` vs
  * `handleHardNavigation`).
  */
-function handleDataRedirect(
-  destination: string,
-  redirectBasePath: unknown,
-  mode: "push" | "replace" = "push",
-): void {
+function handleDataRedirect(destination: string, redirectBasePath: unknown): never {
   const isInternal = destination.startsWith("/") && redirectBasePath !== false;
   if (!isInternal) {
     // External or basePath-less redirect — hard navigate to the redirect
@@ -1997,9 +1994,7 @@ function handleDataRedirect(
     scheduleHardNavigationAndThrow(destination, "Navigation redirected externally");
   }
 
-  // Re-dispatch as a fresh navigation. `locale: false` matches Next.js, which
-  // does not re-apply the locale prefix to a redirect destination.
-  void performNavigation(destination, undefined, { locale: false }, mode);
+  throw new InternalNavigationRedirect(destination);
 }
 
 async function loadTargetPageModule(
@@ -2283,16 +2278,7 @@ async function navigateClientData(
       scheduleHardNavigationAndThrow(softRedirect, "Navigation redirected externally");
     }
 
-    options.pendingRedirectHistoryUrl = redirectedUrl;
-    await navigateClientHtml(
-      redirectedUrl,
-      redirectedUrl,
-      controller,
-      navId,
-      assertStillCurrent,
-      options,
-    );
-    return;
+    throw new InternalNavigationRedirect(redirectedUrl);
   }
 
   if (!res.ok) {
@@ -2350,8 +2336,7 @@ async function navigateClientData(
   // packages/next/src/shared/lib/router/router.ts (`this.change(method, ...)`).
   const redirectDestination = pageProps.__N_REDIRECT;
   if (typeof redirectDestination === "string") {
-    handleDataRedirect(redirectDestination, pageProps.__N_REDIRECT_BASE_PATH, options.mode);
-    throw new NavigationCancelledError(url);
+    handleDataRedirect(redirectDestination, pageProps.__N_REDIRECT_BASE_PATH);
   }
 
   await renderPagesNavigationTarget(url, target, props, options, assertStillCurrent);
@@ -2376,9 +2361,6 @@ async function navigateClientHtml(
   options: NavigateClientOptions = {},
 ): Promise<void> {
   let browserUrl = url;
-  if (options.pendingRedirectHistoryUrl === undefined && fetchUrl !== url) {
-    options.pendingRedirectHistoryUrl = url;
-  }
   const root = window.__VINEXT_ROOT__;
   if (!root) {
     // No React root yet — fall back to hard navigation
@@ -2405,8 +2387,7 @@ async function navigateClientHtml(
   if (res.redirected && res.url) {
     const redirectedUrl = resolveSameOriginRedirectedUrl(res.url);
     if (redirectedUrl) {
-      browserUrl = redirectedUrl;
-      options.pendingRedirectHistoryUrl = redirectedUrl;
+      throw new InternalNavigationRedirect(redirectedUrl);
     }
   }
 
@@ -2605,11 +2586,9 @@ async function navigateClient(
         if (!redirectedUrl) {
           scheduleHardNavigationAndThrow(configRedirect, "Navigation redirected externally");
         }
-        options.pendingRedirectHistoryUrl = redirectedUrl;
-        browserUrl = redirectedUrl;
-        htmlFetchUrl = redirectedUrl;
+        throw new InternalNavigationRedirect(redirectedUrl);
       }
-      let routeLookupUrl = configRedirect ? browserUrl : routeUrl;
+      let routeLookupUrl = routeUrl;
       if (routeUrl === url && hasClientRewriteRules()) {
         const syncConfigRewrite = hasClientAppRouteManifest()
           ? undefined
@@ -2683,9 +2662,7 @@ async function navigateClient(
         if (!redirectedUrl) {
           scheduleHardNavigationAndThrow(redirectLocation, "Navigation redirected externally");
         }
-        options.pendingRedirectHistoryUrl = redirectedUrl;
-        browserUrl = redirectedUrl;
-        htmlFetchUrl = redirectedUrl;
+        throw new InternalNavigationRedirect(redirectedUrl);
       } else if (middlewareEffect) {
         // A masked navigation probes middleware using the browser-visible URL but must fetch page
         // data using the route URL. Without a rewrite header those are different requests, so do
@@ -2779,13 +2756,16 @@ async function runNavigateClient(
    */
   routeUrl: string = fullUrl,
   eventContext?: PagesNavigationEventContext,
-): Promise<"completed" | "cancelled" | "failed"> {
+): Promise<"completed" | "cancelled" | "failed" | { redirectDestination: string }> {
   try {
     await navigateClient(fullUrl, fetchUrl, options, routeUrl);
     return "completed";
   } catch (err: unknown) {
     if (eventContext?.cancellationEmitted) {
       return "cancelled";
+    }
+    if (err instanceof InternalNavigationRedirect) {
+      return { redirectDestination: err.destination };
     }
     routerEvents.emit("routeChangeError", err, resolvedUrl, { shallow: false });
     if (eventContext) clearActiveNavigationEvent(eventContext);
@@ -2977,6 +2957,11 @@ async function performNavigation(
   options: TransitionOptions | undefined,
   mode: "push" | "replace",
   onStateUpdate?: () => void,
+  // A validated same-origin absolute redirect whose app pathname starts with
+  // `//` must stay absolute when written to history. Its app-relative form is
+  // still used for route state and fetching so the leading slashes remain a
+  // pathname rather than being reinterpreted as a protocol-relative host.
+  redirectHistoryHref?: string,
 ): Promise<boolean> {
   // SSR / prerender guard. Calling Router.push or Router.replace from a
   // Pages Router component during server rendering would otherwise crash
@@ -3312,16 +3297,7 @@ async function performNavigation(
     if (beforeHistoryChangeEmitted) return;
     beforeHistoryChangeEmitted = true;
     routerEvents.emit("beforeHistoryChange", full, { shallow });
-    updateHistory(mode, full, navState);
-    if (navigateOptions.pendingRedirectHistoryUrl !== undefined) {
-      window.history.replaceState(
-        window.history.state ?? {},
-        "",
-        navigateOptions.pendingRedirectHistoryUrl,
-      );
-      routerRuntimeState.lastPathnameAndSearch = window.location.pathname + window.location.search;
-      routerRuntimeState.lastHash = window.location.hash;
-    }
+    updateHistory(mode, redirectHistoryHref ?? full, navState);
   };
   if (!shallow) {
     navigateOptions.beforeHistoryChange = emitBeforeHistoryChange;
@@ -3337,6 +3313,19 @@ async function performNavigation(
       fullRouteUrl,
       eventContext,
     );
+    if (typeof result === "object") {
+      if (eventContext) clearActiveNavigationEvent(eventContext);
+      return performNavigation(
+        result.redirectDestination,
+        undefined,
+        { ...options, locale: false },
+        mode,
+        onStateUpdate,
+        isAbsoluteOrProtocolRelativeUrl(result.redirectDestination)
+          ? result.redirectDestination
+          : undefined,
+      );
+    }
     if (result === "cancelled") return true;
     if (result === "failed") return false;
   } else {

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -1595,10 +1595,15 @@ function isAppComponent(value: unknown): value is NonNullable<Window["__VINEXT_A
 function resolveSameOriginRedirectedUrl(responseUrl: string): string | null {
   const appPath = toSameOriginAppPath(responseUrl, __basePath);
   if (appPath === null) return null;
-  return normalizePathTrailingSlash(
-    toBrowserNavigationHref(appPath, window.location.href, __basePath),
-    __trailingSlash,
-  );
+  // Keep a same-origin absolute URL when stripping its origin/basePath would
+  // expose a leading `//`; performNavigation uses that absolute form for the
+  // history URL while retaining the app path for route state and fetching.
+  if (appPath.startsWith("//")) {
+    return normalizePathTrailingSlash(responseUrl, __trailingSlash);
+  }
+  // Followed HTML redirects re-enter performNavigation(), so return its
+  // app-relative input rather than a browser URL that already has basePath.
+  return normalizePathTrailingSlash(appPath, __trailingSlash);
 }
 
 function stripLocalePrefixForApiRedirect(appPath: string): string {

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -406,6 +406,12 @@ type RouterEvents = {
   emit(event: string, ...args: unknown[]): void;
 };
 
+type PagesNavigationEventContext = {
+  cancellationEmitted: boolean;
+  routeProps: { shallow: boolean };
+  url: string;
+};
+
 function createRouterEvents(): RouterEvents {
   const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
 
@@ -430,6 +436,7 @@ type PagesRouterRuntimeState = {
   historyKeyCounter: number;
   navigationId: number;
   activeAbortController: AbortController | null;
+  activeNavigationEvent: PagesNavigationEventContext | null;
   cancelPendingRenderCommit: (() => void) | null;
   beforePopStateCb?: BeforePopStateCallback;
   lastPathnameAndSearch: string;
@@ -458,6 +465,7 @@ function createPagesRouterRuntimeState(): PagesRouterRuntimeState {
     historyKeyCounter: 0,
     navigationId: 0,
     activeAbortController: null,
+    activeNavigationEvent: null,
     cancelPendingRenderCommit: null,
     lastPathnameAndSearch:
       typeof window !== "undefined" ? window.location.pathname + window.location.search : "",
@@ -797,15 +805,13 @@ function getPagesHtmlFetchUrl(browserUrl: string, locale: string | undefined): s
 
 export { isExternalUrl };
 
-/** Resolve a hash URL to a basePath-stripped app URL for event payloads */
+/** Resolve a hash URL to the browser-visible URL used by Next.js router events. */
 function resolveHashUrl(url: string): string {
   if (typeof window === "undefined") return url;
-  if (url.startsWith("#"))
-    return stripBasePath(window.location.pathname, __basePath) + window.location.search + url;
-  // Full-path hash URL — strip basePath for consistency with other events
+  if (url.startsWith("#")) return window.location.pathname + window.location.search + url;
   try {
     const parsed = new URL(url, window.location.href);
-    return stripBasePath(parsed.pathname, __basePath) + parsed.search + parsed.hash;
+    return parsed.pathname + parsed.search + parsed.hash;
   } catch {
     return url;
   }
@@ -1475,9 +1481,31 @@ function notifyNextNavigationPagesContext(): void {
  */
 class NavigationCancelledError extends Error {
   cancelled = true;
-  constructor(route: string) {
-    super(`Abort fetching component for route: "${route}"`);
+  constructor(_route: string) {
+    super("Route Cancelled");
     this.name = "NavigationCancelledError";
+  }
+}
+
+function cancelActiveNavigationEvent(): void {
+  const active = routerRuntimeState.activeNavigationEvent;
+  if (active === null || active.cancellationEmitted) return;
+
+  active.cancellationEmitted = true;
+  routerEvents.emit(
+    "routeChangeError",
+    new NavigationCancelledError(active.url),
+    active.url,
+    active.routeProps,
+  );
+  if (routerRuntimeState.activeNavigationEvent === active) {
+    routerRuntimeState.activeNavigationEvent = null;
+  }
+}
+
+function clearActiveNavigationEvent(context: PagesNavigationEventContext): void {
+  if (routerRuntimeState.activeNavigationEvent === context) {
+    routerRuntimeState.activeNavigationEvent = null;
   }
 }
 
@@ -1519,6 +1547,7 @@ type NavigateClientOptions = {
    */
   mode?: "push" | "replace";
   scroll?: ScrollPosition | null;
+  beforeHistoryChange?: () => void;
 };
 
 /** Wire format of `/_next/data/<id>/<page>.json` response bodies. */
@@ -2111,6 +2140,7 @@ async function renderPagesNavigationTarget(
   }
 
   const nextData = buildPagesNavigationNextData(target, props);
+  options.beforeHistoryChange?.();
   window.__NEXT_DATA__ = nextData;
   applyVinextLocaleGlobals(window, nextData);
   await renderPagesRouterElement(element, options.scroll);
@@ -2261,7 +2291,7 @@ async function navigateClientData(
     // reload to land on the new build's HTML. Any other non-OK status is
     // treated the same way per the user-configured "always hard reload"
     // fallback policy.
-    scheduleHardNavigationAndThrow(url, `Data navigation failed: ${res.status} ${res.statusText}`);
+    scheduleHardNavigationAndThrow(url, "Failed to load static props");
   }
 
   const rewriteTarget = res.headers.get("x-nextjs-rewrite");
@@ -2484,6 +2514,7 @@ async function navigateClientHtml(
   // has passed assertStillCurrent(). The post-render await below waits for the
   // stable Pages Router commit boundary before routeChangeComplete, matching
   // Next.js's client Root callback without remounting the page tree.
+  options.beforeHistoryChange?.();
   if (pendingRedirectHistoryUrl) {
     window.history.replaceState(window.history.state ?? {}, "", pendingRedirectHistoryUrl);
     routerRuntimeState.lastPathnameAndSearch = window.location.pathname + window.location.search;
@@ -2744,12 +2775,17 @@ async function runNavigateClient(
    * Defaults to `fullUrl`, making this a no-op for callers without a mask.
    */
   routeUrl: string = fullUrl,
+  eventContext?: PagesNavigationEventContext,
 ): Promise<"completed" | "cancelled" | "failed"> {
   try {
     await navigateClient(fullUrl, fetchUrl, options, routeUrl);
     return "completed";
   } catch (err: unknown) {
+    if (eventContext?.cancellationEmitted) {
+      return "cancelled";
+    }
     routerEvents.emit("routeChangeError", err, resolvedUrl, { shallow: false });
+    if (eventContext) clearActiveNavigationEvent(eventContext);
     if (err instanceof NavigationCancelledError) {
       return "cancelled";
     }
@@ -3185,6 +3221,8 @@ async function performNavigation(
     options: navStateOptions,
   };
 
+  if (options?._h !== 1) cancelActiveNavigationEvent();
+
   // Hash-only change — no page fetch needed.
   // Guard: when the route URL differs from the display URL (i.e. href and as
   // disagree), the underlying page module changes even if the address bar
@@ -3256,15 +3294,29 @@ async function performNavigation(
 
   if (mode === "push") saveScrollPosition();
   const isQueryUpdating = options?._h === 1;
+  const eventContext: PagesNavigationEventContext | undefined = isQueryUpdating
+    ? undefined
+    : {
+        cancellationEmitted: false,
+        routeProps: { shallow },
+        url: full,
+      };
+  if (eventContext) routerRuntimeState.activeNavigationEvent = eventContext;
   if (!isQueryUpdating) {
-    routerEvents.emit("routeChangeStart", resolved, { shallow });
+    routerEvents.emit("routeChangeStart", full, { shallow });
   }
-  routerEvents.emit("beforeHistoryChange", resolved, { shallow });
   updateHistory(mode, full, navState);
+  let beforeHistoryChangeEmitted = false;
+  const emitBeforeHistoryChange = () => {
+    if (beforeHistoryChangeEmitted) return;
+    beforeHistoryChangeEmitted = true;
+    routerEvents.emit("beforeHistoryChange", full, { shallow });
+  };
   if (!shallow) {
+    navigateOptions.beforeHistoryChange = emitBeforeHistoryChange;
     const result = await runNavigateClient(
       full,
-      resolved,
+      full,
       htmlFetchUrl,
       navigateOptions,
       // When href and as differ, the data fetch must target the route URL
@@ -3272,10 +3324,12 @@ async function performNavigation(
       // fullRouteUrl === full when there is no mask, so this is a no-op
       // for the dominant case.
       fullRouteUrl,
+      eventContext,
     );
     if (result === "cancelled") return true;
     if (result === "failed") return false;
   } else {
+    emitBeforeHistoryChange();
     // Shallow navigations skip the render-commit path, so apply the scroll
     // reset synchronously here — before routeChangeComplete. This matches the
     // non-shallow path, where the x/y reset runs inside the render-commit
@@ -3288,7 +3342,8 @@ async function performNavigation(
   }
   onStateUpdate?.();
   if (!isQueryUpdating) {
-    routerEvents.emit("routeChangeComplete", resolved, { shallow });
+    routerEvents.emit("routeChangeComplete", full, { shallow });
+    if (eventContext) clearActiveNavigationEvent(eventContext);
   }
   // Hash scrolling after routeChangeComplete, matching Next.js ordering:
   // x/y restoration happens during the render commit, then hash scrolling
@@ -3630,7 +3685,7 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
     // path (.nextjs-ref/packages/next/src/shared/lib/router/router.ts around
     // L1381-1403 and L1780). The snapshot stays in sessionStorage, so a later
     // non-hash popstate to this entry still restores the saved position.
-    const hashUrl = appUrl + window.location.hash;
+    const hashUrl = browserUrl + window.location.hash;
     routerEvents.emit("hashChangeStart", hashUrl, { shallow: false });
     scrollToHashTarget(window.location.hash);
     routerEvents.emit("hashChangeComplete", hashUrl, { shallow: false });
@@ -3644,14 +3699,14 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
   const stateLocale = isNextRouterState(state) ? state.options?.locale : undefined;
   const effectiveLocale = typeof stateLocale === "string" ? stateLocale : window.__VINEXT_LOCALE__;
 
-  const fullAppUrl = appUrl + window.location.hash;
-  routerEvents.emit("routeChangeStart", fullAppUrl, { shallow: false });
+  const fullEventUrl = browserUrl + window.location.hash;
+  routerEvents.emit("routeChangeStart", fullEventUrl, { shallow: false });
   // Note: The browser has already updated window.location by the time popstate
   // fires, so this is not truly "before" the URL change. In Next.js the popstate
   // handler calls replaceState to store history metadata — beforeHistoryChange
   // precedes that call, not the URL change itself. We emit it here for API
   // compatibility.
-  routerEvents.emit("beforeHistoryChange", fullAppUrl, { shallow: false });
+  routerEvents.emit("beforeHistoryChange", fullEventUrl, { shallow: false });
   void (async () => {
     // When manual scroll restoration is enabled we drive the position from the
     // sessionStorage snapshot keyed by history key. When it is disabled we
@@ -3689,13 +3744,13 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
     })();
     const result = await runNavigateClient(
       browserUrl,
-      fullAppUrl,
+      fullEventUrl,
       getPagesHtmlFetchUrl(stateRouteUrl, effectiveLocale),
       { scroll: scrollTarget },
       stateRouteUrl,
     );
     if (result === "completed") {
-      routerEvents.emit("routeChangeComplete", fullAppUrl, { shallow: false });
+      routerEvents.emit("routeChangeComplete", fullEventUrl, { shallow: false });
       dispatchNavigateEvent();
     }
     // "cancelled": superseded by a newer navigation, so this popstate no longer wins.

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -1490,6 +1490,14 @@ function cancelActiveNavigationEvent(): void {
   const active = routerRuntimeState.activeNavigationEvent;
   if (active === null || active.cancellationEmitted) return;
 
+  // Event cancellation and runtime cancellation are one operation. Hash-only
+  // and shallow winners never enter navigateClient(), so relying on its normal
+  // supersession path would let the abandoned fetch or render commit later.
+  routerRuntimeState.navigationId += 1;
+  routerRuntimeState.activeAbortController?.abort();
+  routerRuntimeState.activeAbortController = null;
+  cancelPreviousRenderCommit();
+
   active.cancellationEmitted = true;
   routerEvents.emit(
     "routeChangeError",
@@ -3661,6 +3669,11 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
     if (!shouldContinue) return;
   }
 
+  // A history traversal is a new navigation just like push/replace. Cancel
+  // the prior fetch/render before announcing this destination so the prior
+  // routeChangeError is always observed before this routeChangeStart.
+  cancelActiveNavigationEvent();
+
   // Update trackers only after beforePopState confirms navigation proceeds.
   // If beforePopState cancels, the app stays on the previous history entry,
   // so both must retain their previous values: `lastPathnameAndSearch` so the
@@ -3699,6 +3712,12 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
   const effectiveLocale = typeof stateLocale === "string" ? stateLocale : window.__VINEXT_LOCALE__;
 
   const fullEventUrl = browserUrl + window.location.hash;
+  const eventContext: PagesNavigationEventContext = {
+    cancellationEmitted: false,
+    routeProps: { shallow: false },
+    url: fullEventUrl,
+  };
+  routerRuntimeState.activeNavigationEvent = eventContext;
   routerEvents.emit("routeChangeStart", fullEventUrl, { shallow: false });
   let beforeHistoryChangeEmitted = false;
   const emitBeforeHistoryChange = () => {
@@ -3747,9 +3766,11 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
       getPagesHtmlFetchUrl(stateRouteUrl, effectiveLocale),
       { scroll: scrollTarget, beforeHistoryChange: emitBeforeHistoryChange },
       stateRouteUrl,
+      eventContext,
     );
     if (result === "completed") {
       routerEvents.emit("routeChangeComplete", fullEventUrl, { shallow: false });
+      clearActiveNavigationEvent(eventContext);
       dispatchNavigateEvent();
     }
     // "cancelled": superseded by a newer navigation, so this popstate no longer wins.

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -2741,6 +2741,7 @@ async function navigateClient(
             __basePath,
           );
           if (rewrittenOwner === "app" || rewrittenOwner === "document") {
+            options.beforeHistoryChange?.();
             scheduleHardNavigationAndThrow(browserUrl, "Navigation rewritten to a non-Pages route");
           }
           const rewrittenTarget =
@@ -2751,6 +2752,7 @@ async function navigateClient(
               pagesDataTargetOptions,
             );
           if (!rewrittenTarget) {
+            options.beforeHistoryChange?.();
             scheduleHardNavigationAndThrow(browserUrl, "Navigation rewritten to a non-Pages route");
           }
           dataTarget = rewrittenTarget;

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -1483,7 +1483,6 @@ class NavigationCancelledError extends Error {
   cancelled = true;
   constructor(_route: string) {
     super("Route Cancelled");
-    this.name = "NavigationCancelledError";
   }
 }
 
@@ -3701,12 +3700,12 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
 
   const fullEventUrl = browserUrl + window.location.hash;
   routerEvents.emit("routeChangeStart", fullEventUrl, { shallow: false });
-  // Note: The browser has already updated window.location by the time popstate
-  // fires, so this is not truly "before" the URL change. In Next.js the popstate
-  // handler calls replaceState to store history metadata — beforeHistoryChange
-  // precedes that call, not the URL change itself. We emit it here for API
-  // compatibility.
-  routerEvents.emit("beforeHistoryChange", fullEventUrl, { shallow: false });
+  let beforeHistoryChangeEmitted = false;
+  const emitBeforeHistoryChange = () => {
+    if (beforeHistoryChangeEmitted) return;
+    beforeHistoryChangeEmitted = true;
+    routerEvents.emit("beforeHistoryChange", fullEventUrl, { shallow: false });
+  };
   void (async () => {
     // When manual scroll restoration is enabled we drive the position from the
     // sessionStorage snapshot keyed by history key. When it is disabled we
@@ -3746,7 +3745,7 @@ function handlePagesRouterPopState(e: PopStateEvent): void {
       browserUrl,
       fullEventUrl,
       getPagesHtmlFetchUrl(stateRouteUrl, effectiveLocale),
-      { scroll: scrollTarget },
+      { scroll: scrollTarget, beforeHistoryChange: emitBeforeHistoryChange },
       stateRouteUrl,
     );
     if (result === "completed") {

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -1646,11 +1646,17 @@ function resolveLocalRedirectUrl(location: string): string | null {
 
   if (appPath === null) return null;
   // Stripping an origin or basePath can expose a leading `//` that the browser
-  // would reinterpret as a different authority. Keep the original same-origin
-  // target instead; absolute and basePath-prefixed forms are both safe inputs
-  // to history navigation.
+  // would reinterpret as a different authority. Resolve the original target
+  // to a validated same-origin absolute URL; recursive navigation retains its
+  // `//` app path as route state but uses this absolute form for browser I/O.
   if (appPath.startsWith("//")) {
-    return normalizePathTrailingSlash(location, __trailingSlash);
+    try {
+      const browserUrl = new URL(location, window.location.href);
+      if (browserUrl.origin !== getWindowOrigin()) return null;
+      return normalizePathTrailingSlash(browserUrl.href, __trailingSlash);
+    } catch {
+      return null;
+    }
   }
   // Internal redirects are re-dispatched through performNavigation(), whose
   // input contract is app-relative. Keep basePath stripped here so the fresh
@@ -3135,6 +3141,18 @@ async function performNavigation(
     toBrowserNavigationHref(resolved, window.location.href, __basePath),
     __trailingSlash,
   );
+  let browserEventUrl = full;
+  if (redirectBrowserHref !== undefined) {
+    try {
+      const parsed = new URL(redirectBrowserHref);
+      if (parsed.origin === getWindowOrigin()) {
+        browserEventUrl = parsed.pathname + parsed.search + parsed.hash;
+      }
+    } catch {
+      // redirectBrowserHref was validated before recursion; keep the local
+      // fallback if the browser rejects it unexpectedly.
+    }
+  }
   // When the (now concrete) route differs from the display URL, fetch HTML/
   // data by the route URL — not the masked address — so the page module that
   // actually renders is the one fetched. When they match (no mask) this is a
@@ -3235,9 +3253,13 @@ async function performNavigation(
     // departed entry.
     // Mirrors Next.js: packages/next/src/shared/lib/router/router.ts:1034-1046.
     if (mode === "push") saveScrollPosition();
-    const eventUrl = resolveHashUrl(full);
+    const eventUrl = resolveHashUrl(browserEventUrl);
     routerEvents.emit("hashChangeStart", eventUrl, { shallow });
-    updateHistory(mode, resolved.startsWith("#") ? resolved : full, navState);
+    updateHistory(
+      mode,
+      resolved.startsWith("#") ? resolved : (redirectBrowserHref ?? full),
+      navState,
+    );
     if (doScroll) scrollToHashTarget(extractHash(resolved));
     onStateUpdate?.();
     routerEvents.emit("hashChangeComplete", eventUrl, { shallow });
@@ -3296,24 +3318,24 @@ async function performNavigation(
     ? undefined
     : {
         cancellationEmitted: false,
-        url: full,
+        url: browserEventUrl,
       };
   if (eventContext) routerRuntimeState.activeNavigationEvent = eventContext;
   if (!isQueryUpdating) {
-    routerEvents.emit("routeChangeStart", full, { shallow });
+    routerEvents.emit("routeChangeStart", browserEventUrl, { shallow });
   }
   let beforeHistoryChangeEmitted = false;
   const emitBeforeHistoryChange = () => {
     if (beforeHistoryChangeEmitted) return;
     beforeHistoryChangeEmitted = true;
-    routerEvents.emit("beforeHistoryChange", full, { shallow });
+    routerEvents.emit("beforeHistoryChange", browserEventUrl, { shallow });
     updateHistory(mode, redirectBrowserHref ?? full, navState);
   };
   if (!shallow) {
     navigateOptions.beforeHistoryChange = emitBeforeHistoryChange;
     const result = await runNavigateClient(
       full,
-      full,
+      browserEventUrl,
       redirectBrowserHref ?? htmlFetchUrl,
       navigateOptions,
       // When href and as differ, the data fetch must target the route URL
@@ -3352,7 +3374,7 @@ async function performNavigation(
   }
   onStateUpdate?.();
   if (!isQueryUpdating) {
-    routerEvents.emit("routeChangeComplete", full, { shallow });
+    routerEvents.emit("routeChangeComplete", browserEventUrl, { shallow });
     if (eventContext) clearActiveNavigationEvent(eventContext);
   }
   // Hash scrolling after routeChangeComplete, matching Next.js ordering:

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -19947,6 +19947,75 @@ describe("Pages Router concurrent navigation", () => {
     }
   });
 
+  it("does not double-prefix basePath for followed HTML redirects", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const previousBasePath = process.env.__NEXT_ROUTER_BASEPATH;
+    const { win, pushState, render } = createNavWindow();
+    const pageModuleUrl = fixtureModuleUrl("fixtures/client-navigation-page.tsx");
+    Object.assign(win.location, {
+      origin: "http://localhost",
+      pathname: "/docs",
+      href: "http://localhost/docs",
+    });
+    process.env.__NEXT_ROUTER_BASEPATH = "/docs";
+    (globalThis as any).window = win;
+
+    const followedRedirect = new Response("", { status: 200 });
+    Object.defineProperties(followedRedirect, {
+      redirected: { value: true },
+      url: { value: "http://localhost/docs/new-home" },
+    });
+    const fetch = vi.fn(async (url: RequestInfo | URL) => {
+      const href = getFetchHref(url);
+      if (href === "/docs/old-home") return followedRedirect;
+      if (href === "/docs/new-home") {
+        return new Response(buildNavHtml("/new-home", pageModuleUrl));
+      }
+      throw new Error(`Unexpected fetch: ${href}`);
+    });
+    globalThis.fetch = fetch;
+
+    try {
+      vi.resetModules();
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      const Router = routerModule.default;
+
+      const result = await Router.push("/old-home", undefined, { scroll: false });
+
+      expect(result).toBe(true);
+      expect(fetch).toHaveBeenNthCalledWith(1, "/docs/old-home", expect.any(Object));
+      expect(fetch).toHaveBeenNthCalledWith(2, "/docs/new-home", expect.any(Object));
+      expect(fetch).not.toHaveBeenCalledWith("/docs/docs/new-home", expect.any(Object));
+      expect(pushState).toHaveBeenCalledTimes(1);
+      expect(pushState).toHaveBeenCalledWith(
+        expect.objectContaining({ url: "/new-home", as: "/new-home", __N: true }),
+        "",
+        "/docs/new-home",
+      );
+      expect(win.history.state).toMatchObject({
+        url: "/new-home",
+        as: "/new-home",
+        __N: true,
+      });
+      expect(win.location.href).toBe("http://localhost/docs/new-home");
+      expect(render).toHaveBeenCalled();
+    } finally {
+      vi.resetModules();
+      if (previousBasePath === undefined) {
+        delete process.env.__NEXT_ROUTER_BASEPATH;
+      } else {
+        process.env.__NEXT_ROUTER_BASEPATH = previousBasePath;
+      }
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("falls through to normal page navigation when the middleware data probe fails", async () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -19720,6 +19720,139 @@ describe("Pages Router concurrent navigation", () => {
     }
   });
 
+  it("keeps same-origin absolute middleware redirects safe when reached by popstate", async () => {
+    const previousWindow = (globalThis as any).window;
+    const previousDocument = (globalThis as any).document;
+    const originalFetch = globalThis.fetch;
+    const originalCustomEvent = globalThis.CustomEvent;
+    const previousBasePath = process.env.__NEXT_ROUTER_BASEPATH;
+    const listeners = new Map<string, (event: any) => void>();
+    const { win, pushState, replaceState, render } = createNavWindow();
+    const pageModuleUrl = fixtureModuleUrl("fixtures/client-navigation-page.tsx");
+    const redirectHeader = "/docs//evil.example/steal?token=secret#fragment";
+    const target = `http://localhost${redirectHeader}`;
+    Object.assign(win.location, {
+      origin: "http://localhost",
+      pathname: "/docs/start",
+      href: "http://localhost/docs/start",
+    });
+    Object.assign(win.__NEXT_DATA__, {
+      buildId: "build-1",
+      __vinext: { ...win.__NEXT_DATA__.__vinext, hasMiddleware: true },
+    });
+    win.addEventListener = vi.fn((type: string, handler: (event: any) => void) => {
+      listeners.set(type, handler);
+    });
+    process.env.__NEXT_ROUTER_BASEPATH = "/docs";
+    (globalThis as any).window = win;
+    (globalThis as any).CustomEvent = class CustomEventMock {
+      constructor(public type: string) {}
+    } as any;
+    (globalThis as any).document = {
+      getElementById: vi.fn(() => null),
+      getElementsByName: vi.fn(() => []),
+    };
+
+    const fetch = vi.fn(async (url: RequestInfo | URL) => {
+      const href = getFetchHref(url);
+      if (href === "/docs/_next/data/build-1/old-home.json") {
+        return new Response("{}", {
+          headers: { "x-nextjs-redirect": redirectHeader },
+          status: 200,
+        });
+      }
+      if (href === target) {
+        return new Response(buildNavHtml("//evil.example/steal", pageModuleUrl));
+      }
+      throw new Error(`Unexpected fetch: ${href}`);
+    });
+    globalThis.fetch = fetch;
+    vi.resetModules();
+
+    const events: Array<[string, string]> = [];
+    const record = (name: string) =>
+      function (...args: unknown[]) {
+        events.push([name, String(args[0])]);
+      };
+    const onStart = record("routeChangeStart");
+    const onBefore = record("beforeHistoryChange");
+    const onComplete = record("routeChangeComplete");
+
+    try {
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+      Router.events.on("routeChangeStart", onStart);
+      Router.events.on("beforeHistoryChange", onBefore);
+      Router.events.on("routeChangeComplete", onComplete);
+      const { installPagesRouterRuntime } =
+        await import("../packages/vinext/src/shims/pages-router-runtime.js");
+      installPagesRouterRuntime();
+      const popstateHandler = listeners.get("popstate");
+      expect(popstateHandler).toBeDefined();
+      replaceState.mockClear();
+
+      const state = {
+        url: "/old-home",
+        as: "/old-home",
+        options: { shallow: false },
+        __N: true,
+        key: "old-home",
+      };
+      Object.assign(win.location, {
+        pathname: "/docs/old-home",
+        href: "http://localhost/docs/old-home",
+      });
+      (win.history as { state: unknown }).state = state;
+      popstateHandler!({ state });
+
+      await vi.waitFor(() =>
+        expect(events).toContainEqual(["routeChangeComplete", redirectHeader]),
+      );
+      await vi.waitFor(() => expect(win.scrollTo).toHaveBeenCalled());
+
+      expect(fetch).toHaveBeenNthCalledWith(
+        1,
+        "/docs/_next/data/build-1/old-home.json",
+        expect.any(Object),
+      );
+      expect(fetch).toHaveBeenNthCalledWith(2, target, expect.any(Object));
+      expect(fetch).not.toHaveBeenCalledWith(
+        "http://localhost/docs/docs//evil.example/steal?token=secret#fragment",
+        expect.any(Object),
+      );
+      expect(events).toEqual([
+        ["routeChangeStart", "/docs/old-home"],
+        ["routeChangeStart", redirectHeader],
+        ["beforeHistoryChange", redirectHeader],
+        ["routeChangeComplete", redirectHeader],
+      ]);
+      expect(pushState).not.toHaveBeenCalled();
+      expect(replaceState).toHaveBeenCalledTimes(1);
+      expect(replaceState).toHaveBeenCalledWith(expect.any(Object), "", target);
+      expect(win.history.state).toMatchObject({
+        url: "//evil.example/steal?token=secret",
+        as: "//evil.example/steal?token=secret",
+        __N: true,
+      });
+      expect(win.location.href).toBe(target);
+      expect(win.location.assign).not.toHaveBeenCalled();
+      expect(render).toHaveBeenCalledTimes(1);
+    } finally {
+      const Router = (await import("../packages/vinext/src/shims/router.js")).default;
+      Router.events.off("routeChangeStart", onStart);
+      Router.events.off("beforeHistoryChange", onBefore);
+      Router.events.off("routeChangeComplete", onComplete);
+      if (previousBasePath === undefined) delete process.env.__NEXT_ROUTER_BASEPATH;
+      else process.env.__NEXT_ROUTER_BASEPATH = previousBasePath;
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      if (previousDocument === undefined) delete (globalThis as any).document;
+      else (globalThis as any).document = previousDocument;
+      globalThis.fetch = originalFetch;
+      (globalThis as any).CustomEvent = originalCustomEvent;
+      vi.resetModules();
+    }
+  });
+
   it("hydrates middleware rewrites to fallback pages from the data response", async () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;
@@ -21919,6 +22052,120 @@ describe("Pages Router _next/data client navigation", () => {
       if (previousWindow === undefined) delete (globalThis as any).window;
       else (globalThis as any).window = previousWindow;
       globalThis.fetch = originalFetch;
+      vi.resetModules();
+    }
+  });
+
+  // Mirrors Next.js popstate calling change("replaceState", ...) and threading
+  // that method through recursive internal redirects.
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/router.ts
+  it("follows config redirects reached by popstate with replace semantics", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const originalCustomEvent = globalThis.CustomEvent;
+    const previousBasePath = process.env.__NEXT_ROUTER_BASEPATH;
+    const sourceLoader = vi.fn(async () => makePageModule("source"));
+    const destinationLoader = vi.fn(async () => makePageModule("destination"));
+    const { win, pushState, replaceState } = createDataNavWindow({
+      page: "/start",
+      pathname: "/docs/start",
+      loaders: {
+        "/start": vi.fn(async () => makePageModule("start")),
+        "/legacy": sourceLoader,
+        "/destination": destinationLoader,
+      },
+      ssgPatterns: [],
+      sspPatterns: [],
+    });
+    (win as any).__VINEXT_CLIENT_REDIRECTS__ = [
+      { source: "/legacy", destination: "/destination", permanent: false },
+    ];
+    const listeners = new Map<string, (event: any) => void>();
+    win.addEventListener = vi.fn((type: string, handler: (event: any) => void) => {
+      listeners.set(type, handler);
+    });
+    process.env.__NEXT_ROUTER_BASEPATH = "/docs";
+    (globalThis as any).window = win;
+    (globalThis as any).CustomEvent = class CustomEventMock {
+      constructor(public type: string) {}
+    } as any;
+    globalThis.fetch = vi.fn(async () => new Response("{}"));
+    vi.resetModules();
+
+    const events: Array<[string, string]> = [];
+    const record = (name: string) =>
+      function (...args: unknown[]) {
+        events.push([name, String(args[0])]);
+      };
+    const onStart = record("routeChangeStart");
+    const onBefore = record("beforeHistoryChange");
+    const onComplete = record("routeChangeComplete");
+
+    try {
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+      Router.events.on("routeChangeStart", onStart);
+      Router.events.on("beforeHistoryChange", onBefore);
+      Router.events.on("routeChangeComplete", onComplete);
+      const { installPagesRouterRuntime } =
+        await import("../packages/vinext/src/shims/pages-router-runtime.js");
+      installPagesRouterRuntime();
+      const popstateHandler = listeners.get("popstate");
+      expect(popstateHandler).toBeDefined();
+      replaceState.mockClear();
+
+      const state = {
+        url: "/legacy",
+        as: "/legacy",
+        options: { shallow: false },
+        __N: true,
+        key: "legacy",
+      };
+      Object.assign(win.location, {
+        pathname: "/docs/legacy",
+        href: "http://localhost/docs/legacy",
+      });
+      (win.history as { state: unknown }).state = state;
+      popstateHandler!({ state });
+
+      await vi.waitFor(() =>
+        expect(events).toContainEqual(["routeChangeComplete", "/docs/destination"]),
+      );
+
+      expect(events).toEqual([
+        ["routeChangeStart", "/docs/legacy"],
+        ["routeChangeStart", "/docs/destination"],
+        ["beforeHistoryChange", "/docs/destination"],
+        ["routeChangeComplete", "/docs/destination"],
+      ]);
+      expect(pushState).not.toHaveBeenCalled();
+      expect(replaceState).toHaveBeenCalledTimes(1);
+      expect(replaceState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "/destination",
+          as: "/destination",
+          __N: true,
+        }),
+        "",
+        "/docs/destination",
+      );
+      expect(sourceLoader).not.toHaveBeenCalled();
+      expect(destinationLoader).toHaveBeenCalledTimes(1);
+      expect(win.location.pathname).toBe("/docs/destination");
+      expect(win.__NEXT_DATA__).toMatchObject({
+        page: "/destination",
+        props: { pageProps: {} },
+      });
+    } finally {
+      const Router = (await import("../packages/vinext/src/shims/router.js")).default;
+      Router.events.off("routeChangeStart", onStart);
+      Router.events.off("beforeHistoryChange", onBefore);
+      Router.events.off("routeChangeComplete", onComplete);
+      if (previousBasePath === undefined) delete process.env.__NEXT_ROUTER_BASEPATH;
+      else process.env.__NEXT_ROUTER_BASEPATH = previousBasePath;
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+      (globalThis as any).CustomEvent = originalCustomEvent;
       vi.resetModules();
     }
   });

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -17064,6 +17064,7 @@ describe("Pages Router concurrent navigation", () => {
 
     // Make pushState update location to simulate real browser behavior
     pushState.mockImplementation((_state: unknown, _title: string, url: string) => {
+      (win.history as { state: unknown }).state = _state;
       try {
         const parsed = new URL(url, "http://localhost");
         win.location.pathname = parsed.pathname;
@@ -17078,6 +17079,7 @@ describe("Pages Router concurrent navigation", () => {
     });
 
     replaceState.mockImplementation((_state: unknown, _title: string, url?: string) => {
+      (win.history as { state: unknown }).state = _state;
       if (!url) return;
       try {
         const parsed = new URL(url, "http://localhost");
@@ -17197,22 +17199,6 @@ describe("Pages Router concurrent navigation", () => {
     const absolutePath = path.resolve(import.meta.dirname, relativePath);
     if (!isWindows) return absolutePath;
     return "/@fs/" + toSlash(absolutePath);
-  }
-
-  function buildNavHtmlWithVinext(
-    page: string,
-    vinext: { pageModuleUrl?: string; appModuleUrl?: string; hasMiddleware?: boolean },
-  ): string {
-    const nextDataScript = buildPagesNextDataScript({
-      buildId: null,
-      i18n: {},
-      pageProps: { page },
-      params: {},
-      routePattern: page,
-      safeJsonStringify,
-      vinext,
-    });
-    return `<html><head></head><body>${nextDataScript}</body></html>`;
   }
 
   function getFetchHref(url: RequestInfo | URL): string {
@@ -19488,7 +19474,7 @@ describe("Pages Router concurrent navigation", () => {
   it("handles Pages Router middleware internal redirects as client-side redirects", async () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;
-    const { win, replaceState, render } = createNavWindow();
+    const { win, pushState, render } = createNavWindow();
     const pageModuleUrl = fixtureModuleUrl("fixtures/client-navigation-page.tsx");
     Object.assign(win.location, { origin: "http://localhost" });
     Object.assign(win, {
@@ -19504,6 +19490,8 @@ describe("Pages Router concurrent navigation", () => {
       __VINEXT_PAGE_LOADERS__: {
         "/new-home": async () => import(pageModuleUrl),
       },
+      __VINEXT_PAGE_PATTERNS__: ["/new-home"],
+      __VINEXT_PAGES_SSP_PATTERNS__: ["/new-home"],
     });
     (globalThis as any).window = win;
 
@@ -19515,8 +19503,10 @@ describe("Pages Router concurrent navigation", () => {
           status: 200,
         });
       }
-      if (href === "/new-home") {
-        return new Response(buildNavHtmlWithVinext("/new-home", { hasMiddleware: true }));
+      if (href === "/_next/data/build-1/new-home.json") {
+        return new Response(JSON.stringify({ pageProps: {} }), {
+          headers: { "content-type": "application/json" },
+        });
       }
       throw new Error(`Unexpected fetch: ${href}`);
     });
@@ -19527,7 +19517,7 @@ describe("Pages Router concurrent navigation", () => {
       const routerModule = await import("../packages/vinext/src/shims/router.js");
       const Router = routerModule.default;
 
-      const result = await Router.push("/old-home");
+      const result = await Router.push("/old-home", undefined, { scroll: false });
 
       expect(result).toBe(true);
       expect(fetch).toHaveBeenNthCalledWith(
@@ -19537,8 +19527,22 @@ describe("Pages Router concurrent navigation", () => {
           headers: expect.objectContaining({ "x-nextjs-data": "1" }),
         }),
       );
-      expect(fetch).toHaveBeenNthCalledWith(2, "/new-home", expect.any(Object));
-      expect(replaceState).toHaveBeenLastCalledWith({}, "", "/new-home");
+      expect(fetch).toHaveBeenNthCalledWith(
+        2,
+        "/_next/data/build-1/new-home.json",
+        expect.any(Object),
+      );
+      expect(pushState).toHaveBeenCalledTimes(1);
+      expect(pushState).toHaveBeenCalledWith(
+        expect.objectContaining({ url: "/new-home", as: "/new-home", __N: true }),
+        "",
+        "/new-home",
+      );
+      expect(win.history.state).toMatchObject({
+        url: "/new-home",
+        as: "/new-home",
+        __N: true,
+      });
       expect(win.location.pathname).toBe("/new-home");
       expect(render).toHaveBeenCalled();
     } finally {
@@ -19555,7 +19559,7 @@ describe("Pages Router concurrent navigation", () => {
   it("preserves the origin for same-host double-slash middleware data redirects", async () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;
-    const { win, replaceState, render } = createNavWindow();
+    const { win, pushState, render } = createNavWindow();
     const pageModuleUrl = fixtureModuleUrl("fixtures/client-navigation-page.tsx");
     const target = "http://localhost//evil.example/steal?token=secret#fragment";
     Object.assign(win.location, { origin: "http://localhost" });
@@ -19573,7 +19577,7 @@ describe("Pages Router concurrent navigation", () => {
           status: 200,
         });
       }
-      if (href === target) {
+      if (href === "//evil.example/steal?token=secret#fragment") {
         return new Response(buildNavHtml("//evil.example/steal", pageModuleUrl));
       }
       throw new Error(`Unexpected fetch: ${href}`);
@@ -19585,12 +19589,19 @@ describe("Pages Router concurrent navigation", () => {
       const routerModule = await import("../packages/vinext/src/shims/router.js");
       const Router = routerModule.default;
 
-      const result = await Router.push("/old-home");
+      const result = await Router.push("/old-home", undefined, { scroll: false });
 
       expect(result).toBe(true);
-      expect(fetch).toHaveBeenNthCalledWith(2, target, expect.any(Object));
-      expect(replaceState).toHaveBeenLastCalledWith({}, "", target);
+      expect(fetch.mock.calls.at(-1)?.[0]).toBe("//evil.example/steal?token=secret#fragment");
+      expect(pushState).toHaveBeenCalledTimes(1);
+      expect(win.history.state).toMatchObject({
+        url: "//evil.example/steal?token=secret",
+        as: "//evil.example/steal?token=secret",
+        __N: true,
+      });
+      expect(pushState).toHaveBeenCalledWith(expect.any(Object), "", target);
       expect(win.location.href).toBe(target);
+      expect(win.location.assign).not.toHaveBeenCalled();
       expect(render).toHaveBeenCalled();
     } finally {
       vi.resetModules();
@@ -19849,7 +19860,7 @@ describe("Pages Router concurrent navigation", () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;
     const previousBasePath = process.env.__NEXT_ROUTER_BASEPATH;
-    const { win, replaceState, render } = createNavWindow();
+    const { win, pushState, render } = createNavWindow();
     const pageModuleUrl = fixtureModuleUrl("fixtures/client-navigation-page.tsx");
     Object.assign(win.location, {
       origin: "http://localhost",
@@ -19864,6 +19875,8 @@ describe("Pages Router concurrent navigation", () => {
       __VINEXT_PAGE_LOADERS__: {
         "/new-home": async () => import(pageModuleUrl),
       },
+      __VINEXT_PAGE_PATTERNS__: ["/new-home"],
+      __VINEXT_PAGES_SSP_PATTERNS__: ["/new-home"],
     });
     process.env.__NEXT_ROUTER_BASEPATH = "/docs";
     (globalThis as any).window = win;
@@ -19876,8 +19889,10 @@ describe("Pages Router concurrent navigation", () => {
           status: 200,
         });
       }
-      if (href === "/docs/new-home") {
-        return new Response(buildNavHtmlWithVinext("/new-home", { hasMiddleware: true }));
+      if (href === "/docs/_next/data/build-1/new-home.json") {
+        return new Response(JSON.stringify({ pageProps: {} }), {
+          headers: { "content-type": "application/json" },
+        });
       }
       throw new Error(`Unexpected fetch: ${href}`);
     });
@@ -19898,9 +19913,22 @@ describe("Pages Router concurrent navigation", () => {
           headers: expect.objectContaining({ "x-nextjs-data": "1" }),
         }),
       );
-      expect(fetch).toHaveBeenNthCalledWith(2, "/docs/new-home", expect.any(Object));
+      expect(fetch).toHaveBeenNthCalledWith(
+        2,
+        "/docs/_next/data/build-1/new-home.json",
+        expect.any(Object),
+      );
       expect(fetch).not.toHaveBeenCalledWith("/docs/docs/new-home", expect.any(Object));
-      expect(replaceState).toHaveBeenLastCalledWith({}, "", "/docs/new-home");
+      expect(pushState).toHaveBeenCalledWith(
+        expect.objectContaining({ url: "/new-home", as: "/new-home", __N: true }),
+        "",
+        "/docs/new-home",
+      );
+      expect(win.history.state).toMatchObject({
+        url: "/new-home",
+        as: "/new-home",
+        __N: true,
+      });
       expect(win.location.href).toBe("http://localhost/docs/new-home");
       expect(render).toHaveBeenCalled();
     } finally {
@@ -20983,6 +21011,7 @@ describe("Pages Router _next/data client navigation", () => {
     };
 
     pushState.mockImplementation((_state: unknown, _title: string, url: string) => {
+      (win.history as { state: unknown }).state = _state;
       try {
         const parsed = new URL(url, "http://localhost");
         win.location.pathname = parsed.pathname;
@@ -20995,6 +21024,7 @@ describe("Pages Router _next/data client navigation", () => {
       }
     });
     replaceState.mockImplementation((_state: unknown, _title: string, url?: string) => {
+      (win.history as { state: unknown }).state = _state;
       if (!url) return;
       try {
         const parsed = new URL(url, "http://localhost");
@@ -21576,7 +21606,7 @@ describe("Pages Router _next/data client navigation", () => {
 
     const dynamicLoader = vi.fn(async () => makePageModule("dynamic"));
     const destinationLoader = vi.fn(async () => makePageModule("destination"));
-    const { win, replaceState } = createDataNavWindow({
+    const { win, pushState } = createDataNavWindow({
       loaders: {
         "/": vi.fn(async () => makePageModule("home")),
         "/[id]": dynamicLoader,
@@ -21594,25 +21624,184 @@ describe("Pages Router _next/data client navigation", () => {
     const fetchMock = vi.fn(async () => new Response("{}"));
     globalThis.fetch = fetchMock as any;
 
+    const eventUrls: Array<[string, string]> = [];
+    const record = (name: string) =>
+      function (...args: unknown[]) {
+        eventUrls.push([name, String(args[0])]);
+      };
+    const onStart = record("routeChangeStart");
+    const onBefore = record("beforeHistoryChange");
+    const onComplete = record("routeChangeComplete");
+
     try {
       const routerModule = await import("../packages/vinext/src/shims/router.js");
       const Router = routerModule.default;
+      Router.events.on("routeChangeStart", onStart);
+      Router.events.on("beforeHistoryChange", onBefore);
+      Router.events.on("routeChangeComplete", onComplete);
       const result = await Router.push("/redirect-1");
 
       expect(result).toBe(true);
       expect(fetchMock).not.toHaveBeenCalled();
       expect(dynamicLoader).not.toHaveBeenCalled();
       expect(destinationLoader).toHaveBeenCalledTimes(1);
-      expect(replaceState).toHaveBeenCalledWith(expect.anything(), "", "/somewhere/else");
+      expect(pushState).toHaveBeenCalledTimes(1);
+      expect(pushState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "/somewhere/else",
+          as: "/somewhere/else",
+          __N: true,
+        }),
+        "",
+        "/somewhere/else",
+      );
+      expect(win.history.state).toMatchObject({
+        url: "/somewhere/else",
+        as: "/somewhere/else",
+        __N: true,
+      });
+      expect(eventUrls).toEqual([
+        ["routeChangeStart", "/redirect-1"],
+        ["routeChangeStart", "/somewhere/else"],
+        ["beforeHistoryChange", "/somewhere/else"],
+        ["routeChangeComplete", "/somewhere/else"],
+      ]);
       expect(win.__NEXT_DATA__).toMatchObject({
         page: "/somewhere/else",
         props: { pageProps: {} },
       });
     } finally {
+      const Router = (await import("../packages/vinext/src/shims/router.js")).default;
+      Router.events.off("routeChangeStart", onStart);
+      Router.events.off("beforeHistoryChange", onBefore);
+      Router.events.off("routeChangeComplete", onComplete);
       if (previousWindow === undefined) delete (globalThis as any).window;
       else (globalThis as any).window = previousWindow;
       globalThis.fetch = originalFetch;
       vi.resetModules();
+    }
+  });
+
+  it("stores a masked redirect destination for beforePopState and forward navigation", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const originalCustomEvent = globalThis.CustomEvent;
+    const sourceLoader = vi.fn(async () => makePageModule("source"));
+    const destinationLoader = vi.fn(async () => makePageModule("destination"));
+    const startLoader = vi.fn(async () => makePageModule("start"));
+    const { win } = createDataNavWindow({
+      page: "/start",
+      pathname: "/start",
+      loaders: {
+        "/start": startLoader,
+        "/source": sourceLoader,
+        "/destination": destinationLoader,
+      },
+      ssgPatterns: [],
+      sspPatterns: [],
+    });
+    (win as any).__VINEXT_CLIENT_REDIRECTS__ = [
+      { source: "/mask", destination: "/destination", permanent: false },
+    ];
+
+    const listeners = new Map<string, (event: any) => void>();
+    win.addEventListener = vi.fn((type: string, handler: (event: any) => void) => {
+      listeners.set(type, handler);
+    });
+    type HistoryEntry = { state: any; url: string };
+    const entries: HistoryEntry[] = [{ state: null, url: "/start" }];
+    let historyIndex = 0;
+    const applyEntry = (entry: HistoryEntry) => {
+      const parsed = new URL(entry.url, "http://localhost");
+      win.location.pathname = parsed.pathname;
+      win.location.search = parsed.search;
+      win.location.hash = parsed.hash;
+      win.location.href = parsed.href;
+      (win.history as { state: unknown }).state = entry.state;
+    };
+    win.history.pushState = vi.fn((state: unknown, _title: string, url: string) => {
+      entries.splice(historyIndex + 1);
+      entries.push({ state, url });
+      historyIndex = entries.length - 1;
+      applyEntry(entries[historyIndex]!);
+    }) as any;
+    win.history.replaceState = vi.fn((state: unknown, _title: string, url?: string) => {
+      entries[historyIndex] = { state, url: url ?? entries[historyIndex]!.url };
+      applyEntry(entries[historyIndex]!);
+    }) as any;
+    win.history.back = vi.fn(() => {
+      if (historyIndex === 0) return;
+      historyIndex -= 1;
+      applyEntry(entries[historyIndex]!);
+      listeners.get("popstate")?.({ state: entries[historyIndex]!.state });
+    });
+    (win.history as any).forward = vi.fn(() => {
+      if (historyIndex >= entries.length - 1) return;
+      historyIndex += 1;
+      applyEntry(entries[historyIndex]!);
+      listeners.get("popstate")?.({ state: entries[historyIndex]!.state });
+    });
+
+    (globalThis as any).window = win;
+    (globalThis as any).CustomEvent = class CustomEventMock {
+      constructor(public type: string) {}
+    } as any;
+    globalThis.fetch = vi.fn(async () => new Response("{}"));
+    vi.resetModules();
+
+    try {
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+      const observedPopStates: Array<{ url: string; as: string }> = [];
+      Router.beforePopState((state) => {
+        observedPopStates.push({ url: state.url, as: state.as });
+        return true;
+      });
+
+      await Router.push("/source", "/mask");
+
+      expect(entries.map((entry) => entry.url)).toEqual(["/start", "/destination"]);
+      expect(entries[1]!.state).toMatchObject({
+        url: "/destination",
+        as: "/destination",
+        __N: true,
+      });
+      expect(sourceLoader).not.toHaveBeenCalled();
+
+      const backComplete = new Promise<void>((resolve) => {
+        const onComplete = (...args: unknown[]) => {
+          if (args[0] !== "/start") return;
+          Router.events.off("routeChangeComplete", onComplete);
+          resolve();
+        };
+        Router.events.on("routeChangeComplete", onComplete);
+      });
+      win.history.back();
+      await backComplete;
+
+      const forwardComplete = new Promise<void>((resolve) => {
+        const onComplete = (...args: unknown[]) => {
+          if (args[0] !== "/destination") return;
+          Router.events.off("routeChangeComplete", onComplete);
+          resolve();
+        };
+        Router.events.on("routeChangeComplete", onComplete);
+      });
+      (win.history as any).forward();
+      await forwardComplete;
+
+      expect(observedPopStates).toEqual([
+        { url: "/start", as: "/start" },
+        { url: "/destination", as: "/destination" },
+      ]);
+      expect(destinationLoader).toHaveBeenCalledTimes(2);
+      expect(sourceLoader).not.toHaveBeenCalled();
+      expect(win.location.pathname).toBe("/destination");
+    } finally {
+      vi.resetModules();
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+      (globalThis as any).CustomEvent = originalCustomEvent;
     }
   });
 

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -18044,6 +18044,7 @@ describe("Pages Router concurrent navigation", () => {
     const onError = (error: unknown, ...args: unknown[]) =>
       events.push([
         "routeChangeError",
+        error instanceof Error ? error.name : null,
         error instanceof Error ? error.message : String(error),
         (error as { cancelled?: unknown })?.cancelled,
         ...args,
@@ -18065,7 +18066,14 @@ describe("Pages Router concurrent navigation", () => {
 
       expect(events).toEqual([
         ["routeChangeStart", "/docs/slow-route", { shallow: false }],
-        ["routeChangeError", "Route Cancelled", true, "/docs/slow-route", { shallow: false }],
+        [
+          "routeChangeError",
+          "Error",
+          "Route Cancelled",
+          true,
+          "/docs/slow-route",
+          { shallow: false },
+        ],
         ["routeChangeStart", "/docs/other-page", { shallow: false }],
         ["beforeHistoryChange", "/docs/other-page", { shallow: false }],
         ["routeChangeComplete", "/docs/other-page", { shallow: false }],
@@ -18615,8 +18623,40 @@ describe("Pages Router concurrent navigation", () => {
       constructor(public type: string) {}
     } as any;
 
-    const fetch = vi.fn(
-      async () =>
+    const response = createDeferred<Response>();
+    const fetch = vi.fn(async () => response.promise);
+    globalThis.fetch = fetch;
+
+    const events: Array<[string, string]> = [];
+    const onStart = (...args: unknown[]) => {
+      events.push(["routeChangeStart", String(args[0])]);
+    };
+    const onBefore = (...args: unknown[]) => {
+      events.push(["beforeHistoryChange", String(args[0])]);
+    };
+    const onComplete = (...args: unknown[]) => {
+      events.push(["routeChangeComplete", String(args[0])]);
+    };
+
+    try {
+      vi.resetModules();
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+      Router.events.on("routeChangeStart", onStart);
+      Router.events.on("beforeHistoryChange", onBefore);
+      Router.events.on("routeChangeComplete", onComplete);
+      const { installPagesRouterRuntime } =
+        await import("../packages/vinext/src/shims/pages-router-runtime.js");
+      installPagesRouterRuntime();
+
+      const popstateHandler = listeners.get("popstate");
+      expect(popstateHandler).toBeDefined();
+
+      win.location.pathname = "/";
+      win.location.href = "http://localhost/";
+      popstateHandler!({ state: null });
+
+      expect(events).toEqual([["routeChangeStart", "/"]]);
+      response.resolve(
         new Response(
           buildNavHtml(
             "/",
@@ -18630,28 +18670,22 @@ describe("Pages Router concurrent navigation", () => {
           ),
           { status: 200 },
         ),
-    );
-    globalThis.fetch = fetch;
-
-    try {
-      vi.resetModules();
-      await import("../packages/vinext/src/shims/router.js");
-      const { installPagesRouterRuntime } =
-        await import("../packages/vinext/src/shims/pages-router-runtime.js");
-      installPagesRouterRuntime();
-
-      const popstateHandler = listeners.get("popstate");
-      expect(popstateHandler).toBeDefined();
-
-      win.location.pathname = "/";
-      win.location.href = "http://localhost/";
-      popstateHandler!({ state: null });
+      );
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       expect(fetch).toHaveBeenCalledWith("/en", expect.any(Object));
       expect(win.location.href).toBe("http://localhost/");
       expect(win.__VINEXT_LOCALE__).toBe("en");
+      expect(events).toEqual([
+        ["routeChangeStart", "/"],
+        ["beforeHistoryChange", "/"],
+        ["routeChangeComplete", "/"],
+      ]);
     } finally {
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+      Router.events.off("routeChangeStart", onStart);
+      Router.events.off("beforeHistoryChange", onBefore);
+      Router.events.off("routeChangeComplete", onComplete);
       vi.resetModules();
       if (previousWindow === undefined) {
         delete (globalThis as any).window;
@@ -20000,9 +20034,23 @@ describe("Pages Router concurrent navigation", () => {
     globalThis.fetch = async (_url: any, _init: any) =>
       new Response("Internal Server Error", { status: 500 });
 
+    const events: Array<[string, string]> = [];
+    const onStart = (...args: unknown[]) => {
+      events.push(["routeChangeStart", String(args[0])]);
+    };
+    const onBefore = (...args: unknown[]) => {
+      events.push(["beforeHistoryChange", String(args[0])]);
+    };
+    const onError = (...args: unknown[]) => {
+      events.push(["routeChangeError", String(args[1])]);
+    };
+
     try {
       vi.resetModules();
-      await import("../packages/vinext/src/shims/router.js");
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+      Router.events.on("routeChangeStart", onStart);
+      Router.events.on("beforeHistoryChange", onBefore);
+      Router.events.on("routeChangeError", onError);
       const { installPagesRouterRuntime } =
         await import("../packages/vinext/src/shims/pages-router-runtime.js");
       installPagesRouterRuntime();
@@ -20021,7 +20069,15 @@ describe("Pages Router concurrent navigation", () => {
 
       expect(hrefAssignments.filter((value) => value === "/failing-page")).toHaveLength(1);
       expect(hrefAssignments).toHaveLength(1);
+      expect(events).toEqual([
+        ["routeChangeStart", "/failing-page"],
+        ["routeChangeError", "/failing-page"],
+      ]);
     } finally {
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+      Router.events.off("routeChangeStart", onStart);
+      Router.events.off("beforeHistoryChange", onBefore);
+      Router.events.off("routeChangeError", onError);
       vi.resetModules();
       if (previousWindow === undefined) {
         delete (globalThis as any).window;

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -22501,7 +22501,14 @@ describe("Pages Router _next/data client navigation", () => {
       const Router = routerModule.default;
 
       const rootPushPromise = Router.push({ query: { param: 1 } });
-      expect(pushState).not.toHaveBeenCalled();
+      expect(pushState).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          as: "/?param=1",
+          url: "/?param=1",
+        }),
+        "",
+        "/?param=1",
+      );
       await expect(rootPushPromise).resolves.toBe(true);
       expect(pushState).toHaveBeenLastCalledWith(
         expect.objectContaining({
@@ -22521,6 +22528,14 @@ describe("Pages Router _next/data client navigation", () => {
       };
 
       const pushPromise = Router.push({ query: { id: 1 } });
+      expect(pushState).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          as: "/rewrite-to-another-segment/0?id=1",
+          url: "/rewrite-to-another-segment/0?id=1",
+        }),
+        "",
+        "/rewrite-to-another-segment/0?id=1",
+      );
       await expect(pushPromise).resolves.toBe(true);
       expect(fetchMock).not.toHaveBeenCalled();
       expect(sourceLoader).not.toHaveBeenCalled();
@@ -22535,7 +22550,16 @@ describe("Pages Router _next/data client navigation", () => {
       );
       expect(Router.asPath).toBe("/rewrite-to-another-segment/0?id=1");
 
-      await expect(Router.replace({ query: { id: 2 } })).resolves.toBe(true);
+      const replacePromise = Router.replace({ query: { id: 2 } });
+      expect(replaceState).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          as: "/rewrite-to-another-segment/0?id=2",
+          url: "/rewrite-to-another-segment/0?id=2",
+        }),
+        "",
+        "/rewrite-to-another-segment/0?id=2",
+      );
+      await expect(replacePromise).resolves.toBe(true);
       expect(fetchMock).not.toHaveBeenCalled();
       expect(destinationLoader).toHaveBeenCalledTimes(2);
       expect(replaceState).toHaveBeenLastCalledWith(

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -17981,7 +17981,11 @@ describe("Pages Router concurrent navigation", () => {
       (...args: unknown[]) =>
         events.push([name, ...args]);
     const onStart = recordEvent("routeChangeStart");
-    const onBefore = recordEvent("beforeHistoryChange");
+    const locationsAtBeforeHistoryChange: string[] = [];
+    const onBefore = (...args: unknown[]) => {
+      locationsAtBeforeHistoryChange.push(win.location.pathname);
+      events.push(["beforeHistoryChange", ...args]);
+    };
     const onComplete = recordEvent("routeChangeComplete");
 
     try {
@@ -17998,6 +18002,8 @@ describe("Pages Router concurrent navigation", () => {
         ["beforeHistoryChange", "/docs/other-page", { shallow: false }],
         ["routeChangeComplete", "/docs/other-page", { shallow: false }],
       ]);
+      expect(locationsAtBeforeHistoryChange).toEqual(["/docs/hello"]);
+      expect(win.location.pathname).toBe("/docs/other-page");
     } finally {
       const { default: Router } = await import("../packages/vinext/src/shims/router.js");
       Router.events.off("routeChangeStart", onStart);
@@ -18018,7 +18024,7 @@ describe("Pages Router concurrent navigation", () => {
     const previousWindow = (globalThis as any).window;
     const previousBasePath = process.env.__NEXT_ROUTER_BASEPATH;
     const originalFetch = globalThis.fetch;
-    const { win } = createNavWindow();
+    const { win, pushState } = createNavWindow();
     const pageModuleUrl = fixtureModuleUrl("fixtures/client-navigation-page.tsx");
     Object.assign(win.location, {
       pathname: "/docs/hello",
@@ -18078,6 +18084,9 @@ describe("Pages Router concurrent navigation", () => {
         ["beforeHistoryChange", "/docs/other-page", { shallow: false }],
         ["routeChangeComplete", "/docs/other-page", { shallow: false }],
       ]);
+      expect(pushState).toHaveBeenCalledTimes(1);
+      expect(pushState.mock.calls[0]![2]).toBe("/docs/other-page");
+      expect(win.location.pathname).toBe("/docs/other-page");
     } finally {
       const { default: Router } = await import("../packages/vinext/src/shims/router.js");
       Router.events.off("routeChangeStart", onStart);
@@ -18151,6 +18160,8 @@ describe("Pages Router concurrent navigation", () => {
           { shallow: false },
         ],
       ]);
+      expect(win.history.pushState).not.toHaveBeenCalled();
+      expect(win.location.pathname).toBe("/docs/hello");
     } finally {
       const { default: Router } = await import("../packages/vinext/src/shims/router.js");
       Router.events.off("routeChangeStart", onStart);
@@ -18169,7 +18180,7 @@ describe("Pages Router concurrent navigation", () => {
     const previousWindow = (globalThis as any).window;
     const previousDocument = (globalThis as any).document;
     const originalFetch = globalThis.fetch;
-    const { win, render } = createNavWindow();
+    const { win, pushState, render } = createNavWindow();
     const pageModuleUrl = fixtureModuleUrl("fixtures/client-navigation-page.tsx");
     const response = createDeferred<Response>();
     let fetchSignal: AbortSignal | undefined;
@@ -18211,8 +18222,12 @@ describe("Pages Router concurrent navigation", () => {
       expect(events.slice(0, 3)).toEqual([
         ["routeChangeStart", "/page-a"],
         ["routeChangeError", "/page-a"],
-        ["hashChangeStart", "/page-a#section"],
+        ["hashChangeStart", "/#section"],
       ]);
+      expect(pushState).toHaveBeenCalledTimes(1);
+      expect(pushState.mock.calls[0]![2]).toBe("#section");
+      expect(win.location.pathname).toBe("/");
+      expect(win.location.hash).toBe("#section");
 
       response.resolve(new Response(buildNavHtml("/page-a", pageModuleUrl)));
       await pendingNavigation;
@@ -18251,12 +18266,16 @@ describe("Pages Router concurrent navigation", () => {
     };
 
     const events: Array<[string, string]> = [];
+    const cancelledRouteProps: unknown[] = [];
     const record = (name: string, urlIndex = 0) =>
       function (...args: unknown[]) {
         events.push([name, String(args[urlIndex])]);
       };
     const onStart = record("routeChangeStart");
-    const onError = record("routeChangeError", 1);
+    const onError = (...args: unknown[]) => {
+      events.push(["routeChangeError", String(args[1])]);
+      cancelledRouteProps.push(args[2]);
+    };
     const onComplete = record("routeChangeComplete");
 
     try {
@@ -18276,6 +18295,7 @@ describe("Pages Router concurrent navigation", () => {
 
       expect(fetchSignal?.aborted).toBe(true);
       expect(events).toContainEqual(["routeChangeError", "/page-a"]);
+      expect(cancelledRouteProps).toEqual([{ shallow: true }]);
       expect(events).not.toContainEqual(["routeChangeComplete", "/page-a"]);
       expect(events).toContainEqual(["routeChangeComplete", "/page-b"]);
     } finally {
@@ -18619,10 +18639,8 @@ describe("Pages Router concurrent navigation", () => {
       const Router = routerModule.default;
 
       const result = await Router.push("/failing-page");
-      // Distinguish the history update from the hard-navigation fallback:
-      // pushState writes the absolute browser URL, while the fallback helper
-      // writes the raw app-relative URL. The guard is correct only if each
-      // happens exactly once.
+      // Failed route loads never enter history; only the hard-navigation
+      // fallback writes the raw app-relative URL.
       const fallbackAssignments = hrefAssignments.filter((value) => value === "/failing-page");
       const pushStateAssignments = hrefAssignments.filter(
         (value) => value === "http://localhost/failing-page",
@@ -18630,9 +18648,8 @@ describe("Pages Router concurrent navigation", () => {
 
       expect(result).toBe(false);
       expect(fallbackAssignments).toHaveLength(1);
-      expect(pushStateAssignments).toHaveLength(1);
-      // Catch-all: exactly one history write plus exactly one hard-nav fallback.
-      expect(hrefAssignments).toHaveLength(2);
+      expect(pushStateAssignments).toHaveLength(0);
+      expect(hrefAssignments).toHaveLength(1);
     } finally {
       if (previousWindow === undefined) {
         delete (globalThis as any).window;
@@ -19756,10 +19773,7 @@ describe("Pages Router concurrent navigation", () => {
       expect(fetch).toHaveBeenCalledOnce();
       expect(sourceLoader).not.toHaveBeenCalled();
       expect(render).not.toHaveBeenCalled();
-      expect(hrefAssignments).toEqual([
-        "http://localhost/exists-but-not-routed",
-        "/exists-but-not-routed",
-      ]);
+      expect(hrefAssignments).toEqual(["/exists-but-not-routed"]);
     } finally {
       vi.resetModules();
       if (previousWindow === undefined) {
@@ -19819,7 +19833,7 @@ describe("Pages Router concurrent navigation", () => {
       expect(fetch).toHaveBeenCalledOnce();
       expect(sourceLoader).not.toHaveBeenCalled();
       expect(render).not.toHaveBeenCalled();
-      expect(hrefAssignments).toEqual(["http://localhost/rewrite-to-app", "/rewrite-to-app"]);
+      expect(hrefAssignments).toEqual(["/rewrite-to-app"]);
     } finally {
       vi.resetModules();
       if (previousWindow === undefined) {
@@ -20003,7 +20017,7 @@ describe("Pages Router concurrent navigation", () => {
           headers: expect.objectContaining({ "x-nextjs-data": "1" }),
         }),
       );
-      expect(hrefAssignments).toContain("http://localhost/nl/to?pathname=/api/ok");
+      expect(hrefAssignments).not.toContain("http://localhost/nl/to?pathname=/api/ok");
       expect(hrefAssignments).toContain("/api/ok");
       expect(hrefAssignments).not.toContain("/nl/api/ok");
     } finally {
@@ -20661,46 +20675,38 @@ describe("Pages Router concurrent navigation", () => {
     (globalThis as any).window = win;
     vi.resetModules();
 
-    // Capture router state mid-navigation, after pushState has updated
-    // window.location but before navigateClient's dynamic import runs (which
-    // would fail in this test env). useRouter() reads from window.location
-    // and window.__NEXT_DATA__ at provider-mount time, so rendering a Probe
-    // inside the mocked fetch handler observes the post-pushState state —
-    // exactly the code path that #1196 corrupts in Next.js.
+    // Capture router state both while route data is loading and after the
+    // successful transition. Next.js keeps the current URL/query visible until
+    // route info is ready, then changes history immediately after
+    // beforeHistoryChange.
     const React = await import("react");
     const { renderToStaticMarkup } = await import("react-dom/server");
     const routerModule = await import("../packages/vinext/src/shims/router.js");
+    const pageModuleUrl = fixtureModuleUrl("fixtures/client-navigation-page.tsx");
 
-    let capturedRouter: any;
+    const capturedRouters: any[] = [];
     function Probe() {
-      capturedRouter = routerModule.useRouter();
+      capturedRouters.push(routerModule.useRouter());
       return React.createElement("span", null, "ok");
     }
 
     globalThis.fetch = async (_url: any, _init: any) => {
       renderToStaticMarkup(routerModule.wrapWithRouterContext(React.createElement(Probe)));
-      // Return HTML containing the destination's __NEXT_DATA__. The dynamic
-      // import of the page module fails in this test env, which is fine — the
-      // assertion above has already captured router.query.
-      return new Response(
-        buildNavHtml("/[...path]", "/@fs/pages/catchall.js", { path: ["second"] }),
-      );
+      return new Response(buildNavHtml("/[...path]", pageModuleUrl, { path: ["second"] }));
     };
-
-    // Silence the expected routeChangeError from the page-module import failure.
-    const onRouteChangeError = vi.fn();
 
     try {
       const Router = routerModule.default;
-      Router.events.on("routeChangeError", onRouteChangeError);
 
       // Router.push() takes an app-relative path; basePath is added internally
-      // by performNavigation → toBrowserNavigationHref before pushState.
+      // by performNavigation → toBrowserNavigationHref before the deferred
+      // history change.
       await Router.push("/second");
+      renderToStaticMarkup(routerModule.wrapWithRouterContext(React.createElement(Probe)));
 
-      // pushState has fired, so location.pathname is "/docs/second".
-      // stripBasePath() removes "/docs", and the catch-all pattern
-      // "/[...path]" from __NEXT_DATA__.page extracts { path: ["second"] }.
+      expect(capturedRouters[0].asPath).toBe("/first");
+      expect(capturedRouters[0].query.path).toEqual(["first"]);
+      const capturedRouter = capturedRouters[1];
       expect(capturedRouter.pathname).toBe("/[...path]");
       expect(capturedRouter.asPath).toBe("/second");
       expect(capturedRouter.query.path).toEqual(["second"]);
@@ -20709,7 +20715,6 @@ describe("Pages Router concurrent navigation", () => {
       expect(capturedRouter.query.path).not.toContain("_next");
       expect(capturedRouter.query.path).not.toContain("data");
     } finally {
-      routerModule.default.events.off("routeChangeError", onRouteChangeError);
       globalThis.fetch = originalFetch;
       if (previousBasePath === undefined) {
         delete process.env.__NEXT_ROUTER_BASEPATH;
@@ -21819,6 +21824,8 @@ describe("Pages Router _next/data client navigation", () => {
       const Router = routerModule.default;
 
       const rootPushPromise = Router.push({ query: { param: 1 } });
+      expect(pushState).not.toHaveBeenCalled();
+      await expect(rootPushPromise).resolves.toBe(true);
       expect(pushState).toHaveBeenLastCalledWith(
         expect.objectContaining({
           as: "/?param=1",
@@ -21827,7 +21834,6 @@ describe("Pages Router _next/data client navigation", () => {
         "",
         "/?param=1",
       );
-      await expect(rootPushPromise).resolves.toBe(true);
       expect(rootDestinationLoader).toHaveBeenCalledTimes(1);
 
       win.history.replaceState({}, "", "/rewrite-to-another-segment/0");
@@ -21838,14 +21844,6 @@ describe("Pages Router _next/data client navigation", () => {
       };
 
       const pushPromise = Router.push({ query: { id: 1 } });
-      expect(pushState).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          as: "/rewrite-to-another-segment/0?id=1",
-          url: "/rewrite-to-another-segment/0?id=1",
-        }),
-        "",
-        "/rewrite-to-another-segment/0?id=1",
-      );
       await expect(pushPromise).resolves.toBe(true);
       expect(fetchMock).not.toHaveBeenCalled();
       expect(sourceLoader).not.toHaveBeenCalled();
@@ -22140,7 +22138,7 @@ describe("Pages Router _next/data client navigation", () => {
       const secondPush = Router.push("/slow?value=one");
 
       expect(fetchMock).toHaveBeenCalledTimes(1);
-      expect(pushState).toHaveBeenCalledTimes(2);
+      expect(pushState).not.toHaveBeenCalled();
 
       resolveFetch(
         new Response(JSON.stringify({ pageProps: { hit: 1 } }), {
@@ -22153,6 +22151,7 @@ describe("Pages Router _next/data client navigation", () => {
       expect(routeChangeErrors).toHaveLength(1);
       expect(routeChangeErrors[0]).toMatchObject({ cancelled: true });
       expect(routeChangeComplete).toHaveBeenCalledTimes(1);
+      expect(pushState).toHaveBeenCalledTimes(1);
       expect(slowLoader).toHaveBeenCalledTimes(1);
       expect(render).toHaveBeenCalledTimes(1);
       expect(win.__NEXT_DATA__).toMatchObject({

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -19614,6 +19614,107 @@ describe("Pages Router concurrent navigation", () => {
     }
   });
 
+  it("normalizes basePath-prefixed double-slash middleware redirects", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const previousBasePath = process.env.__NEXT_ROUTER_BASEPATH;
+    const { win, pushState, render } = createNavWindow();
+    const pageModuleUrl = fixtureModuleUrl("fixtures/client-navigation-page.tsx");
+    const redirectHeader = "/docs//evil.example/steal?token=secret#fragment";
+    const target = `http://localhost${redirectHeader}`;
+    Object.assign(win.location, {
+      origin: "http://localhost",
+      pathname: "/docs",
+      href: "http://localhost/docs",
+    });
+    Object.assign(win.__NEXT_DATA__, {
+      buildId: "build-1",
+      __vinext: { ...win.__NEXT_DATA__.__vinext, hasMiddleware: true },
+    });
+    process.env.__NEXT_ROUTER_BASEPATH = "/docs";
+    (globalThis as any).window = win;
+
+    const fetch = vi.fn(async (url: RequestInfo | URL) => {
+      const href = getFetchHref(url);
+      if (href === "/docs/_next/data/build-1/old-home.json") {
+        return new Response("{}", {
+          headers: { "x-nextjs-redirect": redirectHeader },
+          status: 200,
+        });
+      }
+      if (href === target) {
+        return new Response(buildNavHtml("//evil.example/steal", pageModuleUrl));
+      }
+      throw new Error(`Unexpected fetch: ${href}`);
+    });
+    globalThis.fetch = fetch;
+
+    const events: Array<[string, string]> = [];
+    const record = (name: string) =>
+      function (...args: unknown[]) {
+        events.push([name, String(args[0])]);
+      };
+    const onStart = record("routeChangeStart");
+    const onBefore = record("beforeHistoryChange");
+    const onComplete = record("routeChangeComplete");
+
+    try {
+      vi.resetModules();
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      const Router = routerModule.default;
+      Router.events.on("routeChangeStart", onStart);
+      Router.events.on("beforeHistoryChange", onBefore);
+      Router.events.on("routeChangeComplete", onComplete);
+
+      const result = await Router.push("/old-home", undefined, { scroll: false });
+
+      expect(result).toBe(true);
+      expect(fetch).toHaveBeenNthCalledWith(
+        1,
+        "/docs/_next/data/build-1/old-home.json",
+        expect.any(Object),
+      );
+      expect(fetch).toHaveBeenNthCalledWith(2, target, expect.any(Object));
+      expect(fetch).not.toHaveBeenCalledWith(
+        "http://localhost/docs/docs//evil.example/steal?token=secret#fragment",
+        expect.any(Object),
+      );
+      expect(pushState).toHaveBeenCalledTimes(1);
+      expect(pushState).toHaveBeenCalledWith(expect.any(Object), "", target);
+      expect(win.history.state).toMatchObject({
+        url: "//evil.example/steal?token=secret",
+        as: "//evil.example/steal?token=secret",
+        __N: true,
+      });
+      expect(events).toEqual([
+        ["routeChangeStart", "/docs/old-home"],
+        ["routeChangeStart", redirectHeader],
+        ["beforeHistoryChange", redirectHeader],
+        ["routeChangeComplete", redirectHeader],
+      ]);
+      expect(win.location.href).toBe(target);
+      expect(win.location.assign).not.toHaveBeenCalled();
+      expect(render).toHaveBeenCalled();
+
+      Router.events.off("routeChangeStart", onStart);
+      Router.events.off("beforeHistoryChange", onBefore);
+      Router.events.off("routeChangeComplete", onComplete);
+    } finally {
+      vi.resetModules();
+      if (previousBasePath === undefined) {
+        delete process.env.__NEXT_ROUTER_BASEPATH;
+      } else {
+        process.env.__NEXT_ROUTER_BASEPATH = previousBasePath;
+      }
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("hydrates middleware rewrites to fallback pages from the data response", async () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -20093,7 +20093,7 @@ describe("Pages Router concurrent navigation", () => {
   it("hard-navigates when middleware rewrites an existing Pages path to App Router", async () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;
-    const { win, render } = createNavWindow();
+    const { win, pushState, render } = createNavWindow();
     const sourceLoader = vi.fn(async () => ({ default: () => null }));
     Object.assign(win.location, { origin: "http://localhost" });
     Object.assign(win.__NEXT_DATA__, {
@@ -20131,7 +20131,12 @@ describe("Pages Router concurrent navigation", () => {
       expect(fetch).toHaveBeenCalledOnce();
       expect(sourceLoader).not.toHaveBeenCalled();
       expect(render).not.toHaveBeenCalled();
-      expect(hrefAssignments).toEqual(["/exists-but-not-routed"]);
+      expect(pushState).toHaveBeenCalledOnce();
+      expect(pushState).toHaveBeenCalledWith(expect.any(Object), "", "/exists-but-not-routed");
+      expect(hrefAssignments).toEqual([
+        "http://localhost/exists-but-not-routed",
+        "/exists-but-not-routed",
+      ]);
     } finally {
       vi.resetModules();
       if (previousWindow === undefined) {
@@ -20146,7 +20151,7 @@ describe("Pages Router concurrent navigation", () => {
   it("hard-navigates when a middleware rewrite target is App-owned before a dynamic Pages route", async () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;
-    const { win, render } = createNavWindow();
+    const { win, pushState, render } = createNavWindow();
     const sourceLoader = vi.fn(async () => ({ default: () => null }));
     Object.assign(win.location, { origin: "http://localhost" });
     Object.assign(win.__NEXT_DATA__, {
@@ -20191,7 +20196,9 @@ describe("Pages Router concurrent navigation", () => {
       expect(fetch).toHaveBeenCalledOnce();
       expect(sourceLoader).not.toHaveBeenCalled();
       expect(render).not.toHaveBeenCalled();
-      expect(hrefAssignments).toEqual(["/rewrite-to-app"]);
+      expect(pushState).toHaveBeenCalledOnce();
+      expect(pushState).toHaveBeenCalledWith(expect.any(Object), "", "/rewrite-to-app");
+      expect(hrefAssignments).toEqual(["http://localhost/rewrite-to-app", "/rewrite-to-app"]);
     } finally {
       vi.resetModules();
       if (previousWindow === undefined) {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -17958,6 +17958,205 @@ describe("Pages Router concurrent navigation", () => {
     }
   });
 
+  // Ported from Next.js: test/e2e/basepath/router-events.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/basepath/router-events.test.ts
+  it("includes basePath in successful Pages Router event URLs", async () => {
+    const previousWindow = (globalThis as any).window;
+    const previousBasePath = process.env.__NEXT_ROUTER_BASEPATH;
+    const originalFetch = globalThis.fetch;
+    const { win } = createNavWindow();
+    const pageModuleUrl = fixtureModuleUrl("fixtures/client-navigation-page.tsx");
+    Object.assign(win.location, {
+      pathname: "/docs/hello",
+      href: "http://localhost/docs/hello",
+      origin: "http://localhost",
+    });
+    (globalThis as any).window = win;
+    process.env.__NEXT_ROUTER_BASEPATH = "/docs";
+    globalThis.fetch = async () => new Response(buildNavHtml("/other-page", pageModuleUrl));
+
+    const events: unknown[][] = [];
+    const recordEvent =
+      (name: string) =>
+      (...args: unknown[]) =>
+        events.push([name, ...args]);
+    const onStart = recordEvent("routeChangeStart");
+    const onBefore = recordEvent("beforeHistoryChange");
+    const onComplete = recordEvent("routeChangeComplete");
+
+    try {
+      vi.resetModules();
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+      Router.events.on("routeChangeStart", onStart);
+      Router.events.on("beforeHistoryChange", onBefore);
+      Router.events.on("routeChangeComplete", onComplete);
+
+      await Router.push("/other-page");
+
+      expect(events).toEqual([
+        ["routeChangeStart", "/docs/other-page", { shallow: false }],
+        ["beforeHistoryChange", "/docs/other-page", { shallow: false }],
+        ["routeChangeComplete", "/docs/other-page", { shallow: false }],
+      ]);
+    } finally {
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+      Router.events.off("routeChangeStart", onStart);
+      Router.events.off("beforeHistoryChange", onBefore);
+      Router.events.off("routeChangeComplete", onComplete);
+      if (previousBasePath === undefined) delete process.env.__NEXT_ROUTER_BASEPATH;
+      else process.env.__NEXT_ROUTER_BASEPATH = previousBasePath;
+      vi.resetModules();
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  // Ported from Next.js: test/e2e/basepath/router-events.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/basepath/router-events.test.ts
+  it("orders a basePath cancellation before the superseding route events", async () => {
+    const previousWindow = (globalThis as any).window;
+    const previousBasePath = process.env.__NEXT_ROUTER_BASEPATH;
+    const originalFetch = globalThis.fetch;
+    const { win } = createNavWindow();
+    const pageModuleUrl = fixtureModuleUrl("fixtures/client-navigation-page.tsx");
+    Object.assign(win.location, {
+      pathname: "/docs/hello",
+      href: "http://localhost/docs/hello",
+    });
+    (globalThis as any).window = win;
+    process.env.__NEXT_ROUTER_BASEPATH = "/docs";
+
+    const slowFetch = createDeferred<Response>();
+    globalThis.fetch = async (url: RequestInfo | URL) =>
+      getFetchHref(url).includes("slow-route")
+        ? slowFetch.promise
+        : new Response(buildNavHtml("/other-page", pageModuleUrl));
+
+    const events: unknown[][] = [];
+    const recordEvent =
+      (name: string) =>
+      (...args: unknown[]) =>
+        events.push([name, ...args]);
+    const onStart = recordEvent("routeChangeStart");
+    const onBefore = recordEvent("beforeHistoryChange");
+    const onComplete = recordEvent("routeChangeComplete");
+    const onError = (error: unknown, ...args: unknown[]) =>
+      events.push([
+        "routeChangeError",
+        error instanceof Error ? error.message : String(error),
+        (error as { cancelled?: unknown })?.cancelled,
+        ...args,
+      ]);
+
+    try {
+      vi.resetModules();
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+      Router.events.on("routeChangeStart", onStart);
+      Router.events.on("beforeHistoryChange", onBefore);
+      Router.events.on("routeChangeComplete", onComplete);
+      Router.events.on("routeChangeError", onError);
+
+      const slowNavigation = Router.push("/slow-route");
+      await Promise.resolve();
+      const winningNavigation = Router.push("/other-page");
+      slowFetch.resolve(new Response(buildNavHtml("/slow-route", pageModuleUrl)));
+      await Promise.allSettled([slowNavigation, winningNavigation]);
+
+      expect(events).toEqual([
+        ["routeChangeStart", "/docs/slow-route", { shallow: false }],
+        ["routeChangeError", "Route Cancelled", true, "/docs/slow-route", { shallow: false }],
+        ["routeChangeStart", "/docs/other-page", { shallow: false }],
+        ["beforeHistoryChange", "/docs/other-page", { shallow: false }],
+        ["routeChangeComplete", "/docs/other-page", { shallow: false }],
+      ]);
+    } finally {
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+      Router.events.off("routeChangeStart", onStart);
+      Router.events.off("beforeHistoryChange", onBefore);
+      Router.events.off("routeChangeComplete", onComplete);
+      Router.events.off("routeChangeError", onError);
+      if (previousBasePath === undefined) delete process.env.__NEXT_ROUTER_BASEPATH;
+      else process.env.__NEXT_ROUTER_BASEPATH = previousBasePath;
+      vi.resetModules();
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  // Ported from Next.js: test/e2e/basepath/router-events.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/basepath/router-events.test.ts
+  it("emits only start and the canonical error when basePath data loading fails", async () => {
+    const previousWindow = (globalThis as any).window;
+    const previousBasePath = process.env.__NEXT_ROUTER_BASEPATH;
+    const originalFetch = globalThis.fetch;
+    const { win } = createNavWindow();
+    Object.assign(win.location, {
+      pathname: "/docs/hello",
+      href: "http://localhost/docs/hello",
+      origin: "http://localhost",
+    });
+    Object.assign(win, {
+      __VINEXT_PAGE_LOADERS__: {
+        "/error-route": async () => ({ default: () => null }),
+      },
+      __VINEXT_PAGE_PATTERNS__: ["/error-route"],
+      __VINEXT_PAGES_SSP_PATTERNS__: ["/error-route"],
+    });
+    Object.assign(win.__NEXT_DATA__, { buildId: "build-1" });
+    (globalThis as any).window = win;
+    process.env.__NEXT_ROUTER_BASEPATH = "/docs";
+    globalThis.fetch = async () => new Response("Internal Server Error", { status: 500 });
+
+    const events: unknown[][] = [];
+    const recordEvent =
+      (name: string) =>
+      (...args: unknown[]) =>
+        events.push([name, ...args]);
+    const onStart = recordEvent("routeChangeStart");
+    const onBefore = recordEvent("beforeHistoryChange");
+    const onError = (error: unknown, ...args: unknown[]) =>
+      events.push([
+        "routeChangeError",
+        error instanceof Error ? error.message : String(error),
+        (error as { cancelled?: unknown })?.cancelled ?? null,
+        ...args,
+      ]);
+
+    try {
+      vi.resetModules();
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+      Router.events.on("routeChangeStart", onStart);
+      Router.events.on("beforeHistoryChange", onBefore);
+      Router.events.on("routeChangeError", onError);
+
+      await Router.push("/error-route");
+
+      expect(events).toEqual([
+        ["routeChangeStart", "/docs/error-route", { shallow: false }],
+        [
+          "routeChangeError",
+          "Failed to load static props",
+          null,
+          "/docs/error-route",
+          { shallow: false },
+        ],
+      ]);
+    } finally {
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+      Router.events.off("routeChangeStart", onStart);
+      Router.events.off("beforeHistoryChange", onBefore);
+      Router.events.off("routeChangeError", onError);
+      if (previousBasePath === undefined) delete process.env.__NEXT_ROUTER_BASEPATH;
+      else process.env.__NEXT_ROUTER_BASEPATH = previousBasePath;
+      vi.resetModules();
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("last push() wins when two overlap — superseded navigation does not render", async () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;
@@ -19644,7 +19843,7 @@ describe("Pages Router concurrent navigation", () => {
       browserPath: "/app/router-events-test",
       target: "/router-events-test#section-1",
       expectedBrowserUrl: "/app/router-events-test#section-1",
-      expectedEventUrl: "/router-events-test#section-1",
+      expectedEventUrl: "/app/router-events-test#section-1",
     });
   });
 
@@ -19779,7 +19978,7 @@ describe("Pages Router concurrent navigation", () => {
       browserPath: "/app/app/foo",
       target: "/app/foo#section-1",
       expectedBrowserUrl: "/app/app/foo#section-1",
-      expectedEventUrl: "/app/foo#section-1",
+      expectedEventUrl: "/app/app/foo#section-1",
     });
   });
 

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -18165,6 +18165,238 @@ describe("Pages Router concurrent navigation", () => {
     }
   });
 
+  it("hash-only navigation aborts and invalidates a pending page fetch", async () => {
+    const previousWindow = (globalThis as any).window;
+    const previousDocument = (globalThis as any).document;
+    const originalFetch = globalThis.fetch;
+    const { win, render } = createNavWindow();
+    const pageModuleUrl = fixtureModuleUrl("fixtures/client-navigation-page.tsx");
+    const response = createDeferred<Response>();
+    let fetchSignal: AbortSignal | undefined;
+
+    (globalThis as any).window = win;
+    (globalThis as any).document = {
+      getElementById: vi.fn(() => null),
+      getElementsByName: vi.fn(() => []),
+    };
+    globalThis.fetch = async (_url: RequestInfo | URL, init?: RequestInit) => {
+      fetchSignal = init?.signal instanceof AbortSignal ? init.signal : undefined;
+      return response.promise;
+    };
+
+    const events: Array<[string, string]> = [];
+    const record = (name: string, urlIndex = 0) =>
+      function (...args: unknown[]) {
+        events.push([name, String(args[urlIndex])]);
+      };
+    const onStart = record("routeChangeStart");
+    const onError = record("routeChangeError", 1);
+    const onComplete = record("routeChangeComplete");
+    const onHashStart = record("hashChangeStart");
+
+    try {
+      vi.resetModules();
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+      Router.events.on("routeChangeStart", onStart);
+      Router.events.on("routeChangeError", onError);
+      Router.events.on("routeChangeComplete", onComplete);
+      Router.events.on("hashChangeStart", onHashStart);
+
+      const pendingNavigation = Router.push("/page-a");
+      await vi.waitFor(() => expect(fetchSignal).toBeDefined());
+
+      await Router.push("#section");
+
+      expect(fetchSignal?.aborted).toBe(true);
+      expect(events.slice(0, 3)).toEqual([
+        ["routeChangeStart", "/page-a"],
+        ["routeChangeError", "/page-a"],
+        ["hashChangeStart", "/page-a#section"],
+      ]);
+
+      response.resolve(new Response(buildNavHtml("/page-a", pageModuleUrl)));
+      await pendingNavigation;
+
+      expect(render).not.toHaveBeenCalled();
+      expect(events).not.toContainEqual(["routeChangeComplete", "/page-a"]);
+    } finally {
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+      Router.events.off("routeChangeStart", onStart);
+      Router.events.off("routeChangeError", onError);
+      Router.events.off("routeChangeComplete", onComplete);
+      Router.events.off("hashChangeStart", onHashStart);
+      vi.resetModules();
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      if (previousDocument === undefined) delete (globalThis as any).document;
+      else (globalThis as any).document = previousDocument;
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("shallow navigation cancels a pending render before it can complete", async () => {
+    const previousWindow = (globalThis as any).window;
+    const previousDocument = (globalThis as any).document;
+    const originalFetch = globalThis.fetch;
+    const { win, render } = createNavWindow();
+    const pageModuleUrl = fixtureModuleUrl("fixtures/client-navigation-page.tsx");
+    let fetchSignal: AbortSignal | undefined;
+
+    render.mockImplementation(() => {});
+    (globalThis as any).window = win;
+    (globalThis as any).document = { documentElement: {} };
+    globalThis.fetch = async (_url: RequestInfo | URL, init?: RequestInit) => {
+      fetchSignal = init?.signal instanceof AbortSignal ? init.signal : undefined;
+      return new Response(buildNavHtml("/page-a", pageModuleUrl));
+    };
+
+    const events: Array<[string, string]> = [];
+    const record = (name: string, urlIndex = 0) =>
+      function (...args: unknown[]) {
+        events.push([name, String(args[urlIndex])]);
+      };
+    const onStart = record("routeChangeStart");
+    const onError = record("routeChangeError", 1);
+    const onComplete = record("routeChangeComplete");
+
+    try {
+      vi.resetModules();
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+      Router.events.on("routeChangeStart", onStart);
+      Router.events.on("routeChangeError", onError);
+      Router.events.on("routeChangeComplete", onComplete);
+
+      const pendingNavigation = Router.push("/page-a");
+      await vi.waitFor(() => expect(render).toHaveBeenCalledTimes(1));
+      const staleTree = render.mock.calls[0]![0] as { props: { onCommit: () => void } };
+
+      await Router.push("/page-b", undefined, { shallow: true });
+      staleTree.props.onCommit();
+      await pendingNavigation;
+
+      expect(fetchSignal?.aborted).toBe(true);
+      expect(events).toContainEqual(["routeChangeError", "/page-a"]);
+      expect(events).not.toContainEqual(["routeChangeComplete", "/page-a"]);
+      expect(events).toContainEqual(["routeChangeComplete", "/page-b"]);
+    } finally {
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+      Router.events.off("routeChangeStart", onStart);
+      Router.events.off("routeChangeError", onError);
+      Router.events.off("routeChangeComplete", onComplete);
+      vi.resetModules();
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      if (previousDocument === undefined) delete (globalThis as any).document;
+      else (globalThis as any).document = previousDocument;
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("overlapping popstates cancel and track each active navigation before starting the next", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const originalCustomEvent = globalThis.CustomEvent;
+    const listeners = new Map<string, (event: any) => void>();
+    const { win, render } = createNavWindow();
+    const pageModuleUrl = fixtureModuleUrl("fixtures/client-navigation-page.tsx");
+    const responses = [
+      createDeferred<Response>(),
+      createDeferred<Response>(),
+      createDeferred<Response>(),
+    ];
+    const fetchSignals: AbortSignal[] = [];
+
+    win.addEventListener = vi.fn((type: string, handler: (event: any) => void) => {
+      listeners.set(type, handler);
+    });
+    (globalThis as any).window = win;
+    (globalThis as any).CustomEvent = class CustomEventMock {
+      constructor(public type: string) {}
+    } as any;
+    globalThis.fetch = async (_url: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.signal instanceof AbortSignal) fetchSignals.push(init.signal);
+      return responses[fetchSignals.length - 1]!.promise;
+    };
+
+    const events: Array<[string, string]> = [];
+    const record = (name: string, urlIndex = 0) =>
+      function (...args: unknown[]) {
+        events.push([name, String(args[urlIndex])]);
+      };
+    const onStart = record("routeChangeStart");
+    const onBefore = record("beforeHistoryChange");
+    const onError = record("routeChangeError", 1);
+    const onComplete = record("routeChangeComplete");
+
+    try {
+      vi.resetModules();
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+      Router.events.on("routeChangeStart", onStart);
+      Router.events.on("beforeHistoryChange", onBefore);
+      Router.events.on("routeChangeError", onError);
+      Router.events.on("routeChangeComplete", onComplete);
+      const { installPagesRouterRuntime } =
+        await import("../packages/vinext/src/shims/pages-router-runtime.js");
+      installPagesRouterRuntime();
+      const popstateHandler = listeners.get("popstate");
+      expect(popstateHandler).toBeDefined();
+
+      const initialNavigation = Router.push("/page-a");
+      await vi.waitFor(() => expect(fetchSignals).toHaveLength(1));
+
+      Object.assign(win.location, {
+        pathname: "/page-b",
+        href: "http://localhost/page-b",
+      });
+      popstateHandler!({ state: null });
+      await vi.waitFor(() => expect(fetchSignals).toHaveLength(2));
+
+      expect(fetchSignals[0]!.aborted).toBe(true);
+      expect(events.slice(0, 3)).toEqual([
+        ["routeChangeStart", "/page-a"],
+        ["routeChangeError", "/page-a"],
+        ["routeChangeStart", "/page-b"],
+      ]);
+
+      Object.assign(win.location, {
+        pathname: "/page-c",
+        href: "http://localhost/page-c",
+      });
+      popstateHandler!({ state: null });
+      await vi.waitFor(() => expect(fetchSignals).toHaveLength(3));
+
+      expect(fetchSignals[1]!.aborted).toBe(true);
+      expect(events.slice(3, 5)).toEqual([
+        ["routeChangeError", "/page-b"],
+        ["routeChangeStart", "/page-c"],
+      ]);
+
+      responses[2]!.resolve(new Response(buildNavHtml("/page-c", pageModuleUrl)));
+      await vi.waitFor(() => expect(events).toContainEqual(["routeChangeComplete", "/page-c"]));
+      responses[0]!.resolve(new Response(buildNavHtml("/page-a", pageModuleUrl)));
+      responses[1]!.resolve(new Response(buildNavHtml("/page-b", pageModuleUrl)));
+      await initialNavigation;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(events).not.toContainEqual(["beforeHistoryChange", "/page-a"]);
+      expect(events).not.toContainEqual(["beforeHistoryChange", "/page-b"]);
+      expect(events).not.toContainEqual(["routeChangeComplete", "/page-a"]);
+      expect(events).not.toContainEqual(["routeChangeComplete", "/page-b"]);
+      expect(render).toHaveBeenCalledTimes(1);
+    } finally {
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+      Router.events.off("routeChangeStart", onStart);
+      Router.events.off("beforeHistoryChange", onBefore);
+      Router.events.off("routeChangeError", onError);
+      Router.events.off("routeChangeComplete", onComplete);
+      vi.resetModules();
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      globalThis.fetch = originalFetch;
+      (globalThis as any).CustomEvent = originalCustomEvent;
+    }
+  });
+
   it("last push() wins when two overlap — superseded navigation does not render", async () => {
     const previousWindow = (globalThis as any).window;
     const originalFetch = globalThis.fetch;

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -19577,7 +19577,7 @@ describe("Pages Router concurrent navigation", () => {
           status: 200,
         });
       }
-      if (href === "//evil.example/steal?token=secret#fragment") {
+      if (href === target) {
         return new Response(buildNavHtml("//evil.example/steal", pageModuleUrl));
       }
       throw new Error(`Unexpected fetch: ${href}`);
@@ -19592,7 +19592,7 @@ describe("Pages Router concurrent navigation", () => {
       const result = await Router.push("/old-home", undefined, { scroll: false });
 
       expect(result).toBe(true);
-      expect(fetch.mock.calls.at(-1)?.[0]).toBe("//evil.example/steal?token=secret#fragment");
+      expect(fetch.mock.calls.at(-1)?.[0]).toBe(target);
       expect(pushState).toHaveBeenCalledTimes(1);
       expect(win.history.state).toMatchObject({
         url: "//evil.example/steal?token=secret",
@@ -19999,6 +19999,72 @@ describe("Pages Router concurrent navigation", () => {
         __N: true,
       });
       expect(win.location.href).toBe("http://localhost/docs/new-home");
+      expect(render).toHaveBeenCalled();
+    } finally {
+      vi.resetModules();
+      if (previousBasePath === undefined) {
+        delete process.env.__NEXT_ROUTER_BASEPATH;
+      } else {
+        process.env.__NEXT_ROUTER_BASEPATH = previousBasePath;
+      }
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("preserves the origin for followed HTML redirects with double-slash paths", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    const previousBasePath = process.env.__NEXT_ROUTER_BASEPATH;
+    const { win, pushState, render } = createNavWindow();
+    const pageModuleUrl = fixtureModuleUrl("fixtures/client-navigation-page.tsx");
+    const target = "http://localhost/docs//evil.example/steal?token=secret#fragment";
+    Object.assign(win.location, {
+      origin: "http://localhost",
+      pathname: "/docs",
+      href: "http://localhost/docs",
+    });
+    process.env.__NEXT_ROUTER_BASEPATH = "/docs";
+    (globalThis as any).window = win;
+
+    const followedRedirect = new Response("", { status: 200 });
+    Object.defineProperties(followedRedirect, {
+      redirected: { value: true },
+      url: { value: target },
+    });
+    const fetch = vi.fn(async (url: RequestInfo | URL) => {
+      const href = getFetchHref(url);
+      if (href === "/docs/old-home") return followedRedirect;
+      if (href === target) {
+        return new Response(buildNavHtml("//evil.example/steal", pageModuleUrl));
+      }
+      throw new Error(`Unexpected fetch: ${href}`);
+    });
+    globalThis.fetch = fetch;
+
+    try {
+      vi.resetModules();
+      const routerModule = await import("../packages/vinext/src/shims/router.js");
+      const Router = routerModule.default;
+
+      const result = await Router.push("/old-home", undefined, { scroll: false });
+
+      expect(result).toBe(true);
+      expect(fetch).toHaveBeenNthCalledWith(1, "/docs/old-home", expect.any(Object));
+      expect(fetch).toHaveBeenNthCalledWith(2, target, expect.any(Object));
+      expect(pushState).toHaveBeenCalledTimes(1);
+      expect(pushState).toHaveBeenCalledWith(expect.any(Object), "", target);
+      expect(win.history.state).toMatchObject({
+        url: "//evil.example/steal?token=secret",
+        as: "//evil.example/steal?token=secret",
+        __N: true,
+      });
+      expect(win.location.href).toBe(target);
+      expect(win.location.assign).not.toHaveBeenCalled();
       expect(render).toHaveBeenCalled();
     } finally {
       vi.resetModules();

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -18863,6 +18863,10 @@ describe("Pages Router concurrent navigation", () => {
     globalThis.fetch = fetch;
 
     const events: Array<[string, string]> = [];
+    let resolveComplete!: () => void;
+    const completed = new Promise<void>((resolve) => {
+      resolveComplete = resolve;
+    });
     const onStart = (...args: unknown[]) => {
       events.push(["routeChangeStart", String(args[0])]);
     };
@@ -18871,6 +18875,7 @@ describe("Pages Router concurrent navigation", () => {
     };
     const onComplete = (...args: unknown[]) => {
       events.push(["routeChangeComplete", String(args[0])]);
+      if (args[0] === "/") resolveComplete();
     };
 
     try {
@@ -18906,7 +18911,7 @@ describe("Pages Router concurrent navigation", () => {
           { status: 200 },
         ),
       );
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      await completed;
 
       expect(fetch).toHaveBeenCalledWith("/en", expect.any(Object));
       expect(win.location.href).toBe("http://localhost/");


### PR DESCRIPTION
## Summary

- preserve browser-visible basePath URLs across Pages Router route, hash, cancellation, failure, popstate, and redirect events
- align superseded navigation cancellation, redirect recursion, event ordering, and destination-only history state with Next.js
- keep leading-double-slash redirects pinned to their validated same origin for fetches and history
- make the deferred popstate regression wait for route completion deterministically

## Failure mapping

Fixes all four non-deferred failures from [Actions run 31439707085, job 93624401572](https://github.com/cloudflare/vinext/actions/runs/31439707085/job/93624401572) in `test/e2e/basepath/router-events.test.ts`:

- `should use urls with basepath in router events`
- `should use urls with basepath in router events for hash changes`
- `should use urls with basepath in router events for cancelled routes`
- `should use urls with basepath in router events for failed route change`

## Validation

- targeted Next.js E2E: 4/4 passed
  - `REPO="$(pwd)" NEXTJS_DIR="/Users/jamesanderson/Developer/vinext/.nextjs-ref" VINEXT_BUILD=0 ./scripts/run-targeted-nextjs-e2e.sh test/e2e/basepath/router-events.test.ts`
- `vp test run tests/shims.test.ts`: 1,293/1,293 passed
- deferred popstate timing regression: 20/20 isolated runs passed
- `vp check`: passed
- `vp run vinext#build`: passed
- independent final review: no findings
