### PR TITLE
test(cloudflare): bind RSC warm proof to each deploy attempt

### DIFF
--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -128,7 +128,7 @@ jobs:
         run: >-
           vp exec wrangler deploy
           --config ../../tests/fixtures/rsc-prewarm-seed/wrangler.jsonc
-          --name rsc-prewarm-${{ github.run_id }}
+          --name rsc-prewarm-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Install Chromium for RSC prewarm verification
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && matrix.example.name == 'workers-cache'
@@ -145,7 +145,7 @@ jobs:
           vp exec vinext-cloudflare deploy
           --skip-build
           --config ${{ matrix.example.wrangler_config }}
-          --name rsc-prewarm-${{ github.run_id }}
+          --name rsc-prewarm-${{ github.run_id }}-${{ github.run_attempt }}
           --experimental-warm-cdn-cache
           --warm-cdn-strict
 
@@ -153,7 +153,7 @@ jobs:
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && matrix.example.name == 'workers-cache'
         env:
           PLAYWRIGHT_PROJECT: cloudflare-workers
-          VINEXT_E2E_BASE_URL: https://rsc-prewarm-${{ github.run_id }}.vinext.workers.dev
+          VINEXT_E2E_BASE_URL: https://rsc-prewarm-${{ github.run_id }}-${{ github.run_attempt }}.vinext.workers.dev
         run: vp exec playwright test tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
 
       - name: Delete RSC prewarm test Worker
@@ -163,7 +163,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: >-
-          vp exec wrangler delete rsc-prewarm-${{ github.run_id }}
+          vp exec wrangler delete rsc-prewarm-${{ github.run_id }}-${{ github.run_attempt }}
           --config ${{ matrix.example.wrangler_config }}
           --force
 

--- a/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
+++ b/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
@@ -12,7 +12,7 @@ import fs from "node:fs";
 const TARGET_PATH = "/prewarm-target";
 const LOADING_SHELL_RSC_SEARCH = "?_rsc=9qLBDIU2NgN178cB";
 const PROMOTION_STABILITY_WINDOW_MS = 60_000;
-const PROMOTION_READINESS_TIMEOUT_MS = 90_000;
+const PROMOTION_READINESS_TIMEOUT_MS = 120_000;
 const PROMOTION_PROBE_INTERVAL_MS = 1_000;
 const STALE_SEED_RETRY_TIMEOUT_MS = 45_000;
 
@@ -77,7 +77,7 @@ async function observeRsc(page: Page, action: () => Promise<unknown>): Promise<O
   };
 }
 
-function expectCanonical(observed: ObservedRsc): void {
+function expectCanonical(observed: ObservedRsc, rscBuildId: string): void {
   rejectStaleSeedWorker(observed.response);
   console.log(
     `RSC cache trace: url=${observed.url.pathname}${observed.url.search} ` +
@@ -91,22 +91,23 @@ function expectCanonical(observed: ObservedRsc): void {
   expect(observed.headers["next-router-state-tree"]).toBeUndefined();
   expect(observed.headers["next-url"]).toBeUndefined();
   expect(observed.headers["x-vinext-rsc-state-fingerprint"]).toBeUndefined();
+  expect(observed.response.headers()["x-vinext-rsc-build-id"]).toBe(rscBuildId);
   expect(
     observed.response.headers()["cf-cache-status"],
     JSON.stringify({ request: observed.headers, response: observed.response.headers() }),
   ).toBe("HIT");
 }
 
-function expectFull(observed: ObservedRsc): void {
-  expectCanonical(observed);
+function expectFull(observed: ObservedRsc, rscBuildId: string): void {
+  expectCanonical(observed, rscBuildId);
   expect(observed.url.search).toBe("?_rsc");
   expect(observed.headers["next-router-prefetch"]).toBeUndefined();
   expect(observed.headers["next-router-segment-prefetch"]).toBeUndefined();
   expect(observed.headers["x-vinext-rsc-render-mode"]).toBeUndefined();
 }
 
-function expectLoadingShell(observed: ObservedRsc): void {
-  expectCanonical(observed);
+function expectLoadingShell(observed: ObservedRsc, rscBuildId: string): void {
+  expectCanonical(observed, rscBuildId);
   expect(observed.url.search).toBe(LOADING_SHELL_RSC_SEARCH);
   expect(observed.headers["next-router-prefetch"]).toBe("1");
   expect(observed.headers["next-router-segment-prefetch"]).toBe("1");
@@ -167,7 +168,7 @@ test("deploy-prewarmed full and loading RSC variants are reused by browser navig
 }) => {
   test.skip(!baseURL?.startsWith("https://"), "requires a deployed Cloudflare Worker");
   if (!baseURL) throw new Error("deployed test requires a base URL");
-  test.setTimeout(180_000);
+  test.setTimeout(240_000);
 
   const buildId = fs.readFileSync("examples/workers-cache/dist/server/BUILD_ID", "utf-8").trim();
   const rscBuildId = fs
@@ -254,30 +255,33 @@ test("deploy-prewarmed full and loading RSC variants are reused by browser navig
     expect(response?.ok()).toBe(true);
     await expect(page.getByTestId("build-id")).toHaveText(buildId);
   };
+  const expectTargetCommit = async (page: Page) => {
+    await expect(page).toHaveURL(new RegExp(`${TARGET_PATH}$`));
+    await expect(page.getByRole("heading", { name: "Prewarm target" })).toBeVisible();
+    await expect(page.getByTestId("build-id")).toHaveText(buildId);
+  };
 
   for (const source of ["/prewarm/link-a", "/prewarm/link-b"]) {
     await runFresh(async (page) => {
       const shell = await observeRsc(page, async () => {
         await gotoCurrentBuild(page, source);
       });
-      expectLoadingShell(shell);
+      expectLoadingShell(shell, rscBuildId);
 
       const full = await observeRsc(page, () => page.getByTestId("link-prefetch").click());
-      expectFull(full);
-      await expect(page).toHaveURL(new RegExp(`${TARGET_PATH}$`));
-      await expect(page.getByRole("heading", { name: "Prewarm target" })).toBeVisible();
+      expectFull(full, rscBuildId);
+      await expectTargetCommit(page);
     });
   }
 
   await runFresh(async (page) => {
     await gotoCurrentBuild(page, "/prewarm/router");
     const shell = await observeRsc(page, () => page.getByTestId("router-prefetch").click());
-    expectLoadingShell(shell);
+    expectLoadingShell(shell, rscBuildId);
 
     const full = await observeRsc(page, () => page.getByTestId("router-navigate").click());
-    expectFull(full);
-    await expect(page).toHaveURL(new RegExp(`${TARGET_PATH}$`));
-    await expect(page.getByRole("heading", { name: "Prewarm target" })).toBeVisible();
+    expectFull(full, rscBuildId);
+    await expectTargetCommit(page);
   });
 
   await runFresh(async (page) => {
@@ -291,19 +295,18 @@ test("deploy-prewarmed full and loading RSC variants are reused by browser navig
     const full = await observeRsc(page, async () => {
       await gotoCurrentBuild(page, "/prewarm/full");
     });
-    expectFull(full);
+    expectFull(full, rscBuildId);
     expect(targetRscRequests).toBe(1);
     await page.getByTestId("link-prefetch").click();
-    await expect(page).toHaveURL(new RegExp(`${TARGET_PATH}$`));
-    await expect(page.getByRole("heading", { name: "Prewarm target" })).toBeVisible();
+    await expectTargetCommit(page);
     expect(targetRscRequests).toBe(1);
   });
 
   await runFresh(async (page) => {
     await gotoCurrentBuild(page, "/prewarm/soft");
     const full = await observeRsc(page, () => page.getByTestId("soft-navigation").click());
-    expectFull(full);
-    await expect(page).toHaveURL(new RegExp(`${TARGET_PATH}$`));
+    expectFull(full, rscBuildId);
+    await expectTargetCommit(page);
   });
 
   await runFresh(async (page) => {


### PR DESCRIPTION
Stacked on #3030.

## Summary

- give every GitHub Actions attempt a unique proof Worker hostname so reruns cannot inherit a previous attempt's Workers Cache entries
- bind every browser-observed full/loading RSC HIT to the expected immutable RSC build identity
- verify the committed target page belongs to the current build after Link, router, full-prefetch, and soft navigation
- allow the full 60-second stability window after realistic promotion propagation

## Scope

Test/workflow hardening only for the deployed RSC CDN prewarming proof. No runtime behavior changes.

## Validation

- `vp check .github/workflows/deploy-examples.yml tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts`
- local Playwright discovery/guard run for the deployed-only spec (1 expected skip without an HTTPS Worker)