### PR TITLE
refactor(plugins): share common Vite plugin utilities

### DIFF
--- a/packages/vinext/src/build/clean-output.ts
+++ b/packages/vinext/src/build/clean-output.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "pathslash";
+import { isPathInsideOrEqual } from "../utils/path.js";
 
 type CleanBuildOutputOptions = {
   root: string;
@@ -16,11 +17,6 @@ function resolveOutDir(root: string, outDir: string | undefined): string {
   const resolvedRoot = path.resolve(root);
   if (!outDir) return path.join(resolvedRoot, "dist");
   return path.isAbsolute(outDir) ? outDir : path.resolve(resolvedRoot, outDir);
-}
-
-function isPathInsideOrEqual(parent: string, child: string): boolean {
-  const relative = path.relative(parent, child);
-  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
 }
 
 function shouldCleanBuildOutput(options: CleanBuildOutputOptions): boolean {

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -275,7 +275,7 @@ import { getPagesPreviewModeId } from "./server/pages-preview.js";
 import commonjs from "vite-plugin-commonjs";
 import { createIgnoreDynamicRequestsPlugin } from "./plugins/ignore-dynamic-requests.js";
 import { createTransformCache } from "./plugins/transform-cache.js";
-import { stripJsExtension, stripViteModuleQuery } from "./utils/path.js";
+import { isPathInside, stripJsExtension, stripViteModuleQuery } from "./utils/path.js";
 import {
   assertSupportedViteVersion,
   getDepOptimizeNodeEnvOptions,
@@ -316,11 +316,6 @@ const ANSI_ESCAPE_RE = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g");
 installSocketErrorBackstop();
 
 type ASTNode = ReturnType<typeof parseAst>["body"][number]["parent"];
-
-function isInsideDirectory(dir: string, filePath: string): boolean {
-  const relativePath = path.relative(dir, filePath);
-  return relativePath !== "" && !relativePath.startsWith("..") && !path.isAbsolute(relativePath);
-}
 
 function hasServerOnlyMarkerImport(code: string): boolean {
   if (!code.includes("server-only")) return false;
@@ -1911,7 +1906,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           // symlinks resolve these files outside node_modules, so skip them
           // explicitly instead of parsing the whole runtime again as possible
           // JSX on every cold request.
-          if (isInsideDirectory(__dirname, cleanId)) return;
+          if (isPathInside(__dirname, cleanId)) return;
 
           // Inside node_modules, restrict the JSX transform to files that carry
           // a React directive. `@vitejs/plugin-rsc` only parses such modules

--- a/packages/vinext/src/plugins/ast-utils.ts
+++ b/packages/vinext/src/plugins/ast-utils.ts
@@ -10,6 +10,20 @@ export type AstRange = AstRecord & {
   end: number;
 };
 
+export type ScriptParserLanguage = "js" | "jsx" | "ts" | "tsx";
+
+const SCRIPT_MODULE_EXTENSION_RE = /^\.(?:[cm]?[jt]s|[jt]sx)$/i;
+export const SCRIPT_MODULE_ID_RE = /\.(?:[cm]?[jt]s|[jt]sx)(?:[?#].*)?$/i;
+const TRANSPARENT_EXPRESSION_TYPES = new Set([
+  "ChainExpression",
+  "ParenthesizedExpression",
+  "TSAsExpression",
+  "TSInstantiationExpression",
+  "TSNonNullExpression",
+  "TSSatisfiesExpression",
+  "TSTypeAssertion",
+]);
+
 /**
  * Cheap pre-parse gate for plugins that only transform *dynamic* `import(...)`.
  *
@@ -38,6 +52,25 @@ export const DYNAMIC_IMPORT_PRESCAN = /\bimport\s*[(/]/;
  */
 export function mayContainDynamicImport(code: string): boolean {
   return DYNAMIC_IMPORT_PRESCAN.test(code);
+}
+
+/**
+ * Select the OXC parser mode for a JavaScript/TypeScript module id.
+ *
+ * JavaScript-family files intentionally use the JSX parser. Next.js accepts
+ * JSX in `.js` files, and every caller using this helper runs before JSX has
+ * necessarily been lowered.
+ */
+export function scriptParserLanguage(id: string): ScriptParserLanguage | null {
+  const cleanId = id.split(/[?#]/, 1)[0];
+  const extensionIndex = cleanId.lastIndexOf(".");
+  if (extensionIndex === -1) return null;
+
+  const extension = cleanId.slice(extensionIndex).toLowerCase();
+  if (!SCRIPT_MODULE_EXTENSION_RE.test(extension)) return null;
+  if (extension === ".ts" || extension === ".mts" || extension === ".cts") return "ts";
+  if (extension === ".tsx") return "tsx";
+  return "jsx";
 }
 
 const SKIP_CHILD_KEYS = new Set(["type", "parent", "loc", "start", "end"]);
@@ -75,6 +108,56 @@ export function getAstName(value: unknown): string | null {
   return null;
 }
 
+/** Remove syntax-only wrappers while preserving the underlying expression. */
+export function unwrapExpression(value: unknown): AstRecord | null {
+  const node = toAstRecord(value);
+  if (!node || !TRANSPARENT_EXPRESSION_TYPES.has(node.type)) return node;
+  return unwrapExpression(node.expression);
+}
+
+/** Return the value of a string literal node, without evaluating expressions. */
+export function stringLiteralValue(value: unknown): string | null {
+  const node = toAstRecord(value);
+  if (
+    (node?.type === "Literal" || node?.type === "StringLiteral") &&
+    typeof node.value === "string"
+  ) {
+    return node.value;
+  }
+  return null;
+}
+
+/** Return the value of a boolean literal node, without evaluating expressions. */
+export function booleanLiteralValue(value: unknown): boolean | null {
+  const node = toAstRecord(value);
+  return node?.type === "Literal" && typeof node.value === "boolean" ? node.value : null;
+}
+
+/**
+ * Return a statically known string literal, including an interpolation-free
+ * template literal. This deliberately does not fold concatenations or other
+ * expressions.
+ */
+export function staticStringValue(value: unknown): string | null {
+  const node = toAstRecord(value);
+  if (!node) return null;
+
+  const literal = stringLiteralValue(node);
+  if (literal !== null) return literal;
+  if (node.type !== "TemplateLiteral" || nodeArray(node.expressions).length !== 0) return null;
+
+  const quasis = nodeArray(node.quasis);
+  if (quasis.length !== 1) return null;
+  const quasi = toAstRecord(quasis[0]);
+  if (quasi?.type !== "TemplateElement" || typeof quasi.value !== "object" || !quasi.value) {
+    return null;
+  }
+
+  const cooked = Reflect.get(quasi.value, "cooked");
+  const raw = Reflect.get(quasi.value, "raw");
+  return typeof cooked === "string" ? cooked : typeof raw === "string" ? raw : null;
+}
+
 export function forEachAstChild(node: AstRecord, callback: (child: AstRecord) => void): void {
   for (const [key, value] of Object.entries(node)) {
     if (SKIP_CHILD_KEYS.has(key)) continue;
@@ -90,6 +173,18 @@ export function forEachAstChild(node: AstRecord, callback: (child: AstRecord) =>
       }
     }
   }
+}
+
+/**
+ * Visit an AST in depth-first order. Returning `false` prunes the current
+ * node's subtree, which is useful once a transform has claimed a complete
+ * expression. Parent links and source-location metadata are skipped by
+ * {@link forEachAstChild}, so OXC's cyclic `parent` references are safe.
+ */
+export function walkAst(value: unknown, visitor: (node: AstRecord) => boolean | void): void {
+  const node = toAstRecord(value);
+  if (!node || visitor(node) === false) return;
+  forEachAstChild(node, (child) => walkAst(child, visitor));
 }
 
 export function collectBindingNames(pattern: unknown, target: Set<string>): void {

--- a/packages/vinext/src/plugins/css-module-imports.ts
+++ b/packages/vinext/src/plugins/css-module-imports.ts
@@ -1,10 +1,15 @@
 import type { Plugin } from "vite";
 import { parseAst } from "vite";
 import MagicString from "magic-string";
+import {
+  SCRIPT_MODULE_ID_RE,
+  scriptParserLanguage,
+  type ScriptParserLanguage,
+} from "./ast-utils.js";
+import { magicStringTransformResult } from "./transform-result.js";
 
 const CSS_MODULE_RE = /\.module\.(?:css|scss|sass)$/i;
 const CSS_MODULE_HINT_RE = /\.module\.(?:css|scss|sass)/i;
-const SCRIPT_RE = /\.(?:[cm]?[jt]sx?)(?:[?#].*)?$/i;
 const MDX_RE = /\.mdx$/i;
 
 type AstImportSpecifier = {
@@ -22,18 +27,9 @@ type AstImportDeclaration = {
   attributes?: unknown[];
 };
 
-type ScriptLanguage = "js" | "jsx" | "ts" | "tsx";
-
-function scriptLanguage(id: string): ScriptLanguage {
-  const cleanId = id.split("?", 1)[0].toLowerCase();
-  if (cleanId.endsWith(".tsx")) return "tsx";
-  if (cleanId.endsWith(".ts") || cleanId.endsWith(".mts") || cleanId.endsWith(".cts")) return "ts";
-  return "jsx";
-}
-
 export function rewriteCssModuleNamespaceImports(
   code: string,
-  lang: ScriptLanguage = "js",
+  lang: ScriptParserLanguage = "js",
 ): {
   code: string;
   map: ReturnType<MagicString["generateMap"]>;
@@ -65,16 +61,13 @@ export function rewriteCssModuleNamespaceImports(
   }
 
   if (!output) return null;
-  return {
-    code: output.toString(),
-    map: output.generateMap({ hires: true }),
-  };
+  return magicStringTransformResult(output, { hires: true });
 }
 
 export function createCssModuleImportCompatibilityPlugin(
   options: { compiledMdx?: boolean } = {},
 ): Plugin {
-  const idFilter = options.compiledMdx ? MDX_RE : SCRIPT_RE;
+  const idFilter = options.compiledMdx ? MDX_RE : SCRIPT_MODULE_ID_RE;
   return {
     name: options.compiledMdx
       ? "vinext:css-module-import-compatibility-mdx"
@@ -85,7 +78,7 @@ export function createCssModuleImportCompatibilityPlugin(
       handler(code, id) {
         return rewriteCssModuleNamespaceImports(
           code,
-          options.compiledMdx ? "jsx" : scriptLanguage(id),
+          options.compiledMdx ? "jsx" : (scriptParserLanguage(id) ?? "jsx"),
         );
       },
     },

--- a/packages/vinext/src/plugins/dynamic-preload-metadata.ts
+++ b/packages/vinext/src/plugins/dynamic-preload-metadata.ts
@@ -5,6 +5,9 @@ import path, { toSlash } from "pathslash";
 import { isUnknownRecord as isRecord } from "../utils/record.js";
 import { hasTrailingComma } from "../utils/has-trailing-comma.js";
 import { relativeWithinRoot, tryRealpathSync } from "../build/ssr-manifest.js";
+import { stripViteModuleQuery } from "../utils/path.js";
+import { getAstName, stringLiteralValue, walkAst } from "./ast-utils.js";
+import { magicStringTransformResult } from "./transform-result.js";
 
 type AstRecord = Record<string, unknown>;
 
@@ -34,40 +37,10 @@ function getBoolean(node: AstRecord, key: string): boolean {
   return node[key] === true;
 }
 
-function nodeName(node: unknown): string | null {
-  if (!isRecord(node)) return null;
-  const name = node.name;
-  if (typeof name === "string") return name;
-  const value = node.value;
-  return typeof value === "string" ? value : null;
-}
-
-function nodeStringValue(node: unknown): string | null {
-  if (!isRecord(node)) return null;
-  const value = node.value;
-  return typeof value === "string" ? value : null;
-}
-
-function walkAst(value: unknown, visitor: (node: AstRecord) => void): void {
-  if (!isRecord(value)) return;
-  visitor(value);
-
-  for (const [key, child] of Object.entries(value)) {
-    if (key === "parent") continue;
-    if (Array.isArray(child)) {
-      for (const item of child) {
-        walkAst(item, visitor);
-      }
-    } else if (isRecord(child)) {
-      walkAst(child, visitor);
-    }
-  }
-}
-
 function importSource(node: AstRecord): string | null {
   const source = node.source;
   if (!isRecord(source)) return null;
-  return nodeStringValue(source);
+  return stringLiteralValue(source);
 }
 
 function isNextDynamicSource(source: string | null): boolean {
@@ -86,7 +59,7 @@ function collectDynamicImportLocals(ast: unknown): Set<string> {
     for (const specifier of getArray(node, "specifiers")) {
       if (!isRecord(specifier)) continue;
       if (getString(specifier, "type") !== "ImportDefaultSpecifier") continue;
-      const local = nodeName(specifier.local);
+      const local = getAstName(specifier.local);
       if (local) locals.add(local);
     }
   }
@@ -164,7 +137,7 @@ function collectBlockScopedBindingNames(body: readonly unknown[]): Set<string> {
     }
 
     if (type === "FunctionDeclaration" || type === "ClassDeclaration") {
-      const name = nodeName(statement.id);
+      const name = getAstName(statement.id);
       if (name) names.add(name);
     }
   }
@@ -219,7 +192,7 @@ function collectFunctionScopeBindingNames(node: AstRecord): Set<string> {
   const names = new Set<string>();
 
   if (getString(node, "type") === "FunctionExpression") {
-    const name = nodeName(node.id);
+    const name = getAstName(node.id);
     if (name) names.add(name);
   }
 
@@ -323,7 +296,7 @@ function visitDynamicCalls(
 
   if (type === "ClassDeclaration" || type === "ClassExpression") {
     const names = new Set<string>();
-    const name = nodeName(value.id);
+    const name = getAstName(value.id);
     if (name) names.add(name);
     visitChildren(value, withoutBindings(dynamicLocals, names), visitor);
     return;
@@ -353,7 +326,7 @@ function collectImportSpecifiers(node: unknown): string[] {
 
   walkAst(node, (item) => {
     if (getString(item, "type") === "ImportExpression") {
-      const specifier = nodeStringValue(item.source);
+      const specifier = stringLiteralValue(item.source);
       if (specifier && !seen.has(specifier)) {
         seen.add(specifier);
         specifiers.push(specifier);
@@ -365,7 +338,7 @@ function collectImportSpecifiers(node: unknown): string[] {
     const callee = item.callee;
     if (!isRecord(callee) || getString(callee, "type") !== "Import") return;
     const firstArg = getArray(item, "arguments")[0];
-    const specifier = nodeStringValue(firstArg);
+    const specifier = stringLiteralValue(firstArg);
     if (specifier && !seen.has(specifier)) {
       seen.add(specifier);
       specifiers.push(specifier);
@@ -378,7 +351,7 @@ function collectImportSpecifiers(node: unknown): string[] {
 function propertyKeyName(property: unknown): string | null {
   if (!isRecord(property)) return null;
   if (getBoolean(property, "computed")) return null;
-  return nodeName(property.key);
+  return getAstName(property.key);
 }
 
 function objectProperties(node: unknown): AstRecord[] {
@@ -476,12 +449,7 @@ function cleanResolvedId(id: string): string {
     start += 1;
   }
 
-  return toSlash(
-    id
-      .slice(start)
-      .replace(/^\/@fs\//, "/")
-      .split("?")[0],
-  );
+  return toSlash(stripViteModuleQuery(id.slice(start).replace(/^\/@fs\//, "/")));
 }
 
 // `toManifestModuleId` runs once per resolved specifier but `root` is constant
@@ -663,10 +631,7 @@ export async function transformNextDynamicPreloadMetadata(
   await Promise.all(pending);
 
   if (!changed) return null;
-  return {
-    code: output.toString(),
-    map: output.generateMap({ hires: "boundary" }),
-  };
+  return magicStringTransformResult(output);
 }
 
 export function createDynamicPreloadMetadataPlugin(): Plugin {

--- a/packages/vinext/src/plugins/environment.ts
+++ b/packages/vinext/src/plugins/environment.ts
@@ -1,0 +1,11 @@
+type PluginEnvironment = {
+  name: string;
+  config: {
+    consumer?: string;
+  };
+};
+
+/** Whether a Vite environment produces server-consumed output. */
+export function isServerEnvironment(environment: PluginEnvironment): boolean {
+  return environment.name !== "client" && environment.config.consumer !== "client";
+}

--- a/packages/vinext/src/plugins/extensionless-dynamic-import.ts
+++ b/packages/vinext/src/plugins/extensionless-dynamic-import.ts
@@ -5,28 +5,21 @@ import path, { toSlash } from "pathslash";
 import { parseAst, type Alias, type Plugin } from "vite";
 import {
   DYNAMIC_IMPORT_PRESCAN,
-  forEachAstChild,
   hasRange,
   isAstRecord,
   nodeArray,
+  SCRIPT_MODULE_ID_RE,
+  scriptParserLanguage,
+  walkAst,
   type AstRecord,
 } from "./ast-utils.js";
 import { createTransformCache } from "./transform-cache.js";
+import { magicStringTransformResult } from "./transform-result.js";
+import { NODE_MODULES_PATH_RE } from "../utils/path.js";
 import { isUnknownRecord } from "../utils/record.js";
 import { escapeRegExp } from "../utils/regex.js";
 
 const MODULE_EXTENSIONS = [".mjs", ".js", ".mts", ".ts", ".jsx", ".tsx", ".json"];
-const TRANSFORMABLE_EXTENSIONS = new Set([
-  ".mjs",
-  ".js",
-  ".mts",
-  ".ts",
-  ".jsx",
-  ".tsx",
-  ".cjs",
-  ".cts",
-]);
-
 type ExtensionlessImport = {
   start: number;
   end: number;
@@ -94,8 +87,8 @@ export function createExtensionlessDynamicImportPlugin(): Plugin {
     transform: {
       filter: {
         id: {
-          include: /\.(?:[cm]?[jt]s|[jt]sx)(?:\?.*)?$/i,
-          exclude: /[\\/]node_modules[\\/]/,
+          include: SCRIPT_MODULE_ID_RE,
+          exclude: NODE_MODULES_PATH_RE,
         },
         code: DYNAMIC_IMPORT_PRESCAN,
       },
@@ -127,7 +120,7 @@ function transformExtensionlessImports(
   id: string,
   config: TransformConfig,
 ): TransformResult {
-  const lang = langForId(id)!;
+  const lang = scriptParserLanguage(id)!;
 
   let ast: unknown;
   try {
@@ -151,21 +144,7 @@ function transformExtensionlessImports(
     );
   }
 
-  return {
-    code: output.toString(),
-    map: output.generateMap({ hires: "boundary" }),
-  };
-}
-
-function langForId(id: string): "js" | "jsx" | "ts" | "tsx" | null {
-  const clean = id.split("?", 1)[0];
-  const dot = clean.lastIndexOf(".");
-  if (dot < 0) return null;
-  const ext = clean.slice(dot).toLowerCase();
-  if (!TRANSFORMABLE_EXTENSIONS.has(ext)) return null;
-  if (ext === ".ts" || ext === ".mts" || ext === ".cts") return "ts";
-  if (ext === ".tsx") return "tsx";
-  return "jsx";
+  return magicStringTransformResult(output);
 }
 
 function collectExtensionlessImports(
@@ -176,17 +155,13 @@ function collectExtensionlessImports(
 ): ExtensionlessImport[] {
   const imports: ExtensionlessImport[] = [];
 
-  function visit(value: unknown): void {
-    if (!isAstRecord(value)) return;
-    const parsed = parseExtensionlessImport(value, code, config, id);
+  walkAst(ast, (node) => {
+    const parsed = parseExtensionlessImport(node, code, config, id);
     if (parsed) {
       imports.push(parsed);
-      return;
+      return false;
     }
-    forEachAstChild(value, visit);
-  }
-
-  visit(ast);
+  });
   return imports;
 }
 

--- a/packages/vinext/src/plugins/fonts.ts
+++ b/packages/vinext/src/plugins/fonts.ts
@@ -31,6 +31,7 @@ import fs from "node:fs";
 import { escapeRegExp } from "../utils/regex.js";
 import { lastSignificantChar } from "../utils/has-trailing-comma.js";
 import MagicString from "magic-string";
+import { magicStringTransformResult } from "./transform-result.js";
 import {
   buildFallbackFontFace,
   getFallbackFontOverrideMetrics,
@@ -1053,10 +1054,7 @@ export function createGoogleFontsPlugin(fontGoogleShimPath: string, shimsDir: st
         }
 
         if (!hasChanges) return null;
-        return {
-          code: s.toString(),
-          map: s.generateMap({ hires: "boundary" }),
-        };
+        return magicStringTransformResult(s);
       },
     },
 
@@ -1246,10 +1244,7 @@ export function createLocalFontsPlugin(shimsDir: string): Plugin {
           s.prepend(imports.join("\n") + "\n");
         }
 
-        return {
-          code: s.toString(),
-          map: s.generateMap({ hires: "boundary" }),
-        };
+        return magicStringTransformResult(s);
       },
     },
   } satisfies Plugin;

--- a/packages/vinext/src/plugins/ignore-dynamic-requests.ts
+++ b/packages/vinext/src/plugins/ignore-dynamic-requests.ts
@@ -11,9 +11,14 @@ import {
   isIdentifierNamed,
   mayContainDynamicImport,
   nodeArray,
+  SCRIPT_MODULE_ID_RE,
+  scriptParserLanguage,
+  stringLiteralValue,
+  unwrapExpression,
   type AstRecord,
 } from "./ast-utils.js";
 import { createTransformCache } from "./transform-cache.js";
+import { magicStringTransformResult } from "./transform-result.js";
 import {
   collectDirectScopeBindings,
   collectLoopScopeBindings,
@@ -23,6 +28,7 @@ import {
   isFunctionNode,
   type AstScope,
 } from "./ast-scope.js";
+import { stripViteModuleQuery } from "../utils/path.js";
 
 const DYNAMIC_REQUEST_ERROR = "Cannot find module as expression is too dynamic";
 const REQUIRE_PRESCAN =
@@ -35,26 +41,6 @@ const MAX_CONSTANT_BINDING_DEPTH = 1_500;
 const VINEXT_SOURCE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const PLUGIN_RSC_PATH =
   /[\\/]node_modules[\\/](?:\.pnpm[\\/][^/\\]+[\\/]node_modules[\\/])?@vitejs[\\/]plugin-rsc[\\/]/;
-const TRANSFORMABLE_EXTENSIONS = new Set([
-  ".js",
-  ".jsx",
-  ".mjs",
-  ".cjs",
-  ".ts",
-  ".tsx",
-  ".mts",
-  ".cts",
-]);
-const TRANSPARENT_EXPRESSIONS = new Set([
-  "ChainExpression",
-  "ParenthesizedExpression",
-  "TSAsExpression",
-  "TSInstantiationExpression",
-  "TSNonNullExpression",
-  "TSSatisfiesExpression",
-  "TSTypeAssertion",
-]);
-
 type Scope = {
   parent: Scope | null;
   bindings: AstScope["bindings"];
@@ -79,22 +65,6 @@ type EnvironmentLike = {
 
 function astNode(value: unknown): AstRecord | null {
   return isAstRecord(value) ? value : null;
-}
-
-function unwrapExpression(value: unknown): AstRecord | null {
-  const node = astNode(value);
-  if (!node || !TRANSPARENT_EXPRESSIONS.has(node.type)) return node;
-  return unwrapExpression(node.expression);
-}
-
-function stringValue(node: AstRecord): string | null {
-  if (
-    (node.type === "Literal" || node.type === "StringLiteral") &&
-    typeof node.value === "string"
-  ) {
-    return node.value;
-  }
-  return null;
 }
 
 function stringFromCharCodeValue(value: unknown, scope: Scope): string | null {
@@ -139,14 +109,14 @@ function isUnboundNumericGlobal(node: AstRecord, scope: Scope): boolean {
   );
 }
 
-function staticStringValue(
+function evaluateStaticString(
   value: unknown,
   scope: Scope,
   resolution: ConstantResolution,
 ): string | null {
   const node = unwrapExpression(value);
   if (!node) return null;
-  const valueString = stringValue(node);
+  const valueString = stringLiteralValue(node);
   if (valueString !== null) return valueString;
   if (node.type === "TemplateLiteral" && nodeArray(node.expressions).length === 0) {
     const quasi = astNode(nodeArray(node.quasis)[0]);
@@ -160,24 +130,24 @@ function staticStringValue(
     return typeof cooked === "string" ? cooked : typeof raw === "string" ? raw : null;
   }
   if (node.type === "BinaryExpression" && node.operator === "+") {
-    const left = staticStringValue(node.left, scope, resolution);
-    const right = staticStringValue(node.right, scope, resolution);
+    const left = evaluateStaticString(node.left, scope, resolution);
+    const right = evaluateStaticString(node.right, scope, resolution);
     return left === null || right === null ? null : left + right;
   }
   if (node.type === "ConditionalExpression") {
     const truthiness = staticTruthiness(node.test, scope, resolution);
     if (truthiness !== null) {
-      return staticStringValue(truthiness ? node.consequent : node.alternate, scope, resolution);
+      return evaluateStaticString(truthiness ? node.consequent : node.alternate, scope, resolution);
     }
-    const consequent = staticStringValue(node.consequent, scope, resolution);
-    const alternate = staticStringValue(node.alternate, scope, resolution);
+    const consequent = evaluateStaticString(node.consequent, scope, resolution);
+    const alternate = evaluateStaticString(node.alternate, scope, resolution);
     return consequent !== null && consequent === alternate ? consequent : null;
   }
   if (node.type === "SequenceExpression") {
-    return staticStringValue(nodeArray(node.expressions).at(-1), scope, resolution);
+    return evaluateStaticString(nodeArray(node.expressions).at(-1), scope, resolution);
   }
   if (node.type === "Identifier" && typeof node.name === "string") {
-    return resolveConstantBinding(scope, node.name, resolution, null, staticStringValue);
+    return resolveConstantBinding(scope, node.name, resolution, null, evaluateStaticString);
   }
   return null;
 }
@@ -339,7 +309,7 @@ function templateTruthiness(
 
   let hasUnknownExpression = false;
   for (const expression of nodeArray(node.expressions)) {
-    const string = staticStringValue(expression, scope, resolution);
+    const string = evaluateStaticString(expression, scope, resolution);
     if (string !== null) {
       if (string !== "") return true;
       continue;
@@ -375,7 +345,7 @@ function staticTruthiness(
       : null;
   }
   if (node.type === "BinaryExpression" && node.operator === "+") {
-    const string = staticStringValue(node, scope, resolution);
+    const string = evaluateStaticString(node, scope, resolution);
     return string === null ? null : Boolean(string);
   }
   if (isIdentifierNamed(node, "undefined") && !hasAstBinding(scope, "undefined")) return false;
@@ -479,7 +449,7 @@ function stringConcatHasStaticPart(
   if (
     callee?.type !== "MemberExpression" ||
     (callee.computed === true
-      ? property === null || staticStringValue(property, scope, resolution) !== "concat"
+      ? property === null || evaluateStaticString(property, scope, resolution) !== "concat"
       : !isIdentifierNamed(property, "concat"))
   ) {
     return null;
@@ -502,7 +472,7 @@ function isStaticStringExpression(
 ): boolean {
   const node = unwrapExpression(value);
   if (!node) return false;
-  if (stringValue(node) !== null || node.type === "TemplateLiteral") return true;
+  if (stringLiteralValue(node) !== null || node.type === "TemplateLiteral") return true;
   if (node.type === "Identifier" && typeof node.name === "string") {
     return resolveConstantBinding(scope, node.name, resolution, false, isStaticStringExpression);
   }
@@ -531,7 +501,7 @@ function additionContainsString(
 ): boolean {
   const node = unwrapExpression(value);
   if (!node) return false;
-  if (stringValue(node) !== null || node.type === "TemplateLiteral") return true;
+  if (stringLiteralValue(node) !== null || node.type === "TemplateLiteral") return true;
   if (node.type === "Identifier" && typeof node.name === "string") {
     return resolveConstantBinding(scope, node.name, resolution, false, additionContainsString);
   }
@@ -561,7 +531,7 @@ function requestHasStaticPart(
   const node = unwrapExpression(value);
   if (!node) return false;
 
-  const constantString = stringValue(node);
+  const constantString = stringLiteralValue(node);
   if (constantString !== null) return constantString.replaceAll("\\", "/") !== "/";
   if (node.type === "Literal") return true;
   if (isUnboundNumericGlobal(node, scope)) return true;
@@ -588,8 +558,8 @@ function requestHasStaticPart(
     if (!additionContainsString(node, scope, resolution)) return false;
     const left = unwrapExpression(node.left);
     const right = unwrapExpression(node.right);
-    const leftString = left ? stringValue(left) : null;
-    const rightString = right ? stringValue(right) : null;
+    const leftString = left ? stringLiteralValue(left) : null;
+    const rightString = right ? stringLiteralValue(right) : null;
     return (
       (leftString !== null && hasSignificantPathPart(leftString)) ||
       (rightString !== null && hasSignificantPathPart(rightString)) ||
@@ -769,18 +739,7 @@ function transformVeryDynamicRequests(code: string, id: string) {
   // parsed the whole graph. See DYNAMIC_IMPORT_PRESCAN for the rationale.
   if (!REQUIRE_PRESCAN.test(code) && !mayContainDynamicImport(code)) return null;
 
-  const extension = path.extname(id.split("?", 1)[0]);
-  const lang =
-    extension === ".ts" || extension === ".mts" || extension === ".cts"
-      ? "ts"
-      : extension === ".tsx"
-        ? "tsx"
-        : extension === ".js" ||
-            extension === ".jsx" ||
-            extension === ".mjs" ||
-            extension === ".cjs"
-          ? "jsx"
-          : "js";
+  const lang = scriptParserLanguage(id) ?? "js";
   let ast: ReturnType<typeof parseAst>;
   try {
     ast = parseAst(code, { lang });
@@ -922,10 +881,7 @@ function transformVeryDynamicRequests(code: string, id: string) {
   }
 
   if (!changed) return null;
-  return {
-    code: output.toString(),
-    map: output.generateMap({ hires: "boundary", source: id }),
-  };
+  return magicStringTransformResult(output, { hires: "boundary", source: id });
 }
 
 export function createIgnoreDynamicRequestsPlugin(
@@ -939,13 +895,13 @@ export function createIgnoreDynamicRequestsPlugin(
     transform: {
       filter: {
         id: {
-          include: /\.(?:[cm]?[jt]s|[jt]sx)(?:\?.*)?$/,
+          include: SCRIPT_MODULE_ID_RE,
         },
         code: DYNAMIC_REQUEST_PRESCAN,
       },
       handler(code, id) {
-        const cleanId = id.split("?", 1)[0];
-        if (!TRANSFORMABLE_EXTENSIONS.has(path.extname(cleanId))) return null;
+        const cleanId = stripViteModuleQuery(id);
+        if (scriptParserLanguage(cleanId) === null) return null;
         if (
           !shouldTransformVeryDynamicRequests(
             this.environment as EnvironmentLike,

--- a/packages/vinext/src/plugins/import-meta-url.ts
+++ b/packages/vinext/src/plugins/import-meta-url.ts
@@ -16,6 +16,7 @@ import MagicString from "magic-string";
 import path, { toSlash } from "pathslash";
 import { pathToFileURL } from "node:url";
 import { tryRealpathSync } from "../build/ssr-manifest.js";
+import { NODE_MODULES_PATH_RE, stripViteModuleQuery } from "../utils/path.js";
 import { VIRTUAL_MODULE_ID_RE, VIRTUAL_PREFIX } from "../utils/virtual-module.js";
 import {
   collectBindingNames,
@@ -24,9 +25,12 @@ import {
   isAstRecord,
   isIdentifierNamed,
   nodeArray,
+  SCRIPT_MODULE_ID_RE,
+  scriptParserLanguage,
   type AstRange,
   type AstRecord,
 } from "./ast-utils.js";
+import { magicStringTransformResult } from "./transform-result.js";
 
 type ImportMetaUrlEnvironment = "client" | "server";
 
@@ -48,16 +52,6 @@ type ImportMetaUrlCacheEntry = {
   results: Map<ImportMetaUrlEnvironment, { value: RewriteResult | null }>;
 };
 
-const TRANSFORMABLE_SCRIPT_EXTENSIONS = new Set([
-  ".cjs",
-  ".cts",
-  ".js",
-  ".jsx",
-  ".mjs",
-  ".mts",
-  ".ts",
-  ".tsx",
-]);
 export function createImportMetaUrlPlugin(options: { getRoot: () => string | undefined }): Plugin {
   let rootPaths: RootPaths | undefined;
   let outputDirs: string[] = [];
@@ -86,8 +80,8 @@ export function createImportMetaUrlPlugin(options: { getRoot: () => string | und
     transform: {
       filter: {
         id: {
-          include: /\.(?:[cm]?[jt]s|[jt]sx)(?:\?.*)?$/,
-          exclude: [/[\\/]node_modules[\\/]/, VIRTUAL_MODULE_ID_RE],
+          include: SCRIPT_MODULE_ID_RE,
+          exclude: [NODE_MODULES_PATH_RE, VIRTUAL_MODULE_ID_RE],
         },
         code: /import\.meta(?:\.|\?\.)url|__filename|__dirname/,
       },
@@ -201,14 +195,11 @@ function rewriteCanonicalSourceIdentity(
   }
 
   if (!changed) return null;
-  return {
-    code: output.toString(),
-    map: output.generateMap({ hires: "boundary" }),
-  };
+  return magicStringTransformResult(output);
 }
 
 function cleanModuleId(id: string): string {
-  return id.split("?", 1)[0];
+  return stripViteModuleQuery(id);
 }
 
 function createRootPaths(root: string, options: { outputDirs?: string[] } = {}): RootPaths {
@@ -233,7 +224,7 @@ function transformableModuleCanonicalId(id: string, rootPaths: RootPaths): strin
   // isPathWithin check below provides a second safety net in case a
   // symlink causes the canonical path to land outside node_modules.
   if (slashedInputId.includes("/node_modules/")) return null;
-  if (!TRANSFORMABLE_SCRIPT_EXTENSIONS.has(path.extname(slashedInputId))) return null;
+  if (scriptParserLanguage(slashedInputId) === null) return null;
 
   const canonicalId = canonicalizePath(id);
   if (!isPathWithin(canonicalId, rootPaths.canonicalRoot)) return null;

--- a/packages/vinext/src/plugins/instrumentation-client.ts
+++ b/packages/vinext/src/plugins/instrumentation-client.ts
@@ -1,6 +1,8 @@
 import type { Plugin } from "vite";
 import { normalizePath, parseAst } from "vite";
 import MagicString from "magic-string";
+import { stripViteModuleQuery } from "../utils/path.js";
+import { magicStringTransformResult } from "./transform-result.js";
 
 export function createInstrumentationClientTransformPlugin(
   getInstrumentationClientPath: () => string | null,
@@ -14,7 +16,7 @@ export function createInstrumentationClientTransformPlugin(
 
       // findInstrumentationClientFile already returns a POSIX path, so only the
       // incoming id needs normalizing before the comparison.
-      const normalizedId = normalizePath(id.split("?", 1)[0]);
+      const normalizedId = normalizePath(stripViteModuleQuery(id));
       if (normalizedId !== instrumentationClientPath) return null;
       if (code.includes("__vinextInstrumentationClientStart")) return null;
 
@@ -40,10 +42,7 @@ export function createInstrumentationClientTransformPlugin(
           "}\n",
       );
 
-      return {
-        code: s.toString(),
-        map: s.generateMap({ hires: true }),
-      };
+      return magicStringTransformResult(s, { hires: true });
     },
   };
 }

--- a/packages/vinext/src/plugins/middleware-export-validation.ts
+++ b/packages/vinext/src/plugins/middleware-export-validation.ts
@@ -1,6 +1,6 @@
 import { parseAst } from "vite";
 import { createMiddlewareMissingExportError } from "../server/middleware-runtime.js";
-import { stripViteModuleQuery } from "../utils/path.js";
+import { getAstName, scriptParserLanguage } from "./ast-utils.js";
 
 type AstName = { name?: unknown; value?: unknown } | null | undefined;
 
@@ -21,22 +21,6 @@ type Statement = {
   specifiers?: ExportSpecifier[];
 };
 
-function parserLanguage(id: string): "js" | "jsx" | "ts" | "tsx" {
-  const cleanId = stripViteModuleQuery(id).toLowerCase();
-  if (cleanId.endsWith(".tsx")) return "tsx";
-  if (cleanId.endsWith(".ts") || cleanId.endsWith(".mts") || cleanId.endsWith(".cts")) {
-    return "ts";
-  }
-  return "jsx";
-}
-
-function astName(value: AstName): string | null {
-  if (!value) return null;
-  if (typeof value.name === "string") return value.name;
-  if (typeof value.value === "string") return value.value;
-  return null;
-}
-
 export function hasValidMiddlewareModuleExport(
   source: string,
   id: string,
@@ -46,7 +30,7 @@ export function hasValidMiddlewareModuleExport(
   // verifies that the expected export name exists, not that its value is
   // callable. The shared runtime validation remains authoritative for values
   // such as `export const proxy = 1` and re-exports from another module.
-  const ast = parseAst(source, { lang: parserLanguage(id) });
+  const ast = parseAst(source, { lang: scriptParserLanguage(id) ?? "jsx" });
   const expectedExport = isProxy ? "proxy" : "middleware";
 
   for (const statement of ast.body as Statement[]) {
@@ -54,16 +38,19 @@ export function hasValidMiddlewareModuleExport(
     if (statement.type !== "ExportNamedDeclaration") continue;
 
     const declaration = statement.declaration;
-    if (declaration?.type === "FunctionDeclaration" && astName(declaration.id) === expectedExport) {
+    if (
+      declaration?.type === "FunctionDeclaration" &&
+      getAstName(declaration.id) === expectedExport
+    ) {
       return true;
     }
     if (declaration?.type === "VariableDeclaration") {
       for (const declarator of declaration.declarations ?? []) {
-        if (astName(declarator.id) === expectedExport) return true;
+        if (getAstName(declarator.id) === expectedExport) return true;
       }
     }
     for (const specifier of statement.specifiers ?? []) {
-      if (astName(specifier.exported ?? specifier.local) === expectedExport) return true;
+      if (getAstName(specifier.exported ?? specifier.local) === expectedExport) return true;
     }
   }
 

--- a/packages/vinext/src/plugins/middleware-server-only.ts
+++ b/packages/vinext/src/plugins/middleware-server-only.ts
@@ -1,5 +1,6 @@
 import type { Plugin } from "vite";
 import { toSlash } from "pathslash";
+import { stripViteModuleQuery } from "../utils/path.js";
 
 /**
  * Allow `import 'server-only'` from neutral server targets (and any module
@@ -67,11 +68,10 @@ export function createMiddlewareServerOnlyPlugin(options: {
   // paths can come from `fs.realpathSync`, which is backslash on Windows, so
   // they must be normalized to match the importer ids Rolldown passes in.
   function canonicalizeId(id: string): string {
-    const queryIndex = id.indexOf("?");
     // Strip query string suffix (e.g. ?v=hash, ?rsc, ?used). Rolldown stores
     // module IDs with the query in `importer` strings for HMR / dep optimizer
     // round-trips; the canonical id we tracked doesn't carry one.
-    return toSlash(queryIndex === -1 ? id : id.slice(0, queryIndex));
+    return toSlash(stripViteModuleQuery(id));
   }
 
   function isTainted(id: string | undefined): boolean {

--- a/packages/vinext/src/plugins/og-asset-ownership.ts
+++ b/packages/vinext/src/plugins/og-asset-ownership.ts
@@ -2,6 +2,8 @@ import fs from "node:fs";
 import path, { toSlash } from "pathslash";
 import { promisify } from "node:util";
 import type { Alias } from "vite";
+import { packageNameFromSpecifier } from "../utils/package-name.js";
+import { isPathInsideOrEqual, stripViteModuleQuery } from "../utils/path.js";
 
 const promisifiedRealpathNative = promisify(fs.realpath.native);
 // fs.realpath.native reports native separators on Windows; keep results in slash space.
@@ -14,14 +16,6 @@ export type OgAssetModuleBoundary = {
   assetRoot: string;
   moduleDir: string;
 };
-
-function isPathInside(root: string, target: string): boolean {
-  const relative = path.relative(root, target);
-  return (
-    relative === "" ||
-    (!path.isAbsolute(relative) && !relative.startsWith("../") && relative !== "..")
-  );
-}
 
 async function findPackageRoot(
   moduleDir: string,
@@ -46,22 +40,6 @@ async function findPackageRoot(
   }
 }
 
-function getPackageNameFromSpecifier(specifier: string): string | null {
-  if (
-    specifier.startsWith(".") ||
-    specifier.startsWith("/") ||
-    specifier.startsWith("\0") ||
-    specifier.startsWith("#")
-  ) {
-    return null;
-  }
-  const segments = specifier.split("/");
-  if (specifier.startsWith("@")) {
-    return segments.length >= 2 ? `${segments[0]}/${segments[1]}` : null;
-  }
-  return segments[0] || null;
-}
-
 function getAliasedPackageName(value: unknown): string | null {
   if (typeof value !== "string") return null;
   const alias = value.match(/^(?:npm:|workspace:)(@[^/]+\/[^@]+|[^@*~^]+)(?:@|$)/);
@@ -84,7 +62,7 @@ function getNodeModulesPackageRoot(
   logicalProjectRoot: string,
   logicalModulePath: string,
 ): string | null {
-  const isProjectPath = isPathInside(logicalProjectRoot, logicalModulePath);
+  const isProjectPath = isPathInsideOrEqual(logicalProjectRoot, logicalModulePath);
   const parsedPath = path.parse(logicalModulePath);
   const baseRoot = isProjectPath ? logicalProjectRoot : parsedPath.root;
   const relativePath = isProjectPath
@@ -148,7 +126,7 @@ async function packageOwnsAliasDirectory(
     return ["main", "module", "source", "browser"].some(
       (field) =>
         typeof manifest[field] === "string" &&
-        isPathInside(aliasDirectory, path.resolve(packageRoot, manifest[field])),
+        isPathInsideOrEqual(aliasDirectory, path.resolve(packageRoot, manifest[field])),
     );
   } catch {
     return false;
@@ -214,13 +192,13 @@ export class OgAssetOwnership {
 
   async recordResolvedImport(source: string, resolvedId: string): Promise<void> {
     const configuredAlias = this.findAlias(source);
-    const sourcePackageName = getPackageNameFromSpecifier(source);
+    const sourcePackageName = packageNameFromSpecifier(source);
     const expectedPackageName = this.getExpectedPackageName(source);
     if (configuredAlias === undefined && expectedPackageName === undefined) return;
 
     let realResolvedPath: string;
     try {
-      realResolvedPath = await realpathNative(path.resolve(resolvedId.split("?")[0]));
+      realResolvedPath = await realpathNative(path.resolve(stripViteModuleQuery(resolvedId)));
     } catch {
       return;
     }
@@ -240,7 +218,7 @@ export class OgAssetOwnership {
   }
 
   async resolveModuleBoundary(moduleId: string): Promise<OgAssetModuleBoundary | null> {
-    const modulePath = path.resolve(moduleId.split("?")[0]);
+    const modulePath = path.resolve(stripViteModuleQuery(moduleId));
     let realProjectRoot: string;
     let realModulePath: string;
     try {
@@ -267,7 +245,7 @@ export class OgAssetOwnership {
       } catch {
         return null;
       }
-      if (isPathInside(realPackageRoot, realModulePath)) {
+      if (isPathInsideOrEqual(realPackageRoot, realModulePath)) {
         return { assetRoot: realPackageRoot, moduleDir };
       }
 
@@ -289,12 +267,12 @@ export class OgAssetOwnership {
       return { assetRoot: canonicalPackageRoot, moduleDir };
     }
 
-    if (isPathInside(realProjectRoot, realModulePath)) {
+    if (isPathInsideOrEqual(realProjectRoot, realModulePath)) {
       return { assetRoot: realProjectRoot, moduleDir };
     }
 
     const linkedPackageRoot = [...this.linkedPackageRoots]
-      .filter((root) => isPathInside(root, realModulePath))
+      .filter((root) => isPathInsideOrEqual(root, realModulePath))
       .sort((a, b) => b.length - a.length)[0];
     if (linkedPackageRoot !== undefined) {
       return { assetRoot: linkedPackageRoot, moduleDir };
@@ -307,7 +285,7 @@ export class OgAssetOwnership {
   async resolveContainedAsset(assetRoot: string, assetPath: string): Promise<string | null> {
     try {
       const realPath = await realpathNative(assetPath);
-      return isPathInside(assetRoot, realPath) ? realPath : null;
+      return isPathInsideOrEqual(assetRoot, realPath) ? realPath : null;
     } catch {
       return null;
     }
@@ -323,7 +301,7 @@ export class OgAssetOwnership {
   }
 
   private getExpectedPackageName(source: string): string | undefined {
-    const packageName = getPackageNameFromSpecifier(source);
+    const packageName = packageNameFromSpecifier(source);
     return packageName === null ? undefined : this.dependencyPackageNames.get(packageName);
   }
 
@@ -350,8 +328,8 @@ export class OgAssetOwnership {
         const packageRoot = await findPackageRoot(path.dirname(realResolvedPath));
         if (
           packageRoot === null ||
-          !isPathInside(aliasBoundary, packageRoot) ||
-          !isPathInside(packageRoot, realResolvedPath)
+          !isPathInsideOrEqual(aliasBoundary, packageRoot) ||
+          !isPathInsideOrEqual(packageRoot, realResolvedPath)
         ) {
           return null;
         }
@@ -362,7 +340,7 @@ export class OgAssetOwnership {
       if (
         packageRoot === null ||
         !(await packageOwnsAliasFile(packageRoot, sourcePackageName, realAliasTarget)) ||
-        !isPathInside(packageRoot, realResolvedPath)
+        !isPathInsideOrEqual(packageRoot, realResolvedPath)
       ) {
         return null;
       }
@@ -374,12 +352,12 @@ export class OgAssetOwnership {
 
   private async resolveConfiguredAliasRoot(realModulePath: string): Promise<string | null> {
     const packageRoot = await findPackageRoot(path.dirname(realModulePath));
-    if (packageRoot === null || !isPathInside(packageRoot, realModulePath)) return null;
+    if (packageRoot === null || !isPathInsideOrEqual(packageRoot, realModulePath)) return null;
 
     for (const alias of this.configuredAliases) {
       if (!path.isAbsolute(alias.replacement)) continue;
       const packageName =
-        typeof alias.find === "string" ? getPackageNameFromSpecifier(alias.find) : null;
+        typeof alias.find === "string" ? packageNameFromSpecifier(alias.find) : null;
 
       const captureIndex = alias.replacement.indexOf("$");
       if (captureIndex !== -1) {
@@ -392,7 +370,8 @@ export class OgAssetOwnership {
           const realAliasTarget = await realpathNative(aliasTarget);
           const aliasTargetStat = await fs.promises.stat(realAliasTarget);
           if (
-            (aliasTargetStat.isDirectory() && isPathInside(realAliasTarget, realModulePath)) ||
+            (aliasTargetStat.isDirectory() &&
+              isPathInsideOrEqual(realAliasTarget, realModulePath)) ||
             (aliasTargetStat.isFile() && realAliasTarget === realModulePath)
           ) {
             return packageRoot;
@@ -406,8 +385,8 @@ export class OgAssetOwnership {
         const replacementStat = await fs.promises.stat(realReplacement);
         if (replacementStat.isDirectory()) {
           if (
-            isPathInside(packageRoot, realReplacement) &&
-            isPathInside(realReplacement, realModulePath) &&
+            isPathInsideOrEqual(packageRoot, realReplacement) &&
+            isPathInsideOrEqual(realReplacement, realModulePath) &&
             (await packageOwnsAliasDirectory(packageRoot, packageName, realReplacement))
           ) {
             return packageRoot;

--- a/packages/vinext/src/plugins/og-assets.ts
+++ b/packages/vinext/src/plugins/og-assets.ts
@@ -49,6 +49,7 @@ import fs from "node:fs";
 import { createRequire } from "node:module";
 import MagicString from "magic-string";
 import { OgAssetOwnership } from "./og-asset-ownership.js";
+import { magicStringTransformResult } from "./transform-result.js";
 
 // ── Plugin factories ──────────────────────────────────────────────────────────
 
@@ -194,7 +195,7 @@ export function createOgInlineFetchAssetsPlugin(): Plugin {
         }
 
         if (!didReplace) return null;
-        return { code: s.toString(), map: s.generateMap({ hires: "boundary" }) };
+        return magicStringTransformResult(s);
       },
     },
   } satisfies Plugin;

--- a/packages/vinext/src/plugins/optimize-imports.ts
+++ b/packages/vinext/src/plugins/optimize-imports.ts
@@ -19,6 +19,7 @@ import path, { toSlash } from "pathslash";
 import MagicString from "magic-string";
 import type { ResolvedNextConfig } from "../config/next-config.js";
 import { getAstName } from "./ast-utils.js";
+import { magicStringTransformResult } from "./transform-result.js";
 import { escapeRegExp } from "../utils/regex.js";
 import { VIRTUAL_MODULE_ID_RE } from "../utils/virtual-module.js";
 
@@ -954,10 +955,7 @@ export function createOptimizeImportsPlugin(
 
         if (!hasChanges) return null;
 
-        return {
-          code: s.toString(),
-          map: s.generateMap({ hires: "boundary" }),
-        };
+        return magicStringTransformResult(s);
       },
     },
   } satisfies Plugin;

--- a/packages/vinext/src/plugins/pages-node-externals.ts
+++ b/packages/vinext/src/plugins/pages-node-externals.ts
@@ -1,14 +1,18 @@
 import fs from "node:fs";
-import path, { toSlash } from "pathslash";
+import path from "pathslash";
 import { parseAst, type Plugin } from "vite";
 import {
-  forEachAstChild,
   isAstRecord,
   mayContainDynamicImport,
-  nodeArray,
+  SCRIPT_MODULE_ID_RE,
+  scriptParserLanguage,
+  staticStringValue,
+  walkAst,
   type AstRecord,
 } from "./ast-utils.js";
-import { stripViteModuleQuery } from "../utils/path.js";
+import { canonicalizeFilePath, isPathInsideOrEqual, stripViteModuleQuery } from "../utils/path.js";
+import { packageNameFromSpecifier } from "../utils/package-name.js";
+import { isServerEnvironment } from "./environment.js";
 
 type PagesNodeExternalsOptions = {
   getRoot: () => string;
@@ -30,27 +34,8 @@ const FRAMEWORK_PACKAGES = new Set([
   "vinext",
 ]);
 
-function packageNameFromSpecifier(id: string): string | null {
-  const [first, second] = id.split("/");
-  if (!first) return null;
-  return first.startsWith("@") ? (second ? `${first}/${second}` : null) : first;
-}
-
 function canonicalFile(id: string): string {
-  const cleanId = toSlash(stripViteModuleQuery(id));
-  try {
-    return toSlash(fs.realpathSync.native(cleanId));
-  } catch {
-    return cleanId;
-  }
-}
-
-function isInsideDirectory(directory: string, file: string): boolean {
-  const relative = path.relative(canonicalFile(directory), canonicalFile(file));
-  return (
-    relative === "" ||
-    (!relative.startsWith("../") && relative !== ".." && !path.isAbsolute(relative))
-  );
+  return canonicalizeFilePath(stripViteModuleQuery(id));
 }
 
 function findPackageJson(file: string): string | null {
@@ -84,19 +69,10 @@ function matchesAlias(id: string, aliases: Readonly<Record<string, string>>): bo
   return Object.keys(aliases).some((alias) => id === alias || id.startsWith(`${alias}/`));
 }
 
-function parserLanguage(id: string): "js" | "jsx" | "ts" | "tsx" {
-  const cleanId = stripViteModuleQuery(id).toLowerCase();
-  if (cleanId.endsWith(".tsx")) return "tsx";
-  if (cleanId.endsWith(".ts") || cleanId.endsWith(".mts") || cleanId.endsWith(".cts")) {
-    return "ts";
-  }
-  return "jsx";
-}
-
 function moduleDependencySpecifiers(code: string, id: string): string[] {
   let ast: ReturnType<typeof parseAst>;
   try {
-    ast = parseAst(code, { lang: parserLanguage(id) });
+    ast = parseAst(code, { lang: scriptParserLanguage(id) ?? "jsx" });
   } catch {
     return [];
   }
@@ -105,22 +81,7 @@ function moduleDependencySpecifiers(code: string, id: string): string[] {
   const seen = new Set<string>();
   const sourceSpecifier = (source: unknown): string | null => {
     if (!isAstRecord(source)) return null;
-    if (source.type === "Literal") {
-      return typeof source.value === "string" ? source.value : null;
-    }
-    if (source.type !== "TemplateLiteral" || nodeArray(source.expressions).length !== 0) {
-      return null;
-    }
-
-    const quasis = nodeArray(source.quasis);
-    if (quasis.length !== 1 || !isAstRecord(quasis[0]) || quasis[0].type !== "TemplateElement") {
-      return null;
-    }
-    const value = quasis[0].value;
-    if (typeof value !== "object" || value === null) return null;
-    const cooked = Reflect.get(value, "cooked");
-    const raw = Reflect.get(value, "raw");
-    return typeof cooked === "string" ? cooked : typeof raw === "string" ? raw : null;
+    return staticStringValue(source);
   };
   const addStaticSource = (source: unknown): void => {
     const specifier = sourceSpecifier(source);
@@ -150,12 +111,10 @@ function moduleDependencySpecifiers(code: string, id: string): string[] {
       // guess at variable or interpolated dynamic imports.
       addStaticSource(node.source);
     }
-
-    forEachAstChild(node, visitDynamicImports);
   };
 
   for (const statement of ast.body) {
-    if (isAstRecord(statement)) visitDynamicImports(statement);
+    walkAst(statement, visitDynamicImports);
   }
   return specifiers;
 }
@@ -190,10 +149,7 @@ export function createPagesNodeExternalsPlugin(options: PagesNodeExternalsOption
     enforce: "pre",
     applyToEnvironment(environment) {
       return (
-        options.isEnabled() &&
-        options.getPagesDir() !== null &&
-        environment.name !== "client" &&
-        environment.config.consumer !== "client"
+        options.isEnabled() && options.getPagesDir() !== null && isServerEnvironment(environment)
       );
     },
     transform: {
@@ -203,7 +159,7 @@ export function createPagesNodeExternalsPlugin(options: PagesNodeExternalsOption
       // other project-local imports before Rolldown traverses the module.
       filter: {
         id: {
-          include: /\.[cm]?[jt]sx?(?:\?.*)?$/,
+          include: SCRIPT_MODULE_ID_RE,
           exclude: /\/node_modules\//,
         },
       },
@@ -220,7 +176,10 @@ export function createPagesNodeExternalsPlugin(options: PagesNodeExternalsOption
         }
 
         const pagesOwnedModules = pagesOwnedModulesFor(environment.name);
-        if (!isInsideDirectory(pagesDir, cleanId) && !pagesOwnedModules.has(cleanId)) {
+        if (
+          !isPathInsideOrEqual(canonicalFile(pagesDir), cleanId) &&
+          !pagesOwnedModules.has(cleanId)
+        ) {
           return null;
         }
 
@@ -255,7 +214,8 @@ export function createPagesNodeExternalsPlugin(options: PagesNodeExternalsOption
         const cleanImporter = canonicalFile(importer);
         const importerIsPagesOwned =
           path.isAbsolute(cleanImporter) &&
-          (isInsideDirectory(pagesDir, cleanImporter) || pagesOwnedModules.has(cleanImporter));
+          (isPathInsideOrEqual(canonicalFile(pagesDir), cleanImporter) ||
+            pagesOwnedModules.has(cleanImporter));
         if (!importerIsPagesOwned) {
           return null;
         }

--- a/packages/vinext/src/plugins/remove-console.ts
+++ b/packages/vinext/src/plugins/remove-console.ts
@@ -16,6 +16,7 @@
  */
 import { parseAst } from "vite";
 import MagicString from "magic-string";
+import { magicStringTransformResult } from "./transform-result.js";
 
 type ASTNode = ReturnType<typeof parseAst>["body"][number]["parent"];
 type BindingNode = Extract<ASTNode, { type: string }>;
@@ -310,5 +311,5 @@ export function removeConsoleCalls(
   if (!changed) return null;
   // Emit the MagicString sourcemap rather than dropping it: stripped calls and
   // statements shift positions, so a null map would break client-build debugging.
-  return { code: s.toString(), map: s.generateMap({ hires: "boundary" }) };
+  return magicStringTransformResult(s);
 }

--- a/packages/vinext/src/plugins/require-condition-resolution.ts
+++ b/packages/vinext/src/plugins/require-condition-resolution.ts
@@ -9,6 +9,10 @@ import {
   isAstRecord,
   isIdentifierNamed,
   nodeArray,
+  SCRIPT_MODULE_ID_RE,
+  scriptParserLanguage,
+  staticStringValue,
+  unwrapExpression,
   type AstRecord,
 } from "./ast-utils.js";
 import {
@@ -21,21 +25,11 @@ import {
   isFunctionNode,
   type AstScope,
 } from "./ast-scope.js";
+import { magicStringTransformResult } from "./transform-result.js";
 import { stripViteModuleQuery } from "../utils/path.js";
 
-const TRANSFORMABLE_ID_RE = /\.(?:[cm]?[jt]s|[jt]sx)(?:\?.*)?$/i;
 const LITERAL_REQUIRE_RE = /\brequire\s*\(/;
 const CONDITIONAL_REQUIRE_SCRIPT_ID_RE = /\.vinext-require\.(?:js|jsx|ts|tsx)$/i;
-const TRANSPARENT_EXPRESSIONS = new Set([
-  "ChainExpression",
-  "ParenthesizedExpression",
-  "TSAsExpression",
-  "TSInstantiationExpression",
-  "TSNonNullExpression",
-  "TSSatisfiesExpression",
-  "TSTypeAssertion",
-]);
-
 type LiteralRequire = {
   argument: AstRecord & { start: number; end: number };
   specifier: string;
@@ -56,37 +50,9 @@ function syntheticModuleType(id: string): SyntheticModuleType {
   return "js";
 }
 
-function parserLanguage(id: string): "js" | "jsx" | "ts" | "tsx" {
-  const cleanId = id.split("?", 1)[0].toLowerCase();
-  if (cleanId.endsWith(".tsx")) return "tsx";
-  if (cleanId.endsWith(".ts") || cleanId.endsWith(".mts") || cleanId.endsWith(".cts")) {
-    return "ts";
-  }
-  return "jsx";
-}
-
-function unwrapExpression(value: unknown): AstRecord | null {
-  const node = isAstRecord(value) ? value : null;
-  if (!node || !TRANSPARENT_EXPRESSIONS.has(node.type)) return node;
-  return unwrapExpression(node.expression);
-}
-
 function literalString(value: unknown): string | null {
   const node = unwrapExpression(value);
-  if (
-    (node?.type === "Literal" || node?.type === "StringLiteral") &&
-    typeof node.value === "string"
-  ) {
-    return node.value;
-  }
-  if (node?.type !== "TemplateLiteral" || nodeArray(node.expressions).length !== 0) return null;
-  const quasiCandidate = nodeArray(node.quasis)[0];
-  const quasi = isAstRecord(quasiCandidate) ? quasiCandidate : null;
-  const quasiValue = quasi && typeof quasi.value === "object" ? quasi.value : null;
-  if (!quasiValue) return null;
-  const cooked = Reflect.get(quasiValue, "cooked");
-  const raw = Reflect.get(quasiValue, "raw");
-  return typeof cooked === "string" ? cooked : typeof raw === "string" ? raw : null;
+  return staticStringValue(node);
 }
 
 function isPackageSpecifier(specifier: string): boolean {
@@ -102,7 +68,7 @@ function isPackageSpecifier(specifier: string): boolean {
 function collectLiteralRequires(code: string, id: string): LiteralRequire[] {
   let ast: ReturnType<typeof parseAst>;
   try {
-    ast = parseAst(code, { lang: parserLanguage(id) });
+    ast = parseAst(code, { lang: scriptParserLanguage(id) ?? "jsx" });
   } catch {
     return [];
   }
@@ -257,7 +223,7 @@ export function createRequireConditionResolutionPlugin(
       }
     },
     transform: {
-      filter: { id: TRANSFORMABLE_ID_RE, code: LITERAL_REQUIRE_RE },
+      filter: { id: SCRIPT_MODULE_ID_RE, code: LITERAL_REQUIRE_RE },
       async handler(code, id) {
         const cleanId = stripViteModuleQuery(id);
         const commonjsDisposition = commonjsTransformFilter?.(cleanId);
@@ -304,10 +270,7 @@ export function createRequireConditionResolutionPlugin(
           changed = true;
         }
         if (!changed) return null;
-        return {
-          code: output.toString(),
-          map: output.generateMap({ hires: "boundary", source: id }),
-        };
+        return magicStringTransformResult(output, { hires: "boundary", source: id });
       },
     },
   };

--- a/packages/vinext/src/plugins/require-context.ts
+++ b/packages/vinext/src/plugins/require-context.ts
@@ -24,24 +24,19 @@ import path, { toSlash } from "pathslash";
 import { parseAst, type Plugin } from "vite";
 import MagicString from "magic-string";
 import {
-  forEachAstChild,
+  booleanLiteralValue,
   hasRange,
   isAstRecord,
   nodeArray,
+  SCRIPT_MODULE_ID_RE,
+  scriptParserLanguage,
+  stringLiteralValue,
+  walkAst,
   type AstRange,
   type AstRecord,
 } from "./ast-utils.js";
-
-const TRANSFORMABLE_EXTENSIONS = new Set([
-  ".js",
-  ".jsx",
-  ".ts",
-  ".tsx",
-  ".mjs",
-  ".cjs",
-  ".mts",
-  ".cts",
-]);
+import { stripViteModuleQuery } from "../utils/path.js";
+import { magicStringTransformResult } from "./transform-result.js";
 
 type ParsedCall = {
   range: AstRange;
@@ -77,7 +72,7 @@ export function createRequireContextPlugin(): Plugin {
     enforce: "pre",
     transform: {
       filter: {
-        id: /\.(?:[cm]?[jt]s|[jt]sx)(?:\?.*)?$/i,
+        id: SCRIPT_MODULE_ID_RE,
         code: /\brequire\b[\s\S]*\.context/,
       },
       async handler(code, id) {
@@ -140,7 +135,7 @@ type TransformResult = {
 };
 
 async function transformRequireContext(code: string, id: string): Promise<TransformResult | null> {
-  const lang = langForId(id)!;
+  const lang = scriptParserLanguage(id)!;
 
   let ast: unknown;
   try {
@@ -174,49 +169,23 @@ async function transformRequireContext(code: string, id: string): Promise<Transf
   }
 
   return {
-    code: output.toString(),
-    map: output.generateMap({ hires: "boundary" }),
+    ...magicStringTransformResult(output),
     contexts,
   };
-}
-
-function langForId(id: string): "js" | "jsx" | "ts" | "tsx" | null {
-  const clean = id.split("?", 1)[0];
-  const dot = clean.lastIndexOf(".");
-  if (dot < 0) return null;
-  const ext = clean.slice(dot).toLowerCase();
-  if (!TRANSFORMABLE_EXTENSIONS.has(ext)) return null;
-  switch (ext) {
-    case ".ts":
-    case ".cts":
-    case ".mts":
-      return "ts";
-    case ".tsx":
-      return "tsx";
-    case ".jsx":
-      return "jsx";
-    default:
-      // .js / .jsx / .mjs / .cjs — parse as jsx so JSX in .js still works.
-      return "jsx";
-  }
 }
 
 function collectRequireContextCalls(ast: unknown): ParsedCall[] {
   const calls: ParsedCall[] = [];
 
-  function visit(value: unknown): void {
-    if (!isAstRecord(value)) return;
-    const parsed = parseRequireContextCall(value);
+  walkAst(ast, (node) => {
+    const parsed = parseRequireContextCall(node);
     if (parsed) {
       calls.push(parsed);
       // A matched call's arguments are all literals (string/boolean/regexp), so
       // there is nothing further to find inside it — stop descending here.
-      return;
+      return false;
     }
-    forEachAstChild(value, visit);
-  }
-
-  visit(ast);
+  });
   return calls;
 }
 
@@ -333,20 +302,6 @@ function isPropertyNamed(value: unknown, name: string): boolean {
   return isAstRecord(value) && value.type === "Identifier" && value.name === name;
 }
 
-function stringLiteralValue(value: unknown): string | null {
-  if (isAstRecord(value) && value.type === "Literal" && typeof value.value === "string") {
-    return value.value;
-  }
-  return null;
-}
-
-function booleanLiteralValue(value: unknown): boolean | null {
-  if (isAstRecord(value) && value.type === "Literal" && typeof value.value === "boolean") {
-    return value.value;
-  }
-  return null;
-}
-
 function regexLiteralValue(value: unknown): { pattern: string; flags: string } | null {
   if (!isAstRecord(value) || value.type !== "Literal") return null;
   // OXC attaches the regex source as a plain `{ pattern, flags }` object on the
@@ -399,7 +354,7 @@ async function resolveContextModules(
   bindingPrefix: string,
   callIndex: number,
 ): Promise<{ context: WatchedContext; modules: ContextModule[] }> {
-  const importer = toSlash(id.split("?", 1)[0]);
+  const importer = toSlash(stripViteModuleQuery(id));
   const directory = path.resolve(path.dirname(importer), call.dir);
   const context: WatchedContext = {
     directory,

--- a/packages/vinext/src/plugins/sass.ts
+++ b/packages/vinext/src/plugins/sass.ts
@@ -28,6 +28,7 @@ import path, { toSlash } from "pathslash";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { preprocessCSS, type PreprocessCSSResult, type ResolvedConfig } from "vite";
 import { markCssUrlAssetReferences, rebaseCssUrlAssetReferences } from "../build/css-url-assets.js";
+import { NODE_MODULES_PATH_RE } from "../utils/path.js";
 
 type AdditionalData = string | ((source: string, filename: string) => string | Promise<string>);
 
@@ -44,7 +45,6 @@ export type SassTsconfigPathAlias = {
 };
 
 const URL_SCHEME_RE = /^[A-Za-z][A-Za-z\d+.-]*:/;
-const NODE_MODULES_PATH_RE = /(?:^|\/)node_modules(?:\/|$)/;
 
 type SassFileImporterContext = {
   containingUrl?: URL | null;

--- a/packages/vinext/src/plugins/server-externals-manifest.ts
+++ b/packages/vinext/src/plugins/server-externals-manifest.ts
@@ -1,54 +1,7 @@
 import fs from "node:fs";
 import path from "pathslash";
-import { builtinModules } from "node:module";
 import type { Plugin } from "vite";
-
-const BUILTIN_MODULES = new Set(
-  builtinModules.flatMap((name) =>
-    name.startsWith("node:") ? [name, name.slice(5)] : [name, `node:${name}`],
-  ),
-);
-
-/**
- * Extract the npm package name from a bare module specifier.
- *
- * Returns null for:
- *  - Relative imports ("./foo", "../bar")
- *  - Absolute paths ("/abs/path")
- *  - Node built-ins ("node:fs")
- *  - Package self-references ("#imports")
- */
-function packageNameFromSpecifier(specifier: string): string | null {
-  if (
-    !specifier ||
-    specifier.startsWith(".") ||
-    specifier.startsWith("/") ||
-    specifier.startsWith("\\") ||
-    specifier.startsWith("#")
-  ) {
-    return null;
-  }
-
-  // External specifiers can include non-package schemes such as
-  // "virtual:vite-rsc" or "file:...". Those are never npm packages.
-  if (/^[a-zA-Z][a-zA-Z\d+.-]*:/.test(specifier)) {
-    return null;
-  }
-
-  if (specifier.startsWith("@")) {
-    const parts = specifier.split("/");
-    if (parts.length >= 2) {
-      return `${parts[0]}/${parts[1]}`;
-    }
-    return null;
-  }
-
-  const packageName = specifier.split("/")[0] || null;
-  if (!packageName || BUILTIN_MODULES.has(specifier) || BUILTIN_MODULES.has(packageName)) {
-    return null;
-  }
-  return packageName;
-}
+import { packageNameFromSpecifier } from "../utils/package-name.js";
 
 /**
  * vinext:server-externals-manifest

--- a/packages/vinext/src/plugins/strip-server-exports.ts
+++ b/packages/vinext/src/plugins/strip-server-exports.ts
@@ -1,5 +1,7 @@
 import { parseAst } from "vite";
 import MagicString from "magic-string";
+import { getAstName } from "./ast-utils.js";
+import { magicStringTransformResult } from "./transform-result.js";
 
 type ParsedAst = ReturnType<typeof parseAst>;
 type ASTNode = ParsedAst["body"][number]["parent"];
@@ -90,12 +92,6 @@ type Binding = {
 
 type Edit = { start: number; end: number; replacement: string };
 
-function nodeName(node: unknown): string | undefined {
-  if (!node || typeof node !== "object") return undefined;
-  const value = node as { name?: string; value?: string };
-  return value.name ?? value.value;
-}
-
 function isInsideRanges(position: number, ranges: Array<{ start: number; end: number }>): boolean {
   return ranges.some((range) => position >= range.start && position < range.end);
 }
@@ -185,7 +181,7 @@ function isReferenceIdentifier(node: PositionedNode, parent?: PositionedNode): b
   return true;
 }
 
-function walkAst(
+function walkAstWithAncestors(
   node: unknown,
   visit: (node: PositionedNode, parent?: PositionedNode, ancestors?: PositionedNode[]) => void,
   parent?: PositionedNode,
@@ -193,7 +189,7 @@ function walkAst(
 ): void {
   if (!node || typeof node !== "object") return;
   if (Array.isArray(node)) {
-    for (const child of node) walkAst(child, visit, parent, ancestors);
+    for (const child of node) walkAstWithAncestors(child, visit, parent, ancestors);
     return;
   }
 
@@ -204,9 +200,9 @@ function walkAst(
   for (const [key, value] of Object.entries(current)) {
     if (key === "parent" || key === "loc" || key === "start" || key === "end") continue;
     if (Array.isArray(value)) {
-      for (const child of value) walkAst(child, visit, current, childAncestors);
+      for (const child of value) walkAstWithAncestors(child, visit, current, childAncestors);
     } else if (value && typeof value === "object") {
-      walkAst(value, visit, current, childAncestors);
+      walkAstWithAncestors(value, visit, current, childAncestors);
     }
   }
 }
@@ -445,7 +441,7 @@ export function stripServerExports(code: string): StripServerExportsResult | nul
       }
     } else if (statement.type === "ImportDeclaration") {
       for (const specifier of statement.specifiers as PositionedNode[]) {
-        const name = nodeName(specifier.local);
+        const name = getAstName(specifier.local);
         if (!name) continue;
         bindingPositions.add(specifier.local.start);
         bindings.set(name, {
@@ -474,7 +470,7 @@ export function stripServerExports(code: string): StripServerExportsResult | nul
     shadowRanges.set(name, ranges);
   };
 
-  walkAst(ast.body, (node, parent, ancestors = []) => {
+  walkAstWithAncestors(ast.body, (node, parent, ancestors = []) => {
     if (
       node.type === "FunctionDeclaration" ||
       node.type === "FunctionExpression" ||
@@ -511,7 +507,7 @@ export function stripServerExports(code: string): StripServerExportsResult | nul
     }
   });
 
-  walkAst(ast.body, (node, parent, ancestors = []) => {
+  walkAstWithAncestors(ast.body, (node, parent, ancestors = []) => {
     if (!isReferenceIdentifier(node, parent)) return;
     if (bindingPositions.has(node.start)) return;
     if (isInsideRanges(node.start, shadowRanges.get(node.name) ?? [])) return;
@@ -563,16 +559,16 @@ export function stripServerExports(code: string): StripServerExportsResult | nul
 
     const removed = new Set<PositionedNode>();
     for (const specifier of statement.specifiers as PositionedNode[]) {
-      const exportedName = nodeName(specifier.exported);
+      const exportedName = getAstName(specifier.exported);
       if (exportedName && SERVER_EXPORTS.has(exportedName)) {
         noteDataExport(exportedName);
         removed.add(specifier);
         if (!statement.source) {
-          const localName = nodeName(specifier.local);
+          const localName = getAstName(specifier.local);
           if (localName) candidateBindings.add(localName);
         }
       } else if (!statement.source) {
-        const localName = nodeName(specifier.local);
+        const localName = getAstName(specifier.local);
         if (localName) {
           const positions = references.get(localName) ?? [];
           positions.push(specifier.local.start);
@@ -763,5 +759,5 @@ export function stripServerExports(code: string): StripServerExportsResult | nul
   // The MagicString already tracks every overwrite, so emit its sourcemap
   // instead of dropping it — removing whole statements shifts line numbers for
   // the rest of the module, which would otherwise break client-build debugging.
-  return { code: string.toString(), map: string.generateMap({ hires: "boundary" }) };
+  return magicStringTransformResult(string);
 }

--- a/packages/vinext/src/plugins/styled-jsx.ts
+++ b/packages/vinext/src/plugins/styled-jsx.ts
@@ -2,6 +2,8 @@ import { createRequire } from "node:module";
 import path from "pathslash";
 import { pathToFileURL } from "node:url";
 import { parseAst, type Plugin } from "vite";
+import { NODE_MODULES_PATH_RE, stripViteModuleQuery } from "../utils/path.js";
+import { SCRIPT_MODULE_ID_RE, walkAst } from "./ast-utils.js";
 
 type NextSwcModule = {
   loadBindings(): Promise<unknown>;
@@ -16,14 +18,13 @@ type StyledJsxPluginOptions = {
 };
 
 const STYLED_JSX_IMPORT_RE = /^styled-jsx(?:\/.*)?$/;
-const NODE_MODULES_RE = /[\\/]node_modules[\\/]/;
 const STYLED_JSX_SOURCE_RE =
   /(?:<style\b|from\s+["']styled-jsx\/css["']|require\s*\(\s*["']styled-jsx\/css["']\s*\))/;
 const STYLED_JSX_CSS_RE =
   /(?:from\s+["']styled-jsx\/css["']|require\s*\(\s*["']styled-jsx\/css["']\s*\))/;
 
 function hasStyledJsxTag(source: string, id: string): boolean {
-  const cleanId = id.split("?")[0];
+  const cleanId = stripViteModuleQuery(id);
   const extension = path.extname(cleanId);
   const lang = extension === ".ts" || extension === ".mts" || extension === ".cts" ? "ts" : "tsx";
   let ast: ReturnType<typeof parseAst>;
@@ -33,14 +34,9 @@ function hasStyledJsxTag(source: string, id: string): boolean {
     return false;
   }
 
-  const pending: unknown[] = [ast];
-  const visited = new Set<object>();
-  while (pending.length > 0) {
-    const value = pending.pop();
-    if (!value || typeof value !== "object" || visited.has(value)) continue;
-    visited.add(value);
-
-    const node = value as Record<string, unknown>;
+  let found = false;
+  walkAst(ast, (node) => {
+    if (found) return false;
     if (node.type === "JSXOpeningElement") {
       const name = node.name as { type?: string; name?: string } | undefined;
       if (name?.type === "JSXIdentifier" && name.name === "style") {
@@ -52,17 +48,13 @@ function hasStyledJsxTag(source: string, id: string): boolean {
             return attributeName?.type === "JSXIdentifier" && attributeName.name === "jsx";
           })
         ) {
-          return true;
+          found = true;
+          return false;
         }
       }
     }
-
-    for (const child of Object.values(node)) {
-      if (Array.isArray(child)) pending.push(...child);
-      else if (child && typeof child === "object") pending.push(child);
-    }
-  }
-  return false;
+  });
+  return found;
 }
 
 function createProjectRequire(projectRoot: string) {
@@ -79,7 +71,7 @@ function resolveNextRequire(projectRoot: string): NodeJS.Require | null {
 }
 
 function parserOptions(id: string): Record<string, unknown> {
-  const extension = path.extname(id.split("?")[0]);
+  const extension = path.extname(stripViteModuleQuery(id));
   if (extension === ".ts" || extension === ".tsx") {
     return { syntax: "typescript", tsx: extension === ".tsx", decorators: true };
   }
@@ -146,13 +138,13 @@ export function createStyledJsxPlugin(
     transform: {
       filter: {
         id: {
-          include: /\.[cm]?[jt]sx?(?:\?.*)?$/,
-          exclude: NODE_MODULES_RE,
+          include: SCRIPT_MODULE_ID_RE,
+          exclude: NODE_MODULES_PATH_RE,
         },
         code: STYLED_JSX_SOURCE_RE,
       },
       async handler(source, id) {
-        if (NODE_MODULES_RE.test(id.split("?")[0])) return null;
+        if (NODE_MODULES_PATH_RE.test(stripViteModuleQuery(id))) return null;
         const hasStyledJsxCss = STYLED_JSX_CSS_RE.test(source);
         const hasStyledJsxElement = !hasStyledJsxCss && hasStyledJsxTag(source, id);
         if (!hasStyledJsxCss && !hasStyledJsxElement) return null;
@@ -163,7 +155,7 @@ export function createStyledJsxPlugin(
         }
         const compiler = await getCompiler();
         const result = await compiler.transform(source, {
-          filename: id.split("?")[0],
+          filename: stripViteModuleQuery(id),
           sourceMaps: true,
           module: { type: "es6" },
           styledJsx: { useLightningcss: false },

--- a/packages/vinext/src/plugins/transform-result.ts
+++ b/packages/vinext/src/plugins/transform-result.ts
@@ -1,0 +1,17 @@
+import type MagicString from "magic-string";
+
+export type MagicStringTransformResult = {
+  code: string;
+  map: ReturnType<MagicString["generateMap"]>;
+};
+
+/** Build the standard code + sourcemap result returned by source transforms. */
+export function magicStringTransformResult(
+  output: MagicString,
+  options: Parameters<MagicString["generateMap"]>[0] = { hires: "boundary" },
+): MagicStringTransformResult {
+  return {
+    code: output.toString(),
+    map: output.generateMap(options),
+  };
+}

--- a/packages/vinext/src/plugins/transitive-externals.ts
+++ b/packages/vinext/src/plugins/transitive-externals.ts
@@ -1,29 +1,11 @@
-import fs from "node:fs";
 import { createRequire } from "node:module";
-import path, { toSlash } from "pathslash";
+import path from "pathslash";
 import { createIdResolver, type Plugin, type Rollup } from "vite";
-import { stripViteModuleQuery } from "../utils/path.js";
+import { BARE_PACKAGE_SPECIFIER_RE, packageNameFromSpecifier } from "../utils/package-name.js";
+import { canonicalizeFilePath, stripViteModuleQuery } from "../utils/path.js";
+import { isServerEnvironment } from "./environment.js";
 
 type ExternalModuleMode = "import" | "require";
-
-const BARE_PACKAGE_SPECIFIER_RE =
-  /^(?:@[A-Za-z0-9._~-]+\/[A-Za-z0-9._~-]+|[A-Za-z0-9_~-][A-Za-z0-9._~-]*)(?:\/[^?#]*)?$/;
-
-function realpath(resolvedPath: string): string {
-  try {
-    return toSlash(fs.realpathSync.native(resolvedPath));
-  } catch {
-    return toSlash(resolvedPath);
-  }
-}
-
-function packageNameFromSpecifier(specifier: string): string | null {
-  if (specifier.startsWith("@")) {
-    const parts = specifier.split("/");
-    return parts.length >= 2 ? `${parts[0]}/${parts[1]}` : null;
-  }
-  return specifier.split("/")[0] || null;
-}
 
 function moduleMode(kind: Rollup.ImportKind | undefined): ExternalModuleMode {
   return kind === "require-call" ? "require" : "import";
@@ -39,9 +21,9 @@ function compareTransitiveExternalResolutions(
   importerResolution: string,
   rootResolution: string | null,
 ): string | null {
-  const importerRealpath = realpath(importerResolution);
+  const importerRealpath = canonicalizeFilePath(importerResolution);
   if (!rootResolution) return importerRealpath;
-  return importerRealpath === realpath(rootResolution) ? null : importerRealpath;
+  return importerRealpath === canonicalizeFilePath(rootResolution) ? null : importerRealpath;
 }
 
 /**
@@ -102,7 +84,7 @@ export function createTransitiveExternalsPlugin(options: {
     apply: "build",
     enforce: "pre",
     applyToEnvironment(environment) {
-      return environment.name !== "client" && environment.config.consumer !== "client";
+      return isServerEnvironment(environment);
     },
 
     configResolved(config) {

--- a/packages/vinext/src/plugins/typeof-window.ts
+++ b/packages/vinext/src/plugins/typeof-window.ts
@@ -2,12 +2,14 @@ import path from "pathslash";
 import { parseAst } from "vite";
 import MagicString from "magic-string";
 import {
+  booleanLiteralValue,
   collectBindingNames,
   forEachAstChild,
   hasRange,
   isAstRecord,
   isIdentifierNamed,
   nodeArray,
+  stringLiteralValue,
 } from "./ast-utils.js";
 import {
   collectDirectScopeBindings,
@@ -19,6 +21,8 @@ import {
   isFunctionNode,
   type AstScope,
 } from "./ast-scope.js";
+import { magicStringTransformResult } from "./transform-result.js";
+import { stripViteModuleQuery } from "../utils/path.js";
 
 type WindowType = "object" | "undefined";
 
@@ -87,12 +91,6 @@ export function getTypeofWindowReplacement(environment: EnvironmentLike): Window
   return environment.config.consumer === "client" ? "object" : "undefined";
 }
 
-function stringLiteralValue(node: unknown): string | null {
-  if (!isAstRecord(node)) return null;
-  if (node.type === "Literal" && typeof node.value === "string") return node.value;
-  return null;
-}
-
 function evaluateTypeofWindowComparison(
   node: unknown,
   replacement: WindowType,
@@ -140,13 +138,6 @@ function isProcessBrowserMember(node: unknown, scope: AstScope): boolean {
       : isIdentifierNamed(candidate.property, "browser")) &&
     !hasAstBinding(scope, "process")
   );
-}
-
-function booleanLiteralValue(node: unknown): boolean | null {
-  if (!isAstRecord(node) || node.type !== "Literal" || typeof node.value !== "boolean") {
-    return null;
-  }
-  return node.value;
 }
 
 function evaluateProcessBrowserCondition(
@@ -247,7 +238,7 @@ export function replaceConsumerEnvironmentConditions(
     ((/\bprocess\b/.test(code) && /\bbrowser\b/.test(code)) || sourceEscapePattern.test(code));
   if (!mayContainTypeofWindow && !mayContainProcessBrowser) return null;
 
-  const extension = path.extname(id.split("?", 1)[0]);
+  const extension = path.extname(stripViteModuleQuery(id));
   const lang =
     extension === ".ts" || extension === ".mts" || extension === ".cts"
       ? "ts"
@@ -422,8 +413,5 @@ export function replaceConsumerEnvironmentConditions(
   }
   if (!changed) return null;
 
-  return {
-    code: output.toString(),
-    map: output.generateMap({ hires: "boundary" }),
-  };
+  return magicStringTransformResult(output);
 }

--- a/packages/vinext/src/plugins/use-cache-callable.ts
+++ b/packages/vinext/src/plugins/use-cache-callable.ts
@@ -7,7 +7,8 @@ import type {
   TransformHoistInlineDirectiveMeta,
 } from "@vitejs/plugin-rsc/transforms";
 import { parseAstAsync, type Plugin } from "vite";
-import { stripViteModuleQuery } from "../utils/path.js";
+import { isPathInside, NODE_MODULES_PATH_RE, stripViteModuleQuery } from "../utils/path.js";
+import { magicStringTransformResult } from "./transform-result.js";
 
 type RscTransforms = typeof import("@vitejs/plugin-rsc/transforms");
 type Program = Awaited<ReturnType<typeof parseAstAsync>>;
@@ -28,7 +29,6 @@ type CacheWrapperOptions = {
 
 const PLUGIN_NAME = "vinext:server-function-directives";
 const SOURCE_MODULE_ID_RE = /\.(?:tsx?|jsx?|mjs)(?:\?.*)?$/;
-const DEPENDENCY_MODULE_ID_RE = /[\\/]node_modules[\\/]/;
 const RESOLVED_VIRTUAL_MODULE_ID_RE = new RegExp(`^${String.fromCharCode(0)}`);
 const USE_CACHE_DIRECTIVE = /^use cache(?:: ([^\s].*))?$/;
 const USE_CACHE_DIRECTIVE_CANDIDATE = /^use cache.*$/;
@@ -103,11 +103,6 @@ function acceptsSecondArgument(
   );
 }
 
-function isInsideDirectory(directory: string, filePath: string): boolean {
-  const relativePath = path.relative(directory, filePath);
-  return relativePath !== "" && !relativePath.startsWith("..") && !path.isAbsolute(relativePath);
-}
-
 function isAppPageDefaultExport(
   options: Options,
   id: string,
@@ -119,7 +114,7 @@ function isAppPageDefaultExport(
   const modulePath = stripViteModuleQuery(id);
   const moduleFileName = path.basename(modulePath);
   return (
-    isInsideDirectory(appDir, modulePath) &&
+    isPathInside(appDir, modulePath) &&
     path.parse(moduleFileName).name === "page" &&
     options.matchesPageExtension(moduleFileName)
   );
@@ -225,7 +220,7 @@ export async function createUseCacheCallablePlugin(options: Options): Promise<Pl
       filter: {
         id: {
           include: SOURCE_MODULE_ID_RE,
-          exclude: [DEPENDENCY_MODULE_ID_RE, RESOLVED_VIRTUAL_MODULE_ID_RE],
+          exclude: [NODE_MODULES_PATH_RE, RESOLVED_VIRTUAL_MODULE_ID_RE],
         },
       },
       async handler(code, id) {
@@ -291,10 +286,7 @@ export async function createUseCacheCallablePlugin(options: Options): Promise<Pl
           result.output.prepend(
             `import * as $$ReactClient from "@vitejs/plugin-rsc/react/${runtimeEnvironment}";\n`,
           );
-          return {
-            code: result.output.toString(),
-            map: result.output.generateMap({ hires: "boundary", source: id }),
-          };
+          return magicStringTransformResult(result.output, { hires: "boundary", source: id });
         }
 
         const wrap = (
@@ -366,10 +358,7 @@ export async function createUseCacheCallablePlugin(options: Options): Promise<Pl
             .filter(Boolean)
             .join("\n") + "\n",
         );
-        return {
-          code: result.output.toString(),
-          map: result.output.generateMap({ hires: "boundary", source: id }),
-        };
+        return magicStringTransformResult(result.output, { hires: "boundary", source: id });
       },
     },
   };

--- a/packages/vinext/src/plugins/wasm-module-import.ts
+++ b/packages/vinext/src/plugins/wasm-module-import.ts
@@ -44,7 +44,7 @@ export function createWasmModuleImportPlugin(): Plugin {
         // font-patch transform could slip past this guard and reintroduce
         // the double-shipped-WASM bug.
         const importerPath = importer
-          ? (importer.startsWith("\0") ? importer.slice(1) : importer).split("?")[0]
+          ? stripViteModuleQuery(importer.startsWith("\0") ? importer.slice(1) : importer)
           : "";
         if (importerPath.includes("@vercel/og")) return null;
 

--- a/packages/vinext/src/plugins/worker-image-imports.ts
+++ b/packages/vinext/src/plugins/worker-image-imports.ts
@@ -3,6 +3,9 @@ import MagicString from "magic-string";
 import path, { toSlash } from "pathslash";
 import { parseAst, type Plugin } from "vite";
 import { appendDeploymentIdQuery } from "../utils/deployment-id.js";
+import { NODE_MODULES_PATH_RE, stripViteModuleQuery } from "../utils/path.js";
+import { staticStringValue, walkAst } from "./ast-utils.js";
+import { magicStringTransformResult } from "./transform-result.js";
 
 const WORKER_IMAGE_METADATA_PREFIX = "\0vinext-worker-image-meta:";
 // oxlint-disable-next-line no-control-regex -- null byte prefix is intentional (Vite virtual module convention)
@@ -11,7 +14,6 @@ const WORKER_SCRIPT_RE = /\.(?:[cm]?[jt]sx?)$/;
 const WORKER_IMAGE_DYNAMIC_IMPORT_RE =
   /import\(\s*["'][^"']+\.(?:png|jpe?g|gif|webp|avif|svg|ico|bmp|tiff?)["']\s*\)/;
 const WORKER_IMAGE_EXTENSION_RE = /\.(?:png|jpe?g|gif|webp|avif|svg|ico|bmp|tiff?)$/;
-const NODE_MODULES_PATH_RE = /[\\/]node_modules[\\/]/;
 
 type AstNode = {
   type?: string;
@@ -22,21 +24,6 @@ type AstNode = {
   source?: AstNode;
   value?: unknown;
 };
-
-function staticStringNodeValue(value: unknown): string | null {
-  if (!value || typeof value !== "object") return null;
-  const node = value as AstNode;
-  if (node.type === "Literal" && typeof node.value === "string") return node.value;
-  if (
-    node.type === "TemplateLiteral" &&
-    node.expressions?.length === 0 &&
-    node.quasis?.length === 1 &&
-    typeof node.quasis[0]?.value?.cooked === "string"
-  ) {
-    return node.quasis[0].value.cooked;
-  }
-  return null;
-}
 
 function workerChunkSpecifier(hostFileName: string, targetFileName: string): string {
   const relative = path.relative(path.dirname(hostFileName), targetFileName);
@@ -94,7 +81,7 @@ export function createWorkerImageImportsPlugin(options: { deploymentId?: string 
         code: WORKER_IMAGE_DYNAMIC_IMPORT_RE,
       },
       async handler(code, id) {
-        const sourceId = toSlash(id.split("?", 1)[0] ?? id);
+        const sourceId = toSlash(stripViteModuleQuery(id));
         let ast: ReturnType<typeof parseAst>;
         try {
           ast = parseAst(code, { lang: /\.(?:[cm]?ts)$/.test(sourceId) ? "ts" : "tsx" });
@@ -109,8 +96,7 @@ export function createWorkerImageImportsPlugin(options: { deploymentId?: string 
           start: number;
         }> = [];
 
-        const visit = (value: unknown): void => {
-          if (!value || typeof value !== "object") return;
+        walkAst(ast, (value) => {
           const node = value as AstNode;
           if (
             node.type === "ImportExpression" &&
@@ -125,23 +111,13 @@ export function createWorkerImageImportsPlugin(options: { deploymentId?: string 
               importPath: node.source.value,
               start: node.start,
             });
-            return;
+            return false;
           }
-
-          for (const child of Object.values(value)) {
-            if (Array.isArray(child)) {
-              for (const item of child) visit(item);
-            } else {
-              visit(child);
-            }
-          }
-        };
-
-        visit(ast);
+        });
         let changed = false;
         for (const imageImport of imageImports) {
           const resolved = await this.resolve(imageImport.importPath, sourceId, { skipSelf: true });
-          const resolvedId = resolved?.id.split("?", 1)[0];
+          const resolvedId = resolved ? stripViteModuleQuery(resolved.id) : undefined;
           const imagePath = resolvedId
             ? toSlash(resolvedId)
             : imageImport.importPath.startsWith(".")
@@ -159,7 +135,7 @@ export function createWorkerImageImportsPlugin(options: { deploymentId?: string 
           changed = true;
         }
         if (!changed) return null;
-        return { code: output.toString(), map: output.generateMap({ hires: "boundary" }) };
+        return magicStringTransformResult(output);
       },
     },
 
@@ -183,8 +159,7 @@ export function createWorkerImageImportsPlugin(options: { deploymentId?: string 
 
         const output = new MagicString(code);
         let changed = false;
-        const visit = (value: unknown): void => {
-          if (!value || typeof value !== "object") return;
+        walkAst(ast, (value) => {
           const node = value as AstNode;
           const source =
             node.type === "ImportExpression" ||
@@ -193,7 +168,7 @@ export function createWorkerImageImportsPlugin(options: { deploymentId?: string 
             node.type === "ExportAllDeclaration"
               ? node.source
               : null;
-          const specifier = staticStringNodeValue(source);
+          const specifier = staticStringValue(source);
           if (
             specifier !== null &&
             chunkSpecifiers.has(specifier) &&
@@ -206,21 +181,11 @@ export function createWorkerImageImportsPlugin(options: { deploymentId?: string 
               JSON.stringify(appendDeploymentIdQuery(specifier, options.deploymentId)),
             );
             changed = true;
-            return;
+            return false;
           }
-
-          for (const child of Object.values(value)) {
-            if (Array.isArray(child)) {
-              for (const item of child) visit(item);
-            } else {
-              visit(child);
-            }
-          }
-        };
-
-        visit(ast);
+        });
         if (!changed) return null;
-        return { code: output.toString(), map: output.generateMap({ hires: "boundary" }) };
+        return magicStringTransformResult(output);
       },
     },
   };

--- a/packages/vinext/src/server/dev-route-files.ts
+++ b/packages/vinext/src/server/dev-route-files.ts
@@ -1,5 +1,6 @@
 import path from "pathslash";
 import type { ValidFileMatcher } from "../routing/file-matcher.js";
+import { isPathInside } from "../utils/path.js";
 import { matchMetadataFileBaseName, METADATA_FILE_MAP } from "./metadata-routes.js";
 
 const APP_ROUTER_STRUCTURE_FILES = [
@@ -14,11 +15,6 @@ const APP_ROUTER_STRUCTURE_FILES = [
   "forbidden",
   "unauthorized",
 ];
-
-function isInsideDirectory(dir: string, filePath: string): boolean {
-  const relativePath = path.relative(dir, filePath);
-  return relativePath !== "" && !relativePath.startsWith("..") && !path.isAbsolute(relativePath);
-}
 
 function relativeParts(dir: string, filePath: string): string[] {
   return path.relative(dir, filePath).split(path.sep).filter(Boolean);
@@ -91,7 +87,7 @@ export function shouldInvalidateAppRouteFile(
   filePath: string,
   matcher: ValidFileMatcher,
 ): boolean {
-  if (!isInsideDirectory(appDir, filePath)) return false;
+  if (!isPathInside(appDir, filePath)) return false;
 
   const parts = relativeParts(appDir, filePath);
   if (parts.length === 0 || isPrivateAppPath(parts)) return false;

--- a/packages/vinext/src/utils/package-name.ts
+++ b/packages/vinext/src/utils/package-name.ts
@@ -1,0 +1,23 @@
+import { builtinModules } from "node:module";
+
+const BUILTIN_MODULES = new Set(
+  builtinModules.flatMap((name) =>
+    name.startsWith("node:") ? [name, name.slice(5)] : [name, `node:${name}`],
+  ),
+);
+
+export const BARE_PACKAGE_SPECIFIER_RE =
+  /^(?:(?<scoped>@[A-Za-z0-9._~-]+\/[A-Za-z0-9._~-]+)|(?<unscoped>[A-Za-z0-9_~-][A-Za-z0-9._~-]*))(?:\/[^?#]*)?$/;
+
+/**
+ * Extract the npm package name from a bare package specifier.
+ *
+ * Relative and absolute paths, package imports, URL/virtual schemes, malformed
+ * scoped names, and Node builtins are not npm package references.
+ */
+export function packageNameFromSpecifier(specifier: string): string | null {
+  const match = BARE_PACKAGE_SPECIFIER_RE.exec(specifier);
+  const packageName = match?.groups?.scoped ?? match?.groups?.unscoped ?? null;
+  if (!packageName || BUILTIN_MODULES.has(packageName)) return null;
+  return packageName;
+}

--- a/packages/vinext/src/utils/path.ts
+++ b/packages/vinext/src/utils/path.ts
@@ -1,8 +1,37 @@
+import fs from "node:fs";
+import path, { toSlash } from "pathslash";
+
 export const isWindows = process.platform === "win32";
+export const NODE_MODULES_PATH_RE = /(?:^|[\\/])node_modules(?:[\\/]|$)/;
 
 export function stripViteModuleQuery(id: string): string {
   const queryIndex = id.search(/[?#]/);
   return queryIndex === -1 ? id : id.slice(0, queryIndex);
+}
+
+/** Canonicalize an external-origin filesystem path for use as a Vite module id. */
+export function canonicalizeFilePath(filePath: string): string {
+  try {
+    return toSlash(fs.realpathSync.native(filePath));
+  } catch {
+    return toSlash(filePath);
+  }
+}
+
+/** Whether `filePath` is a strict descendant of `directory`. */
+export function isPathInside(directory: string, filePath: string): boolean {
+  const relativePath = path.relative(directory, filePath);
+  return (
+    relativePath !== "" &&
+    relativePath !== ".." &&
+    !relativePath.startsWith("../") &&
+    !path.isAbsolute(relativePath)
+  );
+}
+
+/** Whether `filePath` is `directory` itself or one of its descendants. */
+export function isPathInsideOrEqual(directory: string, filePath: string): boolean {
+  return path.relative(directory, filePath) === "" || isPathInside(directory, filePath);
 }
 
 /** Strip a trailing `.js` extension from a module specifier so

--- a/tests/plugin-utils.test.ts
+++ b/tests/plugin-utils.test.ts
@@ -1,0 +1,136 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { toSlash } from "pathslash";
+import { describe, expect, it } from "vite-plus/test";
+import {
+  booleanLiteralValue,
+  getAstName,
+  SCRIPT_MODULE_ID_RE,
+  scriptParserLanguage,
+  staticStringValue,
+  stringLiteralValue,
+  unwrapExpression,
+  walkAst,
+} from "../packages/vinext/src/plugins/ast-utils.js";
+import { isServerEnvironment } from "../packages/vinext/src/plugins/environment.js";
+import {
+  BARE_PACKAGE_SPECIFIER_RE,
+  packageNameFromSpecifier,
+} from "../packages/vinext/src/utils/package-name.js";
+import {
+  canonicalizeFilePath,
+  isPathInside,
+  isPathInsideOrEqual,
+  NODE_MODULES_PATH_RE,
+  stripViteModuleQuery,
+} from "../packages/vinext/src/utils/path.js";
+
+describe("plugin AST utilities", () => {
+  it.each([
+    ["/app/page.js", "jsx"],
+    ["/app/page.jsx?direct", "jsx"],
+    ["/app/page.cjs#fragment", "jsx"],
+    ["/app/page.ts", "ts"],
+    ["/app/page.mts?direct", "ts"],
+    ["/app/page.cts", "ts"],
+    ["/app/page.tsx", "tsx"],
+    ["/app/page.json", null],
+  ] as const)("classifies %s as %s", (id, expected) => {
+    expect(scriptParserLanguage(id)).toBe(expected);
+    expect(SCRIPT_MODULE_ID_RE.test(id)).toBe(expected !== null);
+  });
+
+  it("reads literal values and syntax-only expression wrappers", () => {
+    const literal = { type: "Literal", value: "value" };
+    const template = {
+      type: "TemplateLiteral",
+      expressions: [],
+      quasis: [{ type: "TemplateElement", value: { cooked: "cooked", raw: "raw" } }],
+    };
+    const wrapped = { type: "TSAsExpression", expression: literal };
+
+    expect(getAstName({ type: "Identifier", name: "binding" })).toBe("binding");
+    expect(stringLiteralValue(literal)).toBe("value");
+    expect(staticStringValue(template)).toBe("cooked");
+    expect(booleanLiteralValue({ type: "Literal", value: false })).toBe(false);
+    expect(unwrapExpression(wrapped)).toBe(literal);
+    expect(staticStringValue({ ...template, expressions: [literal] })).toBeNull();
+  });
+
+  it("walks children without following parent cycles and supports pruning", () => {
+    const prunedChild = { type: "Literal", value: "hidden" };
+    const pruned = { type: "CallExpression", arguments: [prunedChild] };
+    const visible = { type: "Identifier", name: "visible" };
+    const root = { type: "Program", body: [pruned, visible] } as Record<string, unknown>;
+    root.parent = root;
+
+    const visited: string[] = [];
+    walkAst(root, (node) => {
+      visited.push(node.type);
+      return node === pruned ? false : undefined;
+    });
+
+    expect(visited).toEqual(["Program", "CallExpression", "Identifier"]);
+  });
+});
+
+describe("plugin module utilities", () => {
+  it.each([
+    ["react", "react", true],
+    ["react/jsx-runtime", "react", true],
+    ["@scope/pkg/subpath", "@scope/pkg", true],
+    ["node:fs", null, false],
+    ["fs/promises", null, true],
+    ["virtual:module", null, false],
+    ["#internal", null, false],
+    ["./local", null, false],
+    ["@scope", null, false],
+  ] as const)("extracts the package name from %s", (specifier, expected, isBare) => {
+    expect(packageNameFromSpecifier(specifier)).toBe(expected);
+    expect(BARE_PACKAGE_SPECIFIER_RE.test(specifier)).toBe(isBare);
+  });
+
+  it("recognizes node_modules as a complete path segment", () => {
+    expect(NODE_MODULES_PATH_RE.test("/app/node_modules/pkg/index.js")).toBe(true);
+    expect(NODE_MODULES_PATH_RE.test("node_modules\\pkg\\index.js")).toBe(true);
+    expect(NODE_MODULES_PATH_RE.test("/app/my_node_modules/pkg/index.js")).toBe(false);
+  });
+
+  it("classifies server-consumed Vite environments", () => {
+    expect(isServerEnvironment({ name: "ssr", config: { consumer: "server" } })).toBe(true);
+    expect(isServerEnvironment({ name: "rsc", config: {} })).toBe(true);
+    expect(isServerEnvironment({ name: "client", config: { consumer: "server" } })).toBe(false);
+    expect(isServerEnvironment({ name: "worker", config: { consumer: "client" } })).toBe(false);
+  });
+});
+
+describe("plugin path utilities", () => {
+  it("strips Vite queries and fragments and checks directory boundaries", () => {
+    const root = path.join(os.tmpdir(), "vinext-plugin-utils-root");
+    const child = path.join(root, "nested", "page.tsx");
+    const dotDotNamedChild = path.join(root, "..cache", "page.tsx");
+    const sibling = path.join(os.tmpdir(), "vinext-plugin-utils-root-sibling", "page.tsx");
+
+    expect(stripViteModuleQuery(`${child}?direct#fragment`)).toBe(child);
+    expect(isPathInside(root, child)).toBe(true);
+    expect(isPathInside(root, dotDotNamedChild)).toBe(true);
+    expect(isPathInside(root, root)).toBe(false);
+    expect(isPathInsideOrEqual(root, root)).toBe(true);
+    expect(isPathInsideOrEqual(root, sibling)).toBe(false);
+  });
+
+  it("canonicalizes existing files and preserves missing paths", () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-plugin-utils-"));
+    const file = path.join(directory, "module.ts");
+    fs.writeFileSync(file, "export {};");
+    try {
+      expect(canonicalizeFilePath(file)).toBe(toSlash(fs.realpathSync.native(file)));
+      expect(canonicalizeFilePath(path.join(directory, "missing.ts"))).toBe(
+        toSlash(path.join(directory, "missing.ts")),
+      );
+    } finally {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- consolidate shared AST traversal, literal parsing, script-module filtering, and transform-result construction used across Vite plugins
- centralize module path, package specifier, node_modules, and server-environment classification
- migrate plugin callers and add focused utility regression coverage

## Validation

- `vp check`
- 25 affected test files: 683 passed, 3 skipped
- `vp run vinext#build`
- `git diff --check`
