### PR TITLE
fix(cache): ISR cache should store the framework preload header

### DIFF
--- a/packages/vinext/src/server/app-page-cache-finalizer.ts
+++ b/packages/vinext/src/server/app-page-cache-finalizer.ts
@@ -48,6 +48,7 @@ type FinalizeAppPageHtmlCacheResponseOptions = {
   preserveClientResponseHeaders?: boolean;
   expireSeconds?: number;
   revalidateSeconds: number | null;
+  linkHeader: string | null;
   waitUntil?: (promise: Promise<void>) => void;
 };
 
@@ -208,7 +209,7 @@ export function finalizeAppPageHtmlCacheResponse(
         cacheTags: pageTags,
         state: observationState,
       });
-      const linkHeader = response.headers.get("link");
+      const linkHeader = options.linkHeader;
       const writes = [
         options.isrSet(
           htmlKey,

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -1276,6 +1276,7 @@ export async function renderAppPageLifecycle(
         isForceStatic: options.isForceStatic,
         revalidateSeconds,
       }),
+      linkHeader: linkHeader ?? null,
       waitUntil(cachePromise) {
         options.waitUntil?.(cachePromise);
       },

--- a/tests/app-page-cache.test.ts
+++ b/tests/app-page-cache.test.ts
@@ -1171,6 +1171,7 @@ describe("app page cache helpers", () => {
         },
         expireSeconds: 300,
         revalidateSeconds: 60,
+        linkHeader: "</fresh.css>; rel=preload; as=style",
         waitUntil(promise) {
           pendingCacheWrites.push(promise);
         },
@@ -1233,6 +1234,7 @@ describe("app page cache helpers", () => {
       },
       isrSet,
       revalidateSeconds: 60,
+      linkHeader: null,
       waitUntil(promise: Promise<void>) {
         pendingCacheWrites.push(promise);
       },
@@ -1306,6 +1308,7 @@ describe("app page cache helpers", () => {
         },
         isrSet,
         revalidateSeconds: 60,
+        linkHeader: null,
         waitUntil(promise) {
           pendingCacheWrites.push(promise);
         },

--- a/tests/app-page-render.test.ts
+++ b/tests/app-page-render.test.ts
@@ -881,6 +881,51 @@ describe("app page render lifecycle", () => {
     );
   });
 
+  it("keeps request-specific middleware Link headers out of live ISR cache entries", async () => {
+    // Related Next.js middleware response-header coverage:
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app-middleware/app-middleware.test.ts
+    const common = createCommonOptions();
+    const frameworkLinkHeader = "</framework.css>; rel=preload; as=style";
+    const middlewareLinkHeader = "</new-ui.css>; rel=preload; as=style";
+
+    const response = await renderAppPageLifecycle({
+      ...common.options,
+      isProduction: true,
+      loadSsrHandler: async () => ({
+        async handleSsr(_rscStream, _navigationContext, _fontData, options) {
+          if (options?.capturedRscDataRef) {
+            options.capturedRscDataRef.value = Promise.resolve(
+              new TextEncoder().encode("flight-data").buffer,
+            );
+          }
+          if (options?.sideStream) {
+            void options.sideStream.getReader().cancel();
+          }
+
+          return {
+            htmlStream: createStream(["<html>page</html>"]),
+            metadataReady: Promise.resolve(),
+            capturedRscData: options?.capturedRscDataRef?.value ?? null,
+            linkHeader: frameworkLinkHeader,
+          };
+        },
+      }),
+      middlewareContext: {
+        headers: new Headers({ Link: middlewareLinkHeader }),
+        status: null,
+      },
+      revalidateSeconds: 30,
+    });
+
+    // Middleware still owns the Link header on this request's outgoing response.
+    expect(response.headers.get("link")).toBe(middlewareLinkHeader);
+    await expect(response.text()).resolves.toBe("<html>page</html>");
+    await Promise.all(common.waitUntilPromises);
+
+    const htmlCacheWrite = common.isrSet.mock.calls.find(([key]) => key === "html:/posts/post");
+    expect(htmlCacheWrite?.[1].headers?.link).toBe(frameworkLinkHeader);
+  });
+
   it("does not wait for cacheLife-only RSC capture before returning production HTML responses", async () => {
     const common = createCommonOptions();
     const releaseRsc = createDeferred();

--- a/tests/cloudflare-cdn-cache.test.ts
+++ b/tests/cloudflare-cdn-cache.test.ts
@@ -192,6 +192,7 @@ describe("CloudflareCdnCacheAdapter", () => {
         },
         isrSet,
         revalidateSeconds: 60,
+        linkHeader: null,
         waitUntil(promise) {
           pendingCacheWrites.push(promise);
         },


### PR DESCRIPTION
Closes #2782

## Overview

On an App Router ISR cache miss, vinext persisted the `Link` header from the finalized response after middleware headers had been merged. A request-specific middleware `Link` could therefore replace the framework preload header, enter the shared ISR cache, and be replayed to subsequent requests.

This caused framework preload hints to be lost and created inconsistent cache contents between live cache fills and background regeneration. It also diverged from Next.js, which caches render metadata separately from request-specific middleware headers.

## What changed

In `packages/vinext/src/server/app-page-cache-finalizer.ts:211`, the ISR just stores the `Link` header from the response directly, which might be modified by the middlewares.

https://github.com/cloudflare/vinext/blob/bdc7703b5ed693625677188b823f7e64156450d6/packages/vinext/src/server/app-page-cache-finalizer.ts#L211

So I added a property `linkHeader` into `FinalizeAppPageHtmlCacheResponseOptions` to hold the framework preload header value.

```diff
type FinalizeAppPageHtmlCacheResponseOptions = {
  // ...
+ linkHeader: string | null;
  waitUntil?: (promise: Promise<void>) => void;
};
```

In `packages/vinext/src/server/app-page-render.ts`, the correct `linkHeader` is passed to the finalizer options.

```diff
return finalizeAppPageHtmlCacheResponse(isrResponse, {
  // ...
+ linkHeader: linkHeader ?? null,
  // ...
});
```

Finally, during the ISR set, the correct `Link` header will be stored.

```diff
- const linkHeader = response.headers.get("link");
+ const linkHeader = options.linkHeader;
```

## Testing

- `pnpm test tests/app-page-render.test.ts`
- `pnpm test tests/app-page-cache.test.ts tests/cloudflare-cdn-cache.test.ts`