### PR TITLE
fix(build): discover localized Pages CDN warmup paths

### DIFF
--- a/packages/vinext/src/build/prerender-paths.ts
+++ b/packages/vinext/src/build/prerender-paths.ts
@@ -221,6 +221,7 @@ async function withPrerenderEndpoints<T>(fn: () => Promise<T>): Promise<T> {
 
 async function collectPagesPaths(options: {
   baseUrl: string | null;
+  i18n: ResolvedNextConfig["i18n"];
   pagesDir: string;
   pageExtensions: readonly string[];
   secretHeaders: Record<string, string>;
@@ -244,7 +245,13 @@ async function collectPagesPaths(options: {
     if (type === "api" || type === "ssr") continue;
 
     if (!route.isDynamic) {
-      addPath(paths, seen, route.pattern);
+      if (options.i18n) {
+        for (const locale of options.i18n.locales) {
+          addPath(paths, seen, localizePagesPath(route.pattern, locale, options.i18n));
+        }
+      } else {
+        addPath(paths, seen, route.pattern);
+      }
       continue;
     }
 
@@ -253,6 +260,10 @@ async function collectPagesPaths(options: {
 
     try {
       const search = new URLSearchParams({ pattern: route.pattern });
+      if (options.i18n) {
+        search.set("locales", JSON.stringify(options.i18n.locales));
+        search.set("defaultLocale", options.i18n.defaultLocale);
+      }
       const text = await fetchDiscoveryEndpoint(
         `${options.baseUrl}/__vinext/prerender/pages-static-paths?${search}`,
         options.secretHeaders,
@@ -264,11 +275,27 @@ async function collectPagesPaths(options: {
         fallback?: unknown;
       };
       for (const item of pathsResult.paths ?? []) {
-        const normalized = normalizeStaticPathsEntry(item, route.pattern);
+        let itemToNormalize = item;
+        let locale = options.i18n?.defaultLocale;
+        if (options.i18n && typeof item === "string") {
+          const localeInfo = extractLocaleFromUrl(item, options.i18n);
+          itemToNormalize = localeInfo.url;
+          locale = localeInfo.locale;
+        } else if (options.i18n && item && typeof item === "object" && item.locale) {
+          if (!options.i18n.locales.includes(item.locale)) {
+            throw new Error(
+              `Invalid locale returned from getStaticPaths for ${route.pattern}: ${item.locale}`,
+            );
+          }
+          locale = item.locale;
+        }
+
+        const normalized = normalizeStaticPathsEntry(itemToNormalize, route.pattern);
         if ("error" in normalized) {
           throw new Error(normalized.error);
         }
-        addPath(paths, seen, buildUrlFromParams(route.pattern, normalized.params));
+        const pathname = buildUrlFromParams(route.pattern, normalized.params);
+        addPath(paths, seen, localizePagesPath(pathname, locale, options.i18n));
       }
     } catch (error) {
       warnDiscoveryFailure(route.pattern, error);
@@ -276,6 +303,15 @@ async function collectPagesPaths(options: {
   }
 
   return paths;
+}
+
+function localizePagesPath(
+  pathname: string,
+  locale: string | undefined,
+  i18n: ResolvedNextConfig["i18n"],
+): string {
+  if (!i18n || !locale || locale === i18n.defaultLocale) return pathname;
+  return pathname === "/" ? `/${locale}` : `/${locale}${pathname}`;
 }
 
 async function collectAppPaths(options: {
@@ -568,6 +604,7 @@ export async function emitPrerenderPathManifest(
       if (pagesDir) {
         for (const pathname of await collectPagesPaths({
           baseUrl,
+          i18n: config.i18n,
           pagesDir,
           pageExtensions: config.pageExtensions,
           secretHeaders,

--- a/tests/prerender-paths.test.ts
+++ b/tests/prerender-paths.test.ts
@@ -450,7 +450,7 @@ describe("prerender path manifest", () => {
     expect(manifest?.paths).toEqual(["/fr/api/status", "/fr/about", "/about"]);
     expect(manifest?.rscPaths).toEqual(["/fr/api/status"]);
     expect(manifest?.loadingShellPaths).toEqual(["/fr/api/status"]);
-    expect(manifest?.pagesPaths).toEqual(["/about"]);
+    expect(manifest?.pagesPaths).toEqual(["/about", "/fr/about"]);
   });
 
   it("skips dynamic warmup paths when static params discovery aborts", async () => {
@@ -603,6 +603,109 @@ describe("prerender path manifest", () => {
 
     expect(manifest?.paths).toEqual(["/pages-only"]);
     expect(manifest?.pagesPaths).toEqual(["/pages-only"]);
+  });
+
+  it("discovers locale-specific Pages Router warmup keys", async () => {
+    // Next.js passes i18n metadata to getStaticPaths and qualifies each
+    // returned pathname with its selected locale:
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/build/static-paths/pages.ts
+    writeFile("package.json", JSON.stringify({ type: "module" }));
+    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile("dist/server/entry.js", "export default {};\n");
+    writeFile("pages/about.tsx", "export default function Page() { return null; }\n");
+    writeFile(
+      "pages/posts/[slug].tsx",
+      [
+        "export function getStaticPaths() { return { paths: [], fallback: false }; }",
+        "export function getStaticProps() { return { props: {}, revalidate: 60 }; }",
+        "export default function Page() { return null; }",
+      ].join("\n"),
+    );
+    vi.mocked(fetch).mockImplementation(async (input) => {
+      const rawUrl =
+        input instanceof URL ? input.href : typeof input === "string" ? input : input.url;
+      const url = new URL(rawUrl);
+      if (url.pathname === "/__vinext/prerender/pages-static-paths") {
+        return Response.json({
+          fallback: false,
+          paths: [
+            { params: { slug: "hello" } },
+            { params: { slug: "bonjour" }, locale: "fr" },
+            "/fr/posts/string-fr",
+            "/posts/string-en",
+          ],
+        });
+      }
+      return new Response("null", { headers: { "content-type": "application/json" } });
+    });
+
+    const [{ emitPrerenderPathManifest }, { resolveNextConfig }, { readPrerenderWarmPlan }] =
+      await Promise.all([
+        import("../packages/vinext/src/build/prerender-paths.js"),
+        import("../packages/vinext/src/config/next-config.js"),
+        import("../packages/cloudflare/src/cdn-warm.js"),
+      ]);
+    const nextConfig = await resolveNextConfig(
+      {
+        basePath: "/docs",
+        i18n: { defaultLocale: "en", locales: ["en", "fr"] },
+        trailingSlash: true,
+      },
+      tmpDir,
+    );
+
+    const manifest = await emitPrerenderPathManifest({ root: tmpDir, nextConfig });
+
+    expect(manifest?.paths).toEqual([
+      "/about",
+      "/fr/about",
+      "/posts/hello",
+      "/fr/posts/bonjour",
+      "/fr/posts/string-fr",
+      "/posts/string-en",
+    ]);
+    expect(manifest?.pagesPaths).toEqual(manifest?.paths);
+    expect(fetch).toHaveBeenCalledWith(
+      "http://127.0.0.1:43210/__vinext/prerender/pages-static-paths?pattern=%2Fposts%2F%3Aslug&locales=%5B%22en%22%2C%22fr%22%5D&defaultLocale=en",
+      expect.any(Object),
+    );
+    expect(readPrerenderWarmPlan(tmpDir).paths).toEqual([
+      "/docs/about/",
+      "/docs/fr/about/",
+      "/docs/posts/hello/",
+      "/docs/fr/posts/bonjour/",
+      "/docs/fr/posts/string-fr/",
+      "/docs/posts/string-en/",
+    ]);
+  });
+
+  it("excludes only the locale-specific Pages key affected by a rewrite", async () => {
+    writeFile("package.json", JSON.stringify({ type: "module" }));
+    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile("dist/server/entry.js", "export default {};\n");
+    writeFile("pages/about.tsx", "export default function Page() { return null; }\n");
+
+    const [{ emitPrerenderPathManifest }, { resolveNextConfig }] = await Promise.all([
+      import("../packages/vinext/src/build/prerender-paths.js"),
+      import("../packages/vinext/src/config/next-config.js"),
+    ]);
+    const nextConfig = await resolveNextConfig(
+      {
+        i18n: { defaultLocale: "en", locales: ["en", "fr"] },
+        rewrites: () => [{ source: "/fr/about", destination: "/other", locale: false }],
+      },
+      tmpDir,
+    );
+
+    const manifest = await emitPrerenderPathManifest({
+      nextConfig,
+      responseVary: "verbatim",
+      root: tmpDir,
+    });
+
+    expect(manifest?.paths).toEqual(["/about"]);
+    expect(manifest?.pagesPaths).toEqual(["/about"]);
+    expect(manifest?.excludedWarmPaths).toEqual(["/fr/about"]);
   });
 
   it("does not reload disk config when supplied resolved config", async () => {


### PR DESCRIPTION
## Summary

- enumerate default and locale-prefixed public cache keys for static Pages Router routes
- pass configured `locales` and `defaultLocale` to `getStaticPaths` discovery
- preserve object-entry `locale` and locale-prefixed string entries when constructing public warmup paths
- apply locale-specific rewrite exclusion before writing the warm plan
- verify basePath and trailingSlash are applied to localized keys by the final Cloudflare warm plan

This is stacked on #3036 and only addresses the Pages Router i18n finding from the fresh cumulative RSC prewarming review.

## Validation

- `vp test run tests/prerender-paths.test.ts tests/cloudflare-cdn-warm.test.ts tests/app-prerender-endpoints.test.ts` (65 passed)
- targeted `vp check` for both touched files
- `vp run vinext#build`
- `vp run @vinext/cloudflare#build`

## Next.js reference

- `packages/next/src/build/static-paths/pages.ts`