### PR TITLE
fix(cache): preserve valid CDN policy during RSC warmup

### DIFF
--- a/packages/cloudflare/src/cdn-warm.ts
+++ b/packages/cloudflare/src/cdn-warm.ts
@@ -559,14 +559,14 @@ function shouldRetryValidationFailure(
       ? null
       : response.headers.get(VINEXT_RSC_BUILD_ID_HEADER) === options.expectedRscBuildId,
   ].filter((matches): matches is boolean => matches !== null);
-  if (expectedIdentities.some((matches) => !matches)) return true;
 
   // A matching identity proves routing reached the uploaded Worker. From that
   // point, retry only transient HTTP failures; response-shape and admission
   // failures are deterministic for that build.
-  if (expectedIdentities.length > 0) {
+  if (expectedIdentities.some((matches) => matches)) {
     return isRetryableStatus(response.status, false);
   }
+  if (expectedIdentities.some((matches) => !matches)) return true;
   return isRetryableStatus(response.status, options.retryNotFound);
 }
 

--- a/packages/vinext/src/shims/cdn-cache.ts
+++ b/packages/vinext/src/shims/cdn-cache.ts
@@ -61,8 +61,6 @@ export type CdnCacheableHeaderInput = {
   tags?: readonly string[];
 };
 
-const NON_CACHEABLE_CACHE_DIRECTIVES = new Set(["private", "no-store", "no-cache"]);
-
 /** Whether a Cache-Control value contains an exact non-cacheable directive. */
 export function isNonCacheableCacheControl(cacheControl: string): boolean {
   let start = 0;
@@ -75,7 +73,9 @@ export function isNonCacheableCacheControl(cacheControl: string): boolean {
       const directive = cacheControl.slice(start, index);
       const equals = directive.indexOf("=");
       const name = (equals === -1 ? directive : directive.slice(0, equals)).trim().toLowerCase();
-      if (NON_CACHEABLE_CACHE_DIRECTIVES.has(name)) return true;
+      if (name === "no-store" || (equals === -1 && (name === "private" || name === "no-cache"))) {
+        return true;
+      }
       start = index + 1;
       continue;
     }

--- a/tests/app-rsc-response-finalizer.test.ts
+++ b/tests/app-rsc-response-finalizer.test.ts
@@ -48,6 +48,20 @@ describe("finalizeAppRscResponse — config header application", () => {
     },
   );
 
+  it("does not collapse field-qualified cache directives to no-store", async () => {
+    const cacheControl = 'public, max-age=60, private="set-cookie", no-cache="set-cookie"';
+    const response = new Response("body", { headers: { "Cache-Control": cacheControl } });
+
+    await finalizeAppRscResponse(response, new Request("http://example.com/about"), {
+      basePath: "",
+      configHeaders: [],
+      i18nConfig: null,
+      requestContext: makeRequestContext(),
+    });
+
+    expect(response.headers.get("cache-control")).toBe(cacheControl);
+  });
+
   it("normalizes an adapter-owned cache opt-out after response headers are finalized", async () => {
     const adapter: CdnCacheAdapter = {
       ownsBackgroundRevalidation: false,

--- a/tests/cache-control.test.ts
+++ b/tests/cache-control.test.ts
@@ -197,6 +197,21 @@ describe("applyCdnResponseHeaders", () => {
     ).toBe(false);
   });
 
+  it("keeps field-qualified private and no-cache policies cacheable", () => {
+    expect(
+      hasExplicitNonCacheableResponsePolicy(
+        new Headers({
+          "Cache-Control": 'public, max-age=60, private="set-cookie", no-cache="set-cookie"',
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      hasExplicitNonCacheableResponsePolicy(
+        new Headers({ "Cache-Control": 'private="set-cookie", no-store' }),
+      ),
+    ).toBe(true);
+  });
+
   it("delegates provider-specific policy interpretation to the active adapter", () => {
     const edge: CdnCacheAdapter = {
       ownsBackgroundRevalidation: false,

--- a/tests/cloudflare-cdn-warm.test.ts
+++ b/tests/cloudflare-cdn-warm.test.ts
@@ -660,6 +660,31 @@ describe("Cloudflare CDN warmup", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
+  it("does not retry a deterministic failure when either build identity matches", async () => {
+    const fetchImpl = vi.fn(async () => {
+      const response = cacheableRsc();
+      response.headers.delete(VINEXT_CDN_BUILD_ID_HEADER);
+      response.headers.set("vary", `${VINEXT_RSC_VARY_HEADER}, User-Agent`);
+      return response;
+    });
+
+    await expect(
+      warmCdnCache({
+        expectedBuildId: "build-a",
+        expectedRscBuildId: "rsc-build-a",
+        fetchImpl: fetchImpl as typeof fetch,
+        paths: [],
+        propagatingTarget: true,
+        retries: 60,
+        retryDelayMs: 0,
+        rscPaths: ["/invalid-current-rsc-build"],
+        strict: true,
+        targetUrl: "https://app.example.com",
+      }),
+    ).rejects.toThrow(`response ${VINEXT_CDN_BUILD_ID_HEADER} does not match build build-a`);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
   it("retries first and later staged-target failures only after the initial queue", async () => {
     const attempts = new Map<string, number>();
     const calls: string[] = [];


### PR DESCRIPTION
Stacked on #3033.

## Summary

- treat field-qualified `private` / `no-cache` directives as field policy rather than whole-response cache opt-outs
- preserve cacheable adapter policy for responses that strip named fields such as `Set-Cookie`
- stop staged propagation retries once either immutable build identity proves the current Worker served a deterministic invalid response

## Scope

Only cache-policy interpretation and warmup retry classification used by the RSC CDN prewarming feature. No general cache key or runtime routing changes.

## Validation

- 106 focused cache policy, RSC finalization, Cloudflare adapter, and warmup tests
- targeted `vp check` on all 5 touched files
- `vp run vinext#build`
- `vp run @vinext/cloudflare#build`