### PR TITLE
fix(router): keep warmed RSC ownership rewrite-safe

### DIFF
--- a/packages/vinext/src/build/prerender-paths.ts
+++ b/packages/vinext/src/build/prerender-paths.ts
@@ -24,8 +24,9 @@ import { VINEXT_PRERENDER_SECRET_HEADER } from "../server/headers.js";
 import type { VinextRouteRootConfig } from "../config/prerender.js";
 import { enterPrerenderPhase } from "./prerender-phase.js";
 import type { CdnCacheAdapterCapabilities } from "../cache/cache-adapters-virtual.js";
+import { matchesRewriteSource } from "../config/config-matchers.js";
 import { pagesRouteHasPriorityOverAppRoute } from "../server/hybrid-route-priority.js";
-import { extractLocaleFromUrl } from "../server/pages-i18n.js";
+import { extractLocaleFromUrl, normalizeDefaultLocalePathname } from "../server/pages-i18n.js";
 
 export type PrerenderPathManifest = {
   basePath?: string;
@@ -386,10 +387,12 @@ async function collectAppPaths(options: {
 
 async function resolveAppRscWarmPaths(options: {
   appDir: string;
+  basePath: string;
   i18n: ResolvedNextConfig["i18n"];
   pagesDir: string | null;
   pageExtensions: readonly string[];
   paths: readonly string[];
+  rewrites: ResolvedNextConfig["rewrites"];
 }): Promise<{ loadingShellPaths: string[]; rscPaths: string[] }> {
   const appRoutes = await appRouter(options.appDir, options.pageExtensions);
   const [pageRoutes, apiRoutes] = options.pagesDir
@@ -401,6 +404,11 @@ async function resolveAppRscWarmPaths(options: {
 
   const rscPaths: string[] = [];
   const loadingShellPaths: string[] = [];
+  const rewrites = [
+    ...options.rewrites.beforeFiles,
+    ...options.rewrites.afterFiles,
+    ...options.rewrites.fallback,
+  ];
   for (const pathname of options.paths) {
     const appMatch = matchAppRoute(pathname, appRoutes);
     if (!appMatch) continue;
@@ -427,6 +435,19 @@ async function resolveAppRscWarmPaths(options: {
     if (pagesMatch && pagesRouteHasPriorityOverAppRoute(pagesMatch.route, matchedAppRoute)) {
       continue;
     }
+
+    // A configured rewrite can make the browser's public URL resolve to a
+    // different route than a direct canonical RSC request. Do not advertise
+    // that public cache key as warmable until discovery can reproduce the
+    // rewrite's request-dependent routing context.
+    const rewritePathname = normalizeDefaultLocalePathname(pathname, options.i18n);
+    const rewriteAffectsPath = rewrites.some((rewrite) =>
+      matchesRewriteSource(rewritePathname, rewrite, {
+        basePath: options.basePath,
+        hadBasePath: true,
+      }),
+    );
+    if (rewriteAffectsPath) continue;
 
     rscPaths.push(pathname);
     if (appRouteHasMainTreeLoadingBoundary(matchedAppRoute)) {
@@ -558,10 +579,12 @@ export async function emitPrerenderPathManifest(
     options.responseVary && appDir
       ? await resolveAppRscWarmPaths({
           appDir,
+          basePath: config.basePath,
           i18n: config.i18n,
           pagesDir,
           pageExtensions: config.pageExtensions,
           paths: discoveredAppPaths,
+          rewrites: config.rewrites,
         })
       : {
           loadingShellPaths: discoveredLoadingShellPaths,

--- a/packages/vinext/src/entries/app-browser-entry.ts
+++ b/packages/vinext/src/entries/app-browser-entry.ts
@@ -24,6 +24,7 @@ export function generateBrowserEntry(
     beforeFiles: [],
     fallback: [],
   },
+  locales: readonly string[] = [],
 ): string {
   const entryPath = resolveRuntimeEntryModule("app-browser-entry");
   const reactInstanceBootstrapPath = resolveClientRuntimeModule("react-instance-bootstrap");
@@ -41,6 +42,7 @@ window.__VINEXT_LINK_PREFETCH_ROUTES__ = ${JSON.stringify(prefetchRoutes)};
 // the same — whichever entry runs first emits both globals).
 window.__VINEXT_PAGES_LINK_PREFETCH_ROUTES__ = ${JSON.stringify(pagesPrefetchRoutes)};
 window.__VINEXT_CLIENT_REWRITES__ = ${JSON.stringify(clientRewrites)};
+window.__VINEXT_LOCALES__ = ${JSON.stringify(locales)};
 registerNavigationRuntimeBootstrap({
     routeManifest: ${buildRouteManifestExpression(routeManifest)}
 });

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -4098,6 +4098,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               graph.routeManifest,
               pagesPrefetchRoutes,
               nextConfig.rewrites,
+              nextConfig.i18n?.locales,
             );
           }
           if (id === RESOLVED_APP_CAPABILITIES && hasAppDir) {

--- a/packages/vinext/src/shims/internal/hybrid-client-route-owner-direct.ts
+++ b/packages/vinext/src/shims/internal/hybrid-client-route-owner-direct.ts
@@ -71,8 +71,8 @@ function resolveSameOriginPathnames(
   };
 }
 
-export function resolveSameOriginPathname(href: string, basePath: string): string | null {
-  return resolveSameOriginPathnames(href, basePath)?.pagesPathname ?? null;
+export function resolveSameOriginAppPathname(href: string, basePath: string): string | null {
+  return resolveSameOriginPathnames(href, basePath)?.appPathname ?? null;
 }
 
 function selectPagesRoutes(

--- a/packages/vinext/src/shims/internal/hybrid-client-route-owner.ts
+++ b/packages/vinext/src/shims/internal/hybrid-client-route-owner.ts
@@ -20,7 +20,7 @@ import type { ClientRewrite } from "../../client/client-rewrites.js";
 import { mergeRewriteQuery } from "../../utils/query.js";
 import {
   matchDirectHybridClientRoutes,
-  resolveSameOriginPathname,
+  resolveSameOriginAppPathname,
   resolveMatchedHybridClientRouteOwner,
   type HybridClientOwner,
 } from "./hybrid-client-route-owner-direct.js";
@@ -44,7 +44,7 @@ function resolveClientRewrite(
   let matched = false;
 
   for (const rewrite of rewrites) {
-    const pathname = resolveSameOriginPathname(currentHref, basePath);
+    const pathname = resolveSameOriginAppPathname(currentHref, basePath);
     if (pathname === null) return null;
     const url = new URL(currentHref, window.location.href);
     const headers = new Headers({ "user-agent": globalThis.navigator?.userAgent ?? "" });

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -188,6 +188,12 @@ describe("App Router generated manifest construction", () => {
     expect(code).not.toContain("cookie-secret-canary");
   });
 
+  it("embeds i18n locales used by hybrid App and Pages route ownership", () => {
+    const code = generateBrowserEntry([], null, [], undefined, ["en", "fr"]);
+
+    expect(code).toContain('window.__VINEXT_LOCALES__ = ["en","fr"]');
+  });
+
   it("embeds the Link auto-prefetch route manifest in the browser entry", () => {
     const code = generateBrowserEntry([
       ...minimalAppRoutes,

--- a/tests/hybrid-client-route-owner.test.ts
+++ b/tests/hybrid-client-route-owner.test.ts
@@ -189,6 +189,26 @@ describe("resolveHybridClientRouteOwner", () => {
     },
   );
 
+  it("matches locale-aware rewrites against the raw App pathname", () => {
+    installWindow({
+      app: [appRoute([":locale", "app-destination"])],
+      locales: ["en", "fr"],
+      pages: [],
+      rewrites: {
+        afterFiles: [],
+        beforeFiles: [
+          {
+            source: "/:nextInternalLocale(en|fr)/source",
+            destination: "/:nextInternalLocale/app-destination",
+          },
+        ],
+        fallback: [],
+      },
+    });
+
+    expect(resolveHybridClientRouteOwner("/fr/source", "")).toBe("app");
+  });
+
   it.each(["beforeFiles", "afterFiles", "fallback"] as const)(
     "returns the %s rewrite destination href",
     (rewritePhase) => {

--- a/tests/pages-router-app-prefetch-detection.test.ts
+++ b/tests/pages-router-app-prefetch-detection.test.ts
@@ -274,9 +274,13 @@ describe("Pages Router records app routes as detected on prefetch", () => {
     });
   });
 
-  it("strips basePath and locale prefixes before matching App routes", async () => {
+  it("keeps locale prefixes for App matching but strips them from the Pages component key", async () => {
     const fakeWindow = installFakeBrowserGlobals([
-      { canPrefetchLoadingShell: false, patternParts: ["about"], isDynamic: false },
+      {
+        canPrefetchLoadingShell: false,
+        patternParts: [":locale", "about"],
+        isDynamic: true,
+      },
     ]);
     fakeWindow.__VINEXT_LOCALES__ = ["en", "fr"];
     fakeWindow.__VINEXT_DEFAULT_LOCALE__ = "en";

--- a/tests/prerender-paths.test.ts
+++ b/tests/prerender-paths.test.ts
@@ -159,6 +159,52 @@ describe("prerender path manifest", () => {
     expect(manifest?.rscBuildId).toBe("rsc-build-a");
   });
 
+  it("excludes App RSC warm paths affected by configured rewrites", async () => {
+    // Rewrite-aware prefetches can resolve a public URL to a different route:
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/concurrent-navigations/mismatching-prefetch.test.ts
+    writeFile("package.json", JSON.stringify({ type: "module" }));
+    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile("dist/server/RSC_BUILD_ID", "rsc-build-a\n");
+    writeFile("dist/server/index.js", "export default {};\n");
+    writeFile(
+      "app/rewrite-me/page.tsx",
+      "export const revalidate = 60; export default function Page() {}\n",
+    );
+    writeFile("app/rewrite-me/loading.tsx", "export default function Loading() { return null; }\n");
+    writeFile(
+      "app/safe/page.tsx",
+      "export const revalidate = 60; export default function Page() {}\n",
+    );
+    writeFile("app/safe/loading.tsx", "export default function Loading() { return null; }\n");
+
+    const [{ emitPrerenderPathManifest }, { resolveNextConfig }] = await Promise.all([
+      import("../packages/vinext/src/build/prerender-paths.js"),
+      import("../packages/vinext/src/config/next-config.js"),
+    ]);
+    const nextConfig = await resolveNextConfig(
+      {
+        rewrites: () => [
+          {
+            source: "/rewrite-me",
+            destination: "/safe",
+            has: [{ type: "header", key: "x-route-variant", value: "1" }],
+          },
+        ],
+      },
+      tmpDir,
+    );
+
+    const manifest = await emitPrerenderPathManifest({
+      nextConfig,
+      responseVary: "verbatim",
+      root: tmpDir,
+    });
+
+    expect(manifest?.paths).toEqual(["/rewrite-me", "/safe"]);
+    expect(manifest?.rscPaths).toEqual(["/safe"]);
+    expect(manifest?.loadingShellPaths).toEqual(["/safe"]);
+  });
+
   it("excludes Pages-owned hybrid paths from App RSC warm discovery", async () => {
     // Next.js resolves matching Pages and App routes by cross-router specificity:
     // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/use-params/use-params.test.ts


### PR DESCRIPTION
Stacked on #3028.

## Summary

- expose configured locales from the App browser entry so hybrid route ownership matches locale-prefixed App paths correctly
- evaluate client rewrites against the raw basePath-stripped App pathname while continuing to locale-normalize Pages matching
- conservatively omit rewrite-affected App paths from canonical RSC and loading-shell warm discovery

## Scope

This only protects the identity shared by client RSC navigation and deploy-time CDN warming. It does not change server rewrite execution, ISR eligibility, HTML discovery, middleware, or development mode.

## Validation

- `vp test run tests/entry-templates.test.ts tests/hybrid-client-route-owner.test.ts tests/pages-router-app-prefetch-detection.test.ts tests/prerender-paths.test.ts` (119 tests)
- `vp check` on all 9 touched files
- `vp run vinext#build`