### PR TITLE
fix(cache): inherit route revalidate for tagged fetches

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -500,6 +500,18 @@ function __resolveRouteDynamicConfig(route) {
   }).dynamicConfig ?? null;
 }
 
+function __resolveRouteRevalidateSeconds(route) {
+  return __resolveAppPageSegmentConfig({
+    layouts: route.layouts,
+    page: route.page,
+    parallelSegments: Object.values(route.slots ?? {}).flatMap((slot) => [
+      slot.layout,
+      ...(slot.configLayouts ?? []),
+      slot.page ?? slot.default,
+    ]),
+  }).revalidateSeconds;
+}
+
 function __resolveRouteRuntime(route) {
   return __resolveAppPageSegmentConfig({
     layouts: route.layouts,
@@ -964,6 +976,9 @@ export default createAppRscHandler({
       resolveRouteFetchCacheMode(targetRoute) {
         return __resolveRouteFetchCacheMode(targetRoute);
       },
+      resolveRouteRevalidateSeconds(targetRoute) {
+        return __resolveRouteRevalidateSeconds(targetRoute);
+      },
       resolveRouteDynamicConfig(targetRoute) {
         return __resolveRouteDynamicConfig(targetRoute);
       },
@@ -1196,6 +1211,9 @@ export default createAppRscHandler({
       reportRequestError: _reportRequestError,
       resolveRouteFetchCacheMode(targetRoute) {
         return __resolveRouteFetchCacheMode(targetRoute);
+      },
+      resolveRouteRevalidateSeconds(targetRoute) {
+        return __resolveRouteRevalidateSeconds(targetRoute);
       },
       resolveRouteDynamicConfig(targetRoute) {
         return __resolveRouteDynamicConfig(targetRoute);

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -30,6 +30,7 @@ import {
   peekDynamicFetchObservations,
   runWithFetchDedupe,
   setCurrentFetchCacheMode,
+  setCurrentFetchRevalidate,
   setCurrentForceDynamicFetchDefault,
   setCurrentFetchSoftTags,
   setRefreshStaleFetchesInForeground,
@@ -396,6 +397,7 @@ export type DispatchAppPageOptions<TRoute extends AppPageDispatchRoute> = {
   revalidateSeconds: number | null;
   renderedPathAndSearch?: string | null;
   resolveRouteFetchCacheMode?: (route: TRoute) => FetchCacheMode | null;
+  resolveRouteRevalidateSeconds?: (route: TRoute) => number | null;
   resolveRouteDynamicConfig?: (route: TRoute) => string | null | undefined;
   rootForbiddenModule?: AppPageModule | null;
   rootNotFoundModule?: AppPageModule | null;
@@ -541,6 +543,7 @@ async function runAppPageRevalidationContext<
     cleanPathname: string;
     displayPathname?: string;
     currentFetchCacheMode?: FetchCacheMode | null;
+    currentFetchRevalidate?: number | null;
     draftModeSecret: string;
     dynamicConfig?: string;
     params: AppPageParams;
@@ -561,6 +564,7 @@ async function runAppPageRevalidationContext<
   const requestContext = createRequestContext({
     headersContext,
     currentFetchCacheMode: options.currentFetchCacheMode ?? null,
+    currentFetchRevalidate: options.currentFetchRevalidate ?? null,
     currentForceDynamicFetchDefault: options.dynamicConfig === "force-dynamic",
     executionContext: getRequestExecutionContext(),
     unstableCacheRevalidation: "foreground",
@@ -659,6 +663,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
 
   setCurrentFetchSoftTags(buildAppPageTags(options.cleanPathname, [], route.routeSegments));
   setCurrentFetchCacheMode(options.fetchCache ?? null);
+  setCurrentFetchRevalidate(currentRevalidateSeconds);
   setCurrentForceDynamicFetchDefault(isForceDynamic);
 
   if (options.hasPageModule && !options.hasPageDefaultExport) {
@@ -781,6 +786,9 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
             currentFetchCacheMode:
               options.resolveRouteFetchCacheMode?.(revalidationTarget.route) ??
               (revalidationTarget.route === route ? (options.fetchCache ?? null) : null),
+            currentFetchRevalidate:
+              options.resolveRouteRevalidateSeconds?.(revalidationTarget.route) ??
+              (revalidationTarget.route === route ? currentRevalidateSeconds : null),
             draftModeSecret: options.draftModeSecret,
             dynamicConfig: revalidationDynamicConfig,
             params: revalidationTarget.navigationParams,
@@ -938,6 +946,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
         setHeadersContext(requestHeadersContext);
       }
       setCurrentFetchCacheMode(options.resolveRouteFetchCacheMode?.(interceptRoute) ?? null);
+      setCurrentFetchRevalidate(options.resolveRouteRevalidateSeconds?.(interceptRoute) ?? null);
       setCurrentForceDynamicFetchDefault(sourceDynamicConfig === "force-dynamic");
       return options.buildPageElement(
         interceptRoute,

--- a/packages/vinext/src/server/app-route-handler-dispatch.ts
+++ b/packages/vinext/src/server/app-route-handler-dispatch.ts
@@ -3,6 +3,7 @@ import {
   getCollectedFetchTags,
   ensureFetchPatch,
   setCurrentFetchCacheMode,
+  setCurrentFetchRevalidate,
   setCurrentFetchSoftTags,
   setCurrentForceDynamicFetchDefault,
   type FetchCacheMode,
@@ -117,6 +118,7 @@ async function runInRouteHandlerRevalidationContext(
     draftModeSecret: string;
     dynamicConfig?: string;
     fetchCacheMode: FetchCacheMode | null;
+    revalidateSeconds: number | null;
     routePattern: string;
     routeSegments: string[];
   },
@@ -143,6 +145,7 @@ async function runInRouteHandlerRevalidationContext(
     // The revalidation render runs in a fresh request context, so the fetch
     // defaults applied by `dispatchAppRouteHandler` must be re-applied here.
     setCurrentFetchCacheMode(options.fetchCacheMode);
+    setCurrentFetchRevalidate(options.revalidateSeconds);
     setCurrentForceDynamicFetchDefault(options.dynamicConfig === "force-dynamic");
     try {
       await renderFn();
@@ -232,6 +235,7 @@ export async function dispatchAppRouteHandler(
   // where handlers ignored their `fetchCache`/`force-dynamic` segment config.
   const fetchCacheMode = resolveAppRouteHandlerFetchCacheMode(handler);
   setCurrentFetchCacheMode(fetchCacheMode);
+  setCurrentFetchRevalidate(revalidateSeconds);
   setCurrentForceDynamicFetchDefault(handler.dynamic === "force-dynamic");
 
   if (
@@ -282,6 +286,7 @@ export async function dispatchAppRouteHandler(
             draftModeSecret: options.draftModeSecret,
             dynamicConfig: handler.dynamic,
             fetchCacheMode,
+            revalidateSeconds,
             routePattern: route.pattern,
             routeSegments: route.routeSegments,
           },

--- a/packages/vinext/src/server/app-server-action-execution.ts
+++ b/packages/vinext/src/server/app-server-action-execution.ts
@@ -11,6 +11,7 @@ import {
 import {
   type FetchCacheMode,
   setCurrentFetchCacheMode,
+  setCurrentFetchRevalidate,
   setCurrentFetchSoftTags,
   setCurrentForceDynamicFetchDefault,
 } from "vinext/shims/fetch-cache";
@@ -322,6 +323,7 @@ export type HandleServerActionRscRequestOptions<
   ) => BodyInit | null | Promise<BodyInit | null>;
   reportRequestError: AppServerActionErrorReporter;
   resolveRouteFetchCacheMode?: (route: TRoute) => FetchCacheMode | null;
+  resolveRouteRevalidateSeconds?: (route: TRoute) => number | null;
   resolveRouteDynamicConfig?: (route: TRoute) => string | null | undefined;
   resolveRouteRuntime?: (route: TRoute) => AppServerActionRouteRuntime;
   request: Request;
@@ -1668,6 +1670,9 @@ export async function handleServerActionRscRequest<
       });
       setCurrentFetchCacheMode(
         options.resolveRouteFetchCacheMode?.(actionRerenderTarget.route) ?? null,
+      );
+      setCurrentFetchRevalidate(
+        options.resolveRouteRevalidateSeconds?.(actionRerenderTarget.route) ?? null,
       );
       setCurrentForceDynamicFetchDefault(actionRerenderDynamicConfig === "force-dynamic");
       setCurrentFetchSoftTags(

--- a/packages/vinext/src/shims/fetch-cache.ts
+++ b/packages/vinext/src/shims/fetch-cache.ts
@@ -24,7 +24,7 @@ import { Buffer } from "node:buffer";
 import { getDataCacheHandler, type CachedFetchValue, type CacheHandler } from "./cache-handler.js";
 import { encodeCacheTags } from "../utils/encode-cache-tag.js";
 import { getOrCreateAls } from "./internal/als-registry.js";
-import { markDynamicUsage } from "./headers.js";
+import { getHeadersContext, markDynamicUsage } from "./headers.js";
 import { _hasPendingRevalidatedTag, _setRequestScopedCacheLife } from "./cache-request-state.js";
 import { getRequestExecutionContext } from "./request-context.js";
 import {
@@ -635,6 +635,13 @@ function recordDynamicFetchObservation(input: string | URL | Request): void {
 
 function markUncachedFetchForPageOutput(input: string | URL | Request): void {
   recordDynamicFetchObservation(input);
+  // Next.js lowers the active prerender store to zero when an uncached fetch
+  // makes the render dynamic. `force-static` is the exception: dynamic usage
+  // is suppressed there, so later metadata-only fetches keep inheriting the
+  // configured route interval.
+  if (getHeadersContext()?.forceStatic !== true) {
+    _getState().currentFetchRevalidate = 0;
+  }
   markDynamicUsage();
 }
 
@@ -645,6 +652,13 @@ function recordCacheableFetchObservation(input: string | URL | Request): void {
 function recordFiniteFetchRevalidate(revalidateSeconds: number): void {
   if (Number.isFinite(revalidateSeconds) && revalidateSeconds > 0) {
     _setRequestScopedCacheLife({ revalidate: revalidateSeconds });
+  }
+}
+
+function lowerCurrentFetchRevalidate(revalidateSeconds: number): void {
+  const state = _getState();
+  if (state.currentFetchRevalidate === null || revalidateSeconds < state.currentFetchRevalidate) {
+    state.currentFetchRevalidate = revalidateSeconds;
   }
 }
 
@@ -1215,6 +1229,12 @@ function createPatchedFetch(): typeof globalThis.fetch {
     // recording both cacheable and dynamic is conservative — a false "unsafe"
     // result costs performance, not correctness.
     recordCacheableFetchObservation(input);
+    if (typeof nextOpts?.revalidate === "number" && nextOpts.revalidate > 0) {
+      // Upstream mutates the active prerender store when an explicit fetch
+      // lifetime is shorter. Later metadata-only fetches inherit that live
+      // minimum rather than the route's original segment-config seed.
+      lowerCurrentFetchRevalidate(nextOpts.revalidate);
+    }
     recordFiniteFetchRevalidate(revalidateSeconds);
     const reqTags = _getState().currentRequestTags;
     const tags = encodeCacheTags(nextOpts?.tags ?? []);

--- a/packages/vinext/src/shims/fetch-cache.ts
+++ b/packages/vinext/src/shims/fetch-cache.ts
@@ -555,6 +555,7 @@ export type FetchCacheState = {
   currentRequestTags: string[];
   currentFetchSoftTags: string[];
   currentFetchCacheMode: FetchCacheMode | null;
+  currentFetchRevalidate: number | null;
   currentForceDynamicFetchDefault: boolean;
   dynamicFetchUrls: Set<string>;
   refreshStaleFetchesInForeground: boolean;
@@ -592,6 +593,7 @@ const _fallbackState = (_g[_FALLBACK_KEY] ??= {
   currentRequestTags: [],
   currentFetchSoftTags: [],
   currentFetchCacheMode: null,
+  currentFetchRevalidate: null,
   currentForceDynamicFetchDefault: false,
   dynamicFetchUrls: new Set<string>(),
   refreshStaleFetchesInForeground: false,
@@ -615,6 +617,7 @@ function _resetFallbackState(isFetchDedupeActive: boolean): void {
   _fallbackState.currentRequestTags = [];
   _fallbackState.currentFetchSoftTags = [];
   _fallbackState.currentFetchCacheMode = null;
+  _fallbackState.currentFetchRevalidate = null;
   _fallbackState.currentForceDynamicFetchDefault = false;
   _fallbackState.dynamicFetchUrls = new Set<string>();
   _fallbackState.refreshStaleFetchesInForeground = false;
@@ -795,6 +798,10 @@ export function getCurrentFetchSoftTags(): string[] {
 
 export function setCurrentFetchCacheMode(mode: FetchCacheMode | null): void {
   _getState().currentFetchCacheMode = mode;
+}
+
+export function setCurrentFetchRevalidate(revalidate: number | null): void {
+  _getState().currentFetchRevalidate = revalidate;
 }
 
 export function setCurrentForceDynamicFetchDefault(enabled: boolean): void {
@@ -1178,11 +1185,20 @@ function createPatchedFetch(): typeof globalThis.fetch {
     } else if (typeof nextOpts?.revalidate === "number" && nextOpts.revalidate > 0) {
       revalidateSeconds = nextOpts.revalidate;
     } else {
-      // Has `next` options but no explicit revalidate — Next.js defaults to
-      // caching when `next` is present (force-cache behavior).
-      // If only tags are specified, cache indefinitely.
+      // During prerender, a fetch without an explicit cache lifetime inherits
+      // the active route's revalidate value in Next.js. Tags make this fetch
+      // cacheable, but do not independently make it cache indefinitely.
       if (nextOpts?.tags && nextOpts.tags.length > 0) {
-        revalidateSeconds = ONE_YEAR_SECONDS;
+        const routeRevalidate = _getState().currentFetchRevalidate;
+        if (routeRevalidate === 0) {
+          const cleanInit = stripNextFromInit(init, cacheDirective);
+          markUncachedFetchForPageOutput(input);
+          return dedupeFetch(input, cleanInit);
+        }
+        revalidateSeconds =
+          routeRevalidate === null || routeRevalidate === Infinity
+            ? ONE_YEAR_SECONDS
+            : routeRevalidate;
       } else {
         // next: {} with no revalidate or tags — pass through
         const cleanInit = stripNextFromInit(init, cacheDirective);
@@ -1440,6 +1456,7 @@ export async function runWithFetchCache<T>(fn: () => Promise<T>): Promise<T> {
       currentRequestTags: [],
       currentFetchSoftTags: [],
       currentFetchCacheMode: null,
+      currentFetchRevalidate: null,
       currentForceDynamicFetchDefault: false,
       dynamicFetchUrls: new Set<string>(),
       refreshStaleFetchesInForeground: false,

--- a/packages/vinext/src/shims/unified-request-context.ts
+++ b/packages/vinext/src/shims/unified-request-context.ts
@@ -119,6 +119,7 @@ export function createRequestContext(opts?: Partial<UnifiedRequestContext>): Uni
     currentRequestTags: [],
     currentFetchSoftTags: [],
     currentFetchCacheMode: null,
+    currentFetchRevalidate: null,
     currentForceDynamicFetchDefault: false,
     dynamicFetchUrls: new Set<string>(),
     refreshStaleFetchesInForeground: false,

--- a/tests/app-page-dispatch.test.ts
+++ b/tests/app-page-dispatch.test.ts
@@ -318,6 +318,7 @@ type CreateDispatchOptionsOverrides = {
   request?: Request;
   revalidateSeconds?: number | null;
   resolveRouteFetchCacheMode?: DispatchOptions["resolveRouteFetchCacheMode"];
+  resolveRouteRevalidateSeconds?: DispatchOptions["resolveRouteRevalidateSeconds"];
   resolveRouteDynamicConfig?: DispatchOptions["resolveRouteDynamicConfig"];
   route?: TestRoute;
   scheduleBackgroundRegeneration?: DispatchOptions["scheduleBackgroundRegeneration"];
@@ -414,6 +415,7 @@ function createDispatchOptions(overrides: CreateDispatchOptionsOverrides = {}) {
     request: overrides.request ?? new Request("https://example.test/posts/hello"),
     revalidateSeconds: overrides.revalidateSeconds ?? null,
     resolveRouteFetchCacheMode: overrides.resolveRouteFetchCacheMode,
+    resolveRouteRevalidateSeconds: overrides.resolveRouteRevalidateSeconds,
     resolveRouteDynamicConfig: overrides.resolveRouteDynamicConfig,
     route,
     runWithSuppressedHookWarning<T>(probe: () => Promise<T>) {
@@ -2393,6 +2395,9 @@ describe("app page dispatch", () => {
     const resolveRouteFetchCacheMode = vi.fn((route: TestRoute) =>
       route === sourceRoute ? "force-cache" : null,
     );
+    const resolveRouteRevalidateSeconds = vi.fn((route: TestRoute) =>
+      route === sourceRoute ? 30 : null,
+    );
     const { options } = createDispatchOptions({
       buildPageElement,
       cleanPathname: "/photos/123",
@@ -2437,6 +2442,7 @@ describe("app page dispatch", () => {
       mountedSlotsHeader: "slot:modal:/feed",
       revalidateSeconds: 60,
       resolveRouteFetchCacheMode,
+      resolveRouteRevalidateSeconds,
       route: currentRoute,
       scheduleBackgroundRegeneration,
       searchParams: new URLSearchParams("tab=popular"),
@@ -2450,6 +2456,7 @@ describe("app page dispatch", () => {
 
     const [routeArg, paramsArg, optsArg, searchParamsArg] = buildPageElement.mock.calls[0];
     expect(resolveRouteFetchCacheMode).toHaveBeenCalledWith(sourceRoute);
+    expect(resolveRouteRevalidateSeconds).toHaveBeenCalledWith(sourceRoute);
     expect(routeArg).toBe(sourceRoute);
     expect(paramsArg).toEqual({});
     expect(searchParamsArg.toString()).toBe("tab=popular");

--- a/tests/app-route-handler-dispatch.test.ts
+++ b/tests/app-route-handler-dispatch.test.ts
@@ -403,6 +403,7 @@ describe("app route handler dispatch", () => {
   it("applies the force-dynamic fetch default before invoking the route handler", async () => {
     const fetchCacheShims = await import("../packages/vinext/src/shims/fetch-cache.js");
     const modeSpy = vi.spyOn(fetchCacheShims, "setCurrentFetchCacheMode");
+    const revalidateSpy = vi.spyOn(fetchCacheShims, "setCurrentFetchRevalidate");
     const forceDynamicSpy = vi.spyOn(fetchCacheShims, "setCurrentForceDynamicFetchDefault");
 
     let forceDynamicDefaultAtHandlerTime: boolean | undefined;
@@ -449,14 +450,17 @@ describe("app route handler dispatch", () => {
     expect(response.status).toBe(200);
     expect(forceDynamicDefaultAtHandlerTime).toBe(true);
     expect(fetchCacheModeAtHandlerTime).toBeNull();
+    expect(revalidateSpy).toHaveBeenCalledWith(null);
 
     modeSpy.mockRestore();
+    revalidateSpy.mockRestore();
     forceDynamicSpy.mockRestore();
   });
 
   it("applies the handler's explicit fetchCache export without the force-dynamic default", async () => {
     const fetchCacheShims = await import("../packages/vinext/src/shims/fetch-cache.js");
     const modeSpy = vi.spyOn(fetchCacheShims, "setCurrentFetchCacheMode");
+    const revalidateSpy = vi.spyOn(fetchCacheShims, "setCurrentFetchRevalidate");
     const forceDynamicSpy = vi.spyOn(fetchCacheShims, "setCurrentForceDynamicFetchDefault");
 
     let forceDynamicDefaultAtHandlerTime: boolean | undefined;
@@ -501,14 +505,17 @@ describe("app route handler dispatch", () => {
     expect(response.status).toBe(200);
     expect(forceDynamicDefaultAtHandlerTime).toBe(false);
     expect(fetchCacheModeAtHandlerTime).toBe("force-cache");
+    expect(revalidateSpy).toHaveBeenCalledWith(null);
 
     modeSpy.mockRestore();
+    revalidateSpy.mockRestore();
     forceDynamicSpy.mockRestore();
   });
 
   it("re-applies the handler's fetch cache mode inside the background regeneration context", async () => {
     const fetchCacheShims = await import("../packages/vinext/src/shims/fetch-cache.js");
     const modeSpy = vi.spyOn(fetchCacheShims, "setCurrentFetchCacheMode");
+    const revalidateSpy = vi.spyOn(fetchCacheShims, "setCurrentFetchRevalidate");
     const forceDynamicSpy = vi.spyOn(fetchCacheShims, "setCurrentForceDynamicFetchDefault");
 
     let scheduledRender: (() => Promise<void>) | undefined;
@@ -566,9 +573,11 @@ describe("app route handler dispatch", () => {
 
     expect(forceDynamicDefaultAtRegenTime).toBe(false);
     expect(fetchCacheModeAtRegenTime).toBe("force-cache");
+    expect(revalidateSpy).toHaveBeenLastCalledWith(60);
     expect(afterRan).toBe(true);
 
     modeSpy.mockRestore();
+    revalidateSpy.mockRestore();
     forceDynamicSpy.mockRestore();
   });
 

--- a/tests/app-server-action-execution.test.ts
+++ b/tests/app-server-action-execution.test.ts
@@ -3185,6 +3185,7 @@ describe("app server action execution helpers", () => {
   it("resolves the re-render target route's dynamic config and fetch cache mode for force-dynamic fetch defaults", async () => {
     const fetchCacheShims = await import("../packages/vinext/src/shims/fetch-cache.js");
     const modeSpy = vi.spyOn(fetchCacheShims, "setCurrentFetchCacheMode");
+    const revalidateSpy = vi.spyOn(fetchCacheShims, "setCurrentFetchRevalidate");
     const forceDynamicSpy = vi.spyOn(fetchCacheShims, "setCurrentForceDynamicFetchDefault");
 
     const targetRoute: TestRoute = {
@@ -3208,6 +3209,9 @@ describe("app server action execution helpers", () => {
         resolveRouteFetchCacheMode(route) {
           return route === targetRoute ? "force-no-store" : null;
         },
+        resolveRouteRevalidateSeconds(route) {
+          return route === targetRoute ? 45 : null;
+        },
         resolveRouteDynamicConfig(route) {
           return route === targetRoute ? "force-dynamic" : null;
         },
@@ -3216,9 +3220,11 @@ describe("app server action execution helpers", () => {
 
     expect(response?.status).toBe(200);
     expect(modeSpy).toHaveBeenCalledWith("force-no-store");
+    expect(revalidateSpy).toHaveBeenCalledWith(45);
     expect(forceDynamicSpy).toHaveBeenCalledWith(true);
 
     modeSpy.mockRestore();
+    revalidateSpy.mockRestore();
     forceDynamicSpy.mockRestore();
   });
 });

--- a/tests/fetch-cache.test.ts
+++ b/tests/fetch-cache.test.ts
@@ -57,7 +57,8 @@ const {
 } = await import("../packages/vinext/src/shims/fetch-cache.js");
 const { getCacheHandler, revalidatePath, revalidateTag, MemoryCacheHandler, setCacheHandler } =
   await import("../packages/vinext/src/shims/cache.js");
-const { consumeDynamicUsage } = await import("../packages/vinext/src/shims/headers.js");
+const { consumeDynamicUsage, setHeadersContext } =
+  await import("../packages/vinext/src/shims/headers.js");
 const { runWithExecutionContext } = await import("../packages/vinext/src/shims/request-context.js");
 const { createRequestContext, runWithRequestContext } =
   await import("../packages/vinext/src/shims/unified-request-context.js");
@@ -829,6 +830,70 @@ describe("fetch cache shim", () => {
     const handler = getCacheHandler() as InstanceType<typeof MemoryCacheHandler>;
     const store = (handler as any).store as Map<string, any>;
     expect([...store.values()][0].value.revalidate).toBe(5);
+  });
+
+  it("tags-only fetch inherits an earlier shorter explicit fetch revalidate", async () => {
+    setCurrentFetchRevalidate(60);
+
+    await fetch("https://api.example.com/shorter-explicit-revalidate", {
+      next: { revalidate: 5 },
+    });
+    await fetch("https://api.example.com/inherit-shorter-revalidate", {
+      next: { tags: ["inherit-shorter-revalidate"] },
+    });
+
+    const handler = getCacheHandler() as InstanceType<typeof MemoryCacheHandler>;
+    const store = (handler as any).store as Map<string, any>;
+    const revalidateByUrl = new Map(
+      [...store.values()].map((entry) => [entry.value.data.url, entry.value.revalidate]),
+    );
+    expect(revalidateByUrl).toEqual(
+      new Map([
+        ["https://api.example.com/shorter-explicit-revalidate", 5],
+        ["https://api.example.com/inherit-shorter-revalidate", 5],
+      ]),
+    );
+  });
+
+  it("tags-only fetch is uncached after an earlier zero revalidate fetch", async () => {
+    setCurrentFetchRevalidate(60);
+
+    await fetch("https://api.example.com/zero-explicit-revalidate", {
+      next: { revalidate: 0 },
+    });
+    await fetch("https://api.example.com/inherit-zero-revalidate", {
+      next: { tags: ["inherit-zero-revalidate"] },
+    });
+
+    const handler = getCacheHandler() as InstanceType<typeof MemoryCacheHandler>;
+    const store = (handler as any).store as Map<string, any>;
+    expect(store).toHaveLength(0);
+    expect(consumeDynamicUsage()).toBe(true);
+  });
+
+  it("force-static preserves the route revalidate after a zero revalidate fetch", async () => {
+    setHeadersContext({
+      cookies: new Map(),
+      forceStatic: true,
+      headers: new Headers(),
+    });
+    try {
+      setCurrentFetchRevalidate(60);
+
+      await fetch("https://api.example.com/force-static-zero-revalidate", {
+        next: { revalidate: 0 },
+      });
+      await fetch("https://api.example.com/force-static-route-revalidate", {
+        next: { tags: ["force-static-route-revalidate"] },
+      });
+
+      const handler = getCacheHandler() as InstanceType<typeof MemoryCacheHandler>;
+      const store = (handler as any).store as Map<string, any>;
+      expect([...store.values()][0].value.revalidate).toBe(60);
+      expect(consumeDynamicUsage()).toBe(false);
+    } finally {
+      setHeadersContext(null);
+    }
   });
 
   it("explicit indefinite fetch caching overrides the active route revalidate", async () => {

--- a/tests/fetch-cache.test.ts
+++ b/tests/fetch-cache.test.ts
@@ -45,6 +45,7 @@ const {
   runWithFetchCache,
   getCollectedFetchTags,
   setCurrentFetchCacheMode,
+  setCurrentFetchRevalidate,
   setCurrentForceDynamicFetchDefault,
   setCurrentFetchSoftTags,
   setRefreshStaleFetchesInForeground,
@@ -799,6 +800,117 @@ describe("fetch cache shim", () => {
   });
 
   // ── Tag-based invalidation ──────────────────────────────────────────
+
+  it("tags-only fetch inherits the active route revalidate", async () => {
+    setCurrentFetchRevalidate(60);
+
+    await fetch("https://api.example.com/route-revalidate", {
+      next: { tags: ["route-revalidate"] },
+    });
+
+    const handler = getCacheHandler() as InstanceType<typeof MemoryCacheHandler>;
+    const store = (handler as any).store as Map<string, any>;
+    const entries = [...store.values()];
+    expect(entries).toHaveLength(1);
+    expect(entries[0].value).toMatchObject({
+      kind: "FETCH",
+      revalidate: 60,
+      tags: ["route-revalidate"],
+    });
+  });
+
+  it("explicit fetch revalidate overrides the active route revalidate", async () => {
+    setCurrentFetchRevalidate(60);
+
+    await fetch("https://api.example.com/explicit-fetch-revalidate", {
+      next: { revalidate: 5, tags: ["explicit-fetch-revalidate"] },
+    });
+
+    const handler = getCacheHandler() as InstanceType<typeof MemoryCacheHandler>;
+    const store = (handler as any).store as Map<string, any>;
+    expect([...store.values()][0].value.revalidate).toBe(5);
+  });
+
+  it("explicit indefinite fetch caching overrides the active route revalidate", async () => {
+    setCurrentFetchRevalidate(60);
+
+    await fetch("https://api.example.com/revalidate-false", {
+      next: { revalidate: false, tags: ["revalidate-false"] },
+    });
+    await fetch("https://api.example.com/force-cache", {
+      cache: "force-cache",
+      next: { tags: ["force-cache"] },
+    });
+
+    const handler = getCacheHandler() as InstanceType<typeof MemoryCacheHandler>;
+    const store = (handler as any).store as Map<string, any>;
+    expect([...store.values()].map((entry) => entry.value.revalidate)).toEqual([
+      31_536_000, 31_536_000,
+    ]);
+  });
+
+  it("resets the active route revalidate between fetch-cache scopes", async () => {
+    setCurrentFetchRevalidate(60);
+    cleanup?.();
+    cleanup = withFetchCache();
+
+    await fetch("https://api.example.com/no-route-revalidate", {
+      next: { tags: ["no-route-revalidate"] },
+    });
+
+    const handler = getCacheHandler() as InstanceType<typeof MemoryCacheHandler>;
+    const store = (handler as any).store as Map<string, any>;
+    expect([...store.values()][0].value.revalidate).toBe(31_536_000);
+  });
+
+  it("tags-only fetch is uncached when the active route revalidate is zero", async () => {
+    setCurrentFetchRevalidate(0);
+
+    await fetch("https://api.example.com/zero-route-revalidate", {
+      next: { tags: ["zero-route-revalidate"] },
+    });
+
+    const handler = getCacheHandler() as InstanceType<typeof MemoryCacheHandler>;
+    const store = (handler as any).store as Map<string, any>;
+    expect(store).toHaveLength(0);
+    expect(consumeDynamicUsage()).toBe(true);
+  });
+
+  it("isolates active route revalidate across concurrent fetch-cache scopes", async () => {
+    cleanup?.();
+    cleanup = null;
+
+    await Promise.all([
+      runWithFetchCache(async () => {
+        setCurrentFetchRevalidate(10);
+        await Promise.resolve();
+        await fetch("https://api.example.com/concurrent-route-a", {
+          next: { tags: ["concurrent-route-a"] },
+        });
+      }),
+      runWithFetchCache(async () => {
+        setCurrentFetchRevalidate(20);
+        await Promise.resolve();
+        await fetch("https://api.example.com/concurrent-route-b", {
+          next: { tags: ["concurrent-route-b"] },
+        });
+      }),
+    ]);
+
+    const handler = getCacheHandler() as InstanceType<typeof MemoryCacheHandler>;
+    const store = (handler as any).store as Map<string, any>;
+    const revalidateByUrl = new Map(
+      [...store.values()].map((entry) => [entry.value.data.url, entry.value.revalidate]),
+    );
+    expect(revalidateByUrl).toEqual(
+      new Map([
+        ["https://api.example.com/concurrent-route-a", 10],
+        ["https://api.example.com/concurrent-route-b", 20],
+      ]),
+    );
+
+    cleanup = withFetchCache();
+  });
 
   it("next.tags caches and revalidateTag invalidates", async () => {
     const res1 = await fetch("https://api.example.com/posts", {


### PR DESCRIPTION
## Summary

- carry the active route revalidation interval in request-scoped fetch-cache state
- make tags-only fetches inherit that interval while preserving explicit fetch cache precedence
- propagate the interval across page, route-handler, interception, regeneration, and action-rerender contexts
- keep the live interval aligned when an earlier fetch lowers the render lifetime

## Next.js parity

During build-time prerendering, Next.js assigns a fetch with metadata-only next options the active revalidation store interval when the fetch has no explicit cache lifetime. For a route exporting revalidate = 60 and a fetch using next.tags only, Next.js writes the fetch-cache entry with revalidate: 60.

Vinext instead hard-coded the one-year sentinel for every tags-only fetch. This made the data-cache entry outlive the route interval even though tags only describe invalidation identity, not lifetime.

Explicit next.revalidate, next.revalidate = false, and cache = force-cache continue to take precedence. A route interval of zero bypasses persistent fetch caching. When an earlier explicit fetch shortens the active render lifetime, later tags-only fetches inherit that live minimum.

## Validation

- vp check on all changed source and test files
- exact-head vp test run tests/fetch-cache.test.ts tests/app-page-dispatch.test.ts tests/app-route-handler-dispatch.test.ts tests/app-server-action-execution.test.ts (334 tests)
- vp test run tests/isr-cache.test.ts tests/kv-cache-handler.test.ts tests/unified-request-context.test.ts (160 tests)
- vp run vinext#build

## Reproduction validation

Validated the original tags-only reproduction without an app-level fetch workaround. Because its upstream endpoint also needs the separate compression fix, the deployed validation build combined exact PR head c680ea8b4 with that fix in a disposable detached checkout; the compression commit is not part of this PR.

- deployed Worker version f02393e8-8e50-4882-99b7-2517a478f400 at 100%
- /isr returned 200 locally and on the deployed Worker
- revalidateTag and revalidatePath endpoints returned 200 and the page remained healthy
- live CDN response used a 60-second cache interval and produced a warm HIT
- remote KV FETCH record stored tags: [data-cache], revalidate: 60, and revalidateAt - lastModified = 60000 ms