### PR TITLE
fix(pages): align middleware rewrite navigation

### DIFF
--- a/packages/vinext/src/entries/pages-client-entry.ts
+++ b/packages/vinext/src/entries/pages-client-entry.ts
@@ -306,13 +306,19 @@ async function hydrate() {
   window.__NEXT_HYDRATED_AT = hydratedAt;
   window.__NEXT_HYDRATED_CB?.();
 
-  if (nextData.isFallback) {
+  const shouldHydrateQuery =
+    nextData.isFallback ||
+    (nextData.gsp === true &&
+      (nextData.__vinext?.hasMiddleware === true ||
+        nextData.__vinext?.hasRewrites === true ||
+        window.location.search !== ""));
+  if (shouldHydrateQuery) {
     const currentUrl = window.location.pathname + window.location.search + window.location.hash;
-    const routeUrl = nextData.__vinext?.routeUrl;
+    const routeUrl = nextData.isFallback ? nextData.__vinext?.routeUrl : undefined;
     await Router.replace(
       routeUrl || currentUrl,
       routeUrl ? currentUrl : undefined,
-      { _h: 1, scroll: false },
+      { _h: 1, scroll: false, shallow: false },
     );
   }
 }

--- a/packages/vinext/src/entries/pages-client-entry.ts
+++ b/packages/vinext/src/entries/pages-client-entry.ts
@@ -306,19 +306,18 @@ async function hydrate() {
   window.__NEXT_HYDRATED_AT = hydratedAt;
   window.__NEXT_HYDRATED_CB?.();
 
+  const initialMatchesMiddleware =
+    nextData.__vinext?.hasMiddleware === true || nextData.__vinext?.hasRewrites === true;
   const shouldHydrateQuery =
     nextData.isFallback ||
-    (nextData.gsp === true &&
-      (nextData.__vinext?.hasMiddleware === true ||
-        nextData.__vinext?.hasRewrites === true ||
-        window.location.search !== ""));
+    (nextData.gsp === true && (initialMatchesMiddleware || window.location.search !== ""));
   if (shouldHydrateQuery) {
     const currentUrl = window.location.pathname + window.location.search + window.location.hash;
     const routeUrl = nextData.isFallback ? nextData.__vinext?.routeUrl : undefined;
     await Router.replace(
       routeUrl || currentUrl,
       routeUrl ? currentUrl : undefined,
-      { _h: 1, scroll: false, shallow: false },
+      { _h: 1, scroll: false, shallow: !nextData.isFallback && !initialMatchesMiddleware },
     );
   }
 }

--- a/packages/vinext/src/server/http-error-responses.ts
+++ b/packages/vinext/src/server/http-error-responses.ts
@@ -91,10 +91,15 @@ export function notFoundResponse(init?: ErrorResponseInit): Response {
  *
  * @see packages/next/src/server/lib/router-server.ts in `.nextjs-ref`
  */
-export function notFoundStaticAssetResponse(): Response {
+export function notFoundStaticAssetResponse(headers?: HeadersInit): Response {
+  const responseHeaders = new Headers(headers);
+  responseHeaders.delete("content-encoding");
+  responseHeaders.delete("content-length");
+  responseHeaders.delete("transfer-encoding");
+  responseHeaders.set("Content-Type", "text/plain; charset=utf-8");
   return new Response("Not Found", {
     status: 404,
-    headers: { "Content-Type": "text/plain; charset=utf-8" },
+    headers: responseHeaders,
   });
 }
 

--- a/packages/vinext/src/server/pages-dev-hydration.ts
+++ b/packages/vinext/src/server/pages-dev-hydration.ts
@@ -27,16 +27,15 @@ export function createPagesDevHydrationScript(options: PagesDevHydrationOptions)
       : 'const pageProps = rawPageProps && typeof rawPageProps === "object" ? rawPageProps : {};';
   const hydrationQueryUpdate = options.replaceFallbackRoute
     ? `
+  const initialMatchesMiddleware =
+    nextData.__vinext?.hasMiddleware === true || nextData.__vinext?.hasRewrites === true;
   const shouldHydrateQuery =
     nextData.isFallback ||
-    (nextData.gsp === true &&
-      (nextData.__vinext?.hasMiddleware === true ||
-        nextData.__vinext?.hasRewrites === true ||
-        window.location.search !== ""));
+    (nextData.gsp === true && (initialMatchesMiddleware || window.location.search !== ""));
   if (shouldHydrateQuery) {
     const currentUrl = window.location.pathname + window.location.search + window.location.hash;
     const routeUrl = nextData.isFallback ? nextData.__vinext?.routeUrl : undefined;
-    await Router.replace(routeUrl || currentUrl, routeUrl ? currentUrl : undefined, { _h: 1, scroll: false, shallow: false });
+    await Router.replace(routeUrl || currentUrl, routeUrl ? currentUrl : undefined, { _h: 1, scroll: false, shallow: !nextData.isFallback && !initialMatchesMiddleware });
   }`
     : "";
   const createElement = options.appModuleSource

--- a/packages/vinext/src/server/pages-dev-hydration.ts
+++ b/packages/vinext/src/server/pages-dev-hydration.ts
@@ -25,10 +25,18 @@ export function createPagesDevHydrationScript(options: PagesDevHydrationOptions)
     options.normalizePageProps === false
       ? "const pageProps = rawPageProps ?? {};"
       : 'const pageProps = rawPageProps && typeof rawPageProps === "object" ? rawPageProps : {};';
-  const fallbackReplacement = options.replaceFallbackRoute
+  const hydrationQueryUpdate = options.replaceFallbackRoute
     ? `
-  if (nextData.isFallback) {
-    await Router.replace(window.location.pathname + window.location.search + window.location.hash, undefined, { _h: 1, scroll: false });
+  const shouldHydrateQuery =
+    nextData.isFallback ||
+    (nextData.gsp === true &&
+      (nextData.__vinext?.hasMiddleware === true ||
+        nextData.__vinext?.hasRewrites === true ||
+        window.location.search !== ""));
+  if (shouldHydrateQuery) {
+    const currentUrl = window.location.pathname + window.location.search + window.location.hash;
+    const routeUrl = nextData.isFallback ? nextData.__vinext?.routeUrl : undefined;
+    await Router.replace(routeUrl || currentUrl, routeUrl ? currentUrl : undefined, { _h: 1, scroll: false, shallow: false });
   }`
     : "";
   const createElement = options.appModuleSource
@@ -99,7 +107,7 @@ async function hydrate() {
   window.__VINEXT_HYDRATED_AT = hydratedAt;
   window.__NEXT_HYDRATED = true;
   window.__NEXT_HYDRATED_AT = hydratedAt;
-  window.__NEXT_HYDRATED_CB?.();${fallbackReplacement}
+  window.__NEXT_HYDRATED_CB?.();${hydrationQueryUpdate}
 }
 hydrate();
 </script>`;

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -1778,9 +1778,12 @@ async function startAppRouterServer(options: AppRouterServerOptions) {
       // identifies the request as a public/static-file lookup. Middleware may
       // still handle or rewrite the request by returning a non-404 response.
       if (missingBuildAsset && response.status === 404) {
-        cancelResponseBody(response);
-        res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
-        res.end("Not Found");
+        await sendWebResponse(
+          finalizeMissingStaticAssetResponse(response, true),
+          req,
+          res,
+          compress,
+        );
         return;
       }
 

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -49,7 +49,7 @@ import {
   type PagesPipelineDeps,
   type PagesRenderOptions,
 } from "./pages-request-pipeline.js";
-import { mergeHeaders } from "./worker-utils.js";
+import { finalizeMissingStaticAssetResponse, mergeHeaders } from "./worker-utils.js";
 import {
   normalizeNextDataPagePathname,
   isNextDataPathname,
@@ -2309,9 +2309,12 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
       if (result.type === "response") {
         const { response } = result;
         if (missingBuildAsset && response.status === 404) {
-          cancelResponseBody(response);
-          res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
-          res.end("Not Found");
+          await sendWebResponse(
+            finalizeMissingStaticAssetResponse(response, true),
+            req,
+            res,
+            compress,
+          );
           return;
         }
         const streamedApi = isVinextStreamedApiResponse(response);

--- a/packages/vinext/src/server/worker-utils.ts
+++ b/packages/vinext/src/server/worker-utils.ts
@@ -42,7 +42,9 @@ export function finalizeMissingStaticAssetResponse(
 ): Response {
   if (!missingBuildAsset || response.status !== 404) return response;
   cancelResponseBody(response);
-  return notFoundStaticAssetResponse();
+  // The missing asset still ran through middleware before route handling.
+  // Replace the rendered 404 body without dropping headers middleware added.
+  return notFoundStaticAssetResponse(response.headers);
 }
 
 function buildHeaderRecord(

--- a/packages/vinext/src/shims/internal/pages-data-target.ts
+++ b/packages/vinext/src/shims/internal/pages-data-target.ts
@@ -15,6 +15,8 @@ import { fetchStaticPagesData, fetchUncachedPagesData } from "./pages-data-fetch
 import { getDeploymentId, NEXT_DEPLOYMENT_ID_HEADER } from "../../utils/deployment-id.js";
 import { isUnknownRecord } from "../../utils/record.js";
 
+const routerBasePath = process.env.__NEXT_ROUTER_BASEPATH ?? "";
+
 export type PagesDataTarget = {
   /** Final fetch URL for the data endpoint, including basePath and search. */
   dataHref: string;
@@ -132,7 +134,11 @@ function clientMiddlewareMatcherMatches(pathname: string, matcher: unknown): boo
   return false;
 }
 
-export function getPagesMiddlewareDataHref(browserUrl: string, basePath: string): string | null {
+export function getPagesMiddlewareDataHref(
+  browserUrl: string,
+  basePath: string,
+  options: PagesDataNavigationTargetOptions = {},
+): string | null {
   const nextData = window.__NEXT_DATA__;
   if (!nextData || !hasVinextMiddleware(nextData)) return null;
   const buildId = nextData.buildId;
@@ -151,7 +157,15 @@ export function getPagesMiddlewareDataHref(browserUrl: string, basePath: string)
     return null;
   }
 
-  return buildPagesDataHref(basePath, buildId, pathname, parsed.search);
+  const pathnameLocale = getLocalePathPrefix(pathname, window.__VINEXT_LOCALES__);
+  const explicitLocale =
+    options.locale === false ? window.__VINEXT_DEFAULT_LOCALE__ : options.locale;
+  const currentLocale = pathnameLocale ?? explicitLocale ?? window.__VINEXT_LOCALE__;
+  const dataPathname =
+    pathnameLocale || !currentLocale || !window.__VINEXT_LOCALES__?.includes(currentLocale)
+      ? pathname
+      : `/${currentLocale}${pathname === "/" ? "" : pathname}`;
+  return buildPagesDataHref(basePath, buildId, dataPathname, parsed.search);
 }
 
 /**
@@ -237,7 +251,7 @@ export function resolvePagesDataNavigationTarget(
     params: match.params,
     loader,
     dataKind,
-    middlewareDataHref: getPagesMiddlewareDataHref(browserUrl, basePath) ?? undefined,
+    middlewareDataHref: getPagesMiddlewareDataHref(browserUrl, basePath, options) ?? undefined,
     buildId,
     pagePath,
     search: parsed.search,
@@ -281,12 +295,25 @@ export function prefetchPagesData(target: PagesDataTarget): void {
         ? target.middlewareDataHref
         : (target.prefetchDataHref ?? target.middlewareDataHref ?? target.dataHref);
     void fetchStaticPagesData(dataHref, { headers })
-      .then((response) => response.arrayBuffer())
+      .then(async (response) => {
+        prefetchMiddlewareRewriteLoader(response);
+        await response.arrayBuffer();
+      })
       .catch(() => {});
     return;
   }
 
   if (target.middlewareDataHref) {
-    void fetchUncachedPagesData(target.middlewareDataHref, { headers }).catch(() => {});
+    void fetchUncachedPagesData(target.middlewareDataHref, { headers })
+      .then(prefetchMiddlewareRewriteLoader)
+      .catch(() => {});
   }
+}
+
+function prefetchMiddlewareRewriteLoader(response: Response): void {
+  const rewriteTarget = response.headers.get("x-nextjs-rewrite");
+  if (!rewriteTarget) return;
+
+  const target = resolvePagesDataNavigationTarget(rewriteTarget, routerBasePath);
+  if (target) void target.loader().catch(() => {});
 }

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -741,7 +741,7 @@ function prefetchUrl(
           const middlewareDataHref =
             fullRouteHref === fullHref
               ? dataTarget.middlewareDataHref
-              : (getPagesMiddlewareDataHref(fullHref, __basePath) ?? undefined);
+              : (getPagesMiddlewareDataHref(fullHref, __basePath, { locale }) ?? undefined);
           prefetchPagesData({ ...dataTarget, middlewareDataHref });
         } else {
           // The target is not a Pages Router route — mark it on the Pages
@@ -1163,6 +1163,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
   // Track pending state for useLinkStatus()
   const [pending, setPending] = useState(false);
   const mountedRef = useRef(true);
+  const pendingPagesIntentPrefetchRef = useRef<(() => void) | null>(null);
   // Stable setter so the global navigation registry can reset this link's
   // pending state from another navigation without depending on render identity.
   const setPendingRef = useRef<PendingLinkSetter | null>(null);
@@ -1176,6 +1177,8 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
     const setter = setPendingRef.current;
     return () => {
       mountedRef.current = false;
+      pendingPagesIntentPrefetchRef.current?.();
+      pendingPagesIntentPrefetchRef.current = null;
       // Drop our setter from the global registry on unmount so a later
       // navigation never calls into an unmounted component.
       if (setter) clearLinkForCurrentNavigation(setter);
@@ -1186,10 +1189,15 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
   // In App Router, null/undefined/"auto" is automatic prefetch and true opts
   // into a full RSC prefetch, matching Next.js's public prefetch contract.
   const internalRef = useRef<HTMLAnchorElement | null>(null);
-  const prefetchMode = resolveLinkPrefetchMode(prefetchProp, isDangerous);
+  // A shallow Pages navigation only mutates the current route's visible URL;
+  // it must not issue a data prefetch for that URL. Besides wasting a request,
+  // such a prefetch would run middleware/getServerSideProps even though the
+  // shallow transition itself deliberately skips them.
+  const effectivePrefetchProp = HAS_PAGES_ROUTER && shallow ? false : prefetchProp;
+  const prefetchMode = resolveLinkPrefetchMode(effectivePrefetchProp, isDangerous);
   const shouldViewportPrefetch = canLinkPrefetch({
     nodeEnv: process.env.NODE_ENV,
-    prefetch: prefetchProp,
+    prefetch: effectivePrefetchProp,
     isDangerous,
   });
 
@@ -1249,9 +1257,10 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
 
   const prefetchOnIntent = useCallback(() => {
     if (
+      (HAS_PAGES_ROUTER && shallow) ||
       !canLinkIntentPrefetch({
         nodeEnv: process.env.NODE_ENV,
-        prefetch: prefetchProp,
+        prefetch: effectivePrefetchProp,
         isDangerous,
         routerMode: getLinkPrefetchRouterMode(),
       })
@@ -1274,8 +1283,9 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
       locale,
     );
   }, [
-    prefetchProp,
+    effectivePrefetchProp,
     isDangerous,
+    shallow,
     prefetchMode,
     normalizedHref,
     normalizedRouteHref,
@@ -1283,26 +1293,42 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
     unstable_dynamicOnHover,
   ]);
 
+  const schedulePrefetchOnIntent = useCallback(() => {
+    if (!HAS_PAGES_ROUTER || typeof window.requestAnimationFrame !== "function") {
+      prefetchOnIntent();
+      return;
+    }
+
+    pendingPagesIntentPrefetchRef.current?.();
+    const frame = window.requestAnimationFrame(() => {
+      pendingPagesIntentPrefetchRef.current = null;
+      prefetchOnIntent();
+    });
+    pendingPagesIntentPrefetchRef.current = () => window.cancelAnimationFrame(frame);
+  }, [prefetchOnIntent]);
+
   const handleMouseEnter = useCallback(
     (e: MouseEvent<HTMLAnchorElement>) => {
       onMouseEnter?.(e);
-      prefetchOnIntent();
+      schedulePrefetchOnIntent();
     },
-    [onMouseEnter, prefetchOnIntent],
+    [onMouseEnter, schedulePrefetchOnIntent],
   );
 
   const handleTouchStart = useCallback(
     (e: TouchEvent<HTMLAnchorElement>) => {
       onTouchStart?.(e);
-      prefetchOnIntent();
+      schedulePrefetchOnIntent();
     },
-    [onTouchStart, prefetchOnIntent],
+    [onTouchStart, schedulePrefetchOnIntent],
   );
 
   const handleClick = async (
     e: MouseEvent<HTMLAnchorElement>,
     options: { skipLinkOnClick?: boolean } = {},
   ) => {
+    pendingPagesIntentPrefetchRef.current?.();
+    pendingPagesIntentPrefetchRef.current = null;
     // In legacyBehavior, the onClick prop on <Link> itself is ignored — the
     // child's onClick is the one that runs (and Next.js even warns when
     // `onClick` is passed to <Link> alongside `legacyBehavior`). Skip the

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -1193,7 +1193,9 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
   // it must not issue a data prefetch for that URL. Besides wasting a request,
   // such a prefetch would run middleware/getServerSideProps even though the
   // shallow transition itself deliberately skips them.
-  const effectivePrefetchProp = HAS_PAGES_ROUTER && shallow ? false : prefetchProp;
+  const prefetchRouterMode = getLinkPrefetchRouterMode();
+  const isShallowPagesLink = prefetchRouterMode === "pages" && shallow;
+  const effectivePrefetchProp = isShallowPagesLink ? false : prefetchProp;
   const prefetchMode = resolveLinkPrefetchMode(effectivePrefetchProp, isDangerous);
   const shouldViewportPrefetch = canLinkPrefetch({
     nodeEnv: process.env.NODE_ENV,
@@ -1241,7 +1243,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
               currentOrigin: window.location.origin,
             }) ?? undefined),
       queuedViewportPrefetch: false,
-      routerMode: getLinkPrefetchRouterMode(),
+      routerMode: prefetchRouterMode,
       viewportPrefetched: false,
     };
     observedLinkPrefetches.set(node, instance);
@@ -1253,16 +1255,23 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
       visibleLinkPrefetches.delete(instance);
       instance.isVisible = false;
     };
-  }, [shouldViewportPrefetch, prefetchMode, normalizedHref, normalizedRouteHref, locale]);
+  }, [
+    shouldViewportPrefetch,
+    prefetchMode,
+    prefetchRouterMode,
+    normalizedHref,
+    normalizedRouteHref,
+    locale,
+  ]);
 
   const prefetchOnIntent = useCallback(() => {
     if (
-      (HAS_PAGES_ROUTER && shallow) ||
+      isShallowPagesLink ||
       !canLinkIntentPrefetch({
         nodeEnv: process.env.NODE_ENV,
         prefetch: effectivePrefetchProp,
         isDangerous,
-        routerMode: getLinkPrefetchRouterMode(),
+        routerMode: prefetchRouterMode,
       })
     ) {
       return;
@@ -1285,8 +1294,9 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
   }, [
     effectivePrefetchProp,
     isDangerous,
-    shallow,
+    isShallowPagesLink,
     prefetchMode,
+    prefetchRouterMode,
     normalizedHref,
     normalizedRouteHref,
     locale,
@@ -1294,7 +1304,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
   ]);
 
   const schedulePrefetchOnIntent = useCallback(() => {
-    if (!HAS_PAGES_ROUTER || typeof window.requestAnimationFrame !== "function") {
+    if (prefetchRouterMode !== "pages" || typeof window.requestAnimationFrame !== "function") {
       prefetchOnIntent();
       return;
     }
@@ -1305,7 +1315,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
       prefetchOnIntent();
     });
     pendingPagesIntentPrefetchRef.current = () => window.cancelAnimationFrame(frame);
-  }, [prefetchOnIntent]);
+  }, [prefetchOnIntent, prefetchRouterMode]);
 
   const handleMouseEnter = useCallback(
     (e: MouseEvent<HTMLAnchorElement>) => {

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -1329,7 +1329,14 @@ function getPathnameAndQuery(): {
   for (const [key, value] of params) {
     addQueryParam(searchQuery, key, value);
   }
-  const query = { ...searchQuery, ...routeQuery };
+  // Rewrites leave the browser on their source pathname. Preserve target
+  // params from __NEXT_DATA__, but let a later shallow navigation's visible
+  // search string replace stale same-key rewrite query state. A normal route
+  // match keeps route params authoritative over same-key search values.
+  const query =
+    extractRouteParamsFromPath(nextData?.page ?? pathname, resolvedPath) === null
+      ? { ...routeQuery, ...searchQuery }
+      : { ...searchQuery, ...routeQuery };
   // asPath uses the resolved browser path, not the route pattern
   const asPath =
     getCurrentHistoryAsPath() ??
@@ -1519,6 +1526,7 @@ type NavigateClientOptions = {
    */
   mode?: "push" | "replace";
   scroll?: ScrollPosition | null;
+  beforeRender?: () => void;
 };
 
 /** Wire format of `/_next/data/<id>/<page>.json` response bodies. */
@@ -1866,7 +1874,11 @@ function getMiddlewarePagesDataFetchUrl(
   browserUrl: string,
   dataTarget?: PagesDataTarget | null,
 ): string | null {
-  const middlewareDataHref = getPagesMiddlewareDataHref(browserUrl, __basePath);
+  const middlewareDataHref = getPagesMiddlewareDataHref(
+    browserUrl,
+    __basePath,
+    dataTarget?.prefetchLocale ? { locale: dataTarget.prefetchLocale } : undefined,
+  );
   if (!middlewareDataHref) return null;
   if (
     dataTarget?.dataKind === "static" &&
@@ -2091,6 +2103,8 @@ async function renderPagesNavigationTarget(
 
   const React = (await import("react")).default;
   assertStillCurrent();
+  options.beforeRender?.();
+  options.beforeRender = undefined;
 
   // Next.js normalizes every successful client transition through
   // `Object.assign({}, props.pageProps)`. Besides ensuring an own pageProps
@@ -2447,6 +2461,8 @@ async function navigateClientHtml(
   // Import React for createElement
   const React = (await import("react")).default;
   assertStillCurrent();
+  options.beforeRender?.();
+  options.beforeRender = undefined;
 
   // Re-render with the new page, loading _app if needed
   let AppComponent = window.__VINEXT_APP__;
@@ -2565,6 +2581,8 @@ async function navigateClient(
         if (!redirectedUrl) {
           scheduleHardNavigationAndThrow(configRedirect, "Navigation redirected externally");
         }
+        options.beforeRender?.();
+        options.beforeRender = undefined;
         window.history.replaceState(window.history.state ?? {}, "", redirectedUrl);
         routerRuntimeState.lastPathnameAndSearch =
           window.location.pathname + window.location.search;
@@ -2646,6 +2664,8 @@ async function navigateClient(
         if (!redirectedUrl) {
           scheduleHardNavigationAndThrow(redirectLocation, "Navigation redirected externally");
         }
+        options.beforeRender?.();
+        options.beforeRender = undefined;
         window.history.replaceState(window.history.state ?? {}, "", redirectedUrl);
         routerRuntimeState.lastPathnameAndSearch =
           window.location.pathname + window.location.search;
@@ -2665,6 +2685,8 @@ async function navigateClient(
             __basePath,
           );
           if (rewrittenOwner === "app" || rewrittenOwner === "document") {
+            options.beforeRender?.();
+            options.beforeRender = undefined;
             scheduleHardNavigationAndThrow(browserUrl, "Navigation rewritten to a non-Pages route");
           }
           const rewrittenTarget =
@@ -2675,6 +2697,8 @@ async function navigateClient(
               pagesDataTargetOptions,
             );
           if (!rewrittenTarget) {
+            options.beforeRender?.();
+            options.beforeRender = undefined;
             scheduleHardNavigationAndThrow(browserUrl, "Navigation rewritten to a non-Pages route");
           }
           dataTarget = rewrittenTarget;
@@ -3078,7 +3102,8 @@ async function performNavigation(
         : [];
       const hasExplicitHrefPathname = typeof url === "string" || url.pathname !== undefined;
       const isMiddlewareMatch =
-        options?.shallow !== true && getPagesMiddlewareDataHref(resolved, __basePath) !== null;
+        options?.shallow !== true &&
+        getPagesMiddlewareDataHref(resolved, __basePath, { locale: navigationLocale }) !== null;
       if (missingParams.length > 0 && hasExplicitHrefPathname && !isMiddlewareMatch) {
         const asPathname = stripHash(resolved).split("?", 1)[0];
         const routePathname =
@@ -3259,8 +3284,18 @@ async function performNavigation(
   if (!isQueryUpdating) {
     routerEvents.emit("routeChangeStart", resolved, { shallow });
   }
-  routerEvents.emit("beforeHistoryChange", resolved, { shallow });
-  updateHistory(mode, full, navState);
+  const delayHistoryForMiddleware =
+    !shallow &&
+    getPagesMiddlewareDataHref(resolved, __basePath, { locale: navigationLocale }) !== null;
+  if (delayHistoryForMiddleware) {
+    navigateOptions.beforeRender = () => {
+      routerEvents.emit("beforeHistoryChange", resolved, { shallow });
+      updateHistory(mode, full, navState);
+    };
+  } else {
+    routerEvents.emit("beforeHistoryChange", resolved, { shallow });
+    updateHistory(mode, full, navState);
+  }
   if (!shallow) {
     const result = await runNavigateClient(
       full,

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -1333,10 +1333,12 @@ function getPathnameAndQuery(): {
   // params from __NEXT_DATA__, but let a later shallow navigation's visible
   // search string replace stale same-key rewrite query state. A normal route
   // match keeps route params authoritative over same-key search values.
-  const query =
-    extractRouteParamsFromPath(nextData?.page ?? pathname, canonicalResolvedPath) === null
-      ? { ...routeQuery, ...searchQuery }
-      : { ...searchQuery, ...routeQuery };
+  const routePattern = nextData?.page ?? pathname;
+  const isRewrite = extractRouteParamsFromPath(routePattern, canonicalResolvedPath) === null;
+  const rewriteRouteParams = isRewrite ? getRouteParamsFromQuery(routePattern, routeQuery) : null;
+  const query = isRewrite
+    ? { ...routeQuery, ...searchQuery, ...rewriteRouteParams }
+    : { ...searchQuery, ...routeQuery };
   // asPath uses the resolved browser path, not the route pattern
   const asPath =
     getCurrentHistoryAsPath() ??

--- a/packages/vinext/src/shims/router.ts
+++ b/packages/vinext/src/shims/router.ts
@@ -1322,7 +1322,7 @@ function getPathnameAndQuery(): {
         canonicalResolvedPath + window.location.search + window.location.hash,
     };
   }
-  const routeQuery = getRouteQueryFromNextData(nextData, resolvedPath);
+  const routeQuery = getRouteQueryFromNextData(nextData, canonicalResolvedPath);
   // URL search params always reflect the current URL
   const searchQuery: Record<string, string | string[]> = {};
   const params = new URLSearchParams(window.location.search);
@@ -1334,7 +1334,7 @@ function getPathnameAndQuery(): {
   // search string replace stale same-key rewrite query state. A normal route
   // match keeps route params authoritative over same-key search values.
   const query =
-    extractRouteParamsFromPath(nextData?.page ?? pathname, resolvedPath) === null
+    extractRouteParamsFromPath(nextData?.page ?? pathname, canonicalResolvedPath) === null
       ? { ...routeQuery, ...searchQuery }
       : { ...searchQuery, ...routeQuery };
   // asPath uses the resolved browser path, not the route pattern

--- a/packages/vinext/src/shims/server.ts
+++ b/packages/vinext/src/shims/server.ts
@@ -26,7 +26,7 @@ import {
   trackAfterPromise,
 } from "./unified-request-context.js";
 import { assertSafeNavigationUrl } from "./url-safety.js";
-import { hasBasePath, stripBasePath } from "../utils/base-path.js";
+import { hasBasePath, removeTrailingSlash, stripBasePath } from "../utils/base-path.js";
 
 /** @deprecated Import ImageResponse from `next/og` instead. */
 export function ImageResponse(): never {
@@ -473,6 +473,13 @@ export class NextURL {
   private _applyTrailingSlash(pathname: string): string {
     // Never strip or add a slash to the root path.
     if (pathname === "" || pathname === "/") return pathname;
+    const pathnameWithoutBasePath = this._basePath
+      ? stripBasePath(pathname, this._basePath)
+      : pathname;
+    // Internal Next.js assets retain their request shape. In particular,
+    // missing build manifests still run middleware without acquiring a slash
+    // from `trailingSlash: true`.
+    if (pathnameWithoutBasePath.startsWith("/_next/")) return removeTrailingSlash(pathname);
     if (this._trailingSlash) {
       return pathname.endsWith("/") ? pathname : pathname + "/";
     }

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -1680,12 +1680,23 @@ describe("readPagesRouterEntrySource", () => {
           canceled = true;
         },
       }),
-      { status: 404, headers: { "content-type": "text/html" } },
+      {
+        status: 404,
+        headers: {
+          "content-length": "12",
+          "content-type": "text/html",
+          "req-url-path": "/_next/static/build/_devMiddlewareManifest.json?foo=1",
+        },
+      },
     );
 
     const finalized = finalizeMissingStaticAssetResponse(routed404, true);
     expect(finalized.status).toBe(404);
     expect(finalized.headers.get("content-type")).toBe("text/plain; charset=utf-8");
+    expect(finalized.headers.get("content-length")).toBeNull();
+    expect(finalized.headers.get("req-url-path")).toBe(
+      "/_next/static/build/_devMiddlewareManifest.json?foo=1",
+    );
     expect(await finalized.text()).toBe("Not Found");
     await vi.waitFor(() => expect(canceled).toBe(true));
 

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -1707,6 +1707,15 @@ describe("readPagesRouterEntrySource", () => {
     expect(finalizeMissingStaticAssetResponse(regular404, false)).toBe(regular404);
   });
 
+  it("finalizes missing build-asset 404s in both Node production routers", () => {
+    const content = fs.readFileSync(
+      path.join(import.meta.dirname, "../packages/vinext/src/server/prod-server.ts"),
+      "utf8",
+    );
+
+    expect(content.match(/finalizeMissingStaticAssetResponse\(/g)).toHaveLength(2);
+  });
+
   it("resolveStaticAssetSignal fetches and merges static asset responses with middleware status", async () => {
     const signalResponse = new Response(null, {
       status: 403,

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -1905,12 +1905,16 @@ describe("Pages Router entry template", () => {
       expect(code).not.toContain("pageProps: rawPageProps,");
       expect(code).toContain("element = wrapWithRouterContext(element, resolveHydrationCommit);");
       expect(code).toContain("await hydrationCommitted;");
-      expect(code).toContain("if (nextData.isFallback) {");
-      expect(code).toContain("const routeUrl = nextData.__vinext?.routeUrl;");
+      expect(code).toContain("const shouldHydrateQuery =");
+      expect(code).toContain("nextData.__vinext?.hasMiddleware === true");
+      expect(code).toContain("nextData.__vinext?.hasRewrites === true");
+      expect(code).toContain(
+        "const routeUrl = nextData.isFallback ? nextData.__vinext?.routeUrl : undefined;",
+      );
       expect(code).toContain("await Router.replace(");
       expect(code).toContain("routeUrl || currentUrl,");
       expect(code).toContain("routeUrl ? currentUrl : undefined,");
-      expect(code).toContain("{ _h: 1, scroll: false },");
+      expect(code).toContain("{ _h: 1, scroll: false, shallow: false },");
       expect(code).not.toContain("function VinextHydrationMarker");
       expect(code).not.toContain("React.createElement(VinextHydrationMarker");
       expect(code).toContain("hydrateRoot(container, element, hydrateRootOptions)");

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -1906,6 +1906,7 @@ describe("Pages Router entry template", () => {
       expect(code).toContain("element = wrapWithRouterContext(element, resolveHydrationCommit);");
       expect(code).toContain("await hydrationCommitted;");
       expect(code).toContain("const shouldHydrateQuery =");
+      expect(code).toContain("const initialMatchesMiddleware =");
       expect(code).toContain("nextData.__vinext?.hasMiddleware === true");
       expect(code).toContain("nextData.__vinext?.hasRewrites === true");
       expect(code).toContain(
@@ -1914,7 +1915,9 @@ describe("Pages Router entry template", () => {
       expect(code).toContain("await Router.replace(");
       expect(code).toContain("routeUrl || currentUrl,");
       expect(code).toContain("routeUrl ? currentUrl : undefined,");
-      expect(code).toContain("{ _h: 1, scroll: false, shallow: false },");
+      expect(code).toContain(
+        "{ _h: 1, scroll: false, shallow: !nextData.isFallback && !initialMatchesMiddleware },",
+      );
       expect(code).not.toContain("function VinextHydrationMarker");
       expect(code).not.toContain("React.createElement(VinextHydrationMarker");
       expect(code).toContain("hydrateRoot(container, element, hydrateRootOptions)");

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -1562,6 +1562,55 @@ describe("Link prefetch scheduling", () => {
     }
   });
 
+  it("keeps shallow hybrid App Router links eligible for viewport prefetch", async () => {
+    vi.stubEnv("__VINEXT_HAS_PAGES_ROUTER", "true");
+    const observer = stubIntersectionObserver();
+    const result = await renderIsolatedLink({
+      href: "/viewport-prefetch-target",
+      nodeEnv: "production",
+      props: { shallow: true },
+    });
+
+    try {
+      expect(observer.observe).toHaveBeenCalledWith(result.anchor);
+      observer.dispatchIntersectingEntry(result.anchor);
+      await waitForFetchCalls(result.fetch, 1);
+
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[0],
+        "/viewport-prefetch-target",
+        expect.objectContaining({ priority: "low" }),
+      );
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("keeps shallow hybrid App Router links eligible for immediate intent prefetch", async () => {
+    vi.stubEnv("__VINEXT_HAS_PAGES_ROUTER", "true");
+    const requestAnimationFrame = vi.fn(() => 1);
+    const result = await renderIsolatedLink({
+      href: "/intent-prefetch-target",
+      nodeEnv: "production",
+      props: { shallow: true },
+      windowOverrides: { requestAnimationFrame },
+    });
+
+    try {
+      result.capturedAnchorProps.onMouseEnter?.({ currentTarget: result.anchor });
+      await waitForFetchCalls(result.fetch, 1);
+
+      expect(requestAnimationFrame).not.toHaveBeenCalled();
+      expectCanonicalRscFetchCall(
+        result.fetch.mock.calls[0],
+        "/intent-prefetch-target",
+        expect.objectContaining({ priority: "high" }),
+      );
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
   it("prefetches visible links in production with low priority", async () => {
     const observer = stubIntersectionObserver();
 

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -1093,6 +1093,7 @@ describe("Pages Router Link onClick semantics", () => {
       href: string;
       as?: string;
       replace: boolean;
+      shallow?: boolean;
       interpolateDynamicRoute?: boolean;
     }[] = [];
     vi.doMock(
@@ -1108,6 +1109,7 @@ describe("Pages Router Link onClick semantics", () => {
             href: string;
             as?: string;
             replace: boolean;
+            shallow?: boolean;
             interpolateDynamicRoute?: boolean;
           };
         }) => {
@@ -1115,6 +1117,7 @@ describe("Pages Router Link onClick semantics", () => {
             href: navigation.href,
             ...(navigation.as === undefined ? undefined : { as: navigation.as }),
             replace: navigation.replace,
+            ...(navigation.shallow ? { shallow: true } : undefined),
             ...(navigation.interpolateDynamicRoute ? { interpolateDynamicRoute: true } : undefined),
           });
         },
@@ -1221,6 +1224,17 @@ describe("Pages Router Link onClick semantics", () => {
     expect(result.clickEvent.defaultPrevented).toBe(true);
     // ...and the Pages Router navigation is actually scheduled.
     expect(result.pagesRouterCalls).toEqual([{ href: "/", replace: false }]);
+  });
+
+  it("forwards shallow Pages links to the router", async () => {
+    const result = await renderPagesRouterLinkAndClick({
+      href: "/sha?hello=world",
+      props: { shallow: true },
+    });
+
+    expect(result.pagesRouterCalls).toEqual([
+      { href: "/sha?hello=world", replace: false, shallow: true },
+    ]);
   });
 
   it("resolves hash-only URL objects against the current locale-free asPath", async () => {
@@ -3046,6 +3060,82 @@ describe("Link prefetch scheduling", () => {
           rel: "prefetch",
         },
       ]);
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("cancels a queued Pages Router intent prefetch when the link is clicked", async () => {
+    let scheduledFrame: (() => void) | null = null;
+    const result = await renderIsolatedLink({
+      appNavigation: false,
+      href: "/pages-click-intent-prefetch-target",
+      nodeEnv: "production",
+      props: {
+        onClick: (event: CapturedClickEvent) => event.preventDefault(),
+      },
+      windowOverrides: {
+        __NEXT_DATA__: {
+          __vinext: {
+            pageModuleUrl: "/_next/static/chunks/pages/current.js",
+          },
+        },
+        requestAnimationFrame: vi.fn((callback: () => void) => {
+          scheduledFrame = callback;
+          return 1;
+        }),
+        cancelAnimationFrame: vi.fn(() => {
+          scheduledFrame = null;
+        }),
+      },
+    });
+
+    try {
+      result.capturedAnchorProps.onMouseEnter?.({ currentTarget: result.anchor });
+      expect(scheduledFrame).not.toBeNull();
+
+      const clickEvent = {
+        button: 0,
+        currentTarget: { hasAttribute: () => false, target: "" },
+        defaultPrevented: false,
+        preventDefault() {
+          this.defaultPrevented = true;
+        },
+      } satisfies CapturedClickEvent;
+      await result.capturedAnchorProps.onClick?.(clickEvent);
+      await flushPrefetchTasks();
+
+      expect(clickEvent.defaultPrevented).toBe(true);
+      expect(scheduledFrame).toBeNull();
+      expect(result.fetch).not.toHaveBeenCalled();
+      expect(result.pagePrefetchLinks).toEqual([]);
+    } finally {
+      result.restoreNodeEnv();
+    }
+  });
+
+  it("does not prefetch shallow Pages Router links on intent", async () => {
+    const result = await renderIsolatedLink({
+      appNavigation: false,
+      href: "/pages-shallow-intent-prefetch-target?hello=world",
+      nodeEnv: "production",
+      props: { shallow: true },
+      windowOverrides: {
+        __NEXT_DATA__: {
+          __vinext: {
+            pageModuleUrl: "/_next/static/chunks/pages/current.js",
+          },
+        },
+      },
+    });
+
+    try {
+      result.capturedAnchorProps.onMouseEnter?.({ currentTarget: result.anchor });
+      result.capturedAnchorProps.onTouchStart?.({ currentTarget: result.anchor });
+      await flushPrefetchTasks();
+
+      expect(result.fetch).not.toHaveBeenCalled();
+      expect(result.pagePrefetchLinks).toEqual([]);
     } finally {
       result.restoreNodeEnv();
     }

--- a/tests/middleware-runtime-trailing-slash.test.ts
+++ b/tests/middleware-runtime-trailing-slash.test.ts
@@ -13,6 +13,28 @@ import { NextResponse } from "../packages/vinext/src/shims/server.js";
 // ---------------------------------------------------------------------------
 
 describe("executeMiddleware propagates trailingSlash to NextURL", () => {
+  it("keeps an internal file request in its original non-trailing shape", async () => {
+    let observedUrl: string | undefined;
+    const result = await executeMiddleware({
+      isProxy: false,
+      module: {
+        middleware: (request: Request) => {
+          observedUrl = request.url;
+          return new Response(null, { headers: { "x-middleware-next": "1" } });
+        },
+      },
+      request: new Request(
+        "http://localhost/_next/static/build-id/_devMiddlewareManifest.json?foo=1",
+      ),
+      trailingSlash: true,
+    });
+
+    expect(result.continue).toBe(true);
+    expect(observedUrl).toBe(
+      "http://localhost/_next/static/build-id/_devMiddlewareManifest.json?foo=1",
+    );
+  });
+
   it("emits Location with trailing slash when middleware redirects via request.nextUrl (trailingSlash: true)", async () => {
     const result = await executeMiddleware({
       isProxy: false,

--- a/tests/pages-dev-hydration.test.ts
+++ b/tests/pages-dev-hydration.test.ts
@@ -18,8 +18,10 @@ describe("createPagesDevHydrationScript", () => {
     expect(script).toContain("const appRouter = Router;");
     expect(script).not.toContain("pageProps: rawPageProps,");
     expect(script).toContain("const shouldHydrateQuery =");
+    expect(script).toContain("const initialMatchesMiddleware =");
     expect(script).toContain("nextData.__vinext?.hasMiddleware === true");
     expect(script).toContain("nextData.__vinext?.hasRewrites === true");
+    expect(script).toContain("shallow: !nextData.isFallback && !initialMatchesMiddleware");
     expect(script).not.toContain("window.__VINEXT_PAGE_PATTERNS__ = [nextData.page]");
   });
 

--- a/tests/pages-dev-hydration.test.ts
+++ b/tests/pages-dev-hydration.test.ts
@@ -17,7 +17,9 @@ describe("createPagesDevHydrationScript", () => {
     expect(script).toContain('() => import("/pages/_app.tsx")');
     expect(script).toContain("const appRouter = Router;");
     expect(script).not.toContain("pageProps: rawPageProps,");
-    expect(script).toContain("if (nextData.isFallback)");
+    expect(script).toContain("const shouldHydrateQuery =");
+    expect(script).toContain("nextData.__vinext?.hasMiddleware === true");
+    expect(script).toContain("nextData.__vinext?.hasRewrites === true");
     expect(script).not.toContain("window.__VINEXT_PAGE_PATTERNS__ = [nextData.page]");
   });
 

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -16820,6 +16820,70 @@ describe("Pages Router router helpers", () => {
     }
   });
 
+  it("lets a shallow visible query update override stale middleware rewrite query state", async () => {
+    // Ported from Next.js: test/e2e/middleware-general/test/index.test.ts
+    // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/middleware-general/test/index.test.ts
+    const React = await import("react");
+    const { renderToStaticMarkup } = await import("react-dom/server");
+    const routerModule = await import("../packages/vinext/src/shims/router.js");
+    const previousWindow = (globalThis as any).window;
+    const win = {
+      location: {
+        pathname: "/sha",
+        search: "?hello=goodbye",
+        hash: "",
+        href: "http://localhost/sha?hello=goodbye",
+        hostname: "localhost",
+        assign: vi.fn(),
+        replace: vi.fn(),
+        reload: vi.fn(),
+      },
+      history: {
+        state: null,
+        pushState: vi.fn((_state: unknown, _title: string, url: string) => {
+          const nextUrl = new URL(url, win.location.href);
+          win.location.pathname = nextUrl.pathname;
+          win.location.search = nextUrl.search;
+          win.location.hash = nextUrl.hash;
+          win.location.href = nextUrl.href;
+        }),
+        replaceState: vi.fn(),
+        back: vi.fn(),
+      },
+      dispatchEvent: vi.fn(),
+      scrollTo: vi.fn(),
+      scrollX: 0,
+      scrollY: 0,
+      __NEXT_DATA__: {
+        page: "/shallow",
+        query: { hello: "goodbye" },
+        isFallback: false,
+      },
+      __VINEXT_LOCALE__: undefined,
+      __VINEXT_LOCALES__: undefined,
+      __VINEXT_DEFAULT_LOCALE__: undefined,
+    };
+    (globalThis as any).window = win;
+
+    try {
+      await routerModule.default.push("/sha?hello=world", undefined, { shallow: true });
+
+      let captured: unknown = "NOT_SET";
+      function Probe() {
+        captured = routerModule.useRouter();
+        return React.createElement("div", null, "probe");
+      }
+
+      renderToStaticMarkup(routerModule.wrapWithRouterContext(React.createElement(Probe)));
+
+      expect((captured as any).query).toEqual({ hello: "world" });
+      expect(win.__NEXT_DATA__.query).toEqual({ hello: "goodbye" });
+    } finally {
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+    }
+  });
+
   it("exposes beforePopState on both the Router singleton and wrapped router context", async () => {
     const React = await import("react");
     const { renderToStaticMarkup } = await import("react-dom/server");
@@ -19027,7 +19091,7 @@ describe("Pages Router concurrent navigation", () => {
 
     const fetch = vi.fn(async (url: RequestInfo | URL) => {
       const href = getFetchHref(url);
-      if (href === "/_next/data/build-1/old-home.json") {
+      if (href === "/_next/data/build-1/en/old-home.json") {
         return new Response("{}", {
           headers: { "x-nextjs-redirect": "/new-home" },
           status: 200,
@@ -19050,7 +19114,7 @@ describe("Pages Router concurrent navigation", () => {
       expect(result).toBe(true);
       expect(fetch).toHaveBeenNthCalledWith(
         1,
-        "/_next/data/build-1/old-home.json",
+        "/_next/data/build-1/en/old-home.json",
         expect.objectContaining({
           headers: expect.objectContaining({ "x-nextjs-data": "1" }),
         }),
@@ -20660,6 +20724,64 @@ describe("Pages Router _next/data client navigation", () => {
     }
   });
 
+  // Ported from Next.js: test/e2e/middleware-rewrites/test/index.test.ts
+  // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/middleware-rewrites/test/index.test.ts
+  it("warms a middleware rewrite destination loader during prefetch", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalDocument = (globalThis as any).document;
+    const originalFetch = globalThis.fetch;
+
+    const sourceLoader = vi.fn(async () => makePageModule("source"));
+    const destinationLoader = vi.fn(async () => makePageModule("about"));
+    const { win, buildId } = createDataNavWindow({
+      loaders: {
+        "/rewrite-me-to-about": sourceLoader,
+        "/about": destinationLoader,
+      },
+      ssgPatterns: [],
+      sspPatterns: [],
+    });
+    (win.__NEXT_DATA__ as any).__vinext = { hasMiddleware: true };
+    (win as any).__VINEXT_MIDDLEWARE_MATCHER__ = ["/:path*"];
+    (globalThis as any).window = win;
+    (globalThis as any).document = {
+      createElement: () => ({ rel: "", as: "", href: "" }),
+      head: { appendChild: vi.fn() },
+    };
+    vi.resetModules();
+
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response("{}", {
+          headers: {
+            "Content-Type": "application/json",
+            "x-nextjs-rewrite": "/about?override=internal",
+          },
+        }),
+    ) as typeof fetch;
+
+    try {
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+
+      await Router.prefetch("/rewrite-me-to-about?override=internal");
+      await vi.waitFor(() => expect(destinationLoader).toHaveBeenCalledOnce());
+
+      expect(sourceLoader).toHaveBeenCalledOnce();
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        `/_next/data/${buildId}/rewrite-me-to-about.json?override=internal`,
+        expect.objectContaining({
+          headers: expect.objectContaining({ "x-middleware-prefetch": "1" }),
+        }),
+      );
+    } finally {
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      (globalThis as any).document = originalDocument;
+      globalThis.fetch = originalFetch;
+      vi.resetModules();
+    }
+  });
+
   it("does not persist middleware-prefetched SSR data between prefetch and navigation", async () => {
     const previousWindow = (globalThis as any).window;
     const originalDocument = (globalThis as any).document;
@@ -20790,6 +20912,80 @@ describe("Pages Router _next/data client navigation", () => {
       if (previousWindow === undefined) delete (globalThis as any).window;
       else (globalThis as any).window = previousWindow;
       (globalThis as any).document = originalDocument;
+      globalThis.fetch = originalFetch;
+      vi.resetModules();
+    }
+  });
+
+  it("uses an explicit default locale for middleware data after a locale switch", async () => {
+    const previousWindow = (globalThis as any).window;
+    const { win, buildId } = createDataNavWindow({
+      loaders: { "/i18n": vi.fn(async () => makePageModule("i18n")) },
+      locale: "ja",
+      sspPatterns: ["/i18n"],
+    });
+    (win.__NEXT_DATA__ as any).__vinext = { hasMiddleware: true };
+    (win as any).__VINEXT_LOCALE__ = "ja";
+    (win as any).__VINEXT_LOCALES__ = ["ja", "en", "fr", "es"];
+    (win as any).__VINEXT_DEFAULT_LOCALE__ = "en";
+    (win as any).__VINEXT_MIDDLEWARE_MATCHER__ = ["/:path*"];
+    (globalThis as any).window = win;
+
+    try {
+      vi.resetModules();
+      const { resolvePagesDataNavigationTarget } =
+        await import("../packages/vinext/src/shims/internal/pages-data-target.js");
+
+      const target = resolvePagesDataNavigationTarget("/i18n", "", { locale: "en" });
+
+      expect(target?.middlewareDataHref).toBe(`/_next/data/${buildId}/en/i18n.json`);
+      expect(target?.prefetchLocale).toBe("en");
+    } finally {
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+      vi.resetModules();
+    }
+  });
+
+  it("commits middleware navigation history only when the destination is ready to render", async () => {
+    const previousWindow = (globalThis as any).window;
+    const originalFetch = globalThis.fetch;
+    let resolveFetch!: (response: Response) => void;
+    const fetchResponse = new Promise<Response>((resolve) => {
+      resolveFetch = resolve;
+    });
+    const { win, pushState } = createDataNavWindow({
+      loaders: {
+        "/": vi.fn(async () => makePageModule("home")),
+        "/about": vi.fn(async () => makePageModule("about")),
+      },
+      sspPatterns: ["/about"],
+    });
+    (win.__NEXT_DATA__ as any).__vinext = { hasMiddleware: true };
+    (win as any).__VINEXT_MIDDLEWARE_MATCHER__ = ["/:path*"];
+    (globalThis as any).window = win;
+    globalThis.fetch = vi.fn(() => fetchResponse) as typeof fetch;
+
+    try {
+      vi.resetModules();
+      const { default: Router } = await import("../packages/vinext/src/shims/router.js");
+      const navigation = Router.push("/about");
+      await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalledOnce());
+
+      expect(pushState).not.toHaveBeenCalled();
+
+      resolveFetch(
+        new Response(JSON.stringify({ pageProps: { ready: true } }), {
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+      await expect(navigation).resolves.toBe(true);
+
+      expect(pushState).toHaveBeenCalledOnce();
+      expect(pushState.mock.calls[0][2]).toBe("/about");
+    } finally {
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
       globalThis.fetch = originalFetch;
       vi.resetModules();
     }
@@ -21506,9 +21702,9 @@ describe("Pages Router _next/data client navigation", () => {
       await Router.push("/regex");
 
       expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
-        `/_next/data/${buildId}/api/hello/world.json`,
+        `/_next/data/${buildId}/en/api/hello/world.json`,
         `/_next/data/${buildId}/en/localized.json`,
-        `/_next/data/${buildId}/regex.json`,
+        `/_next/data/${buildId}/en/regex.json`,
       ]);
       expect(loaderApiPath).toHaveBeenCalledTimes(1);
       expect(loaderLocalized).toHaveBeenCalledTimes(1);

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -16884,6 +16884,48 @@ describe("Pages Router router helpers", () => {
     }
   });
 
+  it("keeps dynamic rewrite route params authoritative over visible query values", async () => {
+    const React = await import("react");
+    const { renderToStaticMarkup } = await import("react-dom/server");
+    const routerModule = await import("../packages/vinext/src/shims/router.js");
+    const previousWindow = (globalThis as any).window;
+    const win = {
+      location: {
+        pathname: "/rewrite-navigation/0",
+        search: "?id=2",
+        hash: "",
+        href: "http://localhost/rewrite-navigation/0?id=2",
+        hostname: "localhost",
+      },
+      history: { state: null },
+      __NEXT_DATA__: {
+        page: "/rewrite-target/[id]",
+        query: { id: "0" },
+        isFallback: false,
+      },
+      __VINEXT_LOCALE__: undefined,
+      __VINEXT_LOCALES__: undefined,
+      __VINEXT_DEFAULT_LOCALE__: undefined,
+    };
+    (globalThis as any).window = win;
+
+    try {
+      let captured: unknown = "NOT_SET";
+      function Probe() {
+        captured = routerModule.useRouter();
+        return React.createElement("div", null, "probe");
+      }
+
+      renderToStaticMarkup(routerModule.wrapWithRouterContext(React.createElement(Probe)));
+
+      expect((captured as any).query).toEqual({ id: "0" });
+      expect((captured as any).asPath).toBe("/rewrite-navigation/0?id=2");
+    } finally {
+      if (previousWindow === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = previousWindow;
+    }
+  });
+
   it("exposes beforePopState on both the Router singleton and wrapped router context", async () => {
     const React = await import("react");
     const { renderToStaticMarkup } = await import("react-dom/server");


### PR DESCRIPTION
## Summary

Fixes the non-cache middleware parity failures from Actions run 31439707085 / job 93624401572:

- middleware rewrite query hydration for SSG/data requests
- non-data request URL shape and locale-qualified middleware data URLs
- shallow routing, prefetch suppression, and history commits across middleware rewrites
- recursive rewrite destination warming
- missing static-asset 404 middleware headers

This covers all 16 reported failures in:

- `test/e2e/middleware-general/test/index.test.ts`
- `test/e2e/middleware-general/test/node-runtime.test.ts`
- `test/e2e/middleware-rewrites/test/index.test.ts`
- `test/e2e/middleware-trailing-slash/test/index.test.ts`

## Validation

- `middleware-general/test/index.test.ts`: 66/66
- `middleware-general/test/node-runtime.test.ts`: 68/68
- `middleware-rewrites/test/index.test.ts`: 56 passed, 2 manifest-skipped
- `middleware-trailing-slash/test/index.test.ts`: 23/23
- Relevant vinext tests: 1,753/1,753
- `vp check`

Independent review: no findings.