### PR TITLE
test(navigation): stabilize queued prefetch promotion

### DIFF
--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -1353,12 +1353,18 @@ describe("prefetch cache eviction", () => {
     });
     (globalThis as any).fetch = fetch;
 
-    for (let index = 0; index < 5; index++) {
+    // Occupy every low-priority slot before scheduling the request whose
+    // promotion this test exercises. Prefetch setup hashes the RSC request
+    // asynchronously, so starting all five together does not guarantee that
+    // dashboard-4 is the request left in the queue.
+    for (let index = 0; index < 4; index++) {
       appRouterInstance.prefetch(`/dashboard-${index}`);
     }
+    await waitForPrefetchSetup(() => fetch.mock.calls.length === 4);
+    appRouterInstance.prefetch("/dashboard-4");
 
     // Four slots are occupied and none of their bodies have been read, so the
-    // fifth request has not been issued — but all five entries are registered.
+    // queued request has not been issued — but its entry is registered.
     await waitForPrefetchSetup(
       () =>
         fetch.mock.calls.length === 4 &&


### PR DESCRIPTION
## Summary

- fill all four low-priority prefetch slots before scheduling the promotion target
- remove the assumption that asynchronous RSC URL hashing preserves prefetch call order
- keep the production prefetch queue behavior unchanged

Fixes the flaky failure observed in https://github.com/cloudflare/vinext/actions/runs/31850022663/job/94923928645.

## Validation

- vp check tests/prefetch-cache.test.ts
- vp test run tests/prefetch-cache.test.ts
- targeted promotion test passed 200 consecutive iterations