### PR TITLE
fix: normalize path.relative results to forward slashes on Windows

### DIFF
--- a/packages/vinext/src/build/css-url-assets.ts
+++ b/packages/vinext/src/build/css-url-assets.ts
@@ -180,7 +180,7 @@ export function rebaseCssUrlAssetReferences(
     if (!CSS_ASSET_EXT_RE.test(lower) || lower.endsWith(".css")) return null;
 
     const absolutePath = path.resolve(sourceDirectory, parts.path);
-    let rebasedPath = toSlash(path.relative(targetDirectory, absolutePath));
+    let rebasedPath = path.relative(targetDirectory, absolutePath);
     if (!rebasedPath.startsWith(".")) rebasedPath = `./${rebasedPath}`;
     return joinUrl({ ...parts, path: rebasedPath });
   });

--- a/packages/vinext/src/build/css-url-assets.ts
+++ b/packages/vinext/src/build/css-url-assets.ts
@@ -180,7 +180,7 @@ export function rebaseCssUrlAssetReferences(
     if (!CSS_ASSET_EXT_RE.test(lower) || lower.endsWith(".css")) return null;
 
     const absolutePath = path.resolve(sourceDirectory, parts.path);
-    let rebasedPath = path.relative(targetDirectory, absolutePath);
+    let rebasedPath = toSlash(path.relative(targetDirectory, absolutePath));
     if (!rebasedPath.startsWith(".")) rebasedPath = `./${rebasedPath}`;
     return joinUrl({ ...parts, path: rebasedPath });
   });

--- a/packages/vinext/src/check.ts
+++ b/packages/vinext/src/check.ts
@@ -9,6 +9,7 @@ import { detectPackageManager, findDir } from "./utils/project.js";
 import { parseAst, type ESTree } from "vite";
 import fs from "node:fs";
 import path from "pathslash";
+import { toPosixRelative } from "./utils/path.js";
 
 // ── Support status definitions ─────────────────────────────────────────────
 
@@ -654,7 +655,7 @@ export function scanImports(root: string): CheckItem[] {
         // Normalize: next/font/google -> next/font/google
         const normalized = mod === "next" ? "next" : mod;
         if (!importUsage.has(normalized)) importUsage.set(normalized, []);
-        const relFile = path.relative(root, file);
+        const relFile = toPosixRelative(root, file);
         const usedInFiles = importUsage.get(normalized) ?? [];
         if (!usedInFiles.includes(relFile)) {
           usedInFiles.push(relFile);
@@ -1102,7 +1103,7 @@ export function checkConventions(root: string): CheckItem[] {
   const cjsGlobalFiles: string[] = [];
   for (const file of allSourceFiles) {
     const content = fs.readFileSync(file, "utf-8");
-    const rel = path.relative(root, file);
+    const rel = toPosixRelative(root, file);
 
     if (viewTransitionRegex.test(content)) {
       viewTransitionFiles.push(rel);

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -4479,7 +4479,7 @@ export const loadServerActionClient = ${
         handler(options: HotUpdateOptions) {
           if (!hasPagesDir) return;
           const isPagesAppFile = (filePath: string): boolean => {
-            const relativePath = path.relative(pagesDir, filePath);
+            const relativePath = toPosixRelative(pagesDir, filePath);
             return (
               !relativePath.includes("/") &&
               relativePath.startsWith("_app.") &&
@@ -4490,7 +4490,7 @@ export const loadServerActionClient = ${
             const cleanPath = stripViteModuleQuery(filePath);
             if (!path.isAbsolute(cleanPath)) return false;
             if (!isScriptModuleId(cleanPath) || cleanPath.endsWith(".d.ts")) return false;
-            const relativeRootPath = path.relative(root, cleanPath);
+            const relativeRootPath = toPosixRelative(root, cleanPath);
             if (relativeRootPath.startsWith("..") || path.isAbsolute(relativeRootPath))
               return false;
             if (
@@ -4721,7 +4721,7 @@ export const loadServerActionClient = ${
         let appRouteTypeGenerationPending = false;
 
         function isPagesAppFile(filePath: string): boolean {
-          const relativePath = path.relative(pagesDir, filePath);
+          const relativePath = toPosixRelative(pagesDir, filePath);
           return (
             !relativePath.includes("/") &&
             relativePath.startsWith("_app.") &&
@@ -4733,7 +4733,7 @@ export const loadServerActionClient = ${
           const cleanPath = stripViteModuleQuery(filePath);
           if (!path.isAbsolute(cleanPath)) return false;
           if (!isScriptModuleId(cleanPath) || cleanPath.endsWith(".d.ts")) return false;
-          const relativeRootPath = path.relative(root, cleanPath);
+          const relativeRootPath = toPosixRelative(root, cleanPath);
           if (relativeRootPath.startsWith("..") || path.isAbsolute(relativeRootPath)) return false;
           if (
             relativeRootPath.includes("/node_modules/") ||

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -283,6 +283,7 @@ import { createTransformCache } from "./plugins/transform-cache.js";
 import {
   isPathInside,
   isPathInsideOrEqual,
+  toPosixRelative,
   stripJsExtension,
   stripViteModuleQuery,
 } from "./utils/path.js";
@@ -430,7 +431,7 @@ function isVinextOgShimImporter(importer: string | undefined): boolean {
 }
 
 function toRelativeFileEntry(root: string, absPath: string): string {
-  return path.relative(root, absPath);
+  return toPosixRelative(root, absPath);
 }
 
 const DEV_PAGES_CLIENT_ENTRY = "/@id/__x00__virtual:vinext-client-entry";
@@ -571,8 +572,13 @@ function resolvedStylesheetToDevManifestAsset(root: string, resolvedId: string):
 
   const rootForRelative = tryRealpathSync(root) ?? root;
   const fileForRelative = tryRealpathSync(cleanId) ?? cleanId;
-  const relativePath = path.relative(rootForRelative, fileForRelative);
-  if (relativePath !== "" && !relativePath.startsWith("..") && !path.isAbsolute(relativePath)) {
+  const relativePath = toPosixRelative(rootForRelative, fileForRelative);
+  if (
+    relativePath !== "" &&
+    relativePath !== ".." &&
+    !relativePath.startsWith("../") &&
+    !path.isAbsolute(relativePath)
+  ) {
     return relativePath;
   }
 
@@ -3656,13 +3662,13 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           validateHybridRouteConflicts(
             [...pageRoutes, ...apiRoutes].map((route) => ({
               ...route,
-              sourcePath: path.relative(root, route.filePath),
+              sourcePath: toPosixRelative(root, route.filePath),
             })),
             appRoutes
               .filter((route) => route.pagePath !== null || route.routePath !== null)
               .map((route) => ({
                 ...route,
-                sourcePath: path.relative(root, route.pagePath ?? route.routePath!),
+                sourcePath: toPosixRelative(root, route.pagePath ?? route.routePath!),
               })),
           );
         }
@@ -4690,13 +4696,13 @@ export const loadServerActionClient = ${
               validateHybridRouteConflicts(
                 [...pageRoutes, ...apiRoutes].map((route) => ({
                   ...route,
-                  sourcePath: path.relative(root, route.filePath),
+                  sourcePath: toPosixRelative(root, route.filePath),
                 })),
                 appRoutes
                   .filter((route) => route.pagePath !== null || route.routePath !== null)
                   .map((route) => ({
                     ...route,
-                    sourcePath: path.relative(root, route.pagePath ?? route.routePath!),
+                    sourcePath: toPosixRelative(root, route.pagePath ?? route.routePath!),
                   })),
               );
               if (hybridRouteValidationError) {

--- a/packages/vinext/src/utils/path.ts
+++ b/packages/vinext/src/utils/path.ts
@@ -18,9 +18,17 @@ export function canonicalizeFilePath(filePath: string): string {
   }
 }
 
+/**
+ * `path.relative` for internal vinext use. Node emits backslashes on Windows;
+ * Vite module ids, glob entries, and `../` boundary checks are forward-slash.
+ */
+export function toPosixRelative(from: string, to: string): string {
+  return toSlash(path.relative(from, to));
+}
+
 /** Whether `filePath` is a strict descendant of `directory`. */
 export function isPathInside(directory: string, filePath: string): boolean {
-  const relativePath = path.relative(directory, filePath);
+  const relativePath = toPosixRelative(directory, filePath);
   return (
     relativePath !== "" &&
     relativePath !== ".." &&
@@ -31,7 +39,7 @@ export function isPathInside(directory: string, filePath: string): boolean {
 
 /** Whether `filePath` is `directory` itself or one of its descendants. */
 export function isPathInsideOrEqual(directory: string, filePath: string): boolean {
-  return path.relative(directory, filePath) === "" || isPathInside(directory, filePath);
+  return toPosixRelative(directory, filePath) === "" || isPathInside(directory, filePath);
 }
 
 /** Strip a trailing `.js` extension from a module specifier so

--- a/packages/vinext/src/utils/path.ts
+++ b/packages/vinext/src/utils/path.ts
@@ -19,11 +19,11 @@ export function canonicalizeFilePath(filePath: string): string {
 }
 
 /**
- * `path.relative` for internal vinext use. Node emits backslashes on Windows;
- * Vite module ids, glob entries, and `../` boundary checks are forward-slash.
+ * `path.relative` for internal vinext use. `path` is pathslash, so the
+ * result is already forward-slash on Windows — no extra `toSlash`.
  */
 export function toPosixRelative(from: string, to: string): string {
-  return toSlash(path.relative(from, to));
+  return path.relative(from, to);
 }
 
 /** Whether `filePath` is a strict descendant of `directory`. */

--- a/tests/plugin-utils.test.ts
+++ b/tests/plugin-utils.test.ts
@@ -24,6 +24,7 @@ import {
   isPathInsideOrEqual,
   NODE_MODULES_PATH_RE,
   stripViteModuleQuery,
+  toPosixRelative,
 } from "../packages/vinext/src/utils/path.js";
 
 describe("plugin AST utilities", () => {
@@ -118,6 +119,18 @@ describe("plugin path utilities", () => {
     expect(isPathInside(root, root)).toBe(false);
     expect(isPathInsideOrEqual(root, root)).toBe(true);
     expect(isPathInsideOrEqual(root, sibling)).toBe(false);
+  });
+
+  it("emits forward-slash relatives for Vite globs and ../ boundary checks", () => {
+    const root = path.join("C:", "proj", "app");
+    const nested = path.join(root, "src", "page.tsx");
+    const posix = toPosixRelative(root, nested);
+    expect(posix.includes("\\")).toBe(false);
+    expect(posix).toBe("src/page.tsx");
+
+    // Mixed separators must not break the descendant check (Windows glob / join).
+    expect(isPathInside(toSlash(root), `${toSlash(root)}/src/page.tsx`)).toBe(true);
+    expect(isPathInside(toSlash(root), `${toSlash(root)}/../outside.tsx`)).toBe(false);
   });
 
   it("canonicalizes existing files and preserves missing paths", () => {


### PR DESCRIPTION
## Summary

- Add `toPosixRelative()` so `path.relative()` results used internally are always forward-slash (Node emits `\` on Windows).
- Use it for `isPathInside` / `isPathInsideOrEqual` (`../` checks), Vite glob `toRelativeFileEntry`, hybrid-route `sourcePath`, and stylesheet manifest relatives.
- `scanWithExtensions` already yields `toSlash()` on main (#1604). This is the leftover `path.relative` slice of #1605.
- Windows CI already runs on `main`; this does not add a second job.

Draft #1745 also claimed #1605 but only touched routing glob discovery and has been stale since June. Happy to rebase or drop if that lands first.

## Testing

- `pnpm exec vp test run --project unit tests/plugin-utils.test.ts` (24 passed, on Windows)

## Notes

Does not close all of #1605 (build packaging + NTFS-illegal fixtures remain). Closes the `path.relative` / `isPathInside` gap.

Related: #1605, #1604, #1578
