### PR TITLE
fix(headers): expose live view of headers to api

### DIFF
--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -1111,15 +1111,10 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
       options.clearRequestContext();
       return notFoundResponse();
     }
-    let addedSourceHeader = false;
     for (const [name, value] of sourceHeadersContext.headers) {
       if (!targetRequestHeaders.has(name)) {
         targetHeadersContext.headers.set(name, value);
-        addedSourceHeader = true;
       }
-    }
-    if (addedSourceHeader) {
-      targetHeadersContext.readonlyHeaders = undefined;
     }
     if (sourceMiddlewareResult.rewritten) {
       // Rewrites such as locale insertion are valid only when they resolve to

--- a/packages/vinext/src/shims/headers.ts
+++ b/packages/vinext/src/shims/headers.ts
@@ -157,27 +157,23 @@ function setCookieNameValue(setCookie: string): { name: string; value: string } 
 }
 
 function rebuildCookiesFromHeader(ctx: HeadersContext, cookieHeader: string | null): void {
-  ctx.cookies.clear();
-  if (cookieHeader === null) return;
-
-  const nextCookies = parseEdgeRequestCookieHeader(cookieHeader);
-  for (const [name, value] of nextCookies) {
-    ctx.cookies.set(name, value);
-  }
+  ctx.cookies = cookieHeader === null ? new Map() : parseEdgeRequestCookieHeader(cookieHeader);
 }
 
 function mergeMiddlewareSetCookies(ctx: HeadersContext, rawHeader: string | null): boolean {
   if (rawHeader === null) return false;
 
-  let merged = false;
+  let nextCookies: Map<string, string> | null = null;
   for (const setCookie of splitMiddlewareSetCookieHeader(rawHeader)) {
     const entry = setCookieNameValue(setCookie);
     if (!entry) continue;
-    ctx.cookies.set(entry.name, entry.value);
-    merged = true;
+    nextCookies ??= new Map(ctx.cookies);
+    nextCookies.set(entry.name, entry.value);
   }
 
-  return merged;
+  if (!nextCookies) return false;
+  ctx.cookies = nextCookies;
+  return true;
 }
 
 function _getState(): VinextHeadersShimState {
@@ -626,15 +622,10 @@ export function runWithHeadersContext<T>(
  * resulting request header set to the live `HeadersContext`. When an override
  * list is present, omitted headers are deleted as part of the rebuild.
  *
- * Cached `readonlyHeaders` and `readonlyCookies` snapshots on the
- * HeadersContext must be invalidated whenever this function rebuilds the
- * underlying `headers`/`cookies`. Otherwise a middleware that reads
- * `headers()` (or `cookies()`) before returning a request-header override —
- * for example `@clerk/nextjs`, whose `clerkClient()` reads `headers()` via
- * `buildRequestLike()` during middleware execution — primes a sealed snapshot
- * built from the *pre*-override request, and any subsequent `headers()` call
- * from a Server Component would return that stale snapshot instead of the
- * middleware-modified view.
+ * The request header set is updated in place so an existing `headers()` view
+ * remains live across the override. `cookies()` intentionally stays a parsed
+ * snapshot, so its cached wrappers are invalidated when the Cookie header
+ * changes.
  */
 export function applyMiddlewareRequestHeaders(middlewareResponseHeaders: Headers): void {
   const state = _getState();
@@ -651,12 +642,8 @@ export function applyMiddlewareRequestHeaders(middlewareResponseHeaders: Headers
   if (!nextHeaders && middlewareSetCookieHeader === null) return;
 
   if (nextHeaders) {
-    ctx.headers = nextHeaders;
-    // Invalidate any sealed snapshot of the pre-override headers. A middleware
-    // that read `headers()` before returning the override (e.g. clerkMiddleware)
-    // would otherwise leak the pre-override view into the Server Component.
-    ctx.readonlyHeaders = undefined;
     const nextCookieHeader = nextHeaders.get("cookie");
+    replaceHeadersContents(ctx.headers, nextHeaders);
     if (previousCookieHeader !== nextCookieHeader) {
       rebuildCookiesFromHeader(ctx, nextCookieHeader);
       ctx.readonlyCookies = undefined;
@@ -670,8 +657,31 @@ export function applyMiddlewareRequestHeaders(middlewareResponseHeaders: Headers
   }
 }
 
+function replaceHeadersContents(target: Headers, source: Headers): void {
+  for (const name of Array.from(target.keys())) {
+    target.delete(name);
+  }
+
+  for (const [name, value] of source.entries()) {
+    if (name !== "set-cookie") {
+      target.set(name, value);
+    }
+  }
+
+  for (const setCookie of source.getSetCookie()) {
+    target.append("set-cookie", setCookie);
+  }
+}
+
 /** Methods on `Headers` that mutate state. Hoisted to module scope — static. */
 const _HEADERS_MUTATING_METHODS = new Set(["set", "delete", "append"]);
+
+/** Internal request headers that stay available to framework plumbing. */
+const _HIDDEN_REQUEST_HEADERS: ReadonlySet<string> = new Set(
+  [...FLIGHT_HEADERS, NEXT_REQUEST_ID_HEADER, NEXT_HTML_REQUEST_ID_HEADER].map((header) =>
+    header.toLowerCase(),
+  ),
+);
 
 class ReadonlyHeadersError extends Error {
   constructor() {
@@ -792,17 +802,87 @@ function _decorateSuspendingRequestApiPromise<T extends object>(
   });
 }
 
-function _sealHeaders(headers: Headers): Headers {
-  return new Proxy(headers, {
-    get(target, prop) {
+type SealedHeaderMethods = Pick<
+  Headers,
+  | "get"
+  | "has"
+  | "getSetCookie"
+  | "keys"
+  | "values"
+  | "entries"
+  | "forEach"
+  | typeof Symbol.iterator
+>;
+
+function _createHidingHeaderMethods(
+  target: Headers,
+  sealed: Headers,
+  isHidden: (name: string) => boolean,
+): SealedHeaderMethods {
+  function* entries(): HeadersIterator<[string, string]> {
+    for (const entry of target.entries()) {
+      if (!isHidden(entry[0])) {
+        yield entry;
+      }
+    }
+  }
+
+  return {
+    entries,
+    [Symbol.iterator]: entries,
+    get: (name) => (isHidden(name) ? null : target.get(name)),
+    has: (name) => (isHidden(name) ? false : target.has(name)),
+    getSetCookie: () => (isHidden("set-cookie") ? [] : target.getSetCookie()),
+    *keys(): HeadersIterator<string> {
+      for (const name of target.keys()) {
+        if (!isHidden(name)) {
+          yield name;
+        }
+      }
+    },
+    *values(): HeadersIterator<string> {
+      for (const [, value] of entries()) {
+        yield value;
+      }
+    },
+    forEach(callbackfn, thisArg) {
+      for (const [name, value] of entries()) {
+        callbackfn.call(thisArg, value, name, sealed);
+      }
+    },
+  };
+}
+
+function _sealHeaders(headers: Headers, hidden: ReadonlySet<string>): Headers {
+  const isHidden = (name: string): boolean => hidden.has(name.toLowerCase());
+  let methods: SealedHeaderMethods;
+
+  const sealed = new Proxy(headers, {
+    get(target, prop, receiver) {
       if (typeof prop === "string" && _HEADERS_MUTATING_METHODS.has(prop)) {
         throw new ReadonlyHeadersError();
       }
 
-      const value = Reflect.get(target, prop, target);
+      switch (prop) {
+        case Symbol.iterator:
+          return methods[Symbol.iterator];
+        case "get":
+        case "has":
+        case "getSetCookie":
+        case "keys":
+        case "values":
+        case "entries":
+        case "forEach":
+          return methods[prop];
+      }
+
+      const value = Reflect.get(target, prop, receiver);
       return typeof value === "function" ? value.bind(target) : value;
     },
   }) as Headers;
+
+  methods = _createHidingHeaderMethods(headers, sealed, isHidden);
+  return sealed;
 }
 
 function _wrapMutableCookies(cookies: RequestCookies): RequestCookies {
@@ -850,8 +930,10 @@ function _getMutableCookies(ctx: HeadersContext): RequestCookies {
 
 function _getReadonlyCookies(ctx: HeadersContext): RequestCookies {
   if (!ctx.readonlyCookies) {
-    // Keep a separate readonly wrapper so render-path reads avoid the
-    // mutable phase-checking proxy while still reflecting the shared cookie map.
+    // Middleware replaces the parsed cookie map rather than mutating it, so an
+    // existing RequestCookies keeps its snapshot while a subsequent call sees
+    // the new map. Server Action synchronization still updates this map in
+    // place, matching Next.js's phase-aware mutable-cookie behavior.
     ctx.readonlyCookies = _sealCookies(new RequestCookies(ctx.cookies));
   }
 
@@ -860,13 +942,7 @@ function _getReadonlyCookies(ctx: HeadersContext): RequestCookies {
 
 function _getReadonlyHeaders(ctx: HeadersContext): Headers {
   if (!ctx.readonlyHeaders) {
-    const cleaned = new Headers(ctx.headers);
-    for (const header of FLIGHT_HEADERS) {
-      cleaned.delete(header);
-    }
-    cleaned.delete(NEXT_REQUEST_ID_HEADER);
-    cleaned.delete(NEXT_HTML_REQUEST_ID_HEADER);
-    ctx.readonlyHeaders = _sealHeaders(cleaned);
+    ctx.readonlyHeaders = _sealHeaders(ctx.headers, _HIDDEN_REQUEST_HEADERS);
   }
 
   return ctx.readonlyHeaders;
@@ -946,6 +1022,9 @@ export function headersContextFromRequest(
     headers: headersProxy,
     get cookies(): Map<string, string> {
       return getCookies();
+    },
+    set cookies(value: Map<string, string>) {
+      _cookies = value;
     },
     draftModeSecret: options?.draftModeSecret,
   } satisfies HeadersContext;

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -3694,6 +3694,118 @@ describe("next/headers shim", () => {
     setHeadersContext(null);
   });
 
+  it("headers() stays a live view while hiding internal headers from every read", async () => {
+    // Ported from Next.js:
+    // test/e2e/app-dir/proxy-headers-live-view/
+    // packages/next/src/server/web/spec-extension/adapters/headers.test.ts
+    // https://github.com/vercel/next.js/blob/3c97df56ead9d1df81b36f891ba5ac0724c4eec0/test/e2e/app-dir/proxy-headers-live-view/proxy.ts
+    // https://github.com/vercel/next.js/blob/3c97df56ead9d1df81b36f891ba5ac0724c4eec0/packages/next/src/server/web/spec-extension/adapters/headers.test.ts
+    const { setHeadersContext, headers } = await import("../packages/vinext/src/shims/headers.js");
+    const reqHeaders = new Headers({
+      "content-type": "application/json",
+      rsc: "before",
+      "x-custom": "original",
+      "x-nextjs-request-id": "before",
+    });
+    setHeadersContext({
+      headers: reqHeaders,
+      cookies: new Map(),
+    });
+
+    try {
+      const firstPromise = headers();
+      const firstView = await firstPromise;
+      expect(firstView.get("x-added-after-first-read")).toBeNull();
+
+      reqHeaders.set("x-added-after-first-read", "live");
+      reqHeaders.delete("x-custom");
+      reqHeaders.set("rsc", "after");
+      reqHeaders.set("x-nextjs-request-id", "after");
+      reqHeaders.set("x-nextjs-html-request-id", "after");
+
+      const secondPromise = headers();
+      const secondView = await secondPromise;
+
+      expect(secondPromise).toBe(firstPromise);
+      expect(secondView).toBe(firstView);
+      expect(firstView.get("x-added-after-first-read")).toBe("live");
+      expect(firstView.get("x-custom")).toBeNull();
+
+      expect(reqHeaders.get("rsc")).toBe("after");
+      expect(reqHeaders.get("x-nextjs-request-id")).toBe("after");
+      expect(reqHeaders.get("x-nextjs-html-request-id")).toBe("after");
+      expect(firstView.get("rsc")).toBeNull();
+      expect(firstView.get("RSC")).toBeNull();
+      expect(firstView.get("x-nextjs-request-id")).toBeNull();
+      expect(firstView.get("x-nextjs-html-request-id")).toBeNull();
+      expect(firstView.has("rsc")).toBe(false);
+      expect(firstView.has("x-nextjs-request-id")).toBe(false);
+      expect(firstView.has("x-nextjs-html-request-id")).toBe(false);
+
+      const visibleEntries = [
+        ["content-type", "application/json"],
+        ["x-added-after-first-read", "live"],
+      ];
+      expect([...firstView.entries()]).toEqual(visibleEntries);
+      expect([...firstView]).toEqual(visibleEntries);
+      expect([...firstView.keys()]).toEqual(visibleEntries.map(([name]) => name));
+      expect([...firstView.values()]).toEqual(visibleEntries.map(([, value]) => value));
+
+      const seen: string[] = [];
+      firstView.forEach((value, name) => {
+        seen.push(`${name}=${value}`);
+      });
+      expect(seen).toEqual(visibleEntries.map(([name, value]) => `${name}=${value}`));
+      expect(Object.fromEntries(firstView)).toEqual({
+        "content-type": "application/json",
+        "x-added-after-first-read": "live",
+      });
+      expect([...new Headers(firstView).keys()]).toEqual(visibleEntries.map(([name]) => name));
+    } finally {
+      setHeadersContext(null);
+    }
+  });
+
+  it("headers() exposes stable methods and passes the sealed view to forEach", async () => {
+    // Ported from Next.js:
+    // packages/next/src/server/web/spec-extension/adapters/headers.test.ts
+    // https://github.com/vercel/next.js/blob/3c97df56ead9d1df81b36f891ba5ac0724c4eec0/packages/next/src/server/web/spec-extension/adapters/headers.test.ts
+    const { setHeadersContext, headers } = await import("../packages/vinext/src/shims/headers.js");
+    const reqHeaders = new Headers({ "content-type": "application/json" });
+    setHeadersContext({
+      headers: reqHeaders,
+      cookies: new Map(),
+    });
+
+    try {
+      const sealed = await headers();
+      for (const method of [
+        "get",
+        "has",
+        "getSetCookie",
+        "keys",
+        "values",
+        "entries",
+        "forEach",
+        Symbol.iterator,
+      ]) {
+        expect(Reflect.get(sealed, method)).toBe(Reflect.get(sealed, method));
+      }
+
+      const parents: Headers[] = [];
+      sealed.forEach((_value, _name, parent) => {
+        parents.push(parent);
+      });
+
+      expect(parents).toHaveLength(1);
+      expect(parents[0]).toBe(sealed);
+      expect(() => parents[0].set("x-escaped", "yes")).toThrow(/Headers cannot be modified/);
+      expect(reqHeaders.get("x-escaped")).toBeNull();
+    } finally {
+      setHeadersContext(null);
+    }
+  });
+
   it("headers() supports the legacy sync access pattern", async () => {
     // Next.js docs: headers() temporarily supports sync property access in v15.
     const { setHeadersContext, headers } = await import("../packages/vinext/src/shims/headers.js");
@@ -12169,14 +12281,11 @@ describe("middleware request header overrides", () => {
     });
   });
 
-  it("next/headers applyMiddlewareRequestHeaders invalidates headers() snapshot taken before the override", async () => {
-    // Regression: a middleware that reads `headers()` (or `cookies()`) before
-    // applying a request-header override would prime a sealed read-only
-    // snapshot built from the *pre*-override request. Discovered with
-    // @clerk/nextjs whose `clerkClient()` reads `headers()` via
-    // `buildRequestLike()` during middleware execution; before the fix, the
-    // Server Component subsequently received the stale snapshot and saw the
-    // pre-override credentials and missing middleware-injected headers.
+  it("next/headers applyMiddlewareRequestHeaders updates the existing live headers() view", async () => {
+    // Next.js keeps headers() live across Proxy/middleware writes while
+    // cookies() remains a parsed snapshot.
+    // Ported from Next.js: test/e2e/app-dir/proxy-headers-live-view/
+    // https://github.com/vercel/next.js/blob/3c97df56ead9d1df81b36f891ba5ac0724c4eec0/test/e2e/app-dir/proxy-headers-live-view/proxy.ts
     const {
       applyMiddlewareRequestHeaders,
       cookies,
@@ -12194,8 +12303,7 @@ describe("middleware request header overrides", () => {
     });
 
     await runWithHeadersContext(headersContextFromRequest(request), async () => {
-      // 1. Prime the sealed snapshot — this is exactly what
-      //    `clerkMiddleware()` does internally via `buildRequestLike()`.
+      // 1. Obtain the request views before middleware applies its override.
       const preHeadersPromise = headers();
       const preCookiesPromise = cookies();
       const preHeaders = await preHeadersPromise;
@@ -12217,20 +12325,29 @@ describe("middleware request header overrides", () => {
         }),
       );
 
-      // 3. A subsequent `headers()` call — for example from the Server
-      //    Component's render — must observe the override, not the snapshot
-      //    captured in step 1.
+      // 3. Both the existing and subsequent headers() reads must observe the
+      //    override through the same live view. cookies() intentionally keeps
+      //    its snapshot behavior.
       const postHeadersPromise = headers();
       const postCookiesPromise = cookies();
       const postHeaders = await postHeadersPromise;
       const postCookies = await postCookiesPromise;
 
-      expect(postHeadersPromise).not.toBe(preHeadersPromise);
+      expect(postHeadersPromise).toBe(preHeadersPromise);
+      expect(postHeaders).toBe(preHeaders);
       expect(postCookiesPromise).not.toBe(preCookiesPromise);
+      expect(preHeaders.get("authorization")).toBeNull();
+      expect(preHeaders.get("cookie")).toBeNull();
+      expect(preHeaders.get("x-keep")).toBe("updated");
+      expect(preHeaders.get("x-added")).toBe("1");
       expect(postHeaders.get("authorization")).toBeNull();
       expect(postHeaders.get("cookie")).toBeNull();
       expect(postHeaders.get("x-keep")).toBe("updated");
       expect(postHeaders.get("x-added")).toBe("1");
+      expect(preCookies.getAll()).toEqual([
+        { name: "a", value: "1" },
+        { name: "b", value: "2" },
+      ]);
       expect(postCookies.getAll()).toEqual([]);
     });
   });


### PR DESCRIPTION
Closes #2908. Ports https://github.com/vercel/next.js/pull/97166 (https://github.com/vercel/next.js/commit/3c97df56ead9d1df81b36f891ba5ac0724c4eec0)

## Overview

Next.js restored `headers()` as a live, read-only view of the incoming request after a regression made it a detached snapshot. The snapshot caused ordering-dependent behavior: headers written by Proxy or middleware after the first `headers()` call were visible on `request.headers` but not through `headers()`.

This PR aligns vinext with the restored nextjs semantics. Request header mutations remain observable through the same `headers()` view, framework-internal headers remain unavailable to userland, and `cookies()` retains its snapshot behavior.

## What changed

- No longer making a cleaned copy of the original Headers. Instead, return the sealed one.

```diff
function _getReadonlyHeaders(ctx: HeadersContext): Headers {
  if (!ctx.readonlyHeaders) {
-   const cleaned = new Headers(ctx.headers);
-   for (const header of FLIGHT_HEADERS) {
-     cleaned.delete(header);
-   }
-   cleaned.delete(NEXT_REQUEST_ID_HEADER);
-   cleaned.delete(NEXT_HTML_REQUEST_ID_HEADER);
-   ctx.readonlyHeaders = _sealHeaders(cleaned);
+   ctx.readonlyHeaders = _sealHeaders(ctx.headers, ...);
  }

  return ctx.readonlyHeaders;
}
```

- `_sealHeaders()` and `_createHidingHeaderMethods()`: Wrap the original Headers, and proxy each method of it to dynamically hide the internal headers.

- `applyMiddlewareRequestHeaders()`:
  - **Before:** Directly set the `ctx.headers` to the upcoming new headers reference. So the old values still hold the old reference, not updated.
  - **After:** Use the new `replaceHeadersContents()` to loop through the upcoming headers and do updates on the original `ctx.headers`.

- For cookies (`rebuildCookiesFromHeader()` and `mergeMiddlewareSetCookies()`):
  - **Before:** Loop through the upcoming cookies and do updates on the original `ctx.cookies`, merging old cookies and new cookies.
  - **After:** Directly set the `ctx.cookies` to the upcoming new cookies reference. So the old values still retain the old, not-updated reference, which aligns with the upstream nextjs's behavior.

`headers()` returns a live view of the real headers, dynamically proxied to hide the internal headers, while `cookies()` still returns a readonly copy of the real cookies.

## Testing

- `pnpm test tests/shims.test.ts`