### PR TITLE
fix(build): filter Pages-owned RSC warm paths

### DIFF
--- a/packages/vinext/src/build/prerender-paths.ts
+++ b/packages/vinext/src/build/prerender-paths.ts
@@ -6,8 +6,8 @@ import {
   resolveNextConfig,
   type ResolvedNextConfig,
 } from "../config/next-config.js";
-import { appRouter } from "../routing/app-router.js";
-import { apiRouter, pagesRouter } from "../routing/pages-router.js";
+import { appRouter, matchAppRoute } from "../routing/app-router.js";
+import { apiRouter, matchRoute, pagesRouter } from "../routing/pages-router.js";
 import { normalizeStaticPathsEntry, type StaticPathsEntry } from "../routing/route-pattern.js";
 import {
   getAppRouteRenderEntryPath,
@@ -24,6 +24,7 @@ import { VINEXT_PRERENDER_SECRET_HEADER } from "../server/headers.js";
 import type { VinextRouteRootConfig } from "../config/prerender.js";
 import { enterPrerenderPhase } from "./prerender-phase.js";
 import type { CdnCacheAdapterCapabilities } from "../cache/cache-adapters-virtual.js";
+import { pagesRouteHasPriorityOverAppRoute } from "../server/hybrid-route-priority.js";
 
 export type PrerenderPathManifest = {
   basePath?: string;
@@ -166,6 +167,18 @@ function resolveConfiguredRouteDirs(
 function appRouteMayHaveGenerateStaticParams(route: Awaited<ReturnType<typeof appRouter>>[number]) {
   if (fileHasNamedExport(route.pagePath, "generateStaticParams")) return true;
   return route.layouts.some((layoutPath) => fileHasNamedExport(layoutPath, "generateStaticParams"));
+}
+
+function appRouteHasMainTreeLoadingBoundary(
+  route: Awaited<ReturnType<typeof appRouter>>[number],
+): boolean {
+  return (
+    route.loadingPath != null ||
+    (route.loadingPaths?.some(
+      (_loadingPath, index) => (route.loadingTreePositions?.[index] ?? 0) > 0,
+    ) ??
+      false)
+  );
 }
 
 async function shouldStartPathDiscoveryServer(options: {
@@ -314,12 +327,7 @@ async function collectAppPaths(options: {
     const { type } = classifyAppRoute(renderEntryPath, route.routePath, route.isDynamic);
     if (type === "api") continue;
 
-    const hasMainTreeLoadingBoundary =
-      route.loadingPath != null ||
-      (route.loadingPaths?.some(
-        (_loadingPath, index) => (route.loadingTreePositions?.[index] ?? 0) > 0,
-      ) ??
-        false);
+    const hasMainTreeLoadingBoundary = appRouteHasMainTreeLoadingBoundary(route);
     const addDiscoveredPath = (pathname: string): void => {
       addPath(paths, seen, pathname);
       if (hasMainTreeLoadingBoundary) {
@@ -371,6 +379,49 @@ async function collectAppPaths(options: {
   }
 
   return { loadingShellPaths, paths };
+}
+
+async function resolveAppRscWarmPaths(options: {
+  appDir: string;
+  pagesDir: string | null;
+  pageExtensions: readonly string[];
+  paths: readonly string[];
+}): Promise<{ loadingShellPaths: string[]; rscPaths: string[] }> {
+  const appRoutes = await appRouter(options.appDir, options.pageExtensions);
+  const [pageRoutes, apiRoutes] = options.pagesDir
+    ? await Promise.all([
+        pagesRouter(options.pagesDir, options.pageExtensions),
+        apiRouter(options.pagesDir, options.pageExtensions),
+      ])
+    : [[], []];
+
+  const rscPaths: string[] = [];
+  const loadingShellPaths: string[] = [];
+  for (const pathname of options.paths) {
+    const appMatch = matchAppRoute(pathname, appRoutes);
+    if (!appMatch) continue;
+    // The trie returns the exact object from appRoutes. Its public matcher type
+    // exposes the shared AppRoute fields, so recover the graph-owned metadata
+    // here without rescanning the route table for every concrete path.
+    const matchedAppRoute = appMatch.route as (typeof appRoutes)[number];
+
+    const appRenderEntryPath = getAppRouteRenderEntryPath(matchedAppRoute);
+    if (!appRenderEntryPath) continue;
+
+    const pagesMatch = matchRoute(
+      pathname,
+      pathname === "/api" || pathname.startsWith("/api/") ? apiRoutes : pageRoutes,
+    );
+    if (pagesMatch && pagesRouteHasPriorityOverAppRoute(pagesMatch.route, matchedAppRoute)) {
+      continue;
+    }
+
+    rscPaths.push(pathname);
+    if (appRouteHasMainTreeLoadingBoundary(matchedAppRoute)) {
+      loadingShellPaths.push(pathname);
+    }
+  }
+  return { loadingShellPaths, rscPaths };
 }
 
 async function startPathDiscoveryServer(options: {
@@ -491,6 +542,19 @@ export async function emitPrerenderPathManifest(
     }
   });
 
+  const appOwnedWarmPaths =
+    options.responseVary && appDir
+      ? await resolveAppRscWarmPaths({
+          appDir,
+          pagesDir,
+          pageExtensions: config.pageExtensions,
+          paths: discoveredAppPaths,
+        })
+      : {
+          loadingShellPaths: discoveredLoadingShellPaths,
+          rscPaths: discoveredAppPaths,
+        };
+
   const manifest: PrerenderPathManifest = {
     ...(config.basePath ? { basePath: config.basePath } : {}),
     buildId: config.buildId,
@@ -498,8 +562,8 @@ export async function emitPrerenderPathManifest(
     ...(pagesDir ? { pagesPaths: discoveredPagesPaths } : {}),
     ...(rscBuildId ? { rscBuildId } : {}),
     ...(options.responseVary ? { responseVary: options.responseVary } : {}),
-    ...(options.responseVary ? { rscPaths: discoveredAppPaths } : {}),
-    ...(options.responseVary ? { loadingShellPaths: discoveredLoadingShellPaths } : {}),
+    ...(options.responseVary ? { rscPaths: appOwnedWarmPaths.rscPaths } : {}),
+    ...(options.responseVary ? { loadingShellPaths: appOwnedWarmPaths.loadingShellPaths } : {}),
     trailingSlash: config.trailingSlash,
     paths,
   };

--- a/tests/prerender-paths.test.ts
+++ b/tests/prerender-paths.test.ts
@@ -38,6 +38,17 @@ describe("prerender path manifest", () => {
         ) {
           return Response.json([{ slug: "intro" }, { slug: "featured" }]);
         }
+        if (
+          url.pathname === "/__vinext/prerender/static-params" &&
+          url.searchParams.get("pattern") === "/:path+"
+        ) {
+          return Response.json([
+            { path: ["pages-dir", "foobar"] },
+            { path: ["pages-dir", "static"] },
+            { path: ["api", "status"] },
+            { path: ["specific", "value"] },
+          ]);
+        }
         return new Response("null", { headers: { "content-type": "application/json" } });
       }),
     );
@@ -133,6 +144,88 @@ describe("prerender path manifest", () => {
 
     expect(manifest?.rscPaths).toEqual(["/"]);
     expect(manifest?.rscBuildId).toBe("rsc-build-a");
+  });
+
+  it("excludes Pages-owned hybrid paths from App RSC warm discovery", async () => {
+    // Next.js resolves matching Pages and App routes by cross-router specificity:
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/use-params/use-params.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/pages-to-app-routing/pages-to-app-routing.test.ts
+    writeFile("package.json", JSON.stringify({ type: "module" }));
+    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile("dist/server/RSC_BUILD_ID", "rsc-build-a\n");
+    writeFile("dist/server/index.js", "export default {};\n");
+    writeFile(
+      "app/[...path]/page.tsx",
+      [
+        "export function generateStaticParams() { return []; }",
+        "export default function Page() { return null; }",
+      ].join("\n"),
+    );
+    writeFile("app/[...path]/loading.tsx", "export default function Loading() { return null; }\n");
+    writeFile("app/pages-dir/static/page.tsx", "export default function Page() { return null; }\n");
+    writeFile("app/specific/[id]/page.tsx", "export default function Page() { return null; }\n");
+    writeFile(
+      "app/specific/[id]/loading.tsx",
+      "export default function Loading() { return null; }\n",
+    );
+    writeFile("pages/pages-dir/[dynamic].tsx", "export default function Page() { return null; }\n");
+    writeFile(
+      "pages/api/[slug].ts",
+      "export default function handler(_request, response) { response.end('ok'); }\n",
+    );
+
+    const { emitPrerenderPathManifest } =
+      await import("../packages/vinext/src/build/prerender-paths.js");
+
+    const manifest = await emitPrerenderPathManifest({
+      root: tmpDir,
+      responseVary: "verbatim",
+    });
+
+    expect(manifest?.paths).toEqual([
+      "/pages-dir/static",
+      "/pages-dir/foobar",
+      "/api/status",
+      "/specific/value",
+    ]);
+    expect(manifest?.rscPaths).toEqual(["/pages-dir/static", "/specific/value"]);
+    expect(manifest?.loadingShellPaths).toEqual(["/specific/value"]);
+    expect(manifest?.pagesPaths).toEqual([]);
+  });
+
+  it("uses the runtime-best App route for App-only loading-shell discovery", async () => {
+    writeFile("package.json", JSON.stringify({ type: "module" }));
+    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile("dist/server/RSC_BUILD_ID", "rsc-build-a\n");
+    writeFile("dist/server/index.js", "export default {};\n");
+    writeFile(
+      "app/[...path]/page.tsx",
+      [
+        "export function generateStaticParams() { return []; }",
+        "export default function Page() { return null; }",
+      ].join("\n"),
+    );
+    writeFile("app/pages-dir/static/page.tsx", "export default function Page() { return null; }\n");
+    writeFile("app/specific/[id]/page.tsx", "export default function Page() { return null; }\n");
+    writeFile(
+      "app/specific/[id]/loading.tsx",
+      "export default function Loading() { return null; }\n",
+    );
+
+    const { emitPrerenderPathManifest } =
+      await import("../packages/vinext/src/build/prerender-paths.js");
+    const manifest = await emitPrerenderPathManifest({
+      root: tmpDir,
+      responseVary: "verbatim",
+    });
+
+    expect(manifest?.rscPaths).toEqual([
+      "/pages-dir/static",
+      "/pages-dir/foobar",
+      "/api/status",
+      "/specific/value",
+    ]);
+    expect(manifest?.loadingShellPaths).toEqual(["/specific/value"]);
   });
 
   it("skips dynamic warmup paths when static params discovery aborts", async () => {


### PR DESCRIPTION
## Summary

- resolve each concrete App-discovered warm path through the same cross-router ownership decision used at runtime
- exclude Pages page and Pages API-owned collisions only from full/loading-shell RSC warm targets
- retain generic HTML warm discovery so the deployed Worker still decides response cacheability
- compare against the best concrete App match, preserving more-specific App routes over broad Pages matches

This remains independent of local prerender output and the prerender flag.

## Next.js references

- [`test/e2e/app-dir/use-params/use-params.test.ts`](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/use-params/use-params.test.ts)
- [`test/e2e/app-dir/pages-to-app-routing/pages-to-app-routing.test.ts`](https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/pages-to-app-routing/pages-to-app-routing.test.ts)
- [`packages/next/src/server/base-server.ts`](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/base-server.ts)

## Testing

- `vp test run tests/prerender-paths.test.ts tests/hybrid-route-priority.test.ts` (28 passed)
- `vp check packages/vinext/src/build/prerender-paths.ts tests/prerender-paths.test.ts`

Stacked on #3022.
