### PR TITLE
fix(test): version duplicate ESM fixture packages

### DIFF
--- a/tests/fixtures/esm-externals/README.md
+++ b/tests/fixtures/esm-externals/README.md
@@ -1,8 +1,9 @@
 # ESM externals fixture
 
-The five core routes and six package directories are ported file-for-file from
-Next.js `test/e2e/esm-externals` at v16.2.6, with only this repository's
-formatting applied:
+The five core routes and six package directories are ported from Next.js
+`test/e2e/esm-externals` at v16.2.6, with this repository's formatting applied
+and explicit versions added to the paired local packages so pnpm can distinguish
+their shared package names:
 
 - `pages/static.js`, `pages/ssr.js`, and `pages/ssg.js`
 - `app/server/page.js` and `app/client/page.js`

--- a/tests/fixtures/esm-externals/__test_packages__/app-esm-package1/package.json
+++ b/tests/fixtures/esm-externals/__test_packages__/app-esm-package1/package.json
@@ -1,5 +1,6 @@
 {
   "name": "app-esm-package",
+  "version": "1.0.0",
   "exports": {
     "./entry": {
       "browser": "./browser.mjs",

--- a/tests/fixtures/esm-externals/__test_packages__/app-esm-package2/package.json
+++ b/tests/fixtures/esm-externals/__test_packages__/app-esm-package2/package.json
@@ -1,5 +1,6 @@
 {
   "name": "app-esm-package",
+  "version": "2.0.0",
   "type": "module",
   "exports": {
     "./entry": {

--- a/tests/fixtures/esm-externals/__test_packages__/esm-package1/package.json
+++ b/tests/fixtures/esm-externals/__test_packages__/esm-package1/package.json
@@ -1,5 +1,6 @@
 {
   "name": "esm-package",
+  "version": "1.0.0",
   "exports": {
     "./entry": {
       "browser": "./browser.mjs",

--- a/tests/fixtures/esm-externals/__test_packages__/esm-package2/package.json
+++ b/tests/fixtures/esm-externals/__test_packages__/esm-package2/package.json
@@ -1,5 +1,6 @@
 {
   "name": "esm-package",
+  "version": "2.0.0",
   "type": "module",
   "exports": {
     "./entry": {


### PR DESCRIPTION
## Summary

- add explicit, distinct versions to the two app-esm-package fixture variants
- add explicit, distinct versions to the two esm-package fixture variants
- document the pnpm-specific fixture metadata adaptation

This prevents pnpm metadata operations from passing undefined versions to semver when sorting the duplicate-name local packages.

## Validation

- pnpm install --frozen-lockfile (lockfile already up to date)
- pnpm licenses list --json
- vp test run tests/esm-externals.test.ts
- vp check