### PR TITLE
refactor(cache): remove dead revalidate duration registry

### DIFF
--- a/packages/vinext/src/server/isr-cache.ts
+++ b/packages/vinext/src/server/isr-cache.ts
@@ -266,10 +266,6 @@ export async function isrSetPrerenderedAppPage(
     ctx.tags = tags;
   }
   await getCdnCacheAdapter().set(key, data, ctx);
-
-  if (revalidateSeconds !== undefined) {
-    setRevalidateDuration(key, revalidateSeconds);
-  }
 }
 
 // ---------------------------------------------------------------------------
@@ -495,39 +491,4 @@ export function appIsrRscKey(
 
 export function appIsrRouteKey(pathname: string): string {
   return appIsrCacheKey(pathname, "route");
-}
-
-// ---------------------------------------------------------------------------
-// Revalidate duration tracking — remembers how long each ISR key's TTL is
-// so we can emit correct Cache-Control headers on cache hits.
-// ---------------------------------------------------------------------------
-
-const MAX_REVALIDATE_ENTRIES = 10_000;
-const _REVALIDATE_KEY = Symbol.for("vinext.isrCache.revalidateDurations");
-const revalidateDurations = (_g[_REVALIDATE_KEY] ??= new Map<string, number>()) as Map<
-  string,
-  number
->;
-
-/**
- * Store the revalidate duration for a cache key.
- * Uses insertion-order LRU eviction to prevent unbounded growth.
- */
-export function setRevalidateDuration(key: string, seconds: number): void {
-  // Simple LRU: delete and re-insert to move to end (most recent)
-  revalidateDurations.delete(key);
-  revalidateDurations.set(key, seconds);
-  // Evict oldest entries if over limit
-  while (revalidateDurations.size > MAX_REVALIDATE_ENTRIES) {
-    const first = revalidateDurations.keys().next().value;
-    if (first !== undefined) revalidateDurations.delete(first);
-    else break;
-  }
-}
-
-/**
- * Get the revalidate duration for a cache key.
- */
-export function getRevalidateDuration(key: string): number | undefined {
-  return revalidateDurations.get(key);
 }

--- a/tests/isr-cache.test.ts
+++ b/tests/isr-cache.test.ts
@@ -1,8 +1,7 @@
 /**
  * ISR cache unit tests.
  *
- * Tests cache key generation, normalization, hash truncation,
- * revalidate duration tracking with LRU eviction, background
+ * Tests cache key generation, normalization, hash truncation, background
  * regeneration deduplication, and cache value builders.
  *
  * These complement the integration-level ISR tests in features.test.ts
@@ -20,8 +19,6 @@ import {
   buildPagesCacheValue,
   buildAppPageCacheValue,
   normalizeMountedSlotsHeader,
-  setRevalidateDuration,
-  getRevalidateDuration,
   triggerBackgroundRegeneration,
 } from "../packages/vinext/src/server/isr-cache.js";
 import { APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL } from "../packages/vinext/src/server/app-rsc-render-mode.js";
@@ -354,30 +351,6 @@ describe("buildAppPageCacheValue", () => {
   it("includes status when provided", () => {
     const value = buildAppPageCacheValue("<html>app</html>", undefined, 200);
     expect(value.status).toBe(200);
-  });
-});
-
-// ─── Revalidate duration tracking ───────────────────────────────────────
-
-describe("setRevalidateDuration / getRevalidateDuration", () => {
-  it("stores and retrieves a duration", () => {
-    setRevalidateDuration("test-key-1", 60);
-    expect(getRevalidateDuration("test-key-1")).toBe(60);
-  });
-
-  it("returns undefined for unknown keys", () => {
-    expect(getRevalidateDuration("nonexistent-key-xyz")).toBeUndefined();
-  });
-
-  it("overwrites previous values", () => {
-    setRevalidateDuration("test-key-2", 60);
-    setRevalidateDuration("test-key-2", 120);
-    expect(getRevalidateDuration("test-key-2")).toBe(120);
-  });
-
-  it("handles zero duration", () => {
-    setRevalidateDuration("test-key-3", 0);
-    expect(getRevalidateDuration("test-key-3")).toBe(0);
   });
 });
 

--- a/tests/nextjs-compat/TRACKING.md
+++ b/tests/nextjs-compat/TRACKING.md
@@ -1141,10 +1141,9 @@ tests are either entirely new coverage or complementary to existing integration/
 | 1-9   | `isrCacheKey()`: pages/app prefix, root, trailing slash, nested, hash for long paths, deterministic hashing, different hashes | PASS   |       |
 | 10-11 | `buildPagesCacheValue()`: structure, status field                                                                             | PASS   |       |
 | 12-14 | `buildAppPageCacheValue()`: structure, rscData, status                                                                        | PASS   |       |
-| 15-18 | `setRevalidateDuration`/`getRevalidateDuration`: store/retrieve, unknown key, overwrite, zero                                 | PASS   |       |
-| 19-23 | `triggerBackgroundRegeneration()`: calls render, deduplicates, allows after completion, handles errors, independent keys      | PASS   |       |
+| 15-19 | `triggerBackgroundRegeneration()`: calls render, deduplicates, allows after completion, handles errors, independent keys      | PASS   |       |
 
-**Result: 23/23 pass**
+**Result: 19/19 pass**
 
 ### P5-8: Error boundary digest classification ✅
 

--- a/tests/seed-cache.test.ts
+++ b/tests/seed-cache.test.ts
@@ -18,11 +18,7 @@ import {
   type CacheHandlerValue,
   type IncrementalCacheValue,
 } from "../packages/vinext/src/shims/cache.js";
-import {
-  appIsrCacheKey,
-  isrCacheKey,
-  getRevalidateDuration,
-} from "../packages/vinext/src/server/isr-cache.js";
+import { appIsrCacheKey, isrCacheKey } from "../packages/vinext/src/server/isr-cache.js";
 import { getRenderedConcreteUrlPathsForRoute } from "../packages/vinext/src/server/pregenerated-concrete-paths.js";
 import { seedMemoryCacheFromPrerender } from "../packages/vinext/src/server/seed-cache.js";
 
@@ -412,29 +408,6 @@ describe("seedMemoryCacheFromPrerender", () => {
     expect(count).toBe(0);
   });
 
-  // ── Revalidate duration tracking ──────────────────────────────────────────
-
-  it("populates revalidate duration map for ISR routes", async () => {
-    const buildId = "reval-duration-test";
-    setupPrerenderFixture(
-      serverDir,
-      {
-        buildId,
-        routes: [{ route: "/isr", status: "rendered", revalidate: 45, router: "app" }],
-      },
-      {
-        "isr.html": "<html>ISR</html>",
-        "isr.rsc": "RSC isr",
-      },
-    );
-
-    await seedMemoryCacheFromPrerender(serverDir);
-
-    const baseKey = isrCacheKey("app", "/isr", buildId);
-    expect(getRevalidateDuration(baseKey + ":html")).toBe(45);
-    expect(getRevalidateDuration(baseKey + ":rsc")).toBe(45);
-  });
-
   it("preserves legacy revalidate context while writing cache-control metadata", async () => {
     const contexts: Record<string, unknown>[] = [];
     const handler: CacheHandler = {
@@ -601,27 +574,6 @@ describe("seedMemoryCacheFromPrerender", () => {
     });
 
     expect(keys).toEqual(["runtime-build:/isr:html", "runtime-build:/isr:rsc"]);
-  });
-
-  it("does not set revalidate duration for static routes", async () => {
-    const buildId = "static-duration-test";
-    setupPrerenderFixture(
-      serverDir,
-      {
-        buildId,
-        routes: [{ route: "/static", status: "rendered", revalidate: false, router: "app" }],
-      },
-      {
-        "static.html": "<html>Static</html>",
-        "static.rsc": "RSC static",
-      },
-    );
-
-    await seedMemoryCacheFromPrerender(serverDir);
-
-    const baseKey = isrCacheKey("app", "/static", buildId);
-    expect(getRevalidateDuration(baseKey + ":html")).toBeUndefined();
-    expect(getRevalidateDuration(baseKey + ":rsc")).toBeUndefined();
   });
 
   // ── revalidatePath invalidation of seeded entries (#1486) ─────────────────


### PR DESCRIPTION
## Summary

- remove the ISR revalidate-duration registry and its global Symbol-backed map
- stop recording TTLs after prerender cache writes
- remove tests that only exercised the orphaned registry

## Dead-code proof

All production reads of `getRevalidateDuration()` were removed when cache-control metadata became authoritative in #2495. Before this change:

- `setRevalidateDuration()` had one production caller, which only wrote the registry
- `getRevalidateDuration()` had no production or package-consumer caller
- the only remaining reads were tests of the registry itself
- `packages/cloudflare` does not import either helper
- the packed JS and declarations no longer contain the registry symbols

## Validation

- `vp test run tests/isr-cache.test.ts tests/seed-cache.test.ts` (93 passed)
- `vp check packages/vinext/src/server/isr-cache.ts tests/isr-cache.test.ts tests/seed-cache.test.ts tests/nextjs-compat/TRACKING.md`
- `vp run knip`
- `vp run vinext#build`
