### PR TITLE
fix(security): validate supplemental interception selectors

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -642,6 +642,10 @@ function findIntercept(pathname, sourcePathname = null, interceptionId = null) {
   return __routeMatcher.findIntercept(pathname, sourcePathname, interceptionId);
 }
 
+function hasInterceptionId(interceptionId) {
+  return __routeMatcher.hasInterceptionId(interceptionId);
+}
+
 async function buildPageElements(route, params, routePath, pageRequest, layoutParamAccess, displayPathname = routePath, scriptNonce) {
   // Hydrate lazy page/route-handler modules before any synchronous read.
   await __ensureRouteLoaded(route);
@@ -1271,6 +1275,7 @@ export default createAppRscHandler({
   }
   matchRoute,
   matchRequestRoute,
+  hasInterceptionId,
   matchInterceptRoute(pathname, sourcePathname, interceptionId) {
     const intercept = findIntercept(pathname, sourcePathname, interceptionId);
     if (!intercept) return null;

--- a/packages/vinext/src/server/app-page-cache-finalizer.ts
+++ b/packages/vinext/src/server/app-page-cache-finalizer.ts
@@ -54,6 +54,7 @@ type FinalizeAppPageHtmlCacheResponseOptions = {
 };
 
 type ScheduleAppPageRscCacheWriteOptions = {
+  bypassRscCache?: boolean;
   capturedRscDataPromise: Promise<ArrayBuffer> | null;
   cleanPathname: string;
   consumeDynamicUsage: () => boolean;
@@ -85,17 +86,15 @@ function applyPendingDynamicCdnHeaders(
   finalizePendingCacheStateHeaders(headers, options);
 }
 
-function applyMountedSlotRscNoStoreHeaders(
+function applyUncacheableRscVariantNoStoreHeaders(
   headers: Headers,
   options: { omitCacheState?: boolean } = {},
 ): void {
-  // Mounted-slot RSC payloads deliberately bypass the slot-blind persistent
-  // cache. Make that same bypass explicit to every CDN adapter: an edge-managed
-  // adapter may intentionally cache pending-dynamic responses, so the generic
-  // pendingDynamicCheck signal is not strong enough for this variant.
-  // This branch additionally forces no-store because mounted variants have no
-  // persistent admission path at all. The active adapter clears any stale
-  // provider-specific headers that it owns.
+  // Mounted-slot and interception-selector RSC payloads deliberately bypass
+  // the slot/selector-blind persistent cache. Make that same bypass explicit to
+  // every CDN adapter: an edge-managed adapter may intentionally cache
+  // pending-dynamic responses, so that generic signal is not strong enough.
+  // The active adapter clears any stale provider-specific headers that it owns.
   applyCdnResponseHeaders(headers, { cacheControl: NO_STORE_CACHE_CONTROL });
   // Dynamic and draft responses intentionally have no cache state. Do not
   // manufacture a MISS solely because the request carried mounted slots.
@@ -266,14 +265,15 @@ export function finalizeAppPageRscCacheResponse(
   // slots because edge-managed adapters may cache pending-dynamic responses.
   scheduleAppPageRscCacheWrite(options);
 
-  const isMountedSlotVariant = Boolean(options.mountedSlotsHeader);
-  if (options.preserveClientResponseHeaders === true && !isMountedSlotVariant) {
+  const isUncacheableVariant =
+    Boolean(options.mountedSlotsHeader) || options.bypassRscCache === true;
+  if (options.preserveClientResponseHeaders === true && !isUncacheableVariant) {
     return response;
   }
 
   const clientHeaders = new Headers(response.headers);
-  if (isMountedSlotVariant) {
-    applyMountedSlotRscNoStoreHeaders(clientHeaders, {
+  if (isUncacheableVariant) {
+    applyUncacheableRscVariantNoStoreHeaders(clientHeaders, {
       omitCacheState: options.omitPendingDynamicCacheState === true,
     });
   } else {
@@ -293,7 +293,12 @@ export function scheduleAppPageRscCacheWrite(
   options: ScheduleAppPageRscCacheWriteOptions,
 ): boolean {
   const capturedRscDataPromise = options.capturedRscDataPromise;
-  if (!capturedRscDataPromise || options.dynamicUsedDuringBuild || options.mountedSlotsHeader) {
+  if (
+    !capturedRscDataPromise ||
+    options.dynamicUsedDuringBuild ||
+    options.mountedSlotsHeader ||
+    options.bypassRscCache === true
+  ) {
     return false;
   }
 

--- a/packages/vinext/src/server/app-page-cache-finalizer.ts
+++ b/packages/vinext/src/server/app-page-cache-finalizer.ts
@@ -19,6 +19,7 @@ type AppPageRscCacheKeyBuilder = (
   mountedSlotsHeader?: string | null,
   renderMode?: AppRscRenderMode,
   interceptionContext?: string | null,
+  interceptionId?: string | null,
 ) => string;
 type AppPageRequestCacheLife = {
   revalidate?: number;
@@ -45,6 +46,7 @@ type FinalizeAppPageHtmlCacheResponseOptions = {
   isrRscKey: AppPageRscCacheKeyBuilder;
   isrSet: AppPageCacheSetter;
   interceptionContext?: string | null;
+  interceptionId?: string | null;
   omitPendingDynamicCacheState?: boolean;
   preserveClientResponseHeaders?: boolean;
   expireSeconds?: number;
@@ -54,7 +56,6 @@ type FinalizeAppPageHtmlCacheResponseOptions = {
 };
 
 type ScheduleAppPageRscCacheWriteOptions = {
-  bypassRscCache?: boolean;
   capturedRscDataPromise: Promise<ArrayBuffer> | null;
   cleanPathname: string;
   consumeDynamicUsage: () => boolean;
@@ -67,6 +68,7 @@ type ScheduleAppPageRscCacheWriteOptions = {
   isrRscKey: AppPageRscCacheKeyBuilder;
   isrSet: AppPageCacheSetter;
   interceptionContext?: string | null;
+  interceptionId?: string | null;
   mountedSlotsHeader?: string | null;
   omitPendingDynamicCacheState?: boolean;
   renderMode?: AppRscRenderMode;
@@ -90,8 +92,8 @@ function applyUncacheableRscVariantNoStoreHeaders(
   headers: Headers,
   options: { omitCacheState?: boolean } = {},
 ): void {
-  // Mounted-slot and interception-selector RSC payloads deliberately bypass
-  // the slot/selector-blind persistent cache. Make that same bypass explicit to
+  // Mounted-slot RSC payloads deliberately bypass the slot-blind persistent
+  // cache. Make that same bypass explicit to
   // every CDN adapter: an edge-managed adapter may intentionally cache
   // pending-dynamic responses, so that generic signal is not strong enough.
   // The active adapter clears any stale provider-specific headers that it owns.
@@ -168,6 +170,7 @@ export function finalizeAppPageHtmlCacheResponse(
     null,
     undefined,
     options.interceptionContext,
+    options.interceptionId,
   );
   const clientHeaders = new Headers(response.headers);
   if (options.preserveClientResponseHeaders !== true) {
@@ -265,8 +268,7 @@ export function finalizeAppPageRscCacheResponse(
   // slots because edge-managed adapters may cache pending-dynamic responses.
   scheduleAppPageRscCacheWrite(options);
 
-  const isUncacheableVariant =
-    Boolean(options.mountedSlotsHeader) || options.bypassRscCache === true;
+  const isUncacheableVariant = Boolean(options.mountedSlotsHeader);
   if (options.preserveClientResponseHeaders === true && !isUncacheableVariant) {
     return response;
   }
@@ -293,12 +295,7 @@ export function scheduleAppPageRscCacheWrite(
   options: ScheduleAppPageRscCacheWriteOptions,
 ): boolean {
   const capturedRscDataPromise = options.capturedRscDataPromise;
-  if (
-    !capturedRscDataPromise ||
-    options.dynamicUsedDuringBuild ||
-    options.mountedSlotsHeader ||
-    options.bypassRscCache === true
-  ) {
+  if (!capturedRscDataPromise || options.dynamicUsedDuringBuild || options.mountedSlotsHeader) {
     return false;
   }
 
@@ -307,6 +304,7 @@ export function scheduleAppPageRscCacheWrite(
     null,
     options.renderMode,
     options.interceptionContext,
+    options.interceptionId,
   );
   const cachePromise = (async () => {
     try {

--- a/packages/vinext/src/server/app-page-cache.ts
+++ b/packages/vinext/src/server/app-page-cache.ts
@@ -38,6 +38,7 @@ type AppPageRscCacheKeyBuilder = (
   mountedSlotsHeader?: string | null,
   renderMode?: AppRscRenderMode,
   interceptionContext?: string | null,
+  interceptionId?: string | null,
 ) => string;
 export type AppPageCacheOutcomeMetric = Readonly<{
   artifact: "html" | "rsc";
@@ -92,6 +93,7 @@ type ReadAppPageCacheResponseOptions = {
   isrRscKey: AppPageRscCacheKeyBuilder;
   isrSet: AppPageCacheSetter;
   interceptionContext?: string | null;
+  interceptionId?: string | null;
   hasRequestSearchParams?: boolean;
   middlewareHeaders?: Headers | null;
   middlewareStatus?: number | null;
@@ -370,6 +372,7 @@ export async function readAppPageCacheResponse(
         null,
         options.renderMode,
         options.interceptionContext,
+        options.interceptionId,
       )
     : options.isrHtmlKey(options.cleanPathname);
   const artifact = options.isRscRequest ? "rsc" : "html";
@@ -479,6 +482,7 @@ export async function readAppPageCacheResponse(
                   null,
                   options.renderMode,
                   options.interceptionContext,
+                  options.interceptionId,
                 ),
             buildAppPageCacheValue(
               "",

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -342,6 +342,7 @@ export type DispatchAppPageOptions<TRoute extends AppPageDispatchRoute> = {
     mountedSlotsHeader?: string | null,
     renderMode?: AppRscRenderMode,
     interceptionContext?: string | null,
+    interceptionId?: string | null,
   ) => string;
   isrSet: AppPageCacheSetter;
   loadSsrHandler: () => Promise<AppPageSsrHandler>;
@@ -627,8 +628,9 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
   const route = options.route;
   const dynamicConfig = options.dynamicConfig;
   const currentRevalidateSeconds = options.revalidateSeconds;
-  const bypassRscCache =
-    options.isRscRequest && options.request.headers.has(VINEXT_INTERCEPTION_ID_HEADER);
+  const interceptionId = options.isRscRequest
+    ? options.request.headers.get(VINEXT_INTERCEPTION_ID_HEADER)
+    : null;
   const isForceStatic = dynamicConfig === "force-static";
   const isDynamicError = dynamicConfig === "error";
   const isForceDynamic = dynamicConfig === "force-dynamic";
@@ -702,7 +704,6 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
   }
 
   if (
-    !bypassRscCache &&
     shouldReadAppPageCache({
       isDraftMode,
       isForceDynamic,
@@ -726,6 +727,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
       isrRscKey: options.isrRscKey,
       isrSet: options.isrSet,
       interceptionContext: options.interceptionContext,
+      interceptionId,
       middlewareHeaders: options.middlewareContext.headers,
       middlewareStatus: options.middlewareContext.status,
       mountedSlotsHeader: options.mountedSlotsHeader,
@@ -1094,7 +1096,6 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
 
   return renderAppPageLifecycle({
     basePath: options.basePath,
-    bypassRscCache,
     clientTraceMetadata: options.clientTraceMetadata,
     reactMaxHeadersLength: options.reactMaxHeadersLength,
     cleanPathname: options.cleanPathname,
@@ -1141,6 +1142,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
     isrRscKey: options.isrRscKey,
     isrSet: options.isrSet,
     interceptionContext: options.interceptionContext,
+    interceptionId,
     expireSeconds: options.expireSeconds,
     // A loading convention at tree position N wraps descendants, but not a
     // layout co-located at N. Probing any deeper async layout before creating

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -82,7 +82,7 @@ import {
 import { shouldServeStreamingMetadata } from "./streaming-metadata.js";
 import { createAppPageTreePath } from "./app-page-route-wiring.js";
 import type { AppPageSsrHandler } from "./app-page-stream.js";
-import { VINEXT_PRERENDER_SPECULATIVE_HEADER } from "./headers.js";
+import { VINEXT_INTERCEPTION_ID_HEADER, VINEXT_PRERENDER_SPECULATIVE_HEADER } from "./headers.js";
 import type { ClientReuseManifestParseResult } from "./client-reuse-manifest.js";
 import { buildAppPageTags } from "./implicit-tags.js";
 import type { AppPageCacheSetter, ISRCacheEntry } from "./isr-cache.js";
@@ -627,6 +627,8 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
   const route = options.route;
   const dynamicConfig = options.dynamicConfig;
   const currentRevalidateSeconds = options.revalidateSeconds;
+  const bypassRscCache =
+    options.isRscRequest && options.request.headers.has(VINEXT_INTERCEPTION_ID_HEADER);
   const isForceStatic = dynamicConfig === "force-static";
   const isDynamicError = dynamicConfig === "error";
   const isForceDynamic = dynamicConfig === "force-dynamic";
@@ -700,6 +702,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
   }
 
   if (
+    !bypassRscCache &&
     shouldReadAppPageCache({
       isDraftMode,
       isForceDynamic,
@@ -1091,6 +1094,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
 
   return renderAppPageLifecycle({
     basePath: options.basePath,
+    bypassRscCache,
     clientTraceMetadata: options.clientTraceMetadata,
     reactMaxHeadersLength: options.reactMaxHeadersLength,
     cleanPathname: options.cleanPathname,

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -100,7 +100,6 @@ type AppPageRequestCacheLife = {
 
 type RenderAppPageLifecycleOptions = {
   basePath?: string;
-  bypassRscCache?: boolean;
   /**
    * Allow-list of OpenTelemetry propagation keys to emit as `<meta>` tags in
    * the SSR head. From `experimental.clientTraceMetadata` in `next.config`.
@@ -152,9 +151,11 @@ type RenderAppPageLifecycleOptions = {
     mountedSlotsHeader?: string | null,
     renderMode?: AppRscRenderMode,
     interceptionContext?: string | null,
+    interceptionId?: string | null,
   ) => string;
   isrSet: AppPageCacheSetter;
   interceptionContext?: string | null;
+  interceptionId?: string | null;
   layoutCount: number;
   loadSsrHandler: () => Promise<AppPageSsrHandler>;
   middlewareContext: AppPageMiddlewareContext;
@@ -821,8 +822,7 @@ export async function renderAppPageLifecycle(
     // When skip transport is enabled, omit cacheState because the response is a
     // per-client payload, not a shared-cache MISS/HIT artifact. The absence also
     // keeps finalizeAppPageRscCacheResponse from overwriting no-store.
-    const shouldBypassRscCache =
-      shouldBypassRscCacheForSkipTransport || options.bypassRscCache === true;
+    const shouldBypassRscCache = shouldBypassRscCacheForSkipTransport;
     const rscResponsePolicy = shouldBypassRscCache
       ? { cacheControl: NO_STORE_CACHE_CONTROL }
       : resolveAppPageRscResponsePolicy({
@@ -836,12 +836,7 @@ export async function renderAppPageLifecycle(
           revalidateSeconds,
         });
     if (shouldBypassRscCache) {
-      options.isrDebug?.(
-        options.bypassRscCache === true
-          ? "RSC cache write skipped (interception selector)"
-          : "RSC cache write skipped (skip transport payload)",
-        options.cleanPathname,
-      );
+      options.isrDebug?.("RSC cache write skipped (skip transport payload)", options.cleanPathname);
     }
     const shouldEmitDynamicStaleTime =
       dynamicStaleTimeSeconds !== undefined &&
@@ -937,7 +932,6 @@ export async function renderAppPageLifecycle(
     return finalizeAppPageRscCacheResponse(devRscResponse, {
       capturedRscDataPromise:
         options.isProduction && shouldCaptureRscForCacheMetadata ? capturedRscDataRef.value : null,
-      bypassRscCache: options.bypassRscCache,
       cleanPathname: options.cleanPathname,
       consumeDynamicUsage: finalizeRenderDynamicUsage,
       consumeRenderObservationState: options.consumeRenderObservationState,
@@ -964,6 +958,7 @@ export async function renderAppPageLifecycle(
       isrRscKey: options.isrRscKey,
       isrSet: options.isrSet,
       interceptionContext: options.interceptionContext,
+      interceptionId: options.interceptionId,
       mountedSlotsHeader: options.mountedSlotsHeader,
       omitPendingDynamicCacheState: options.omitPendingDynamicCacheState,
       renderMode: options.renderMode,
@@ -1277,6 +1272,7 @@ export async function renderAppPageLifecycle(
       isrRscKey: options.isrRscKey,
       isrSet: options.isrSet,
       interceptionContext: options.interceptionContext,
+      interceptionId: options.interceptionId,
       omitPendingDynamicCacheState: options.omitPendingDynamicCacheState,
       preserveClientResponseHeaders: !htmlResponsePolicy.shouldWriteToCache,
       expireSeconds,

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -100,6 +100,7 @@ type AppPageRequestCacheLife = {
 
 type RenderAppPageLifecycleOptions = {
   basePath?: string;
+  bypassRscCache?: boolean;
   /**
    * Allow-list of OpenTelemetry propagation keys to emit as `<meta>` tags in
    * the SSR head. From `experimental.clientTraceMetadata` in `next.config`.
@@ -820,7 +821,9 @@ export async function renderAppPageLifecycle(
     // When skip transport is enabled, omit cacheState because the response is a
     // per-client payload, not a shared-cache MISS/HIT artifact. The absence also
     // keeps finalizeAppPageRscCacheResponse from overwriting no-store.
-    const rscResponsePolicy = shouldBypassRscCacheForSkipTransport
+    const shouldBypassRscCache =
+      shouldBypassRscCacheForSkipTransport || options.bypassRscCache === true;
+    const rscResponsePolicy = shouldBypassRscCache
       ? { cacheControl: NO_STORE_CACHE_CONTROL }
       : resolveAppPageRscResponsePolicy({
           dynamicUsedDuringBuild,
@@ -832,8 +835,13 @@ export async function renderAppPageLifecycle(
           expireSeconds,
           revalidateSeconds,
         });
-    if (shouldBypassRscCacheForSkipTransport) {
-      options.isrDebug?.("RSC cache write skipped (skip transport payload)", options.cleanPathname);
+    if (shouldBypassRscCache) {
+      options.isrDebug?.(
+        options.bypassRscCache === true
+          ? "RSC cache write skipped (interception selector)"
+          : "RSC cache write skipped (skip transport payload)",
+        options.cleanPathname,
+      );
     }
     const shouldEmitDynamicStaleTime =
       dynamicStaleTimeSeconds !== undefined &&
@@ -929,6 +937,7 @@ export async function renderAppPageLifecycle(
     return finalizeAppPageRscCacheResponse(devRscResponse, {
       capturedRscDataPromise:
         options.isProduction && shouldCaptureRscForCacheMetadata ? capturedRscDataRef.value : null,
+      bypassRscCache: options.bypassRscCache,
       cleanPathname: options.cleanPathname,
       consumeDynamicUsage: finalizeRenderDynamicUsage,
       consumeRenderObservationState: options.consumeRenderObservationState,

--- a/packages/vinext/src/server/app-rsc-cache-busting.ts
+++ b/packages/vinext/src/server/app-rsc-cache-busting.ts
@@ -417,39 +417,51 @@ export async function resolveInvalidRscCacheBustingRequest(
   if (actualHash !== null && actualHash !== expectedHash) {
     acceptedHashes.add(computeLegacyRscCacheBustingSearchParam(options.request.headers));
     const compatibilityInputs: CreateCacheBustingInputOptions[] = [];
+    const hasInterceptionId = options.request.headers.has(VINEXT_INTERCEPTION_ID_HEADER);
     const hasStateFingerprint = options.request.headers.has(VINEXT_RSC_STATE_FINGERPRINT_HEADER);
     const hasNormalRenderMode =
       normalizeRenderModeHeaderValue(options.request.headers.get(VINEXT_RSC_RENDER_MODE_HEADER)) ===
       null;
     // The interception ID is a positional hash input, so omitting it changes
-    // hashes even when the request does not carry the header. Accept every
-    // combination of the rollout-era inputs to keep in-flight RSC requests
-    // valid while old and new clients overlap.
-    compatibilityInputs.push({ includeInterceptionIdHeader: false });
+    // hashes even when the request does not carry the header. Requests from
+    // clients predating that positional input remain compatible when the
+    // header is absent. Once the header is present, however, only hashes that
+    // include its value are safe: Cloudflare's default cache key is URL-based
+    // and does not vary on arbitrary headers, while different graph-owned IDs
+    // can intentionally select different slot bytes for one source/target.
+    if (!hasInterceptionId) {
+      compatibilityInputs.push({ includeInterceptionIdHeader: false });
+    }
     if (hasStateFingerprint) {
       compatibilityInputs.push({ includeStateFingerprintHeader: false });
-      compatibilityInputs.push({
-        includeInterceptionIdHeader: false,
-        includeStateFingerprintHeader: false,
-      });
+      if (!hasInterceptionId) {
+        compatibilityInputs.push({
+          includeInterceptionIdHeader: false,
+          includeStateFingerprintHeader: false,
+        });
+      }
     }
     if (hasNormalRenderMode) {
       compatibilityInputs.push({ includeRenderModeHeader: false });
-      compatibilityInputs.push({
-        includeInterceptionIdHeader: false,
-        includeRenderModeHeader: false,
-      });
+      if (!hasInterceptionId) {
+        compatibilityInputs.push({
+          includeInterceptionIdHeader: false,
+          includeRenderModeHeader: false,
+        });
+      }
     }
     if (hasStateFingerprint && hasNormalRenderMode) {
       compatibilityInputs.push({
         includeRenderModeHeader: false,
         includeStateFingerprintHeader: false,
       });
-      compatibilityInputs.push({
-        includeInterceptionIdHeader: false,
-        includeRenderModeHeader: false,
-        includeStateFingerprintHeader: false,
-      });
+      if (!hasInterceptionId) {
+        compatibilityInputs.push({
+          includeInterceptionIdHeader: false,
+          includeRenderModeHeader: false,
+          includeStateFingerprintHeader: false,
+        });
+      }
     }
     for (const compatibilityOptions of compatibilityInputs) {
       const input = createCacheBustingInput(options.request.headers, compatibilityOptions);

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -565,12 +565,6 @@ function requestWithoutRscSuffix(request: Request): Request {
 function markInvalidInterceptionIdResponseUncacheable(response: Response): Response {
   const applyNoStore = (headers: Headers): void => {
     applyCdnResponseHeaders(headers, { cacheControl: NEVER_CACHE_CONTROL });
-    // These standard/provider-specific shared-cache controls can be supplied by
-    // next.config headers even when the active origin adapter does not own them.
-    // Never let them override this security boundary downstream.
-    headers.delete("CDN-Cache-Control");
-    headers.delete("Cloudflare-CDN-Cache-Control");
-    headers.delete("Cache-Tag");
   };
   let markedResponse = response;
   try {

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -60,11 +60,7 @@ import {
   stripRscSuffix,
   VINEXT_RSC_CACHE_BUSTING_SEARCH_PARAM,
 } from "./app-rsc-cache-busting.js";
-import {
-  applyAppRscConfigHeaders,
-  finalizeAppRscResponse,
-  markAppRscResponseConfigHeadersApplied,
-} from "./app-rsc-response-finalizer.js";
+import { applyAppRscConfigHeaders, finalizeAppRscResponse } from "./app-rsc-response-finalizer.js";
 import { normalizeRscRequest } from "./app-rsc-request-normalization.js";
 import { buildNextDataNotFoundResponse, normalizePagesDataRequest } from "./pages-data-route.js";
 import { normalizeDefaultLocalePathname } from "./pages-i18n.js";
@@ -565,11 +561,31 @@ function requestWithoutRscSuffix(request: Request): Request {
   return cloneRequestWithUrl(request, url.toString());
 }
 
-function markRejectedInterceptionIdResponse(response: Response): Response {
-  applyCdnResponseHeaders(response.headers, { cacheControl: NEVER_CACHE_CONTROL });
-  // A matching headers() rule must not make an attacker-selected cache variant
-  // public again after this security decision.
-  return markAppRscResponseConfigHeadersApplied(response);
+function markInterceptionIdResponseUncacheable(response: Response): Response {
+  const applyNoStore = (headers: Headers): void => {
+    applyCdnResponseHeaders(headers, { cacheControl: NEVER_CACHE_CONTROL });
+    // These standard/provider-specific shared-cache controls can be supplied by
+    // next.config headers even when the active origin adapter does not own them.
+    // Never let them override this security boundary downstream.
+    headers.delete("CDN-Cache-Control");
+    headers.delete("Cloudflare-CDN-Cache-Control");
+    headers.delete("Cache-Tag");
+  };
+  let markedResponse = response;
+  try {
+    applyNoStore(markedResponse.headers);
+  } catch {
+    // Response.redirect() and some middleware responses expose immutable
+    // headers. Rebuild them before applying the fail-closed cache policy.
+    const headers = new Headers(response.headers);
+    applyNoStore(headers);
+    markedResponse = new Response(response.body, {
+      headers,
+      status: response.status,
+      statusText: response.statusText,
+    });
+  }
+  return markedResponse;
 }
 
 async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
@@ -599,11 +615,8 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
       ...options.configRewrites.fallback,
       ...options.configHeaders,
     ].some((rule) => rule.basePath === false);
-  const hasInterceptionIdHeader = request.headers.has(VINEXT_INTERCEPTION_ID_HEADER);
   const normalized = normalizeRscRequest(request, options.basePath, canHandleOutsideBasePath);
-  if (normalized instanceof Response) {
-    return hasInterceptionIdHeader ? markRejectedInterceptionIdResponse(normalized) : normalized;
-  }
+  if (normalized instanceof Response) return normalized;
 
   const {
     url,
@@ -1019,7 +1032,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     // rendering or shared caches; otherwise arbitrary short values can create
     // unbounded `_rsc` and Vary variants.
     options.clearRequestContext();
-    return markRejectedInterceptionIdResponse(badRequestResponse());
+    return badRequestResponse();
   }
   if (
     interceptionSourceMatch !== null &&
@@ -1780,13 +1793,16 @@ export function createAppRscHandler<TRoute extends AppRscHandlerRoute>(
             throw error;
           }
 
-          return finalizeAppRscResponse(response, request, {
+          response = await finalizeAppRscResponse(response, request, {
             basePath: options.basePath,
             configHeaders: options.configHeaders,
             i18nConfig: options.i18nConfig,
             middlewareHeaders: middlewareContext.headers,
             requestContext: preMiddlewareRequestContext,
           });
+          return request.headers.has(VINEXT_INTERCEPTION_ID_HEADER)
+            ? markInterceptionIdResponseUncacheable(response)
+            : response;
         },
         { route: () => new URL(request.url).pathname },
       ),

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -382,6 +382,7 @@ type CreateAppRscHandlerOptions<TRoute extends AppRscHandlerRoute> = {
   i18nConfig: NextI18nConfig | null;
   imageConfig?: ImageConfig;
   isDev: boolean;
+  hasInterceptionId: (interceptionId: string) => boolean;
   loadPrerenderPagesRoutes?: () => Promise<unknown>;
   matchInterceptRoute?: (
     pathname: string,
@@ -561,7 +562,7 @@ function requestWithoutRscSuffix(request: Request): Request {
   return cloneRequestWithUrl(request, url.toString());
 }
 
-function markInterceptionIdResponseUncacheable(response: Response): Response {
+function markInvalidInterceptionIdResponseUncacheable(response: Response): Response {
   const applyNoStore = (headers: Headers): void => {
     applyCdnResponseHeaders(headers, { cacheControl: NEVER_CACHE_CONTROL });
     // These standard/provider-specific shared-cache controls can be supplied by
@@ -598,6 +599,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
   pagesDataRequest: Request | null,
   dispatchInternalRequest: (request: Request) => Promise<Response>,
   allowInternalRscDocumentFallback: boolean,
+  markInterceptionIdRejected: () => void,
 ): Promise<Response> {
   const handlerStart = process.env.NODE_ENV !== "production" ? performance.now() : 0;
 
@@ -616,7 +618,12 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
       ...options.configHeaders,
     ].some((rule) => rule.basePath === false);
   const normalized = normalizeRscRequest(request, options.basePath, canHandleOutsideBasePath);
-  if (normalized instanceof Response) return normalized;
+  if (normalized instanceof Response) {
+    if (request.headers.has(VINEXT_INTERCEPTION_ID_HEADER)) {
+      markInterceptionIdRejected();
+    }
+    return normalized;
+  }
 
   const {
     url,
@@ -647,6 +654,31 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     cleanPathnameIsRequestPathname && options.matchRequestRoute
       ? options.matchRequestRoute(requestCleanPathname)
       : options.matchRoute(cleanPathname);
+
+  if (
+    interceptionIdHeader !== null &&
+    (!isRscRequest ||
+      interceptionContextHeader === null ||
+      !options.hasInterceptionId(interceptionIdHeader))
+  ) {
+    // Reject attacker-selected selector values before middleware, redirects,
+    // or other early responders can attach a cacheable policy. Exact
+    // source/target verification still happens after rewrites below.
+    markInterceptionIdRejected();
+    return badRequestResponse();
+  }
+
+  if (interceptionIdHeader !== null) {
+    // Canonicalize selector-bearing URLs before any cacheable redirect can
+    // depend on the selector. During rollout, a pre-selector `_rsc` hash can
+    // otherwise give two graph-owned IDs the same request URL while producing
+    // different redirect locations.
+    const selectorCacheBustingRedirect = await resolveInvalidRscCacheBustingRequest({
+      isRscRequest,
+      request,
+    });
+    if (selectorCacheBustingRedirect) return selectorCacheBustingRedirect;
+  }
 
   if (
     pathname === VINEXT_PRERENDER_STATIC_PARAMS_PATH ||
@@ -729,9 +761,10 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     });
   }
 
-  const rscCacheBustingRedirect = hadBasePath
-    ? await resolveInvalidRscCacheBustingRequest({ isRscRequest, request })
-    : null;
+  const rscCacheBustingRedirect =
+    hadBasePath && interceptionIdHeader === null
+      ? await resolveInvalidRscCacheBustingRequest({ isRscRequest, request })
+      : null;
   if (rscCacheBustingRedirect) return rscCacheBustingRedirect;
 
   let filesystemRouteEligible = hadBasePath;
@@ -1015,6 +1048,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
       );
     } catch {
       options.clearRequestContext();
+      if (interceptionIdHeader !== null) markInterceptionIdRejected();
       return badRequestResponse();
     }
   }
@@ -1032,6 +1066,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     // rendering or shared caches; otherwise arbitrary short values can create
     // unbounded `_rsc` and Vary variants.
     options.clearRequestContext();
+    markInterceptionIdRejected();
     return badRequestResponse();
   }
   if (
@@ -1761,6 +1796,7 @@ export function createAppRscHandler<TRoute extends AppRscHandlerRoute>(
       executionContext,
       unstableCacheRevalidation: "background",
     });
+    let interceptionIdRejected = false;
 
     const responsePromise = runWithRequestContext(requestContext, () =>
       runWithPrerenderWorkUnit(
@@ -1785,6 +1821,9 @@ export function createAppRscHandler<TRoute extends AppRscHandlerRoute>(
               pagesDataRequest,
               (internalRequest) => appRscHandler(internalRequest, ctx, true),
               allowInternalRscDocumentFallback,
+              () => {
+                interceptionIdRejected = true;
+              },
             );
           } catch (error) {
             if (process.env.NODE_ENV !== "production") {
@@ -1800,8 +1839,8 @@ export function createAppRscHandler<TRoute extends AppRscHandlerRoute>(
             middlewareHeaders: middlewareContext.headers,
             requestContext: preMiddlewareRequestContext,
           });
-          return request.headers.has(VINEXT_INTERCEPTION_ID_HEADER)
-            ? markInterceptionIdResponseUncacheable(response)
+          return interceptionIdRejected
+            ? markInvalidInterceptionIdResponseUncacheable(response)
             : response;
         },
         { route: () => new URL(request.url).pathname },

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -27,6 +27,7 @@ import {
   VINEXT_PRERENDER_SPECULATIVE_HEADER,
   VINEXT_PRERENDER_STATIC_PARAMS_PATH,
   VINEXT_REVALIDATE_HOST_HEADER,
+  VINEXT_INTERCEPTION_ID_HEADER,
 } from "./headers.js";
 import { ensureFetchPatch, setCurrentFetchSoftTags } from "vinext/shims/fetch-cache";
 import type { ReactFormState } from "react-dom/client";
@@ -59,7 +60,11 @@ import {
   stripRscSuffix,
   VINEXT_RSC_CACHE_BUSTING_SEARCH_PARAM,
 } from "./app-rsc-cache-busting.js";
-import { applyAppRscConfigHeaders, finalizeAppRscResponse } from "./app-rsc-response-finalizer.js";
+import {
+  applyAppRscConfigHeaders,
+  finalizeAppRscResponse,
+  markAppRscResponseConfigHeadersApplied,
+} from "./app-rsc-response-finalizer.js";
 import { normalizeRscRequest } from "./app-rsc-request-normalization.js";
 import { buildNextDataNotFoundResponse, normalizePagesDataRequest } from "./pages-data-route.js";
 import { normalizeDefaultLocalePathname } from "./pages-i18n.js";
@@ -82,6 +87,7 @@ import { buildPostMwRequestContext } from "./app-post-middleware-context.js";
 import type { AppRscRenderMode } from "./app-rsc-render-mode.js";
 import type { AppPagePprFallbackCacheShell } from "./app-ppr-fallback-shell.js";
 import type { ClientReuseManifestParseResult } from "./client-reuse-manifest.js";
+import { applyCdnResponseHeaders, NEVER_CACHE_CONTROL } from "./cache-control.js";
 import {
   cloneRequestWithHeaders,
   cloneRequestWithUrl,
@@ -559,6 +565,13 @@ function requestWithoutRscSuffix(request: Request): Request {
   return cloneRequestWithUrl(request, url.toString());
 }
 
+function markRejectedInterceptionIdResponse(response: Response): Response {
+  applyCdnResponseHeaders(response.headers, { cacheControl: NEVER_CACHE_CONTROL });
+  // A matching headers() rule must not make an attacker-selected cache variant
+  // public again after this security decision.
+  return markAppRscResponseConfigHeadersApplied(response);
+}
+
 async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
   options: CreateAppRscHandlerOptions<TRoute>,
   request: Request,
@@ -586,8 +599,11 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
       ...options.configRewrites.fallback,
       ...options.configHeaders,
     ].some((rule) => rule.basePath === false);
+  const hasInterceptionIdHeader = request.headers.has(VINEXT_INTERCEPTION_ID_HEADER);
   const normalized = normalizeRscRequest(request, options.basePath, canHandleOutsideBasePath);
-  if (normalized instanceof Response) return normalized;
+  if (normalized instanceof Response) {
+    return hasInterceptionIdHeader ? markRejectedInterceptionIdResponse(normalized) : normalized;
+  }
 
   const {
     url,
@@ -997,6 +1013,14 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
           interceptionIdHeader,
         ) ?? null)
       : null;
+  if (interceptionIdHeader !== null && interceptionSourceMatch === null) {
+    // The supplemental-refresh selector is an untrusted request header. Only
+    // graph-owned identities that match this exact target and source may reach
+    // rendering or shared caches; otherwise arbitrary short values can create
+    // unbounded `_rsc` and Vary variants.
+    options.clearRequestContext();
+    return markRejectedInterceptionIdResponse(badRequestResponse());
+  }
   if (
     interceptionSourceMatch !== null &&
     interceptionSourcePathname !== null &&

--- a/packages/vinext/src/server/app-rsc-route-matching.ts
+++ b/packages/vinext/src/server/app-rsc-route-matching.ts
@@ -191,6 +191,7 @@ function normalizeMatchedParamsForRoute(result: {
 export function createAppRscRouteMatcher<Route extends AppRscRouteForMatching>(
   routes: Route[],
 ): {
+  hasInterceptionId(interceptionId: string): boolean;
   matchRoute(url: string): { route: Route; params: AppRscRouteParams } | null;
   matchRequestRoute(url: string): { route: Route; params: AppRscRouteParams } | null;
   findIntercept(
@@ -201,9 +202,17 @@ export function createAppRscRouteMatcher<Route extends AppRscRouteForMatching>(
 } {
   const routeTrie = buildRouteTrie(routes);
   const interceptLookup = createInterceptLookup(routes);
+  const interceptionIds = new Set(
+    interceptLookup.flatMap((entry) =>
+      entry.interceptionId === null ? [] : [entry.interceptionId],
+    ),
+  );
   const routeIndexes = new Map<Route, number>(routes.map((route, index) => [route, index]));
 
   return {
+    hasInterceptionId(interceptionId) {
+      return interceptionIds.has(interceptionId);
+    },
     matchRoute(url) {
       const rawParts = appRscPathnameParts(url, true);
       const result = trieMatchRaw(routeTrie, appRscPathnameParts(url, false));

--- a/packages/vinext/src/server/isr-cache.ts
+++ b/packages/vinext/src/server/isr-cache.ts
@@ -466,8 +466,9 @@ function normalizeInterceptionContextForCacheKey(interceptionContext: string): s
  * Build the ISR cache key for an RSC payload.
  *
  * Variants are sequenced in order: `source:<hash>` (intercepted source context,
- * only when an interception context is present), `slots:<hash>` (mounted parallel
- * route slots), and optionally `<render-mode-variant>` (for example,
+ * only when an interception context is present), `selector:<hash>` (a verified
+ * supplemental interception edge), `slots:<hash>` (mounted parallel route slots),
+ * and optionally `<render-mode-variant>` (for example,
  * `prefetch-loading-shell`). Existing cached entries under the old format will
  * become unreachable after deployment. This is acceptable because ISR entries
  * have TTLs and will be regenerated on the next request.
@@ -477,6 +478,7 @@ export function appIsrRscKey(
   mountedSlotsHeader?: string | null,
   renderMode: AppRscRenderMode = APP_RSC_RENDER_MODE_NAVIGATION,
   interceptionContext?: string | null,
+  interceptionId?: string | null,
 ): string {
   const normalizedMountedSlotsHeader = normalizeMountedSlotsHeader(mountedSlotsHeader);
   const sourceVariant =
@@ -485,6 +487,7 @@ export function appIsrRscKey(
       : normalizeInterceptionContextForCacheKey(interceptionContext);
   const variant = [
     sourceVariant ? `source:${fnv1a64(sourceVariant)}` : null,
+    interceptionId ? `selector:${fnv1a64(interceptionId)}` : null,
     normalizedMountedSlotsHeader ? `slots:${fnv1a64(normalizedMountedSlotsHeader)}` : null,
     getRscRenderModeCacheVariant(renderMode),
   ]

--- a/tests/app-page-dispatch.test.ts
+++ b/tests/app-page-dispatch.test.ts
@@ -2464,7 +2464,17 @@ describe("app page dispatch", () => {
     expect(options.isrSet).not.toHaveBeenCalled();
   });
 
-  it("bypasses persistent and CDN caches for interception-id RSC requests", async () => {
+  it("uses a verified interception id in the persistent RSC cache key", async () => {
+    const interceptionId = "interception:slot:modal:/feed:/feed->/photos/:id";
+    const isrRscKey = vi.fn(
+      (
+        pathname: string,
+        _mountedSlotsHeader?: string | null,
+        _renderMode?: DispatchOptions["renderMode"],
+        _interceptionContext?: string | null,
+        selector?: string | null,
+      ) => `rsc:${pathname}:${selector ?? "none"}`,
+    );
     const isrGet = vi.fn(async () =>
       buildISRCacheEntry(
         buildCachedAppPageValue(
@@ -2478,7 +2488,7 @@ describe("app page dispatch", () => {
     const isrSet = vi.fn<DispatchOptions["isrSet"]>(async () => {});
     const request = new Request("https://example.test/photos/123", {
       headers: {
-        [VINEXT_INTERCEPTION_ID_HEADER]: "interception:slot:modal:/feed:/feed->/photos/:id",
+        [VINEXT_INTERCEPTION_ID_HEADER]: interceptionId,
       },
     });
     const { options } = createDispatchOptions({
@@ -2486,17 +2496,19 @@ describe("app page dispatch", () => {
       isProduction: true,
       isRscRequest: true,
       isrGet,
+      isrRscKey,
       isrSet,
       request,
       revalidateSeconds: 60,
     });
 
     const response = await dispatchAppPage(options);
-    await response.arrayBuffer();
+    await expect(response.text()).resolves.toBe("stale-flight");
 
-    expect(response.headers.get("cache-control")).toBe("no-store, must-revalidate");
-    expect(response.headers.get("x-vinext-cache")).toBeNull();
-    expect(isrGet).not.toHaveBeenCalled();
+    expect(response.headers.get("cache-control")).not.toContain("no-store");
+    expect(response.headers.get("x-vinext-cache")).toBe("HIT");
+    expect(isrRscKey).toHaveBeenCalledWith("/photos/123", null, undefined, null, interceptionId);
+    expect(isrGet).toHaveBeenCalledWith(`rsc:/photos/123:${interceptionId}`);
     expect(isrSet).not.toHaveBeenCalled();
   });
 

--- a/tests/app-page-dispatch.test.ts
+++ b/tests/app-page-dispatch.test.ts
@@ -59,6 +59,7 @@ import {
 import { isPromiseLike } from "../packages/vinext/src/utils/promise.js";
 import { isUnknownRecord } from "../packages/vinext/src/utils/record.js";
 import { extractRscCompletionMetadata } from "../packages/vinext/src/server/rsc-completion-metadata.js";
+import { VINEXT_INTERCEPTION_ID_HEADER } from "../packages/vinext/src/server/headers.js";
 
 type TestRoute = {
   __buildTimeClassifications?: ReadonlyMap<number, "static" | "dynamic"> | null;
@@ -2461,6 +2462,42 @@ describe("app page dispatch", () => {
     });
     expect(options.isrGet).not.toHaveBeenCalled();
     expect(options.isrSet).not.toHaveBeenCalled();
+  });
+
+  it("bypasses persistent and CDN caches for interception-id RSC requests", async () => {
+    const isrGet = vi.fn(async () =>
+      buildISRCacheEntry(
+        buildCachedAppPageValue(
+          "",
+          new TextEncoder().encode("stale-flight").buffer,
+          undefined,
+          buildQueryInvariantRenderObservation(),
+        ),
+      ),
+    );
+    const isrSet = vi.fn<DispatchOptions["isrSet"]>(async () => {});
+    const request = new Request("https://example.test/photos/123", {
+      headers: {
+        [VINEXT_INTERCEPTION_ID_HEADER]: "interception:slot:modal:/feed:/feed->/photos/:id",
+      },
+    });
+    const { options } = createDispatchOptions({
+      cleanPathname: "/photos/123",
+      isProduction: true,
+      isRscRequest: true,
+      isrGet,
+      isrSet,
+      request,
+      revalidateSeconds: 60,
+    });
+
+    const response = await dispatchAppPage(options);
+    await response.arrayBuffer();
+
+    expect(response.headers.get("cache-control")).toBe("no-store, must-revalidate");
+    expect(response.headers.get("x-vinext-cache")).toBeNull();
+    expect(isrGet).not.toHaveBeenCalled();
+    expect(isrSet).not.toHaveBeenCalled();
   });
 
   it("resolves the intercept source route's dynamic config for force-dynamic fetch defaults", async () => {

--- a/tests/app-rsc-cache-busting.test.ts
+++ b/tests/app-rsc-cache-busting.test.ts
@@ -337,6 +337,27 @@ describe("App Router RSC cache-busting", () => {
     ).resolves.toBeNull();
   });
 
+  it("canonicalizes interception id requests whose hash omits the id", async () => {
+    const interceptionId = "interception:slot:modal:/feed:/feed->/photos/:id";
+    const headers = createRscRequestHeaders({
+      interceptionContext: "/feed",
+      interceptionId,
+    });
+    const previousHash = await sha256CacheBustingHash("0,0,0,0,/feed,0,0");
+    const currentHash = await computeRscCacheBustingSearchParam(headers);
+    const request = new Request(`https://example.com/photos/42.rsc?_rsc=${previousHash}`, {
+      headers,
+    });
+
+    const response = await resolveInvalidRscCacheBustingRequest({
+      isRscRequest: true,
+      request,
+    });
+
+    expect(response?.status).toBe(307);
+    expect(response?.headers.get("Location")).toBe(`/photos/42.rsc?_rsc=${currentHash}`);
+  });
+
   it("accepts the prior bare navigation query after adding the state fingerprint", async () => {
     const headers = createRscRequestHeaders({
       routerState: { pathAndSearch: "/current", routeId: "route:/current" },

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -818,6 +818,7 @@ describe("createAppRscHandler", () => {
           headers: [
             { key: "Cache-Control", value: "public, max-age=3600" },
             { key: "CDN-Cache-Control", value: "public, max-age=3600" },
+            { key: "X-Security-Test", value: "preserved" },
           ],
         },
       ],
@@ -839,11 +840,88 @@ describe("createAppRscHandler", () => {
       "private, no-cache, no-store, max-age=0, must-revalidate",
     );
     expect(response.headers.get("cdn-cache-control")).toBeNull();
+    expect(response.headers.get("x-security-test")).toBe("preserved");
     expect(matchInterceptRoute).toHaveBeenCalledWith(
       "/photos/1",
       "/feed",
       "interception:attacker-selected",
     );
+    expect(dispatchMatchedPage).not.toHaveBeenCalled();
+  });
+
+  it("forces middleware responses with unverified interception ids to no-store", async () => {
+    const dispatchMatchedPage = vi.fn(async () => new Response("page"));
+    const matchInterceptRoute = vi.fn(() => null);
+    const handler = createHandler({
+      configHeaders: [
+        {
+          source: "/photos/:path*",
+          headers: [
+            { key: "Cache-Control", value: "public, max-age=3600" },
+            { key: "CDN-Cache-Control", value: "public, max-age=3600" },
+          ],
+        },
+      ],
+      dispatchMatchedPage,
+      matchInterceptRoute,
+      async runMiddleware() {
+        return {
+          kind: "response",
+          response: new Response("middleware", {
+            headers: { "Cache-Control": "public, max-age=3600" },
+          }),
+        };
+      },
+    });
+
+    const headers = createRscRequestHeaders({
+      interceptionContext: "/feed",
+      interceptionId: "interception:attacker-selected",
+    });
+    const rscUrl = await createRscRequestUrl("/docs/photos/1", headers);
+    const response = await handler(new Request(`https://example.test${rscUrl}`, { headers }), null);
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("middleware");
+    expect(response.headers.get("cache-control")).toBe(
+      "private, no-cache, no-store, max-age=0, must-revalidate",
+    );
+    expect(response.headers.get("cdn-cache-control")).toBeNull();
+    expect(matchInterceptRoute).not.toHaveBeenCalled();
+    expect(dispatchMatchedPage).not.toHaveBeenCalled();
+  });
+
+  it("forces malformed interception contexts paired with an id to no-store", async () => {
+    const dispatchMatchedPage = vi.fn(async () => new Response("page"));
+    const handler = createHandler({
+      configHeaders: [
+        {
+          source: "/photos/:path*",
+          headers: [{ key: "CDN-Cache-Control", value: "public, max-age=3600" }],
+        },
+      ],
+      dispatchMatchedPage,
+      matchRoute: (pathname: string) =>
+        pathname === "/photos/1"
+          ? {
+              params: {},
+              route: createPageRoute({
+                pattern: "/photos/1",
+                routeSegments: ["photos", "1"],
+              }),
+            }
+          : null,
+    });
+    const headers = createRscRequestHeaders({
+      interceptionContext: "/feed/%GG",
+      interceptionId: "interception:slot:modal:/feed:/feed->/photos/:id",
+    });
+    const rscUrl = await createRscRequestUrl("/docs/photos/1", headers);
+    const response = await handler(new Request(`https://example.test${rscUrl}`, { headers }), null);
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("cache-control")).toContain("no-store");
+    expect(response.headers.get("cdn-cache-control")).toBeNull();
     expect(dispatchMatchedPage).not.toHaveBeenCalled();
   });
 
@@ -872,6 +950,12 @@ describe("createAppRscHandler", () => {
         requestedId === interceptionId ? { route: sourceRoute, params: {} } : null,
     );
     const handler = createHandler({
+      configHeaders: [
+        {
+          source: "/photos/:path*",
+          headers: [{ key: "Cache-Control", value: "public, max-age=3600" }],
+        },
+      ],
       dispatchMatchedPage,
       matchInterceptRoute,
       matchRoute: () => null,
@@ -885,6 +969,9 @@ describe("createAppRscHandler", () => {
 
     expect(response.status).toBe(200);
     expect(await response.text()).toBe("intercepted");
+    expect(response.headers.get("cache-control")).toBe(
+      "private, no-cache, no-store, max-age=0, must-revalidate",
+    );
     expect(dispatchMatchedPage).toHaveBeenCalledWith(
       expect.objectContaining({ interceptionContext: "/feed", interceptionId }),
     );

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -818,7 +818,6 @@ describe("createAppRscHandler", () => {
           source: "/photos/:path*",
           headers: [
             { key: "Cache-Control", value: "public, max-age=3600" },
-            { key: "CDN-Cache-Control", value: "public, max-age=3600" },
             { key: "X-Security-Test", value: "preserved" },
           ],
         },
@@ -841,7 +840,6 @@ describe("createAppRscHandler", () => {
     expect(response.headers.get("cache-control")).toBe(
       "private, no-cache, no-store, max-age=0, must-revalidate",
     );
-    expect(response.headers.get("cdn-cache-control")).toBeNull();
     expect(response.headers.get("x-security-test")).toBe("preserved");
     expect(matchInterceptRoute).not.toHaveBeenCalled();
     expect(dispatchMatchedPage).not.toHaveBeenCalled();
@@ -884,10 +882,7 @@ describe("createAppRscHandler", () => {
       configHeaders: [
         {
           source: "/photos/:path*",
-          headers: [
-            { key: "Cache-Control", value: "public, max-age=3600" },
-            { key: "CDN-Cache-Control", value: "public, max-age=3600" },
-          ],
+          headers: [{ key: "Cache-Control", value: "public, max-age=3600" }],
         },
       ],
       dispatchMatchedPage,
@@ -914,7 +909,6 @@ describe("createAppRscHandler", () => {
     expect(response.headers.get("cache-control")).toBe(
       "private, no-cache, no-store, max-age=0, must-revalidate",
     );
-    expect(response.headers.get("cdn-cache-control")).toBeNull();
     expect(matchInterceptRoute).not.toHaveBeenCalled();
     expect(dispatchMatchedPage).not.toHaveBeenCalled();
   });
@@ -953,12 +947,7 @@ describe("createAppRscHandler", () => {
   it("forces malformed interception contexts paired with an id to no-store", async () => {
     const dispatchMatchedPage = vi.fn(async () => new Response("page"));
     const handler = createHandler({
-      configHeaders: [
-        {
-          source: "/photos/:path*",
-          headers: [{ key: "CDN-Cache-Control", value: "public, max-age=3600" }],
-        },
-      ],
+      configHeaders: [],
       dispatchMatchedPage,
       hasInterceptionId: () => true,
       matchRoute: (pathname: string) =>
@@ -981,7 +970,6 @@ describe("createAppRscHandler", () => {
 
     expect(response.status).toBe(400);
     expect(response.headers.get("cache-control")).toContain("no-store");
-    expect(response.headers.get("cdn-cache-control")).toBeNull();
     expect(dispatchMatchedPage).not.toHaveBeenCalled();
   });
 

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -125,6 +125,7 @@ function createHandler(overrides: Partial<TestHandlerOptions> = {}) {
     i18nConfig: overrides.i18nConfig ?? null,
     imageConfig: overrides.imageConfig,
     isDev: overrides.isDev ?? true,
+    hasInterceptionId: overrides.hasInterceptionId ?? (() => false),
     matchInterceptRoute: overrides.matchInterceptRoute,
     matchRoute:
       overrides.matchRoute ??
@@ -823,6 +824,7 @@ describe("createAppRscHandler", () => {
         },
       ],
       dispatchMatchedPage,
+      hasInterceptionId: () => false,
       matchInterceptRoute,
       matchRoute: (pathname: string) =>
         pathname === "/photos/1" ? { params: {}, route: targetRoute } : null,
@@ -841,15 +843,41 @@ describe("createAppRscHandler", () => {
     );
     expect(response.headers.get("cdn-cache-control")).toBeNull();
     expect(response.headers.get("x-security-test")).toBe("preserved");
-    expect(matchInterceptRoute).toHaveBeenCalledWith(
-      "/photos/1",
-      "/feed",
-      "interception:attacker-selected",
-    );
+    expect(matchInterceptRoute).not.toHaveBeenCalled();
     expect(dispatchMatchedPage).not.toHaveBeenCalled();
   });
 
-  it("forces middleware responses with unverified interception ids to no-store", async () => {
+  it("canonicalizes selector hashes before permanent config redirects", async () => {
+    const interceptionId = "interception:slot:modal:/feed:/feed->/photos/:id";
+    const handler = createHandler({
+      configHeaders: [],
+      configRedirects: [
+        {
+          source: "/photos/:id",
+          destination: "/viewer/:id",
+          permanent: true,
+        },
+      ],
+      hasInterceptionId: (requestedId) => requestedId === interceptionId,
+    });
+    const headers = createRscRequestHeaders({
+      interceptionContext: "/feed",
+      interceptionId,
+    });
+    const currentHash = await computeRscCacheBustingSearchParam(headers);
+    // Hash produced before X-Vinext-Interception-Id became a positional input.
+    const previousHash = "xut9sI3k0WVES6tW";
+
+    const response = await handler(
+      new Request(`https://example.test/docs/photos/1?_rsc=${previousHash}`, { headers }),
+      null,
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(`/docs/photos/1?_rsc=${currentHash}`);
+  });
+
+  it("rejects unknown interception ids before middleware can respond", async () => {
     const dispatchMatchedPage = vi.fn(async () => new Response("page"));
     const matchInterceptRoute = vi.fn(() => null);
     const handler = createHandler({
@@ -863,6 +891,7 @@ describe("createAppRscHandler", () => {
         },
       ],
       dispatchMatchedPage,
+      hasInterceptionId: () => false,
       matchInterceptRoute,
       async runMiddleware() {
         return {
@@ -881,13 +910,43 @@ describe("createAppRscHandler", () => {
     const rscUrl = await createRscRequestUrl("/docs/photos/1", headers);
     const response = await handler(new Request(`https://example.test${rscUrl}`, { headers }), null);
 
-    expect(response.status).toBe(200);
-    expect(await response.text()).toBe("middleware");
+    expect(response.status).toBe(400);
     expect(response.headers.get("cache-control")).toBe(
       "private, no-cache, no-store, max-age=0, must-revalidate",
     );
     expect(response.headers.get("cdn-cache-control")).toBeNull();
     expect(matchInterceptRoute).not.toHaveBeenCalled();
+    expect(dispatchMatchedPage).not.toHaveBeenCalled();
+  });
+
+  it("preserves a cacheable middleware 400 for a graph-owned id", async () => {
+    const interceptionId = "interception:slot:modal:/feed:/feed->/photos/:id";
+    const dispatchMatchedPage = vi.fn(async () => new Response("page"));
+    const handler = createHandler({
+      configHeaders: [],
+      dispatchMatchedPage,
+      hasInterceptionId: (requestedId) => requestedId === interceptionId,
+      async runMiddleware() {
+        return {
+          kind: "response",
+          response: new Response("middleware", {
+            status: 400,
+            headers: { "Cache-Control": "public, max-age=3600" },
+          }),
+        };
+      },
+    });
+
+    const headers = createRscRequestHeaders({
+      interceptionContext: "/feed",
+      interceptionId,
+    });
+    const rscUrl = await createRscRequestUrl("/docs/photos/1", headers);
+    const response = await handler(new Request(`https://example.test${rscUrl}`, { headers }), null);
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe("middleware");
+    expect(response.headers.get("cache-control")).toBe("public, max-age=3600");
     expect(dispatchMatchedPage).not.toHaveBeenCalled();
   });
 
@@ -901,6 +960,7 @@ describe("createAppRscHandler", () => {
         },
       ],
       dispatchMatchedPage,
+      hasInterceptionId: () => true,
       matchRoute: (pathname: string) =>
         pathname === "/photos/1"
           ? {
@@ -928,7 +988,11 @@ describe("createAppRscHandler", () => {
   it("rejects interception ids without a source context", async () => {
     const dispatchMatchedPage = vi.fn(async () => new Response("page"));
     const matchInterceptRoute = vi.fn(() => null);
-    const handler = createHandler({ dispatchMatchedPage, matchInterceptRoute });
+    const handler = createHandler({
+      dispatchMatchedPage,
+      hasInterceptionId: () => true,
+      matchInterceptRoute,
+    });
     const headers = createRscRequestHeaders({
       interceptionId: "interception:slot:modal:/feed:/feed->/photos/:id",
     });
@@ -957,6 +1021,7 @@ describe("createAppRscHandler", () => {
         },
       ],
       dispatchMatchedPage,
+      hasInterceptionId: (requestedId) => requestedId === interceptionId,
       matchInterceptRoute,
       matchRoute: () => null,
     });
@@ -969,9 +1034,7 @@ describe("createAppRscHandler", () => {
 
     expect(response.status).toBe(200);
     expect(await response.text()).toBe("intercepted");
-    expect(response.headers.get("cache-control")).toBe(
-      "private, no-cache, no-store, max-age=0, must-revalidate",
-    );
+    expect(response.headers.get("cache-control")).toBe("public, max-age=3600");
     expect(dispatchMatchedPage).toHaveBeenCalledWith(
       expect.objectContaining({ interceptionContext: "/feed", interceptionId }),
     );

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -21,6 +21,7 @@ import {
   NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
   RSC_HEADER,
   VINEXT_CLIENT_REUSE_MANIFEST_HEADER,
+  VINEXT_INTERCEPTION_ID_HEADER,
   VINEXT_MW_CTX_HEADER,
 } from "../packages/vinext/src/server/headers.js";
 import { applyAppMiddleware } from "../packages/vinext/src/server/app-middleware.js";
@@ -804,6 +805,104 @@ describe("createAppRscHandler", () => {
     expect(dispatchMatchedPage).toHaveBeenCalledWith(
       expect.objectContaining({ interceptionContext: "/%2561dmin" }),
     );
+  });
+
+  it("rejects unverified interception ids before page dispatch or shared caching", async () => {
+    const targetRoute = createPageRoute({ pattern: "/photos/1", routeSegments: ["photos", "1"] });
+    const matchInterceptRoute = vi.fn(() => null);
+    const dispatchMatchedPage = vi.fn(async () => new Response("page"));
+    const handler = createHandler({
+      configHeaders: [
+        {
+          source: "/photos/:path*",
+          headers: [
+            { key: "Cache-Control", value: "public, max-age=3600" },
+            { key: "CDN-Cache-Control", value: "public, max-age=3600" },
+          ],
+        },
+      ],
+      dispatchMatchedPage,
+      matchInterceptRoute,
+      matchRoute: (pathname: string) =>
+        pathname === "/photos/1" ? { params: {}, route: targetRoute } : null,
+    });
+
+    const headers = createRscRequestHeaders({
+      interceptionContext: "/feed",
+      interceptionId: "interception:attacker-selected",
+    });
+    const rscUrl = await createRscRequestUrl("/docs/photos/1", headers);
+    const response = await handler(new Request(`https://example.test${rscUrl}`, { headers }), null);
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("cache-control")).toBe(
+      "private, no-cache, no-store, max-age=0, must-revalidate",
+    );
+    expect(response.headers.get("cdn-cache-control")).toBeNull();
+    expect(matchInterceptRoute).toHaveBeenCalledWith(
+      "/photos/1",
+      "/feed",
+      "interception:attacker-selected",
+    );
+    expect(dispatchMatchedPage).not.toHaveBeenCalled();
+  });
+
+  it("rejects interception ids without a source context", async () => {
+    const dispatchMatchedPage = vi.fn(async () => new Response("page"));
+    const matchInterceptRoute = vi.fn(() => null);
+    const handler = createHandler({ dispatchMatchedPage, matchInterceptRoute });
+    const headers = createRscRequestHeaders({
+      interceptionId: "interception:slot:modal:/feed:/feed->/photos/:id",
+    });
+    const rscUrl = await createRscRequestUrl("/docs/about", headers);
+    const response = await handler(new Request(`https://example.test${rscUrl}`, { headers }), null);
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("cache-control")).toContain("no-store");
+    expect(matchInterceptRoute).not.toHaveBeenCalled();
+    expect(dispatchMatchedPage).not.toHaveBeenCalled();
+  });
+
+  it("allows an exact graph-owned interception id", async () => {
+    const sourceRoute = createPageRoute({ pattern: "/feed", routeSegments: ["feed"] });
+    const interceptionId = "interception:slot:modal:/feed:/feed->/photos/:id";
+    const dispatchMatchedPage = vi.fn(async () => new Response("intercepted"));
+    const matchInterceptRoute = vi.fn(
+      (_pathname: string, _sourcePathname: string, requestedId?: string | null) =>
+        requestedId === interceptionId ? { route: sourceRoute, params: {} } : null,
+    );
+    const handler = createHandler({
+      dispatchMatchedPage,
+      matchInterceptRoute,
+      matchRoute: () => null,
+    });
+    const headers = createRscRequestHeaders({
+      interceptionContext: "/feed",
+      interceptionId,
+    });
+    const rscUrl = await createRscRequestUrl("/docs/photos/1", headers);
+    const response = await handler(new Request(`https://example.test${rscUrl}`, { headers }), null);
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("intercepted");
+    expect(dispatchMatchedPage).toHaveBeenCalledWith(
+      expect.objectContaining({ interceptionContext: "/feed", interceptionId }),
+    );
+  });
+
+  it("marks malformed interception ids non-cacheable", async () => {
+    const dispatchMatchedPage = vi.fn(async () => new Response("page"));
+    const handler = createHandler({ dispatchMatchedPage });
+    const headers = createRscRequestHeaders();
+    headers.set(VINEXT_INTERCEPTION_ID_HEADER, "attacker-selected");
+    const response = await handler(
+      new Request("https://example.test/docs/about?_rsc=invalid", { headers }),
+      null,
+    );
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("cache-control")).toContain("no-store");
+    expect(dispatchMatchedPage).not.toHaveBeenCalled();
   });
 
   it("passes the raw interception source to Server Action dispatch", async () => {

--- a/tests/app-rsc-route-matching.test.ts
+++ b/tests/app-rsc-route-matching.test.ts
@@ -219,6 +219,36 @@ describe("App RSC route matching", () => {
     });
   });
 
+  it("accepts only the graph-owned interception id for an exact source and target", () => {
+    const interceptionId = "interception:slot:modal:/feed:/feed->/photos/:id";
+    const matcher = createAppRscRouteMatcher([
+      route("/feed", ["feed"], {
+        modal: {
+          id: "slot:modal:/feed",
+          intercepts: [
+            {
+              sourceMatchPattern: "/feed",
+              targetPattern: "/photos/:id",
+              interceptLayouts: ["modal-layout"],
+              page: "photo-page",
+              params: ["id"],
+            },
+          ],
+        },
+      }),
+    ]);
+
+    expect(matcher.findIntercept("/photos/42", "/feed", interceptionId)).toMatchObject({
+      interceptionId,
+      slotId: "slot:modal:/feed",
+    });
+    expect(
+      matcher.findIntercept("/photos/42", "/feed", "interception:attacker-selected"),
+    ).toBeNull();
+    expect(matcher.findIntercept("/other/42", "/feed", interceptionId)).toBeNull();
+    expect(matcher.findIntercept("/photos/42", "/other", interceptionId)).toBeNull();
+  });
+
   it("prefers static interception targets over dynamic targets", () => {
     // Ported from Next.js:
     // test/e2e/app-dir/interception-dynamic-segment/interception-dynamic-segment.test.ts
@@ -1017,7 +1047,7 @@ describe("App RSC route matching", () => {
 function route(
   pattern: string,
   patternParts: string[],
-  slots?: Record<string, { intercepts?: TestIntercept[] }>,
+  slots?: Record<string, { id?: string; intercepts?: TestIntercept[] }>,
 ): TestRoute {
   return {
     pattern,
@@ -1044,7 +1074,7 @@ type TestRoute = {
   pattern: string;
   patternParts: string[];
   routeHandler?: unknown;
-  slots?: Record<string, { intercepts?: TestIntercept[] }>;
+  slots?: Record<string, { id?: string; intercepts?: TestIntercept[] }>;
   siblingIntercepts?: TestSiblingIntercept[];
 };
 

--- a/tests/app-rsc-route-matching.test.ts
+++ b/tests/app-rsc-route-matching.test.ts
@@ -242,6 +242,8 @@ describe("App RSC route matching", () => {
       interceptionId,
       slotId: "slot:modal:/feed",
     });
+    expect(matcher.hasInterceptionId(interceptionId)).toBe(true);
+    expect(matcher.hasInterceptionId("interception:attacker-selected")).toBe(false);
     expect(
       matcher.findIntercept("/photos/42", "/feed", "interception:attacker-selected"),
     ).toBeNull();

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -1083,6 +1083,8 @@ describe("App Router entry templates", () => {
     const code = generateRscEntry("/tmp/test/app", minimalAppRoutes, null, [], null, "", false);
 
     expect(code).toContain("matchInterceptRoute(pathname, sourcePathname, interceptionId)");
+    expect(code).toContain("hasInterceptionId(interceptionId)");
+    expect(code).toContain("return __routeMatcher.hasInterceptionId(interceptionId)");
     expect(code).toContain(
       "const intercept = findIntercept(pathname, sourcePathname, interceptionId)",
     );

--- a/tests/isr-cache.test.ts
+++ b/tests/isr-cache.test.ts
@@ -269,6 +269,28 @@ describe("App Router ISR cache key primitives", () => {
     expect(fromFeed).toMatch(/^app:\/photos\/42:rsc:source:[a-z0-9]+:slots:[a-z0-9]+$/);
   });
 
+  it("keys supplemental RSC variants by their verified interception id", () => {
+    delete process.env.__VINEXT_BUILD_ID;
+
+    const modal = appIsrRscKey(
+      "/photos/42",
+      null,
+      undefined,
+      "/feed",
+      "interception:slot:modal:/feed:/feed->/photos/:id",
+    );
+    const drawer = appIsrRscKey(
+      "/photos/42",
+      null,
+      undefined,
+      "/feed",
+      "interception:slot:drawer:/feed:/feed->/photos/:id",
+    );
+
+    expect(modal).not.toBe(drawer);
+    expect(modal).toMatch(/^app:\/photos\/42:rsc:source:[a-z0-9]+:selector:[a-z0-9]+$/);
+  });
+
   it("normalizes source context before keying intercepted RSC variants", () => {
     delete process.env.__VINEXT_BUILD_ID;
 


### PR DESCRIPTION
## Summary

- reject unknown `X-Vinext-Interception-Id` values before middleware, redirects, or other cacheable early responses
- require graph-owned IDs to match the exact requested target and source context before page dispatch
- canonicalize ID-bearing requests to an ID-inclusive `_rsc` URL before cacheable redirects
- include verified IDs in origin ISR read, regeneration, and write keys so valid supplemental refreshes remain cacheable
- force only rejected selector responses to no-store; preserve cache policy for valid selector responses
- express invalid-selector cache policy through the configured CDN adapter without provider header coupling in vinext core
- preserve context-only interception compatibility and valid supplemental refreshes from #2880

## Security impact

Previously arbitrary `interception:*` values could add an unbounded cache dimension, early responders could escape exact verification, rollout hashes could collapse different selectors onto one URL key, and origin ISR keys did not include the selector. Unknown or mismatched selectors are now rejected, while graph-owned selectors are isolated by both the canonical URL hash and origin ISR key.

## Next.js / Cloudflare reference

Next.js gates generated interception rewrites with `Next-Url`, emits it in `Vary` for interception responses, and validates the header-derived `_rsc` URL hash because CDNs may ignore `Vary`. `X-Vinext-Interception-Id` is vinext-specific because supplemental refreshes fan out retained branches; vinext applies the same URL-key principle and additionally validates the ID against its generated route graph.

## Validation

- focused handler, cache-busting, route-matching, page-dispatch, ISR, cache, render, adapter, and codegen suites — 581 passed
- App Router E2E interception coverage — 37 passed, 1 existing skip
- full `vp check`
- `vp run vinext#build`
- independent cumulative review and re-review — no findings
