### PR TITLE
fix(web): add search indexing metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Run Next.js applications on Vite, with Cloudflare Workers as the primary deployment target.
 
+**Website:** [vinext.dev](https://vinext.dev)
+
 > **Read the announcement:** [How we rebuilt Next.js with AI in one week](https://blog.cloudflare.com/vinext/)
 
 > **Under active development.** vinext supports substantial Next.js applications today, but it is not yet a drop-in replacement for every application or production workload. Expect compatibility gaps, especially in newer App Router features, and evaluate it against your own application before adopting it.

--- a/apps/web/app/benchmarks/page.tsx
+++ b/apps/web/app/benchmarks/page.tsx
@@ -1,7 +1,28 @@
+import type { Metadata } from "next";
 import { Dashboard } from "./components/dashboard";
 import { getPerformanceRuns } from "@/app/lib/benchmarks/server";
 
 export const revalidate = 300;
+
+const title = "Performance benchmarks — vinext";
+const description =
+  "Compare vinext and Next.js production build time, dev server startup, and bundle size.";
+
+export const metadata: Metadata = {
+  title,
+  description,
+  alternates: {
+    canonical: "/benchmarks",
+  },
+  openGraph: {
+    type: "website",
+    locale: "en_US",
+    siteName: "vinext",
+    title,
+    description,
+    url: "/benchmarks",
+  },
+};
 
 /**
  * Homepage — server component shell.

--- a/apps/web/app/compatibility/page.tsx
+++ b/apps/web/app/compatibility/page.tsx
@@ -13,6 +13,7 @@ import { LinkButton } from "@cloudflare/kumo/components/button";
 import { Text } from "@cloudflare/kumo/components/text";
 import { ArrowSquareOutIcon } from "@phosphor-icons/react/dist/ssr";
 import { and, desc, eq, sql } from "drizzle-orm";
+import type { Metadata } from "next";
 import { getDb } from "@/app/lib/db/client";
 import {
   compatRuns,
@@ -30,6 +31,26 @@ import { getSuiteSupport, NON_SUPPORTED_SUITES } from "./suite-support";
 // when a nightly deploy-suite run lands, so 5 minutes of staleness is fine
 // and keeps the page snappy without re-querying D1 on every request.
 export const revalidate = 300;
+
+const title = "Next.js compatibility — vinext";
+const description =
+  "Track vinext compatibility with the Next.js API surface using results from the Next.js deploy test suite.";
+
+export const metadata: Metadata = {
+  title,
+  description,
+  alternates: {
+    canonical: "/compatibility",
+  },
+  openGraph: {
+    type: "website",
+    locale: "en_US",
+    siteName: "vinext",
+    title,
+    description,
+    url: "/compatibility",
+  },
+};
 
 /**
  * The `kind` discriminator on stored runs. The schema is designed to support

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -15,9 +15,21 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL("https://vinext.dev"),
   title: "vinext — The Next.js API surface, reimplemented on Vite",
   description:
     "Take any Next.js app and deploy it anywhere with one command. App Router, Pages Router, RSC, ISR — all on Vite.",
+  applicationName: "vinext",
+  creator: "Cloudflare",
+  publisher: "Cloudflare",
+  openGraph: {
+    type: "website",
+    locale: "en_US",
+    siteName: "vinext",
+  },
+  twitter: {
+    card: "summary",
+  },
 };
 
 export default function RootLayout({

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -21,6 +21,59 @@ import typescript from "shiki/langs/typescript.mjs";
 import githubDarkDefault from "shiki/themes/github-dark-default.mjs";
 import { createHighlighterCore } from "shiki/core";
 import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
+import type { Metadata } from "next";
+
+const title = "vinext — The Next.js API surface, reimplemented on Vite";
+const description =
+  "Take any Next.js app and deploy it anywhere with one command. App Router, Pages Router, RSC, ISR — all on Vite.";
+
+export const metadata: Metadata = {
+  alternates: {
+    canonical: "/",
+  },
+  openGraph: {
+    type: "website",
+    locale: "en_US",
+    siteName: "vinext",
+    title,
+    description,
+    url: "/",
+  },
+  twitter: {
+    title,
+    description,
+  },
+};
+
+const structuredData = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebSite",
+      name: "vinext",
+      description,
+      url: "https://vinext.dev",
+      publisher: {
+        "@type": "Organization",
+        name: "Cloudflare",
+        url: "https://www.cloudflare.com",
+      },
+    },
+    {
+      "@type": "SoftwareSourceCode",
+      name: "vinext",
+      description,
+      url: "https://vinext.dev",
+      codeRepository: "https://github.com/cloudflare/vinext",
+      programmingLanguage: "TypeScript",
+      author: {
+        "@type": "Organization",
+        name: "Cloudflare",
+        url: "https://www.cloudflare.com",
+      },
+    },
+  ],
+};
 
 // ISR: 5-minute revalidate. The home page is fully static so the cached
 // output is effectively reused indefinitely between deploys; the revalidate
@@ -203,6 +256,10 @@ async function CodeExample({ code }: { code: string }) {
 export default function Home() {
   return (
     <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
       <section className="mx-auto flex w-full max-w-6xl flex-col items-center px-6 pb-20 pt-24 text-center">
         <Badge variant="outline" className="mb-6">
           The Next.js API surface, re-implemented on Vite

--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -1,0 +1,11 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: "https://vinext.dev/sitemap.xml",
+  };
+}

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -1,0 +1,21 @@
+import type { MetadataRoute } from "next";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: "https://vinext.dev",
+      changeFrequency: "weekly",
+      priority: 1,
+    },
+    {
+      url: "https://vinext.dev/compatibility",
+      changeFrequency: "weekly",
+      priority: 0.8,
+    },
+    {
+      url: "https://vinext.dev/benchmarks",
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+  ];
+}

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -9,12 +9,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
     },
     {
       url: "https://vinext.dev/compatibility",
-      changeFrequency: "weekly",
+      changeFrequency: "daily",
       priority: 0.8,
     },
     {
       url: "https://vinext.dev/benchmarks",
-      changeFrequency: "monthly",
+      changeFrequency: "daily",
       priority: 0.8,
     },
   ];


### PR DESCRIPTION
## Summary

- add route-specific canonical and Open Graph metadata for the public website pages
- publish robots.txt, sitemap.xml, and WebSite/SoftwareSourceCode structured data for vinext.dev
- link the official website prominently from the repository README

## Testing

- pnpm run check
- pnpm --filter @apps/web exec tsc --noEmit
- pnpm --filter @apps/web build:vinext
- verified production responses for /robots.txt and /sitemap.xml