### PR TITLE
fix(app-router): settle optimistic search navigations

### DIFF
--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -168,7 +168,10 @@ jobs:
         env:
           PLAYWRIGHT_PROJECT: cloudflare-workers
           VINEXT_E2E_BASE_URL: ${{ github.event_name == 'pull_request' && format('https://pr-{0}-app-router-cloudflare.vinext.workers.dev', github.event.pull_request.number) || 'https://app-router-cloudflare.vinext.workers.dev' }}
-        run: vp exec playwright test tests/e2e/cloudflare-workers/web-worker.spec.ts
+        run: >-
+          vp exec playwright test
+          tests/e2e/cloudflare-workers/web-worker.spec.ts
+          tests/e2e/cloudflare-workers/optimistic-search-navigation.spec.ts
 
   comment:
     name: Comment Preview URLs

--- a/examples/app-router-cloudflare/app/optimistic-search-navigation/@modal/default.tsx
+++ b/examples/app-router-cloudflare/app/optimistic-search-navigation/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function ModalDefault() {
+  return null;
+}

--- a/examples/app-router-cloudflare/app/optimistic-search-navigation/layout.tsx
+++ b/examples/app-router-cloudflare/app/optimistic-search-navigation/layout.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from "react";
+
+export default function OptimisticSearchNavigationLayout({
+  children,
+  modal,
+}: {
+  children: ReactNode;
+  modal?: ReactNode;
+}) {
+  return (
+    <div data-testid="provider-list-layout">
+      {children}
+      {modal}
+    </div>
+  );
+}

--- a/examples/app-router-cloudflare/app/optimistic-search-navigation/page.tsx
+++ b/examples/app-router-cloudflare/app/optimistic-search-navigation/page.tsx
@@ -1,0 +1,52 @@
+import { Suspense } from "react";
+
+import { ProviderToggle, RouterOnlyControl } from "./provider-toggle";
+
+export const dynamic = "force-dynamic";
+
+export default async function OptimisticSearchNavigationPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ provider?: string }>;
+}) {
+  const provider = (await searchParams).provider ?? null;
+
+  return (
+    <main>
+      <h1>Optimistic search navigation</h1>
+      <p>
+        This reproduces a provider filter that optimistically updates before a same-path search
+        parameter navigation commits.
+      </p>
+      <ProviderToggle />
+      <RouterOnlyControl />
+      <Suspense fallback={<p data-testid="provider-results-loading">Loading results…</p>}>
+        <ProviderResults key={provider ?? "all"} provider={provider} />
+      </Suspense>
+    </main>
+  );
+}
+
+async function ProviderResults({ provider }: { provider: string | null }) {
+  // The reported route streams its filter shell before a slower provider-specific
+  // list. Keep that production timing characteristic in this self-contained fixture.
+  await new Promise((resolve) => setTimeout(resolve, provider ? 600 : 50));
+
+  const listPrefix = provider ?? "all";
+
+  return (
+    <section data-testid="provider-results">
+      <dl>
+        <dt>Server provider</dt>
+        <dd data-testid="server-provider">{provider ?? "none"}</dd>
+      </dl>
+      <ol>
+        {Array.from({ length: 3 }, (_, index) => (
+          <li key={index}>
+            {listPrefix} provider result {index + 1}
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/examples/app-router-cloudflare/app/optimistic-search-navigation/page.tsx
+++ b/examples/app-router-cloudflare/app/optimistic-search-navigation/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from "react";
+import { headers } from "next/headers";
 
 import { ProviderToggle, RouterOnlyControl } from "./provider-toggle";
 
@@ -10,6 +11,10 @@ export default async function OptimisticSearchNavigationPage({
   searchParams: Promise<{ provider?: string }>;
 }) {
   const provider = (await searchParams).provider ?? null;
+  const requestedResultCount = Number(
+    (await headers()).get("x-vinext-e2e-provider-result-count"),
+  );
+  const resultCount = requestedResultCount === 1_000 ? requestedResultCount : 3;
 
   return (
     <main>
@@ -21,13 +26,23 @@ export default async function OptimisticSearchNavigationPage({
       <ProviderToggle />
       <RouterOnlyControl />
       <Suspense fallback={<p data-testid="provider-results-loading">Loading results…</p>}>
-        <ProviderResults key={provider ?? "all"} provider={provider} />
+        <ProviderResults
+          key={`${provider ?? "all"}:${resultCount}`}
+          provider={provider}
+          resultCount={resultCount}
+        />
       </Suspense>
     </main>
   );
 }
 
-async function ProviderResults({ provider }: { provider: string | null }) {
+async function ProviderResults({
+  provider,
+  resultCount,
+}: {
+  provider: string | null;
+  resultCount: number;
+}) {
   // The reported route streams its filter shell before a slower provider-specific
   // list. Keep that production timing characteristic in this self-contained fixture.
   await new Promise((resolve) => setTimeout(resolve, provider ? 600 : 50));
@@ -41,7 +56,7 @@ async function ProviderResults({ provider }: { provider: string | null }) {
         <dd data-testid="server-provider">{provider ?? "none"}</dd>
       </dl>
       <ol>
-        {Array.from({ length: 3 }, (_, index) => (
+        {Array.from({ length: resultCount }, (_, index) => (
           <li key={index}>
             {listPrefix} provider result {index + 1}
           </li>

--- a/examples/app-router-cloudflare/app/optimistic-search-navigation/provider-toggle.tsx
+++ b/examples/app-router-cloudflare/app/optimistic-search-navigation/provider-toggle.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useLayoutEffect, useOptimistic, useRef, useTransition } from "react";
+
+const providers = [
+  { name: "netflix", value: "8" },
+  { name: "prime", value: "9" },
+  { name: "disney", value: "337" },
+] as const;
+
+function nextProviderQuery(currentQuery: string, provider: string) {
+  const params = new URLSearchParams(currentQuery);
+
+  if (params.get("provider") === provider) {
+    params.delete("provider");
+  } else {
+    params.set("provider", provider);
+  }
+
+  return params.toString();
+}
+
+export function ProviderToggle() {
+  const pathname = usePathname();
+  const router = useRouter();
+  const routeSearchParams = useSearchParams();
+  const [isPending, startTransition] = useTransition();
+  const [optimisticQuery, setOptimisticQuery] = useOptimistic(
+    routeSearchParams.toString(),
+    (_currentQuery, nextQuery: string) => nextQuery,
+  );
+  const optimisticQueryRef = useRef(optimisticQuery);
+
+  useLayoutEffect(() => {
+    optimisticQueryRef.current = optimisticQuery;
+  }, [optimisticQuery]);
+
+  const toggleProvider = useCallback(
+    (provider: string) => {
+      const query = nextProviderQuery(optimisticQueryRef.current, provider);
+
+      startTransition(() => {
+        setOptimisticQuery(query);
+        router.push(query ? `${pathname}?${query}` : pathname, { scroll: false });
+      });
+    },
+    [pathname, router, setOptimisticQuery],
+  );
+
+  const selectedProvider = new URLSearchParams(optimisticQuery).get("provider");
+
+  return (
+    <section aria-labelledby="optimistic-provider-heading">
+      <h2 id="optimistic-provider-heading">Optimistic provider filter</h2>
+      <div role="group" aria-label="Streaming provider">
+        {providers.map((provider) => (
+          <button
+            aria-pressed={selectedProvider === provider.value}
+            data-testid={`provider-${provider.name}`}
+            key={provider.value}
+            onClick={() => toggleProvider(provider.value)}
+            type="button"
+          >
+            {provider.name}
+          </button>
+        ))}
+      </div>
+      <dl>
+        <dt>Client provider</dt>
+        <dd data-testid="client-provider">{selectedProvider ?? "none"}</dd>
+        <dt>Navigation pending</dt>
+        <dd data-testid="navigation-pending">{String(isPending)}</dd>
+      </dl>
+    </section>
+  );
+}
+
+export function RouterOnlyControl() {
+  const pathname = usePathname();
+  const router = useRouter();
+
+  return (
+    <section aria-labelledby="router-control-heading">
+      <h2 id="router-control-heading">Router-only control</h2>
+      <button
+        data-testid="router-only-control"
+        onClick={() => router.push(`${pathname}?provider=control`, { scroll: false })}
+        type="button"
+      >
+        Select control provider
+      </button>
+    </section>
+  );
+}

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -88,7 +88,7 @@ import {
   type PendingBrowserRouterState,
 } from "./app-browser-navigation-controller.js";
 import { AppBrowserMpaNavigationScheduler } from "./app-browser-mpa-navigation.js";
-import { shouldWaitForSamePathSearchNavigationResponse } from "./app-browser-navigation-response.js";
+import { shouldRecoverSamePathSearchCommitOnResponseCompletion } from "./app-browser-navigation-response.js";
 import {
   resolveManifestNavigationInterceptionContext,
   resolveMiddlewareRewriteNavigationInterceptionContext,
@@ -618,6 +618,7 @@ type RenderNavigationPayloadOptions = {
   historyUpdateMode: HistoryUpdateMode | undefined;
   navigationCommitKind?: "authoritative" | "detached";
   navigationInitiationState: AppRouterState;
+  navigationResponseCompletion?: Promise<unknown>;
   navigationSnapshot: ClientNavigationRenderSnapshot;
   navId: number;
   onCommittedState?: (state: AppRouterState) => void;
@@ -645,6 +646,7 @@ async function renderNavigationPayload(
     historyUpdateMode: options.historyUpdateMode,
     navigationCommitKind: options.navigationCommitKind,
     navigationInitiationState: options.navigationInitiationState,
+    navigationResponseCompletion: options.navigationResponseCompletion,
     navigationSnapshot: options.navigationSnapshot,
     navId: options.navId,
     nextElements: options.payload,
@@ -2256,26 +2258,6 @@ function bootstrapHydration(
         const cacheBufferPromise = new Response(cacheBranch).arrayBuffer();
         void cacheBufferPromise.catch(() => {});
 
-        // A same-path useRouter transition retains the client subtree that may
-        // own an optimistic update. Resolving its router-state promise from the
-        // first Flight model while later chunks are still arriving can leave
-        // that render entangled with the optimistic transition indefinitely.
-        // Next's uncached navigation path waits for fetchServerResponse before
-        // resolving the router action, retaining the old content in the
-        // meantime. Consume the cache branch to the same completion boundary;
-        // React's tee is then fully buffered when createFromFetch starts below.
-        if (
-          shouldWaitForSamePathSearchNavigationResponse({
-            basePath: __basePath,
-            currentSnapshot: navigationInitiationState.navigationSnapshot,
-            navigationKind,
-            programmaticTransition,
-            targetUrl: url,
-          })
-        ) {
-          await cacheBufferPromise;
-        }
-
         if (!browserNavigationController.isCurrentNavigation(navId)) return;
 
         if (prefetchedElements) {
@@ -2296,6 +2278,15 @@ function bootstrapHydration(
           navigationCommitKind: detachedNavigationCommits ? "authoritative" : undefined,
           navigationInitiationState,
           navigationSnapshot,
+          navigationResponseCompletion: shouldRecoverSamePathSearchCommitOnResponseCompletion({
+            basePath: __basePath,
+            currentSnapshot: navigationInitiationState.navigationSnapshot,
+            navigationKind,
+            programmaticTransition,
+            targetUrl: url,
+          })
+            ? cacheBufferPromise
+            : undefined,
           navId,
           onCommittedState: (state) => {
             committedState = state;

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -88,6 +88,7 @@ import {
   type PendingBrowserRouterState,
 } from "./app-browser-navigation-controller.js";
 import { AppBrowserMpaNavigationScheduler } from "./app-browser-mpa-navigation.js";
+import { shouldWaitForSamePathSearchNavigationResponse } from "./app-browser-navigation-response.js";
 import {
   resolveManifestNavigationInterceptionContext,
   resolveMiddlewareRewriteNavigationInterceptionContext,
@@ -2254,6 +2255,26 @@ function bootstrapHydration(
         );
         const cacheBufferPromise = new Response(cacheBranch).arrayBuffer();
         void cacheBufferPromise.catch(() => {});
+
+        // A same-path useRouter transition retains the client subtree that may
+        // own an optimistic update. Resolving its router-state promise from the
+        // first Flight model while later chunks are still arriving can leave
+        // that render entangled with the optimistic transition indefinitely.
+        // Next's uncached navigation path waits for fetchServerResponse before
+        // resolving the router action, retaining the old content in the
+        // meantime. Consume the cache branch to the same completion boundary;
+        // React's tee is then fully buffered when createFromFetch starts below.
+        if (
+          shouldWaitForSamePathSearchNavigationResponse({
+            basePath: __basePath,
+            currentSnapshot: navigationInitiationState.navigationSnapshot,
+            navigationKind,
+            programmaticTransition,
+            targetUrl: url,
+          })
+        ) {
+          await cacheBufferPromise;
+        }
 
         if (!browserNavigationController.isCurrentNavigation(navId)) return;
 

--- a/packages/vinext/src/server/app-browser-navigation-controller.ts
+++ b/packages/vinext/src/server/app-browser-navigation-controller.ts
@@ -99,6 +99,7 @@ type BrowserNavigationPayloadOptions = {
   historyUpdateMode: HistoryUpdateMode | undefined;
   navigationCommitKind?: "authoritative" | "detached";
   navigationInitiationState: AppRouterState;
+  navigationResponseCompletion?: Promise<unknown>;
   navigationSnapshot: ClientNavigationRenderSnapshot;
   navId: number;
   nextElements: Promise<AppElements> | AppElements;
@@ -159,6 +160,7 @@ type BrowserNavigationController = {
    * navigation would otherwise be lost.
    */
   drainPrePaintEffects(renderId: number): void;
+  commitNavigationRender(renderId: number): void;
   clearCommittedNavigationFailureTargets(renderId: number): void;
   NavigationCommitSignal(
     this: void,
@@ -484,6 +486,11 @@ export function createAppBrowserNavigationController(
     }
   }
 
+  function commitNavigationRender(renderId: number): void {
+    drainPrePaintEffects(renderId);
+    settleNavigationCommits(renderId, true);
+  }
+
   function clearCommittedNavigationFailureTargets(renderId: number): void {
     for (const [pendingId, targetHref] of pendingNavigationFailureTargets) {
       if (pendingId > renderId) {
@@ -551,8 +558,7 @@ export function createAppBrowserNavigationController(
     }, [renderId]);
 
     useLayoutEffect(() => {
-      drainPrePaintEffects(renderId);
-      settleNavigationCommits(renderId, true);
+      commitNavigationRender(renderId);
 
       return () => {
         // Settle pending renders without publishing their candidate state when
@@ -857,6 +863,25 @@ export function createAppBrowserNavigationController(
           ? "synchronous"
           : (options.visibleCommitMode ?? "transition"),
       );
+      if (options.navigationResponseCompletion) {
+        // Keep the live Flight branch streaming. If React commits it normally,
+        // NavigationCommitSignal removes this render from the pending map
+        // before the cache tee reaches EOF. A retained optimistic subtree can
+        // otherwise leave the fully received candidate uncommitted; publish it
+        // synchronously only as that terminal recovery path.
+        void options.navigationResponseCompletion.then(
+          () => {
+            if (!isCurrentNavigation(options.navId) || !hasBrowserRouterState()) return;
+            const pendingCommit = pendingNavigationCommits.get(renderId);
+            const committedState = pendingCommit?.committedState;
+            if (!committedState) return;
+            flushSync(() => {
+              getBrowserRouterStateSetter()(committedState);
+            });
+          },
+          () => {},
+        );
+      }
     } catch (error) {
       pendingNavigationFailureTargets.delete(renderId);
       pendingNavigationPrePaintEffects.delete(renderId);
@@ -998,6 +1023,7 @@ export function createAppBrowserNavigationController(
     commitSameUrlNavigatePayload,
     hmrReplaceTree,
     drainPrePaintEffects,
+    commitNavigationRender,
     clearCommittedNavigationFailureTargets,
     NavigationCommitSignal,
   };

--- a/packages/vinext/src/server/app-browser-navigation-response.ts
+++ b/packages/vinext/src/server/app-browser-navigation-response.ts
@@ -1,7 +1,7 @@
 import type { ClientNavigationRenderSnapshot } from "vinext/shims/navigation";
 import { stripBasePath } from "../utils/base-path.js";
 
-export function shouldWaitForSamePathSearchNavigationResponse(options: {
+export function shouldRecoverSamePathSearchCommitOnResponseCompletion(options: {
   basePath: string;
   currentSnapshot: ClientNavigationRenderSnapshot;
   navigationKind: "navigate" | "traverse" | "refresh";

--- a/packages/vinext/src/server/app-browser-navigation-response.ts
+++ b/packages/vinext/src/server/app-browser-navigation-response.ts
@@ -1,0 +1,20 @@
+import type { ClientNavigationRenderSnapshot } from "vinext/shims/navigation";
+import { stripBasePath } from "../utils/base-path.js";
+
+export function shouldWaitForSamePathSearchNavigationResponse(options: {
+  basePath: string;
+  currentSnapshot: ClientNavigationRenderSnapshot;
+  navigationKind: "navigate" | "traverse" | "refresh";
+  programmaticTransition: boolean;
+  targetUrl: URL;
+}): boolean {
+  if (!options.programmaticTransition || options.navigationKind !== "navigate") {
+    return false;
+  }
+
+  return (
+    options.currentSnapshot.pathname ===
+      stripBasePath(options.targetUrl.pathname, options.basePath) &&
+    options.currentSnapshot.search !== options.targetUrl.search
+  );
+}

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -32,6 +32,7 @@ import {
   hydrateRootInTransition,
 } from "../packages/vinext/src/server/app-browser-hydration.js";
 import { createAppBrowserNavigationController } from "../packages/vinext/src/server/app-browser-navigation-controller.js";
+import { shouldWaitForSamePathSearchNavigationResponse } from "../packages/vinext/src/server/app-browser-navigation-response.js";
 import {
   peekSettledPrefetchResponseForNavigation,
   preserveCommittedPrefetchExpiry,
@@ -839,6 +840,35 @@ describe("app browser entry inline CSS cleanup", () => {
 });
 
 describe("app browser entry navigation scheduling", () => {
+  it("waits for same-path programmatic search responses without broadening other navigation modes", () => {
+    const currentSnapshot = {
+      ...createClientNavigationRenderSnapshot("https://example.com/base/products?provider=8", {}),
+      pathname: "/products",
+    };
+    const classify = (overrides: {
+      navigationKind?: "navigate" | "traverse" | "refresh";
+      programmaticTransition?: boolean;
+      target?: string;
+    }) =>
+      shouldWaitForSamePathSearchNavigationResponse({
+        basePath: "/base",
+        currentSnapshot,
+        navigationKind: overrides.navigationKind ?? "navigate",
+        programmaticTransition: overrides.programmaticTransition ?? true,
+        targetUrl: new URL(overrides.target ?? "https://example.com/base/products?provider=9"),
+      });
+
+    expect(classify({})).toBe(true);
+    expect(classify({ target: "https://example.com/base/products" })).toBe(true);
+    expect(classify({ programmaticTransition: false })).toBe(false);
+    expect(classify({ navigationKind: "traverse" })).toBe(false);
+    expect(classify({ navigationKind: "refresh" })).toBe(false);
+    expect(classify({ target: "https://example.com/base/details?provider=9" })).toBe(false);
+    expect(classify({ target: "https://example.com/base/products?provider=8#reviews" })).toBe(
+      false,
+    );
+  });
+
   it("peeks at a settled prefetch without transferring ownership before reuse planning", () => {
     const snapshot = {
       buffer: new ArrayBuffer(0),

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -32,7 +32,7 @@ import {
   hydrateRootInTransition,
 } from "../packages/vinext/src/server/app-browser-hydration.js";
 import { createAppBrowserNavigationController } from "../packages/vinext/src/server/app-browser-navigation-controller.js";
-import { shouldWaitForSamePathSearchNavigationResponse } from "../packages/vinext/src/server/app-browser-navigation-response.js";
+import { shouldRecoverSamePathSearchCommitOnResponseCompletion } from "../packages/vinext/src/server/app-browser-navigation-response.js";
 import {
   peekSettledPrefetchResponseForNavigation,
   preserveCommittedPrefetchExpiry,
@@ -840,7 +840,7 @@ describe("app browser entry inline CSS cleanup", () => {
 });
 
 describe("app browser entry navigation scheduling", () => {
-  it("waits for same-path programmatic search responses without broadening other navigation modes", () => {
+  it("recovers completed same-path search responses without broadening other modes", () => {
     const currentSnapshot = {
       ...createClientNavigationRenderSnapshot("https://example.com/base/products?provider=8", {}),
       pathname: "/products",
@@ -850,7 +850,7 @@ describe("app browser entry navigation scheduling", () => {
       programmaticTransition?: boolean;
       target?: string;
     }) =>
-      shouldWaitForSamePathSearchNavigationResponse({
+      shouldRecoverSamePathSearchCommitOnResponseCompletion({
         basePath: "/base",
         currentSnapshot,
         navigationKind: overrides.navigationKind ?? "navigate",
@@ -3534,6 +3534,181 @@ describe("app browser navigation controller", () => {
     } finally {
       detach();
     }
+  });
+
+  it("recovers an uncommitted navigation after its streamed response completes", async () => {
+    const { controller, detach, setBrowserRouterState, stateRef } = createControllerHarness();
+    const pendingRouterState = controller.beginPendingBrowserRouterState();
+    const commitEffect = vi.fn();
+    let resolveResponse!: () => void;
+    const navigationResponseCompletion = new Promise<void>((resolve) => {
+      resolveResponse = resolve;
+    });
+
+    try {
+      const renderPromise = renderCurrentStateNavigationPayload(controller, {
+        actionType: "navigate",
+        createNavigationCommitEffect: () => commitEffect,
+        historyUpdateMode: "push",
+        navigationResponseCompletion,
+        navigationSnapshot: createClientNavigationRenderSnapshot(
+          "https://example.com/dashboard?provider=8",
+          {},
+        ),
+        nextElements: Promise.resolve(
+          createResolvedElements("route:/dashboard", "/", null, {
+            "page:/dashboard": React.createElement("main", null, "dashboard"),
+          }),
+        ),
+        operationLane: "navigation",
+        params: {},
+        payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
+        pendingRouterState,
+        previousNextUrl: null,
+        targetHref: "https://example.com/dashboard?provider=8",
+        navId: controller.beginNavigation(),
+      });
+
+      await expect(pendingRouterState.promise).resolves.toMatchObject({ renderId: 1 });
+      expect(setBrowserRouterState).toHaveBeenCalledTimes(1);
+
+      resolveResponse();
+      await Promise.resolve();
+
+      expect(setBrowserRouterState).toHaveBeenCalledTimes(2);
+      expect(setBrowserRouterState).toHaveBeenLastCalledWith(stateRef.current);
+      expect(stateRef.current.renderId).toBe(1);
+
+      controller.commitNavigationRender(1);
+      await expect(renderPromise).resolves.toBe("committed");
+      expect(commitEffect).toHaveBeenCalledTimes(1);
+      expect(setBrowserRouterState).toHaveBeenCalledTimes(2);
+    } finally {
+      detach();
+    }
+  });
+
+  it("suppresses response-completion recovery after the render already committed", async () => {
+    const { controller, detach, setBrowserRouterState } = createControllerHarness();
+    const pendingRouterState = controller.beginPendingBrowserRouterState();
+    const commitEffect = vi.fn();
+    let resolveResponse!: () => void;
+    const navigationResponseCompletion = new Promise<void>((resolve) => {
+      resolveResponse = resolve;
+    });
+
+    try {
+      const renderPromise = renderCurrentStateNavigationPayload(controller, {
+        actionType: "navigate",
+        createNavigationCommitEffect: () => commitEffect,
+        historyUpdateMode: "push",
+        navigationResponseCompletion,
+        navigationSnapshot: createClientNavigationRenderSnapshot(
+          "https://example.com/dashboard?provider=8",
+          {},
+        ),
+        nextElements: Promise.resolve(
+          createResolvedElements("route:/dashboard", "/", null, {
+            "page:/dashboard": React.createElement("main", null, "dashboard"),
+          }),
+        ),
+        operationLane: "navigation",
+        params: {},
+        payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
+        pendingRouterState,
+        previousNextUrl: null,
+        targetHref: "https://example.com/dashboard?provider=8",
+        navId: controller.beginNavigation(),
+      });
+
+      await expect(pendingRouterState.promise).resolves.toBeDefined();
+      controller.commitNavigationRender(1);
+      await expect(renderPromise).resolves.toBe("committed");
+      resolveResponse();
+      await Promise.resolve();
+
+      expect(commitEffect).toHaveBeenCalledTimes(1);
+      expect(setBrowserRouterState).toHaveBeenCalledTimes(1);
+    } finally {
+      detach();
+    }
+  });
+
+  it("does not recover a completed response after a newer navigation starts", async () => {
+    const { controller, detach, setBrowserRouterState, stateRef } = createControllerHarness();
+    const pendingRouterState = controller.beginPendingBrowserRouterState();
+    let resolveResponse!: () => void;
+    const navigationResponseCompletion = new Promise<void>((resolve) => {
+      resolveResponse = resolve;
+    });
+    const navId = controller.beginNavigation();
+
+    try {
+      void renderCurrentStateNavigationPayload(controller, {
+        actionType: "navigate",
+        createNavigationCommitEffect: () => () => {},
+        historyUpdateMode: "push",
+        navigationResponseCompletion,
+        navigationSnapshot: stateRef.current.navigationSnapshot,
+        nextElements: Promise.resolve(
+          createResolvedElements("route:/dashboard", "/", null, {
+            "page:/dashboard": React.createElement("main", null, "dashboard"),
+          }),
+        ),
+        operationLane: "navigation",
+        params: {},
+        payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
+        pendingRouterState,
+        previousNextUrl: null,
+        targetHref: "https://example.com/dashboard?provider=8",
+        navId,
+      });
+
+      await expect(pendingRouterState.promise).resolves.toBeDefined();
+      controller.beginNavigation();
+      resolveResponse();
+      await Promise.resolve();
+
+      expect(setBrowserRouterState).toHaveBeenCalledTimes(1);
+    } finally {
+      detach();
+    }
+  });
+
+  it("does not recover a completed response after the browser root detaches", async () => {
+    const { controller, detach, setBrowserRouterState, stateRef } = createControllerHarness();
+    const pendingRouterState = controller.beginPendingBrowserRouterState();
+    let resolveResponse!: () => void;
+    const navigationResponseCompletion = new Promise<void>((resolve) => {
+      resolveResponse = resolve;
+    });
+
+    void renderCurrentStateNavigationPayload(controller, {
+      actionType: "navigate",
+      createNavigationCommitEffect: () => () => {},
+      historyUpdateMode: "push",
+      navigationResponseCompletion,
+      navigationSnapshot: stateRef.current.navigationSnapshot,
+      nextElements: Promise.resolve(
+        createResolvedElements("route:/dashboard", "/", null, {
+          "page:/dashboard": React.createElement("main", null, "dashboard"),
+        }),
+      ),
+      operationLane: "navigation",
+      params: {},
+      payloadOrigin: FRESH_APP_NAVIGATION_PAYLOAD_ORIGIN,
+      pendingRouterState,
+      previousNextUrl: null,
+      targetHref: "https://example.com/dashboard?provider=8",
+      navId: controller.beginNavigation(),
+    });
+
+    await expect(pendingRouterState.promise).resolves.toBeDefined();
+    detach();
+    resolveResponse();
+    await Promise.resolve();
+
+    expect(setBrowserRouterState).toHaveBeenCalledTimes(1);
   });
 
   it("hard-navigates cache-restored payloads missing cache-entry proof metadata", async () => {

--- a/tests/e2e/cloudflare-workers/optimistic-search-navigation.spec.ts
+++ b/tests/e2e/cloudflare-workers/optimistic-search-navigation.spec.ts
@@ -1,0 +1,95 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const ROUTE = "/optimistic-search-navigation";
+const DEPLOYED_RUNTIME = process.env.VINEXT_E2E_BASE_URL?.startsWith("https://") ?? false;
+
+const providers = [
+  { name: "netflix", value: "8" },
+  { name: "prime", value: "9" },
+  { name: "disney", value: "337" },
+] as const;
+
+async function markDocument(page: Page) {
+  await page.locator("html").evaluate((element) => {
+    element.dataset.optimisticNavigationDocument = "preserved";
+  });
+}
+
+async function expectDocumentPreserved(page: Page) {
+  await expect(page.locator("html")).toHaveAttribute(
+    "data-optimistic-navigation-document",
+    "preserved",
+  );
+}
+
+async function expectProvider(page: Page, provider: string | null) {
+  const expectedUrl = provider ? `${ROUTE}?provider=${provider}` : ROUTE;
+  await expect(page).toHaveURL(expectedUrl);
+  await expect(page.getByTestId("server-provider")).toHaveText(provider ?? "none");
+  await expect(page.getByTestId("navigation-pending")).toHaveText("false");
+  await expectDocumentPreserved(page);
+}
+
+test.describe("optimistic same-path search navigation", () => {
+  test("router.push commits the server response without useOptimistic", async ({ page }) => {
+    await page.goto(ROUTE);
+    await markDocument(page);
+
+    await page.getByTestId("router-only-control").click();
+
+    await expect(page).toHaveURL(`${ROUTE}?provider=control`);
+    await expect(page.getByTestId("server-provider")).toHaveText("control");
+    await expectDocumentPreserved(page);
+  });
+
+  test("commits a provider selected inside a useOptimistic transition", async ({ page }) => {
+    await page.goto(ROUTE);
+    await markDocument(page);
+
+    await page.getByTestId("provider-disney").click();
+
+    await expect(page.getByTestId("client-provider")).toHaveText("337");
+    await expectProvider(page, "337");
+  });
+
+  test("commits the final state when the active provider is toggled off", async ({ page }) => {
+    await page.goto(`${ROUTE}?provider=8`);
+    await expect(page.getByTestId("server-provider")).toHaveText("8");
+    await markDocument(page);
+
+    await page.getByTestId("provider-netflix").click();
+
+    await expect(page.getByTestId("client-provider")).toHaveText("none");
+    await expectProvider(page, null);
+  });
+
+  test("commits the last provider when transitions overlap", async ({ page }) => {
+    await page.goto(ROUTE);
+    await markDocument(page);
+
+    await page.getByTestId("provider-netflix").click();
+    await expect(page.getByTestId("client-provider")).toHaveText("8");
+    await page.getByTestId("provider-disney").click();
+
+    await expect(page.getByTestId("client-provider")).toHaveText("337");
+    await expectProvider(page, "337");
+  });
+
+  test("commits repeated provider changes in a deployed Worker", async ({ page }) => {
+    test.skip(!DEPLOYED_RUNTIME, "This race has only reproduced on a deployed Worker");
+    test.setTimeout(120_000);
+
+    await page.goto(ROUTE);
+    await markDocument(page);
+
+    for (let cycle = 0; cycle < 5; cycle += 1) {
+      for (const provider of providers) {
+        await page.getByTestId(`provider-${provider.name}`).click();
+        await expectProvider(page, provider.value);
+
+        await page.getByTestId(`provider-${provider.name}`).click();
+        await expectProvider(page, null);
+      }
+    }
+  });
+});

--- a/tests/e2e/cloudflare-workers/optimistic-search-navigation.spec.ts
+++ b/tests/e2e/cloudflare-workers/optimistic-search-navigation.spec.ts
@@ -22,6 +22,18 @@ async function expectDocumentPreserved(page: Page) {
   );
 }
 
+async function trackProviderResultsFallback(page: Page) {
+  await page.evaluate(() => {
+    const recordFallback = () => {
+      if (document.querySelector('[data-testid="provider-results-loading"]')) {
+        document.documentElement.dataset.optimisticNavigationFallback = "shown";
+      }
+    };
+    recordFallback();
+    new MutationObserver(recordFallback).observe(document.body, { childList: true, subtree: true });
+  });
+}
+
 async function expectProvider(page: Page, provider: string | null) {
   const expectedUrl = provider ? `${ROUTE}?provider=${provider}` : ROUTE;
   await expect(page).toHaveURL(expectedUrl);
@@ -110,6 +122,16 @@ test.describe("optimistic same-path search navigation", () => {
 
     await page.goto(ROUTE);
     await markDocument(page);
+    await trackProviderResultsFallback(page);
+    const initialHistoryLength = await page.evaluate(() => window.history.length);
+
+    await page.getByTestId("provider-netflix").click();
+    await expect(page.getByTestId("client-provider")).toHaveText("8");
+    await expect(page.getByTestId("server-provider")).toHaveText("none");
+    await expect(page.getByTestId("navigation-pending")).toHaveText("true");
+    await expectProvider(page, "8");
+    await page.getByTestId("provider-netflix").click();
+    await expectProvider(page, null);
 
     for (let cycle = 0; cycle < 5; cycle += 1) {
       for (const provider of providers) {
@@ -120,5 +142,11 @@ test.describe("optimistic same-path search navigation", () => {
         await expectProvider(page, null);
       }
     }
+
+    await expect(page.locator("html")).not.toHaveAttribute(
+      "data-optimistic-navigation-fallback",
+      "shown",
+    );
+    expect(await page.evaluate(() => window.history.length)).toBe(initialHistoryLength + 32);
   });
 });

--- a/tests/e2e/cloudflare-workers/optimistic-search-navigation.spec.ts
+++ b/tests/e2e/cloudflare-workers/optimistic-search-navigation.spec.ts
@@ -92,4 +92,33 @@ test.describe("optimistic same-path search navigation", () => {
       }
     }
   });
+
+  test("commits a large streamed tree under constrained scheduling", async ({ page }) => {
+    test.setTimeout(120_000);
+
+    await page.setExtraHTTPHeaders({ "x-vinext-e2e-provider-result-count": "1000" });
+    const cdp = await page.context().newCDPSession(page);
+    await cdp.send("Network.enable");
+    await cdp.send("Network.emulateNetworkConditions", {
+      connectionType: "cellular3g",
+      downloadThroughput: 256 * 1024,
+      latency: 150,
+      offline: false,
+      uploadThroughput: 256 * 1024,
+    });
+    await cdp.send("Emulation.setCPUThrottlingRate", { rate: 4 });
+
+    await page.goto(ROUTE);
+    await markDocument(page);
+
+    for (let cycle = 0; cycle < 5; cycle += 1) {
+      for (const provider of providers) {
+        await page.getByTestId(`provider-${provider.name}`).click();
+        await expectProvider(page, provider.value);
+
+        await page.getByTestId(`provider-${provider.name}`).click();
+        await expectProvider(page, null);
+      }
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- carry forward the deployed-Workers reproduction from #2948
- add a deterministic local production-Worker stress case for the same stuck optimistic transition
- keep Flight decoding streaming from the first response bytes
- recover only a still-uncommitted programmatic same-path search navigation when its complete response is available
- leave links, traversals, refreshes, different-path navigations, and unchanged-search/hash navigations on their existing paths

## Root cause

Vinext resolves the deferred browser-router state as soon as the first Flight model decodes, while nested chunks for the retained same-route tree can still be arriving. When that retained client subtree owns a `useOptimistic()` update in the same transition, React can render the approved router state but leave that concurrent render uncommitted indefinitely. URL publication, snapshot release, and `useTransition()` settlement are commit-gated, so all three remain stuck even though the RSC request and router-state promise have resolved.

The fix starts `createFromFetch()` immediately, preserving progressive Flight decoding and the existing streamed render. For the narrow programmatic same-path search case, it also observes completion of the already-existing cache tee. If the normal React commit has not removed that render from the pending-commit map by response completion, and the navigation is still current with an attached browser root, it synchronously republishes the fully received candidate as a terminal recovery. Normal commits suppress recovery; stale navigations and detached roots cannot recover; the existing commit signal remains responsible for history, scroll, and settlement exactly once.

## Next.js parity

An equivalent Next.js 16.2.7 production app with the same 1,000-row streamed response and the same CDP CPU/network constraints completed 3/3 five-cycle runs. It retained the old provider content while pending and committed the URL and new content together without showing the Suspense fallback.

The lifecycle matches the current Next.js action queue and uncached Segment Cache path:

- [`use-action-queue.ts`](https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/packages/next/src/client/components/use-action-queue.ts) resolves the deferred router action with the completed navigation state.
- [`segment-cache/navigation.ts`](https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/packages/next/src/client/components/segment-cache/navigation.ts) awaits `fetchServerResponse()` for an uncached navigation before constructing that state.
- [`app-router.tsx`](https://github.com/vercel/next.js/blob/ee6e79b1792a4d401ddf2480f40a83549fe8e722/packages/next/src/client/components/app-router.tsx) publishes history from the committed state in an insertion effect.

## Validation

Baseline on the reproduction commit:

- constrained large streamed tree: 3/3 failed
- large tree without constraints: 3/3 passed
- CPU constraints only: 3/3 passed
- network constraints only: 3/3 passed
- original local controls: 4/4 passed

Fixed head `ea796ebe8`:

- hardened constrained Worker stress: 3/3 passed
- each stress run completed 32 pushes with exact history growth
- old content remained visible while pending, with no Suspense fallback flash
- original four Worker controls: 4/4 passed
- `vp test run tests/app-browser-entry.test.ts`: 241/241 passed
- focused `vp check`: passed
- `vp run vinext#build`: passed
- independent exact-head review: no actionable findings

## Status

Ready for review on `ea796ebe8f72fac426522711bed9087c20815e79`:

- all 70 exact-head checks green
- [Big Bonk](https://github.com/cloudflare/vinext/actions/runs/32031482495): LGTM, no actionable defects
- [Next.js deploy suite](https://github.com/cloudflare/vinext/actions/runs/32031865120): 2,680 passed / 124 failed / 631 skipped
- matching baseline: 2,678 passed / 126 failed / 631 skipped; zero new failure identities and two resolved

Refs #2865. Supersedes the reproduction-only #2948.
