### PR TITLE
fix(cache): compare tag revalidation timestamps

### DIFF
--- a/packages/cloudflare/src/cache/kv-data-adapter.runtime.ts
+++ b/packages/cloudflare/src/cache/kv-data-adapter.runtime.ts
@@ -298,13 +298,28 @@ export class KVCacheHandler implements CacheHandler {
     const entryTags = validUniqueTags(entry.tags);
     const requestStartTime = _ctx?.requestStartTime;
     const forwardedTags = new Set(_ctx?.revalidatedTags ?? []);
+    const matchedForwardedTags = entryTags.filter((tag) => forwardedTags.has(tag));
     if (
       typeof requestStartTime === "number" &&
       Number.isFinite(requestStartTime) &&
       entry.lastModified <= requestStartTime &&
-      entryTags.some((tag) => forwardedTags.has(tag))
+      matchedForwardedTags.length > 0
     ) {
-      this._deleteInBackground(kvKey);
+      // Keep the authenticated invalidation visible after this redirected
+      // request. Otherwise a cached null/older marker from #3187's shared
+      // tag cache could admit the same stale KV value on the next request.
+      // Do not delete the entry: this read may itself be a stale colo-cached
+      // value, and an unconditional delete could remove a newer central write.
+      const order = ++this._tagCacheOrder;
+      const fetchedAt = Date.now();
+      for (const tag of matchedForwardedTags) {
+        const current = this._tagCache.get(tag);
+        const timestamp =
+          current && (Number.isNaN(current.timestamp) || current.timestamp > requestStartTime)
+            ? current.timestamp
+            : requestStartTime;
+        this._tagCache.set(tag, { timestamp, fetchedAt, order });
+      }
       return null;
     }
 

--- a/packages/cloudflare/src/cache/kv-data-adapter.runtime.ts
+++ b/packages/cloudflare/src/cache/kv-data-adapter.runtime.ts
@@ -29,6 +29,7 @@ import type {
   CachedImageValue,
   IncrementalCacheValue,
 } from "vinext/shims/cache";
+import { getCacheTimestamp } from "vinext/shims/cache";
 import {
   getRequestExecutionContext,
   type ExecutionContextLike,
@@ -470,7 +471,7 @@ export class KVCacheHandler implements CacheHandler {
     }
     if (effectiveRevalidate === 0) return Promise.resolve();
 
-    const now = Date.now();
+    const now = getCacheTimestamp();
     const revalidateAt =
       typeof effectiveRevalidate === "number" && effectiveRevalidate > 0
         ? now + effectiveRevalidate * 1000
@@ -533,7 +534,7 @@ export class KVCacheHandler implements CacheHandler {
 
   async revalidateTag(tags: string | string[], _durations?: { expire?: number }): Promise<void> {
     const tagList = Array.isArray(tags) ? tags : [tags];
-    const now = Date.now();
+    const now = getCacheTimestamp();
     const validTags = tagList.filter((t) => validateTag(t) !== null);
     // Store invalidation timestamp for each tag
     // Use a long TTL (30 days) so recent invalidations are always found

--- a/packages/cloudflare/src/cache/kv-data-adapter.runtime.ts
+++ b/packages/cloudflare/src/cache/kv-data-adapter.runtime.ts
@@ -243,7 +243,7 @@ export class KVCacheHandler implements CacheHandler {
     return this.keySpace.tagKey(tag);
   }
 
-  async get(key: string, _ctx?: Record<string, unknown>): Promise<CacheHandlerValue | null> {
+  async get(key: string, _ctx?: CacheHandlerContext): Promise<CacheHandlerValue | null> {
     const kvKey = this._entryKey(key);
     const softTags = validUniqueTags(readStringArrayField(_ctx, "softTags"));
     // Soft tags are known before the entry arrives, so their markers ride the
@@ -296,6 +296,17 @@ export class KVCacheHandler implements CacheHandler {
     }
 
     const entryTags = validUniqueTags(entry.tags);
+    const requestStartTime = _ctx?.requestStartTime;
+    const forwardedTags = new Set(_ctx?.revalidatedTags ?? []);
+    if (
+      typeof requestStartTime === "number" &&
+      Number.isFinite(requestStartTime) &&
+      entry.lastModified <= requestStartTime &&
+      entryTags.some((tag) => forwardedTags.has(tag))
+    ) {
+      this._deleteInBackground(kvKey);
+      return null;
+    }
 
     // A marker an earlier read already cached settles the entry on its own, so
     // check before awaiting reads whose failure would otherwise mask it.

--- a/packages/cloudflare/src/cache/kv-data-adapter.runtime.ts
+++ b/packages/cloudflare/src/cache/kv-data-adapter.runtime.ts
@@ -29,7 +29,11 @@ import type {
   CachedImageValue,
   IncrementalCacheValue,
 } from "vinext/shims/cache";
-import { getCacheTimestamp } from "vinext/shims/cache";
+import {
+  getCacheTimestamp,
+  getCacheTimestampFromContext,
+  type CacheHandlerContext,
+} from "vinext/shims/cache-handler";
 import {
   getRequestExecutionContext,
   type ExecutionContextLike,
@@ -443,11 +447,7 @@ export class KVCacheHandler implements CacheHandler {
     return false;
   }
 
-  set(
-    key: string,
-    data: IncrementalCacheValue | null,
-    ctx?: Record<string, unknown>,
-  ): Promise<void> {
+  set(key: string, data: IncrementalCacheValue | null, ctx?: CacheHandlerContext): Promise<void> {
     // Collect, validate, and dedupe tags from data and context
     const tagSet = new Set<string>();
     if (data && "tags" in data && Array.isArray(data.tags)) {
@@ -476,7 +476,9 @@ export class KVCacheHandler implements CacheHandler {
     }
     if (effectiveRevalidate === 0) return Promise.resolve();
 
-    const lastModified = getCacheTimestamp();
+    // Preserve the producer's pre-fill timestamp. Falling back here retains
+    // compatibility with direct and older callers that do not provide one.
+    const lastModified = getCacheTimestampFromContext(ctx);
     const writtenAt = Date.now();
     const revalidateAt =
       typeof effectiveRevalidate === "number" && effectiveRevalidate > 0

--- a/packages/cloudflare/src/cache/kv-data-adapter.runtime.ts
+++ b/packages/cloudflare/src/cache/kv-data-adapter.runtime.ts
@@ -174,6 +174,20 @@ function isPathChildOf(path: string, prefix: string): boolean {
   return path.startsWith(prefix + "/");
 }
 
+type TagCacheEntry = {
+  timestamp: number;
+  fetchedAt: number;
+  /** Monotonic order of local cache updates. */
+  order: number;
+  /** Forwarded markers use an inclusive boundary and must not delete KV entries. */
+  forwarded: boolean;
+};
+
+type TagInvalidation = {
+  invalidated: boolean;
+  destructive: boolean;
+};
+
 /**
  * Cloudflare KV data cache handler.
  *
@@ -202,7 +216,7 @@ export class KVCacheHandler implements CacheHandler {
   private ttlSeconds: number;
 
   /** Local in-memory cache for tag invalidation timestamps. Avoids redundant KV reads. */
-  private _tagCache = new Map<string, { timestamp: number; fetchedAt: number; order: number }>();
+  private _tagCache = new Map<string, TagCacheEntry>();
   /** Monotonic ordering for concurrent tag-cache fills and local invalidations. */
   private _tagCacheOrder = 0;
   /** TTL (ms) for local tag cache entries. After this, re-fetch from KV. */
@@ -314,19 +328,23 @@ export class KVCacheHandler implements CacheHandler {
       const fetchedAt = Date.now();
       for (const tag of matchedForwardedTags) {
         const current = this._tagCache.get(tag);
-        const timestamp =
-          current && (Number.isNaN(current.timestamp) || current.timestamp > requestStartTime)
-            ? current.timestamp
-            : requestStartTime;
-        this._tagCache.set(tag, { timestamp, fetchedAt, order });
+        const preserveCurrent =
+          current && (Number.isNaN(current.timestamp) || current.timestamp > requestStartTime);
+        this._tagCache.set(tag, {
+          timestamp: preserveCurrent ? current.timestamp : requestStartTime,
+          fetchedAt,
+          order,
+          forwarded: preserveCurrent ? current.forwarded : true,
+        });
       }
       return null;
     }
 
     // A marker an earlier read already cached settles the entry on its own, so
     // check before awaiting reads whose failure would otherwise mask it.
-    if (this._hasRevalidatedTag(entryTags, entry.lastModified, true)) {
-      this._deleteEntryReadInBackground(kvKey);
+    const cachedInvalidation = this._getTagInvalidation(entryTags, entry.lastModified, true);
+    if (cachedInvalidation.invalidated) {
+      if (cachedInvalidation.destructive) this._deleteEntryReadInBackground(kvKey);
       return null;
     }
 
@@ -340,8 +358,8 @@ export class KVCacheHandler implements CacheHandler {
 
     // The soft-tag batch may have covered an entry tag too, which spares the
     // second hop. Only the post-prime check trusts an entry past its TTL.
-    let invalidated = this._hasRevalidatedTag(entryTags, entry.lastModified, true);
-    if (!invalidated) {
+    let invalidation = this._getTagInvalidation(entryTags, entry.lastModified, true);
+    if (!invalidation.invalidated) {
       await this._primeTagCache(entryTags);
       // The entry-tag hop can race a reset too. Re-prime the complete
       // validation set until one cache generation survives the whole read.
@@ -349,14 +367,14 @@ export class KVCacheHandler implements CacheHandler {
         softTagCache = this._tagCache;
         await this._primeTagCache([...new Set([...softTags, ...entryTags])]);
       }
-      invalidated = this._hasRevalidatedTag(entryTags, entry.lastModified);
+      invalidation = this._getTagInvalidation(entryTags, entry.lastModified);
     }
-    if (invalidated) {
-      this._deleteEntryReadInBackground(kvKey);
+    if (invalidation.invalidated) {
+      if (invalidation.destructive) this._deleteEntryReadInBackground(kvKey);
       return null;
     }
 
-    if (this._hasRevalidatedTag(softTags, entry.lastModified)) {
+    if (this._getTagInvalidation(softTags, entry.lastModified).invalidated) {
       return null;
     }
 
@@ -423,7 +441,12 @@ export class KVCacheHandler implements CacheHandler {
       const current = tagCache.get(tag);
       if (current && current.order >= order) continue;
       const marker = markers.get(this._tagKey(tag));
-      tagCache.set(tag, { timestamp: marker ? Number(marker) : 0, fetchedAt: now, order });
+      tagCache.set(tag, {
+        timestamp: marker ? Number(marker) : 0,
+        fetchedAt: now,
+        order,
+        forwarded: false,
+      });
     }
   }
 
@@ -460,17 +483,27 @@ export class KVCacheHandler implements CacheHandler {
    * counts as never invalidated. Pass `requireFresh` to call it before a prime,
    * so an entry past `tagCacheTtlMs` does not answer for a tag it never re-read.
    */
-  private _hasRevalidatedTag(tags: string[], lastModified: number, requireFresh = false): boolean {
+  private _getTagInvalidation(
+    tags: string[],
+    lastModified: number,
+    requireFresh = false,
+  ): TagInvalidation {
     const now = requireFresh ? Date.now() : 0;
+    let invalidated = false;
+    let destructive = false;
     for (const tag of tags) {
       const cached = this._tagCache.get(tag);
-      if (!cached || cached.timestamp === 0) continue;
+      if (!cached || (cached.timestamp === 0 && !cached.forwarded)) continue;
       if (requireFresh && now - cached.fetchedAt >= this._tagCacheTtl) continue;
-      if (Number.isNaN(cached.timestamp) || cached.timestamp >= lastModified) {
-        return true;
+      if (
+        Number.isNaN(cached.timestamp) ||
+        (cached.forwarded ? cached.timestamp >= lastModified : cached.timestamp > lastModified)
+      ) {
+        invalidated = true;
+        destructive ||= !cached.forwarded;
       }
     }
-    return false;
+    return { invalidated, destructive };
   }
 
   set(key: string, data: IncrementalCacheValue | null, ctx?: CacheHandlerContext): Promise<void> {
@@ -584,7 +617,7 @@ export class KVCacheHandler implements CacheHandler {
     // Update local tag cache immediately so invalidations are reflected
     // without waiting for the TTL to expire
     for (const tag of validTags) {
-      this._tagCache.set(tag, { timestamp: now, fetchedAt: now, order });
+      this._tagCache.set(tag, { timestamp: now, fetchedAt: now, order, forwarded: false });
     }
   }
 

--- a/packages/cloudflare/src/cache/kv-data-adapter.runtime.ts
+++ b/packages/cloudflare/src/cache/kv-data-adapter.runtime.ts
@@ -92,6 +92,8 @@ type KVCacheEntry = {
   value: SerializedIncrementalCacheValue | null;
   tags: string[];
   lastModified: number;
+  /** Wall-clock write time used for duration-based cache policy. */
+  writtenAt?: number;
   /** Absolute timestamp (ms) after which the entry is "stale" (but still served). */
   revalidateAt: number | null;
   /** Absolute timestamp (ms) after which the entry must block on fresh render. */
@@ -336,8 +338,11 @@ export class KVCacheHandler implements CacheHandler {
     // Check time-based revalidation — return stale with cacheState.
     const now = Date.now();
     const requestedRevalidate = readPositiveNumberField(_ctx, "revalidate");
+    // Entries written before `writtenAt` was introduced used an epoch-based
+    // `lastModified`, so it remains a compatible fallback for persisted data.
+    const writtenAt = entry.writtenAt ?? entry.lastModified;
     const requestedRevalidateAt =
-      requestedRevalidate === undefined ? null : entry.lastModified + requestedRevalidate * 1000;
+      requestedRevalidate === undefined ? null : writtenAt + requestedRevalidate * 1000;
     const isStale =
       (entry.revalidateAt !== null && now > entry.revalidateAt) ||
       (requestedRevalidateAt !== null && now > requestedRevalidateAt);
@@ -471,14 +476,15 @@ export class KVCacheHandler implements CacheHandler {
     }
     if (effectiveRevalidate === 0) return Promise.resolve();
 
-    const now = getCacheTimestamp();
+    const lastModified = getCacheTimestamp();
+    const writtenAt = Date.now();
     const revalidateAt =
       typeof effectiveRevalidate === "number" && effectiveRevalidate > 0
-        ? now + effectiveRevalidate * 1000
+        ? writtenAt + effectiveRevalidate * 1000
         : null;
     const expireAt =
       typeof effectiveExpire === "number" && effectiveExpire > 0
-        ? now + effectiveExpire * 1000
+        ? writtenAt + effectiveExpire * 1000
         : null;
     const cacheControl: CacheControlMetadata | undefined =
       typeof effectiveRevalidate === "number"
@@ -497,7 +503,8 @@ export class KVCacheHandler implements CacheHandler {
     const entry: KVCacheEntry = {
       value: serializable,
       tags,
-      lastModified: now,
+      lastModified,
+      writtenAt,
       revalidateAt,
       expireAt,
       cacheControl,
@@ -678,6 +685,7 @@ function validateCacheEntry(raw: unknown): KVCacheEntry | null {
 
   // Required fields
   if (typeof obj.lastModified !== "number") return null;
+  if (obj.writtenAt !== undefined && typeof obj.writtenAt !== "number") return null;
   if (!Array.isArray(obj.tags)) return null;
   if (obj.revalidateAt !== null && typeof obj.revalidateAt !== "number") return null;
   if (obj.expireAt !== undefined && obj.expireAt !== null && typeof obj.expireAt !== "number") {

--- a/packages/vinext/src/server/app-page-cache-finalizer.ts
+++ b/packages/vinext/src/server/app-page-cache-finalizer.ts
@@ -75,6 +75,8 @@ type FinalizeAppPageHtmlCacheResponseOptions = {
   preserveClientResponseHeaders?: boolean;
   expireSeconds?: number;
   revalidateSeconds: number | null;
+  /** Render-start timestamp supplied by the page renderer. */
+  timestamp?: number;
   linkHeader: string | null;
   waitUntil?: (promise: Promise<void>) => void;
 };
@@ -100,6 +102,8 @@ type ScheduleAppPageRscCacheWriteOptions = {
   preserveClientResponseHeaders?: boolean;
   expireSeconds?: number;
   revalidateSeconds: number | null;
+  /** Render-start timestamp supplied by the page renderer. */
+  timestamp?: number;
   waitUntil?: (promise: Promise<void>) => void;
 };
 
@@ -329,7 +333,7 @@ export function finalizeAppPageHtmlCacheResponse(
             htmlRenderObservation,
             linkHeader ? { link: linkHeader } : undefined,
           ),
-          { cacheControl, tags: pageTags },
+          { cacheControl, tags: pageTags, timestamp: options.timestamp },
         ),
       ];
 
@@ -339,6 +343,7 @@ export function finalizeAppPageHtmlCacheResponse(
             options.isrSet(rscKey, buildAppPageCacheValue("", rscData, 200, rscRenderObservation), {
               cacheControl,
               tags: pageTags,
+              timestamp: options.timestamp,
             }),
           ),
         );
@@ -452,6 +457,7 @@ export function scheduleAppPageRscCacheWrite(
       await options.isrSet(rscKey, buildAppPageCacheValue("", rscData, 200, rscRenderObservation), {
         cacheControl,
         tags: pageTags,
+        timestamp: options.timestamp,
       });
       options.isrDebug?.("RSC cache written", rscKey);
     } catch (cacheError) {

--- a/packages/vinext/src/server/app-page-cache.ts
+++ b/packages/vinext/src/server/app-page-cache.ts
@@ -1,4 +1,5 @@
 import type { CachedAppPageValue, CacheControlMetadata } from "vinext/shims/cache-handler";
+import { getCacheTimestamp } from "vinext/shims/cache-handler";
 import {
   VINEXT_RSC_CONTENT_TYPE,
   VINEXT_RSC_VARY_HEADER,
@@ -464,6 +465,7 @@ export async function readAppPageCacheResponse(
       // above (the RSC variant when `isRscRequest`, the HTML key otherwise), so
       // reuse it instead of recomputing the hash.
       options.scheduleBackgroundRegeneration(isrKey, async () => {
+        const fillStartedAt = getCacheTimestamp();
         const revalidatedPage = await options.renderFreshPageForCache();
         const cacheControl = resolveRegeneratedAppPageCacheControl({
           expireSeconds: options.expireSeconds,
@@ -490,7 +492,7 @@ export async function readAppPageCacheResponse(
               200,
               revalidatedPage.rscRenderObservation,
             ),
-            { cacheControl, tags: revalidatedPage.tags },
+            { cacheControl, tags: revalidatedPage.tags, timestamp: fillStartedAt },
           ),
         ];
 
@@ -509,7 +511,7 @@ export async function readAppPageCacheResponse(
                 revalidatedPage.htmlRenderObservation,
                 revalidatedPage.linkHeader ? { link: revalidatedPage.linkHeader } : undefined,
               ),
-              { cacheControl, tags: revalidatedPage.tags },
+              { cacheControl, tags: revalidatedPage.tags, timestamp: fillStartedAt },
             ),
           );
         }

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import type { ReactFormState } from "react-dom/client";
 import type { NavigationContext } from "vinext/shims/navigation";
+import { getCacheTimestamp } from "vinext/shims/cache-handler";
 import type { AppPageCacheSetter } from "./isr-cache.js";
 import type { RootParams } from "vinext/shims/root-params";
 import { runWithFetchDedupe } from "vinext/shims/fetch-cache";
@@ -632,6 +633,7 @@ function wrapRscResponseForDevErrorReporting(
 export async function renderAppPageLifecycle(
   options: RenderAppPageLifecycleOptions,
 ): Promise<Response> {
+  const fillStartedAt = getCacheTimestamp();
   // Request dynamic state is consumptive, but both cache finalization and the
   // streamed client completion marker need the final answer. Keep the first
   // positive observation for this render so whichever branch drains first
@@ -978,6 +980,7 @@ export async function renderAppPageLifecycle(
         isForceStatic: options.isForceStatic,
         revalidateSeconds,
       }),
+      timestamp: fillStartedAt,
       waitUntil(promise) {
         options.waitUntil?.(promise);
       },
@@ -1291,6 +1294,7 @@ export async function renderAppPageLifecycle(
         isForceStatic: options.isForceStatic,
         revalidateSeconds,
       }),
+      timestamp: fillStartedAt,
       linkHeader: linkHeader ?? null,
       waitUntil(cachePromise) {
         options.waitUntil?.(cachePromise);

--- a/packages/vinext/src/server/app-route-handler-cache.ts
+++ b/packages/vinext/src/server/app-route-handler-cache.ts
@@ -1,4 +1,5 @@
 import type { NextI18nConfig } from "../config/next-config.js";
+import { getCacheTimestamp } from "vinext/shims/cache-handler";
 import type { HeadersAccessPhase } from "vinext/shims/headers";
 import { isrCacheControl, type ISRCacheEntry } from "./isr-cache.js";
 import type { RouteHandlerMiddlewareContext } from "./app-route-handler-response.js";
@@ -108,6 +109,7 @@ export async function readAppRouteHandlerCacheResponse(
 
       options.scheduleBackgroundRegeneration(routeKey, async () => {
         await options.runInRevalidationContext(async () => {
+          const fillStartedAt = getCacheTimestamp();
           options.setNavigationContext({
             pathname: options.cleanPathname,
             searchParams: revalidateSearchParams,
@@ -147,6 +149,7 @@ export async function readAppRouteHandlerCacheResponse(
               expireSeconds: options.expireSeconds,
             }),
             tags: routeTags,
+            timestamp: fillStartedAt,
           });
           options.isrDebug?.("route regen complete", routeKey);
         });

--- a/packages/vinext/src/server/app-route-handler-execution.ts
+++ b/packages/vinext/src/server/app-route-handler-execution.ts
@@ -5,7 +5,7 @@ import {
   type HeadersAccessPhase,
 } from "vinext/shims/headers";
 import type { ExecutionContextLike } from "vinext/shims/request-context";
-import type { CachedRouteValue } from "vinext/shims/cache-handler";
+import { getCacheTimestamp, type CachedRouteValue } from "vinext/shims/cache-handler";
 import type { NextRequest } from "vinext/shims/server";
 import { _drainPendingRevalidations } from "vinext/shims/cache-request-state";
 import { runWithRootParamsUsage } from "vinext/shims/root-params";
@@ -298,6 +298,7 @@ export async function runAppRouteHandler(
 export async function executeAppRouteHandler(
   options: ExecuteAppRouteHandlerOptions,
 ): Promise<Response> {
+  const fillStartedAt = getCacheTimestamp();
   const previousHeadersPhase = options.setHeadersAccessPhase("route-handler");
   let cleanupDeferredToBody = false;
   const middlewareMergeOptions = {
@@ -436,6 +437,7 @@ export async function executeAppRouteHandler(
               expireSeconds: options.expireSeconds,
             }),
             tags: routeTags,
+            timestamp: fillStartedAt,
           });
           options.isrDebug?.("route cache written", routeKey);
         } catch (cacheErr) {

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -22,6 +22,8 @@ import {
   ACTION_REVALIDATED_HEADER,
   FLIGHT_HEADERS,
   NEXT_ACTION_HEADER,
+  NEXT_CACHE_REVALIDATED_TAGS_HEADER,
+  NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER,
   RSC_ACTION_HEADER,
   RSC_HEADER,
   VINEXT_MW_CTX_HEADER,
@@ -37,6 +39,7 @@ import {
   VINEXT_INTERCEPTION_CONTEXT_HEADER,
   VINEXT_INTERCEPTION_ID_HEADER,
 } from "./headers.js";
+import { getCacheTimestamp } from "vinext/shims/cache";
 import type { ReactFormState } from "react-dom/client";
 import {
   getRequestExecutionContext,
@@ -97,6 +100,7 @@ import {
 } from "./image-optimization.js";
 import { runWithPrerenderWorkUnit } from "./prerender-work-unit-setup.js";
 import { buildPostMwRequestContext } from "./app-post-middleware-context.js";
+import { readPreviouslyRevalidatedTags } from "./revalidated-tags.js";
 import type { AppRscRenderMode } from "./app-rsc-render-mode.js";
 import type { AppPagePprFallbackCacheShell } from "./app-ppr-fallback-shell.js";
 import type { ClientReuseManifestParseResult } from "./client-reuse-manifest.js";
@@ -2367,6 +2371,7 @@ export function createAppRscRequestHandler<TRoute extends AppRscHandlerRoute>(
     responseStageProbeMode: VinextCacheabilityProbeMode | null = null,
     transportedPrerenderState?: TrustedPrerenderState | null,
   ): Promise<Response> {
+    const requestStartTime = getCacheTimestamp();
     // Register config-driven cache adapters before anything touches the cache.
     // On the Cloudflare worker the entry already registered them with `env` (this
     // guarded call is a no-op); on Node/dev this is where they get wired, with no
@@ -2387,6 +2392,10 @@ export function createAppRscRequestHandler<TRoute extends AppRscHandlerRoute>(
     // visible to .get() but lost when filterInternalHeaders iterates. Read it
     // BEFORE iterating so applyForwardedMiddlewareContext can skip middleware.
     const mwCtx = rawRequest.headers.get(VINEXT_MW_CTX_HEADER);
+    const previouslyRevalidatedTags = readPreviouslyRevalidatedTags(
+      rawRequest.headers,
+      options.draftModeSecret,
+    );
     const pagesDataUrl = new URL(rawRequest.url);
     const pagesDataInScope =
       !options.basePath || hasBasePath(pagesDataUrl.pathname, options.basePath);
@@ -2438,6 +2447,10 @@ export function createAppRscRequestHandler<TRoute extends AppRscHandlerRoute>(
     const filteredHeaders = executionContext?.isInternalPagesRevalidation
       ? new Headers(rawRequest.headers)
       : filterInternalHeaders(rawRequest.headers);
+    // The authenticated forwarding protocol is consumed into request state;
+    // neither the invalidated tags nor its secret token is application data.
+    filteredHeaders.delete(NEXT_CACHE_REVALIDATED_TAGS_HEADER);
+    filteredHeaders.delete(NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER);
     filteredHeaders.delete(VINEXT_REVALIDATE_HOST_HEADER);
     if (isForwardedActionContext(ctx)) {
       filteredHeaders.set("x-action-forwarded", "1");
@@ -2471,6 +2484,8 @@ export function createAppRscRequestHandler<TRoute extends AppRscHandlerRoute>(
     const requestContext = createRequestContext({
       headersContext,
       executionContext,
+      previouslyRevalidatedTags: new Set(previouslyRevalidatedTags),
+      requestStartTime,
       unstableCacheRevalidation: "background",
     });
     let interceptionResponseUncacheable = false;

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -24,6 +24,7 @@ import {
   NEXT_ACTION_HEADER,
   NEXT_CACHE_REVALIDATED_TAGS_HEADER,
   NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER,
+  VINEXT_CACHE_REVALIDATED_TAGS_HEADER,
   RSC_ACTION_HEADER,
   RSC_HEADER,
   VINEXT_MW_CTX_HEADER,
@@ -39,7 +40,7 @@ import {
   VINEXT_INTERCEPTION_CONTEXT_HEADER,
   VINEXT_INTERCEPTION_ID_HEADER,
 } from "./headers.js";
-import { getCacheTimestamp } from "vinext/shims/cache";
+import { getCacheTimestamp } from "vinext/shims/cache-handler";
 import type { ReactFormState } from "react-dom/client";
 import {
   getRequestExecutionContext,
@@ -2451,6 +2452,7 @@ export function createAppRscRequestHandler<TRoute extends AppRscHandlerRoute>(
     // neither the invalidated tags nor its secret token is application data.
     filteredHeaders.delete(NEXT_CACHE_REVALIDATED_TAGS_HEADER);
     filteredHeaders.delete(NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER);
+    filteredHeaders.delete(VINEXT_CACHE_REVALIDATED_TAGS_HEADER);
     filteredHeaders.delete(VINEXT_REVALIDATE_HOST_HEADER);
     if (isForwardedActionContext(ctx)) {
       filteredHeaders.set("x-action-forwarded", "1");

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -51,6 +51,7 @@ import {
   closeAfterResponse,
   closeAfterResponseWithBody,
   createRequestContext,
+  getRequestContext,
   preserveFullyBufferedBodyMetadata,
   runWithRequestContext,
 } from "vinext/shims/unified-request-context";
@@ -1056,6 +1057,14 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     : null;
   const draftModeCookie =
     dispatchResponseStage || options.renderResponseStageLocally ? getDraftModeCookieHeader() : null;
+  const cacheRequestContext = getRequestContext();
+  const forwardedRevalidation =
+    cacheRequestContext.previouslyRevalidatedTags.size > 0
+      ? {
+          requestStartTime: cacheRequestContext.requestStartTime,
+          tags: [...cacheRequestContext.previouslyRevalidatedTags],
+        }
+      : undefined;
   const responseStageCacheability = (resolvedRouteUrl: string) => ({
     policyHeaders: null,
     probeMode: responseStageProbeMode,
@@ -1076,6 +1085,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
         )
       : Promise.resolve(null));
   let canUseSharedWorkerResponseStage =
+    forwardedRevalidation === undefined &&
     draftModeCookie === null &&
     !hasMiddlewareCookieOverlay &&
     !hasMiddlewareRequestHeaderOverrides(
@@ -1108,6 +1118,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
               : stageRequest,
             {
               ...props,
+              ...(forwardedRevalidation ? { forwardedRevalidation } : {}),
               cacheability: {
                 ...props.cacheability,
                 policyHeaders: await loadResponseStagePolicy(),
@@ -1808,6 +1819,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
               canonicalPathname,
               cleanPathname,
               draftModeCookie,
+              ...(forwardedRevalidation ? { forwardedRevalidation } : {}),
               isDataRequest,
               isRscRequest,
               matchKind,

--- a/packages/vinext/src/server/app-rsc-response-stage.ts
+++ b/packages/vinext/src/server/app-rsc-response-stage.ts
@@ -229,6 +229,12 @@ export async function renderAppWorkerResponseStage<TRoute extends AppRscHandlerR
   const requestContext = createRequestContext({
     headersContext,
     executionContext,
+    ...(props.forwardedRevalidation
+      ? {
+          previouslyRevalidatedTags: new Set(props.forwardedRevalidation.tags),
+          requestStartTime: props.forwardedRevalidation.requestStartTime,
+        }
+      : {}),
     unstableCacheRevalidation: "background",
   });
   const middlewareContext: AppMiddlewareContext = {

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -1,5 +1,6 @@
 import {
   _drainPendingRevalidations,
+  _getPendingRevalidatedTags,
   getAndClearActionRevalidationKind,
   type ActionRevalidationKind,
 } from "vinext/shims/cache-request-state";
@@ -66,6 +67,7 @@ import {
 import { internalServerErrorResponse, payloadTooLargeResponse } from "./http-error-responses.js";
 import { createStaticGenerationHeadersContext } from "./app-static-generation.js";
 import { markAppRscResponseConfigHeadersApplied } from "./app-rsc-response-finalizer.js";
+import { writePreviouslyRevalidatedTags } from "./revalidated-tags.js";
 
 type AppPageParams = Record<string, string | string[]>;
 
@@ -619,6 +621,8 @@ async function createActionRedirectTargetRequest(options: {
   actionMiddlewareRequestHeaders: Headers | null;
   pendingCookies: readonly string[];
   request: Request;
+  revalidatedTags: readonly string[];
+  revalidationToken: string;
   sourceConfigHeaders: Headers | null;
   url: URL;
 }): Promise<Request> {
@@ -645,6 +649,7 @@ async function createActionRedirectTargetRequest(options: {
   // target request, so an empty jar is represented as Cookie: rather than by
   // omitting the header.
   headers.set("cookie", cookieHeader ?? "");
+  writePreviouslyRevalidatedTags(headers, options.revalidatedTags, options.revalidationToken);
 
   // Match Next.js' internal redirect fetch: it is a fresh full-tree RSC GET,
   // not another action request or a patch against the action route's tree.
@@ -1640,6 +1645,8 @@ export async function handleServerActionRscRequest<
             ...(actionDraftCookie ? [actionDraftCookie] : []),
           ],
           request: options.request,
+          revalidatedTags: _getPendingRevalidatedTags(),
+          revalidationToken: options.draftModeSecret,
           sourceConfigHeaders: options.sourceConfigHeaders ?? null,
           url: redirectTarget,
         });

--- a/packages/vinext/src/server/app-worker-stages.ts
+++ b/packages/vinext/src/server/app-worker-stages.ts
@@ -6,7 +6,7 @@ import type {
 } from "./multi-stage.js";
 import { isTrustedPrerenderState, type TrustedPrerenderState } from "./prerender-route-params.js";
 
-export const APP_WORKER_RESPONSE_STAGE_PROTOCOL_VERSION = 7;
+export const APP_WORKER_RESPONSE_STAGE_PROTOCOL_VERSION = 8;
 export const APP_METADATA_RESPONSE_STAGE_NO_MATCH_HEADER = "x-vinext-app-metadata-stage-no-match";
 const STATIC_FILE_SIGNAL_TOKEN_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -17,6 +17,11 @@ type AppWorkerResponseStageEnvelope = {
   buildId: string | null;
   cacheability: VinextResponseStageCacheability;
   draftModeCookie: string | null;
+  /** Authenticated invalidations consumed by the request stage before dispatch. */
+  forwardedRevalidation?: {
+    requestStartTime: number;
+    tags: string[];
+  };
   middlewareCookieOverlay: string | null;
   protocolVersion: typeof APP_WORKER_RESPONSE_STAGE_PROTOCOL_VERSION;
   /** Canonical public request origin used to partition and validate shared renders. */
@@ -131,6 +136,22 @@ function isCanonicalHttpOrigin(value: unknown): value is string {
   }
 }
 
+function isForwardedRevalidation(
+  value: unknown,
+): value is NonNullable<AppWorkerResponseStageEnvelope["forwardedRevalidation"]> {
+  if (!value || typeof value !== "object") return false;
+  const state = value as Partial<
+    NonNullable<AppWorkerResponseStageEnvelope["forwardedRevalidation"]>
+  >;
+  return (
+    typeof state.requestStartTime === "number" &&
+    Number.isFinite(state.requestStartTime) &&
+    Array.isArray(state.tags) &&
+    state.tags.length > 0 &&
+    state.tags.every((tag) => typeof tag === "string" && tag.length > 0)
+  );
+}
+
 export function isAppWorkerResponseStageProps(
   value: unknown,
 ): value is AppWorkerResponseStageProps {
@@ -141,6 +162,8 @@ export function isAppWorkerResponseStageProps(
     (props.buildId !== null && typeof props.buildId !== "string") ||
     !isResponseStageCacheability(props.cacheability) ||
     (props.draftModeCookie !== null && typeof props.draftModeCookie !== "string") ||
+    (props.forwardedRevalidation !== undefined &&
+      !isForwardedRevalidation(props.forwardedRevalidation)) ||
     (props.middlewareCookieOverlay !== null && typeof props.middlewareCookieOverlay !== "string") ||
     !isCanonicalHttpOrigin(props.requestOrigin) ||
     (props.scriptNonce !== null && typeof props.scriptNonce !== "string")

--- a/packages/vinext/src/server/headers.ts
+++ b/packages/vinext/src/server/headers.ts
@@ -167,6 +167,9 @@ export const ACTION_FORWARDED_HEADER = "x-action-forwarded";
 /** Tags invalidated by a redirecting/forwarded Server Action. */
 export const NEXT_CACHE_REVALIDATED_TAGS_HEADER = "x-next-revalidated-tags";
 
+/** Lossless JSON form of forwarded cache tags used by vinext peers. */
+export const VINEXT_CACHE_REVALIDATED_TAGS_HEADER = "x-vinext-revalidated-tags-json";
+
 /** Secret token authenticating `x-next-revalidated-tags`. */
 export const NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER = "x-next-revalidate-tag-token";
 

--- a/packages/vinext/src/server/headers.ts
+++ b/packages/vinext/src/server/headers.ts
@@ -164,6 +164,12 @@ export const NEXTJS_DEPLOYMENT_ID_HEADER = "x-nextjs-deployment-id";
 /** Forwarded action marker — set when a request has already been forwarded between workers. */
 export const ACTION_FORWARDED_HEADER = "x-action-forwarded";
 
+/** Tags invalidated by a redirecting/forwarded Server Action. */
+export const NEXT_CACHE_REVALIDATED_TAGS_HEADER = "x-next-revalidated-tags";
+
+/** Secret token authenticating `x-next-revalidated-tags`. */
+export const NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER = "x-next-revalidate-tag-token";
+
 // ---------------------------------------------------------------------------
 // Server Action response headers (`x-action-*`)
 // ---------------------------------------------------------------------------

--- a/packages/vinext/src/server/isr-cache.ts
+++ b/packages/vinext/src/server/isr-cache.ts
@@ -24,6 +24,7 @@ import {
 import { getCdnCacheAdapter } from "vinext/shims/cdn-cache";
 import { fnv1a64 } from "../utils/hash.js";
 import { getRequestExecutionContext } from "vinext/shims/request-context";
+import { getRequestContext, isInsideUnifiedScope } from "vinext/shims/unified-request-context";
 import { reportRequestError, type OnRequestErrorContext } from "./instrumentation.js";
 import { normalizeMountedSlotsHeader } from "./app-mounted-slots-header.js";
 import {
@@ -89,7 +90,16 @@ export type ISRCacheEntry = {
 export async function isrGet(key: string): Promise<ISRCacheEntry | null> {
   // Page-level reads go through the CDN cache adapter. The default adapter
   // reads the data cache; an edge adapter may return null so the CDN serves.
-  const result = await getCdnCacheAdapter().get(key);
+  const requestContext = isInsideUnifiedScope() ? getRequestContext() : null;
+  const result = await getCdnCacheAdapter().get(
+    key,
+    requestContext && requestContext.previouslyRevalidatedTags.size > 0
+      ? {
+          requestStartTime: requestContext.requestStartTime,
+          revalidatedTags: [...requestContext.previouslyRevalidatedTags],
+        }
+      : undefined,
+  );
   if (!result) return null;
   const isExpired = result.cacheState === "expired";
 

--- a/packages/vinext/src/server/isr-cache.ts
+++ b/packages/vinext/src/server/isr-cache.ts
@@ -14,6 +14,7 @@
  */
 
 import {
+  getCacheTimestamp,
   type CacheControlMetadata,
   type CacheHandlerValue,
   type IncrementalCacheValue,
@@ -124,6 +125,8 @@ export function isrCacheControl(
 export type IsrWritePolicy = {
   cacheControl: CacheControlMetadata;
   tags?: string[];
+  /** Causal timestamp captured immediately before the producing fill starts. */
+  timestamp?: number;
 };
 
 /**
@@ -134,6 +137,9 @@ export async function isrSet(
   data: IncrementalCacheValue | null,
   policy: IsrWritePolicy,
 ): Promise<void> {
+  // Framework producers pass the pre-fill boundary explicitly. Keep the
+  // call-time fallback for custom/direct callers using the legacy policy.
+  const timestamp = policy.timestamp ?? getCacheTimestamp();
   await getCdnCacheAdapter().set(key, data, {
     cacheControl: policy.cacheControl,
     // `revalidate` is the legacy vinext CacheHandler context field. `expire`
@@ -141,6 +147,7 @@ export async function isrSet(
     // cacheControl.
     revalidate: policy.cacheControl.revalidate,
     tags: policy.tags ?? [],
+    timestamp,
   });
 }
 
@@ -178,6 +185,10 @@ export async function isrSetPrerenderedAppPage(
   // (cloudflare/vinext#1486) so prerender-seeded entries are reachable by
   // revalidatePath()/revalidateTag().
   const ctx: Record<string, unknown> = {};
+  // Prerender seeding does not execute a runtime fill. Timestamp the seed at
+  // the point it enters the adapter so built-in handlers still persist a
+  // producer-owned value rather than inventing one internally.
+  ctx.timestamp = getCacheTimestamp();
   if (revalidateSeconds !== undefined) {
     ctx.revalidate = revalidateSeconds;
     ctx.cacheControl = isrCacheControl(revalidateSeconds, metadata);

--- a/packages/vinext/src/server/metadata-route-response.ts
+++ b/packages/vinext/src/server/metadata-route-response.ts
@@ -37,6 +37,7 @@ import {
 } from "vinext/shims/fetch-cache";
 import { getRequestExecutionContext } from "vinext/shims/request-context";
 import type { CachedRouteValue } from "vinext/shims/cache-handler";
+import { getCacheTimestamp } from "vinext/shims/cache-handler";
 import { buildPageCacheTags } from "./implicit-tags.js";
 import { resolveClientStaleTimeSeconds } from "../utils/cache-control-metadata.js";
 import { VINEXT_METADATA_ROUTE_CACHE_HEADER } from "./headers.js";
@@ -97,6 +98,7 @@ type RenderedMetadataRoute = {
   cacheLife: CacheLifeConfig | null;
   collectedTags: string[];
   response: Response;
+  timestamp: number;
 };
 
 function isOuterMetadataCacheEnabled(): boolean {
@@ -278,14 +280,17 @@ function buildMetadataRouteTags(
   return buildPageCacheTags(cleanPathname, collectedTags, route.routeSegments ?? [], "route");
 }
 
-function captureRenderedMetadataRoute(response: Response): RenderedMetadataRoute {
+function captureRenderedMetadataRoute(
+  response: Response,
+  timestamp: number,
+): RenderedMetadataRoute {
   const cacheLife = _consumeRequestScopedCacheLife();
   const collectedTags = getCollectedFetchTags();
   if (process.env.VINEXT_PRERENDER === "1") {
     applyPrerenderCacheLifeHeader(response.headers, cacheLife);
     applyPrerenderCacheTagsHeader(response.headers, collectedTags);
   }
-  return { cacheLife, collectedTags, response };
+  return { cacheLife, collectedTags, response, timestamp };
 }
 
 async function writeRenderedMetadataRoute(
@@ -315,6 +320,7 @@ async function writeRenderedMetadataRoute(
       ...(typeof stale === "number" ? { staleSeconds: stale } : {}),
     }),
     tags: buildMetadataRouteTags(route, options.cleanPathname, rendered.collectedTags),
+    timestamp: rendered.timestamp,
   });
 }
 
@@ -731,9 +737,10 @@ export async function handleMetadataRouteRequest(
       if (functions.generateSitemaps) {
         if (isGeneratedSitemapPath(route, options.cleanPathname)) {
           const render = async (): Promise<RenderedMetadataRoute | null> => {
+            const fillStartedAt = getCacheTimestamp();
             setCurrentFetchSoftTags(buildMetadataRouteTags(route, options.cleanPathname, []));
             const response = await handleGeneratedSitemap(route, options.cleanPathname, functions);
-            return response ? captureRenderedMetadataRoute(response) : null;
+            return response ? captureRenderedMetadataRoute(response, fillStartedAt) : null;
           };
           const cached = await readMatchedPrerenderedMetadataRouteResponse(
             options,
@@ -761,11 +768,12 @@ export async function handleMetadataRouteRequest(
     }
 
     const render = async (): Promise<RenderedMetadataRoute> => {
+      const fillStartedAt = getCacheTimestamp();
       setCurrentFetchSoftTags(buildMetadataRouteTags(route, options.cleanPathname, []));
       const response = route.isDynamic
         ? await callDynamicMetadataRoute(route, match, options.makeThenableParams, functions)
         : serveStaticMetadataRoute(route);
-      return captureRenderedMetadataRoute(response);
+      return captureRenderedMetadataRoute(response, fillStartedAt);
     };
     const cached = await readMatchedPrerenderedMetadataRouteResponse(
       options,

--- a/packages/vinext/src/server/pages-page-data.ts
+++ b/packages/vinext/src/server/pages-page-data.ts
@@ -3,11 +3,12 @@ import type { VinextNextData } from "../client/vinext-next-data.js";
 import type { Route } from "../routing/pages-router.js";
 import { normalizeStaticPathname } from "../routing/route-pattern.js";
 import { normalizePathnameForRouteMatch } from "../routing/utils.js";
-import type {
-  CachedPagesValue,
-  CachedRedirectValue,
-  CacheHandlerValue,
-  CacheControlMetadata,
+import {
+  getCacheTimestamp,
+  type CachedPagesValue,
+  type CachedRedirectValue,
+  type CacheHandlerValue,
+  type CacheControlMetadata,
 } from "vinext/shims/cache-handler";
 import { applyCdnResponseHeaders } from "./cache-control.js";
 import { buildMissIsrCacheControl, decideIsr } from "./isr-decision.js";
@@ -382,6 +383,8 @@ type ResolvePagesPageDataRenderResult = {
   gsspRes: PagesGsspResponse | null;
   isrRevalidateSeconds: number | false | null;
   isrExpireSeconds?: number;
+  /** Timestamp captured before getStaticProps begins for this cache fill. */
+  isrFillStartedAt?: number;
   pageProps: Record<string, unknown>;
   props: PagesRenderProps;
   /**
@@ -1401,6 +1404,7 @@ export async function resolvePagesPageData(
 
   let isrRevalidateSeconds: number | false | null = null;
   let isrExpireSeconds: number | undefined;
+  let isrFillStartedAt: number | undefined;
 
   if (typeof options.pageModule.getStaticProps === "function") {
     const pathname = options.isrCachePathname ?? options.routeUrl.split("?")[0];
@@ -1422,6 +1426,7 @@ export async function resolvePagesPageData(
         cacheKey,
         async function () {
           return options.runInFreshUnifiedContext(async () => {
+            const fillStartedAt = getCacheTimestamp();
             options.applyRequestContexts();
             const freshAppResult = await loadPagesAppInitialRenderProps(options, () =>
               options.createGsspReqRes(),
@@ -1455,7 +1460,10 @@ export async function resolvePagesPageData(
                   kind: "REDIRECT",
                   props: buildPagesRedirectProps(redirect, freshRenderProps),
                 },
-                { cacheControl: isrCacheControl(revalidateSeconds, { expireSeconds }) },
+                {
+                  cacheControl: isrCacheControl(revalidateSeconds, { expireSeconds }),
+                  timestamp: fillStartedAt,
+                },
               );
               return;
             }
@@ -1463,6 +1471,7 @@ export async function resolvePagesPageData(
             if (freshResult.notFound) {
               await options.isrSet(cacheKey, null, {
                 cacheControl: isrCacheControl(revalidateSeconds, { expireSeconds }),
+                timestamp: fillStartedAt,
               });
               return;
             }
@@ -1494,7 +1503,10 @@ export async function resolvePagesPageData(
               await options.isrSet(
                 cacheKey,
                 buildPagesCacheValue(freshHtml, freshRenderProps, options.statusCode),
-                { cacheControl: isrCacheControl(revalidateSeconds, { expireSeconds }) },
+                {
+                  cacheControl: isrCacheControl(revalidateSeconds, { expireSeconds }),
+                  timestamp: fillStartedAt,
+                },
               );
               return;
             }
@@ -1512,7 +1524,10 @@ export async function resolvePagesPageData(
                 headers: undefined,
                 status: undefined,
               },
-              { cacheControl: isrCacheControl(revalidateSeconds, { expireSeconds }) },
+              {
+                cacheControl: isrCacheControl(revalidateSeconds, { expireSeconds }),
+                timestamp: fillStartedAt,
+              },
             );
           });
         },
@@ -1691,6 +1706,7 @@ export async function resolvePagesPageData(
         ? cachedValue.pageData
         : null;
     if (!generatedPageData) {
+      isrFillStartedAt = getCacheTimestamp();
       const shortCircuit = await loadForegroundAppInitialRenderProps();
       if (shortCircuit) return shortCircuit;
     }
@@ -1736,7 +1752,10 @@ export async function resolvePagesPageData(
             kind: "REDIRECT",
             props: buildPagesRedirectProps(redirect, renderProps),
           },
-          { cacheControl: isrCacheControl(revalidateSeconds, { expireSeconds }) },
+          {
+            cacheControl: isrCacheControl(revalidateSeconds, { expireSeconds }),
+            timestamp: isrFillStartedAt,
+          },
         );
         applyPagesTerminalMissHeaders(response, revalidateSeconds, pathname, expireSeconds);
       }
@@ -1752,6 +1771,7 @@ export async function resolvePagesPageData(
       if (previewData === false) {
         await options.isrSet(cacheKey, null, {
           cacheControl: isrCacheControl(revalidateSeconds, { expireSeconds }),
+          timestamp: isrFillStartedAt,
         });
       }
       const notFoundResult = buildPagesNotFoundResult(
@@ -1812,7 +1832,10 @@ export async function resolvePagesPageData(
           headers: undefined,
           status: undefined,
         },
-        { cacheControl: isrCacheControl(revalidateSeconds, { expireSeconds: isrExpireSeconds }) },
+        {
+          cacheControl: isrCacheControl(revalidateSeconds, { expireSeconds: isrExpireSeconds }),
+          timestamp: isrFillStartedAt,
+        },
       );
     }
   }
@@ -1866,6 +1889,7 @@ export async function resolvePagesPageData(
     gsspRes,
     isrRevalidateSeconds,
     isrExpireSeconds,
+    isrFillStartedAt,
     pageProps,
     props: renderProps,
     isFallback: false,

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -1151,6 +1151,7 @@ export function createPagesPageHandler(
           isrCachePathname,
           expireSeconds: isrExpireSeconds,
           isrRevalidateSeconds,
+          isrFillStartedAt: pageDataResult.isrFillStartedAt,
           isOnDemandRevalidate,
           isStaticPropsRoute,
           isrSet: routeIsrSet,

--- a/packages/vinext/src/server/pages-page-response.ts
+++ b/packages/vinext/src/server/pages-page-response.ts
@@ -1,6 +1,6 @@
 import React, { type ComponentType, type ReactNode } from "react";
 import type { VinextNextData } from "../client/vinext-next-data.js";
-import type { CachedPagesValue } from "vinext/shims/cache-handler";
+import { getCacheTimestamp, type CachedPagesValue } from "vinext/shims/cache-handler";
 import { withScriptNonce } from "vinext/shims/script-nonce-context";
 import { getRequestExecutionContext } from "vinext/shims/request-context";
 import {
@@ -159,6 +159,8 @@ type RenderPagesPageResponseOptions = {
   isrCachePathname?: string;
   expireSeconds?: number;
   isrRevalidateSeconds: number | false | null;
+  /** Timestamp captured before getStaticProps began, when applicable. */
+  isrFillStartedAt?: number;
   /** Synchronous `res.revalidate()` render; cache persistence must finish before returning. */
   isOnDemandRevalidate?: boolean;
   isStaticPropsRoute?: boolean;
@@ -443,6 +445,7 @@ async function writePagesIsrCache(options: {
   shellSuffix: string;
   status: number;
   stream: ReadableStream<Uint8Array>;
+  timestamp: number;
   setCache: RenderPagesPageResponseOptions["isrSet"];
 }): Promise<void> {
   const bodyHtml = await readStreamAsText(options.stream);
@@ -459,6 +462,7 @@ async function writePagesIsrCache(options: {
       cacheControl: isrCacheControl(options.revalidateSeconds, {
         expireSeconds: options.expireSeconds,
       }),
+      timestamp: options.timestamp,
     },
   );
 }
@@ -506,6 +510,7 @@ function applyGsspHeaders(
 export async function renderPagesPageResponse(
   options: RenderPagesPageResponseOptions,
 ): Promise<Response> {
+  const fillStartedAt = options.isrFillStartedAt ?? getCacheTimestamp();
   const renderProps = options.props ?? { pageProps: options.pageProps };
   options.resetSSRHead?.();
   await options.flushPreloads?.();
@@ -671,6 +676,7 @@ export async function renderPagesPageResponse(
       shellSuffix,
       status: finalStatus,
       stream: cacheBodyStream,
+      timestamp: fillStartedAt,
     };
     if (options.isOnDemandRevalidate) {
       // Next.js's internal revalidate path waits for `mocked.res.hasStreamed`.

--- a/packages/vinext/src/server/revalidated-tags.ts
+++ b/packages/vinext/src/server/revalidated-tags.ts
@@ -1,6 +1,7 @@
 import {
   NEXT_CACHE_REVALIDATED_TAGS_HEADER,
   NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER,
+  VINEXT_CACHE_REVALIDATED_TAGS_HEADER,
 } from "./headers.js";
 
 /**
@@ -8,10 +9,26 @@ import {
  *
  * The draft-mode secret authenticates this internal protocol so an external
  * caller cannot forge cache invalidations by setting the header directly.
- * Mirrors Next.js `getPreviouslyRevalidatedTags()`.
+ * This mirrors the authenticated state forwarding performed by Next.js
+ * `getPreviouslyRevalidatedTags()`. Vinext also carries an independent JSON
+ * header so tags containing commas round-trip losslessly without guessing the
+ * wire format from tag contents. The Next.js comma-delimited header remains
+ * available to older peers; only new peers can preserve comma-containing tags.
  */
 export function readPreviouslyRevalidatedTags(headers: Headers, token: string): string[] {
   if (!token || headers.get(NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER) !== token) return [];
+  const jsonValue = headers.get(VINEXT_CACHE_REVALIDATED_TAGS_HEADER);
+  if (jsonValue) {
+    try {
+      const parsed: unknown = JSON.parse(jsonValue);
+      if (Array.isArray(parsed) && parsed.every((tag) => typeof tag === "string")) {
+        return [...new Set(parsed.filter(Boolean))];
+      }
+    } catch {
+      // Fall through to the Next.js-compatible header for rolling upgrades.
+    }
+  }
+
   const value = headers.get(NEXT_CACHE_REVALIDATED_TAGS_HEADER);
   if (!value) return [];
   return [...new Set(value.split(",").filter(Boolean))];
@@ -24,6 +41,8 @@ export function writePreviouslyRevalidatedTags(
   token: string,
 ): void {
   if (!token || tags.length === 0) return;
-  headers.set(NEXT_CACHE_REVALIDATED_TAGS_HEADER, [...new Set(tags)].join(","));
+  const uniqueTags = [...new Set(tags)];
+  headers.set(NEXT_CACHE_REVALIDATED_TAGS_HEADER, uniqueTags.join(","));
+  headers.set(VINEXT_CACHE_REVALIDATED_TAGS_HEADER, JSON.stringify(uniqueTags));
   headers.set(NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER, token);
 }

--- a/packages/vinext/src/server/revalidated-tags.ts
+++ b/packages/vinext/src/server/revalidated-tags.ts
@@ -1,0 +1,29 @@
+import {
+  NEXT_CACHE_REVALIDATED_TAGS_HEADER,
+  NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER,
+} from "./headers.js";
+
+/**
+ * Read tags forwarded by an earlier Server Action request.
+ *
+ * The draft-mode secret authenticates this internal protocol so an external
+ * caller cannot forge cache invalidations by setting the header directly.
+ * Mirrors Next.js `getPreviouslyRevalidatedTags()`.
+ */
+export function readPreviouslyRevalidatedTags(headers: Headers, token: string): string[] {
+  if (!token || headers.get(NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER) !== token) return [];
+  const value = headers.get(NEXT_CACHE_REVALIDATED_TAGS_HEADER);
+  if (!value) return [];
+  return [...new Set(value.split(",").filter(Boolean))];
+}
+
+/** Forward request-local invalidations to an internal redirect target. */
+export function writePreviouslyRevalidatedTags(
+  headers: Headers,
+  tags: readonly string[],
+  token: string,
+): void {
+  if (!token || tags.length === 0) return;
+  headers.set(NEXT_CACHE_REVALIDATED_TAGS_HEADER, [...new Set(tags)].join(","));
+  headers.set(NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER, token);
+}

--- a/packages/vinext/src/shims/cache-handler.ts
+++ b/packages/vinext/src/shims/cache-handler.ts
@@ -37,6 +37,12 @@ export function getCacheTimestamp(): number {
   return wallTime;
 }
 
+/** Resolve a producer timestamp while retaining compatibility with legacy callers. */
+export function getCacheTimestampFromContext(ctx: Record<string, unknown> | undefined): number {
+  const value = ctx?.timestamp;
+  return typeof value === "number" && Number.isFinite(value) ? value : getCacheTimestamp();
+}
+
 export type CacheControlMetadata = {
   revalidate: number | false;
   expire?: number;
@@ -111,29 +117,30 @@ export type CacheHandlerContext = {
   dev?: boolean;
   maxMemoryCacheSize?: number;
   revalidatedTags?: string[];
+  /**
+   * Causal timestamp captured by the producer before cache filling starts.
+   * Handlers must persist it as `lastModified` and return it unchanged.
+   */
+  timestamp?: number;
   [key: string]: unknown;
 };
 
 export type CacheHandler = {
-  get(key: string, ctx?: Record<string, unknown>): Promise<CacheHandlerValue | null>;
-  set(
-    key: string,
-    data: IncrementalCacheValue | null,
-    ctx?: Record<string, unknown>,
-  ): Promise<void>;
+  get(key: string, ctx?: CacheHandlerContext): Promise<CacheHandlerValue | null>;
+  set(key: string, data: IncrementalCacheValue | null, ctx?: CacheHandlerContext): Promise<void>;
   revalidateTag(tags: string | string[], durations?: { expire?: number }): Promise<void>;
   resetRequestCache?(): void;
 };
 
 export class NoOpCacheHandler implements CacheHandler {
-  async get(_key: string, _ctx?: Record<string, unknown>): Promise<CacheHandlerValue | null> {
+  async get(_key: string, _ctx?: CacheHandlerContext): Promise<CacheHandlerValue | null> {
     return null;
   }
 
   async set(
     _key: string,
     _data: IncrementalCacheValue | null,
-    _ctx?: Record<string, unknown>,
+    _ctx?: CacheHandlerContext,
   ): Promise<void> {}
 
   async revalidateTag(_tags: string | string[], _durations?: { expire?: number }): Promise<void> {}
@@ -260,7 +267,7 @@ export class MemoryCacheHandler implements CacheHandler {
     }
   }
 
-  async get(key: string, ctx?: Record<string, unknown>): Promise<CacheHandlerValue | null> {
+  async get(key: string, ctx?: CacheHandlerContext): Promise<CacheHandlerValue | null> {
     const entry = this.store.get(key);
     if (!entry) return null;
 
@@ -317,7 +324,7 @@ export class MemoryCacheHandler implements CacheHandler {
   async set(
     key: string,
     data: IncrementalCacheValue | null,
-    ctx?: Record<string, unknown>,
+    ctx?: CacheHandlerContext,
   ): Promise<void> {
     const tagSet = new Set<string>();
     if (data && "tags" in data && Array.isArray(data.tags)) {
@@ -340,7 +347,10 @@ export class MemoryCacheHandler implements CacheHandler {
     }
     if (effectiveRevalidate === 0) return;
 
-    const lastModified = getCacheTimestamp();
+    // Framework producers capture this before running user work, matching
+    // Next.js CacheEntry.timestamp. The fallback keeps direct and legacy calls
+    // backward compatible without letting adapters replace a supplied value.
+    const lastModified = getCacheTimestampFromContext(ctx);
     const writtenAt = Date.now();
     const revalidateAt =
       typeof effectiveRevalidate === "number" && effectiveRevalidate > 0

--- a/packages/vinext/src/shims/cache-handler.ts
+++ b/packages/vinext/src/shims/cache-handler.ts
@@ -143,6 +143,8 @@ type MemoryEntry = {
   value: IncrementalCacheValue | null;
   tags: string[];
   lastModified: number;
+  /** Wall-clock write time used for duration-based cache policy. */
+  writtenAt: number;
   revalidateAt: number | null;
   expireAt: number | null;
   cacheControl?: CacheControlMetadata;
@@ -291,7 +293,7 @@ export class MemoryCacheHandler implements CacheHandler {
 
     const requestedRevalidate = readPositiveNumberField(ctx, "revalidate");
     const requestedRevalidateAt =
-      requestedRevalidate === undefined ? null : entry.lastModified + requestedRevalidate * 1000;
+      requestedRevalidate === undefined ? null : entry.writtenAt + requestedRevalidate * 1000;
     const isStale =
       (entry.revalidateAt !== null && now > entry.revalidateAt) ||
       (requestedRevalidateAt !== null && now > requestedRevalidateAt);
@@ -338,14 +340,15 @@ export class MemoryCacheHandler implements CacheHandler {
     }
     if (effectiveRevalidate === 0) return;
 
-    const now = getCacheTimestamp();
+    const lastModified = getCacheTimestamp();
+    const writtenAt = Date.now();
     const revalidateAt =
       typeof effectiveRevalidate === "number" && effectiveRevalidate > 0
-        ? now + effectiveRevalidate * 1000
+        ? writtenAt + effectiveRevalidate * 1000
         : null;
     const expireAt =
       typeof effectiveExpire === "number" && effectiveExpire > 0
-        ? now + effectiveExpire * 1000
+        ? writtenAt + effectiveExpire * 1000
         : null;
     // Absent fields stay absent rather than becoming explicit `undefined`, so a
     // round trip through a serializing cache adapter cannot turn "no claim"
@@ -364,7 +367,8 @@ export class MemoryCacheHandler implements CacheHandler {
     const entry = {
       value: data,
       tags,
-      lastModified: now,
+      lastModified,
+      writtenAt,
       revalidateAt,
       expireAt,
       cacheControl,

--- a/packages/vinext/src/shims/cache-handler.ts
+++ b/packages/vinext/src/shims/cache-handler.ts
@@ -12,6 +12,31 @@ export type CacheHandlerValue = {
   value: IncrementalCacheValue | null;
 };
 
+/**
+ * Epoch timestamp with sub-millisecond ordering when the runtime exposes the
+ * High Resolution Time API. Cache fills and tag invalidations must share this
+ * clock so two operations in the same `Date.now()` millisecond remain ordered.
+ * @internal
+ */
+export function getCacheTimestamp(): number {
+  const wallTime = Date.now();
+  if (
+    typeof performance !== "undefined" &&
+    Number.isFinite(performance.timeOrigin) &&
+    performance.timeOrigin > 0
+  ) {
+    const highResolutionTime = performance.timeOrigin + performance.now();
+    // Fake timers and wall-clock corrections can move Date.now() onto a
+    // different epoch while the monotonic clock keeps its original origin.
+    // Persist the wall clock in that case rather than comparing unrelated
+    // timestamp domains across cache handlers or Worker isolates.
+    if (Math.abs(highResolutionTime - wallTime) < 60_000) {
+      return highResolutionTime;
+    }
+  }
+  return wallTime;
+}
+
 export type CacheControlMetadata = {
   revalidate: number | false;
   expire?: number;
@@ -239,7 +264,7 @@ export class MemoryCacheHandler implements CacheHandler {
 
     for (const tag of entry.tags) {
       const revalidatedAt = this.tagRevalidatedAt.get(tag);
-      if (revalidatedAt && revalidatedAt >= entry.lastModified) {
+      if (revalidatedAt && revalidatedAt > entry.lastModified) {
         this.deleteEntry(key);
         return null;
       }
@@ -247,7 +272,7 @@ export class MemoryCacheHandler implements CacheHandler {
 
     for (const tag of readStringArrayField(ctx, "softTags")) {
       const revalidatedAt = this.tagRevalidatedAt.get(tag);
-      if (revalidatedAt && revalidatedAt >= entry.lastModified) {
+      if (revalidatedAt && revalidatedAt > entry.lastModified) {
         return null;
       }
     }
@@ -313,7 +338,7 @@ export class MemoryCacheHandler implements CacheHandler {
     }
     if (effectiveRevalidate === 0) return;
 
-    const now = Date.now();
+    const now = getCacheTimestamp();
     const revalidateAt =
       typeof effectiveRevalidate === "number" && effectiveRevalidate > 0
         ? now + effectiveRevalidate * 1000
@@ -358,7 +383,7 @@ export class MemoryCacheHandler implements CacheHandler {
 
   async revalidateTag(tags: string | string[]): Promise<void> {
     const tagList = Array.isArray(tags) ? tags : [tags];
-    const now = Date.now();
+    const now = getCacheTimestamp();
     for (const tag of tagList) {
       this.tagRevalidatedAt.set(tag, now);
       while (this.tagRevalidatedAt.size > MAX_REVALIDATED_TAG_ENTRIES) {

--- a/packages/vinext/src/shims/cache-handler.ts
+++ b/packages/vinext/src/shims/cache-handler.ts
@@ -116,7 +116,10 @@ export type CachedImageValue = {
 export type CacheHandlerContext = {
   dev?: boolean;
   maxMemoryCacheSize?: number;
+  /** Authenticated invalidations forwarded from an earlier request. */
   revalidatedTags?: string[];
+  /** Start of the current request, used to order forwarded invalidations. */
+  requestStartTime?: number;
   /**
    * Causal timestamp captured by the producer before cache filling starts.
    * Handlers must persist it as `lastModified` and return it unchanged.
@@ -270,6 +273,18 @@ export class MemoryCacheHandler implements CacheHandler {
   async get(key: string, ctx?: CacheHandlerContext): Promise<CacheHandlerValue | null> {
     const entry = this.store.get(key);
     if (!entry) return null;
+
+    const requestStartTime = ctx?.requestStartTime;
+    const revalidatedTags = new Set(ctx?.revalidatedTags ?? []);
+    if (
+      typeof requestStartTime === "number" &&
+      Number.isFinite(requestStartTime) &&
+      entry.lastModified <= requestStartTime &&
+      entry.tags.some((tag) => revalidatedTags.has(tag))
+    ) {
+      this.deleteEntry(key);
+      return null;
+    }
 
     for (const tag of entry.tags) {
       const revalidatedAt = this.tagRevalidatedAt.get(tag);

--- a/packages/vinext/src/shims/cache-handler.ts
+++ b/packages/vinext/src/shims/cache-handler.ts
@@ -23,7 +23,9 @@ export function getCacheTimestamp(): number {
   if (
     typeof performance !== "undefined" &&
     Number.isFinite(performance.timeOrigin) &&
-    performance.timeOrigin > 0
+    // Cloudflare Workers intentionally expose zero while performance.now()
+    // remains an epoch timestamp, so zero is a valid origin here.
+    performance.timeOrigin >= 0
   ) {
     const highResolutionTime = performance.timeOrigin + performance.now();
     // Fake timers and wall-clock corrections can move Date.now() onto a

--- a/packages/vinext/src/shims/cache-request-state.ts
+++ b/packages/vinext/src/shims/cache-request-state.ts
@@ -1,5 +1,6 @@
 import { getHeadersAccessPhase } from "./headers.js";
 import { getOrCreateAls } from "./internal/als-registry.js";
+import { getCacheTimestamp } from "./cache-handler.js";
 import {
   getRequestContext,
   isInsideUnifiedScope,
@@ -63,6 +64,8 @@ export type UnstableCacheObservation = Readonly<{
 export type CacheState = {
   actionRevalidationKind: ActionRevalidationKind;
   pendingRevalidatedTags: Map<string, number>;
+  previouslyRevalidatedTags: Set<string>;
+  requestStartTime: number;
   pendingRevalidations: Set<Promise<void>>;
   requestScopedCacheLife: CacheLifeConfig | null;
   unstableCacheObservations: Map<string, UnstableCacheObservation>;
@@ -80,6 +83,8 @@ export const ACTION_DID_REVALIDATE_DYNAMIC_ONLY = 2 satisfies ActionRevalidation
 const fallbackState = (globalState[FALLBACK_KEY] ??= {
   actionRevalidationKind: ACTION_DID_NOT_REVALIDATE,
   pendingRevalidatedTags: new Map<string, number>(),
+  previouslyRevalidatedTags: new Set<string>(),
+  requestStartTime: getCacheTimestamp(),
   pendingRevalidations: new Set<Promise<void>>(),
   requestScopedCacheLife: null,
   unstableCacheObservations: new Map<string, UnstableCacheObservation>(),
@@ -107,6 +112,8 @@ export function _runWithCacheState<T>(fn: () => T | Promise<T>): T | Promise<T> 
   const state: CacheState = {
     actionRevalidationKind: ACTION_DID_NOT_REVALIDATE,
     pendingRevalidatedTags: new Map<string, number>(),
+    previouslyRevalidatedTags: new Set<string>(),
+    requestStartTime: getCacheTimestamp(),
     pendingRevalidations: new Set<Promise<void>>(),
     requestScopedCacheLife: null,
     unstableCacheObservations: new Map<string, UnstableCacheObservation>(),
@@ -148,7 +155,13 @@ function hasRequestScopedCacheState(): boolean {
 /** @internal */
 export function _markPendingRevalidatedTag(tag: string): void {
   if (!hasRequestScopedCacheState()) return;
-  getCacheState().pendingRevalidatedTags.set(tag, Date.now());
+  getCacheState().pendingRevalidatedTags.set(tag, getCacheTimestamp());
+}
+
+/** @internal */
+export function _getPendingRevalidatedTags(): string[] {
+  if (!hasRequestScopedCacheState()) return [];
+  return [...getCacheState().pendingRevalidatedTags.keys()];
 }
 
 /** @internal */
@@ -166,10 +179,18 @@ export function _getPendingRevalidatedTagTimestamp(tags: readonly string[]): num
 }
 
 /** @internal */
-export function _wasPendingTagRevalidatedAfter(
+export function _wasTagRevalidatedAfter(
   tags: readonly string[],
   entryLastModified: number,
 ): boolean {
+  if (!hasRequestScopedCacheState()) return false;
+  const state = getCacheState();
+  if (
+    entryLastModified <= state.requestStartTime &&
+    tags.some((tag) => state.previouslyRevalidatedTags.has(tag))
+  ) {
+    return true;
+  }
   const revalidatedAt = _getPendingRevalidatedTagTimestamp(tags);
   return revalidatedAt !== null && revalidatedAt > entryLastModified;
 }

--- a/packages/vinext/src/shims/cache-request-state.ts
+++ b/packages/vinext/src/shims/cache-request-state.ts
@@ -62,7 +62,7 @@ export type UnstableCacheObservation = Readonly<{
 
 export type CacheState = {
   actionRevalidationKind: ActionRevalidationKind;
-  pendingRevalidatedTags: Set<string>;
+  pendingRevalidatedTags: Map<string, number>;
   pendingRevalidations: Set<Promise<void>>;
   requestScopedCacheLife: CacheLifeConfig | null;
   unstableCacheObservations: Map<string, UnstableCacheObservation>;
@@ -79,7 +79,7 @@ export const ACTION_DID_REVALIDATE_DYNAMIC_ONLY = 2 satisfies ActionRevalidation
 
 const fallbackState = (globalState[FALLBACK_KEY] ??= {
   actionRevalidationKind: ACTION_DID_NOT_REVALIDATE,
-  pendingRevalidatedTags: new Set<string>(),
+  pendingRevalidatedTags: new Map<string, number>(),
   pendingRevalidations: new Set<Promise<void>>(),
   requestScopedCacheLife: null,
   unstableCacheObservations: new Map<string, UnstableCacheObservation>(),
@@ -106,7 +106,7 @@ export function _runWithCacheState<T>(fn: () => T | Promise<T>): T | Promise<T> 
   }
   const state: CacheState = {
     actionRevalidationKind: ACTION_DID_NOT_REVALIDATE,
-    pendingRevalidatedTags: new Set<string>(),
+    pendingRevalidatedTags: new Map<string, number>(),
     pendingRevalidations: new Set<Promise<void>>(),
     requestScopedCacheLife: null,
     unstableCacheObservations: new Map<string, UnstableCacheObservation>(),
@@ -148,14 +148,30 @@ function hasRequestScopedCacheState(): boolean {
 /** @internal */
 export function _markPendingRevalidatedTag(tag: string): void {
   if (!hasRequestScopedCacheState()) return;
-  getCacheState().pendingRevalidatedTags.add(tag);
+  getCacheState().pendingRevalidatedTags.set(tag, Date.now());
 }
 
 /** @internal */
-export function _hasPendingRevalidatedTag(tags: readonly string[]): boolean {
-  if (!hasRequestScopedCacheState()) return false;
+export function _getPendingRevalidatedTagTimestamp(tags: readonly string[]): number | null {
+  if (!hasRequestScopedCacheState()) return null;
   const pendingTags = getCacheState().pendingRevalidatedTags;
-  return tags.some((tag) => pendingTags.has(tag));
+  let latest: number | null = null;
+  for (const tag of tags) {
+    const revalidatedAt = pendingTags.get(tag);
+    if (revalidatedAt !== undefined && (latest === null || revalidatedAt > latest)) {
+      latest = revalidatedAt;
+    }
+  }
+  return latest;
+}
+
+/** @internal */
+export function _wasPendingTagRevalidatedAfter(
+  tags: readonly string[],
+  entryLastModified: number,
+): boolean {
+  const revalidatedAt = _getPendingRevalidatedTagTimestamp(tags);
+  return revalidatedAt !== null && revalidatedAt > entryLastModified;
 }
 
 /**

--- a/packages/vinext/src/shims/cache-runtime.ts
+++ b/packages/vinext/src/shims/cache-runtime.ts
@@ -30,13 +30,14 @@
 
 import {
   getDataCacheHandler,
+  getCacheTimestamp,
   type CachedFetchValue,
   type CacheControlMetadata,
   type CacheHandlerValue,
 } from "./cache-handler.js";
 import {
   cacheLifeProfiles,
-  _wasPendingTagRevalidatedAfter,
+  _wasTagRevalidatedAfter,
   _setRequestScopedCacheLife,
   _registerCacheContextAccessor,
   type CacheLifeConfig,
@@ -754,7 +755,7 @@ export function registerCachedFunction<TArgs extends unknown[], TResult>(
         existing?.cacheState !== "stale" &&
         rootParams &&
         redirectValue?.kind === "FETCH" &&
-        !_wasPendingTagRevalidatedAfter(
+        !_wasTagRevalidatedAfter(
           [...(redirectValue.tags ?? []), ...softTags],
           existing.lastModified,
         )
@@ -773,7 +774,7 @@ export function registerCachedFunction<TArgs extends unknown[], TResult>(
         existing?.value &&
         existing.value.kind === "FETCH" &&
         existing.cacheState !== "stale" &&
-        !_wasPendingTagRevalidatedAfter(
+        !_wasTagRevalidatedAfter(
           [...(existing.value.tags ?? []), ...softTags],
           existing.lastModified,
         )
@@ -806,7 +807,10 @@ export function registerCachedFunction<TArgs extends unknown[], TResult>(
         }
       }
 
-      // Cache miss (or stale) — execute with context
+      // Cache miss (or stale) — execute with context. Capture the boundary
+      // before user code starts because handlers timestamp entries only when
+      // set() completes; an invalidation during the fill must still win.
+      const fillStartedAt = getCacheTimestamp();
       const { result, ctx, effectiveLife, collectedResult } = await runCachedFunctionWithContext(
         fn,
         callArgs,
@@ -827,10 +831,11 @@ export function registerCachedFunction<TArgs extends unknown[], TResult>(
       propagateCacheTagsToRequest(ctx.tags);
       const revalidateSeconds =
         effectiveLife.revalidate ?? cacheLifeProfiles.default.revalidate ?? 900;
+      const fillWasInvalidated = _wasTagRevalidatedAfter([...ctx.tags, ...softTags], fillStartedAt);
 
       // Serialization ran while the cache ALS was active so lazy Server
       // Component work is reflected in `ctx` before selecting the final key.
-      if (collectedResult?.cacheEntry) {
+      if (collectedResult?.cacheEntry && !fillWasInvalidated) {
         try {
           const serialized = collectedResult.cacheEntry;
           const cacheValue = {

--- a/packages/vinext/src/shims/cache-runtime.ts
+++ b/packages/vinext/src/shims/cache-runtime.ts
@@ -36,7 +36,7 @@ import {
 } from "./cache-handler.js";
 import {
   cacheLifeProfiles,
-  _hasPendingRevalidatedTag,
+  _wasPendingTagRevalidatedAfter,
   _setRequestScopedCacheLife,
   _registerCacheContextAccessor,
   type CacheLifeConfig,
@@ -742,20 +742,22 @@ export function registerCachedFunction<TArgs extends unknown[], TResult>(
       // `fn` still propagate with their digest intact instead of being masked
       // by the handler's own exception.
       let existing: CacheHandlerValue | null = null;
-      if (!_hasPendingRevalidatedTag(softTags)) {
-        try {
-          existing = await handler.get(cacheKey, { kind: "FETCH", softTags });
-        } catch (error) {
-          console.error("[vinext] use cache: handler.get failed; treating as a cache miss:", error);
-        }
+      try {
+        existing = await handler.get(cacheKey, { kind: "FETCH", softTags });
+      } catch (error) {
+        console.error("[vinext] use cache: handler.get failed; treating as a cache miss:", error);
       }
       const redirectValue = existing?.value;
       if (
+        existing !== null &&
         isRootParamRedirect(existing) &&
         existing?.cacheState !== "stale" &&
         rootParams &&
         redirectValue?.kind === "FETCH" &&
-        !_hasPendingRevalidatedTag([...(redirectValue.tags ?? []), ...softTags])
+        !_wasPendingTagRevalidatedAfter(
+          [...(redirectValue.tags ?? []), ...softTags],
+          existing.lastModified,
+        )
       ) {
         const redirectNames = rootParamNamesFromTags(redirectValue.tags);
         const combinedNames = addKnownRootParamNames(id, redirectNames);
@@ -771,7 +773,10 @@ export function registerCachedFunction<TArgs extends unknown[], TResult>(
         existing?.value &&
         existing.value.kind === "FETCH" &&
         existing.cacheState !== "stale" &&
-        !_hasPendingRevalidatedTag([...(existing.value.tags ?? []), ...softTags])
+        !_wasPendingTagRevalidatedAfter(
+          [...(existing.value.tags ?? []), ...softTags],
+          existing.lastModified,
+        )
       ) {
         try {
           propagateRootParamNamesToParent(knownRootParamsByFunctionId.get(id));

--- a/packages/vinext/src/shims/cache-runtime.ts
+++ b/packages/vinext/src/shims/cache-runtime.ts
@@ -807,9 +807,9 @@ export function registerCachedFunction<TArgs extends unknown[], TResult>(
         }
       }
 
-      // Cache miss (or stale) — execute with context. Capture the boundary
-      // before user code starts because handlers timestamp entries only when
-      // set() completes; an invalidation during the fill must still win.
+      // Cache miss (or stale) — capture the entry timestamp before user code
+      // starts. Handlers persist this causal boundary unchanged, matching
+      // Next.js CacheEntry.timestamp.
       const fillStartedAt = getCacheTimestamp();
       const { result, ctx, effectiveLife, collectedResult } = await runCachedFunctionWithContext(
         fn,
@@ -851,6 +851,7 @@ export function registerCachedFunction<TArgs extends unknown[], TResult>(
           const cacheContext = {
             fetchCache: true,
             tags: ctx.tags,
+            timestamp: fillStartedAt,
             cacheControl: {
               revalidate: revalidateSeconds,
               expire: effectiveLife.expire,

--- a/packages/vinext/src/shims/cache.ts
+++ b/packages/vinext/src/shims/cache.ts
@@ -30,14 +30,14 @@ import { workUnitAsyncStorage } from "./internal/work-unit-async-storage.js";
 import { makeHangingPromise } from "./internal/make-hanging-promise.js";
 import { encodeCacheTag, encodeCacheTags } from "../utils/encode-cache-tag.js";
 import { getCdnCacheAdapter } from "./cdn-cache.js";
-import { getDataCacheHandler, type CachedFetchValue } from "./cache-handler.js";
+import { getCacheTimestamp, getDataCacheHandler, type CachedFetchValue } from "./cache-handler.js";
 import { getRequestExecutionContext } from "./request-context.js";
 import { isStagedCacheabilityProbeActive } from "./cacheability-classification.js";
 import { addCollectedRequestTags, getCurrentFetchSoftTags } from "./fetch-cache.js";
 import {
   ACTION_DID_REVALIDATE_DYNAMIC_ONLY,
   ACTION_DID_REVALIDATE_STATIC_AND_DYNAMIC,
-  _wasPendingTagRevalidatedAfter,
+  _wasTagRevalidatedAfter,
   _markPendingRevalidatedTag,
   _queuePendingRevalidation,
   _setRequestScopedCacheLife,
@@ -574,6 +574,9 @@ async function refreshUnstableCacheResult<Args extends unknown[], Result>(
   tags: string[],
   revalidateSeconds: number | false | undefined,
 ): Promise<Result> {
+  // Cache handlers timestamp at set() completion. Keep the earlier boundary
+  // so a fill that overlaps tag invalidation is not persisted as fresh.
+  const fillStartedAt = getCacheTimestamp();
   const result = await _unstableCacheAls.run(true, () => fn(...args));
 
   const cacheValue: CachedFetchValue = {
@@ -590,6 +593,10 @@ async function refreshUnstableCacheResult<Args extends unknown[], Result>(
     // Next.js behavior for unstable_cache without explicit revalidate.
     revalidate: typeof revalidateSeconds === "number" ? revalidateSeconds : false,
   };
+
+  if (_wasTagRevalidatedAfter([...tags, ...getCurrentFetchSoftTags()], fillStartedAt)) {
+    return result;
+  }
 
   await getDataCacheHandler().set(cacheKey, cacheValue, {
     fetchCache: true,
@@ -649,10 +656,7 @@ export function unstable_cache<T extends (...args: any[]) => Promise<any>>(
         tags,
         softTags,
       });
-      if (
-        existing &&
-        _wasPendingTagRevalidatedAfter([...tags, ...softTags], existing.lastModified)
-      ) {
+      if (existing && _wasTagRevalidatedAfter([...tags, ...softTags], existing.lastModified)) {
         existing = null;
       }
       if (existing?.value && existing.value.kind === "FETCH") {

--- a/packages/vinext/src/shims/cache.ts
+++ b/packages/vinext/src/shims/cache.ts
@@ -574,8 +574,8 @@ async function refreshUnstableCacheResult<Args extends unknown[], Result>(
   tags: string[],
   revalidateSeconds: number | false | undefined,
 ): Promise<Result> {
-  // Cache handlers timestamp at set() completion. Keep the earlier boundary
-  // so a fill that overlaps tag invalidation is not persisted as fresh.
+  // This becomes the persisted entry timestamp, so a fill that overlaps tag
+  // invalidation cannot appear newer merely because storage completed later.
   const fillStartedAt = getCacheTimestamp();
   const result = await _unstableCacheAls.run(true, () => fn(...args));
 
@@ -602,6 +602,7 @@ async function refreshUnstableCacheResult<Args extends unknown[], Result>(
     fetchCache: true,
     tags,
     revalidate: revalidateSeconds,
+    timestamp: fillStartedAt,
   });
 
   return result;

--- a/packages/vinext/src/shims/cache.ts
+++ b/packages/vinext/src/shims/cache.ts
@@ -37,7 +37,7 @@ import { addCollectedRequestTags, getCurrentFetchSoftTags } from "./fetch-cache.
 import {
   ACTION_DID_REVALIDATE_DYNAMIC_ONLY,
   ACTION_DID_REVALIDATE_STATIC_AND_DYNAMIC,
-  _hasPendingRevalidatedTag,
+  _wasPendingTagRevalidatedAfter,
   _markPendingRevalidatedTag,
   _queuePendingRevalidation,
   _setRequestScopedCacheLife,
@@ -644,13 +644,17 @@ export function unstable_cache<T extends (...args: any[]) => Promise<any>>(
       // requests, but foreground-refresh inside revalidation scopes so the
       // regenerated page/route stores fresh data.
       const softTags = getCurrentFetchSoftTags();
-      const existing = _hasPendingRevalidatedTag([...tags, ...softTags])
-        ? null
-        : await getDataCacheHandler().get(cacheKey, {
-            kind: "FETCH",
-            tags,
-            softTags,
-          });
+      let existing = await getDataCacheHandler().get(cacheKey, {
+        kind: "FETCH",
+        tags,
+        softTags,
+      });
+      if (
+        existing &&
+        _wasPendingTagRevalidatedAfter([...tags, ...softTags], existing.lastModified)
+      ) {
+        existing = null;
+      }
       if (existing?.value && existing.value.kind === "FETCH") {
         const cached = tryDeserializeUnstableCacheResult(existing.value.data.body);
         if (cached.ok) {

--- a/packages/vinext/src/shims/cdn-cache.ts
+++ b/packages/vinext/src/shims/cdn-cache.ts
@@ -25,7 +25,11 @@
  * pre-split implementation.
  */
 
-import type { CacheHandlerValue, IncrementalCacheValue } from "./cache-handler.js";
+import type {
+  CacheHandlerContext,
+  CacheHandlerValue,
+  IncrementalCacheValue,
+} from "./cache-handler.js";
 import { getExplicitCdnCacheAdapter } from "./cdn-cache-state.js";
 export { setCdnCacheAdapter } from "./cdn-cache-state.js";
 
@@ -145,7 +149,7 @@ export type CdnCacheAdapter = {
    * Default: reads the data cache. Edge adapters typically return `null` so the
    * edge owns serving.
    */
-  get(key: string, ctx?: Record<string, unknown>): Promise<CacheHandlerValue | null>;
+  get(key: string, ctx?: CacheHandlerContext): Promise<CacheHandlerValue | null>;
 
   /**
    * Persist a freshly-rendered page-level artifact.
@@ -153,11 +157,7 @@ export type CdnCacheAdapter = {
    * Default: writes to the data cache. Edge adapters that rely entirely on the
    * CDN may make this a no-op.
    */
-  set(
-    key: string,
-    data: IncrementalCacheValue | null,
-    ctx?: Record<string, unknown>,
-  ): Promise<void>;
+  set(key: string, data: IncrementalCacheValue | null, ctx?: CacheHandlerContext): Promise<void>;
 
   /**
    * Build the response cache headers for a given policy. Returns a map so an
@@ -207,7 +207,7 @@ const PENDING_DYNAMIC_CACHE_CONTROL = "no-store, must-revalidate";
 export class DefaultCdnCacheAdapter implements CdnCacheAdapter {
   readonly ownsBackgroundRevalidation = true;
 
-  async get(key: string, ctx?: Record<string, unknown>): Promise<CacheHandlerValue | null> {
+  async get(key: string, ctx?: CacheHandlerContext): Promise<CacheHandlerValue | null> {
     const { getDataCacheHandler } = await import("./cache-handler.js");
     return getDataCacheHandler().get(key, ctx);
   }
@@ -215,7 +215,7 @@ export class DefaultCdnCacheAdapter implements CdnCacheAdapter {
   async set(
     key: string,
     data: IncrementalCacheValue | null,
-    ctx?: Record<string, unknown>,
+    ctx?: CacheHandlerContext,
   ): Promise<void> {
     const { getDataCacheHandler } = await import("./cache-handler.js");
     await getDataCacheHandler().set(key, data, ctx);

--- a/packages/vinext/src/shims/fetch-cache.ts
+++ b/packages/vinext/src/shims/fetch-cache.ts
@@ -21,14 +21,19 @@
 
 import { Buffer } from "node:buffer";
 
-import { getDataCacheHandler, type CachedFetchValue, type CacheHandler } from "./cache-handler.js";
+import {
+  getCacheTimestamp,
+  getDataCacheHandler,
+  type CachedFetchValue,
+  type CacheHandler,
+} from "./cache-handler.js";
 import { encodeCacheTags } from "../utils/encode-cache-tag.js";
 import { getOrCreateAls } from "./internal/als-registry.js";
 import { getHeadersContext, isInsideAnyCacheScope, markDynamicUsage } from "./headers.js";
 import {
   _getPendingRevalidatedTagTimestamp,
   _setRequestScopedCacheLife,
-  _wasPendingTagRevalidatedAfter,
+  _wasTagRevalidatedAfter,
 } from "./cache-request-state.js";
 import { getRequestExecutionContext } from "./request-context.js";
 import {
@@ -711,10 +716,20 @@ async function writeFetchCacheResponse(
   response: Response,
   tags: string[],
   revalidateSeconds: number,
-  options?: { cloneForReturn?: boolean },
+  options?: {
+    cloneForReturn?: boolean;
+    fillStartedAt?: number;
+    softTags?: readonly string[];
+  },
 ): Promise<void> {
   const cacheValue = await buildFetchCacheValue(response, tags, revalidateSeconds, options);
   if (!cacheValue) return;
+  if (
+    options?.fillStartedAt !== undefined &&
+    _wasTagRevalidatedAfter([...tags, ...(options.softTags ?? [])], options.fillStartedAt)
+  ) {
+    return;
+  }
 
   await handler.set(cacheKey, cacheValue, {
     fetchCache: true,
@@ -1294,7 +1309,7 @@ function createPatchedFetch(): typeof globalThis.fetch {
       });
       if (
         cached?.value?.kind === "FETCH" &&
-        _wasPendingTagRevalidatedAfter(
+        _wasTagRevalidatedAfter(
           [...(cached.value.tags ?? []), ...tags, ...softTags],
           cached.lastModified,
         )
@@ -1319,8 +1334,12 @@ function createPatchedFetch(): typeof globalThis.fetch {
       // However, if we have a stale entry, return it and trigger background refetch.
       if (cached?.value && cached.value.kind === "FETCH" && cached.cacheState === "stale") {
         if (shouldRefreshStaleFetchInForeground()) {
+          const fillStartedAt = getCacheTimestamp();
           const freshResponse = await dedupeFetch(input, fetchInit);
-          await writeFetchCacheResponse(handler, cacheKey, freshResponse, tags, revalidateSeconds);
+          await writeFetchCacheResponse(handler, cacheKey, freshResponse, tags, revalidateSeconds, {
+            fillStartedAt,
+            softTags,
+          });
           return freshResponse;
         }
 
@@ -1329,10 +1348,13 @@ function createPatchedFetch(): typeof globalThis.fetch {
         // Background refetch — deduped so only one in-flight refetch runs
         // per cache key, preventing thundering herd on popular endpoints.
         if (!pendingRefetches.has(cacheKey)) {
+          const fillStartedAt = getCacheTimestamp();
           const refetchPromise = originalFetch(input, fetchInit)
             .then(async (freshResp) => {
               await writeFetchCacheResponse(handler, cacheKey, freshResp, tags, revalidateSeconds, {
                 cloneForReturn: false,
+                fillStartedAt,
+                softTags,
               });
             })
             .catch((err) => {
@@ -1378,13 +1400,15 @@ function createPatchedFetch(): typeof globalThis.fetch {
       console.error("[vinext] fetch cache read error:", cacheErr);
     }
 
-    // Cache miss — fetch from network
+    // Cache miss — fetch from network. Preserve the pre-fetch boundary so a
+    // response that overlaps tag invalidation is not cached afterward.
+    const fillStartedAt = getCacheTimestamp();
     const response = await (mustBypassPendingRevalidation
       ? originalFetch(input, fetchInit)
       : dedupeFetch(input, fetchInit));
 
     const cacheValue = await buildFetchCacheValue(response, tags, revalidateSeconds);
-    if (cacheValue) {
+    if (cacheValue && !_wasTagRevalidatedAfter([...tags, ...softTags], fillStartedAt)) {
       handler
         .set(cacheKey, cacheValue, {
           fetchCache: true,

--- a/packages/vinext/src/shims/fetch-cache.ts
+++ b/packages/vinext/src/shims/fetch-cache.ts
@@ -25,7 +25,11 @@ import { getDataCacheHandler, type CachedFetchValue, type CacheHandler } from ".
 import { encodeCacheTags } from "../utils/encode-cache-tag.js";
 import { getOrCreateAls } from "./internal/als-registry.js";
 import { getHeadersContext, isInsideAnyCacheScope, markDynamicUsage } from "./headers.js";
-import { _hasPendingRevalidatedTag, _setRequestScopedCacheLife } from "./cache-request-state.js";
+import {
+  _getPendingRevalidatedTagTimestamp,
+  _setRequestScopedCacheLife,
+  _wasPendingTagRevalidatedAfter,
+} from "./cache-request-state.js";
 import { getRequestExecutionContext } from "./request-context.js";
 import {
   isInsideUnifiedScope,
@@ -1277,21 +1281,23 @@ function createPatchedFetch(): typeof globalThis.fetch {
       throw err;
     }
     const handler = getDataCacheHandler();
-    let mustBypassPendingRevalidation = _hasPendingRevalidatedTag([...tags, ...softTags]);
+    let mustBypassPendingRevalidation =
+      _getPendingRevalidatedTagTimestamp([...tags, ...softTags]) !== null;
 
     // Try cache first
     try {
-      let cached = mustBypassPendingRevalidation
-        ? null
-        : await handler.get(cacheKey, {
-            kind: "FETCH",
-            tags,
-            softTags,
-            revalidate: revalidateSeconds,
-          });
+      let cached = await handler.get(cacheKey, {
+        kind: "FETCH",
+        tags,
+        softTags,
+        revalidate: revalidateSeconds,
+      });
       if (
         cached?.value?.kind === "FETCH" &&
-        _hasPendingRevalidatedTag([...(cached.value.tags ?? []), ...tags, ...softTags])
+        _wasPendingTagRevalidatedAfter(
+          [...(cached.value.tags ?? []), ...tags, ...softTags],
+          cached.lastModified,
+        )
       ) {
         mustBypassPendingRevalidation = true;
         cached = null;

--- a/packages/vinext/src/shims/fetch-cache.ts
+++ b/packages/vinext/src/shims/fetch-cache.ts
@@ -716,18 +716,15 @@ async function writeFetchCacheResponse(
   response: Response,
   tags: string[],
   revalidateSeconds: number,
-  options?: {
+  options: {
     cloneForReturn?: boolean;
-    fillStartedAt?: number;
+    fillStartedAt: number;
     softTags?: readonly string[];
   },
 ): Promise<void> {
   const cacheValue = await buildFetchCacheValue(response, tags, revalidateSeconds, options);
   if (!cacheValue) return;
-  if (
-    options?.fillStartedAt !== undefined &&
-    _wasTagRevalidatedAfter([...tags, ...(options.softTags ?? [])], options.fillStartedAt)
-  ) {
+  if (_wasTagRevalidatedAfter([...tags, ...(options.softTags ?? [])], options.fillStartedAt)) {
     return;
   }
 
@@ -735,6 +732,7 @@ async function writeFetchCacheResponse(
     fetchCache: true,
     tags,
     revalidate: revalidateSeconds,
+    timestamp: options.fillStartedAt,
   });
 }
 
@@ -744,6 +742,7 @@ async function lowerFetchCacheRevalidateIfNeeded(
   cachedValue: CachedFetchValue,
   tags: string[],
   revalidateSeconds: number,
+  timestamp: number,
 ): Promise<void> {
   if (
     !Number.isFinite(revalidateSeconds) ||
@@ -764,6 +763,7 @@ async function lowerFetchCacheRevalidateIfNeeded(
     fetchCache: true,
     tags: mergedTags,
     revalidate: revalidateSeconds,
+    timestamp,
   });
 }
 
@@ -1324,6 +1324,7 @@ function createPatchedFetch(): typeof globalThis.fetch {
           cached.value,
           tags,
           revalidateSeconds,
+          cached.lastModified,
         );
         const cachedData = cached.value.data;
         return buildCachedFetchResponse(cachedData, input);
@@ -1414,6 +1415,7 @@ function createPatchedFetch(): typeof globalThis.fetch {
           fetchCache: true,
           tags,
           revalidate: revalidateSeconds,
+          timestamp: fillStartedAt,
         })
         .catch((err) => {
           console.error("[vinext] fetch cache write error:", err);

--- a/packages/vinext/src/shims/unified-request-context.ts
+++ b/packages/vinext/src/shims/unified-request-context.ts
@@ -99,7 +99,7 @@ export function createRequestContext(opts?: Partial<UnifiedRequestContext>): Uni
   return {
     headersContext: null,
     actionRevalidationKind: 0,
-    pendingRevalidatedTags: new Set<string>(),
+    pendingRevalidatedTags: new Map<string, number>(),
     pendingRevalidations: new Set<Promise<void>>(),
     dynamicUsageDetected: false,
     renderRequestApiUsage: new Set(),
@@ -378,9 +378,9 @@ export function runWithUnifiedStateMutation<T>(
   const childCtx = { ...parentCtx };
   // NOTE: This is a shallow clone. Object/array fields (afterContext, pendingSetCookies,
   // serverInsertedHTMLCallbacks, currentRequestTags, ssrHeadChildren), Set
-  // fields (renderRequestApiUsage, pendingRevalidatedTags, pendingRevalidations,
+  // Set fields (renderRequestApiUsage, pendingRevalidations,
   // cacheableFetchUrls, dynamicFetchUrls),
-  // Map fields (unstableCacheObservations, _privateCache),
+  // Map fields (pendingRevalidatedTags, unstableCacheObservations, _privateCache),
   // requestCache WeakMap, and object fields (headersContext,
   // i18nContext, serverContext, ssrContext, executionContext,
   // requestScopedCacheLife) still share references with the parent until

--- a/packages/vinext/src/shims/unified-request-context.ts
+++ b/packages/vinext/src/shims/unified-request-context.ts
@@ -12,6 +12,7 @@
 
 import type { AsyncLocalStorage } from "node:async_hooks";
 import { getOrCreateAls } from "./internal/als-registry.js";
+import { getCacheTimestamp } from "./cache-handler.js";
 import type {
   CacheState,
   ExecutionContextLike,
@@ -100,6 +101,8 @@ export function createRequestContext(opts?: Partial<UnifiedRequestContext>): Uni
     headersContext: null,
     actionRevalidationKind: 0,
     pendingRevalidatedTags: new Map<string, number>(),
+    previouslyRevalidatedTags: new Set<string>(),
+    requestStartTime: getCacheTimestamp(),
     pendingRevalidations: new Set<Promise<void>>(),
     dynamicUsageDetected: false,
     renderRequestApiUsage: new Set(),
@@ -378,7 +381,7 @@ export function runWithUnifiedStateMutation<T>(
   const childCtx = { ...parentCtx };
   // NOTE: This is a shallow clone. Object/array fields (afterContext, pendingSetCookies,
   // serverInsertedHTMLCallbacks, currentRequestTags, ssrHeadChildren), Set
-  // Set fields (renderRequestApiUsage, pendingRevalidations,
+  // Set fields (renderRequestApiUsage, previouslyRevalidatedTags, pendingRevalidations,
   // cacheableFetchUrls, dynamicFetchUrls),
   // Map fields (pendingRevalidatedTags, unstableCacheObservations, _privateCache),
   // requestCache WeakMap, and object fields (headersContext,

--- a/tests/app-page-render.test.ts
+++ b/tests/app-page-render.test.ts
@@ -554,7 +554,11 @@ describe("app page render lifecycle", () => {
     expect(common.isrSet).toHaveBeenCalledWith(
       "rsc:/posts/post",
       expect.objectContaining({ kind: "APP_PAGE" }),
-      { cacheControl: { revalidate: 60 }, tags: ["_N_T_/posts/post"] },
+      {
+        cacheControl: { revalidate: 60 },
+        tags: ["_N_T_/posts/post"],
+        timestamp: expect.any(Number),
+      },
     );
     const cachedValue = common.isrSet.mock.calls[0]?.[1];
     expect(cachedValue?.renderObservation).toMatchObject({
@@ -706,7 +710,11 @@ describe("app page render lifecycle", () => {
     expect(common.isrSet).toHaveBeenCalledWith(
       "rsc:/posts/post",
       expect.objectContaining({ kind: "APP_PAGE" }),
-      { cacheControl: { revalidate: 1, expire: 60, stale: 30 }, tags: ["_N_T_/posts/post"] },
+      {
+        cacheControl: { revalidate: 1, expire: 60, stale: 30 },
+        tags: ["_N_T_/posts/post"],
+        timestamp: expect.any(Number),
+      },
     );
   });
 
@@ -732,7 +740,11 @@ describe("app page render lifecycle", () => {
     expect(common.isrSet).toHaveBeenCalledWith(
       "rsc:/posts/post",
       expect.objectContaining({ kind: "APP_PAGE" }),
-      { cacheControl: { revalidate: 10, expire: 45, stale: 300 }, tags: ["_N_T_/posts/post"] },
+      {
+        cacheControl: { revalidate: 10, expire: 45, stale: 300 },
+        tags: ["_N_T_/posts/post"],
+        timestamp: expect.any(Number),
+      },
     );
   });
 
@@ -784,7 +796,11 @@ describe("app page render lifecycle", () => {
     expect(common.isrSet).toHaveBeenCalledWith(
       "rsc:/posts/post",
       expect.objectContaining({ kind: "APP_PAGE" }),
-      { cacheControl: { revalidate: 7, expire: 11 }, tags: ["_N_T_/posts/post"] },
+      {
+        cacheControl: { revalidate: 7, expire: 11 },
+        tags: ["_N_T_/posts/post"],
+        timestamp: expect.any(Number),
+      },
     );
   });
 
@@ -871,13 +887,21 @@ describe("app page render lifecycle", () => {
       1,
       "html:/posts/post",
       expect.objectContaining({ kind: "APP_PAGE" }),
-      { cacheControl: { revalidate: 30 }, tags: ["_N_T_/posts/post"] },
+      {
+        cacheControl: { revalidate: 30 },
+        tags: ["_N_T_/posts/post"],
+        timestamp: expect.any(Number),
+      },
     );
     expect(common.isrSet).toHaveBeenNthCalledWith(
       2,
       "rsc:/posts/post",
       expect.objectContaining({ kind: "APP_PAGE" }),
-      { cacheControl: { revalidate: 30 }, tags: ["_N_T_/posts/post"] },
+      {
+        cacheControl: { revalidate: 30 },
+        tags: ["_N_T_/posts/post"],
+        timestamp: expect.any(Number),
+      },
     );
   });
 
@@ -970,13 +994,21 @@ describe("app page render lifecycle", () => {
       1,
       "html:/posts/post",
       expect.objectContaining({ kind: "APP_PAGE" }),
-      { cacheControl: { revalidate: 5, expire: 9 }, tags: ["_N_T_/posts/post"] },
+      {
+        cacheControl: { revalidate: 5, expire: 9 },
+        tags: ["_N_T_/posts/post"],
+        timestamp: expect.any(Number),
+      },
     );
     expect(common.isrSet).toHaveBeenNthCalledWith(
       2,
       "rsc:/posts/post",
       expect.objectContaining({ kind: "APP_PAGE" }),
-      { cacheControl: { revalidate: 5, expire: 9 }, tags: ["_N_T_/posts/post"] },
+      {
+        cacheControl: { revalidate: 5, expire: 9 },
+        tags: ["_N_T_/posts/post"],
+        timestamp: expect.any(Number),
+      },
     );
   });
 

--- a/tests/app-route-handler-execution.test.ts
+++ b/tests/app-route-handler-execution.test.ts
@@ -74,6 +74,9 @@ function createDynamicUsageState(): {
 }
 
 describe("app route handler execution helpers", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
   it("runs route handlers with tracked requests and returns dynamic usage", async () => {
     const dynamicUsage = createDynamicUsageState();
     let receivedParams: Record<string, string | string[]> | null = null;
@@ -210,6 +213,8 @@ describe("app route handler execution helpers", () => {
   });
 
   it("finalizes static route handler responses and schedules cache writes", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(1_000);
     const dynamicUsage = createDynamicUsageState();
     const waitUntilPromises: Promise<unknown>[] = [];
     const isrSetCalls: Array<{
@@ -217,6 +222,7 @@ describe("app route handler execution helpers", () => {
       expireSeconds: number | undefined;
       revalidateSeconds: number | false;
       tags: string[];
+      timestamp: number | undefined;
     }> = [];
     const phaseCalls: string[] = [];
     const reportCalls: Error[] = [];
@@ -247,6 +253,7 @@ describe("app route handler execution helpers", () => {
       },
       handler: { dynamic: "auto" },
       handlerFn() {
+        vi.setSystemTime(2_000);
         return new Response("ok", {
           status: 201,
           headers: {
@@ -267,6 +274,7 @@ describe("app route handler execution helpers", () => {
           expireSeconds: policy.cacheControl.expire,
           revalidateSeconds: policy.cacheControl.revalidate,
           tags: policy.tags ?? [],
+          timestamp: policy.timestamp,
         });
       },
       markDynamicUsage: dynamicUsage.markDynamicUsage,
@@ -303,6 +311,7 @@ describe("app route handler execution helpers", () => {
         expireSeconds: 300,
         revalidateSeconds: 60,
         tags: ["/api/static-data", "tag:demo"],
+        timestamp: 1_000,
       },
     ]);
     expect(phaseCalls).toEqual(["route-handler", "render"]);

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -25,6 +25,8 @@ import {
 import {
   NEXT_ROUTER_PREFETCH_HEADER,
   NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
+  NEXT_CACHE_REVALIDATED_TAGS_HEADER,
+  NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER,
   RSC_HEADER,
   VINEXT_CLIENT_REUSE_MANIFEST_HEADER,
   VINEXT_INTERCEPTION_ID_HEADER,
@@ -61,6 +63,7 @@ import {
   CACHEABILITY_REQUEST_STATE,
   type RouteCacheabilityState,
 } from "../packages/vinext/src/shims/cacheability-classification.js";
+import { _wasTagRevalidatedAfter } from "../packages/vinext/src/shims/cache-request-state.js";
 import {
   DefaultCdnCacheAdapter,
   setCdnCacheAdapter,
@@ -230,6 +233,38 @@ function useSplitPolicyAdapter(): void {
 afterEach(() => setCdnCacheAdapter(new DefaultCdnCacheAdapter()));
 
 describe("createAppRscHandler", () => {
+  it("restores authenticated forwarded invalidations without exposing protocol headers", async () => {
+    const observed: Record<string, boolean | string | null> = {};
+    const handler = createHandler({
+      async dispatchMatchedPage() {
+        observed.oldEntry = _wasTagRevalidatedAfter(["posts"], 0);
+        observed.newEntry = _wasTagRevalidatedAfter(["posts"], Date.now() + 10_000);
+        const headers = await requestHeaders();
+        observed.tagsHeader = headers.get(NEXT_CACHE_REVALIDATED_TAGS_HEADER);
+        observed.tokenHeader = headers.get(NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER);
+        return new Response("page");
+      },
+    });
+
+    const response = await handler(
+      new Request("https://example.test/docs/about", {
+        headers: {
+          [NEXT_CACHE_REVALIDATED_TAGS_HEADER]: "posts",
+          [NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER]: "test-draft-secret",
+        },
+      }),
+      null,
+    );
+
+    expect(response.status).toBe(200);
+    expect(observed).toEqual({
+      oldEntry: true,
+      newEntry: false,
+      tagsHeader: null,
+      tokenHeader: null,
+    });
+  });
+
   it("dispatches a matched GET through the App response stage and composes request-stage headers", async () => {
     const dispatchResponseStage = vi.fn<DispatchAppWorkerResponseStage>(async (_request, props) => {
       expect(props).toMatchObject({

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -27,6 +27,7 @@ import {
   NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
   NEXT_CACHE_REVALIDATED_TAGS_HEADER,
   NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER,
+  VINEXT_CACHE_REVALIDATED_TAGS_HEADER,
   RSC_HEADER,
   VINEXT_CLIENT_REUSE_MANIFEST_HEADER,
   VINEXT_INTERCEPTION_ID_HEADER,
@@ -237,11 +238,12 @@ describe("createAppRscHandler", () => {
     const observed: Record<string, boolean | string | null> = {};
     const handler = createHandler({
       async dispatchMatchedPage() {
-        observed.oldEntry = _wasTagRevalidatedAfter(["posts"], 0);
-        observed.newEntry = _wasTagRevalidatedAfter(["posts"], Date.now() + 10_000);
+        observed.oldEntry = _wasTagRevalidatedAfter(["posts,tenant"], 0);
+        observed.newEntry = _wasTagRevalidatedAfter(["posts,tenant"], Date.now() + 10_000);
         const headers = await requestHeaders();
         observed.tagsHeader = headers.get(NEXT_CACHE_REVALIDATED_TAGS_HEADER);
         observed.tokenHeader = headers.get(NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER);
+        observed.vinextTagsHeader = headers.get(VINEXT_CACHE_REVALIDATED_TAGS_HEADER);
         return new Response("page");
       },
     });
@@ -249,8 +251,9 @@ describe("createAppRscHandler", () => {
     const response = await handler(
       new Request("https://example.test/docs/about", {
         headers: {
-          [NEXT_CACHE_REVALIDATED_TAGS_HEADER]: "posts",
+          [NEXT_CACHE_REVALIDATED_TAGS_HEADER]: "posts,tenant",
           [NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER]: "test-draft-secret",
+          [VINEXT_CACHE_REVALIDATED_TAGS_HEADER]: '["posts,tenant"]',
         },
       }),
       null,
@@ -262,6 +265,7 @@ describe("createAppRscHandler", () => {
       newEntry: false,
       tagsHeader: null,
       tokenHeader: null,
+      vinextTagsHeader: null,
     });
   });
 

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -300,6 +300,49 @@ describe("createAppRscHandler", () => {
     expect(await response.text()).toBe("response-stage");
   });
 
+  it("restores authenticated forwarded invalidations across the App response stage", async () => {
+    const observed: Record<string, boolean | string | null> = {};
+    const responseHandler = createHandler({
+      async dispatchMatchedPage() {
+        observed.oldEntry = _wasTagRevalidatedAfter(["posts,tenant"], 0);
+        observed.newEntry = _wasTagRevalidatedAfter(["posts,tenant"], Date.now() + 10_000);
+        const headers = await requestHeaders();
+        observed.tagsHeader = headers.get(NEXT_CACHE_REVALIDATED_TAGS_HEADER);
+        observed.tokenHeader = headers.get(NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER);
+        observed.vinextTagsHeader = headers.get(VINEXT_CACHE_REVALIDATED_TAGS_HEADER);
+        return new Response("page");
+      },
+    });
+    const requestHandler = createHandler();
+    const dispatchResponseStage = vi.fn<DispatchAppWorkerResponseStage>(
+      (request, props, stageOptions) =>
+        responseHandler.handleResponseStage(request, null, props, stageOptions),
+    );
+
+    const response = await requestHandler(
+      new Request("https://example.test/docs/about", {
+        headers: {
+          [NEXT_CACHE_REVALIDATED_TAGS_HEADER]: "posts,tenant",
+          [NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER]: "test-draft-secret",
+          [VINEXT_CACHE_REVALIDATED_TAGS_HEADER]: '["posts,tenant"]',
+        },
+      }),
+      null,
+      false,
+      dispatchResponseStage,
+    );
+
+    expect(response.status).toBe(200);
+    expect(dispatchResponseStage.mock.calls[0]?.[2]).toEqual({ cache: "bypass" });
+    expect(observed).toEqual({
+      oldEntry: true,
+      newEntry: false,
+      tagsHeader: null,
+      tokenHeader: null,
+      vinextTagsHeader: null,
+    });
+  });
+
   it.each(["no-cache", "no-store", "max-age=0, no-cache"])(
     "keeps production App responses shareable with request Cache-Control %s",
     async (cacheControl) => {

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -22,8 +22,13 @@ import {
   VINEXT_RSC_VARY_HEADER,
 } from "../packages/vinext/src/server/app-rsc-cache-busting.js";
 import {
+  NEXT_CACHE_REVALIDATED_TAGS_HEADER,
+  NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER,
+} from "../packages/vinext/src/server/headers.js";
+import {
   cacheTag,
   getAndClearActionRevalidationKind,
+  MemoryCacheHandler,
   refresh,
   revalidatePath,
   revalidateTag,
@@ -1829,25 +1834,30 @@ describe("app server action execution helpers", () => {
     });
     Object.defineProperty(actionRequest, "cf", { value: { country: "AU" }, enumerable: true });
 
-    const response = await handleServerActionRscRequest(
-      createRscOptions({
-        async dispatchRedirectTargetRequest(request) {
-          targetRequest = request;
-          return new Response("target-flight", {
-            headers: {
-              "content-type": "text/x-component",
-              "x-target-pipeline": "1",
-            },
-          });
-        },
-        getAndClearPendingCookies() {
-          return ["theme=dark; Path=/", "deleted=; Path=/; Max-Age=0"];
-        },
-        loadServerAction() {
-          return Promise.resolve(() => redirect("/redirect-target?from=action"));
-        },
-        request: actionRequest,
-      }),
+    const response = await runWithRequestContext(createRequestContext(), () =>
+      handleServerActionRscRequest(
+        createRscOptions({
+          async dispatchRedirectTargetRequest(request) {
+            targetRequest = request;
+            return new Response("target-flight", {
+              headers: {
+                "content-type": "text/x-component",
+                "x-target-pipeline": "1",
+              },
+            });
+          },
+          getAndClearPendingCookies() {
+            return ["theme=dark; Path=/", "deleted=; Path=/; Max-Age=0"];
+          },
+          loadServerAction() {
+            return Promise.resolve(() => {
+              updateTag("redirected-posts");
+              redirect("/redirect-target?from=action");
+            });
+          },
+          request: actionRequest,
+        }),
+      ),
     );
 
     expect(response?.status).toBe(303);
@@ -1864,6 +1874,8 @@ describe("app server action execution helpers", () => {
     expect(targetRequest!.headers.get("x-rsc-action")).toBeNull();
     expect(targetRequest!.headers.get("next-router-state-tree")).toBeNull();
     expect(targetRequest!.headers.get("x-vinext-mw-ctx")).toBeNull();
+    expect(targetRequest!.headers.get(NEXT_CACHE_REVALIDATED_TAGS_HEADER)).toBe("redirected-posts");
+    expect(targetRequest!.headers.get(NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER)).toBe("draft-secret");
     expect(targetRequest!.headers.get("cookie")).toBe("session=1; theme=dark");
     expect(Reflect.get(targetRequest!, "cf")).toEqual({ country: "AU" });
   });
@@ -2403,6 +2415,48 @@ describe("app server action execution helpers", () => {
     expect(response?.headers.get("x-action-revalidated")).toBe("1");
   });
 
+  // Ported from Next.js: test/e2e/app-dir/use-cache/use-cache.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/use-cache/use-cache.test.ts
+  it("reuses each use cache value before and after updateTag across an action rerender", async () => {
+    const previousHandler = getDataCacheHandler();
+    setDataCacheHandler(new MemoryCacheHandler());
+    let callCount = 0;
+    const actionValues: number[] = [];
+    const rerenderValues: number[] = [];
+    const cached = registerCachedFunction(async () => {
+      cacheTag("action-dedupe-integration");
+      return ++callCount;
+    }, "test:action-dedupe-integration");
+
+    try {
+      const response = await runWithRequestContext(createRequestContext(), () =>
+        handleServerActionRscRequest(
+          createRscOptions({
+            loadServerAction() {
+              return Promise.resolve(async () => {
+                actionValues.push(await cached(), await cached());
+                updateTag("action-dedupe-integration");
+                return "revalidated";
+              });
+            },
+            async renderToReadableStream(model) {
+              rerenderValues.push(await cached(), await cached());
+              return new Response(JSON.stringify(model)).body!;
+            },
+          }),
+        ),
+      );
+
+      expect(response?.status).toBe(200);
+      await response?.text();
+      expect(actionValues).toEqual([1, 1]);
+      expect(rerenderValues).toEqual([2, 2]);
+      expect(callCount).toBe(2);
+    } finally {
+      setDataCacheHandler(previousHandler);
+    }
+  });
+
   // Covers the read-your-own-writes ordering asserted by Next.js:
   // test/e2e/app-dir/resume-data-cache/resume-data-cache.test.ts
   // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/resume-data-cache/resume-data-cache.test.ts
@@ -2434,11 +2488,15 @@ describe("app server action execution helpers", () => {
       cacheTag("dashboard");
       return "fresh-use-cache";
     }, "test:update-tag-read-your-own-writes");
+    // This fixture represents a value persisted before the action invalidates
+    // its tag. Keep that creation time stable: returning Date.now() from get()
+    // would falsely describe the old value as newly written on every read.
+    const storedAt = Date.now() - 1_000;
 
     setDataCacheHandler({
       async get() {
         return {
-          lastModified: Date.now(),
+          lastModified: storedAt,
           value: {
             kind: "FETCH",
             data: {

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -24,6 +24,7 @@ import {
 import {
   NEXT_CACHE_REVALIDATED_TAGS_HEADER,
   NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER,
+  VINEXT_CACHE_REVALIDATED_TAGS_HEADER,
 } from "../packages/vinext/src/server/headers.js";
 import {
   cacheTag,
@@ -1851,7 +1852,7 @@ describe("app server action execution helpers", () => {
           },
           loadServerAction() {
             return Promise.resolve(() => {
-              updateTag("redirected-posts");
+              updateTag("redirected,posts");
               redirect("/redirect-target?from=action");
             });
           },
@@ -1874,7 +1875,10 @@ describe("app server action execution helpers", () => {
     expect(targetRequest!.headers.get("x-rsc-action")).toBeNull();
     expect(targetRequest!.headers.get("next-router-state-tree")).toBeNull();
     expect(targetRequest!.headers.get("x-vinext-mw-ctx")).toBeNull();
-    expect(targetRequest!.headers.get(NEXT_CACHE_REVALIDATED_TAGS_HEADER)).toBe("redirected-posts");
+    expect(targetRequest!.headers.get(NEXT_CACHE_REVALIDATED_TAGS_HEADER)).toBe("redirected,posts");
+    expect(targetRequest!.headers.get(VINEXT_CACHE_REVALIDATED_TAGS_HEADER)).toBe(
+      '["redirected,posts"]',
+    );
     expect(targetRequest!.headers.get(NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER)).toBe("draft-secret");
     expect(targetRequest!.headers.get("cookie")).toBe("session=1; theme=dark");
     expect(Reflect.get(targetRequest!, "cf")).toEqual({ country: "AU" });

--- a/tests/app-worker-stages.test.ts
+++ b/tests/app-worker-stages.test.ts
@@ -186,6 +186,27 @@ describe("App Worker response stage", () => {
     expect(isAppWorkerResponseStageProps(withoutInterceptionId)).toBe(false);
   });
 
+  it("validates forwarded revalidation state", () => {
+    expect(
+      isAppWorkerResponseStageProps({
+        ...notFoundStage,
+        forwardedRevalidation: { requestStartTime: 1_000, tags: ["posts"] },
+      }),
+    ).toBe(true);
+    expect(
+      isAppWorkerResponseStageProps({
+        ...notFoundStage,
+        forwardedRevalidation: { requestStartTime: Number.NaN, tags: ["posts"] },
+      }),
+    ).toBe(false);
+    expect(
+      isAppWorkerResponseStageProps({
+        ...notFoundStage,
+        forwardedRevalidation: { requestStartTime: 1_000, tags: [] },
+      }),
+    ).toBe(false);
+  });
+
   it.each([
     { name: "missing", requestOrigin: undefined },
     { name: "relative", requestOrigin: "example.com" },

--- a/tests/fetch-cache.test.ts
+++ b/tests/fetch-cache.test.ts
@@ -1037,6 +1037,7 @@ describe("fetch cache shim", () => {
 
   it("bypasses a stored tagged fetch while its request-local invalidation is pending", async () => {
     const previousHandler = getCacheHandler();
+    const storedAt = Date.now();
     let markInvalidationStarted!: () => void;
     const invalidationStarted = new Promise<void>((resolve) => {
       markInvalidationStarted = resolve;
@@ -1052,7 +1053,7 @@ describe("fetch cache shim", () => {
         getCalls++;
         if (getCalls === 1) return null;
         return {
-          lastModified: Date.now(),
+          lastModified: storedAt,
           value: {
             kind: "FETCH",
             data: {
@@ -1099,6 +1100,39 @@ describe("fetch cache shim", () => {
   });
 
   // ── TTL expiry (stale-while-revalidate) ─────────────────────────────
+
+  it("reuses a tagged fetch cached after request-local revalidation", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-08-15T00:00:00.000Z"));
+
+      await runWithRequestContext(createRequestContext(), () =>
+        runWithFetchDedupe(async () => {
+          const initial = await fetch("https://api.example.com/post-revalidation-reuse", {
+            next: { revalidate: 60, tags: ["posts"] },
+          });
+          expect((await initial.json()).count).toBe(1);
+
+          vi.advanceTimersByTime(10);
+          expect(revalidateTag("posts", { expire: 0 })).toBeUndefined();
+
+          vi.advanceTimersByTime(10);
+          const regenerated = await fetch("https://api.example.com/post-revalidation-reuse", {
+            next: { revalidate: 60, tags: ["posts"] },
+          });
+          expect((await regenerated.json()).count).toBe(2);
+
+          const reused = await fetch("https://api.example.com/post-revalidation-reuse", {
+            next: { revalidate: 60, tags: ["posts"] },
+          });
+          expect((await reused.json()).count).toBe(2);
+          expect(fetchMock).toHaveBeenCalledTimes(2);
+        }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 
   it("returns stale data after TTL expires and triggers background refetch", async () => {
     const res1 = await fetch("https://api.example.com/stale-test", {

--- a/tests/fetch-cache.test.ts
+++ b/tests/fetch-cache.test.ts
@@ -55,8 +55,14 @@ const {
   consumeDynamicFetchObservations,
   peekDynamicFetchObservations,
 } = await import("../packages/vinext/src/shims/fetch-cache.js");
-const { getCacheHandler, revalidatePath, revalidateTag, MemoryCacheHandler, setCacheHandler } =
-  await import("../packages/vinext/src/shims/cache.js");
+const {
+  getCacheHandler,
+  getCacheTimestamp,
+  revalidatePath,
+  revalidateTag,
+  MemoryCacheHandler,
+  setCacheHandler,
+} = await import("../packages/vinext/src/shims/cache.js");
 const { consumeDynamicUsage, setHeadersContext } =
   await import("../packages/vinext/src/shims/headers.js");
 const { runWithExecutionContext } = await import("../packages/vinext/src/shims/request-context.js");
@@ -107,6 +113,72 @@ describe("fetch cache shim", () => {
     const data2 = await res2.json();
     expect(data2.count).toBe(1); // Same count = cached
     expect(fetchMock).toHaveBeenCalledTimes(1); // Only one real fetch
+  });
+
+  it("passes the fetch-start timestamp to the cache handler", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-08-17T00:00:00.000Z"));
+      let persistedTimestamp: unknown;
+      let observedDuringFetch = 0;
+      setCacheHandler({
+        async get() {
+          return null;
+        },
+        async set(_key, _value, ctx) {
+          persistedTimestamp = ctx?.timestamp;
+        },
+        async revalidateTag() {},
+      });
+      fetchMock.mockImplementationOnce(async (input: string | URL | Request) => {
+        vi.advanceTimersByTime(10);
+        observedDuringFetch = getCacheTimestamp();
+        return defaultFetchMockImplementation(input);
+      });
+
+      await fetch("https://api.example.com/producer-timestamp", {
+        next: { revalidate: 60, tags: ["producer-timestamp"] },
+      });
+
+      expect(typeof persistedTimestamp).toBe("number");
+      expect(persistedTimestamp as number).toBeLessThan(observedDuringFetch);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("preserves an entry timestamp when lowering its revalidate policy", async () => {
+    const existingTimestamp = 0;
+    let persistedTimestamp: unknown;
+    setCacheHandler({
+      async get() {
+        return {
+          lastModified: existingTimestamp,
+          value: {
+            kind: "FETCH",
+            data: {
+              headers: { "content-type": "application/json" },
+              body: Buffer.from(JSON.stringify({ cached: true })).toString("base64"),
+              url: "https://api.example.com/lower-policy-timestamp",
+            },
+            tags: ["existing"],
+            revalidate: 60,
+          },
+        };
+      },
+      async set(_key, _value, ctx) {
+        persistedTimestamp = ctx?.timestamp;
+      },
+      async revalidateTag() {},
+    });
+
+    const response = await fetch("https://api.example.com/lower-policy-timestamp", {
+      next: { revalidate: 30, tags: ["additional"] },
+    });
+
+    expect(await response.json()).toEqual({ cached: true });
+    expect(persistedTimestamp).toBe(existingTimestamp);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("cache: 'force-cache' caches indefinitely", async () => {

--- a/tests/fetch-cache.test.ts
+++ b/tests/fetch-cache.test.ts
@@ -1112,6 +1112,10 @@ describe("fetch cache shim", () => {
             next: { revalidate: 60, tags: ["posts"] },
           });
           expect((await initial.json()).count).toBe(1);
+          const initialReuse = await fetch("https://api.example.com/post-revalidation-reuse", {
+            next: { revalidate: 60, tags: ["posts"] },
+          });
+          expect((await initialReuse.json()).count).toBe(1);
 
           vi.advanceTimersByTime(10);
           expect(revalidateTag("posts", { expire: 0 })).toBeUndefined();
@@ -1129,6 +1133,56 @@ describe("fetch cache shim", () => {
           expect(fetchMock).toHaveBeenCalledTimes(2);
         }),
       );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not persist a tagged fetch fill that straddles request-local revalidation", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-08-15T00:00:00.000Z"));
+      let releaseFill!: () => void;
+      const fillGate = new Promise<void>((resolve) => {
+        releaseFill = resolve;
+      });
+      let markFillStarted!: () => void;
+      const fillStarted = new Promise<void>((resolve) => {
+        markFillStarted = resolve;
+      });
+      fetchMock.mockImplementationOnce(async (input: string | URL | Request) => {
+        requestCount++;
+        markFillStarted();
+        await fillGate;
+        const url =
+          typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+        return new Response(JSON.stringify({ url, count: requestCount }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      });
+
+      await runWithRequestContext(createRequestContext(), async () => {
+        const straddled = fetch("https://api.example.com/straddled-tagged-fill", {
+          next: { revalidate: 60, tags: ["posts"] },
+        });
+        await fillStarted;
+        vi.advanceTimersByTime(10);
+        expect(revalidateTag("posts", { expire: 0 })).toBeUndefined();
+        vi.advanceTimersByTime(10);
+        releaseFill();
+
+        expect((await (await straddled).json()).count).toBe(1);
+        const regenerated = await fetch("https://api.example.com/straddled-tagged-fill", {
+          next: { revalidate: 60, tags: ["posts"] },
+        });
+        expect((await regenerated.json()).count).toBe(2);
+        const reused = await fetch("https://api.example.com/straddled-tagged-fill", {
+          next: { revalidate: 60, tags: ["posts"] },
+        });
+        expect((await reused.json()).count).toBe(2);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+      });
     } finally {
       vi.useRealTimers();
     }

--- a/tests/fetch-cache.test.ts
+++ b/tests/fetch-cache.test.ts
@@ -1248,7 +1248,7 @@ describe("fetch cache shim", () => {
     const handler = getCacheHandler() as InstanceType<typeof MemoryCacheHandler>;
     const store = (handler as any).store as Map<string, any>;
     for (const [, entry] of store) {
-      entry.lastModified = Date.now() - 2_000;
+      entry.writtenAt = Date.now() - 2_000;
       entry.revalidateAt = Date.now() + 58_000;
     }
     startNewFetchCacheScope();
@@ -1273,7 +1273,7 @@ describe("fetch cache shim", () => {
     const handler = getCacheHandler() as InstanceType<typeof MemoryCacheHandler>;
     const store = (handler as any).store as Map<string, any>;
     for (const [, entry] of store) {
-      entry.lastModified = Date.now() - 2_000;
+      entry.writtenAt = Date.now() - 2_000;
       entry.revalidateAt = Date.now() + 58_000;
     }
     startNewFetchCacheScope();

--- a/tests/isr-cache.test.ts
+++ b/tests/isr-cache.test.ts
@@ -410,6 +410,18 @@ describe("ISR expire ceiling", () => {
     });
   });
 
+  it("keeps a newly written entry fresh after the wall clock advances independently", async () => {
+    const initialWallTime = Date.now();
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(initialWallTime + 2_000);
+
+    await isrSet("advanced-wall-clock", buildPagesCacheValue("<html>fresh</html>", {}), {
+      cacheControl: { revalidate: 1 },
+    });
+
+    await expect(isrGet("advanced-wall-clock")).resolves.toMatchObject({ isStale: false });
+  });
+
   it("preserves legacy revalidate context while writing cache-control metadata", async () => {
     let setContext: Record<string, unknown> | undefined;
     setCacheHandler({

--- a/tests/isr-cache.test.ts
+++ b/tests/isr-cache.test.ts
@@ -437,12 +437,59 @@ describe("ISR expire ceiling", () => {
     await isrSet("compat-test", buildPagesCacheValue("<html>cached</html>", {}), {
       cacheControl: { revalidate: 60, expire: 300 },
       tags: ["tag"],
+      timestamp: 123,
     });
 
     expect(setContext).toEqual({
       cacheControl: { revalidate: 60, expire: 300 },
       revalidate: 60,
       tags: ["tag"],
+      timestamp: 123,
+    });
+  });
+
+  it("keeps an invalidation during an ISR render newer than the eventual write", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(0);
+    setCacheHandler(new MemoryCacheHandler());
+
+    await runWithRequestContext(createRequestContext({ requestStartTime: 0 }), async () => {
+      vi.setSystemTime(10);
+      await Promise.resolve(revalidatePath("/isr-race"));
+
+      await isrSet("isr-race", buildPagesCacheValue("<html>stale render</html>", {}), {
+        cacheControl: { revalidate: 60 },
+        tags: ["_N_T_/isr-race"],
+        timestamp: 0,
+      });
+
+      await expect(isrGet("isr-race")).resolves.toBeNull();
+    });
+  });
+
+  it("keeps an ISR fill started after invalidation reusable", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(0);
+    setCacheHandler(new MemoryCacheHandler());
+
+    await runWithRequestContext(createRequestContext({ requestStartTime: 0 }), async () => {
+      vi.setSystemTime(10);
+      await Promise.resolve(revalidatePath("/fresh-after-invalidation"));
+
+      vi.setSystemTime(20);
+      await isrSet(
+        "fresh-after-invalidation",
+        buildPagesCacheValue("<html>fresh render</html>", {}),
+        {
+          cacheControl: { revalidate: 60 },
+          tags: ["_N_T_/fresh-after-invalidation"],
+          timestamp: Date.now(),
+        },
+      );
+
+      expect(await isrGet("fresh-after-invalidation")).toMatchObject({
+        value: { value: { kind: "PAGES", html: "<html>fresh render</html>" } },
+      });
     });
   });
 

--- a/tests/isr-cache.test.ts
+++ b/tests/isr-cache.test.ts
@@ -493,6 +493,25 @@ describe("ISR expire ceiling", () => {
     });
   });
 
+  it("rejects an older ISR entry invalidated by a forwarded request", async () => {
+    setCacheHandler(new MemoryCacheHandler());
+    await isrSet("forwarded-invalidation", buildPagesCacheValue("<html>stale</html>", {}), {
+      cacheControl: { revalidate: 60 },
+      tags: ["posts"],
+      timestamp: 1_000,
+    });
+
+    await runWithRequestContext(
+      createRequestContext({
+        previouslyRevalidatedTags: new Set(["posts"]),
+        requestStartTime: 2_000,
+      }),
+      async () => {
+        await expect(isrGet("forwarded-invalidation")).resolves.toBeNull();
+      },
+    );
+  });
+
   it("stores revalidate false without creating a revalidation deadline", async () => {
     vi.useFakeTimers({ toFake: ["Date"] });
     vi.setSystemTime(1_000);

--- a/tests/kv-cache-handler.test.ts
+++ b/tests/kv-cache-handler.test.ts
@@ -801,7 +801,7 @@ describe("KVCacheHandler", () => {
             revalidate: 3600,
           },
           tags: ["posts"],
-          lastModified: 1_000,
+          lastModified: 2_000,
           revalidateAt: null,
         }),
       );
@@ -818,6 +818,7 @@ describe("KVCacheHandler", () => {
       expect(await handler.get("forwarded-invalidation")).toBeNull();
       expect(kv.get).toHaveBeenCalledTimes(1);
       expect(kv.get).toHaveBeenCalledWith("cache:forwarded-invalidation");
+      expect(kv.delete).not.toHaveBeenCalled();
     });
 
     it("does not delete a newer central entry after a forwarded stale read", async () => {
@@ -843,6 +844,13 @@ describe("KVCacheHandler", () => {
           revalidatedTags: ["posts"],
         }),
       ).toBeNull();
+      expect(kv.delete).not.toHaveBeenCalled();
+      expect(store.get("cache:forwarded-stale-read")).toBe(replacement);
+
+      kv.get.mockClear();
+      expect(await handler.get("forwarded-stale-read")).toBeNull();
+      expect(kv.get).toHaveBeenCalledTimes(1);
+      expect(kv.get).toHaveBeenCalledWith("cache:forwarded-stale-read");
       expect(kv.delete).not.toHaveBeenCalled();
       expect(store.get("cache:forwarded-stale-read")).toBe(replacement);
     });

--- a/tests/kv-cache-handler.test.ts
+++ b/tests/kv-cache-handler.test.ts
@@ -375,6 +375,22 @@ describe("KVCacheHandler", () => {
       expect(kv.delete).toHaveBeenCalledWith("cache:bad-reval");
     });
 
+    it("rejects entry with invalid writtenAt type", async () => {
+      store.set(
+        "cache:bad-written-at",
+        JSON.stringify({
+          value: null,
+          tags: [],
+          lastModified: 123,
+          writtenAt: "not-a-number",
+          revalidateAt: null,
+        }),
+      );
+      const result = await handler.get("bad-written-at");
+      expect(result).toBeNull();
+      expect(kv.delete).toHaveBeenCalledWith("cache:bad-written-at");
+    });
+
     it("rejects entry with invalid expireAt type", async () => {
       store.set(
         "cache:bad-expire",
@@ -619,6 +635,27 @@ describe("KVCacheHandler", () => {
       vi.setSystemTime(4_500);
       await expect(handler.get("expire-test")).resolves.toBeNull();
       expect(kv.delete).toHaveBeenCalledWith("cache:expire-test");
+    });
+
+    it("keeps a newly written entry fresh after the wall clock advances independently", async () => {
+      const initialWallTime = Date.now();
+      vi.useFakeTimers({ toFake: ["Date"] });
+      vi.setSystemTime(initialWallTime + 2_000);
+
+      await handler.set(
+        "advanced-wall-clock",
+        {
+          kind: "FETCH",
+          data: { headers: {}, body: "fresh", url: "https://example.com/data" },
+          tags: [],
+          revalidate: 1,
+        },
+        { revalidate: 1 },
+      );
+
+      const hit = await handler.get("advanced-wall-clock", { revalidate: 1 });
+      expect(hit?.cacheState).toBeUndefined();
+      expect(hit?.value?.kind).toBe("FETCH");
     });
 
     it("round-trips the client stale claim through stored cacheControl", async () => {

--- a/tests/kv-cache-handler.test.ts
+++ b/tests/kv-cache-handler.test.ts
@@ -669,8 +669,8 @@ describe("KVCacheHandler", () => {
     it("revalidateTag persists slash-based path invalidation markers", async () => {
       await handler.revalidateTag(["/revalidate-tag-test", "_N_T_/revalidate-tag-test"]);
 
-      expect(store.get("__tag:/revalidate-tag-test")).toMatch(/^\d+$/);
-      expect(store.get("__tag:_N_T_/revalidate-tag-test")).toMatch(/^\d+$/);
+      expect(Number(store.get("__tag:/revalidate-tag-test"))).toBeGreaterThan(0);
+      expect(Number(store.get("__tag:_N_T_/revalidate-tag-test"))).toBeGreaterThan(0);
     });
 
     it("slash-based path tags invalidate persisted APP_PAGE entries", async () => {
@@ -699,6 +699,26 @@ describe("KVCacheHandler", () => {
 
       expect(result).toBeNull();
       expect(kv.delete).toHaveBeenCalledWith("cache:app-page");
+    });
+
+    it("keeps an entry created at the same timestamp as tag invalidation", async () => {
+      store.set(
+        "cache:same-timestamp",
+        JSON.stringify({
+          value: {
+            kind: "FETCH",
+            data: { headers: {}, body: "fresh", url: "https://example.test/data" },
+            revalidate: 3600,
+          },
+          tags: ["posts"],
+          lastModified: 2_000,
+          revalidateAt: null,
+        }),
+      );
+      store.set("__tag:posts", "2000");
+
+      expect(await handler.get("same-timestamp")).not.toBeNull();
+      expect(kv.delete).not.toHaveBeenCalledWith("cache:same-timestamp");
     });
 
     it("softTags invalidate FETCH reads without deleting the shared entry", async () => {
@@ -1781,6 +1801,7 @@ describe("KVCacheHandler", () => {
         },
         { revalidate: 60, tags },
       );
+      vi.advanceTimersByTime(1);
     }
 
     it("invalidates entries whose paths match the prefix (segment-aware)", async () => {
@@ -1893,6 +1914,7 @@ describe("KVCacheHandler", () => {
       expect(await handler.get("/big-tags")).not.toBeNull();
 
       // Exact-path invalidation via revalidateTag still works
+      vi.advanceTimersByTime(1);
       await handler.revalidateTag(allTags.slice(0, 2));
       handler.resetRequestCache();
       expect(await handler.get("/big-tags")).toBeNull();
@@ -1928,6 +1950,7 @@ describe("KVCacheHandler", () => {
         },
         { revalidate: 60, tags },
       );
+      vi.advanceTimersByTime(1);
     }
 
     it("invalidates the cached page after revalidatePath('/foo')", async () => {
@@ -2025,6 +2048,7 @@ describe("KVCacheHandler", () => {
       const beforeHit = await handler.get("/seeded");
       expect(beforeHit).not.toBeNull();
 
+      vi.advanceTimersByTime(1);
       await Promise.resolve(revalidatePath("/seeded"));
 
       handler.resetRequestCache();

--- a/tests/kv-cache-handler.test.ts
+++ b/tests/kv-cache-handler.test.ts
@@ -584,6 +584,24 @@ describe("KVCacheHandler", () => {
       expect((result!.value as any).html).toBe("<div>hi</div>");
     });
 
+    it("persists and returns a zero producer timestamp", async () => {
+      const timestamp = 0;
+      await handler.set(
+        "producer-timestamp",
+        {
+          kind: "PAGES",
+          html: "<div>timestamped</div>",
+          pageData: {},
+          headers: undefined,
+          status: 200,
+        },
+        { timestamp },
+      );
+
+      expect(JSON.parse(store.get("cache:producer-timestamp")!).lastModified).toBe(timestamp);
+      expect((await handler.get("producer-timestamp"))?.lastModified).toBe(timestamp);
+    });
+
     it("preserves slash-based path tags for Workers invalidation", async () => {
       await handler.set(
         "rt-path-tags",

--- a/tests/kv-cache-handler.test.ts
+++ b/tests/kv-cache-handler.test.ts
@@ -776,6 +776,30 @@ describe("KVCacheHandler", () => {
       expect(kv.delete).not.toHaveBeenCalledWith("cache:same-timestamp");
     });
 
+    it("rejects an older entry invalidated by a forwarded request", async () => {
+      store.set(
+        "cache:forwarded-invalidation",
+        JSON.stringify({
+          value: {
+            kind: "FETCH",
+            data: { headers: {}, body: "stale", url: "https://example.test/data" },
+            revalidate: 3600,
+          },
+          tags: ["posts"],
+          lastModified: 1_000,
+          revalidateAt: null,
+        }),
+      );
+
+      expect(
+        await handler.get("forwarded-invalidation", {
+          requestStartTime: 2_000,
+          revalidatedTags: ["posts"],
+        }),
+      ).toBeNull();
+      expect(kv.delete).toHaveBeenCalledWith("cache:forwarded-invalidation");
+    });
+
     it("softTags invalidate FETCH reads without deleting the shared entry", async () => {
       store.set(
         "cache:fetch-entry",

--- a/tests/kv-cache-handler.test.ts
+++ b/tests/kv-cache-handler.test.ts
@@ -778,6 +778,21 @@ describe("KVCacheHandler", () => {
 
     it("rejects an older entry invalidated by a forwarded request", async () => {
       store.set(
+        "cache:forwarded-primer",
+        JSON.stringify({
+          value: {
+            kind: "FETCH",
+            data: { headers: {}, body: "newer", url: "https://example.test/data" },
+            revalidate: 3600,
+          },
+          tags: ["posts"],
+          lastModified: 3_000,
+          revalidateAt: null,
+        }),
+      );
+      expect(await handler.get("forwarded-primer")).not.toBeNull();
+
+      store.set(
         "cache:forwarded-invalidation",
         JSON.stringify({
           value: {
@@ -797,7 +812,39 @@ describe("KVCacheHandler", () => {
           revalidatedTags: ["posts"],
         }),
       ).toBeNull();
-      expect(kv.delete).toHaveBeenCalledWith("cache:forwarded-invalidation");
+      expect(kv.delete).not.toHaveBeenCalled();
+
+      kv.get.mockClear();
+      expect(await handler.get("forwarded-invalidation")).toBeNull();
+      expect(kv.get).toHaveBeenCalledTimes(1);
+      expect(kv.get).toHaveBeenCalledWith("cache:forwarded-invalidation");
+    });
+
+    it("does not delete a newer central entry after a forwarded stale read", async () => {
+      const value = {
+        kind: "FETCH",
+        data: { headers: {}, body: "value", url: "https://example.test/data" },
+        revalidate: 3600,
+      };
+      const stale = validEntry(value, { tags: ["posts"], lastModified: 1_000 });
+      const replacement = validEntry(value, { tags: ["posts"], lastModified: 3_000 });
+      store.set("cache:forwarded-stale-read", replacement);
+      kv.get.mockImplementation(async (key: string | string[]) => {
+        if (key === "cache:forwarded-stale-read") return stale;
+        if (Array.isArray(key)) {
+          return new Map(key.map((item) => [item, store.get(item) ?? null]));
+        }
+        return store.get(key) ?? null;
+      });
+
+      expect(
+        await handler.get("forwarded-stale-read", {
+          requestStartTime: 2_000,
+          revalidatedTags: ["posts"],
+        }),
+      ).toBeNull();
+      expect(kv.delete).not.toHaveBeenCalled();
+      expect(store.get("cache:forwarded-stale-read")).toBe(replacement);
     });
 
     it("softTags invalidate FETCH reads without deleting the shared entry", async () => {

--- a/tests/metadata-route-response.test.ts
+++ b/tests/metadata-route-response.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vite-plus/test";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import {
   getPrerenderableMetadataRoutePaths,
   handleMetadataRouteRequest,
@@ -27,6 +27,9 @@ function markUseCache<T extends (...args: never[]) => unknown>(fn: T): T {
 }
 
 describe("handleMetadataRouteRequest", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
   it("enumerates cached text metadata routes for build prerendering", async () => {
     // Ported from Next.js:
     // test/e2e/app-dir/use-cache-metadata-route-handler/use-cache-metadata-route-handler.test.ts
@@ -346,15 +349,18 @@ describe("handleMetadataRouteRequest", () => {
   });
 
   it("serves stale metadata while regenerating its value and invalidation tags", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(1_000);
     let metadataCalls = 0;
     let regenerate: (() => Promise<void>) | undefined;
     const writes: Array<{
       key: string;
-      policy: { cacheControl?: unknown; tags?: string[] };
+      policy: { cacheControl?: unknown; tags?: string[]; timestamp?: number };
       value: { headers: Record<string, string | string[]>; body: ArrayBuffer };
     }> = [];
     const defaultExport = markUseCache(async () => {
       metadataCalls++;
+      vi.setSystemTime(3_000);
       addCollectedRequestTags(["metadata-user-tag"]);
       return { rules: { userAgent: "*", allow: "/regenerated" } };
     });
@@ -405,6 +411,7 @@ describe("handleMetadataRouteRequest", () => {
     expect(await response?.text()).toContain("/stale");
     expect(regenerate).toBeTypeOf("function");
 
+    vi.setSystemTime(2_000);
     await regenerate?.();
     expect(metadataCalls).toBe(1);
     expect(writes).toHaveLength(1);
@@ -414,6 +421,7 @@ describe("handleMetadataRouteRequest", () => {
       expire: 300,
       stale: 30,
     });
+    expect(writes[0].policy.timestamp).toBe(2_000);
     expect(writes[0].policy.tags).toEqual(
       expect.arrayContaining([
         "/robots.txt",

--- a/tests/pages-page-data.test.ts
+++ b/tests/pages-page-data.test.ts
@@ -386,7 +386,10 @@ describe("pages page data", () => {
           pageProps: { fromApp: true, fromStatic: true },
         },
       }),
-      { cacheControl: { revalidate: 10, expire: 300 } },
+      {
+        cacheControl: { revalidate: 10, expire: 300 },
+        timestamp: expect.any(Number),
+      },
     );
   });
 
@@ -1380,7 +1383,7 @@ describe("pages page data", () => {
         html: expect.stringContaining("<div>fresh-body</div>"),
         pageData: { pageProps: { title: "fresh" } },
       }),
-      { cacheControl: { revalidate: false } },
+      { cacheControl: { revalidate: false }, timestamp: expect.any(Number) },
     );
     expect(isrSet).toHaveBeenCalledWith(
       "pages:/posts/post",
@@ -1389,7 +1392,7 @@ describe("pages page data", () => {
         html: expect.stringContaining('"__vinext":{"hasMiddleware":true}'),
         pageData: { pageProps: { title: "fresh" } },
       }),
-      { cacheControl: { revalidate: false } },
+      { cacheControl: { revalidate: false }, timestamp: expect.any(Number) },
     );
   });
 
@@ -1733,6 +1736,7 @@ describe("pages page data", () => {
       documentReqRes: null,
       gsspRes: null,
       isrExpireSeconds: 300,
+      isrFillStartedAt: expect.any(Number),
       isrRevalidateSeconds: 30,
       pageProps: { title: "hello" },
       props: { pageProps: { title: "hello" } },

--- a/tests/pages-page-response.test.ts
+++ b/tests/pages-page-response.test.ts
@@ -292,7 +292,10 @@ describe("pages page response", () => {
         html: expect.stringContaining("<div>live-body</div>"),
         pageData: { pageProps: { title: "hello" } },
       }),
-      { cacheControl: { revalidate: 60, expire: 300 } },
+      {
+        cacheControl: { revalidate: 60, expire: 300 },
+        timestamp: expect.any(Number),
+      },
     );
   });
 
@@ -331,7 +334,7 @@ describe("pages page response", () => {
     expect(common.isrSet).toHaveBeenCalledWith(
       "pages:/posts/post",
       expect.objectContaining({ kind: "PAGES" }),
-      { cacheControl: { revalidate: false } },
+      { cacheControl: { revalidate: false }, timestamp: expect.any(Number) },
     );
   });
 
@@ -358,7 +361,7 @@ describe("pages page response", () => {
       expect.objectContaining({
         html: expect.stringContaining("\u20ac<div>live-body</div>"),
       }),
-      { cacheControl: { revalidate: 60 } },
+      { cacheControl: { revalidate: 60 }, timestamp: expect.any(Number) },
     );
   });
 

--- a/tests/revalidated-tags.test.ts
+++ b/tests/revalidated-tags.test.ts
@@ -36,6 +36,16 @@ describe("forwarded cache revalidation tags", () => {
     expect(readPreviouslyRevalidatedTags(headers, "draft-secret")).toEqual(['["posts"]']);
   });
 
+  it("falls back to the legacy header when the JSON side channel is malformed", () => {
+    const headers = new Headers({
+      [NEXT_CACHE_REVALIDATED_TAGS_HEADER]: "posts,users",
+      [NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER]: "draft-secret",
+      [VINEXT_CACHE_REVALIDATED_TAGS_HEADER]: "not-json",
+    });
+
+    expect(readPreviouslyRevalidatedTags(headers, "draft-secret")).toEqual(["posts", "users"]);
+  });
+
   it("rejects forged tags with a missing or mismatched token", () => {
     const headers = new Headers({
       [NEXT_CACHE_REVALIDATED_TAGS_HEADER]: "posts",

--- a/tests/revalidated-tags.test.ts
+++ b/tests/revalidated-tags.test.ts
@@ -6,6 +6,7 @@ import {
 import {
   NEXT_CACHE_REVALIDATED_TAGS_HEADER,
   NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER,
+  VINEXT_CACHE_REVALIDATED_TAGS_HEADER,
 } from "../packages/vinext/src/server/headers.js";
 
 describe("forwarded cache revalidation tags", () => {
@@ -14,8 +15,25 @@ describe("forwarded cache revalidation tags", () => {
     writePreviouslyRevalidatedTags(headers, ["posts", "users", "posts"], "draft-secret");
 
     expect(headers.get(NEXT_CACHE_REVALIDATED_TAGS_HEADER)).toBe("posts,users");
+    expect(headers.get(VINEXT_CACHE_REVALIDATED_TAGS_HEADER)).toBe('["posts","users"]');
     expect(headers.get(NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER)).toBe("draft-secret");
     expect(readPreviouslyRevalidatedTags(headers, "draft-secret")).toEqual(["posts", "users"]);
+  });
+
+  it("round-trips tags containing commas without splitting them", () => {
+    const headers = new Headers();
+    writePreviouslyRevalidatedTags(headers, ["tenant,42", "posts"], "draft-secret");
+
+    expect(readPreviouslyRevalidatedTags(headers, "draft-secret")).toEqual(["tenant,42", "posts"]);
+  });
+
+  it("does not reinterpret a JSON-looking tag from the legacy header", () => {
+    const headers = new Headers({
+      [NEXT_CACHE_REVALIDATED_TAGS_HEADER]: '["posts"]',
+      [NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER]: "draft-secret",
+    });
+
+    expect(readPreviouslyRevalidatedTags(headers, "draft-secret")).toEqual(['["posts"]']);
   });
 
   it("rejects forged tags with a missing or mismatched token", () => {
@@ -28,13 +46,24 @@ describe("forwarded cache revalidation tags", () => {
     expect(readPreviouslyRevalidatedTags(headers, "")).toEqual([]);
   });
 
+  it("accepts the legacy comma-delimited form during mixed-version requests", () => {
+    const headers = new Headers({
+      [NEXT_CACHE_REVALIDATED_TAGS_HEADER]: "posts,users,posts",
+      [NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER]: "draft-secret",
+    });
+
+    expect(readPreviouslyRevalidatedTags(headers, "draft-secret")).toEqual(["posts", "users"]);
+  });
+
   it("does not emit forwarding headers without tags or a token", () => {
     const missingTags = new Headers();
     writePreviouslyRevalidatedTags(missingTags, [], "draft-secret");
     expect(missingTags.has(NEXT_CACHE_REVALIDATED_TAGS_HEADER)).toBe(false);
+    expect(missingTags.has(VINEXT_CACHE_REVALIDATED_TAGS_HEADER)).toBe(false);
 
     const missingToken = new Headers();
     writePreviouslyRevalidatedTags(missingToken, ["posts"], "");
     expect(missingToken.has(NEXT_CACHE_REVALIDATED_TAGS_HEADER)).toBe(false);
+    expect(missingToken.has(VINEXT_CACHE_REVALIDATED_TAGS_HEADER)).toBe(false);
   });
 });

--- a/tests/revalidated-tags.test.ts
+++ b/tests/revalidated-tags.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  readPreviouslyRevalidatedTags,
+  writePreviouslyRevalidatedTags,
+} from "../packages/vinext/src/server/revalidated-tags.js";
+import {
+  NEXT_CACHE_REVALIDATED_TAGS_HEADER,
+  NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER,
+} from "../packages/vinext/src/server/headers.js";
+
+describe("forwarded cache revalidation tags", () => {
+  it("round-trips unique tags with the authenticated internal protocol", () => {
+    const headers = new Headers();
+    writePreviouslyRevalidatedTags(headers, ["posts", "users", "posts"], "draft-secret");
+
+    expect(headers.get(NEXT_CACHE_REVALIDATED_TAGS_HEADER)).toBe("posts,users");
+    expect(headers.get(NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER)).toBe("draft-secret");
+    expect(readPreviouslyRevalidatedTags(headers, "draft-secret")).toEqual(["posts", "users"]);
+  });
+
+  it("rejects forged tags with a missing or mismatched token", () => {
+    const headers = new Headers({
+      [NEXT_CACHE_REVALIDATED_TAGS_HEADER]: "posts",
+      [NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER]: "attacker-token",
+    });
+
+    expect(readPreviouslyRevalidatedTags(headers, "draft-secret")).toEqual([]);
+    expect(readPreviouslyRevalidatedTags(headers, "")).toEqual([]);
+  });
+
+  it("does not emit forwarding headers without tags or a token", () => {
+    const missingTags = new Headers();
+    writePreviouslyRevalidatedTags(missingTags, [], "draft-secret");
+    expect(missingTags.has(NEXT_CACHE_REVALIDATED_TAGS_HEADER)).toBe(false);
+
+    const missingToken = new Headers();
+    writePreviouslyRevalidatedTags(missingToken, ["posts"], "");
+    expect(missingToken.has(NEXT_CACHE_REVALIDATED_TAGS_HEADER)).toBe(false);
+  });
+});

--- a/tests/seed-cache.test.ts
+++ b/tests/seed-cache.test.ts
@@ -451,8 +451,18 @@ describe("seedMemoryCacheFromPrerender", () => {
       "_N_T_/isr/page",
     ];
     expect(contexts).toEqual([
-      { cacheControl: { revalidate: 60, expire: 300 }, revalidate: 60, tags: expectedTags },
-      { cacheControl: { revalidate: 60, expire: 300 }, revalidate: 60, tags: expectedTags },
+      {
+        cacheControl: { revalidate: 60, expire: 300 },
+        revalidate: 60,
+        tags: expectedTags,
+        timestamp: expect.any(Number),
+      },
+      {
+        cacheControl: { revalidate: 60, expire: 300 },
+        revalidate: 60,
+        tags: expectedTags,
+        timestamp: expect.any(Number),
+      },
     ]);
   });
 

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -6063,6 +6063,40 @@ describe("next/cache shim", () => {
     }
   });
 
+  it("passes the unstable_cache fill-start timestamp to the cache handler", async () => {
+    const { getCacheTimestamp, MemoryCacheHandler, setCacheHandler, unstable_cache } =
+      await import("../packages/vinext/src/shims/cache.js");
+
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-08-17T00:00:00.000Z"));
+      let persistedTimestamp: unknown;
+      let observedDuringFill = 0;
+      setCacheHandler({
+        async get() {
+          return null;
+        },
+        async set(_key, _value, ctx) {
+          persistedTimestamp = ctx?.timestamp;
+        },
+        async revalidateTag() {},
+      });
+
+      const cached = unstable_cache(async () => {
+        vi.advanceTimersByTime(10);
+        observedDuringFill = getCacheTimestamp();
+        return "value";
+      }, ["producer-timestamp-unstable"]);
+
+      await cached();
+      expect(typeof persistedTimestamp).toBe("number");
+      expect(persistedTimestamp as number).toBeLessThan(observedDuringFill);
+    } finally {
+      vi.useRealTimers();
+      setCacheHandler(new MemoryCacheHandler());
+    }
+  });
+
   it("does not persist an unstable_cache fill that straddles updateTag", async () => {
     const { _runWithCacheState, MemoryCacheHandler, setCacheHandler, unstable_cache, updateTag } =
       await import("../packages/vinext/src/shims/cache.js");
@@ -6373,6 +6407,25 @@ describe("next/cache shim", () => {
     if (result!.value!.kind === "FETCH") {
       expect(result!.value!.data.body).toBe('{"x":1}');
     }
+  });
+
+  it("MemoryCacheHandler persists a zero producer timestamp", async () => {
+    const { MemoryCacheHandler } = await import("../packages/vinext/src/shims/cache.js");
+    const handler = new MemoryCacheHandler();
+    const timestamp = 0;
+
+    await handler.set(
+      "producer-timestamp",
+      {
+        kind: "FETCH",
+        data: { headers: {}, body: '"cached"', url: "test" },
+        tags: [],
+        revalidate: 3600,
+      },
+      { timestamp },
+    );
+
+    expect((await handler.get("producer-timestamp"))?.lastModified).toBe(timestamp);
   });
 
   it("MemoryCacheHandler evicts least-recently-used entries when max size is exceeded", async () => {
@@ -7351,17 +7404,47 @@ describe('"use cache" runtime', () => {
     }
   });
 
+  it("passes the use cache fill-start timestamp to the cache handler", async () => {
+    const { registerCachedFunction } =
+      await import("../packages/vinext/src/shims/cache-runtime.js");
+    const { getCacheTimestamp, MemoryCacheHandler, setCacheHandler } =
+      await import("../packages/vinext/src/shims/cache.js");
+
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-08-17T00:00:00.000Z"));
+      let persistedTimestamp: unknown;
+      let observedDuringFill = 0;
+      setCacheHandler({
+        async get() {
+          return null;
+        },
+        async set(_key, _value, ctx) {
+          persistedTimestamp = ctx?.timestamp;
+        },
+        async revalidateTag() {},
+      });
+
+      const cached = registerCachedFunction(async () => {
+        vi.advanceTimersByTime(10);
+        observedDuringFill = getCacheTimestamp();
+        return "value";
+      }, "test:producer-timestamp-use-cache");
+
+      await cached();
+      expect(typeof persistedTimestamp).toBe("number");
+      expect(persistedTimestamp as number).toBeLessThan(observedDuringFill);
+    } finally {
+      vi.useRealTimers();
+      setCacheHandler(new MemoryCacheHandler());
+    }
+  });
+
   it("uses custom handler timestamps when tag invalidation is not enforced by the handler", async () => {
     const { registerCachedFunction } =
       await import("../packages/vinext/src/shims/cache-runtime.js");
-    const {
-      _runWithCacheState,
-      cacheTag,
-      getCacheTimestamp,
-      MemoryCacheHandler,
-      setCacheHandler,
-      updateTag,
-    } = await import("../packages/vinext/src/shims/cache.js");
+    const { _runWithCacheState, cacheTag, MemoryCacheHandler, setCacheHandler, updateTag } =
+      await import("../packages/vinext/src/shims/cache.js");
     const { setHeadersAccessPhase } = await import("../packages/vinext/src/shims/headers.js");
 
     vi.useFakeTimers();
@@ -7372,8 +7455,9 @@ describe('"use cache" runtime', () => {
         async get() {
           return stored;
         },
-        async set(_key, value) {
-          stored = { lastModified: getCacheTimestamp(), value };
+        async set(_key, value, ctx) {
+          expect(typeof ctx?.timestamp).toBe("number");
+          stored = { lastModified: ctx!.timestamp as number, value };
         },
         async revalidateTag() {},
       });

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -6041,6 +6041,7 @@ describe("next/cache shim", () => {
 
       await _runWithCacheState(async () => {
         expect(await cached()).toBe(1);
+        expect(await cached()).toBe(1);
 
         vi.advanceTimersByTime(10);
         const previousPhase = setHeadersAccessPhase("action");
@@ -6051,6 +6052,63 @@ describe("next/cache shim", () => {
         }
 
         vi.advanceTimersByTime(10);
+        expect(await cached()).toBe(2);
+        expect(await cached()).toBe(2);
+      });
+
+      expect(callCount).toBe(2);
+    } finally {
+      vi.useRealTimers();
+      setCacheHandler(new MemoryCacheHandler());
+    }
+  });
+
+  it("does not persist an unstable_cache fill that straddles updateTag", async () => {
+    const { _runWithCacheState, MemoryCacheHandler, setCacheHandler, unstable_cache, updateTag } =
+      await import("../packages/vinext/src/shims/cache.js");
+    const { setHeadersAccessPhase } = await import("../packages/vinext/src/shims/headers.js");
+
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-08-15T00:00:00.000Z"));
+      setCacheHandler(new MemoryCacheHandler());
+
+      let releaseFill!: () => void;
+      const fillGate = new Promise<void>((resolve) => {
+        releaseFill = resolve;
+      });
+      let markFillStarted!: () => void;
+      const fillStarted = new Promise<void>((resolve) => {
+        markFillStarted = resolve;
+      });
+      let callCount = 0;
+      const cached = unstable_cache(
+        async () => {
+          callCount++;
+          if (callCount === 1) {
+            markFillStarted();
+            await fillGate;
+          }
+          return callCount;
+        },
+        ["straddled-unstable-fill"],
+        { tags: ["straddled-unstable-fill"] },
+      );
+
+      await _runWithCacheState(async () => {
+        const straddled = cached();
+        await fillStarted;
+        vi.advanceTimersByTime(10);
+        const previousPhase = setHeadersAccessPhase("action");
+        try {
+          updateTag("straddled-unstable-fill");
+        } finally {
+          setHeadersAccessPhase(previousPhase);
+        }
+        vi.advanceTimersByTime(10);
+        releaseFill();
+
+        expect(await straddled).toBe(1);
         expect(await cached()).toBe(2);
         expect(await cached()).toBe(2);
       });
@@ -6398,6 +6456,31 @@ describe("next/cache shim", () => {
     // Should now return null (invalidated)
     result = await handler.get("tagged-entry");
     expect(result).toBeNull();
+  });
+
+  it("MemoryCacheHandler keeps an entry written after invalidation in the same wall-clock millisecond", async () => {
+    const { MemoryCacheHandler } = await import("../packages/vinext/src/shims/cache.js");
+    const handler = new MemoryCacheHandler();
+
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-08-15T00:00:00.000Z"));
+      await handler.revalidateTag("same-timestamp-tag");
+      await handler.set(
+        "same-timestamp-entry",
+        {
+          kind: "FETCH",
+          data: { headers: {}, body: '"fresh"', url: "test" },
+          tags: ["same-timestamp-tag"],
+          revalidate: 3600,
+        },
+        { tags: ["same-timestamp-tag"] },
+      );
+
+      expect(await handler.get("same-timestamp-entry")).not.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("exports unstable_noStore and noStore as no-ops", async () => {
@@ -7246,6 +7329,7 @@ describe('"use cache" runtime', () => {
 
       await _runWithCacheState(async () => {
         expect(await cached()).toBe(1);
+        expect(await cached()).toBe(1);
 
         vi.advanceTimersByTime(10);
         const previousPhase = setHeadersAccessPhase("action");
@@ -7261,6 +7345,156 @@ describe('"use cache" runtime', () => {
       });
 
       expect(callCount).toBe(2);
+    } finally {
+      vi.useRealTimers();
+      setCacheHandler(new MemoryCacheHandler());
+    }
+  });
+
+  it("uses custom handler timestamps when tag invalidation is not enforced by the handler", async () => {
+    const { registerCachedFunction } =
+      await import("../packages/vinext/src/shims/cache-runtime.js");
+    const {
+      _runWithCacheState,
+      cacheTag,
+      getCacheTimestamp,
+      MemoryCacheHandler,
+      setCacheHandler,
+      updateTag,
+    } = await import("../packages/vinext/src/shims/cache.js");
+    const { setHeadersAccessPhase } = await import("../packages/vinext/src/shims/headers.js");
+
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-08-15T00:00:00.000Z"));
+      let stored: Awaited<ReturnType<InstanceType<typeof MemoryCacheHandler>["get"]>> = null;
+      setCacheHandler({
+        async get() {
+          return stored;
+        },
+        async set(_key, value) {
+          stored = { lastModified: getCacheTimestamp(), value };
+        },
+        async revalidateTag() {},
+      });
+
+      let callCount = 0;
+      const cached = registerCachedFunction(async () => {
+        cacheTag("custom-handler-action-dedupe");
+        return ++callCount;
+      }, "test:custom-handler-action-dedupe");
+
+      await _runWithCacheState(async () => {
+        expect(await cached()).toBe(1);
+        vi.advanceTimersByTime(10);
+        const previousPhase = setHeadersAccessPhase("action");
+        try {
+          updateTag("custom-handler-action-dedupe");
+        } finally {
+          setHeadersAccessPhase(previousPhase);
+        }
+        vi.advanceTimersByTime(10);
+        expect(await cached()).toBe(2);
+        expect(await cached()).toBe(2);
+      });
+
+      expect(callCount).toBe(2);
+    } finally {
+      vi.useRealTimers();
+      setCacheHandler(new MemoryCacheHandler());
+    }
+  });
+
+  it("does not persist a use cache fill that straddles updateTag", async () => {
+    const { registerCachedFunction } =
+      await import("../packages/vinext/src/shims/cache-runtime.js");
+    const { _runWithCacheState, cacheTag, MemoryCacheHandler, setCacheHandler, updateTag } =
+      await import("../packages/vinext/src/shims/cache.js");
+    const { setHeadersAccessPhase } = await import("../packages/vinext/src/shims/headers.js");
+
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-08-15T00:00:00.000Z"));
+      setCacheHandler(new MemoryCacheHandler());
+
+      let releaseFill!: () => void;
+      const fillGate = new Promise<void>((resolve) => {
+        releaseFill = resolve;
+      });
+      let markFillStarted!: () => void;
+      const fillStarted = new Promise<void>((resolve) => {
+        markFillStarted = resolve;
+      });
+      let callCount = 0;
+      const cached = registerCachedFunction(async () => {
+        cacheTag("straddled-use-cache-fill");
+        callCount++;
+        if (callCount === 1) {
+          markFillStarted();
+          await fillGate;
+        }
+        return callCount;
+      }, "test:straddled-use-cache-fill");
+
+      await _runWithCacheState(async () => {
+        const straddled = cached();
+        await fillStarted;
+        vi.advanceTimersByTime(10);
+        const previousPhase = setHeadersAccessPhase("action");
+        try {
+          updateTag("straddled-use-cache-fill");
+        } finally {
+          setHeadersAccessPhase(previousPhase);
+        }
+        vi.advanceTimersByTime(10);
+        releaseFill();
+
+        expect(await straddled).toBe(1);
+        expect(await cached()).toBe(2);
+        expect(await cached()).toBe(2);
+      });
+
+      expect(callCount).toBe(2);
+    } finally {
+      vi.useRealTimers();
+      setCacheHandler(new MemoryCacheHandler());
+    }
+  });
+
+  it("advances a repeated tag revalidation past entries created after the first one", async () => {
+    const { registerCachedFunction } =
+      await import("../packages/vinext/src/shims/cache-runtime.js");
+    const { _runWithCacheState, cacheTag, MemoryCacheHandler, setCacheHandler, updateTag } =
+      await import("../packages/vinext/src/shims/cache.js");
+    const { setHeadersAccessPhase } = await import("../packages/vinext/src/shims/headers.js");
+
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-08-15T00:00:00.000Z"));
+      setCacheHandler(new MemoryCacheHandler());
+      let callCount = 0;
+      const cached = registerCachedFunction(async () => {
+        cacheTag("repeated-action-dedupe");
+        return ++callCount;
+      }, "test:repeated-action-dedupe");
+
+      await _runWithCacheState(async () => {
+        expect(await cached()).toBe(1);
+        for (const expected of [2, 3]) {
+          vi.advanceTimersByTime(10);
+          const previousPhase = setHeadersAccessPhase("action");
+          try {
+            updateTag("repeated-action-dedupe");
+          } finally {
+            setHeadersAccessPhase(previousPhase);
+          }
+          vi.advanceTimersByTime(10);
+          expect(await cached()).toBe(expected);
+          expect(await cached()).toBe(expected);
+        }
+      });
+
+      expect(callCount).toBe(3);
     } finally {
       vi.useRealTimers();
       setCacheHandler(new MemoryCacheHandler());

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -6024,6 +6024,44 @@ describe("next/cache shim", () => {
     setCacheHandler(new MemoryCacheHandler());
   });
 
+  it("reuses an unstable_cache entry created after updateTag in the same request", async () => {
+    const { _runWithCacheState, MemoryCacheHandler, setCacheHandler, unstable_cache, updateTag } =
+      await import("../packages/vinext/src/shims/cache.js");
+    const { setHeadersAccessPhase } = await import("../packages/vinext/src/shims/headers.js");
+
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-08-15T00:00:00.000Z"));
+      setCacheHandler(new MemoryCacheHandler());
+
+      let callCount = 0;
+      const cached = unstable_cache(async () => ++callCount, ["action-dedupe-unstable"], {
+        tags: ["action-dedupe-unstable"],
+      });
+
+      await _runWithCacheState(async () => {
+        expect(await cached()).toBe(1);
+
+        vi.advanceTimersByTime(10);
+        const previousPhase = setHeadersAccessPhase("action");
+        try {
+          updateTag("action-dedupe-unstable");
+        } finally {
+          setHeadersAccessPhase(previousPhase);
+        }
+
+        vi.advanceTimersByTime(10);
+        expect(await cached()).toBe(2);
+        expect(await cached()).toBe(2);
+      });
+
+      expect(callCount).toBe(2);
+    } finally {
+      vi.useRealTimers();
+      setCacheHandler(new MemoryCacheHandler());
+    }
+  });
+
   it("updateTag throws when called outside a Server Action (e.g. route handler)", async () => {
     const { updateTag } = await import("../packages/vinext/src/shims/cache.js");
     const { setHeadersAccessPhase } = await import("../packages/vinext/src/shims/headers.js");
@@ -7184,6 +7222,49 @@ describe('"use cache" runtime', () => {
     const r3 = await cached();
     expect(r3).toEqual({ count: 2 });
     expect(callCount).toBe(2);
+  });
+
+  // Ported from Next.js: test/e2e/app-dir/use-cache/use-cache.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/use-cache/use-cache.test.ts
+  it("reuses a use cache entry created after updateTag in the same request", async () => {
+    const { registerCachedFunction } =
+      await import("../packages/vinext/src/shims/cache-runtime.js");
+    const { _runWithCacheState, cacheTag, MemoryCacheHandler, setCacheHandler, updateTag } =
+      await import("../packages/vinext/src/shims/cache.js");
+    const { setHeadersAccessPhase } = await import("../packages/vinext/src/shims/headers.js");
+
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-08-15T00:00:00.000Z"));
+      setCacheHandler(new MemoryCacheHandler());
+
+      let callCount = 0;
+      const cached = registerCachedFunction(async () => {
+        cacheTag("action-dedupe");
+        return ++callCount;
+      }, "test:action-dedupe");
+
+      await _runWithCacheState(async () => {
+        expect(await cached()).toBe(1);
+
+        vi.advanceTimersByTime(10);
+        const previousPhase = setHeadersAccessPhase("action");
+        try {
+          updateTag("action-dedupe");
+        } finally {
+          setHeadersAccessPhase(previousPhase);
+        }
+
+        vi.advanceTimersByTime(10);
+        expect(await cached()).toBe(2);
+        expect(await cached()).toBe(2);
+      });
+
+      expect(callCount).toBe(2);
+    } finally {
+      vi.useRealTimers();
+      setCacheHandler(new MemoryCacheHandler());
+    }
   });
 
   it("nested cacheTag bubbles to the outer cache entry even when the inner HITs", async () => {

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -5861,6 +5861,20 @@ describe("next/config shim", () => {
 });
 
 describe("next/cache shim", () => {
+  it("uses the high-resolution Workers clock when timeOrigin is zero", async () => {
+    const { getCacheTimestamp } = await import("../packages/vinext/src/shims/cache-handler.js");
+    const originalPerformance = globalThis.performance;
+    const dateNow = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    vi.stubGlobal("performance", { now: () => 1_000.25, timeOrigin: 0 });
+
+    try {
+      expect(getCacheTimestamp()).toBe(1_000.25);
+    } finally {
+      vi.stubGlobal("performance", originalPerformance);
+      dateNow.mockRestore();
+    }
+  });
+
   it("exports revalidateTag, revalidatePath, unstable_cache", async () => {
     const mod = await import("../packages/vinext/src/shims/cache.js");
     expect(typeof mod.revalidateTag).toBe("function");

--- a/tests/unified-request-context.test.ts
+++ b/tests/unified-request-context.test.ts
@@ -17,9 +17,24 @@ import {
 import {
   _captureRequestScopedCacheLifeAccessors,
   _setRequestScopedCacheLife,
+  _wasTagRevalidatedAfter,
 } from "../packages/vinext/src/shims/cache-request-state.js";
 
 describe("unified-request-context", () => {
+  it("treats forwarded tags as revalidated at request start", () => {
+    const ctx = createRequestContext({
+      previouslyRevalidatedTags: new Set(["posts", "users"]),
+      requestStartTime: 1_000,
+    });
+
+    void runWithRequestContext(ctx, () => {
+      expect(_wasTagRevalidatedAfter(["other", "posts"], 999)).toBe(true);
+      expect(_wasTagRevalidatedAfter(["posts"], 1_000)).toBe(true);
+      expect(_wasTagRevalidatedAfter(["posts"], 1_001)).toBe(false);
+      expect(_wasTagRevalidatedAfter(["other"], 999)).toBe(false);
+    });
+  });
+
   describe("isInsideUnifiedScope", () => {
     it("returns false outside any scope", () => {
       expect(isInsideUnifiedScope()).toBe(false);


### PR DESCRIPTION
## Summary

- record request-local tag revalidations with timestamps instead of membership only
- capture each cache fill's causal timestamp at the producer, before user work starts, then pass it through the cache adapter unchanged
- persist and return producer timestamps in Memory and Cloudflare KV while keeping adapter-owned `writtenAt` for TTL accounting
- apply the same ordering contract to `use cache`, `unstable_cache`, tagged fetch, App/Pages ISR, Route Handlers, and metadata routes
- discard entries only when they predate the latest matching revalidation, including fills that straddle an invalidation
- securely forward revalidated-tag state across internal Server Action redirect dispatches without exposing protocol headers to application code
- preserve comma-containing tags losslessly in a separate authenticated vinext JSON header while retaining the Next.js comma-delimited header for ordinary-tag rolling compatibility

This follows the behavior introduced by vercel/next.js#96726 and commit 5da1c1ae03d2ee39c27a2d6d8807c573c46b37f9.

The separate JSON tag header is a deliberate vinext protocol extension: Next.js's comma-delimited wire format cannot represent a legal tag containing a comma. New vinext peers prefer the authenticated JSON header; the standard header remains available to older peers for ordinary tags. Older peers cannot preserve comma-containing tags.

Closes #2819

## Tests

- 17-file cache/ISR/action/router matrix passed, including the required `isr-cache`, `fetch-cache`, and `kv-cache-handler` coverage
- focused producer-ordering tests prove App Route and metadata timestamps are captured before user handlers run
- `vp check` passed for all 26 changed product/test files
- `git diff --check` passed

Adversarial coverage includes invalidation during a fill and immediately before a new fill, repeated same-tag invalidation, all three public cache APIs, App/Pages foreground and background ISR writes, Route Handlers, metadata routes, two-read Server Action dedupe, custom-handler old/new timestamps, authenticated redirect forwarding, comma-containing and JSON-looking legacy tags, protocol-header filtering, soft/hard tags, and Memory/KV strict timestamp boundaries.