### PR TITLE
refactor(pages): remove superseded helper wrappers

### DIFF
--- a/packages/vinext/src/server/dev-server.ts
+++ b/packages/vinext/src/server/dev-server.ts
@@ -44,8 +44,6 @@ import {
 } from "../routing/file-matcher.js";
 import {
   extractLocaleFromUrl as extractLocaleFromUrlShared,
-  detectLocaleFromAcceptLanguage,
-  parseCookieLocaleFromHeader,
   resolvePagesI18nRequest,
 } from "./pages-i18n.js";
 import { buildDefaultPagesNotFoundResponse } from "./pages-default-404.js";
@@ -566,25 +564,6 @@ export function extractLocaleFromUrl(
   i18nConfig: NextI18nConfig,
 ): { locale: string; url: string; hadPrefix: boolean } {
   return extractLocaleFromUrlShared(url, i18nConfig);
-}
-
-/**
- * Detect the preferred locale from the Accept-Language header.
- * Returns the best matching locale or null.
- */
-export function detectLocaleFromHeaders(
-  req: IncomingMessage,
-  i18nConfig: NextI18nConfig,
-): string | null {
-  return detectLocaleFromAcceptLanguage(req.headers["accept-language"], i18nConfig);
-}
-
-/**
- * Parse the NEXT_LOCALE cookie from a request.
- * Returns the cookie value if it matches a configured locale, otherwise null.
- */
-export function parseCookieLocale(req: IncomingMessage, i18nConfig: NextI18nConfig): string | null {
-  return parseCookieLocaleFromHeader(req.headers.cookie, i18nConfig);
 }
 
 /**

--- a/packages/vinext/src/server/pages-data-route.ts
+++ b/packages/vinext/src/server/pages-data-route.ts
@@ -130,22 +130,6 @@ export function shouldAddTrailingSlashToPagesDataPath(
 }
 
 /**
- * Build the JSON envelope returned by `/_next/data/<buildId>/<page>.json`.
- * Mirrors Next.js' `RenderResult(JSON.stringify(props))` path in
- * `packages/next/src/server/render.tsx` (search for `isNextDataRequest`).
- *
- * The envelope is the outer `props` object the React tree would receive:
- *   { pageProps: {...}, /* optional locale data, redirect markers, etc. *\/ }
- */
-export function buildNextDataJsonResponse(
-  pageProps: Record<string, unknown>,
-  safeJsonStringify: (value: unknown) => string,
-  init?: ResponseInit,
-): Response {
-  return buildNextDataPropsJsonResponse({ pageProps }, safeJsonStringify, init);
-}
-
-/**
  * Build a `_next/data` JSON response from the full Pages props object returned
  * through `_app.getInitialProps`. Next.js serializes the same outer props
  * object that would be passed to `<App />`, so custom app-level props remain

--- a/packages/vinext/src/server/pages-node-compat.ts
+++ b/packages/vinext/src/server/pages-node-compat.ts
@@ -186,20 +186,6 @@ function parsePagesRequestCookies(cookieHeader: string | string[] | null | undef
   return parseCookieHeader(Array.isArray(cookieHeader) ? cookieHeader.join("; ") : cookieHeader);
 }
 
-function getPagesPreviewDataFromCookieHeader(
-  cookieHeader: string | string[] | null | undefined,
-  options: { isOnDemandRevalidate?: boolean } = {},
-): PagesPreviewData | false {
-  return getPagesPreviewState(cookieHeader, options).data;
-}
-
-export function getPagesPreviewData(
-  request: Request,
-  options: { isOnDemandRevalidate?: boolean } = {},
-): PagesPreviewData | false {
-  return getPagesPreviewDataFromCookieHeader(request.headers.get("cookie"), options);
-}
-
 export function attachPagesRequestCookies(req: PagesRequestCookiesCarrier): void {
   if (Object.hasOwn(req, "cookies")) return;
 

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -1073,59 +1073,6 @@ describe("extractLocaleFromUrl", () => {
   });
 });
 
-describe("detectLocaleFromHeaders", () => {
-  let detectLocaleFromHeaders: typeof import("../packages/vinext/src/server/dev-server.js").detectLocaleFromHeaders;
-
-  beforeAll(async () => {
-    const mod = await import("../packages/vinext/src/server/dev-server.js");
-    detectLocaleFromHeaders = mod.detectLocaleFromHeaders;
-  });
-
-  const i18nConfig = {
-    locales: ["en", "fr", "de"],
-    defaultLocale: "en",
-    localeDetection: true,
-  };
-
-  function fakeReq(acceptLanguage?: string) {
-    return { headers: acceptLanguage ? { "accept-language": acceptLanguage } : {} } as any;
-  }
-
-  it("returns null when no Accept-Language header", () => {
-    expect(detectLocaleFromHeaders(fakeReq(), i18nConfig)).toBeNull();
-  });
-
-  it("detects exact locale match", () => {
-    expect(detectLocaleFromHeaders(fakeReq("fr"), i18nConfig)).toBe("fr");
-  });
-
-  it("detects locale by quality preference", () => {
-    expect(detectLocaleFromHeaders(fakeReq("de;q=0.9,fr;q=0.8"), i18nConfig)).toBe("de");
-  });
-
-  it("does not truncate an unconfigured regional locale", () => {
-    expect(detectLocaleFromHeaders(fakeReq("en-US"), i18nConfig)).toBeNull();
-  });
-
-  it("falls through an unconfigured regional locale to the next preference", () => {
-    expect(detectLocaleFromHeaders(fakeReq("fr-FR,en;q=0.5"), i18nConfig)).toBe("en");
-  });
-
-  it("returns null for unrecognized language", () => {
-    expect(detectLocaleFromHeaders(fakeReq("ja"), i18nConfig)).toBeNull();
-  });
-
-  it("picks highest quality match", () => {
-    // fr has higher quality than en
-    expect(detectLocaleFromHeaders(fakeReq("en;q=0.5,fr;q=0.9"), i18nConfig)).toBe("fr");
-  });
-
-  it("handles complex Accept-Language with fallback", () => {
-    // Japanese first (no match), then French
-    expect(detectLocaleFromHeaders(fakeReq("ja;q=1.0,fr;q=0.8,en;q=0.5"), i18nConfig)).toBe("fr");
-  });
-});
-
 // ---------------------------------------------------------------------------
 // i18n routing integration (Pages Router)
 // ---------------------------------------------------------------------------
@@ -5618,51 +5565,6 @@ describe("applyNavigationLocale", () => {
       }
       vi.resetModules();
     }
-  });
-});
-
-// ---------------------------------------------------------------------------
-// parseCookieLocale (NEXT_LOCALE cookie support)
-// ---------------------------------------------------------------------------
-
-describe("parseCookieLocale", () => {
-  let parseCookieLocale: (req: any, i18nConfig: any) => string | null;
-
-  beforeAll(async () => {
-    const mod = await import("../packages/vinext/src/server/dev-server.js");
-    parseCookieLocale = mod.parseCookieLocale;
-  });
-
-  const config = { locales: ["en", "fr", "de"], defaultLocale: "en", localeDetection: true };
-
-  it("returns null when no cookie header", () => {
-    expect(parseCookieLocale({ headers: {} }, config)).toBeNull();
-  });
-
-  it("returns null when cookie header has no NEXT_LOCALE", () => {
-    expect(parseCookieLocale({ headers: { cookie: "foo=bar; baz=qux" } }, config)).toBeNull();
-  });
-
-  it("returns locale from NEXT_LOCALE cookie", () => {
-    expect(parseCookieLocale({ headers: { cookie: "NEXT_LOCALE=fr" } }, config)).toBe("fr");
-  });
-
-  it("returns locale when NEXT_LOCALE is among multiple cookies", () => {
-    expect(
-      parseCookieLocale({ headers: { cookie: "theme=dark; NEXT_LOCALE=de; session=abc" } }, config),
-    ).toBe("de");
-  });
-
-  it("returns null for invalid locale in cookie", () => {
-    expect(parseCookieLocale({ headers: { cookie: "NEXT_LOCALE=es" } }, config)).toBeNull();
-  });
-
-  it("returns locale for URL-encoded cookie value", () => {
-    expect(parseCookieLocale({ headers: { cookie: "NEXT_LOCALE=fr" } }, config)).toBe("fr");
-  });
-
-  it("returns default locale when cookie matches default", () => {
-    expect(parseCookieLocale({ headers: { cookie: "NEXT_LOCALE=en" } }, config)).toBe("en");
   });
 });
 

--- a/tests/pages-data-route.test.ts
+++ b/tests/pages-data-route.test.ts
@@ -3,7 +3,6 @@ import {
   buildMiddlewarePrefetchSkipResponse,
   isNextDataPathname,
   parseNextDataPathname,
-  buildNextDataJsonResponse,
   buildNextDataNotFoundResponse,
   encodeUrlParserIgnoredCharacters,
   normalizePagesDataRequest,
@@ -11,9 +10,6 @@ import {
   normalizeNextDataPagePathname,
   urlParserCreatesPagesDataPath,
 } from "../packages/vinext/src/server/pages-data-route.js";
-
-// Helper mirroring vinext/html safeJsonStringify behavior for tests.
-const safeJsonStringify = (value: unknown) => JSON.stringify(value);
 
 describe("pages-data-route", () => {
   describe("isNextDataPathname", () => {
@@ -101,15 +97,6 @@ describe("pages-data-route", () => {
 
     it("returns null when buildId is empty", () => {
       expect(parseNextDataPathname(`/_next/data/abc/about.json`, "")).toBeNull();
-    });
-  });
-
-  describe("buildNextDataJsonResponse", () => {
-    it("returns a 200 JSON envelope with pageProps key", async () => {
-      const res = buildNextDataJsonResponse({ message: "hi" }, safeJsonStringify);
-      expect(res.status).toBe(200);
-      expect(res.headers.get("Content-Type")).toBe("application/json");
-      expect(await res.json()).toEqual({ pageProps: { message: "hi" } });
     });
   });
 

--- a/tests/pages-node-compat.test.ts
+++ b/tests/pages-node-compat.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 import { once } from "node:events";
-import {
-  createPagesReqRes,
-  getPagesPreviewData,
-} from "../packages/vinext/src/server/pages-node-compat.js";
+import { createPagesReqRes } from "../packages/vinext/src/server/pages-node-compat.js";
 import type { NextApiHandler, NextApiRequest, NextApiResponse, PreviewData } from "next";
 
 declare module "next" {
@@ -162,11 +159,15 @@ describe("Pages Node compat response", () => {
     if (!Array.isArray(cookies)) throw new Error("expected Set-Cookie array");
     const cookieHeader = cookies.map((value) => value.split(";", 1)[0]).join("; ");
 
-    const request = new Request("https://example.test/preview", {
-      headers: { cookie: cookieHeader },
+    const { req } = createPagesReqRes({
+      body: undefined,
+      query: {},
+      request: new Request("https://example.test/preview", {
+        headers: { cookie: cookieHeader },
+      }),
+      url: "/preview",
     });
-    expect(getPagesPreviewData(request)).toEqual({ hello: "world" });
-    expect(getPagesPreviewData(request, { isOnDemandRevalidate: true })).toBe(false);
+    expect(req.previewData).toEqual({ hello: "world" });
   });
 
   it("accepts a bypass-only draft mode cookie with empty preview data", () => {
@@ -219,10 +220,15 @@ describe("Pages Node compat response", () => {
       )
       .join("; ");
 
-    const request = new Request("https://example.test/preview", {
-      headers: { cookie: cookieHeader },
+    const { req } = createPagesReqRes({
+      body: undefined,
+      query: {},
+      request: new Request("https://example.test/preview", {
+        headers: { cookie: cookieHeader },
+      }),
+      url: "/preview",
     });
-    expect(getPagesPreviewData(request)).toBe(false);
+    expect(req.previewData).toBe(false);
   });
 
   it("exposes preview state on API requests and clears both cookies", async () => {


### PR DESCRIPTION
## Summary

Remove four Pages Router adapters left behind after production moved to shared implementations:

- `detectLocaleFromHeaders` and `parseCookieLocale` → `pages-i18n`
- `buildNextDataJsonResponse` → full-props `buildNextDataPropsJsonResponse`
- `getPagesPreviewData` → preview state attached by `createPagesReqRes`

Duplicate wrapper-only tests are removed; preview tests now assert through the live request adapter.

## Dead-code proof

Each removed export had zero production, generated-entry, package-export, or cross-package callers. The only callers were tests of the adapter itself, while the underlying active implementations have their own focused tests and production consumers. The packed JS and declarations no longer contain these names.

## Validation

- `tests/pages-i18n.test.ts` (30 passed)
- `tests/pages-data-route.test.ts` (28 passed)
- `tests/pages-node-compat.test.ts` and `tests/pages-preview.test.ts` (18 passed)
- `vp check` on all changed source and test files
- `vp run knip`
- `vp run vinext#build`
