### PR TITLE
fix(rsc): preserve BOM bytes in embedded Flight chunks

### DIFF
--- a/packages/vinext/src/server/app-ssr-stream.ts
+++ b/packages/vinext/src/server/app-ssr-stream.ts
@@ -140,7 +140,7 @@ export function createRscEmbedTransform(
         if (result.done) break;
         rawChunks.push(result.value);
         try {
-          const decoder = new TextDecoder("utf-8", { fatal: true });
+          const decoder = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true });
           const text = decoder.decode(result.value);
           pendingChunks.push(text);
         } catch {

--- a/tests/app-ssr-stream.test.ts
+++ b/tests/app-ssr-stream.test.ts
@@ -3,6 +3,11 @@ import { describe, it, expect } from "vite-plus/test";
 import { createElement, Suspense, use } from "react";
 import { renderToReadableStream } from "react-dom/server.edge";
 import {
+  concatUint8Arrays,
+  decodeRscEmbeddedChunk,
+  type RscEmbeddedChunk,
+} from "../packages/vinext/src/server/app-rsc-embedded-chunks.js";
+import {
   createNavigationRuntimeRscMetadataScript,
   createRscEmbedTransform,
   createTickBufferedTransform,
@@ -277,6 +282,34 @@ describe("createRscEmbedTransform raw buffer (#981)", () => {
     const finalScripts = await transform.finalize();
     expect(finalScripts).toContain("stylesheet");
     expect(finalScripts).toContain(".done=true");
+  });
+
+  it("preserves a UTF-8 BOM at an embedded Flight chunk boundary", async () => {
+    const flightChunks = [
+      new TextEncoder().encode("1:T4,"),
+      new Uint8Array([0xef, 0xbb, 0xbf, 0x61]),
+      new TextEncoder().encode("2:T1,b"),
+    ];
+    const expectedBytes = concatUint8Arrays(flightChunks);
+
+    const transform = createRscEmbedTransform(createByteStream(flightChunks));
+    const finalScripts = await transform.finalize();
+    const self: Record<PropertyKey, unknown> = {};
+    const context = createContext({ self });
+
+    for (const scriptSource of finalScripts
+      .slice("<script>".length, -"</script>".length)
+      .split("</script><script>")) {
+      runInContext(scriptSource, context);
+    }
+
+    const navigationRuntime = self[Symbol.for("vinext.navigationRuntime")] as {
+      bootstrap: { rsc: { rsc: RscEmbeddedChunk[] } };
+    };
+    const embeddedChunks = navigationRuntime.bootstrap.rsc.rsc.map(decodeRscEmbeddedChunk);
+    const embeddedBytes = concatUint8Arrays(embeddedChunks);
+
+    expect(embeddedBytes).toEqual(expectedBytes);
   });
 
   it("embeds non-UTF-8 RSC chunks as base64 binary chunks", async () => {


### PR DESCRIPTION
## Summary

- preserve UTF-8 BOM bytes when embedding Flight chunks into the initial HTML
- add a byte-level regression test for a BOM that starts an upstream RSC chunk

## Root cause

`createRscEmbedTransform` decodes each upstream RSC chunk independently before serializing it into an inline script. `TextDecoder` treats a leading UTF-8 BOM as a signature by default and omits it from the decoded string.

When a valid U+FEFF value starts an upstream chunk inside a length-prefixed Flight text row, re-encoding the embedded string produces three fewer bytes than the server declared. The client parser then consumes bytes from the next row and can fail with errors such as `Cannot read properties of null (reading 'enqueueValue')`.

Setting `ignoreBOM: true` preserves U+FEFF in the decoded string so the existing `TextEncoder` round trip remains byte-exact. Invalid UTF-8 continues to use the existing base64 fallback.
