### PR TITLE
test(app-router): reproduce deployed optimistic search navigation stall

### DIFF
--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -168,7 +168,10 @@ jobs:
         env:
           PLAYWRIGHT_PROJECT: cloudflare-workers
           VINEXT_E2E_BASE_URL: ${{ github.event_name == 'pull_request' && format('https://pr-{0}-app-router-cloudflare.vinext.workers.dev', github.event.pull_request.number) || 'https://app-router-cloudflare.vinext.workers.dev' }}
-        run: vp exec playwright test tests/e2e/cloudflare-workers/web-worker.spec.ts
+        run: >-
+          vp exec playwright test
+          tests/e2e/cloudflare-workers/web-worker.spec.ts
+          tests/e2e/cloudflare-workers/optimistic-search-navigation.spec.ts
 
   comment:
     name: Comment Preview URLs

--- a/examples/app-router-cloudflare/app/optimistic-search-navigation/@modal/default.tsx
+++ b/examples/app-router-cloudflare/app/optimistic-search-navigation/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function ModalDefault() {
+  return null;
+}

--- a/examples/app-router-cloudflare/app/optimistic-search-navigation/layout.tsx
+++ b/examples/app-router-cloudflare/app/optimistic-search-navigation/layout.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from "react";
+
+export default function OptimisticSearchNavigationLayout({
+  children,
+  modal,
+}: {
+  children: ReactNode;
+  modal?: ReactNode;
+}) {
+  return (
+    <div data-testid="provider-list-layout">
+      {children}
+      {modal}
+    </div>
+  );
+}

--- a/examples/app-router-cloudflare/app/optimistic-search-navigation/page.tsx
+++ b/examples/app-router-cloudflare/app/optimistic-search-navigation/page.tsx
@@ -1,0 +1,52 @@
+import { Suspense } from "react";
+
+import { ProviderToggle, RouterOnlyControl } from "./provider-toggle";
+
+export const dynamic = "force-dynamic";
+
+export default async function OptimisticSearchNavigationPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ provider?: string }>;
+}) {
+  const provider = (await searchParams).provider ?? null;
+
+  return (
+    <main>
+      <h1>Optimistic search navigation</h1>
+      <p>
+        This reproduces a provider filter that optimistically updates before a same-path search
+        parameter navigation commits.
+      </p>
+      <ProviderToggle />
+      <RouterOnlyControl />
+      <Suspense fallback={<p data-testid="provider-results-loading">Loading results…</p>}>
+        <ProviderResults key={provider ?? "all"} provider={provider} />
+      </Suspense>
+    </main>
+  );
+}
+
+async function ProviderResults({ provider }: { provider: string | null }) {
+  // The reported route streams its filter shell before a slower provider-specific
+  // list. Keep that production timing characteristic in this self-contained fixture.
+  await new Promise((resolve) => setTimeout(resolve, provider ? 600 : 50));
+
+  const listPrefix = provider ?? "all";
+
+  return (
+    <section data-testid="provider-results">
+      <dl>
+        <dt>Server provider</dt>
+        <dd data-testid="server-provider">{provider ?? "none"}</dd>
+      </dl>
+      <ol>
+        {Array.from({ length: 3 }, (_, index) => (
+          <li key={index}>
+            {listPrefix} provider result {index + 1}
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/examples/app-router-cloudflare/app/optimistic-search-navigation/provider-toggle.tsx
+++ b/examples/app-router-cloudflare/app/optimistic-search-navigation/provider-toggle.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useLayoutEffect, useOptimistic, useRef, useTransition } from "react";
+
+const providers = [
+  { name: "netflix", value: "8" },
+  { name: "prime", value: "9" },
+  { name: "disney", value: "337" },
+] as const;
+
+function nextProviderQuery(currentQuery: string, provider: string) {
+  const params = new URLSearchParams(currentQuery);
+
+  if (params.get("provider") === provider) {
+    params.delete("provider");
+  } else {
+    params.set("provider", provider);
+  }
+
+  return params.toString();
+}
+
+export function ProviderToggle() {
+  const pathname = usePathname();
+  const router = useRouter();
+  const routeSearchParams = useSearchParams();
+  const [isPending, startTransition] = useTransition();
+  const [optimisticQuery, setOptimisticQuery] = useOptimistic(
+    routeSearchParams.toString(),
+    (_currentQuery, nextQuery: string) => nextQuery,
+  );
+  const optimisticQueryRef = useRef(optimisticQuery);
+
+  useLayoutEffect(() => {
+    optimisticQueryRef.current = optimisticQuery;
+  }, [optimisticQuery]);
+
+  const toggleProvider = useCallback(
+    (provider: string) => {
+      const query = nextProviderQuery(optimisticQueryRef.current, provider);
+
+      startTransition(() => {
+        setOptimisticQuery(query);
+        router.push(query ? `${pathname}?${query}` : pathname, { scroll: false });
+      });
+    },
+    [pathname, router, setOptimisticQuery],
+  );
+
+  const selectedProvider = new URLSearchParams(optimisticQuery).get("provider");
+
+  return (
+    <section aria-labelledby="optimistic-provider-heading">
+      <h2 id="optimistic-provider-heading">Optimistic provider filter</h2>
+      <div role="group" aria-label="Streaming provider">
+        {providers.map((provider) => (
+          <button
+            aria-pressed={selectedProvider === provider.value}
+            data-testid={`provider-${provider.name}`}
+            key={provider.value}
+            onClick={() => toggleProvider(provider.value)}
+            type="button"
+          >
+            {provider.name}
+          </button>
+        ))}
+      </div>
+      <dl>
+        <dt>Client provider</dt>
+        <dd data-testid="client-provider">{selectedProvider ?? "none"}</dd>
+        <dt>Navigation pending</dt>
+        <dd data-testid="navigation-pending">{String(isPending)}</dd>
+      </dl>
+    </section>
+  );
+}
+
+export function RouterOnlyControl() {
+  const pathname = usePathname();
+  const router = useRouter();
+
+  return (
+    <section aria-labelledby="router-control-heading">
+      <h2 id="router-control-heading">Router-only control</h2>
+      <button
+        data-testid="router-only-control"
+        onClick={() => router.push(`${pathname}?provider=control`, { scroll: false })}
+        type="button"
+      >
+        Select control provider
+      </button>
+    </section>
+  );
+}

--- a/tests/e2e/cloudflare-workers/optimistic-search-navigation.spec.ts
+++ b/tests/e2e/cloudflare-workers/optimistic-search-navigation.spec.ts
@@ -1,0 +1,95 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const ROUTE = "/optimistic-search-navigation";
+const DEPLOYED_RUNTIME = process.env.VINEXT_E2E_BASE_URL?.startsWith("https://") ?? false;
+
+const providers = [
+  { name: "netflix", value: "8" },
+  { name: "prime", value: "9" },
+  { name: "disney", value: "337" },
+] as const;
+
+async function markDocument(page: Page) {
+  await page.locator("html").evaluate((element) => {
+    element.dataset.optimisticNavigationDocument = "preserved";
+  });
+}
+
+async function expectDocumentPreserved(page: Page) {
+  await expect(page.locator("html")).toHaveAttribute(
+    "data-optimistic-navigation-document",
+    "preserved",
+  );
+}
+
+async function expectProvider(page: Page, provider: string | null) {
+  const expectedUrl = provider ? `${ROUTE}?provider=${provider}` : ROUTE;
+  await expect(page).toHaveURL(expectedUrl);
+  await expect(page.getByTestId("server-provider")).toHaveText(provider ?? "none");
+  await expect(page.getByTestId("navigation-pending")).toHaveText("false");
+  await expectDocumentPreserved(page);
+}
+
+test.describe("optimistic same-path search navigation", () => {
+  test("router.push commits the server response without useOptimistic", async ({ page }) => {
+    await page.goto(ROUTE);
+    await markDocument(page);
+
+    await page.getByTestId("router-only-control").click();
+
+    await expect(page).toHaveURL(`${ROUTE}?provider=control`);
+    await expect(page.getByTestId("server-provider")).toHaveText("control");
+    await expectDocumentPreserved(page);
+  });
+
+  test("commits a provider selected inside a useOptimistic transition", async ({ page }) => {
+    await page.goto(ROUTE);
+    await markDocument(page);
+
+    await page.getByTestId("provider-disney").click();
+
+    await expect(page.getByTestId("client-provider")).toHaveText("337");
+    await expectProvider(page, "337");
+  });
+
+  test("commits the final state when the active provider is toggled off", async ({ page }) => {
+    await page.goto(`${ROUTE}?provider=8`);
+    await expect(page.getByTestId("server-provider")).toHaveText("8");
+    await markDocument(page);
+
+    await page.getByTestId("provider-netflix").click();
+
+    await expect(page.getByTestId("client-provider")).toHaveText("none");
+    await expectProvider(page, null);
+  });
+
+  test("commits the last provider when transitions overlap", async ({ page }) => {
+    await page.goto(ROUTE);
+    await markDocument(page);
+
+    await page.getByTestId("provider-netflix").click();
+    await expect(page.getByTestId("client-provider")).toHaveText("8");
+    await page.getByTestId("provider-disney").click();
+
+    await expect(page.getByTestId("client-provider")).toHaveText("337");
+    await expectProvider(page, "337");
+  });
+
+  test("commits repeated provider changes in a deployed Worker", async ({ page }) => {
+    test.skip(!DEPLOYED_RUNTIME, "This race has only reproduced on a deployed Worker");
+    test.setTimeout(120_000);
+
+    await page.goto(ROUTE);
+    await markDocument(page);
+
+    for (let cycle = 0; cycle < 5; cycle += 1) {
+      for (const provider of providers) {
+        await page.getByTestId(`provider-${provider.name}`).click();
+        await expectProvider(page, provider.value);
+
+        await page.getByTestId(`provider-${provider.name}`).click();
+        await expectProvider(page, null);
+      }
+    }
+  });
+});


### PR DESCRIPTION
> **Draft: reproduction only.** This PR contains no Vinext fix. It adds a deployed-Workers regression target for #2865 so the navigation path can be investigated in the environment where it fails.

## Problem

A dynamic App Router page uses `useSearchParams()` as its committed state, mirrors the query with `useOptimistic()`, and calls `router.push()` inside the same transition. On a deployed Cloudflare Worker, a same-path provider change can receive a successful RSC response but never commit the new router state.

The visible result is intermittent: Netflix or Prime may select and clear normally, then Disney can remain stuck in its optimistic state. Removing the active provider can fail in the same way, leaving the filtered tree mounted at the old URL state.

This is the deployed-runtime follow-up to #2865. The same application and reduced interaction pass under `wrangler dev`, so a local preview is not a sufficient control for this bug.

## What was added

A production-shaped `/optimistic-search-navigation` fixture in `examples/app-router-cloudflare`:

- a dynamic server page that reads `searchParams.provider`
- a provider filter using `useSearchParams()`, `useOptimistic()`, `useTransition()`, and `router.push()`
- a streamed provider-specific result list behind `Suspense`
- a parallel modal slot matching the affected list route
- Netflix (`8`), Prime (`9`), and Disney (`337`) provider transitions

The Cloudflare Workers E2E covers:

- plain `router.push()` as a control
- selecting a provider inside the optimistic transition
- removing the only search parameter
- overlapping provider transitions
- document identity, proving each successful result is a soft navigation
- five deployed-only cycles across all three providers (30 commits total)

The deployed-example workflow now includes this spec, so an internal preview deployment exercises the race on `workers.dev` rather than Miniflare.

## Results on this branch

Local production Workers build:

```text
✓ router.push commits the server response without useOptimistic
✓ commits a provider selected inside a useOptimistic transition
✓ commits the final state when the active provider is toggled off
✓ commits the last provider when transitions overlap
- deployed-only provider cycle skipped

4 passed, 1 skipped
```

The selected-provider control also passed 40 fresh local browser runs on current `main`. The same reduced fixture passed locally on the `vinext@1.0.0-beta.6` tag. That is expected and preserves the important finding from the affected application: both beta.6 and current `main` pass under `wrangler dev`, while the beta.6 deployed Worker fails intermittently.

Run the local controls with:

```sh
cd examples/app-router-cloudflare
npx vp build
npx wrangler dev --config dist/server/wrangler.json --port 4176

PLAYWRIGHT_PROJECT=cloudflare-workers \
  npx playwright test tests/e2e/cloudflare-workers/optimistic-search-navigation.spec.ts
```

To run the deployed stress case, point Playwright at an HTTPS deployment:

```sh
PLAYWRIGHT_PROJECT=cloudflare-workers \
VINEXT_E2E_BASE_URL=https://<preview>-app-router-cloudflare.vinext.workers.dev \
  npx playwright test tests/e2e/cloudflare-workers/optimistic-search-navigation.spec.ts
```

Fork PRs do not receive the repository deploy secrets, so the deployed lane will remain skipped until a maintainer runs the branch with repository deployment access.

## Isolating the trigger

Captured on the affected deployment:

| interaction | result |
| --- | --- |
| direct `router.push()` | commits |
| outer transition plus ordinary state | commits |
| `useOptimistic()` plus `router.push()` | can remain pending |
| same navigation with Vinext synchronous visible commits forced | 20 consecutive Disney toggles committed |

During a failed navigation, the provider API and RSC request both completed with status 200. The client navigation promise remained unresolved and Vinext retained one active navigation snapshot. This points to the transition visible-commit path, not provider data or network failure.

## Where I think the gap is

`dispatchApprovedVisibleCommit()` resolves `pendingRouterState` and normally relies on React mounting the new `NavigationCommitSignal` to publish URL and scroll effects. The failed deployed sessions never settled that signal: the optimistic transition stayed pending and the navigation snapshot remained active. Forcing the existing synchronous visible-commit mode removed the failure in the affected app.

I have not attempted a fix here. The fixture and deployed stress lane are intended to give the maintainer a focused red/green target for that commit lifecycle.

## Validation

- `npx vp build` in `examples/app-router-cloudflare`
- targeted Cloudflare Workers E2E: 4 passed, 1 skipped
- selected-provider E2E repeated 40 times: 40 passed locally
- `npx vp check`
- full pre-commit checks and Knip

Tracks #2865. The issue should remain open until the deployed stress case is confirmed green with a fix.
