### PR TITLE
test(tsconfig-paths): assert canonical forward-slash alias paths

### DIFF
--- a/tests/tsconfig-paths-config-loader.test.ts
+++ b/tests/tsconfig-paths-config-loader.test.ts
@@ -192,8 +192,8 @@ describe("loadTsconfigPathAliasesForRoot", () => {
 
     const aliases = loadTsconfigPathAliasesForRoot(tmpDir);
     expect(Object.keys(aliases)).toEqual(["@/public", "@"]);
-    expect(aliases["@/public"]).toBe(path.join(tmpDir, "public"));
-    expect(aliases["@"]).toBe(path.join(tmpDir, "src"));
+    expect(aliases["@/public"]).toBe(canonical(tmpDir, "public"));
+    expect(aliases["@"]).toBe(canonical(tmpDir, "src"));
   });
 
   it("returns empty object when tsconfig.json is missing", () => {


### PR DESCRIPTION
## Problem

`tests/tsconfig-paths-config-loader.test.ts` fails on Windows. `loadTsconfigPathAliasesForRoot` returns canonical forward-slash alias targets, but the "orders overlapping aliases longest-prefix-first" case asserted against raw `path.join(tmpDir, …)`, which yields native backslashes on Windows. The file already has a `canonical()` helper (`toSlash(path.join(...))`) that every other case uses; this one case was missed. On Linux `path.join` is already forward-slash, so it passed there.

Fix: assert against `canonical(tmpDir, …)`, matching the rest of the file.

## Affected tests

- `tests/tsconfig-paths-config-loader.test.ts > loadTsconfigPathAliasesForRoot > orders overlapping aliases longest-prefix-first regardless of declaration order`