### PR TITLE
fix(workers): expose Cloudflare country to Next request headers

### DIFF
--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -172,6 +172,7 @@ jobs:
           vp exec playwright test
           tests/e2e/cloudflare-workers/web-worker.spec.ts
           tests/e2e/cloudflare-workers/optimistic-search-navigation.spec.ts
+          tests/e2e/cloudflare-workers/provider-region.spec.ts
 
   comment:
     name: Comment Preview URLs

--- a/examples/app-router-cloudflare/app/api/provider-region/route.ts
+++ b/examples/app-router-cloudflare/app/api/provider-region/route.ts
@@ -1,0 +1,22 @@
+import { getProvidersForRegion, getRequestRegion } from "../../provider-region/region";
+
+export const dynamic = "force-dynamic";
+
+type CloudflareRequest = Request & {
+  cf?: { country?: string };
+};
+
+export async function GET(request: Request) {
+  const headerCountry = request.headers.get("cf-ipcountry");
+  const resolvedCountry = getRequestRegion(request.headers);
+
+  return Response.json(
+    {
+      cfCountry: (request as CloudflareRequest).cf?.country ?? null,
+      headerCountry,
+      resolvedCountry,
+      providers: getProvidersForRegion(resolvedCountry),
+    },
+    { headers: { "cache-control": "private, no-store" } },
+  );
+}

--- a/examples/app-router-cloudflare/app/provider-region/page.tsx
+++ b/examples/app-router-cloudflare/app/provider-region/page.tsx
@@ -1,0 +1,60 @@
+import { headers } from "next/headers";
+import { Suspense } from "react";
+
+import { ProviderFilter } from "./provider-filter";
+import { getRequestRegion } from "./region";
+
+export const dynamic = "force-dynamic";
+
+export default async function ProviderRegionPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ provider?: string }>;
+}) {
+  const provider = (await searchParams).provider ?? null;
+  const requestHeaders = await headers();
+  const headerCountry = requestHeaders.get("cf-ipcountry");
+  const resolvedCountry = getRequestRegion(requestHeaders);
+
+  return (
+    <main>
+      <h1>Provider region propagation</h1>
+      <p>
+        This reproduces a region-specific provider filter that reads the visitor country only from
+        cf-ipcountry and falls back to the US.
+      </p>
+      <dl>
+        <dt>Page cf-ipcountry header</dt>
+        <dd data-testid="page-header-country">{headerCountry ?? "missing"}</dd>
+        <dt>Page resolved country</dt>
+        <dd data-testid="page-resolved-country">{resolvedCountry}</dd>
+      </dl>
+      <ProviderFilter />
+      <Suspense fallback={<p data-testid="provider-results-loading">Loading results…</p>}>
+        <ProviderResults key={provider ?? "all"} provider={provider} region={resolvedCountry} />
+      </Suspense>
+    </main>
+  );
+}
+
+async function ProviderResults({
+  provider,
+  region,
+}: {
+  provider: string | null;
+  region: string;
+}) {
+  await new Promise((resolve) => setTimeout(resolve, provider ? 300 : 25));
+
+  return (
+    <section data-testid="provider-results">
+      <h2>Server-filtered results</h2>
+      <dl>
+        <dt>Server provider</dt>
+        <dd data-testid="server-provider">{provider ?? "none"}</dd>
+        <dt>Server region</dt>
+        <dd data-testid="server-region">{region}</dd>
+      </dl>
+    </section>
+  );
+}

--- a/examples/app-router-cloudflare/app/provider-region/provider-filter.tsx
+++ b/examples/app-router-cloudflare/app/provider-region/provider-filter.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useOptimistic,
+  useRef,
+  useState,
+  useTransition,
+} from "react";
+
+type Provider = {
+  id: number;
+  name: string;
+};
+
+type ProviderResponse = {
+  cfCountry: string | null;
+  headerCountry: string | null;
+  resolvedCountry: string;
+  providers: Provider[];
+};
+
+export function ProviderFilter() {
+  const pathname = usePathname();
+  const router = useRouter();
+  const routeSearchParams = useSearchParams();
+  const [providerData, setProviderData] = useState<ProviderResponse | null>(null);
+  const [providerError, setProviderError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const [optimisticQuery, setOptimisticQuery] = useOptimistic(
+    routeSearchParams.toString(),
+    (_currentQuery, nextQuery: string) => nextQuery,
+  );
+  const optimisticQueryRef = useRef(optimisticQuery);
+
+  useLayoutEffect(() => {
+    optimisticQueryRef.current = optimisticQuery;
+  }, [optimisticQuery]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    const loadProviders = async () => {
+      try {
+        const response = await fetch("/api/provider-region", {
+          cache: "no-store",
+          signal: controller.signal,
+        });
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const data = (await response.json()) as ProviderResponse;
+        if (!controller.signal.aborted) setProviderData(data);
+      } catch (error: unknown) {
+        if (controller.signal.aborted) return;
+        setProviderError(error instanceof Error ? error.message : String(error));
+      }
+    };
+
+    void loadProviders();
+
+    return () => controller.abort();
+  }, []);
+
+  const toggleProvider = useCallback(
+    (provider: string) => {
+      const params = new URLSearchParams(optimisticQueryRef.current);
+      if (params.get("provider") === provider) {
+        params.delete("provider");
+      } else {
+        params.set("provider", provider);
+      }
+      const query = params.toString();
+
+      startTransition(() => {
+        setOptimisticQuery(query);
+        router.push(query ? `${pathname}?${query}` : pathname, { scroll: false });
+      });
+    },
+    [pathname, router, setOptimisticQuery],
+  );
+
+  const selectedProvider = new URLSearchParams(optimisticQuery).get("provider");
+
+  return (
+    <section aria-labelledby="provider-region-filter-heading">
+      <h2 id="provider-region-filter-heading">Provider catalog returned to the client</h2>
+      {providerData ? (
+        <>
+          <dl>
+            <dt>Raw request.cf.country</dt>
+            <dd data-testid="api-cf-country">{providerData.cfCountry ?? "missing"}</dd>
+            <dt>API cf-ipcountry header</dt>
+            <dd data-testid="api-header-country">{providerData.headerCountry ?? "missing"}</dd>
+            <dt>API resolved country</dt>
+            <dd data-testid="api-resolved-country">{providerData.resolvedCountry}</dd>
+          </dl>
+          <div role="radiogroup" aria-label="Streaming service">
+            {providerData.providers.map((provider) => {
+              const value = String(provider.id);
+              const isActive = selectedProvider === value;
+              return (
+                <button
+                  aria-checked={isActive}
+                  data-testid={`provider-${provider.id}`}
+                  key={provider.id}
+                  onClick={() => toggleProvider(value)}
+                  role="radio"
+                  type="button"
+                >
+                  {provider.name}
+                </button>
+              );
+            })}
+          </div>
+        </>
+      ) : providerError ? (
+        <p data-testid="providers-error">Provider request failed: {providerError}</p>
+      ) : (
+        <p data-testid="providers-loading">Loading providers…</p>
+      )}
+      <dl>
+        <dt>Client provider</dt>
+        <dd data-testid="client-provider">{selectedProvider ?? "none"}</dd>
+        <dt>Navigation pending</dt>
+        <dd data-testid="navigation-pending">{String(isPending)}</dd>
+      </dl>
+    </section>
+  );
+}

--- a/examples/app-router-cloudflare/app/provider-region/region.ts
+++ b/examples/app-router-cloudflare/app/provider-region/region.ts
@@ -1,0 +1,22 @@
+export function getRequestRegion(headers: Headers, fallback = "US"): string {
+  return headers.get("cf-ipcountry") ?? fallback;
+}
+
+export const providersByRegion = {
+  AU: [
+    { id: 8, name: "Netflix" },
+    { id: 9, name: "Amazon Prime Video" },
+    { id: 337, name: "Disney Plus" },
+    { id: 385, name: "BINGE" },
+  ],
+  US: [
+    { id: 8, name: "Netflix" },
+    { id: 9, name: "Amazon Prime Video" },
+    { id: 337, name: "Disney Plus" },
+    { id: 1899, name: "Max" },
+  ],
+} as const;
+
+export function getProvidersForRegion(region: string) {
+  return region === "AU" ? providersByRegion.AU : providersByRegion.US;
+}

--- a/examples/pages-router-cloudflare/pages/api/hello.ts
+++ b/examples/pages-router-cloudflare/pages/api/hello.ts
@@ -1,7 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
-export default function handler(_req: NextApiRequest, res: NextApiResponse) {
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
   res.json({
+    country: req.headers["cf-ipcountry"] ?? null,
     message: "Hello from Pages Router API on Workers!",
     runtime: typeof navigator !== "undefined" ? navigator.userAgent : "unknown",
   });

--- a/packages/vinext/src/server/app-router-entry.ts
+++ b/packages/vinext/src/server/app-router-entry.ts
@@ -45,6 +45,7 @@ import {
   resolveStaticAssetSignal,
 } from "./worker-utils.js";
 import {
+  applyCloudflareCountryHeader,
   cloneRequestWithHeaders,
   filterInternalHeaders,
   isOpenRedirectShaped,
@@ -160,6 +161,7 @@ async function handleRequest(
     const filteredHeaders = ctx.isInternalPagesRevalidation
       ? new Headers(request.headers)
       : filterInternalHeaders(request.headers);
+    applyCloudflareCountryHeader(request, filteredHeaders);
     filteredHeaders.delete(VINEXT_REVALIDATE_HOST_HEADER);
     const prerenderRouteParamsHeader = serializePrerenderRouteParamsHeader(
       trustedPrerenderRouteParams,

--- a/packages/vinext/src/server/pages-router-entry.ts
+++ b/packages/vinext/src/server/pages-router-entry.ts
@@ -27,6 +27,7 @@ import {
 } from "./image-optimization.js";
 import type { ImageConfig } from "./image-optimization.js";
 import {
+  applyCloudflareCountryHeader,
   cloneRequestWithHeaders,
   cloneRequestWithUrl,
   filterInternalHeaders,
@@ -149,6 +150,7 @@ async function handleRequest(
     const filteredHeaders = ctx.isInternalPagesRevalidation
       ? new Headers(request.headers)
       : filterInternalHeaders(request.headers);
+    applyCloudflareCountryHeader(request, filteredHeaders);
     filteredHeaders.delete(VINEXT_REVALIDATE_HOST_HEADER);
     request = cloneRequestWithHeaders(request, filteredHeaders);
 

--- a/packages/vinext/src/server/request-pipeline.ts
+++ b/packages/vinext/src/server/request-pipeline.ts
@@ -545,6 +545,24 @@ function getRequestCf(request: Request): unknown {
 }
 
 /**
+ * Expose the trusted Workers country metadata through the request-header
+ * surface used by Next applications. `request.cf.country` is available on
+ * Workers even when the optional CF-IPCountry transform is not enabled.
+ *
+ * The platform value wins over an existing header so userland always observes
+ * the country attached by Cloudflare, not a conflicting client-supplied value.
+ */
+export function applyCloudflareCountryHeader(request: Request, headers: Headers): void {
+  const cf = getRequestCf(request);
+  if (typeof cf !== "object" || cf === null) return;
+
+  const country = Reflect.get(cf, "country");
+  if (typeof country === "string" && country.length > 0) {
+    headers.set("cf-ipcountry", country);
+  }
+}
+
+/**
  * Re-attach the Workers-specific `cf` metadata from `source` onto a rebuilt
  * Request. `new Request()` never copies it, and middleware/authorization code
  * can key off `request.cf` (geo checks, bot scores), so every reconstruction

--- a/tests/e2e/cloudflare-pages-router/middleware.spec.ts
+++ b/tests/e2e/cloudflare-pages-router/middleware.spec.ts
@@ -28,9 +28,13 @@ test.describe("middleware.ts on Pages Router Cloudflare Workers (prod build)", (
   });
 
   test("API route still returns correct JSON after middleware runs", async ({ request }) => {
-    const res = await request.get(`${BASE}/api/hello`);
+    const res = await request.get(`${BASE}/api/hello`, {
+      headers: { "cf-ipcountry": "ZZ" },
+    });
     expect(res.status()).toBe(200);
-    const data = (await res.json()) as { message: string; runtime: string };
+    const data = (await res.json()) as { country: string | null; message: string; runtime: string };
+    expect(data.country).toMatch(/^(?:[A-Z]{2}|T1)$/);
+    expect(data.country).not.toBe("ZZ");
     expect(data.message).toBe("Hello from Pages Router API on Workers!");
     expect(data.runtime).toBe("Cloudflare-Workers");
   });

--- a/tests/e2e/cloudflare-workers/provider-region.spec.ts
+++ b/tests/e2e/cloudflare-workers/provider-region.spec.ts
@@ -4,6 +4,7 @@ const ROUTE = "/provider-region";
 
 test.describe("provider country propagation", () => {
   test("propagates the native Workers country to Next request headers", async ({ page }) => {
+    await page.setExtraHTTPHeaders({ "cf-ipcountry": "ZZ" });
     await page.goto(ROUTE);
 
     await expect(page.getByTestId("api-resolved-country")).toBeVisible();

--- a/tests/e2e/cloudflare-workers/provider-region.spec.ts
+++ b/tests/e2e/cloudflare-workers/provider-region.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "@playwright/test";
+
+const ROUTE = "/provider-region";
+
+test.describe("provider country propagation", () => {
+  test("propagates the native Workers country to Next request headers", async ({ page }) => {
+    await page.goto(ROUTE);
+
+    await expect(page.getByTestId("api-resolved-country")).toBeVisible();
+    const cfCountry = await page.getByTestId("api-cf-country").innerText();
+    const headerCountry = await page.getByTestId("api-header-country").innerText();
+    const resolvedCountry = await page.getByTestId("api-resolved-country").innerText();
+
+    if (cfCountry !== "missing") {
+      expect(headerCountry).toBe(cfCountry);
+      expect(resolvedCountry).toBe(cfCountry);
+      await expect(page.getByTestId("page-header-country")).toHaveText(cfCountry);
+      await expect(page.getByTestId("page-resolved-country")).toHaveText(cfCountry);
+    }
+
+    if (process.env.VINEXT_E2E_BASE_URL?.startsWith("https://")) {
+      expect(cfCountry).toMatch(/^(?:[A-Z]{2}|T1)$/);
+    }
+  });
+
+  test("uses the provider catalog returned by the API for App Router navigation", async ({
+    page,
+  }) => {
+    await page.goto(ROUTE);
+    await expect(page.getByTestId("provider-8")).toBeVisible();
+
+    await page.getByTestId("provider-8").click();
+    await expect(page).toHaveURL(`${ROUTE}?provider=8`);
+    await expect(page.getByTestId("client-provider")).toHaveText("8");
+    await expect(page.getByTestId("server-provider")).toHaveText("8");
+    const pageRegion = await page.getByTestId("page-resolved-country").innerText();
+    await expect(page.getByTestId("server-region")).toHaveText(pageRegion);
+
+    await page.getByTestId("provider-8").click();
+    await expect(page).toHaveURL(ROUTE);
+    await expect(page.getByTestId("client-provider")).toHaveText("none");
+    await expect(page.getByTestId("server-provider")).toHaveText("none");
+  });
+});

--- a/tests/request-pipeline.test.ts
+++ b/tests/request-pipeline.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vite-plus/test";
 import {
+  applyCloudflareCountryHeader,
   canonicalizeRequestPathname,
   canonicalizeRequestUrlPathname,
   cloneRequestWithHeaders,
@@ -949,6 +950,49 @@ describe("filterInternalHeaders", () => {
     const headers = new Headers();
     const result = filterInternalHeaders(headers);
     expect([...result.keys()]).toEqual([]);
+  });
+});
+
+describe("applyCloudflareCountryHeader", () => {
+  function requestWithCf(country: unknown): Request {
+    const request = new Request("https://example.com");
+    Object.defineProperty(request, "cf", {
+      configurable: true,
+      value: { country },
+    });
+    return request;
+  }
+
+  it("exposes request.cf.country to Next application headers", () => {
+    const headers = new Headers();
+
+    applyCloudflareCountryHeader(requestWithCf("AU"), headers);
+
+    expect(headers.get("cf-ipcountry")).toBe("AU");
+  });
+
+  it("uses trusted request.cf.country over a conflicting incoming header", () => {
+    const headers = new Headers({ "cf-ipcountry": "US" });
+
+    applyCloudflareCountryHeader(requestWithCf("AU"), headers);
+
+    expect(headers.get("cf-ipcountry")).toBe("AU");
+  });
+
+  it("keeps the incoming header when Cloudflare country metadata is unavailable", () => {
+    const headers = new Headers({ "cf-ipcountry": "GB" });
+
+    applyCloudflareCountryHeader(new Request("https://example.com"), headers);
+
+    expect(headers.get("cf-ipcountry")).toBe("GB");
+  });
+
+  it("ignores malformed Cloudflare country metadata", () => {
+    const headers = new Headers();
+
+    applyCloudflareCountryHeader(requestWithCf(null), headers);
+
+    expect(headers.has("cf-ipcountry")).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Overview

| | |
| --- | --- |
| Goal | Make Cloudflare visitor country metadata available through Next.js request headers. |
| Core change | Copy `request.cf.country` to `cf-ipcountry` before Vinext runs middleware or routing. |
| Key boundary | Apply the platform adapter in both App Router and Pages Router Worker entries. |
| Expected impact | Region-dependent applications receive the Cloudflare country instead of falling back to a default region. |

## Why

Cloudflare Workers attach the visitor country to `request.cf.country`. The `cf-ipcountry` header can remain absent when its optional managed transform is not enabled.

Vinext already preserved `request.cf` when it cloned requests. However, Next.js `headers()` and route handler request headers only exposed the HTTP header surface. An Australian request could therefore contain `request.cf.country === "AU"` while application code observed no country header and selected a US fallback.

The Worker entry owns the conversion from platform metadata to the Next.js request contract. The trusted Cloudflare value replaces a conflicting incoming header. Non-Workers requests without `request.cf.country` keep their existing headers unchanged.

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| Worker request with native country metadata | `request.cf.country` was present, but `headers().get("cf-ipcountry")` was null. | App Router and Pages Router receive the native country as `cf-ipcountry`. |
| Conflicting incoming country header | Application code could observe the incoming value. | The trusted `request.cf.country` value wins. |
| Runtime without Cloudflare metadata | Existing request headers passed through. | Existing request headers still pass through. |
| Deployed App Router example | No country propagation regression route existed. | The example reports raw metadata, header metadata, and the resolved provider catalog. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/server/request-pipeline.ts` defines the platform adapter and trust rule.
2. `packages/vinext/src/server/app-router-entry.ts` and `pages-router-entry.ts` apply it before userland request handling.
3. `tests/request-pipeline.test.ts` covers platform, conflict, absence, and malformed metadata cases.
4. `examples/app-router-cloudflare/app/provider-region` reproduces the region-dependent provider pattern.
5. `tests/e2e/cloudflare-workers/provider-region.spec.ts` proves Worker metadata reaches the API and Server Component paths.

</details>

<details>
<summary>Validation</summary>

- Passed 223 focused unit and integration tests across the request pipeline and both router paths.
- Passed both provider-region Playwright tests against the Miniflare Worker build.
- Passed the repository pre-commit full check, staged tests, and Knip.
- Passed targeted formatting, lint, type checks, and `git diff --check`.

```text
vp test run tests/request-pipeline.test.ts tests/app-router-worker-entry.test.ts tests/fetch-handler.test.ts tests/pages-request-pipeline.test.ts
PLAYWRIGHT_PROJECT=cloudflare-workers vp exec playwright test tests/e2e/cloudflare-workers/provider-region.spec.ts
```

</details>

<details>
<summary>Risk and compatibility</summary>

- Public API: no exported type or configuration changes.
- Runtime scope: only requests with a string `request.cf.country` receive a synthesized header.
- Trust boundary: the Cloudflare platform value deliberately overrides a conflicting request header.
- Non-Workers compatibility: requests without Cloudflare metadata keep their current header behavior.

</details>

## References

- [Cloudflare Request `cf` properties](https://developers.cloudflare.com/workers/runtime-apis/request/#incomingrequestcfproperties)
- [Cloudflare visitor location headers](https://developers.cloudflare.com/rules/transform/managed-transforms/reference/#add-visitor-location-headers)
