### PR TITLE
Increase Big Bonk timeout

### DIFF
--- a/.github/workflows/bigbonk.yml
+++ b/.github/workflows/bigbonk.yml
@@ -21,7 +21,7 @@ jobs:
         github.event.comment.author_association == 'OWNER'
       )
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
## Summary

- increase the `/bigbonk` workflow timeout from 10 to 30 minutes

## Why

`/bigbonk` now uses GPT-5.6 Sol with `max` reasoning. The model and gateway configuration passed a dedicated smoke test, but a 10-minute workflow limit is unnecessarily tight for a full repository review.

This PR also provides an open pull request for validating the real default-branch `/bonk` and `/bigbonk` comment workflows after #2987 merged.

## Validation

- workflow YAML parses successfully
- `git diff --check` passes
- live `/bonk` and `/bigbonk` results will be recorded here
