### PR TITLE
fix(cloudflare): default CDN warmup concurrency to 25

### DIFF
--- a/packages/cloudflare/src/cdn-warm.ts
+++ b/packages/cloudflare/src/cdn-warm.ts
@@ -43,6 +43,7 @@ export type CdnWarmOptions = {
   fetchImpl?: typeof fetch;
 };
 
+export const DEFAULT_CDN_WARM_CONCURRENCY = 25;
 export const DEFAULT_CDN_WARM_TIMEOUT_MS = 10_000;
 
 export type PrerenderCdnWarmOptions = Omit<CdnWarmOptions, "paths"> & {
@@ -571,7 +572,7 @@ export async function warmCdnCache(options: CdnWarmOptions): Promise<CdnWarmResu
   // policy. Once those gates pass, fill the remaining independent cache keys
   // concurrently. Propagation is bounded by the retry count, never by a
   // queue-wide wall-clock deadline that can expire before work starts.
-  const concurrency = Math.max(1, options.concurrency ?? 10);
+  const concurrency = Math.max(1, options.concurrency ?? DEFAULT_CDN_WARM_CONCURRENCY);
   const normalRetries = Math.max(0, options.retries ?? 1);
   const propagationRetries = Math.max(0, options.retries ?? 30);
   const normalRetryDelayMs = Math.max(0, options.retryDelayMs ?? 0);

--- a/packages/cloudflare/src/deploy-help.ts
+++ b/packages/cloudflare/src/deploy-help.ts
@@ -25,7 +25,7 @@ export function formatDeployHelp(): string {
                              Upload a Worker version, warm build-discovered paths
                              through the production URL, then promote it (experimental)
     --warm-cdn-concurrency <count>
-                             Maximum number of CDN warmup requests in parallel
+                             Maximum number of CDN warmup requests in parallel (default: 25)
     --warm-cdn-timeout <ms>  Per-request CDN warmup timeout (default: 10000)
     --warm-cdn-retries <n>   Retries for transient CDN warmup failures (default: 1)
     --warm-cdn-strict        Fail deploy when any CDN warmup request fails

--- a/tests/cloudflare-cdn-warm.test.ts
+++ b/tests/cloudflare-cdn-warm.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import {
   buildWarmupUrl,
+  DEFAULT_CDN_WARM_CONCURRENCY,
   DEFAULT_CDN_WARM_TIMEOUT_MS,
   readPrerenderWarmPlan,
   warmCdnCache,
@@ -62,7 +63,8 @@ afterEach(() => {
 });
 
 describe("Cloudflare CDN warmup", () => {
-  it("uses a 10 second default timeout and preserves query strings", () => {
+  it("uses the documented warmup defaults and preserves query strings", () => {
+    expect(DEFAULT_CDN_WARM_CONCURRENCY).toBe(25);
     expect(DEFAULT_CDN_WARM_TIMEOUT_MS).toBe(10_000);
     expect(buildWarmupUrl("https://app.example.com", "/search?q=x").href).toBe(
       "https://app.example.com/search?q=x",


### PR DESCRIPTION
## Summary

- raise the default CDN warmup concurrency from 10 to 25
- document the default in deploy help
- preserve `--warm-cdn-concurrency` as an explicit override

## Test plan

- `vp test run tests/cloudflare-cdn-warm.test.ts tests/cloudflare-cdn-warm-deploy.test.ts tests/deploy.test.ts`
- `vp check packages/cloudflare/src/cdn-warm.ts packages/cloudflare/src/deploy-help.ts tests/cloudflare-cdn-warm.test.ts`

Stacked on #3002.