### PR TITLE
fix(app-router): retain loading shell prefetches

### DIFF
--- a/packages/vinext/src/shims/internal/app-route-prefetch-policy.ts
+++ b/packages/vinext/src/shims/internal/app-route-prefetch-policy.ts
@@ -35,15 +35,14 @@ const ENCODED_PATH_DELIMITER_RE = /%(?:2f|5c)/i;
  */
 export type AppRoutePrefetchPolicy = {
   cacheForNavigation: boolean;
-  fallbackTtl: "dynamic" | "static";
   /**
-   * Whether a dynamic render's stale-time bound applies verbatim, including
-   * below the 30s prefetch floor. Automatic prefetches take it verbatim, so a
-   * dynamic `0` is never reused. `prefetch={true}` opts into caching dynamic
-   * content and keeps the floored static window, mirroring Next's split
-   * between `auto` and `full` in `getPrefetchEntryCacheStatus`.
+   * How the dynamic stale-time signal affects this prefetch. Navigation data
+   * takes it verbatim, explicit full prefetches fall back to the static window
+   * only when it is zero, and loading shells ignore it because their contents
+   * are static.
    */
-  honorDynamicStaleTime: boolean;
+  dynamicStaleTime: "verbatim" | "full-prefetch" | "ignore";
+  fallbackTtl: "dynamic" | "static";
   prefetchShellFirst: boolean;
   /** Fetch the route tree before the concrete page segment. */
   requiresRouteTreePrefetch?: true;
@@ -68,8 +67,8 @@ function toSameOriginRouteHref(href: string): string | null {
 /** Href the manifest does not cover: no request, nothing reusable. */
 const NO_APP_ROUTE_PREFETCH: AppRoutePrefetchPolicy = {
   cacheForNavigation: false,
+  dynamicStaleTime: "verbatim",
   fallbackTtl: "static",
-  honorDynamicStaleTime: true,
   prefetchShellFirst: false,
   shouldPrefetch: false,
 };
@@ -114,19 +113,20 @@ export function resolveAutoAppRoutePrefetch(href: string): AppRoutePrefetchPolic
     String(process.env.__NEXT_CACHE_COMPONENTS) === "true" &&
     (ENCODED_PATH_DELIMITER_RE.test(routeUrl.pathname) ||
       (isFullyDynamicRootRoute && !requiresRouteTreePrefetch));
+  const cacheForNavigation =
+    !hasSearchParams &&
+    !hasCacheComponentsLearningOnlyDynamicPath &&
+    (requiresRouteTreePrefetch ||
+      (!route.canPrefetchLoadingShell && route.requiresDynamicNavigationRequest !== true));
   return {
     // Vinext does not yet have Next.js's per-segment runtime-prefetch hints.
     // Routes with loading boundaries prefetch a shell first so navigation can
     // commit loading.js immediately. Dynamic routes without loading-shell
     // fallbacks can be cached for navigation unless their active parallel
     // branches must be derived from the click-time target tree.
-    cacheForNavigation:
-      !hasSearchParams &&
-      !hasCacheComponentsLearningOnlyDynamicPath &&
-      (requiresRouteTreePrefetch ||
-        (!route.canPrefetchLoadingShell && route.requiresDynamicNavigationRequest !== true)),
+    cacheForNavigation,
+    dynamicStaleTime: cacheForNavigation ? "verbatim" : "ignore",
     fallbackTtl: "static",
-    honorDynamicStaleTime: true,
     prefetchShellFirst: requiresRouteTreePrefetch || hasSearchParams || !route.isDynamic,
     ...(requiresRouteTreePrefetch ? { requiresRouteTreePrefetch: true } : {}),
     shouldPrefetch: true,
@@ -136,8 +136,8 @@ export function resolveAutoAppRoutePrefetch(href: string): AppRoutePrefetchPolic
 export function resolveFullAppRoutePrefetch(): AppRoutePrefetchPolicy {
   return {
     cacheForNavigation: true,
+    dynamicStaleTime: "full-prefetch",
     fallbackTtl: "static",
-    honorDynamicStaleTime: false,
     prefetchShellFirst: true,
     shouldPrefetch: true,
   };

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -716,7 +716,7 @@ function prefetchUrl(
               autoPrefetch.fallbackTtl === "dynamic"
                 ? DYNAMIC_NAVIGATION_CACHE_TTL
                 : PREFETCH_CACHE_TTL,
-            honorDynamicStaleTime: autoPrefetch.honorDynamicStaleTime,
+            dynamicStaleTime: autoPrefetch.dynamicStaleTime,
             optimisticRouteShell: isOptimisticRouteShellPrefetch,
             prefetchKind: isOptimisticRouteShellPrefetch ? "loading-shell" : "navigation",
             prepareSnapshot: autoPrefetch.cacheForNavigation

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -506,7 +506,7 @@ function resolvePrefetchedRscResponseExpiresAt(
   timestamp: number,
   cached: Pick<CachedRscResponse, "dynamicStaleTimeSeconds" | "expiresAt" | "serverStaleTime">,
   fallbackTtlMs: number,
-  honorDynamicStaleTime: boolean,
+  dynamicStaleTime: "verbatim" | "full-prefetch" | "ignore",
 ): number {
   if (isCacheExpiresAt(cached.expiresAt)) {
     return cached.expiresAt;
@@ -518,11 +518,14 @@ function resolvePrefetchedRscResponseExpiresAt(
   // is unresolved. If the render completes with a real cacheLife or dynamic
   // bound, completion metadata replaces the provisional marker below.
   const serverSeconds =
-    cached.serverStaleTime?.kind === "pending" && !honorDynamicStaleTime
+    cached.serverStaleTime?.kind === "pending" && dynamicStaleTime !== "verbatim"
       ? undefined
       : serverStaleTimeSeconds(cached.serverStaleTime);
   if (serverSeconds !== undefined) {
     return timestamp + serverSeconds * 1000;
+  }
+  if (dynamicStaleTime === "ignore") {
+    return timestamp + Math.max(fallbackTtlMs, MIN_PREFETCH_STALE_TIME_MS);
   }
   const seconds = isStaleTimeSeconds(cached.dynamicStaleTimeSeconds)
     ? cached.dynamicStaleTimeSeconds
@@ -538,7 +541,7 @@ function resolvePrefetchedRscResponseExpiresAt(
   // reuse. `prefetch={true}` uses Next's Full fetch strategy, so a config
   // dynamic bound of zero selects STATIC_STALETIME_MS. Nonzero completed
   // dynamic bounds keep their existing per-page expiry.
-  return honorDynamicStaleTime
+  return dynamicStaleTime === "verbatim"
     ? timestamp + seconds * 1000
     : timestamp +
         (seconds === 0
@@ -1437,8 +1440,8 @@ export function prefetchRscResponse(
   options?: PrefetchOptions,
   behavior: {
     cacheForNavigation?: boolean;
+    dynamicStaleTime?: "verbatim" | "full-prefetch" | "ignore";
     fallbackTtlMs?: number;
-    honorDynamicStaleTime?: boolean;
     optimisticRouteShell?: boolean;
     prefetchKind?: PrefetchCacheKind;
     prepareSnapshot?: (snapshot: CachedRscResponse) => Promise<AppElements>;
@@ -1486,7 +1489,10 @@ export function prefetchRscResponse(
           // data and is never navigation-consumable. Keep it on the prefetch
           // freshness lattice so another search string can reuse the shell;
           // the later navigation response still honors dynamicStaleTime.
-          behavior.honorDynamicStaleTime !== false && behavior.searchAgnosticShell !== true,
+          behavior.searchAgnosticShell === true
+            ? "ignore"
+            : (behavior.dynamicStaleTime ??
+                (behavior.optimisticRouteShell === true ? "ignore" : "verbatim")),
         );
         if (behavior.prepareSnapshot) {
           try {
@@ -2940,13 +2946,18 @@ const _appRouter: AppRouterInstance = {
                 policy.fallbackTtl === "dynamic"
                   ? DYNAMIC_NAVIGATION_CACHE_TTL
                   : PREFETCH_CACHE_TTL,
-              honorDynamicStaleTime: policy.honorDynamicStaleTime,
+              dynamicStaleTime: policy.dynamicStaleTime,
               optimisticRouteShell: false,
               prefetchKind: "navigation",
               prepareSnapshot: prepareNavigationPrefetchSnapshot,
             }
           : {
               cacheForNavigation: false,
+              fallbackTtlMs:
+                policy.fallbackTtl === "dynamic"
+                  ? DYNAMIC_NAVIGATION_CACHE_TTL
+                  : PREFETCH_CACHE_TTL,
+              dynamicStaleTime: policy.dynamicStaleTime,
               optimisticRouteShell: true,
               prefetchKind: "navigation",
             },

--- a/tests/e2e/app-router/nextjs-compat/client-cache.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/client-cache.spec.ts
@@ -163,6 +163,51 @@ test.describe("Next.js compat: client cache", () => {
     expect(requestsFor(requests, `${ROOT}/1`)).toEqual([]);
   });
 
+  test("re-hovering an auto loading shell reuses the cached prefetch (#2937)", async ({ page }) => {
+    // Next.js parity:
+    // test/e2e/app-dir/app-client-cache/client-cache.experimental.test.ts
+    // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/app-client-cache/client-cache.experimental.test.ts
+    const requests = trackRscRequests(page);
+    const target = `${ROOT}/default-stale/1`;
+    await openHome(page);
+
+    await expect
+      .poll(() => requestsFor(requests, target).some((request) => request.partial))
+      .toBe(true);
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const cache = Reflect.get(window, "__VINEXT_RSC_PREFETCH_CACHE__") as Map<
+            string,
+            {
+              cacheForNavigation?: boolean;
+              expiresAt?: number;
+              outcome?: string;
+              pending?: Promise<void>;
+              timestamp: number;
+            }
+          >;
+          return Array.from(cache.entries()).some(
+            ([key, entry]) =>
+              key.includes("/nextjs-compat/client-cache/default-stale/1") &&
+              entry.cacheForNavigation === false &&
+              entry.outcome === "cache-seeded" &&
+              entry.pending === undefined &&
+              entry.expiresAt !== undefined &&
+              entry.expiresAt - entry.timestamp === 300_000,
+          );
+        }),
+      )
+      .toBe(true);
+
+    requests.length = 0;
+    await page.hover("#client-cache-home");
+    await page.hover("#client-cache-default-stale-auto");
+    await page.waitForTimeout(250);
+
+    expect(requestsFor(requests, target)).toEqual([]);
+  });
+
   test("hovering prefetch={false} emits zero requests", async ({ page }) => {
     const requests = trackRscRequests(page);
     await openHome(page);

--- a/tests/fixtures/app-basic/app/nextjs-compat/client-cache/default-stale/[id]/loading.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/client-cache/default-stale/[id]/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div>Loading default-stale client cache route</div>;
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/client-cache/default-stale/[id]/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/client-cache/default-stale/[id]/page.tsx
@@ -1,0 +1,20 @@
+import Link from "next/link";
+
+export const dynamic = "force-dynamic";
+
+export default async function DefaultStaleClientCacheTarget({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+
+  return (
+    <main>
+      <Link href="/nextjs-compat/client-cache" prefetch={false}>
+        Back to client cache home
+      </Link>
+      <div>Default-stale client cache target {id}</div>
+    </main>
+  );
+}

--- a/tests/fixtures/app-basic/app/nextjs-compat/client-cache/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/client-cache/page.tsx
@@ -15,6 +15,9 @@ export default function ClientCacheHome() {
       <Link href="/nextjs-compat/client-cache/1" id="client-cache-auto">
         Auto prefetch
       </Link>
+      <Link href="/nextjs-compat/client-cache/default-stale/1" id="client-cache-default-stale-auto">
+        Auto prefetch with the default stale time
+      </Link>
       <Link href="/nextjs-compat/client-cache/2" prefetch={false} id="client-cache-none">
         No prefetch
       </Link>

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -345,29 +345,29 @@ describe("Link App Router prefetch mode", () => {
     try {
       expect(resolveAutoAppRoutePrefetch("/about")).toEqual({
         cacheForNavigation: true,
+        dynamicStaleTime: "verbatim",
         fallbackTtl: "static",
-        honorDynamicStaleTime: true,
         prefetchShellFirst: true,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/blog/hello-world")).toEqual({
         cacheForNavigation: false,
+        dynamicStaleTime: "ignore",
         fallbackTtl: "static",
-        honorDynamicStaleTime: true,
         prefetchShellFirst: false,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/settings")).toEqual({
         cacheForNavigation: false,
+        dynamicStaleTime: "ignore",
         fallbackTtl: "static",
-        honorDynamicStaleTime: true,
         prefetchShellFirst: true,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/products/1")).toEqual({
         cacheForNavigation: true,
+        dynamicStaleTime: "verbatim",
         fallbackTtl: "static",
-        honorDynamicStaleTime: true,
         prefetchShellFirst: false,
         shouldPrefetch: true,
       });
@@ -376,38 +376,38 @@ describe("Link App Router prefetch mode", () => {
       // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/segment-cache/client-params/client-params.test.ts
       expect(resolveAutoAppRoutePrefetch("/clothing/1")).toEqual({
         cacheForNavigation: true,
+        dynamicStaleTime: "verbatim",
         fallbackTtl: "static",
-        honorDynamicStaleTime: true,
         prefetchShellFirst: false,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/root-param/aaa")).toEqual({
         cacheForNavigation: true,
+        dynamicStaleTime: "verbatim",
         fallbackTtl: "static",
-        honorDynamicStaleTime: true,
         prefetchShellFirst: true,
         requiresRouteTreePrefetch: true,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/root-param/aaa?q=1")).toEqual({
         cacheForNavigation: false,
+        dynamicStaleTime: "ignore",
         fallbackTtl: "static",
-        honorDynamicStaleTime: true,
         prefetchShellFirst: true,
         requiresRouteTreePrefetch: true,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/teams/vercel/dashboard")).toEqual({
         cacheForNavigation: false,
+        dynamicStaleTime: "ignore",
         fallbackTtl: "static",
-        honorDynamicStaleTime: true,
         prefetchShellFirst: false,
         shouldPrefetch: true,
       });
       expect(resolveAutoAppRoutePrefetch("/missing")).toEqual({
         cacheForNavigation: false,
+        dynamicStaleTime: "verbatim",
         fallbackTtl: "static",
-        honorDynamicStaleTime: true,
         prefetchShellFirst: false,
         shouldPrefetch: false,
       });
@@ -442,8 +442,8 @@ describe("Link App Router prefetch mode", () => {
     try {
       expect(resolveAutoAppRoutePrefetch("/root-param/aaa")).toEqual({
         cacheForNavigation: false,
+        dynamicStaleTime: "ignore",
         fallbackTtl: "static",
-        honorDynamicStaleTime: true,
         prefetchShellFirst: false,
         shouldPrefetch: true,
       });

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -1285,6 +1285,61 @@ describe("prefetch cache eviction", () => {
     expect(consumePrefetchResponse(fetchedUrl, null, null)).toBeNull();
   });
 
+  it("keeps automatic loading shells on the static window across dynamic bounds (#2937)", async () => {
+    // Next.js parity:
+    // test/e2e/app-dir/app-client-cache/client-cache.experimental.test.ts
+    // https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/app-client-cache/client-cache.experimental.test.ts
+    // A loading-boundary prefetch contains static shell data. Next keeps that
+    // shell cached when the same Link is hovered again, even though the
+    // default dynamic stale time reported by the server is zero.
+    (globalThis as any).window.__VINEXT_LINK_PREFETCH_ROUTES__ = [
+      { canPrefetchLoadingShell: true, patternParts: ["items", ":slug"], isDynamic: true },
+    ];
+    const dynamicStaleTimes = new Map([
+      ["alpha", 0],
+      ["bravo", 60],
+      ["charlie", 600],
+    ]);
+    const fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const pathname = new URL(toRscUrlString(input), "http://localhost").pathname;
+      const slug = pathname.split("/").at(-1);
+      const dynamicStaleTime = slug === undefined ? undefined : dynamicStaleTimes.get(slug);
+      if (dynamicStaleTime === undefined) throw new Error(`Unexpected prefetch URL: ${pathname}`);
+      return new Response("loading shell", {
+        headers: {
+          "content-type": "text/x-component",
+          [VINEXT_DYNAMIC_STALE_TIME_HEADER]: String(dynamicStaleTime),
+        },
+      });
+    });
+    (globalThis as any).fetch = fetch;
+
+    for (const [slug, dynamicStaleTime] of dynamicStaleTimes) {
+      appRouterInstance.prefetch(`/items/${slug}`);
+      await waitForPrefetchSetup(() =>
+        Array.from(getPrefetchCache().values()).some(
+          (entry) =>
+            entry.snapshot?.dynamicStaleTimeSeconds === dynamicStaleTime &&
+            entry.outcome === "cache-seeded" &&
+            entry.pending === undefined,
+        ),
+      );
+
+      const entry = Array.from(getPrefetchCache().values()).find(
+        (candidate) => candidate.snapshot?.dynamicStaleTimeSeconds === dynamicStaleTime,
+      );
+      expect(entry).toBeDefined();
+      if (!entry) return;
+      expect(entry.cacheForNavigation).toBe(false);
+      expect(entry.optimisticRouteShell).toBe(true);
+      expect(entry.expiresAt).toBe(entry.timestamp + PREFETCH_CACHE_TTL);
+    }
+
+    appRouterInstance.prefetch("/items/alpha");
+    await settlePrefetchSetup();
+    expect(fetch).toHaveBeenCalledTimes(dynamicStaleTimes.size);
+  });
+
   it("dedupes pending and fresh Cache Components encoded dynamic router.prefetch calls but refetches after expiry", async () => {
     // Ported from Next.js:
     // test/e2e/app-dir/segment-cache/encoded-slash-params/encoded-slash-params.test.ts
@@ -1547,6 +1602,33 @@ describe("prefetch cache eviction", () => {
     expect(getPrefetchCache().get(rscUrl)?.expiresAt).toBe(now + 30_000);
   });
 
+  it("defaults optimistic loading shells to the static prefetch window", async () => {
+    const now = 1_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const rscUrl = "/implicit-loading-shell.rsc";
+
+    prefetchRscResponse(
+      rscUrl,
+      Promise.resolve(
+        new Response("loading shell", {
+          headers: {
+            "content-type": "text/x-component",
+            [VINEXT_DYNAMIC_STALE_TIME_HEADER]: "0",
+          },
+        }),
+      ),
+      null,
+      null,
+      undefined,
+      { cacheForNavigation: false, optimisticRouteShell: true },
+    );
+    await getPrefetchCache().get(rscUrl)?.pending;
+
+    const entry = getPrefetchCache().get(rscUrl);
+    expect(entry?.prefetchKind).toBe("loading-shell");
+    expect(entry?.expiresAt).toBe(now + PREFETCH_CACHE_TTL);
+  });
+
   it("expires a zero dynamic stale time immediately instead of flooring it", async () => {
     // Every dynamic render emits this header (app-page-render.ts defaults it
     // to `experimental.staleTimes.dynamic`, which is 0). Next keeps the two
@@ -1665,7 +1747,7 @@ describe("prefetch cache eviction", () => {
       null,
       null,
       undefined,
-      { fallbackTtlMs: staticStaleTimeMs, honorDynamicStaleTime: false },
+      { fallbackTtlMs: staticStaleTimeMs, dynamicStaleTime: "full-prefetch" },
     );
     await getPrefetchCache().get(rscUrl)?.pending;
 
@@ -1690,7 +1772,7 @@ describe("prefetch cache eviction", () => {
       null,
       null,
       undefined,
-      { fallbackTtlMs: 300_000, honorDynamicStaleTime: false },
+      { fallbackTtlMs: 300_000, dynamicStaleTime: "full-prefetch" },
     );
     await getPrefetchCache().get(rscUrl)?.pending;
 


### PR DESCRIPTION
Closes #2937

## Summary

- keep automatic loading-shell prefetches on the static stale-time window instead of applying `staleTimes.dynamic`
- distinguish verbatim dynamic reuse, explicit full-prefetch behavior, and static-shell freshness in the shared prefetch cache
- apply the shell invariant to Link, router prefetch, companion full-prefetch shells, and Form through the shared cache seam

## Root cause

The automatic prefetch policy applied the dynamic stale-time signal to learning-only loading shells. With the default `dynamic: 0`, those shell entries expired at their insertion timestamp, so every later hover evicted and refetched the same RSC payload. The previous boolean also allowed nonzero dynamic values to shorten or extend static-shell freshness.

This matches the loading-boundary/static stale-time split covered by Next.js in https://github.com/vercel/next.js/blob/v16.2.6/test/e2e/app-dir/app-client-cache/client-cache.experimental.test.ts.

## Validation

- `vp test run tests/prefetch-cache.test.ts tests/link.test.ts tests/shims.test.ts` (1,510 passed)
- dedicated production Playwright: `client-cache.spec.ts -g "re-hovering an auto loading shell"` (1 passed)
- targeted `vp check` for all changed TypeScript files
- two independent review passes: no findings