### PR TITLE
fix(router): reuse warmed RSC on locale-prefixed hybrid routes

### DIFF
--- a/packages/vinext/src/shims/internal/hybrid-client-route-owner-direct.ts
+++ b/packages/vinext/src/shims/internal/hybrid-client-route-owner-direct.ts
@@ -31,12 +31,23 @@ declare global {
 
 const appRouteTrieCache = createRouteTrieCache<VinextLinkPrefetchRoute>();
 const pagesRouteTrieCache = createRouteTrieCache<VinextPagesLinkPrefetchRoute>();
+const pagesPageRoutesCache = new WeakMap<
+  VinextPagesLinkPrefetchRoute[],
+  VinextPagesLinkPrefetchRoute[]
+>();
+const pagesApiRoutesCache = new WeakMap<
+  VinextPagesLinkPrefetchRoute[],
+  VinextPagesLinkPrefetchRoute[]
+>();
 
 function patternFromParts(parts: readonly string[]): string {
   return "/" + parts.join("/");
 }
 
-export function resolveSameOriginPathname(href: string, basePath: string): string | null {
+function resolveSameOriginPathnames(
+  href: string,
+  basePath: string,
+): { appPathname: string; pagesApiRequest: boolean; pagesPathname: string } | null {
   if (typeof window === "undefined") return null;
   let url: URL;
   try {
@@ -45,28 +56,57 @@ export function resolveSameOriginPathname(href: string, basePath: string): strin
     return null;
   }
   if (url.origin !== window.location.origin) return null;
-  const pathname = stripBasePath(url.pathname, basePath);
-  const locale = getLocalePathPrefix(pathname, window.__VINEXT_LOCALES__);
-  if (!locale) return pathname;
-  const localePrefixLength = locale.length + 1;
-  return pathname.length === localePrefixLength ? "/" : pathname.slice(localePrefixLength);
+  const appPathname = stripBasePath(url.pathname, basePath);
+  const locale = getLocalePathPrefix(appPathname, window.__VINEXT_LOCALES__);
+  const localePrefixLength = locale ? locale.length + 1 : 0;
+  const pagesPathname = !locale
+    ? appPathname
+    : appPathname.length === localePrefixLength
+      ? "/"
+      : appPathname.slice(localePrefixLength);
+  return {
+    appPathname,
+    pagesApiRequest: appPathname === "/api" || appPathname.startsWith("/api/"),
+    pagesPathname,
+  };
+}
+
+export function resolveSameOriginPathname(href: string, basePath: string): string | null {
+  return resolveSameOriginPathnames(href, basePath)?.pagesPathname ?? null;
+}
+
+function selectPagesRoutes(
+  routes: VinextPagesLinkPrefetchRoute[],
+  apiRequest: boolean,
+): VinextPagesLinkPrefetchRoute[] {
+  const cache = apiRequest ? pagesApiRoutesCache : pagesPageRoutesCache;
+  let selected = cache.get(routes);
+  if (!selected) {
+    selected = routes.filter((route) => Boolean(route.documentOnly) === apiRequest);
+    cache.set(routes, selected);
+  }
+  return selected;
 }
 
 export function matchDirectHybridClientRoutes(
   href: string,
   basePath: string,
 ): HybridClientRouteMatches {
-  const pathname = resolveSameOriginPathname(href, basePath);
-  if (pathname === null) return { appMatch: null, pagesMatch: null };
+  const pathnames = resolveSameOriginPathnames(href, basePath);
+  if (pathnames === null) return { appMatch: null, pagesMatch: null };
 
   const appRoutes = window.__VINEXT_LINK_PREFETCH_ROUTES__;
   const pagesRoutes = window.__VINEXT_PAGES_LINK_PREFETCH_ROUTES__;
   return {
     appMatch: appRoutes
-      ? (matchRouteWithTrie(pathname, appRoutes, appRouteTrieCache)?.route ?? null)
+      ? (matchRouteWithTrie(pathnames.appPathname, appRoutes, appRouteTrieCache)?.route ?? null)
       : null,
     pagesMatch: pagesRoutes
-      ? (matchRouteWithTrie(pathname, pagesRoutes, pagesRouteTrieCache)?.route ?? null)
+      ? (matchRouteWithTrie(
+          pathnames.pagesPathname,
+          selectPagesRoutes(pagesRoutes, pathnames.pagesApiRequest),
+          pagesRouteTrieCache,
+        )?.route ?? null)
       : null,
   };
 }

--- a/tests/hybrid-client-route-owner.test.ts
+++ b/tests/hybrid-client-route-owner.test.ts
@@ -35,14 +35,16 @@ const APP_BASE = "http://localhost/";
 
 type WindowState = {
   app: VinextLinkPrefetchRoute[];
+  locales?: string[];
   pages: VinextPagesLinkPrefetchRoute[];
   rewrites?: ClientRewrites;
 };
 
-function installWindow({ app, pages, rewrites }: WindowState): void {
+function installWindow({ app, locales, pages, rewrites }: WindowState): void {
   (globalThis as any).window = {
     location: { href: APP_BASE, origin: "http://localhost" },
     __VINEXT_LINK_PREFETCH_ROUTES__: app,
+    __VINEXT_LOCALES__: locales,
     __VINEXT_PAGES_LINK_PREFETCH_ROUTES__: pages,
     __VINEXT_CLIENT_REWRITES__: rewrites,
   };
@@ -123,6 +125,30 @@ describe("resolveHybridClientRouteOwner", () => {
     expect(resolveHybridClientRouteOwner("/api/test", "")).toBe("document");
   });
 
+  it("keeps locale-prefixed App pages distinct from unprefixed Pages API routes", () => {
+    // Next.js treats /fr/api/* as a localized page path, not a Pages API path:
+    // test/e2e/i18n-api-support/index.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/i18n-api-support/index.test.ts
+    installWindow({
+      app: [appRoute([":locale", "api", "status"])],
+      locales: ["en", "fr"],
+      pages: [{ ...pagesRoute(["api", "status"], false), documentOnly: true }],
+    });
+
+    expect(resolveHybridClientRouteOwner("/fr/api/status", "")).toBe("app");
+    expect(resolveHybridClientRouteOwner("/api/status", "")).toBe("document");
+  });
+
+  it("still locale-normalizes Pages page matching", () => {
+    installWindow({
+      app: [appRoute([":locale", "dashboard"])],
+      locales: ["en", "fr"],
+      pages: [pagesRoute(["about"], false)],
+    });
+
+    expect(resolveHybridClientRouteOwner("/fr/about", "")).toBe("pages");
+  });
+
   it("applies document ownership only after choosing the most specific route", () => {
     installWindow({
       app: [appRoute(["api", "settings"], false)],
@@ -131,10 +157,10 @@ describe("resolveHybridClientRouteOwner", () => {
     expect(resolveHybridClientRouteOwner("/api/settings", "")).toBe("app");
 
     installWindow({
-      app: [documentRoute(["api", ":slug"])],
-      pages: [pagesRoute(["api", "settings"], false)],
+      app: [documentRoute(["docs", ":slug"])],
+      pages: [pagesRoute(["docs", "settings"], false)],
     });
-    expect(resolveHybridClientRouteOwner("/api/settings", "")).toBe("pages");
+    expect(resolveHybridClientRouteOwner("/docs/settings", "")).toBe("pages");
   });
 
   it.each(["beforeFiles", "afterFiles", "fallback"] as const)(


### PR DESCRIPTION
## Summary

Aligns browser hybrid-route ownership with the runtime and CDN warm-path discovery rules introduced by the RSC prewarming stack.

- match App routes against the raw, basePath-stripped pathname so an App route such as `/:locale/api/status` still owns `/fr/api/status`
- locale-normalize only the Pages pathname
- select the Pages API versus page manifest partition from the raw pathname, so `/fr/api/status` is not reclassified as the unprefixed Pages API route `/api/status`
- preserve existing locale-normalized Pages page matching and rewrite matching

This lets Link prefetch, `router.prefetch()`, and soft navigation reuse the App RSC entry that deploy-time discovery warmed for locale-prefixed hybrid routes.

This is stacked on #3026.

## Validation

- 173 focused tests across hybrid client ownership, Link behavior, prerender path discovery, and hybrid i18n runtime handoff
- targeted formatting, lint, and type checks
- `vp run vinext#build`

The API-path distinction follows Next.js' `test/e2e/i18n-api-support/index.test.ts` behavior for locale-prefixed `/fr/api/*` paths.
