### PR TITLE
refactor(app-router): remove dead RSC nav global

### DIFF
--- a/packages/vinext/src/client/navigation-runtime.ts
+++ b/packages/vinext/src/client/navigation-runtime.ts
@@ -2,7 +2,7 @@ import type { RouteManifest, RouteManifestInterception } from "../routing/app-ro
 import { isUnknownRecord } from "../utils/record.js";
 import type { AppRouterScrollIntent } from "vinext/shims/app-router-scroll-state";
 
-export type NavigationRuntimeSnapshot = {
+type NavigationRuntimeSnapshot = {
   pathname: string;
   searchParams: [string, string][];
 };

--- a/packages/vinext/src/global.d.ts
+++ b/packages/vinext/src/global.d.ts
@@ -246,17 +246,6 @@ declare global {
   var __VINEXT_RSC_PARAMS__: Record<string, string | string[]> | undefined;
 
   /**
-   * Navigation context embedded by `generateSsrEntry()` for hydration
-   * snapshot consistency. Contains the pathname and searchParams used
-   * during SSR so `useSyncExternalStore` `getServerSnapshot` matches the
-   * SSR-rendered HTML.
-   * `searchParams` is serialised as an array of `[key, value]` pairs to
-   * preserve duplicate keys (e.g. `?tag=a&tag=b`).
-   */
-  // oxlint-disable-next-line no-var
-  var __VINEXT_RSC_NAV__: { pathname: string; searchParams: [string, string][] } | undefined;
-
-  /**
    * Maps emitted CSS asset hrefs to file contents when next.config enables
    * `experimental.inlineCss`. Injected into edge bundles at build time and
    * populated by the Node.js production server at startup.

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -1387,16 +1387,8 @@ async function readInitialRscStream(): Promise<ReadableStream<Uint8Array> | null
       return createProgressiveRscStream();
     }
 
-    const params = vinext.__VINEXT_RSC_PARAMS__ ?? {};
     if (vinext.__VINEXT_RSC_PARAMS__) {
       applyClientParams(vinext.__VINEXT_RSC_PARAMS__);
-    }
-    if (vinext.__VINEXT_RSC_NAV__) {
-      restoreHydrationNavigationContext(
-        vinext.__VINEXT_RSC_NAV__.pathname,
-        vinext.__VINEXT_RSC_NAV__.searchParams,
-        params,
-      );
     }
 
     return createProgressiveRscStream();

--- a/packages/vinext/src/server/app-browser-stream.ts
+++ b/packages/vinext/src/server/app-browser-stream.ts
@@ -3,7 +3,6 @@ import {
   ensureNavigationRuntimeRscBootstrap,
   getNavigationRuntime,
   type NavigationRuntimeRscBootstrap,
-  type NavigationRuntimeSnapshot,
 } from "../client/navigation-runtime.js";
 import { RSC_FORM_STATE_GLOBAL } from "./app-browser-hydration.js";
 import { decodeRscEmbeddedChunk, type RscEmbeddedChunk } from "./app-rsc-embedded-chunks.js";
@@ -13,7 +12,6 @@ type VinextBrowserGlobals = {
   __VINEXT_RSC_DONE__?: boolean;
   [RSC_FORM_STATE_GLOBAL]?: ReactFormState;
   __VINEXT_RSC_PARAMS__?: Record<string, string | string[]>;
-  __VINEXT_RSC_NAV__?: NavigationRuntimeSnapshot;
 };
 
 export function getVinextBrowserGlobal(): typeof globalThis & VinextBrowserGlobals {

--- a/tests/app-browser-stream.test.ts
+++ b/tests/app-browser-stream.test.ts
@@ -17,7 +17,6 @@ function resetBrowserGlobals(): void {
   delete vinext.__VINEXT_RSC_CHUNKS__;
   delete vinext.__VINEXT_RSC_DONE__;
   delete vinext.__VINEXT_RSC_PARAMS__;
-  delete vinext.__VINEXT_RSC_NAV__;
   Reflect.deleteProperty(globalThis, "window");
 }
 

--- a/tests/fixtures/app-basic/app/nextjs-compat/nav-context-hydration/[id]/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/nav-context-hydration/[id]/page.tsx
@@ -3,17 +3,17 @@ import { NavInfo } from "../nav-info";
 /**
  * Dynamic-segment page for the nav-context-hydration regression fixture.
  *
- * The [id] segment exercises the params-carrying side of __VINEXT_RSC_NAV__:
- * both __VINEXT_RSC_PARAMS__ and the params field passed to setNavigationContext
- * must reflect the matched segment value so that useParams() returns the right
- * thing during hydration.
+ * The [id] segment exercises the params-carrying side of the navigation runtime
+ * RSC bootstrap. Its params field and the value passed to setNavigationContext
+ * must reflect the matched segment so useParams() returns the right value during
+ * hydration.
  *
  * The test verifies:
  *  1. The SSR HTML renders the correct pathname (e.g. "/nextjs-compat/nav-context-hydration/hello")
- *  2. __VINEXT_RSC_NAV__ in the HTML payload carries that same pathname
- *  3. __VINEXT_RSC_PARAMS__ carries { id: "hello" }
+ *  2. The HTML bootstrap carries that same pathname
+ *  3. The bootstrap params carry { id: "hello" }
  *
- * Without the __VINEXT_RSC_NAV__ fix, getServerSnapshot returns "/" during
+ * Without the navigation bootstrap, getServerSnapshot returns "/" during
  * hydration even though SSR rendered the real pathname, triggering React
  * hydration mismatch error #418.
  */

--- a/tests/fixtures/app-basic/app/nextjs-compat/nav-context-hydration/nav-info.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/nav-context-hydration/nav-info.tsx
@@ -6,12 +6,12 @@ import { usePathname, useSearchParams } from "next/navigation";
  * "use client" component for the nav-context-hydration regression fixture.
  *
  * Renders usePathname() and useSearchParams() during SSR so the test can
- * assert the SSR-rendered values match the __VINEXT_RSC_NAV__ payload that
+ * assert the SSR-rendered values match the navigation bootstrap payload that
  * the browser entry restores before hydration.
  *
- * The fix under test: __VINEXT_RSC_NAV__ is embedded in <head> as a script
- * tag so that useSyncExternalStore's getServerSnapshot returns the same
- * pathname/searchParams that were rendered on the server, preventing React
+ * The fix under test: navigation state is embedded in <head> as part of the
+ * runtime bootstrap so useSyncExternalStore's getServerSnapshot returns the
+ * same pathname/searchParams that were rendered on the server, preventing React
  * hydration mismatch error #418.
  *
  * Without the fix, getServerSnapshot falls back to "/" and empty search

--- a/tests/fixtures/app-basic/app/nextjs-compat/nav-context-hydration/page.tsx
+++ b/tests/fixtures/app-basic/app/nextjs-compat/nav-context-hydration/page.tsx
@@ -6,12 +6,12 @@ import { NavInfo } from "./nav-info";
  * Renders the <NavInfo /> client component so the test can assert:
  *  1. The SSR HTML contains the correct pathname and searchParams values
  *     (rendered server-side via the RSC→SSR nav context pass-through).
- *  2. The HTML contains a __VINEXT_RSC_NAV__ script tag with a payload
+ *  2. The HTML contains a navigation runtime RSC bootstrap with a payload
  *     whose pathname/searchParams match what was SSR-rendered, ensuring
  *     useSyncExternalStore's getServerSnapshot will agree with the
  *     SSR-rendered HTML during client hydration.
  *
- * Without __VINEXT_RSC_NAV__, getServerSnapshot returns "/" and empty
+ * Without that navigation bootstrap, getServerSnapshot returns "/" and empty
  * URLSearchParams regardless of the actual request URL, causing React to
  * detect a mismatch between the server-rendered HTML and the client snapshot
  * (React hydration error #418).

--- a/tests/nextjs-compat/rsc-context-lazy-stream.test.ts
+++ b/tests/nextjs-compat/rsc-context-lazy-stream.test.ts
@@ -1,5 +1,5 @@
 /**
- * Regression tests: RSC lazy stream context-clear bug + __VINEXT_RSC_NAV__ hydration embedding
+ * Regression tests: RSC lazy stream context-clear bug + navigation hydration bootstrap
  *
  * ── Bug 1: RSC lazy stream context-clear ────────────────────────────────────
  *
@@ -31,7 +31,7 @@
  * and asserts the sentinel value appears in the RSC flight response, proving
  * the layout's headers() call ran successfully during lazy stream consumption.
  *
- * ── Bug 2: __VINEXT_RSC_NAV__ missing from HTML (hydration mismatch) ────────
+ * Bug 2: navigation state missing from HTML (hydration mismatch)
  *
  * useSyncExternalStore requires that the getServerSnapshot callback returns the
  * same value that was rendered by the server. For usePathname() and
@@ -45,25 +45,24 @@
  * React hydration mismatch error #418 whenever any "use client" component
  * called usePathname() or useSearchParams().
  *
- * Fix: generateSsrEntry() embeds __VINEXT_RSC_NAV__ = { pathname, searchParams }
- * (where searchParams is an array of [key, value] pairs to preserve duplicates)
- * and __VINEXT_RSC_PARAMS__ = { ...params } as <script> tags in <head>.
- * generateBrowserEntry() reads self.__VINEXT_RSC_NAV__ before hydrateRoot()
- * and calls setNavigationContext() so the client snapshot matches the server.
+ * Fix: the SSR entry embeds the pathname, searchParams, and params in the
+ * symbol-backed navigation runtime RSC bootstrap in <head>. The browser entry
+ * restores that state before hydrateRoot() so the client snapshot matches the
+ * server.
  *
  * The tests verify:
- *   1. The HTML <head> contains the __VINEXT_RSC_NAV__ script tag
+ *   1. The HTML <head> contains the navigation runtime RSC bootstrap
  *   2. The embedded pathname matches the actual request path
  *   3. The embedded searchParams matches the actual query string
- *   4. __VINEXT_RSC_PARAMS__ carries dynamic segment values
+ *   4. The bootstrap params carry dynamic segment values
  *   5. The SSR-rendered values from usePathname()/useSearchParams() agree with
- *      the __VINEXT_RSC_NAV__ payload — ensuring getServerSnapshot will match
+ *      the navigation bootstrap — ensuring getServerSnapshot will match
  *      the HTML React tries to hydrate
  *
  * Fixture: tests/fixtures/app-basic/app/nextjs-compat/nav-context-hydration/
  *   page.tsx   — RSC page rendering <NavInfo /> (a "use client" component)
  *   nav-info.tsx — "use client": renders usePathname(), useSearchParams()
- *   [id]/page.tsx — dynamic-segment variant for __VINEXT_RSC_PARAMS__ testing
+ *   [id]/page.tsx — dynamic-segment variant for bootstrap params testing
  */
 
 import { describe, it, expect, beforeAll, afterAll } from "vite-plus/test";
@@ -184,9 +183,9 @@ describe("RSC lazy stream: headers() context survives until stream is consumed",
   });
 });
 
-// ── Suite 2: __VINEXT_RSC_NAV__ hydration embedding ──────────────────────────
+// Suite 2: navigation runtime hydration bootstrap
 //
-// These tests verify the server embeds a correct __VINEXT_RSC_NAV__ payload so
+// These tests verify the server embeds the correct navigation bootstrap so
 // useSyncExternalStore's getServerSnapshot agrees with the SSR-rendered HTML.
 //
 // Fixture: tests/fixtures/app-basic/app/nextjs-compat/nav-context-hydration/
@@ -253,8 +252,8 @@ describe("navigation runtime RSC bootstrap: nav context embedded for hydration s
     const html = await res.text();
 
     // The "use client" NavInfo component renders usePathname() into #nav-pathname.
-    // During SSR this is resolved from the navigation context (same source as
-    // __VINEXT_RSC_NAV__). Both must agree — if getServerSnapshot returns the
+    // During SSR this is resolved from the navigation context (the same source
+    // as the embedded bootstrap). Both must agree — if getServerSnapshot returns the
     // embedded pathname and it matches the SSR-rendered value, React won't detect
     // a mismatch.
     expect(html).toContain(`<span id="nav-pathname">${NAV_ROUTE}</span>`);
@@ -290,12 +289,12 @@ describe("navigation runtime RSC bootstrap: nav context embedded for hydration s
 
   // ── 4. searchParams are correct (with query string) ───────────────────────
   //
-  // This is the critical hydration parity test. Without __VINEXT_RSC_NAV__:
+  // This is the critical hydration parity test. Without the navigation bootstrap:
   //   - SSR renders: <span id="nav-search-q">hello</span>
   //   - getServerSnapshot returns: new URLSearchParams() → ""
   //   → React sees "hello" ≠ "" → hydration mismatch error #418
   //
-  // With __VINEXT_RSC_NAV__:
+  // With the navigation bootstrap:
   //   - SSR renders: <span id="nav-search-q">hello</span>
   //   - browser entry calls setNavigationContext with new URLSearchParams([["q","hello"]])
   //   - getServerSnapshot returns: "hello"
@@ -338,7 +337,7 @@ describe("navigation runtime RSC bootstrap: nav context embedded for hydration s
     // The SSR path: RSC environment sets navigation context from request URL,
     // passes it to SSR environment via handleSsr(rscStream, navContext, ...).
     // The SSR environment's useSearchParams() reads navContext.searchParams.
-    // The __VINEXT_RSC_NAV__ payload comes from the same navContext.
+    // The embedded navigation payload comes from the same navContext.
     // Both should reflect the request query string.
     expect(html).toContain('<span id="nav-search-q">hello</span>');
     expect(html).toContain('<span id="nav-search-page">3</span>');
@@ -367,12 +366,11 @@ describe("navigation runtime RSC bootstrap: nav context embedded for hydration s
     expect(sp.get("q")).toBe(specialQ);
   });
 
-  // ── 6. __VINEXT_RSC_PARAMS__ for dynamic segment routes ──────────────────
+  // 6. Bootstrap params for dynamic segment routes
   //
   // When the route has a dynamic segment (e.g. /nav-context-hydration/hello),
-  // __VINEXT_RSC_PARAMS__ must carry { id: "hello" }.
-  // The browser entry reads self.__VINEXT_RSC_PARAMS__ and passes it as
-  // params: to setNavigationContext(), so useParams() returns the right value
+  // The bootstrap params must carry { id: "hello" }. The browser entry passes
+  // them to setNavigationContext(), so useParams() returns the right value
   // during client hydration.
 
   it("navigation runtime params contains dynamic segment value for [id] route", async () => {
@@ -401,7 +399,7 @@ describe("navigation runtime RSC bootstrap: nav context embedded for hydration s
     const html = await res.text();
 
     // The "use client" NavInfo component also renders on the dynamic page.
-    // Its usePathname() output must match __VINEXT_RSC_NAV__.pathname.
+    // Its usePathname() output must match the embedded bootstrap pathname.
     expect(html).toContain(`<span id="nav-pathname">${dynamicPath}</span>`);
 
     const { nav } = extractRscBootstrap(html);
@@ -410,8 +408,8 @@ describe("navigation runtime RSC bootstrap: nav context embedded for hydration s
 
   // ── 7. Script tags appear before </head> ─────────────────────────────────
   //
-  // Both __VINEXT_RSC_NAV__ and __VINEXT_RSC_PARAMS__ are injected into <head>
-  // by generateSsrEntry(). They must appear before </head> so they are always
+  // Navigation and params are injected into <head> as one runtime bootstrap.
+  // It must appear before </head> so the state is always
   // available by the time the bootstrap script runs and calls main().
   // If they were injected into the body stream they could arrive after
   // hydrateRoot() is called, making the hydration snapshot stale.
@@ -433,7 +431,7 @@ describe("navigation runtime RSC bootstrap: nav context embedded for hydration s
   //
   // The navigation context is built from cleanPathname (the URL pathname with
   // the trailing slash normalised). This must be the value embedded in
-  // __VINEXT_RSC_NAV__, not the raw URL including query string.
+  // the navigation bootstrap, not the raw URL including query string.
 
   it("navigation runtime pathname does not include query string", async () => {
     const res = await fetch(`${_baseUrl}${NAV_ROUTE}?q=shouldnotbehere`);


### PR DESCRIPTION
## Summary

- remove the unreachable `__VINEXT_RSC_NAV__` browser fallback and global type
- drop its leftover browser-stream test cleanup and type import
- update hydration regression documentation to describe the active symbol-backed navigation runtime bootstrap

The global has had no producer since #1322 moved SSR, PPR, and streamed RSC metadata to `navigationRuntime.bootstrap.rsc.nav`. Current prerender extraction also recognizes the symbol-backed payload (plus legacy chunk/done formats), but never emits or reconstructs `__VINEXT_RSC_NAV__`.

## Testing

- `vp test run tests/app-browser-stream.test.ts tests/nextjs-compat/rsc-context-lazy-stream.test.ts` (29 tests)
- `vp check` on all 8 changed files
- `git grep __VINEXT_RSC_NAV__` returns no matches