### PR TITLE
test(pages): cover metadata-like route filenames

### DIFF
--- a/tests/pages-server-exports-security.test.ts
+++ b/tests/pages-server-exports-security.test.ts
@@ -194,6 +194,33 @@ export default function handler() {}
     },
   );
 
+  it.each([
+    ["sitemap", "getStaticProps"],
+    ["robots", "getServerSideProps"],
+    ["manifest", "getStaticProps"],
+    ["icon", "getServerSideProps"],
+    ["opengraph-image", "getStaticProps"],
+    ["twitter-image", "getServerSideProps"],
+  ])("allows %s Pages routes to export %s", async (fileName, dataExport) => {
+    // Ported from Next.js: test/e2e/pages-app-router-filenames/
+    // https://github.com/vercel/next.js/tree/canary/test/e2e/pages-app-router-filenames
+    const pageSource = `
+export async function ${dataExport}() {
+  return { props: { name: "${fileName}" } };
+}
+
+export default function Page({ name }: { name: string }) {
+  return <main>{name}</main>;
+}
+`;
+    const fixtureDir = await buildPagesFixture(
+      pageSource,
+      `vinext-pages-${fileName}-parity-`,
+      path.join("pages", `${fileName}.tsx`),
+    );
+    await fsp.rm(fixtureDir, { recursive: true, force: true });
+  });
+
   it("rejects mixed SSR and SSG exports with the Next.js error", async () => {
     const pageSource = `
 export function getServerSideProps() { return { props: {} }; }


### PR DESCRIPTION
Closes #2923

## Summary
- add build-level regression coverage for Pages Router files whose basenames overlap App Router metadata conventions
- cover sitemap, robots, manifest, icon, opengraph-image, and twitter-image
- exercise both getStaticProps and getServerSideProps exports

The cases mirror the Next.js pages-app-router-filenames regression coverage while extending it across the metadata-like filenames called out in the issue.

## Verification
- `pnpm test tests/pages-server-exports-security.test.ts`
- `pnpm run check`

Next.js reference: https://github.com/vercel/next.js/tree/canary/test/e2e/pages-app-router-filenames