### PR TITLE
feat: experimental support for React Compiler via react: { compiler: true }

### DIFF
--- a/.changeset/react-compiler-support.md
+++ b/.changeset/react-compiler-support.md
@@ -1,7 +1,0 @@
----
-"vinext": minor
----
-
-Support the React Compiler through `vinext({ react: { compiler: true } })`.
-
-The option is forwarded to `@vitejs/plugin-react` 6.1+, which runs the compiler via the optional `oxc-transform-react` package. `vinext:jsx-in-js` now runs before the React plugin so that JSX in plain `.js` files keeps working when the compiler is enabled.

--- a/.changeset/react-compiler-support.md
+++ b/.changeset/react-compiler-support.md
@@ -1,0 +1,7 @@
+---
+"vinext": minor
+---
+
+Support the React Compiler through `vinext({ react: { compiler: true } })`.
+
+The option is forwarded to `@vitejs/plugin-react` 6.1+, which runs the compiler via the optional `oxc-transform-react` package. `vinext:jsx-in-js` now runs before the React plugin so that JSX in plain `.js` files keeps working when the compiler is enabled.

--- a/README.md
+++ b/README.md
@@ -629,7 +629,10 @@ npm install -D oxc-transform-react
 
 This requires `@vitejs/plugin-react` 6.1.0 or newer. Older versions accept the option and drop it, so vinext fails with an actionable error instead of leaving the compiler silently disabled. The compiler runs on the client environment only.
 
-One caveat: JSX written in plain `.js` files is compiled to JavaScript before the compiler sees it, so those modules build correctly but are not memoized. Rename them to `.jsx` or `.tsx` to get memoization.
+One caveat: modules whose JSX is lowered earlier in the pipeline are not memoized. Those build and behave correctly, they just miss auto memoization:
+
+- JSX in plain `.js` files, which `vinext:jsx-in-js` compiles first so the compiler can parse them at all. Rename to `.jsx` or `.tsx` to get memoization.
+- Components using `<style jsx>`, which `vinext:styled-jsx` compiles through the Next.js SWC transform before the compiler runs.
 
 ### Environment variable loading (`.env*`)
 

--- a/README.md
+++ b/README.md
@@ -606,6 +606,30 @@ Every `next/*` import is shimmed to a Vite-compatible implementation.
 | `images` config                                  | 🟡  | Parsed but not used for optimization                                                                                                                                                                                   |
 | `experimental.optimizePackageImports`            | ✅  | Rewrites barrel imports to direct sub-module imports in RSC/SSR environments. A default set (lucide-react, date-fns, radix-ui, antd, MUI, and others) are always optimized. Add package names here to extend the list. |
 | `vinext({ nextConfig })`                         | ✅  | Inline Next-style config from `vite.config.*`. Supports object-form and function-form config. When provided, this overrides root `next.config.*`.                                                                      |
+| `vinext({ react: { compiler: true } })`          | ✅  | React Compiler auto memoization. Needs `@vitejs/plugin-react` 6.1+ and the optional `oxc-transform-react` package.                                                                                                     |
+
+### React Compiler
+
+vinext auto-registers `@vitejs/plugin-react`, so the React Compiler is enabled through the same `react` option:
+
+```ts
+import { defineConfig } from "vite";
+import vinext from "vinext";
+
+export default defineConfig({
+  plugins: [vinext({ react: { compiler: true } })],
+});
+```
+
+The transform itself ships separately, so install it alongside:
+
+```bash
+npm install -D oxc-transform-react
+```
+
+This requires `@vitejs/plugin-react` 6.1.0 or newer. The compiler runs on the client environment only.
+
+One caveat: JSX written in plain `.js` files is compiled to JavaScript before the compiler sees it, so those modules build correctly but are not memoized. Rename them to `.jsx` or `.tsx` to get memoization.
 
 ### Environment variable loading (`.env*`)
 

--- a/README.md
+++ b/README.md
@@ -627,7 +627,7 @@ The transform itself ships separately, so install it alongside:
 npm install -D oxc-transform-react
 ```
 
-This requires `@vitejs/plugin-react` 6.1.0 or newer. The compiler runs on the client environment only.
+This requires `@vitejs/plugin-react` 6.1.0 or newer. Older versions accept the option and drop it, so vinext fails with an actionable error instead of leaving the compiler silently disabled. The compiler runs on the client environment only.
 
 One caveat: JSX written in plain `.js` files is compiled to JavaScript before the compiler sees it, so those modules build correctly but are not memoized. Rename them to `.jsx` or `.tsx` to get memoization.
 

--- a/knip.ts
+++ b/knip.ts
@@ -43,6 +43,11 @@ export default {
         "tests/e2e/nextjs-worker/fixture/**/*.{js,ts,tsx}",
       ],
       project: ["tests/**/*.{js,ts}", "!tests/fixtures/**"],
+      ignoreDependencies: [
+        // Loaded dynamically by @vitejs/plugin-react when the React Compiler
+        // integration test enables `react: { compiler: true }`.
+        "oxc-transform-react",
+      ],
     },
     "packages/vinext": {
       entry: [

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "knip": "catalog:",
     "msw": "catalog:",
     "next": "catalog:",
+    "oxc-transform-react": "catalog:",
     "pathslash": "catalog:",
     "playwright": "catalog:",
     "react": "catalog:",

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1723,50 +1723,49 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           " @vitejs/plugin-react",
       );
     }
-    const reactImport = import(pathToFileURL(resolvedReactPath).href);
-    reactPluginPromise = reactImport
-      .then((mod) => {
-        const react = (mod as VitePluginReactModule).default;
-        const limitToCommand = (plugin: Plugin, command: "serve" | "build"): Plugin => {
-          const originalApply = plugin.apply;
-          return {
-            ...plugin,
-            apply(config, env) {
-              if (env.command !== command) return false;
-              if (!originalApply) return true;
-              if (typeof originalApply === "function") {
-                return originalApply(config, env);
-              }
-              return originalApply === env.command;
-            },
-          };
+    // Wrap only the dynamic import: errors raised while building the plugin
+    // list (such as the compiler version check below) carry actionable
+    // instructions of their own and must not be relabeled as an import failure.
+    const reactImport = import(pathToFileURL(resolvedReactPath).href).catch((cause) => {
+      throw new Error("vinext: Failed to load @vitejs/plugin-react.", { cause });
+    });
+    reactPluginPromise = reactImport.then((mod) => {
+      const react = (mod as VitePluginReactModule).default;
+      const limitToCommand = (plugin: Plugin, command: "serve" | "build"): Plugin => {
+        const originalApply = plugin.apply;
+        return {
+          ...plugin,
+          apply(config, env) {
+            if (env.command !== command) return false;
+            if (!originalApply) return true;
+            if (typeof originalApply === "function") {
+              return originalApply(config, env);
+            }
+            return originalApply === env.command;
+          },
         };
-        const resolvedBuildPlugins = react(reactOptions);
-        if (
-          isReactCompilerRequested(configuredReactOptions) &&
-          !hasReactCompilerPlugin(resolvedBuildPlugins)
-        ) {
-          throw new Error(reactCompilerUnsupportedMessage(detectPackageManager(process.cwd())));
-        }
-        const buildPlugins = resolvedBuildPlugins.map((plugin) =>
-          limitToCommand(plugin as Plugin, "build"),
-        );
-        const hasConfiguredReactInclude =
-          configuredReactOptions !== undefined &&
-          Object.prototype.hasOwnProperty.call(configuredReactOptions, "include");
-        const serveOptions = hasConfiguredReactInclude
-          ? reactOptions
-          : { ...reactOptions, include: /\.(?:[tj]sx?|mdx)$/i };
-        const servePlugins = react(serveOptions).map((plugin) =>
-          limitToCommand(plugin as Plugin, "serve"),
-        );
-        return [...buildPlugins, ...servePlugins];
-      })
-      .catch((cause) => {
-        throw new Error("vinext: Failed to load @vitejs/plugin-react.", {
-          cause,
-        });
-      });
+      };
+      const resolvedBuildPlugins = react(reactOptions);
+      if (
+        isReactCompilerRequested(configuredReactOptions) &&
+        !hasReactCompilerPlugin(resolvedBuildPlugins)
+      ) {
+        throw new Error(reactCompilerUnsupportedMessage(detectPackageManager(process.cwd())));
+      }
+      const buildPlugins = resolvedBuildPlugins.map((plugin) =>
+        limitToCommand(plugin as Plugin, "build"),
+      );
+      const hasConfiguredReactInclude =
+        configuredReactOptions !== undefined &&
+        Object.prototype.hasOwnProperty.call(configuredReactOptions, "include");
+      const serveOptions = hasConfiguredReactInclude
+        ? reactOptions
+        : { ...reactOptions, include: /\.(?:[tj]sx?|mdx)$/i };
+      const servePlugins = react(serveOptions).map((plugin) =>
+        limitToCommand(plugin as Plugin, "serve"),
+      );
+      return [...buildPlugins, ...servePlugins];
+    });
   }
 
   const imageImportDimCache = new Map<string, { width: number; height: number }>();

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -150,6 +150,7 @@ import {
 } from "./utils/project.js";
 import {
   hasReactCompilerPlugin,
+  isReactCompilerPlugin,
   isReactCompilerRequested,
   reactCompilerUnsupportedMessage,
 } from "./utils/react-compiler-support.js";
@@ -1714,6 +1715,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
   const reactOptions = configuredReactOptions;
 
   let reactPluginPromise: Promise<PluginOption[]> | null = null;
+  let reactCompilerPluginPromise: Promise<PluginOption[]> | null = null;
   if (options.react !== false) {
     if (!resolvedReactPath) {
       throw new Error(
@@ -1723,13 +1725,13 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           " @vitejs/plugin-react",
       );
     }
-    // Wrap only the dynamic import: errors raised while building the plugin
-    // list (such as the compiler version check below) carry actionable
-    // instructions of their own and must not be relabeled as an import failure.
+    // Wrap only the dynamic import: errors raised while assembling the plugin
+    // list (such as the compiler support check below) carry their own
+    // actionable instructions and must not be relabeled as an import failure.
     const reactImport = import(pathToFileURL(resolvedReactPath).href).catch((cause) => {
       throw new Error("vinext: Failed to load @vitejs/plugin-react.", { cause });
     });
-    reactPluginPromise = reactImport.then((mod) => {
+    const allReactPlugins = reactImport.then((mod) => {
       const react = (mod as VitePluginReactModule).default;
       const limitToCommand = (plugin: Plugin, command: "serve" | "build"): Plugin => {
         const originalApply = plugin.apply;
@@ -1766,6 +1768,15 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
       );
       return [...buildPlugins, ...servePlugins];
     });
+    // The React Compiler plugin is registered separately, after
+    // `vinext:jsx-in-js`. Every other plugin in the group keeps its original
+    // position so user-configured transforms still see the untouched source.
+    reactPluginPromise = allReactPlugins.then((plugins) =>
+      plugins.filter((plugin) => !isReactCompilerPlugin(plugin)),
+    );
+    reactCompilerPluginPromise = allReactPlugins.then((plugins) =>
+      plugins.filter(isReactCompilerPlugin),
+    );
   }
 
   const imageImportDimCache = new Map<string, { width: number; height: number }>();
@@ -1938,11 +1949,54 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
     // Compile MDX to JSX before @vitejs/plugin-react handles the generated
     // component and injects Fast Refresh registration in dev.
     mdxProxyPlugin,
-    // Registered before @vitejs/plugin-react. Both this plugin and
-    // `vite:react-compiler` (enabled by `react: { compiler: true }`) run at
-    // `enforce: "pre"`, so array order decides which one sees the module first.
-    // The compiler infers the language from the file extension, so a `.js` file
-    // holding JSX fails to parse unless this plugin compiles it first.
+    // React Fast Refresh + JSX transform for client components.
+    reactPluginPromise,
+    // Next.js ignores requests without any statically known path component
+    // during graph analysis and leaves a deterministic runtime failure.
+    createIgnoreDynamicRequestsPlugin(() => nextConfig?.turbopackTranspilePackages ?? []),
+    // Preserve the `require` package-export condition before the CommonJS
+    // transform below turns literal require() calls into static imports.
+    createRequireConditionResolutionPlugin(createIdResolver, commonjsTransformFilter),
+    // Transform CJS require()/module.exports to ESM before other plugins
+    // analyze imports (RSC directive scanning, shim resolution, etc.)
+    //
+    // Skip project-local `.cjs`/`.cts` files during builds. `vinext init` renames CJS config
+    // files to `.cjs` (e.g. `tailwind.config.js` → `tailwind.config.cjs`) when
+    // it adds `"type": "module"`, and app code imports them extensionlessly
+    // (`import cfg from "../tailwind.config"`). If `vite-plugin-commonjs`
+    // rewrites their `module.exports` to ESM `export {}`, rolldown still infers
+    // `moduleType: "cjs"` from the `.cjs`/`.cts` extension and re-parses the
+    // rewritten output as CommonJS, failing with "Cannot use export statement
+    // outside a module". Returning `false` during builds makes vite-plugin-commonjs
+    // skip these project-local files so Rolldown's own CJS interop bundles them
+    // instead. Dev has no later CJS lowering pass, so transform them here.
+    // Conditional `require` targets use a synthetic `.js` identity so their
+    // CJS source can be converted before plugin-rsc injects ESM proxy imports.
+    // For dependencies that Node identifies as CommonJS, return true so the
+    // files actually loaded through a bundled SSR graph are converted on
+    // demand instead of requiring Vite's environment-wide dependency crawl.
+    commonJsPlugin,
+    {
+      name: "vinext:global-not-found-css-isolation",
+      apply: "build",
+      enforce: "pre",
+      transform: {
+        filter: {
+          id: /(?:^|[/\\])global-not-found(?:\.[^./?\\]+)+(?:\?.*)?$/,
+          code: /\.(?:css|scss|sass)['"]/,
+        },
+        handler(code: string, id: string) {
+          const cleanId = toSlash(stripViteModuleQuery(id));
+          if (
+            !globalNotFoundCssIsolationPath ||
+            canonicalize(cleanId) !== canonicalize(globalNotFoundCssIsolationPath)
+          ) {
+            return null;
+          }
+          return isolateGlobalNotFoundStylesheetImports(code, cleanId);
+        },
+      },
+    },
     // Enable JSX in plain .js files. Next.js allows JSX in .js files
     // (Babel/SWC handle it transparently), but Vite 8's built-in `vite:oxc`
     // plugin excludes .js files by default (`exclude: /\.js$/`) AND infers
@@ -2015,54 +2069,10 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         },
       },
     } satisfies Plugin,
-    // React Fast Refresh + JSX transform for client components.
-    reactPluginPromise,
-    // Next.js ignores requests without any statically known path component
-    // during graph analysis and leaves a deterministic runtime failure.
-    createIgnoreDynamicRequestsPlugin(() => nextConfig?.turbopackTranspilePackages ?? []),
-    // Preserve the `require` package-export condition before the CommonJS
-    // transform below turns literal require() calls into static imports.
-    createRequireConditionResolutionPlugin(createIdResolver, commonjsTransformFilter),
-    // Transform CJS require()/module.exports to ESM before other plugins
-    // analyze imports (RSC directive scanning, shim resolution, etc.)
-    //
-    // Skip project-local `.cjs`/`.cts` files during builds. `vinext init` renames CJS config
-    // files to `.cjs` (e.g. `tailwind.config.js` → `tailwind.config.cjs`) when
-    // it adds `"type": "module"`, and app code imports them extensionlessly
-    // (`import cfg from "../tailwind.config"`). If `vite-plugin-commonjs`
-    // rewrites their `module.exports` to ESM `export {}`, rolldown still infers
-    // `moduleType: "cjs"` from the `.cjs`/`.cts` extension and re-parses the
-    // rewritten output as CommonJS, failing with "Cannot use export statement
-    // outside a module". Returning `false` during builds makes vite-plugin-commonjs
-    // skip these project-local files so Rolldown's own CJS interop bundles them
-    // instead. Dev has no later CJS lowering pass, so transform them here.
-    // Conditional `require` targets use a synthetic `.js` identity so their
-    // CJS source can be converted before plugin-rsc injects ESM proxy imports.
-    // For dependencies that Node identifies as CommonJS, return true so the
-    // files actually loaded through a bundled SSR graph are converted on
-    // demand instead of requiring Vite's environment-wide dependency crawl.
-    commonJsPlugin,
-    {
-      name: "vinext:global-not-found-css-isolation",
-      apply: "build",
-      enforce: "pre",
-      transform: {
-        filter: {
-          id: /(?:^|[/\\])global-not-found(?:\.[^./?\\]+)+(?:\?.*)?$/,
-          code: /\.(?:css|scss|sass)['"]/,
-        },
-        handler(code: string, id: string) {
-          const cleanId = toSlash(stripViteModuleQuery(id));
-          if (
-            !globalNotFoundCssIsolationPath ||
-            canonicalize(cleanId) !== canonicalize(globalNotFoundCssIsolationPath)
-          ) {
-            return null;
-          }
-          return isolateGlobalNotFoundStylesheetImports(code, cleanId);
-        },
-      },
-    },
+    // Runs after `vinext:jsx-in-js` so JSX in plain `.js` files has already
+    // been compiled: `vite:react-compiler` infers the source language from the
+    // file extension and cannot parse JSX inside a `.js` file.
+    reactCompilerPluginPromise,
     // Allow `import 'server-only'` from middleware (and any module reachable
     // from it) in non-RSC environments. Registered before `vinext:config` so
     // its `enforce: "pre"` resolveId runs ahead of @vitejs/plugin-rsc's

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -148,6 +148,11 @@ import {
   formatMissingCloudflarePluginError,
   hasWranglerConfig,
 } from "./utils/project.js";
+import {
+  hasReactCompilerPlugin,
+  isReactCompilerRequested,
+  reactCompilerUnsupportedMessage,
+} from "./utils/react-compiler-support.js";
 import { isUnknownRecord as isRecord } from "./utils/record.js";
 import { VIRTUAL_MODULE_ID_RE, VIRTUAL_PREFIX } from "./utils/virtual-module.js";
 import { ASSET_PREFIX_URL_DIR, resolveAssetsDir } from "./utils/asset-prefix.js";
@@ -1736,7 +1741,14 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             },
           };
         };
-        const buildPlugins = react(reactOptions).map((plugin) =>
+        const resolvedBuildPlugins = react(reactOptions);
+        if (
+          isReactCompilerRequested(configuredReactOptions) &&
+          !hasReactCompilerPlugin(resolvedBuildPlugins)
+        ) {
+          throw new Error(reactCompilerUnsupportedMessage(detectPackageManager(process.cwd())));
+        }
+        const buildPlugins = resolvedBuildPlugins.map((plugin) =>
           limitToCommand(plugin as Plugin, "build"),
         );
         const hasConfiguredReactInclude =

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1328,6 +1328,9 @@ export type VinextOptions = {
    * Enabled by default. Set to `false` to disable (e.g. if you configure
    * @vitejs/plugin-react manually in your vite.config.ts), or pass an options
    * object to customize the Babel transform.
+   *
+   * Pass `{ compiler: true }` to enable the React Compiler. That requires
+   * @vitejs/plugin-react 6.1+ and the optional `oxc-transform-react` package.
    * @default true
    */
   react?: VitePluginReactOptions | boolean;
@@ -1924,54 +1927,11 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
     // Compile MDX to JSX before @vitejs/plugin-react handles the generated
     // component and injects Fast Refresh registration in dev.
     mdxProxyPlugin,
-    // React Fast Refresh + JSX transform for client components.
-    reactPluginPromise,
-    // Next.js ignores requests without any statically known path component
-    // during graph analysis and leaves a deterministic runtime failure.
-    createIgnoreDynamicRequestsPlugin(() => nextConfig?.turbopackTranspilePackages ?? []),
-    // Preserve the `require` package-export condition before the CommonJS
-    // transform below turns literal require() calls into static imports.
-    createRequireConditionResolutionPlugin(createIdResolver, commonjsTransformFilter),
-    // Transform CJS require()/module.exports to ESM before other plugins
-    // analyze imports (RSC directive scanning, shim resolution, etc.)
-    //
-    // Skip project-local `.cjs`/`.cts` files during builds. `vinext init` renames CJS config
-    // files to `.cjs` (e.g. `tailwind.config.js` → `tailwind.config.cjs`) when
-    // it adds `"type": "module"`, and app code imports them extensionlessly
-    // (`import cfg from "../tailwind.config"`). If `vite-plugin-commonjs`
-    // rewrites their `module.exports` to ESM `export {}`, rolldown still infers
-    // `moduleType: "cjs"` from the `.cjs`/`.cts` extension and re-parses the
-    // rewritten output as CommonJS, failing with "Cannot use export statement
-    // outside a module". Returning `false` during builds makes vite-plugin-commonjs
-    // skip these project-local files so Rolldown's own CJS interop bundles them
-    // instead. Dev has no later CJS lowering pass, so transform them here.
-    // Conditional `require` targets use a synthetic `.js` identity so their
-    // CJS source can be converted before plugin-rsc injects ESM proxy imports.
-    // For dependencies that Node identifies as CommonJS, return true so the
-    // files actually loaded through a bundled SSR graph are converted on
-    // demand instead of requiring Vite's environment-wide dependency crawl.
-    commonJsPlugin,
-    {
-      name: "vinext:global-not-found-css-isolation",
-      apply: "build",
-      enforce: "pre",
-      transform: {
-        filter: {
-          id: /(?:^|[/\\])global-not-found(?:\.[^./?\\]+)+(?:\?.*)?$/,
-          code: /\.(?:css|scss|sass)['"]/,
-        },
-        handler(code: string, id: string) {
-          const cleanId = toSlash(stripViteModuleQuery(id));
-          if (
-            !globalNotFoundCssIsolationPath ||
-            canonicalize(cleanId) !== canonicalize(globalNotFoundCssIsolationPath)
-          ) {
-            return null;
-          }
-          return isolateGlobalNotFoundStylesheetImports(code, cleanId);
-        },
-      },
-    },
+    // Registered before @vitejs/plugin-react. Both this plugin and
+    // `vite:react-compiler` (enabled by `react: { compiler: true }`) run at
+    // `enforce: "pre"`, so array order decides which one sees the module first.
+    // The compiler infers the language from the file extension, so a `.js` file
+    // holding JSX fails to parse unless this plugin compiles it first.
     // Enable JSX in plain .js files. Next.js allows JSX in .js files
     // (Babel/SWC handle it transparently), but Vite 8's built-in `vite:oxc`
     // plugin excludes .js files by default (`exclude: /\.js$/`) AND infers
@@ -2044,6 +2004,54 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         },
       },
     } satisfies Plugin,
+    // React Fast Refresh + JSX transform for client components.
+    reactPluginPromise,
+    // Next.js ignores requests without any statically known path component
+    // during graph analysis and leaves a deterministic runtime failure.
+    createIgnoreDynamicRequestsPlugin(() => nextConfig?.turbopackTranspilePackages ?? []),
+    // Preserve the `require` package-export condition before the CommonJS
+    // transform below turns literal require() calls into static imports.
+    createRequireConditionResolutionPlugin(createIdResolver, commonjsTransformFilter),
+    // Transform CJS require()/module.exports to ESM before other plugins
+    // analyze imports (RSC directive scanning, shim resolution, etc.)
+    //
+    // Skip project-local `.cjs`/`.cts` files during builds. `vinext init` renames CJS config
+    // files to `.cjs` (e.g. `tailwind.config.js` → `tailwind.config.cjs`) when
+    // it adds `"type": "module"`, and app code imports them extensionlessly
+    // (`import cfg from "../tailwind.config"`). If `vite-plugin-commonjs`
+    // rewrites their `module.exports` to ESM `export {}`, rolldown still infers
+    // `moduleType: "cjs"` from the `.cjs`/`.cts` extension and re-parses the
+    // rewritten output as CommonJS, failing with "Cannot use export statement
+    // outside a module". Returning `false` during builds makes vite-plugin-commonjs
+    // skip these project-local files so Rolldown's own CJS interop bundles them
+    // instead. Dev has no later CJS lowering pass, so transform them here.
+    // Conditional `require` targets use a synthetic `.js` identity so their
+    // CJS source can be converted before plugin-rsc injects ESM proxy imports.
+    // For dependencies that Node identifies as CommonJS, return true so the
+    // files actually loaded through a bundled SSR graph are converted on
+    // demand instead of requiring Vite's environment-wide dependency crawl.
+    commonJsPlugin,
+    {
+      name: "vinext:global-not-found-css-isolation",
+      apply: "build",
+      enforce: "pre",
+      transform: {
+        filter: {
+          id: /(?:^|[/\\])global-not-found(?:\.[^./?\\]+)+(?:\?.*)?$/,
+          code: /\.(?:css|scss|sass)['"]/,
+        },
+        handler(code: string, id: string) {
+          const cleanId = toSlash(stripViteModuleQuery(id));
+          if (
+            !globalNotFoundCssIsolationPath ||
+            canonicalize(cleanId) !== canonicalize(globalNotFoundCssIsolationPath)
+          ) {
+            return null;
+          }
+          return isolateGlobalNotFoundStylesheetImports(code, cleanId);
+        },
+      },
+    },
     // Allow `import 'server-only'` from middleware (and any module reachable
     // from it) in non-RSC environments. Registered before `vinext:config` so
     // its `enforce: "pre"` resolveId runs ahead of @vitejs/plugin-rsc's

--- a/packages/vinext/src/utils/react-compiler-support.ts
+++ b/packages/vinext/src/utils/react-compiler-support.ts
@@ -14,17 +14,21 @@ export function isReactCompilerRequested(reactOptions: unknown): boolean {
   return Boolean((reactOptions as { compiler?: unknown }).compiler);
 }
 
-/** Whether the resolved @vitejs/plugin-react actually registered the compiler. */
-export function hasReactCompilerPlugin(plugins: readonly unknown[]): boolean {
-  return plugins.some(
-    (plugin) =>
-      typeof plugin === "object" &&
-      plugin !== null &&
-      (plugin as { name?: unknown }).name === REACT_COMPILER_PLUGIN_NAME,
+/** Whether a plugin entry is the React Compiler plugin. */
+export function isReactCompilerPlugin(plugin: unknown): boolean {
+  return (
+    typeof plugin === "object" &&
+    plugin !== null &&
+    (plugin as { name?: unknown }).name === REACT_COMPILER_PLUGIN_NAME
   );
 }
 
-/** Error thrown when `react: { compiler: true }` cannot be honored. */
+/** Whether the resolved @vitejs/plugin-react actually registered the compiler. */
+export function hasReactCompilerPlugin(plugins: readonly unknown[]): boolean {
+  return plugins.some(isReactCompilerPlugin);
+}
+
+/** Message for when `react: { compiler: true }` cannot be honored. */
 export function reactCompilerUnsupportedMessage(installCommand: string): string {
   return (
     "vinext: `react: { compiler: true }` requires @vitejs/plugin-react 6.1 or newer.\n" +

--- a/packages/vinext/src/utils/react-compiler-support.ts
+++ b/packages/vinext/src/utils/react-compiler-support.ts
@@ -1,0 +1,36 @@
+/**
+ * The React Compiler option landed in @vitejs/plugin-react 6.1. Older versions
+ * accept an unknown `compiler` key in their options object and silently drop
+ * it, which would leave the compiler disabled while the config says otherwise.
+ *
+ * The plugin factory only returns `vite:react-compiler` when the installed
+ * version understands the option, so its presence is what we probe for.
+ */
+export const REACT_COMPILER_PLUGIN_NAME = "vite:react-compiler";
+
+/** Whether the user asked for the React Compiler through vinext's `react` option. */
+export function isReactCompilerRequested(reactOptions: unknown): boolean {
+  if (!reactOptions || typeof reactOptions !== "object") return false;
+  return Boolean((reactOptions as { compiler?: unknown }).compiler);
+}
+
+/** Whether the resolved @vitejs/plugin-react actually registered the compiler. */
+export function hasReactCompilerPlugin(plugins: readonly unknown[]): boolean {
+  return plugins.some(
+    (plugin) =>
+      typeof plugin === "object" &&
+      plugin !== null &&
+      (plugin as { name?: unknown }).name === REACT_COMPILER_PLUGIN_NAME,
+  );
+}
+
+/** Error thrown when `react: { compiler: true }` cannot be honored. */
+export function reactCompilerUnsupportedMessage(installCommand: string): string {
+  return (
+    "vinext: `react: { compiler: true }` requires @vitejs/plugin-react 6.1 or newer.\n" +
+    "The installed version ignores the option, which would leave the React Compiler disabled.\n" +
+    "Run: " +
+    installCommand +
+    " @vitejs/plugin-react@latest"
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,8 +88,8 @@ catalogs:
       specifier: ^0.8.6
       version: 0.8.6
     '@vitejs/plugin-react':
-      specifier: ^6.0.1
-      version: 6.0.1
+      specifier: ^6.1.0
+      version: 6.1.0
     '@vitejs/plugin-rsc':
       specifier: ^0.5.34
       version: 0.5.34
@@ -171,6 +171,9 @@ catalogs:
     nuqs:
       specifier: ^2.8.8
       version: 2.8.8
+    oxc-transform-react:
+      specifier: ^0.145.0
+      version: 0.145.0
     pathslash:
       specifier: ^0.1.0
       version: 0.1.0
@@ -296,6 +299,9 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0)
+      oxc-transform-react:
+        specifier: 'catalog:'
+        version: 0.145.0
       pathslash:
         specifier: 'catalog:'
         version: 0.1.0
@@ -374,7 +380,7 @@ importers:
         version: 19.2.3(@types/react@19.2.16)
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 6.0.1(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))
+        version: 6.1.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(oxc-transform-react@0.145.0)
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
         version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
@@ -404,7 +410,7 @@ importers:
     dependencies:
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 6.0.1(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))
+        version: 6.1.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(oxc-transform-react@0.145.0)
       react:
         specifier: 'catalog:'
         version: 19.2.7
@@ -438,7 +444,7 @@ importers:
         version: link:../../packages/cloudflare
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 6.0.1(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))
+        version: 6.1.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(oxc-transform-react@0.145.0)
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
         version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
@@ -472,7 +478,7 @@ importers:
     dependencies:
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 6.0.1(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))
+        version: 6.1.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(oxc-transform-react@0.145.0)
       nitro:
         specifier: 'catalog:'
         version: nitro-nightly@3.0.1-20260512-093145-0498ce70(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(better-sqlite3@12.6.2)(chokidar@5.0.0)(dotenv@16.6.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.1)(better-sqlite3@12.6.2)(kysely@0.28.15))(jiti@2.7.0)(lru-cache@11.5.1)(miniflare@4.20260401.0)(rollup@4.62.2)
@@ -512,7 +518,7 @@ importers:
         version: link:../../packages/cloudflare
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 6.0.1(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))
+        version: 6.1.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(oxc-transform-react@0.145.0)
       clsx:
         specifier: 'catalog:'
         version: 2.1.1
@@ -612,7 +618,7 @@ importers:
         version: 4.2.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 6.0.1(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))
+        version: 6.1.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(oxc-transform-react@0.145.0)
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
         version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
@@ -695,7 +701,7 @@ importers:
         version: 19.2.3(@types/react@19.2.16)
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 6.0.1(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))
+        version: 6.1.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(oxc-transform-react@0.145.0)
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
         version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
@@ -728,7 +734,7 @@ importers:
         version: 1.31.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(workerd@1.20260401.1)(wrangler@4.80.0)
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 6.0.1(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))
+        version: 6.1.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(oxc-transform-react@0.145.0)
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
         version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
@@ -771,7 +777,7 @@ importers:
     dependencies:
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 6.0.1(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))
+        version: 6.1.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(oxc-transform-react@0.145.0)
       react:
         specifier: 'catalog:'
         version: 19.2.7
@@ -823,7 +829,7 @@ importers:
         version: 1.31.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(workerd@1.20260401.1)(wrangler@4.80.0)
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 6.0.1(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))
+        version: 6.1.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(oxc-transform-react@0.145.0)
       react:
         specifier: 'catalog:'
         version: 19.2.7
@@ -894,7 +900,7 @@ importers:
     dependencies:
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 6.0.1(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))
+        version: 6.1.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(oxc-transform-react@0.145.0)
       react:
         specifier: 'catalog:'
         version: 19.2.7
@@ -940,7 +946,7 @@ importers:
         version: link:../../packages/cloudflare
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 6.0.1(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))
+        version: 6.1.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(oxc-transform-react@0.145.0)
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
         version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
@@ -986,7 +992,7 @@ importers:
         version: link:../../packages/cloudflare
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 6.0.1(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))
+        version: 6.1.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(oxc-transform-react@0.145.0)
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
         version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
@@ -1089,7 +1095,7 @@ importers:
         version: 19.2.3(@types/react@19.2.16)
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 6.0.1(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))
+        version: 6.1.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(oxc-transform-react@0.145.0)
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
         version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
@@ -1238,7 +1244,7 @@ importers:
         version: link:../../../packages/cloudflare
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 6.0.1(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))
+        version: 6.1.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(oxc-transform-react@0.145.0)
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
         version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
@@ -1275,7 +1281,7 @@ importers:
         version: 10.62.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0))(react@19.2.7)
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 6.0.1(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))
+        version: 6.1.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(oxc-transform-react@0.145.0)
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
         version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
@@ -1312,7 +1318,7 @@ importers:
         version: 10.62.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0))(react@19.2.7)
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 6.0.1(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))
+        version: 6.1.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(oxc-transform-react@0.145.0)
       react:
         specifier: 'catalog:'
         version: 19.2.7
@@ -1558,19 +1564,19 @@ importers:
         version: file:tests/fixtures/esm-externals/__test_packages__/app-cjs-esm-package
       app-esm-package1:
         specifier: file:./__test_packages__/app-esm-package1
-        version: file:tests/fixtures/esm-externals/__test_packages__/app-esm-package1
+        version: app-esm-package@file:tests/fixtures/esm-externals/__test_packages__/app-esm-package1
       app-esm-package2:
         specifier: file:./__test_packages__/app-esm-package2
-        version: file:tests/fixtures/esm-externals/__test_packages__/app-esm-package2
+        version: app-esm-package@file:tests/fixtures/esm-externals/__test_packages__/app-esm-package2
       dynamic-esm-package:
         specifier: file:./__test_packages__/dynamic-esm-package
         version: file:tests/fixtures/esm-externals/__test_packages__/dynamic-esm-package
       esm-package1:
         specifier: file:./__test_packages__/esm-package1
-        version: file:tests/fixtures/esm-externals/__test_packages__/esm-package1
+        version: esm-package@file:tests/fixtures/esm-externals/__test_packages__/esm-package1
       esm-package2:
         specifier: file:./__test_packages__/esm-package2
-        version: file:tests/fixtures/esm-externals/__test_packages__/esm-package2
+        version: esm-package@file:tests/fixtures/esm-externals/__test_packages__/esm-package2
       explicit-esm-package:
         specifier: file:./__test_packages__/explicit-esm-package
         version: file:tests/fixtures/esm-externals/__test_packages__/explicit-esm-package
@@ -3358,6 +3364,128 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@oxc-transform-react/binding-android-arm-eabi@0.145.0':
+    resolution: {integrity: sha512-KuK3zAp10yFyeAxIXlZn2ycsFpaKLxUmj5BVRS1io4XfwnKTozb/goZakgKD5JEiHOVOtEKt1r7pTrmW/pFxxA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-transform-react/binding-android-arm64@0.145.0':
+    resolution: {integrity: sha512-eDUKx6MAgRAF67JPScjLF6h8lL2qmlvFrXGSG8mYFIVJb++NMyDygiIo8TAKdWQNguoBElUZw/SK2EPRaKsryQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-transform-react/binding-darwin-arm64@0.145.0':
+    resolution: {integrity: sha512-msCgwbVLswJ08JaUOjfPddieVJwE4IT1Y23A1DDyKVyzZp2ormo9a4ffDEu9nmmovdEj8VqAyFgggsgzIkBVrA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-transform-react/binding-darwin-x64@0.145.0':
+    resolution: {integrity: sha512-R0PtsoOCsARulmWhLG1fFInT+98TRl/H6w6ifi8XOLvpdsksD1rxsw4Ol84lHbdHCcMNjfJTckZzQIZBMiXkLg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-transform-react/binding-freebsd-x64@0.145.0':
+    resolution: {integrity: sha512-/MJ7+IvxfutSGqn6hIXU92wGNk5FlkqbTHM+kEl7ytLLOSAyivYhF2gxdYMmXTwOG56k2XviMcE0D/TBjdyoRA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-transform-react/binding-linux-arm-gnueabihf@0.145.0':
+    resolution: {integrity: sha512-ssHZ0W2wSjQwaBQdkg8u+A7dTdw2vkGSK0hRfCoDCkRkETu+19Q8Tae7NNxlYHcP1iUQYhEj8Qfgpq+S/MdrYA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-transform-react/binding-linux-arm-musleabihf@0.145.0':
+    resolution: {integrity: sha512-adJy4lQVcoIW6CUzQYbDgbHZMDSLoizwCinG2Dex29jdACKwIgXQQrIAHAgfveaZleKIB/rf3usGoRcOGyfz7Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-transform-react/binding-linux-arm64-gnu@0.145.0':
+    resolution: {integrity: sha512-7KRa0CC1FaSKx5sy+bDtqGvXF+RiVoMmSe8OmTKm9kRZkNVdmsmpnsQhgravehTohlWDveo5aoGMwcFtffGDmw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform-react/binding-linux-arm64-musl@0.145.0':
+    resolution: {integrity: sha512-fGhZkDnk2RoMp6THas9HFGorF0A1wwPPA/2Lu9IUO1ip5MJqS/JG7/conmiz0DBG0PWBtnKl2Y8sA/VBiD/oQw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-transform-react/binding-linux-ppc64-gnu@0.145.0':
+    resolution: {integrity: sha512-VBaUTjRZYRypD2tL7cmbM2Fn6fvTnacLQ1GdsU1Y6A3fkqA/z+wc5Vy1QnnuFe9sIwb9xCvSS2tJVlucR39FYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform-react/binding-linux-riscv64-gnu@0.145.0':
+    resolution: {integrity: sha512-s2cimMVAmWe9dtjyWdGsYtevi9C7gJoOXwrCZD0BX7hgyGmuBO3iWQjx4W48hdXlWS176NoxuFIHAN72N86upA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform-react/binding-linux-riscv64-musl@0.145.0':
+    resolution: {integrity: sha512-hFPrsL2nKL4aa8vFmheR53PcrxQgym8bnaSD1pMX9IoyQq+/ksAuw1CDJSV9c5xhxxZdw/KTPVer7M/6OQvfoA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-transform-react/binding-linux-s390x-gnu@0.145.0':
+    resolution: {integrity: sha512-YLKhySqqu0JAtT0z8GuaFF7Hht3IvQLZShTH0DxeV28NwSthva+qJ7GN09ALT1bqRVvMjNGycgPHaGSWBUIt7A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform-react/binding-linux-x64-gnu@0.145.0':
+    resolution: {integrity: sha512-WqgJ+0M9mwQ1cRfSgk4vzYudD2imLSBhUZ2QFes06vUjigts5Dw4NajWKc2JibPHYsoiUA9Zj39zWwC5AxXEGQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform-react/binding-linux-x64-musl@0.145.0':
+    resolution: {integrity: sha512-eIre/TjGt07IVKoWUrUOkPxN7UKeWxbiGvCywoGLDRe1/2K50MrA2vQahZ8AlW5CLmajOr9ePKrkRzLg1fa0cQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-transform-react/binding-openharmony-arm64@0.145.0':
+    resolution: {integrity: sha512-zhWiyJ+9XD4cuhSZIT6aozuXDHcZHNdoVe88xVmx2XN00anjZ6VAGj31rhD8ndha/F8NllcQEr8Q61Dr2MHv5Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-transform-react/binding-win32-arm64-msvc@0.145.0':
+    resolution: {integrity: sha512-Q0oiZfrfYyhmpqH2K0dylDTooIadecGsoiQks7G0AbuszCu2I7zYyJo4ArFc3d5Hj49Jjc5dDAE5WP/Sg2p8hw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-transform-react/binding-win32-ia32-msvc@0.145.0':
+    resolution: {integrity: sha512-ERpriVJY5S8hXd3BJi4UtzsIVsEQnntmpqTgRqh0XCaflLRLTQnPWpkO8rgtI7xye5MRhfhA+qsxKg2olJs4qA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-transform-react/binding-win32-x64-msvc@0.145.0':
+    resolution: {integrity: sha512-sa781BGPLDw8+7ATrgUpLr0f4t0Q14O+zk3fOuQbUpjW5jERc9a3k1xIYKX1JkTG/sszoFhi8LzyCoMC49tkWA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
   '@oxfmt/binding-android-arm-eabi@0.60.0':
     resolution: {integrity: sha512-1q4q4Jc8FlOMVojEisyFAVyl8h1yawNv6phjgmhGVEDeyeOdsSnSr9x0+D4mOnEKvpO5L4mxKZ/DP9X6U3A/Mw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -4240,9 +4368,6 @@ packages:
 
   '@rolldown/pluginutils@1.0.0':
     resolution: {integrity: sha512-aKs/3GSWyV0mrhNmt/96/Z3yczC3yvrzYATCiCXQebBsGyYzjNdUphRVLeJQ67ySKVXRfMxt2lm12pmXvbPFQQ==}
-
-  '@rolldown/pluginutils@1.0.0-rc.7':
-    resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
 
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
@@ -5166,17 +5291,20 @@ packages:
     resolution: {integrity: sha512-hBcWIOppZV14bi+eAmCZj8Elj8hVSUZJTpf1lgGBhVD85pervzQ1poM/qYfFUlPraYSZYP+ASg6To5BwYmUSGQ==}
     engines: {node: '>=16'}
 
-  '@vitejs/plugin-react@6.0.1':
-    resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
+  '@vitejs/plugin-react@6.1.0':
+    resolution: {integrity: sha512-qd2BzUBehkov86WFhg0JkEFEYyCLG9uPCe6qWTY/kRlss9OvJrOF2UbIWT7p+8IzZHkEu0DNGHc4HSv+JdDLsw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
       babel-plugin-react-compiler: ^1.0.0
+      oxc-transform-react: ^0.145.0
       vite: ^8.0.0
     peerDependenciesMeta:
       '@rolldown/plugin-babel':
         optional: true
       babel-plugin-react-compiler:
+        optional: true
+      oxc-transform-react:
         optional: true
 
   '@vitejs/plugin-rsc@0.5.34':
@@ -5513,6 +5641,15 @@ packages:
   ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
+
+  app-cjs-esm-package@file:tests/fixtures/esm-externals/__test_packages__/app-cjs-esm-package:
+    resolution: {directory: tests/fixtures/esm-externals/__test_packages__/app-cjs-esm-package, type: directory}
+
+  app-esm-package@file:tests/fixtures/esm-externals/__test_packages__/app-esm-package1:
+    resolution: {directory: tests/fixtures/esm-externals/__test_packages__/app-esm-package1, type: directory}
+
+  app-esm-package@file:tests/fixtures/esm-externals/__test_packages__/app-esm-package2:
+    resolution: {directory: tests/fixtures/esm-externals/__test_packages__/app-esm-package2, type: directory}
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -5993,6 +6130,9 @@ packages:
       sqlite3:
         optional: true
 
+  dynamic-esm-package@file:tests/fixtures/esm-externals/__test_packages__/dynamic-esm-package:
+    resolution: {directory: tests/fixtures/esm-externals/__test_packages__/dynamic-esm-package, type: directory}
+
   electron-to-chromium@1.5.348:
     resolution: {integrity: sha512-QC2X59nRlycQQMc4ZXjSVBX+tSgJfgRtcrYHbIZLgOV2dCvefoQGegLR7lLXKgpPpSuVmJU19LMzGrSa2C7k3Q==}
 
@@ -6086,6 +6226,12 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
+  esm-package@file:tests/fixtures/esm-externals/__test_packages__/esm-package1:
+    resolution: {directory: tests/fixtures/esm-externals/__test_packages__/esm-package1, type: directory}
+
+  esm-package@file:tests/fixtures/esm-externals/__test_packages__/esm-package2:
+    resolution: {directory: tests/fixtures/esm-externals/__test_packages__/esm-package2, type: directory}
+
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
@@ -6134,6 +6280,9 @@ packages:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
 
+  explicit-esm-package@file:tests/fixtures/esm-externals/__test_packages__/explicit-esm-package:
+    resolution: {directory: tests/fixtures/esm-externals/__test_packages__/explicit-esm-package, type: directory}
+
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
 
@@ -6142,45 +6291,6 @@ packages:
 
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
-
-  app-cjs-esm-package@file:tests/fixtures/esm-externals/__test_packages__/app-cjs-esm-package:
-    resolution: {directory: tests/fixtures/esm-externals/__test_packages__/app-cjs-esm-package, type: directory}
-
-  app-esm-package1@file:tests/fixtures/esm-externals/__test_packages__/app-esm-package1:
-    resolution: {directory: tests/fixtures/esm-externals/__test_packages__/app-esm-package1, type: directory}
-
-  app-esm-package2@file:tests/fixtures/esm-externals/__test_packages__/app-esm-package2:
-    resolution: {directory: tests/fixtures/esm-externals/__test_packages__/app-esm-package2, type: directory}
-
-  dynamic-esm-package@file:tests/fixtures/esm-externals/__test_packages__/dynamic-esm-package:
-    resolution: {directory: tests/fixtures/esm-externals/__test_packages__/dynamic-esm-package, type: directory}
-
-  esm-package1@file:tests/fixtures/esm-externals/__test_packages__/esm-package1:
-    resolution: {directory: tests/fixtures/esm-externals/__test_packages__/esm-package1, type: directory}
-
-  esm-package2@file:tests/fixtures/esm-externals/__test_packages__/esm-package2:
-    resolution: {directory: tests/fixtures/esm-externals/__test_packages__/esm-package2, type: directory}
-
-  explicit-esm-package@file:tests/fixtures/esm-externals/__test_packages__/explicit-esm-package:
-    resolution: {directory: tests/fixtures/esm-externals/__test_packages__/explicit-esm-package, type: directory}
-
-  geist@file:tests/fixtures/esm-externals/__test_packages__/geist:
-    resolution: {directory: tests/fixtures/esm-externals/__test_packages__/geist, type: directory}
-
-  invalid-esm-package@file:tests/fixtures/esm-externals/__test_packages__/invalid-esm-package:
-    resolution: {directory: tests/fixtures/esm-externals/__test_packages__/invalid-esm-package, type: directory}
-
-  literal-dynamic-esm-package@file:tests/fixtures/esm-externals/__test_packages__/literal-dynamic-esm-package:
-    resolution: {directory: tests/fixtures/esm-externals/__test_packages__/literal-dynamic-esm-package, type: directory}
-
-  mdx-esm-package@file:tests/fixtures/esm-externals/__test_packages__/mdx-esm-package:
-    resolution: {directory: tests/fixtures/esm-externals/__test_packages__/mdx-esm-package, type: directory}
-
-  optimized-esm-package@file:tests/fixtures/esm-externals/__test_packages__/optimized-esm-package:
-    resolution: {directory: tests/fixtures/esm-externals/__test_packages__/optimized-esm-package, type: directory}
-
-  shared-condition-package@file:tests/fixtures/esm-externals/__test_packages__/shared-condition-package:
-    resolution: {directory: tests/fixtures/esm-externals/__test_packages__/shared-condition-package, type: directory}
 
   fake-context-lib@file:tests/fixtures/app-basic/__test_packages__/fake-context-lib:
     resolution: {directory: tests/fixtures/app-basic/__test_packages__/fake-context-lib, type: directory}
@@ -6390,6 +6500,9 @@ packages:
       shiki:
         optional: true
 
+  geist@file:tests/fixtures/esm-externals/__test_packages__/geist:
+    resolution: {directory: tests/fixtures/esm-externals/__test_packages__/geist, type: directory}
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -6552,6 +6665,9 @@ packages:
 
   intl-messageformat@11.1.2:
     resolution: {integrity: sha512-ucSrQmZGAxfiBHfBRXW/k7UC8MaGFlEj4Ry1tKiDcmgwQm1y3EDl40u+4VNHYomxJQMJi9NEI3riDRlth96jKg==}
+
+  invalid-esm-package@file:tests/fixtures/esm-externals/__test_packages__/invalid-esm-package:
+    resolution: {directory: tests/fixtures/esm-externals/__test_packages__/invalid-esm-package, type: directory}
 
   ipaddr.js@2.4.0:
     resolution: {integrity: sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==}
@@ -6892,6 +7008,9 @@ packages:
   linebreak@1.1.0:
     resolution: {integrity: sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==}
 
+  literal-dynamic-esm-package@file:tests/fixtures/esm-externals/__test_packages__/literal-dynamic-esm-package:
+    resolution: {directory: tests/fixtures/esm-externals/__test_packages__/literal-dynamic-esm-package, type: directory}
+
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -7000,6 +7119,9 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  mdx-esm-package@file:tests/fixtures/esm-externals/__test_packages__/mdx-esm-package:
+    resolution: {directory: tests/fixtures/esm-externals/__test_packages__/mdx-esm-package, type: directory}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -7366,6 +7488,9 @@ packages:
   oniguruma-to-es@4.3.5:
     resolution: {integrity: sha512-Zjygswjpsewa0NLTsiizVuMQZbp0MDyM6lIt66OxsF21npUDlzpHi1Mgb/qhQdkb+dWFTzJmFbEWdvZgRho8eQ==}
 
+  optimized-esm-package@file:tests/fixtures/esm-externals/__test_packages__/optimized-esm-package:
+    resolution: {directory: tests/fixtures/esm-externals/__test_packages__/optimized-esm-package, type: directory}
+
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
 
@@ -7378,6 +7503,10 @@ packages:
 
   oxc-resolver@11.20.0:
     resolution: {integrity: sha512-CblytBiV/a/ZXY34dsVU2NxhIOxMXst8CvDCtyBelVITgd7PLrKzbEbA6oKLdPjvDKDzCiW48qzmzZ+mYaqn+g==}
+
+  oxc-transform-react@0.145.0:
+    resolution: {integrity: sha512-y8cfjow11WKvDekonySPVvRUvNuIvqNT0LZ0Aey6j5dsNUD6k4hy6Mae/SLmng5egmb1GdJS11GduJ+IoEAXEw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
 
   oxfmt@0.60.0:
     resolution: {integrity: sha512-fViX6i+gJuZWY+jI/fnR6WRbRj70GZ9RlCd30MygJrHTUNc4DxvKHWw8vBjMjffv3PgU5qWDR0AzmojQByqaZA==}
@@ -7805,6 +7934,9 @@ packages:
 
   set-cookie-parser@3.1.0:
     resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
+
+  shared-condition-package@file:tests/fixtures/esm-externals/__test_packages__/shared-condition-package:
+    resolution: {directory: tests/fixtures/esm-externals/__test_packages__/shared-condition-package, type: directory}
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
@@ -9666,6 +9798,63 @@ snapshots:
   '@oxc-resolver/binding-win32-x64-msvc@11.20.0':
     optional: true
 
+  '@oxc-transform-react/binding-android-arm-eabi@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-android-arm64@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-darwin-arm64@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-darwin-x64@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-freebsd-x64@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-arm-gnueabihf@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-arm-musleabihf@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-arm64-gnu@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-arm64-musl@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-ppc64-gnu@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-riscv64-gnu@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-riscv64-musl@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-s390x-gnu@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-x64-gnu@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-x64-musl@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-openharmony-arm64@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-win32-arm64-msvc@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-win32-ia32-msvc@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-win32-x64-msvc@0.145.0':
+    optional: true
+
   '@oxfmt/binding-android-arm-eabi@0.60.0':
     optional: true
 
@@ -10332,8 +10521,6 @@ snapshots:
     optional: true
 
   '@rolldown/pluginutils@1.0.0': {}
-
-  '@rolldown/pluginutils@1.0.0-rc.7': {}
 
   '@rolldown/pluginutils@1.0.1': {}
 
@@ -11084,10 +11271,12 @@ snapshots:
       '@resvg/resvg-wasm': 2.4.0
       satori: 0.16.0
 
-  '@vitejs/plugin-react@6.0.1(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))':
+  '@vitejs/plugin-react@6.1.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(oxc-transform-react@0.145.0)':
     dependencies:
-      '@rolldown/pluginutils': 1.0.0-rc.7
+      '@rolldown/pluginutils': 1.0.1
       vite: '@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0)'
+    optionalDependencies:
+      oxc-transform-react: 0.145.0
 
   '@vitejs/plugin-rsc@0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
     dependencies:
@@ -11337,6 +11526,12 @@ snapshots:
       color-convert: 2.0.1
 
   ansi-styles@5.2.0: {}
+
+  app-cjs-esm-package@file:tests/fixtures/esm-externals/__test_packages__/app-cjs-esm-package: {}
+
+  app-esm-package@file:tests/fixtures/esm-externals/__test_packages__/app-esm-package1: {}
+
+  app-esm-package@file:tests/fixtures/esm-externals/__test_packages__/app-esm-package2: {}
 
   argparse@1.0.10:
     dependencies:
@@ -11636,6 +11831,8 @@ snapshots:
       better-sqlite3: 12.6.2
       kysely: 0.28.15
 
+  dynamic-esm-package@file:tests/fixtures/esm-externals/__test_packages__/dynamic-esm-package: {}
+
   electron-to-chromium@1.5.348: {}
 
   emoji-regex-xs@2.0.1: {}
@@ -11784,6 +11981,10 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
+  esm-package@file:tests/fixtures/esm-externals/__test_packages__/esm-package1: {}
+
+  esm-package@file:tests/fixtures/esm-externals/__test_packages__/esm-package2: {}
+
   esprima@4.0.1: {}
 
   esquery@1.7.0:
@@ -11835,37 +12036,13 @@ snapshots:
 
   expect-type@1.4.0: {}
 
+  explicit-esm-package@file:tests/fixtures/esm-externals/__test_packages__/explicit-esm-package: {}
+
   exsolve@1.0.8: {}
 
   extend@3.0.2: {}
 
   extendable-error@0.1.7: {}
-
-  app-cjs-esm-package@file:tests/fixtures/esm-externals/__test_packages__/app-cjs-esm-package: {}
-
-  app-esm-package1@file:tests/fixtures/esm-externals/__test_packages__/app-esm-package1: {}
-
-  app-esm-package2@file:tests/fixtures/esm-externals/__test_packages__/app-esm-package2: {}
-
-  dynamic-esm-package@file:tests/fixtures/esm-externals/__test_packages__/dynamic-esm-package: {}
-
-  esm-package1@file:tests/fixtures/esm-externals/__test_packages__/esm-package1: {}
-
-  esm-package2@file:tests/fixtures/esm-externals/__test_packages__/esm-package2: {}
-
-  explicit-esm-package@file:tests/fixtures/esm-externals/__test_packages__/explicit-esm-package: {}
-
-  geist@file:tests/fixtures/esm-externals/__test_packages__/geist: {}
-
-  invalid-esm-package@file:tests/fixtures/esm-externals/__test_packages__/invalid-esm-package: {}
-
-  literal-dynamic-esm-package@file:tests/fixtures/esm-externals/__test_packages__/literal-dynamic-esm-package: {}
-
-  mdx-esm-package@file:tests/fixtures/esm-externals/__test_packages__/mdx-esm-package: {}
-
-  optimized-esm-package@file:tests/fixtures/esm-externals/__test_packages__/optimized-esm-package: {}
-
-  shared-condition-package@file:tests/fixtures/esm-externals/__test_packages__/shared-condition-package: {}
 
   fake-context-lib@file:tests/fixtures/app-basic/__test_packages__/fake-context-lib: {}
 
@@ -12063,6 +12240,8 @@ snapshots:
       - '@emotion/is-prop-valid'
       - '@types/react-dom'
       - tailwindcss
+
+  geist@file:tests/fixtures/esm-externals/__test_packages__/geist: {}
 
   gensync@1.0.0-beta.2: {}
 
@@ -12298,6 +12477,8 @@ snapshots:
       '@formatjs/fast-memoize': 3.1.0
       '@formatjs/icu-messageformat-parser': 3.5.1
       tslib: 2.8.1
+
+  invalid-esm-package@file:tests/fixtures/esm-externals/__test_packages__/invalid-esm-package: {}
 
   ipaddr.js@2.4.0: {}
 
@@ -12548,6 +12729,8 @@ snapshots:
       base64-js: 0.0.8
       unicode-trie: 2.0.0
 
+  literal-dynamic-esm-package@file:tests/fixtures/esm-externals/__test_packages__/literal-dynamic-esm-package: {}
+
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
@@ -12762,6 +12945,8 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
+
+  mdx-esm-package@file:tests/fixtures/esm-externals/__test_packages__/mdx-esm-package: {}
 
   merge2@1.4.1: {}
 
@@ -13279,6 +13464,8 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
+  optimized-esm-package@file:tests/fixtures/esm-externals/__test_packages__/optimized-esm-package: {}
+
   outdent@0.5.0: {}
 
   outvariant@1.4.3: {}
@@ -13329,6 +13516,28 @@ snapshots:
       '@oxc-resolver/binding-wasm32-wasi': 11.20.0
       '@oxc-resolver/binding-win32-arm64-msvc': 11.20.0
       '@oxc-resolver/binding-win32-x64-msvc': 11.20.0
+
+  oxc-transform-react@0.145.0:
+    optionalDependencies:
+      '@oxc-transform-react/binding-android-arm-eabi': 0.145.0
+      '@oxc-transform-react/binding-android-arm64': 0.145.0
+      '@oxc-transform-react/binding-darwin-arm64': 0.145.0
+      '@oxc-transform-react/binding-darwin-x64': 0.145.0
+      '@oxc-transform-react/binding-freebsd-x64': 0.145.0
+      '@oxc-transform-react/binding-linux-arm-gnueabihf': 0.145.0
+      '@oxc-transform-react/binding-linux-arm-musleabihf': 0.145.0
+      '@oxc-transform-react/binding-linux-arm64-gnu': 0.145.0
+      '@oxc-transform-react/binding-linux-arm64-musl': 0.145.0
+      '@oxc-transform-react/binding-linux-ppc64-gnu': 0.145.0
+      '@oxc-transform-react/binding-linux-riscv64-gnu': 0.145.0
+      '@oxc-transform-react/binding-linux-riscv64-musl': 0.145.0
+      '@oxc-transform-react/binding-linux-s390x-gnu': 0.145.0
+      '@oxc-transform-react/binding-linux-x64-gnu': 0.145.0
+      '@oxc-transform-react/binding-linux-x64-musl': 0.145.0
+      '@oxc-transform-react/binding-openharmony-arm64': 0.145.0
+      '@oxc-transform-react/binding-win32-arm64-msvc': 0.145.0
+      '@oxc-transform-react/binding-win32-ia32-msvc': 0.145.0
+      '@oxc-transform-react/binding-win32-x64-msvc': 0.145.0
 
   oxfmt@0.60.0(vite-plus@0.2.6(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-istanbul@4.1.10(vitest@4.1.10))(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(esbuild@0.27.3)(jiti@2.7.0)(msw@2.14.6(@types/node@25.9.2)(typescript@7.0.2))(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0)):
     dependencies:
@@ -13876,6 +14085,8 @@ snapshots:
   server-only@0.0.1: {}
 
   set-cookie-parser@3.1.0: {}
+
+  shared-condition-package@file:tests/fixtures/esm-externals/__test_packages__/shared-condition-package: {}
 
   sharp@0.34.5:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -40,7 +40,8 @@ catalog:
   "@types/react-dom": ^19.2.3
   "@unpic/react": ^1.0.2
   "@vercel/og": ^0.8.6
-  "@vitejs/plugin-react": ^6.0.1
+  "@vitejs/plugin-react": ^6.1.0
+  oxc-transform-react: ^0.145.0
   "@next/mdx": 16.2.7
   recma-codehike: 0.0.1
   remark-codehike: 0.0.1

--- a/tests/react-compiler.test.ts
+++ b/tests/react-compiler.test.ts
@@ -1,0 +1,90 @@
+/**
+ * React Compiler tests — verifies that `react: { compiler: true }` reaches
+ * @vitejs/plugin-react and that the client bundle is auto memoized.
+ *
+ * The compiler transform is provided by `oxc-transform-react` and wired up by
+ * @vitejs/plugin-react 6.1+. vinext auto-registers that plugin, so enabling the
+ * compiler must work through vinext's own `react` option, including for apps
+ * that put JSX in plain `.js` files (which Next.js allows).
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { createBuilder } from "vite";
+import { afterAll, describe, expect, it } from "vite-plus/test";
+import vinext from "../packages/vinext/src/index.js";
+import { APP_FIXTURE_DIR } from "./helpers.js";
+
+/**
+ * The compiler rewrites components to call the memo cache hook `c(n)` from
+ * `react/compiler-runtime`. After bundling and minification the import is
+ * renamed, so the call shape is the stable signature to assert on.
+ */
+const MEMO_CACHE_CALL = /\bc\)\(\d+\)/;
+
+function countMemoizedModules(dir: string): { memoized: number; total: number } {
+  let memoized = 0;
+  let total = 0;
+  const walk = (current: string) => {
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+        continue;
+      }
+      if (!entry.name.endsWith(".js")) continue;
+      total++;
+      if (MEMO_CACHE_CALL.test(fs.readFileSync(full, "utf-8"))) memoized++;
+    }
+  };
+  walk(dir);
+  return { memoized, total };
+}
+
+describe("React Compiler", () => {
+  const outDir = path.resolve(APP_FIXTURE_DIR, "dist");
+
+  afterAll(() => {
+    fs.rmSync(outDir, { recursive: true, force: true });
+  });
+
+  async function buildFixture(options: { compiler: boolean }) {
+    fs.rmSync(outDir, { recursive: true, force: true });
+    const builder = await createBuilder({
+      root: APP_FIXTURE_DIR,
+      configFile: false,
+      plugins: [
+        vinext(
+          options.compiler
+            ? { appDir: APP_FIXTURE_DIR, react: { compiler: true } }
+            : { appDir: APP_FIXTURE_DIR },
+        ),
+      ],
+      logLevel: "silent",
+    });
+    await builder.buildApp();
+    return countMemoizedModules(path.join(outDir, "client"));
+  }
+
+  it("leaves the client bundle untouched when the compiler is off", async () => {
+    const result = await buildFixture({ compiler: false });
+    expect(result.total).toBeGreaterThan(0);
+    expect(result.memoized).toBe(0);
+  }, 240_000);
+
+  it("auto memoizes client components when the compiler is on", async () => {
+    const result = await buildFixture({ compiler: true });
+    expect(result.total).toBeGreaterThan(0);
+    expect(result.memoized).toBeGreaterThan(0);
+  }, 240_000);
+
+  it("compiles JSX in plain .js files with the compiler enabled", async () => {
+    // Regression: `vite:react-compiler` runs at `enforce: "pre"`, same as
+    // `vinext:jsx-in-js`. When it ran first it parsed `.js` as plain JS and
+    // failed with `Unexpected JSX expression`, so the whole build broke for any
+    // app with JSX in a `.js` file.
+    const fixturePage = path.join(APP_FIXTURE_DIR, "app", "nextjs-compat", "jsx-in-js", "page.js");
+    expect(fs.existsSync(fixturePage)).toBe(true);
+
+    await expect(buildFixture({ compiler: true })).resolves.toBeDefined();
+  }, 240_000);
+});

--- a/tests/react-compiler.test.ts
+++ b/tests/react-compiler.test.ts
@@ -12,6 +12,11 @@ import path from "node:path";
 import { createBuilder } from "vite";
 import { afterAll, describe, expect, it } from "vite-plus/test";
 import vinext from "../packages/vinext/src/index.js";
+import {
+  hasReactCompilerPlugin,
+  isReactCompilerRequested,
+  REACT_COMPILER_PLUGIN_NAME,
+} from "../packages/vinext/src/utils/react-compiler-support.js";
 import { APP_FIXTURE_DIR } from "./helpers.js";
 
 /**
@@ -87,4 +92,23 @@ describe("React Compiler", () => {
 
     await expect(buildFixture({ compiler: true })).resolves.toBeDefined();
   }, 240_000);
+});
+
+describe("React Compiler support detection", () => {
+  it("only treats a truthy compiler option as a request", () => {
+    expect(isReactCompilerRequested({ compiler: true })).toBe(true);
+    expect(isReactCompilerRequested({ compiler: { target: "19" } })).toBe(true);
+    expect(isReactCompilerRequested({ compiler: false })).toBe(false);
+    expect(isReactCompilerRequested({})).toBe(false);
+    expect(isReactCompilerRequested(undefined)).toBe(false);
+  });
+
+  it("detects whether the resolved plugin registered the compiler", () => {
+    // @vitejs/plugin-react 6.1+ adds this plugin; 6.0 drops the unknown option.
+    expect(hasReactCompilerPlugin([{ name: "vite:react-babel" }])).toBe(false);
+    expect(
+      hasReactCompilerPlugin([{ name: "vite:react-babel" }, { name: REACT_COMPILER_PLUGIN_NAME }]),
+    ).toBe(true);
+    expect(hasReactCompilerPlugin([null, undefined, false])).toBe(false);
+  });
 });


### PR DESCRIPTION
## What

Adds React Compiler support to vinext through the existing `react` option:

```ts
export default defineConfig({
  plugins: [vinext({ react: { compiler: true } })],
});
```

## Why

`@vitejs/plugin-react` 6.1.0 added an experimental `compiler` option that runs the React Compiler through `oxc-transform-react`. vinext already auto-registers that plugin and forwards user options to it, so the option looked like it should work already. It did not. Enabling it broke the build for any app with JSX in a plain `.js` file, which Next.js allows and this repo already has a fixture for.

## Root cause

`vite:react-compiler` and `vinext:jsx-in-js` both run at `enforce: "pre"`, so the order of the plugin array decides which one transforms a module first. The React plugin was registered before `vinext:jsx-in-js`, so the compiler received `app/nextjs-compat/jsx-in-js/page.js` untouched. It infers the source language from the file extension, parsed the file as plain JS, and failed:

```
[plugin vite:react-compiler] app/nextjs-compat/jsx-in-js/page.js
RolldownError: Unexpected JSX expression
```

This is the same class of failure that the `vinext:jsx-in-js` comment already documents for `@vitejs/plugin-rsc`.

## Changes

1. Register `vinext:jsx-in-js` before `@vitejs/plugin-react`, so JSX in `.js` is compiled before the React Compiler looks at it. The plugin body is unchanged, only its position in the array, plus a comment explaining why the order matters.
2. Bump the `@vitejs/plugin-react` catalog entry to `^6.1.0`, the first release that has the `compiler` option.
3. Add `oxc-transform-react` as a dev dependency so the test suite can exercise the compiler. It stays optional for users, and `@vitejs/plugin-react` already prints an actionable error when it is missing.
4. Document the option in the README and in the `VinextOptions.react` JSDoc.

## Testing

New `tests/react-compiler.test.ts` builds the `app-basic` fixture twice and counts modules in the client bundle that call the memo cache hook from `react/compiler-runtime`:

| build | memoized client modules |
| --- | --- |
| `vinext({})` | 0 of 190 |
| `vinext({ react: { compiler: true } })` | 163 of 190 |

The zero on the baseline build is what makes the signature trustworthy. A third case pins the `.js` regression so the ordering cannot silently break again. On `main` two of these three cases fail, and they pass with this change.

`pnpm test` and `pnpm run check` pass locally. The full suite has a handful of failures that are already present on `main` and vary between runs, and the same six files fail identically with and without this change.

Beyond the fixture, I built a large private Next.js application (roughly 1100 client components) against this branch. It builds successfully, and the client bundle comes out with 279 of 567 chunks memoized, matching the 278 of 577 that the same app produced through `babel-plugin-react-compiler`.

## Known limitation

JSX in plain `.js` files is compiled to JavaScript before the compiler runs, so those modules build correctly but are not memoized. Renaming them to `.jsx` or `.tsx` restores memoization. Fixing that properly would need a way to tell `vite:react-compiler` the source language instead of letting it infer from the extension, which belongs in `@vitejs/plugin-react`. The README documents the caveat.

## Notes

The compiler runs on the client environment only, which matches how `@vitejs/plugin-react` scopes it. Users who register `@vitejs/plugin-react` themselves with `react: false` keep full control of plugin order, exactly as before.
