### PR TITLE
fix(fetch-cache): decode residual stacked compression on Workers

### DIFF
--- a/packages/vinext/src/server/cloudflare-fetch-adapter.ts
+++ b/packages/vinext/src/server/cloudflare-fetch-adapter.ts
@@ -1,0 +1,219 @@
+import type { Readable as NodeReadable } from "node:stream";
+
+type SupportedContentEncoding = "br" | "deflate" | "gzip";
+
+type WorkersRequestInit = RequestInit & {
+  encodeResponseBody?: "automatic" | "manual";
+};
+
+type WorkersResponse = Response & {
+  cf?: unknown;
+};
+
+const INSTALL_KEY = Symbol.for("vinext.cloudflareFetchAdapter.installed");
+const ORIGINAL_FETCH_KEY = Symbol.for("vinext.cloudflareFetchAdapter.originalFetch");
+const NODE_DEFAULT_ACCEPT_ENCODING = "gzip, deflate";
+
+function isCloudflareWorkersRuntime(): boolean {
+  return globalThis.navigator?.userAgent === "Cloudflare-Workers";
+}
+
+function getEffectiveRequestHeaders(
+  input: string | URL | Request,
+  init: RequestInit | undefined,
+): Headers | null {
+  if (init?.headers !== undefined) return new Headers(init.headers);
+  return input instanceof Request ? input.headers : null;
+}
+
+function requestsEncodedPassthrough(init: RequestInit | undefined): boolean {
+  return (init as WorkersRequestInit | undefined)?.encodeResponseBody === "manual";
+}
+
+function parseContentEncodings(headers: Headers): SupportedContentEncoding[] | null {
+  const contentEncoding = headers.get("content-encoding");
+  if (!contentEncoding) return [];
+
+  const encodings: SupportedContentEncoding[] = [];
+  for (const value of contentEncoding.split(",")) {
+    const encoding = value.trim().toLowerCase();
+    if (!encoding || encoding === "identity") continue;
+    if (encoding === "x-gzip") {
+      encodings.push("gzip");
+    } else if (encoding === "br" || encoding === "deflate" || encoding === "gzip") {
+      encodings.push(encoding);
+    } else {
+      return null;
+    }
+  }
+  return encodings;
+}
+
+async function createDecodedBodyReader(
+  body: ReadableStream<Uint8Array>,
+  encodings: SupportedContentEncoding[],
+): Promise<ReadableStreamDefaultReader<Uint8Array>> {
+  const [{ Readable }, zlib] = await Promise.all([import("node:stream"), import("node:zlib")]);
+  let decoded: NodeReadable = Readable.fromWeb(body as Parameters<typeof Readable.fromWeb>[0]);
+
+  // Content codings are listed in the order in which they were applied, so
+  // decoding runs in reverse. Node's zlib streams accept concatenated gzip
+  // members, matching the HTTP decoder used by Next.js's native fetch.
+  for (const encoding of [...encodings].reverse()) {
+    const decoder =
+      encoding === "br"
+        ? zlib.createBrotliDecompress()
+        : encoding === "deflate"
+          ? zlib.createInflate()
+          : zlib.createGunzip();
+    decoded = decoded.pipe(decoder);
+  }
+
+  return (Readable.toWeb(decoded) as unknown as ReadableStream<Uint8Array>).getReader();
+}
+
+function decodeBodyLazily(
+  body: ReadableStream<Uint8Array>,
+  encodings: SupportedContentEncoding[],
+): ReadableStream<Uint8Array> {
+  let readerPromise: Promise<ReadableStreamDefaultReader<Uint8Array>> | undefined;
+
+  return new ReadableStream<Uint8Array>(
+    {
+      async pull(controller) {
+        const reader = await (readerPromise ??= createDecodedBodyReader(body, encodings));
+        const { done, value } = await reader.read();
+        if (done) {
+          controller.close();
+        } else {
+          controller.enqueue(value);
+        }
+      },
+      async cancel(reason) {
+        if (readerPromise) {
+          await (await readerPromise).cancel(reason);
+        } else {
+          await body.cancel(reason);
+        }
+      },
+    },
+    // Do not pull from the origin until the caller consumes the body. Native
+    // fetch (and Next.js) resolves as soon as response headers are available.
+    { highWaterMark: 0 },
+  );
+}
+
+function copyResponseProperty(
+  target: Response,
+  source: Response,
+  property: "redirected" | "url",
+): void {
+  Object.defineProperty(target, property, {
+    value: source[property],
+    configurable: true,
+    enumerable: true,
+    writable: false,
+  });
+}
+
+function preserveFetchResponseMetadata(target: Response, source: Response): Response {
+  const nativeClone = target.clone.bind(target);
+
+  copyResponseProperty(target, source, "redirected");
+  copyResponseProperty(target, source, "url");
+  Object.defineProperty(target, "type", {
+    // Server-side HTTP fetches are `basic` in Node/Undici. Workerd reports
+    // `default`, so normalize this observable field to the Next.js oracle.
+    value: "basic",
+    configurable: true,
+    enumerable: true,
+    writable: false,
+  });
+
+  const cf = (source as WorkersResponse).cf;
+  if (cf !== undefined) {
+    Object.defineProperty(target, "cf", {
+      value: structuredClone(cf),
+      configurable: true,
+      enumerable: true,
+      writable: false,
+    });
+  }
+
+  // Response.clone() operates on internal slots, which do not include the URL
+  // list from the original fetch response after reconstruction. Decorate each
+  // clone so metadata parity survives the same operation Next.js performs.
+  // Keep the Response constructor's own Headers object: Next's cloneResponse
+  // helper does the same, giving every response and clone distinct header
+  // storage instead of exposing a separate copied object.
+  Object.defineProperty(target, "clone", {
+    value: () => preserveFetchResponseMetadata(nativeClone(), source),
+    configurable: true,
+    enumerable: false,
+    writable: false,
+  });
+
+  return target;
+}
+
+function decodeResponse(response: Response): Response {
+  if (!response.body) return response;
+
+  const encodings = parseContentEncodings(response.headers);
+  if (!encodings || encodings.length === 0) return response;
+
+  return preserveFetchResponseMetadata(
+    new Response(decodeBodyLazily(response.body, encodings), {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    }),
+    response,
+  );
+}
+
+/**
+ * Reproduce the complete content decoding performed by Node's native fetch.
+ *
+ * Workerd's automatic decoder currently handles only a single `gzip` or `br`
+ * token. Asking it for the raw body lets vinext decode the complete advertised
+ * chain while preserving the response headers and metadata that Next.js sees.
+ * Explicit Workers compressed-passthrough requests remain untouched.
+ */
+export function createCloudflareFetchAdapter(
+  originalFetch: typeof globalThis.fetch,
+): typeof globalThis.fetch {
+  return async function cloudflareFetch(
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> {
+    if (requestsEncodedPassthrough(init)) return originalFetch(input, init);
+
+    const headers = new Headers(getEffectiveRequestHeaders(input, init) ?? undefined);
+    // Node's native fetch (the transport used by Next.js) sends this default.
+    // Workerd stops adding Accept-Encoding when manual body mode is selected,
+    // so provide the same value explicitly before decoding the raw response.
+    if (!headers.has("accept-encoding")) {
+      headers.set("accept-encoding", NODE_DEFAULT_ACCEPT_ENCODING);
+    }
+    const response = await originalFetch(input, {
+      ...init,
+      headers,
+      encodeResponseBody: "manual",
+    } as WorkersRequestInit);
+    return decodeResponse(response);
+  } as typeof globalThis.fetch;
+}
+
+/** Install once, before generated server entries evaluate user modules. */
+export function installCloudflareFetchAdapter(): void {
+  if (!isCloudflareWorkersRuntime()) return;
+
+  const globals = globalThis as unknown as Record<PropertyKey, unknown>;
+  if (globals[INSTALL_KEY]) return;
+
+  const originalFetch = (globals[ORIGINAL_FETCH_KEY] ??=
+    globalThis.fetch) as typeof globalThis.fetch;
+  globalThis.fetch = createCloudflareFetchAdapter(originalFetch);
+  globals[INSTALL_KEY] = true;
+}

--- a/packages/vinext/src/server/server-globals.ts
+++ b/packages/vinext/src/server/server-globals.ts
@@ -8,6 +8,7 @@
  * body would run after static user imports have already evaluated.
  */
 import { AsyncLocalStorage } from "node:async_hooks";
+import { installCloudflareFetchAdapter } from "./cloudflare-fetch-adapter.js";
 
 type BrowserGlobalName = "window" | "document";
 
@@ -39,6 +40,7 @@ function clearBrowserGlobal(name: BrowserGlobalName): void {
 export function installServerGlobals(): void {
   clearBrowserGlobal("window");
   clearBrowserGlobal("document");
+  installCloudflareFetchAdapter();
 
   // Next.js's edge sandbox exposes AsyncLocalStorage as a global. Cloudflare
   // Workers exposes it via node:async_hooks under nodejs_compat, so mirror the

--- a/packages/vinext/src/shims/fetch-cache.ts
+++ b/packages/vinext/src/shims/fetch-cache.ts
@@ -45,7 +45,7 @@ import {
 const HEADER_BLOCKLIST = ["traceparent", "tracestate"];
 
 // Cache key version — bump when changing the key format to bust stale entries
-const CACHE_KEY_PREFIX = "v5";
+const CACHE_KEY_PREFIX = "v6";
 const MAX_CACHE_KEY_BODY_BYTES = 1024 * 1024; // 1 MiB
 
 // "Cache indefinitely" duration — mirrors upstream's CACHE_ONE_YEAR_SECONDS.
@@ -545,6 +545,78 @@ const _gFetch = globalThis as unknown as Record<PropertyKey, unknown>;
 const originalFetch: typeof globalThis.fetch = (_gFetch[_ORIG_FETCH_KEY] ??=
   globalThis.fetch) as typeof globalThis.fetch;
 
+const JSON_CONTENT_TYPE_RE = /^(?:application\/(?:[a-z0-9!#$&^_.+-]+\+)?json)(?:\s*;|$)/i;
+const GZIP_MAGIC = [0x1f, 0x8b] as const;
+
+function isCloudflareWorkersRuntime(): boolean {
+  return globalThis.navigator?.userAgent === "Cloudflare-Workers";
+}
+
+async function startsWithGzipMagic(response: Response): Promise<boolean> {
+  const reader = response.clone().body?.getReader();
+  if (!reader) return false;
+
+  const prefix: number[] = [];
+  try {
+    while (prefix.length < GZIP_MAGIC.length) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      for (const byte of value) {
+        prefix.push(byte);
+        if (prefix.length === GZIP_MAGIC.length) break;
+      }
+    }
+  } catch {
+    return false;
+  } finally {
+    // A cloned response body is a tee branch. Do not await cancellation: the
+    // streams implementation may wait for the caller-owned branch to finish.
+    void reader.cancel().catch(() => {});
+  }
+
+  return prefix[0] === GZIP_MAGIC[0] && prefix[1] === GZIP_MAGIC[1];
+}
+
+/**
+ * Cloudflare Workers currently decodes only the outer Brotli layer when an
+ * origin responds with stacked `Content-Encoding: gzip, br` fields. The
+ * resulting Response still advertises an encoding but exposes gzip bytes,
+ * while Node's fetch (and therefore Next.js) decodes the complete chain.
+ *
+ * Normalize the affected JSON response before vinext returns or caches it.
+ * The runtime, media-type, encoding, and gzip-magic checks keep genuine gzip
+ * downloads byte-for-byte intact.
+ */
+async function normalizeRuntimeFetchResponse(response: Response): Promise<Response> {
+  if (!isCloudflareWorkersRuntime() || !response.body) return response;
+
+  const contentType = response.headers.get("content-type") ?? "";
+  const contentEncoding = response.headers.get("content-encoding");
+  if (!JSON_CONTENT_TYPE_RE.test(contentType) || !contentEncoding) return response;
+  if (!(await startsWithGzipMagic(response))) return response;
+
+  const headers = new Headers(response.headers);
+  headers.delete("content-encoding");
+  headers.delete("content-length");
+
+  const normalized = new Response(response.body.pipeThrough(new DecompressionStream("gzip")), {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+  Object.defineProperty(normalized, "url", {
+    value: response.url,
+    configurable: true,
+    enumerable: true,
+    writable: false,
+  });
+  return normalized;
+}
+
+async function runtimeFetch(input: string | URL | Request, init?: RequestInit): Promise<Response> {
+  return normalizeRuntimeFetchResponse(await originalFetch(input, init));
+}
+
 // ---------------------------------------------------------------------------
 // AsyncLocalStorage for request-scoped fetch cache state.
 // Uses Symbol.for() on globalThis so the storage is shared across Vite's
@@ -1027,12 +1099,12 @@ function dedupeFetch(
 ): Promise<Response> {
   const state = _getState();
   if (!state.isFetchDedupeActive) {
-    return originalFetch(input, init);
+    return runtimeFetch(input, init);
   }
 
   const candidate = createFetchDedupeCandidate(input, init);
   if (!candidate) {
-    return originalFetch(input, init);
+    return runtimeFetch(input, init);
   }
 
   const entriesByUrl = state.currentFetchDedupeEntries;
@@ -1055,7 +1127,7 @@ function dedupeFetch(
     });
   }
 
-  const promise = originalFetch(input, init);
+  const promise = runtimeFetch(input, init);
   const entry: FetchDedupeEntry = {
     key: candidate.key,
     promise,
@@ -1281,7 +1353,7 @@ function createPatchedFetch(): typeof globalThis.fetch {
         // Background refetch — deduped so only one in-flight refetch runs
         // per cache key, preventing thundering herd on popular endpoints.
         if (!pendingRefetches.has(cacheKey)) {
-          const refetchPromise = originalFetch(input, fetchInit)
+          const refetchPromise = runtimeFetch(input, fetchInit)
             .then(async (freshResp) => {
               await writeFetchCacheResponse(handler, cacheKey, freshResp, tags, revalidateSeconds, {
                 cloneForReturn: false,
@@ -1332,7 +1404,7 @@ function createPatchedFetch(): typeof globalThis.fetch {
 
     // Cache miss — fetch from network
     const response = await (mustBypassPendingRevalidation
-      ? originalFetch(input, fetchInit)
+      ? runtimeFetch(input, fetchInit)
       : dedupeFetch(input, fetchInit));
 
     const cacheValue = await buildFetchCacheValue(response, tags, revalidateSeconds);

--- a/packages/vinext/src/shims/fetch-cache.ts
+++ b/packages/vinext/src/shims/fetch-cache.ts
@@ -545,78 +545,6 @@ const _gFetch = globalThis as unknown as Record<PropertyKey, unknown>;
 const originalFetch: typeof globalThis.fetch = (_gFetch[_ORIG_FETCH_KEY] ??=
   globalThis.fetch) as typeof globalThis.fetch;
 
-const JSON_CONTENT_TYPE_RE = /^(?:application\/(?:[a-z0-9!#$&^_.+-]+\+)?json)(?:\s*;|$)/i;
-const GZIP_MAGIC = [0x1f, 0x8b] as const;
-
-function isCloudflareWorkersRuntime(): boolean {
-  return globalThis.navigator?.userAgent === "Cloudflare-Workers";
-}
-
-async function startsWithGzipMagic(response: Response): Promise<boolean> {
-  const reader = response.clone().body?.getReader();
-  if (!reader) return false;
-
-  const prefix: number[] = [];
-  try {
-    while (prefix.length < GZIP_MAGIC.length) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      for (const byte of value) {
-        prefix.push(byte);
-        if (prefix.length === GZIP_MAGIC.length) break;
-      }
-    }
-  } catch {
-    return false;
-  } finally {
-    // A cloned response body is a tee branch. Do not await cancellation: the
-    // streams implementation may wait for the caller-owned branch to finish.
-    void reader.cancel().catch(() => {});
-  }
-
-  return prefix[0] === GZIP_MAGIC[0] && prefix[1] === GZIP_MAGIC[1];
-}
-
-/**
- * Cloudflare Workers currently decodes only the outer Brotli layer when an
- * origin responds with stacked `Content-Encoding: gzip, br` fields. The
- * resulting Response still advertises an encoding but exposes gzip bytes,
- * while Node's fetch (and therefore Next.js) decodes the complete chain.
- *
- * Normalize the affected JSON response before vinext returns or caches it.
- * The runtime, media-type, encoding, and gzip-magic checks keep genuine gzip
- * downloads byte-for-byte intact.
- */
-async function normalizeRuntimeFetchResponse(response: Response): Promise<Response> {
-  if (!isCloudflareWorkersRuntime() || !response.body) return response;
-
-  const contentType = response.headers.get("content-type") ?? "";
-  const contentEncoding = response.headers.get("content-encoding");
-  if (!JSON_CONTENT_TYPE_RE.test(contentType) || !contentEncoding) return response;
-  if (!(await startsWithGzipMagic(response))) return response;
-
-  const headers = new Headers(response.headers);
-  headers.delete("content-encoding");
-  headers.delete("content-length");
-
-  const normalized = new Response(response.body.pipeThrough(new DecompressionStream("gzip")), {
-    status: response.status,
-    statusText: response.statusText,
-    headers,
-  });
-  Object.defineProperty(normalized, "url", {
-    value: response.url,
-    configurable: true,
-    enumerable: true,
-    writable: false,
-  });
-  return normalized;
-}
-
-async function runtimeFetch(input: string | URL | Request, init?: RequestInit): Promise<Response> {
-  return normalizeRuntimeFetchResponse(await originalFetch(input, init));
-}
-
 // ---------------------------------------------------------------------------
 // AsyncLocalStorage for request-scoped fetch cache state.
 // Uses Symbol.for() on globalThis so the storage is shared across Vite's
@@ -1099,12 +1027,12 @@ function dedupeFetch(
 ): Promise<Response> {
   const state = _getState();
   if (!state.isFetchDedupeActive) {
-    return runtimeFetch(input, init);
+    return originalFetch(input, init);
   }
 
   const candidate = createFetchDedupeCandidate(input, init);
   if (!candidate) {
-    return runtimeFetch(input, init);
+    return originalFetch(input, init);
   }
 
   const entriesByUrl = state.currentFetchDedupeEntries;
@@ -1127,7 +1055,7 @@ function dedupeFetch(
     });
   }
 
-  const promise = runtimeFetch(input, init);
+  const promise = originalFetch(input, init);
   const entry: FetchDedupeEntry = {
     key: candidate.key,
     promise,
@@ -1353,7 +1281,7 @@ function createPatchedFetch(): typeof globalThis.fetch {
         // Background refetch — deduped so only one in-flight refetch runs
         // per cache key, preventing thundering herd on popular endpoints.
         if (!pendingRefetches.has(cacheKey)) {
-          const refetchPromise = runtimeFetch(input, fetchInit)
+          const refetchPromise = originalFetch(input, fetchInit)
             .then(async (freshResp) => {
               await writeFetchCacheResponse(handler, cacheKey, freshResp, tags, revalidateSeconds, {
                 cloneForReturn: false,
@@ -1404,10 +1332,19 @@ function createPatchedFetch(): typeof globalThis.fetch {
 
     // Cache miss — fetch from network
     const response = await (mustBypassPendingRevalidation
-      ? runtimeFetch(input, fetchInit)
+      ? originalFetch(input, fetchInit)
       : dedupeFetch(input, fetchInit));
 
-    const cacheValue = await buildFetchCacheValue(response, tags, revalidateSeconds);
+    let cacheValue: CachedFetchValue | null = null;
+    try {
+      cacheValue = await buildFetchCacheValue(response, tags, revalidateSeconds);
+    } catch (error) {
+      // A response body can fail after fetch has resolved (for example, a
+      // truncated compressed stream). Cache serialization must not turn that
+      // late body error into a rejected fetch before callers can inspect the
+      // response status and headers.
+      console.error("[vinext] fetch cache serialization error:", error);
+    }
     if (cacheValue) {
       handler
         .set(cacheKey, cacheValue, {

--- a/tests/cloudflare-fetch-adapter.test.ts
+++ b/tests/cloudflare-fetch-adapter.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import { brotliCompressSync, gzipSync } from "node:zlib";
+import { createCloudflareFetchAdapter } from "../packages/vinext/src/server/cloudflare-fetch-adapter.js";
+
+type WorkersRequestInit = RequestInit & {
+  encodeResponseBody?: "automatic" | "manual";
+};
+
+function responseWithMetadata(
+  body: BodyInit,
+  contentEncoding: string,
+  url = "https://api.example.com/final",
+): Response {
+  const response = new Response(body, {
+    headers: {
+      "content-encoding": contentEncoding,
+      "content-length": String(body instanceof Uint8Array ? body.byteLength : 0),
+      "content-type": "application/json",
+    },
+  });
+  Object.defineProperties(response, {
+    url: { value: url, configurable: true, enumerable: true },
+    redirected: { value: true, configurable: true, enumerable: true },
+    type: { value: "default", configurable: true, enumerable: true },
+    cf: { value: { colo: "LHR" }, configurable: true, enumerable: true },
+  });
+  return response;
+}
+
+describe("Cloudflare fetch adapter", () => {
+  it("decodes the complete content-encoding chain and preserves fetch metadata", async () => {
+    const payload = { timestamp: 1_787_056_318 };
+    const compressed = brotliCompressSync(gzipSync(JSON.stringify(payload)));
+    const source = responseWithMetadata(compressed, "gzip, br");
+    const originalFetch = vi.fn(
+      async (_input: string | URL | Request, _init?: RequestInit) => source,
+    );
+    const runtimeFetch = createCloudflareFetchAdapter(originalFetch);
+
+    const response = await runtimeFetch("https://api.example.com/redirect");
+
+    expect(originalFetch).toHaveBeenCalledWith(
+      "https://api.example.com/redirect",
+      expect.objectContaining({
+        encodeResponseBody: "manual",
+        headers: expect.any(Headers),
+      }),
+    );
+    expect(new Headers(originalFetch.mock.calls[0]?.[1]?.headers).get("accept-encoding")).toBe(
+      "gzip, deflate",
+    );
+    expect(response.headers).not.toBe(source.headers);
+    expect(response.headers.get("content-encoding")).toBe("gzip, br");
+    expect(response.headers.get("content-length")).toBe(String(compressed.byteLength));
+    response.headers.set("x-test", "response");
+    expect(response.headers.get("x-test")).toBe("response");
+    expect(response.url).toBe(source.url);
+    expect(response.redirected).toBe(true);
+    expect(response.type).toBe("basic");
+    expect(Reflect.get(response, "cf")).toEqual({ colo: "LHR" });
+    const cloned = response.clone();
+    expect(cloned.headers).not.toBe(response.headers);
+    cloned.headers.set("x-test", "clone");
+    expect(cloned.headers.get("x-test")).toBe("clone");
+    expect(response.headers.get("x-test")).toBe("response");
+    expect(cloned.url).toBe(source.url);
+    expect(cloned.redirected).toBe(true);
+    expect(cloned.type).toBe("basic");
+    expect(Reflect.get(cloned, "cf")).toEqual({ colo: "LHR" });
+    expect(Reflect.get(cloned, "cf")).not.toBe(Reflect.get(response, "cf"));
+    await expect(Promise.all([response.json(), cloned.json()])).resolves.toEqual([
+      payload,
+      payload,
+    ]);
+  });
+
+  it.each([
+    {
+      name: "repeated gzip codings",
+      encoding: "gzip, gzip",
+      body: (value: string) => gzipSync(gzipSync(value)),
+    },
+    {
+      name: "concatenated gzip members",
+      encoding: "gzip",
+      body: (value: string) =>
+        Buffer.concat([gzipSync(value.slice(0, 5)), gzipSync(value.slice(5))]),
+    },
+  ])("decodes $name like Node fetch", async ({ encoding, body }) => {
+    const json = JSON.stringify({ ok: true });
+    const originalFetch = vi.fn(async () => responseWithMetadata(body(json), encoding));
+    const runtimeFetch = createCloudflareFetchAdapter(originalFetch);
+
+    await expect((await runtimeFetch("https://api.example.com/data")).json()).resolves.toEqual({
+      ok: true,
+    });
+  });
+
+  it("resolves at headers without pulling the encoded body", async () => {
+    const compressed = gzipSync(JSON.stringify({ delayed: true }));
+    let pulled = false;
+    let release: (() => void) | undefined;
+    const body = new ReadableStream<Uint8Array>(
+      {
+        pull(controller) {
+          pulled = true;
+          return new Promise<void>((resolve) => {
+            release = () => {
+              controller.enqueue(compressed);
+              controller.close();
+              resolve();
+            };
+          });
+        },
+      },
+      { highWaterMark: 0 },
+    );
+    const originalFetch = vi.fn(async () => responseWithMetadata(body, "gzip"));
+    const runtimeFetch = createCloudflareFetchAdapter(originalFetch);
+
+    const response = await runtimeFetch("https://api.example.com/slow");
+    expect(pulled).toBe(false);
+
+    const data = response.json();
+    await vi.waitFor(() => expect(pulled).toBe(true));
+    release?.();
+    await expect(data).resolves.toEqual({ delayed: true });
+  });
+
+  it("cancels an unconsumed origin body without starting decompression", async () => {
+    const cancel = vi.fn();
+    const body = new ReadableStream<Uint8Array>(
+      {
+        pull() {
+          return new Promise(() => {});
+        },
+        cancel,
+      },
+      { highWaterMark: 0 },
+    );
+    const originalFetch = vi.fn(async () => responseWithMetadata(body, "gzip"));
+    const runtimeFetch = createCloudflareFetchAdapter(originalFetch);
+
+    const response = await runtimeFetch("https://api.example.com/stalled");
+    await response.body?.cancel("caller stopped");
+
+    expect(cancel).toHaveBeenCalledWith("caller stopped");
+  });
+
+  it("decodes caller-supplied Accept-Encoding like Node fetch", async () => {
+    const payload = { callerSelected: true };
+    const compressed = gzipSync(JSON.stringify(payload));
+    const source = responseWithMetadata(compressed, "gzip");
+    const originalFetch = vi.fn(
+      async (_input: string | URL | Request, _init?: RequestInit) => source,
+    );
+    const runtimeFetch = createCloudflareFetchAdapter(originalFetch);
+    const init = { headers: { "accept-encoding": "gzip" } };
+
+    const response = await runtimeFetch("https://api.example.com/archive.json", init);
+
+    expect(new Headers(originalFetch.mock.calls[0]?.[1]?.headers).get("accept-encoding")).toBe(
+      "gzip",
+    );
+    expect(originalFetch.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({ encodeResponseBody: "manual" }),
+    );
+    await expect(response.json()).resolves.toEqual(payload);
+  });
+
+  it("honors the Workers manual response-body mode", async () => {
+    const compressed = gzipSync(JSON.stringify({ manual: true }));
+    const source = responseWithMetadata(compressed, "gzip");
+    const originalFetch = vi.fn(async () => source);
+    const runtimeFetch = createCloudflareFetchAdapter(originalFetch);
+    const init: WorkersRequestInit = { encodeResponseBody: "manual" };
+
+    const response = await runtimeFetch("https://api.example.com/manual", init);
+
+    expect(originalFetch).toHaveBeenCalledWith("https://api.example.com/manual", init);
+    expect(response).toBe(source);
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(new Uint8Array(compressed));
+  });
+});

--- a/tests/cloudflare-fetch-cache-integration.test.ts
+++ b/tests/cloudflare-fetch-cache-integration.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { brotliCompressSync, gzipSync } from "node:zlib";
+import { createCloudflareFetchAdapter } from "../packages/vinext/src/server/cloudflare-fetch-adapter.js";
+
+const payload = { timestamp: 1_787_056_318 };
+const encodedBody = brotliCompressSync(gzipSync(JSON.stringify(payload)));
+const networkFetch = vi.fn(
+  async () =>
+    new Response(encodedBody, {
+      headers: {
+        "content-encoding": "gzip, br",
+        "content-length": String(encodedBody.byteLength),
+        "content-type": "application/json",
+      },
+    }),
+);
+
+vi.stubGlobal("fetch", createCloudflareFetchAdapter(networkFetch));
+
+const { withFetchCache } = await import("../packages/vinext/src/shims/fetch-cache.js");
+const { MemoryCacheHandler, setCacheHandler } =
+  await import("../packages/vinext/src/shims/cache.js");
+
+describe("Cloudflare fetch adapter with fetch cache", () => {
+  let cleanup: (() => void) | undefined;
+
+  afterEach(() => {
+    cleanup?.();
+    cleanup = undefined;
+  });
+
+  it("caches and replays the fully decoded body with Next-compatible headers", async () => {
+    networkFetch.mockClear();
+    setCacheHandler(new MemoryCacheHandler());
+    cleanup = withFetchCache();
+
+    const cold = await fetch("https://api.example.com/stacked", { cache: "force-cache" });
+    expect(cold.headers.get("content-encoding")).toBe("gzip, br");
+    await expect(cold.json()).resolves.toEqual(payload);
+
+    const cached = await fetch("https://api.example.com/stacked", { cache: "force-cache" });
+    expect(cached.headers.get("content-encoding")).toBe("gzip, br");
+    await expect(cached.json()).resolves.toEqual(payload);
+    expect(networkFetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/fetch-cache.test.ts
+++ b/tests/fetch-cache.test.ts
@@ -11,7 +11,6 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vite-plus/test";
-import { gzipSync } from "node:zlib";
 
 // We need to mock fetch at the module level BEFORE fetch-cache.ts captures
 // `originalFetch`. Use vi.stubGlobal to intercept at import time.
@@ -36,23 +35,6 @@ const defaultFetchMockImplementation = async (
   return response;
 };
 const fetchMock = vi.fn(defaultFetchMockImplementation);
-
-async function withRuntimeUserAgent<T>(userAgent: string, fn: () => Promise<T>): Promise<T> {
-  const descriptor = Object.getOwnPropertyDescriptor(globalThis, "navigator");
-  Object.defineProperty(globalThis, "navigator", {
-    value: { userAgent },
-    configurable: true,
-  });
-  try {
-    return await fn();
-  } finally {
-    if (descriptor) {
-      Object.defineProperty(globalThis, "navigator", descriptor);
-    } else {
-      Reflect.deleteProperty(globalThis, "navigator");
-    }
-  }
-}
 
 // Stub globalThis.fetch BEFORE importing modules that capture it
 vi.stubGlobal("fetch", fetchMock);
@@ -172,75 +154,30 @@ describe("fetch cache shim", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it("decodes residual gzip JSON from Cloudflare Workers before caching", async () => {
-    const url = "https://api.example.com/stacked-content-encoding";
-    const payload = { timestamp: 1_787_056_318 };
-    const compressedBody = gzipSync(JSON.stringify(payload));
-
-    fetchMock.mockImplementationOnce(async () => {
-      const response = new Response(compressedBody, {
+  it("returns the response when cache serialization hits a late body error", async () => {
+    const cacheError = new Error("truncated compressed body");
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.error(cacheError);
+      },
+    });
+    fetchMock.mockResolvedValueOnce(
+      new Response(body, {
         status: 200,
-        headers: {
-          "content-encoding": "br",
-          "content-length": String(compressedBody.byteLength),
-          "content-type": "application/json",
-        },
-      });
-      Object.defineProperty(response, "url", {
-        value: url,
-        configurable: true,
-        enumerable: true,
-        writable: false,
-      });
-      return response;
-    });
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
 
-    await withRuntimeUserAgent("Cloudflare-Workers", async () => {
-      const cold = await fetch(url, { cache: "force-cache" });
-      expect(cold.url).toBe(url);
-      expect(cold.headers.get("content-encoding")).toBeNull();
-      expect(cold.headers.get("content-length")).toBeNull();
-      expect(await cold.json()).toEqual(payload);
+    const response = await fetch("https://api.example.com/truncated", { cache: "force-cache" });
 
-      const cached = await fetch(url, { cache: "force-cache" });
-      expect(cached.url).toBe(url);
-      expect(cached.headers.get("content-encoding")).toBeNull();
-      expect(await cached.json()).toEqual(payload);
-    });
-
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not decompress genuine gzip downloads on Cloudflare Workers", async () => {
-    const url = "https://api.example.com/archive.json.gz";
-    const compressedBody = gzipSync(JSON.stringify({ archived: true }));
-
-    fetchMock.mockImplementationOnce(async () => {
-      const response = new Response(compressedBody, {
-        status: 200,
-        headers: {
-          "content-encoding": "br",
-          "content-type": "application/gzip",
-        },
-      });
-      Object.defineProperty(response, "url", {
-        value: url,
-        configurable: true,
-        enumerable: true,
-        writable: false,
-      });
-      return response;
-    });
-
-    await withRuntimeUserAgent("Cloudflare-Workers", async () => {
-      const cold = await fetch(url, { cache: "force-cache" });
-      expect(new Uint8Array(await cold.arrayBuffer())).toEqual(new Uint8Array(compressedBody));
-
-      const cached = await fetch(url, { cache: "force-cache" });
-      expect(new Uint8Array(await cached.arrayBuffer())).toEqual(new Uint8Array(compressedBody));
-    });
-
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(200);
+    await expect(response.text()).rejects.toThrow("truncated compressed body");
+    expect(consoleError).toHaveBeenCalledWith(
+      "[vinext] fetch cache serialization error:",
+      cacheError,
+    );
+    consoleError.mockRestore();
   });
 
   it("preserves Response.url on cached fetch responses", async () => {

--- a/tests/fetch-cache.test.ts
+++ b/tests/fetch-cache.test.ts
@@ -11,6 +11,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vite-plus/test";
+import { gzipSync } from "node:zlib";
 
 // We need to mock fetch at the module level BEFORE fetch-cache.ts captures
 // `originalFetch`. Use vi.stubGlobal to intercept at import time.
@@ -35,6 +36,23 @@ const defaultFetchMockImplementation = async (
   return response;
 };
 const fetchMock = vi.fn(defaultFetchMockImplementation);
+
+async function withRuntimeUserAgent<T>(userAgent: string, fn: () => Promise<T>): Promise<T> {
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+  Object.defineProperty(globalThis, "navigator", {
+    value: { userAgent },
+    configurable: true,
+  });
+  try {
+    return await fn();
+  } finally {
+    if (descriptor) {
+      Object.defineProperty(globalThis, "navigator", descriptor);
+    } else {
+      Reflect.deleteProperty(globalThis, "navigator");
+    }
+  }
+}
 
 // Stub globalThis.fetch BEFORE importing modules that capture it
 vi.stubGlobal("fetch", fetchMock);
@@ -151,6 +169,77 @@ describe("fetch cache shim", () => {
     const cached = await fetch(url, { cache: "force-cache" });
     expect(new Uint8Array(await cached.arrayBuffer())).toEqual(body);
     expect(cached.headers.get("content-encoding")).toBe("gzip");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("decodes residual gzip JSON from Cloudflare Workers before caching", async () => {
+    const url = "https://api.example.com/stacked-content-encoding";
+    const payload = { timestamp: 1_787_056_318 };
+    const compressedBody = gzipSync(JSON.stringify(payload));
+
+    fetchMock.mockImplementationOnce(async () => {
+      const response = new Response(compressedBody, {
+        status: 200,
+        headers: {
+          "content-encoding": "br",
+          "content-length": String(compressedBody.byteLength),
+          "content-type": "application/json",
+        },
+      });
+      Object.defineProperty(response, "url", {
+        value: url,
+        configurable: true,
+        enumerable: true,
+        writable: false,
+      });
+      return response;
+    });
+
+    await withRuntimeUserAgent("Cloudflare-Workers", async () => {
+      const cold = await fetch(url, { cache: "force-cache" });
+      expect(cold.url).toBe(url);
+      expect(cold.headers.get("content-encoding")).toBeNull();
+      expect(cold.headers.get("content-length")).toBeNull();
+      expect(await cold.json()).toEqual(payload);
+
+      const cached = await fetch(url, { cache: "force-cache" });
+      expect(cached.url).toBe(url);
+      expect(cached.headers.get("content-encoding")).toBeNull();
+      expect(await cached.json()).toEqual(payload);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not decompress genuine gzip downloads on Cloudflare Workers", async () => {
+    const url = "https://api.example.com/archive.json.gz";
+    const compressedBody = gzipSync(JSON.stringify({ archived: true }));
+
+    fetchMock.mockImplementationOnce(async () => {
+      const response = new Response(compressedBody, {
+        status: 200,
+        headers: {
+          "content-encoding": "br",
+          "content-type": "application/gzip",
+        },
+      });
+      Object.defineProperty(response, "url", {
+        value: url,
+        configurable: true,
+        enumerable: true,
+        writable: false,
+      });
+      return response;
+    });
+
+    await withRuntimeUserAgent("Cloudflare-Workers", async () => {
+      const cold = await fetch(url, { cache: "force-cache" });
+      expect(new Uint8Array(await cold.arrayBuffer())).toEqual(new Uint8Array(compressedBody));
+
+      const cached = await fetch(url, { cache: "force-cache" });
+      expect(new Uint8Array(await cached.arrayBuffer())).toEqual(new Uint8Array(compressedBody));
+    });
+
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
## Summary

- install a Cloudflare fetch transport adapter before user server modules evaluate
- reproduce Node/Undici content decoding on Workers by fetching raw encoded bodies and decoding the complete `Content-Encoding` chain lazily
- preserve Next-observable response headers, URL, redirect state, type, cloning behavior, and explicit Workers manual-body passthrough
- bump the fetch-cache key prefix to `v6` so older partially decoded cache entries cannot be replayed

Fixes #2983.

## Root cause

The failing origin emits stacked content codings. Node's native fetch, which Next.js uses through `originFetch`, decodes the complete chain while retaining the response headers. Workerd's automatic decoder currently handles only a single `gzip` or `br` coding, so a stacked response can expose residual compressed bytes to `response.json()` and to vinext's binary-safe fetch cache.

The adapter keeps the generic fetch-cache implementation platform-neutral. On Cloudflare Workers it:

- uses Workerd's `encodeResponseBody: "manual"` transport mode
- sends Node's default `Accept-Encoding: gzip, deflate` when the caller supplied none
- decodes codings in reverse application order with streaming Node-compatible codecs
- supports repeated codings and concatenated gzip members
- defers body reads until the caller consumes the response, so `fetch()` still resolves at headers
- leaves explicit `encodeResponseBody: "manual"` calls untouched

Next.js reference: https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/patch-fetch.ts

## Validation

- `vp check packages/vinext/src/server/cloudflare-fetch-adapter.ts packages/vinext/src/server/server-globals.ts packages/vinext/src/shims/fetch-cache.ts tests/cloudflare-fetch-adapter.test.ts tests/cloudflare-fetch-cache-integration.test.ts tests/fetch-cache.test.ts`
- `vp test run tests/cloudflare-fetch-adapter.test.ts tests/cloudflare-fetch-cache-integration.test.ts tests/fetch-cache.test.ts tests/kv-cache-handler.test.ts tests/isr-cache.test.ts tests/edge-globals.test.ts` (293 passed)
- `vp run vinext#build`
- local Workerd against the issue's live origin: default fetch and caller-supplied `Accept-Encoding: gzip` both decoded the full `gzip, gzip` response and returned JSON successfully
- four independent cumulative reviews; final runtime, Workers-platform, and parity/security/performance verdicts: no blocking findings
