### PR TITLE
docs: align README cache claims with the implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ the compatibility report.
 
 Vite has become the default build tool for modern web frameworks — fast HMR, a clean plugin API, native ESM, and a growing ecosystem. With [`@vitejs/plugin-rsc`](https://github.com/vitejs/vite-plugin-react/tree/main/packages/plugin-rsc) adding React Server Components support, it's now possible to build a full RSC framework on Vite.
 
-vinext reimplements the Next.js API surface on Vite to find out how much of a real Next.js application can run on a different toolchain. The answer, so far, is that substantial applications can.
+vinext reimplements the Next.js API surface on Vite so existing Next.js applications can run on a different toolchain. The answer, so far, is that substantial applications can.
 
 vinext works everywhere. It natively supports Cloudflare Workers (with `npx @vinext/cloudflare deploy` or `vp exec vinext-cloudflare deploy`, bindings, KV caching), and can be deployed to Vercel, Netlify, AWS, Deno Deploy, and more via the [Nitro](https://v3.nitro.build/) Vite plugin. Native support for additional platforms is [planned](https://github.com/cloudflare/vinext/issues/80).
 
@@ -683,7 +683,7 @@ The KV data adapter reads `env[binding]` at runtime, so add the matching KV name
 }
 ```
 
-Where the data adapter stores entries and serves HIT/STALE itself, the CDN adapter delegates serving to Cloudflare's edge: the origin renders fresh responses and tags them with `Cache-Tag`, and `revalidateTag()` / `revalidatePath()` purge the edge through `ctx.cache.purge({ tags })`. See [examples/workers-cache](examples/workers-cache) for both adapters wired up together.
+While the data adapter can store entries and serve HIT/STALE itself, the CDN adapter delegates serving to Cloudflare's edge: the origin renders fresh responses and tags them with `Cache-Tag`, and `revalidateTag()` / `revalidatePath()` purge the edge through `ctx.cache.purge({ tags })`. See [examples/workers-cache](examples/workers-cache) for both adapters wired up together.
 
 Each builder returns a plain, serializable `{ adapter, options }` descriptor — **it never touches the Workers runtime**, so nothing throws at build or dev time when bindings aren't available. The actual adapter (and its `env` binding lookup) is instantiated lazily on the first request.
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ the compatibility report.
 
 Vite has become the default build tool for modern web frameworks — fast HMR, a clean plugin API, native ESM, and a growing ecosystem. With [`@vitejs/plugin-rsc`](https://github.com/vitejs/vite-plugin-react/tree/main/packages/plugin-rsc) adding React Server Components support, it's now possible to build a full RSC framework on Vite.
 
-vinext reimplements the Next.js API surface on Vite so existing Next.js applications can run on a different toolchain. The answer, so far, is that substantial applications can.
+vinext reimplements the Next.js API surface on Vite to find out how much of a real Next.js application can run on a different toolchain. The answer, so far, is that substantial applications can.
 
 vinext works everywhere. It natively supports Cloudflare Workers (with `npx @vinext/cloudflare deploy` or `vp exec vinext-cloudflare deploy`, bindings, KV caching), and can be deployed to Vercel, Netlify, AWS, Deno Deploy, and more via the [Nitro](https://v3.nitro.build/) Vite plugin. Native support for additional platforms is [planned](https://github.com/cloudflare/vinext/issues/80).
 
@@ -521,7 +521,7 @@ These are deployed to Cloudflare Workers and updated on every push to `main`:
 
 ## API coverage
 
-~94% of the Next.js 16 API surface has full or partial support. The remaining gaps are intentional stubs for deprecated features and Partial Prerendering (which Next.js 16 reworked into `"use cache"` — that directive is fully supported).
+~94% of the Next.js 16 API surface has full or partial support. The remaining gaps are intentional stubs for deprecated features, plus Partial Prerendering and Cache Components. Next.js 16 reworked PPR into `"use cache"`; vinext implements that directive for file-level and function-level caching, but full `cacheComponents` behavior is still incomplete — see [Known gaps we're working on](#known-gaps-were-working-on).
 
 > ✅ = full implementation | 🟡 = partial (runtime behavior correct, some build-time optimizations missing) | ⬜ = intentional stub/no-op
 
@@ -643,16 +643,21 @@ The cache is pluggable. The default `MemoryCacheHandler` works out of the box. S
 Instead of wiring up cache handlers imperatively from a worker entry, you can declare them in the `vinext()` plugin config. The `@vinext/cloudflare` package ships Cloudflare adapters for this:
 
 - **`kvDataAdapter()`** (`@vinext/cloudflare/cache/kv-data-adapter`) — backs the `"use cache"` data cache with a Workers KV namespace.
+- **`cdnAdapter()`** (`@vinext/cloudflare/cache/cdn-adapter`) — serves page-level ISR from the Cloudflare Workers Cache (`ctx.cache`) instead of from the origin.
+
+The two fill different slots and can be used together:
 
 ```ts
 import { defineConfig } from "vite";
 import vinext from "vinext";
+import { cdnAdapter } from "@vinext/cloudflare/cache/cdn-adapter";
 import { kvDataAdapter } from "@vinext/cloudflare/cache/kv-data-adapter";
 
 export default defineConfig({
   plugins: [
     vinext({
       cache: {
+        cdn: cdnAdapter(),
         data: kvDataAdapter(),
       },
     }),
@@ -669,6 +674,16 @@ The KV data adapter reads `env[binding]` at runtime, so add the matching KV name
 ```
 
 `binding` defaults to `VINEXT_KV_CACHE`, so `kvDataAdapter()` with no options works as long as that's your binding name. Other options: `appPrefix` (namespace cache keys to isolate multiple apps in one KV namespace), `ttlSeconds` (default KV `expirationTtl`, default 30 days), and `tagCacheTtlMs` (in-memory tag-invalidation cache TTL, default 5s).
+
+`cdnAdapter()` takes no options, but the Workers Cache only exposes `ctx.cache` when `cache.enabled` is set in `wrangler.jsonc`:
+
+```jsonc
+{
+  "cache": { "enabled": true },
+}
+```
+
+Where the data adapter stores entries and serves HIT/STALE itself, the CDN adapter delegates serving to Cloudflare's edge: the origin renders fresh responses and tags them with `Cache-Tag`, and `revalidateTag()` / `revalidatePath()` purge the edge through `ctx.cache.purge({ tags })`. See [examples/workers-cache](examples/workers-cache) for both adapters wired up together.
 
 Each builder returns a plain, serializable `{ adapter, options }` descriptor — **it never touches the Workers runtime**, so nothing throws at build or dev time when bindings aren't available. The actual adapter (and its `env` binding lookup) is instantiated lazily on the first request.
 


### PR DESCRIPTION
Three README corrections, each checked against the code on `main` (`a5f0bb4`). All docs-only.

## 1. The API coverage section contradicts the Known gaps section

[README.md#L524](https://github.com/cloudflare/vinext/blob/main/README.md?plain=1#L524) opened the API coverage section with:

> The remaining gaps are intentional stubs for deprecated features and Partial Prerendering (which Next.js 16 reworked into `"use cache"` — **that directive is fully supported**).

But [README.md#L26](https://github.com/cloudflare/vinext/blob/main/README.md?plain=1#L26), in the same file, says:

> `"use cache"` is **partially implemented**, but full `cacheComponents` behavior is **still incomplete**.

The compatibility scanner agrees with line 26:

```ts
// packages/vinext/src/check.ts:205
cacheComponents: { status: "partial", detail: "experimental support; behavior is incomplete" },
"experimental.ppr": { status: "unsupported", detail: "partial prerendering not yet implemented" },
```

The practical cost is that someone evaluating a migration reads "fully supported", then gets `partial` / `unsupported` out of `vinext check`. Rewrote the sentence to match `check.ts` and cross-linked Known gaps.

**One thing I left alone, since it's your call:** the `"use cache"` directive row in the Server features table is `✅`, which has the same tension with line 26. I didn't want to downgrade a support marker unilaterally — happy to change it to `🟡` in this PR if you'd prefer, or leave it.

## 2. "The answer, so far" answers a question that was never asked

[README.md#L187](https://github.com/cloudflare/vinext/blob/main/README.md?plain=1#L187):

> vinext reimplements the Next.js API surface on Vite so existing Next.js applications can run on a different toolchain. **The answer, so far, is that substantial applications can.**

Nothing before it poses a question, so "The answer" has no referent. Kept both sentences and restored the question to the first one, rather than deleting the second — the "so far" framing seemed deliberate.

## 3. `cdnAdapter()` is undocumented

The cache adapter section promises "Cloudflare **adapters**" (plural) and then lists one. `cdnAdapter()` appears nowhere in the README, despite being:

- publicly exported as `@vinext/cloudflare/cache/cdn-adapter` (`packages/cloudflare/src/cache/cdn-adapter.ts`)
- a real config slot — `cdn?: CacheAdapterDescriptor` in `packages/vinext/src/cache/cache-adapters-virtual.ts:43`
- **written into the user's Vite config by default** — `init-cloudflare.ts:489` pushes `cdn: cdnAdapter()` whenever `cdnCache === "workers-cache"`, which is the default
- already documented in `examples/workers-cache/README.md`

So `vinext init --platform=cloudflare` generates a call that the main README never explains. Added a bullet, folded it into the existing config example, and added a short paragraph covering the `cache.enabled` requirement in `wrangler.jsonc` and how it differs from the data adapter (edge-served, `Cache-Tag` + `ctx.cache.purge({ tags })`, per `cdn-adapter.runtime.ts:23`).

---

Descriptions of runtime behavior are paraphrased from the adapter source and the `workers-cache` example rather than from a live deploy — I haven't run a Workers deployment against this. Everything else is a direct file-to-file comparison.
