### PR TITLE
refactor(server): remove dead encoding helper

### DIFF
--- a/packages/vinext/src/server/accept-encoding.ts
+++ b/packages/vinext/src/server/accept-encoding.ts
@@ -78,10 +78,6 @@ export function getEncodingQuality(parsed: ParsedAcceptEncoding, encoding: strin
   return 0;
 }
 
-export function isEncodingAccepted(parsed: ParsedAcceptEncoding, encoding: string): boolean {
-  return getEncodingQuality(parsed, encoding) > 0;
-}
-
 /** Choose the highest-quality available coding, using array order as the tie-breaker. */
 export function selectAcceptedEncoding<T extends string>(
   parsed: ParsedAcceptEncoding,

--- a/tests/accept-encoding-negotiation.test.ts
+++ b/tests/accept-encoding-negotiation.test.ts
@@ -10,7 +10,6 @@ import type { IncomingMessage } from "node:http";
 import {
   getEncodingQuality,
   HAS_ZSTD,
-  isEncodingAccepted,
   negotiateEncoding,
   parseAcceptedEncodings,
   selectAcceptedEncoding,
@@ -62,9 +61,9 @@ describe("parseAcceptedEncodings", () => {
 
   it("matches coding tokens exactly and case-insensitively", () => {
     const parsed = parseAcceptedEncodings("GZIP, brotli-future");
-    expect(isEncodingAccepted(parsed, "gzip")).toBe(true);
-    expect(isEncodingAccepted(parsed, "br")).toBe(false);
-    expect(isEncodingAccepted(parsed, "brotli-future")).toBe(true);
+    expect(getEncodingQuality(parsed, "gzip")).toBe(1);
+    expect(getEncodingQuality(parsed, "br")).toBe(0);
+    expect(getEncodingQuality(parsed, "brotli-future")).toBe(1);
   });
 
   it("matches Next.js parameter-name casing semantics", () => {


### PR DESCRIPTION
## Summary

- remove `isEncodingAccepted`, which had no runtime caller
- keep the authoritative `getEncodingQuality` helper used by encoding selection
- assert exact token behavior directly through quality values

## Dead-code proof

The boolean helper was not package-exported and had no production, generated-entry, or cross-package caller. Its only caller was one unit test; production selection already uses `getEncodingQuality` directly. The packed JS and declarations no longer contain it.

## Validation

- `tests/accept-encoding-negotiation.test.ts` (32 passed)
- `vp check packages/vinext/src/server/accept-encoding.ts tests/accept-encoding-negotiation.test.ts`
- `vp run knip`
- `vp run vinext#build`
