### PR TITLE
fix(web): consolidate vinext.dev SEO signals

### DIFF
--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -197,7 +197,7 @@ jobs:
               { name: 'benchmarks', project: 'benchmarks' },
               { name: 'hackernews', project: 'hackernews', original: 'https://next-react-server-components.vercel.app' },
               { name: 'workers-cache', project: 'workers-cache' },
-              { name: 'web', project: 'vinext-web' },
+              { name: 'web', project: 'vinext-web', production: 'https://vinext.dev' },
             ];
 
             const { data: comments } = await github.rest.issues.listComments({
@@ -212,7 +212,8 @@ jobs:
             const rows = examples
               .map(e => {
                 const orig = e.original ? `[original](${e.original})` : '';
-                return `| ${e.name} | [preview](https://${alias}-${e.project}.vinext.workers.dev) | [production](https://${e.project}.vinext.workers.dev) | ${orig} |`;
+                const production = e.production || `https://${e.project}.vinext.workers.dev`;
+                return `| ${e.name} | [preview](https://${alias}-${e.project}.vinext.workers.dev) | [production](${production}) | ${orig} |`;
               })
               .join('\n');
 

--- a/README.md
+++ b/README.md
@@ -518,7 +518,7 @@ These are deployed to Cloudflare Workers and updated on every push to `main`:
 | App Router (minimal)   | Minimal App Router on Workers                                                                                    | [app-router-cloudflare.vinext.workers.dev](https://app-router-cloudflare.vinext.workers.dev)     |
 | Pages Router (minimal) | Minimal Pages Router on Workers                                                                                  | [pages-router-cloudflare.vinext.workers.dev](https://pages-router-cloudflare.vinext.workers.dev) |
 | RealWorld API          | REST API routes example                                                                                          | [realworld-api-rest.vinext.workers.dev](https://realworld-api-rest.vinext.workers.dev)           |
-| Benchmarks Dashboard   | Build performance tracking over time (D1-backed)                                                                 | [vinext-web.vinext.workers.dev/benchmarks](https://vinext-web.vinext.workers.dev/benchmarks)     |
+| Benchmarks Dashboard   | Build performance tracking over time (D1-backed)                                                                 | [vinext.dev/benchmarks](https://vinext.dev/benchmarks)                                           |
 | App Router + Nitro     | App Router deployed via Nitro (multi-platform)                                                                   | [examples/app-router-nitro](examples/app-router-nitro)                                           |
 
 ## API coverage
@@ -730,7 +730,7 @@ We measure three things:
 - **Client bundle size** — gzipped output of each build.
 - **Dev server cold start** — 10 runs, randomized execution order. Vite's dependency optimizer cache is cleared before each run.
 
-Benchmarks run on GitHub CI runners (2-core Ubuntu) on every merge to `main`. See the launch numbers in the [announcement blog post](https://blog.cloudflare.com/vinext/) and the latest results at **[vinext-web.vinext.workers.dev/benchmarks](https://vinext-web.vinext.workers.dev/benchmarks)**.
+Benchmarks run on GitHub CI runners (2-core Ubuntu) on every merge to `main`. See the launch numbers in the [announcement blog post](https://blog.cloudflare.com/vinext/) and the latest results at **[vinext.dev/benchmarks](https://vinext.dev/benchmarks)**.
 
 <details>
 <summary>Why the bundle size difference?</summary>

--- a/apps/web/app/_components/site-footer.tsx
+++ b/apps/web/app/_components/site-footer.tsx
@@ -5,7 +5,14 @@ export function SiteFooter() {
     <footer className="mt-auto border-t border-kumo-hairline">
       <div className="mx-auto flex w-full max-w-6xl items-center justify-center px-6 py-6">
         <Text variant="secondary" size="sm">
-          vinext is open source and under active development. Issues and PRs are welcome.
+          vinext is an open-source{" "}
+          <a
+            href="https://www.cloudflare.com/"
+            className="underline underline-offset-2 hover:text-kumo-default"
+          >
+            Cloudflare
+          </a>{" "}
+          project under active development. Issues and PRs are welcome.
         </Text>
       </div>
     </footer>

--- a/apps/web/app/benchmarks/commit/[sha]/page.tsx
+++ b/apps/web/app/benchmarks/commit/[sha]/page.tsx
@@ -1,14 +1,43 @@
+import type { Metadata } from "next";
 import Link from "next/link";
-import { notFound } from "next/navigation";
+import { notFound, permanentRedirect } from "next/navigation";
 import { getCommitComparison } from "@/app/lib/benchmarks/server";
 import { PerformanceComparison } from "../../components/performance-comparison";
+import { createBenchmarkMetadata } from "../../metadata";
 
 export const revalidate = 300;
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ sha: string }>;
+}): Promise<Metadata> {
+  const { sha } = await params;
+  if (!/^[0-9a-f]{7,40}$/i.test(sha)) {
+    return createBenchmarkMetadata({
+      title: "Commit performance benchmarks",
+      description: "Historical vinext performance measurements by commit.",
+      path: "/benchmarks",
+      index: false,
+    });
+  }
+
+  const normalizedSha = sha.toLowerCase();
+  const shortSha = normalizedSha.slice(0, 7);
+  return createBenchmarkMetadata({
+    title: `Commit ${shortSha} performance benchmarks`,
+    description: `Build, bundle-size, and development-startup performance measurements for vinext commit ${shortSha}.`,
+    path: `/benchmarks/commit/${normalizedSha}`,
+    index: false,
+  });
+}
 
 export default async function CommitPage({ params }: { params: Promise<{ sha: string }> }) {
   const { sha } = await params;
   const comparison = await getCommitComparison(sha);
   if (!comparison) notFound();
+  const canonicalSha = comparison.head.sha.toLowerCase();
+  if (sha !== canonicalSha) permanentRedirect(`/benchmarks/commit/${canonicalSha}`);
   return (
     <div className="mx-auto w-full max-w-6xl px-6 py-8">
       <div className="mb-6">

--- a/apps/web/app/benchmarks/metadata.ts
+++ b/apps/web/app/benchmarks/metadata.ts
@@ -1,0 +1,35 @@
+import type { Metadata } from "next";
+
+type BenchmarkMetadataOptions = {
+  title: string;
+  description: string;
+  path: string;
+  index?: boolean;
+};
+
+export function createBenchmarkMetadata({
+  title,
+  description,
+  path,
+  index = true,
+}: BenchmarkMetadataOptions): Metadata {
+  const brandedTitle = `${title} — vinext`;
+  return {
+    title: brandedTitle,
+    description,
+    alternates: { canonical: path },
+    robots: index ? undefined : { index: false, follow: true },
+    openGraph: {
+      type: "website",
+      locale: "en_US",
+      siteName: "vinext",
+      title: brandedTitle,
+      description,
+      url: path,
+    },
+    twitter: {
+      title: brandedTitle,
+      description,
+    },
+  };
+}

--- a/apps/web/app/benchmarks/pull/[number]/page.tsx
+++ b/apps/web/app/benchmarks/pull/[number]/page.tsx
@@ -1,9 +1,35 @@
+import type { Metadata } from "next";
 import Link from "next/link";
-import { notFound } from "next/navigation";
+import { notFound, permanentRedirect } from "next/navigation";
 import { getPullComparison } from "@/app/lib/benchmarks/server";
 import { PerformanceComparison } from "../../components/performance-comparison";
+import { createBenchmarkMetadata } from "../../metadata";
 
 export const revalidate = 300;
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ number: string }>;
+}): Promise<Metadata> {
+  const { number } = await params;
+  if (!/^\d+$/.test(number) || Number(number) <= 0) {
+    return createBenchmarkMetadata({
+      title: "Pull request performance benchmarks",
+      description: "Exact-head vinext pull request performance measurements.",
+      path: "/benchmarks",
+      index: false,
+    });
+  }
+
+  const canonicalNumber = String(Number(number));
+  return createBenchmarkMetadata({
+    title: `PR #${canonicalNumber} performance benchmarks`,
+    description: `Exact-head build, bundle-size, and development-startup performance measurements for vinext pull request #${canonicalNumber}.`,
+    path: `/benchmarks/pull/${canonicalNumber}`,
+    index: false,
+  });
+}
 
 export default async function PullComparisonPage({
   params,
@@ -11,6 +37,10 @@ export default async function PullComparisonPage({
   params: Promise<{ number: string }>;
 }) {
   const { number } = await params;
+  if (/^\d+$/.test(number) && Number(number) > 0) {
+    const canonicalNumber = String(Number(number));
+    if (number !== canonicalNumber) permanentRedirect(`/benchmarks/pull/${canonicalNumber}`);
+  }
   const comparison = await getPullComparison(number);
   if (!comparison) notFound();
   return (

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -94,7 +94,7 @@ const STATS = [
       "185 KB → 125 KB gzipped on the same benchmark. Tree-shaking and a lighter client runtime do the work.",
   },
   {
-    value: "92%",
+    value: "94%",
     label: "of the Next.js 16 API surface",
     detail:
       "App Router, Pages Router, RSC, server actions, ISR, middleware, route handlers. Coverage and gaps tracked openly.",
@@ -268,8 +268,8 @@ export default function Home() {
           Run your Next.js app on Vite. Deploy anywhere.
         </h1>
         <p className="mt-6 max-w-2xl text-lg leading-relaxed text-kumo-subtle">
-          Vinext is a Vite plugin that re-implements the Next.js API from scratch. Keep your{" "}
-          <code className="font-mono text-kumo-default">app/</code>,{" "}
+          Vinext is an open-source Vite plugin from Cloudflare that re-implements the Next.js API
+          from scratch. Keep your <code className="font-mono text-kumo-default">app/</code>,{" "}
           <code className="font-mono text-kumo-default">pages/</code>, and{" "}
           <code className="font-mono text-kumo-default">next.config.js</code> as they are. Get a
           faster dev loop, smaller bundles, and a clean path to deploy on any host.

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -1,5 +1,6 @@
 /** Cloudflare Worker entry point for web-specific APIs and scheduled maintenance. */
 import handler from "vinext/server/fetch-handler";
+import { addPreviewRobotsHeader, getCanonicalRedirect } from "./seo";
 
 type Env = {
   ASSETS: Fetcher;
@@ -151,6 +152,9 @@ export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     const url = new URL(request.url);
 
+    const canonicalRedirect = getCanonicalRedirect(request);
+    if (canonicalRedirect) return canonicalRedirect;
+
     if (request.method === "PUT" && url.pathname === "/api/benchmarks/profile-upload") {
       return uploadPerformanceProfile(request, env);
     }
@@ -161,7 +165,8 @@ export default {
     // Delegate everything else to vinext, forwarding ctx so that
     // ctx.waitUntil() is available to background cache writes and
     // other deferred work via getRequestExecutionContext().
-    return handler.fetch(request, env, ctx);
+    const response = await handler.fetch(request, env, ctx);
+    return addPreviewRobotsHeader(request, response);
   },
   async scheduled(_controller: ScheduledController, env: Env, ctx: ExecutionContext) {
     ctx.waitUntil(sweepPerformanceProfiles(env));

--- a/apps/web/worker/seo.ts
+++ b/apps/web/worker/seo.ts
@@ -1,0 +1,46 @@
+const CANONICAL_HOSTNAME = "vinext.dev";
+const WWW_HOSTNAME = "www.vinext.dev";
+const PRODUCTION_WORKERS_HOSTNAME = "vinext-web.vinext.workers.dev";
+const PREVIEW_HOST_SUFFIX = `-${PRODUCTION_WORKERS_HOSTNAME}`;
+
+function isPublicDocumentRequest(request: Request, url: URL): boolean {
+  return (
+    (request.method === "GET" || request.method === "HEAD") && !url.pathname.startsWith("/api/")
+  );
+}
+
+/**
+ * Consolidate public production traffic on vinext.dev while leaving the
+ * workers.dev API endpoints available to existing CI upload jobs.
+ */
+export function getCanonicalRedirect(request: Request): Response | null {
+  const url = new URL(request.url);
+  if (!isPublicDocumentRequest(request, url)) return null;
+  if (url.hostname !== WWW_HOSTNAME && url.hostname !== PRODUCTION_WORKERS_HOSTNAME) return null;
+
+  url.protocol = "https:";
+  url.hostname = CANONICAL_HOSTNAME;
+  url.port = "";
+
+  return new Response(null, {
+    status: 308,
+    headers: {
+      location: url.href,
+      "cache-control": "public, max-age=3600",
+    },
+  });
+}
+
+/** Prevent public preview aliases from competing with the production domain. */
+export function addPreviewRobotsHeader(request: Request, response: Response): Response {
+  const { hostname } = new URL(request.url);
+  if (!hostname.endsWith(PREVIEW_HOST_SUFFIX)) return response;
+
+  const headers = new Headers(response.headers);
+  headers.set("x-robots-tag", "noindex");
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -2,6 +2,7 @@
   "name": "@vinext/cloudflare",
   "version": "1.0.0-beta.6",
   "description": "Cloudflare adapters for vinext (KV data cache and Images-backed image optimization).",
+  "homepage": "https://vinext.dev/",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/create-vinext-app/package.json
+++ b/packages/create-vinext-app/package.json
@@ -2,6 +2,7 @@
   "name": "create-vinext-app",
   "version": "1.0.0-beta.2",
   "description": "Create a vinext app for Cloudflare Workers.",
+  "homepage": "https://vinext.dev/",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -2,6 +2,7 @@
   "name": "@vinext/types",
   "version": "1.0.0-beta.2",
   "description": "Type declarations for vinext's Next.js-compatible public API.",
+  "homepage": "https://vinext.dev/",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/vinext/package.json
+++ b/packages/vinext/package.json
@@ -2,6 +2,7 @@
   "name": "vinext",
   "version": "1.0.0-beta.6",
   "description": "Run Next.js apps on Vite. Drop-in replacement for the next CLI.",
+  "homepage": "https://vinext.dev/",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/tests/web-seo.test.ts
+++ b/tests/web-seo.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { createBenchmarkMetadata } from "../apps/web/app/benchmarks/metadata";
+import robots from "../apps/web/app/robots";
+import sitemap from "../apps/web/app/sitemap";
+import { addPreviewRobotsHeader, getCanonicalRedirect } from "../apps/web/worker/seo";
+
+describe("vinext.dev SEO metadata", () => {
+  it("builds canonical and social metadata for benchmark detail pages", () => {
+    const metadata = createBenchmarkMetadata({
+      title: "Commit abc1234 performance benchmarks",
+      description: "Historical vinext performance measurements by commit.",
+      path: "/benchmarks/commit/abc1234",
+    });
+
+    const canonical = metadata.alternates?.canonical;
+    expect(canonical).toBe("/benchmarks/commit/abc1234");
+    expect(metadata.openGraph).toMatchObject({
+      title: "Commit abc1234 performance benchmarks — vinext",
+      url: "/benchmarks/commit/abc1234",
+      siteName: "vinext",
+    });
+    expect(metadata.robots).toBeUndefined();
+  });
+
+  it("publishes a crawlable robots policy pointing at the canonical sitemap", () => {
+    expect(robots()).toEqual({
+      rules: {
+        userAgent: "*",
+        allow: "/",
+      },
+      sitemap: "https://vinext.dev/sitemap.xml",
+    });
+  });
+
+  it("lists only stable, indexable pages in the sitemap", () => {
+    expect(sitemap().map(({ url }) => url)).toEqual([
+      "https://vinext.dev",
+      "https://vinext.dev/compatibility",
+      "https://vinext.dev/benchmarks",
+    ]);
+  });
+});
+
+describe("vinext.dev canonical host handling", () => {
+  it.each(["www.vinext.dev", "vinext-web.vinext.workers.dev"])(
+    "redirects public documents from %s while preserving path and query",
+    (hostname) => {
+      const response = getCanonicalRedirect(
+        new Request(`https://${hostname}/benchmarks?view=bundles`),
+      );
+
+      expect(response?.status).toBe(308);
+      expect(response?.headers.get("location")).toBe("https://vinext.dev/benchmarks?view=bundles");
+    },
+  );
+
+  it("keeps the workers.dev API origin available to existing CI uploaders", () => {
+    expect(
+      getCanonicalRedirect(
+        new Request("https://vinext-web.vinext.workers.dev/api/benchmarks/upload"),
+      ),
+    ).toBeNull();
+    expect(
+      getCanonicalRedirect(
+        new Request("https://vinext-web.vinext.workers.dev/benchmarks", { method: "POST" }),
+      ),
+    ).toBeNull();
+  });
+
+  it("marks preview aliases as non-indexable without buffering the response body", async () => {
+    const response = addPreviewRobotsHeader(
+      new Request("https://pr-123-vinext-web.vinext.workers.dev/"),
+      new Response("preview", { headers: { "content-type": "text/plain" } }),
+    );
+
+    expect(response.headers.get("x-robots-tag")).toBe("noindex");
+    expect(response.headers.get("content-type")).toBe("text/plain");
+    await expect(response.text()).resolves.toBe("preview");
+  });
+
+  it("does not add preview directives to canonical production hosts", () => {
+    for (const hostname of ["vinext.dev", "vinext-web.vinext.workers.dev"]) {
+      const original = new Response("production");
+      expect(addPreviewRobotsHeader(new Request(`https://${hostname}/`), original)).toBe(original);
+    }
+  });
+});


### PR DESCRIPTION
## Relationship to #2988

Builds directly on Scott Buscemi’s merged #2988 work. This PR retains its canonical metadata, structured data, robots policy, and sitemap as the base and adds only the follow-up SEO consolidation.

## Summary

- redirect public `vinext-web.vinext.workers.dev` and `www.vinext.dev` documents to the canonical domain while preserving existing workers.dev API upload endpoints
- keep PR preview environments available and explicitly non-indexable
- add descriptive metadata for benchmark commit and pull-request detail pages while marking both route families `noindex, follow` and keeping them out of the sitemap
- canonicalize benchmark URL aliases to stable full-SHA and numeric PR forms
- consolidate official links in the README, npm package metadata, footer, and deploy-preview comments on `vinext.dev`
- clarify Cloudflare ownership and align the homepage compatibility figure with the README

## Validation

- `vp check`
- `vp test run tests/web-seo.test.ts` (8 tests)
- `vp build` in `apps/web`

The local build only warned that `COMPAT_INGEST_SECRET` was not set; that secret is not needed for the audited public routes.