### PR TITLE
test(app-router): reproduce shared layout teardown on soft navigation

### DIFF
--- a/examples/app-router-cloudflare/app/layout-identity/@aside/[slug]/child/page.tsx
+++ b/examples/app-router-cloudflare/app/layout-identity/@aside/[slug]/child/page.tsx
@@ -1,0 +1,4 @@
+export default async function AsideChild({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  return <p data-testid="aside-content">aside: {slug} child</p>;
+}

--- a/examples/app-router-cloudflare/app/layout-identity/@aside/[slug]/items/[item]/page.tsx
+++ b/examples/app-router-cloudflare/app/layout-identity/@aside/[slug]/items/[item]/page.tsx
@@ -1,0 +1,12 @@
+export default async function AsideItem({
+  params,
+}: {
+  params: Promise<{ slug: string; item: string }>;
+}) {
+  const { slug, item } = await params;
+  return (
+    <p data-testid="aside-content">
+      aside: {slug} / {item}
+    </p>
+  );
+}

--- a/examples/app-router-cloudflare/app/layout-identity/@aside/[slug]/page.tsx
+++ b/examples/app-router-cloudflare/app/layout-identity/@aside/[slug]/page.tsx
@@ -1,0 +1,4 @@
+export default async function AsideParent({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  return <p data-testid="aside-content">aside: {slug} parent</p>;
+}

--- a/examples/app-router-cloudflare/app/layout-identity/@aside/default.tsx
+++ b/examples/app-router-cloudflare/app/layout-identity/@aside/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null;
+}

--- a/examples/app-router-cloudflare/app/layout-identity/[slug]/child/page.tsx
+++ b/examples/app-router-cloudflare/app/layout-identity/[slug]/child/page.tsx
@@ -1,0 +1,18 @@
+import Link from "next/link";
+
+export default async function LayoutIdentityChildPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+
+  return (
+    <main>
+      <h1 data-testid="page-title">Child page</h1>
+      <Link data-testid="to-parent" href={`/layout-identity/${slug}`}>
+        Back to parent
+      </Link>
+    </main>
+  );
+}

--- a/examples/app-router-cloudflare/app/layout-identity/[slug]/items/[item]/layout.tsx
+++ b/examples/app-router-cloudflare/app/layout-identity/[slug]/items/[item]/layout.tsx
@@ -1,0 +1,17 @@
+import type { PropsWithChildren } from "react";
+
+// A second nested layout beneath the shared `[slug]` layout, owning its own
+// dynamic segment, so the navigation crosses two layout levels at once.
+export default async function ItemLayout({
+  children,
+  params,
+}: PropsWithChildren<{ params: Promise<{ item: string }> }>) {
+  const { item } = await params;
+
+  return (
+    <div data-testid="item-layout">
+      <p data-testid="item-layout-value">Item layout: {item}</p>
+      {children}
+    </div>
+  );
+}

--- a/examples/app-router-cloudflare/app/layout-identity/[slug]/items/[item]/page.tsx
+++ b/examples/app-router-cloudflare/app/layout-identity/[slug]/items/[item]/page.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link";
+
+export default async function ItemPage({
+  params,
+}: {
+  params: Promise<{ slug: string; item: string }>;
+}) {
+  const { slug, item } = await params;
+
+  return (
+    <main>
+      <h1 data-testid="page-title">Item page</h1>
+      <p data-testid="item-value">Item: {item}</p>
+      <Link data-testid="to-parent" href={`/layout-identity/${slug}`}>
+        Back to parent
+      </Link>
+    </main>
+  );
+}

--- a/examples/app-router-cloudflare/app/layout-identity/[slug]/layout-state.tsx
+++ b/examples/app-router-cloudflare/app/layout-identity/[slug]/layout-state.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { useState } from "react";
+
+// State owned by the shared layout, so it only resets if the layout remounts.
+export function LayoutState() {
+  const [count, setCount] = useState(0);
+
+  return (
+    <div>
+      <p data-testid="layout-count">Layout count: {count}</p>
+      <button data-testid="layout-increment" onClick={() => setCount((c) => c + 1)}>
+        Increment layout counter
+      </button>
+    </div>
+  );
+}

--- a/examples/app-router-cloudflare/app/layout-identity/[slug]/layout.tsx
+++ b/examples/app-router-cloudflare/app/layout-identity/[slug]/layout.tsx
@@ -1,0 +1,21 @@
+import type { PropsWithChildren } from "react";
+import { LayoutState } from "./layout-state";
+
+// `/layout-identity/[slug]` and `/layout-identity/[slug]/child` share this
+// layout and resolve the same `[slug]` value, so navigating between them changes
+// only the child segment. The layout must stay mounted across that navigation:
+// its DOM node keeps its identity and any client state inside it survives.
+export default async function LayoutIdentityLayout({
+  children,
+  params,
+}: PropsWithChildren<{ params: Promise<{ slug: string }> }>) {
+  const { slug } = await params;
+
+  return (
+    <div data-testid="shared-layout">
+      <p data-testid="layout-slug">Layout slug: {slug}</p>
+      <LayoutState />
+      {children}
+    </div>
+  );
+}

--- a/examples/app-router-cloudflare/app/layout-identity/[slug]/page.tsx
+++ b/examples/app-router-cloudflare/app/layout-identity/[slug]/page.tsx
@@ -1,0 +1,21 @@
+import Link from "next/link";
+
+export default async function LayoutIdentityPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+
+  return (
+    <main>
+      <h1 data-testid="page-title">Parent page</h1>
+      <Link data-testid="to-child" href={`/layout-identity/${slug}/child`}>
+        Go to child
+      </Link>
+      <Link data-testid="to-item" href={`/layout-identity/${slug}/items/first`}>
+        Go to item
+      </Link>
+    </main>
+  );
+}

--- a/examples/app-router-cloudflare/app/layout-identity/layout.tsx
+++ b/examples/app-router-cloudflare/app/layout-identity/layout.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from "react";
+
+// A parallel slot sits beside `children`, above the shared `[slug]` layout —
+// the shape an app has when route-derived chrome (breadcrumbs, a sidebar) is
+// rendered as a slot. The slot's content changes on every navigation while the
+// `[slug]` layout below stays on the same segment value.
+export default function LayoutIdentityRootLayout({
+  children,
+  aside,
+}: {
+  children: ReactNode;
+  aside: ReactNode;
+}) {
+  return (
+    <div>
+      <div data-testid="aside-slot">{aside}</div>
+      {children}
+    </div>
+  );
+}

--- a/examples/app-router-cloudflare/app/layout-identity/loading.tsx
+++ b/examples/app-router-cloudflare/app/layout-identity/loading.tsx
@@ -1,0 +1,5 @@
+// A loading boundary above the shared `[slug]` layout. Its presence is what
+// turns a same-layout navigation into a full teardown of everything below it.
+export default function Loading() {
+  return <p data-testid="loading-fallback">Loading…</p>;
+}

--- a/tests/e2e/cloudflare-workers/layout-identity.spec.ts
+++ b/tests/e2e/cloudflare-workers/layout-identity.spec.ts
@@ -1,0 +1,110 @@
+import { test, expect, type Page } from "@playwright/test";
+
+const BASE = "http://localhost:4176";
+const PARENT = `${BASE}/layout-identity/alpha`;
+
+const readLayoutHandle = (page: Page) =>
+  page.evaluateHandle(() => document.querySelector('[data-testid="shared-layout"]'));
+
+// `/layout-identity/[slug]` and everything beneath it share the `[slug]` layout
+// and resolve the same slug value, so navigating between them changes only the
+// segments below that layout. The layout must stay mounted: its DOM node keeps
+// its identity and the client state it owns survives.
+//
+// vinext currently discards the layout subtree on these navigations. The trigger
+// is the `loading.tsx` boundary above the shared layout — with that file removed
+// from the fixture, every assertion below passes.
+test.describe("App Router shared layout identity", () => {
+  test("navigates without a full document load", async ({ page }) => {
+    await page.goto(PARENT);
+    await expect(page.getByTestId("page-title")).toHaveText("Parent page");
+
+    await page.evaluate(() => {
+      (window as Window & { __softNavigationMarker?: boolean }).__softNavigationMarker = true;
+    });
+
+    await page.getByTestId("to-child").click();
+    await expect(page.getByTestId("page-title")).toHaveText("Child page");
+
+    // Control: the marker survives, so this is a client-side navigation rather
+    // than a document load. The teardown below is therefore the router
+    // discarding a layout it should have retained, not a full page reload.
+    const marker = await page.evaluate(
+      () => (window as Window & { __softNavigationMarker?: boolean }).__softNavigationMarker,
+    );
+    expect(marker).toBe(true);
+  });
+
+  test("keeps the shared layout element mounted across a static child segment", async ({
+    page,
+  }) => {
+    await page.goto(PARENT);
+    await expect(page.getByTestId("page-title")).toHaveText("Parent page");
+
+    const layout = await readLayoutHandle(page);
+    expect(await layout.evaluate((element) => element?.isConnected ?? false)).toBe(true);
+
+    await page.getByTestId("to-child").click();
+    await expect(page.getByTestId("page-title")).toHaveText("Child page");
+
+    // The same DOM node must still be in the document: a retained layout is
+    // reconciled in place, a discarded one is replaced by a fresh element.
+    expect(await layout.evaluate((element) => element?.isConnected ?? false)).toBe(true);
+  });
+
+  test("keeps the shared layout element mounted across a nested dynamic segment", async ({
+    page,
+  }) => {
+    await page.goto(PARENT);
+    await expect(page.getByTestId("page-title")).toHaveText("Parent page");
+
+    const layout = await readLayoutHandle(page);
+
+    // Crosses two layout levels at once: the shared `[slug]` layout stays on the
+    // same value while `items/[item]` mounts its own layout beneath it.
+    await page.getByTestId("to-item").click();
+    await expect(page.getByTestId("page-title")).toHaveText("Item page");
+    await expect(page.getByTestId("item-layout-value")).toHaveText("Item layout: first");
+
+    expect(await layout.evaluate((element) => element?.isConnected ?? false)).toBe(true);
+  });
+
+  test("preserves client state owned by the shared layout", async ({ page }) => {
+    await page.goto(PARENT);
+    await page.getByTestId("layout-increment").click();
+    await expect(page.getByTestId("layout-count")).toHaveText("Layout count: 1");
+
+    await page.getByTestId("to-child").click();
+    await expect(page.getByTestId("page-title")).toHaveText("Child page");
+
+    // The counter lives in the layout, not the page, so it only resets when the
+    // layout remounts.
+    await expect(page.getByTestId("layout-count")).toHaveText("Layout count: 1");
+  });
+
+  test("keeps the shared layout mounted when navigating back to the parent", async ({ page }) => {
+    await page.goto(`${PARENT}/items/first`);
+    await expect(page.getByTestId("page-title")).toHaveText("Item page");
+
+    const layout = await readLayoutHandle(page);
+
+    await page.getByTestId("to-parent").click();
+    await expect(page.getByTestId("page-title")).toHaveText("Parent page");
+
+    expect(await layout.evaluate((element) => element?.isConnected ?? false)).toBe(true);
+  });
+
+  test("updates the parallel slot alongside the retained layout", async ({ page }) => {
+    await page.goto(PARENT);
+    await expect(page.getByTestId("aside-content")).toHaveText("aside: alpha parent");
+
+    const layout = await readLayoutHandle(page);
+
+    await page.getByTestId("to-item").click();
+    await expect(page.getByTestId("aside-content")).toHaveText("aside: alpha / first");
+
+    // The slot beside `children` changing must not cost the sibling layout its
+    // identity.
+    expect(await layout.evaluate((element) => element?.isConnected ?? false)).toBe(true);
+  });
+});


### PR DESCRIPTION
> **Draft: reproduction only.** This PR contains no fix — the added e2es are expected to fail on CI. It exists to pin down the failure described in #1523 with a runnable fixture.

## Problem

A shared layout is discarded during a soft navigation that only changes segments *below* it. The layout's DOM node is replaced and any client state it owns is lost, even though its dynamic segment never changes value.

`/layout-identity/[slug]` and everything beneath it resolve the same `slug`, so navigating from the parent into a child changes only the segments under the `[slug]` layout. That layout should be reconciled in place.

This is the client-side half of #1523 ("Soft `<Link>` navigation triggers full server re-render… Layout is re-rendered when it should be reused"). #2876 fixes the three non-cache failures in that suite and deliberately leaves this one.

## What was added

A `/layout-identity` fixture in `examples/app-router-cloudflare`, deliberately shaped like a real app rather than reduced to the smallest possible case:

- a shared `[slug]/layout.tsx` holding a client component with state
- a **`loading.tsx` boundary above** the shared layout
- a **parallel slot** (`@aside`) beside `children`, whose content changes on every navigation
- a **static** child segment (`[slug]/child`)
- a **nested dynamic** segment with its own layout (`[slug]/items/[item]`), so a navigation can cross two layout levels at once

Plus `tests/e2e/cloudflare-workers/layout-identity.spec.ts` covering each navigation shape.

## Results on this branch

```
✓ navigates without a full document load
✘ keeps the shared layout element mounted across a static child segment
✘ keeps the shared layout element mounted across a nested dynamic segment
✘ preserves client state owned by the shared layout
✘ keeps the shared layout mounted when navigating back to the parent
✘ updates the parallel slot alongside the retained layout

5 failed, 1 passed
```

Run with:

```sh
cd examples/app-router-cloudflare && npx vp build && npx wrangler dev --config dist/server/wrangler.json --port 4176
npx playwright test --project=cloudflare-workers layout-identity
```

The passing test is the control: a `window` marker set before the click survives it, so this is a client-side navigation, not a document load. The teardown is the router discarding a layout it should have retained.

The state failure is the user-visible one — the layout's counter is incremented to 1, and after navigating reads `Layout count: 0`.

## Isolating the trigger

The `loading.tsx` boundary above the shared layout is what causes it. Measured on this fixture:

| fixture | result |
| --- | --- |
| as committed | 5 failed, 1 passed |
| identical tree, `layout-identity/loading.tsx` deleted | **6 passed** |

I also built the fixture up incrementally, and neither the parallel slot nor the nested dynamic segment triggers it on their own — with no `loading.tsx` present, every combination of those passed. Only introducing the boundary above the shared layout produces the teardown.

## Where I think the gap is

`preserveElementIds` in the visible-commit path never admits layout-kind elements. The only element kind preserved across a navigation lane is `template` (`app-browser-visible-commit.ts`, via the `preserveTemplateIds` logic that #2876 carries). Layout-kind machinery exists elsewhere (`app-elements-wire.ts`, `app-history-state.ts`) but is not wired into that decision, so a layout whose segment value is unchanged is not retained when the boundary above it re-suspends.

I have not attempted a fix here — happy to follow up with one, or hand this to whoever picks up #1523.

## Environment

Reproduced on `main` (`vinext@1.0.0-beta.6`, 6 commits behind HEAD at the time of writing, none touching App Router navigation), Next.js 16.2.2, React 19.2.5, production build served with `wrangler dev`.

Separately confirmed against the pkg.pr.new prerelease of #2876 (`5719d11`) on a real application: the shared layout is still torn down there, consistent with that PR scoping itself away from this failure.
