### PR TITLE
fix(cloudflare): retry staged warmup failures safely

### DIFF
--- a/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
@@ -42,13 +42,20 @@ import {
 } from "vinext/shims/cdn-cache";
 import type { CacheHandlerValue, IncrementalCacheValue } from "vinext/shims/cache";
 import { getRequestExecutionContext } from "vinext/shims/request-context";
+import { VINEXT_CDN_BUILD_ID_HEADER } from "./cdn-build-id.js";
 
 const CACHEABLE_EDGE_DIRECTIVE_RE = /(?:^|,)\s*(?:s-maxage|max-age)\s*=/i;
 const EDGE_POLICY_HEADERS = ["CDN-Cache-Control", "Cloudflare-CDN-Cache-Control"] as const;
 
+function getBuildIdentityResponseHeader(): CdnResponseHeaders {
+  const buildId = process.env.__VINEXT_BUILD_ID;
+  return buildId ? { [VINEXT_CDN_BUILD_ID_HEADER]: buildId } : {};
+}
+
 /** Remove every response header whose cache semantics are owned by Cloudflare. */
 function clearCloudflareCdnResponseHeaders(cacheControl: string): CdnResponseHeaders {
   return {
+    ...getBuildIdentityResponseHeader(),
     "Cache-Control": cacheControl,
     "CDN-Cache-Control": null,
     "Cloudflare-CDN-Cache-Control": null,
@@ -188,6 +195,7 @@ export class CloudflareCdnCacheAdapter implements CdnCacheAdapter {
     // SWR policy on CDN-Cache-Control (edge caches + revalidates); the browser
     // is told to revalidate every reuse so it never serves a stale stored copy.
     const headers: CdnResponseHeaders = {
+      ...getBuildIdentityResponseHeader(),
       "Cache-Control": BROWSER_REVALIDATE,
       "CDN-Cache-Control": toEdgeCacheControl(input.cacheControl),
       "Cloudflare-CDN-Cache-Control": null,

--- a/packages/cloudflare/src/cache/cdn-build-id.ts
+++ b/packages/cloudflare/src/cache/cdn-build-id.ts
@@ -1,0 +1,2 @@
+/** Build identity stamped by the Cloudflare CDN adapter on page responses. */
+export const VINEXT_CDN_BUILD_ID_HEADER = "X-Vinext-Build-Id";

--- a/packages/cloudflare/src/cdn-warm.ts
+++ b/packages/cloudflare/src/cdn-warm.ts
@@ -21,6 +21,7 @@ import {
 } from "vinext/internal/server/app-rsc-cache-busting";
 import { isNonCacheableCacheControl } from "vinext/shims/cdn-cache";
 import { normalizePathTrailingSlash } from "vinext/shims/url-utils";
+import { VINEXT_CDN_BUILD_ID_HEADER } from "./cache/cdn-build-id.js";
 
 export type CdnWarmOptions = {
   targetUrl: string;
@@ -31,6 +32,8 @@ export type CdnWarmOptions = {
   loadingShellPaths?: readonly string[];
   /** Build identity that the warmed RSC response must have been rendered by. */
   expectedRscBuildId?: string;
+  /** Application build identity stamped by the configured CDN adapter. */
+  expectedBuildId?: string;
   deploymentId?: string;
   headers?: HeadersInit;
   concurrency?: number;
@@ -57,9 +60,17 @@ export type CdnWarmResult = {
   skipped: number;
   failed: number;
   failures: Array<{ path: string; error: string }>;
+  retryPlan: CdnWarmRequestPlan;
+};
+
+export type CdnWarmRequestPlan = {
+  loadingShellPaths: string[];
+  paths: string[];
+  rscPaths: string[];
 };
 
 export type PrerenderWarmPlan = {
+  buildId?: string;
   deploymentId?: string;
   loadingShellPaths: string[];
   paths: string[];
@@ -195,6 +206,7 @@ export function readPrerenderWarmPlan(
     }
   }
   return {
+    buildId: manifest.buildId,
     ...(manifest.deploymentId ? { deploymentId: manifest.deploymentId } : {}),
     loadingShellPaths: supportsCanonicalRsc
       ? (manifest.loadingShellPaths ?? []).map(applyConfig)
@@ -281,9 +293,10 @@ async function fetchWithTimeout(
 
 type WarmTarget = {
   headers?: HeadersInit;
-  kind: "html" | "rsc";
+  kind: "html" | "rsc-full" | "rsc-loading-shell";
   label: string;
   pathname: string;
+  sourcePathname: string;
 };
 
 class CdnWarmProgress {
@@ -391,7 +404,27 @@ function getSharedCacheFreshnessSeconds(cacheControl: string): number | null {
   return null;
 }
 
-function validateRscWarmResponse(response: Response, expectedRscBuildId?: string): WarmValidation {
+function validateBuildIdentity(
+  response: Response,
+  expectedBuildId?: string,
+): WarmValidation | null {
+  if (
+    expectedBuildId !== undefined &&
+    response.headers.get(VINEXT_CDN_BUILD_ID_HEADER) !== expectedBuildId
+  ) {
+    return {
+      outcome: "failed",
+      error: `response ${VINEXT_CDN_BUILD_ID_HEADER} does not match build ${expectedBuildId}`,
+    };
+  }
+  return null;
+}
+
+function validateRscWarmResponse(
+  response: Response,
+  expectedBuildId?: string,
+  expectedRscBuildId?: string,
+): WarmValidation {
   if (response.redirected || response.status < 200 || response.status >= 300) {
     return {
       outcome: "failed",
@@ -401,6 +434,8 @@ function validateRscWarmResponse(response: Response, expectedRscBuildId?: string
   if (!response.headers.get("Content-Type")?.toLowerCase().startsWith(VINEXT_RSC_CONTENT_TYPE)) {
     return { outcome: "failed", error: `expected ${VINEXT_RSC_CONTENT_TYPE} response` };
   }
+  const buildIdentityValidation = validateBuildIdentity(response, expectedBuildId);
+  if (buildIdentityValidation) return buildIdentityValidation;
   if (
     expectedRscBuildId !== undefined &&
     response.headers.get(VINEXT_RSC_BUILD_ID_HEADER) !== expectedRscBuildId
@@ -427,13 +462,15 @@ function validateRscWarmResponse(response: Response, expectedRscBuildId?: string
   return validateCachePolicy(response, true);
 }
 
-function validateHtmlWarmResponse(response: Response): WarmValidation {
+function validateHtmlWarmResponse(response: Response, expectedBuildId?: string): WarmValidation {
   if (response.redirected || response.status < 200 || response.status >= 300) {
     return {
       outcome: "failed",
       error: response.redirected ? "redirected response" : `HTTP ${response.status}`,
     };
   }
+  const buildIdentityValidation = validateBuildIdentity(response, expectedBuildId);
+  if (buildIdentityValidation) return buildIdentityValidation;
   return validateCachePolicy(response, true);
 }
 
@@ -442,6 +479,7 @@ async function warmOnePath(
   options: Required<Pick<CdnWarmOptions, "targetUrl" | "timeoutMs" | "retries">> & {
     fetchImpl: typeof fetch;
     headers?: HeadersInit;
+    expectedBuildId?: string;
     expectedRscBuildId?: string;
     retryAllValidationErrors: boolean;
     retryDelayMs: number;
@@ -483,8 +521,12 @@ async function warmOnePath(
         );
       }
 
-      if (target.kind === "rsc") {
-        const validation = validateRscWarmResponse(response, options.expectedRscBuildId);
+      if (target.kind !== "html") {
+        const validation = validateRscWarmResponse(
+          response,
+          options.expectedBuildId,
+          options.expectedRscBuildId,
+        );
         if (validation.outcome === "warmed") {
           return { path: target.label, ok: true, skipped: false };
         }
@@ -502,7 +544,7 @@ async function warmOnePath(
         continue;
       }
 
-      const validation = validateHtmlWarmResponse(response);
+      const validation = validateHtmlWarmResponse(response, options.expectedBuildId);
       if (validation.outcome === "warmed") {
         return { path: target.label, ok: true, skipped: false };
       }
@@ -553,19 +595,23 @@ async function runWithConcurrency<T, R>(
 export async function warmCdnCache(options: CdnWarmOptions): Promise<CdnWarmResult> {
   const requests: WarmTarget[] = [];
   const htmlRequests: WarmTarget[] = [];
+  const fullRscPaths = new Set(options.rscPaths ?? []);
   const loadingShellPaths = new Set(options.loadingShellPaths ?? []);
   const commonHeaders = new Headers(options.headers);
-  for (const pathname of options.rscPaths ?? []) {
-    const rscHeaders = new Headers(commonHeaders);
-    for (const [name, value] of createCanonicalRscRequestHeaders(options.deploymentId)) {
-      rscHeaders.set(name, value);
+  for (const pathname of new Set([...fullRscPaths, ...loadingShellPaths])) {
+    if (fullRscPaths.has(pathname)) {
+      const rscHeaders = new Headers(commonHeaders);
+      for (const [name, value] of createCanonicalRscRequestHeaders(options.deploymentId)) {
+        rscHeaders.set(name, value);
+      }
+      requests.push({
+        headers: rscHeaders,
+        kind: "rsc-full",
+        label: `${pathname} (RSC full)`,
+        pathname: createCanonicalRscRequestUrl(pathname),
+        sourcePathname: pathname,
+      });
     }
-    requests.push({
-      headers: rscHeaders,
-      kind: "rsc",
-      label: `${pathname} (RSC full)`,
-      pathname: createCanonicalRscRequestUrl(pathname),
-    });
 
     if (loadingShellPaths.has(pathname)) {
       const loadingHeaders = new Headers(commonHeaders);
@@ -576,9 +622,10 @@ export async function warmCdnCache(options: CdnWarmOptions): Promise<CdnWarmResu
       }
       requests.push({
         headers: loadingHeaders,
-        kind: "rsc",
+        kind: "rsc-loading-shell",
         label: `${pathname} (RSC loading shell)`,
         pathname: await createRscRequestUrl(pathname, loadingHeaders),
+        sourcePathname: pathname,
       });
     }
   }
@@ -586,19 +633,21 @@ export async function warmCdnCache(options: CdnWarmOptions): Promise<CdnWarmResu
   for (const pathname of options.paths) {
     const htmlHeaders = new Headers(commonHeaders);
     htmlHeaders.set("Accept", "text/html");
-    htmlRequests.push({ headers: htmlHeaders, kind: "html", label: pathname, pathname });
+    htmlRequests.push({
+      headers: htmlHeaders,
+      kind: "html",
+      label: pathname,
+      pathname,
+      sourcePathname: pathname,
+    });
   }
-  // For a serialized propagating target, prove that requests have reached the
-  // uploaded build before filling any HTML cache entries.
   requests.push(...htmlRequests);
   const timeoutMs = Math.max(1, options.timeoutMs ?? DEFAULT_CDN_WARM_TIMEOUT_MS);
   const hasVersionOverride = new Headers(options.headers).has(WORKER_VERSION_OVERRIDE_HEADER);
   const propagatingTarget = options.propagatingTarget ?? hasVersionOverride;
-  // Immediately after upload, prove the RSC handler and immutable assets have
-  // reached the new build, then give the first real HTML fill the same retry
-  // policy. Once those gates pass, fill the remaining independent cache keys
-  // concurrently. Propagation is bounded by the retry count, never by a
-  // queue-wide wall-clock deadline that can expire before work starts.
+  // A propagating target gives every key one initial attempt, then retries only
+  // failed keys after the queue completes. Build identity validation prevents
+  // an old Worker response from being mistaken for a successful fill.
   const concurrency = Math.max(1, options.concurrency ?? DEFAULT_CDN_WARM_CONCURRENCY);
   const normalRetries = Math.max(0, options.retries ?? 1);
   const propagationRetries = Math.max(0, options.retries ?? 30);
@@ -607,32 +656,38 @@ export async function warmCdnCache(options: CdnWarmOptions): Promise<CdnWarmResu
   const fetchImpl = options.fetchImpl ?? fetch;
 
   if (requests.length === 0) {
-    return { total: 0, warmed: 0, skipped: 0, failed: 0, failures: [] };
+    return {
+      total: 0,
+      warmed: 0,
+      skipped: 0,
+      failed: 0,
+      failures: [],
+      retryPlan: { loadingShellPaths: [], paths: [], rscPaths: [] },
+    };
   }
 
   console.log(`\n  Warming CDN cache with ${requests.length} discovered request(s)...`);
 
   const progress = new CdnWarmProgress();
   let completedRequests = 0;
-  progress.update(0, requests.length, "waiting for uploaded build");
+  progress.update(0, requests.length, "starting warmup");
 
-  type WarmRetryMode = "normal" | "propagation-gate" | "propagation-pass" | "propagation-retry";
+  type WarmRetryMode = "normal" | "propagation-pass" | "propagation-retry";
   const warmTarget = (target: WarmTarget, retryMode: WarmRetryMode = "normal") => {
     const isPropagationRequest = retryMode !== "normal";
     const retries =
-      retryMode === "propagation-gate"
-        ? propagationRetries
-        : retryMode === "propagation-retry"
-          ? Math.max(0, propagationRetries - 1)
-          : retryMode === "propagation-pass"
-            ? 0
-            : normalRetries;
+      retryMode === "propagation-retry"
+        ? Math.max(0, propagationRetries - 1)
+        : retryMode === "propagation-pass"
+          ? 0
+          : normalRetries;
     return warmOnePath(target, {
       targetUrl: options.targetUrl,
       timeoutMs,
       retries,
       fetchImpl,
       headers: options.headers,
+      expectedBuildId: options.expectedBuildId,
       expectedRscBuildId: options.expectedRscBuildId,
       retryAllValidationErrors: isPropagationRequest,
       retryDelayMs: isPropagationRequest ? propagationRetryDelayMs : normalRetryDelayMs,
@@ -681,74 +736,26 @@ export async function warmCdnCache(options: CdnWarmOptions): Promise<CdnWarmResu
     return results;
   };
 
-  /*
-   * The two gates below establish that the uploaded RSC and HTML handlers are
-   * reachable before the large concurrent pass starts. Remaining requests get
-   * one attempt first, then only failures consume their retry budget after the
-   * queue has completed. This lets a large successful queue provide additional
-   * propagation time without fetching successful cache keys twice.
-   */
-
-  const skipRequests = (
-    targets: readonly WarmTarget[],
-    error: string,
-  ): Array<{ path: string; ok: false; error: string }> =>
-    targets.map((target) => {
-      progress.update(++completedRequests, requests.length, target.label);
-      return { path: target.label, ok: false as const, error };
-    });
-
-  const warmAfterHtmlGate = async (
-    confirmed: Awaited<ReturnType<typeof warmOnePath>>[],
-    remaining: readonly WarmTarget[],
-  ): Promise<Awaited<ReturnType<typeof warmOnePath>>[]> => {
-    const htmlGateIndex = remaining.findIndex((target) => target.kind === "html");
-    if (htmlGateIndex < 0) {
-      return [...confirmed, ...(await warmPropagatingPass(remaining))];
-    }
-
-    const htmlGateResult = await warmRequest(remaining[htmlGateIndex], "propagation-gate");
-    const afterHtmlGate = remaining.filter((_target, index) => index !== htmlGateIndex);
-    if (!htmlGateResult.ok) {
-      return [
-        ...confirmed,
-        htmlGateResult,
-        ...skipRequests(
-          afterHtmlGate,
-          `skipped because the first HTML request did not reach the uploaded build: ${htmlGateResult.error}`,
-        ),
-      ];
-    }
-    return [...confirmed, htmlGateResult, ...(await warmPropagatingPass(afterHtmlGate))];
-  };
-
-  const gateIndex = propagatingTarget ? requests.findIndex((target) => target.kind === "rsc") : -1;
   let results: Awaited<ReturnType<typeof warmOnePath>>[];
-  if (gateIndex >= 0) {
-    const gateResult = await warmRequest(requests[gateIndex], "propagation-gate");
-    const remaining = requests.filter((_target, index) => index !== gateIndex);
-    if (gateResult.ok) {
-      results = await warmAfterHtmlGate([gateResult], remaining);
-    } else {
-      results = [
-        gateResult,
-        ...skipRequests(
-          remaining,
-          "skipped because the uploaded RSC build identity was not confirmed",
-        ),
-      ];
-    }
-  } else if (propagatingTarget) {
-    results = await warmAfterHtmlGate([], requests);
+  if (propagatingTarget) {
+    results = await warmPropagatingPass(requests);
   } else {
     results = await runWithConcurrency(requests, concurrency, (target) => warmRequest(target));
   }
 
   progress.finish();
 
-  const failures = results
-    .filter((result): result is { path: string; ok: false; error: string } => !result.ok)
-    .map(({ path, error }) => ({ path, error }));
+  const failedRequests = requests
+    .map((target, index) => ({ result: results[index], target }))
+    .filter(
+      (
+        entry,
+      ): entry is {
+        result: { path: string; ok: false; error: string };
+        target: WarmTarget;
+      } => !entry.result.ok,
+    );
+  const failures = failedRequests.map(({ result: { path, error } }) => ({ path, error }));
   const skippedResults = results.filter((result) => result.ok && result.skipped);
   const warmed = results.length - failures.length - skippedResults.length;
 
@@ -773,6 +780,17 @@ export async function warmCdnCache(options: CdnWarmOptions): Promise<CdnWarmResu
     skipped: skippedResults.length,
     failed: failures.length,
     failures,
+    retryPlan: {
+      loadingShellPaths: failedRequests
+        .filter(({ target }) => target.kind === "rsc-loading-shell")
+        .map(({ target }) => target.sourcePathname),
+      paths: failedRequests
+        .filter(({ target }) => target.kind === "html")
+        .map(({ target }) => target.sourcePathname),
+      rscPaths: failedRequests
+        .filter(({ target }) => target.kind === "rsc-full")
+        .map(({ target }) => target.sourcePathname),
+    },
   };
 
   if (options.strict && failures.length > 0) {
@@ -792,5 +810,10 @@ export async function warmCdnCacheFromPrerender(
     includeFallbackShells: options.includeFallbackShells,
     strict: options.strict,
   });
-  return warmCdnCache({ ...options, ...plan });
+  const { buildId, ...warmPlan } = plan;
+  return warmCdnCache({
+    ...options,
+    ...warmPlan,
+    expectedBuildId: options.expectedBuildId ?? buildId,
+  });
 }

--- a/packages/cloudflare/src/cdn-warm.ts
+++ b/packages/cloudflare/src/cdn-warm.ts
@@ -650,7 +650,7 @@ export async function warmCdnCache(options: CdnWarmOptions): Promise<CdnWarmResu
   // an old Worker response from being mistaken for a successful fill.
   const concurrency = Math.max(1, options.concurrency ?? DEFAULT_CDN_WARM_CONCURRENCY);
   const normalRetries = Math.max(0, options.retries ?? 1);
-  const propagationRetries = Math.max(0, options.retries ?? 30);
+  const propagationRetries = Math.max(0, options.retries ?? 60);
   const normalRetryDelayMs = Math.max(0, options.retryDelayMs ?? 0);
   const propagationRetryDelayMs = Math.max(0, options.retryDelayMs ?? 1_000);
   const fetchImpl = options.fetchImpl ?? fetch;

--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -45,7 +45,12 @@ import {
   type ProjectInfo,
 } from "vinext/internal/utils/project";
 import { parseWranglerConfig, runTPR } from "./tpr.js";
-import { readPrerenderWarmPlan, warmCdnCache, type CdnWarmOptions } from "./cdn-warm.js";
+import {
+  readPrerenderWarmPlan,
+  warmCdnCache,
+  type CdnWarmOptions,
+  type CdnWarmRequestPlan,
+} from "./cdn-warm.js";
 import {
   formatMissingCacheAdapterError,
   formatImageOptimizationHint,
@@ -570,23 +575,32 @@ export async function deployWithCdnWarmup(
     | "warmCdnPromote"
     | "warmCdnPromotionDelay"
   > &
-    Pick<CdnWarmOptions, "deploymentId" | "expectedRscBuildId" | "loadingShellPaths" | "rscPaths">,
+    Pick<
+      CdnWarmOptions,
+      "deploymentId" | "expectedBuildId" | "expectedRscBuildId" | "loadingShellPaths" | "rscPaths"
+    >,
 ): Promise<string> {
   const upload = runWranglerVersionUpload(root, options);
   const warmUploadedVersion = (
     targetUrl: string,
     headers?: HeadersInit,
     propagatingTarget = false,
+    plan: CdnWarmRequestPlan = {
+      loadingShellPaths: [...(options.loadingShellPaths ?? [])],
+      paths: [...paths],
+      rscPaths: [...(options.rscPaths ?? [])],
+    },
   ) =>
     warmCdnCache({
       targetUrl,
-      paths,
+      paths: plan.paths,
       headers,
       propagatingTarget,
       deploymentId: options.deploymentId,
+      expectedBuildId: options.expectedBuildId,
       expectedRscBuildId: options.expectedRscBuildId,
-      loadingShellPaths: options.loadingShellPaths,
-      rscPaths: options.rscPaths,
+      loadingShellPaths: plan.loadingShellPaths,
+      rscPaths: plan.rscPaths,
       concurrency: options.warmCdnConcurrency,
       timeoutMs: options.warmCdnTimeout,
       retries: options.warmCdnRetries,
@@ -598,7 +612,12 @@ export async function deployWithCdnWarmup(
   const stagingTraffic = getZeroPercentStagingTraffic(deploymentStatus, upload.versionId);
   let staged: ReturnType<typeof runWranglerVersionDeploy> | null = null;
   let triggersDeployedUrl: string | null = null;
-  let warmedBeforePromotion = false;
+  let stagedCacheFilled = false;
+  let remainingWarmPlan: CdnWarmRequestPlan = {
+    loadingShellPaths: [...(options.loadingShellPaths ?? [])],
+    paths: [...paths],
+    rscPaths: [...(options.rscPaths ?? [])],
+  };
   let triggersApplied = false;
 
   function applyTriggers(): void {
@@ -624,7 +643,8 @@ export async function deployWithCdnWarmup(
     if (targetUrl && headers) {
       try {
         const warmResult = await warmUploadedVersion(targetUrl, headers, true);
-        warmedBeforePromotion = warmResult.failed === 0;
+        stagedCacheFilled = warmResult.warmed > 0;
+        remainingWarmPlan = warmResult.retryPlan;
       } catch (error) {
         throw withStagedVersionCleanupNote(error);
       }
@@ -661,7 +681,7 @@ export async function deployWithCdnWarmup(
 
   let deployed: ReturnType<typeof runWranglerVersionDeploy>;
   try {
-    if (warmedBeforePromotion) {
+    if (stagedCacheFilled) {
       const promotionDelay = options.warmCdnPromotionDelay ?? DEFAULT_CDN_WARM_PROMOTION_DELAY_MS;
       if (promotionDelay > 0) {
         console.log(
@@ -674,12 +694,16 @@ export async function deployWithCdnWarmup(
       root,
       [{ versionId: upload.versionId, percentage: 100 }],
       options,
-      warmedBeforePromotion ? "promote-warmed" : "promote-uploaded",
+      stagedCacheFilled ? "promote-warmed" : "promote-uploaded",
     );
   } catch (error) {
     throw staged ? withStagedVersionCleanupNote(error) : error;
   }
-  if (!warmedBeforePromotion) {
+  const remainingWarmRequests =
+    remainingWarmPlan.paths.length +
+    remainingWarmPlan.rscPaths.length +
+    remainingWarmPlan.loadingShellPaths.length;
+  if (remainingWarmRequests > 0) {
     try {
       applyTriggers();
     } catch (error) {
@@ -692,7 +716,7 @@ export async function deployWithCdnWarmup(
     );
     if (targetUrl) {
       try {
-        await warmUploadedVersion(targetUrl, undefined, true);
+        await warmUploadedVersion(targetUrl, undefined, true, remainingWarmPlan);
       } catch (error) {
         throw withPromotedVersionWarmupNote(error);
       }
@@ -1025,6 +1049,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
       url = await deployWithCdnWarmup(root, warmPlan.paths, {
         ...wranglerOptions,
         deploymentId: warmPlan.deploymentId,
+        expectedBuildId: warmPlan.buildId,
         expectedRscBuildId: warmPlan.rscBuildId,
         loadingShellPaths: warmPlan.loadingShellPaths,
         rscPaths: warmPlan.rscPaths,

--- a/tests/cloudflare-cdn-cache.test.ts
+++ b/tests/cloudflare-cdn-cache.test.ts
@@ -22,6 +22,7 @@ import {
 } from "../packages/vinext/src/server/app-page-cache-finalizer.js";
 import { finalizeAppRscResponse } from "../packages/vinext/src/server/app-rsc-response-finalizer.js";
 import type { RequestContext } from "../packages/vinext/src/config/request-context.js";
+import { VINEXT_CDN_BUILD_ID_HEADER } from "../packages/cloudflare/src/cache/cdn-build-id.js";
 
 const CDN_KEY = Symbol.for("vinext.cdnCacheAdapter");
 
@@ -68,7 +69,10 @@ function finalizePendingDynamicRscResponse(): Response {
 }
 
 beforeEach(resetActiveAdapter);
-afterEach(resetActiveAdapter);
+afterEach(() => {
+  resetActiveAdapter();
+  vi.unstubAllEnvs();
+});
 
 // ─── Adapter behavior ────────────────────────────────────────────────────
 
@@ -77,6 +81,17 @@ describe("CloudflareCdnCacheAdapter", () => {
 
   it("does not own background revalidation (the edge re-requests origin)", () => {
     expect(adapter.ownsBackgroundRevalidation).toBe(false);
+  });
+
+  it("stamps the application build identity on cacheable and no-store responses", () => {
+    vi.stubEnv("__VINEXT_BUILD_ID", "build-a");
+
+    expect(adapter.buildResponseHeaders({ cacheControl: "s-maxage=60" })).toMatchObject({
+      [VINEXT_CDN_BUILD_ID_HEADER]: "build-a",
+    });
+    expect(adapter.buildResponseHeaders({ cacheControl: "no-store" })).toMatchObject({
+      [VINEXT_CDN_BUILD_ID_HEADER]: "build-a",
+    });
   });
 
   it("get returns null so the origin always renders fresh", async () => {

--- a/tests/cloudflare-cdn-warm-deploy.test.ts
+++ b/tests/cloudflare-cdn-warm-deploy.test.ts
@@ -6,6 +6,7 @@ import {
   VINEXT_RSC_BUILD_ID_HEADER,
   VINEXT_RSC_VARY_HEADER,
 } from "../packages/vinext/src/server/app-rsc-cache-busting.js";
+import { VINEXT_CDN_BUILD_ID_HEADER } from "../packages/cloudflare/src/cache/cdn-build-id.js";
 
 const execFileSyncMock = vi.hoisted(() => vi.fn());
 const delayMock = vi.hoisted(() => vi.fn());
@@ -86,10 +87,15 @@ describe("Cloudflare CDN warmup deploy flow", () => {
               "cdn-cache-control": "public, max-age=60",
               "cf-cache-status": "MISS",
               "content-type": "text/x-component",
+              [VINEXT_CDN_BUILD_ID_HEADER]: "app-build-a",
               [VINEXT_RSC_BUILD_ID_HEADER]: "build-a",
               vary: VINEXT_RSC_VARY_HEADER,
             }
-          : { "cf-cache-status": "MISS", "content-type": "text/html" },
+          : {
+              "cf-cache-status": "MISS",
+              "content-type": "text/html",
+              [VINEXT_CDN_BUILD_ID_HEADER]: "app-build-a",
+            },
       });
     });
     execFileSyncMock.mockImplementation((_file: string, args: string[]) => {
@@ -125,6 +131,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
 
     const url = await deployWithCdnWarmup(tmpDir, ["/", "/about"], {
       deploymentId: "dpl_123",
+      expectedBuildId: "app-build-a",
       expectedRscBuildId: "build-a",
       loadingShellPaths: ["/about"],
       rscPaths: ["/about"],
@@ -163,12 +170,12 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     );
     expect(fetch).toHaveBeenNthCalledWith(
       2,
-      new URL("https://app.example.com/"),
+      new URL("https://app.example.com/about?_rsc=9qLBDIU2NgN178cB"),
       expect.any(Object),
     );
     expect(fetch).toHaveBeenNthCalledWith(
       3,
-      new URL("https://app.example.com/about?_rsc=9qLBDIU2NgN178cB"),
+      new URL("https://app.example.com/"),
       expect.any(Object),
     );
     expect(fetch).toHaveBeenNthCalledWith(
@@ -186,18 +193,18 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     expect(rscHeaders.get("next-router-prefetch")).toBeNull();
     expect(rscHeaders.get("next-router-state-tree")).toBeNull();
     expect(rscHeaders.get("next-url")).toBeNull();
-    const firstHtmlHeaders = new Headers(vi.mocked(fetch).mock.calls[1]![1]?.headers);
-    expect(firstHtmlHeaders.get("Cloudflare-Workers-Version-Overrides")).toBe(
-      'my-worker="22222222-2222-4222-8222-222222222222"',
-    );
-    expect(firstHtmlHeaders.get("accept")).toBe("text/html");
-    const loadingHeaders = new Headers(vi.mocked(fetch).mock.calls[2]![1]?.headers);
+    const loadingHeaders = new Headers(vi.mocked(fetch).mock.calls[1]![1]?.headers);
     expect(loadingHeaders.get("Cloudflare-Workers-Version-Overrides")).toBe(
       'my-worker="22222222-2222-4222-8222-222222222222"',
     );
     expect(loadingHeaders.get("next-router-prefetch")).toBe("1");
     expect(loadingHeaders.get("next-router-segment-prefetch")).toBe("1");
     expect(loadingHeaders.get("x-vinext-rsc-render-mode")).toBe("prefetch-loading-shell");
+    const firstHtmlHeaders = new Headers(vi.mocked(fetch).mock.calls[2]![1]?.headers);
+    expect(firstHtmlHeaders.get("Cloudflare-Workers-Version-Overrides")).toBe(
+      'my-worker="22222222-2222-4222-8222-222222222222"',
+    );
+    expect(firstHtmlHeaders.get("accept")).toBe("text/html");
     expect(execFileSyncMock).toHaveBeenNthCalledWith(
       4,
       process.execPath,
@@ -216,8 +223,8 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       "stage",
       "triggers",
       "fetch:https://app.example.com/about?_rsc",
-      "fetch:https://app.example.com/",
       "fetch:https://app.example.com/about?_rsc=9qLBDIU2NgN178cB",
+      "fetch:https://app.example.com/",
       "fetch:https://app.example.com/about",
       "delay:15000",
       "promote",
@@ -226,9 +233,8 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     expect(delayMock).toHaveBeenCalledWith(15_000);
   });
 
-  it("falls back to post-promotion warming after a non-strict staged failure", async () => {
+  it("does not replay successful staged fills after a non-strict partial failure", async () => {
     const events: string[] = [];
-    let promotedRscAttempts = 0;
     writeFile(
       "wrangler.jsonc",
       JSON.stringify({ name: "my-worker", custom_domains: ["app.example.com"] }),
@@ -236,9 +242,10 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     vi.mocked(fetch).mockImplementation(async (_url, init) => {
       const headers = new Headers(init?.headers);
       const isRsc = headers.get("rsc") === "1";
+      const isLoadingShell = headers.has("next-router-segment-prefetch");
       const staged = headers.has("Cloudflare-Workers-Version-Overrides");
-      events.push(`fetch:${staged ? "staged" : "promoted"}:${isRsc ? "rsc" : "html"}`);
-      if (isRsc && !staged) promotedRscAttempts++;
+      const kind = isLoadingShell ? "loading" : isRsc ? "rsc" : "html";
+      events.push(`fetch:${staged ? "staged" : "promoted"}:${kind}`);
       return new Response(isRsc ? "flight" : "html", {
         headers: isRsc
           ? {
@@ -246,11 +253,15 @@ describe("Cloudflare CDN warmup deploy flow", () => {
               "cdn-cache-control": "public, max-age=60",
               "cf-cache-status": "MISS",
               "content-type": "text/x-component",
-              [VINEXT_RSC_BUILD_ID_HEADER]:
-                staged || promotedRscAttempts === 1 ? "old-build" : "new-build",
+              [VINEXT_CDN_BUILD_ID_HEADER]: "app-build-a",
+              [VINEXT_RSC_BUILD_ID_HEADER]: staged && isLoadingShell ? "old-build" : "new-build",
               vary: VINEXT_RSC_VARY_HEADER,
             }
-          : { "cf-cache-status": "MISS", "content-type": "text/html" },
+          : {
+              "cf-cache-status": "MISS",
+              "content-type": "text/html",
+              [VINEXT_CDN_BUILD_ID_HEADER]: "app-build-a",
+            },
       });
     });
     execFileSyncMock.mockImplementation((_file: string, args: string[]) => {
@@ -281,7 +292,9 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     const { deployWithCdnWarmup } = await import("../packages/cloudflare/src/deploy.js");
 
     await deployWithCdnWarmup(tmpDir, ["/about"], {
+      expectedBuildId: "app-build-a",
       expectedRscBuildId: "new-build",
+      loadingShellPaths: ["/about"],
       rscPaths: ["/about"],
       warmCdnRetries: 1,
     });
@@ -292,11 +305,75 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       "stage",
       "triggers",
       "fetch:staged:rsc",
-      "fetch:staged:rsc",
+      "fetch:staged:loading",
+      "fetch:staged:html",
+      "fetch:staged:loading",
       "promote",
-      "fetch:promoted:rsc",
-      "fetch:promoted:rsc",
-      "fetch:promoted:html",
+      "fetch:promoted:loading",
+    ]);
+    expect(delayMock).toHaveBeenCalledOnce();
+    expect(delayMock).toHaveBeenCalledWith(15_000);
+  });
+
+  it("falls back after every staged response comes from the wrong build", async () => {
+    const events: string[] = [];
+    writeFile(
+      "wrangler.jsonc",
+      JSON.stringify({ name: "my-worker", custom_domains: ["app.example.com"] }),
+    );
+    vi.mocked(fetch).mockImplementation(async (_url, init) => {
+      const staged = new Headers(init?.headers).has("Cloudflare-Workers-Version-Overrides");
+      events.push(`fetch:${staged ? "staged" : "promoted"}`);
+      return new Response("html", {
+        headers: {
+          "cdn-cache-control": "public, max-age=60",
+          "cf-cache-status": "MISS",
+          "content-type": "text/html",
+          [VINEXT_CDN_BUILD_ID_HEADER]: staged ? "old-build" : "new-build",
+        },
+      });
+    });
+    execFileSyncMock.mockImplementation((_file: string, args: string[]) => {
+      if (args.includes("upload")) {
+        events.push("upload");
+        return "Uploaded version 22222222-2222-4222-8222-222222222222\n";
+      }
+      if (args.includes("status")) {
+        events.push("status");
+        return JSON.stringify({
+          versions: [{ version_id: "11111111-1111-4111-8111-111111111111", percentage: 100 }],
+        });
+      }
+      if (args.includes("11111111-1111-4111-8111-111111111111@100%")) {
+        events.push("stage");
+        return "Staged version\nhttps://app.example.com\n";
+      }
+      if (args.includes("22222222-2222-4222-8222-222222222222@100%")) {
+        events.push("promote");
+        return "Deployed version\nhttps://app.example.com\n";
+      }
+      if (args.includes("triggers")) {
+        events.push("triggers");
+        return "Triggers deployed\n";
+      }
+      throw new Error(`Unexpected Wrangler args: ${args.join(" ")}`);
+    });
+    const { deployWithCdnWarmup } = await import("../packages/cloudflare/src/deploy.js");
+
+    await deployWithCdnWarmup(tmpDir, ["/about"], {
+      expectedBuildId: "new-build",
+      warmCdnRetries: 1,
+    });
+
+    expect(events).toEqual([
+      "upload",
+      "status",
+      "stage",
+      "triggers",
+      "fetch:staged",
+      "fetch:staged",
+      "promote",
+      "fetch:promoted",
     ]);
     expect(delayMock).not.toHaveBeenCalled();
   });

--- a/tests/cloudflare-cdn-warm.test.ts
+++ b/tests/cloudflare-cdn-warm.test.ts
@@ -483,6 +483,34 @@ describe("Cloudflare CDN warmup", () => {
     expect(attempts.get("/later:html")).toBe(2);
   });
 
+  it("keeps the staged propagation budget independent for each failed key", async () => {
+    const attempts = new Map<string, number>();
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const pathname = new URL(requestHref(input)!).pathname;
+      const attempt = (attempts.get(pathname) ?? 0) + 1;
+      attempts.set(pathname, attempt);
+      if (pathname === "/slow" && attempt <= 30) {
+        return new Response("not propagated", { status: 404 });
+      }
+      return cacheableRsc();
+    });
+
+    await expect(
+      warmCdnCache({
+        expectedRscBuildId: "rsc-build-a",
+        fetchImpl: fetchImpl as typeof fetch,
+        paths: [],
+        propagatingTarget: true,
+        retryDelayMs: 0,
+        rscPaths: ["/ready", "/slow"],
+        strict: true,
+        targetUrl: "https://app.example.com",
+      }),
+    ).resolves.toMatchObject({ total: 2, warmed: 2, failed: 0 });
+    expect(attempts.get("/ready")).toBe(1);
+    expect(attempts.get("/slow")).toBe(31);
+  });
+
   it("warms directly from the discovery manifest", async () => {
     writeFile("dist/server/BUILD_ID", "build-a\n");
     writeFile(

--- a/tests/cloudflare-cdn-warm.test.ts
+++ b/tests/cloudflare-cdn-warm.test.ts
@@ -14,6 +14,7 @@ import {
   VINEXT_RSC_BUILD_ID_HEADER,
   VINEXT_RSC_VARY_HEADER,
 } from "../packages/vinext/src/server/app-rsc-cache-busting.js";
+import { VINEXT_CDN_BUILD_ID_HEADER } from "../packages/cloudflare/src/cache/cdn-build-id.js";
 
 let tmpDir: string;
 
@@ -30,6 +31,7 @@ function cacheableRsc(body = "flight"): Response {
       "cdn-cache-control": "public, max-age=60",
       "cf-cache-status": "MISS",
       "content-type": "text/x-component",
+      [VINEXT_CDN_BUILD_ID_HEADER]: "build-a",
       [VINEXT_RSC_BUILD_ID_HEADER]: "rsc-build-a",
       vary: VINEXT_RSC_VARY_HEADER,
     },
@@ -43,6 +45,7 @@ function cacheableHtml(body = "html"): Response {
       "cdn-cache-control": "public, max-age=60",
       "cf-cache-status": "MISS",
       "content-type": "text/html",
+      [VINEXT_CDN_BUILD_ID_HEADER]: "build-a",
     },
   });
 }
@@ -93,6 +96,7 @@ describe("Cloudflare CDN warmup", () => {
     );
 
     expect(readPrerenderWarmPlan(tmpDir)).toEqual({
+      buildId: "build-a",
       deploymentId: "dpl_123",
       loadingShellPaths: ["/docs/dashboard/"],
       paths: ["/docs/dashboard/", "/docs/dynamic/", "/docs/pages/"],
@@ -115,6 +119,7 @@ describe("Cloudflare CDN warmup", () => {
     );
 
     expect(readPrerenderWarmPlan(tmpDir)).toEqual({
+      buildId: "build-a",
       loadingShellPaths: [],
       paths: ["/dashboard"],
       rscPaths: [],
@@ -187,6 +192,7 @@ describe("Cloudflare CDN warmup", () => {
 
     const result = await warmCdnCache({
       deploymentId: "dpl_123",
+      expectedBuildId: "build-a",
       expectedRscBuildId: "rsc-build-a",
       fetchImpl: fetchImpl as typeof fetch,
       loadingShellPaths: ["/search?q=x"],
@@ -195,7 +201,14 @@ describe("Cloudflare CDN warmup", () => {
       targetUrl: "https://app.example.com",
     });
 
-    expect(result).toEqual({ total: 3, warmed: 3, skipped: 0, failed: 0, failures: [] });
+    expect(result).toEqual({
+      total: 3,
+      warmed: 3,
+      skipped: 0,
+      failed: 0,
+      failures: [],
+      retryPlan: { loadingShellPaths: [], paths: [], rscPaths: [] },
+    });
     expect(fetchImpl).toHaveBeenCalledTimes(3);
     const fullCall = fetchImpl.mock.calls.find((call) => {
       const headers = new Headers(call[1]?.headers);
@@ -265,7 +278,14 @@ describe("Cloudflare CDN warmup", () => {
         strict: true,
         targetUrl: "https://app.example.com",
       }),
-    ).resolves.toEqual({ total: 2, warmed: 0, skipped: 2, failed: 0, failures: [] });
+    ).resolves.toEqual({
+      total: 2,
+      warmed: 0,
+      skipped: 2,
+      failed: 0,
+      failures: [],
+      retryPlan: { loadingShellPaths: [], paths: [], rscPaths: [] },
+    });
   });
 
   it("uses Cloudflare cache-control precedence when validating admission", async () => {
@@ -355,7 +375,31 @@ describe("Cloudflare CDN warmup", () => {
     ).rejects.toThrow("response is missing CF-Cache-Status");
   });
 
-  it("retries staged-target failures after the initial queue has completed", async () => {
+  it("rejects responses rendered by a different application build", async () => {
+    const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const response =
+        new Headers(init?.headers).get("rsc") === "1" ? cacheableRsc() : cacheableHtml();
+      response.headers.set(VINEXT_CDN_BUILD_ID_HEADER, "old-build");
+      return response;
+    });
+
+    await expect(
+      warmCdnCache({
+        expectedBuildId: "build-a",
+        expectedRscBuildId: "rsc-build-a",
+        fetchImpl: fetchImpl as typeof fetch,
+        paths: ["/about"],
+        propagatingTarget: true,
+        retries: 0,
+        rscPaths: ["/about"],
+        strict: true,
+        targetUrl: "https://app.example.com",
+      }),
+    ).rejects.toThrow(`response ${VINEXT_CDN_BUILD_ID_HEADER} does not match build build-a`);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries first and later staged-target failures only after the initial queue", async () => {
     const attempts = new Map<string, number>();
     const calls: string[] = [];
     const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -365,7 +409,7 @@ describe("Cloudflare CDN warmup", () => {
       calls.push(key);
       const attempt = (attempts.get(key) ?? 0) + 1;
       attempts.set(key, attempt);
-      if (url.pathname === "/later" && attempt === 1) {
+      if ((url.pathname === "/first" || url.pathname === "/later") && attempt === 1) {
         if (!isRsc) return new Response("not propagated", { status: 500 });
         const stale = cacheableRsc();
         stale.headers.set(VINEXT_RSC_BUILD_ID_HEADER, "stale-rsc-build");
@@ -388,13 +432,15 @@ describe("Cloudflare CDN warmup", () => {
         targetUrl: "https://app.example.com",
       }),
     ).resolves.toMatchObject({ total: 6, warmed: 6, failed: 0 });
-    expect(attempts.get("/first:rsc")).toBe(1);
-    expect(attempts.get("/first:html")).toBe(1);
+    expect(attempts.get("/first:rsc")).toBe(2);
+    expect(attempts.get("/first:html")).toBe(2);
     expect(attempts.get("/later:rsc")).toBe(2);
     expect(attempts.get("/later:html")).toBe(2);
     expect(attempts.get("/tail:rsc")).toBe(1);
     expect(attempts.get("/tail:html")).toBe(1);
     const lastInitialRequest = Math.max(calls.indexOf("/tail:rsc"), calls.indexOf("/tail:html"));
+    expect(calls.lastIndexOf("/first:rsc")).toBeGreaterThan(lastInitialRequest);
+    expect(calls.lastIndexOf("/first:html")).toBeGreaterThan(lastInitialRequest);
     expect(calls.lastIndexOf("/later:rsc")).toBeGreaterThan(lastInitialRequest);
     expect(calls.lastIndexOf("/later:html")).toBeGreaterThan(lastInitialRequest);
   });


### PR DESCRIPTION
## Summary

- stamp cacheable Worker responses with the application build ID and validate it during HTML and RSC warming
- give every staged cache key one initial attempt, then retry only failures after the queue completes
- after promotion, retry only the keys that still failed without replaying successful full RSC, loading-shell RSC, or HTML fills
- retain the propagation delay whenever at least one staged cache entry was filled

## Testing

- `vp test run tests/cloudflare-cdn-warm.test.ts tests/cloudflare-cdn-warm-deploy.test.ts tests/cloudflare-cdn-cache.test.ts` (57 passed)
- `vp check packages/cloudflare/src/cache/cdn-build-id.ts packages/cloudflare/src/cache/cdn-adapter.runtime.ts packages/cloudflare/src/cdn-warm.ts packages/cloudflare/src/deploy.ts tests/cloudflare-cdn-cache.test.ts tests/cloudflare-cdn-warm.test.ts tests/cloudflare-cdn-warm-deploy.test.ts`

Stacked on #3021.
