### PR TITLE
docs: next/web-vitals is implemented, not a no-op stub

### DIFF
--- a/.agents/skills/migrate-to-vinext/references/compatibility.md
+++ b/.agents/skills/migrate-to-vinext/references/compatibility.md
@@ -26,7 +26,7 @@ All of these resolve automatically to vinext shims. Do not rewrite imports in ap
 | `next/document`     | Full    | Pages Router                                                     |
 | `next/constants`    | Full    |                                                                  |
 | `next/amp`          | Stub    | No-op; AMP deprecated since Next.js 13                           |
-| `next/web-vitals`   | Stub    | No-op                                                            |
+| `next/web-vitals`   | Full    | `useReportWebVitals`; not the `_app` export                      |
 | `server-only`       | Full    |                                                                  |
 | `client-only`       | Full    |                                                                  |
 

--- a/README.md
+++ b/README.md
@@ -553,7 +553,7 @@ Every `next/*` import is shimmed to a Vite-compatible implementation.
 | `next/document`     | ✅  | `Html`, `Head`, `Main`, `NextScript`                                                                                                   |
 | `next/constants`    | ✅  | All phase constants                                                                                                                    |
 | `next/amp`          | ⬜  | No-op (AMP is deprecated)                                                                                                              |
-| `next/web-vitals`   | ⬜  | No-op (use the `web-vitals` library directly)                                                                                          |
+| `next/web-vitals`   | ✅  | `useReportWebVitals` reports CLS, FCP, FID, INP, LCP, TTFB via the `web-vitals` library                                                |
 
 ### Routing
 


### PR DESCRIPTION
The README and the shipped `migrate-to-vinext` skill both list `next/web-vitals` as an intentional no-op stub. It is a working implementation, and `check.ts` already says so — the docs are the ones that are wrong.

## The implementation

`packages/vinext/src/shims/web-vitals.ts` subscribes to all six metrics and forwards each to the caller:

```ts
onCLS(reportWebVitals);
onFID(reportWebVitals);
onLCP(reportWebVitals);
onINP(reportWebVitals);
onFCP(reportWebVitals);
onTTFB(reportWebVitals);
```

`web-vitals` is a real dependency (`packages/vinext/package.json:183`), the public signature is declared in `packages/types/next/next-shims-vinext.d.ts:13`, and there is an E2E test ported from Next.js's own suite — `tests/e2e/app-router/nextjs-compat/web-vitals.spec.ts`, from `test/e2e/app-dir/app/useReportWebVitals.test.ts` — which asserts the browser actually reports the full set:

```ts
const expectedMetricNames = ["CLS", "FCP", "FID", "LCP", "TTFB"];
...
await expect
  .poll(() => [...new Set(reportedMetricNames)].sort().join(","), { timeout: 10_000 })
  .toBe(expectedMetricNamesKey);
expect(eventsCount).toBeGreaterThanOrEqual(6);
```

## The disagreement

| Source | Says |
| --- | --- |
| `packages/vinext/src/check.ts:113` | `supported` — "reportWebVitals helper" |
| `README.md` API coverage table | ⬜ — "No-op (use the `web-vitals` library directly)" |
| `.agents/skills/migrate-to-vinext/references/compatibility.md` | `Stub` — "No-op" |

So `vinext check` and the README told a user opposite things about the same module, and the README's advice actively steered people away from an API that works. The skill matters here too, since it ships to users via `npx skills add cloudflare/vinext` and is what an agent reads when deciding what to migrate.

## Scope

Docs only — no behavior change. I marked the row ✅ per the legend ("full implementation") because the module's only export is `useReportWebVitals`.

One thing I deliberately did **not** claim: the Pages Router `_app` `reportWebVitals` export is a separate Next.js API and is not wired up (`grep -rn reportWebVitals packages/vinext/src/` returns only the shim and the `check.ts` entry). The new skill note says "not the `_app` export" so that gap stays visible.

## Verification

State: base `7ed5570`, head `39a3996`.

`pnpm run fmt:check` passes at head (3098 files). I did not run the E2E suite locally — the spec above is cited as existing CI coverage for the behavior, not as something I re-ran. No source files are touched, so no unit test outcome should change.
