### PR TITLE
fix(build): keep CDN warm discovery route-correct

### DIFF
--- a/packages/cloudflare/src/cdn-warm.ts
+++ b/packages/cloudflare/src/cdn-warm.ts
@@ -118,6 +118,9 @@ function readPrerenderPathManifest(manifestPath: string): PrerenderPathManifest 
       (manifest.pagesPaths !== undefined &&
         (!Array.isArray(manifest.pagesPaths) ||
           !manifest.pagesPaths.every((pathname) => typeof pathname === "string"))) ||
+      (manifest.excludedWarmPaths !== undefined &&
+        (!Array.isArray(manifest.excludedWarmPaths) ||
+          !manifest.excludedWarmPaths.every((pathname) => typeof pathname === "string"))) ||
       (manifest.rscPaths !== undefined &&
         (!Array.isArray(manifest.rscPaths) ||
           !manifest.rscPaths.every((pathname) => typeof pathname === "string"))) ||
@@ -162,9 +165,11 @@ function readPrerenderPathWarmPaths(
     manifest,
     pagesPaths: (manifest.pagesPaths ?? [])
       .filter((pathname) => pathname.startsWith("/"))
+      .filter((pathname) => !manifest.excludedWarmPaths?.includes(pathname))
       .map((pathname) => applyWarmPathConfig(pathname, manifest)),
     paths: manifest.paths
       .filter((pathname) => pathname.startsWith("/"))
+      .filter((pathname) => !manifest.excludedWarmPaths?.includes(pathname))
       .map((pathname) => applyWarmPathConfig(pathname, manifest)),
   };
 }
@@ -206,6 +211,7 @@ export function readPrerenderWarmPlan(
         includeFallbackShells: true,
       })
         .filter((pathname) => pathname.startsWith("/"))
+        .filter((pathname) => !manifest.excludedWarmPaths?.includes(pathname))
         .map(applyConfig);
     }
   }

--- a/packages/vinext/src/build/prerender-paths.ts
+++ b/packages/vinext/src/build/prerender-paths.ts
@@ -31,6 +31,7 @@ import type { CdnCacheAdapterCapabilities } from "../cache/cache-adapters-virtua
 import { matchesRewriteSource } from "../config/config-matchers.js";
 import { pagesRouteHasPriorityOverAppRoute } from "../server/hybrid-route-priority.js";
 import { extractLocaleFromUrl, normalizeDefaultLocalePathname } from "../server/pages-i18n.js";
+import { normalizePathTrailingSlash } from "vinext/shims/url-utils";
 
 export type PrerenderPathManifest = {
   basePath?: string;
@@ -47,6 +48,8 @@ export type PrerenderPathManifest = {
   loadingShellPaths?: string[];
   /** Pages Router paths selected by the existing HTML warm discovery pass. */
   pagesPaths?: string[];
+  /** Public paths omitted because configured rewrites can change their response identity. */
+  excludedWarmPaths?: string[];
   trailingSlash?: boolean;
   paths: string[];
 };
@@ -360,7 +363,14 @@ async function collectAppPaths(options: {
         }
       } else {
         const results = await generateStaticParams({ params: {} });
-        paramSets = Array.isArray(results) || results === null ? results : [];
+        if (results === null) {
+          const layoutParamSets = await resolveParentParams(route, staticParamsMap, {
+            includeLastDynamicSegment: true,
+          });
+          paramSets = layoutParamSets.length > 0 ? layoutParamSets : null;
+        } else {
+          paramSets = Array.isArray(results) ? results : [];
+        }
       }
 
       if (!paramSets?.length) continue;
@@ -379,12 +389,10 @@ async function collectAppPaths(options: {
 
 async function resolveAppRscWarmPaths(options: {
   appDir: string;
-  basePath: string;
   i18n: ResolvedNextConfig["i18n"];
   pagesDir: string | null;
   pageExtensions: readonly string[];
   paths: readonly string[];
-  rewrites: ResolvedNextConfig["rewrites"];
 }): Promise<{ loadingShellPaths: string[]; rscPaths: string[] }> {
   const appRoutes = await appRouter(options.appDir, options.pageExtensions);
   const [pageRoutes, apiRoutes] = options.pagesDir
@@ -396,11 +404,6 @@ async function resolveAppRscWarmPaths(options: {
 
   const rscPaths: string[] = [];
   const loadingShellPaths: string[] = [];
-  const rewrites = [
-    ...options.rewrites.beforeFiles,
-    ...options.rewrites.afterFiles,
-    ...options.rewrites.fallback,
-  ];
   for (const pathname of options.paths) {
     const appMatch = matchAppRoute(pathname, appRoutes);
     if (!appMatch) continue;
@@ -428,25 +431,38 @@ async function resolveAppRscWarmPaths(options: {
       continue;
     }
 
-    // A configured rewrite can make the browser's public URL resolve to a
-    // different route than a direct canonical RSC request. Do not advertise
-    // that public cache key as warmable until discovery can reproduce the
-    // rewrite's request-dependent routing context.
-    const rewritePathname = normalizeDefaultLocalePathname(pathname, options.i18n);
-    const rewriteAffectsPath = rewrites.some((rewrite) =>
-      matchesRewriteSource(rewritePathname, rewrite, {
-        basePath: options.basePath,
-        hadBasePath: true,
-      }),
-    );
-    if (rewriteAffectsPath) continue;
-
     rscPaths.push(pathname);
     if (appRouteHasMainTreeLoadingBoundary(matchedAppRoute)) {
       loadingShellPaths.push(pathname);
     }
   }
   return { loadingShellPaths, rscPaths };
+}
+
+function configuredRewriteAffectsWarmPath(
+  pathname: string,
+  config: Pick<ResolvedNextConfig, "basePath" | "i18n" | "rewrites" | "trailingSlash">,
+): boolean {
+  const canonicalPathname = normalizePathTrailingSlash(pathname, config.trailingSlash);
+  const hostnames = [undefined, ...(config.i18n?.domains?.map((domain) => domain.domain) ?? [])];
+  const matchPathnames = new Set(
+    hostnames.map((hostname) =>
+      normalizeDefaultLocalePathname(canonicalPathname, config.i18n, { hostname }),
+    ),
+  );
+  const rewrites = [
+    ...config.rewrites.beforeFiles,
+    ...config.rewrites.afterFiles,
+    ...config.rewrites.fallback,
+  ];
+  return rewrites.some((rewrite) =>
+    Array.from(matchPathnames).some((matchPathname) =>
+      matchesRewriteSource(matchPathname, rewrite, {
+        basePath: config.basePath,
+        hadBasePath: true,
+      }),
+    ),
+  );
 }
 
 async function startPathDiscoveryServer(options: {
@@ -567,16 +583,20 @@ export async function emitPrerenderPathManifest(
     }
   });
 
+  const excludedWarmPathSet = new Set(
+    options.responseVary
+      ? paths.filter((pathname) => configuredRewriteAffectsWarmPath(pathname, config))
+      : [],
+  );
+  const warmPaths = paths.filter((pathname) => !excludedWarmPathSet.has(pathname));
   const appOwnedWarmPaths =
     options.responseVary && appDir
       ? await resolveAppRscWarmPaths({
           appDir,
-          basePath: config.basePath,
           i18n: config.i18n,
           pagesDir,
           pageExtensions: config.pageExtensions,
-          paths: discoveredAppPaths,
-          rewrites: config.rewrites,
+          paths: discoveredAppPaths.filter((pathname) => !excludedWarmPathSet.has(pathname)),
         })
       : {
           loadingShellPaths: discoveredLoadingShellPaths,
@@ -588,13 +608,18 @@ export async function emitPrerenderPathManifest(
     buildId: config.buildId,
     ...(rscBuildId ? { buildIdentity: rscBuildId } : {}),
     ...(config.deploymentId ? { deploymentId: config.deploymentId } : {}),
-    ...(pagesDir ? { pagesPaths: discoveredPagesPaths } : {}),
+    ...(pagesDir
+      ? {
+          pagesPaths: discoveredPagesPaths.filter((pathname) => !excludedWarmPathSet.has(pathname)),
+        }
+      : {}),
+    ...(excludedWarmPathSet.size > 0 ? { excludedWarmPaths: Array.from(excludedWarmPathSet) } : {}),
     ...(rscBuildId ? { rscBuildId } : {}),
     ...(options.responseVary ? { responseVary: options.responseVary } : {}),
     ...(options.responseVary ? { rscPaths: appOwnedWarmPaths.rscPaths } : {}),
     ...(options.responseVary ? { loadingShellPaths: appOwnedWarmPaths.loadingShellPaths } : {}),
     trailingSlash: config.trailingSlash,
-    paths,
+    paths: warmPaths,
   };
   fs.mkdirSync(manifestDir, { recursive: true });
   fs.writeFileSync(
@@ -602,7 +627,7 @@ export async function emitPrerenderPathManifest(
     JSON.stringify(manifest, null, 2) + "\n",
     "utf-8",
   );
-  console.log(`  Discovered ${paths.length} CDN warmup path(s).`);
+  console.log(`  Discovered ${warmPaths.length} CDN warmup path(s).`);
 
   return manifest;
 }

--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -528,6 +528,7 @@ export type StaticParamsMap = Record<
 export async function resolveParentParams(
   childRoute: AppRoute,
   staticParamsMap: StaticParamsMap,
+  options: { includeLastDynamicSegment?: boolean } = {},
 ): Promise<Record<string, string | string[]>[]> {
   const { patternParts } = childRoute;
 
@@ -549,7 +550,8 @@ export async function resolveParentParams(
   const parentSegments: GenerateStaticParamsFn[] = [];
 
   let prefixPattern = "";
-  for (let i = 0; i < lastDynamicIdx; i++) {
+  const prefixEnd = options.includeLastDynamicSegment ? lastDynamicIdx + 1 : lastDynamicIdx;
+  for (let i = 0; i < prefixEnd; i++) {
     const part = patternParts[i];
     prefixPattern += "/" + part;
     if (!part.startsWith(":")) continue;

--- a/tests/cloudflare-cdn-warm.test.ts
+++ b/tests/cloudflare-cdn-warm.test.ts
@@ -132,7 +132,11 @@ describe("Cloudflare CDN warmup", () => {
     writeFile("dist/server/BUILD_ID", "build-a\n");
     writeFile(
       "dist/server/vinext-prerender-paths.json",
-      JSON.stringify({ buildId: "build-a", paths: ["/", "/cached/intro"] }),
+      JSON.stringify({
+        buildId: "build-a",
+        excludedWarmPaths: ["/blog/[slug]"],
+        paths: ["/", "/cached/intro"],
+      }),
     );
     writeFile(
       "dist/server/vinext-prerender.json",
@@ -151,10 +155,7 @@ describe("Cloudflare CDN warmup", () => {
       }),
     );
 
-    expect(readPrerenderWarmPlan(tmpDir, { includeFallbackShells: true }).paths).toEqual([
-      "/",
-      "/blog/[slug]",
-    ]);
+    expect(readPrerenderWarmPlan(tmpDir, { includeFallbackShells: true }).paths).toEqual(["/"]);
   });
 
   it("falls back to discovered paths when fallback shells were not locally rendered", () => {

--- a/tests/prerender-paths.test.ts
+++ b/tests/prerender-paths.test.ts
@@ -61,6 +61,12 @@ describe("prerender path manifest", () => {
         ) {
           return Response.json([{ locale: "fr" }]);
         }
+        if (
+          url.pathname === "/__vinext/prerender/static-params" &&
+          url.searchParams.get("pattern") === "/:category"
+        ) {
+          return Response.json([{ category: "news" }]);
+        }
         return new Response("null", { headers: { "content-type": "application/json" } });
       }),
     );
@@ -200,9 +206,111 @@ describe("prerender path manifest", () => {
       root: tmpDir,
     });
 
-    expect(manifest?.paths).toEqual(["/rewrite-me", "/safe"]);
+    expect(manifest?.paths).toEqual(["/safe"]);
+    expect(manifest?.excludedWarmPaths).toEqual(["/rewrite-me"]);
     expect(manifest?.rscPaths).toEqual(["/safe"]);
     expect(manifest?.loadingShellPaths).toEqual(["/safe"]);
+  });
+
+  it("discovers a static child route from parent-layout generateStaticParams", async () => {
+    // Next.js supports parent layouts generating params for static child pages:
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app-prefetch-static/app/[region]/(default)/layout.js
+    writeFile("package.json", JSON.stringify({ type: "module" }));
+    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile("dist/server/RSC_BUILD_ID", "rsc-build-a\n");
+    writeFile("dist/server/index.js", "export default {};\n");
+    writeFile(
+      "app/[category]/layout.tsx",
+      [
+        "export function generateStaticParams() { return [{ category: 'news' }]; }",
+        "export default function Layout({ children }) { return children; }",
+      ].join("\n"),
+    );
+    writeFile(
+      "app/[category]/foo/page.tsx",
+      "export const revalidate = 60; export default function Page() {}\n",
+    );
+    writeFile(
+      "app/[category]/foo/loading.tsx",
+      "export default function Loading() { return null; }\n",
+    );
+
+    const { emitPrerenderPathManifest } =
+      await import("../packages/vinext/src/build/prerender-paths.js");
+    const manifest = await emitPrerenderPathManifest({
+      responseVary: "verbatim",
+      root: tmpDir,
+    });
+
+    expect(manifest?.paths).toEqual(["/news/foo"]);
+    expect(manifest?.rscPaths).toEqual(["/news/foo"]);
+    expect(manifest?.loadingShellPaths).toEqual(["/news/foo"]);
+    expect(fetch).toHaveBeenCalledWith(
+      "http://127.0.0.1:43210/__vinext/prerender/static-params?pattern=%2F%3Acategory",
+      expect.any(Object),
+    );
+  });
+
+  it("matches rewrites against the trailing-slash warm URL", async () => {
+    writeFile("package.json", JSON.stringify({ type: "module" }));
+    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile("dist/server/RSC_BUILD_ID", "rsc-build-a\n");
+    writeFile("dist/server/index.js", "export default {};\n");
+    writeFile("app/foo/page.tsx", "export default function Page() {}\n");
+
+    const [{ emitPrerenderPathManifest }, { resolveNextConfig }] = await Promise.all([
+      import("../packages/vinext/src/build/prerender-paths.js"),
+      import("../packages/vinext/src/config/next-config.js"),
+    ]);
+    const nextConfig = await resolveNextConfig(
+      {
+        trailingSlash: true,
+        rewrites: () => [{ source: "/foo/", destination: "/other" }],
+      },
+      tmpDir,
+    );
+    const manifest = await emitPrerenderPathManifest({
+      nextConfig,
+      responseVary: "verbatim",
+      root: tmpDir,
+    });
+
+    expect(manifest?.paths).toEqual([]);
+    expect(manifest?.rscPaths).toEqual([]);
+    expect(manifest?.excludedWarmPaths).toEqual(["/foo"]);
+  });
+
+  it("checks rewrite identity for every configured domain default locale", async () => {
+    writeFile("package.json", JSON.stringify({ type: "module" }));
+    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile("dist/server/RSC_BUILD_ID", "rsc-build-a\n");
+    writeFile("dist/server/index.js", "export default {};\n");
+    writeFile("app/foo/page.tsx", "export default function Page() {}\n");
+
+    const [{ emitPrerenderPathManifest }, { resolveNextConfig }] = await Promise.all([
+      import("../packages/vinext/src/build/prerender-paths.js"),
+      import("../packages/vinext/src/config/next-config.js"),
+    ]);
+    const nextConfig = await resolveNextConfig(
+      {
+        i18n: {
+          defaultLocale: "en",
+          locales: ["en", "fr"],
+          domains: [{ domain: "example.fr", defaultLocale: "fr" }],
+        },
+        rewrites: () => [{ source: "/fr/foo", destination: "/other", locale: false }],
+      },
+      tmpDir,
+    );
+    const manifest = await emitPrerenderPathManifest({
+      nextConfig,
+      responseVary: "verbatim",
+      root: tmpDir,
+    });
+
+    expect(manifest?.paths).toEqual([]);
+    expect(manifest?.rscPaths).toEqual([]);
+    expect(manifest?.excludedWarmPaths).toEqual(["/foo"]);
   });
 
   it("excludes Pages-owned hybrid paths from App RSC warm discovery", async () => {

--- a/tests/prerender.test.ts
+++ b/tests/prerender.test.ts
@@ -2194,6 +2194,17 @@ describe("resolveParentParams", () => {
     expect(result).toEqual([{ category: "electronics" }, { category: "clothing" }]);
   });
 
+  it("can include a provider for the last dynamic segment", async () => {
+    const child = mockRoute("/:category/foo");
+    const staticParamsMap: StaticParamsMap = {
+      "/:category": async () => [{ category: "news" }],
+    };
+
+    await expect(
+      resolveParentParams(child, staticParamsMap, { includeLastDynamicSegment: true }),
+    ).resolves.toEqual([{ category: "news" }]);
+  });
+
   it("resolves two levels of parent dynamic segments", async () => {
     const child = mockRoute("/a/:b/c/:d/:e");
     const staticParamsMap: StaticParamsMap = {


### PR DESCRIPTION
Stacked on #3032.

## Summary

- discover normal static child routes whose params are generated by a parent layout
- exclude configured-rewrite public paths from both HTML and canonical RSC warming
- preserve that exclusion when optional locally-prerendered fallback shells are included
- evaluate rewrite sources against the actual trailing-slash warm URL and every configured domain default locale

## Scope

Only changes the deploy warm plan. It does not execute rewrites during discovery, locally render pages, alter runtime routing, or expand the deferred special RSC variants.

## Validation

- 149 focused discovery, prerender, and Cloudflare warm-plan tests
- targeted `vp check` on all 6 touched files
- `vp run vinext#build`
- `vp run @vinext/cloudflare#build`