### PR TITLE
refactor(dev): remove dead stack-line wrapper

### DIFF
--- a/packages/vinext/src/server/dev-stack-sourcemap.ts
+++ b/packages/vinext/src/server/dev-stack-sourcemap.ts
@@ -200,15 +200,6 @@ async function resolveDevServerStackTrace(
   };
 }
 
-export async function mapStackLine(
-  server: ViteDevServer,
-  line: string,
-  requestHost: string | undefined,
-  sourceMapCache: Map<string, Promise<SourceMapPayload | null>>,
-): Promise<string> {
-  return (await mapStackLineWithMetadata(server, line, requestHost, sourceMapCache)).line;
-}
-
 export async function mapStackLineWithMetadata(
   server: ViteDevServer,
   line: string,

--- a/tests/dev-stack-sourcemap.test.ts
+++ b/tests/dev-stack-sourcemap.test.ts
@@ -6,7 +6,6 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   decodeVlqSegment,
   installDevStackSourcemapMiddleware,
-  mapStackLine,
   mapStackLineWithMetadata,
   originalPositionFor,
   resolveSourceFile,
@@ -18,6 +17,12 @@ const SOURCE_MAP = {
   sources: ["./original.tsx"],
   mappings: "AAAA,KASE",
 } satisfies SourceMapPayload;
+
+async function mapStackLineForTest(
+  ...args: Parameters<typeof mapStackLineWithMetadata>
+): Promise<string> {
+  return (await mapStackLineWithMetadata(...args)).line;
+}
 
 const SITE_FOOTER_SOURCE = [
   "line 1",
@@ -342,7 +347,7 @@ describe("mapStackLine", () => {
       const { server, transformRequests } = createServer();
 
       await expect(
-        mapStackLine(
+        mapStackLineForTest(
           server,
           input,
           "localhost:5173",
@@ -358,7 +363,7 @@ describe("mapStackLine", () => {
     const line = "    at onClick (http://evil.test/src/App.tsx?t=1:1:6)";
 
     await expect(
-      mapStackLine(
+      mapStackLineForTest(
         server,
         line,
         "localhost:5173",
@@ -507,7 +512,12 @@ describe("mapStackLine", () => {
 
     const mappedFileUrl = pathToFileURL("/repo/app/app/_components/site-footer.tsx").href;
     await expect(
-      mapStackLine(server, line, undefined, new Map<string, Promise<SourceMapPayload | null>>()),
+      mapStackLineForTest(
+        server,
+        line,
+        undefined,
+        new Map<string, Promise<SourceMapPayload | null>>(),
+      ),
     ).resolves.toBe(`    at SiteFooter (${mappedFileUrl}:6:9)`);
     expect(transformRequests).toEqual(["rsc:/repo/app/app/_components/site-footer.tsx"]);
   });
@@ -520,7 +530,12 @@ describe("mapStackLine", () => {
       const line = "    at SiteFooter (C:\\repo\\app\\app\\_components\\site-footer.tsx:9:8)";
 
       await expect(
-        mapStackLine(server, line, undefined, new Map<string, Promise<SourceMapPayload | null>>()),
+        mapStackLineForTest(
+          server,
+          line,
+          undefined,
+          new Map<string, Promise<SourceMapPayload | null>>(),
+        ),
       ).resolves.toBe(line);
       expect(transformRequests).toEqual(["rsc:C:\\repo\\app\\app\\_components\\site-footer.tsx"]);
     },
@@ -531,7 +546,12 @@ describe("mapStackLine", () => {
     const line = "    at SiteFooter (/repo/app/app/_components/site-footer.tsx:9:8)";
 
     await expect(
-      mapStackLine(server, line, undefined, new Map<string, Promise<SourceMapPayload | null>>()),
+      mapStackLineForTest(
+        server,
+        line,
+        undefined,
+        new Map<string, Promise<SourceMapPayload | null>>(),
+      ),
     ).resolves.toBe(line);
     expect(transformRequests).toEqual(["rsc:/repo/app/app/_components/site-footer.tsx"]);
   });
@@ -549,7 +569,12 @@ describe("mapStackLine", () => {
     const line = `    at SiteFooter (about://React/Server/${footerUrl}?9:9:8)`;
 
     await expect(
-      mapStackLine(server, line, undefined, new Map<string, Promise<SourceMapPayload | null>>()),
+      mapStackLineForTest(
+        server,
+        line,
+        undefined,
+        new Map<string, Promise<SourceMapPayload | null>>(),
+      ),
     ).resolves.toBe(`    at SiteFooter (${footerUrl}:6:9)`);
     expect(transformRequests).toEqual([`rsc:${fileURLToPath(footerUrl)}`]);
   });
@@ -564,7 +589,12 @@ describe("mapStackLine", () => {
     const line = `    at SiteFooter (about://React/Server/${footerUrl}?9:9:8)`;
 
     await expect(
-      mapStackLine(server, line, undefined, new Map<string, Promise<SourceMapPayload | null>>()),
+      mapStackLineForTest(
+        server,
+        line,
+        undefined,
+        new Map<string, Promise<SourceMapPayload | null>>(),
+      ),
     ).resolves.toBe(`    at SiteFooter (${footerUrl}:6:9)`);
     expect(transformRequests).toEqual([`rsc:${fileURLToPath(footerUrl)}`]);
   });


### PR DESCRIPTION
## Summary

- remove the string-only `mapStackLine` wrapper
- keep `mapStackLineWithMetadata`, which is the production stack resolver
- adapt string assertions through a test-local projection of the active result

## Dead-code proof

Production switched to `mapStackLineWithMetadata` when ignored-frame and code-frame metadata were added. The old wrapper had no package export, runtime caller, generated-entry caller, or cross-package caller; only unit tests still imported it. The packed JS and declarations no longer contain it.

## Validation

- `tests/dev-stack-sourcemap.test.ts` (22 passed, 2 platform-skipped)
- `vp check tests/dev-stack-sourcemap.test.ts packages/vinext/src/server/dev-stack-sourcemap.ts`
- `vp run knip`
- `vp run vinext#build`
