### PR TITLE
refactor(app-router): remove superseded helper wrappers

### DIFF
--- a/packages/vinext/src/server/app-browser-error.ts
+++ b/packages/vinext/src/server/app-browser-error.ts
@@ -75,11 +75,6 @@ export function createDevOnCaughtError(
   };
 }
 
-export function prodOnCaughtError(error: unknown, errorInfo: VinextHydrateRootErrorInfo): void {
-  if (isNavigationSignalError(error)) return;
-  logCaughtError(error, errorInfo);
-}
-
 export function prodOnRecoverableError(error: unknown): void {
   reportGlobalError(error instanceof Error && error.cause !== undefined ? error.cause : error);
 }

--- a/packages/vinext/src/server/app-page-segment-state.ts
+++ b/packages/vinext/src/server/app-page-segment-state.ts
@@ -201,19 +201,6 @@ export function resolveAppPagePatternStateKey(
   );
 }
 
-export function resolveAppPageLeafSegmentStateKey(
-  routeSegments: readonly string[],
-  params: AppPageParams,
-): string {
-  for (let treePosition = routeSegments.length - 1; treePosition >= 0; treePosition--) {
-    const segmentStateKey = resolveAppPageSegmentStateKey(routeSegments, treePosition, params);
-    if (segmentStateKey) {
-      return segmentStateKey;
-    }
-  }
-  return "";
-}
-
 export function resolveAppPageTemplateStateKey(
   routeSegments: readonly string[],
   treePosition: number,

--- a/packages/vinext/src/server/app-ppr-fallback-shell.ts
+++ b/packages/vinext/src/server/app-ppr-fallback-shell.ts
@@ -56,13 +56,6 @@ function pushParamValue(segments: string[], value: string | string[] | undefined
   return true;
 }
 
-export function createAppPprFallbackShell(
-  route: AppPprFallbackShellRoute,
-  matchedParams: Record<string, string | string[]>,
-): AppPprFallbackShell | null {
-  return createAppPprFallbackShells(route, matchedParams).at(-1) ?? null;
-}
-
 export function createAppPprFallbackShells(
   route: AppPprFallbackShellRoute,
   matchedParams: Record<string, string | string[]>,

--- a/packages/vinext/src/server/app-rsc-route-matching.ts
+++ b/packages/vinext/src/server/app-rsc-route-matching.ts
@@ -1,7 +1,6 @@
 import { buildRouteTrie, trieMatchRaw } from "../routing/route-trie.js";
 import {
   extractRawRoutePatternParams,
-  matchRoutePattern,
   matchRoutePatternRaw,
   matchRoutePatternPrefix,
   type RoutePatternParams,
@@ -520,13 +519,6 @@ function createInterceptLookup<Route extends AppRscRouteForMatching>(
   // Array.prototype.sort is stable, so entries with identical target patterns
   // retain declaration order across slots and sources.
   return interceptLookup.sort(compareInterceptTargetPatterns);
-}
-
-export function matchAppRscRoutePattern(
-  urlParts: string[],
-  patternParts: string[],
-): AppRscRouteParams | null {
-  return matchRoutePattern(urlParts, patternParts);
 }
 
 function mergeMatchedParams(

--- a/packages/vinext/src/server/prerender-route-params.ts
+++ b/packages/vinext/src/server/prerender-route-params.ts
@@ -136,15 +136,6 @@ function decodedPrerenderRouteParamEquals(
   return prerenderValue === matchedValue || (decoded !== null && decoded === matchedValue);
 }
 
-export function prerenderRouteParamsPayloadMatchesRoute(
-  payload: PrerenderRouteParamsPayload | null,
-  routePattern: string,
-  params: PrerenderRouteParams,
-): payload is PrerenderRouteParamsPayload {
-  const match = matchPrerenderRouteParamsPayload(payload, routePattern, params);
-  return match?.kind === "exact";
-}
-
 export function matchPrerenderRouteParamsPayload(
   payload: PrerenderRouteParamsPayload | null,
   routePattern: string,

--- a/tests/app-browser-entry.test.ts
+++ b/tests/app-browser-entry.test.ts
@@ -4,7 +4,6 @@ import {
   createDevOnCaughtError,
   createOnUncaughtError,
   createProdOnCaughtError,
-  prodOnCaughtError,
   prodOnRecoverableError,
 } from "../packages/vinext/src/server/app-browser-error.js";
 import {
@@ -8880,6 +8879,8 @@ describe("app navigation failure handling", () => {
 });
 
 describe("prodOnCaughtError (hydrateRoot prod handler)", () => {
+  const prodOnCaughtError = createProdOnCaughtError(() => {});
+
   it("ignores redirect sentinels handled by RedirectBoundary", () => {
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     try {

--- a/tests/app-page-segment-state.test.ts
+++ b/tests/app-page-segment-state.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 import {
   canonicalizeAppPageParams,
-  resolveAppPageLeafSegmentStateKey,
   resolveAppPagePatternStateKey,
   resolveAppPageRouteStateKey,
   resolveAppPageSegmentStateKey,
@@ -36,15 +35,6 @@ describe("app page segment state keys", () => {
         slug: "launch",
       }),
     ).toBe("slug|launch|d");
-  });
-
-  it("keeps the leaf segment helper scoped to the active local segment", () => {
-    expect(
-      resolveAppPageLeafSegmentStateKey(["(marketing)", "blog", "[slug]"], {
-        slug: "launch",
-      }),
-    ).toBe("slug|launch|d");
-    expect(resolveAppPageLeafSegmentStateKey(["(marketing)"], {})).toBe("");
   });
 
   it("uses the full visible segment-state path for route-wide reset keys", () => {

--- a/tests/app-ppr-fallback-shell.test.ts
+++ b/tests/app-ppr-fallback-shell.test.ts
@@ -1,15 +1,14 @@
 import { describe, expect, it } from "vite-plus/test";
 import {
-  createAppPprFallbackShell,
   createAppPprFallbackShells,
   isAppPprDynamicFallbackShellHtml,
   markAppPprDynamicFallbackShellHtml,
   rewriteAppPprFallbackShellHtmlNavigation,
 } from "../packages/vinext/src/server/app-ppr-fallback-shell.js";
 
-describe("createAppPprFallbackShell", () => {
+describe("createAppPprFallbackShells", () => {
   it("builds a cacheComponents fallback shell from known root params and missing child params", () => {
-    const shell = createAppPprFallbackShell(
+    const shells = createAppPprFallbackShells(
       {
         params: ["locale", "slug"],
         pattern: "/:locale/blog/:slug",
@@ -18,7 +17,7 @@ describe("createAppPprFallbackShell", () => {
       { locale: "en", slug: "new-post" },
     );
 
-    expect(shell).toEqual({
+    expect(shells).toContainEqual({
       fallbackParamNames: ["slug"],
       pathname: "/en/blog/[slug]",
       params: { locale: "en", slug: "[slug]" },
@@ -26,7 +25,7 @@ describe("createAppPprFallbackShell", () => {
   });
 
   it("preserves catch-all placeholder shape in the shell path and params", () => {
-    const shell = createAppPprFallbackShell(
+    const shells = createAppPprFallbackShells(
       {
         params: ["locale", "slug"],
         pattern: "/:locale/docs/:slug+",
@@ -35,7 +34,7 @@ describe("createAppPprFallbackShell", () => {
       { locale: "fr", slug: ["guides", "intro"] },
     );
 
-    expect(shell).toEqual({
+    expect(shells).toContainEqual({
       fallbackParamNames: ["slug"],
       pathname: "/fr/docs/[...slug]",
       params: { locale: "fr", slug: ["[...slug]"] },
@@ -43,7 +42,7 @@ describe("createAppPprFallbackShell", () => {
   });
 
   it("preserves optional catch-all placeholder shape in the shell path and params", () => {
-    const shell = createAppPprFallbackShell(
+    const shells = createAppPprFallbackShells(
       {
         params: ["locale", "slug"],
         pattern: "/:locale/docs/:slug*",
@@ -52,7 +51,7 @@ describe("createAppPprFallbackShell", () => {
       { locale: "fr", slug: ["guides", "intro"] },
     );
 
-    expect(shell).toEqual({
+    expect(shells).toContainEqual({
       fallbackParamNames: ["slug"],
       pathname: "/fr/docs/[[...slug]]",
       params: { locale: "fr", slug: ["[[...slug]]"] },
@@ -85,7 +84,7 @@ describe("createAppPprFallbackShell", () => {
 
   it("does not create a fallback shell without a known root-param boundary", () => {
     expect(
-      createAppPprFallbackShell(
+      createAppPprFallbackShells(
         {
           params: ["locale", "slug"],
           pattern: "/:locale/blog/:slug",
@@ -93,12 +92,12 @@ describe("createAppPprFallbackShell", () => {
         },
         { locale: "en", slug: "new-post" },
       ),
-    ).toBeNull();
+    ).toEqual([]);
   });
 
   it("does not create a fallback shell when the matched request lacks a root param", () => {
     expect(
-      createAppPprFallbackShell(
+      createAppPprFallbackShells(
         {
           params: ["locale", "slug"],
           pattern: "/:locale/blog/:slug",
@@ -106,7 +105,7 @@ describe("createAppPprFallbackShell", () => {
         },
         { slug: "new-post" },
       ),
-    ).toBeNull();
+    ).toEqual([]);
   });
 });
 

--- a/tests/app-rsc-route-matching.test.ts
+++ b/tests/app-rsc-route-matching.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 import {
   createAppRscRouteMatcher,
-  matchAppRscRoutePattern,
   SIBLING_PAGE_INTERCEPT_SLOT_KEY,
 } from "../packages/vinext/src/server/app-rsc-route-matching.js";
 
@@ -41,13 +40,6 @@ describe("App RSC route matching", () => {
     expect(result).not.toBeNull();
     expect(result!.route.pattern).toBe("/shop/:path*");
     expect(result!.params).toEqual({});
-  });
-
-  it("omits optional catch-all params from standalone route pattern matches", () => {
-    expect(matchAppRscRoutePattern(["shop"], ["shop", ":path*"])).toEqual({});
-    expect(matchAppRscRoutePattern(["shop", "a", "b"], ["shop", ":path*"])).toEqual({
-      path: ["a", "b"],
-    });
   });
 
   // Ported from Next.js: route-matcher.ts decodeURIComponent behaviour.
@@ -174,24 +166,6 @@ describe("App RSC route matching", () => {
     expect(matcher.findIntercept("/photos/%e2%9c%93", "/feed/a%2561")).toMatchObject({
       matchedParams: { slug: "a%61", id: "%E2%9C%93" },
     });
-  });
-
-  it("matches standalone route patterns for dynamic metadata routes", () => {
-    expect(
-      matchAppRscRoutePattern(["blog", "hello", "sitemap.xml"], ["blog", ":slug", "sitemap.xml"]),
-    ).toMatchObject({
-      slug: "hello",
-    });
-  });
-
-  it("treats static segments ending in plus or star as literals", () => {
-    expect(matchAppRscRoutePattern(["c++", "intro"], ["c++", ":slug"])).toMatchObject({
-      slug: "intro",
-    });
-
-    const starResult = matchAppRscRoutePattern(["file*"], ["file*"]);
-    expect(starResult).not.toBeNull();
-    expect(Object.keys(starResult ?? {})).toEqual([]);
   });
 
   it("finds intercepting routes and merges source and target params", () => {

--- a/tests/prerender-route-params.test.ts
+++ b/tests/prerender-route-params.test.ts
@@ -2,11 +2,18 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   encodePrerenderRouteParams,
   matchPrerenderRouteParamsPayload,
-  prerenderRouteParamsPayloadMatchesRoute,
   type PrerenderRouteParamsPayload,
 } from "../packages/vinext/src/server/prerender-route-params.js";
 
-describe("prerenderRouteParamsPayloadMatchesRoute", () => {
+function matchesExactRoute(
+  payload: PrerenderRouteParamsPayload | null,
+  routePattern: string,
+  params: Record<string, string | string[]>,
+): boolean {
+  return matchPrerenderRouteParamsPayload(payload, routePattern, params)?.kind === "exact";
+}
+
+describe("matchPrerenderRouteParamsPayload exact matches", () => {
   it("requires the decoded prerender params to match the final route params", () => {
     const payload: PrerenderRouteParamsPayload = {
       routePattern: "/product/:id",
@@ -14,22 +21,22 @@ describe("prerenderRouteParamsPayloadMatchesRoute", () => {
     };
 
     expect(
-      prerenderRouteParamsPayloadMatchesRoute(payload, "/product/:id", {
+      matchesExactRoute(payload, "/product/:id", {
         id: "sticks & stones",
       }),
     ).toBe(true);
     expect(
-      prerenderRouteParamsPayloadMatchesRoute(payload, "/product/:id", {
+      matchesExactRoute(payload, "/product/:id", {
         id: "sticks%20%26%20stones",
       }),
     ).toBe(true);
     expect(
-      prerenderRouteParamsPayloadMatchesRoute(payload, "/product/:id", {
+      matchesExactRoute(payload, "/product/:id", {
         id: "sticks-and-stones",
       }),
     ).toBe(false);
     expect(
-      prerenderRouteParamsPayloadMatchesRoute(payload, "/source/:slug", {
+      matchesExactRoute(payload, "/source/:slug", {
         id: "sticks & stones",
       }),
     ).toBe(false);
@@ -42,22 +49,22 @@ describe("prerenderRouteParamsPayloadMatchesRoute", () => {
     };
 
     expect(
-      prerenderRouteParamsPayloadMatchesRoute(payload, "/docs/:slug+", {
+      matchesExactRoute(payload, "/docs/:slug+", {
         slug: ["sticks & stones", "more words"],
       }),
     ).toBe(true);
     expect(
-      prerenderRouteParamsPayloadMatchesRoute(payload, "/docs/:slug+", {
+      matchesExactRoute(payload, "/docs/:slug+", {
         slug: ["sticks%20%26%20stones", "more%20words"],
       }),
     ).toBe(true);
     expect(
-      prerenderRouteParamsPayloadMatchesRoute(payload, "/docs/:slug+", {
+      matchesExactRoute(payload, "/docs/:slug+", {
         slug: ["more words", "sticks & stones"],
       }),
     ).toBe(false);
     expect(
-      prerenderRouteParamsPayloadMatchesRoute(payload, "/docs/:slug+", {
+      matchesExactRoute(payload, "/docs/:slug+", {
         slug: "sticks & stones",
       }),
     ).toBe(false);
@@ -71,7 +78,7 @@ describe("prerenderRouteParamsPayloadMatchesRoute", () => {
     };
 
     expect(
-      prerenderRouteParamsPayloadMatchesRoute(payload, "/product/:id", {
+      matchesExactRoute(payload, "/product/:id", {
         id: "abc",
       }),
     ).toBe(false);
@@ -85,7 +92,7 @@ describe("prerenderRouteParamsPayloadMatchesRoute", () => {
     };
 
     expect(
-      prerenderRouteParamsPayloadMatchesRoute(payload, "/product/:id", {
+      matchesExactRoute(payload, "/product/:id", {
         id: "abc",
       }),
     ).toBe(false);
@@ -99,7 +106,7 @@ describe("prerenderRouteParamsPayloadMatchesRoute", () => {
     };
 
     expect(
-      prerenderRouteParamsPayloadMatchesRoute(payload, "/product/:id", {
+      matchesExactRoute(payload, "/product/:id", {
         id: "abc",
       }),
     ).toBe(false);


### PR DESCRIPTION
## Summary

Remove five App Router helper wrappers left behind after production moved to richer implementations:

- `prodOnCaughtError` → `createProdOnCaughtError`
- `resolveAppPageLeafSegmentStateKey` → position-aware segment/route key helpers
- `matchAppRscRoutePattern` → shared route-pattern matcher and App route trie
- `createAppPprFallbackShell` → plural fallback-shell generation
- `prerenderRouteParamsPayloadMatchesRoute` → discriminated payload matcher

Tests now exercise the active production functions, or were removed where the shared route-pattern suite already owns identical coverage.

## Dead-code proof

Each removed export had zero production, generated-entry, package-export, or cross-package callers. Their only references were their declarations and tests. History shows the active replacements now used by runtime code; the packed JS and declarations no longer contain these names.

## Validation

- focused App browser handler tests (8 passed)
- App segment, route matcher, and shared route-pattern tests (67 passed)
- PPR fallback-shell and prerender-param tests (34 passed)
- `vp check` on all changed source and test files
- `vp run knip`
- `vp run vinext#build`
