### PR TITLE
fix(cloudflare): validate reusable warm responses

### DIFF
--- a/packages/cloudflare/src/cdn-warm.ts
+++ b/packages/cloudflare/src/cdn-warm.ts
@@ -312,15 +312,17 @@ class CdnWarmProgress {
 const REQUIRED_RSC_VARY_HEADERS = VINEXT_RSC_VARY_HEADER.split(",").map((name) =>
   name.trim().toLowerCase(),
 );
-const ADMITTED_CF_CACHE_STATUSES = new Set([
-  "HIT",
-  "MISS",
-  "EXPIRED",
-  "REVALIDATED",
-  "UPDATING",
-  "STALE",
-]);
+const ADMITTED_CF_CACHE_STATUSES = new Set(["HIT", "MISS", "EXPIRED", "REVALIDATED", "UPDATING"]);
 const NON_CACHEABLE_CF_CACHE_STATUSES = new Set(["BYPASS", "DYNAMIC"]);
+const CDN_CACHE_POLICY_HEADERS = [
+  "Cloudflare-CDN-Cache-Control",
+  "CDN-Cache-Control",
+  "Cache-Control",
+] as const;
+const SHARED_CACHE_FRESHNESS_RES = [
+  /(?:^|,)\s*s-maxage\s*=\s*"?(-?\d+)"?/i,
+  /(?:^|,)\s*max-age\s*=\s*"?(-?\d+)"?/i,
+] as const;
 
 type WarmValidation =
   | { outcome: "warmed" }
@@ -328,14 +330,17 @@ type WarmValidation =
   | { outcome: "failed"; error: string };
 
 function validateCachePolicy(response: Response, requireCacheStatus: boolean): WarmValidation {
-  const nonCacheableHeaders = [
-    "Cache-Control",
-    "CDN-Cache-Control",
-    "Cloudflare-CDN-Cache-Control",
-  ].filter((name) => {
-    const value = response.headers.get(name);
-    return value !== null && isNonCacheableCacheControl(value);
-  });
+  const effectivePolicy = CDN_CACHE_POLICY_HEADERS.map((name) => ({
+    name,
+    value: response.headers.get(name),
+  })).find(
+    (entry): entry is { name: (typeof CDN_CACHE_POLICY_HEADERS)[number]; value: string } =>
+      entry.value !== null,
+  );
+  const nonCacheableHeaders =
+    effectivePolicy && isNonCacheableCacheControl(effectivePolicy.value)
+      ? [effectivePolicy.name]
+      : [];
   const hasSetCookie = response.headers.has("Set-Cookie");
   const cacheStatus = response.headers.get("CF-Cache-Status")?.trim().toUpperCase();
 
@@ -344,6 +349,20 @@ function validateCachePolicy(response: Response, requireCacheStatus: boolean): W
       nonCacheableHeaders.length > 0
         ? `${nonCacheableHeaders.join(", ")} opts out of caching`
         : "response sets a cookie";
+    if (cacheStatus && NON_CACHEABLE_CF_CACHE_STATUSES.has(cacheStatus)) {
+      return { outcome: "skipped", reason };
+    }
+    return {
+      outcome: "failed",
+      error: `${reason}, but CF-Cache-Status is ${cacheStatus ?? "missing"}`,
+    };
+  }
+
+  const sharedFreshness = effectivePolicy
+    ? getSharedCacheFreshnessSeconds(effectivePolicy.value)
+    : null;
+  if (sharedFreshness !== null && sharedFreshness <= 0) {
+    const reason = `${effectivePolicy!.name} has no positive shared-cache freshness`;
     if (cacheStatus && NON_CACHEABLE_CF_CACHE_STATUSES.has(cacheStatus)) {
       return { outcome: "skipped", reason };
     }
@@ -362,6 +381,14 @@ function validateCachePolicy(response: Response, requireCacheStatus: boolean): W
     return { outcome: "failed", error: `CF-Cache-Status is ${cacheStatus}` };
   }
   return { outcome: "warmed" };
+}
+
+function getSharedCacheFreshnessSeconds(cacheControl: string): number | null {
+  for (const pattern of SHARED_CACHE_FRESHNESS_RES) {
+    const match = pattern.exec(cacheControl);
+    if (match) return Number(match[1]);
+  }
+  return null;
 }
 
 function validateRscWarmResponse(response: Response, expectedRscBuildId?: string): WarmValidation {

--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -731,7 +731,7 @@ export function resolveCdnWarmupTargetUrl(
 ): string | null {
   const config = parseWranglerConfig(root, options?.config);
   const env = getWranglerTargetEnv(options ?? {});
-  const customDomain = (env ? config?.env?.[env]?.customDomain : undefined) ?? config?.customDomain;
+  const customDomain = env ? config?.env?.[env]?.customDomain : config?.customDomain;
   if (customDomain) {
     return `https://${customDomain}`;
   }

--- a/tests/cloudflare-cdn-warm-deploy.test.ts
+++ b/tests/cloudflare-cdn-warm-deploy.test.ts
@@ -83,6 +83,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
         headers: isRsc
           ? {
               "cache-control": "public, max-age=0, must-revalidate",
+              "cdn-cache-control": "public, max-age=60",
               "cf-cache-status": "MISS",
               "content-type": "text/x-component",
               [VINEXT_RSC_BUILD_ID_HEADER]: "build-a",
@@ -242,6 +243,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
         headers: isRsc
           ? {
               "cache-control": "public, max-age=0, must-revalidate",
+              "cdn-cache-control": "public, max-age=60",
               "cf-cache-status": "MISS",
               "content-type": "text/x-component",
               [VINEXT_RSC_BUILD_ID_HEADER]:
@@ -350,6 +352,24 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     for (const [, args] of execFileSyncMock.mock.calls as Array<[string, string[]]>) {
       expect(args).toEqual(expect.arrayContaining(["--env", "staging"]));
     }
+  });
+
+  it("does not inherit the production custom domain for a named environment", async () => {
+    writeFile(
+      "wrangler.jsonc",
+      JSON.stringify({
+        name: "my-worker",
+        custom_domains: ["app.example.com"],
+        env: { staging: { name: "my-worker-staging" } },
+      }),
+    );
+    const { resolveCdnWarmupTargetUrl } = await import("../packages/cloudflare/src/deploy.js");
+
+    expect(
+      resolveCdnWarmupTargetUrl(tmpDir, "https://my-worker-staging.example.workers.dev", {
+        env: "staging",
+      }),
+    ).toBe("https://my-worker-staging.example.workers.dev");
   });
 
   it("applies triggers before post-promotion fallback warmup", async () => {

--- a/tests/cloudflare-cdn-warm.test.ts
+++ b/tests/cloudflare-cdn-warm.test.ts
@@ -268,7 +268,7 @@ describe("Cloudflare CDN warmup", () => {
     ).resolves.toEqual({ total: 2, warmed: 0, skipped: 2, failed: 0, failures: [] });
   });
 
-  it("fails contradictory cache policy instead of claiming a warm", async () => {
+  it("uses Cloudflare cache-control precedence when validating admission", async () => {
     const fetchImpl = vi.fn(async () => {
       const response = cacheableRsc();
       response.headers.set("cache-control", "no-store");
@@ -284,7 +284,62 @@ describe("Cloudflare CDN warmup", () => {
         strict: true,
         targetUrl: "https://app.example.com",
       }),
-    ).rejects.toThrow("opts out of caching, but CF-Cache-Status is MISS");
+    ).resolves.toMatchObject({ warmed: 1, failed: 0 });
+  });
+
+  it("fails contradictory effective cache policy instead of claiming a warm", async () => {
+    const fetchImpl = vi.fn(async () => {
+      const response = cacheableRsc();
+      response.headers.set("cdn-cache-control", "no-store");
+      return response;
+    });
+
+    await expect(
+      warmCdnCache({
+        expectedRscBuildId: "rsc-build-a",
+        fetchImpl: fetchImpl as typeof fetch,
+        paths: [],
+        rscPaths: ["/broken"],
+        strict: true,
+        targetUrl: "https://app.example.com",
+      }),
+    ).rejects.toThrow("CDN-Cache-Control opts out of caching, but CF-Cache-Status is MISS");
+  });
+
+  it("rejects stale cache objects and zero-freshness responses", async () => {
+    const staleFetch = vi.fn(async () => {
+      const response = cacheableRsc();
+      response.headers.set("cf-cache-status", "STALE");
+      return response;
+    });
+    await expect(
+      warmCdnCache({
+        expectedRscBuildId: "rsc-build-a",
+        fetchImpl: staleFetch as typeof fetch,
+        paths: [],
+        rscPaths: ["/stale"],
+        strict: true,
+        targetUrl: "https://app.example.com",
+      }),
+    ).rejects.toThrow("CF-Cache-Status is STALE");
+
+    const zeroFreshnessFetch = vi.fn(async () => {
+      const response = cacheableRsc();
+      response.headers.set("cdn-cache-control", "public, max-age=0");
+      return response;
+    });
+    await expect(
+      warmCdnCache({
+        expectedRscBuildId: "rsc-build-a",
+        fetchImpl: zeroFreshnessFetch as typeof fetch,
+        paths: [],
+        rscPaths: ["/immediately-stale"],
+        strict: true,
+        targetUrl: "https://app.example.com",
+      }),
+    ).rejects.toThrow(
+      "CDN-Cache-Control has no positive shared-cache freshness, but CF-Cache-Status is MISS",
+    );
   });
 
   it("requires CDN admission evidence for HTML responses", async () => {


### PR DESCRIPTION
## Summary

- validate the effective Cloudflare cache policy using `Cloudflare-CDN-Cache-Control` / `CDN-Cache-Control` / `Cache-Control` precedence
- reject `CF-Cache-Status: STALE` because it does not prove a fresh fill completed
- reject zero or negative shared-cache freshness instead of reporting it as warmed
- preserve coherent non-cacheable responses as skipped
- prevent named Wrangler environments from inheriting the top-level production custom domain

## Test plan

- `vp test run tests/cloudflare-cdn-warm.test.ts tests/cloudflare-cdn-warm-deploy.test.ts`
- `vp check packages/cloudflare/src/cdn-warm.ts packages/cloudflare/src/deploy.ts tests/cloudflare-cdn-warm.test.ts tests/cloudflare-cdn-warm-deploy.test.ts`

Stacked on #3020.