### PR TITLE
test(e2e): avoid max-scroll autoscroll race

### DIFF
--- a/tests/e2e/app-router/nextjs-compat/router-autoscroll.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/router-autoscroll.spec.ts
@@ -347,9 +347,12 @@ test.describe("Next.js compat: App Router autoscroll", () => {
     await expect(page.locator("#current-page")).toHaveText("2");
     await expectScroll(page, { x: 0, y: 0 });
 
-    await page.locator("#pages").scrollIntoViewIfNeeded();
-    const noScrollY = await page.evaluate(() => Math.round(window.scrollY));
-    expect(noScrollY).toBeGreaterThan(0);
+    // Keep this away from the document's maximum scroll position. The loading
+    // shell can briefly make the document shorter during the navigation, and
+    // browsers permanently clamp a scroll position that exceeds that
+    // intermediate maximum even after the final content restores the height.
+    const noScrollY = 1_000;
+    await scrollTo(page, { x: 0, y: noScrollY });
 
     await push(page, "/nextjs-compat/router-autoscroll/loading-scroll?page=3&skipSleep=1", {
       scroll: false,


### PR DESCRIPTION
## Summary

- keep the same-page `scroll: false` assertion away from the document maximum
- avoid Chromium clamping the scroll position when the loading shell briefly shortens the document
- preserve the exact scroll-position assertion for the router behavior under test

Fixes the flake observed in [CI job 95673497683](https://github.com/cloudflare/vinext/actions/runs/32125009018/job/95673497683).

## Validation

- baseline reproduction: 8 failures / 20 runs with one worker and zero retries
- stabilized case: 30 / 30 passed with one worker and zero retries
- full `router-autoscroll.spec.ts`: 29 / 29 passed
- `vp check tests/e2e/app-router/nextjs-compat/router-autoscroll.spec.ts`
- `git diff --check`