### PR TITLE
refactor(app-router): remove dead RSC chunk subscriber

### DIFF
--- a/packages/vinext/src/client/navigation-runtime.ts
+++ b/packages/vinext/src/client/navigation-runtime.ts
@@ -345,14 +345,6 @@ function ensureNavigationRuntimeRscBootstrapForRuntime(
   return rscBootstrap;
 }
 
-export function subscribeNavigationRuntimeRscChunk(
-  chunk: NavigationRuntimeRscChunk,
-): NavigationRuntime {
-  const runtime = ensureNavigationRuntime();
-  ensureNavigationRuntimeRscBootstrapForRuntime(runtime).rsc.push(chunk);
-  return runtime;
-}
-
 export function hasAppNavigationRuntime(): boolean {
   return typeof getNavigationRuntime()?.functions.navigate === "function";
 }

--- a/tests/navigation-runtime.test.ts
+++ b/tests/navigation-runtime.test.ts
@@ -5,7 +5,6 @@ import {
   hasAppNavigationRuntime,
   registerNavigationRuntimeBootstrap,
   registerNavigationRuntimeFunctions,
-  subscribeNavigationRuntimeRscChunk,
   type NavigationRuntime,
   type NavigationRuntimeBootstrap,
   type NavigationRuntimeFunctions,
@@ -42,14 +41,6 @@ describe("navigation runtime contract", () => {
     expect(getNavigationRuntime()?.bootstrap.routeManifest).toBeNull();
   });
 
-  it("creates the RSC bootstrap buffer when subscribing the first chunk", () => {
-    Reflect.set(globalThis, "window", {});
-
-    subscribeNavigationRuntimeRscChunk("chunk");
-
-    expect(getNavigationRuntime()?.bootstrap.rsc?.rsc).toEqual(["chunk"]);
-  });
-
   it("reports app navigation availability from the registered navigate slot", () => {
     Reflect.set(globalThis, "window", {});
 
@@ -72,15 +63,6 @@ describe("navigation runtime contract", () => {
 
     expect(getNavigationRuntime()?.functions.navigate).toBe(navigate);
     expect(getNavigationRuntime()?.functions.pingVisibleLinks).toBe(pingVisibleLinks);
-  });
-
-  it("keeps server-side runtime creation detached from the window contract", () => {
-    Reflect.deleteProperty(globalThis, "window");
-
-    const runtime = subscribeNavigationRuntimeRscChunk("server-chunk");
-
-    expect(runtime.bootstrap.rsc?.rsc).toEqual(["server-chunk"]);
-    expect(getNavigationRuntime()).toBeNull();
   });
 
   it("rejects runtime objects with non-function capability slots", () => {


### PR DESCRIPTION
## Summary

- remove the orphaned `subscribeNavigationRuntimeRscChunk` helper
- remove the two unit tests whose only purpose was exercising that helper

## Dead-code proof

- the helper has no production caller, generated-string reference, or package export
- its only references were its declaration and the two removed unit tests
- it was introduced with the symbol-backed runtime in #1322, but the actual SSR producer has always emitted direct `bootstrap.rsc.rsc.push(...)` scripts
- the browser consumer intercepts that array push directly in `app-browser-stream.ts`
- the packed producer and consumer retain those active paths, while the helper is absent from packed JS and declarations

## Validation

- `vp test run tests/navigation-runtime.test.ts tests/app-ssr-stream.test.ts tests/app-browser-stream.test.ts tests/prerender.test.ts` (163 tests)
- `vp run knip`
- `vp check`
- `vp run vinext#build`
- verified zero remaining `subscribeNavigationRuntimeRscChunk` references in source, tests, and packed output