### PR TITLE
fix(build): preserve server export conditions

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -4129,14 +4129,13 @@ export const loadServerActionClient = ${
       enforce: "post",
 
       configEnvironment(name, config) {
-        if (!hasCloudflarePlugin || (name !== "rsc" && name !== "ssr")) return null;
+        if (name !== "rsc" && name !== "ssr") return null;
 
-        // @cloudflare/vite-plugin enables the `browser` condition for generic
-        // Worker applications. Vinext's Worker environments render Next.js
-        // server code, however, so selecting a package's browser export here
-        // diverges from Next.js and can execute a client-only implementation
-        // during SSR. Keep the Worker-specific conditions, but let ESM imports
-        // fall through to their `import` export instead of `browser`.
+        // Vinext's RSC and SSR environments render Next.js server code, so
+        // selecting a package's browser export here diverges from Next.js and
+        // can execute a client-only implementation during SSR. Preserve every
+        // host-specific condition, but let ESM imports fall through to their
+        // `import` export instead of `browser`.
         if (config.resolve?.conditions?.includes("browser")) {
           config.resolve.conditions = config.resolve.conditions.filter(
             (condition) => condition !== "browser",

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -4125,6 +4125,32 @@ export const loadServerActionClient = ${
       },
     },
     {
+      name: "vinext:cloudflare-server-conditions",
+      enforce: "post",
+
+      configEnvironment(name, config) {
+        if (!hasCloudflarePlugin || (name !== "rsc" && name !== "ssr")) return null;
+
+        // @cloudflare/vite-plugin enables the `browser` condition for generic
+        // Worker applications. Vinext's Worker environments render Next.js
+        // server code, however, so selecting a package's browser export here
+        // diverges from Next.js and can execute a client-only implementation
+        // during SSR. Keep the Worker-specific conditions, but let ESM imports
+        // fall through to their `import` export instead of `browser`.
+        if (config.resolve?.conditions?.includes("browser")) {
+          config.resolve.conditions = config.resolve.conditions.filter(
+            (condition) => condition !== "browser",
+          );
+        }
+        const optimizerConditions = config.optimizeDeps?.rolldownOptions?.resolve?.conditionNames;
+        if (optimizerConditions?.includes("browser")) {
+          config.optimizeDeps!.rolldownOptions!.resolve!.conditionNames =
+            optimizerConditions.filter((condition) => condition !== "browser");
+        }
+        return null;
+      },
+    },
+    {
       name: "vinext:css-url-assets-restore",
       enforce: "post",
       apply: "build",

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -4125,7 +4125,7 @@ export const loadServerActionClient = ${
       },
     },
     {
-      name: "vinext:cloudflare-server-conditions",
+      name: "vinext:server-conditions",
       enforce: "post",
 
       configEnvironment(name, config) {


### PR DESCRIPTION
## Summary

- remove the `browser` export condition from every vinext `rsc` and `ssr` environment, regardless of deployment adapter
- apply the same filtering to optimize-deps Rolldown resolution so dependency optimization and production resolution select the same server export
- preserve all other host-specific conditions and leave the client environment unchanged

This is the narrowly scoped production-code extraction of `vinext:server-conditions` from #2877. Environment identity is the contract: vinext `rsc` and `ssr` graphs render server code, so filtering does not depend on detecting the Cloudflare plugin.

## Why

A deployment adapter can add `browser` to its default resolution conditions, but a vinext `rsc` or `ssr` graph must not select a package browser export. Doing so diverges from Next.js server resolution and can execute a client-only implementation during SSR. The filter removes only `browser`; conditions for the active host remain available before resolution falls through to `import`.

## Tests

The behavioral ESM-externals and real workerd tests intentionally remain in #2877, as requested. This extraction does not duplicate or move them.

Validation on this branch:

- `vp run vinext#build`
- `vp run check`
- `git diff --check`

Related: #2877
