### PR TITLE
test(client-assets-build): root fixtures on the repo volume to avoid EXDEV

### DIFF
--- a/tests/client-assets-build.test.ts
+++ b/tests/client-assets-build.test.ts
@@ -1,5 +1,4 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { build, createBuilder } from "vite";
 import { describe, expect, it } from "vite-plus/test";
@@ -18,7 +17,7 @@ async function writeFile(file: string, source: string): Promise<void> {
 }
 
 async function createFixture(): Promise<string> {
-  const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-client-assets-build-"));
+  const fixtureRoot = await fs.mkdtemp(path.join(import.meta.dirname, ".tmp-client-assets-build-"));
   await fs.symlink(ROOT_NODE_MODULES, path.join(fixtureRoot, "node_modules"), "junction");
   await writeFile(
     path.join(fixtureRoot, "package.json"),
@@ -54,7 +53,7 @@ describe("client asset sidecar builds", () => {
 
   it("keeps App Router metadata at the stable root of nested custom server outputs", async () => {
     const fixtureRoot = await createFixture();
-    const outRoot = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-client-assets-out-"));
+    const outRoot = await fs.mkdtemp(path.join(import.meta.dirname, ".tmp-client-assets-out-"));
     try {
       const serverRoot = path.join(outRoot, "custom", "server");
       const rscOutDir = path.join(serverRoot, "rsc");
@@ -84,7 +83,9 @@ describe("client asset sidecar builds", () => {
 
   it("keeps disjoint App Router outputs self-contained", async () => {
     const fixtureRoot = await createFixture();
-    const outRoot = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-client-assets-disjoint-"));
+    const outRoot = await fs.mkdtemp(
+      path.join(import.meta.dirname, ".tmp-client-assets-disjoint-"),
+    );
     try {
       const rscOutDir = path.join(outRoot, "rsc-output");
       const ssrOutDir = path.join(outRoot, "ssr-output");


### PR DESCRIPTION
## Problem

`tests/client-assets-build.test.ts` fails on Windows with `EXDEV: cross-device link not permitted`. The fixture is created under `os.tmpdir()` (drive C: on this machine) but junctions its `node_modules` to the repo's `node_modules` (drive E:), so plugin-rsc's `.vite-rsc-temp` staging directory lands on E:. The build output dirs are also created under `os.tmpdir()` (C:), and plugin-rsc renames between the two — a cross-drive rename, which fails on Windows. On Linux `os.tmpdir()` and the repo share one filesystem, so the rename stays intra-volume and passes.

Fix: root the fixture and its output dirs under `import.meta.dirname` (same volume as the repo `node_modules`), matching the pattern already used by `externals-transitive.test.ts` and `static-image-emission.test.ts`. All build inputs, staging, and outputs then live on one volume.

## Affected tests

- `tests/client-assets-build.test.ts > client asset sidecar builds > keeps App Router metadata at the stable root of nested custom server outputs`