### PR TITLE
fix(test): mark hybrid i18n fixture private

### DIFF
--- a/tests/fixtures/hybrid-i18n-api-handoff/package.json
+++ b/tests/fixtures/hybrid-i18n-api-handoff/package.json
@@ -1,4 +1,5 @@
 {
   "name": "hybrid-i18n-api-handoff-fixture",
+  "private": true,
   "type": "module"
 }


### PR DESCRIPTION
Fixes the release failure in https://github.com/cloudflare/vinext/actions/runs/32244819833.

`hybrid-i18n-api-handoff-fixture` is a workspace test fixture, but its manifest was the only workspace importer outside `packages/*` not marked private. Changesets consequently tried to publish it with an undefined version. Mark it private so release publishing only considers the four intended packages.

Validation:
- `vp fmt --check tests/fixtures/hybrid-i18n-api-handoff/package.json`
- workspace manifest audit via `pnpm -r list --depth -1 --json` (no public importers outside `packages/*`)
- `git diff --check`
