### PR TITLE
test(cloudflare): prove browser reuse of warmed RSC variants

### DIFF
--- a/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
+++ b/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
@@ -270,6 +270,17 @@ test("deploy-prewarmed full and loading RSC variants are reused by browser navig
   }
 
   await runFresh(async (page) => {
+    await gotoCurrentBuild(page, "/prewarm/router");
+    const shell = await observeRsc(page, () => page.getByTestId("router-prefetch").click());
+    expectLoadingShell(shell);
+
+    const full = await observeRsc(page, () => page.getByTestId("router-navigate").click());
+    expectFull(full);
+    await expect(page).toHaveURL(new RegExp(`${TARGET_PATH}$`));
+    await expect(page.getByRole("heading", { name: "Prewarm target" })).toBeVisible();
+  });
+
+  await runFresh(async (page) => {
     let targetRscRequests = 0;
     page.on("request", (request) => {
       const url = new URL(request.url());
@@ -295,8 +306,16 @@ test("deploy-prewarmed full and loading RSC variants are reused by browser navig
     await expect(page).toHaveURL(new RegExp(`${TARGET_PATH}$`));
   });
 
-  const dynamic = await request.get(`${baseURL}/dynamic?_rsc`, { headers: fullHeaders });
-  expect(dynamic.ok()).toBe(true);
-  expect(dynamic.headers()["cache-control"]).toContain("no-store");
-  expect(dynamic.headers()["cf-cache-status"]).toBe("BYPASS");
+  await runFresh(async (page) => {
+    const dynamicResponsePromise = page.waitForResponse((response) => {
+      const request = response.request();
+      return new URL(response.url()).pathname === "/dynamic" && request.headers().rsc === "1";
+    });
+    await gotoCurrentBuild(page, "/prewarm/dynamic");
+    const dynamic = await dynamicResponsePromise;
+    rejectStaleSeedWorker(dynamic);
+    expect(dynamic.ok()).toBe(true);
+    expect(dynamic.headers()["cache-control"]).toContain("no-store");
+    expect(dynamic.headers()["cf-cache-status"]).toBe("BYPASS");
+  });
 });


### PR DESCRIPTION
Stacked on #3029.

## Summary

Extend the deployed Workers cache E2E to prove the remaining browser request shapes in the RSC CDN prewarming acceptance criteria:

- `router.prefetch()` reuses the prewarmed loading-shell entry, then `router.push()` reuses the prewarmed full RSC entry
- an actual `<Link prefetch>` request to a non-cacheable dynamic route remains `no-store` / `CF-Cache-Status: BYPASS`

The same deployed test already proves Link loading-shell/full reuse from multiple source routes, full-prefetch reuse without a second request, and direct soft-navigation reuse.

## Scope

Test-only. No runtime, cache, routing, deploy, or development-mode behavior changes.

## Validation

- `vp check tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts`
- local Playwright discovery/guard run for the deployed-only spec (1 expected skip without an HTTPS Worker)