### PR TITLE
fix(fonts): normalize self-hosted URLs on Windows

### DIFF
--- a/packages/vinext/src/plugins/fonts.ts
+++ b/packages/vinext/src/plugins/fonts.ts
@@ -26,7 +26,7 @@
 
 import type { Plugin } from "vite";
 import { parseAst } from "vite";
-import path from "pathslash";
+import path, { toSlash } from "pathslash";
 import fs from "node:fs";
 import { escapeRegExp } from "../utils/regex.js";
 import { lastSignificantChar } from "../utils/has-trailing-comma.js";
@@ -138,9 +138,10 @@ export function _rewriteCachedFontCssToServedUrls(
   cacheDir: string,
   assetsDir: string = DEFAULT_ASSETS_DIR,
 ): string {
-  if (!cacheDir || !css.includes(cacheDir)) return css;
+  const normalizedCacheDir = toSlash(cacheDir);
+  if (!normalizedCacheDir || !css.includes(normalizedCacheDir)) return css;
   const prefix = assetsDir || DEFAULT_ASSETS_DIR;
-  return css.split(cacheDir).join(`/${prefix}/${VINEXT_FONT_URL_NAMESPACE}`);
+  return css.split(normalizedCacheDir).join(`/${prefix}/${VINEXT_FONT_URL_NAMESPACE}`);
 }
 
 /**
@@ -661,7 +662,7 @@ export function createGoogleFontsPlugin(fontGoogleShimPath: string, shimsDir: st
     enforce: "pre",
 
     configResolved(config) {
-      cacheDir = path.join(config.root, ".vinext", "fonts");
+      cacheDir = path.join(toSlash(config.root), ".vinext", "fonts");
     },
 
     // Dev-mode equivalent of the production `writeBundle` copy step. In dev

--- a/tests/font-google.test.ts
+++ b/tests/font-google.test.ts
@@ -1464,6 +1464,27 @@ describe("_rewriteCachedFontCssToServedUrls", () => {
     expect(out).toContain("format('woff2')");
   });
 
+  it.runIf(process.platform === "win32")(
+    "matches writer-normalized CSS when the cache directory uses native Windows separators",
+    () => {
+      // Regression for the 0.0.50 / 0.2.1 shape reported in #2933: the CSS
+      // writer used forward slashes while configResolved retained backslashes.
+      // Next.js emits font URLs under /_next/static/media rather than leaking
+      // the build machine's filesystem path:
+      // https://github.com/vercel/next.js/blob/canary/test/e2e/next-font/index.test.ts
+      const cacheDir = path.join("C:\\", "Users", "me", "project", ".vinext", "fonts");
+      const canonicalCacheDir = cacheDir.replaceAll("\\", "/");
+      const css = `src: url(${canonicalCacheDir}/geist-abc/geist-def.woff2) format('woff2');`;
+
+      const out = rewriteCachedFontCssToServedUrls(css, cacheDir);
+
+      expect(out).toBe(
+        "src: url(/_next/static/_vinext_fonts/geist-abc/geist-def.woff2) format('woff2');",
+      );
+      expect(out).not.toContain("C:/Users/me/project/.vinext/fonts");
+    },
+  );
+
   it("rewrites every occurrence when the same path appears multiple times", () => {
     // The broken path can appear in the same cached CSS via the cyrillic /
     // latin-ext / latin @font-face blocks Google Fonts returns per family,


### PR DESCRIPTION
## Summary

- normalize the Vite project root before deriving the Google Fonts cache directory
- canonicalize the cache-directory argument before matching writer-normalized CSS
- add a Windows regression for the 0.0.50/0.2.1 prefix mismatch reported in #2933

The fix is confined to build-time path normalization. It adds no request-time work and does not migrate pre-existing `.vinext` font caches.

Next.js emits origin-served font URLs under `/_next/static/media`; this keeps vinext self-hosted font CSS, preload tags, and `Link` headers on the equivalent URL-space contract.

Fixes #2933

## Testing

- `vp test run tests/font-google.test.ts tests/app-router-font-google-prod.test.ts tests/pages-router-font-google-prod.test.ts`
- `vp check tests/font-google.test.ts packages/vinext/src/plugins/fonts.ts`
- `vp run vinext#build`