### PR TITLE
feat(cloudflare): allow CDN warmup without promotion

### DIFF
--- a/packages/cloudflare/src/cli.ts
+++ b/packages/cloudflare/src/cli.ts
@@ -55,6 +55,7 @@ async function deployCommand(): Promise<void> {
     warmCdnTimeout: parsed.warmCdnTimeout,
     warmCdnRetries: parsed.warmCdnRetries,
     warmCdnStrict: parsed.warmCdnStrict,
+    warmCdnPromote: parsed.warmCdnPromote,
     warmCdnIncludeFallbacks: parsed.warmCdnIncludeFallbacks,
     experimentalTPR: parsed.experimentalTPR,
     tprCoverage: parsed.tprCoverage,

--- a/packages/cloudflare/src/deploy-help.ts
+++ b/packages/cloudflare/src/deploy-help.ts
@@ -29,6 +29,7 @@ export function formatDeployHelp(): string {
     --warm-cdn-timeout <ms>  Per-request CDN warmup timeout (default: 10000)
     --warm-cdn-retries <n>   Retries for transient CDN warmup failures (default: 1)
     --warm-cdn-strict        Fail deploy when any CDN warmup request fails
+    --warm-cdn-no-promote    Leave the warmed Worker version staged at 0% traffic
     --warm-cdn-include-fallbacks
                              Also warm PPR fallback-shell placeholder paths
     -h, --help               Show this help

--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -100,6 +100,8 @@ export type DeployOptions = {
   warmCdnRetries?: number;
   /** Fail deployment if any CDN warmup request fails */
   warmCdnStrict?: boolean;
+  /** Promote the warmed Worker version to 100% traffic (default: true) */
+  warmCdnPromote?: boolean;
   /** Include PPR fallback-shell placeholder paths during CDN warmup */
   warmCdnIncludeFallbacks?: boolean;
   /** Enable experimental TPR (Traffic-aware Pre-Rendering) */
@@ -166,6 +168,7 @@ const deployArgOptions = {
   "warm-cdn-timeout": { type: "string" },
   "warm-cdn-retries": { type: "string" },
   "warm-cdn-strict": { type: "boolean", default: false },
+  "warm-cdn-no-promote": { type: "boolean", default: false },
   "warm-cdn-include-fallbacks": { type: "boolean", default: false },
   "experimental-tpr": { type: "boolean", default: false },
   "tpr-coverage": { type: "string" },
@@ -213,6 +216,7 @@ export function parseDeployArgs(args: string[]) {
         ? undefined
         : parseNonNegativeIntegerArg(values["warm-cdn-retries"], "--warm-cdn-retries"),
     warmCdnStrict: values["warm-cdn-strict"],
+    warmCdnPromote: !values["warm-cdn-no-promote"],
     warmCdnIncludeFallbacks: values["warm-cdn-include-fallbacks"],
     experimentalTPR: values["experimental-tpr"],
     tprCoverage: parseIntArg("tpr-coverage", values["tpr-coverage"]),
@@ -553,6 +557,7 @@ export async function deployWithCdnWarmup(
     | "warmCdnTimeout"
     | "warmCdnRetries"
     | "warmCdnStrict"
+    | "warmCdnPromote"
   > &
     Pick<CdnWarmOptions, "deploymentId" | "expectedRscBuildId" | "loadingShellPaths" | "rscPaths">,
 ): Promise<string> {
@@ -622,6 +627,24 @@ export async function deployWithCdnWarmup(
   } else {
     console.warn(
       "  CDN warmup: pre-traffic version override skipped because the current deployment is not one version serving 100% traffic.",
+    );
+  }
+
+  if (options.warmCdnPromote === false) {
+    if (!staged) {
+      throw new Error(
+        "CDN warmup cannot skip promotion because the uploaded Worker version could not be staged at 0% traffic. " +
+          "The current deployment must have exactly one version serving 100% traffic.",
+      );
+    }
+    console.log(
+      "  CDN warmup: promotion disabled; uploaded Worker version remains staged at 0% traffic.",
+    );
+    return (
+      staged.deployedUrl ??
+      triggersDeployedUrl ??
+      upload.previewUrl ??
+      "(URL not detected in wrangler output)"
     );
   }
 
@@ -993,6 +1016,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
         warmCdnTimeout: options.warmCdnTimeout,
         warmCdnRetries: options.warmCdnRetries,
         warmCdnStrict: options.warmCdnStrict,
+        warmCdnPromote: options.warmCdnPromote,
       });
     } else {
       console.log("\n  CDN warmup skipped: no build-discovered paths found.");

--- a/tests/cloudflare-cdn-warm-deploy.test.ts
+++ b/tests/cloudflare-cdn-warm-deploy.test.ts
@@ -402,6 +402,59 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     ]);
   });
 
+  it("leaves the warmed Worker version staged when promotion is disabled", async () => {
+    const events: string[] = [];
+    delayMock.mockImplementation(async (milliseconds: number) => {
+      events.push(`delay:${milliseconds}`);
+    });
+    writeFile(
+      "wrangler.jsonc",
+      JSON.stringify({ name: "my-worker", custom_domains: ["app.example.com"] }),
+    );
+    vi.mocked(fetch).mockImplementation(async (url) => {
+      events.push(`fetch:${formatFetchUrl(url)}`);
+      return cacheableHtml();
+    });
+    execFileSyncMock.mockImplementation((_file: string, args: string[]) => {
+      if (args.includes("upload")) {
+        events.push("upload");
+        return "Uploaded version 22222222-2222-4222-8222-222222222222\nhttps://preview.example.workers.dev\n";
+      }
+      if (args.includes("status")) {
+        events.push("status");
+        return JSON.stringify({
+          versions: [{ version_id: "11111111-1111-4111-8111-111111111111", percentage: 100 }],
+        });
+      }
+      if (args.includes("deploy") && args.includes("22222222-2222-4222-8222-222222222222@0%")) {
+        events.push("stage");
+        return "Staged version\nhttps://stable.example.workers.dev\n";
+      }
+      if (args.includes("triggers")) {
+        events.push("triggers");
+        return "Triggers deployed\n";
+      }
+      throw new Error(`Unexpected Wrangler args: ${args.join(" ")}`);
+    });
+    const { deployWithCdnWarmup } = await import("../packages/cloudflare/src/deploy.js");
+
+    await expect(
+      deployWithCdnWarmup(tmpDir, ["/about"], {
+        warmCdnConcurrency: 1,
+        warmCdnPromote: false,
+      }),
+    ).resolves.toBe("https://stable.example.workers.dev");
+
+    expect(events).toEqual([
+      "upload",
+      "status",
+      "stage",
+      "triggers",
+      "fetch:https://app.example.com/about",
+    ]);
+    expect(delayMock).not.toHaveBeenCalled();
+  });
+
   it("replaces a stale 0% version and uses the triggers URL for pre-promotion warmup", async () => {
     const events: string[] = [];
     writeFile(

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -768,6 +768,7 @@ describe("parseDeployArgs", () => {
       "--warm-cdn-retries",
       "0",
       "--warm-cdn-strict",
+      "--warm-cdn-no-promote",
       "--warm-cdn-include-fallbacks",
     ]);
 
@@ -776,7 +777,12 @@ describe("parseDeployArgs", () => {
     expect(parsed.warmCdnTimeout).toBe(1500);
     expect(parsed.warmCdnRetries).toBe(0);
     expect(parsed.warmCdnStrict).toBe(true);
+    expect(parsed.warmCdnPromote).toBe(false);
     expect(parsed.warmCdnIncludeFallbacks).toBe(true);
+  });
+
+  it("promotes warmed Worker versions by default", () => {
+    expect(parseDeployArgs([]).warmCdnPromote).toBe(true);
   });
 
   it("throws for invalid CDN warmup numeric flags", () => {


### PR DESCRIPTION
## Summary

- add `--warm-cdn-no-promote`
- leave a successfully staged Worker version at 0% after CDN warmup
- skip the propagation delay and 100% promotion command when requested
- fail rather than silently promote when the current deployment cannot stage the upload at 0%

## Test plan

- `vp test run tests/cloudflare-cdn-warm-deploy.test.ts tests/deploy.test.ts`
- `vp check packages/cloudflare/src/deploy.ts packages/cloudflare/src/cli.ts packages/cloudflare/src/deploy-help.ts tests/cloudflare-cdn-warm-deploy.test.ts tests/deploy.test.ts`

Stacked on #3015.