### PR TITLE
fix(check): match @next/third-parties by package name

### DIFF
--- a/packages/vinext/src/check.ts
+++ b/packages/vinext/src/check.ts
@@ -112,10 +112,6 @@ const IMPORT_SUPPORT: Record<string, { status: Status; detail?: string }> = {
   "next/form": { status: "supported", detail: "Form component with client-side navigation" },
   "next/web-vitals": { status: "supported", detail: "reportWebVitals helper" },
   "next/constants": { status: "supported", detail: "PHASE_* constants" },
-  "next/third-parties/google": {
-    status: "unsupported",
-    detail: "third-party script optimization not implemented",
-  },
   "server-only": { status: "supported" },
   "client-only": { status: "supported" },
   // Internal next/dist/* paths used by libraries (testing utilities, older libs, etc.)
@@ -310,6 +306,10 @@ const LIBRARY_SUPPORT: Record<string, { status: Status; detail?: string }> = {
   nuqs: { status: "supported" },
   "next-view-transitions": { status: "supported" },
   "@vercel/analytics": { status: "supported", detail: "analytics script injected client-side" },
+  "@next/third-parties": {
+    status: "unsupported",
+    detail: "third-party script optimization not implemented",
+  },
   "next-intl": {
     status: "supported",
     detail:

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -884,6 +884,23 @@ describe("checkLibraries", () => {
     expect(items[0].detail).toContain("clerkMiddleware");
   });
 
+  it("detects @next/third-parties as unsupported", () => {
+    // The published package is `@next/third-parties` and its only export is
+    // `@next/third-parties/google`. It must be matched here rather than by the
+    // import scanner, which only collects specifiers starting with `next/`.
+    writeFile(
+      "package.json",
+      JSON.stringify({
+        dependencies: { "@next/third-parties": "^16.0.0" },
+      }),
+    );
+
+    const items = checkLibraries(tmpDir);
+    expect(items).toHaveLength(1);
+    expect(items[0].name).toBe("@next/third-parties");
+    expect(items[0].status).toBe("unsupported");
+  });
+
   it("detects supported CSS-in-JS libraries", () => {
     writeFile(
       "package.json",


### PR DESCRIPTION
`vinext check` never warns about `@next/third-parties`, even though there is an entry intended to flag it.

## The unreachable entry

`packages/vinext/src/check.ts` carried this in `IMPORT_SUPPORT`:

```ts
"next/third-parties/google": {
  status: "unsupported",
  detail: "third-party script optimization not implemented",
},
```

`IMPORT_SUPPORT` is keyed by import specifier, and the scanner only collects a specifier when it passes this filter:

```ts
// packages/vinext/src/check.ts:648
if (
  mod.startsWith("next/") ||
  mod === "next" ||
  mod === "server-only" ||
  mod === "client-only"
)
```

The published package is **`@next/third-parties`** (npm `latest` is 16.3.1, and its only export subpath is `./google`), so the real import is `@next/third-parties/google`. `@next/` does not start with `next/`, so the specifier is never collected and the entry can never be reached. There is no `next/third-parties/google` module for it to match instead.

`LIBRARY_SUPPORT` — the map checked against `package.json` dependencies — had no `@next/third-parties` key either. Net effect: a project that depends on the package gets nothing from `vinext check`, despite the clear intent to mark it `unsupported`.

## The fix

Move the entry to `LIBRARY_SUPPORT` keyed by the real package name, so it is matched via `allDeps` (`check.ts:973`) like `@vercel/analytics` and `@clerk/nextjs`. Status and detail text are unchanged.

## Verification

State: base `a5f0bb4`, head `45c3295`.

Reproduction: `pnpm exec vitest run tests/check.test.ts`, local Linux, Node 24.19.0, no network or external service involved.

Capture — the added test on the **pre-fix** source (source change reverted, test kept):

```
FAIL  |unit| tests/check.test.ts > checkLibraries > detects @next/third-parties as unsupported
AssertionError: expected [] to have a length of 1 but got +0
 Tests  1 failed | 145 passed (146)
```

The empty array is the bug: no item is produced at all. With the fix applied:

```
✓ |unit| tests/check.test.ts (146 tests) 428ms
 Test Files  1 passed (1)
      Tests  146 passed (146)
```

This is a deterministic regression test over `checkLibraries`; it pins that the dependency is reported, not that the underlying `@next/third-parties` support assessment is correct.

Scope: covers `checkLibraries` dependency matching. Excludes any change to whether the package could be supported — the `unsupported` status is carried over as-is, not re-evaluated.

Status at head: `pnpm exec vitest run tests/check.test.ts` passes (146/146); `pnpm run fmt:check` passes. `pnpm run lint` reports 9 `Cannot find module` TypeScript errors, but it reports the identical 9 on a clean `a5f0bb4` in my environment — they come from unbuilt `dist/` type declarations because I installed with `--ignore-scripts`, not from this change. I did not run the full suite or E2E locally; leaving those to CI.
