### PR TITLE
refactor(dynamic): remove dead preload queue

### DIFF
--- a/packages/vinext/src/shims/dynamic.ts
+++ b/packages/vinext/src/shims/dynamic.ts
@@ -186,19 +186,13 @@ function getDynamicErrorBoundary() {
 // Detect server vs client
 const isServer = typeof window === "undefined";
 
-// Legacy preload queue — kept for backward compatibility with Pages Router
-// which calls flushPreloads() before rendering. The App Router uses React.lazy
-// + Suspense instead, so this queue is no longer populated.
-const preloadQueue: Promise<void>[] = [];
-
 /**
- * Wait for all pending dynamic() preloads to resolve, then clear the queue.
- * Called by the Pages Router SSR handler before rendering.
- * No-op for the App Router path which uses React.lazy + Suspense.
+ * Retained for the Pages Router render pipeline, which calls this before
+ * rendering. Dynamic imports now use React.lazy + Suspense, so there is no
+ * separate preload work to await.
  */
 export function flushPreloads(): Promise<void[]> {
-  const pending = preloadQueue.splice(0);
-  return Promise.all(pending);
+  return Promise.resolve([]);
 }
 
 function dynamic<P = {}>(

--- a/tests/dynamic.test.ts
+++ b/tests/dynamic.test.ts
@@ -172,7 +172,7 @@ describe("next/dynamic defaults", () => {
 // ─── flushPreloads ──────────────────────────────────────────────────────
 
 describe("flushPreloads", () => {
-  it("returns an empty array when no preloads queued", async () => {
+  it("returns an empty array when there is no separate preload work", async () => {
     const result = await flushPreloads();
     expect(result).toEqual([]);
   });

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -15126,13 +15126,10 @@ describe("next/dynamic shim", () => {
     expect(htmlB).toContain("Component B");
   });
 
-  it("flushPreloads second call resolves immediately (queue drained)", async () => {
+  it("flushPreloads remains an immediate no-op across repeated calls", async () => {
     const { flushPreloads } = await import("../packages/vinext/src/shims/dynamic.js");
 
-    // First call should drain whatever's in the queue
     await flushPreloads();
-
-    // Second call should resolve immediately with empty array
     const result = await flushPreloads();
     expect(result).toEqual([]);
   });


### PR DESCRIPTION
## Summary

- keep the live `flushPreloads()` compatibility API used by the Pages Router
- remove its module-level queue, which has no producer
- return the same resolved empty array directly

## Dead-code proof

The queue had no `push`, assignment, registration path, generated-entry producer, or external access. Every call to `flushPreloads()` therefore spliced an array that was permanently empty. The API remains because both Pages Router server paths call it.

## Validation

- `vp test run tests/dynamic.test.ts tests/shims.test.ts -t "flushPreloads|next/dynamic"` (37 passed)
- `vp test run tests/pages-page-response.test.ts tests/pages-page-handler.test.ts -t "flushPreloads|dynamic"`
- `vp check packages/vinext/src/shims/dynamic.ts tests/dynamic.test.ts tests/shims.test.ts`
- `vp run knip`
- `vp run vinext#build`
