### PR TITLE
fix(cloudflare): verify exact build and variant during CDN warmup

### DIFF
--- a/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
@@ -48,7 +48,7 @@ const CACHEABLE_EDGE_DIRECTIVE_RE = /(?:^|,)\s*(?:s-maxage|max-age)\s*=/i;
 const EDGE_POLICY_HEADERS = ["CDN-Cache-Control", "Cloudflare-CDN-Cache-Control"] as const;
 
 function getBuildIdentityResponseHeader(): CdnResponseHeaders {
-  const buildId = process.env.__VINEXT_BUILD_ID;
+  const buildId = process.env.__VINEXT_RSC_BUILD_IDENTITY ?? process.env.__VINEXT_BUILD_ID;
   return buildId ? { [VINEXT_CDN_BUILD_ID_HEADER]: buildId } : {};
 }
 

--- a/packages/cloudflare/src/cdn-warm.ts
+++ b/packages/cloudflare/src/cdn-warm.ts
@@ -52,7 +52,7 @@ export const DEFAULT_CDN_WARM_TIMEOUT_MS = 10_000;
 export type PrerenderCdnWarmOptions = Omit<CdnWarmOptions, "paths"> & {
   root: string;
   includeFallbackShells?: boolean;
-  /** Use the manifest build ID unless the configured adapter cannot expose it. */
+  /** Use the manifest build identity unless the configured adapter cannot expose it. */
   validateBuildIdentity?: boolean;
 };
 
@@ -73,6 +73,7 @@ export type CdnWarmRequestPlan = {
 
 export type PrerenderWarmPlan = {
   buildId?: string;
+  buildIdentity?: string;
   deploymentId?: string;
   loadingShellPaths: string[];
   paths: string[];
@@ -124,6 +125,7 @@ function readPrerenderPathManifest(manifestPath: string): PrerenderPathManifest 
         (!Array.isArray(manifest.loadingShellPaths) ||
           !manifest.loadingShellPaths.every((pathname) => typeof pathname === "string"))) ||
       (manifest.basePath !== undefined && typeof manifest.basePath !== "string") ||
+      (manifest.buildIdentity !== undefined && typeof manifest.buildIdentity !== "string") ||
       (manifest.deploymentId !== undefined && typeof manifest.deploymentId !== "string") ||
       (manifest.rscBuildId !== undefined && typeof manifest.rscBuildId !== "string") ||
       (manifest.trailingSlash !== undefined && typeof manifest.trailingSlash !== "boolean") ||
@@ -209,6 +211,7 @@ export function readPrerenderWarmPlan(
   }
   return {
     buildId: manifest.buildId,
+    ...(manifest.buildIdentity ? { buildIdentity: manifest.buildIdentity } : {}),
     ...(manifest.deploymentId ? { deploymentId: manifest.deploymentId } : {}),
     loadingShellPaths: supportsCanonicalRsc
       ? (manifest.loadingShellPaths ?? []).map(applyConfig)
@@ -518,6 +521,13 @@ function validateHtmlWarmResponse(response: Response, expectedBuildId?: string):
   if (buildIdentityValidation) return buildIdentityValidation;
   const cachePolicyValidation = validateCachePolicy(response, true);
   if (cachePolicyValidation.outcome !== "warmed") return cachePolicyValidation;
+  const extraVary = (response.headers.get("Vary") ?? "")
+    .split(",")
+    .map((name) => name.trim().toLowerCase())
+    .find((name) => name && !REQUIRED_RSC_VARY_HEADERS.includes(name));
+  if (extraVary) {
+    return { outcome: "failed", error: `response Vary has unsupported field ${extraVary}` };
+  }
   return { outcome: "warmed" };
 }
 
@@ -895,11 +905,18 @@ export async function warmCdnCacheFromPrerender(
     includeFallbackShells: options.includeFallbackShells,
     strict: options.strict,
   });
-  const { buildId, ...warmPlan } = plan;
+  const warmPlan = {
+    deploymentId: plan.deploymentId,
+    loadingShellPaths: plan.loadingShellPaths,
+    paths: plan.paths,
+    rscPaths: plan.rscPaths,
+  };
   return warmCdnCache({
     ...options,
     ...warmPlan,
     expectedBuildId:
-      options.expectedBuildId ?? (options.validateBuildIdentity === false ? undefined : buildId),
+      options.expectedBuildId ??
+      (options.validateBuildIdentity === false ? undefined : plan.buildIdentity),
+    expectedRscBuildId: options.expectedRscBuildId ?? plan.rscBuildId,
   });
 }

--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -1082,7 +1082,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
       url = await deployWithCdnWarmup(root, warmPlan.paths, {
         ...wranglerOptions,
         deploymentId: warmPlan.deploymentId,
-        expectedBuildId: hasBuildIdentityHeader ? warmPlan.buildId : undefined,
+        expectedBuildId: hasBuildIdentityHeader ? warmPlan.buildIdentity : undefined,
         expectedRscBuildId: warmPlan.rscBuildId,
         loadingShellPaths: warmPlan.loadingShellPaths,
         rscPaths: warmPlan.rscPaths,

--- a/packages/vinext/src/build/prerender-paths.ts
+++ b/packages/vinext/src/build/prerender-paths.ts
@@ -30,6 +30,8 @@ import { extractLocaleFromUrl } from "../server/pages-i18n.js";
 export type PrerenderPathManifest = {
   basePath?: string;
   buildId?: string;
+  /** Opaque per-build identity emitted by CDN adapter page responses. */
+  buildIdentity?: string;
   deploymentId?: string;
   /** Opaque per-build identity emitted by RSC responses. */
   rscBuildId?: string;
@@ -569,6 +571,7 @@ export async function emitPrerenderPathManifest(
   const manifest: PrerenderPathManifest = {
     ...(config.basePath ? { basePath: config.basePath } : {}),
     buildId: config.buildId,
+    ...(rscBuildId ? { buildIdentity: rscBuildId } : {}),
     ...(config.deploymentId ? { deploymentId: config.deploymentId } : {}),
     ...(pagesDir ? { pagesPaths: discoveredPagesPaths } : {}),
     ...(rscBuildId ? { rscBuildId } : {}),

--- a/tests/cloudflare-cdn-cache.test.ts
+++ b/tests/cloudflare-cdn-cache.test.ts
@@ -85,13 +85,14 @@ describe("CloudflareCdnCacheAdapter", () => {
   });
 
   it("stamps the application build identity on cacheable and no-store responses", () => {
-    vi.stubEnv("__VINEXT_BUILD_ID", "build-a");
+    vi.stubEnv("__VINEXT_BUILD_ID", "pinned-build");
+    vi.stubEnv("__VINEXT_RSC_BUILD_IDENTITY", "instance-a");
 
     expect(adapter.buildResponseHeaders({ cacheControl: "s-maxage=60" })).toMatchObject({
-      [VINEXT_CDN_BUILD_ID_HEADER]: "build-a",
+      [VINEXT_CDN_BUILD_ID_HEADER]: "instance-a",
     });
     expect(adapter.buildResponseHeaders({ cacheControl: "no-store" })).toMatchObject({
-      [VINEXT_CDN_BUILD_ID_HEADER]: "build-a",
+      [VINEXT_CDN_BUILD_ID_HEADER]: "instance-a",
     });
   });
 

--- a/tests/cloudflare-cdn-warm.test.ts
+++ b/tests/cloudflare-cdn-warm.test.ts
@@ -81,6 +81,7 @@ describe("Cloudflare CDN warmup", () => {
       JSON.stringify({
         basePath: "/docs",
         buildId: "build-a",
+        buildIdentity: "rsc-build-a",
         deploymentId: "dpl_123",
         loadingShellPaths: ["/dashboard"],
         paths: ["/dashboard", "/dynamic", "/pages"],
@@ -97,6 +98,7 @@ describe("Cloudflare CDN warmup", () => {
 
     expect(readPrerenderWarmPlan(tmpDir)).toEqual({
       buildId: "build-a",
+      buildIdentity: "rsc-build-a",
       deploymentId: "dpl_123",
       loadingShellPaths: ["/docs/dashboard/"],
       paths: ["/docs/dashboard/", "/docs/dynamic/", "/docs/pages/"],
@@ -530,6 +532,42 @@ describe("Cloudflare CDN warmup", () => {
     ).rejects.toThrow("response is missing CF-Cache-Status");
   });
 
+  it("rejects HTML variants that the warmer request cannot share with browsers", async () => {
+    const fetchImpl = vi.fn(async () => {
+      const response = cacheableHtml();
+      response.headers.set("vary", `${VINEXT_RSC_VARY_HEADER}, User-Agent`);
+      return response;
+    });
+
+    await expect(
+      warmCdnCache({
+        expectedBuildId: "build-a",
+        fetchImpl: fetchImpl as typeof fetch,
+        paths: ["/browser-specific-html"],
+        strict: true,
+        targetUrl: "https://app.example.com",
+      }),
+    ).rejects.toThrow("response Vary has unsupported field user-agent");
+  });
+
+  it("accepts HTML varied only by framework RSC selector headers", async () => {
+    const fetchImpl = vi.fn(async () => {
+      const response = cacheableHtml();
+      response.headers.set("vary", VINEXT_RSC_VARY_HEADER);
+      return response;
+    });
+
+    await expect(
+      warmCdnCache({
+        expectedBuildId: "build-a",
+        fetchImpl: fetchImpl as typeof fetch,
+        paths: ["/shared-html"],
+        strict: true,
+        targetUrl: "https://app.example.com",
+      }),
+    ).resolves.toMatchObject({ warmed: 1, failed: 0 });
+  });
+
   it("rejects responses rendered by a different application build", async () => {
     const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
       const response =
@@ -780,14 +818,18 @@ describe("Cloudflare CDN warmup", () => {
   });
 
   it("uses the discovery manifest build identity by default", async () => {
-    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile("dist/server/BUILD_ID", "pinned-build\n");
     writeFile(
       "dist/server/vinext-prerender-paths.json",
-      JSON.stringify({ buildId: "build-a", paths: ["/wrong-build"] }),
+      JSON.stringify({
+        buildId: "pinned-build",
+        buildIdentity: "instance-a",
+        paths: ["/wrong-build"],
+      }),
     );
     const fetchImpl = vi.fn(async () => {
       const response = cacheableHtml();
-      response.headers.set(VINEXT_CDN_BUILD_ID_HEADER, "old-build");
+      response.headers.set(VINEXT_CDN_BUILD_ID_HEADER, "old-instance");
       return response;
     });
 
@@ -798,6 +840,36 @@ describe("Cloudflare CDN warmup", () => {
         strict: true,
         targetUrl: "https://app.example.com",
       }),
-    ).rejects.toThrow(`response ${VINEXT_CDN_BUILD_ID_HEADER} does not match build build-a`);
+    ).rejects.toThrow(`response ${VINEXT_CDN_BUILD_ID_HEADER} does not match build instance-a`);
+  });
+
+  it("uses the discovery manifest RSC build identity by default", async () => {
+    writeFile("dist/server/BUILD_ID", "pinned-build\n");
+    writeFile(
+      "dist/server/vinext-prerender-paths.json",
+      JSON.stringify({
+        buildId: "pinned-build",
+        buildIdentity: "instance-a",
+        paths: [],
+        responseVary: "verbatim",
+        rscBuildId: "instance-a",
+        rscPaths: ["/wrong-rsc-build"],
+      }),
+    );
+    const fetchImpl = vi.fn(async () => {
+      const response = cacheableRsc();
+      response.headers.set(VINEXT_RSC_BUILD_ID_HEADER, "old-instance");
+      return response;
+    });
+
+    await expect(
+      warmCdnCacheFromPrerender({
+        fetchImpl: fetchImpl as typeof fetch,
+        root: tmpDir,
+        strict: true,
+        targetUrl: "https://app.example.com",
+        validateBuildIdentity: false,
+      }),
+    ).rejects.toThrow(`response ${VINEXT_RSC_BUILD_ID_HEADER} does not match build instance-a`);
   });
 });

--- a/tests/prerender-paths.test.ts
+++ b/tests/prerender-paths.test.ts
@@ -99,6 +99,7 @@ describe("prerender path manifest", () => {
 
     expect(manifest).toEqual({
       buildId: "build-a",
+      buildIdentity: "rsc-build-a",
       loadingShellPaths: ["/cached/intro", "/cached/featured"],
       rscBuildId: "rsc-build-a",
       responseVary: "verbatim",


### PR DESCRIPTION
Stacked on #3027.

## Summary

- stamp CDN-adapter responses with the immutable vinext RSC build identity instead of an application-controlled `generateBuildId()` value
- validate HTML and RSC warm responses against the exact build identity recorded during discovery
- reject HTML responses with unsupported `Vary` dimensions that the canonical warm request cannot reproduce

## Scope

This only hardens correctness of the RSC CDN prewarming feature. It does not change general ISR eligibility, middleware behavior, or development mode.

## Validation

- `vp test run tests/cloudflare-cdn-cache.test.ts tests/cloudflare-cdn-warm.test.ts tests/prerender-paths.test.ts` (71 tests)
- `vp check` on all 7 touched files
- `vp run vinext#build`
- `vp run @vinext/cloudflare#build`