### PR TITLE
fix(build): avoid workerd cwd in module identity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -521,6 +521,10 @@ jobs:
             label: cloudflare-workers
             shardIndex: 1
             shardTotal: 1
+          - project: cloudflare-encoded-paths
+            label: cloudflare-encoded-paths
+            shardIndex: 1
+            shardTotal: 1
           - project: cloudflare-sentry-app
             label: cloudflare-sentry-app
             shardIndex: 1

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@ tests/e2e/cloudflare-workers/fixtures/client-module-with-package-type/node_modul
 !tests/e2e/cloudflare-workers/fixtures/client-module-with-package-type/node_modules/lib-cjs/**
 !tests/e2e/cloudflare-workers/fixtures/client-module-with-package-type/node_modules/lib-esm/
 !tests/e2e/cloudflare-workers/fixtures/client-module-with-package-type/node_modules/lib-esm/**
+!tests/fixtures/cf-app-basic/node_modules/
+tests/fixtures/cf-app-basic/node_modules/*
+!tests/fixtures/cf-app-basic/node_modules/module-identity-dependency/
+!tests/fixtures/cf-app-basic/node_modules/module-identity-dependency/**
 dist/
 !packages/types/next/upstream/dist/
 !packages/types/next/upstream/dist/**

--- a/packages/vinext/src/plugins/import-meta-url.ts
+++ b/packages/vinext/src/plugins/import-meta-url.ts
@@ -443,15 +443,16 @@ function finalizeEmittedModuleIdentity(
   const urlNamespaceBinding = selectRuntimeBinding("__vinext_module_url");
   const identityBinding = selectRuntimeBinding("__vinext_module_identity");
   const emittedFileName = toSlash(fileName).replace(/^\.\//, "").replace(/^\/+/, "");
-  const processCwd = `${processNamespaceBinding}.cwd()`;
+  const processCwd = `(typeof ${processNamespaceBinding}.cwd === "function" ? ${processNamespaceBinding}.cwd() : "")`;
   const emittedPathFallback = emittedFileName
     ? `(${processCwd}.replace(/[\\\\/]$/, "") + ${JSON.stringify(`/${emittedFileName}`)})`
-    : processCwd;
+    : `(${processCwd} || "/")`;
   const emittedDirName = path.dirname(emittedFileName);
   const emittedDirFallback =
     emittedDirName === "."
-      ? processCwd
+      ? `(${processCwd} || "/")`
       : `(${processCwd}.replace(/[\\\\/]$/, "") + ${JSON.stringify(`/${emittedDirName}`)})`;
+  const absoluteEmittedPath = JSON.stringify(`/${emittedFileName}`.replace(/\/$/, "") || "/");
   const replacements: Record<EmittedModuleIdentityField, string> = {
     __filename: `${identityBinding}.filename`,
     __dirname: `${identityBinding}.dirname`,
@@ -473,7 +474,7 @@ function finalizeEmittedModuleIdentity(
   const needsUrl = usedFields.has("url");
   const needsPath = usedFields.has("__filename") || usedFields.has("__dirname");
   const runtimePreamble = [
-    `import * as ${processNamespaceBinding} from "node:process";`,
+    ...(needsPath ? [`import * as ${processNamespaceBinding} from "node:process";`] : []),
     ...(needsPath ? [`import * as ${fsNamespaceBinding} from "node:fs";`] : []),
     ...(needsUrl ? [`import * as ${urlNamespaceBinding} from "node:url";`] : []),
     `const ${identityBinding} = (() => {`,
@@ -483,7 +484,10 @@ function finalizeEmittedModuleIdentity(
           `  const native = typeof filename === "string" && ${fsNamespaceBinding}.existsSync(filename);`,
           `  const resolvedFilename = native ? filename : ${emittedPathFallback};`,
         ]
-      : [`  const runtimeUrl = import.meta.url;`]),
+      : [
+          `  const runtimeUrl = import.meta.url;`,
+          `  const runtimeFilename = import.meta.filename;`,
+        ]),
     `  return {`,
     ...(needsPath
       ? [
@@ -495,7 +499,7 @@ function finalizeEmittedModuleIdentity(
       ? [
           needsPath
             ? `    url: ${urlNamespaceBinding}.pathToFileURL(resolvedFilename).href,`
-            : `    url: typeof runtimeUrl === "string" && runtimeUrl.startsWith("file:") ? runtimeUrl : ${urlNamespaceBinding}.pathToFileURL(${emittedPathFallback}).href,`,
+            : `    url: typeof runtimeUrl === "string" && runtimeUrl.startsWith("file:") ? runtimeUrl : ${urlNamespaceBinding}.pathToFileURL(typeof runtimeFilename === "string" ? runtimeFilename : ${absoluteEmittedPath}).href,`,
         ]
       : []),
     `  };`,

--- a/tests/cjs-globals-runtime.test.ts
+++ b/tests/cjs-globals-runtime.test.ts
@@ -1214,12 +1214,18 @@ describe("bundled module identity on the Cloudflare Workers runtime", () => {
       nextDependencySpecifier: NEXT_CJS_PATH_FILE,
     }));
     await fs.writeFile(
+      path.join(root, "worker.ts"),
+      `import handler from "vinext/server/fetch-handler";
+export default handler;
+`,
+    );
+    await fs.writeFile(
       path.join(root, "wrangler.jsonc"),
       JSON.stringify({
         name: "vinext-cjs-globals-worker",
         compatibility_date: "2026-04-01",
         compatibility_flags: ["nodejs_compat"],
-        main: "vinext/server/fetch-handler",
+        main: "worker.ts",
         assets: { not_found_handling: "none", binding: "ASSETS" },
       }),
     );

--- a/tests/e2e/cloudflare-encoded-paths/module-identity.spec.ts
+++ b/tests/e2e/cloudflare-encoded-paths/module-identity.spec.ts
@@ -1,0 +1,11 @@
+import { expect, test } from "@playwright/test";
+
+// Regression: https://github.com/cloudflare/vinext/issues/3006
+test("evaluates URL-only SSR chunks without process.cwd", async ({ request }) => {
+  const response = await request.get("/module-identity");
+
+  expect(response.status()).toBe(200);
+  expect(await response.text()).toMatch(
+    /Module URL: <!-- -->file:\/\/\/ssr\/_next\/static\/module-url-[\w-]+\.js/,
+  );
+});

--- a/tests/fixtures/cf-app-basic/app/module-identity/module-url.tsx
+++ b/tests/fixtures/cf-app-basic/app/module-identity/module-url.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { moduleUrl } from "module-identity-dependency";
+
+export function ModuleUrl() {
+  return <p suppressHydrationWarning>Module URL: {moduleUrl}</p>;
+}

--- a/tests/fixtures/cf-app-basic/app/module-identity/page.tsx
+++ b/tests/fixtures/cf-app-basic/app/module-identity/page.tsx
@@ -1,0 +1,7 @@
+import { ModuleUrl } from "./module-url";
+
+export const dynamic = "force-dynamic";
+
+export default function ModuleIdentityPage() {
+  return <ModuleUrl />;
+}

--- a/tests/fixtures/cf-app-basic/node_modules/module-identity-dependency/index.js
+++ b/tests/fixtures/cf-app-basic/node_modules/module-identity-dependency/index.js
@@ -1,0 +1,1 @@
+export const moduleUrl = import.meta.url;

--- a/tests/fixtures/cf-app-basic/node_modules/module-identity-dependency/package.json
+++ b/tests/fixtures/cf-app-basic/node_modules/module-identity-dependency/package.json
@@ -1,5 +1,6 @@
 {
   "name": "module-identity-dependency",
+  "version": "1.0.0",
   "type": "module",
   "exports": "./index.js"
 }

--- a/tests/fixtures/cf-app-basic/node_modules/module-identity-dependency/package.json
+++ b/tests/fixtures/cf-app-basic/node_modules/module-identity-dependency/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "module-identity-dependency",
+  "type": "module",
+  "exports": "./index.js"
+}

--- a/tests/fixtures/cf-app-basic/vite.config.ts
+++ b/tests/fixtures/cf-app-basic/vite.config.ts
@@ -1,10 +1,45 @@
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 import vinext from "vinext";
 import { cloudflare } from "@cloudflare/vite-plugin";
+
+function simulateLegacyWorkerdModuleIdentity(): Plugin {
+  return {
+    name: "cf-app-basic:legacy-workerd-module-identity",
+    apply: "build",
+    enforce: "post",
+    generateBundle(_options, bundle) {
+      if (this.environment.name !== "ssr" || this.environment.config.build.write === false) return;
+
+      const chunk = Object.values(bundle).find(
+        (output) =>
+          output.type === "chunk" &&
+          output.moduleIds.some((id) =>
+            id.replaceAll("\\", "/").endsWith("/node_modules/module-identity-dependency/index.js"),
+          ),
+      );
+      if (!chunk || chunk.type !== "chunk") {
+        this.error("Expected the module identity chunk in the final SSR bundle");
+      }
+
+      // The Workerd version from #3006 exposed a non-file module URL and a
+      // node:process namespace without cwd() or a module filename. Model that
+      // runtime contract in one URL-only SSR chunk while still evaluating the
+      // real built Worker.
+      const nonFileUrl = chunk.code.replace("import.meta.url", JSON.stringify("worker"));
+      if (nonFileUrl === chunk.code) {
+        this.error("Expected the module identity chunk to contain import.meta.url");
+      }
+      chunk.code = nonFileUrl
+        .replace(/import\s*\*\s*as\s+([\w$]+)\s*from\s*["']node:process["'];?/, "const $1={};")
+        .replace("import.meta.filename", "undefined");
+    },
+  };
+}
 
 export default defineConfig({
   plugins: [
     vinext(),
+    simulateLegacyWorkerdModuleIdentity(),
     cloudflare({
       viteEnvironment: { name: "rsc", childEnvironments: ["ssr"] },
     }),

--- a/tests/fixtures/cf-app-basic/worker/index.ts
+++ b/tests/fixtures/cf-app-basic/worker/index.ts
@@ -1,0 +1,3 @@
+import handler from "vinext/server/fetch-handler";
+
+export default handler;

--- a/tests/fixtures/cf-app-basic/wrangler.jsonc
+++ b/tests/fixtures/cf-app-basic/wrangler.jsonc
@@ -2,7 +2,7 @@
   "name": "cf-app-basic",
   "compatibility_date": "2026-02-12",
   "compatibility_flags": ["nodejs_compat"],
-  "main": "vinext/server/fetch-handler",
+  "main": "worker/index.ts",
   "assets": {
     "not_found_handling": "none",
     "binding": "ASSETS",

--- a/tests/import-meta-url.test.ts
+++ b/tests/import-meta-url.test.ts
@@ -54,9 +54,11 @@ function expectFinalizedImportMetaUrl(code: string | undefined, fileName = "entr
     `const value = fileURLToPath(({ get value() { return ${identityBinding}.url; } }).value);`,
   );
   expect(code).toContain("const runtimeUrl = import.meta.url;");
+  expect(code).toContain("const runtimeFilename = import.meta.filename;");
   expect(code).toContain(
     `runtimeUrl.startsWith("file:") ? runtimeUrl : ${urlNamespaceBinding}.pathToFileURL(`,
   );
+  expect(code).not.toContain('from "node:process"');
   expect(code).toContain(JSON.stringify(`/${fileName}`));
   expect(code).not.toMatch(/__VINEXT_EMITTED_MODULE_URL_[a-f0-9]{32}__/);
 }
@@ -429,6 +431,63 @@ describe("vinext:import-meta-url plugin", () => {
     expectFinalizedImportMetaUrl(emitted?.code, "deps/esm-identity.js");
     expect(emitted?.code).not.toContain('from "node:fs"');
     expect(emitted?.code).not.toContain("existsSync");
+  });
+
+  it("evaluates a URL-only emitted module without cwd when its runtime URL is non-file", async () => {
+    const capability = createImportMetaUrlPlugin({ getRoot: () => realRoot });
+    const transformed = unwrapHook(capability.optimizeDepsPlugin.transform).call(
+      {},
+      [
+        'import { fileURLToPath } from "node:url";',
+        "const filename = fileURLToPath(import.meta.url);",
+        "export default { fetch() { return new Response(filename); } };",
+      ].join("\n"),
+      esmDependencyPath,
+    );
+    const emitted = unwrapHook(capability.optimizeDepsPlugin.renderChunk).call(
+      {},
+      transformed?.code ?? "",
+      { fileName: "worker.mjs" },
+      { format: "es" },
+    );
+    const code = emitted?.code ?? "";
+    const processImport = code.match(/import \* as (\w+) from "node:process";/);
+    // Workerd exposes the node:process module but not process.cwd(), and its
+    // module-registry URL is not guaranteed to use the file: scheme.
+    const workerdLikeCode = code
+      .replace(processImport?.[0] ?? "", processImport ? `const ${processImport[1]} = {};` : "")
+      .replace("const runtimeUrl = import.meta.url;", 'const runtimeUrl = "worker";');
+    const module = await import(
+      `data:text/javascript;base64,${Buffer.from(workerdLikeCode).toString("base64")}`
+    );
+    const response = await module.default.fetch();
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("/worker.mjs");
+  });
+
+  it("evaluates emitted CJS paths without import.meta.filename or cwd", async () => {
+    const capability = createImportMetaUrlPlugin({ getRoot: () => realRoot });
+    const transformed = unwrapHook(capability.optimizeDepsPlugin.transform).call(
+      {},
+      "export const paths = [__filename, __dirname];",
+      cjsDependencyPath,
+    );
+    const emitted = unwrapHook(capability.optimizeDepsPlugin.renderChunk).call(
+      {},
+      transformed?.code ?? "",
+      { fileName: "chunks/worker.mjs" },
+      { format: "es" },
+    );
+    const code = emitted?.code ?? "";
+    const processImport = code.match(/import \* as (\w+) from "node:process";/);
+    expect(processImport).not.toBeNull();
+    const workerdLikeCode = code
+      .replace(processImport![0], `const ${processImport![1]} = {};`)
+      .replace("const filename = import.meta.filename;", "const filename = undefined;");
+    const module = await import(
+      `data:text/javascript;base64,${Buffer.from(workerdLikeCode).toString("base64")}`
+    );
+    expect(module.paths).toEqual(["/chunks/worker.mjs", "/chunks"]);
   });
 
   it("preserves dependency new URL asset bases while rewriting direct identity reads", () => {


### PR DESCRIPTION
## Summary

- resolve URL-only emitted module identity from `import.meta.filename` before using the emitted absolute fallback
- stop importing `node:process` for URL-only preambles and guard the remaining CJS `cwd()` fallback
- cover the reported runtime contract in the checked-in `cf-app-basic` Cloudflare fixture and run that Playwright project in CI

## Root cause

The emitted URL-only preamble treated every non-`file:` `import.meta.url` as a filesystem-relative Node path and called `process.cwd()` during module evaluation. The Workerd runtime from the report exposed `node:process` without `cwd()`, so SSR chunks could throw before the Worker handler initialized.

Workerd may instead supply emitted identity through `import.meta.filename`. When neither a file URL nor a filename is available, the emitted chunk filename itself is a safe absolute fallback.

The custom Worker entry is not the cause: the same checked-in reproduction returns 500 on the pre-fix base with the stock `vinext/server/fetch-handler` entry. The trigger is any emitted server chunk that reads module identity under the affected Workerd contract.

## Regression coverage

`tests/fixtures/cf-app-basic` now contains:

- a custom Worker entry matching the report
- a dynamic App Router page so the request cannot pass through prerendered output
- a checked-in URL-only ESM dependency that becomes a dedicated SSR chunk
- a final-bundle-only simulation of Workerd's non-file URL, absent filename, and missing `cwd()` behavior

Applying the exact fixture commit to pre-fix `main` makes the Playwright spec fail with HTTP 500 and emits the reported `cwd()` call. The fixed branch returns 200 and `file:///ssr/_next/static/module-url-*.js`.

The `cloudflare-encoded-paths` project is now included in the CI Playwright matrix, so this regression runs on every PR.

## Validation

- pre-fix exact fixture commit: focused Cloudflare spec fails with HTTP 500
- fixed focused Cloudflare spec: 1 passed
- full `cloudflare-encoded-paths` project locally: 9 passed
- exact-head CI `cloudflare-encoded-paths`: 9 passed
- `tests/prerender.test.ts`: 100 passed
- `tests/nextjs-compat/hybrid-pages-api.test.ts`: 5 passed
- `vp test run tests/import-meta-url.test.ts tests/cjs-globals-runtime.test.ts`: 88 passed
- targeted formatting/checks, actionlint, and zizmor: clean
- `vp run vinext#build`: passed
- three fresh independent reviews: no findings

Closes #3006
