### PR TITLE
fix(cloudflare): stabilize staged Worker before CDN warmup

### DIFF
--- a/packages/cloudflare/src/cdn-warm.ts
+++ b/packages/cloudflare/src/cdn-warm.ts
@@ -1,5 +1,7 @@
 import path from "node:path";
 import fs from "node:fs";
+import { randomUUID } from "node:crypto";
+import { setTimeout as delay } from "node:timers/promises";
 import {
   PRERENDER_PATHS_MANIFEST,
   type PrerenderPathManifest,
@@ -48,6 +50,10 @@ export type CdnWarmOptions = {
 
 export const DEFAULT_CDN_WARM_CONCURRENCY = 25;
 export const DEFAULT_CDN_WARM_TIMEOUT_MS = 10_000;
+const DEFAULT_STAGED_READINESS_ATTEMPTS = 60;
+const DEFAULT_STAGED_READINESS_INTERVAL_MS = 1_000;
+const DEFAULT_STAGED_READINESS_SUCCESSES = 6;
+const STAGED_READINESS_QUERY_PARAM = "__vinext_cdn_warm_readiness";
 
 export type PrerenderCdnWarmOptions = Omit<CdnWarmOptions, "paths"> & {
   root: string;
@@ -70,6 +76,8 @@ export type CdnWarmRequestPlan = {
   paths: string[];
   rscPaths: string[];
 };
+
+export type CdnWarmReadinessResult = { ready: true } | { error: string; ready: false };
 
 export type PrerenderWarmPlan = {
   buildId?: string;
@@ -299,6 +307,37 @@ async function fetchWithTimeout(
     if (controller.signal.aborted && response?.body) {
       void response.body.cancel().catch(() => {});
     }
+  }
+}
+
+async function fetchHeadersWithTimeout(
+  fetchImpl: typeof fetch,
+  url: URL,
+  timeoutMs: number,
+  headers?: HeadersInit,
+): Promise<Response> {
+  const controller = new AbortController();
+  const requestHeaders = new Headers(headers);
+  requestHeaders.set("User-Agent", "vinext-cloudflare-cdn-warm");
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const timedOut = new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(() => {
+        controller.abort();
+        reject(new DOMException(`Timed out after ${timeoutMs}ms`, "AbortError"));
+      }, timeoutMs);
+    });
+    return await Promise.race([
+      fetchImpl(url, {
+        method: "GET",
+        redirect: "manual",
+        headers: requestHeaders,
+        signal: controller.signal,
+      }),
+      timedOut,
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
   }
 }
 
@@ -535,6 +574,140 @@ function validateHtmlWarmResponse(response: Response, expectedBuildId?: string):
     return { outcome: "failed", error: `response Vary has unsupported field ${extraVary}` };
   }
   return { outcome: "warmed" };
+}
+
+function validateReadinessResponse(
+  response: Response,
+  kind: "html" | "rsc",
+  expectedBuildId?: string,
+  expectedRscBuildId?: string,
+): string | null {
+  if (response.redirected || response.status < 200 || response.status >= 300) {
+    return response.redirected ? "redirected response" : `HTTP ${response.status}`;
+  }
+  if (
+    kind === "rsc" &&
+    !response.headers.get("Content-Type")?.toLowerCase().startsWith(VINEXT_RSC_CONTENT_TYPE)
+  ) {
+    return `expected ${VINEXT_RSC_CONTENT_TYPE} response`;
+  }
+  const buildIdentityValidation = validateBuildIdentity(response, expectedBuildId);
+  if (buildIdentityValidation?.outcome === "failed") return buildIdentityValidation.error;
+  if (
+    kind === "rsc" &&
+    expectedRscBuildId !== undefined &&
+    response.headers.get(VINEXT_RSC_BUILD_ID_HEADER) !== expectedRscBuildId
+  ) {
+    return `response ${VINEXT_RSC_BUILD_ID_HEADER} does not match build ${expectedRscBuildId}`;
+  }
+  return null;
+}
+
+/**
+ * Wait until version-override requests consistently reach the uploaded build
+ * before any real cache key is filled. Every probe has a unique query key, so
+ * an early response cannot make a later readiness attempt pass from cache.
+ */
+export async function waitForCdnWarmTargetReadiness(
+  options: Pick<
+    CdnWarmOptions,
+    | "deploymentId"
+    | "expectedBuildId"
+    | "expectedRscBuildId"
+    | "fetchImpl"
+    | "headers"
+    | "targetUrl"
+    | "timeoutMs"
+  > & {
+    plan: CdnWarmRequestPlan;
+    maxAttempts?: number;
+    probeIntervalMs?: number;
+    requiredConsecutiveSuccesses?: number;
+  },
+): Promise<CdnWarmReadinessResult> {
+  const rscPath = options.plan.rscPaths[0] ?? options.plan.loadingShellPaths[0];
+  const htmlPath = options.plan.paths[0];
+  const kind = rscPath ? "rsc" : "html";
+  const pathname = rscPath ?? htmlPath;
+  if (!pathname) return { ready: true };
+  if (options.expectedBuildId === undefined && options.expectedRscBuildId === undefined) {
+    return {
+      error: "no response build identity is available for a staged-version readiness probe",
+      ready: false,
+    };
+  }
+
+  const headers = new Headers(options.headers);
+  const probePath = kind === "rsc" ? createCanonicalRscRequestUrl(pathname) : pathname;
+  if (kind === "rsc") {
+    for (const [name, value] of createCanonicalRscRequestHeaders(options.deploymentId)) {
+      headers.set(name, value);
+    }
+  } else {
+    headers.set("Accept", "text/html");
+  }
+  headers.set("Cache-Control", "no-cache");
+  headers.set("Pragma", "no-cache");
+
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const timeoutMs = Math.max(1, options.timeoutMs ?? DEFAULT_CDN_WARM_TIMEOUT_MS);
+  const maxAttempts = Math.max(1, options.maxAttempts ?? DEFAULT_STAGED_READINESS_ATTEMPTS);
+  const probeIntervalMs = Math.max(
+    0,
+    options.probeIntervalMs ?? DEFAULT_STAGED_READINESS_INTERVAL_MS,
+  );
+  const requiredConsecutiveSuccesses = Math.max(
+    1,
+    options.requiredConsecutiveSuccesses ?? DEFAULT_STAGED_READINESS_SUCCESSES,
+  );
+  const probeId = randomUUID();
+  let consecutiveSuccesses = 0;
+  let lastError = "readiness probe did not run";
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const url = buildWarmupUrl(options.targetUrl, probePath);
+    url.searchParams.set(STAGED_READINESS_QUERY_PARAM, `${probeId}-${attempt}`);
+    let response: Response | undefined;
+    try {
+      response = await fetchHeadersWithTimeout(fetchImpl, url, timeoutMs, headers);
+      const validationError = validateReadinessResponse(
+        response,
+        kind,
+        options.expectedBuildId,
+        options.expectedRscBuildId,
+      );
+      if (process.env.VINEXT_CDN_WARM_DEBUG === "1") {
+        console.log(
+          `  CDN warm readiness attempt ${attempt + 1}: ` +
+            `${url.pathname}${url.search} HTTP ${response.status} ` +
+            `build=${response.headers.get(VINEXT_RSC_BUILD_ID_HEADER) ?? response.headers.get(VINEXT_CDN_BUILD_ID_HEADER) ?? "missing"}`,
+        );
+      }
+      if (validationError === null) {
+        consecutiveSuccesses++;
+        if (consecutiveSuccesses >= requiredConsecutiveSuccesses) return { ready: true };
+      } else {
+        consecutiveSuccesses = 0;
+        lastError = validationError;
+      }
+    } catch (error) {
+      consecutiveSuccesses = 0;
+      lastError =
+        error instanceof DOMException && error.name === "AbortError"
+          ? `timed out after ${timeoutMs}ms`
+          : error instanceof Error
+            ? error.message
+            : String(error);
+    } finally {
+      if (response?.body) await response.body.cancel().catch(() => {});
+    }
+    if (attempt + 1 < maxAttempts && probeIntervalMs > 0) await delay(probeIntervalMs);
+  }
+
+  return {
+    error: `${lastError}; uploaded build was not stable for ${requiredConsecutiveSuccesses} consecutive probe(s)`,
+    ready: false,
+  };
 }
 
 function shouldRetryValidationFailure(

--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -48,6 +48,7 @@ import {
 import { parseWranglerConfig, runTPR } from "./tpr.js";
 import {
   readPrerenderWarmPlan,
+  waitForCdnWarmTargetReadiness,
   warmCdnCache,
   type CdnWarmOptions,
   type CdnWarmRequestPlan,
@@ -669,13 +670,30 @@ export async function deployWithCdnWarmup(
           stagedWarmPlan.rscPaths.length +
           stagedWarmPlan.loadingShellPaths.length;
         if (stagedWarmRequests > 0) {
-          const warmResult = await warmUploadedVersion(targetUrl, headers, true, stagedWarmPlan);
-          stagedCacheFilled = warmResult.warmed > 0;
-          remainingWarmPlan = {
-            loadingShellPaths: warmResult.retryPlan.loadingShellPaths,
-            paths: warmResult.retryPlan.paths,
-            rscPaths: warmResult.retryPlan.rscPaths,
-          };
+          console.log("  CDN warmup: waiting for the staged Worker version to become stable...");
+          const readiness = await waitForCdnWarmTargetReadiness({
+            targetUrl,
+            headers,
+            plan: stagedWarmPlan,
+            deploymentId: options.deploymentId,
+            expectedBuildId: options.expectedBuildId,
+            expectedRscBuildId: options.expectedRscBuildId,
+            timeoutMs: options.warmCdnTimeout,
+          });
+          if (!readiness.ready) {
+            const message = `CDN warmup could not verify staged Worker readiness: ${readiness.error}.`;
+            if (options.warmCdnStrict) throw new Error(message);
+            console.warn(`  ${message} Warming after promotion instead.`);
+          } else {
+            console.log("  CDN warmup: staged Worker version is stable.");
+            const warmResult = await warmUploadedVersion(targetUrl, headers, true, stagedWarmPlan);
+            stagedCacheFilled = warmResult.warmed > 0;
+            remainingWarmPlan = {
+              loadingShellPaths: warmResult.retryPlan.loadingShellPaths,
+              paths: warmResult.retryPlan.paths,
+              rscPaths: warmResult.retryPlan.rscPaths,
+            };
+          }
         }
       } catch (error) {
         throw withStagedVersionCleanupNote(error);

--- a/tests/cloudflare-cdn-warm-deploy.test.ts
+++ b/tests/cloudflare-cdn-warm-deploy.test.ts
@@ -41,6 +41,14 @@ function formatFetchUrl(url: Parameters<typeof fetch>[0]): string {
   return url.url;
 }
 
+function isReadinessFetch(url: Parameters<typeof fetch>[0]): boolean {
+  return new URL(formatFetchUrl(url)).searchParams.has("__vinext_cdn_warm_readiness");
+}
+
+function getRealWarmFetchCalls() {
+  return vi.mocked(fetch).mock.calls.filter(([url]) => !isReadinessFetch(url));
+}
+
 function cacheableHtml(body = "ok"): Response {
   return new Response(body, {
     headers: {
@@ -115,6 +123,109 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
+  it("waits for staged build stability before sending each real warm key once", async () => {
+    const events: string[] = [];
+    const readinessHeaders: Headers[] = [];
+    const readinessUrls: string[] = [];
+    let readinessAttempt = 0;
+    delayMock.mockImplementation(async (milliseconds: number) => {
+      events.push(`delay:${milliseconds}`);
+    });
+    writeFile(
+      "wrangler.jsonc",
+      JSON.stringify({ name: "my-worker", custom_domains: ["app.example.com"] }),
+    );
+    vi.mocked(fetch).mockImplementation(async (input, init) => {
+      const url = new URL(formatFetchUrl(input));
+      const isReadinessProbe = url.searchParams.has("__vinext_cdn_warm_readiness");
+      if (isReadinessProbe) {
+        readinessHeaders.push(new Headers(init?.headers));
+        readinessUrls.push(url.href);
+      }
+      const buildId = isReadinessProbe && readinessAttempt++ === 0 ? "old-build" : "app-build-a";
+      events.push(isReadinessProbe ? `readiness:${buildId}` : `warm:${url.pathname}${url.search}`);
+      return new Response("flight", {
+        headers: {
+          "cache-control": "public, max-age=0, must-revalidate",
+          "cdn-cache-control": "public, max-age=60",
+          "cf-cache-status": "MISS",
+          "content-type": "text/x-component",
+          [VINEXT_RSC_BUILD_ID_HEADER]: buildId,
+          vary: VINEXT_RSC_VARY_HEADER,
+        },
+      });
+    });
+    execFileSyncMock.mockImplementation((_file: string, args: string[]) => {
+      if (args.includes("upload")) {
+        return "Uploaded my-worker\nWorker Version ID: 22222222-2222-4222-8222-222222222222\n";
+      }
+      if (args.includes("status")) {
+        return JSON.stringify({
+          versions: [{ version_id: "11111111-1111-4111-8111-111111111111", percentage: 100 }],
+        });
+      }
+      if (args.includes("11111111-1111-4111-8111-111111111111@100%")) {
+        events.push("stage");
+        return "Staged version\nhttps://app.example.com\n";
+      }
+      if (args.includes("22222222-2222-4222-8222-222222222222@100%")) {
+        events.push("promote");
+        return "Deployed version\nhttps://app.example.com\n";
+      }
+      if (args.includes("triggers")) {
+        events.push("triggers");
+        return "Triggers deployed\n  app.example.com (custom domain)\n";
+      }
+      throw new Error(`Unexpected Wrangler args: ${args.join(" ")}`);
+    });
+    const { deployWithCdnWarmup } = await import("../packages/cloudflare/src/deploy.js");
+
+    await deployWithCdnWarmup(tmpDir, [], {
+      expectedRscBuildId: "app-build-a",
+      rscPaths: ["/about"],
+      warmCdnConcurrency: 1,
+      warmCdnPromotionDelay: 0,
+      warmCdnStrict: true,
+    });
+
+    expect(events).toEqual([
+      "stage",
+      "triggers",
+      "readiness:old-build",
+      "delay:1000",
+      "readiness:app-build-a",
+      "delay:1000",
+      "readiness:app-build-a",
+      "delay:1000",
+      "readiness:app-build-a",
+      "delay:1000",
+      "readiness:app-build-a",
+      "delay:1000",
+      "readiness:app-build-a",
+      "delay:1000",
+      "readiness:app-build-a",
+      "warm:/about?_rsc",
+      "promote",
+    ]);
+    expect(
+      vi.mocked(fetch).mock.calls.filter(([input]) => {
+        const url = new URL(formatFetchUrl(input));
+        return url.pathname === "/about" && url.search === "?_rsc";
+      }),
+    ).toHaveLength(1);
+    expect(new Set(readinessUrls).size).toBe(7);
+    expect(readinessUrls.every((url) => new URL(url).searchParams.has("_rsc"))).toBe(true);
+    expect(
+      readinessHeaders.every(
+        (value) =>
+          value.get("accept") === "text/x-component" &&
+          value.get("cache-control") === "no-cache" &&
+          value.get("rsc") === "1" &&
+          value.has("Cloudflare-Workers-Version-Overrides"),
+      ),
+    ).toBe(true);
+  });
+
   it("warms the production custom domain through a 0% staged version override", async () => {
     const events: string[] = [];
     delayMock.mockImplementation(async (milliseconds: number) => {
@@ -128,7 +239,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       }),
     );
     vi.mocked(fetch).mockImplementation(async (url, init) => {
-      events.push(`fetch:${formatFetchUrl(url)}`);
+      events.push(isReadinessFetch(url) ? "readiness" : `fetch:${formatFetchUrl(url)}`);
       const headers = new Headers(init?.headers);
       const isRsc = headers.get("rsc") === "1";
       return new Response(isRsc ? "flight" : "html", {
@@ -214,28 +325,19 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       ]),
       expect.any(Object),
     );
-    expect(fetch).toHaveBeenCalledTimes(4);
-    expect(fetch).toHaveBeenNthCalledWith(
-      1,
+    const warmCalls = getRealWarmFetchCalls();
+    expect(warmCalls).toHaveLength(4);
+    expect(warmCalls[0]).toEqual([
       new URL("https://app.example.com/about?_rsc"),
       expect.any(Object),
-    );
-    expect(fetch).toHaveBeenNthCalledWith(
-      2,
+    ]);
+    expect(warmCalls[1]).toEqual([
       new URL("https://app.example.com/about?_rsc=9qLBDIU2NgN178cB"),
       expect.any(Object),
-    );
-    expect(fetch).toHaveBeenNthCalledWith(
-      3,
-      new URL("https://app.example.com/"),
-      expect.any(Object),
-    );
-    expect(fetch).toHaveBeenNthCalledWith(
-      4,
-      new URL("https://app.example.com/about"),
-      expect.any(Object),
-    );
-    const rscHeaders = new Headers(vi.mocked(fetch).mock.calls[0]![1]?.headers);
+    ]);
+    expect(warmCalls[2]).toEqual([new URL("https://app.example.com/"), expect.any(Object)]);
+    expect(warmCalls[3]).toEqual([new URL("https://app.example.com/about"), expect.any(Object)]);
+    const rscHeaders = new Headers(warmCalls[0]![1]?.headers);
     expect(rscHeaders.get("Cloudflare-Workers-Version-Overrides")).toBe(
       'my-worker="22222222-2222-4222-8222-222222222222"',
     );
@@ -245,14 +347,14 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     expect(rscHeaders.get("next-router-prefetch")).toBeNull();
     expect(rscHeaders.get("next-router-state-tree")).toBeNull();
     expect(rscHeaders.get("next-url")).toBeNull();
-    const loadingHeaders = new Headers(vi.mocked(fetch).mock.calls[1]![1]?.headers);
+    const loadingHeaders = new Headers(warmCalls[1]![1]?.headers);
     expect(loadingHeaders.get("Cloudflare-Workers-Version-Overrides")).toBe(
       'my-worker="22222222-2222-4222-8222-222222222222"',
     );
     expect(loadingHeaders.get("next-router-prefetch")).toBe("1");
     expect(loadingHeaders.get("next-router-segment-prefetch")).toBe("1");
     expect(loadingHeaders.get("x-vinext-rsc-render-mode")).toBe("prefetch-loading-shell");
-    const firstHtmlHeaders = new Headers(vi.mocked(fetch).mock.calls[2]![1]?.headers);
+    const firstHtmlHeaders = new Headers(warmCalls[2]![1]?.headers);
     expect(firstHtmlHeaders.get("Cloudflare-Workers-Version-Overrides")).toBe(
       'my-worker="22222222-2222-4222-8222-222222222222"',
     );
@@ -274,6 +376,17 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       "status",
       "stage",
       "triggers",
+      "readiness",
+      "delay:1000",
+      "readiness",
+      "delay:1000",
+      "readiness",
+      "delay:1000",
+      "readiness",
+      "delay:1000",
+      "readiness",
+      "delay:1000",
+      "readiness",
       "fetch:https://app.example.com/about?_rsc",
       "fetch:https://app.example.com/about?_rsc=9qLBDIU2NgN178cB",
       "fetch:https://app.example.com/",
@@ -281,8 +394,8 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       "delay:15000",
       "promote",
     ]);
-    expect(delayMock).toHaveBeenCalledOnce();
-    expect(delayMock).toHaveBeenCalledWith(15_000);
+    expect(delayMock).toHaveBeenCalledTimes(6);
+    expect(delayMock).toHaveBeenLastCalledWith(15_000);
   });
 
   it.each([
@@ -342,13 +455,15 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       "wrangler.jsonc",
       JSON.stringify({ name: "my-worker", custom_domains: ["app.example.com"] }),
     );
-    vi.mocked(fetch).mockImplementation(async (_url, init) => {
+    vi.mocked(fetch).mockImplementation(async (url, init) => {
       const headers = new Headers(init?.headers);
       const isRsc = headers.get("rsc") === "1";
       const isLoadingShell = headers.has("next-router-segment-prefetch");
       const staged = headers.has("Cloudflare-Workers-Version-Overrides");
       const kind = isLoadingShell ? "loading" : isRsc ? "rsc" : "html";
-      events.push(`fetch:${staged ? "staged" : "promoted"}:${kind}`);
+      events.push(
+        isReadinessFetch(url) ? "readiness" : `fetch:${staged ? "staged" : "promoted"}:${kind}`,
+      );
       return new Response(isRsc ? "flight" : "html", {
         headers: isRsc
           ? {
@@ -407,17 +522,23 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       "status",
       "stage",
       "triggers",
+      "readiness",
+      "readiness",
+      "readiness",
+      "readiness",
+      "readiness",
+      "readiness",
       "fetch:staged:rsc",
       "fetch:staged:loading",
       "fetch:staged:html",
       "promote",
       "fetch:promoted:loading",
     ]);
-    expect(delayMock).toHaveBeenCalledOnce();
-    expect(delayMock).toHaveBeenCalledWith(15_000);
+    expect(delayMock).toHaveBeenCalledTimes(6);
+    expect(delayMock).toHaveBeenLastCalledWith(15_000);
   });
 
-  it("falls back after every staged response comes from the wrong build", async () => {
+  it("falls back when staged Worker readiness never reaches the uploaded build", async () => {
     const events: string[] = [];
     writeFile(
       "wrangler.jsonc",
@@ -467,17 +588,11 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       warmCdnRetries: 1,
     });
 
-    expect(events).toEqual([
-      "upload",
-      "status",
-      "stage",
-      "triggers",
-      "fetch:staged",
-      "fetch:staged",
-      "promote",
-      "fetch:promoted",
-    ]);
-    expect(delayMock).not.toHaveBeenCalled();
+    expect(events.slice(0, 4)).toEqual(["upload", "status", "stage", "triggers"]);
+    expect(events.filter((event) => event === "fetch:staged")).toHaveLength(60);
+    expect(events.slice(-2)).toEqual(["promote", "fetch:promoted"]);
+    expect(delayMock).toHaveBeenCalledTimes(59);
+    expect(delayMock).toHaveBeenCalledWith(1_000);
   });
 
   it("uses the env Worker name and env custom domain for version override warmup", async () => {
@@ -573,7 +688,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       JSON.stringify({ name: "my-worker", custom_domains: ["app.example.com"] }),
     );
     vi.mocked(fetch).mockImplementation(async (url) => {
-      events.push(`fetch:${formatFetchUrl(url)}`);
+      events.push(isReadinessFetch(url) ? "readiness" : `fetch:${formatFetchUrl(url)}`);
       return cacheableHtml();
     });
     execFileSyncMock.mockImplementation((_file: string, args: string[]) => {
@@ -673,7 +788,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       JSON.stringify({ name: "my-worker", custom_domains: ["app.example.com"] }),
     );
     vi.mocked(fetch).mockImplementation(async (url) => {
-      events.push(`fetch:${formatFetchUrl(url)}`);
+      events.push(isReadinessFetch(url) ? "readiness" : `fetch:${formatFetchUrl(url)}`);
       return cacheableHtml();
     });
     execFileSyncMock.mockImplementation((_file: string, args: string[]) => {
@@ -707,14 +822,15 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       }),
     ).resolves.toBe("https://stable.example.workers.dev");
 
-    expect(events).toEqual([
+    expect(events.filter((event) => event !== "readiness" && !event.startsWith("delay:"))).toEqual([
       "upload",
       "status",
       "stage",
       "triggers",
       "fetch:https://app.example.com/about",
     ]);
-    expect(delayMock).not.toHaveBeenCalled();
+    expect(events.filter((event) => event === "readiness")).toHaveLength(6);
+    expect(events.filter((event) => event === "delay:1000")).toHaveLength(5);
   });
 
   it("rejects strict HTML warmup without verifiable build identity before upload", async () => {
@@ -759,7 +875,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       }),
     );
     vi.mocked(fetch).mockImplementation(async (url) => {
-      events.push(`fetch:${formatFetchUrl(url)}`);
+      events.push(isReadinessFetch(url) ? "readiness" : `fetch:${formatFetchUrl(url)}`);
       return cacheableHtml();
     });
     execFileSyncMock.mockImplementation((_file: string, args: string[]) => {
@@ -811,6 +927,12 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       "status",
       "stage",
       "triggers",
+      "readiness",
+      "readiness",
+      "readiness",
+      "readiness",
+      "readiness",
+      "readiness",
       "fetch:https://workers-cache.vinext.workers.dev/cached/intro",
       "promote",
     ]);


### PR DESCRIPTION
## Summary

- wait for version-override routing to remain on the uploaded build before sending any real CDN warm key
- use unique no-cache readiness queries so a probe can never satisfy a later probe from cache
- keep each canonical full/loading/HTML warm request single-shot after readiness, with existing failed-key retry behavior unchanged
- fail strict deployment before promotion when readiness cannot be established; non-strict deployment promotes and warms the untouched plan afterward

## Root cause

The deployed proof failed twice while staging was still visibly routing a mix of the seed and uploaded Workers. In the second attempt, the loading-shell key accepted immediately during that mixed phase later missed, while the full key that reached the uploaded build only after six attempts later hit. URL, query, Vary fields, build ID, version UUID, host, and TTL matched. The existing 15-second post-fill delay occurred too late to make an early transitional fill reusable.

## Scope

This changes only Cloudflare CDN warmup orchestration and its focused tests. It does not change client RSC identity, ISR eligibility/discovery, middleware, dev mode, TPR, cache adapters, or general request handling.

## Validation

- 77 focused Cloudflare warm/deploy/version tests passed
- vp check passed across 3,104 formatted files and 1,315 lint/typechecked files
- vinext build passed
- @vinext/cloudflare build passed

## References

- https://developers.cloudflare.com/workers/cache/cache-keys/
- https://developers.cloudflare.com/workers/cache/
- https://developers.cloudflare.com/workers/versions-and-deployments/version-overrides/