### PR TITLE
refactor(client): remove dead instrumentation exports

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -64,12 +64,10 @@ export default {
         "src/server/app-page-ppr-runtime.ts",
         "src/server/app-prerender-static-params.ts",
         "src/server/app-route-module-loader.ts",
-        // Client-side instrumentation bundle: loaded as a side-effect module
-        // by the generated hydration entries (import "vinext/instrumentation-client"),
-        // so its public surface (clientInstrumentationHooks, getClientInstrumentationHooks)
-        // is consumed by the user's app at runtime, not by imports knip can follow.
+        // Client-side instrumentation bootstrap: loaded as a side-effect module
+        // by generated hydration entries (import "vinext/instrumentation-client"),
+        // so knip cannot follow the import statically.
         "src/client/instrumentation-client.ts",
-        "src/client/instrumentation-client-state.ts",
         // Shims for `next/*` internal modules — their exports are consumed by
         // type-only imports in third-party packages' .d.ts files (e.g.
         // @clerk/nextjs, @sentry/nextjs, nextjs-toploader). Those imports

--- a/packages/vinext/src/client/instrumentation-client-state.ts
+++ b/packages/vinext/src/client/instrumentation-client-state.ts
@@ -8,15 +8,8 @@ export function normalizeClientInstrumentationHooks(
   return Object.values(hooks).some((value) => typeof value === "function") ? hooks : null;
 }
 
-export function setClientInstrumentationHooks(
-  hooks: ClientInstrumentationHooks | null,
-): ClientInstrumentationHooks | null {
+export function setClientInstrumentationHooks(hooks: ClientInstrumentationHooks | null): void {
   clientInstrumentationHooks = hooks;
-  return clientInstrumentationHooks;
-}
-
-export function getClientInstrumentationHooks(): ClientInstrumentationHooks | null {
-  return clientInstrumentationHooks;
 }
 
 export function notifyAppRouterTransitionStart(

--- a/packages/vinext/src/client/instrumentation-client.ts
+++ b/packages/vinext/src/client/instrumentation-client.ts
@@ -8,6 +8,6 @@ export type ClientInstrumentationHooks = {
   onRouterTransitionStart?: (href: string, navigationType: "push" | "replace" | "traverse") => void;
 };
 
-export const clientInstrumentationHooks = setClientInstrumentationHooks(
+setClientInstrumentationHooks(
   normalizeClientInstrumentationHooks(instrumentationClientHooks as ClientInstrumentationHooks),
 );


### PR DESCRIPTION
## Summary

- remove the unreferenced `getClientInstrumentationHooks` internal getter
- preserve instrumentation bootstrap initialization without retaining an unused exported binding or return value
- remove the reachable state module from the Knip entry exemptions so future unused exports are reported

## Reachability evidence

- neither removed value has a source, test, generated-import, or string reference
- `vinext/client/instrumentation-client-state` and `vinext/instrumentation-client` are not package exports
- the generated Pages bootstrap and App browser entry consume instrumentation as a side effect; the packed output still performs that initialization

## Validation

- `vp run knip`
- `vp check`
- `vp test run tests/instrumentation.test.ts tests/app-browser-entry.test.ts tests/entry-templates.test.ts` (331 tests)
- `vp run vinext#build`
- inspected packed JS and declarations to confirm the dead exports are absent and initialization remains