### PR TITLE
test(app-router): cover cross-path hash push URL replacement

### DIFF
--- a/tests/e2e/app-router/nextjs-compat/hash-cross-path-push.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/hash-cross-path-push.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "@playwright/test";
+import { waitForAppRouterHydration } from "../../helpers";
+
+const BASE = "http://localhost:4174";
+const START = "/nextjs-compat/hash-cross-path-push";
+const DESTINATION = "/nextjs-compat/hash-cross-path-push/destination";
+
+// Ported from Next.js: test/e2e/app-dir/navigation/navigation.test.ts
+// ("cross-pathname Link then same-pathname hash change")
+// https://github.com/vercel/next.js/pull/93132
+//
+// Next.js regressed here because its segment cache stored one canonical URL per
+// route entry, shared across every hash target, and a later same-route hash
+// navigation appended `url.hash` to it — producing `/destination#foo#bar`.
+// vinext resolves each navigation target against the live location instead
+// (`toBrowserNavigationHref`) and writes that resolved href to history
+// (`commitNavigationHistory`), so the hash is replaced rather than concatenated.
+// These tests lock that in for both navigation entry points.
+test.describe("Next.js compat: cross-path push with hash then same-path hash change", () => {
+  test("<Link> replaces the hash instead of concatenating it", async ({ page }) => {
+    await page.goto(`${BASE}${START}`);
+    await waitForAppRouterHydration(page);
+    await expect(page.locator("h1")).toHaveText("Hash Cross Path Push Start");
+
+    await page.click("#link-to-target-foo");
+    await expect(page).toHaveURL(`${BASE}${DESTINATION}#foo`);
+
+    await page.click("#link-to-target-baz");
+    await expect(page).toHaveURL(`${BASE}${DESTINATION}#baz`);
+  });
+
+  test("router.push replaces the hash instead of concatenating it", async ({ page }) => {
+    await page.goto(`${BASE}${START}`);
+    await waitForAppRouterHydration(page);
+    await expect(page.locator("h1")).toHaveText("Hash Cross Path Push Start");
+
+    await page.click("#push-to-target-foo");
+    await expect(page).toHaveURL(`${BASE}${DESTINATION}#foo`);
+
+    await page.click("#push-to-target-baz");
+    await expect(page).toHaveURL(`${BASE}${DESTINATION}#baz`);
+  });
+});

--- a/tests/fixtures/app-basic/app/nextjs-compat/hash-cross-path-push/destination/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/hash-cross-path-push/destination/page.tsx
@@ -1,0 +1,18 @@
+import Link from "next/link";
+import { HashCrossPathPushDestinationActions } from "./push-actions";
+
+export default function HashCrossPathPushDestinationPage() {
+  return (
+    <main>
+      <h1>Hash Cross Path Push Destination</h1>
+      <Link href="/nextjs-compat/hash-cross-path-push/destination#baz" id="link-to-target-baz">
+        Link to destination#baz
+      </Link>
+      <HashCrossPathPushDestinationActions />
+      <div style={{ height: 1200 }} />
+      <section id="foo">Foo target</section>
+      <div style={{ height: 1200 }} />
+      <section id="baz">Baz target</section>
+    </main>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/hash-cross-path-push/destination/push-actions.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/hash-cross-path-push/destination/push-actions.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+/** Same-pathname hash change issued programmatically instead of through `<Link>`. */
+export function HashCrossPathPushDestinationActions() {
+  const router = useRouter();
+
+  return (
+    <button
+      id="push-to-target-baz"
+      onClick={() => router.push("/nextjs-compat/hash-cross-path-push/destination#baz")}
+      type="button"
+    >
+      Push destination#baz
+    </button>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/hash-cross-path-push/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/hash-cross-path-push/page.tsx
@@ -1,0 +1,14 @@
+import Link from "next/link";
+import { HashCrossPathPushActions } from "./push-actions";
+
+export default function HashCrossPathPushPage() {
+  return (
+    <main>
+      <h1>Hash Cross Path Push Start</h1>
+      <Link href="/nextjs-compat/hash-cross-path-push/destination#foo" id="link-to-target-foo">
+        Link to destination#foo
+      </Link>
+      <HashCrossPathPushActions />
+    </main>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/hash-cross-path-push/push-actions.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/hash-cross-path-push/push-actions.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+/** Programmatic counterpart to the cross-path `<Link>` on the start page. */
+export function HashCrossPathPushActions() {
+  const router = useRouter();
+
+  return (
+    <button
+      id="push-to-target-foo"
+      onClick={() => router.push("/nextjs-compat/hash-cross-path-push/destination#foo")}
+      type="button"
+    >
+      Push destination#foo
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary

- port the Next.js `hash-cross-path-push` navigation regression as an App Router browser test
- add the matching `nextjs-compat` fixture routes (start page + destination page)
- cover both navigation entry points: `<Link>` and `router.push`

Closes #2809.

## Context

vercel/next.js#93132 fixes a client-navigation bug where the URL hash is
appended twice (`/abc#foo#bar`). Its cause is specific to the Next.js segment
cache: `createRouteCacheEntry` stored one canonical URL per route entry, shared
across every hash target of that route, and a later same-route hash navigation
appended `url.hash` to it. The upstream fix stores a hashless canonical href.

## Triage

The defect does not reproduce in vinext, and the reason is structural rather
than incidental.

- vinext has no per-route canonical URL. `rg 'canonicalUrl' packages/vinext/src`
  matches only the Sass plugin.
- Every navigation resolves its own target against the live location
  (`toBrowserNavigationHref` -> `resolveRelativeHref`, `shims/url-utils.ts`), and
  the committed history write uses that resolved target
  (`AppBrowserHistoryController.commitNavigationHistory`,
  `createCanonicalBrowserHistoryHref`). Nothing concatenates a new hash onto a
  stored href from an earlier navigation.
- Reproduced the upstream scenario against `main` (`<Link>` clicks,
  `router.push`, and a search+hash variant): all landed on the correct single
  hash.

Existing coverage did not reach this case. `hash-popstate-scroll.spec.ts` and
`hash-rsc-requests.browser.spec.ts` only change hashes after a direct document
load of the route; the upstream regression requires the route entry to be
created by a *cross-path client push that already carries a hash*.

Since the behavior is correct, this follows the precedent of #2758: a
tracking issue resolved with focused regression coverage rather than a
production change.

## Verification

- `vp check` on the five new files: pass (format, lint, types)
- pre-commit full check + knip: pass
- `PLAYWRIGHT_PROJECT=app-router npx playwright test hash-cross-path-push.spec.ts`: 2/2 passed
- repeated 5x (`--repeat-each=5 --retries=0`): 10/10 passed
- neighbouring suites `hash-popstate-scroll.spec.ts` + `router-autoscroll.spec.ts`: 38/38 passed

**Mutation check (the tests have real signal).** Temporarily injected the
upstream failure mechanism into `navigateClientSide`'s `sameDocumentScroll`
branch — committing `location.pathname + location.search + location.hash +
intent.hash` instead of the resolved target — then rebuilt `vinext`. Both new
tests failed with exactly the reported malformed URL:

```
Expected: ".../hash-cross-path-push/destination#baz"
Received: ".../hash-cross-path-push/destination#foo#baz"
```

The mutation was reverted and `vinext` rebuilt before committing; the working
tree contains no production changes (`git diff` against `packages/` is empty).

## Scope

Test and fixture only — no runtime behavior changes, so no changeset. The
Pages Router hash lifecycle (`shims/router.ts`, `hashChangeStart`) is a separate
navigation path and is out of scope for this upstream port.
