### PR TITLE
fix(cache): reject unserializable use cache results

### DIFF
--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -43,6 +43,7 @@ import {
   VINEXT_METADATA_ROUTE_CACHE_HEADER,
   VINEXT_PRERENDER_CACHE_LIFE_HEADER,
   VINEXT_PRERENDER_METADATA_ROUTES_PATH,
+  VINEXT_PRERENDER_RENDER_ERROR_HEADER,
   VINEXT_PRERENDER_ROUTE_PARAMS_HEADER,
   VINEXT_PRERENDER_SECRET_HEADER,
   VINEXT_PRERENDER_SPECULATIVE_HEADER,
@@ -1498,11 +1499,13 @@ export async function prerenderApp({
             rscHandler(request),
           );
           if (!response.ok) {
+            const fatal = response.headers.get(VINEXT_PRERENDER_RENDER_ERROR_HEADER) === "1";
             await response.body?.cancel();
             return {
               route: routePattern,
               status: "error",
               error: `Metadata route returned ${response.status}`,
+              ...(fatal ? { fatal: true as const } : {}),
             };
           }
           const cacheControl = response.headers.get("cache-control") ?? "";
@@ -1573,6 +1576,7 @@ export async function prerenderApp({
             const linkHeader = response.headers.get("link");
             const responseCacheLife = readPrerenderCacheLifeHeader(response.headers);
             const cacheTags = readPrerenderCacheTagsHeader(response.headers);
+            const fatal = response.headers.get(VINEXT_PRERENDER_RENDER_ERROR_HEADER) === "1";
             if (!response.ok || cacheControl.includes("no-store")) {
               await response.body?.cancel();
               return {
@@ -1583,6 +1587,7 @@ export async function prerenderApp({
                 requestCacheLife: null,
                 tags: [],
                 status: response.status,
+                fatal,
               };
             }
 
@@ -1599,18 +1604,20 @@ export async function prerenderApp({
               requestCacheLife: responseCacheLife ?? processCacheLife,
               status: response.status,
               tags: cacheTags,
+              fatal: false,
             };
           },
         );
         const htmlCacheControl = htmlRender.cacheControl;
         if (!htmlRender.ok) {
-          if (isSpeculative) {
+          if (isSpeculative && !htmlRender.fatal) {
             return { route: routePattern, status: "skipped", reason: "dynamic" };
           }
           return {
             route: routePattern,
             status: "error",
             error: `RSC handler returned ${htmlRender.status}`,
+            ...(htmlRender.fatal ? { fatal: true as const } : {}),
           };
         }
 

--- a/packages/vinext/src/server/headers.ts
+++ b/packages/vinext/src/server/headers.ts
@@ -78,6 +78,9 @@ export const VINEXT_RENDERED_PATH_AND_SEARCH_HEADER = "X-Vinext-Rendered-Path-An
 /** Prerender-only JSON side channel carrying request cacheLife metadata. */
 export const VINEXT_PRERENDER_CACHE_LIFE_HEADER = "x-vinext-prerender-cache-life";
 
+/** Marks a local prerender-server 500 that originated from a thrown render error. */
+export const VINEXT_PRERENDER_RENDER_ERROR_HEADER = "x-vinext-prerender-render-error";
+
 /** Internal marker persisted only inside metadata-route APP_ROUTE cache values. */
 export const VINEXT_METADATA_ROUTE_CACHE_HEADER = "x-vinext-metadata-route-cache";
 

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -74,6 +74,7 @@ import { collectInlineCssManifest } from "../build/inline-css.js";
 import { readPrerenderSecret } from "../build/server-manifest.js";
 import {
   VINEXT_PRERENDER_ROUTE_PARAMS_HEADER,
+  VINEXT_PRERENDER_RENDER_ERROR_HEADER,
   VINEXT_PRERENDER_SECRET_HEADER,
   VINEXT_PRERENDER_SPECULATIVE_HEADER,
   VINEXT_STATIC_FILE_HEADER,
@@ -1828,6 +1829,9 @@ async function startAppRouterServer(options: AppRouterServerOptions) {
     } catch (e) {
       console.error("[vinext] Server error:", e);
       if (!res.headersSent) {
+        if (purpose === "prerender") {
+          res.setHeader(VINEXT_PRERENDER_RENDER_ERROR_HEADER, "1");
+        }
         res.writeHead(500);
         res.end("Internal Server Error");
       }
@@ -2372,6 +2376,9 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
     } catch (e) {
       console.error("[vinext] Server error:", e);
       if (!res.headersSent) {
+        if (purpose === "prerender") {
+          res.setHeader(VINEXT_PRERENDER_RENDER_ERROR_HEADER, "1");
+        }
         res.writeHead(500);
         res.end("Internal Server Error");
       }

--- a/packages/vinext/src/shims/cache-runtime.ts
+++ b/packages/vinext/src/shims/cache-runtime.ts
@@ -176,7 +176,10 @@ export function getCacheContext(): CacheContext | null {
  * In test environments, the import fails and we fall back to JSON.
  */
 type RscModule = {
-  renderToReadableStream: (data: unknown, options?: object) => ReadableStream<Uint8Array>;
+  renderToReadableStream: (
+    data: unknown,
+    options?: { onError?: (error: unknown) => string | undefined },
+  ) => ReadableStream<Uint8Array>;
   createFromReadableStream: <T>(
     stream: ReadableStream<Uint8Array>,
     options?: object,
@@ -188,9 +191,12 @@ type RscModule = {
   decodeReply: (body: string | FormData, options?: unknown) => Promise<unknown[]>;
 };
 
-type SerializedCacheResult = {
-  body: string;
-  headers: Record<string, string>;
+type SerializedCacheResult<TResult = unknown> = {
+  result: TResult;
+  cacheEntry: {
+    body: string;
+    headers: Record<string, string>;
+  } | null;
 };
 
 function getUseCacheDeploymentIdDefine(): string | undefined {
@@ -296,28 +302,48 @@ function uint8ToStream(bytes: Uint8Array): ReadableStream<Uint8Array> {
   });
 }
 
-async function serializeCacheResult(
-  result: unknown,
+async function serializeCacheResult<TResult>(
+  result: TResult,
   rsc: RscModule | null,
-): Promise<SerializedCacheResult | null> {
-  try {
-    if (rsc) {
-      // Draining the stream is part of cache entry generation: lazy Server
-      // Components may execute here and contribute tags, cache life, or root
-      // param dependencies to the active cache scope.
-      const stream = rsc.renderToReadableStream(result);
-      const bytes = await collectStream(stream);
-      return {
-        body: uint8ToBase64(bytes),
-        headers: { [VINEXT_RSC_MARKER_HEADER]: "1" },
-      };
-    }
+): Promise<SerializedCacheResult<TResult> | null> {
+  if (rsc) {
+    let serializationError: { value: unknown } | undefined;
+    const stream = rsc.renderToReadableStream(result, {
+      onError(error) {
+        serializationError ??= { value: error };
+        return undefined;
+      },
+    });
+    const [returnStream, savedStream] = stream.tee();
 
-    const body = JSON.stringify(result);
-    return body === undefined ? null : { body, headers: {} };
-  } catch {
-    return null;
+    try {
+      // Decode the value that the caller receives from the same Flight stream
+      // whose other branch is persisted. This matches Next.js and ensures an
+      // errored Flight row rejects the callable-cache invocation instead of
+      // returning the original, unserializable object.
+      const [deserializedResult, bytes] = await Promise.all([
+        rsc.createFromReadableStream<TResult>(returnStream, {}, { preserveServerReferences: true }),
+        // Draining the saved branch is part of cache entry generation: lazy
+        // Server Components may execute here and contribute tags, cache life,
+        // or root param dependencies to the active cache scope.
+        collectStream(savedStream),
+      ]);
+      return {
+        result: deserializedResult,
+        cacheEntry: serializationError
+          ? null
+          : {
+              body: uint8ToBase64(bytes),
+              headers: { [VINEXT_RSC_MARKER_HEADER]: "1" },
+            },
+      };
+    } catch (error) {
+      throw serializationError?.value ?? error;
+    }
   }
+
+  const body = JSON.stringify(result);
+  return body === undefined ? null : { result, cacheEntry: { body, headers: {} } };
 }
 
 /**
@@ -639,9 +665,9 @@ export function registerCachedFunction<TArgs extends unknown[], TResult>(
           return privateHit as TResult;
         }
 
-        const result = await executeWithContext(fn, callArgs, cacheVariant);
-        privateCache.set(cacheKey, result);
-        return result;
+        const execution = await executeWithContext(fn, callArgs, cacheVariant, rsc);
+        if (execution.cacheable) privateCache.set(cacheKey, execution.result);
+        return execution.result;
       }
 
       // Draft mode joins dev in skipping shared cache lookup/storage: the key
@@ -649,7 +675,7 @@ export function registerCachedFunction<TArgs extends unknown[], TResult>(
       // preview request would otherwise seed unpublished content into an entry
       // later served to public requests. Mirrors Next.js's `isDraftMode` guard.
       if (isDev || isDraftModeEnabled()) {
-        return executeWithContext(fn, callArgs, cacheVariant);
+        return (await executeWithContext(fn, callArgs, cacheVariant, rsc)).result;
       }
 
       // Shared cache ("use cache" / "use cache: remote")
@@ -756,13 +782,14 @@ export function registerCachedFunction<TArgs extends unknown[], TResult>(
 
       // Serialization ran while the cache ALS was active so lazy Server
       // Component work is reflected in `ctx` before selecting the final key.
-      if (collectedResult) {
+      if (collectedResult?.cacheEntry) {
         try {
+          const serialized = collectedResult.cacheEntry;
           const cacheValue = {
             kind: "FETCH",
             data: {
-              headers: collectedResult.headers,
-              body: collectedResult.body,
+              headers: serialized.headers,
+              body: serialized.body,
               url: cacheKey,
             },
             tags: ctx.tags,
@@ -813,7 +840,7 @@ export function registerCachedFunction<TArgs extends unknown[], TResult>(
         }
       }
 
-      return result;
+      return collectedResult ? collectedResult.result : result;
     }, cacheVariant);
 
   // Preserve the original function's arity on the wrapper. The wrapper is
@@ -933,14 +960,24 @@ async function executeWithContext<T extends (...args: any[]) => Promise<any>>(
   // oxlint-disable-next-line @typescript-eslint/no-explicit-any
   args: any[],
   variant: string,
-): Promise<Awaited<ReturnType<T>>> {
+  rsc?: RscModule | null,
+): Promise<{ result: Awaited<ReturnType<T>>; cacheable: boolean }> {
   const {
     result,
     ctx: _ctx,
     effectiveLife,
-  } = await runCachedFunctionWithContext(fn, args, variant);
+    collectedResult,
+  } = await runCachedFunctionWithContext<T, SerializedCacheResult<Awaited<ReturnType<T>>> | null>(
+    fn,
+    args,
+    variant,
+    rsc ? (value) => serializeCacheResult(value, rsc) : undefined,
+  );
   recordRequestScopedCacheLife(effectiveLife);
-  return result;
+  return {
+    result: collectedResult ? collectedResult.result : result,
+    cacheable: collectedResult?.cacheEntry !== null,
+  };
 }
 
 /**

--- a/tests/app-router-production-build.test.ts
+++ b/tests/app-router-production-build.test.ts
@@ -5,6 +5,7 @@ import { pathToFileURL } from "node:url";
 import { createBuilder } from "vite";
 import { afterAll, describe, expect, it, vi } from "vite-plus/test";
 import vinext from "../packages/vinext/src/index.js";
+import { runPrerender } from "../packages/vinext/src/build/run-prerender.js";
 import { APP_FIXTURE_DIR } from "./helpers.js";
 
 type BuiltAppHandler = (request: Request) => Promise<Response | string | null | undefined>;
@@ -470,6 +471,77 @@ export function GET(request) {
       });
       await expect(builder.buildApp()).rejects.toThrow(
         'The file "./proxy.ts" must export a function, either as a default export or as a named "proxy" export.',
+      );
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  }, 120000);
+
+  // Next.js returns the value decoded from one branch of the callable-cache
+  // Flight stream and saves the other branch, so a serializer error rejects
+  // the call instead of persisting an error row.
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/use-cache/use-cache-wrapper.ts
+  it('fails prerendering when a callable "use cache" result cannot be serialized', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-use-cache-serialization-"));
+
+    try {
+      fs.writeFileSync(path.join(tmpDir, "package.json"), `{"type":"module"}`);
+      fs.symlinkSync(
+        path.resolve(import.meta.dirname, "../node_modules"),
+        path.join(tmpDir, "node_modules"),
+        "junction",
+      );
+      fs.mkdirSync(path.join(tmpDir, "app"), { recursive: true });
+      fs.writeFileSync(
+        path.join(tmpDir, "app", "layout.tsx"),
+        `export default function Root({ children }: { children: React.ReactNode }) {
+  return <html><body>{children}</body></html>;
+}
+`,
+      );
+      fs.writeFileSync(
+        path.join(tmpDir, "app", "page.tsx"),
+        `export default function Page() { return <p>hello world</p>; }\n`,
+      );
+      fs.writeFileSync(
+        path.join(tmpDir, "app", "opengraph-image.tsx"),
+        `import { ImageResponse } from "next/og";
+
+export const size = { width: 1200, height: 630 };
+
+export default async function OpenGraphImage() {
+  "use cache";
+
+  return new ImageResponse(
+    <div style={{ display: "flex", width: "100%", height: "100%" }}>
+      vinext use-cache serialization regression
+    </div>,
+    size,
+  );
+}
+`,
+      );
+
+      const builder = await createBuilder({
+        root: tmpDir,
+        configFile: false,
+        plugins: [vinext({ appDir: tmpDir })],
+        logLevel: "silent",
+      });
+      await builder.buildApp();
+
+      const built: { default?: unknown } = await import(
+        `${pathToFileURL(path.join(tmpDir, "dist", "server", "index.js")).href}?t=${Date.now()}`
+      );
+      expect(isBuiltAppHandler(built.default)).toBe(true);
+      if (!isBuiltAppHandler(built.default)) return;
+
+      await expect(built.default(new Request("http://localhost/opengraph-image"))).rejects.toThrow(
+        /Only plain objects/,
+      );
+
+      await expect(runPrerender({ root: tmpDir, concurrency: 1 })).rejects.toThrow(
+        /Metadata route returned 500/,
       );
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/tests/use-cache-serialization.test.ts
+++ b/tests/use-cache-serialization.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const flightState = vi.hoisted(() => ({
+  mode: "root" as "root" | "nested" | "success",
+}));
+
+vi.mock("@vitejs/plugin-rsc/react/rsc", () => {
+  const serializationError = new Error("Flight serialization failed");
+
+  return {
+    renderToReadableStream(
+      _value: unknown,
+      options?: { onError?: (error: unknown) => string | undefined },
+    ) {
+      if (flightState.mode !== "success") options?.onError?.(serializationError);
+      return new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('0:E{"digest":""}\n'));
+          controller.close();
+        },
+      });
+    },
+    async createFromReadableStream() {
+      if (flightState.mode === "root") throw serializationError;
+      if (flightState.mode === "success") return { value: "decoded" };
+      const nested = Promise.reject(serializationError);
+      void nested.catch(() => undefined);
+      return { nested };
+    },
+    async encodeReply() {
+      return "[]";
+    },
+    createTemporaryReferenceSet() {
+      return new Set();
+    },
+    createClientTemporaryReferenceSet() {
+      return new Set();
+    },
+    async decodeReply() {
+      return [];
+    },
+  };
+});
+
+describe('callable "use cache" Flight serialization', () => {
+  let restoreCacheHandler: (() => void) | undefined;
+
+  beforeEach(async () => {
+    const { getCacheHandler, setCacheHandler } =
+      await import("../packages/vinext/src/shims/cache.js");
+    const original = getCacheHandler();
+    restoreCacheHandler = () => setCacheHandler(original);
+    flightState.mode = "root";
+  });
+
+  afterEach(() => {
+    restoreCacheHandler?.();
+    restoreCacheHandler = undefined;
+  });
+
+  async function installRecordingCacheHandler() {
+    const { setCacheHandler } = await import("../packages/vinext/src/shims/cache.js");
+    const set = vi.fn(async () => undefined);
+    setCacheHandler({
+      async get() {
+        return null;
+      },
+      set,
+      async revalidateTag() {},
+    });
+    return set;
+  }
+
+  it("rejects a root-model serialization error without writing the Flight error row", async () => {
+    const set = await installRecordingCacheHandler();
+    const { registerCachedFunction } =
+      await import("../packages/vinext/src/shims/cache-runtime.js");
+    const cached = registerCachedFunction(
+      async () => new Response("unsupported"),
+      "test:root-serialization-error",
+    );
+
+    await expect(cached()).rejects.toThrow("Flight serialization failed");
+    expect(set).not.toHaveBeenCalled();
+  });
+
+  it("returns the decoded Flight value and writes a successful cache entry", async () => {
+    flightState.mode = "success";
+    const set = await installRecordingCacheHandler();
+    const { registerCachedFunction } =
+      await import("../packages/vinext/src/shims/cache-runtime.js");
+    const cached = registerCachedFunction(
+      async () => ({ value: "original" }),
+      "test:successful-serialization",
+    );
+
+    await expect(cached()).resolves.toEqual({ value: "decoded" });
+    expect(set).toHaveBeenCalledOnce();
+  });
+
+  it("returns a decoded root with a nested rejection but does not cache the errored stream", async () => {
+    flightState.mode = "nested";
+    const set = await installRecordingCacheHandler();
+    const { registerCachedFunction } =
+      await import("../packages/vinext/src/shims/cache-runtime.js");
+    const cached = registerCachedFunction(
+      async () => ({ nested: Promise.resolve("unused") }),
+      "test:nested-serialization-error",
+    );
+
+    const result = await cached();
+    await expect(result.nested).rejects.toThrow("Flight serialization failed");
+    expect(set).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #2949

## Summary

- decode callable `use cache` misses from the same Flight stream that is persisted, matching Next.js
- reject root-model serialization failures and skip cache writes for any errored Flight stream
- propagate thrown prerender render failures separately from intentional HTTP statuses so builds fail without changing metadata status semantics

## Root cause

Vinext drained the cache Flight stream without an `onError` callback, persisted bytes even when React emitted an error row, and returned the original function value. An unsupported value such as `ImageResponse` therefore logged a serialization error but still reached the metadata response cache as a successful PNG.

## Regression coverage

- real production build and directive transform with a cached `ImageResponse` metadata route
- root Flight serialization rejection with no callable cache write
- successful Flight decode and cache write
- nested rejected Flight model returned to the caller but not persisted

## Validation

- `vp check --fix packages/vinext/src/shims/cache-runtime.ts packages/vinext/src/server/headers.ts packages/vinext/src/server/prod-server.ts packages/vinext/src/build/prerender.ts tests/app-router-production-build.test.ts tests/use-cache-serialization.test.ts`
- `vp test run tests/use-cache-serialization.test.ts` (3 passed)
- `vp test run tests/shims.test.ts -t "use cache.*runtime"` (42 passed)
- `vp test run tests/prod-server-logs.test.ts` (3 passed)
- `vp test run tests/prerender.test.ts -t metadata` (5 passed)
- `vp test run tests/app-router-production-build.test.ts` (11 passed)
- `vp run vinext#build`
- two fresh independent reviews: NO FINDINGS