### PR TITLE
test(build): relax hybrid client assets timeout

### DIFF
--- a/tests/client-assets-build.test.ts
+++ b/tests/client-assets-build.test.ts
@@ -163,5 +163,5 @@ describe("client asset sidecar builds", () => {
       }
       await fs.rm(fixtureRoot, { recursive: true, force: true });
     }
-  });
+  }, 20_000);
 });


### PR DESCRIPTION
## Summary

- give the hybrid client-assets build test a 20-second timeout
- keep the timeout scoped to the only case that performs both the App Router multi-environment build and a separate Pages Router server build

## Context

[CI run 31890871350](https://github.com/cloudflare/vinext/actions/runs/31890871350/job/95026828388) timed out at Vitest's 5-second default. The same test completed in 4,664 ms on the next successful main run, leaving only 336 ms of headroom and confirming this is runtime variance rather than an assertion failure.

## Testing

- `vp check tests/client-assets-build.test.ts`
- `vp test run tests/client-assets-build.test.ts --reporter=dot` (5 consecutive runs; 20/20 tests passed)