### PR TITLE
test(worker-image-imports): assert the canonical forward-slash metadata path

### DIFF
--- a/tests/worker-image-imports.test.ts
+++ b/tests/worker-image-imports.test.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { toSlash } from "pathslash";
 import { describe, expect, it, vi } from "vite-plus/test";
 import { createWorkerImageImportsPlugin } from "../packages/vinext/src/plugins/worker-image-imports.js";
 
@@ -35,7 +36,7 @@ describe("worker image imports", () => {
     });
     expect(result?.code).toContain('import("@images/test.png")');
     expect(result?.code).toContain("vinext-worker-image-meta:");
-    expect(result?.code).toContain(imagePath);
+    expect(result?.code).toContain(toSlash(imagePath));
   });
 
   it("versions only emitted static and dynamic worker chunk edges", () => {


### PR DESCRIPTION
## Problem

`tests/worker-image-imports.test.ts` fails on Windows. The plugin canonicalizes the resolved image id with `toSlash`, so the embedded `vinext-worker-image-meta:` path is forward-slash (`E:/…/icon.png`). The test built its expected path with `path.resolve`, which yields native backslashes on Windows (`E:\…\icon.png`), so the `toContain` assertion never matched. On Linux `path.resolve` already returns forward slashes, so it passed there.

Fix: assert `toSlash(imagePath)` so the expectation matches the plugin's canonical output on both platforms. The mock resolver still returns a native backslash id, which keeps the test exercising the plugin's `toSlash` normalization.

## Affected tests

- `tests/worker-image-imports.test.ts > worker image imports > resolves aliased dynamic image imports before adding metadata`
