### PR TITLE
fix(app-router): retain shared layouts across loading shells

### DIFF
--- a/examples/app-router-cloudflare/app/layout-identity/@aside/[slug]/child/page.tsx
+++ b/examples/app-router-cloudflare/app/layout-identity/@aside/[slug]/child/page.tsx
@@ -1,0 +1,4 @@
+export default async function AsideChild({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  return <p data-testid="aside-content">aside: {slug} child</p>;
+}

--- a/examples/app-router-cloudflare/app/layout-identity/@aside/[slug]/items/[item]/page.tsx
+++ b/examples/app-router-cloudflare/app/layout-identity/@aside/[slug]/items/[item]/page.tsx
@@ -1,0 +1,12 @@
+export default async function AsideItem({
+  params,
+}: {
+  params: Promise<{ slug: string; item: string }>;
+}) {
+  const { slug, item } = await params;
+  return (
+    <p data-testid="aside-content">
+      aside: {slug} / {item}
+    </p>
+  );
+}

--- a/examples/app-router-cloudflare/app/layout-identity/@aside/[slug]/page.tsx
+++ b/examples/app-router-cloudflare/app/layout-identity/@aside/[slug]/page.tsx
@@ -1,0 +1,4 @@
+export default async function AsideParent({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  return <p data-testid="aside-content">aside: {slug} parent</p>;
+}

--- a/examples/app-router-cloudflare/app/layout-identity/@aside/default.tsx
+++ b/examples/app-router-cloudflare/app/layout-identity/@aside/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null;
+}

--- a/examples/app-router-cloudflare/app/layout-identity/[slug]/child/page.tsx
+++ b/examples/app-router-cloudflare/app/layout-identity/[slug]/child/page.tsx
@@ -1,0 +1,18 @@
+import Link from "next/link";
+
+export default async function LayoutIdentityChildPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+
+  return (
+    <main>
+      <h1 data-testid="page-title">Child page</h1>
+      <Link data-testid="to-parent" href={`/layout-identity/${slug}`}>
+        Back to parent
+      </Link>
+    </main>
+  );
+}

--- a/examples/app-router-cloudflare/app/layout-identity/[slug]/items/[item]/layout.tsx
+++ b/examples/app-router-cloudflare/app/layout-identity/[slug]/items/[item]/layout.tsx
@@ -1,0 +1,17 @@
+import type { PropsWithChildren } from "react";
+
+// A second nested layout beneath the shared `[slug]` layout, owning its own
+// dynamic segment, so the navigation crosses two layout levels at once.
+export default async function ItemLayout({
+  children,
+  params,
+}: PropsWithChildren<{ params: Promise<{ item: string }> }>) {
+  const { item } = await params;
+
+  return (
+    <div data-testid="item-layout">
+      <p data-testid="item-layout-value">Item layout: {item}</p>
+      {children}
+    </div>
+  );
+}

--- a/examples/app-router-cloudflare/app/layout-identity/[slug]/items/[item]/page.tsx
+++ b/examples/app-router-cloudflare/app/layout-identity/[slug]/items/[item]/page.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link";
+
+export default async function ItemPage({
+  params,
+}: {
+  params: Promise<{ slug: string; item: string }>;
+}) {
+  const { slug, item } = await params;
+
+  return (
+    <main>
+      <h1 data-testid="page-title">Item page</h1>
+      <p data-testid="item-value">Item: {item}</p>
+      <Link data-testid="to-parent" href={`/layout-identity/${slug}`}>
+        Back to parent
+      </Link>
+    </main>
+  );
+}

--- a/examples/app-router-cloudflare/app/layout-identity/[slug]/layout-state.tsx
+++ b/examples/app-router-cloudflare/app/layout-identity/[slug]/layout-state.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { useState } from "react";
+
+// State owned by the shared layout, so it only resets if the layout remounts.
+export function LayoutState() {
+  const [count, setCount] = useState(0);
+
+  return (
+    <div>
+      <p data-testid="layout-count">Layout count: {count}</p>
+      <button data-testid="layout-increment" onClick={() => setCount((c) => c + 1)}>
+        Increment layout counter
+      </button>
+    </div>
+  );
+}

--- a/examples/app-router-cloudflare/app/layout-identity/[slug]/layout.tsx
+++ b/examples/app-router-cloudflare/app/layout-identity/[slug]/layout.tsx
@@ -1,0 +1,21 @@
+import type { PropsWithChildren } from "react";
+import { LayoutState } from "./layout-state";
+
+// `/layout-identity/[slug]` and `/layout-identity/[slug]/child` share this
+// layout and resolve the same `[slug]` value, so navigating between them changes
+// only the child segment. The layout must stay mounted across that navigation:
+// its DOM node keeps its identity and any client state inside it survives.
+export default async function LayoutIdentityLayout({
+  children,
+  params,
+}: PropsWithChildren<{ params: Promise<{ slug: string }> }>) {
+  const { slug } = await params;
+
+  return (
+    <div data-testid="shared-layout">
+      <p data-testid="layout-slug">Layout slug: {slug}</p>
+      <LayoutState />
+      {children}
+    </div>
+  );
+}

--- a/examples/app-router-cloudflare/app/layout-identity/[slug]/page.tsx
+++ b/examples/app-router-cloudflare/app/layout-identity/[slug]/page.tsx
@@ -1,0 +1,21 @@
+import Link from "next/link";
+
+export default async function LayoutIdentityPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+
+  return (
+    <main>
+      <h1 data-testid="page-title">Parent page</h1>
+      <Link data-testid="to-child" href={`/layout-identity/${slug}/child`}>
+        Go to child
+      </Link>
+      <Link data-testid="to-item" href={`/layout-identity/${slug}/items/first`}>
+        Go to item
+      </Link>
+    </main>
+  );
+}

--- a/examples/app-router-cloudflare/app/layout-identity/layout.tsx
+++ b/examples/app-router-cloudflare/app/layout-identity/layout.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from "react";
+
+// A parallel slot sits beside `children`, above the shared `[slug]` layout —
+// the shape an app has when route-derived chrome (breadcrumbs, a sidebar) is
+// rendered as a slot. The slot's content changes on every navigation while the
+// `[slug]` layout below stays on the same segment value.
+export default function LayoutIdentityRootLayout({
+  children,
+  aside,
+}: {
+  children: ReactNode;
+  aside: ReactNode;
+}) {
+  return (
+    <div>
+      <div data-testid="aside-slot">{aside}</div>
+      {children}
+    </div>
+  );
+}

--- a/examples/app-router-cloudflare/app/layout-identity/loading.tsx
+++ b/examples/app-router-cloudflare/app/layout-identity/loading.tsx
@@ -1,0 +1,5 @@
+// A loading boundary above the shared `[slug]` layout. Its presence is what
+// turns a same-layout navigation into a full teardown of everything below it.
+export default function Loading() {
+  return <p data-testid="loading-fallback">Loading…</p>;
+}

--- a/packages/vinext/src/routing/route-pattern.ts
+++ b/packages/vinext/src/routing/route-pattern.ts
@@ -149,6 +149,41 @@ export function matchRoutePatternRaw(
   return matchFrom(0, 0) ? params : null;
 }
 
+/**
+ * Extract params from the original encoded URL parts after route selection has
+ * already succeeded against normalized parts. Static parts are positional and
+ * intentionally not compared because their raw encoding can differ from the
+ * normalized route spelling (for example `%5Fsites` versus `_sites`).
+ */
+export function extractRawRoutePatternParams(
+  patternParts: readonly string[],
+  urlParts: readonly string[],
+): RoutePatternParams {
+  const params: RoutePatternParams = Object.create(null);
+  let urlIndex = 0;
+
+  for (const patternPart of patternParts) {
+    if (!patternPart.startsWith(":")) {
+      urlIndex += 1;
+      continue;
+    }
+
+    const isCatchAll = patternPart.endsWith("+") || patternPart.endsWith("*");
+    const paramName = patternPart.slice(1, isCatchAll ? -1 : undefined);
+    if (isCatchAll) {
+      const remaining = urlParts.slice(urlIndex);
+      if (remaining.length > 0) params[paramName] = [...remaining];
+      break;
+    }
+
+    const value = urlParts[urlIndex];
+    if (value !== undefined) params[paramName] = value;
+    urlIndex += 1;
+  }
+
+  return params;
+}
+
 export function matchRoutePatternPrefix(
   pathParts: readonly string[],
   patternParts: readonly string[],

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -176,6 +176,7 @@ import {
   resolvePrefetchNavigationResponseUrl,
 } from "./app-browser-prefetch-response.js";
 import {
+  canCommitOptimisticRouteTemplate,
   createOptimisticRouteTemplate,
   getOptimisticPrefetchSourceKey,
   getOptimisticRouteTemplateKey,
@@ -2054,7 +2055,17 @@ function bootstrapHydration(
               templates: optimisticRouteTemplates,
             });
 
-            if (optimisticPayload !== null) {
+            if (
+              optimisticPayload !== null &&
+              canCommitOptimisticRouteTemplate({
+                currentElements: navigationInitiationState.elements,
+                currentLayoutIds: navigationInitiationState.layoutIds,
+                currentParams: navigationInitiationState.navigationSnapshot.params,
+                routeManifest,
+                targetParams: optimisticPayload.params,
+                template: optimisticPayload.template,
+              })
+            ) {
               detachedNavigationCommits = true;
               const optimisticNavigationSnapshot = createClientNavigationRenderSnapshot(
                 currentHref,

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -2062,7 +2062,8 @@ function bootstrapHydration(
                 currentLayoutIds: navigationInitiationState.layoutIds,
                 currentParams: navigationInitiationState.navigationSnapshot.params,
                 routeManifest,
-                targetParams: optimisticPayload.params,
+                targetRouteParams: optimisticPayload.routeParams,
+                targetUrlParts: optimisticPayload.urlParts,
                 template: optimisticPayload.template,
               })
             ) {

--- a/packages/vinext/src/server/app-optimistic-routing.ts
+++ b/packages/vinext/src/server/app-optimistic-routing.ts
@@ -3,7 +3,12 @@ import { isUnknownRecord } from "../utils/record.js";
 import { stripBasePath } from "../utils/base-path.js";
 import { buildParams, decodeMatchedParams, splitPathnameForRouteMatch } from "../routing/utils.js";
 import type { RouteManifest, RouteManifestRoute } from "../routing/app-route-graph.js";
-import { matchRoutePattern } from "../routing/route-pattern.js";
+import { extractRawRoutePatternParams, matchRoutePattern } from "../routing/route-pattern.js";
+import {
+  createNestedBfcacheSlotSegmentId,
+  deriveBfcacheSegmentIdentity,
+  isNestedBfcacheSlotSegmentId,
+} from "./bfcache-identity.js";
 import { stripRscCacheBustingSearchParam, stripRscSuffix } from "./app-rsc-cache-busting.js";
 import {
   AppElementsWire,
@@ -11,7 +16,11 @@ import {
   type AppElementValue,
   type AppElements,
 } from "./app-elements.js";
-import { resolveAppPagePatternStateKey } from "./app-page-segment-state.js";
+import {
+  canonicalizeAppPageParams,
+  resolveAppPagePatternStateKey,
+  resolveAppPageSemanticSegmentStateKey,
+} from "./app-page-segment-state.js";
 
 type OptimisticRouteTrieNode = {
   catchAllChild: { paramName: string; route: RouteManifestRoute } | null;
@@ -29,6 +38,7 @@ type OptimisticRouteMatch = {
 export type OptimisticRouteTemplate = {
   elements: AppElements;
   mountedSlotsHeader: string | null;
+  omittedBfcacheSegmentIds: readonly string[];
   omittedLayoutIds: readonly string[];
   pageElementIds: readonly string[];
   routeId: string;
@@ -37,7 +47,9 @@ export type OptimisticRouteTemplate = {
 type OptimisticNavigationPayload = {
   elements: AppElements;
   params: Record<string, string | string[]>;
+  routeParams: Record<string, string | string[]>;
   template: OptimisticRouteTemplate;
+  urlParts: readonly string[];
 };
 
 const routeTrieCache = new WeakMap<RouteManifest, OptimisticRouteTrieNode>();
@@ -186,7 +198,10 @@ function matchNode(
   return null;
 }
 
-function hrefToRouteParts(href: string, basePath: string): string[] | null {
+function hrefToRouteParts(
+  href: string,
+  basePath: string,
+): { normalized: string[]; raw: string[] } | null {
   let url: URL;
   try {
     url = new URL(href, "https://vinext.local");
@@ -197,7 +212,11 @@ function hrefToRouteParts(href: string, basePath: string): string[] | null {
   stripRscCacheBustingSearchParam(url);
   const withoutRscSuffix = stripRscSuffix(url.pathname);
   const appPathname = stripBasePath(withoutRscSuffix, basePath);
-  return splitPathnameForRouteMatch(appPathname === "" ? "/" : appPathname);
+  const pathname = appPathname === "" ? "/" : appPathname;
+  return {
+    normalized: splitPathnameForRouteMatch(pathname),
+    raw: pathname.split("/").filter(Boolean),
+  };
 }
 
 export function matchOptimisticRouteManifestRoute(options: {
@@ -208,7 +227,7 @@ export function matchOptimisticRouteManifestRoute(options: {
   const urlParts = hrefToRouteParts(options.href, options.basePath);
   if (urlParts === null) return null;
 
-  const match = matchNode(getRouteTrie(options.routeManifest), urlParts, 0, []);
+  const match = matchNode(getRouteTrie(options.routeManifest), urlParts.normalized, 0, []);
   if (match === null) return null;
 
   decodeMatchedParams(match.params);
@@ -226,15 +245,22 @@ function mergeParams(
 
 function resolveOptimisticNavigationParams(options: {
   match: OptimisticRouteMatch;
+  rawUrlParts: readonly string[];
   routeManifest: RouteManifest;
   urlParts: readonly string[];
-}): Record<string, string | string[]> {
-  const navigationParams: Record<string, string | string[]> = { ...options.match.params };
+}): {
+  navigationParams: Record<string, string | string[]>;
+  routeParams: Record<string, string | string[]>;
+} {
+  const routeParams = extractRawRoutePatternParams(
+    options.match.route.patternParts,
+    options.rawUrlParts,
+  );
+  canonicalizeAppPageParams(routeParams);
+  const navigationParams: Record<string, string | string[]> = { ...routeParams };
+  const routeParamNames = new Set(options.match.route.paramNames);
 
   for (const binding of options.routeManifest.segmentGraph.slotBindings.values()) {
-    // Unlike the server-side resolveSlotParamOverrides, this loop doesn't skip
-    // slots whose slotParamNames are all already route params. That's a no-op
-    // merge in practice (identical values) but keeps client-side logic simpler.
     if (binding.routeId !== options.match.route.id || binding.state !== "active") {
       continue;
     }
@@ -243,20 +269,129 @@ function resolveOptimisticNavigationParams(options: {
     if (!patternParts) {
       continue;
     }
+    if (binding.slotParamNames?.every((name) => routeParamNames.has(name))) {
+      continue;
+    }
 
-    // Slot params are decoded once (from urlParts via splitPathnameForRouteMatch),
-    // matching the server-side resolveSlotParamOverrides decode pass. Route params
-    // are decoded a second time via decodeMatchedParams(match.params) above — a
-    // pre-existing asymmetry that has no practical effect for normal segments but
-    // means an encoded catch-all (%25/%2F) could differ between route and slot
-    // params in the same payload. TODO: converge the decode passes.
     const matched = matchRoutePattern(options.urlParts, patternParts);
     if (matched) {
       mergeParams(navigationParams, matched);
     }
   }
 
-  return navigationParams;
+  return { navigationParams, routeParams };
+}
+
+function collectRenderedBfcacheSegmentIds(
+  value: unknown,
+  candidates: ReadonlySet<string>,
+  rendered: Set<string>,
+  depth = 0,
+): void {
+  if (depth > 100) return;
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      collectRenderedBfcacheSegmentIds(entry, candidates, rendered, depth + 1);
+    }
+    return;
+  }
+  if (!isValidElement(value)) return;
+
+  const props = Reflect.get(value, "props");
+  if (!isUnknownRecord(props)) return;
+  const id = Reflect.get(props, "id");
+  if (typeof id === "string" && candidates.has(id)) {
+    rendered.add(id);
+  }
+  for (const prop of Object.values(props)) {
+    collectRenderedBfcacheSegmentIds(prop, candidates, rendered, depth + 1);
+  }
+}
+
+function getOmittedBfcacheSegmentIds(elements: AppElements): string[] {
+  const identities = AppElementsWire.readMetadata(elements).bfcacheSegmentIdentities;
+  const candidates = new Set(
+    Object.keys(identities).filter(
+      (id) => isNestedBfcacheSlotSegmentId(id) && Object.hasOwn(elements, id),
+    ),
+  );
+  if (candidates.size === 0) return [];
+
+  const rendered = new Set<string>();
+  for (const value of Object.values(elements)) {
+    collectRenderedBfcacheSegmentIds(value, candidates, rendered);
+  }
+  return [...candidates].filter((id) => !rendered.has(id));
+}
+
+function resolveTargetBfcacheSegmentIdentity(options: {
+  routeId: string;
+  routeManifest: RouteManifest;
+  segmentId: string;
+  targetRouteParams: Readonly<Record<string, string | string[]>>;
+  targetUrlParts: readonly string[];
+}): string | undefined {
+  const route = options.routeManifest.segmentGraph.routes.get(options.routeId);
+  if (!route) return undefined;
+  const routeParamNames = new Set(route.paramNames);
+
+  for (const binding of options.routeManifest.segmentGraph.slotBindings.values()) {
+    if (binding.routeId !== options.routeId) continue;
+
+    const needsSlotParamOverride =
+      binding.state === "active" &&
+      binding.slotPatternParts !== undefined &&
+      binding.slotPatternParts.length > 0 &&
+      !binding.slotParamNames?.every((name) => routeParamNames.has(name));
+    const segmentParams = needsSlotParamOverride
+      ? (matchRoutePattern(options.targetUrlParts, binding.slotPatternParts!) ??
+        options.targetRouteParams)
+      : options.targetRouteParams;
+
+    const ownerLayout = binding.ownerLayoutId
+      ? options.routeManifest.segmentGraph.layouts.get(binding.ownerLayoutId)
+      : undefined;
+    const ownerStateKey = ownerLayout
+      ? resolveAppPagePatternStateKey(ownerLayout.patternParts, options.targetRouteParams)
+      : "";
+    const boundSegmentKeys: string[] = [];
+    let level = 0;
+    for (const segment of binding.routeSegments ?? []) {
+      if (segment.startsWith("@")) continue;
+      level += 1;
+      boundSegmentKeys.push(
+        resolveAppPageSemanticSegmentStateKey(
+          { marker: null, paramSource: "slot", segment },
+          segmentParams,
+        ),
+      );
+      if (createNestedBfcacheSlotSegmentId(binding.slotId, level) !== options.segmentId) continue;
+
+      const identityKey = JSON.stringify(boundSegmentKeys);
+      return deriveBfcacheSegmentIdentity({
+        activeRouteGraphId: null,
+        boundSegmentKey: ownerStateKey ? JSON.stringify([ownerStateKey, identityKey]) : identityKey,
+        interceptionTargetRouteGraphId: null,
+        kind: "slot",
+        ownerLayoutGraphId: binding.ownerLayoutId,
+        slotGraphId: binding.slotId,
+        state: binding.state,
+      });
+    }
+
+    if (level === 0 && createNestedBfcacheSlotSegmentId(binding.slotId, 1) === options.segmentId) {
+      return deriveBfcacheSegmentIdentity({
+        activeRouteGraphId: null,
+        boundSegmentKey: ownerStateKey ? JSON.stringify([ownerStateKey, ""]) : "",
+        interceptionTargetRouteGraphId: null,
+        kind: "slot",
+        ownerLayoutGraphId: binding.ownerLayoutId,
+        slotGraphId: binding.slotId,
+        state: binding.state,
+      });
+    }
+  }
+  return undefined;
 }
 
 function elementHasSuspenseFallback(value: unknown, depth = 0): boolean {
@@ -345,6 +480,10 @@ export function createOptimisticRouteTemplate(options: {
   return {
     elements: options.elements,
     mountedSlotsHeader: options.mountedSlotsHeader,
+    omittedBfcacheSegmentIds:
+      options.elements[APP_PREFETCH_LOADING_SHELL_MARKER_KEY] === "LoadingBoundary"
+        ? getOmittedBfcacheSegmentIds(options.elements)
+        : [],
     omittedLayoutIds:
       options.elements[APP_PREFETCH_LOADING_SHELL_MARKER_KEY] === "LoadingBoundary"
         ? metadata.layoutIds.filter((layoutId) => !Object.hasOwn(options.elements, layoutId))
@@ -375,14 +514,21 @@ export function canCommitOptimisticRouteTemplate(options: {
   currentLayoutIds: readonly string[];
   currentParams: Readonly<Record<string, string | string[]>>;
   routeManifest: RouteManifest;
-  targetParams: Readonly<Record<string, string | string[]>>;
+  targetRouteParams: Readonly<Record<string, string | string[]>>;
+  targetUrlParts: readonly string[];
   template: OptimisticRouteTemplate;
 }): boolean {
-  if (options.template.omittedLayoutIds.length === 0) {
+  if (
+    options.template.omittedLayoutIds.length === 0 &&
+    options.template.omittedBfcacheSegmentIds.length === 0
+  ) {
     return true;
   }
 
   const currentLayoutIds = new Set(options.currentLayoutIds);
+  const currentIdentities = AppElementsWire.readMetadata(
+    options.currentElements,
+  ).bfcacheSegmentIdentities;
 
   for (const layoutId of options.template.omittedLayoutIds) {
     if (!currentLayoutIds.has(layoutId)) continue;
@@ -390,9 +536,42 @@ export function canCommitOptimisticRouteTemplate(options: {
 
     const layout = options.routeManifest.segmentGraph.layouts.get(layoutId);
     if (layout === undefined) continue;
+    const currentIdentity = currentIdentities[layoutId];
+    if (currentIdentity !== undefined) {
+      const targetIdentity = deriveBfcacheSegmentIdentity({
+        boundSegmentKey: resolveAppPagePatternStateKey(
+          layout.patternParts,
+          options.targetRouteParams,
+        ),
+        graphId: layout.id,
+        kind: "layout",
+        rootBoundaryId: layout.rootBoundaryId,
+      });
+      if (currentIdentity === targetIdentity) return false;
+      continue;
+    }
     if (
       resolveAppPagePatternStateKey(layout.patternParts, options.currentParams) ===
-      resolveAppPagePatternStateKey(layout.patternParts, options.targetParams)
+      resolveAppPagePatternStateKey(layout.patternParts, options.targetRouteParams)
+    ) {
+      return false;
+    }
+  }
+
+  for (const segmentId of options.template.omittedBfcacheSegmentIds) {
+    if (!Object.hasOwn(options.currentElements, segmentId)) continue;
+    const currentIdentity = currentIdentities[segmentId];
+    const targetIdentity = resolveTargetBfcacheSegmentIdentity({
+      routeId: options.template.routeId,
+      routeManifest: options.routeManifest,
+      segmentId,
+      targetRouteParams: options.targetRouteParams,
+      targetUrlParts: options.targetUrlParts,
+    });
+    if (
+      currentIdentity !== undefined &&
+      targetIdentity !== undefined &&
+      currentIdentity === targetIdentity
     ) {
       return false;
     }
@@ -431,13 +610,17 @@ export function resolveOptimisticNavigationPayload(options: {
   if (template === undefined) return null;
   if (template.mountedSlotsHeader !== options.mountedSlotsHeader) return null;
 
+  const { navigationParams, routeParams } = resolveOptimisticNavigationParams({
+    match,
+    rawUrlParts: urlParts.raw,
+    routeManifest: options.routeManifest,
+    urlParts: urlParts.normalized,
+  });
   return {
     elements: createOptimisticRouteElements(template),
-    params: resolveOptimisticNavigationParams({
-      match,
-      routeManifest: options.routeManifest,
-      urlParts,
-    }),
+    params: navigationParams,
+    routeParams,
     template,
+    urlParts: urlParts.normalized,
   };
 }

--- a/packages/vinext/src/server/app-optimistic-routing.ts
+++ b/packages/vinext/src/server/app-optimistic-routing.ts
@@ -11,6 +11,7 @@ import {
   type AppElementValue,
   type AppElements,
 } from "./app-elements.js";
+import { resolveAppPagePatternStateKey } from "./app-page-segment-state.js";
 
 type OptimisticRouteTrieNode = {
   catchAllChild: { paramName: string; route: RouteManifestRoute } | null;
@@ -28,6 +29,7 @@ type OptimisticRouteMatch = {
 export type OptimisticRouteTemplate = {
   elements: AppElements;
   mountedSlotsHeader: string | null;
+  omittedLayoutIds: readonly string[];
   pageElementIds: readonly string[];
   routeId: string;
 };
@@ -343,6 +345,10 @@ export function createOptimisticRouteTemplate(options: {
   return {
     elements: options.elements,
     mountedSlotsHeader: options.mountedSlotsHeader,
+    omittedLayoutIds:
+      options.elements[APP_PREFETCH_LOADING_SHELL_MARKER_KEY] === "LoadingBoundary"
+        ? metadata.layoutIds.filter((layoutId) => !Object.hasOwn(options.elements, layoutId))
+        : [],
     pageElementIds,
     routeId: match.route.id,
   };
@@ -354,6 +360,45 @@ export function createOptimisticRouteElements(template: OptimisticRouteTemplate)
     elements[pageElementId] = createElement(OptimisticRouteSegment);
   }
   return elements;
+}
+
+/**
+ * A loading-shell prefetch stops at the first loading boundary, so layouts
+ * below that boundary are present in the route metadata but absent from the
+ * rendered shell. Do not commit that ancestor fallback when one of those
+ * omitted layouts is already mounted with the same semantic identity. Next.js
+ * keeps the shared segment active in this case, which also means the ancestor
+ * loading boundary does not re-trigger.
+ */
+export function canCommitOptimisticRouteTemplate(options: {
+  currentElements: AppElements;
+  currentLayoutIds: readonly string[];
+  currentParams: Readonly<Record<string, string | string[]>>;
+  routeManifest: RouteManifest;
+  targetParams: Readonly<Record<string, string | string[]>>;
+  template: OptimisticRouteTemplate;
+}): boolean {
+  if (options.template.omittedLayoutIds.length === 0) {
+    return true;
+  }
+
+  const currentLayoutIds = new Set(options.currentLayoutIds);
+
+  for (const layoutId of options.template.omittedLayoutIds) {
+    if (!currentLayoutIds.has(layoutId)) continue;
+    if (!Object.hasOwn(options.currentElements, layoutId)) continue;
+
+    const layout = options.routeManifest.segmentGraph.layouts.get(layoutId);
+    if (layout === undefined) continue;
+    if (
+      resolveAppPagePatternStateKey(layout.patternParts, options.currentParams) ===
+      resolveAppPagePatternStateKey(layout.patternParts, options.targetParams)
+    ) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 export function resolveOptimisticNavigationPayload(options: {

--- a/packages/vinext/src/server/app-page-segment-state.ts
+++ b/packages/vinext/src/server/app-page-segment-state.ts
@@ -18,6 +18,23 @@ type AppPageSegmentParam = {
   type: AppPageSegmentParamType;
 };
 
+function canonicalizeAppPageParam(value: string): string {
+  try {
+    return encodeURIComponent(decodeURIComponent(value));
+  } catch {
+    return value;
+  }
+}
+
+export function canonicalizeAppPageParams(params: AppPageParams): void {
+  for (const key of Object.keys(params)) {
+    const value = params[key];
+    params[key] = Array.isArray(value)
+      ? value.map(canonicalizeAppPageParam)
+      : canonicalizeAppPageParam(value);
+  }
+}
+
 function formatParamSegmentValue(value: string | string[] | undefined): string | undefined {
   if (Array.isArray(value)) {
     return value.join("/");

--- a/packages/vinext/src/server/app-rsc-route-matching.ts
+++ b/packages/vinext/src/server/app-rsc-route-matching.ts
@@ -1,5 +1,6 @@
 import { buildRouteTrie, trieMatchRaw } from "../routing/route-trie.js";
 import {
+  extractRawRoutePatternParams,
   matchRoutePattern,
   matchRoutePatternRaw,
   matchRoutePatternPrefix,
@@ -10,6 +11,7 @@ import {
   splitPathnameForRouteMatch,
   splitPathSegments,
 } from "../routing/utils.js";
+import { canonicalizeAppPageParams } from "./app-page-segment-state.js";
 
 /**
  * Sentinel slot key used for sibling-style interception entries.
@@ -166,23 +168,6 @@ function appRscInterceptionSourcePathnameParts(pathname: string): string[] {
   });
 }
 
-function canonicalizeAppPageParam(value: string): string {
-  try {
-    return encodeURIComponent(decodeURIComponent(value));
-  } catch {
-    return value;
-  }
-}
-
-function canonicalizeAppPageParams(params: AppRscRouteParams): void {
-  for (const key of Object.keys(params)) {
-    const value = params[key];
-    params[key] = Array.isArray(value)
-      ? value.map(canonicalizeAppPageParam)
-      : canonicalizeAppPageParam(value);
-  }
-}
-
 function isAppRouteHandlerRoute(route: AppRscRouteForMatching): boolean {
   // Generated manifests retain the lazy loader before the first request and
   // hydrate routeHandler afterwards. Classification must not change when that
@@ -201,39 +186,6 @@ function normalizeMatchedParamsForRoute(result: {
   }
 }
 
-function extractRawParamsForMatchedRoute(
-  patternParts: readonly string[],
-  pathnameParts: readonly string[],
-): AppRscRouteParams {
-  // Route selection uses the normalized pathname so encoded static segments
-  // cannot alias filesystem routes. Param values come from the encoded URL
-  // parts, matching Next.js client/route-params.ts before the route-kind-
-  // specific canonicalize/decode step below.
-  const params = createRouteParams();
-  let pathnameIndex = 0;
-
-  for (const part of patternParts) {
-    if (!part.startsWith(":")) {
-      pathnameIndex += 1;
-      continue;
-    }
-
-    const isCatchAll = part.endsWith("+") || part.endsWith("*");
-    const paramName = part.slice(1, isCatchAll ? -1 : undefined);
-    if (isCatchAll) {
-      const remaining = pathnameParts.slice(pathnameIndex);
-      if (remaining.length > 0) params[paramName] = [...remaining];
-      break;
-    }
-
-    const value = pathnameParts[pathnameIndex];
-    if (value !== undefined) params[paramName] = value;
-    pathnameIndex += 1;
-  }
-
-  return params;
-}
-
 export function createAppRscRouteMatcher<Route extends AppRscRouteForMatching>(
   routes: Route[],
 ): {
@@ -250,7 +202,7 @@ export function createAppRscRouteMatcher<Route extends AppRscRouteForMatching>(
       const rawParts = appRscPathnameParts(url, true);
       const result = trieMatchRaw(routeTrie, appRscPathnameParts(url, false));
       if (!result) return null;
-      result.params = extractRawParamsForMatchedRoute(result.route.patternParts, rawParts);
+      result.params = extractRawRoutePatternParams(result.route.patternParts, rawParts);
       normalizeMatchedParamsForRoute(result);
       return result;
     },
@@ -368,7 +320,7 @@ function matchSlotOwnerSourceParams(
   const exact = matchRoutePatternRaw(sourceParts, patternParts);
   if (exact !== null) return exact;
   if (!descendantsAllowed || !matchRoutePatternPrefix(sourceParts, patternParts)) return null;
-  return extractRawParamsForMatchedRoute(patternParts, sourceParts);
+  return extractRawRoutePatternParams(patternParts, sourceParts);
 }
 
 /**

--- a/tests/app-optimistic-routing.test.ts
+++ b/tests/app-optimistic-routing.test.ts
@@ -6,6 +6,7 @@ import {
   type AppElements,
 } from "../packages/vinext/src/server/app-elements.js";
 import {
+  canCommitOptimisticRouteTemplate,
   createOptimisticRouteElements,
   createOptimisticRouteTemplate,
   getOptimisticPrefetchSourceKey,
@@ -48,6 +49,13 @@ function route(input: {
 function manifest(
   routes: readonly RouteManifestRoute[],
   slotBindings: readonly RouteManifestSlotBinding[] = [],
+  layouts: readonly {
+    id: string;
+    paramNames: readonly string[];
+    patternParts: readonly string[];
+    rootBoundaryId: null;
+    treePath: string;
+  }[] = [],
 ): RouteManifest {
   return {
     graphVersion: "graph:test" as GraphVersion,
@@ -56,7 +64,7 @@ function manifest(
       defaults: new Map(),
       interceptions: new Map(),
       interceptionsBySlotId: new Map(),
-      layouts: new Map(),
+      layouts: new Map(layouts.map((entry) => [entry.id, entry])),
       pages: new Map(),
       rootBoundaries: new Map(),
       routeHandlers: new Map(),
@@ -516,6 +524,90 @@ describe("App Router optimistic routing", () => {
 
     expect(navigationPayload?.params).toEqual({});
     expect(navigationPayload?.template).toBe(template);
+  });
+
+  // Ported from Next.js: test/e2e/app-dir/app-prefetch-false-loading/app-prefetch-false-loading.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app-prefetch-false-loading/app-prefetch-false-loading.test.ts
+  it("does not commit an ancestor loading shell over a retained layout", () => {
+    const rootLayoutId = AppElementsWire.encodeLayoutId("/");
+    const sharedLayoutId = AppElementsWire.encodeLayoutId("/projects/[projectId]");
+    const currentElements: AppElements = {
+      ...AppElementsWire.createMetadataEntries({
+        interceptionContext: null,
+        layoutIds: [rootLayoutId, sharedLayoutId],
+        rootLayoutTreePath: "/",
+        routeId: "route:/projects/alpha",
+      }),
+      [rootLayoutId]: createElement("div", null, "root"),
+      [sharedLayoutId]: createElement("section", null, "shared layout"),
+    };
+    const loadingShellElements: AppElements = {
+      ...AppElementsWire.createMetadataEntries({
+        interceptionContext: null,
+        layoutIds: [rootLayoutId, sharedLayoutId],
+        rootLayoutTreePath: "/",
+        routeId: "route:/projects/alpha/activity",
+      }),
+      [APP_PREFETCH_LOADING_SHELL_MARKER_KEY]: "LoadingBoundary",
+      [rootLayoutId]: createElement("div", null, "root"),
+      "page:/projects/:projectId/activity": null,
+      "route:/projects/alpha/activity": createElement("p", null, "Loading"),
+    };
+    const routeManifest = manifest(
+      [
+        route({
+          id: "route:/projects/:projectId/activity",
+          isDynamic: true,
+          paramNames: ["projectId"],
+          pattern: "/projects/:projectId/activity",
+          patternParts: ["projects", ":projectId", "activity"],
+        }),
+      ],
+      [],
+      [
+        {
+          id: sharedLayoutId,
+          paramNames: ["projectId"],
+          patternParts: ["projects", ":projectId"],
+          rootBoundaryId: null,
+          treePath: "/projects/[projectId]",
+        },
+      ],
+    );
+    const template = createOptimisticRouteTemplate({
+      allowLoadingShell: true,
+      basePath: "",
+      elements: loadingShellElements,
+      href: "/projects/alpha/activity",
+      interceptionContext: null,
+      mountedSlotsHeader: null,
+      routeManifest,
+    });
+    if (template === null) {
+      throw new Error("Expected optimistic route template");
+    }
+
+    expect(template.omittedLayoutIds).toEqual([sharedLayoutId]);
+    expect(
+      canCommitOptimisticRouteTemplate({
+        currentElements,
+        currentLayoutIds: [rootLayoutId, sharedLayoutId],
+        currentParams: { projectId: "alpha" },
+        routeManifest,
+        targetParams: { projectId: "alpha" },
+        template,
+      }),
+    ).toBe(false);
+    expect(
+      canCommitOptimisticRouteTemplate({
+        currentElements,
+        currentLayoutIds: [rootLayoutId, sharedLayoutId],
+        currentParams: { projectId: "alpha" },
+        routeManifest,
+        targetParams: { projectId: "beta" },
+        template,
+      }),
+    ).toBe(true);
   });
 
   it("keeps learned templates distinct across mounted slot headers", () => {

--- a/tests/app-optimistic-routing.test.ts
+++ b/tests/app-optimistic-routing.test.ts
@@ -21,6 +21,10 @@ import type {
   RouteManifestRoute,
   RouteManifestSlotBinding,
 } from "../packages/vinext/src/routing/app-route-graph.js";
+import {
+  createNestedBfcacheSlotSegmentId,
+  deriveBfcacheSegmentIdentity,
+} from "../packages/vinext/src/server/bfcache-identity.js";
 
 function route(input: {
   id: string;
@@ -594,7 +598,8 @@ describe("App Router optimistic routing", () => {
         currentLayoutIds: [rootLayoutId, sharedLayoutId],
         currentParams: { projectId: "alpha" },
         routeManifest,
-        targetParams: { projectId: "alpha" },
+        targetRouteParams: { projectId: "alpha" },
+        targetUrlParts: ["projects", "alpha", "activity"],
         template,
       }),
     ).toBe(false);
@@ -604,10 +609,318 @@ describe("App Router optimistic routing", () => {
         currentLayoutIds: [rootLayoutId, sharedLayoutId],
         currentParams: { projectId: "alpha" },
         routeManifest,
-        targetParams: { projectId: "beta" },
+        targetRouteParams: { projectId: "beta" },
+        targetUrlParts: ["projects", "beta", "activity"],
         template,
       }),
     ).toBe(true);
+
+    const templates = new Map([
+      [
+        getOptimisticRouteTemplateKey({
+          interceptionContext: null,
+          mountedSlotsHeader: null,
+          routeId: template.routeId,
+        }),
+        template,
+      ],
+    ]);
+    for (const [href, projectId] of [
+      ["/projects/a%2Fb/activity", "a%2Fb"],
+      ["/projects/caf%C3%A9/activity", "caf%C3%A9"],
+      ["/projects/a%252Fb/activity", "a%252Fb"],
+      ["/projects/a%2561/activity", "a%2561"],
+      ["/projects/a%25b/activity", "a%25b"],
+    ]) {
+      const encodedPayload = resolveOptimisticNavigationPayload({
+        basePath: "",
+        href,
+        interceptionContext: null,
+        mountedSlotsHeader: null,
+        routeManifest,
+        templates,
+      });
+      expect(encodedPayload?.params).toEqual({ projectId });
+      expect(
+        encodedPayload &&
+          canCommitOptimisticRouteTemplate({
+            currentElements,
+            currentLayoutIds: [rootLayoutId, sharedLayoutId],
+            currentParams: { projectId },
+            routeManifest,
+            targetRouteParams: encodedPayload.routeParams,
+            targetUrlParts: encodedPayload.urlParts,
+            template: encodedPayload.template,
+          }),
+      ).toBe(false);
+    }
+  });
+
+  it("preserves raw encoded catch-all params in optimistic payloads", () => {
+    const rootLayoutId = AppElementsWire.encodeLayoutId("/");
+    const routeManifest = manifest([
+      route({
+        id: "route:/docs/:parts+",
+        isDynamic: true,
+        paramNames: ["parts"],
+        pattern: "/docs/:parts+",
+        patternParts: ["docs", ":parts+"],
+      }),
+    ]);
+    const elements: AppElements = {
+      ...AppElementsWire.createMetadataEntries({
+        interceptionContext: null,
+        layoutIds: [rootLayoutId],
+        rootLayoutTreePath: "/",
+        routeId: "route:/docs/source",
+      }),
+      [APP_PREFETCH_LOADING_SHELL_MARKER_KEY]: "LoadingBoundary",
+      [rootLayoutId]: createElement("div", null, "root"),
+      "page:/docs/:parts+": null,
+      "route:/docs/source": createElement("p", null, "Loading"),
+    };
+    const template = createOptimisticRouteTemplate({
+      allowLoadingShell: true,
+      basePath: "",
+      elements,
+      href: "/docs/source",
+      interceptionContext: null,
+      mountedSlotsHeader: null,
+      routeManifest,
+    });
+    if (template === null) throw new Error("Expected optimistic route template");
+
+    const payload = resolveOptimisticNavigationPayload({
+      basePath: "",
+      href: "/docs/a%2561/b%252Fc",
+      interceptionContext: null,
+      mountedSlotsHeader: null,
+      routeManifest,
+      templates: new Map([
+        [
+          getOptimisticRouteTemplateKey({
+            interceptionContext: null,
+            mountedSlotsHeader: null,
+            routeId: template.routeId,
+          }),
+          template,
+        ],
+      ]),
+    });
+
+    expect(payload?.routeParams).toEqual({ parts: ["a%2561", "b%252Fc"] });
+    expect(payload?.params).toEqual(payload?.routeParams);
+  });
+
+  it("does not commit a slot loading shell over a retained nested slot segment", () => {
+    const rootLayoutId = AppElementsWire.encodeLayoutId("/");
+    const sidebarSlotId = AppElementsWire.encodeSlotId("sidebar", "/");
+    const nestedSegmentId = createNestedBfcacheSlotSegmentId(sidebarSlotId, 1);
+    const routeId = "route:/:slug";
+    const routeManifest = manifest(
+      [
+        route({
+          id: routeId,
+          isDynamic: true,
+          paramNames: ["slug"],
+          pattern: "/:slug",
+          patternParts: [":slug"],
+          slotIds: [sidebarSlotId],
+        }),
+      ],
+      [
+        {
+          defaultId: null,
+          id: `${routeId}::${sidebarSlotId}`,
+          ownerLayoutId: rootLayoutId,
+          routeId,
+          routeSegments: ["[slug]"],
+          slotId: sidebarSlotId,
+          slotParamNames: ["slug"],
+          slotPatternParts: [":slug"],
+          state: "active",
+        },
+      ],
+      [
+        {
+          id: rootLayoutId,
+          paramNames: [],
+          patternParts: [],
+          rootBoundaryId: null,
+          treePath: "/",
+        },
+      ],
+    );
+    const identityFor = (slug: string) =>
+      deriveBfcacheSegmentIdentity({
+        activeRouteGraphId: null,
+        boundSegmentKey: JSON.stringify([`slug|${slug}|d`]),
+        interceptionTargetRouteGraphId: null,
+        kind: "slot",
+        ownerLayoutGraphId: rootLayoutId,
+        slotGraphId: sidebarSlotId,
+        state: "active",
+      });
+    const currentElements: AppElements = {
+      ...AppElementsWire.createMetadataEntries({
+        bfcacheSegmentIdentities: { [nestedSegmentId]: identityFor("alpha") },
+        interceptionContext: null,
+        layoutIds: [rootLayoutId],
+        rootLayoutTreePath: "/",
+        routeId: "route:/alpha",
+      }),
+      [nestedSegmentId]: null,
+      [rootLayoutId]: createElement("div", null, "root"),
+    };
+    const createTemplate = (sourceSlug: string, renderedSegment = false) => {
+      const elements: AppElements = {
+        ...AppElementsWire.createMetadataEntries({
+          bfcacheSegmentIdentities: { [nestedSegmentId]: identityFor(sourceSlug) },
+          interceptionContext: null,
+          layoutIds: [rootLayoutId],
+          rootLayoutTreePath: "/",
+          routeId: `route:/${sourceSlug}`,
+        }),
+        [APP_PREFETCH_LOADING_SHELL_MARKER_KEY]: "LoadingBoundary",
+        [nestedSegmentId]: null,
+        [rootLayoutId]: createElement("div", null, "root"),
+        "page:/:slug": null,
+        [`route:/${sourceSlug}`]: createElement(
+          "div",
+          renderedSegment ? { id: nestedSegmentId } : null,
+          "Slot loading",
+        ),
+      };
+      const template = createOptimisticRouteTemplate({
+        allowLoadingShell: true,
+        basePath: "",
+        elements,
+        href: `/${sourceSlug}`,
+        interceptionContext: null,
+        mountedSlotsHeader: "sidebar",
+        routeManifest,
+      });
+      if (template === null) throw new Error("Expected optimistic route template");
+      return template;
+    };
+
+    // The learned shell came from beta, but the target/current route is alpha.
+    // The commit check must reify the omitted segment identity for alpha rather
+    // than comparing against the stale identity stored in the learned shell.
+    const retainedTemplate = createTemplate("beta");
+    expect(retainedTemplate.omittedBfcacheSegmentIds).toEqual([nestedSegmentId]);
+    expect(
+      canCommitOptimisticRouteTemplate({
+        currentElements,
+        currentLayoutIds: [rootLayoutId],
+        currentParams: { slug: "alpha" },
+        routeManifest,
+        targetRouteParams: { slug: "alpha" },
+        targetUrlParts: ["alpha"],
+        template: retainedTemplate,
+      }),
+    ).toBe(false);
+
+    expect(
+      canCommitOptimisticRouteTemplate({
+        currentElements,
+        currentLayoutIds: [rootLayoutId],
+        currentParams: { slug: "alpha" },
+        routeManifest,
+        targetRouteParams: { slug: "gamma" },
+        targetUrlParts: ["gamma"],
+        template: retainedTemplate,
+      }),
+    ).toBe(true);
+    expect(createTemplate("beta", true).omittedBfcacheSegmentIds).toEqual([]);
+  });
+
+  it("reifies omitted empty slot branches", () => {
+    const rootLayoutId = AppElementsWire.encodeLayoutId("/");
+    const sidebarSlotId = AppElementsWire.encodeSlotId("sidebar", "/");
+    const nestedSegmentId = createNestedBfcacheSlotSegmentId(sidebarSlotId, 1);
+    const routeId = "route:/dashboard";
+    const routeManifest = manifest(
+      [
+        route({
+          id: routeId,
+          isDynamic: false,
+          pattern: "/dashboard",
+          patternParts: ["dashboard"],
+          slotIds: [sidebarSlotId],
+        }),
+      ],
+      [
+        {
+          defaultId: "default:sidebar",
+          id: `${routeId}::${sidebarSlotId}`,
+          ownerLayoutId: rootLayoutId,
+          routeId,
+          routeSegments: null,
+          slotId: sidebarSlotId,
+          state: "default",
+        },
+      ],
+      [
+        {
+          id: rootLayoutId,
+          paramNames: [],
+          patternParts: [],
+          rootBoundaryId: null,
+          treePath: "/",
+        },
+      ],
+    );
+    const identity = deriveBfcacheSegmentIdentity({
+      activeRouteGraphId: null,
+      boundSegmentKey: "",
+      interceptionTargetRouteGraphId: null,
+      kind: "slot",
+      ownerLayoutGraphId: rootLayoutId,
+      slotGraphId: sidebarSlotId,
+      state: "default",
+    });
+    const metadata = AppElementsWire.createMetadataEntries({
+      bfcacheSegmentIdentities: { [nestedSegmentId]: identity },
+      interceptionContext: null,
+      layoutIds: [rootLayoutId],
+      rootLayoutTreePath: "/",
+      routeId,
+    });
+    const currentElements: AppElements = {
+      ...metadata,
+      [nestedSegmentId]: null,
+      [rootLayoutId]: createElement("div", null, "root"),
+    };
+    const template = createOptimisticRouteTemplate({
+      allowLoadingShell: true,
+      basePath: "",
+      elements: {
+        ...metadata,
+        [APP_PREFETCH_LOADING_SHELL_MARKER_KEY]: "LoadingBoundary",
+        [nestedSegmentId]: null,
+        [rootLayoutId]: createElement("div", null, "root"),
+        "page:/dashboard": null,
+        [routeId]: createElement("p", null, "Loading"),
+      },
+      href: "/dashboard",
+      interceptionContext: null,
+      mountedSlotsHeader: "sidebar",
+      routeManifest,
+    });
+    if (template === null) throw new Error("Expected optimistic route template");
+
+    expect(
+      canCommitOptimisticRouteTemplate({
+        currentElements,
+        currentLayoutIds: [rootLayoutId],
+        currentParams: {},
+        routeManifest,
+        targetRouteParams: {},
+        targetUrlParts: ["dashboard"],
+        template,
+      }),
+    ).toBe(false);
   });
 
   it("keeps learned templates distinct across mounted slot headers", () => {

--- a/tests/app-page-route-wiring.test.ts
+++ b/tests/app-page-route-wiring.test.ts
@@ -42,6 +42,15 @@ import {
 import { createNextBfcacheIdMap } from "../packages/vinext/src/server/app-bfcache-identity.js";
 import type { AppPageSemanticSegment } from "../packages/vinext/src/server/app-page-segment-state.js";
 import { createAppPageRenderDependency } from "../packages/vinext/src/server/app-render-dependency.js";
+import {
+  canCommitOptimisticRouteTemplate,
+  createOptimisticRouteTemplate,
+} from "../packages/vinext/src/server/app-optimistic-routing.js";
+import { createNestedBfcacheSlotSegmentId } from "../packages/vinext/src/server/bfcache-identity.js";
+import type {
+  GraphVersion,
+  RouteManifest,
+} from "../packages/vinext/src/routing/app-route-graph.js";
 
 /**
  * Build the resolved semantic branch the route matcher hands to slot overrides.
@@ -1377,56 +1386,63 @@ describe("app page route wiring helpers", () => {
       return createElement("p", null, "Unprotected slot page");
     }
 
-    const elements = buildAppPageElements({
-      element: createElement(PageProbe),
-      makeThenableParams(params) {
-        return Promise.resolve(params);
-      },
-      matchedParams: {},
-      resolvedMetadata: null,
-      resolvedViewport: {},
-      route: {
-        error: null,
-        errors: [null],
-        layoutTreePositions: [0],
-        layouts: [{ default: RootLayout }],
-        loading: null,
-        notFound: null,
-        notFounds: [null],
-        routeSegments: ["dashboard"],
-        slots: {
-          sidebar: {
-            default: null,
-            error: null,
-            layout: null,
-            layoutIndex: 0,
-            loading: null,
-            loadings: [{ default: SlotLoading }],
-            loadingTreePositions: [1],
-            name: "sidebar",
-            ownerTreePosition: 0,
-            page: { default: SlotPage },
-            routeSegments: ["slow"],
-          },
-          panel: {
-            default: null,
-            error: null,
-            layout: null,
-            layoutIndex: 0,
-            loading: null,
-            name: "panel",
-            ownerTreePosition: 0,
-            page: { default: UnprotectedPage },
-            routeSegments: [],
-          },
+    const buildElements = (
+      renderMode?: typeof APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+    ): AppElements =>
+      buildAppPageElements({
+        element: createElement(PageProbe),
+        makeThenableParams(params) {
+          return Promise.resolve(params);
         },
-        templateTreePositions: [],
-        templates: [],
-      },
-      routePath: "/dashboard",
-      rootNotFoundModule: null,
-      renderMode: APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
-    });
+        matchedParams: {},
+        resolvedMetadata: null,
+        resolvedViewport: {},
+        route: {
+          error: null,
+          errors: [null],
+          layoutTreePositions: [0],
+          layouts: [{ default: RootLayout }],
+          loading: null,
+          notFound: null,
+          notFounds: [null],
+          routeSegments: ["dashboard"],
+          slots: {
+            sidebar: {
+              configLayouts: [{ default: NestedSlotLayout }],
+              configLayoutTreePositions: [1],
+              default: null,
+              error: null,
+              layout: null,
+              layoutIndex: 0,
+              loading: null,
+              loadings: [{ default: SlotLoading }],
+              loadingTreePositions: [0],
+              name: "sidebar",
+              ownerTreePosition: 0,
+              page: { default: SlotPage },
+              routeSegments: ["slow", "child"],
+            },
+            panel: {
+              default: null,
+              error: null,
+              layout: null,
+              layoutIndex: 0,
+              loading: null,
+              name: "panel",
+              ownerTreePosition: 0,
+              page: { default: UnprotectedPage },
+              routeSegments: [],
+            },
+          },
+          templateTreePositions: [],
+          templates: [],
+        },
+        routePath: "/dashboard",
+        rootNotFoundModule: null,
+        ...(renderMode ? { renderMode } : {}),
+      });
+
+    const elements = buildElements(APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL);
 
     expect(elements[APP_PREFETCH_LOADING_SHELL_MARKER_KEY]).toBe("LoadingBoundary");
     expect(elements[AppElementsWire.encodeSlotId("panel", "/")]).toBeUndefined();
@@ -1434,6 +1450,94 @@ describe("app page route wiring helpers", () => {
     expect(html).toContain("Slot loading shell");
     expect(html).not.toContain("Unprotected slot page");
     expect(html).not.toContain("Page");
+
+    const rootLayoutId = AppElementsWire.encodeLayoutId("/");
+    const sidebarSlotId = AppElementsWire.encodeSlotId("sidebar", "/");
+    const routeId = "route:/dashboard";
+    const routeManifest: RouteManifest = {
+      graphVersion: "graph:test" as GraphVersion,
+      segmentGraph: {
+        boundaries: new Map(),
+        defaults: new Map(),
+        interceptions: new Map(),
+        interceptionsBySlotId: new Map(),
+        layouts: new Map([
+          [
+            rootLayoutId,
+            {
+              id: rootLayoutId,
+              paramNames: [],
+              patternParts: [],
+              rootBoundaryId: null,
+              treePath: "/",
+            },
+          ],
+        ]),
+        pages: new Map(),
+        rootBoundaries: new Map(),
+        routeHandlers: new Map(),
+        routes: new Map([
+          [
+            routeId,
+            {
+              id: routeId,
+              isDynamic: false,
+              layoutIds: [rootLayoutId],
+              pageId: "page:/dashboard",
+              paramNames: [],
+              pattern: "/dashboard",
+              patternParts: ["dashboard"],
+              rootBoundaryId: null,
+              rootParamNames: [],
+              routeHandlerId: null,
+              slotIds: [sidebarSlotId],
+              templateIds: [],
+            },
+          ],
+        ]),
+        slotBindings: new Map([
+          [
+            `${routeId}::${sidebarSlotId}`,
+            {
+              defaultId: null,
+              id: `${routeId}::${sidebarSlotId}`,
+              ownerLayoutId: rootLayoutId,
+              routeId,
+              routeSegments: ["slow", "child"],
+              slotId: sidebarSlotId,
+              state: "active",
+            },
+          ],
+        ]),
+        slots: new Map(),
+        templates: new Map(),
+      },
+    };
+    const template = createOptimisticRouteTemplate({
+      allowLoadingShell: true,
+      basePath: "",
+      elements,
+      href: "/dashboard",
+      interceptionContext: null,
+      mountedSlotsHeader: "sidebar",
+      routeManifest,
+    });
+    if (template === null) throw new Error("Expected optimistic route template");
+
+    const omittedSegmentId = createNestedBfcacheSlotSegmentId(sidebarSlotId, 2);
+    expect(template.omittedBfcacheSegmentIds).toContain(omittedSegmentId);
+    const currentElements = buildElements();
+    expect(
+      canCommitOptimisticRouteTemplate({
+        currentElements,
+        currentLayoutIds: AppElementsWire.readMetadata(currentElements).layoutIds,
+        currentParams: {},
+        routeManifest,
+        targetRouteParams: {},
+        targetUrlParts: ["dashboard"],
+        template,
+      }),
+    ).toBe(false);
   });
 
   it("emits the route loading fallback for slots owned at the shell cutoff", async () => {

--- a/tests/app-page-segment-state.test.ts
+++ b/tests/app-page-segment-state.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 import {
+  canonicalizeAppPageParams,
   resolveAppPageLeafSegmentStateKey,
   resolveAppPagePatternStateKey,
   resolveAppPageRouteStateKey,
@@ -79,6 +80,16 @@ describe("app page segment state keys", () => {
         parts: [],
       }),
     ).toBe("parts||oc");
+
+    const first = { parts: ["a/b", "c"] };
+    const second = { parts: ["a", "b/c"] };
+    canonicalizeAppPageParams(first);
+    canonicalizeAppPageParams(second);
+    expect(first).toEqual({ parts: ["a%2Fb", "c"] });
+    expect(second).toEqual({ parts: ["a", "b%2Fc"] });
+    expect(resolveAppPageRouteStateKey(["docs", "[...parts]"], first)).not.toBe(
+      resolveAppPageRouteStateKey(["docs", "[...parts]"], second),
+    );
   });
 
   it("canonicalizes interception pattern params with their full target path", () => {

--- a/tests/e2e/cloudflare-workers/layout-identity.spec.ts
+++ b/tests/e2e/cloudflare-workers/layout-identity.spec.ts
@@ -1,0 +1,110 @@
+import { test, expect, type Page } from "@playwright/test";
+
+const BASE = "http://localhost:4176";
+const PARENT = `${BASE}/layout-identity/alpha`;
+
+const readLayoutHandle = (page: Page) =>
+  page.evaluateHandle(() => document.querySelector('[data-testid="shared-layout"]'));
+
+// `/layout-identity/[slug]` and everything beneath it share the `[slug]` layout
+// and resolve the same slug value, so navigating between them changes only the
+// segments below that layout. The layout must stay mounted: its DOM node keeps
+// its identity and the client state it owns survives.
+//
+// vinext currently discards the layout subtree on these navigations. The trigger
+// is the `loading.tsx` boundary above the shared layout — with that file removed
+// from the fixture, every assertion below passes.
+test.describe("App Router shared layout identity", () => {
+  test("navigates without a full document load", async ({ page }) => {
+    await page.goto(PARENT);
+    await expect(page.getByTestId("page-title")).toHaveText("Parent page");
+
+    await page.evaluate(() => {
+      (window as Window & { __softNavigationMarker?: boolean }).__softNavigationMarker = true;
+    });
+
+    await page.getByTestId("to-child").click();
+    await expect(page.getByTestId("page-title")).toHaveText("Child page");
+
+    // Control: the marker survives, so this is a client-side navigation rather
+    // than a document load. The teardown below is therefore the router
+    // discarding a layout it should have retained, not a full page reload.
+    const marker = await page.evaluate(
+      () => (window as Window & { __softNavigationMarker?: boolean }).__softNavigationMarker,
+    );
+    expect(marker).toBe(true);
+  });
+
+  test("keeps the shared layout element mounted across a static child segment", async ({
+    page,
+  }) => {
+    await page.goto(PARENT);
+    await expect(page.getByTestId("page-title")).toHaveText("Parent page");
+
+    const layout = await readLayoutHandle(page);
+    expect(await layout.evaluate((element) => element?.isConnected ?? false)).toBe(true);
+
+    await page.getByTestId("to-child").click();
+    await expect(page.getByTestId("page-title")).toHaveText("Child page");
+
+    // The same DOM node must still be in the document: a retained layout is
+    // reconciled in place, a discarded one is replaced by a fresh element.
+    expect(await layout.evaluate((element) => element?.isConnected ?? false)).toBe(true);
+  });
+
+  test("keeps the shared layout element mounted across a nested dynamic segment", async ({
+    page,
+  }) => {
+    await page.goto(PARENT);
+    await expect(page.getByTestId("page-title")).toHaveText("Parent page");
+
+    const layout = await readLayoutHandle(page);
+
+    // Crosses two layout levels at once: the shared `[slug]` layout stays on the
+    // same value while `items/[item]` mounts its own layout beneath it.
+    await page.getByTestId("to-item").click();
+    await expect(page.getByTestId("page-title")).toHaveText("Item page");
+    await expect(page.getByTestId("item-layout-value")).toHaveText("Item layout: first");
+
+    expect(await layout.evaluate((element) => element?.isConnected ?? false)).toBe(true);
+  });
+
+  test("preserves client state owned by the shared layout", async ({ page }) => {
+    await page.goto(PARENT);
+    await page.getByTestId("layout-increment").click();
+    await expect(page.getByTestId("layout-count")).toHaveText("Layout count: 1");
+
+    await page.getByTestId("to-child").click();
+    await expect(page.getByTestId("page-title")).toHaveText("Child page");
+
+    // The counter lives in the layout, not the page, so it only resets when the
+    // layout remounts.
+    await expect(page.getByTestId("layout-count")).toHaveText("Layout count: 1");
+  });
+
+  test("keeps the shared layout mounted when navigating back to the parent", async ({ page }) => {
+    await page.goto(`${PARENT}/items/first`);
+    await expect(page.getByTestId("page-title")).toHaveText("Item page");
+
+    const layout = await readLayoutHandle(page);
+
+    await page.getByTestId("to-parent").click();
+    await expect(page.getByTestId("page-title")).toHaveText("Parent page");
+
+    expect(await layout.evaluate((element) => element?.isConnected ?? false)).toBe(true);
+  });
+
+  test("updates the parallel slot alongside the retained layout", async ({ page }) => {
+    await page.goto(PARENT);
+    await expect(page.getByTestId("aside-content")).toHaveText("aside: alpha parent");
+
+    const layout = await readLayoutHandle(page);
+
+    await page.getByTestId("to-item").click();
+    await expect(page.getByTestId("aside-content")).toHaveText("aside: alpha / first");
+
+    // The slot beside `children` changing must not cost the sibling layout its
+    // identity.
+    expect(await layout.evaluate((element) => element?.isConnected ?? false)).toBe(true);
+  });
+});

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -9558,7 +9558,12 @@ describe("double-encoded path handling in middleware", () => {
       "utf8",
     );
     expect(routeMatchingSource).toContain("trieMatchRaw(routeTrie");
-    expect(routeMatchingSource).toContain("encodeURIComponent(decodeURIComponent(value))");
+    expect(routeMatchingSource).toContain("canonicalizeAppPageParams(result.params)");
+    const segmentStateSource = await readFile(
+      new URL("../packages/vinext/src/server/app-page-segment-state.ts", import.meta.url),
+      "utf8",
+    );
+    expect(segmentStateSource).toContain("encodeURIComponent(decodeURIComponent(value))");
   });
 
   it("App Router middleware receives a Request with the original encoded pathname", async () => {


### PR DESCRIPTION
## Summary

- retain mounted layouts while an optimistic loading shell omits them only when their target-side segment identities are unchanged
- preserve remount/loading behavior for genuinely changed dynamic params and parallel-slot branches
- derive optimistic identities from the same canonical raw route params as authoritative RSC matching, including encoded slashes, UTF-8, percent signs, double encoding, and catch-all arrays
- cover active, default, empty, and overridden parallel slots plus target-side identity reification

This PR includes the production Cloudflare Worker E2E reproduction originally added in #2939, so the regression and fix land together.

## Root cause and Next.js parity

A loading-shell prefetch carries the route's layout identities, but its rendered element stops at the first loading boundary and can omit mounted layouts below that boundary. Vinext committed the shell before the authoritative RSC payload, disconnecting those layouts and resetting their client state even when the destination reused the same layout segment.

Next.js keys each layout-router branch by segment identity. Navigating below an unchanged layout preserves that branch; changing its dynamic segment or parallel-slot branch replaces it. The direct behavioral oracle is [`test/e2e/app-dir/app-prefetch-false-loading/app-prefetch-false-loading.test.ts`](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app-prefetch-false-loading/app-prefetch-false-loading.test.ts), backed by [`layout-router.tsx`](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/layout-router.tsx).

The fix records omitted named-slot segments from existing BFCache identities, then reifies those identities from the target route rather than copying learned source identities. Before committing a loading shell, vinext compares the mounted and target identities: unchanged omitted layouts keep rendering until the authoritative payload arrives, while changed params or slot branches retain normal loading/remount behavior. Optimistic and authoritative matching now share canonical raw-param extraction so encoded dynamic values cannot disagree about identity.

## Validation

- 400 focused unit tests across optimistic routing, page wiring, segment state, RSC matching, route patterns, and shims
- 1,473-test independent exact-head parity review pass across the cumulative diff
- production `app-router-cloudflare` build served with Wrangler plus `layout-identity.spec.ts` — 6 passed
- changed-file `vp check`, Knip, `vp run vinext#build`, and `git diff --check`
- four independent exact-head review lanes (Next.js parity, route identity, navigation lifecycle, and regression coverage) — no findings