### PR TITLE
test(dynamic-requests-build): raise the build/dev-server case timeout on Windows

### DIFF
--- a/tests/dynamic-requests-build.test.ts
+++ b/tests/dynamic-requests-build.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import vm from "node:vm";
 import { createBuilder, createServer } from "vite";
-import { describe, expect, it } from "vite-plus/test";
+import { describe, expect, it, vi } from "vite-plus/test";
 import vinext from "../packages/vinext/src/index.js";
 import {
   _transformVeryDynamicRequests,
@@ -12,6 +12,9 @@ import {
 } from "../packages/vinext/src/plugins/ignore-dynamic-requests.js";
 
 const ROOT_NODE_MODULES = path.resolve(import.meta.dirname, "../node_modules");
+
+// The dev-server and build cases exceed the 5s default under Windows parallelism.
+if (process.platform === "win32") vi.setConfig({ testTimeout: 30000 });
 
 async function withTempDir<T>(run: (root: string) => Promise<T>): Promise<T> {
   const root = await mkdtemp(path.join(os.tmpdir(), "vinext-dynamic-requests-"));


### PR DESCRIPTION
## Problem

`tests/dynamic-requests-build.test.ts` fails on Windows in the full parallel unit run — the three cases that spin up a dev server or run a full `buildApp` hit `Test timed out in 5000ms`, never an assertion mismatch. The file passes in isolation (46 tests, ~3s); those three build/dev cases only exceed the 5s default under full-suite parallelism, where Windows I/O is slower. Linux CI stays under the limit.

Fix: raise the per-test timeout to 30000ms for this file on Windows only (`vi.setConfig`). Linux keeps the default. No production code changes.

## Affected tests

- `serves guarded fully dynamic requests in pages and route handlers during development`
- `builds guarded fully dynamic requests in pages and route handlers`
- `builds JS files that contain JSX and guarded fully dynamic requests`
