### PR TITLE
fix(test): avoid fixture server localhost DNS race

### DIFF
--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -96,6 +96,8 @@ export async function startFixtureServer(
       holdUntilCrawlEnd: true,
     },
     server: {
+      // Avoid localhost resolving to ::1 when the test server is bound to IPv4.
+      host: "127.0.0.1",
       port: 0,
       cors: false,
       ...opts?.server,
@@ -108,7 +110,8 @@ export async function startFixtureServer(
     await server.listen();
     const addr = server.httpServer?.address();
     if (addr && typeof addr === "object") {
-      baseUrl = `http://localhost:${addr.port}`;
+      const host = addr.family === "IPv6" ? `[${addr.address}]` : addr.address;
+      baseUrl = `http://${host}:${addr.port}`;
     }
   }
 


### PR DESCRIPTION
## Summary

- bind shared Vite fixture servers to IPv4 loopback by default
- build the test base URL from the address the HTTP server actually bound
- avoid `localhost` resolving to `::1` while Vite is listening on `127.0.0.1`

Fixes the flake in [main CI run 32250259370](https://github.com/cloudflare/vinext/actions/runs/32250259370/job/96059434092), where the first request in `app-route-handler-trailing-slash.test.ts` timed out on `::1:5174` and then found `127.0.0.1:5174` closed.

## Validation

- `vp test run tests/app-route-handler-trailing-slash.test.ts tests/app-router-origin-check.test.ts tests/vite-hmr-websocket.test.ts tests/pages-router-concurrency.test.ts tests/hybrid-i18n-api-handoff.test.ts` (21 passed)
- `vp check tests/helpers.ts tests/app-route-handler-trailing-slash.test.ts`