### PR TITLE
test(app-router): cover data-returning server actions skipping visible commits

### DIFF
--- a/tests/app-browser-server-action-client.test.ts
+++ b/tests/app-browser-server-action-client.test.ts
@@ -22,6 +22,7 @@ vi.mock("@vitejs/plugin-rsc/browser", () => ({
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.clearAllMocks();
 });
 
 describe("app browser server action client", () => {
@@ -426,30 +427,37 @@ describe("app browser server action client", () => {
         }),
       ),
     );
+    // The server always pairs a re-rendered root with a returnValue record —
+    // void actions come back as `{ ok: true, data: undefined }`, which Flight
+    // serializes as `$undefined` and decodes to a truthy object, never an
+    // omitted key (app-server-action-execution.ts renderToReadableStream).
     vi.mocked(createFromFetch).mockResolvedValueOnce({
       root: wireElements,
+      returnValue: { ok: true, data: undefined },
     });
     const commitSameUrlNavigatePayload = vi.fn();
     const clearClientNavigationCaches = vi.fn();
 
-    await invokeClientServerAction("action-id", [], actionInitiation, {
-      basePath: "",
-      clearClientNavigationCaches,
-      clientRscCompatibilityId: null,
-      commitSameUrlNavigatePayload,
-      navigationPlanner,
-      performHardNavigation: vi.fn(),
-      renderRedirectPayload: vi.fn(),
-      syncCurrentHistoryState: vi.fn(),
-      syncServerActionHttpFallbackHead: vi.fn(),
-    });
+    await expect(
+      invokeClientServerAction("action-id", [], actionInitiation, {
+        basePath: "",
+        clearClientNavigationCaches,
+        clientRscCompatibilityId: null,
+        commitSameUrlNavigatePayload,
+        navigationPlanner,
+        performHardNavigation: vi.fn(),
+        renderRedirectPayload: vi.fn(),
+        syncCurrentHistoryState: vi.fn(),
+        syncServerActionHttpFallbackHead: vi.fn(),
+      }),
+    ).resolves.toBeUndefined();
 
     expect(clearClientNavigationCaches).toHaveBeenCalledTimes(1);
     expect(commitSameUrlNavigatePayload).toHaveBeenCalledTimes(1);
     const [elementsArg, , returnValueArg, revalidationArg] =
       commitSameUrlNavigatePayload.mock.calls[0];
     await expect(elementsArg).resolves.toEqual(normalizeAppElements(wireElements));
-    expect(returnValueArg).toBeUndefined();
+    expect(returnValueArg).toEqual({ ok: true, data: undefined });
     expect(revalidationArg).toBe("staticAndDynamic");
   });
 

--- a/tests/app-browser-server-action-client.test.ts
+++ b/tests/app-browser-server-action-client.test.ts
@@ -8,7 +8,10 @@ import {
   AppElementsWire,
   normalizeAppElements,
 } from "../packages/vinext/src/server/app-elements.js";
-import { ACTION_REDIRECT_HEADER } from "../packages/vinext/src/server/headers.js";
+import {
+  ACTION_REDIRECT_HEADER,
+  ACTION_REVALIDATED_HEADER,
+} from "../packages/vinext/src/server/headers.js";
 import { navigationPlanner } from "../packages/vinext/src/server/navigation-planner.js";
 
 vi.mock("@vitejs/plugin-rsc/browser", () => ({
@@ -242,4 +245,235 @@ describe("app browser server action client", () => {
     );
     expect(renderRedirectPayload).not.toHaveBeenCalled();
   });
+
+  // Next.js parity contract: a fetch action that neither revalidates nor
+  // redirects gets an empty Flight payload — the client resolves the action
+  // value without committing a visible router update. The server omits `root`
+  // for these responses (packages/vinext/src/server/app-server-action-execution.ts,
+  // shouldSkipPageRendering), mirroring Next.js' skip-page-rendering decision:
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/action-handler.ts
+  // and its client-side bail-out:
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+  it("returns the action value without committing when the server omits the tree", async () => {
+    const routerState = createActionTestRouterState();
+    const actionInitiation = createServerActionInitiationSnapshot({
+      href: "https://example.com/source",
+      navigationId: 1,
+      routerState,
+    });
+    vi.stubGlobal("window", {
+      location: { href: "https://example.com/source", origin: "https://example.com" },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response("flight", {
+          status: 200,
+          headers: { "content-type": "text/x-component" },
+        }),
+      ),
+    );
+    vi.mocked(createFromFetch).mockResolvedValueOnce({
+      returnValue: { ok: true, data: "latest-form-state" },
+    });
+    const commitSameUrlNavigatePayload = vi.fn();
+    const clearClientNavigationCaches = vi.fn();
+
+    await expect(
+      invokeClientServerAction("action-id", [], actionInitiation, {
+        basePath: "",
+        clearClientNavigationCaches,
+        clientRscCompatibilityId: null,
+        commitSameUrlNavigatePayload,
+        navigationPlanner,
+        performHardNavigation: vi.fn(),
+        renderRedirectPayload: vi.fn(),
+        syncCurrentHistoryState: vi.fn(),
+        syncServerActionHttpFallbackHead: vi.fn(),
+      }),
+    ).resolves.toBe("latest-form-state");
+
+    expect(commitSameUrlNavigatePayload).not.toHaveBeenCalled();
+    expect(clearClientNavigationCaches).not.toHaveBeenCalled();
+  });
+
+  it("throws the action error without committing when the action failed", async () => {
+    const routerState = createActionTestRouterState();
+    const actionInitiation = createServerActionInitiationSnapshot({
+      href: "https://example.com/source",
+      navigationId: 1,
+      routerState,
+    });
+    vi.stubGlobal("window", {
+      location: { href: "https://example.com/source", origin: "https://example.com" },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response("flight", {
+          status: 200,
+          headers: { "content-type": "text/x-component" },
+        }),
+      ),
+    );
+    vi.mocked(createFromFetch).mockResolvedValueOnce({
+      returnValue: { ok: false, data: new Error("action boom") },
+    });
+    const commitSameUrlNavigatePayload = vi.fn();
+
+    await expect(
+      invokeClientServerAction("action-id", [], actionInitiation, {
+        basePath: "",
+        clearClientNavigationCaches: vi.fn(),
+        clientRscCompatibilityId: null,
+        commitSameUrlNavigatePayload,
+        navigationPlanner,
+        performHardNavigation: vi.fn(),
+        renderRedirectPayload: vi.fn(),
+        syncCurrentHistoryState: vi.fn(),
+        syncServerActionHttpFallbackHead: vi.fn(),
+      }),
+    ).rejects.toMatchObject({ message: "action boom" });
+
+    expect(commitSameUrlNavigatePayload).not.toHaveBeenCalled();
+  });
+
+  it("commits the RSC tree for revalidated actions and returns the action value", async () => {
+    const wireElements = AppElementsWire.createMetadataEntries({
+      interception: null,
+      interceptionContext: null,
+      layoutIds: [AppElementsWire.encodeLayoutId("/")],
+      rootLayoutTreePath: "/",
+      routeId: AppElementsWire.encodeRouteId("/source", null),
+      slotBindings: [],
+    });
+    const routerState = createActionTestRouterState();
+    const actionInitiation = createServerActionInitiationSnapshot({
+      href: "https://example.com/source",
+      navigationId: 1,
+      routerState,
+    });
+    vi.stubGlobal("window", {
+      location: { href: "https://example.com/source", origin: "https://example.com" },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response("flight", {
+          status: 200,
+          headers: {
+            "content-type": "text/x-component",
+            [ACTION_REVALIDATED_HEADER]: "2",
+          },
+        }),
+      ),
+    );
+    vi.mocked(createFromFetch).mockResolvedValueOnce({
+      root: wireElements,
+      returnValue: { ok: true, data: "value-after-revalidation" },
+    });
+    const commitSameUrlNavigatePayload = vi.fn();
+    const clearClientNavigationCaches = vi.fn();
+
+    await invokeClientServerAction("action-id", [], actionInitiation, {
+      basePath: "",
+      clearClientNavigationCaches,
+      clientRscCompatibilityId: null,
+      commitSameUrlNavigatePayload,
+      navigationPlanner,
+      performHardNavigation: vi.fn(),
+      renderRedirectPayload: vi.fn(),
+      syncCurrentHistoryState: vi.fn(),
+      syncServerActionHttpFallbackHead: vi.fn(),
+    });
+
+    expect(clearClientNavigationCaches).toHaveBeenCalledTimes(1);
+    expect(commitSameUrlNavigatePayload).toHaveBeenCalledTimes(1);
+    const [elementsArg, , returnValueArg, revalidationArg] =
+      commitSameUrlNavigatePayload.mock.calls[0];
+    await expect(elementsArg).resolves.toEqual(normalizeAppElements(wireElements));
+    expect(returnValueArg).toEqual({ ok: true, data: "value-after-revalidation" });
+    expect(revalidationArg).toBe("dynamicOnly");
+  });
+
+  it("commits a raw full-tree payload from a non-action RSC response", async () => {
+    const wireElements = AppElementsWire.createMetadataEntries({
+      interception: null,
+      interceptionContext: null,
+      layoutIds: [AppElementsWire.encodeLayoutId("/")],
+      rootLayoutTreePath: "/",
+      routeId: AppElementsWire.encodeRouteId("/source", null),
+      slotBindings: [],
+    });
+    const routerState = createActionTestRouterState();
+    const actionInitiation = createServerActionInitiationSnapshot({
+      href: "https://example.com/source",
+      navigationId: 1,
+      routerState,
+    });
+    vi.stubGlobal("window", {
+      location: { href: "https://example.com/source", origin: "https://example.com" },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response("flight", {
+          status: 200,
+          headers: { "content-type": "text/x-component" },
+        }),
+      ),
+    );
+    vi.mocked(createFromFetch).mockResolvedValueOnce(wireElements);
+    const commitSameUrlNavigatePayload = vi.fn();
+    const clearClientNavigationCaches = vi.fn();
+
+    await invokeClientServerAction("action-id", [], actionInitiation, {
+      basePath: "",
+      clearClientNavigationCaches,
+      clientRscCompatibilityId: null,
+      commitSameUrlNavigatePayload,
+      navigationPlanner,
+      performHardNavigation: vi.fn(),
+      renderRedirectPayload: vi.fn(),
+      syncCurrentHistoryState: vi.fn(),
+      syncServerActionHttpFallbackHead: vi.fn(),
+    });
+
+    expect(clearClientNavigationCaches).toHaveBeenCalledTimes(1);
+    expect(commitSameUrlNavigatePayload).toHaveBeenCalledTimes(1);
+    const [elementsArg, , returnValueArg, revalidationArg] =
+      commitSameUrlNavigatePayload.mock.calls[0];
+    await expect(elementsArg).resolves.toEqual(normalizeAppElements(wireElements));
+    expect(returnValueArg).toBeUndefined();
+    expect(revalidationArg).toBe("none");
+  });
 });
+
+function createActionTestRouterState(): AppRouterState {
+  const elements = normalizeAppElements(
+    AppElementsWire.createMetadataEntries({
+      interception: null,
+      interceptionContext: null,
+      layoutIds: [AppElementsWire.encodeLayoutId("/")],
+      rootLayoutTreePath: "/",
+      routeId: "route:/source",
+      slotBindings: [],
+    }),
+  );
+  return {
+    activeOperation: null,
+    bfcacheIds: {},
+    elements,
+    interception: null,
+    interceptionContext: null,
+    layoutFlags: {},
+    layoutIds: [AppElementsWire.encodeLayoutId("/")],
+    navigationSnapshot: createClientNavigationRenderSnapshot("https://example.com/source", {}),
+    previousNextUrl: null,
+    renderId: 0,
+    rootLayoutTreePath: "/",
+    routeId: "route:/source",
+    slotBindings: [],
+    visibleCommitVersion: 0,
+  };
+}

--- a/tests/app-browser-server-action-client.test.ts
+++ b/tests/app-browser-server-action-client.test.ts
@@ -396,6 +396,63 @@ describe("app browser server action client", () => {
     expect(revalidationArg).toBe("dynamicOnly");
   });
 
+  it("commits the RSC tree for revalidated void actions with no return value", async () => {
+    const wireElements = AppElementsWire.createMetadataEntries({
+      interception: null,
+      interceptionContext: null,
+      layoutIds: [AppElementsWire.encodeLayoutId("/")],
+      rootLayoutTreePath: "/",
+      routeId: AppElementsWire.encodeRouteId("/source", null),
+      slotBindings: [],
+    });
+    const routerState = createActionTestRouterState();
+    const actionInitiation = createServerActionInitiationSnapshot({
+      href: "https://example.com/source",
+      navigationId: 1,
+      routerState,
+    });
+    vi.stubGlobal("window", {
+      location: { href: "https://example.com/source", origin: "https://example.com" },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response("flight", {
+          status: 200,
+          headers: {
+            "content-type": "text/x-component",
+            [ACTION_REVALIDATED_HEADER]: "1",
+          },
+        }),
+      ),
+    );
+    vi.mocked(createFromFetch).mockResolvedValueOnce({
+      root: wireElements,
+    });
+    const commitSameUrlNavigatePayload = vi.fn();
+    const clearClientNavigationCaches = vi.fn();
+
+    await invokeClientServerAction("action-id", [], actionInitiation, {
+      basePath: "",
+      clearClientNavigationCaches,
+      clientRscCompatibilityId: null,
+      commitSameUrlNavigatePayload,
+      navigationPlanner,
+      performHardNavigation: vi.fn(),
+      renderRedirectPayload: vi.fn(),
+      syncCurrentHistoryState: vi.fn(),
+      syncServerActionHttpFallbackHead: vi.fn(),
+    });
+
+    expect(clearClientNavigationCaches).toHaveBeenCalledTimes(1);
+    expect(commitSameUrlNavigatePayload).toHaveBeenCalledTimes(1);
+    const [elementsArg, , returnValueArg, revalidationArg] =
+      commitSameUrlNavigatePayload.mock.calls[0];
+    await expect(elementsArg).resolves.toEqual(normalizeAppElements(wireElements));
+    expect(returnValueArg).toBeUndefined();
+    expect(revalidationArg).toBe("staticAndDynamic");
+  });
+
   it("commits a raw full-tree payload from a non-action RSC response", async () => {
     const wireElements = AppElementsWire.createMetadataEntries({
       interception: null,

--- a/tests/e2e/app-router/server-actions.spec.ts
+++ b/tests/e2e/app-router/server-actions.spec.ts
@@ -493,14 +493,14 @@ test.describe("Server action forwarding loop guard", () => {
     expect(response.status).toBe(404);
     expect(response.hasNotFoundHeader).toBe(true);
   });
+});
 
+test.describe("Data-returning server actions", () => {
   // Regression contract for the Payload getFormState pattern: a data-returning
   // server action with no revalidation must resolve its value without applying
   // the RSC tree (Next.js' bail-out in server-action-reducer.ts). Re-applying
   // the tree would hand the form a fresh initialState and wipe pending edits.
-  test("data-returning server action preserves form edits without re-rendering", async ({
-    page,
-  }) => {
+  test("preserves form edits without re-rendering the page", async ({ page }) => {
     await page.goto(`${BASE}/action-form-preserved`);
     await expect(page.locator("h1")).toHaveText("Action Form Preserved Test");
     await waitForAppRouterHydration(page);

--- a/tests/e2e/app-router/server-actions.spec.ts
+++ b/tests/e2e/app-router/server-actions.spec.ts
@@ -498,8 +498,12 @@ test.describe("Server action forwarding loop guard", () => {
 test.describe("Data-returning server actions", () => {
   // Regression contract for the Payload getFormState pattern: a data-returning
   // server action with no revalidation must resolve its value without applying
-  // the RSC tree (Next.js' bail-out in server-action-reducer.ts). Re-applying
-  // the tree would hand the form a fresh initialState and wipe pending edits.
+  // the RSC tree (Next.js' bail-out in server-action-reducer.ts). The server
+  // render counter is the discriminator: re-applying the tree would re-render
+  // the page server-side and advance it. The input assertion guards the
+  // user-visible contract (pending edits survive the roundtrip) but is not
+  // itself proof of no tree update, since React can reconcile an uncontrolled
+  // input in place.
   test("preserves form edits without re-rendering the page", async ({ page }) => {
     await page.goto(`${BASE}/action-form-preserved`);
     await expect(page.locator("h1")).toHaveText("Action Form Preserved Test");

--- a/tests/e2e/app-router/server-actions.spec.ts
+++ b/tests/e2e/app-router/server-actions.spec.ts
@@ -493,4 +493,39 @@ test.describe("Server action forwarding loop guard", () => {
     expect(response.status).toBe(404);
     expect(response.hasNotFoundHeader).toBe(true);
   });
+
+  // Regression contract for the Payload getFormState pattern: a data-returning
+  // server action with no revalidation must resolve its value without applying
+  // the RSC tree (Next.js' bail-out in server-action-reducer.ts). Re-applying
+  // the tree would hand the form a fresh initialState and wipe pending edits.
+  test("data-returning server action preserves form edits without re-rendering", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}/action-form-preserved`);
+    await expect(page.locator("h1")).toHaveText("Action Form Preserved Test");
+    await waitForAppRouterHydration(page);
+
+    const renderCount = async () =>
+      parseInt(
+        (await page.locator('[data-testid="server-render-count"]').textContent())!.split(": ")[1],
+        10,
+      );
+    const renderCountBefore = await renderCount();
+
+    // Type an edit, then move focus away to trigger the blur action.
+    await page.fill("#edit-input", "pending-edit");
+    await page.click("#blur-target");
+
+    // The action's return value surfaces through client state...
+    await expect(page.locator('[data-testid="action-result"]')).toHaveText(
+      "action returned 3 fields",
+      { timeout: 10_000 },
+    );
+
+    // ...and the pending edit survives because the server tree was not re-applied.
+    await expect(page.locator("#edit-input")).toHaveValue("pending-edit");
+
+    // The page did not re-render on the server.
+    expect(await renderCount()).toBe(renderCountBefore);
+  });
 });

--- a/tests/fixtures/app-basic/app/action-form-preserved/actions.ts
+++ b/tests/fixtures/app-basic/app/action-form-preserved/actions.ts
@@ -1,0 +1,11 @@
+"use server";
+
+/**
+ * Data-returning server action that performs no revalidation — the same
+ * shape as Payload's getFormState. Next.js resolves the action value without
+ * touching the React tree (see server-action-reducer bail-out); the e2e
+ * verifies vinext matches so pending form edits survive.
+ */
+export async function refreshFormState(): Promise<{ fieldCount: number }> {
+  return { fieldCount: 3 };
+}

--- a/tests/fixtures/app-basic/app/action-form-preserved/form.tsx
+++ b/tests/fixtures/app-basic/app/action-form-preserved/form.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useState } from "react";
+import { refreshFormState } from "./actions";
+
+/**
+ * Mirrors the Payload getFormState pattern: a blur-triggered server action
+ * that returns form state without revalidating. Pending edits must survive
+ * the roundtrip — the server tree must not be re-applied.
+ */
+export default function ActionFormPreservedForm() {
+  const [actionResult, setActionResult] = useState<string | null>(null);
+
+  async function handleBlur() {
+    const result = await refreshFormState();
+    setActionResult(`action returned ${result.fieldCount} fields`);
+  }
+
+  return (
+    <div>
+      <input id="edit-input" name="name" placeholder="Type something" onBlur={handleBlur} />
+      <button id="blur-target" type="button">
+        Move focus here
+      </button>
+      <p data-testid="action-result">{actionResult ?? "no action yet"}</p>
+    </div>
+  );
+}

--- a/tests/fixtures/app-basic/app/action-form-preserved/page.tsx
+++ b/tests/fixtures/app-basic/app/action-form-preserved/page.tsx
@@ -1,0 +1,17 @@
+import ActionFormPreservedForm from "./form";
+
+// Module-level counter: advances on every server render of this page. If a
+// data-returning server action wrongly commits a visible router update, the
+// page re-renders and this counter moves — the e2e asserts it stays flat.
+let serverRenderCount = 0;
+
+export default function ActionFormPreservedPage() {
+  serverRenderCount++;
+  return (
+    <div>
+      <h1>Action Form Preserved Test</h1>
+      <p data-testid="server-render-count">Server render count: {serverRenderCount}</p>
+      <ActionFormPreservedForm />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Lock in the Next.js parity contract for data-returning server actions: a fetch action that neither revalidates nor redirects resolves its value **without applying the RSC tree**. Re-applying the tree hands forms a fresh `initialState`, wiping pending edits and looping `getFormState`-style actions (the pattern Payload CMS relies on).

vinext already implements this — the server omits `root` for non-revalidating actions (`shouldSkipPageRendering` in `app-server-action-execution.ts`) and the client returns the value directly without committing (`app-browser-server-action-client.ts`). But the behavior had **zero unit coverage** and no e2e asserting form edits survive the roundtrip. Given it has silently regressed across multiple vinext versions (a third-party Payload plugin AST-patches vinext's dist for this bug), this PR makes the contract explicit.

## Next.js reference

- Server skips page rendering when nothing was revalidated: [`action-handler.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/action-handler.ts#L1424-L1428)
- Client bails out without a navigation when there is no revalidation/flight data: [`server-action-reducer.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts#L415-L427)

## Tests

**Unit — `tests/app-browser-server-action-client.test.ts`** (4 new):
- root omitted + ok `returnValue` → resolves data, `commitSameUrlNavigatePayload` **not** called, caches not cleared
- root omitted + failed action → throws, no commit
- root present + `x-action-revalidated` → commits decoded tree and returns the value
- raw full-tree payload (non-action response) → commits with `undefined` returnValue

**E2e — `tests/e2e/app-router/server-actions.spec.ts`** (1 new) + fixture `app/action-form-preserved/`:
- types a pending edit, blur-triggers a data-returning action (Payload `getFormState` shape), asserts the edit survives and the page's server-render counter does not advance

## Validation

- `vp test run tests/app-browser-server-action-client.test.ts` — 7/7 pass
- `PLAYWRIGHT_PROJECT=app-router` server-actions spec — 23/23 pass
- `vp lint` clean; typecheck clean for changed files (pre-existing `apps/web` cloudflare-types errors unrelated)