### PR TITLE
fix(pages-router): emit dev build ID in next data

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -4379,6 +4379,8 @@ export const loadServerActionClient = ${
       },
 
       configureServer(server: ViteDevServer) {
+        const devBuildId = nextConfig?.buildId ?? process.env.__VINEXT_BUILD_ID ?? "development";
+
         server.middlewares.use((req, _res, next) => {
           req.__vinextOriginalEncodedUrl ??= req.url;
           next();
@@ -5298,8 +5300,6 @@ export const loadServerActionClient = ${
                 // matching the value embedded into the prod entry. Fall back
                 // to the env-var define (set by the plugin) and finally
                 // "development" if the plugin hasn't resolved a config yet.
-                const devBuildId =
-                  nextConfig?.buildId ?? process.env.__VINEXT_BUILD_ID ?? "development";
                 const dataMatch = parseNextDataPathname(pathname, devBuildId);
                 if (dataMatch) {
                   isDataReq = true;
@@ -5839,6 +5839,7 @@ export const loadServerActionClient = ${
                       nextConfig?.reactStrictMode === true,
                       nextConfig?.expireTime,
                       nextConfig?.crossOrigin,
+                      devBuildId,
                     ),
                   };
                 }

--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -627,6 +627,8 @@ export function createSSRHandler(
   /** Next.js `expireTime`, used when formatting terminal GSP responses. */
   expireTime = PAGES_CACHE_ONE_YEAR_SECONDS,
   crossOrigin?: string,
+  /** Resolved Pages Router build ID shared with the dev data-route parser. */
+  buildId = process.env.__VINEXT_BUILD_ID ?? "development",
 ) {
   const matcher = fileMatcher ?? createValidFileMatcher();
 
@@ -718,6 +720,7 @@ export function createSSRHandler(
 
     const errorPageContext = {
       basePath,
+      buildId,
       clientTraceMetadata,
       locale: locale ?? currentDefaultLocale,
       locales: i18nConfig?.locales,
@@ -1569,7 +1572,7 @@ export function createSSRHandler(
             props: renderProps,
             page: patternToNextFormat(route.pattern),
             query: isFallbackRender ? {} : params,
-            buildId: process.env.__VINEXT_BUILD_ID,
+            buildId,
             isFallback: isFallbackRender,
             locale: locale ?? currentDefaultLocale,
             locales: i18nConfig?.locales,
@@ -1784,6 +1787,7 @@ async function renderErrorPage(
   reactStrictMode = false,
   context: {
     basePath: string;
+    buildId?: string;
     clientTraceMetadata?: readonly string[];
     locale?: string;
     locales?: string[];
@@ -1984,7 +1988,7 @@ async function renderErrorPage(
           props: renderProps,
           page: errorPage,
           query: parseQuery(url),
-          buildId: process.env.__VINEXT_BUILD_ID,
+          buildId: context.buildId ?? process.env.__VINEXT_BUILD_ID ?? "development",
           isFallback: false,
           notFoundSrcPage: context.notFoundSrcPage,
           __vinext: {

--- a/tests/pages-router.test.ts
+++ b/tests/pages-router.test.ts
@@ -1207,6 +1207,11 @@ describe("Pages Router integration", () => {
     // Should render the custom 404 page
     expect(html).toContain("404 - Page Not Found");
     expect(html).toContain("does not exist");
+    const nextDataMatch = html.match(
+      /<script id="__NEXT_DATA__" type="application\/json"(?: nonce="[^"]+")?>([\s\S]*?)<\/script>/,
+    );
+    expect(nextDataMatch).toBeTruthy();
+    expect(JSON.parse(nextDataMatch![1]).buildId).toBe("test-build-id");
   });
 
   // Ported from Next.js: test/e2e/not-found-revalidate/not-found-revalidate.test.ts
@@ -1503,6 +1508,59 @@ export default function Page({ marker }: { marker: string }) {
     const res = await fetch(`${baseUrl}/`);
     const html = await res.text();
     expect(html).toContain("__NEXT_DATA__");
+  });
+
+  it("emits the resolved dev build ID so Pages Router data requests are addressable", async () => {
+    const tmpRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "vinext-pages-dev-build-id-"));
+    const rootNodeModules = path.resolve(import.meta.dirname, "../node_modules");
+    let started: Awaited<ReturnType<typeof startFixtureServer>> | undefined;
+
+    try {
+      await fsp.symlink(rootNodeModules, path.join(tmpRoot, "node_modules"), "junction");
+      await fsp.mkdir(path.join(tmpRoot, "pages"), { recursive: true });
+      await fsp.writeFile(path.join(tmpRoot, "package.json"), JSON.stringify({ type: "module" }));
+      await fsp.writeFile(
+        path.join(tmpRoot, "pages", "index.tsx"),
+        `export default function Home() { return <h1>Home</h1>; }\n`,
+      );
+      await fsp.writeFile(
+        path.join(tmpRoot, "pages", "about.tsx"),
+        `export function getServerSideProps() {
+  return { props: { source: "about-data" } };
+}
+export default function About({ source }) { return <h1>{source}</h1>; }
+`,
+      );
+      started = await startFixtureServer(tmpRoot);
+      const response = await fetch(`${started.baseUrl}/`);
+      expect(response.status).toBe(200);
+      const html = await response.text();
+      const nextDataMatch = html.match(
+        /<script id="__NEXT_DATA__" type="application\/json"(?: nonce="[^"]+")?>([\s\S]*?)<\/script>/,
+      );
+      expect(nextDataMatch).toBeTruthy();
+      const nextData = JSON.parse(nextDataMatch![1]) as { buildId?: string };
+
+      // Next.js' dev server returns "development" from getBuildId(), and its
+      // renderer always serializes that value into __NEXT_DATA__. Vinext may
+      // resolve an opaque ID instead, but the emitted value must be present and
+      // accepted by the dev data-route parser.
+      // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/dev/next-dev-server.ts
+      // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/render.tsx
+      expect(nextData.buildId).toEqual(expect.any(String));
+      expect(nextData.buildId).not.toHaveLength(0);
+
+      const dataResponse = await fetch(
+        `${started.baseUrl}/_next/data/${nextData.buildId}/about.json`,
+      );
+      expect(dataResponse.status).toBe(200);
+      await expect(dataResponse.json()).resolves.toMatchObject({
+        pageProps: { source: "about-data" },
+      });
+    } finally {
+      await started?.server.close();
+      await fsp.rm(tmpRoot, { recursive: true, force: true });
+    }
   });
 
   // Dev/prod parity: the production client entry exposes


### PR DESCRIPTION
Closes #2960

## Summary

- resolve one Pages Router dev build ID for both data-route parsing and HTML rendering
- include that ID in normal and error `__NEXT_DATA__` payloads
- cover default dev IDs, configured IDs, and an addressable `/_next/data/<id>/...` response

## Root cause

The dev request parser used the resolved Next config build ID, while the SSR payload read only `process.env.__VINEXT_BUILD_ID`. In ordinary dev sessions that env value is absent, so JSON serialization dropped `buildId` and the client could not construct a data URL.

## Validation

- `vp test run tests/pages-router.test.ts` (382 passed)
- `vp test run tests/link-navigation.test.ts -t "prefetches implicit dynamic Pages Router links through a concrete route URL"`
- `vp check packages/vinext/src/index.ts packages/vinext/src/server/dev-server.ts tests/pages-router.test.ts`
- two independent reviews: `NO FINDINGS`