### PR TITLE
fix(rsc): web crypto subtle api is unavailable in non-secure contexts

### DIFF
--- a/packages/vinext/src/server/app-rsc-cache-busting.ts
+++ b/packages/vinext/src/server/app-rsc-cache-busting.ts
@@ -215,7 +215,12 @@ function createCacheBustingInput(
 }
 
 async function sha256CacheBustingHash(input: string): Promise<string> {
-  const digest = await globalThis.crypto.subtle.digest("SHA-256", textEncoder.encode(input));
+  const subtle = globalThis.crypto?.subtle;
+  // `globalThis.crypto.subtle` is undefined in non-secure browser contexts
+  // just fallback to legacy fnv1a64.
+  if (!subtle) return fnv1a64(input);
+
+  const digest = await subtle.digest("SHA-256", textEncoder.encode(input));
   return encodeBase64Url(new Uint8Array(digest).subarray(0, CACHE_BUSTING_DIGEST_BYTES));
 }
 

--- a/tests/app-rsc-cache-busting.test.ts
+++ b/tests/app-rsc-cache-busting.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vite-plus/test";
+import { describe, expect, it, vi } from "vite-plus/test";
 import {
   applyRscCompatibilityIdHeader,
   applyRscDeploymentIdHeader,
@@ -109,6 +109,24 @@ describe("App Router RSC cache-busting", () => {
     await expect(createRscRequestUrl("/photos/42", headers)).resolves.toBe(
       `/photos/42?${VINEXT_RSC_CACHE_BUSTING_SEARCH_PARAM}=${hash}`,
     );
+  });
+
+  // Ported from Next.js:
+  // packages/next/src/client/components/router-reducer/set-cache-busting-search-param.test.ts
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/router-reducer/set-cache-busting-search-param.test.ts
+  it("falls back to the legacy FNV hash when Web Crypto is unavailable", async () => {
+    vi.stubGlobal("crypto", {});
+
+    try {
+      const headers = createRscRequestHeaders({ mountedSlotsHeader: "slot:modal:/" });
+      const legacyHash = fnv1a64("0,0,0,0,0,slot:modal:/,0");
+
+      await expect(createRscRequestUrl("/photos/42", headers)).resolves.toBe(
+        `/photos/42?_rsc=${legacyHash}`,
+      );
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   it("adds a valued _rsc query for visible App Router state", async () => {


### PR DESCRIPTION
Closes #2927

## Overview

In non-secure browser contexts, such as an app accessed over plain HTTP from a non-localhost hostname, the Web Crypto `SubtleCrypto` API may be unavailable. Because RSC cache-busting depends on digest generation, this can cause RSC prefetch requests to fail repeatedly and trap users in a reload loop.

This PR restores reliable App Router prefetching and navigation in both secure and non-secure browser contexts while preserving existing behavior where `SubtleCrypto` is available, aligning with nextjs's behavior.

## What changed

Fallback to `fnv1a64()` to generate the digest if `SubtleCrypto` is unavailable.

```ts
const subtle = globalThis.crypto?.subtle;
if (!subtle) return fnv1a64(input);
```

## Testing

- `pnpm test tests/app-rsc-cache-busting.test.ts`
