### PR TITLE
fix(init): stabilize Pages Cloudflare output path

### DIFF
--- a/packages/vinext/src/init-cloudflare.ts
+++ b/packages/vinext/src/init-cloudflare.ts
@@ -60,6 +60,17 @@ export function validateCloudflarePlatformSetup(
   const imagesBinding = updatedWranglerCode
     ? getWranglerImagesBinding(updatedWranglerCode)
     : "IMAGES";
+  const pagesRouterProjectEnvironmentName = context.isAppRouter
+    ? undefined
+    : getCloudflareProjectEnvironmentName(context.root);
+  const pagesRouterEnvironmentName = pagesRouterProjectEnvironmentName
+    ? getCloudflareWorkerEnvironmentName(
+        updatedWranglerCode,
+        updatedWranglerCode === undefined
+          ? projectInfo.projectName
+          : pagesRouterProjectEnvironmentName,
+      )
+    : undefined;
 
   if (context.existingViteConfigPath) {
     updateViteConfigForCloudflare(
@@ -71,6 +82,9 @@ export function validateCloudflarePlatformSetup(
         cache: cloudflare,
         imagesBinding,
         prerender: context.prerender,
+        pagesRouterEnvironmentName,
+        pagesRouterProjectEnvironmentName,
+        root: context.root,
       },
     );
   }
@@ -86,6 +100,15 @@ export function setupCloudflarePlatform(
     .find((candidate) => fs.existsSync(candidate));
   const wranglerCode = wranglerPath ? fs.readFileSync(wranglerPath, "utf-8") : undefined;
   const imagesBinding = wranglerCode ? getWranglerImagesBinding(wranglerCode) : "IMAGES";
+  const pagesRouterProjectEnvironmentName = context.isAppRouter
+    ? undefined
+    : getCloudflareProjectEnvironmentName(context.root);
+  const pagesRouterEnvironmentName = pagesRouterProjectEnvironmentName
+    ? getCloudflareWorkerEnvironmentName(
+        wranglerCode,
+        wranglerCode === undefined ? projectInfo.projectName : pagesRouterProjectEnvironmentName,
+      )
+    : undefined;
 
   let generatedViteConfig = false;
   let skippedViteConfig = false;
@@ -100,6 +123,9 @@ export function setupCloudflarePlatform(
         cache: cloudflare,
         imagesBinding,
         prerender: context.prerender,
+        pagesRouterEnvironmentName,
+        pagesRouterProjectEnvironmentName,
+        root: context.root,
       },
     );
     if (updatedConfig !== currentConfig) {
@@ -111,7 +137,13 @@ export function setupCloudflarePlatform(
   } else {
     const configContent = context.isAppRouter
       ? generateAppRouterViteConfig(projectInfo, cloudflare, imagesBinding, context.prerender)
-      : generatePagesRouterViteConfig(projectInfo, cloudflare, imagesBinding, context.prerender);
+      : generatePagesRouterViteConfig(
+          projectInfo,
+          cloudflare,
+          imagesBinding,
+          context.prerender,
+          pagesRouterEnvironmentName,
+        );
     fs.writeFileSync(path.join(context.root, "vite.config.ts"), configContent, "utf-8");
     generatedViteConfig = true;
   }
@@ -252,6 +284,76 @@ function stripJsonComments(code: string): string {
     output += char;
   }
   return output.replace(/,\s*([}\]])/g, "$1");
+}
+
+function getCloudflareWorkerEnvironmentName(
+  wranglerCode: string | undefined,
+  fallbackWorkerName: string,
+): string {
+  const config = wranglerCode
+    ? (JSON.parse(stripJsonComments(wranglerCode)) as { name?: unknown })
+    : undefined;
+  const workerName =
+    typeof config?.name === "string" && config.name.length > 0 ? config.name : fallbackWorkerName;
+  // Mirrors @cloudflare/vite-plugin's workerNameToEnvironmentName().
+  return workerName.replaceAll("-", "_");
+}
+
+function getCloudflareProjectEnvironmentName(root: string): string {
+  let packageName: string | undefined;
+  try {
+    const packageJson = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf-8")) as {
+      name?: unknown;
+    };
+    if (typeof packageJson.name === "string") packageName = packageJson.name;
+  } catch {
+    // Wrangler falls back to the project directory when package.json is absent or invalid.
+  }
+  const rawName = process.env.WRANGLER_CI_OVERRIDE_NAME ?? (packageName || path.basename(root));
+  const invalidCharacters = /[^a-z0-9- ]/g;
+  const invalidBoundary = /^(-+)|(-+)$/g;
+  const isValid =
+    rawName.length > 0 &&
+    rawName.length <= 63 &&
+    !/[^a-z0-9- ]/.test(rawName) &&
+    !/^-|-$/.test(rawName);
+  const workerName = isValid
+    ? rawName
+    : rawName
+        .replaceAll("_", "-")
+        .replace(invalidCharacters, "-")
+        .replace(invalidBoundary, "")
+        .slice(0, 63) || "my-worker";
+  // Mirrors Wrangler's unstable_getWorkerNameFromProject() and the Cloudflare
+  // Vite plugin's workerNameToEnvironmentName().
+  return workerName.replaceAll("-", "_");
+}
+
+function readCloudflareWorkerEnvironmentName(
+  configPath: string,
+  fallbackEnvironmentName: string,
+): string {
+  let code: string;
+  try {
+    code = fs.readFileSync(configPath, "utf-8");
+  } catch (cause) {
+    throw new Error(
+      `Could not read the cloudflare() configPath at ${JSON.stringify(configPath)}.`,
+      { cause },
+    );
+  }
+  let config: { name?: unknown };
+  try {
+    config = JSON.parse(stripJsonComments(code)) as { name?: unknown };
+  } catch (cause) {
+    throw new Error(
+      `Could not parse the cloudflare() configPath at ${JSON.stringify(configPath)}.`,
+      { cause },
+    );
+  }
+  return typeof config.name === "string" && config.name.length > 0
+    ? getCloudflareWorkerEnvironmentName(undefined, config.name)
+    : fallbackEnvironmentName;
 }
 
 function findTopLevelJsonProperty(
@@ -569,6 +671,10 @@ export function generatePagesRouterViteConfig(
   options: CloudflareInitOptions = DEFAULT_CLOUDFLARE_INIT_OPTIONS,
   imagesBinding = "IMAGES",
   prerender = false,
+  cloudflareEnvironmentName = getCloudflareWorkerEnvironmentName(
+    undefined,
+    info?.projectName ?? "server",
+  ),
 ): string {
   const imports: string[] = [
     `import { defineConfig } from "vite";`,
@@ -603,6 +709,11 @@ export default defineConfig({
     ${vinextExpression(options, "vinext", "imagesOptimizer", imagesBinding, prerender).replace(/\n/g, "\n    ")},
     cloudflare(),
   ],${resolveBlock}
+  environments: {
+    ${JSON.stringify(cloudflareEnvironmentName)}: {
+      build: { outDir: "dist/server" },
+    },
+  },
 });
 `;
 }
@@ -1090,6 +1201,225 @@ function ensureCloudflareViteEnvironment(
   insertObjectProperty(output, argumentObject, `${callIndent}  ${viteEnvironment},`, code);
 }
 
+function hasAmbiguousPropertyAfter(object: AstObject, property: AstProperty): boolean {
+  const propertyIndex = object.properties.lastIndexOf(property);
+  return object.properties
+    .slice(propertyIndex + 1)
+    .some(
+      (candidate) =>
+        candidate.type === "SpreadElement" || (candidate.type === "Property" && candidate.computed),
+    );
+}
+
+function findUniqueProperty(object: AstObject, name: string): AstProperty | undefined {
+  const properties = object.properties.filter(
+    (property): property is AstProperty =>
+      property.type === "Property" && propertyName(property) === name,
+  );
+  if (properties.length > 1) {
+    throw new Error(
+      `The Vite config ${name} option must not be duplicated when vinext init configures the Pages Router output.`,
+    );
+  }
+  return properties[0];
+}
+
+function resolvePagesRouterCloudflareEnvironmentName(
+  config: AstObject,
+  binding: string,
+  fallbackEnvironmentName: string,
+  projectEnvironmentName: string,
+  root: string,
+): string {
+  const call = findPluginCall(config, binding);
+  const firstArgument = call?.arguments[0];
+  if (!firstArgument) return fallbackEnvironmentName;
+  if (firstArgument.type === "SpreadElement" || firstArgument.type !== "ObjectExpression") {
+    throw new Error(
+      "The cloudflare() plugin options must be a static object for vinext init to configure the Pages Router output directory.",
+    );
+  }
+  const argumentObject = firstArgument as AstObject;
+  const viteEnvironment = findUniqueProperty(argumentObject, "viteEnvironment");
+  if (viteEnvironment) {
+    if (
+      viteEnvironment.value.type !== "ObjectExpression" ||
+      hasAmbiguousPropertyAfter(argumentObject, viteEnvironment)
+    ) {
+      throw new Error(
+        "The cloudflare() viteEnvironment option must be a static object for vinext init to configure the Pages Router output directory.",
+      );
+    }
+    const environmentObject = viteEnvironment.value as AstObject;
+    const name = findUniqueProperty(environmentObject, "name");
+    if (name) {
+      if (
+        name.value.type !== "Literal" ||
+        typeof name.value.value !== "string" ||
+        name.value.value.length === 0 ||
+        hasAmbiguousPropertyAfter(environmentObject, name)
+      ) {
+        throw new Error(
+          "The cloudflare() viteEnvironment name must be a static non-empty string for vinext init to configure the Pages Router output directory.",
+        );
+      }
+      return name.value.value;
+    }
+    if (
+      environmentObject.properties.some(
+        (property) => property.type === "SpreadElement" || property.computed,
+      )
+    ) {
+      throw new Error(
+        "The cloudflare() viteEnvironment name must be statically known for vinext init to configure the Pages Router output directory.",
+      );
+    }
+  }
+  if (
+    argumentObject.properties.some(
+      (property) => property.type === "SpreadElement" || property.computed,
+    )
+  ) {
+    throw new Error(
+      "The cloudflare() plugin options cannot use spreads or computed properties unless viteEnvironment.name is explicitly configured after them.",
+    );
+  }
+  if (findUniqueProperty(argumentObject, "config")) {
+    throw new Error(
+      "The cloudflare() inline config can change the Worker identity, so vinext init requires an explicit viteEnvironment.name to configure the Pages Router output directory.",
+    );
+  }
+  const configPath = findUniqueProperty(argumentObject, "configPath");
+  if (!configPath) return fallbackEnvironmentName;
+  if (
+    configPath.value.type !== "Literal" ||
+    typeof configPath.value.value !== "string" ||
+    configPath.value.value.length === 0
+  ) {
+    throw new Error(
+      "The cloudflare() configPath must be a static non-empty string for vinext init to configure the Pages Router output directory.",
+    );
+  }
+  return readCloudflareWorkerEnvironmentName(
+    path.resolve(root, configPath.value.value),
+    projectEnvironmentName,
+  );
+}
+
+function hasAmbiguousProperty(object: AstObject): boolean {
+  return object.properties.some(
+    (property) =>
+      property.type === "SpreadElement" || (property.type === "Property" && property.computed),
+  );
+}
+
+function ensurePagesRouterCloudflareOutputDirectory(
+  output: MagicString,
+  config: AstObject,
+  cloudflareBinding: string,
+  isAppRouter: boolean,
+  fallbackEnvironmentName: string,
+  projectEnvironmentName: string,
+  root: string,
+  code: string,
+): void {
+  if (isAppRouter) return;
+  const environmentName = resolvePagesRouterCloudflareEnvironmentName(
+    config,
+    cloudflareBinding,
+    fallbackEnvironmentName,
+    projectEnvironmentName,
+    root,
+  );
+  const environmentProperty = JSON.stringify(environmentName);
+  const environments = findUniqueProperty(config, "environments");
+  if (!environments) {
+    if (hasAmbiguousProperty(config)) {
+      throw new Error(
+        "The Vite config uses top-level spreads or computed properties, so vinext init cannot safely add the Pages Router environment output directory.",
+      );
+    }
+    insertObjectProperty(
+      output,
+      config,
+      `  environments: {\n    ${environmentProperty}: {\n      build: { outDir: "dist/server" },\n    },\n  },`,
+      code,
+    );
+    return;
+  }
+  if (
+    environments.value.type !== "ObjectExpression" ||
+    hasAmbiguousPropertyAfter(config, environments)
+  ) {
+    throw new Error(
+      'The Vite config environments option must be a static object for vinext init to configure the Pages Router output at "dist/server".',
+    );
+  }
+  const environmentsObject = environments.value as AstObject;
+  const environment = findUniqueProperty(environmentsObject, environmentName);
+  if (!environment) {
+    if (hasAmbiguousProperty(environmentsObject)) {
+      throw new Error(
+        "The Vite config environments option uses spreads or computed properties, so vinext init cannot safely add the Pages Router environment output directory.",
+      );
+    }
+    insertObjectProperty(
+      output,
+      environmentsObject,
+      `    ${environmentProperty}: {\n      build: { outDir: "dist/server" },\n    },`,
+      code,
+    );
+    return;
+  }
+  if (
+    environment.value.type !== "ObjectExpression" ||
+    hasAmbiguousPropertyAfter(environmentsObject, environment)
+  ) {
+    throw new Error(
+      `The Vite config environments.${environmentName} option must be a static object for vinext init to configure the Pages Router output at "dist/server".`,
+    );
+  }
+  const environmentObject = environment.value as AstObject;
+  const build = findUniqueProperty(environmentObject, "build");
+  if (!build) {
+    if (hasAmbiguousProperty(environmentObject)) {
+      throw new Error(
+        `The Vite config environments.${environmentName} option uses spreads or computed properties, so vinext init cannot safely add its build output directory.`,
+      );
+    }
+    insertObjectProperty(
+      output,
+      environmentObject,
+      '      build: { outDir: "dist/server" },',
+      code,
+    );
+    return;
+  }
+  if (
+    build.value.type !== "ObjectExpression" ||
+    hasAmbiguousPropertyAfter(environmentObject, build)
+  ) {
+    throw new Error(
+      `The Vite config environments.${environmentName}.build option must be a static object for vinext init to configure the Pages Router output at "dist/server".`,
+    );
+  }
+  const buildObject = build.value as AstObject;
+  const outDir = findUniqueProperty(buildObject, "outDir");
+  if (!outDir) {
+    insertObjectProperty(output, buildObject, '        outDir: "dist/server",', code);
+    return;
+  }
+  if (
+    hasAmbiguousPropertyAfter(buildObject, outDir) ||
+    outDir.value.type !== "Literal" ||
+    outDir.value.value !== "dist/server"
+  ) {
+    throw new Error(
+      `The Vite config environments.${environmentName}.build.outDir must be "dist/server" so the scaffolded Cloudflare commands target the emitted Worker config.`,
+    );
+  }
+}
+
 function findPluginCall(
   config: AstObject,
   binding: string,
@@ -1443,6 +1773,9 @@ export function updateViteConfigForCloudflare(
     cache?: CloudflareInitOptions;
     imagesBinding?: string;
     prerender?: boolean;
+    pagesRouterEnvironmentName?: string;
+    pagesRouterProjectEnvironmentName?: string;
+    root?: string;
   },
 ): string {
   const program = parseViteConfig(filePath, code);
@@ -1576,6 +1909,16 @@ export function updateViteConfigForCloudflare(
     code,
   );
   ensureCloudflareViteEnvironment(output, config, cloudflareBinding, options.isAppRouter, code);
+  ensurePagesRouterCloudflareOutputDirectory(
+    output,
+    config,
+    cloudflareBinding,
+    options.isAppRouter,
+    options.pagesRouterEnvironmentName ?? "server",
+    options.pagesRouterProjectEnvironmentName ?? options.pagesRouterEnvironmentName ?? "server",
+    options.root ?? path.dirname(path.resolve(filePath)),
+    code,
+  );
   if (existingVinextCall) {
     if (
       existingVinextCall.arguments.length === 0 &&

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -2083,6 +2083,8 @@ describe("generatePagesRouterViteConfig", () => {
     expect(content).toContain('from "@cloudflare/vite-plugin"');
     expect(content).toContain("vinext({");
     expect(content).toContain("cloudflare()");
+    expect(content).toContain('"server": {');
+    expect(content).toContain('build: { outDir: "dist/server" }');
     // Should NOT include RSC plugin
     expect(content).not.toContain("plugin-rsc");
   });
@@ -2822,6 +2824,8 @@ describe("generatePagesRouterViteConfig — with project info", () => {
     const config = generatePagesRouterViteConfig();
     expect(config).toContain("vinext({");
     expect(config).toContain("cloudflare()");
+    expect(config).toContain('"server": {');
+    expect(config).toContain('build: { outDir: "dist/server" }');
     expect(config).not.toContain("resolve:");
   });
 });

--- a/tests/init-cloudflare-build.test.ts
+++ b/tests/init-cloudflare-build.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createBuilder } from "vite";
+import { setupCloudflarePlatform } from "../packages/vinext/src/init-cloudflare.js";
+import { addScripts } from "../packages/vinext/src/init.js";
+
+const repositoryRoot = process.cwd();
+const projectNodeModules = path.join(
+  repositoryRoot,
+  "examples/pages-router-cloudflare/node_modules",
+);
+const noCloudflareAdapters = {
+  dataCache: "none" as const,
+  cdnCache: "data-cache" as const,
+  imageOptimization: "none" as const,
+};
+
+let tmpDir: string | undefined;
+
+function writeFile(relativePath: string, content: string): void {
+  if (!tmpDir) throw new Error("Test directory is not initialized.");
+  const filePath = path.join(tmpDir, relativePath);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, "utf-8");
+}
+
+afterEach(() => {
+  if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  tmpDir = undefined;
+});
+
+describe("Cloudflare init build output", () => {
+  it("emits the Pages Router config at the scaffolded deploy path", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-init-cloudflare-build-"));
+    fs.symlinkSync(projectNodeModules, path.join(tmpDir, "node_modules"), "junction");
+    writeFile(
+      "package.json",
+      JSON.stringify({ name: "@scope/MyApp", private: true, type: "module", scripts: {} }),
+    );
+    writeFile("pages/index.tsx", "export default function Page() { return <main>hello</main>; }\n");
+    writeFile(
+      "wrangler.jsonc",
+      JSON.stringify({
+        name: "root-worker-name",
+        compatibility_date: "2026-08-18",
+        compatibility_flags: ["nodejs_compat"],
+        main: "vinext/server/fetch-handler",
+        assets: {
+          directory: "dist/client",
+          not_found_handling: "none",
+          binding: "ASSETS",
+        },
+      }),
+    );
+    writeFile(
+      "worker.wrangler.jsonc",
+      JSON.stringify({
+        compatibility_date: "2026-08-18",
+        compatibility_flags: ["nodejs_compat"],
+        main: "vinext/server/fetch-handler",
+        assets: {
+          directory: "dist/client",
+          not_found_handling: "none",
+          binding: "ASSETS",
+        },
+      }),
+    );
+    writeFile(
+      "vite.config.ts",
+      `import { cloudflare } from "@cloudflare/vite-plugin";
+import vinext from "vinext";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [vinext(), cloudflare({ configPath: "./worker.wrangler.jsonc" })],
+});
+`,
+    );
+    setupCloudflarePlatform(
+      {
+        root: tmpDir,
+        isAppRouter: false,
+        existingViteConfigPath: path.join(tmpDir, "vite.config.ts"),
+        today: "2026-08-18",
+      },
+      noCloudflareAdapters,
+    );
+    addScripts(tmpDir, false, "cloudflare", { scriptNames: "standard" });
+
+    const viteConfig = fs.readFileSync(path.join(tmpDir, "vite.config.ts"), "utf-8");
+    expect(viteConfig).toContain('configPath: "./worker.wrangler.jsonc"');
+    expect(viteConfig).not.toContain("viteEnvironment");
+    expect(viteConfig).toContain('"scope__y_pp": {');
+
+    const builder = await createBuilder({ root: tmpDir, logLevel: "silent" });
+    await builder.buildApp();
+
+    const packageJson = JSON.parse(fs.readFileSync(path.join(tmpDir, "package.json"), "utf-8"));
+    expect(packageJson.scripts.deploy).toBe(
+      "vinext-cloudflare deploy --config dist/server/wrangler.json",
+    );
+    expect(fs.existsSync(path.join(tmpDir, "dist/server/wrangler.json"))).toBe(true);
+  });
+
+  it("uses Wrangler's project-name fallback for a nameless root config", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-init-cloudflare-build-"));
+    fs.symlinkSync(projectNodeModules, path.join(tmpDir, "node_modules"), "junction");
+    writeFile(
+      "package.json",
+      JSON.stringify({ name: "@scope/MyApp", private: true, type: "module", scripts: {} }),
+    );
+    writeFile("pages/index.tsx", "export default function Page() { return <main>hello</main>; }\n");
+    writeFile(
+      "wrangler.jsonc",
+      JSON.stringify({
+        compatibility_date: "2026-08-18",
+        compatibility_flags: ["nodejs_compat"],
+        main: "vinext/server/fetch-handler",
+        assets: {
+          directory: "dist/client",
+          not_found_handling: "none",
+          binding: "ASSETS",
+        },
+      }),
+    );
+    setupCloudflarePlatform(
+      { root: tmpDir, isAppRouter: false, today: "2026-08-18" },
+      noCloudflareAdapters,
+    );
+    addScripts(tmpDir, false, "cloudflare", { scriptNames: "standard" });
+
+    const viteConfig = fs.readFileSync(path.join(tmpDir, "vite.config.ts"), "utf-8");
+    expect(viteConfig).toContain("cloudflare()");
+    expect(viteConfig).not.toContain("viteEnvironment");
+    expect(viteConfig).toContain('"scope__y_pp": {');
+
+    const builder = await createBuilder({ root: tmpDir, logLevel: "silent" });
+    await builder.buildApp();
+
+    expect(fs.existsSync(path.join(tmpDir, "dist/server/wrangler.json"))).toBe(true);
+  });
+
+  it("uses the generated Worker name when scaffolding without a Wrangler config", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-init-cloudflare-build-"));
+    fs.symlinkSync(projectNodeModules, path.join(tmpDir, "node_modules"), "junction");
+    writeFile(
+      "package.json",
+      JSON.stringify({ name: "@scope/MyApp", private: true, type: "module", scripts: {} }),
+    );
+    writeFile("pages/index.tsx", "export default function Page() { return <main>hello</main>; }\n");
+    setupCloudflarePlatform(
+      { root: tmpDir, isAppRouter: false, today: "2026-08-18" },
+      noCloudflareAdapters,
+    );
+    addScripts(tmpDir, false, "cloudflare", { scriptNames: "standard" });
+
+    const wranglerConfig = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, "wrangler.jsonc"), "utf-8"),
+    );
+    expect(wranglerConfig.name).toBe("myapp");
+    const viteConfig = fs.readFileSync(path.join(tmpDir, "vite.config.ts"), "utf-8");
+    expect(viteConfig).toContain("cloudflare()");
+    expect(viteConfig).not.toContain("viteEnvironment");
+    expect(viteConfig).toContain('"myapp": {');
+
+    const builder = await createBuilder({ root: tmpDir, logLevel: "silent" });
+    await builder.buildApp();
+
+    expect(fs.existsSync(path.join(tmpDir, "dist/server/wrangler.json"))).toBe(true);
+  });
+});

--- a/tests/init-cloudflare.test.ts
+++ b/tests/init-cloudflare.test.ts
@@ -142,7 +142,7 @@ export default { plugins: [vinext(), cloudflare({
     ).toBe(input);
   });
 
-  it("leaves an existing cloudflare() call alone for the Pages Router", () => {
+  it("pins an existing Pages Router Worker output directory without renaming its environment", () => {
     const input = `import { defineConfig } from "vite";
 import vinext from "vinext";
 import { cloudflare } from "@cloudflare/vite-plugin";
@@ -155,9 +155,258 @@ export default defineConfig({
     const output = updateViteConfigForCloudflare("vite.config.ts", input, {
       isAppRouter: false,
       nativeModulesToStub: [],
+      pagesRouterEnvironmentName: "test_project",
     });
 
+    expectValidConfig(output);
+    expect(output).toContain("cloudflare()");
     expect(output).not.toContain("viteEnvironment");
+    expect(output).toContain('"test_project": {');
+    expect(output).toContain('build: { outDir: "dist/server" }');
+    expect(output.match(/cloudflare\(/g)).toHaveLength(1);
+    expect(
+      updateViteConfigForCloudflare("vite.config.ts", output, {
+        isAppRouter: false,
+        nativeModulesToStub: [],
+        pagesRouterEnvironmentName: "test_project",
+      }),
+    ).toBe(output);
+  });
+
+  it("preserves existing Pages Router cloudflare options while pinning the output directory", () => {
+    const input = `import vinext from "vinext";
+import { cloudflare } from "@cloudflare/vite-plugin";
+export default { plugins: [vinext(), cloudflare({ configPath: "./examples/pages-router-cloudflare/wrangler.jsonc" })] };
+`;
+
+    const output = updateViteConfigForCloudflare("vite.config.ts", input, {
+      isAppRouter: false,
+      nativeModulesToStub: [],
+      root: process.cwd(),
+    });
+
+    expectValidConfig(output);
+    expect(output).toContain('configPath: "./examples/pages-router-cloudflare/wrangler.jsonc"');
+    expect(output).not.toContain("viteEnvironment");
+    expect(output).toContain('"pages_router_cloudflare": {');
+    expect(output).toContain('build: { outDir: "dist/server" }');
+  });
+
+  it("overrides a custom root outDir only for the Pages Router Worker environment", () => {
+    const input = `import vinext from "vinext";
+import { cloudflare } from "@cloudflare/vite-plugin";
+export default {
+  plugins: [vinext(), cloudflare()],
+  build: { outDir: "build" },
+};
+`;
+
+    const output = updateViteConfigForCloudflare("vite.config.ts", input, {
+      isAppRouter: false,
+      nativeModulesToStub: [],
+    });
+
+    expectValidConfig(output);
+    expect(output).toContain('build: { outDir: "build" }');
+    expect(output).toContain('build: { outDir: "dist/server" }');
+  });
+
+  it("uses an explicitly configured Pages Router environment name for the output directory", () => {
+    const pluginInput = `import vinext from "vinext";
+import { cloudflare } from "@cloudflare/vite-plugin";
+export default { plugins: [vinext(), cloudflare({
+  viteEnvironment: { name: "custom" },
+})] };
+`;
+    const output = updateViteConfigForCloudflare("vite.config.ts", pluginInput, {
+      isAppRouter: false,
+      nativeModulesToStub: [],
+      pagesRouterEnvironmentName: "worker_default",
+    });
+    expectValidConfig(output);
+    expect(output).toContain('viteEnvironment: { name: "custom" }');
+    expect(output).toContain('"custom": {');
+    expect(output).toContain('build: { outDir: "dist/server" }');
+  });
+
+  it("rejects an inline Worker config without an explicit environment name", () => {
+    const input = `import vinext from "vinext";
+import { cloudflare } from "@cloudflare/vite-plugin";
+export default { plugins: [vinext(), cloudflare({ config: { name: "other-worker" } })] };
+`;
+
+    expect(() =>
+      updateViteConfigForCloudflare("vite.config.ts", input, {
+        isAppRouter: false,
+        nativeModulesToStub: [],
+      }),
+    ).toThrow("inline config can change the Worker identity");
+  });
+
+  it("rejects incompatible Pages Router output configuration", () => {
+    const outDirInput = `import vinext from "vinext";
+import { cloudflare } from "@cloudflare/vite-plugin";
+export default {
+  plugins: [vinext(), cloudflare()],
+  environments: { server: { build: { outDir: "build/worker" } } },
+};
+`;
+    expect(() =>
+      updateViteConfigForCloudflare("vite.config.ts", outDirInput, {
+        isAppRouter: false,
+        nativeModulesToStub: [],
+      }),
+    ).toThrow('environments.server.build.outDir must be "dist/server"');
+
+    const customEnvironmentInput = `import vinext from "vinext";
+import { cloudflare } from "@cloudflare/vite-plugin";
+export default {
+  plugins: [vinext(), cloudflare()],
+  environments: { custom: {} },
+};
+`;
+    const customEnvironmentOutput = updateViteConfigForCloudflare(
+      "vite.config.ts",
+      customEnvironmentInput,
+      {
+        isAppRouter: false,
+        nativeModulesToStub: [],
+      },
+    );
+    expect(customEnvironmentOutput).toContain("custom: {}");
+    expect(customEnvironmentOutput).toContain('"server": {');
+
+    const duplicateOutputConfigs = [
+      `environments: { server: { build: { outDir: "dist/server" } } },
+  environments: { server: { build: { outDir: "build/worker" } } }`,
+      `environments: {
+    server: { build: { outDir: "dist/server" } },
+    server: { build: { outDir: "build/worker" } },
+  }`,
+      `environments: { server: {
+    build: { outDir: "dist/server" },
+    build: { outDir: "build/worker" },
+  } }`,
+      `environments: { server: { build: {
+    outDir: "dist/server",
+    outDir: "build/worker",
+  } } }`,
+    ];
+    for (const duplicateOutputConfig of duplicateOutputConfigs) {
+      const input = `import vinext from "vinext";
+import { cloudflare } from "@cloudflare/vite-plugin";
+export default {
+  plugins: [vinext(), cloudflare()],
+  ${duplicateOutputConfig},
+};
+`;
+      expect(() =>
+        updateViteConfigForCloudflare("vite.config.ts", input, {
+          isAppRouter: false,
+          nativeModulesToStub: [],
+        }),
+      ).toThrow("must not be duplicated");
+    }
+
+    const spreadInput = `import vinext from "vinext";
+import { cloudflare } from "@cloudflare/vite-plugin";
+const custom = {};
+export default {
+  plugins: [vinext(), cloudflare()],
+  environments: { ...custom, server: { build: { outDir: "dist/server" } } },
+};
+`;
+    const spreadOutput = updateViteConfigForCloudflare("vite.config.ts", spreadInput, {
+      isAppRouter: false,
+      nativeModulesToStub: [],
+    });
+    expectValidConfig(spreadOutput);
+    expect(spreadOutput).toContain("environments: { ...custom, server:");
+
+    const ambiguousNestedInputs = [
+      `environments: { ...custom }`,
+      `environments: { server: { ...custom } }`,
+    ];
+    for (const environmentsConfig of ambiguousNestedInputs) {
+      const input = `import vinext from "vinext";
+import { cloudflare } from "@cloudflare/vite-plugin";
+const custom = {};
+export default {
+  plugins: [vinext(), cloudflare()],
+  ${environmentsConfig},
+};
+`;
+      expect(() =>
+        updateViteConfigForCloudflare("vite.config.ts", input, {
+          isAppRouter: false,
+          nativeModulesToStub: [],
+        }),
+      ).toThrow("spreads or computed properties");
+    }
+
+    const ambiguousTopLevelInputs = [
+      `const base = { environments: { client: {} } };
+export default { ...base, plugins: [vinext(), cloudflare()] };`,
+      `const environmentKey = "environments";
+export default { [environmentKey]: { client: {} }, plugins: [vinext(), cloudflare()] };`,
+    ];
+    for (const configBody of ambiguousTopLevelInputs) {
+      const input = `import vinext from "vinext";
+import { cloudflare } from "@cloudflare/vite-plugin";
+${configBody}
+`;
+      expect(() =>
+        updateViteConfigForCloudflare("vite.config.ts", input, {
+          isAppRouter: false,
+          nativeModulesToStub: [],
+        }),
+      ).toThrow("top-level spreads or computed properties");
+    }
+
+    const computedOverrideInputs = [
+      `const key = "environments";
+export default {
+  plugins: [vinext(), cloudflare()],
+  environments: { server: { build: { outDir: "dist/server" } } },
+  [key]: { server: { build: { outDir: "build/worker" } } },
+};`,
+      `const key = "server";
+export default {
+  plugins: [vinext(), cloudflare()],
+  environments: {
+    server: { build: { outDir: "dist/server" } },
+    [key]: { build: { outDir: "build/worker" } },
+  },
+};`,
+      `const key = "build";
+export default {
+  plugins: [vinext(), cloudflare()],
+  environments: { server: {
+    build: { outDir: "dist/server" },
+    [key]: { outDir: "build/worker" },
+  } },
+};`,
+      `const key = "outDir";
+export default {
+  plugins: [vinext(), cloudflare()],
+  environments: { server: { build: {
+    outDir: "dist/server",
+    [key]: "build/worker",
+  } } },
+};`,
+    ];
+    for (const configBody of computedOverrideInputs) {
+      const input = `import vinext from "vinext";
+import { cloudflare } from "@cloudflare/vite-plugin";
+${configBody}
+`;
+      expect(() =>
+        updateViteConfigForCloudflare("vite.config.ts", input, {
+          isAppRouter: false,
+          nativeModulesToStub: [],
+        }),
+      ).toThrow();
+    }
   });
 
   it("updates a CommonJS Pages Router config", () => {
@@ -692,6 +941,14 @@ export default { plugins: [vinext({ imageOptimization: true })] };
     expect(generatePagesRouterViteConfig(undefined, options, "IMAGES", true)).toContain(
       'prerender: { routes: "*" }',
     );
+  });
+
+  it("pins generated Pages Router worker output to dist/server", () => {
+    const output = generatePagesRouterViteConfig();
+
+    expect(output).toContain("cloudflare()");
+    expect(output).not.toContain("viteEnvironment");
+    expect(output).toContain('build: { outDir: "dist/server" }');
   });
 
   it("repairs an unusable Wrangler Images binding", () => {

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -550,6 +550,7 @@ describe("init — basic functionality", () => {
 
     expect(result.generatedPlatformFiles).toEqual(["wrangler.jsonc"]);
     expect(fs.existsSync(path.join(tmpDir, "worker", "index.ts"))).toBe(false);
+    expect(readFile(tmpDir, "vite.config.ts")).toContain('build: { outDir: "dist/server" }');
     expect(JSON.parse(readFile(tmpDir, "wrangler.jsonc"))).toMatchObject({
       main: "vinext/server/fetch-handler",
     });


### PR DESCRIPTION
Closes #2965.

## Summary

- keep the Pages Router Cloudflare Vite environment name unchanged
- configure that existing environment to emit its Worker bundle and generated config under `dist/server`
- resolve the environment key from the generated or selected Wrangler config, including Wrangler project-name fallback behavior for nameless configs
- safely migrate static existing Vite configs while rejecting ambiguous spreads, computed overrides, or inline Worker identity changes
- retain the scaffolded explicit `--config dist/server/wrangler.json` start and deploy commands

## Root cause

Pages Router used a bare `cloudflare()` call, so the Cloudflare Vite plugin derived the environment and default output directory from the Worker identity. `vinext init` separately scaffolded commands targeting `dist/server/wrangler.json`, but did not configure the derived environment build output to match.

## Validation

- `vp test run tests/init-cloudflare-build.test.ts tests/init-cloudflare.test.ts tests/init.test.ts tests/deploy.test.ts tests/create-vinext-app.test.ts` (494 tests)
- `vp check packages/vinext/src/init-cloudflare.ts tests/init-cloudflare-build.test.ts tests/init-cloudflare.test.ts tests/deploy.test.ts tests/init.test.ts`
- `vp run vinext#build`
- real temporary-project builds cover fresh init, an existing nameless root Wrangler config, and a custom `configPath`
- independent reviews: two clean `NO FINDINGS` verdicts
