### PR TITLE
fix(cloudflare): preserve strict CDN warmup invariants

### DIFF
--- a/packages/cloudflare/src/cdn-warm.ts
+++ b/packages/cloudflare/src/cdn-warm.ts
@@ -50,7 +50,7 @@ export type CdnWarmOptions = {
 
 export const DEFAULT_CDN_WARM_CONCURRENCY = 25;
 export const DEFAULT_CDN_WARM_TIMEOUT_MS = 10_000;
-const DEFAULT_STAGED_READINESS_ATTEMPTS = 60;
+const DEFAULT_STAGED_READINESS_RETRIES = 60;
 const DEFAULT_STAGED_READINESS_INTERVAL_MS = 1_000;
 const DEFAULT_STAGED_READINESS_SUCCESSES = 6;
 const STAGED_READINESS_QUERY_PARAM = "__vinext_cdn_warm_readiness";
@@ -616,6 +616,7 @@ export async function waitForCdnWarmTargetReadiness(
     | "expectedRscBuildId"
     | "fetchImpl"
     | "headers"
+    | "retries"
     | "targetUrl"
     | "timeoutMs"
   > & {
@@ -651,7 +652,6 @@ export async function waitForCdnWarmTargetReadiness(
 
   const fetchImpl = options.fetchImpl ?? fetch;
   const timeoutMs = Math.max(1, options.timeoutMs ?? DEFAULT_CDN_WARM_TIMEOUT_MS);
-  const maxAttempts = Math.max(1, options.maxAttempts ?? DEFAULT_STAGED_READINESS_ATTEMPTS);
   const probeIntervalMs = Math.max(
     0,
     options.probeIntervalMs ?? DEFAULT_STAGED_READINESS_INTERVAL_MS,
@@ -659,6 +659,11 @@ export async function waitForCdnWarmTargetReadiness(
   const requiredConsecutiveSuccesses = Math.max(
     1,
     options.requiredConsecutiveSuccesses ?? DEFAULT_STAGED_READINESS_SUCCESSES,
+  );
+  const readinessRetries = Math.max(0, options.retries ?? DEFAULT_STAGED_READINESS_RETRIES);
+  const maxAttempts = Math.max(
+    requiredConsecutiveSuccesses,
+    options.maxAttempts ?? requiredConsecutiveSuccesses + readinessRetries,
   );
   const probeId = randomUUID();
   let consecutiveSuccesses = 0;

--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -636,6 +636,10 @@ export async function deployWithCdnWarmup(
     paths: canVerifyStagedHtml ? [...paths] : [],
     rscPaths: [...(options.rscPaths ?? [])],
   };
+  const initialWarmRequests =
+    remainingWarmPlan.paths.length +
+    remainingWarmPlan.rscPaths.length +
+    remainingWarmPlan.loadingShellPaths.length;
   let triggersApplied = false;
 
   function applyTriggers(): void {
@@ -678,11 +682,18 @@ export async function deployWithCdnWarmup(
             deploymentId: options.deploymentId,
             expectedBuildId: options.expectedBuildId,
             expectedRscBuildId: options.expectedRscBuildId,
+            retries: options.warmCdnRetries,
             timeoutMs: options.warmCdnTimeout,
           });
           if (!readiness.ready) {
             const message = `CDN warmup could not verify staged Worker readiness: ${readiness.error}.`;
-            if (options.warmCdnStrict) throw new Error(message);
+            if (options.warmCdnStrict || options.warmCdnPromote === false) {
+              const noPromoteNote =
+                options.warmCdnPromote === false
+                  ? " CDN warmup cannot continue because promotion is disabled and the staged version was not warmed."
+                  : "";
+              throw new Error(`${message}${noPromoteNote}`);
+            }
             console.warn(`  ${message} Warming after promotion instead.`);
           } else {
             console.log("  CDN warmup: staged Worker version is stable.");
@@ -706,6 +717,11 @@ export async function deployWithCdnWarmup(
       );
     }
   } else {
+    if (options.warmCdnStrict && initialWarmRequests > 0) {
+      throw new Error(
+        "Strict CDN warmup cannot stage the uploaded Worker at 0% because the current deployment is not exactly one version serving 100% traffic. No traffic or triggers were changed.",
+      );
+    }
     console.warn(
       "  CDN warmup: pre-traffic version override skipped because the current deployment is not one version serving 100% traffic.",
     );

--- a/tests/cloudflare-cdn-warm-deploy.test.ts
+++ b/tests/cloudflare-cdn-warm-deploy.test.ts
@@ -589,9 +589,9 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     });
 
     expect(events.slice(0, 4)).toEqual(["upload", "status", "stage", "triggers"]);
-    expect(events.filter((event) => event === "fetch:staged")).toHaveLength(60);
+    expect(events.filter((event) => event === "fetch:staged")).toHaveLength(7);
     expect(events.slice(-2)).toEqual(["promote", "fetch:promoted"]);
-    expect(delayMock).toHaveBeenCalledTimes(59);
+    expect(delayMock).toHaveBeenCalledTimes(6);
     expect(delayMock).toHaveBeenCalledWith(1_000);
   });
 
@@ -831,6 +831,54 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     ]);
     expect(events.filter((event) => event === "readiness")).toHaveLength(6);
     expect(events.filter((event) => event === "delay:1000")).toHaveLength(5);
+  });
+
+  it("fails no-promote deployment when staged readiness cannot be established", async () => {
+    writeFile(
+      "wrangler.jsonc",
+      JSON.stringify({ name: "my-worker", custom_domains: ["app.example.com"] }),
+    );
+    vi.mocked(fetch).mockResolvedValue(
+      new Response("old", {
+        headers: {
+          "cf-cache-status": "MISS",
+          "content-type": "text/html",
+          [VINEXT_CDN_BUILD_ID_HEADER]: "old-build",
+        },
+      }),
+    );
+    execFileSyncMock.mockImplementation((_file: string, args: string[]) => {
+      if (args.includes("upload")) {
+        return "Uploaded my-worker\nWorker Version ID: 22222222-2222-4222-8222-222222222222\n";
+      }
+      if (args.includes("status")) {
+        return JSON.stringify({
+          versions: [{ version_id: "11111111-1111-4111-8111-111111111111", percentage: 100 }],
+        });
+      }
+      if (args.includes("22222222-2222-4222-8222-222222222222@0%")) {
+        return "Staged version\nhttps://app.example.com\n";
+      }
+      if (args.includes("triggers")) {
+        return "Triggers deployed\n  app.example.com (custom domain)\n";
+      }
+      throw new Error(`Unexpected Wrangler args: ${args.join(" ")}`);
+    });
+    const { deployWithCdnWarmup } = await import("../packages/cloudflare/src/deploy.js");
+
+    await expect(
+      deployWithCdnWarmup(tmpDir, ["/about"], {
+        expectedBuildId: "app-build-a",
+        warmCdnPromote: false,
+        warmCdnRetries: 0,
+      }),
+    ).rejects.toThrow("promotion is disabled");
+    expect(fetch).toHaveBeenCalledTimes(6);
+    expect(
+      (execFileSyncMock.mock.calls as Array<[string, string[]]>).some(([, args]) =>
+        args.includes("22222222-2222-4222-8222-222222222222@100%"),
+      ),
+    ).toBe(false);
   });
 
   it("rejects strict HTML warmup without verifiable build identity before upload", async () => {
@@ -1166,12 +1214,11 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
-  it("explains promoted version state when strict fallback warming fails", async () => {
+  it("does not promote strict warmup when the existing deployment cannot be staged", async () => {
     writeFile(
       "wrangler.jsonc",
       JSON.stringify({ name: "my-worker", custom_domains: ["app.example.com"] }),
     );
-    vi.mocked(fetch).mockResolvedValue(new Response("not ready", { status: 500 }));
     execFileSyncMock.mockImplementation((_file: string, args: string[]) => {
       if (args.includes("upload")) {
         return "Uploaded version 22222222-2222-4222-8222-222222222222\n";
@@ -1184,10 +1231,6 @@ describe("Cloudflare CDN warmup deploy flow", () => {
           ],
         });
       }
-      if (args.includes("deploy") && args.includes("22222222-2222-4222-8222-222222222222@100%")) {
-        return "Deployed version\nhttps://stable.example.workers.dev\n";
-      }
-      if (args.includes("triggers")) return "Triggers deployed\n";
       throw new Error(`Unexpected Wrangler args: ${args.join(" ")}`);
     });
     const { deployWithCdnWarmup } = await import("../packages/cloudflare/src/deploy.js");
@@ -1198,10 +1241,12 @@ describe("Cloudflare CDN warmup deploy flow", () => {
         warmCdnRetries: 0,
         warmCdnStrict: true,
       }),
-    ).rejects.toThrow("already promoted to 100% and its Worker triggers/routes were updated");
+    ).rejects.toThrow("cannot stage the uploaded Worker at 0%");
+    expect(execFileSyncMock).toHaveBeenCalledTimes(2);
+    expect(fetch).not.toHaveBeenCalled();
   });
 
-  it("explains promoted version state when strict fallback has no target URL", async () => {
+  it("does not require a target URL before rejecting unstaged strict warmup", async () => {
     writeFile("wrangler.jsonc", JSON.stringify({ name: "my-worker", workers_dev: false }));
     execFileSyncMock.mockImplementation((_file: string, args: string[]) => {
       if (args.includes("upload")) {
@@ -1228,7 +1273,8 @@ describe("Cloudflare CDN warmup deploy flow", () => {
         expectedBuildId: "app-build-a",
         warmCdnStrict: true,
       }),
-    ).rejects.toThrow("already promoted to 100% and its Worker triggers/routes were updated");
+    ).rejects.toThrow("cannot stage the uploaded Worker at 0%");
+    expect(execFileSyncMock).toHaveBeenCalledTimes(2);
     expect(fetch).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- abort strict warmup before promotion when the current traffic split cannot stage the upload at 0%
- fail no-promote mode when staged readiness fails instead of returning an unwarmed 0% version as success
- apply the configured warmup retry budget to readiness failures while retaining the fixed six-probe stability window

## Scope

This is a focused follow-up from the cumulative RSC prewarming review. It changes only staged deploy failure semantics and focused tests.

## Validation

- 78 focused Cloudflare warm/deploy/version tests passed
- vp check passed
- @vinext/cloudflare build passed