### PR TITLE
fix(app-router): preserve static hydration search params

### DIFF
--- a/packages/vinext/src/client/navigation-runtime.ts
+++ b/packages/vinext/src/client/navigation-runtime.ts
@@ -13,6 +13,7 @@ export type NavigationRuntimeRscBootstrap = {
   done?: boolean;
   dynamicStaleTimeSeconds?: number;
   initialCacheKind?: "dynamic" | "static";
+  searchParamsFromBrowser?: boolean;
   nav?: NavigationRuntimeSnapshot;
   params?: Record<string, string | string[]>;
   rsc: NavigationRuntimeRscChunk[];
@@ -174,6 +175,7 @@ function isNavigationRuntimeRscBootstrap(value: unknown): value is NavigationRun
   const done = Reflect.get(value, "done");
   const dynamicStaleTimeSeconds = Reflect.get(value, "dynamicStaleTimeSeconds");
   const initialCacheKind = Reflect.get(value, "initialCacheKind");
+  const searchParamsFromBrowser = Reflect.get(value, "searchParamsFromBrowser");
   const nav = Reflect.get(value, "nav");
   const params = Reflect.get(value, "params");
   const rsc = Reflect.get(value, "rsc");
@@ -187,6 +189,7 @@ function isNavigationRuntimeRscBootstrap(value: unknown): value is NavigationRun
     (initialCacheKind === undefined ||
       initialCacheKind === "dynamic" ||
       initialCacheKind === "static") &&
+    (searchParamsFromBrowser === undefined || typeof searchParamsFromBrowser === "boolean") &&
     (nav === undefined || isNavigationRuntimeSnapshot(nav)) &&
     (params === undefined || isNavigationRuntimeParams(params)) &&
     Array.isArray(rsc) &&

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -1245,6 +1245,19 @@ function restoreHydrationNavigationContext(
   });
 }
 
+function restoreEmbeddedHydrationNavigationContext(
+  pathname: string,
+  searchParams: SearchParamInput,
+  params: Record<string, string | string[]>,
+  searchParamsFromBrowser: boolean,
+): void {
+  restoreHydrationNavigationContext(
+    pathname,
+    searchParamsFromBrowser ? window.location.search : searchParams,
+    params,
+  );
+}
+
 function restorePopstateScrollPosition(
   state: unknown,
   options?: {
@@ -1440,7 +1453,12 @@ function applyRuntimeRscBootstrap(rsc: NavigationRuntimeRscBootstrap): void {
     applyClientParams(rsc.params);
   }
   if (rsc.nav) {
-    restoreHydrationNavigationContext(rsc.nav.pathname, rsc.nav.searchParams, params);
+    restoreEmbeddedHydrationNavigationContext(
+      rsc.nav.pathname,
+      rsc.nav.searchParams,
+      params,
+      rsc.searchParamsFromBrowser === true,
+    );
   }
 }
 

--- a/packages/vinext/src/server/app-page-ppr-runtime.ts
+++ b/packages/vinext/src/server/app-page-ppr-runtime.ts
@@ -70,6 +70,7 @@ async function probePprFallbackShellCache<TRoute extends AppPageDispatchRoute>(
   options: DispatchAppPageOptions<TRoute>,
   fallbackShells: NonNullable<DispatchAppPageOptions<TRoute>["pprFallbackCacheShells"]>,
   currentRevalidateSeconds: number | null,
+  isForceStatic: boolean,
 ): Promise<Response | null> {
   const { readAppPageFallbackShellCacheResponse } = await import("./app-page-cache.js");
   const { rewriteAppPprFallbackShellHtmlNavigation } = await import("./app-ppr-fallback-shell.js");
@@ -88,6 +89,7 @@ async function probePprFallbackShellCache<TRoute extends AppPageDispatchRoute>(
       rewriteHtml(html) {
         return rewriteAppPprFallbackShellHtmlNavigation({
           html,
+          isForceStatic,
           params: options.params,
           pathname: options.cleanPathname,
           searchParams: options.searchParams,
@@ -114,7 +116,12 @@ export const appPagePprRuntime: AppPagePprRuntime<AppPageDispatchRoute> = {
       isForceDynamic,
     );
     return decision.kind === "probe-fallback-shells"
-      ? probePprFallbackShellCache(options, decision.fallbackShells, currentRevalidateSeconds)
+      ? probePprFallbackShellCache(
+          options,
+          decision.fallbackShells,
+          currentRevalidateSeconds,
+          isForceStatic,
+        )
       : null;
   },
   async warm(options) {

--- a/packages/vinext/src/server/app-ppr-fallback-shell.ts
+++ b/packages/vinext/src/server/app-ppr-fallback-shell.ts
@@ -134,15 +134,21 @@ export function createAppPprFallbackShells(
 
 export function rewriteAppPprFallbackShellHtmlNavigation(options: {
   html: string;
+  isForceStatic?: boolean;
   params: Record<string, string | string[]>;
   pathname: string;
   searchParams: URLSearchParams;
 }): string {
   const metadataScript = createInlineScriptTag(
-    createNavigationRuntimeRscMetadataScript(options.params, {
-      pathname: options.pathname,
-      searchParams: [...options.searchParams.entries()],
-    }),
+    createNavigationRuntimeRscMetadataScript(
+      options.params,
+      {
+        pathname: options.pathname,
+        searchParams: options.isForceStatic ? [] : [...options.searchParams.entries()],
+      },
+      undefined,
+      options.isForceStatic !== true,
+    ),
   );
 
   const headCloseIndex = options.html.indexOf("</head>");

--- a/packages/vinext/src/server/app-ssr-entry.ts
+++ b/packages/vinext/src/server/app-ssr-entry.ts
@@ -318,6 +318,7 @@ function buildHeadInjectionHtml(
   insertedHTML: string,
   fontHTML: string,
   dynamicStaleTimeSeconds?: number,
+  searchParamsFromBrowser?: boolean,
   scriptNonce?: string,
 ): string {
   const navPayload = {
@@ -329,6 +330,7 @@ function buildHeadInjectionHtml(
       navContext.params,
       navPayload,
       dynamicStaleTimeSeconds,
+      searchParamsFromBrowser,
     ),
     scriptNonce,
   );
@@ -708,6 +710,7 @@ export async function handleSsr(
             insertedHTML + errorMetaHTML + getTraceMetaHTML() + initialDevServerErrorHTML,
             fontHTML,
             options?.dynamicStaleTimeSeconds,
+            options?.isStaticGeneration === true ? options.isForceStatic !== true : undefined,
             options?.scriptNonce,
           );
         };

--- a/packages/vinext/src/server/app-ssr-stream.ts
+++ b/packages/vinext/src/server/app-ssr-stream.ts
@@ -60,6 +60,7 @@ export function createNavigationRuntimeRscMetadataScript(
   params: Record<string, string | string[]>,
   nav: { pathname: string; searchParams: [string, string][] },
   dynamicStaleTimeSeconds?: number,
+  searchParamsFromBrowser?: boolean,
 ): string {
   return (
     "Object.assign(" +
@@ -68,6 +69,9 @@ export function createNavigationRuntimeRscMetadataScript(
     safeJsonStringify(params) +
     ",nav:" +
     safeJsonStringify(nav) +
+    (searchParamsFromBrowser === undefined
+      ? ""
+      : ",searchParamsFromBrowser:" + safeJsonStringify(searchParamsFromBrowser)) +
     (dynamicStaleTimeSeconds === undefined
       ? ""
       : ",dynamicStaleTimeSeconds:" + safeJsonStringify(dynamicStaleTimeSeconds)) +

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -57,7 +57,11 @@ const projectServers = {
   },
   "app-router-isr-prod": {
     testDir: "./tests/e2e",
-    testMatch: ["app-router/isr.spec.ts", "app-router-prod/use-cache.spec.ts"],
+    testMatch: [
+      "app-router/isr.spec.ts",
+      "app-router-prod/static-hydration.spec.ts",
+      "app-router-prod/use-cache.spec.ts",
+    ],
     use: { baseURL: "http://localhost:4198" },
     server: {
       command:

--- a/tests/app-ppr-fallback-shell.test.ts
+++ b/tests/app-ppr-fallback-shell.test.ts
@@ -122,11 +122,26 @@ describe("rewriteAppPprFallbackShellHtmlNavigation", () => {
     expect(html).toContain('params:{"locale":"en","slug":"new-post"}');
     expect(html).toContain('"pathname":"/en/blog/new-post"');
     expect(html).toContain('"searchParams":[["preview","1"]]');
+    expect(html).toContain("searchParamsFromBrowser:true");
     const paramsIndex = html.indexOf('params:{"locale":"en","slug":"new-post"}');
     const headCloseIndex = html.indexOf("</head>");
     expect(paramsIndex).toBeGreaterThanOrEqual(0);
     expect(headCloseIndex).toBeGreaterThanOrEqual(0);
     expect(paramsIndex).toBeLessThan(headCloseIndex);
+  });
+
+  it("keeps force-static fallback-shell search params server-owned", () => {
+    const html = rewriteAppPprFallbackShellHtmlNavigation({
+      html: "<html><head></head><body>shell</body></html>",
+      isForceStatic: true,
+      params: { slug: "new-post" },
+      pathname: "/blog/new-post",
+      searchParams: new URLSearchParams([["preview", "1"]]),
+    });
+
+    expect(html).toContain("searchParamsFromBrowser:false");
+    expect(html).toContain('"searchParams":[]');
+    expect(html).not.toContain('"preview","1"');
   });
 
   it("appends actual request metadata after cached placeholder metadata", () => {

--- a/tests/app-ssr-stream.test.ts
+++ b/tests/app-ssr-stream.test.ts
@@ -25,6 +25,17 @@ it("serializes dynamic stale time into the hydration bootstrap", () => {
   ).toContain("dynamicStaleTimeSeconds:30");
 });
 
+it("serializes browser search-param ownership into the early hydration bootstrap", () => {
+  expect(
+    createNavigationRuntimeRscMetadataScript(
+      {},
+      { pathname: "/static", searchParams: [] },
+      undefined,
+      true,
+    ),
+  ).toContain("searchParamsFromBrowser:true");
+});
+
 describe("App SSR stream helpers", () => {
   describe("fixPreloadAs", () => {
     it('replaces as="stylesheet" with as="style" for preload links', () => {

--- a/tests/e2e/app-router-prod/static-hydration.spec.ts
+++ b/tests/e2e/app-router-prod/static-hydration.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "@playwright/test";
+import { waitForAppRouterHydration } from "../helpers";
+
+// Ported from Next.js: test/e2e/app-dir/app-static/app-static.test.ts
+// https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app-static/app-static.test.ts
+test("statically prerendered useSearchParams reads the browser query after hydration", async ({
+  page,
+}) => {
+  let rscRequests = 0;
+  page.on("request", (request) => {
+    if (request.headers().rsc === "1") rscRequests++;
+  });
+  await page.goto("/nextjs-compat/use-search-params-static-bailout?value=runtime");
+  await waitForAppRouterHydration(page);
+  await expect(page.locator("#search-params-value")).toHaveText("runtime");
+  expect(rscRequests).toBe(0);
+});
+
+test("force-static hydration keeps search params empty", async ({ page }) => {
+  await page.goto("/static-test?value=hidden");
+  await waitForAppRouterHydration(page);
+  await expect(page.getByTestId("force-static-search-params")).toHaveText("N/A");
+});

--- a/tests/e2e/static-export/app-router.spec.ts
+++ b/tests/e2e/static-export/app-router.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { waitForAppRouterHydration } from "../helpers";
 
 /**
  * Static export E2E tests for the App Router.
@@ -70,6 +71,34 @@ test.describe("Static Export — App Router", () => {
     await page.locator('a[href="/about"]').click();
     await page.waitForURL(`${BASE}/about`);
     await expect(page.locator("h1")).toHaveText("About");
+  });
+
+  // Ported from Next.js: test/e2e/app-dir/app-static/app-static.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app-static/app-static.test.ts
+  test("useSearchParams reads the browser query after hydration", async ({ page }) => {
+    let rscRequests = 0;
+    page.on("request", (request) => {
+      if (request.headers().rsc === "1") rscRequests++;
+    });
+    const response = await page.goto(`${BASE}/search-params?value=expected`);
+    expect(response?.status()).toBe(200);
+    await waitForAppRouterHydration(page);
+    await expect(page.getByTestId("query-value")).toHaveText("expected");
+    expect(page.url()).toBe(`${BASE}/search-params?value=expected`);
+    expect(rscRequests).toBe(0);
+  });
+
+  test("useSearchParams reads the query after static-host navigation fallback", async ({
+    page,
+  }) => {
+    await page.goto(`${BASE}/`);
+    await page.evaluate(() => Reflect.set(window, "__staticExportSoftNavigation", true));
+    await page.locator('a[href="/search-params?value=navigated"]').click();
+    await page.waitForURL(`${BASE}/search-params?value=navigated`);
+    await expect(page.getByTestId("query-value")).toHaveText("navigated");
+    expect(
+      await page.evaluate(() => Reflect.get(window, "__staticExportSoftNavigation")),
+    ).toBeUndefined();
   });
 
   test("root layout metadata is applied", async ({ page }) => {

--- a/tests/fixtures/app-basic/app/static-test/page.tsx
+++ b/tests/fixtures/app-basic/app/static-test/page.tsx
@@ -10,6 +10,8 @@ export default function StaticTestPage() {
       <p>
         Rendered at: <span data-testid="timestamp">{timestamp}</span>
       </p>
+      <ForceStaticSearchParams />
     </div>
   );
 }
+import ForceStaticSearchParams from "./search-params";

--- a/tests/fixtures/app-basic/app/static-test/search-params.tsx
+++ b/tests/fixtures/app-basic/app/static-test/search-params.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+
+export default function ForceStaticSearchParams() {
+  return <p data-testid="force-static-search-params">{useSearchParams().get("value") ?? "N/A"}</p>;
+}

--- a/tests/fixtures/static-export/app/page.tsx
+++ b/tests/fixtures/static-export/app/page.tsx
@@ -11,6 +11,9 @@ export default function HomePage() {
             <Link href="/about">About (App Router)</Link>
           </li>
           <li>
+            <Link href="/search-params?value=navigated">Search params (App Router)</Link>
+          </li>
+          <li>
             <Link href="/blog/hello-world">Blog: hello-world</Link>
           </li>
           <li>

--- a/tests/fixtures/static-export/app/search-params/page.tsx
+++ b/tests/fixtures/static-export/app/search-params/page.tsx
@@ -1,0 +1,13 @@
+import { Suspense } from "react";
+import { SearchParamsValue } from "./search-params-value";
+
+export default function SearchParamsPage() {
+  return (
+    <main>
+      <h1>Search Params</h1>
+      <Suspense fallback={<p data-testid="query-value">loading</p>}>
+        <SearchParamsValue />
+      </Suspense>
+    </main>
+  );
+}

--- a/tests/fixtures/static-export/app/search-params/search-params-value.tsx
+++ b/tests/fixtures/static-export/app/search-params/search-params-value.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+
+export function SearchParamsValue() {
+  const searchParams = useSearchParams();
+  return <p data-testid="query-value">{searchParams.get("value") ?? "missing"}</p>;
+}

--- a/tests/prerender.test.ts
+++ b/tests/prerender.test.ts
@@ -1058,6 +1058,8 @@ describe("prerenderApp — default mode (app-basic)", () => {
       expect(r.outputFiles).toContain("static-test.html");
       expect(r.outputFiles).toContain("static-test.rsc");
     }
+    const html = fs.readFileSync(path.join(outDir, "static-test.html"), "utf-8");
+    expect(html).toContain("searchParamsFromBrowser:false");
   });
 
   it("emits the nearest Suspense fallback when useSearchParams bails out during prerender", () => {
@@ -1147,6 +1149,7 @@ describe("prerenderApp — default mode (app-basic)", () => {
     });
 
     const html = fs.readFileSync(path.join(outDir, "use-cache-test.html"), "utf-8");
+    expect(html).toContain("searchParamsFromBrowser:true");
     expect(html).toContain('"initialCacheKind":"static"');
     expect(html).toContain('"staleTimeSeconds":30');
   });


### PR DESCRIPTION
Fixes #2928

## Summary

- mark prerendered hydration payloads whose search params must come from the browser URL
- preserve server-owned search params for dynamic SSR, force-static routes, and force-static PPR fallback shells
- cover static export and ordinary production prerender hydration through the embedded RSC path

## Root cause

Static App Router HTML embedded the build-time empty search-param snapshot, and the browser restored that snapshot as authoritative during hydration instead of using the visible URL query.

## Validation

- vp check
- vp run vinext#build
- vp test run tests/app-ssr-stream.test.ts tests/navigation-runtime.test.ts tests/prerender.test.ts tests/app-browser-entry.test.ts tests/app-ppr-fallback-shell.test.ts (400 passed)
- PLAYWRIGHT_PROJECT=static-export vp run test:e2e -- tests/e2e/static-export/app-router.spec.ts (12 passed)
- PLAYWRIGHT_PROJECT=app-router-isr-prod vp run test:e2e -- tests/e2e/app-router-prod/static-hydration.spec.ts (2 passed)
- independent correctness, parity, and test reviews: no findings