### PR TITLE
fix(rsc): align canonical warm ownership and request variants

### DIFF
--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -128,7 +128,7 @@ jobs:
         run: >-
           vp exec wrangler deploy
           --config ../../tests/fixtures/rsc-prewarm-seed/wrangler.jsonc
-          --name rsc-prewarm-${{ github.run_id }}
+          --name rsc-prewarm-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Install Chromium for RSC prewarm verification
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && matrix.example.name == 'workers-cache'
@@ -145,7 +145,7 @@ jobs:
           vp exec vinext-cloudflare deploy
           --skip-build
           --config ${{ matrix.example.wrangler_config }}
-          --name rsc-prewarm-${{ github.run_id }}
+          --name rsc-prewarm-${{ github.run_id }}-${{ github.run_attempt }}
           --experimental-warm-cdn-cache
           --warm-cdn-strict
 
@@ -153,7 +153,7 @@ jobs:
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && matrix.example.name == 'workers-cache'
         env:
           PLAYWRIGHT_PROJECT: cloudflare-workers
-          VINEXT_E2E_BASE_URL: https://rsc-prewarm-${{ github.run_id }}.vinext.workers.dev
+          VINEXT_E2E_BASE_URL: https://rsc-prewarm-${{ github.run_id }}-${{ github.run_attempt }}.vinext.workers.dev
         run: vp exec playwright test tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
 
       - name: Delete RSC prewarm test Worker
@@ -163,7 +163,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: >-
-          vp exec wrangler delete rsc-prewarm-${{ github.run_id }}
+          vp exec wrangler delete rsc-prewarm-${{ github.run_id }}-${{ github.run_attempt }}
           --config ${{ matrix.example.wrangler_config }}
           --force
 

--- a/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
@@ -48,7 +48,7 @@ const CACHEABLE_EDGE_DIRECTIVE_RE = /(?:^|,)\s*(?:s-maxage|max-age)\s*=/i;
 const EDGE_POLICY_HEADERS = ["CDN-Cache-Control", "Cloudflare-CDN-Cache-Control"] as const;
 
 function getBuildIdentityResponseHeader(): CdnResponseHeaders {
-  const buildId = process.env.__VINEXT_BUILD_ID;
+  const buildId = process.env.__VINEXT_RSC_BUILD_IDENTITY ?? process.env.__VINEXT_BUILD_ID;
   return buildId ? { [VINEXT_CDN_BUILD_ID_HEADER]: buildId } : {};
 }
 

--- a/packages/cloudflare/src/cdn-warm.ts
+++ b/packages/cloudflare/src/cdn-warm.ts
@@ -52,7 +52,7 @@ export const DEFAULT_CDN_WARM_TIMEOUT_MS = 10_000;
 export type PrerenderCdnWarmOptions = Omit<CdnWarmOptions, "paths"> & {
   root: string;
   includeFallbackShells?: boolean;
-  /** Use the manifest build ID unless the configured adapter cannot expose it. */
+  /** Use the manifest build identity unless the configured adapter cannot expose it. */
   validateBuildIdentity?: boolean;
 };
 
@@ -73,6 +73,7 @@ export type CdnWarmRequestPlan = {
 
 export type PrerenderWarmPlan = {
   buildId?: string;
+  buildIdentity?: string;
   deploymentId?: string;
   loadingShellPaths: string[];
   paths: string[];
@@ -124,6 +125,7 @@ function readPrerenderPathManifest(manifestPath: string): PrerenderPathManifest 
         (!Array.isArray(manifest.loadingShellPaths) ||
           !manifest.loadingShellPaths.every((pathname) => typeof pathname === "string"))) ||
       (manifest.basePath !== undefined && typeof manifest.basePath !== "string") ||
+      (manifest.buildIdentity !== undefined && typeof manifest.buildIdentity !== "string") ||
       (manifest.deploymentId !== undefined && typeof manifest.deploymentId !== "string") ||
       (manifest.rscBuildId !== undefined && typeof manifest.rscBuildId !== "string") ||
       (manifest.trailingSlash !== undefined && typeof manifest.trailingSlash !== "boolean") ||
@@ -209,6 +211,7 @@ export function readPrerenderWarmPlan(
   }
   return {
     buildId: manifest.buildId,
+    ...(manifest.buildIdentity ? { buildIdentity: manifest.buildIdentity } : {}),
     ...(manifest.deploymentId ? { deploymentId: manifest.deploymentId } : {}),
     loadingShellPaths: supportsCanonicalRsc
       ? (manifest.loadingShellPaths ?? []).map(applyConfig)
@@ -518,6 +521,13 @@ function validateHtmlWarmResponse(response: Response, expectedBuildId?: string):
   if (buildIdentityValidation) return buildIdentityValidation;
   const cachePolicyValidation = validateCachePolicy(response, true);
   if (cachePolicyValidation.outcome !== "warmed") return cachePolicyValidation;
+  const extraVary = (response.headers.get("Vary") ?? "")
+    .split(",")
+    .map((name) => name.trim().toLowerCase())
+    .find((name) => name && !REQUIRED_RSC_VARY_HEADERS.includes(name));
+  if (extraVary) {
+    return { outcome: "failed", error: `response Vary has unsupported field ${extraVary}` };
+  }
   return { outcome: "warmed" };
 }
 
@@ -895,11 +905,18 @@ export async function warmCdnCacheFromPrerender(
     includeFallbackShells: options.includeFallbackShells,
     strict: options.strict,
   });
-  const { buildId, ...warmPlan } = plan;
+  const warmPlan = {
+    deploymentId: plan.deploymentId,
+    loadingShellPaths: plan.loadingShellPaths,
+    paths: plan.paths,
+    rscPaths: plan.rscPaths,
+  };
   return warmCdnCache({
     ...options,
     ...warmPlan,
     expectedBuildId:
-      options.expectedBuildId ?? (options.validateBuildIdentity === false ? undefined : buildId),
+      options.expectedBuildId ??
+      (options.validateBuildIdentity === false ? undefined : plan.buildIdentity),
+    expectedRscBuildId: options.expectedRscBuildId ?? plan.rscBuildId,
   });
 }

--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -1082,7 +1082,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
       url = await deployWithCdnWarmup(root, warmPlan.paths, {
         ...wranglerOptions,
         deploymentId: warmPlan.deploymentId,
-        expectedBuildId: hasBuildIdentityHeader ? warmPlan.buildId : undefined,
+        expectedBuildId: hasBuildIdentityHeader ? warmPlan.buildIdentity : undefined,
         expectedRscBuildId: warmPlan.rscBuildId,
         loadingShellPaths: warmPlan.loadingShellPaths,
         rscPaths: warmPlan.rscPaths,

--- a/packages/vinext/src/build/prerender-paths.ts
+++ b/packages/vinext/src/build/prerender-paths.ts
@@ -30,6 +30,8 @@ import { extractLocaleFromUrl } from "../server/pages-i18n.js";
 export type PrerenderPathManifest = {
   basePath?: string;
   buildId?: string;
+  /** Opaque per-build identity emitted by CDN adapter page responses. */
+  buildIdentity?: string;
   deploymentId?: string;
   /** Opaque per-build identity emitted by RSC responses. */
   rscBuildId?: string;
@@ -569,6 +571,7 @@ export async function emitPrerenderPathManifest(
   const manifest: PrerenderPathManifest = {
     ...(config.basePath ? { basePath: config.basePath } : {}),
     buildId: config.buildId,
+    ...(rscBuildId ? { buildIdentity: rscBuildId } : {}),
     ...(config.deploymentId ? { deploymentId: config.deploymentId } : {}),
     ...(pagesDir ? { pagesPaths: discoveredPagesPaths } : {}),
     ...(rscBuildId ? { rscBuildId } : {}),

--- a/packages/vinext/src/build/prerender-paths.ts
+++ b/packages/vinext/src/build/prerender-paths.ts
@@ -24,8 +24,9 @@ import { VINEXT_PRERENDER_SECRET_HEADER } from "../server/headers.js";
 import type { VinextRouteRootConfig } from "../config/prerender.js";
 import { enterPrerenderPhase } from "./prerender-phase.js";
 import type { CdnCacheAdapterCapabilities } from "../cache/cache-adapters-virtual.js";
+import { matchesRewriteSource } from "../config/config-matchers.js";
 import { pagesRouteHasPriorityOverAppRoute } from "../server/hybrid-route-priority.js";
-import { extractLocaleFromUrl } from "../server/pages-i18n.js";
+import { extractLocaleFromUrl, normalizeDefaultLocalePathname } from "../server/pages-i18n.js";
 
 export type PrerenderPathManifest = {
   basePath?: string;
@@ -386,10 +387,12 @@ async function collectAppPaths(options: {
 
 async function resolveAppRscWarmPaths(options: {
   appDir: string;
+  basePath: string;
   i18n: ResolvedNextConfig["i18n"];
   pagesDir: string | null;
   pageExtensions: readonly string[];
   paths: readonly string[];
+  rewrites: ResolvedNextConfig["rewrites"];
 }): Promise<{ loadingShellPaths: string[]; rscPaths: string[] }> {
   const appRoutes = await appRouter(options.appDir, options.pageExtensions);
   const [pageRoutes, apiRoutes] = options.pagesDir
@@ -401,6 +404,11 @@ async function resolveAppRscWarmPaths(options: {
 
   const rscPaths: string[] = [];
   const loadingShellPaths: string[] = [];
+  const rewrites = [
+    ...options.rewrites.beforeFiles,
+    ...options.rewrites.afterFiles,
+    ...options.rewrites.fallback,
+  ];
   for (const pathname of options.paths) {
     const appMatch = matchAppRoute(pathname, appRoutes);
     if (!appMatch) continue;
@@ -427,6 +435,19 @@ async function resolveAppRscWarmPaths(options: {
     if (pagesMatch && pagesRouteHasPriorityOverAppRoute(pagesMatch.route, matchedAppRoute)) {
       continue;
     }
+
+    // A configured rewrite can make the browser's public URL resolve to a
+    // different route than a direct canonical RSC request. Do not advertise
+    // that public cache key as warmable until discovery can reproduce the
+    // rewrite's request-dependent routing context.
+    const rewritePathname = normalizeDefaultLocalePathname(pathname, options.i18n);
+    const rewriteAffectsPath = rewrites.some((rewrite) =>
+      matchesRewriteSource(rewritePathname, rewrite, {
+        basePath: options.basePath,
+        hadBasePath: true,
+      }),
+    );
+    if (rewriteAffectsPath) continue;
 
     rscPaths.push(pathname);
     if (appRouteHasMainTreeLoadingBoundary(matchedAppRoute)) {
@@ -558,10 +579,12 @@ export async function emitPrerenderPathManifest(
     options.responseVary && appDir
       ? await resolveAppRscWarmPaths({
           appDir,
+          basePath: config.basePath,
           i18n: config.i18n,
           pagesDir,
           pageExtensions: config.pageExtensions,
           paths: discoveredAppPaths,
+          rewrites: config.rewrites,
         })
       : {
           loadingShellPaths: discoveredLoadingShellPaths,

--- a/packages/vinext/src/build/prerender-paths.ts
+++ b/packages/vinext/src/build/prerender-paths.ts
@@ -6,7 +6,11 @@ import {
   resolveNextConfig,
   type ResolvedNextConfig,
 } from "../config/next-config.js";
-import { appRouter, matchAppRoute } from "../routing/app-router.js";
+import {
+  appRouteHasMainTreeLoadingBoundary,
+  appRouter,
+  matchAppRoute,
+} from "../routing/app-router.js";
 import { apiRouter, matchRoute, pagesRouter } from "../routing/pages-router.js";
 import { normalizeStaticPathsEntry, type StaticPathsEntry } from "../routing/route-pattern.js";
 import {
@@ -171,18 +175,6 @@ function resolveConfiguredRouteDirs(
 function appRouteMayHaveGenerateStaticParams(route: Awaited<ReturnType<typeof appRouter>>[number]) {
   if (fileHasNamedExport(route.pagePath, "generateStaticParams")) return true;
   return route.layouts.some((layoutPath) => fileHasNamedExport(layoutPath, "generateStaticParams"));
-}
-
-function appRouteHasMainTreeLoadingBoundary(
-  route: Awaited<ReturnType<typeof appRouter>>[number],
-): boolean {
-  return (
-    route.loadingPath != null ||
-    (route.loadingPaths?.some(
-      (_loadingPath, index) => (route.loadingTreePositions?.[index] ?? 0) > 0,
-    ) ??
-      false)
-  );
 }
 
 async function shouldStartPathDiscoveryServer(options: {

--- a/packages/vinext/src/client/vinext-next-data.ts
+++ b/packages/vinext/src/client/vinext-next-data.ts
@@ -10,6 +10,8 @@ import { isUnknownRecord } from "../utils/record.js";
 
 export type VinextLinkPrefetchRoute = {
   canPrefetchLoadingShell: boolean;
+  /** The loading shell is an ordinary main-tree variant shared with deploy warmup. */
+  canUseCanonicalLoadingShell?: true;
   documentOnly?: boolean;
   isDynamic: boolean;
   patternParts: string[];

--- a/packages/vinext/src/entries/app-browser-entry.ts
+++ b/packages/vinext/src/entries/app-browser-entry.ts
@@ -4,7 +4,7 @@ import type {
   VinextPagesLinkPrefetchRoute,
 } from "../client/vinext-next-data.js";
 import { toClientRewrites } from "../client/client-rewrites.js";
-import type { AppRoute } from "../routing/app-router.js";
+import { appRouteHasMainTreeLoadingBoundary, type AppRoute } from "../routing/app-router.js";
 import { patternsStructurallyEquivalent, type RouteManifest } from "../routing/app-route-graph.js";
 import type { NextRewrite } from "../config/next-config.js";
 
@@ -117,6 +117,9 @@ export function toLinkPrefetchRoute(
 ): VinextLinkPrefetchRoute {
   return {
     canPrefetchLoadingShell: hasLoadingBoundary(route, hasSiblingInterceptLoading),
+    ...(appRouteHasMainTreeLoadingBoundary(route)
+      ? { canUseCanonicalLoadingShell: true as const }
+      : {}),
     patternParts: [...route.patternParts],
     isDynamic: route.isDynamic,
     ...(requiresDynamicNavigationRequest(route) ? { requiresDynamicNavigationRequest: true } : {}),

--- a/packages/vinext/src/entries/app-browser-entry.ts
+++ b/packages/vinext/src/entries/app-browser-entry.ts
@@ -24,6 +24,7 @@ export function generateBrowserEntry(
     beforeFiles: [],
     fallback: [],
   },
+  locales: readonly string[] = [],
 ): string {
   const entryPath = resolveRuntimeEntryModule("app-browser-entry");
   const reactInstanceBootstrapPath = resolveClientRuntimeModule("react-instance-bootstrap");
@@ -41,6 +42,7 @@ window.__VINEXT_LINK_PREFETCH_ROUTES__ = ${JSON.stringify(prefetchRoutes)};
 // the same — whichever entry runs first emits both globals).
 window.__VINEXT_PAGES_LINK_PREFETCH_ROUTES__ = ${JSON.stringify(pagesPrefetchRoutes)};
 window.__VINEXT_CLIENT_REWRITES__ = ${JSON.stringify(clientRewrites)};
+window.__VINEXT_LOCALES__ = ${JSON.stringify(locales)};
 registerNavigationRuntimeBootstrap({
     routeManifest: ${buildRouteManifestExpression(routeManifest)}
 });

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -4098,6 +4098,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               graph.routeManifest,
               pagesPrefetchRoutes,
               nextConfig.rewrites,
+              nextConfig.i18n?.locales,
             );
           }
           if (id === RESOLVED_APP_CAPABILITIES && hasAppDir) {

--- a/packages/vinext/src/routing/app-router.ts
+++ b/packages/vinext/src/routing/app-router.ts
@@ -92,6 +92,17 @@ export async function appRouter(
   return graph.routes;
 }
 
+/** Whether the route's ordinary main tree has a loading boundary unique to it. */
+export function appRouteHasMainTreeLoadingBoundary(route: AppRoute): boolean {
+  return (
+    route.loadingPath != null ||
+    (route.loadingPaths?.some(
+      (_loadingPath, index) => (route.loadingTreePositions?.[index] ?? 0) > 0,
+    ) ??
+      false)
+  );
+}
+
 // Trie cache — keyed by route array identity (same array = same trie)
 const appTrieCache = createRouteTrieCache<AppRoute>();
 

--- a/packages/vinext/src/shims/internal/app-prefetch-rsc-request.ts
+++ b/packages/vinext/src/shims/internal/app-prefetch-rsc-request.ts
@@ -6,6 +6,7 @@ import {
 } from "../../server/app-rsc-cache-busting.js";
 
 export type ResolveAppPrefetchRscRequestOptions = {
+  canUseCanonicalLoadingShell: boolean;
   fullHref: string;
   headers: Headers;
   interceptionContext: string | null;
@@ -28,6 +29,7 @@ export type ResolvedAppPrefetchRscRequest = {
  * their varying headers and deterministic `_rsc` digest.
  */
 export async function resolveAppPrefetchRscRequest({
+  canUseCanonicalLoadingShell,
   fullHref,
   headers,
   interceptionContext,
@@ -44,7 +46,9 @@ export async function resolveAppPrefetchRscRequest({
     !requiresRouteTreePrefetch &&
     !prefetchInlining;
   const usesCanonicalLoadingShell =
-    canUseCanonicalSharedRequest && canonicalizeLoadingShellRscRequestHeaders(headers);
+    canUseCanonicalSharedRequest &&
+    canUseCanonicalLoadingShell &&
+    canonicalizeLoadingShellRscRequestHeaders(headers);
   const usesCanonicalFullRoute =
     canUseCanonicalSharedRequest &&
     !usesCanonicalLoadingShell &&

--- a/packages/vinext/src/shims/internal/app-route-prefetch-policy.ts
+++ b/packages/vinext/src/shims/internal/app-route-prefetch-policy.ts
@@ -35,6 +35,8 @@ const ENCODED_PATH_DELIMITER_RE = /%(?:2f|5c)/i;
  */
 export type AppRoutePrefetchPolicy = {
   cacheForNavigation: boolean;
+  /** The selected loading shell has the canonical deploy-warmed identity. */
+  canUseCanonicalLoadingShell?: true;
   /**
    * How the dynamic stale-time signal affects this prefetch. Navigation data
    * takes it verbatim, explicit full prefetches fall back to the static window
@@ -125,6 +127,9 @@ export function resolveAutoAppRoutePrefetch(href: string): AppRoutePrefetchPolic
     // fallbacks can be cached for navigation unless their active parallel
     // branches must be derived from the click-time target tree.
     cacheForNavigation,
+    ...(route.canUseCanonicalLoadingShell === true
+      ? { canUseCanonicalLoadingShell: true as const }
+      : {}),
     dynamicStaleTime: cacheForNavigation ? "verbatim" : "ignore",
     fallbackTtl: "static",
     prefetchShellFirst: requiresRouteTreePrefetch || hasSearchParams || !route.isDynamic,

--- a/packages/vinext/src/shims/internal/hybrid-client-route-owner-direct.ts
+++ b/packages/vinext/src/shims/internal/hybrid-client-route-owner-direct.ts
@@ -71,8 +71,8 @@ function resolveSameOriginPathnames(
   };
 }
 
-export function resolveSameOriginPathname(href: string, basePath: string): string | null {
-  return resolveSameOriginPathnames(href, basePath)?.pagesPathname ?? null;
+export function resolveSameOriginAppPathname(href: string, basePath: string): string | null {
+  return resolveSameOriginPathnames(href, basePath)?.appPathname ?? null;
 }
 
 function selectPagesRoutes(

--- a/packages/vinext/src/shims/internal/hybrid-client-route-owner-direct.ts
+++ b/packages/vinext/src/shims/internal/hybrid-client-route-owner-direct.ts
@@ -31,12 +31,23 @@ declare global {
 
 const appRouteTrieCache = createRouteTrieCache<VinextLinkPrefetchRoute>();
 const pagesRouteTrieCache = createRouteTrieCache<VinextPagesLinkPrefetchRoute>();
+const pagesPageRoutesCache = new WeakMap<
+  VinextPagesLinkPrefetchRoute[],
+  VinextPagesLinkPrefetchRoute[]
+>();
+const pagesApiRoutesCache = new WeakMap<
+  VinextPagesLinkPrefetchRoute[],
+  VinextPagesLinkPrefetchRoute[]
+>();
 
 function patternFromParts(parts: readonly string[]): string {
   return "/" + parts.join("/");
 }
 
-export function resolveSameOriginPathname(href: string, basePath: string): string | null {
+function resolveSameOriginPathnames(
+  href: string,
+  basePath: string,
+): { appPathname: string; pagesApiRequest: boolean; pagesPathname: string } | null {
   if (typeof window === "undefined") return null;
   let url: URL;
   try {
@@ -45,28 +56,57 @@ export function resolveSameOriginPathname(href: string, basePath: string): strin
     return null;
   }
   if (url.origin !== window.location.origin) return null;
-  const pathname = stripBasePath(url.pathname, basePath);
-  const locale = getLocalePathPrefix(pathname, window.__VINEXT_LOCALES__);
-  if (!locale) return pathname;
-  const localePrefixLength = locale.length + 1;
-  return pathname.length === localePrefixLength ? "/" : pathname.slice(localePrefixLength);
+  const appPathname = stripBasePath(url.pathname, basePath);
+  const locale = getLocalePathPrefix(appPathname, window.__VINEXT_LOCALES__);
+  const localePrefixLength = locale ? locale.length + 1 : 0;
+  const pagesPathname = !locale
+    ? appPathname
+    : appPathname.length === localePrefixLength
+      ? "/"
+      : appPathname.slice(localePrefixLength);
+  return {
+    appPathname,
+    pagesApiRequest: appPathname === "/api" || appPathname.startsWith("/api/"),
+    pagesPathname,
+  };
+}
+
+export function resolveSameOriginPathname(href: string, basePath: string): string | null {
+  return resolveSameOriginPathnames(href, basePath)?.pagesPathname ?? null;
+}
+
+function selectPagesRoutes(
+  routes: VinextPagesLinkPrefetchRoute[],
+  apiRequest: boolean,
+): VinextPagesLinkPrefetchRoute[] {
+  const cache = apiRequest ? pagesApiRoutesCache : pagesPageRoutesCache;
+  let selected = cache.get(routes);
+  if (!selected) {
+    selected = routes.filter((route) => Boolean(route.documentOnly) === apiRequest);
+    cache.set(routes, selected);
+  }
+  return selected;
 }
 
 export function matchDirectHybridClientRoutes(
   href: string,
   basePath: string,
 ): HybridClientRouteMatches {
-  const pathname = resolveSameOriginPathname(href, basePath);
-  if (pathname === null) return { appMatch: null, pagesMatch: null };
+  const pathnames = resolveSameOriginPathnames(href, basePath);
+  if (pathnames === null) return { appMatch: null, pagesMatch: null };
 
   const appRoutes = window.__VINEXT_LINK_PREFETCH_ROUTES__;
   const pagesRoutes = window.__VINEXT_PAGES_LINK_PREFETCH_ROUTES__;
   return {
     appMatch: appRoutes
-      ? (matchRouteWithTrie(pathname, appRoutes, appRouteTrieCache)?.route ?? null)
+      ? (matchRouteWithTrie(pathnames.appPathname, appRoutes, appRouteTrieCache)?.route ?? null)
       : null,
     pagesMatch: pagesRoutes
-      ? (matchRouteWithTrie(pathname, pagesRoutes, pagesRouteTrieCache)?.route ?? null)
+      ? (matchRouteWithTrie(
+          pathnames.pagesPathname,
+          selectPagesRoutes(pagesRoutes, pathnames.pagesApiRequest),
+          pagesRouteTrieCache,
+        )?.route ?? null)
       : null,
   };
 }

--- a/packages/vinext/src/shims/internal/hybrid-client-route-owner.ts
+++ b/packages/vinext/src/shims/internal/hybrid-client-route-owner.ts
@@ -20,7 +20,7 @@ import type { ClientRewrite } from "../../client/client-rewrites.js";
 import { mergeRewriteQuery } from "../../utils/query.js";
 import {
   matchDirectHybridClientRoutes,
-  resolveSameOriginPathname,
+  resolveSameOriginAppPathname,
   resolveMatchedHybridClientRouteOwner,
   type HybridClientOwner,
 } from "./hybrid-client-route-owner-direct.js";
@@ -44,7 +44,7 @@ function resolveClientRewrite(
   let matched = false;
 
   for (const rewrite of rewrites) {
-    const pathname = resolveSameOriginPathname(currentHref, basePath);
+    const pathname = resolveSameOriginAppPathname(currentHref, basePath);
     if (pathname === null) return null;
     const url = new URL(currentHref, window.location.href);
     const headers = new Headers({ "user-agent": globalThis.navigator?.userAgent ?? "" });

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -534,6 +534,7 @@ function prefetchUrl(
         }
         const { additionalRscUrls, rscUrl, usesCanonicalPrewarmedRequest } =
           await resolveAppPrefetchRscRequest({
+            canUseCanonicalLoadingShell: autoPrefetch.canUseCanonicalLoadingShell === true,
             fullHref,
             headers,
             interceptionContext,

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -2935,6 +2935,7 @@ const _appRouter: AppRouterInstance = {
       }
       const { additionalRscUrls, rscUrl, usesCanonicalPrewarmedRequest } =
         await resolveAppPrefetchRscRequest({
+          canUseCanonicalLoadingShell: policy.canUseCanonicalLoadingShell === true,
           fullHref,
           headers,
           interceptionContext,

--- a/tests/app-prefetch-rsc-request.test.ts
+++ b/tests/app-prefetch-rsc-request.test.ts
@@ -11,6 +11,7 @@ import {
 import { resolveAppPrefetchRscRequest } from "../packages/vinext/src/shims/internal/app-prefetch-rsc-request.js";
 
 const DEFAULT_OPTIONS = {
+  canUseCanonicalLoadingShell: true,
   interceptionContext: null,
   mountedSlotsHeader: null,
   prefetchInlining: false,
@@ -88,6 +89,32 @@ describe("shared App Router prefetch RSC request resolution", () => {
     expect(headers.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER)).toBe("1");
     expect(headers.get("next-router-state-tree")).toBeNull();
     expect(headers.get("next-url")).toBeNull();
+  });
+
+  it("keeps non-main-tree loading shells contextual", async () => {
+    vi.stubEnv("__VINEXT_CANONICAL_RSC_REQUESTS", "1");
+    const headers = createRscRequestHeaders({
+      nextUrl: "/source",
+      prefetchRouterState: { pathAndSearch: "/source", routeId: "route:/source" },
+      renderMode: APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+    });
+    headers.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "1");
+    const expectedUrl = await createRscRequestUrl("/parallel", new Headers(headers));
+
+    const resolved = await resolveAppPrefetchRscRequest({
+      ...DEFAULT_OPTIONS,
+      canUseCanonicalLoadingShell: false,
+      fullHref: "/parallel",
+      headers,
+    });
+
+    expect(resolved).toEqual({
+      additionalRscUrls: [],
+      rscUrl: expectedUrl,
+      usesCanonicalPrewarmedRequest: false,
+    });
+    expect(headers.get("next-url")).toBe("/source");
+    expect(new URL(expectedUrl, "http://vinext.local").searchParams.get("_rsc")).not.toBe("");
   });
 
   it.each(CONTEXTUAL_CASES)("keeps the request contextual when %s", async (_label, overrides) => {

--- a/tests/cloudflare-cdn-cache.test.ts
+++ b/tests/cloudflare-cdn-cache.test.ts
@@ -85,13 +85,14 @@ describe("CloudflareCdnCacheAdapter", () => {
   });
 
   it("stamps the application build identity on cacheable and no-store responses", () => {
-    vi.stubEnv("__VINEXT_BUILD_ID", "build-a");
+    vi.stubEnv("__VINEXT_BUILD_ID", "pinned-build");
+    vi.stubEnv("__VINEXT_RSC_BUILD_IDENTITY", "instance-a");
 
     expect(adapter.buildResponseHeaders({ cacheControl: "s-maxage=60" })).toMatchObject({
-      [VINEXT_CDN_BUILD_ID_HEADER]: "build-a",
+      [VINEXT_CDN_BUILD_ID_HEADER]: "instance-a",
     });
     expect(adapter.buildResponseHeaders({ cacheControl: "no-store" })).toMatchObject({
-      [VINEXT_CDN_BUILD_ID_HEADER]: "build-a",
+      [VINEXT_CDN_BUILD_ID_HEADER]: "instance-a",
     });
   });
 

--- a/tests/cloudflare-cdn-warm.test.ts
+++ b/tests/cloudflare-cdn-warm.test.ts
@@ -81,6 +81,7 @@ describe("Cloudflare CDN warmup", () => {
       JSON.stringify({
         basePath: "/docs",
         buildId: "build-a",
+        buildIdentity: "rsc-build-a",
         deploymentId: "dpl_123",
         loadingShellPaths: ["/dashboard"],
         paths: ["/dashboard", "/dynamic", "/pages"],
@@ -97,6 +98,7 @@ describe("Cloudflare CDN warmup", () => {
 
     expect(readPrerenderWarmPlan(tmpDir)).toEqual({
       buildId: "build-a",
+      buildIdentity: "rsc-build-a",
       deploymentId: "dpl_123",
       loadingShellPaths: ["/docs/dashboard/"],
       paths: ["/docs/dashboard/", "/docs/dynamic/", "/docs/pages/"],
@@ -530,6 +532,42 @@ describe("Cloudflare CDN warmup", () => {
     ).rejects.toThrow("response is missing CF-Cache-Status");
   });
 
+  it("rejects HTML variants that the warmer request cannot share with browsers", async () => {
+    const fetchImpl = vi.fn(async () => {
+      const response = cacheableHtml();
+      response.headers.set("vary", `${VINEXT_RSC_VARY_HEADER}, User-Agent`);
+      return response;
+    });
+
+    await expect(
+      warmCdnCache({
+        expectedBuildId: "build-a",
+        fetchImpl: fetchImpl as typeof fetch,
+        paths: ["/browser-specific-html"],
+        strict: true,
+        targetUrl: "https://app.example.com",
+      }),
+    ).rejects.toThrow("response Vary has unsupported field user-agent");
+  });
+
+  it("accepts HTML varied only by framework RSC selector headers", async () => {
+    const fetchImpl = vi.fn(async () => {
+      const response = cacheableHtml();
+      response.headers.set("vary", VINEXT_RSC_VARY_HEADER);
+      return response;
+    });
+
+    await expect(
+      warmCdnCache({
+        expectedBuildId: "build-a",
+        fetchImpl: fetchImpl as typeof fetch,
+        paths: ["/shared-html"],
+        strict: true,
+        targetUrl: "https://app.example.com",
+      }),
+    ).resolves.toMatchObject({ warmed: 1, failed: 0 });
+  });
+
   it("rejects responses rendered by a different application build", async () => {
     const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
       const response =
@@ -780,14 +818,18 @@ describe("Cloudflare CDN warmup", () => {
   });
 
   it("uses the discovery manifest build identity by default", async () => {
-    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile("dist/server/BUILD_ID", "pinned-build\n");
     writeFile(
       "dist/server/vinext-prerender-paths.json",
-      JSON.stringify({ buildId: "build-a", paths: ["/wrong-build"] }),
+      JSON.stringify({
+        buildId: "pinned-build",
+        buildIdentity: "instance-a",
+        paths: ["/wrong-build"],
+      }),
     );
     const fetchImpl = vi.fn(async () => {
       const response = cacheableHtml();
-      response.headers.set(VINEXT_CDN_BUILD_ID_HEADER, "old-build");
+      response.headers.set(VINEXT_CDN_BUILD_ID_HEADER, "old-instance");
       return response;
     });
 
@@ -798,6 +840,36 @@ describe("Cloudflare CDN warmup", () => {
         strict: true,
         targetUrl: "https://app.example.com",
       }),
-    ).rejects.toThrow(`response ${VINEXT_CDN_BUILD_ID_HEADER} does not match build build-a`);
+    ).rejects.toThrow(`response ${VINEXT_CDN_BUILD_ID_HEADER} does not match build instance-a`);
+  });
+
+  it("uses the discovery manifest RSC build identity by default", async () => {
+    writeFile("dist/server/BUILD_ID", "pinned-build\n");
+    writeFile(
+      "dist/server/vinext-prerender-paths.json",
+      JSON.stringify({
+        buildId: "pinned-build",
+        buildIdentity: "instance-a",
+        paths: [],
+        responseVary: "verbatim",
+        rscBuildId: "instance-a",
+        rscPaths: ["/wrong-rsc-build"],
+      }),
+    );
+    const fetchImpl = vi.fn(async () => {
+      const response = cacheableRsc();
+      response.headers.set(VINEXT_RSC_BUILD_ID_HEADER, "old-instance");
+      return response;
+    });
+
+    await expect(
+      warmCdnCacheFromPrerender({
+        fetchImpl: fetchImpl as typeof fetch,
+        root: tmpDir,
+        strict: true,
+        targetUrl: "https://app.example.com",
+        validateBuildIdentity: false,
+      }),
+    ).rejects.toThrow(`response ${VINEXT_RSC_BUILD_ID_HEADER} does not match build instance-a`);
   });
 });

--- a/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
+++ b/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
@@ -12,7 +12,7 @@ import fs from "node:fs";
 const TARGET_PATH = "/prewarm-target";
 const LOADING_SHELL_RSC_SEARCH = "?_rsc=9qLBDIU2NgN178cB";
 const PROMOTION_STABILITY_WINDOW_MS = 60_000;
-const PROMOTION_READINESS_TIMEOUT_MS = 90_000;
+const PROMOTION_READINESS_TIMEOUT_MS = 120_000;
 const PROMOTION_PROBE_INTERVAL_MS = 1_000;
 const STALE_SEED_RETRY_TIMEOUT_MS = 45_000;
 
@@ -77,7 +77,7 @@ async function observeRsc(page: Page, action: () => Promise<unknown>): Promise<O
   };
 }
 
-function expectCanonical(observed: ObservedRsc): void {
+function expectCanonical(observed: ObservedRsc, rscBuildId: string): void {
   rejectStaleSeedWorker(observed.response);
   console.log(
     `RSC cache trace: url=${observed.url.pathname}${observed.url.search} ` +
@@ -91,22 +91,23 @@ function expectCanonical(observed: ObservedRsc): void {
   expect(observed.headers["next-router-state-tree"]).toBeUndefined();
   expect(observed.headers["next-url"]).toBeUndefined();
   expect(observed.headers["x-vinext-rsc-state-fingerprint"]).toBeUndefined();
+  expect(observed.response.headers()["x-vinext-rsc-build-id"]).toBe(rscBuildId);
   expect(
     observed.response.headers()["cf-cache-status"],
     JSON.stringify({ request: observed.headers, response: observed.response.headers() }),
   ).toBe("HIT");
 }
 
-function expectFull(observed: ObservedRsc): void {
-  expectCanonical(observed);
+function expectFull(observed: ObservedRsc, rscBuildId: string): void {
+  expectCanonical(observed, rscBuildId);
   expect(observed.url.search).toBe("?_rsc");
   expect(observed.headers["next-router-prefetch"]).toBeUndefined();
   expect(observed.headers["next-router-segment-prefetch"]).toBeUndefined();
   expect(observed.headers["x-vinext-rsc-render-mode"]).toBeUndefined();
 }
 
-function expectLoadingShell(observed: ObservedRsc): void {
-  expectCanonical(observed);
+function expectLoadingShell(observed: ObservedRsc, rscBuildId: string): void {
+  expectCanonical(observed, rscBuildId);
   expect(observed.url.search).toBe(LOADING_SHELL_RSC_SEARCH);
   expect(observed.headers["next-router-prefetch"]).toBe("1");
   expect(observed.headers["next-router-segment-prefetch"]).toBe("1");
@@ -167,7 +168,7 @@ test("deploy-prewarmed full and loading RSC variants are reused by browser navig
 }) => {
   test.skip(!baseURL?.startsWith("https://"), "requires a deployed Cloudflare Worker");
   if (!baseURL) throw new Error("deployed test requires a base URL");
-  test.setTimeout(180_000);
+  test.setTimeout(240_000);
 
   const buildId = fs.readFileSync("examples/workers-cache/dist/server/BUILD_ID", "utf-8").trim();
   const rscBuildId = fs
@@ -254,30 +255,33 @@ test("deploy-prewarmed full and loading RSC variants are reused by browser navig
     expect(response?.ok()).toBe(true);
     await expect(page.getByTestId("build-id")).toHaveText(buildId);
   };
+  const expectTargetCommit = async (page: Page) => {
+    await expect(page).toHaveURL(new RegExp(`${TARGET_PATH}$`));
+    await expect(page.getByRole("heading", { name: "Prewarm target" })).toBeVisible();
+    await expect(page.getByTestId("build-id")).toHaveText(buildId);
+  };
 
   for (const source of ["/prewarm/link-a", "/prewarm/link-b"]) {
     await runFresh(async (page) => {
       const shell = await observeRsc(page, async () => {
         await gotoCurrentBuild(page, source);
       });
-      expectLoadingShell(shell);
+      expectLoadingShell(shell, rscBuildId);
 
       const full = await observeRsc(page, () => page.getByTestId("link-prefetch").click());
-      expectFull(full);
-      await expect(page).toHaveURL(new RegExp(`${TARGET_PATH}$`));
-      await expect(page.getByRole("heading", { name: "Prewarm target" })).toBeVisible();
+      expectFull(full, rscBuildId);
+      await expectTargetCommit(page);
     });
   }
 
   await runFresh(async (page) => {
     await gotoCurrentBuild(page, "/prewarm/router");
     const shell = await observeRsc(page, () => page.getByTestId("router-prefetch").click());
-    expectLoadingShell(shell);
+    expectLoadingShell(shell, rscBuildId);
 
     const full = await observeRsc(page, () => page.getByTestId("router-navigate").click());
-    expectFull(full);
-    await expect(page).toHaveURL(new RegExp(`${TARGET_PATH}$`));
-    await expect(page.getByRole("heading", { name: "Prewarm target" })).toBeVisible();
+    expectFull(full, rscBuildId);
+    await expectTargetCommit(page);
   });
 
   await runFresh(async (page) => {
@@ -291,19 +295,18 @@ test("deploy-prewarmed full and loading RSC variants are reused by browser navig
     const full = await observeRsc(page, async () => {
       await gotoCurrentBuild(page, "/prewarm/full");
     });
-    expectFull(full);
+    expectFull(full, rscBuildId);
     expect(targetRscRequests).toBe(1);
     await page.getByTestId("link-prefetch").click();
-    await expect(page).toHaveURL(new RegExp(`${TARGET_PATH}$`));
-    await expect(page.getByRole("heading", { name: "Prewarm target" })).toBeVisible();
+    await expectTargetCommit(page);
     expect(targetRscRequests).toBe(1);
   });
 
   await runFresh(async (page) => {
     await gotoCurrentBuild(page, "/prewarm/soft");
     const full = await observeRsc(page, () => page.getByTestId("soft-navigation").click());
-    expectFull(full);
-    await expect(page).toHaveURL(new RegExp(`${TARGET_PATH}$`));
+    expectFull(full, rscBuildId);
+    await expectTargetCommit(page);
   });
 
   await runFresh(async (page) => {

--- a/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
+++ b/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
@@ -270,6 +270,17 @@ test("deploy-prewarmed full and loading RSC variants are reused by browser navig
   }
 
   await runFresh(async (page) => {
+    await gotoCurrentBuild(page, "/prewarm/router");
+    const shell = await observeRsc(page, () => page.getByTestId("router-prefetch").click());
+    expectLoadingShell(shell);
+
+    const full = await observeRsc(page, () => page.getByTestId("router-navigate").click());
+    expectFull(full);
+    await expect(page).toHaveURL(new RegExp(`${TARGET_PATH}$`));
+    await expect(page.getByRole("heading", { name: "Prewarm target" })).toBeVisible();
+  });
+
+  await runFresh(async (page) => {
     let targetRscRequests = 0;
     page.on("request", (request) => {
       const url = new URL(request.url());
@@ -295,8 +306,16 @@ test("deploy-prewarmed full and loading RSC variants are reused by browser navig
     await expect(page).toHaveURL(new RegExp(`${TARGET_PATH}$`));
   });
 
-  const dynamic = await request.get(`${baseURL}/dynamic?_rsc`, { headers: fullHeaders });
-  expect(dynamic.ok()).toBe(true);
-  expect(dynamic.headers()["cache-control"]).toContain("no-store");
-  expect(dynamic.headers()["cf-cache-status"]).toBe("BYPASS");
+  await runFresh(async (page) => {
+    const dynamicResponsePromise = page.waitForResponse((response) => {
+      const request = response.request();
+      return new URL(response.url()).pathname === "/dynamic" && request.headers().rsc === "1";
+    });
+    await gotoCurrentBuild(page, "/prewarm/dynamic");
+    const dynamic = await dynamicResponsePromise;
+    rejectStaleSeedWorker(dynamic);
+    expect(dynamic.ok()).toBe(true);
+    expect(dynamic.headers()["cache-control"]).toContain("no-store");
+    expect(dynamic.headers()["cf-cache-status"]).toBe("BYPASS");
+  });
 });

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -188,6 +188,12 @@ describe("App Router generated manifest construction", () => {
     expect(code).not.toContain("cookie-secret-canary");
   });
 
+  it("embeds i18n locales used by hybrid App and Pages route ownership", () => {
+    const code = generateBrowserEntry([], null, [], undefined, ["en", "fr"]);
+
+    expect(code).toContain('window.__VINEXT_LOCALES__ = ["en","fr"]');
+  });
+
   it("embeds the Link auto-prefetch route manifest in the browser entry", () => {
     const code = generateBrowserEntry([
       ...minimalAppRoutes,

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -353,10 +353,10 @@ describe("App Router generated manifest construction", () => {
       '{"canPrefetchLoadingShell":false,"patternParts":["blog",":slug"],"isDynamic":true}',
     );
     expect(code).toContain(
-      '{"canPrefetchLoadingShell":true,"patternParts":["docs",":slug"],"isDynamic":true}',
+      '{"canPrefetchLoadingShell":true,"canUseCanonicalLoadingShell":true,"patternParts":["docs",":slug"],"isDynamic":true}',
     );
     expect(code).toContain(
-      '{"canPrefetchLoadingShell":true,"patternParts":["ancestor-loading","slow"],"isDynamic":false}',
+      '{"canPrefetchLoadingShell":true,"canUseCanonicalLoadingShell":true,"patternParts":["ancestor-loading","slow"],"isDynamic":false}',
     );
     expect(code).toContain(
       '{"canPrefetchLoadingShell":false,"patternParts":["teams",":team","dashboard"],"isDynamic":true,"requiresDynamicNavigationRequest":true}',
@@ -410,6 +410,7 @@ describe("App Router generated manifest construction", () => {
     } satisfies AppRoute;
 
     expect(toLinkPrefetchRoute(route).canPrefetchLoadingShell).toBe(true);
+    expect(toLinkPrefetchRoute(route).canUseCanonicalLoadingShell).toBeUndefined();
     expect(
       toLinkPrefetchRoute({
         ...route,
@@ -464,6 +465,7 @@ describe("App Router generated manifest construction", () => {
     } satisfies AppRoute;
 
     expect(toLinkPrefetchRoute(route).canPrefetchLoadingShell).toBe(true);
+    expect(toLinkPrefetchRoute(route).canUseCanonicalLoadingShell).toBeUndefined();
   });
 
   it("marks root-param routes for concrete route-tree prefetching", () => {
@@ -484,6 +486,7 @@ describe("App Router generated manifest construction", () => {
     expect(toLinkPrefetchRoute(route)).toEqual(
       expect.objectContaining({
         canPrefetchLoadingShell: true,
+        canUseCanonicalLoadingShell: true,
         hasRootParams: true,
       }),
     );
@@ -532,6 +535,7 @@ describe("App Router generated manifest construction", () => {
     ]);
     expect(source.canPrefetchLoadingShell).toBe(false);
     expect(target.canPrefetchLoadingShell).toBe(true);
+    expect(target.canUseCanonicalLoadingShell).toBeUndefined();
     expect(unrelated.canPrefetchLoadingShell).toBe(false);
   });
 

--- a/tests/hybrid-client-route-owner.test.ts
+++ b/tests/hybrid-client-route-owner.test.ts
@@ -189,6 +189,26 @@ describe("resolveHybridClientRouteOwner", () => {
     },
   );
 
+  it("matches locale-aware rewrites against the raw App pathname", () => {
+    installWindow({
+      app: [appRoute([":locale", "app-destination"])],
+      locales: ["en", "fr"],
+      pages: [],
+      rewrites: {
+        afterFiles: [],
+        beforeFiles: [
+          {
+            source: "/:nextInternalLocale(en|fr)/source",
+            destination: "/:nextInternalLocale/app-destination",
+          },
+        ],
+        fallback: [],
+      },
+    });
+
+    expect(resolveHybridClientRouteOwner("/fr/source", "")).toBe("app");
+  });
+
   it.each(["beforeFiles", "afterFiles", "fallback"] as const)(
     "returns the %s rewrite destination href",
     (rewritePhase) => {

--- a/tests/hybrid-client-route-owner.test.ts
+++ b/tests/hybrid-client-route-owner.test.ts
@@ -35,14 +35,16 @@ const APP_BASE = "http://localhost/";
 
 type WindowState = {
   app: VinextLinkPrefetchRoute[];
+  locales?: string[];
   pages: VinextPagesLinkPrefetchRoute[];
   rewrites?: ClientRewrites;
 };
 
-function installWindow({ app, pages, rewrites }: WindowState): void {
+function installWindow({ app, locales, pages, rewrites }: WindowState): void {
   (globalThis as any).window = {
     location: { href: APP_BASE, origin: "http://localhost" },
     __VINEXT_LINK_PREFETCH_ROUTES__: app,
+    __VINEXT_LOCALES__: locales,
     __VINEXT_PAGES_LINK_PREFETCH_ROUTES__: pages,
     __VINEXT_CLIENT_REWRITES__: rewrites,
   };
@@ -123,6 +125,30 @@ describe("resolveHybridClientRouteOwner", () => {
     expect(resolveHybridClientRouteOwner("/api/test", "")).toBe("document");
   });
 
+  it("keeps locale-prefixed App pages distinct from unprefixed Pages API routes", () => {
+    // Next.js treats /fr/api/* as a localized page path, not a Pages API path:
+    // test/e2e/i18n-api-support/index.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/i18n-api-support/index.test.ts
+    installWindow({
+      app: [appRoute([":locale", "api", "status"])],
+      locales: ["en", "fr"],
+      pages: [{ ...pagesRoute(["api", "status"], false), documentOnly: true }],
+    });
+
+    expect(resolveHybridClientRouteOwner("/fr/api/status", "")).toBe("app");
+    expect(resolveHybridClientRouteOwner("/api/status", "")).toBe("document");
+  });
+
+  it("still locale-normalizes Pages page matching", () => {
+    installWindow({
+      app: [appRoute([":locale", "dashboard"])],
+      locales: ["en", "fr"],
+      pages: [pagesRoute(["about"], false)],
+    });
+
+    expect(resolveHybridClientRouteOwner("/fr/about", "")).toBe("pages");
+  });
+
   it("applies document ownership only after choosing the most specific route", () => {
     installWindow({
       app: [appRoute(["api", "settings"], false)],
@@ -131,10 +157,10 @@ describe("resolveHybridClientRouteOwner", () => {
     expect(resolveHybridClientRouteOwner("/api/settings", "")).toBe("app");
 
     installWindow({
-      app: [documentRoute(["api", ":slug"])],
-      pages: [pagesRoute(["api", "settings"], false)],
+      app: [documentRoute(["docs", ":slug"])],
+      pages: [pagesRoute(["docs", "settings"], false)],
     });
-    expect(resolveHybridClientRouteOwner("/api/settings", "")).toBe("pages");
+    expect(resolveHybridClientRouteOwner("/docs/settings", "")).toBe("pages");
   });
 
   it.each(["beforeFiles", "afterFiles", "fallback"] as const)(

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -59,7 +59,12 @@ const linkPrefetchRoutes = [
     patternParts: ["same-origin-intent-prefetch-target"],
     isDynamic: false,
   },
-  { canPrefetchLoadingShell: true, patternParts: ["blog", ":slug"], isDynamic: true },
+  {
+    canPrefetchLoadingShell: true,
+    canUseCanonicalLoadingShell: true,
+    patternParts: ["blog", ":slug"],
+    isDynamic: true,
+  },
   { canPrefetchLoadingShell: false, patternParts: ["products", ":id"], isDynamic: true },
   { canPrefetchLoadingShell: false, patternParts: ["clothing", ":product"], isDynamic: true },
   {

--- a/tests/pages-router-app-prefetch-detection.test.ts
+++ b/tests/pages-router-app-prefetch-detection.test.ts
@@ -274,9 +274,13 @@ describe("Pages Router records app routes as detected on prefetch", () => {
     });
   });
 
-  it("strips basePath and locale prefixes before matching App routes", async () => {
+  it("keeps locale prefixes for App matching but strips them from the Pages component key", async () => {
     const fakeWindow = installFakeBrowserGlobals([
-      { canPrefetchLoadingShell: false, patternParts: ["about"], isDynamic: false },
+      {
+        canPrefetchLoadingShell: false,
+        patternParts: [":locale", "about"],
+        isDynamic: true,
+      },
     ]);
     fakeWindow.__VINEXT_LOCALES__ = ["en", "fr"];
     fakeWindow.__VINEXT_DEFAULT_LOCALE__ = "en";

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -261,6 +261,14 @@ describe("prefetch cache eviction", () => {
 
   it("automatic router.prefetch uses the canonical loading-shell variant", async () => {
     vi.stubEnv("__VINEXT_CANONICAL_RSC_REQUESTS", "1");
+    (globalThis as any).window.__VINEXT_LINK_PREFETCH_ROUTES__ = [
+      {
+        canPrefetchLoadingShell: true,
+        canUseCanonicalLoadingShell: true,
+        patternParts: ["dashboard"],
+        isDynamic: false,
+      },
+    ];
     vi.resetModules();
     const navigation = await import("../packages/vinext/src/shims/navigation.js");
     const fetch = vi.fn(

--- a/tests/prerender-paths.test.ts
+++ b/tests/prerender-paths.test.ts
@@ -99,6 +99,7 @@ describe("prerender path manifest", () => {
 
     expect(manifest).toEqual({
       buildId: "build-a",
+      buildIdentity: "rsc-build-a",
       loadingShellPaths: ["/cached/intro", "/cached/featured"],
       rscBuildId: "rsc-build-a",
       responseVary: "verbatim",

--- a/tests/prerender-paths.test.ts
+++ b/tests/prerender-paths.test.ts
@@ -159,6 +159,52 @@ describe("prerender path manifest", () => {
     expect(manifest?.rscBuildId).toBe("rsc-build-a");
   });
 
+  it("excludes App RSC warm paths affected by configured rewrites", async () => {
+    // Rewrite-aware prefetches can resolve a public URL to a different route:
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/concurrent-navigations/mismatching-prefetch.test.ts
+    writeFile("package.json", JSON.stringify({ type: "module" }));
+    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile("dist/server/RSC_BUILD_ID", "rsc-build-a\n");
+    writeFile("dist/server/index.js", "export default {};\n");
+    writeFile(
+      "app/rewrite-me/page.tsx",
+      "export const revalidate = 60; export default function Page() {}\n",
+    );
+    writeFile("app/rewrite-me/loading.tsx", "export default function Loading() { return null; }\n");
+    writeFile(
+      "app/safe/page.tsx",
+      "export const revalidate = 60; export default function Page() {}\n",
+    );
+    writeFile("app/safe/loading.tsx", "export default function Loading() { return null; }\n");
+
+    const [{ emitPrerenderPathManifest }, { resolveNextConfig }] = await Promise.all([
+      import("../packages/vinext/src/build/prerender-paths.js"),
+      import("../packages/vinext/src/config/next-config.js"),
+    ]);
+    const nextConfig = await resolveNextConfig(
+      {
+        rewrites: () => [
+          {
+            source: "/rewrite-me",
+            destination: "/safe",
+            has: [{ type: "header", key: "x-route-variant", value: "1" }],
+          },
+        ],
+      },
+      tmpDir,
+    );
+
+    const manifest = await emitPrerenderPathManifest({
+      nextConfig,
+      responseVary: "verbatim",
+      root: tmpDir,
+    });
+
+    expect(manifest?.paths).toEqual(["/rewrite-me", "/safe"]);
+    expect(manifest?.rscPaths).toEqual(["/safe"]);
+    expect(manifest?.loadingShellPaths).toEqual(["/safe"]);
+  });
+
   it("excludes Pages-owned hybrid paths from App RSC warm discovery", async () => {
     // Next.js resolves matching Pages and App routes by cross-router specificity:
     // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/use-params/use-params.test.ts


### PR DESCRIPTION
## Summary

Consolidates the client-identity, route-ownership, and deployed-proof work previously split across #3027–#3032.

- align locale-prefixed hybrid App/Pages ownership between browser navigation, runtime routing, and warm discovery
- verify warmed HTML and RSC responses against the exact immutable build and supported variant
- conservatively keep rewrite-affected requests contextual instead of collapsing them into canonical cache entries
- prove Link, `router.prefetch()`, `router.push()`, explicit full prefetch, and soft navigation reuse on a real deployed Worker
- isolate every deployed proof attempt behind a fresh Worker/cache namespace and bind observed hits to the expected build
- keep parallel/interception-only loading shells contextual and hashed while canonicalizing ordinary main-tree `loading.tsx` shells

## Scope

Only the request identity shared by browser RSC navigation and deploy-time CDN warming, plus its deployed proof. Special interception, mounted-slot, route-tree, segment, and other contextual variants remain deferred.

## Validation

The retained commits keep their focused client, ownership, discovery, cache-validation, workflow, and deployed Playwright coverage. The cumulative exact head has passed the complete CI suite and deployed browser-reuse proof.

Consolidates #3027, #3028, #3029, #3030, #3031, and #3032. Stacked on #3026.