### PR TITLE
fix(dev): absorb gzip JSON parse in socket-error backstop

### DIFF
--- a/packages/vinext/src/server/socket-error-backstop.ts
+++ b/packages/vinext/src/server/socket-error-backstop.ts
@@ -14,12 +14,14 @@
  * `uncaughtException`, where this listener filters it.
  *
  * Filters strictly on peer-disconnect codes (ECONNRESET / EPIPE /
- * ECONNABORTED) plus benign static-asset `import()` rejections (see
- * `isBenignAssetImportError`), and synchronously re-throws everything
- * else, preserving Node's default crash semantics for genuine bugs.
- * This is more conservative than Next.js's equivalent
- * (`router-server.ts`'s log-only handler), which silently swallows
- * every uncaught — vinext keeps real bugs surfacing.
+ * ECONNABORTED), benign static-asset `import()` rejections (see
+ * `isBenignAssetImportError`), and gzip-bodied `response.json()`
+ * failures from miniflare's `dispatchFetch` (see
+ * `isGzipJsonParseError`). Synchronously re-throws everything else,
+ * preserving Node's default crash semantics for genuine bugs. This is
+ * more conservative than Next.js's equivalent (`router-server.ts`'s
+ * log-only handler), which silently swallows every uncaught — vinext
+ * keeps real bugs surfacing.
  *
  * **Installed at module load.** Earlier iterations tried to gate
  * install via Vite's `config()` hook (`command === "serve"`) so it
@@ -170,6 +172,39 @@ export function isBenignAssetImportError(err: unknown): boolean {
 }
 
 /**
+ * Gzip magic first byte. miniflare's `dispatchFetch` calls
+ * `response.json()` on a workerd 500 that still has
+ * `Content-Encoding: gzip` (the vite-plugin forwards the browser's
+ * `Accept-Encoding` on WebSocket upgrades; the custom undici
+ * dispatcher does not decompress). `JSON.parse` then sees this byte
+ * as the unexpected token.
+ */
+const GZIP_MAGIC_BYTE = 0x1f;
+
+/**
+ * Pure predicate: returns `true` when `err` is the `SyntaxError`
+ * `JSON.parse` throws on a gzip-compressed body. Node quotes the
+ * unexpected token as the U+001F unit-separator character (gzip's
+ * first magic byte) and ends the message with `is not valid JSON`.
+ *
+ * Kept narrow: HTML error pages (`Unexpected token '<'`), empty
+ * bodies (`Unexpected end of JSON input`), and other parse failures
+ * still crash. Dev-only: the listener absorbs this after the
+ * prerender re-throw, so a gzip parse during `vinext build` still
+ * fails the build. Exported for unit testing in isolation.
+ *
+ * @see https://github.com/cloudflare/vinext/issues/2921
+ */
+export function isGzipJsonParseError(err: unknown): boolean {
+  if (err === null || typeof err !== "object") return false;
+  const name = (err as { name?: string }).name;
+  if (name !== "SyntaxError") return false;
+  const message = (err as { message?: string }).message ?? "";
+  if (!message.includes("is not valid JSON")) return false;
+  return message.includes(String.fromCharCode(GZIP_MAGIC_BYTE));
+}
+
+/**
  * Test-only: returns whether the backstop has been installed in this
  * process. Used by the unit test to assert idempotent install via the
  * Symbol.for guard. Not part of the public API.
@@ -206,6 +241,12 @@ export function installSocketErrorBackstop(): void {
     return true;
   };
 
+  const absorbGzipJsonParse = (reason: unknown, kind: string): boolean => {
+    if (!isGzipJsonParseError(reason)) return false;
+    if (debug) console.warn(`[vinext] absorbed ${kind} gzip JSON parse`);
+    return true;
+  };
+
   process.on("uncaughtException", (err: Error) => {
     if (absorbBenignAssetImport(err, "uncaughtException")) return;
     if (process.env.VINEXT_PRERENDER === "1") throw err;
@@ -214,6 +255,7 @@ export function installSocketErrorBackstop(): void {
       if (debug) console.warn(`[vinext] absorbed uncaughtException ${code}`);
       return;
     }
+    if (absorbGzipJsonParse(err, "uncaughtException")) return;
     throw err;
   });
   process.on("unhandledRejection", (reason: unknown) => {
@@ -224,6 +266,7 @@ export function installSocketErrorBackstop(): void {
       if (debug) console.warn(`[vinext] absorbed unhandledRejection ${code}`);
       return;
     }
+    if (absorbGzipJsonParse(reason, "unhandledRejection")) return;
     throw reason;
   });
 }

--- a/tests/socket-error-backstop.test.ts
+++ b/tests/socket-error-backstop.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 import {
   isBenignAssetImportError,
+  isGzipJsonParseError,
   isSocketErrorBackstopInstalled,
   peerDisconnectCode,
 } from "../packages/vinext/src/server/socket-error-backstop.js";
@@ -107,6 +108,67 @@ describe("isBenignAssetImportError", () => {
     expect(isBenignAssetImportError(undefined)).toBe(false);
     expect(isBenignAssetImportError("ERR_UNKNOWN_FILE_EXTENSION")).toBe(false);
     expect(isBenignAssetImportError(42)).toBe(false);
+  });
+});
+
+describe("isGzipJsonParseError", () => {
+  // Regression coverage for issue #2921: miniflare's dispatchFetch calls
+  // response.json() on a gzip-encoded workerd 500 during a Worker
+  // WebSocket upgrade. The resulting SyntaxError escaped the
+  // vite-plugin upgrade handler and the backstop re-threw it, killing
+  // the dev server.
+
+  it("matches JSON.parse of gzip magic bytes", () => {
+    // 1f 8b 08 is the gzip header. Node quotes the first byte as the
+    // unexpected token (U+001F). Use the real parser so the predicate
+    // tracks Node's message shape rather than a hand-built string.
+    let err: unknown;
+    try {
+      JSON.parse(
+        Buffer.from([0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x13]).toString("utf8"),
+      );
+    } catch (caught) {
+      err = caught;
+    }
+    expect(err).toBeInstanceOf(SyntaxError);
+    expect(isGzipJsonParseError(err)).toBe(true);
+  });
+
+  it("matches a truncated gzip snippet the way a longer body prints", () => {
+    // Longer compressed bodies produce the `...` truncation in Node's
+    // SyntaxError message. Still the same unexpected token.
+    const gzipPrefix = Buffer.alloc(80, 0);
+    gzipPrefix[0] = 0x1f;
+    gzipPrefix[1] = 0x8b;
+    gzipPrefix[2] = 0x08;
+    let err: unknown;
+    try {
+      JSON.parse(gzipPrefix.toString("utf8"));
+    } catch (caught) {
+      err = caught;
+    }
+    expect(isGzipJsonParseError(err)).toBe(true);
+  });
+
+  it("does NOT absorb other JSON parse failures (real bugs must still crash)", () => {
+    for (const input of ["", "not json", "<html>", '{"a":']) {
+      let err: unknown;
+      try {
+        JSON.parse(input);
+      } catch (caught) {
+        err = caught;
+      }
+      expect(isGzipJsonParseError(err), input).toBe(false);
+    }
+  });
+
+  it("does NOT absorb unrelated errors or non-object reasons", () => {
+    expect(isGzipJsonParseError(new Error("boom"))).toBe(false);
+    expect(isGzipJsonParseError(new SyntaxError("Unexpected token 'A'"))).toBe(false);
+    expect(isGzipJsonParseError(null)).toBe(false);
+    expect(isGzipJsonParseError(undefined)).toBe(false);
+    expect(isGzipJsonParseError("is not valid JSON")).toBe(false);
+    expect(isGzipJsonParseError(42)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- absorb the `JSON.parse` `SyntaxError` that miniflare's `dispatchFetch` throws on a gzip-encoded workerd 500 during a Worker WebSocket upgrade
- keep the match narrow: gzip magic as the unexpected token plus `is not valid JSON`; HTML bodies, empty bodies, and other parse failures still crash
- skip the absorb during prerender so `vinext build` still fails on a gzip parse

Closes #2921

The vite-plugin upgrade handler awaits `dispatchFetch` with no try/catch. When workerd returns a 500 JSON error with `Content-Encoding: gzip` (the plugin forwards the browser's `Accept-Encoding`), miniflare's custom dispatcher does not decompress before `response.json()`. The resulting `SyntaxError` becomes an unhandled rejection, the socket-error backstop rethrows it, and the dev server exits.

This is the vinext-side absorb, following #1846. The durable fixes remain in miniflare (decompress before `response.json()`) and `@cloudflare/vite-plugin` (catch `dispatchFetch` on upgrade).

## Validation

- `pnpm exec vp check packages/vinext/src/server/socket-error-backstop.ts tests/socket-error-backstop.test.ts`
- `pnpm test tests/socket-error-backstop.test.ts` (12 passed)
- `git diff --check`
- listener smoke: gzip `unhandledRejection` keeps the process alive; a genuine `Error` still exits 7; `VINEXT_PRERENDER=1` still crashes on gzip parse