### PR TITLE
fix(cloudflare): harden canonical RSC warmup end to end

### DIFF
--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -128,7 +128,7 @@ jobs:
         run: >-
           vp exec wrangler deploy
           --config ../../tests/fixtures/rsc-prewarm-seed/wrangler.jsonc
-          --name rsc-prewarm-${{ github.run_id }}
+          --name rsc-prewarm-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Install Chromium for RSC prewarm verification
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && matrix.example.name == 'workers-cache'
@@ -145,7 +145,7 @@ jobs:
           vp exec vinext-cloudflare deploy
           --skip-build
           --config ${{ matrix.example.wrangler_config }}
-          --name rsc-prewarm-${{ github.run_id }}
+          --name rsc-prewarm-${{ github.run_id }}-${{ github.run_attempt }}
           --experimental-warm-cdn-cache
           --warm-cdn-strict
 
@@ -153,7 +153,7 @@ jobs:
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && matrix.example.name == 'workers-cache'
         env:
           PLAYWRIGHT_PROJECT: cloudflare-workers
-          VINEXT_E2E_BASE_URL: https://rsc-prewarm-${{ github.run_id }}.vinext.workers.dev
+          VINEXT_E2E_BASE_URL: https://rsc-prewarm-${{ github.run_id }}-${{ github.run_attempt }}.vinext.workers.dev
         run: vp exec playwright test tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
 
       - name: Delete RSC prewarm test Worker
@@ -163,7 +163,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: >-
-          vp exec wrangler delete rsc-prewarm-${{ github.run_id }}
+          vp exec wrangler delete rsc-prewarm-${{ github.run_id }}-${{ github.run_attempt }}
           --config ${{ matrix.example.wrangler_config }}
           --force
 

--- a/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
@@ -42,13 +42,20 @@ import {
 } from "vinext/shims/cdn-cache";
 import type { CacheHandlerValue, IncrementalCacheValue } from "vinext/shims/cache";
 import { getRequestExecutionContext } from "vinext/shims/request-context";
+import { VINEXT_CDN_BUILD_ID_HEADER } from "./cdn-build-id.js";
 
 const CACHEABLE_EDGE_DIRECTIVE_RE = /(?:^|,)\s*(?:s-maxage|max-age)\s*=/i;
 const EDGE_POLICY_HEADERS = ["CDN-Cache-Control", "Cloudflare-CDN-Cache-Control"] as const;
 
+function getBuildIdentityResponseHeader(): CdnResponseHeaders {
+  const buildId = process.env.__VINEXT_BUILD_ID;
+  return buildId ? { [VINEXT_CDN_BUILD_ID_HEADER]: buildId } : {};
+}
+
 /** Remove every response header whose cache semantics are owned by Cloudflare. */
 function clearCloudflareCdnResponseHeaders(cacheControl: string): CdnResponseHeaders {
   return {
+    ...getBuildIdentityResponseHeader(),
     "Cache-Control": cacheControl,
     "CDN-Cache-Control": null,
     "Cloudflare-CDN-Cache-Control": null,
@@ -188,6 +195,7 @@ export class CloudflareCdnCacheAdapter implements CdnCacheAdapter {
     // SWR policy on CDN-Cache-Control (edge caches + revalidates); the browser
     // is told to revalidate every reuse so it never serves a stale stored copy.
     const headers: CdnResponseHeaders = {
+      ...getBuildIdentityResponseHeader(),
       "Cache-Control": BROWSER_REVALIDATE,
       "CDN-Cache-Control": toEdgeCacheControl(input.cacheControl),
       "Cloudflare-CDN-Cache-Control": null,

--- a/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
@@ -179,6 +179,10 @@ export class CloudflareCdnCacheAdapter implements CdnCacheAdapter {
     // intentionally empty
   }
 
+  buildResponseIdentityHeaders(): CdnResponseHeaders {
+    return getBuildIdentityResponseHeader();
+  }
+
   buildResponseHeaders(input: CdnCacheableHeaderInput): CdnResponseHeaders {
     // No cacheable policy → nobody stores it.
     if (!input.cacheControl) {

--- a/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
@@ -48,7 +48,7 @@ const CACHEABLE_EDGE_DIRECTIVE_RE = /(?:^|,)\s*(?:s-maxage|max-age)\s*=/i;
 const EDGE_POLICY_HEADERS = ["CDN-Cache-Control", "Cloudflare-CDN-Cache-Control"] as const;
 
 function getBuildIdentityResponseHeader(): CdnResponseHeaders {
-  const buildId = process.env.__VINEXT_BUILD_ID;
+  const buildId = process.env.__VINEXT_RSC_BUILD_IDENTITY ?? process.env.__VINEXT_BUILD_ID;
   return buildId ? { [VINEXT_CDN_BUILD_ID_HEADER]: buildId } : {};
 }
 

--- a/packages/cloudflare/src/cache/cdn-adapter.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.ts
@@ -23,6 +23,7 @@ export function cdnAdapter(options?: Record<string, never>) {
     adapter: fileURLToPath(import.meta.resolve("./cdn-adapter.runtime.js")),
     options,
     capabilities: {
+      buildIdentity: "response-header" as const,
       responseVary: "verbatim" as const,
     },
   };

--- a/packages/cloudflare/src/cache/cdn-build-id.ts
+++ b/packages/cloudflare/src/cache/cdn-build-id.ts
@@ -1,0 +1,2 @@
+/** Build identity stamped by the Cloudflare CDN adapter on page responses. */
+export const VINEXT_CDN_BUILD_ID_HEADER = "X-Vinext-Build-Id";

--- a/packages/cloudflare/src/cdn-warm.ts
+++ b/packages/cloudflare/src/cdn-warm.ts
@@ -559,14 +559,14 @@ function shouldRetryValidationFailure(
       ? null
       : response.headers.get(VINEXT_RSC_BUILD_ID_HEADER) === options.expectedRscBuildId,
   ].filter((matches): matches is boolean => matches !== null);
-  if (expectedIdentities.some((matches) => !matches)) return true;
 
   // A matching identity proves routing reached the uploaded Worker. From that
   // point, retry only transient HTTP failures; response-shape and admission
   // failures are deterministic for that build.
-  if (expectedIdentities.length > 0) {
+  if (expectedIdentities.some((matches) => matches)) {
     return isRetryableStatus(response.status, false);
   }
+  if (expectedIdentities.some((matches) => !matches)) return true;
   return isRetryableStatus(response.status, options.retryNotFound);
 }
 

--- a/packages/cloudflare/src/cdn-warm.ts
+++ b/packages/cloudflare/src/cdn-warm.ts
@@ -50,7 +50,7 @@ export type CdnWarmOptions = {
 
 export const DEFAULT_CDN_WARM_CONCURRENCY = 25;
 export const DEFAULT_CDN_WARM_TIMEOUT_MS = 10_000;
-const DEFAULT_STAGED_READINESS_ATTEMPTS = 60;
+const DEFAULT_STAGED_READINESS_RETRIES = 60;
 const DEFAULT_STAGED_READINESS_INTERVAL_MS = 1_000;
 const DEFAULT_STAGED_READINESS_SUCCESSES = 6;
 const STAGED_READINESS_QUERY_PARAM = "__vinext_cdn_warm_readiness";
@@ -616,6 +616,7 @@ export async function waitForCdnWarmTargetReadiness(
     | "expectedRscBuildId"
     | "fetchImpl"
     | "headers"
+    | "retries"
     | "targetUrl"
     | "timeoutMs"
   > & {
@@ -651,7 +652,6 @@ export async function waitForCdnWarmTargetReadiness(
 
   const fetchImpl = options.fetchImpl ?? fetch;
   const timeoutMs = Math.max(1, options.timeoutMs ?? DEFAULT_CDN_WARM_TIMEOUT_MS);
-  const maxAttempts = Math.max(1, options.maxAttempts ?? DEFAULT_STAGED_READINESS_ATTEMPTS);
   const probeIntervalMs = Math.max(
     0,
     options.probeIntervalMs ?? DEFAULT_STAGED_READINESS_INTERVAL_MS,
@@ -659,6 +659,11 @@ export async function waitForCdnWarmTargetReadiness(
   const requiredConsecutiveSuccesses = Math.max(
     1,
     options.requiredConsecutiveSuccesses ?? DEFAULT_STAGED_READINESS_SUCCESSES,
+  );
+  const readinessRetries = Math.max(0, options.retries ?? DEFAULT_STAGED_READINESS_RETRIES);
+  const maxAttempts = Math.max(
+    requiredConsecutiveSuccesses,
+    options.maxAttempts ?? requiredConsecutiveSuccesses + readinessRetries,
   );
   const probeId = randomUUID();
   let consecutiveSuccesses = 0;

--- a/packages/cloudflare/src/cdn-warm.ts
+++ b/packages/cloudflare/src/cdn-warm.ts
@@ -312,15 +312,17 @@ class CdnWarmProgress {
 const REQUIRED_RSC_VARY_HEADERS = VINEXT_RSC_VARY_HEADER.split(",").map((name) =>
   name.trim().toLowerCase(),
 );
-const ADMITTED_CF_CACHE_STATUSES = new Set([
-  "HIT",
-  "MISS",
-  "EXPIRED",
-  "REVALIDATED",
-  "UPDATING",
-  "STALE",
-]);
+const ADMITTED_CF_CACHE_STATUSES = new Set(["HIT", "MISS", "EXPIRED", "REVALIDATED", "UPDATING"]);
 const NON_CACHEABLE_CF_CACHE_STATUSES = new Set(["BYPASS", "DYNAMIC"]);
+const CDN_CACHE_POLICY_HEADERS = [
+  "Cloudflare-CDN-Cache-Control",
+  "CDN-Cache-Control",
+  "Cache-Control",
+] as const;
+const SHARED_CACHE_FRESHNESS_RES = [
+  /(?:^|,)\s*s-maxage\s*=\s*"?(-?\d+)"?/i,
+  /(?:^|,)\s*max-age\s*=\s*"?(-?\d+)"?/i,
+] as const;
 
 type WarmValidation =
   | { outcome: "warmed" }
@@ -328,14 +330,17 @@ type WarmValidation =
   | { outcome: "failed"; error: string };
 
 function validateCachePolicy(response: Response, requireCacheStatus: boolean): WarmValidation {
-  const nonCacheableHeaders = [
-    "Cache-Control",
-    "CDN-Cache-Control",
-    "Cloudflare-CDN-Cache-Control",
-  ].filter((name) => {
-    const value = response.headers.get(name);
-    return value !== null && isNonCacheableCacheControl(value);
-  });
+  const effectivePolicy = CDN_CACHE_POLICY_HEADERS.map((name) => ({
+    name,
+    value: response.headers.get(name),
+  })).find(
+    (entry): entry is { name: (typeof CDN_CACHE_POLICY_HEADERS)[number]; value: string } =>
+      entry.value !== null,
+  );
+  const nonCacheableHeaders =
+    effectivePolicy && isNonCacheableCacheControl(effectivePolicy.value)
+      ? [effectivePolicy.name]
+      : [];
   const hasSetCookie = response.headers.has("Set-Cookie");
   const cacheStatus = response.headers.get("CF-Cache-Status")?.trim().toUpperCase();
 
@@ -344,6 +349,20 @@ function validateCachePolicy(response: Response, requireCacheStatus: boolean): W
       nonCacheableHeaders.length > 0
         ? `${nonCacheableHeaders.join(", ")} opts out of caching`
         : "response sets a cookie";
+    if (cacheStatus && NON_CACHEABLE_CF_CACHE_STATUSES.has(cacheStatus)) {
+      return { outcome: "skipped", reason };
+    }
+    return {
+      outcome: "failed",
+      error: `${reason}, but CF-Cache-Status is ${cacheStatus ?? "missing"}`,
+    };
+  }
+
+  const sharedFreshness = effectivePolicy
+    ? getSharedCacheFreshnessSeconds(effectivePolicy.value)
+    : null;
+  if (sharedFreshness !== null && sharedFreshness <= 0) {
+    const reason = `${effectivePolicy!.name} has no positive shared-cache freshness`;
     if (cacheStatus && NON_CACHEABLE_CF_CACHE_STATUSES.has(cacheStatus)) {
       return { outcome: "skipped", reason };
     }
@@ -362,6 +381,14 @@ function validateCachePolicy(response: Response, requireCacheStatus: boolean): W
     return { outcome: "failed", error: `CF-Cache-Status is ${cacheStatus}` };
   }
   return { outcome: "warmed" };
+}
+
+function getSharedCacheFreshnessSeconds(cacheControl: string): number | null {
+  for (const pattern of SHARED_CACHE_FRESHNESS_RES) {
+    const match = pattern.exec(cacheControl);
+    if (match) return Number(match[1]);
+  }
+  return null;
 }
 
 function validateRscWarmResponse(response: Response, expectedRscBuildId?: string): WarmValidation {

--- a/packages/cloudflare/src/cdn-warm.ts
+++ b/packages/cloudflare/src/cdn-warm.ts
@@ -21,6 +21,7 @@ import {
 } from "vinext/internal/server/app-rsc-cache-busting";
 import { isNonCacheableCacheControl } from "vinext/shims/cdn-cache";
 import { normalizePathTrailingSlash } from "vinext/shims/url-utils";
+import { VINEXT_CDN_BUILD_ID_HEADER } from "./cache/cdn-build-id.js";
 
 export type CdnWarmOptions = {
   targetUrl: string;
@@ -31,6 +32,8 @@ export type CdnWarmOptions = {
   loadingShellPaths?: readonly string[];
   /** Build identity that the warmed RSC response must have been rendered by. */
   expectedRscBuildId?: string;
+  /** Application build identity stamped by the configured CDN adapter. */
+  expectedBuildId?: string;
   deploymentId?: string;
   headers?: HeadersInit;
   concurrency?: number;
@@ -57,9 +60,17 @@ export type CdnWarmResult = {
   skipped: number;
   failed: number;
   failures: Array<{ path: string; error: string }>;
+  retryPlan: CdnWarmRequestPlan;
+};
+
+export type CdnWarmRequestPlan = {
+  loadingShellPaths: string[];
+  paths: string[];
+  rscPaths: string[];
 };
 
 export type PrerenderWarmPlan = {
+  buildId?: string;
   deploymentId?: string;
   loadingShellPaths: string[];
   paths: string[];
@@ -195,6 +206,7 @@ export function readPrerenderWarmPlan(
     }
   }
   return {
+    buildId: manifest.buildId,
     ...(manifest.deploymentId ? { deploymentId: manifest.deploymentId } : {}),
     loadingShellPaths: supportsCanonicalRsc
       ? (manifest.loadingShellPaths ?? []).map(applyConfig)
@@ -281,9 +293,10 @@ async function fetchWithTimeout(
 
 type WarmTarget = {
   headers?: HeadersInit;
-  kind: "html" | "rsc";
+  kind: "html" | "rsc-full" | "rsc-loading-shell";
   label: string;
   pathname: string;
+  sourcePathname: string;
 };
 
 class CdnWarmProgress {
@@ -391,7 +404,27 @@ function getSharedCacheFreshnessSeconds(cacheControl: string): number | null {
   return null;
 }
 
-function validateRscWarmResponse(response: Response, expectedRscBuildId?: string): WarmValidation {
+function validateBuildIdentity(
+  response: Response,
+  expectedBuildId?: string,
+): WarmValidation | null {
+  if (
+    expectedBuildId !== undefined &&
+    response.headers.get(VINEXT_CDN_BUILD_ID_HEADER) !== expectedBuildId
+  ) {
+    return {
+      outcome: "failed",
+      error: `response ${VINEXT_CDN_BUILD_ID_HEADER} does not match build ${expectedBuildId}`,
+    };
+  }
+  return null;
+}
+
+function validateRscWarmResponse(
+  response: Response,
+  expectedBuildId?: string,
+  expectedRscBuildId?: string,
+): WarmValidation {
   if (response.redirected || response.status < 200 || response.status >= 300) {
     return {
       outcome: "failed",
@@ -401,6 +434,8 @@ function validateRscWarmResponse(response: Response, expectedRscBuildId?: string
   if (!response.headers.get("Content-Type")?.toLowerCase().startsWith(VINEXT_RSC_CONTENT_TYPE)) {
     return { outcome: "failed", error: `expected ${VINEXT_RSC_CONTENT_TYPE} response` };
   }
+  const buildIdentityValidation = validateBuildIdentity(response, expectedBuildId);
+  if (buildIdentityValidation) return buildIdentityValidation;
   if (
     expectedRscBuildId !== undefined &&
     response.headers.get(VINEXT_RSC_BUILD_ID_HEADER) !== expectedRscBuildId
@@ -427,13 +462,15 @@ function validateRscWarmResponse(response: Response, expectedRscBuildId?: string
   return validateCachePolicy(response, true);
 }
 
-function validateHtmlWarmResponse(response: Response): WarmValidation {
+function validateHtmlWarmResponse(response: Response, expectedBuildId?: string): WarmValidation {
   if (response.redirected || response.status < 200 || response.status >= 300) {
     return {
       outcome: "failed",
       error: response.redirected ? "redirected response" : `HTTP ${response.status}`,
     };
   }
+  const buildIdentityValidation = validateBuildIdentity(response, expectedBuildId);
+  if (buildIdentityValidation) return buildIdentityValidation;
   return validateCachePolicy(response, true);
 }
 
@@ -442,6 +479,7 @@ async function warmOnePath(
   options: Required<Pick<CdnWarmOptions, "targetUrl" | "timeoutMs" | "retries">> & {
     fetchImpl: typeof fetch;
     headers?: HeadersInit;
+    expectedBuildId?: string;
     expectedRscBuildId?: string;
     retryAllValidationErrors: boolean;
     retryDelayMs: number;
@@ -483,8 +521,12 @@ async function warmOnePath(
         );
       }
 
-      if (target.kind === "rsc") {
-        const validation = validateRscWarmResponse(response, options.expectedRscBuildId);
+      if (target.kind !== "html") {
+        const validation = validateRscWarmResponse(
+          response,
+          options.expectedBuildId,
+          options.expectedRscBuildId,
+        );
         if (validation.outcome === "warmed") {
           return { path: target.label, ok: true, skipped: false };
         }
@@ -502,7 +544,7 @@ async function warmOnePath(
         continue;
       }
 
-      const validation = validateHtmlWarmResponse(response);
+      const validation = validateHtmlWarmResponse(response, options.expectedBuildId);
       if (validation.outcome === "warmed") {
         return { path: target.label, ok: true, skipped: false };
       }
@@ -553,19 +595,23 @@ async function runWithConcurrency<T, R>(
 export async function warmCdnCache(options: CdnWarmOptions): Promise<CdnWarmResult> {
   const requests: WarmTarget[] = [];
   const htmlRequests: WarmTarget[] = [];
+  const fullRscPaths = new Set(options.rscPaths ?? []);
   const loadingShellPaths = new Set(options.loadingShellPaths ?? []);
   const commonHeaders = new Headers(options.headers);
-  for (const pathname of options.rscPaths ?? []) {
-    const rscHeaders = new Headers(commonHeaders);
-    for (const [name, value] of createCanonicalRscRequestHeaders(options.deploymentId)) {
-      rscHeaders.set(name, value);
+  for (const pathname of new Set([...fullRscPaths, ...loadingShellPaths])) {
+    if (fullRscPaths.has(pathname)) {
+      const rscHeaders = new Headers(commonHeaders);
+      for (const [name, value] of createCanonicalRscRequestHeaders(options.deploymentId)) {
+        rscHeaders.set(name, value);
+      }
+      requests.push({
+        headers: rscHeaders,
+        kind: "rsc-full",
+        label: `${pathname} (RSC full)`,
+        pathname: createCanonicalRscRequestUrl(pathname),
+        sourcePathname: pathname,
+      });
     }
-    requests.push({
-      headers: rscHeaders,
-      kind: "rsc",
-      label: `${pathname} (RSC full)`,
-      pathname: createCanonicalRscRequestUrl(pathname),
-    });
 
     if (loadingShellPaths.has(pathname)) {
       const loadingHeaders = new Headers(commonHeaders);
@@ -576,9 +622,10 @@ export async function warmCdnCache(options: CdnWarmOptions): Promise<CdnWarmResu
       }
       requests.push({
         headers: loadingHeaders,
-        kind: "rsc",
+        kind: "rsc-loading-shell",
         label: `${pathname} (RSC loading shell)`,
         pathname: await createRscRequestUrl(pathname, loadingHeaders),
+        sourcePathname: pathname,
       });
     }
   }
@@ -586,19 +633,21 @@ export async function warmCdnCache(options: CdnWarmOptions): Promise<CdnWarmResu
   for (const pathname of options.paths) {
     const htmlHeaders = new Headers(commonHeaders);
     htmlHeaders.set("Accept", "text/html");
-    htmlRequests.push({ headers: htmlHeaders, kind: "html", label: pathname, pathname });
+    htmlRequests.push({
+      headers: htmlHeaders,
+      kind: "html",
+      label: pathname,
+      pathname,
+      sourcePathname: pathname,
+    });
   }
-  // For a serialized propagating target, prove that requests have reached the
-  // uploaded build before filling any HTML cache entries.
   requests.push(...htmlRequests);
   const timeoutMs = Math.max(1, options.timeoutMs ?? DEFAULT_CDN_WARM_TIMEOUT_MS);
   const hasVersionOverride = new Headers(options.headers).has(WORKER_VERSION_OVERRIDE_HEADER);
   const propagatingTarget = options.propagatingTarget ?? hasVersionOverride;
-  // Immediately after upload, prove the RSC handler and immutable assets have
-  // reached the new build, then give the first real HTML fill the same retry
-  // policy. Once those gates pass, fill the remaining independent cache keys
-  // concurrently. Propagation is bounded by the retry count, never by a
-  // queue-wide wall-clock deadline that can expire before work starts.
+  // A propagating target gives every key one initial attempt, then retries only
+  // failed keys after the queue completes. Build identity validation prevents
+  // an old Worker response from being mistaken for a successful fill.
   const concurrency = Math.max(1, options.concurrency ?? DEFAULT_CDN_WARM_CONCURRENCY);
   const normalRetries = Math.max(0, options.retries ?? 1);
   const propagationRetries = Math.max(0, options.retries ?? 30);
@@ -607,32 +656,38 @@ export async function warmCdnCache(options: CdnWarmOptions): Promise<CdnWarmResu
   const fetchImpl = options.fetchImpl ?? fetch;
 
   if (requests.length === 0) {
-    return { total: 0, warmed: 0, skipped: 0, failed: 0, failures: [] };
+    return {
+      total: 0,
+      warmed: 0,
+      skipped: 0,
+      failed: 0,
+      failures: [],
+      retryPlan: { loadingShellPaths: [], paths: [], rscPaths: [] },
+    };
   }
 
   console.log(`\n  Warming CDN cache with ${requests.length} discovered request(s)...`);
 
   const progress = new CdnWarmProgress();
   let completedRequests = 0;
-  progress.update(0, requests.length, "waiting for uploaded build");
+  progress.update(0, requests.length, "starting warmup");
 
-  type WarmRetryMode = "normal" | "propagation-gate" | "propagation-pass" | "propagation-retry";
+  type WarmRetryMode = "normal" | "propagation-pass" | "propagation-retry";
   const warmTarget = (target: WarmTarget, retryMode: WarmRetryMode = "normal") => {
     const isPropagationRequest = retryMode !== "normal";
     const retries =
-      retryMode === "propagation-gate"
-        ? propagationRetries
-        : retryMode === "propagation-retry"
-          ? Math.max(0, propagationRetries - 1)
-          : retryMode === "propagation-pass"
-            ? 0
-            : normalRetries;
+      retryMode === "propagation-retry"
+        ? Math.max(0, propagationRetries - 1)
+        : retryMode === "propagation-pass"
+          ? 0
+          : normalRetries;
     return warmOnePath(target, {
       targetUrl: options.targetUrl,
       timeoutMs,
       retries,
       fetchImpl,
       headers: options.headers,
+      expectedBuildId: options.expectedBuildId,
       expectedRscBuildId: options.expectedRscBuildId,
       retryAllValidationErrors: isPropagationRequest,
       retryDelayMs: isPropagationRequest ? propagationRetryDelayMs : normalRetryDelayMs,
@@ -681,74 +736,26 @@ export async function warmCdnCache(options: CdnWarmOptions): Promise<CdnWarmResu
     return results;
   };
 
-  /*
-   * The two gates below establish that the uploaded RSC and HTML handlers are
-   * reachable before the large concurrent pass starts. Remaining requests get
-   * one attempt first, then only failures consume their retry budget after the
-   * queue has completed. This lets a large successful queue provide additional
-   * propagation time without fetching successful cache keys twice.
-   */
-
-  const skipRequests = (
-    targets: readonly WarmTarget[],
-    error: string,
-  ): Array<{ path: string; ok: false; error: string }> =>
-    targets.map((target) => {
-      progress.update(++completedRequests, requests.length, target.label);
-      return { path: target.label, ok: false as const, error };
-    });
-
-  const warmAfterHtmlGate = async (
-    confirmed: Awaited<ReturnType<typeof warmOnePath>>[],
-    remaining: readonly WarmTarget[],
-  ): Promise<Awaited<ReturnType<typeof warmOnePath>>[]> => {
-    const htmlGateIndex = remaining.findIndex((target) => target.kind === "html");
-    if (htmlGateIndex < 0) {
-      return [...confirmed, ...(await warmPropagatingPass(remaining))];
-    }
-
-    const htmlGateResult = await warmRequest(remaining[htmlGateIndex], "propagation-gate");
-    const afterHtmlGate = remaining.filter((_target, index) => index !== htmlGateIndex);
-    if (!htmlGateResult.ok) {
-      return [
-        ...confirmed,
-        htmlGateResult,
-        ...skipRequests(
-          afterHtmlGate,
-          `skipped because the first HTML request did not reach the uploaded build: ${htmlGateResult.error}`,
-        ),
-      ];
-    }
-    return [...confirmed, htmlGateResult, ...(await warmPropagatingPass(afterHtmlGate))];
-  };
-
-  const gateIndex = propagatingTarget ? requests.findIndex((target) => target.kind === "rsc") : -1;
   let results: Awaited<ReturnType<typeof warmOnePath>>[];
-  if (gateIndex >= 0) {
-    const gateResult = await warmRequest(requests[gateIndex], "propagation-gate");
-    const remaining = requests.filter((_target, index) => index !== gateIndex);
-    if (gateResult.ok) {
-      results = await warmAfterHtmlGate([gateResult], remaining);
-    } else {
-      results = [
-        gateResult,
-        ...skipRequests(
-          remaining,
-          "skipped because the uploaded RSC build identity was not confirmed",
-        ),
-      ];
-    }
-  } else if (propagatingTarget) {
-    results = await warmAfterHtmlGate([], requests);
+  if (propagatingTarget) {
+    results = await warmPropagatingPass(requests);
   } else {
     results = await runWithConcurrency(requests, concurrency, (target) => warmRequest(target));
   }
 
   progress.finish();
 
-  const failures = results
-    .filter((result): result is { path: string; ok: false; error: string } => !result.ok)
-    .map(({ path, error }) => ({ path, error }));
+  const failedRequests = requests
+    .map((target, index) => ({ result: results[index], target }))
+    .filter(
+      (
+        entry,
+      ): entry is {
+        result: { path: string; ok: false; error: string };
+        target: WarmTarget;
+      } => !entry.result.ok,
+    );
+  const failures = failedRequests.map(({ result: { path, error } }) => ({ path, error }));
   const skippedResults = results.filter((result) => result.ok && result.skipped);
   const warmed = results.length - failures.length - skippedResults.length;
 
@@ -773,6 +780,17 @@ export async function warmCdnCache(options: CdnWarmOptions): Promise<CdnWarmResu
     skipped: skippedResults.length,
     failed: failures.length,
     failures,
+    retryPlan: {
+      loadingShellPaths: failedRequests
+        .filter(({ target }) => target.kind === "rsc-loading-shell")
+        .map(({ target }) => target.sourcePathname),
+      paths: failedRequests
+        .filter(({ target }) => target.kind === "html")
+        .map(({ target }) => target.sourcePathname),
+      rscPaths: failedRequests
+        .filter(({ target }) => target.kind === "rsc-full")
+        .map(({ target }) => target.sourcePathname),
+    },
   };
 
   if (options.strict && failures.length > 0) {
@@ -792,5 +810,10 @@ export async function warmCdnCacheFromPrerender(
     includeFallbackShells: options.includeFallbackShells,
     strict: options.strict,
   });
-  return warmCdnCache({ ...options, ...plan });
+  const { buildId, ...warmPlan } = plan;
+  return warmCdnCache({
+    ...options,
+    ...warmPlan,
+    expectedBuildId: options.expectedBuildId ?? buildId,
+  });
 }

--- a/packages/cloudflare/src/cdn-warm.ts
+++ b/packages/cloudflare/src/cdn-warm.ts
@@ -650,7 +650,7 @@ export async function warmCdnCache(options: CdnWarmOptions): Promise<CdnWarmResu
   // an old Worker response from being mistaken for a successful fill.
   const concurrency = Math.max(1, options.concurrency ?? DEFAULT_CDN_WARM_CONCURRENCY);
   const normalRetries = Math.max(0, options.retries ?? 1);
-  const propagationRetries = Math.max(0, options.retries ?? 30);
+  const propagationRetries = Math.max(0, options.retries ?? 60);
   const normalRetryDelayMs = Math.max(0, options.retryDelayMs ?? 0);
   const propagationRetryDelayMs = Math.max(0, options.retryDelayMs ?? 1_000);
   const fetchImpl = options.fetchImpl ?? fetch;

--- a/packages/cloudflare/src/cdn-warm.ts
+++ b/packages/cloudflare/src/cdn-warm.ts
@@ -52,7 +52,7 @@ export const DEFAULT_CDN_WARM_TIMEOUT_MS = 10_000;
 export type PrerenderCdnWarmOptions = Omit<CdnWarmOptions, "paths"> & {
   root: string;
   includeFallbackShells?: boolean;
-  /** Use the manifest build ID unless the configured adapter cannot expose it. */
+  /** Use the manifest build identity unless the configured adapter cannot expose it. */
   validateBuildIdentity?: boolean;
 };
 
@@ -73,6 +73,7 @@ export type CdnWarmRequestPlan = {
 
 export type PrerenderWarmPlan = {
   buildId?: string;
+  buildIdentity?: string;
   deploymentId?: string;
   loadingShellPaths: string[];
   paths: string[];
@@ -124,6 +125,7 @@ function readPrerenderPathManifest(manifestPath: string): PrerenderPathManifest 
         (!Array.isArray(manifest.loadingShellPaths) ||
           !manifest.loadingShellPaths.every((pathname) => typeof pathname === "string"))) ||
       (manifest.basePath !== undefined && typeof manifest.basePath !== "string") ||
+      (manifest.buildIdentity !== undefined && typeof manifest.buildIdentity !== "string") ||
       (manifest.deploymentId !== undefined && typeof manifest.deploymentId !== "string") ||
       (manifest.rscBuildId !== undefined && typeof manifest.rscBuildId !== "string") ||
       (manifest.trailingSlash !== undefined && typeof manifest.trailingSlash !== "boolean") ||
@@ -209,6 +211,7 @@ export function readPrerenderWarmPlan(
   }
   return {
     buildId: manifest.buildId,
+    ...(manifest.buildIdentity ? { buildIdentity: manifest.buildIdentity } : {}),
     ...(manifest.deploymentId ? { deploymentId: manifest.deploymentId } : {}),
     loadingShellPaths: supportsCanonicalRsc
       ? (manifest.loadingShellPaths ?? []).map(applyConfig)
@@ -518,6 +521,13 @@ function validateHtmlWarmResponse(response: Response, expectedBuildId?: string):
   if (buildIdentityValidation) return buildIdentityValidation;
   const cachePolicyValidation = validateCachePolicy(response, true);
   if (cachePolicyValidation.outcome !== "warmed") return cachePolicyValidation;
+  const extraVary = (response.headers.get("Vary") ?? "")
+    .split(",")
+    .map((name) => name.trim().toLowerCase())
+    .find((name) => name && !REQUIRED_RSC_VARY_HEADERS.includes(name));
+  if (extraVary) {
+    return { outcome: "failed", error: `response Vary has unsupported field ${extraVary}` };
+  }
   return { outcome: "warmed" };
 }
 
@@ -895,11 +905,18 @@ export async function warmCdnCacheFromPrerender(
     includeFallbackShells: options.includeFallbackShells,
     strict: options.strict,
   });
-  const { buildId, ...warmPlan } = plan;
+  const warmPlan = {
+    deploymentId: plan.deploymentId,
+    loadingShellPaths: plan.loadingShellPaths,
+    paths: plan.paths,
+    rscPaths: plan.rscPaths,
+  };
   return warmCdnCache({
     ...options,
     ...warmPlan,
     expectedBuildId:
-      options.expectedBuildId ?? (options.validateBuildIdentity === false ? undefined : buildId),
+      options.expectedBuildId ??
+      (options.validateBuildIdentity === false ? undefined : plan.buildIdentity),
+    expectedRscBuildId: options.expectedRscBuildId ?? plan.rscBuildId,
   });
 }

--- a/packages/cloudflare/src/cdn-warm.ts
+++ b/packages/cloudflare/src/cdn-warm.ts
@@ -52,6 +52,8 @@ export const DEFAULT_CDN_WARM_TIMEOUT_MS = 10_000;
 export type PrerenderCdnWarmOptions = Omit<CdnWarmOptions, "paths"> & {
   root: string;
   includeFallbackShells?: boolean;
+  /** Use the manifest build ID unless the configured adapter cannot expose it. */
+  validateBuildIdentity?: boolean;
 };
 
 export type CdnWarmResult = {
@@ -332,10 +334,8 @@ const CDN_CACHE_POLICY_HEADERS = [
   "CDN-Cache-Control",
   "Cache-Control",
 ] as const;
-const SHARED_CACHE_FRESHNESS_RES = [
-  /(?:^|,)\s*s-maxage\s*=\s*"?(-?\d+)"?/i,
-  /(?:^|,)\s*max-age\s*=\s*"?(-?\d+)"?/i,
-] as const;
+const FIELD_QUALIFIED_SET_COOKIE_RE =
+  /(?:^|,)\s*(?:private|no-cache)\s*=\s*(?:"[^"]*\bset-cookie\b[^"]*"|[^,]*\bset-cookie\b)/i;
 
 type WarmValidation =
   | { outcome: "warmed" }
@@ -357,28 +357,41 @@ function validateCachePolicy(response: Response, requireCacheStatus: boolean): W
   const hasSetCookie = response.headers.has("Set-Cookie");
   const cacheStatus = response.headers.get("CF-Cache-Status")?.trim().toUpperCase();
 
+  // Cloudflare-CDN-Cache-Control is consumed at the edge and is deliberately
+  // not forwarded to clients. A cacheable Cloudflare-specific policy can
+  // therefore coexist with a downstream `no-store` policy or a Set-Cookie
+  // header that is stripped from the cached object. CF-Cache-Status is the
+  // authoritative admission result: MISS means the response was eligible for
+  // cache, while response-time rejection is reported as BYPASS. Downstream
+  // freshness cannot reveal a stripped higher-priority edge policy.
+  if (cacheStatus && ADMITTED_CF_CACHE_STATUSES.has(cacheStatus)) {
+    if (
+      hasSetCookie &&
+      (!effectivePolicy || !FIELD_QUALIFIED_SET_COOKIE_RE.test(effectivePolicy.value))
+    ) {
+      return {
+        outcome: "failed",
+        error: "response sets a cookie without an observable field-qualified cache policy",
+      };
+    }
+    return { outcome: "warmed" };
+  }
+
+  if (cacheStatus && NON_CACHEABLE_CF_CACHE_STATUSES.has(cacheStatus)) {
+    const reason =
+      nonCacheableHeaders.length > 0
+        ? `${nonCacheableHeaders.join(", ")} opts out of caching`
+        : hasSetCookie
+          ? "response sets a cookie"
+          : `CF-Cache-Status is ${cacheStatus}`;
+    return { outcome: "skipped", reason };
+  }
+
   if (nonCacheableHeaders.length > 0 || hasSetCookie) {
     const reason =
       nonCacheableHeaders.length > 0
         ? `${nonCacheableHeaders.join(", ")} opts out of caching`
         : "response sets a cookie";
-    if (cacheStatus && NON_CACHEABLE_CF_CACHE_STATUSES.has(cacheStatus)) {
-      return { outcome: "skipped", reason };
-    }
-    return {
-      outcome: "failed",
-      error: `${reason}, but CF-Cache-Status is ${cacheStatus ?? "missing"}`,
-    };
-  }
-
-  const sharedFreshness = effectivePolicy
-    ? getSharedCacheFreshnessSeconds(effectivePolicy.value)
-    : null;
-  if (sharedFreshness !== null && sharedFreshness <= 0) {
-    const reason = `${effectivePolicy!.name} has no positive shared-cache freshness`;
-    if (cacheStatus && NON_CACHEABLE_CF_CACHE_STATUSES.has(cacheStatus)) {
-      return { outcome: "skipped", reason };
-    }
     return {
       outcome: "failed",
       error: `${reason}, but CF-Cache-Status is ${cacheStatus ?? "missing"}`,
@@ -390,18 +403,7 @@ function validateCachePolicy(response: Response, requireCacheStatus: boolean): W
       ? { outcome: "failed", error: "response is missing CF-Cache-Status" }
       : { outcome: "warmed" };
   }
-  if (!ADMITTED_CF_CACHE_STATUSES.has(cacheStatus)) {
-    return { outcome: "failed", error: `CF-Cache-Status is ${cacheStatus}` };
-  }
-  return { outcome: "warmed" };
-}
-
-function getSharedCacheFreshnessSeconds(cacheControl: string): number | null {
-  for (const pattern of SHARED_CACHE_FRESHNESS_RES) {
-    const match = pattern.exec(cacheControl);
-    if (match) return Number(match[1]);
-  }
-  return null;
+  return { outcome: "failed", error: `CF-Cache-Status is ${cacheStatus}` };
 }
 
 function validateBuildIdentity(
@@ -445,6 +447,8 @@ function validateRscWarmResponse(
       error: `response ${VINEXT_RSC_BUILD_ID_HEADER} does not match build ${expectedRscBuildId}`,
     };
   }
+  const cachePolicyValidation = validateCachePolicy(response, true);
+  if (cachePolicyValidation.outcome !== "warmed") return cachePolicyValidation;
   const vary = new Set(
     (response.headers.get("Vary") ?? "")
       .split(",")
@@ -459,7 +463,7 @@ function validateRscWarmResponse(
   if (extraVary) {
     return { outcome: "failed", error: `response Vary has unsupported field ${extraVary}` };
   }
-  return validateCachePolicy(response, true);
+  return { outcome: "warmed" };
 }
 
 function validateHtmlWarmResponse(response: Response, expectedBuildId?: string): WarmValidation {
@@ -471,7 +475,9 @@ function validateHtmlWarmResponse(response: Response, expectedBuildId?: string):
   }
   const buildIdentityValidation = validateBuildIdentity(response, expectedBuildId);
   if (buildIdentityValidation) return buildIdentityValidation;
-  return validateCachePolicy(response, true);
+  const cachePolicyValidation = validateCachePolicy(response, true);
+  if (cachePolicyValidation.outcome !== "warmed") return cachePolicyValidation;
+  return { outcome: "warmed" };
 }
 
 async function warmOnePath(
@@ -814,6 +820,7 @@ export async function warmCdnCacheFromPrerender(
   return warmCdnCache({
     ...options,
     ...warmPlan,
-    expectedBuildId: options.expectedBuildId ?? buildId,
+    expectedBuildId:
+      options.expectedBuildId ?? (options.validateBuildIdentity === false ? undefined : buildId),
   });
 }

--- a/packages/cloudflare/src/cdn-warm.ts
+++ b/packages/cloudflare/src/cdn-warm.ts
@@ -118,6 +118,9 @@ function readPrerenderPathManifest(manifestPath: string): PrerenderPathManifest 
       (manifest.pagesPaths !== undefined &&
         (!Array.isArray(manifest.pagesPaths) ||
           !manifest.pagesPaths.every((pathname) => typeof pathname === "string"))) ||
+      (manifest.excludedWarmPaths !== undefined &&
+        (!Array.isArray(manifest.excludedWarmPaths) ||
+          !manifest.excludedWarmPaths.every((pathname) => typeof pathname === "string"))) ||
       (manifest.rscPaths !== undefined &&
         (!Array.isArray(manifest.rscPaths) ||
           !manifest.rscPaths.every((pathname) => typeof pathname === "string"))) ||
@@ -162,9 +165,11 @@ function readPrerenderPathWarmPaths(
     manifest,
     pagesPaths: (manifest.pagesPaths ?? [])
       .filter((pathname) => pathname.startsWith("/"))
+      .filter((pathname) => !manifest.excludedWarmPaths?.includes(pathname))
       .map((pathname) => applyWarmPathConfig(pathname, manifest)),
     paths: manifest.paths
       .filter((pathname) => pathname.startsWith("/"))
+      .filter((pathname) => !manifest.excludedWarmPaths?.includes(pathname))
       .map((pathname) => applyWarmPathConfig(pathname, manifest)),
   };
 }
@@ -206,6 +211,7 @@ export function readPrerenderWarmPlan(
         includeFallbackShells: true,
       })
         .filter((pathname) => pathname.startsWith("/"))
+        .filter((pathname) => !manifest.excludedWarmPaths?.includes(pathname))
         .map(applyConfig);
     }
   }

--- a/packages/cloudflare/src/cdn-warm.ts
+++ b/packages/cloudflare/src/cdn-warm.ts
@@ -328,14 +328,47 @@ const REQUIRED_RSC_VARY_HEADERS = VINEXT_RSC_VARY_HEADER.split(",").map((name) =
   name.trim().toLowerCase(),
 );
 const ADMITTED_CF_CACHE_STATUSES = new Set(["HIT", "MISS", "EXPIRED", "REVALIDATED", "UPDATING"]);
-const NON_CACHEABLE_CF_CACHE_STATUSES = new Set(["BYPASS", "DYNAMIC"]);
+const NON_CACHEABLE_CF_CACHE_STATUSES = new Set(["BYPASS"]);
 const CDN_CACHE_POLICY_HEADERS = [
   "Cloudflare-CDN-Cache-Control",
   "CDN-Cache-Control",
   "Cache-Control",
 ] as const;
-const FIELD_QUALIFIED_SET_COOKIE_RE =
-  /(?:^|,)\s*(?:private|no-cache)\s*=\s*(?:"[^"]*\bset-cookie\b[^"]*"|[^,]*\bset-cookie\b)/i;
+
+function splitCacheControlDirectives(value: string): string[] {
+  const directives: string[] = [];
+  let start = 0;
+  let quoted = false;
+  let escaped = false;
+  for (let index = 0; index < value.length; index++) {
+    const character = value[index];
+    if (escaped) {
+      escaped = false;
+    } else if (quoted && character === "\\") {
+      escaped = true;
+    } else if (character === '"') {
+      quoted = !quoted;
+    } else if (character === "," && !quoted) {
+      directives.push(value.slice(start, index));
+      start = index + 1;
+    }
+  }
+  directives.push(value.slice(start));
+  return directives;
+}
+
+function hasFieldQualifiedSetCookie(value: string): boolean {
+  return splitCacheControlDirectives(value).some((directive) => {
+    const separator = directive.indexOf("=");
+    if (separator === -1) return false;
+    const name = directive.slice(0, separator).trim().toLowerCase();
+    if (name !== "private" && name !== "no-cache") return false;
+    const rawFields = directive.slice(separator + 1).trim();
+    const fields =
+      rawFields.startsWith('"') && rawFields.endsWith('"') ? rawFields.slice(1, -1) : rawFields;
+    return fields.split(",").some((field) => field.trim().toLowerCase() === "set-cookie");
+  });
+}
 
 type WarmValidation =
   | { outcome: "warmed" }
@@ -365,10 +398,7 @@ function validateCachePolicy(response: Response, requireCacheStatus: boolean): W
   // cache, while response-time rejection is reported as BYPASS. Downstream
   // freshness cannot reveal a stripped higher-priority edge policy.
   if (cacheStatus && ADMITTED_CF_CACHE_STATUSES.has(cacheStatus)) {
-    if (
-      hasSetCookie &&
-      (!effectivePolicy || !FIELD_QUALIFIED_SET_COOKIE_RE.test(effectivePolicy.value))
-    ) {
+    if (hasSetCookie && (!effectivePolicy || !hasFieldQualifiedSetCookie(effectivePolicy.value))) {
       return {
         outcome: "failed",
         error: "response sets a cookie without an observable field-qualified cache policy",
@@ -385,6 +415,17 @@ function validateCachePolicy(response: Response, requireCacheStatus: boolean): W
           ? "response sets a cookie"
           : `CF-Cache-Status is ${cacheStatus}`;
     return { outcome: "skipped", reason };
+  }
+
+  if (cacheStatus === "DYNAMIC") {
+    if (nonCacheableHeaders.length > 0 || hasSetCookie) {
+      const reason =
+        nonCacheableHeaders.length > 0
+          ? `${nonCacheableHeaders.join(", ")} opts out of caching`
+          : "response sets a cookie";
+      return { outcome: "skipped", reason };
+    }
+    return { outcome: "failed", error: "CF-Cache-Status is DYNAMIC" };
   }
 
   if (nonCacheableHeaders.length > 0 || hasSetCookie) {
@@ -480,6 +521,39 @@ function validateHtmlWarmResponse(response: Response, expectedBuildId?: string):
   return { outcome: "warmed" };
 }
 
+function shouldRetryValidationFailure(
+  response: Response,
+  target: WarmTarget,
+  options: {
+    expectedBuildId?: string;
+    expectedRscBuildId?: string;
+    retryNotFound: boolean;
+    retryPropagationFailures: boolean;
+  },
+): boolean {
+  if (!options.retryPropagationFailures) {
+    return isRetryableStatus(response.status, options.retryNotFound);
+  }
+
+  const expectedIdentities = [
+    options.expectedBuildId === undefined
+      ? null
+      : response.headers.get(VINEXT_CDN_BUILD_ID_HEADER) === options.expectedBuildId,
+    target.kind === "html" || options.expectedRscBuildId === undefined
+      ? null
+      : response.headers.get(VINEXT_RSC_BUILD_ID_HEADER) === options.expectedRscBuildId,
+  ].filter((matches): matches is boolean => matches !== null);
+  if (expectedIdentities.some((matches) => !matches)) return true;
+
+  // A matching identity proves routing reached the uploaded Worker. From that
+  // point, retry only transient HTTP failures; response-shape and admission
+  // failures are deterministic for that build.
+  if (expectedIdentities.length > 0) {
+    return isRetryableStatus(response.status, false);
+  }
+  return isRetryableStatus(response.status, options.retryNotFound);
+}
+
 async function warmOnePath(
   target: WarmTarget,
   options: Required<Pick<CdnWarmOptions, "targetUrl" | "timeoutMs" | "retries">> & {
@@ -487,17 +561,18 @@ async function warmOnePath(
     headers?: HeadersInit;
     expectedBuildId?: string;
     expectedRscBuildId?: string;
-    retryAllValidationErrors: boolean;
+    retryPropagationFailures: boolean;
     retryDelayMs: number;
     retryNotFound: boolean;
   },
 ): Promise<
   | { path: string; ok: true; skipped: false }
   | { path: string; ok: true; skipped: true; reason: string }
-  | { path: string; ok: false; error: string }
+  | { path: string; ok: false; error: string; retryable: boolean }
 > {
   const url = buildWarmupUrl(options.targetUrl, target.pathname);
   let lastError = "request failed before the first attempt";
+  let lastRetryable = true;
 
   const canRetry = (attempt: number): boolean => attempt < options.retries;
 
@@ -540,11 +615,8 @@ async function warmOnePath(
           return { path: target.label, ok: true, skipped: true, reason: validation.reason };
         }
         lastError = validation.error;
-        if (
-          !options.retryAllValidationErrors &&
-          !isRetryableStatus(response.status, options.retryNotFound)
-        )
-          break;
+        lastRetryable = shouldRetryValidationFailure(response, target, options);
+        if (!lastRetryable) break;
         if (!canRetry(attempt)) break;
         await waitBeforeRetry();
         continue;
@@ -558,12 +630,10 @@ async function warmOnePath(
         return { path: target.label, ok: true, skipped: true, reason: validation.reason };
       }
       lastError = validation.error;
-      if (
-        !options.retryAllValidationErrors &&
-        !isRetryableStatus(response.status, options.retryNotFound)
-      )
-        break;
+      lastRetryable = shouldRetryValidationFailure(response, target, options);
+      if (!lastRetryable) break;
     } catch (error) {
+      lastRetryable = true;
       if (error instanceof DOMException && error.name === "AbortError") {
         lastError = `timed out after ${options.timeoutMs}ms`;
       } else {
@@ -574,7 +644,7 @@ async function warmOnePath(
     await waitBeforeRetry();
   }
 
-  return { path: target.label, ok: false, error: lastError };
+  return { path: target.label, ok: false, error: lastError, retryable: lastRetryable };
 }
 
 async function runWithConcurrency<T, R>(
@@ -695,7 +765,7 @@ export async function warmCdnCache(options: CdnWarmOptions): Promise<CdnWarmResu
       headers: options.headers,
       expectedBuildId: options.expectedBuildId,
       expectedRscBuildId: options.expectedRscBuildId,
-      retryAllValidationErrors: isPropagationRequest,
+      retryPropagationFailures: isPropagationRequest,
       retryDelayMs: isPropagationRequest ? propagationRetryDelayMs : normalRetryDelayMs,
       retryNotFound: isPropagationRequest,
     });
@@ -724,19 +794,28 @@ export async function warmCdnCache(options: CdnWarmOptions): Promise<CdnWarmResu
     );
     const failed = targets
       .map((target, index) => ({ index, result: results[index], target }))
-      .filter(({ result }) => !result.ok);
-    if (failed.length === 0 || propagationRetries === 0) return results;
+      .filter(
+        (
+          entry,
+        ): entry is {
+          index: number;
+          result: { path: string; ok: false; error: string; retryable: boolean };
+          target: WarmTarget;
+        } => !entry.result.ok,
+      );
+    const retryableFailed = failed.filter(({ result }) => result.retryable);
+    if (retryableFailed.length === 0 || propagationRetries === 0) return results;
 
     progress.finish();
     console.log(
-      `  CDN warmup: retrying ${failed.length} failed request(s) after completing the initial pass...`,
+      `  CDN warmup: retrying ${retryableFailed.length} failed request(s) after completing the initial pass...`,
     );
     const retried = await runWithConcurrency(
-      failed.map(({ target }) => target),
+      retryableFailed.map(({ target }) => target),
       concurrency,
       (target) => warmRequest(target, "propagation-retry", false),
     );
-    for (const [retryIndex, { index }] of failed.entries()) {
+    for (const [retryIndex, { index }] of retryableFailed.entries()) {
       results[index] = retried[retryIndex];
     }
     return results;
@@ -757,7 +836,7 @@ export async function warmCdnCache(options: CdnWarmOptions): Promise<CdnWarmResu
       (
         entry,
       ): entry is {
-        result: { path: string; ok: false; error: string };
+        result: { path: string; ok: false; error: string; retryable: boolean };
         target: WarmTarget;
       } => !entry.result.ok,
     );

--- a/packages/cloudflare/src/cdn-warm.ts
+++ b/packages/cloudflare/src/cdn-warm.ts
@@ -1,5 +1,7 @@
 import path from "node:path";
 import fs from "node:fs";
+import { randomUUID } from "node:crypto";
+import { setTimeout as delay } from "node:timers/promises";
 import {
   PRERENDER_PATHS_MANIFEST,
   type PrerenderPathManifest,
@@ -48,6 +50,10 @@ export type CdnWarmOptions = {
 
 export const DEFAULT_CDN_WARM_CONCURRENCY = 25;
 export const DEFAULT_CDN_WARM_TIMEOUT_MS = 10_000;
+const DEFAULT_STAGED_READINESS_ATTEMPTS = 60;
+const DEFAULT_STAGED_READINESS_INTERVAL_MS = 1_000;
+const DEFAULT_STAGED_READINESS_SUCCESSES = 6;
+const STAGED_READINESS_QUERY_PARAM = "__vinext_cdn_warm_readiness";
 
 export type PrerenderCdnWarmOptions = Omit<CdnWarmOptions, "paths"> & {
   root: string;
@@ -70,6 +76,8 @@ export type CdnWarmRequestPlan = {
   paths: string[];
   rscPaths: string[];
 };
+
+export type CdnWarmReadinessResult = { ready: true } | { error: string; ready: false };
 
 export type PrerenderWarmPlan = {
   buildId?: string;
@@ -299,6 +307,37 @@ async function fetchWithTimeout(
     if (controller.signal.aborted && response?.body) {
       void response.body.cancel().catch(() => {});
     }
+  }
+}
+
+async function fetchHeadersWithTimeout(
+  fetchImpl: typeof fetch,
+  url: URL,
+  timeoutMs: number,
+  headers?: HeadersInit,
+): Promise<Response> {
+  const controller = new AbortController();
+  const requestHeaders = new Headers(headers);
+  requestHeaders.set("User-Agent", "vinext-cloudflare-cdn-warm");
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const timedOut = new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(() => {
+        controller.abort();
+        reject(new DOMException(`Timed out after ${timeoutMs}ms`, "AbortError"));
+      }, timeoutMs);
+    });
+    return await Promise.race([
+      fetchImpl(url, {
+        method: "GET",
+        redirect: "manual",
+        headers: requestHeaders,
+        signal: controller.signal,
+      }),
+      timedOut,
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
   }
 }
 
@@ -535,6 +574,140 @@ function validateHtmlWarmResponse(response: Response, expectedBuildId?: string):
     return { outcome: "failed", error: `response Vary has unsupported field ${extraVary}` };
   }
   return { outcome: "warmed" };
+}
+
+function validateReadinessResponse(
+  response: Response,
+  kind: "html" | "rsc",
+  expectedBuildId?: string,
+  expectedRscBuildId?: string,
+): string | null {
+  if (response.redirected || response.status < 200 || response.status >= 300) {
+    return response.redirected ? "redirected response" : `HTTP ${response.status}`;
+  }
+  if (
+    kind === "rsc" &&
+    !response.headers.get("Content-Type")?.toLowerCase().startsWith(VINEXT_RSC_CONTENT_TYPE)
+  ) {
+    return `expected ${VINEXT_RSC_CONTENT_TYPE} response`;
+  }
+  const buildIdentityValidation = validateBuildIdentity(response, expectedBuildId);
+  if (buildIdentityValidation?.outcome === "failed") return buildIdentityValidation.error;
+  if (
+    kind === "rsc" &&
+    expectedRscBuildId !== undefined &&
+    response.headers.get(VINEXT_RSC_BUILD_ID_HEADER) !== expectedRscBuildId
+  ) {
+    return `response ${VINEXT_RSC_BUILD_ID_HEADER} does not match build ${expectedRscBuildId}`;
+  }
+  return null;
+}
+
+/**
+ * Wait until version-override requests consistently reach the uploaded build
+ * before any real cache key is filled. Every probe has a unique query key, so
+ * an early response cannot make a later readiness attempt pass from cache.
+ */
+export async function waitForCdnWarmTargetReadiness(
+  options: Pick<
+    CdnWarmOptions,
+    | "deploymentId"
+    | "expectedBuildId"
+    | "expectedRscBuildId"
+    | "fetchImpl"
+    | "headers"
+    | "targetUrl"
+    | "timeoutMs"
+  > & {
+    plan: CdnWarmRequestPlan;
+    maxAttempts?: number;
+    probeIntervalMs?: number;
+    requiredConsecutiveSuccesses?: number;
+  },
+): Promise<CdnWarmReadinessResult> {
+  const rscPath = options.plan.rscPaths[0] ?? options.plan.loadingShellPaths[0];
+  const htmlPath = options.plan.paths[0];
+  const kind = rscPath ? "rsc" : "html";
+  const pathname = rscPath ?? htmlPath;
+  if (!pathname) return { ready: true };
+  if (options.expectedBuildId === undefined && options.expectedRscBuildId === undefined) {
+    return {
+      error: "no response build identity is available for a staged-version readiness probe",
+      ready: false,
+    };
+  }
+
+  const headers = new Headers(options.headers);
+  const probePath = kind === "rsc" ? createCanonicalRscRequestUrl(pathname) : pathname;
+  if (kind === "rsc") {
+    for (const [name, value] of createCanonicalRscRequestHeaders(options.deploymentId)) {
+      headers.set(name, value);
+    }
+  } else {
+    headers.set("Accept", "text/html");
+  }
+  headers.set("Cache-Control", "no-cache");
+  headers.set("Pragma", "no-cache");
+
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const timeoutMs = Math.max(1, options.timeoutMs ?? DEFAULT_CDN_WARM_TIMEOUT_MS);
+  const maxAttempts = Math.max(1, options.maxAttempts ?? DEFAULT_STAGED_READINESS_ATTEMPTS);
+  const probeIntervalMs = Math.max(
+    0,
+    options.probeIntervalMs ?? DEFAULT_STAGED_READINESS_INTERVAL_MS,
+  );
+  const requiredConsecutiveSuccesses = Math.max(
+    1,
+    options.requiredConsecutiveSuccesses ?? DEFAULT_STAGED_READINESS_SUCCESSES,
+  );
+  const probeId = randomUUID();
+  let consecutiveSuccesses = 0;
+  let lastError = "readiness probe did not run";
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const url = buildWarmupUrl(options.targetUrl, probePath);
+    url.searchParams.set(STAGED_READINESS_QUERY_PARAM, `${probeId}-${attempt}`);
+    let response: Response | undefined;
+    try {
+      response = await fetchHeadersWithTimeout(fetchImpl, url, timeoutMs, headers);
+      const validationError = validateReadinessResponse(
+        response,
+        kind,
+        options.expectedBuildId,
+        options.expectedRscBuildId,
+      );
+      if (process.env.VINEXT_CDN_WARM_DEBUG === "1") {
+        console.log(
+          `  CDN warm readiness attempt ${attempt + 1}: ` +
+            `${url.pathname}${url.search} HTTP ${response.status} ` +
+            `build=${response.headers.get(VINEXT_RSC_BUILD_ID_HEADER) ?? response.headers.get(VINEXT_CDN_BUILD_ID_HEADER) ?? "missing"}`,
+        );
+      }
+      if (validationError === null) {
+        consecutiveSuccesses++;
+        if (consecutiveSuccesses >= requiredConsecutiveSuccesses) return { ready: true };
+      } else {
+        consecutiveSuccesses = 0;
+        lastError = validationError;
+      }
+    } catch (error) {
+      consecutiveSuccesses = 0;
+      lastError =
+        error instanceof DOMException && error.name === "AbortError"
+          ? `timed out after ${timeoutMs}ms`
+          : error instanceof Error
+            ? error.message
+            : String(error);
+    } finally {
+      if (response?.body) await response.body.cancel().catch(() => {});
+    }
+    if (attempt + 1 < maxAttempts && probeIntervalMs > 0) await delay(probeIntervalMs);
+  }
+
+  return {
+    error: `${lastError}; uploaded build was not stable for ${requiredConsecutiveSuccesses} consecutive probe(s)`,
+    ready: false,
+  };
 }
 
 function shouldRetryValidationFailure(

--- a/packages/cloudflare/src/deploy-help.ts
+++ b/packages/cloudflare/src/deploy-help.ts
@@ -49,8 +49,9 @@ export function formatDeployHelp(): string {
   a custom domain (zone analytics are unavailable on *.workers.dev) and the
   CLOUDFLARE_API_TOKEN environment variable with Zone.Analytics read permission.
 
-  CDN warmup requests populate the edge cache only in the Cloudflare data centers
-  reached by the warmup run; they do not globally prefill every edge location.
+  Workers Cache automatically uses tiered caching. Warmed entries can therefore
+  be reused outside the data center reached by the warmup request after cache
+  propagation, but the deploy does not wait for every edge location to fill.
 
   Examples:
     npx @vinext/cloudflare deploy                                      Build and deploy to production

--- a/packages/cloudflare/src/deploy-help.ts
+++ b/packages/cloudflare/src/deploy-help.ts
@@ -27,7 +27,8 @@ export function formatDeployHelp(): string {
     --warm-cdn-concurrency <count>
                              Maximum number of CDN warmup requests in parallel (default: 25)
     --warm-cdn-timeout <ms>  Per-request CDN warmup timeout (default: 10000)
-    --warm-cdn-retries <n>   Retries for transient CDN warmup failures (default: 1)
+    --warm-cdn-retries <n>   Retries per failed CDN warmup request (default: 1;
+                             staged-version propagation default: 60)
     --warm-cdn-strict        Fail deploy when any CDN warmup request fails
     --warm-cdn-no-promote    Leave the warmed Worker version staged at 0% traffic
     --warm-cdn-promotion-delay <ms>

--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -48,6 +48,7 @@ import {
 import { parseWranglerConfig, runTPR } from "./tpr.js";
 import {
   readPrerenderWarmPlan,
+  waitForCdnWarmTargetReadiness,
   warmCdnCache,
   type CdnWarmOptions,
   type CdnWarmRequestPlan,
@@ -669,13 +670,30 @@ export async function deployWithCdnWarmup(
           stagedWarmPlan.rscPaths.length +
           stagedWarmPlan.loadingShellPaths.length;
         if (stagedWarmRequests > 0) {
-          const warmResult = await warmUploadedVersion(targetUrl, headers, true, stagedWarmPlan);
-          stagedCacheFilled = warmResult.warmed > 0;
-          remainingWarmPlan = {
-            loadingShellPaths: warmResult.retryPlan.loadingShellPaths,
-            paths: warmResult.retryPlan.paths,
-            rscPaths: warmResult.retryPlan.rscPaths,
-          };
+          console.log("  CDN warmup: waiting for the staged Worker version to become stable...");
+          const readiness = await waitForCdnWarmTargetReadiness({
+            targetUrl,
+            headers,
+            plan: stagedWarmPlan,
+            deploymentId: options.deploymentId,
+            expectedBuildId: options.expectedBuildId,
+            expectedRscBuildId: options.expectedRscBuildId,
+            timeoutMs: options.warmCdnTimeout,
+          });
+          if (!readiness.ready) {
+            const message = `CDN warmup could not verify staged Worker readiness: ${readiness.error}.`;
+            if (options.warmCdnStrict) throw new Error(message);
+            console.warn(`  ${message} Warming after promotion instead.`);
+          } else {
+            console.log("  CDN warmup: staged Worker version is stable.");
+            const warmResult = await warmUploadedVersion(targetUrl, headers, true, stagedWarmPlan);
+            stagedCacheFilled = warmResult.warmed > 0;
+            remainingWarmPlan = {
+              loadingShellPaths: warmResult.retryPlan.loadingShellPaths,
+              paths: warmResult.retryPlan.paths,
+              rscPaths: warmResult.retryPlan.rscPaths,
+            };
+          }
         }
       } catch (error) {
         throw withStagedVersionCleanupNote(error);

--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -731,7 +731,7 @@ export function resolveCdnWarmupTargetUrl(
 ): string | null {
   const config = parseWranglerConfig(root, options?.config);
   const env = getWranglerTargetEnv(options ?? {});
-  const customDomain = (env ? config?.env?.[env]?.customDomain : undefined) ?? config?.customDomain;
+  const customDomain = env ? config?.env?.[env]?.customDomain : config?.customDomain;
   if (customDomain) {
     return `https://${customDomain}`;
   }

--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -560,6 +560,10 @@ export async function runWranglerDeploy(
   return deployedUrl ?? "(URL not detected in wrangler output)";
 }
 
+export function hasCdnWarmRequests(plan: CdnWarmRequestPlan): boolean {
+  return plan.paths.length + plan.rscPaths.length + plan.loadingShellPaths.length > 0;
+}
+
 export async function deployWithCdnWarmup(
   root: string,
   paths: readonly string[],
@@ -618,12 +622,17 @@ export async function deployWithCdnWarmup(
   const deploymentStatus = readWranglerDeploymentStatus(root, options);
   const stagingTraffic = getZeroPercentStagingTraffic(deploymentStatus, upload.versionId);
   const canVerifyStagedHtml = options.expectedBuildId !== undefined;
+  if (!canVerifyStagedHtml && paths.length > 0) {
+    console.warn(
+      `  CDN warmup: skipping ${paths.length} HTML request(s) because the CDN adapter does not declare build-identity response headers.`,
+    );
+  }
   let staged: ReturnType<typeof runWranglerVersionDeploy> | null = null;
   let triggersDeployedUrl: string | null = null;
   let stagedCacheFilled = false;
   let remainingWarmPlan: CdnWarmRequestPlan = {
     loadingShellPaths: [...(options.loadingShellPaths ?? [])],
-    paths: [...paths],
+    paths: canVerifyStagedHtml ? [...paths] : [],
     rscPaths: [...(options.rscPaths ?? [])],
   };
   let triggersApplied = false;
@@ -650,14 +659,9 @@ export async function deployWithCdnWarmup(
     const headers = buildVersionOverrideHeaders(workerName, upload.versionId);
     if (targetUrl && headers) {
       try {
-        if (!canVerifyStagedHtml && remainingWarmPlan.paths.length > 0) {
-          console.log(
-            `  CDN warmup: deferring ${remainingWarmPlan.paths.length} HTML request(s) until after promotion because the CDN adapter does not declare build-identity response headers.`,
-          );
-        }
         const stagedWarmPlan: CdnWarmRequestPlan = {
           loadingShellPaths: remainingWarmPlan.loadingShellPaths,
-          paths: canVerifyStagedHtml ? remainingWarmPlan.paths : [],
+          paths: remainingWarmPlan.paths,
           rscPaths: remainingWarmPlan.rscPaths,
         };
         const stagedWarmRequests =
@@ -669,7 +673,7 @@ export async function deployWithCdnWarmup(
           stagedCacheFilled = warmResult.warmed > 0;
           remainingWarmPlan = {
             loadingShellPaths: warmResult.retryPlan.loadingShellPaths,
-            paths: canVerifyStagedHtml ? warmResult.retryPlan.paths : remainingWarmPlan.paths,
+            paths: warmResult.retryPlan.paths,
             rscPaths: warmResult.retryPlan.rscPaths,
           };
         }
@@ -695,12 +699,6 @@ export async function deployWithCdnWarmup(
         "CDN warmup cannot skip promotion because the uploaded Worker version could not be staged at 0% traffic. " +
           "The current deployment must have exactly one version serving 100% traffic.",
       );
-    }
-    if (!canVerifyStagedHtml && remainingWarmPlan.paths.length > 0) {
-      const message =
-        "CDN warmup cannot verify HTML responses before promotion because the configured CDN adapter " +
-        "does not declare build-identity response headers.";
-      console.warn(`  ${message} HTML warmup was deferred and promotion is disabled.`);
     }
     console.log(
       "  CDN warmup: promotion disabled; uploaded Worker version remains staged at 0% traffic.",
@@ -733,21 +731,16 @@ export async function deployWithCdnWarmup(
   } catch (error) {
     throw staged ? withStagedVersionCleanupNote(error) : error;
   }
+  try {
+    applyTriggers();
+  } catch (error) {
+    throw withPromotedVersionTriggerNote(error);
+  }
   const remainingWarmRequests =
     remainingWarmPlan.paths.length +
     remainingWarmPlan.rscPaths.length +
     remainingWarmPlan.loadingShellPaths.length;
   if (remainingWarmRequests > 0) {
-    if (!canVerifyStagedHtml && remainingWarmPlan.paths.length > 0) {
-      console.warn(
-        "  CDN warmup: post-promotion HTML warming is best-effort because the CDN adapter does not declare build-identity response headers.",
-      );
-    }
-    try {
-      applyTriggers();
-    } catch (error) {
-      throw withPromotedVersionTriggerNote(error);
-    }
     const targetUrl = resolveCdnWarmupTargetUrl(
       root,
       deployed.deployedUrl ?? triggersDeployedUrl,
@@ -1085,7 +1078,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
       includeFallbackShells: options.warmCdnIncludeFallbacks,
       strict: options.warmCdnStrict,
     });
-    if (warmPlan.paths.length > 0) {
+    if (hasCdnWarmRequests(warmPlan)) {
       url = await deployWithCdnWarmup(root, warmPlan.paths, {
         ...wranglerOptions,
         deploymentId: warmPlan.deploymentId,

--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -31,6 +31,7 @@ import {
   findVinextPrerenderConfigInPlugins,
   findVinextRouteRootConfigInPlugins,
   formatVinextPrerenderLabel,
+  hasBuildIdentityResponseHeader,
   hasVerbatimResponseVary,
   resolveVinextPrerenderDecision,
   type ResolvedVinextPrerenderConfig,
@@ -580,6 +581,12 @@ export async function deployWithCdnWarmup(
       "deploymentId" | "expectedBuildId" | "expectedRscBuildId" | "loadingShellPaths" | "rscPaths"
     >,
 ): Promise<string> {
+  if (options.warmCdnStrict && paths.length > 0 && options.expectedBuildId === undefined) {
+    throw new Error(
+      "Strict CDN HTML warmup requires a CDN adapter that declares build-identity response headers. " +
+        "Configure that adapter capability or rerun without --warm-cdn-strict.",
+    );
+  }
   const upload = runWranglerVersionUpload(root, options);
   const warmUploadedVersion = (
     targetUrl: string,
@@ -610,6 +617,7 @@ export async function deployWithCdnWarmup(
   const wranglerConfig = parseWranglerConfig(root, options.config);
   const deploymentStatus = readWranglerDeploymentStatus(root, options);
   const stagingTraffic = getZeroPercentStagingTraffic(deploymentStatus, upload.versionId);
+  const canVerifyStagedHtml = options.expectedBuildId !== undefined;
   let staged: ReturnType<typeof runWranglerVersionDeploy> | null = null;
   let triggersDeployedUrl: string | null = null;
   let stagedCacheFilled = false;
@@ -642,9 +650,29 @@ export async function deployWithCdnWarmup(
     const headers = buildVersionOverrideHeaders(workerName, upload.versionId);
     if (targetUrl && headers) {
       try {
-        const warmResult = await warmUploadedVersion(targetUrl, headers, true);
-        stagedCacheFilled = warmResult.warmed > 0;
-        remainingWarmPlan = warmResult.retryPlan;
+        if (!canVerifyStagedHtml && remainingWarmPlan.paths.length > 0) {
+          console.log(
+            `  CDN warmup: deferring ${remainingWarmPlan.paths.length} HTML request(s) until after promotion because the CDN adapter does not declare build-identity response headers.`,
+          );
+        }
+        const stagedWarmPlan: CdnWarmRequestPlan = {
+          loadingShellPaths: remainingWarmPlan.loadingShellPaths,
+          paths: canVerifyStagedHtml ? remainingWarmPlan.paths : [],
+          rscPaths: remainingWarmPlan.rscPaths,
+        };
+        const stagedWarmRequests =
+          stagedWarmPlan.paths.length +
+          stagedWarmPlan.rscPaths.length +
+          stagedWarmPlan.loadingShellPaths.length;
+        if (stagedWarmRequests > 0) {
+          const warmResult = await warmUploadedVersion(targetUrl, headers, true, stagedWarmPlan);
+          stagedCacheFilled = warmResult.warmed > 0;
+          remainingWarmPlan = {
+            loadingShellPaths: warmResult.retryPlan.loadingShellPaths,
+            paths: canVerifyStagedHtml ? warmResult.retryPlan.paths : remainingWarmPlan.paths,
+            rscPaths: warmResult.retryPlan.rscPaths,
+          };
+        }
       } catch (error) {
         throw withStagedVersionCleanupNote(error);
       }
@@ -667,6 +695,12 @@ export async function deployWithCdnWarmup(
         "CDN warmup cannot skip promotion because the uploaded Worker version could not be staged at 0% traffic. " +
           "The current deployment must have exactly one version serving 100% traffic.",
       );
+    }
+    if (!canVerifyStagedHtml && remainingWarmPlan.paths.length > 0) {
+      const message =
+        "CDN warmup cannot verify HTML responses before promotion because the configured CDN adapter " +
+        "does not declare build-identity response headers.";
+      console.warn(`  ${message} HTML warmup was deferred and promotion is disabled.`);
     }
     console.log(
       "  CDN warmup: promotion disabled; uploaded Worker version remains staged at 0% traffic.",
@@ -704,6 +738,11 @@ export async function deployWithCdnWarmup(
     remainingWarmPlan.rscPaths.length +
     remainingWarmPlan.loadingShellPaths.length;
   if (remainingWarmRequests > 0) {
+    if (!canVerifyStagedHtml && remainingWarmPlan.paths.length > 0) {
+      console.warn(
+        "  CDN warmup: post-promotion HTML warming is best-effort because the CDN adapter does not declare build-identity response headers.",
+      );
+    }
     try {
       applyTriggers();
     } catch (error) {
@@ -964,6 +1003,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
     nextOutput: nextConfig.output,
   });
   const hasStrictResponseVary = hasVerbatimResponseVary(viteConfigMetadata.cacheConfig);
+  const hasBuildIdentityHeader = hasBuildIdentityResponseHeader(viteConfigMetadata.cacheConfig);
   const shouldEmitPrerenderPathManifest =
     options.warmCdnCache || (!options.skipBuild && prerenderDecision);
 
@@ -1049,7 +1089,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
       url = await deployWithCdnWarmup(root, warmPlan.paths, {
         ...wranglerOptions,
         deploymentId: warmPlan.deploymentId,
-        expectedBuildId: warmPlan.buildId,
+        expectedBuildId: hasBuildIdentityHeader ? warmPlan.buildId : undefined,
         expectedRscBuildId: warmPlan.rscBuildId,
         loadingShellPaths: warmPlan.loadingShellPaths,
         rscPaths: warmPlan.rscPaths,

--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -636,6 +636,10 @@ export async function deployWithCdnWarmup(
     paths: canVerifyStagedHtml ? [...paths] : [],
     rscPaths: [...(options.rscPaths ?? [])],
   };
+  const initialWarmRequests =
+    remainingWarmPlan.paths.length +
+    remainingWarmPlan.rscPaths.length +
+    remainingWarmPlan.loadingShellPaths.length;
   let triggersApplied = false;
 
   function applyTriggers(): void {
@@ -678,11 +682,18 @@ export async function deployWithCdnWarmup(
             deploymentId: options.deploymentId,
             expectedBuildId: options.expectedBuildId,
             expectedRscBuildId: options.expectedRscBuildId,
+            retries: options.warmCdnRetries,
             timeoutMs: options.warmCdnTimeout,
           });
           if (!readiness.ready) {
             const message = `CDN warmup could not verify staged Worker readiness: ${readiness.error}.`;
-            if (options.warmCdnStrict) throw new Error(message);
+            if (options.warmCdnStrict || options.warmCdnPromote === false) {
+              const noPromoteNote =
+                options.warmCdnPromote === false
+                  ? " CDN warmup cannot continue because promotion is disabled and the staged version was not warmed."
+                  : "";
+              throw new Error(`${message}${noPromoteNote}`);
+            }
             console.warn(`  ${message} Warming after promotion instead.`);
           } else {
             console.log("  CDN warmup: staged Worker version is stable.");
@@ -706,6 +717,11 @@ export async function deployWithCdnWarmup(
       );
     }
   } else {
+    if (options.warmCdnStrict && initialWarmRequests > 0) {
+      throw new Error(
+        "Strict CDN warmup cannot stage the uploaded Worker at 0% because the current deployment is not exactly one version serving 100% traffic. No traffic or triggers were changed.",
+      );
+    }
     console.warn(
       "  CDN warmup: pre-traffic version override skipped because the current deployment is not one version serving 100% traffic.",
     );

--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -45,7 +45,12 @@ import {
   type ProjectInfo,
 } from "vinext/internal/utils/project";
 import { parseWranglerConfig, runTPR } from "./tpr.js";
-import { readPrerenderWarmPlan, warmCdnCache, type CdnWarmOptions } from "./cdn-warm.js";
+import {
+  readPrerenderWarmPlan,
+  warmCdnCache,
+  type CdnWarmOptions,
+  type CdnWarmRequestPlan,
+} from "./cdn-warm.js";
 import {
   formatMissingCacheAdapterError,
   formatImageOptimizationHint,
@@ -570,23 +575,32 @@ export async function deployWithCdnWarmup(
     | "warmCdnPromote"
     | "warmCdnPromotionDelay"
   > &
-    Pick<CdnWarmOptions, "deploymentId" | "expectedRscBuildId" | "loadingShellPaths" | "rscPaths">,
+    Pick<
+      CdnWarmOptions,
+      "deploymentId" | "expectedBuildId" | "expectedRscBuildId" | "loadingShellPaths" | "rscPaths"
+    >,
 ): Promise<string> {
   const upload = runWranglerVersionUpload(root, options);
   const warmUploadedVersion = (
     targetUrl: string,
     headers?: HeadersInit,
     propagatingTarget = false,
+    plan: CdnWarmRequestPlan = {
+      loadingShellPaths: [...(options.loadingShellPaths ?? [])],
+      paths: [...paths],
+      rscPaths: [...(options.rscPaths ?? [])],
+    },
   ) =>
     warmCdnCache({
       targetUrl,
-      paths,
+      paths: plan.paths,
       headers,
       propagatingTarget,
       deploymentId: options.deploymentId,
+      expectedBuildId: options.expectedBuildId,
       expectedRscBuildId: options.expectedRscBuildId,
-      loadingShellPaths: options.loadingShellPaths,
-      rscPaths: options.rscPaths,
+      loadingShellPaths: plan.loadingShellPaths,
+      rscPaths: plan.rscPaths,
       concurrency: options.warmCdnConcurrency,
       timeoutMs: options.warmCdnTimeout,
       retries: options.warmCdnRetries,
@@ -598,7 +612,12 @@ export async function deployWithCdnWarmup(
   const stagingTraffic = getZeroPercentStagingTraffic(deploymentStatus, upload.versionId);
   let staged: ReturnType<typeof runWranglerVersionDeploy> | null = null;
   let triggersDeployedUrl: string | null = null;
-  let warmedBeforePromotion = false;
+  let stagedCacheFilled = false;
+  let remainingWarmPlan: CdnWarmRequestPlan = {
+    loadingShellPaths: [...(options.loadingShellPaths ?? [])],
+    paths: [...paths],
+    rscPaths: [...(options.rscPaths ?? [])],
+  };
   let triggersApplied = false;
 
   function applyTriggers(): void {
@@ -624,7 +643,8 @@ export async function deployWithCdnWarmup(
     if (targetUrl && headers) {
       try {
         const warmResult = await warmUploadedVersion(targetUrl, headers, true);
-        warmedBeforePromotion = warmResult.failed === 0;
+        stagedCacheFilled = warmResult.warmed > 0;
+        remainingWarmPlan = warmResult.retryPlan;
       } catch (error) {
         throw withStagedVersionCleanupNote(error);
       }
@@ -661,7 +681,7 @@ export async function deployWithCdnWarmup(
 
   let deployed: ReturnType<typeof runWranglerVersionDeploy>;
   try {
-    if (warmedBeforePromotion) {
+    if (stagedCacheFilled) {
       const promotionDelay = options.warmCdnPromotionDelay ?? DEFAULT_CDN_WARM_PROMOTION_DELAY_MS;
       if (promotionDelay > 0) {
         console.log(
@@ -674,12 +694,16 @@ export async function deployWithCdnWarmup(
       root,
       [{ versionId: upload.versionId, percentage: 100 }],
       options,
-      warmedBeforePromotion ? "promote-warmed" : "promote-uploaded",
+      stagedCacheFilled ? "promote-warmed" : "promote-uploaded",
     );
   } catch (error) {
     throw staged ? withStagedVersionCleanupNote(error) : error;
   }
-  if (!warmedBeforePromotion) {
+  const remainingWarmRequests =
+    remainingWarmPlan.paths.length +
+    remainingWarmPlan.rscPaths.length +
+    remainingWarmPlan.loadingShellPaths.length;
+  if (remainingWarmRequests > 0) {
     try {
       applyTriggers();
     } catch (error) {
@@ -692,7 +716,7 @@ export async function deployWithCdnWarmup(
     );
     if (targetUrl) {
       try {
-        await warmUploadedVersion(targetUrl, undefined, true);
+        await warmUploadedVersion(targetUrl, undefined, true, remainingWarmPlan);
       } catch (error) {
         throw withPromotedVersionWarmupNote(error);
       }
@@ -1025,6 +1049,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
       url = await deployWithCdnWarmup(root, warmPlan.paths, {
         ...wranglerOptions,
         deploymentId: warmPlan.deploymentId,
+        expectedBuildId: warmPlan.buildId,
         expectedRscBuildId: warmPlan.rscBuildId,
         loadingShellPaths: warmPlan.loadingShellPaths,
         rscPaths: warmPlan.rscPaths,

--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -650,11 +650,8 @@ export async function deployWithCdnWarmup(
     } catch (error) {
       throw withStagedVersionCleanupNote(error);
     }
-    const targetUrl = resolveCdnWarmupTargetUrl(
-      root,
-      staged.deployedUrl ?? triggersDeployedUrl,
-      options,
-    );
+    const targetUrl =
+      resolveCdnWarmupTargetUrl(root, triggersDeployedUrl, options) ?? staged.deployedUrl;
     const workerName = resolveWorkerNameForVersionOverride(wranglerConfig, options);
     const headers = buildVersionOverrideHeaders(workerName, upload.versionId);
     if (targetUrl && headers) {
@@ -741,11 +738,8 @@ export async function deployWithCdnWarmup(
     remainingWarmPlan.rscPaths.length +
     remainingWarmPlan.loadingShellPaths.length;
   if (remainingWarmRequests > 0) {
-    const targetUrl = resolveCdnWarmupTargetUrl(
-      root,
-      deployed.deployedUrl ?? triggersDeployedUrl,
-      options,
-    );
+    const targetUrl =
+      resolveCdnWarmupTargetUrl(root, triggersDeployedUrl, options) ?? deployed.deployedUrl;
     if (targetUrl) {
       try {
         await warmUploadedVersion(targetUrl, undefined, true, remainingWarmPlan);
@@ -781,16 +775,10 @@ export function resolveCdnWarmupTargetUrl(
   options: Pick<DeployOptions, "preview" | "env" | "config">,
 ): string | null;
 export function resolveCdnWarmupTargetUrl(
-  root: string,
+  _root: string,
   deployedUrl: string | null,
-  options?: Pick<DeployOptions, "preview" | "env" | "config">,
+  _options?: Pick<DeployOptions, "preview" | "env" | "config">,
 ): string | null {
-  const config = parseWranglerConfig(root, options?.config);
-  const env = getWranglerTargetEnv(options ?? {});
-  const customDomain = env ? config?.env?.[env]?.customDomain : config?.customDomain;
-  if (customDomain) {
-    return `https://${customDomain}`;
-  }
   return deployedUrl;
 }
 

--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -1082,7 +1082,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
       url = await deployWithCdnWarmup(root, warmPlan.paths, {
         ...wranglerOptions,
         deploymentId: warmPlan.deploymentId,
-        expectedBuildId: hasBuildIdentityHeader ? warmPlan.buildId : undefined,
+        expectedBuildId: hasBuildIdentityHeader ? warmPlan.buildIdentity : undefined,
         expectedRscBuildId: warmPlan.rscBuildId,
         loadingShellPaths: warmPlan.loadingShellPaths,
         rscPaths: warmPlan.rscPaths,

--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -619,7 +619,7 @@ export async function deployWithCdnWarmup(
     });
 
   const wranglerConfig = parseWranglerConfig(root, options.config);
-  const deploymentStatus = readWranglerDeploymentStatus(root, options);
+  const deploymentStatus = runWranglerDeploymentStatus(root, options);
   const stagingTraffic = getZeroPercentStagingTraffic(deploymentStatus, upload.versionId);
   const canVerifyStagedHtml = options.expectedBuildId !== undefined;
   if (!canVerifyStagedHtml && paths.length > 0) {
@@ -652,7 +652,10 @@ export async function deployWithCdnWarmup(
     }
     const targetUrl =
       resolveCdnWarmupTargetUrl(root, triggersDeployedUrl, options) ?? staged.deployedUrl;
-    const workerName = resolveWorkerNameForVersionOverride(wranglerConfig, options);
+    const workerName =
+      options.name ??
+      upload.workerName ??
+      resolveWorkerNameForVersionOverride(wranglerConfig, options);
     const headers = buildVersionOverrideHeaders(workerName, upload.versionId);
     if (targetUrl && headers) {
       try {
@@ -780,17 +783,6 @@ export function resolveCdnWarmupTargetUrl(
   _options?: Pick<DeployOptions, "preview" | "env" | "config">,
 ): string | null {
   return deployedUrl;
-}
-
-function readWranglerDeploymentStatus(
-  root: string,
-  options: Pick<DeployOptions, "preview" | "env" | "name" | "config">,
-): WranglerDeploymentStatus | null {
-  try {
-    return runWranglerDeploymentStatus(root, options);
-  } catch {
-    return null;
-  }
 }
 
 export function getZeroPercentStagingTraffic(

--- a/packages/cloudflare/src/version-deploy.ts
+++ b/packages/cloudflare/src/version-deploy.ts
@@ -13,6 +13,7 @@ export { parseWorkersDevUrl } from "./workers-dev-url.js";
 export type WranglerVersionUploadResult = {
   versionId: string;
   previewUrl: string | null;
+  workerName: string | null;
   output: string;
 };
 
@@ -90,16 +91,21 @@ export function parseVersionId(output: string): string | null {
   return output.match(new RegExp(`\\b${versionIdPattern}\\b`))?.[0] ?? null;
 }
 
+export function parseUploadedWorkerName(output: string): string | null {
+  return output.match(/^\s*Uploaded\s+(\S+)\s+\(\d+(?:\.\d+)?\s+sec\)\s*$/im)?.[1] ?? null;
+}
+
 export function parseWranglerVersionUploadOutput(output: string): WranglerVersionUploadResult {
   const parsed = parseJsonObject(output);
   const versionId = findVersionIdInUploadJson(parsed) ?? parseVersionId(output);
   const previewUrl = findPreviewUrlInUploadJson(parsed) ?? parseWorkersDevUrl(output);
+  const workerName = parseUploadedWorkerName(output);
 
   if (!versionId) {
     throw new Error("Could not detect Worker version ID from `wrangler versions upload` output.");
   }
 
-  return { versionId, previewUrl, output };
+  return { versionId, previewUrl, workerName, output };
 }
 
 export function buildWranglerVersionUploadArgs(

--- a/packages/cloudflare/src/version-deploy.ts
+++ b/packages/cloudflare/src/version-deploy.ts
@@ -5,6 +5,7 @@ import {
   validateWranglerEnvName,
   type DeployOptions,
 } from "./deploy.js";
+import { parseCdnWarmupDeploymentUrl } from "./worker-deployment-url.js";
 import { parseWorkersDevUrl } from "./workers-dev-url.js";
 
 export { parseWorkersDevUrl } from "./workers-dev-url.js";
@@ -324,5 +325,5 @@ export function runWranglerTriggersDeploy(
     console.log("\n  Applying Worker triggers...");
   }
   const output = runWranglerCommand(root, args, execute);
-  return { deployedUrl: parseWorkersDevUrl(output), output };
+  return { deployedUrl: parseCdnWarmupDeploymentUrl(output), output };
 }

--- a/packages/cloudflare/src/worker-deployment-url.ts
+++ b/packages/cloudflare/src/worker-deployment-url.ts
@@ -10,7 +10,11 @@ export function parseWorkerDeploymentUrl(output: string): string | null {
  * canonical deployment URLs for general CLI reporting.
  */
 export function parseCdnWarmupDeploymentUrl(output: string): string | null {
-  return parseWorkerDeploymentUrl(output) ?? parseCatchAllWorkerRouteOrigin(output);
+  return (
+    parseCustomDomainUrl(output) ??
+    parseCatchAllWorkerRouteOrigin(output) ??
+    parseWorkersDevUrl(output)
+  );
 }
 
 function parseCatchAllWorkerRouteOrigin(output: string): string | null {

--- a/packages/cloudflare/src/worker-deployment-url.ts
+++ b/packages/cloudflare/src/worker-deployment-url.ts
@@ -4,6 +4,43 @@ export function parseWorkerDeploymentUrl(output: string): string | null {
   return parseWorkersDevUrl(output) ?? parseCustomDomainUrl(output);
 }
 
+/**
+ * Parse the concrete hostname that Wrangler reports after applying Worker
+ * triggers. Catch-all routes are valid warmup targets even though they are not
+ * canonical deployment URLs for general CLI reporting.
+ */
+export function parseCdnWarmupDeploymentUrl(output: string): string | null {
+  return parseWorkerDeploymentUrl(output) ?? parseCatchAllWorkerRouteOrigin(output);
+}
+
+function parseCatchAllWorkerRouteOrigin(output: string): string | null {
+  for (const line of output.split(/\r?\n/)) {
+    const route = line.trim().split(/\s+/, 1)[0];
+    if (!route || !route.endsWith("/*")) continue;
+
+    try {
+      const url = new URL(route.includes("://") ? route : `https://${route}`);
+      if (
+        (url.protocol !== "https:" && url.protocol !== "http:") ||
+        url.hostname.includes("*") ||
+        url.username !== "" ||
+        url.password !== "" ||
+        url.port !== "" ||
+        url.pathname !== "/*" ||
+        url.search !== "" ||
+        url.hash !== ""
+      ) {
+        continue;
+      }
+      return url.origin;
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}
+
 function parseCustomDomainUrl(output: string): string | null {
   // Wrangler adds a scheme only to workers.dev targets. A successful custom-domain
   // deployment is printed as a bare hostname with this explicit route-type marker.

--- a/packages/vinext/src/build/prerender-paths.ts
+++ b/packages/vinext/src/build/prerender-paths.ts
@@ -31,6 +31,7 @@ import type { CdnCacheAdapterCapabilities } from "../cache/cache-adapters-virtua
 import { matchesRewriteSource } from "../config/config-matchers.js";
 import { pagesRouteHasPriorityOverAppRoute } from "../server/hybrid-route-priority.js";
 import { extractLocaleFromUrl, normalizeDefaultLocalePathname } from "../server/pages-i18n.js";
+import { normalizePathTrailingSlash } from "vinext/shims/url-utils";
 
 export type PrerenderPathManifest = {
   basePath?: string;
@@ -47,6 +48,8 @@ export type PrerenderPathManifest = {
   loadingShellPaths?: string[];
   /** Pages Router paths selected by the existing HTML warm discovery pass. */
   pagesPaths?: string[];
+  /** Public paths omitted because configured rewrites can change their response identity. */
+  excludedWarmPaths?: string[];
   trailingSlash?: boolean;
   paths: string[];
 };
@@ -360,7 +363,14 @@ async function collectAppPaths(options: {
         }
       } else {
         const results = await generateStaticParams({ params: {} });
-        paramSets = Array.isArray(results) || results === null ? results : [];
+        if (results === null) {
+          const layoutParamSets = await resolveParentParams(route, staticParamsMap, {
+            includeLastDynamicSegment: true,
+          });
+          paramSets = layoutParamSets.length > 0 ? layoutParamSets : null;
+        } else {
+          paramSets = Array.isArray(results) ? results : [];
+        }
       }
 
       if (!paramSets?.length) continue;
@@ -379,12 +389,10 @@ async function collectAppPaths(options: {
 
 async function resolveAppRscWarmPaths(options: {
   appDir: string;
-  basePath: string;
   i18n: ResolvedNextConfig["i18n"];
   pagesDir: string | null;
   pageExtensions: readonly string[];
   paths: readonly string[];
-  rewrites: ResolvedNextConfig["rewrites"];
 }): Promise<{ loadingShellPaths: string[]; rscPaths: string[] }> {
   const appRoutes = await appRouter(options.appDir, options.pageExtensions);
   const [pageRoutes, apiRoutes] = options.pagesDir
@@ -396,11 +404,6 @@ async function resolveAppRscWarmPaths(options: {
 
   const rscPaths: string[] = [];
   const loadingShellPaths: string[] = [];
-  const rewrites = [
-    ...options.rewrites.beforeFiles,
-    ...options.rewrites.afterFiles,
-    ...options.rewrites.fallback,
-  ];
   for (const pathname of options.paths) {
     const appMatch = matchAppRoute(pathname, appRoutes);
     if (!appMatch) continue;
@@ -428,25 +431,38 @@ async function resolveAppRscWarmPaths(options: {
       continue;
     }
 
-    // A configured rewrite can make the browser's public URL resolve to a
-    // different route than a direct canonical RSC request. Do not advertise
-    // that public cache key as warmable until discovery can reproduce the
-    // rewrite's request-dependent routing context.
-    const rewritePathname = normalizeDefaultLocalePathname(pathname, options.i18n);
-    const rewriteAffectsPath = rewrites.some((rewrite) =>
-      matchesRewriteSource(rewritePathname, rewrite, {
-        basePath: options.basePath,
-        hadBasePath: true,
-      }),
-    );
-    if (rewriteAffectsPath) continue;
-
     rscPaths.push(pathname);
     if (appRouteHasMainTreeLoadingBoundary(matchedAppRoute)) {
       loadingShellPaths.push(pathname);
     }
   }
   return { loadingShellPaths, rscPaths };
+}
+
+function configuredRewriteAffectsWarmPath(
+  pathname: string,
+  config: Pick<ResolvedNextConfig, "basePath" | "i18n" | "rewrites" | "trailingSlash">,
+): boolean {
+  const canonicalPathname = normalizePathTrailingSlash(pathname, config.trailingSlash);
+  const hostnames = [undefined, ...(config.i18n?.domains?.map((domain) => domain.domain) ?? [])];
+  const matchPathnames = new Set(
+    hostnames.map((hostname) =>
+      normalizeDefaultLocalePathname(canonicalPathname, config.i18n, { hostname }),
+    ),
+  );
+  const rewrites = [
+    ...config.rewrites.beforeFiles,
+    ...config.rewrites.afterFiles,
+    ...config.rewrites.fallback,
+  ];
+  return rewrites.some((rewrite) =>
+    Array.from(matchPathnames).some((matchPathname) =>
+      matchesRewriteSource(matchPathname, rewrite, {
+        basePath: config.basePath,
+        hadBasePath: true,
+      }),
+    ),
+  );
 }
 
 async function startPathDiscoveryServer(options: {
@@ -567,16 +583,20 @@ export async function emitPrerenderPathManifest(
     }
   });
 
+  const excludedWarmPathSet = new Set(
+    options.responseVary
+      ? paths.filter((pathname) => configuredRewriteAffectsWarmPath(pathname, config))
+      : [],
+  );
+  const warmPaths = paths.filter((pathname) => !excludedWarmPathSet.has(pathname));
   const appOwnedWarmPaths =
     options.responseVary && appDir
       ? await resolveAppRscWarmPaths({
           appDir,
-          basePath: config.basePath,
           i18n: config.i18n,
           pagesDir,
           pageExtensions: config.pageExtensions,
-          paths: discoveredAppPaths,
-          rewrites: config.rewrites,
+          paths: discoveredAppPaths.filter((pathname) => !excludedWarmPathSet.has(pathname)),
         })
       : {
           loadingShellPaths: discoveredLoadingShellPaths,
@@ -588,13 +608,18 @@ export async function emitPrerenderPathManifest(
     buildId: config.buildId,
     ...(rscBuildId ? { buildIdentity: rscBuildId } : {}),
     ...(config.deploymentId ? { deploymentId: config.deploymentId } : {}),
-    ...(pagesDir ? { pagesPaths: discoveredPagesPaths } : {}),
+    ...(pagesDir
+      ? {
+          pagesPaths: discoveredPagesPaths.filter((pathname) => !excludedWarmPathSet.has(pathname)),
+        }
+      : {}),
+    ...(excludedWarmPathSet.size > 0 ? { excludedWarmPaths: Array.from(excludedWarmPathSet) } : {}),
     ...(rscBuildId ? { rscBuildId } : {}),
     ...(options.responseVary ? { responseVary: options.responseVary } : {}),
     ...(options.responseVary ? { rscPaths: appOwnedWarmPaths.rscPaths } : {}),
     ...(options.responseVary ? { loadingShellPaths: appOwnedWarmPaths.loadingShellPaths } : {}),
     trailingSlash: config.trailingSlash,
-    paths,
+    paths: warmPaths,
   };
   fs.mkdirSync(manifestDir, { recursive: true });
   fs.writeFileSync(
@@ -602,7 +627,7 @@ export async function emitPrerenderPathManifest(
     JSON.stringify(manifest, null, 2) + "\n",
     "utf-8",
   );
-  console.log(`  Discovered ${paths.length} CDN warmup path(s).`);
+  console.log(`  Discovered ${warmPaths.length} CDN warmup path(s).`);
 
   return manifest;
 }

--- a/packages/vinext/src/build/prerender-paths.ts
+++ b/packages/vinext/src/build/prerender-paths.ts
@@ -30,6 +30,8 @@ import { extractLocaleFromUrl } from "../server/pages-i18n.js";
 export type PrerenderPathManifest = {
   basePath?: string;
   buildId?: string;
+  /** Opaque per-build identity emitted by CDN adapter page responses. */
+  buildIdentity?: string;
   deploymentId?: string;
   /** Opaque per-build identity emitted by RSC responses. */
   rscBuildId?: string;
@@ -569,6 +571,7 @@ export async function emitPrerenderPathManifest(
   const manifest: PrerenderPathManifest = {
     ...(config.basePath ? { basePath: config.basePath } : {}),
     buildId: config.buildId,
+    ...(rscBuildId ? { buildIdentity: rscBuildId } : {}),
     ...(config.deploymentId ? { deploymentId: config.deploymentId } : {}),
     ...(pagesDir ? { pagesPaths: discoveredPagesPaths } : {}),
     ...(rscBuildId ? { rscBuildId } : {}),

--- a/packages/vinext/src/build/prerender-paths.ts
+++ b/packages/vinext/src/build/prerender-paths.ts
@@ -6,8 +6,8 @@ import {
   resolveNextConfig,
   type ResolvedNextConfig,
 } from "../config/next-config.js";
-import { appRouter } from "../routing/app-router.js";
-import { apiRouter, pagesRouter } from "../routing/pages-router.js";
+import { appRouter, matchAppRoute } from "../routing/app-router.js";
+import { apiRouter, matchRoute, pagesRouter } from "../routing/pages-router.js";
 import { normalizeStaticPathsEntry, type StaticPathsEntry } from "../routing/route-pattern.js";
 import {
   getAppRouteRenderEntryPath,
@@ -24,6 +24,7 @@ import { VINEXT_PRERENDER_SECRET_HEADER } from "../server/headers.js";
 import type { VinextRouteRootConfig } from "../config/prerender.js";
 import { enterPrerenderPhase } from "./prerender-phase.js";
 import type { CdnCacheAdapterCapabilities } from "../cache/cache-adapters-virtual.js";
+import { pagesRouteHasPriorityOverAppRoute } from "../server/hybrid-route-priority.js";
 
 export type PrerenderPathManifest = {
   basePath?: string;
@@ -166,6 +167,18 @@ function resolveConfiguredRouteDirs(
 function appRouteMayHaveGenerateStaticParams(route: Awaited<ReturnType<typeof appRouter>>[number]) {
   if (fileHasNamedExport(route.pagePath, "generateStaticParams")) return true;
   return route.layouts.some((layoutPath) => fileHasNamedExport(layoutPath, "generateStaticParams"));
+}
+
+function appRouteHasMainTreeLoadingBoundary(
+  route: Awaited<ReturnType<typeof appRouter>>[number],
+): boolean {
+  return (
+    route.loadingPath != null ||
+    (route.loadingPaths?.some(
+      (_loadingPath, index) => (route.loadingTreePositions?.[index] ?? 0) > 0,
+    ) ??
+      false)
+  );
 }
 
 async function shouldStartPathDiscoveryServer(options: {
@@ -314,12 +327,7 @@ async function collectAppPaths(options: {
     const { type } = classifyAppRoute(renderEntryPath, route.routePath, route.isDynamic);
     if (type === "api") continue;
 
-    const hasMainTreeLoadingBoundary =
-      route.loadingPath != null ||
-      (route.loadingPaths?.some(
-        (_loadingPath, index) => (route.loadingTreePositions?.[index] ?? 0) > 0,
-      ) ??
-        false);
+    const hasMainTreeLoadingBoundary = appRouteHasMainTreeLoadingBoundary(route);
     const addDiscoveredPath = (pathname: string): void => {
       addPath(paths, seen, pathname);
       if (hasMainTreeLoadingBoundary) {
@@ -371,6 +379,49 @@ async function collectAppPaths(options: {
   }
 
   return { loadingShellPaths, paths };
+}
+
+async function resolveAppRscWarmPaths(options: {
+  appDir: string;
+  pagesDir: string | null;
+  pageExtensions: readonly string[];
+  paths: readonly string[];
+}): Promise<{ loadingShellPaths: string[]; rscPaths: string[] }> {
+  const appRoutes = await appRouter(options.appDir, options.pageExtensions);
+  const [pageRoutes, apiRoutes] = options.pagesDir
+    ? await Promise.all([
+        pagesRouter(options.pagesDir, options.pageExtensions),
+        apiRouter(options.pagesDir, options.pageExtensions),
+      ])
+    : [[], []];
+
+  const rscPaths: string[] = [];
+  const loadingShellPaths: string[] = [];
+  for (const pathname of options.paths) {
+    const appMatch = matchAppRoute(pathname, appRoutes);
+    if (!appMatch) continue;
+    // The trie returns the exact object from appRoutes. Its public matcher type
+    // exposes the shared AppRoute fields, so recover the graph-owned metadata
+    // here without rescanning the route table for every concrete path.
+    const matchedAppRoute = appMatch.route as (typeof appRoutes)[number];
+
+    const appRenderEntryPath = getAppRouteRenderEntryPath(matchedAppRoute);
+    if (!appRenderEntryPath) continue;
+
+    const pagesMatch = matchRoute(
+      pathname,
+      pathname === "/api" || pathname.startsWith("/api/") ? apiRoutes : pageRoutes,
+    );
+    if (pagesMatch && pagesRouteHasPriorityOverAppRoute(pagesMatch.route, matchedAppRoute)) {
+      continue;
+    }
+
+    rscPaths.push(pathname);
+    if (appRouteHasMainTreeLoadingBoundary(matchedAppRoute)) {
+      loadingShellPaths.push(pathname);
+    }
+  }
+  return { loadingShellPaths, rscPaths };
 }
 
 async function startPathDiscoveryServer(options: {
@@ -491,6 +542,19 @@ export async function emitPrerenderPathManifest(
     }
   });
 
+  const appOwnedWarmPaths =
+    options.responseVary && appDir
+      ? await resolveAppRscWarmPaths({
+          appDir,
+          pagesDir,
+          pageExtensions: config.pageExtensions,
+          paths: discoveredAppPaths,
+        })
+      : {
+          loadingShellPaths: discoveredLoadingShellPaths,
+          rscPaths: discoveredAppPaths,
+        };
+
   const manifest: PrerenderPathManifest = {
     ...(config.basePath ? { basePath: config.basePath } : {}),
     buildId: config.buildId,
@@ -498,8 +562,8 @@ export async function emitPrerenderPathManifest(
     ...(pagesDir ? { pagesPaths: discoveredPagesPaths } : {}),
     ...(rscBuildId ? { rscBuildId } : {}),
     ...(options.responseVary ? { responseVary: options.responseVary } : {}),
-    ...(options.responseVary ? { rscPaths: discoveredAppPaths } : {}),
-    ...(options.responseVary ? { loadingShellPaths: discoveredLoadingShellPaths } : {}),
+    ...(options.responseVary ? { rscPaths: appOwnedWarmPaths.rscPaths } : {}),
+    ...(options.responseVary ? { loadingShellPaths: appOwnedWarmPaths.loadingShellPaths } : {}),
     trailingSlash: config.trailingSlash,
     paths,
   };

--- a/packages/vinext/src/build/prerender-paths.ts
+++ b/packages/vinext/src/build/prerender-paths.ts
@@ -221,6 +221,7 @@ async function withPrerenderEndpoints<T>(fn: () => Promise<T>): Promise<T> {
 
 async function collectPagesPaths(options: {
   baseUrl: string | null;
+  i18n: ResolvedNextConfig["i18n"];
   pagesDir: string;
   pageExtensions: readonly string[];
   secretHeaders: Record<string, string>;
@@ -244,7 +245,13 @@ async function collectPagesPaths(options: {
     if (type === "api" || type === "ssr") continue;
 
     if (!route.isDynamic) {
-      addPath(paths, seen, route.pattern);
+      if (options.i18n) {
+        for (const locale of options.i18n.locales) {
+          addPath(paths, seen, localizePagesPath(route.pattern, locale, options.i18n));
+        }
+      } else {
+        addPath(paths, seen, route.pattern);
+      }
       continue;
     }
 
@@ -253,6 +260,10 @@ async function collectPagesPaths(options: {
 
     try {
       const search = new URLSearchParams({ pattern: route.pattern });
+      if (options.i18n) {
+        search.set("locales", JSON.stringify(options.i18n.locales));
+        search.set("defaultLocale", options.i18n.defaultLocale);
+      }
       const text = await fetchDiscoveryEndpoint(
         `${options.baseUrl}/__vinext/prerender/pages-static-paths?${search}`,
         options.secretHeaders,
@@ -264,11 +275,27 @@ async function collectPagesPaths(options: {
         fallback?: unknown;
       };
       for (const item of pathsResult.paths ?? []) {
-        const normalized = normalizeStaticPathsEntry(item, route.pattern);
+        let itemToNormalize = item;
+        let locale = options.i18n?.defaultLocale;
+        if (options.i18n && typeof item === "string") {
+          const localeInfo = extractLocaleFromUrl(item, options.i18n);
+          itemToNormalize = localeInfo.url;
+          locale = localeInfo.locale;
+        } else if (options.i18n && item && typeof item === "object" && item.locale) {
+          if (!options.i18n.locales.includes(item.locale)) {
+            throw new Error(
+              `Invalid locale returned from getStaticPaths for ${route.pattern}: ${item.locale}`,
+            );
+          }
+          locale = item.locale;
+        }
+
+        const normalized = normalizeStaticPathsEntry(itemToNormalize, route.pattern);
         if ("error" in normalized) {
           throw new Error(normalized.error);
         }
-        addPath(paths, seen, buildUrlFromParams(route.pattern, normalized.params));
+        const pathname = buildUrlFromParams(route.pattern, normalized.params);
+        addPath(paths, seen, localizePagesPath(pathname, locale, options.i18n));
       }
     } catch (error) {
       warnDiscoveryFailure(route.pattern, error);
@@ -276,6 +303,15 @@ async function collectPagesPaths(options: {
   }
 
   return paths;
+}
+
+function localizePagesPath(
+  pathname: string,
+  locale: string | undefined,
+  i18n: ResolvedNextConfig["i18n"],
+): string {
+  if (!i18n || !locale || locale === i18n.defaultLocale) return pathname;
+  return pathname === "/" ? `/${locale}` : `/${locale}${pathname}`;
 }
 
 async function collectAppPaths(options: {
@@ -568,6 +604,7 @@ export async function emitPrerenderPathManifest(
       if (pagesDir) {
         for (const pathname of await collectPagesPaths({
           baseUrl,
+          i18n: config.i18n,
           pagesDir,
           pageExtensions: config.pageExtensions,
           secretHeaders,

--- a/packages/vinext/src/build/prerender-paths.ts
+++ b/packages/vinext/src/build/prerender-paths.ts
@@ -48,7 +48,7 @@ export type PrerenderPathManifest = {
   loadingShellPaths?: string[];
   /** Pages Router paths selected by the existing HTML warm discovery pass. */
   pagesPaths?: string[];
-  /** Public paths omitted because configured rewrites can change their response identity. */
+  /** Public paths omitted because configured routes can replace their page response. */
   excludedWarmPaths?: string[];
   trailingSlash?: boolean;
   paths: string[];
@@ -101,9 +101,9 @@ function addPath(paths: string[], seen: Set<string>, pathname: string): void {
   paths.push(pathname);
 }
 
-function warnDiscoveryFailure(route: string, error: unknown): void {
+function throwDiscoveryFailure(route: string, error: unknown): never {
   const message = error instanceof Error ? error.message : String(error);
-  console.warn(`[vinext] Warning: failed to discover warmup path(s) for ${route}: ${message}`);
+  throw new Error(`Failed to discover warmup path(s) for ${route}: ${message}`, { cause: error });
 }
 
 async function fetchDiscoveryEndpoint(
@@ -118,7 +118,8 @@ async function fetchDiscoveryEndpoint(
       signal: controller.signal,
     });
     const text = await res.text();
-    if (!res.ok || text === "null") return null;
+    if (!res.ok) throw new Error(`path discovery returned HTTP ${res.status}`);
+    if (text === "null") return null;
     return text;
   } catch (error) {
     if (error instanceof Error && error.name === "AbortError") {
@@ -278,7 +279,7 @@ async function collectPagesPaths(options: {
         let itemToNormalize = item;
         let locale = options.i18n?.defaultLocale;
         if (options.i18n && typeof item === "string") {
-          const localeInfo = extractLocaleFromUrl(item, options.i18n);
+          const localeInfo = extractPagesStaticPathLocale(item, options.i18n);
           itemToNormalize = localeInfo.url;
           locale = localeInfo.locale;
         } else if (options.i18n && item && typeof item === "object" && item.locale) {
@@ -298,7 +299,7 @@ async function collectPagesPaths(options: {
         addPath(paths, seen, localizePagesPath(pathname, locale, options.i18n));
       }
     } catch (error) {
-      warnDiscoveryFailure(route.pattern, error);
+      throwDiscoveryFailure(route.pattern, error);
     }
   }
 
@@ -312,6 +313,23 @@ function localizePagesPath(
 ): string {
   if (!i18n || !locale || locale === i18n.defaultLocale) return pathname;
   return pathname === "/" ? `/${locale}` : `/${locale}${pathname}`;
+}
+
+function extractPagesStaticPathLocale(
+  url: string,
+  i18n: NonNullable<ResolvedNextConfig["i18n"]>,
+): { locale: string; url: string } {
+  const queryIndex = url.indexOf("?");
+  const pathname = queryIndex === -1 ? url : url.slice(0, queryIndex);
+  const query = queryIndex === -1 ? "" : url.slice(queryIndex);
+  const parts = pathname.split("/").filter(Boolean);
+  const locale =
+    parts.length > 0
+      ? i18n.locales.find((candidate) => candidate.toLowerCase() === parts[0].toLowerCase())
+      : undefined;
+  if (!locale) return extractLocaleFromUrl(url, i18n);
+  const rest = `/${parts.slice(1).join("/")}`;
+  return { locale, url: `${rest || "/"}${query}` };
 }
 
 async function collectAppPaths(options: {
@@ -416,7 +434,7 @@ async function collectAppPaths(options: {
         addDiscoveredPath(buildUrlFromParams(route.pattern, params));
       }
     } catch (error) {
-      warnDiscoveryFailure(route.pattern, error);
+      throwDiscoveryFailure(route.pattern, error);
     }
   }
 
@@ -475,9 +493,12 @@ async function resolveAppRscWarmPaths(options: {
   return { loadingShellPaths, rscPaths };
 }
 
-function configuredRewriteAffectsWarmPath(
+function configuredRouteAffectsWarmPath(
   pathname: string,
-  config: Pick<ResolvedNextConfig, "basePath" | "i18n" | "rewrites" | "trailingSlash">,
+  config: Pick<
+    ResolvedNextConfig,
+    "basePath" | "i18n" | "redirects" | "rewrites" | "trailingSlash"
+  >,
 ): boolean {
   const canonicalPathname = normalizePathTrailingSlash(pathname, config.trailingSlash);
   const hostnames = [undefined, ...(config.i18n?.domains?.map((domain) => domain.domain) ?? [])];
@@ -491,9 +512,9 @@ function configuredRewriteAffectsWarmPath(
     ...config.rewrites.afterFiles,
     ...config.rewrites.fallback,
   ];
-  return rewrites.some((rewrite) =>
+  return [...rewrites, ...config.redirects].some((rule) =>
     Array.from(matchPathnames).some((matchPathname) =>
-      matchesRewriteSource(matchPathname, rewrite, {
+      matchesRewriteSource(matchPathname, rule, {
         basePath: config.basePath,
         hadBasePath: true,
       }),
@@ -571,9 +592,9 @@ export async function emitPrerenderPathManifest(
         });
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        console.warn(
-          `[vinext] Warning: failed to start prerender path discovery server: ${message}`,
-        );
+        throw new Error(`Failed to start prerender path discovery server: ${message}`, {
+          cause: error,
+        });
       }
     }
 
@@ -622,7 +643,7 @@ export async function emitPrerenderPathManifest(
 
   const excludedWarmPathSet = new Set(
     options.responseVary
-      ? paths.filter((pathname) => configuredRewriteAffectsWarmPath(pathname, config))
+      ? paths.filter((pathname) => configuredRouteAffectsWarmPath(pathname, config))
       : [],
   );
   const warmPaths = paths.filter((pathname) => !excludedWarmPathSet.has(pathname));

--- a/packages/vinext/src/build/prerender-paths.ts
+++ b/packages/vinext/src/build/prerender-paths.ts
@@ -24,8 +24,9 @@ import { VINEXT_PRERENDER_SECRET_HEADER } from "../server/headers.js";
 import type { VinextRouteRootConfig } from "../config/prerender.js";
 import { enterPrerenderPhase } from "./prerender-phase.js";
 import type { CdnCacheAdapterCapabilities } from "../cache/cache-adapters-virtual.js";
+import { matchesRewriteSource } from "../config/config-matchers.js";
 import { pagesRouteHasPriorityOverAppRoute } from "../server/hybrid-route-priority.js";
-import { extractLocaleFromUrl } from "../server/pages-i18n.js";
+import { extractLocaleFromUrl, normalizeDefaultLocalePathname } from "../server/pages-i18n.js";
 
 export type PrerenderPathManifest = {
   basePath?: string;
@@ -386,10 +387,12 @@ async function collectAppPaths(options: {
 
 async function resolveAppRscWarmPaths(options: {
   appDir: string;
+  basePath: string;
   i18n: ResolvedNextConfig["i18n"];
   pagesDir: string | null;
   pageExtensions: readonly string[];
   paths: readonly string[];
+  rewrites: ResolvedNextConfig["rewrites"];
 }): Promise<{ loadingShellPaths: string[]; rscPaths: string[] }> {
   const appRoutes = await appRouter(options.appDir, options.pageExtensions);
   const [pageRoutes, apiRoutes] = options.pagesDir
@@ -401,6 +404,11 @@ async function resolveAppRscWarmPaths(options: {
 
   const rscPaths: string[] = [];
   const loadingShellPaths: string[] = [];
+  const rewrites = [
+    ...options.rewrites.beforeFiles,
+    ...options.rewrites.afterFiles,
+    ...options.rewrites.fallback,
+  ];
   for (const pathname of options.paths) {
     const appMatch = matchAppRoute(pathname, appRoutes);
     if (!appMatch) continue;
@@ -427,6 +435,19 @@ async function resolveAppRscWarmPaths(options: {
     if (pagesMatch && pagesRouteHasPriorityOverAppRoute(pagesMatch.route, matchedAppRoute)) {
       continue;
     }
+
+    // A configured rewrite can make the browser's public URL resolve to a
+    // different route than a direct canonical RSC request. Do not advertise
+    // that public cache key as warmable until discovery can reproduce the
+    // rewrite's request-dependent routing context.
+    const rewritePathname = normalizeDefaultLocalePathname(pathname, options.i18n);
+    const rewriteAffectsPath = rewrites.some((rewrite) =>
+      matchesRewriteSource(rewritePathname, rewrite, {
+        basePath: options.basePath,
+        hadBasePath: true,
+      }),
+    );
+    if (rewriteAffectsPath) continue;
 
     rscPaths.push(pathname);
     if (appRouteHasMainTreeLoadingBoundary(matchedAppRoute)) {
@@ -558,10 +579,12 @@ export async function emitPrerenderPathManifest(
     options.responseVary && appDir
       ? await resolveAppRscWarmPaths({
           appDir,
+          basePath: config.basePath,
           i18n: config.i18n,
           pagesDir,
           pageExtensions: config.pageExtensions,
           paths: discoveredAppPaths,
+          rewrites: config.rewrites,
         })
       : {
           loadingShellPaths: discoveredLoadingShellPaths,

--- a/packages/vinext/src/build/prerender-paths.ts
+++ b/packages/vinext/src/build/prerender-paths.ts
@@ -25,6 +25,7 @@ import type { VinextRouteRootConfig } from "../config/prerender.js";
 import { enterPrerenderPhase } from "./prerender-phase.js";
 import type { CdnCacheAdapterCapabilities } from "../cache/cache-adapters-virtual.js";
 import { pagesRouteHasPriorityOverAppRoute } from "../server/hybrid-route-priority.js";
+import { extractLocaleFromUrl } from "../server/pages-i18n.js";
 
 export type PrerenderPathManifest = {
   basePath?: string;
@@ -383,6 +384,7 @@ async function collectAppPaths(options: {
 
 async function resolveAppRscWarmPaths(options: {
   appDir: string;
+  i18n: ResolvedNextConfig["i18n"];
   pagesDir: string | null;
   pageExtensions: readonly string[];
   paths: readonly string[];
@@ -408,10 +410,18 @@ async function resolveAppRscWarmPaths(options: {
     const appRenderEntryPath = getAppRouteRenderEntryPath(matchedAppRoute);
     if (!appRenderEntryPath) continue;
 
-    const pagesMatch = matchRoute(
-      pathname,
-      pathname === "/api" || pathname.startsWith("/api/") ? apiRoutes : pageRoutes,
-    );
+    // Pages Router i18n prefixes are routing metadata rather than part of the
+    // filesystem route. Production strips them before matching Pages/API
+    // routes, while the App Router still matches the original pathname.
+    const pagesPathname = options.i18n
+      ? extractLocaleFromUrl(pathname, options.i18n).url
+      : pathname;
+    // The App-to-Pages production bridge selects the API handler from the raw
+    // request pathname before the Pages matcher strips i18n metadata. A
+    // locale-prefixed `/fr/api/*` path therefore remains a page candidate,
+    // rather than becoming a Pages API request after normalization.
+    const isPagesApiRequest = pathname === "/api" || pathname.startsWith("/api/");
+    const pagesMatch = matchRoute(pagesPathname, isPagesApiRequest ? apiRoutes : pageRoutes);
     if (pagesMatch && pagesRouteHasPriorityOverAppRoute(pagesMatch.route, matchedAppRoute)) {
       continue;
     }
@@ -546,6 +556,7 @@ export async function emitPrerenderPathManifest(
     options.responseVary && appDir
       ? await resolveAppRscWarmPaths({
           appDir,
+          i18n: config.i18n,
           pagesDir,
           pageExtensions: config.pageExtensions,
           paths: discoveredAppPaths,

--- a/packages/vinext/src/build/prerender-paths.ts
+++ b/packages/vinext/src/build/prerender-paths.ts
@@ -6,7 +6,11 @@ import {
   resolveNextConfig,
   type ResolvedNextConfig,
 } from "../config/next-config.js";
-import { appRouter, matchAppRoute } from "../routing/app-router.js";
+import {
+  appRouteHasMainTreeLoadingBoundary,
+  appRouter,
+  matchAppRoute,
+} from "../routing/app-router.js";
 import { apiRouter, matchRoute, pagesRouter } from "../routing/pages-router.js";
 import { normalizeStaticPathsEntry, type StaticPathsEntry } from "../routing/route-pattern.js";
 import {
@@ -171,18 +175,6 @@ function resolveConfiguredRouteDirs(
 function appRouteMayHaveGenerateStaticParams(route: Awaited<ReturnType<typeof appRouter>>[number]) {
   if (fileHasNamedExport(route.pagePath, "generateStaticParams")) return true;
   return route.layouts.some((layoutPath) => fileHasNamedExport(layoutPath, "generateStaticParams"));
-}
-
-function appRouteHasMainTreeLoadingBoundary(
-  route: Awaited<ReturnType<typeof appRouter>>[number],
-): boolean {
-  return (
-    route.loadingPath != null ||
-    (route.loadingPaths?.some(
-      (_loadingPath, index) => (route.loadingTreePositions?.[index] ?? 0) > 0,
-    ) ??
-      false)
-  );
 }
 
 async function shouldStartPathDiscoveryServer(options: {

--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -528,6 +528,7 @@ export type StaticParamsMap = Record<
 export async function resolveParentParams(
   childRoute: AppRoute,
   staticParamsMap: StaticParamsMap,
+  options: { includeLastDynamicSegment?: boolean } = {},
 ): Promise<Record<string, string | string[]>[]> {
   const { patternParts } = childRoute;
 
@@ -549,7 +550,8 @@ export async function resolveParentParams(
   const parentSegments: GenerateStaticParamsFn[] = [];
 
   let prefixPattern = "";
-  for (let i = 0; i < lastDynamicIdx; i++) {
+  const prefixEnd = options.includeLastDynamicSegment ? lastDynamicIdx + 1 : lastDynamicIdx;
+  for (let i = 0; i < prefixEnd; i++) {
     const part = patternParts[i];
     prefixPattern += "/" + part;
     if (!part.startsWith(":")) continue;

--- a/packages/vinext/src/cache/cache-adapters-virtual.ts
+++ b/packages/vinext/src/cache/cache-adapters-virtual.ts
@@ -25,6 +25,15 @@ import { flattenPluginOptions } from "../utils/plugin-options.js";
  */
 export type CdnCacheAdapterCapabilities = {
   /**
+   * Page responses include the current application build identity in the
+   * framework-owned `X-Vinext-Build-Id` response header, including responses
+   * that are ultimately marked non-cacheable.
+   *
+   * Deploy adapters use this guarantee to distinguish the newly uploaded
+   * Worker from an older version while staged traffic is propagating.
+   */
+  buildIdentity?: "response-header";
+  /**
    * The shared cache selects response variants using every request header
    * named by `Vary`, comparing the header values verbatim.
    *
@@ -48,6 +57,10 @@ export type CacheAdapterDescriptor<O extends Record<string, unknown> = Record<st
 
 export function hasVerbatimResponseVary(cache?: VinextCacheConfig | null): boolean {
   return cache?.cdn?.capabilities?.responseVary === "verbatim";
+}
+
+export function hasBuildIdentityResponseHeader(cache?: VinextCacheConfig | null): boolean {
+  return cache?.cdn?.capabilities?.buildIdentity === "response-header";
 }
 
 /**

--- a/packages/vinext/src/client/vinext-next-data.ts
+++ b/packages/vinext/src/client/vinext-next-data.ts
@@ -10,6 +10,8 @@ import { isUnknownRecord } from "../utils/record.js";
 
 export type VinextLinkPrefetchRoute = {
   canPrefetchLoadingShell: boolean;
+  /** The loading shell is an ordinary main-tree variant shared with deploy warmup. */
+  canUseCanonicalLoadingShell?: true;
   documentOnly?: boolean;
   isDynamic: boolean;
   patternParts: string[];

--- a/packages/vinext/src/config/prerender.ts
+++ b/packages/vinext/src/config/prerender.ts
@@ -3,6 +3,7 @@ import { flattenPluginOptions } from "../utils/plugin-options.js";
 import { isUnknownRecord } from "../utils/record.js";
 export {
   findVinextCacheConfigInPlugins,
+  hasBuildIdentityResponseHeader,
   hasVerbatimResponseVary,
   loadVinextCacheConfigFromViteConfig,
   VINEXT_CACHE_CONFIG_PLUGIN_PROPERTY,

--- a/packages/vinext/src/entries/app-browser-entry.ts
+++ b/packages/vinext/src/entries/app-browser-entry.ts
@@ -4,7 +4,7 @@ import type {
   VinextPagesLinkPrefetchRoute,
 } from "../client/vinext-next-data.js";
 import { toClientRewrites } from "../client/client-rewrites.js";
-import type { AppRoute } from "../routing/app-router.js";
+import { appRouteHasMainTreeLoadingBoundary, type AppRoute } from "../routing/app-router.js";
 import { patternsStructurallyEquivalent, type RouteManifest } from "../routing/app-route-graph.js";
 import type { NextRewrite } from "../config/next-config.js";
 
@@ -117,6 +117,9 @@ export function toLinkPrefetchRoute(
 ): VinextLinkPrefetchRoute {
   return {
     canPrefetchLoadingShell: hasLoadingBoundary(route, hasSiblingInterceptLoading),
+    ...(appRouteHasMainTreeLoadingBoundary(route)
+      ? { canUseCanonicalLoadingShell: true as const }
+      : {}),
     patternParts: [...route.patternParts],
     isDynamic: route.isDynamic,
     ...(requiresDynamicNavigationRequest(route) ? { requiresDynamicNavigationRequest: true } : {}),

--- a/packages/vinext/src/entries/app-browser-entry.ts
+++ b/packages/vinext/src/entries/app-browser-entry.ts
@@ -24,6 +24,7 @@ export function generateBrowserEntry(
     beforeFiles: [],
     fallback: [],
   },
+  locales: readonly string[] = [],
 ): string {
   const entryPath = resolveRuntimeEntryModule("app-browser-entry");
   const reactInstanceBootstrapPath = resolveClientRuntimeModule("react-instance-bootstrap");
@@ -41,6 +42,7 @@ window.__VINEXT_LINK_PREFETCH_ROUTES__ = ${JSON.stringify(prefetchRoutes)};
 // the same — whichever entry runs first emits both globals).
 window.__VINEXT_PAGES_LINK_PREFETCH_ROUTES__ = ${JSON.stringify(pagesPrefetchRoutes)};
 window.__VINEXT_CLIENT_REWRITES__ = ${JSON.stringify(clientRewrites)};
+window.__VINEXT_LOCALES__ = ${JSON.stringify(locales)};
 registerNavigationRuntimeBootstrap({
     routeManifest: ${buildRouteManifestExpression(routeManifest)}
 });

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -4098,6 +4098,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               graph.routeManifest,
               pagesPrefetchRoutes,
               nextConfig.rewrites,
+              nextConfig.i18n?.locales,
             );
           }
           if (id === RESOLVED_APP_CAPABILITIES && hasAppDir) {

--- a/packages/vinext/src/routing/app-router.ts
+++ b/packages/vinext/src/routing/app-router.ts
@@ -92,6 +92,17 @@ export async function appRouter(
   return graph.routes;
 }
 
+/** Whether the route's ordinary main tree has a loading boundary unique to it. */
+export function appRouteHasMainTreeLoadingBoundary(route: AppRoute): boolean {
+  return (
+    route.loadingPath != null ||
+    (route.loadingPaths?.some(
+      (_loadingPath, index) => (route.loadingTreePositions?.[index] ?? 0) > 0,
+    ) ??
+      false)
+  );
+}
+
 // Trie cache — keyed by route array identity (same array = same trie)
 const appTrieCache = createRouteTrieCache<AppRoute>();
 

--- a/packages/vinext/src/server/app-router-entry.ts
+++ b/packages/vinext/src/server/app-router-entry.ts
@@ -32,6 +32,7 @@ import rscHandler, {
 import { runWithExecutionContext, type ExecutionContextLike } from "vinext/shims/request-context";
 // @ts-expect-error -- virtual module resolved by vinext at build time
 import { registerConfiguredCacheAdapters } from "virtual:vinext-cache-adapters";
+import { applyCdnResponseIdentityHeaders } from "./cache-control.js";
 // @ts-expect-error -- virtual module resolved by vinext at build time
 import { registerConfiguredImageOptimizer } from "virtual:vinext-image-adapters";
 import {
@@ -82,7 +83,7 @@ export default {
     env?: WorkerAssetEnv,
     ctx?: ExecutionContextLike,
   ): Promise<Response> {
-    return handleRequest(request, env, ctx);
+    return applyCdnResponseIdentityHeaders(await handleRequest(request, env, ctx), request);
   },
 };
 

--- a/packages/vinext/src/server/cache-control.ts
+++ b/packages/vinext/src/server/cache-control.ts
@@ -75,6 +75,36 @@ export function applyCdnResponseHeaders(headers: Headers, input: CdnCacheableHea
   }
 }
 
+/** Apply adapter-owned build identity to an HTML or RSC page response. */
+export function applyCdnResponseIdentityHeaders(response: Response, request: Request): Response {
+  const accept = request.headers.get("Accept")?.toLowerCase() ?? "";
+  if (request.headers.get("RSC") !== "1" && !accept.includes("text/html")) return response;
+  const map = getCdnCacheAdapter().buildResponseIdentityHeaders?.();
+  if (!map || Object.keys(map).length === 0) return response;
+
+  try {
+    applyResponseHeaderMap(response.headers, map);
+    return response;
+  } catch {
+    // Response.redirect() has immutable headers. Recreate only those responses
+    // that need adapter identity so the outer runtime boundary can stamp them.
+    const headers = new Headers(response.headers);
+    applyResponseHeaderMap(headers, map);
+    return new Response(response.body, {
+      headers,
+      status: response.status,
+      statusText: response.statusText,
+    });
+  }
+}
+
+function applyResponseHeaderMap(headers: Headers, map: Record<string, string | null>): void {
+  for (const [name, value] of Object.entries(map)) {
+    if (value === null) headers.delete(name);
+    else headers.set(name, value);
+  }
+}
+
 /**
  * Matches Next.js's `getCacheControlHeader` stale window semantics while
  * preserving vinext's legacy unbounded SWR header when no expire ceiling is

--- a/packages/vinext/src/server/pages-router-entry.ts
+++ b/packages/vinext/src/server/pages-router-entry.ts
@@ -43,6 +43,7 @@ import { normalizePathnameForRouteMatchStrict } from "../routing/utils.js";
 
 // @ts-expect-error -- virtual module resolved by vinext at build time
 import { registerConfiguredCacheAdapters } from "virtual:vinext-cache-adapters";
+import { applyCdnResponseIdentityHeaders } from "./cache-control.js";
 // @ts-expect-error -- virtual module resolved by vinext at build time
 import { registerConfiguredImageOptimizer } from "virtual:vinext-image-adapters";
 // @ts-expect-error -- virtual module resolved by vinext at build time
@@ -102,7 +103,7 @@ export default {
     env?: PagesWorkerEnv,
     ctx?: PagesWorkerExecutionContext,
   ): Promise<Response> {
-    return handleRequest(request, env, ctx);
+    return applyCdnResponseIdentityHeaders(await handleRequest(request, env, ctx), request);
   },
 };
 

--- a/packages/vinext/src/shims/cdn-cache.ts
+++ b/packages/vinext/src/shims/cdn-cache.ts
@@ -61,8 +61,6 @@ export type CdnCacheableHeaderInput = {
   tags?: readonly string[];
 };
 
-const NON_CACHEABLE_CACHE_DIRECTIVES = new Set(["private", "no-store", "no-cache"]);
-
 /** Whether a Cache-Control value contains an exact non-cacheable directive. */
 export function isNonCacheableCacheControl(cacheControl: string): boolean {
   let start = 0;
@@ -75,7 +73,9 @@ export function isNonCacheableCacheControl(cacheControl: string): boolean {
       const directive = cacheControl.slice(start, index);
       const equals = directive.indexOf("=");
       const name = (equals === -1 ? directive : directive.slice(0, equals)).trim().toLowerCase();
-      if (NON_CACHEABLE_CACHE_DIRECTIVES.has(name)) return true;
+      if (name === "no-store" || (equals === -1 && (name === "private" || name === "no-cache"))) {
+        return true;
+      }
       start = index + 1;
       continue;
     }

--- a/packages/vinext/src/shims/cdn-cache.ts
+++ b/packages/vinext/src/shims/cdn-cache.ts
@@ -131,6 +131,13 @@ export type CdnCacheAdapter = {
   buildResponseHeaders(input: CdnCacheableHeaderInput): CdnResponseHeaders;
 
   /**
+   * Build adapter-owned headers that identify the deployed application build.
+   * Core applies these at the outer page-response boundary, including response
+   * paths that do not pass through cache-policy finalization.
+   */
+  buildResponseIdentityHeaders?(): CdnResponseHeaders;
+
+  /**
    * Whether existing response headers explicitly opt out of storage. Adapters
    * that split browser and provider cache policy should implement this so they
    * can interpret the provider-specific headers they own.

--- a/packages/vinext/src/shims/internal/app-prefetch-rsc-request.ts
+++ b/packages/vinext/src/shims/internal/app-prefetch-rsc-request.ts
@@ -6,6 +6,7 @@ import {
 } from "../../server/app-rsc-cache-busting.js";
 
 export type ResolveAppPrefetchRscRequestOptions = {
+  canUseCanonicalLoadingShell: boolean;
   fullHref: string;
   headers: Headers;
   interceptionContext: string | null;
@@ -28,6 +29,7 @@ export type ResolvedAppPrefetchRscRequest = {
  * their varying headers and deterministic `_rsc` digest.
  */
 export async function resolveAppPrefetchRscRequest({
+  canUseCanonicalLoadingShell,
   fullHref,
   headers,
   interceptionContext,
@@ -44,7 +46,9 @@ export async function resolveAppPrefetchRscRequest({
     !requiresRouteTreePrefetch &&
     !prefetchInlining;
   const usesCanonicalLoadingShell =
-    canUseCanonicalSharedRequest && canonicalizeLoadingShellRscRequestHeaders(headers);
+    canUseCanonicalSharedRequest &&
+    canUseCanonicalLoadingShell &&
+    canonicalizeLoadingShellRscRequestHeaders(headers);
   const usesCanonicalFullRoute =
     canUseCanonicalSharedRequest &&
     !usesCanonicalLoadingShell &&

--- a/packages/vinext/src/shims/internal/app-route-prefetch-policy.ts
+++ b/packages/vinext/src/shims/internal/app-route-prefetch-policy.ts
@@ -35,6 +35,8 @@ const ENCODED_PATH_DELIMITER_RE = /%(?:2f|5c)/i;
  */
 export type AppRoutePrefetchPolicy = {
   cacheForNavigation: boolean;
+  /** The selected loading shell has the canonical deploy-warmed identity. */
+  canUseCanonicalLoadingShell?: true;
   /**
    * How the dynamic stale-time signal affects this prefetch. Navigation data
    * takes it verbatim, explicit full prefetches fall back to the static window
@@ -125,6 +127,9 @@ export function resolveAutoAppRoutePrefetch(href: string): AppRoutePrefetchPolic
     // fallbacks can be cached for navigation unless their active parallel
     // branches must be derived from the click-time target tree.
     cacheForNavigation,
+    ...(route.canUseCanonicalLoadingShell === true
+      ? { canUseCanonicalLoadingShell: true as const }
+      : {}),
     dynamicStaleTime: cacheForNavigation ? "verbatim" : "ignore",
     fallbackTtl: "static",
     prefetchShellFirst: requiresRouteTreePrefetch || hasSearchParams || !route.isDynamic,

--- a/packages/vinext/src/shims/internal/hybrid-client-route-owner-direct.ts
+++ b/packages/vinext/src/shims/internal/hybrid-client-route-owner-direct.ts
@@ -71,8 +71,8 @@ function resolveSameOriginPathnames(
   };
 }
 
-export function resolveSameOriginPathname(href: string, basePath: string): string | null {
-  return resolveSameOriginPathnames(href, basePath)?.pagesPathname ?? null;
+export function resolveSameOriginAppPathname(href: string, basePath: string): string | null {
+  return resolveSameOriginPathnames(href, basePath)?.appPathname ?? null;
 }
 
 function selectPagesRoutes(

--- a/packages/vinext/src/shims/internal/hybrid-client-route-owner-direct.ts
+++ b/packages/vinext/src/shims/internal/hybrid-client-route-owner-direct.ts
@@ -31,12 +31,23 @@ declare global {
 
 const appRouteTrieCache = createRouteTrieCache<VinextLinkPrefetchRoute>();
 const pagesRouteTrieCache = createRouteTrieCache<VinextPagesLinkPrefetchRoute>();
+const pagesPageRoutesCache = new WeakMap<
+  VinextPagesLinkPrefetchRoute[],
+  VinextPagesLinkPrefetchRoute[]
+>();
+const pagesApiRoutesCache = new WeakMap<
+  VinextPagesLinkPrefetchRoute[],
+  VinextPagesLinkPrefetchRoute[]
+>();
 
 function patternFromParts(parts: readonly string[]): string {
   return "/" + parts.join("/");
 }
 
-export function resolveSameOriginPathname(href: string, basePath: string): string | null {
+function resolveSameOriginPathnames(
+  href: string,
+  basePath: string,
+): { appPathname: string; pagesApiRequest: boolean; pagesPathname: string } | null {
   if (typeof window === "undefined") return null;
   let url: URL;
   try {
@@ -45,28 +56,57 @@ export function resolveSameOriginPathname(href: string, basePath: string): strin
     return null;
   }
   if (url.origin !== window.location.origin) return null;
-  const pathname = stripBasePath(url.pathname, basePath);
-  const locale = getLocalePathPrefix(pathname, window.__VINEXT_LOCALES__);
-  if (!locale) return pathname;
-  const localePrefixLength = locale.length + 1;
-  return pathname.length === localePrefixLength ? "/" : pathname.slice(localePrefixLength);
+  const appPathname = stripBasePath(url.pathname, basePath);
+  const locale = getLocalePathPrefix(appPathname, window.__VINEXT_LOCALES__);
+  const localePrefixLength = locale ? locale.length + 1 : 0;
+  const pagesPathname = !locale
+    ? appPathname
+    : appPathname.length === localePrefixLength
+      ? "/"
+      : appPathname.slice(localePrefixLength);
+  return {
+    appPathname,
+    pagesApiRequest: appPathname === "/api" || appPathname.startsWith("/api/"),
+    pagesPathname,
+  };
+}
+
+export function resolveSameOriginPathname(href: string, basePath: string): string | null {
+  return resolveSameOriginPathnames(href, basePath)?.pagesPathname ?? null;
+}
+
+function selectPagesRoutes(
+  routes: VinextPagesLinkPrefetchRoute[],
+  apiRequest: boolean,
+): VinextPagesLinkPrefetchRoute[] {
+  const cache = apiRequest ? pagesApiRoutesCache : pagesPageRoutesCache;
+  let selected = cache.get(routes);
+  if (!selected) {
+    selected = routes.filter((route) => Boolean(route.documentOnly) === apiRequest);
+    cache.set(routes, selected);
+  }
+  return selected;
 }
 
 export function matchDirectHybridClientRoutes(
   href: string,
   basePath: string,
 ): HybridClientRouteMatches {
-  const pathname = resolveSameOriginPathname(href, basePath);
-  if (pathname === null) return { appMatch: null, pagesMatch: null };
+  const pathnames = resolveSameOriginPathnames(href, basePath);
+  if (pathnames === null) return { appMatch: null, pagesMatch: null };
 
   const appRoutes = window.__VINEXT_LINK_PREFETCH_ROUTES__;
   const pagesRoutes = window.__VINEXT_PAGES_LINK_PREFETCH_ROUTES__;
   return {
     appMatch: appRoutes
-      ? (matchRouteWithTrie(pathname, appRoutes, appRouteTrieCache)?.route ?? null)
+      ? (matchRouteWithTrie(pathnames.appPathname, appRoutes, appRouteTrieCache)?.route ?? null)
       : null,
     pagesMatch: pagesRoutes
-      ? (matchRouteWithTrie(pathname, pagesRoutes, pagesRouteTrieCache)?.route ?? null)
+      ? (matchRouteWithTrie(
+          pathnames.pagesPathname,
+          selectPagesRoutes(pagesRoutes, pathnames.pagesApiRequest),
+          pagesRouteTrieCache,
+        )?.route ?? null)
       : null,
   };
 }

--- a/packages/vinext/src/shims/internal/hybrid-client-route-owner.ts
+++ b/packages/vinext/src/shims/internal/hybrid-client-route-owner.ts
@@ -20,7 +20,7 @@ import type { ClientRewrite } from "../../client/client-rewrites.js";
 import { mergeRewriteQuery } from "../../utils/query.js";
 import {
   matchDirectHybridClientRoutes,
-  resolveSameOriginPathname,
+  resolveSameOriginAppPathname,
   resolveMatchedHybridClientRouteOwner,
   type HybridClientOwner,
 } from "./hybrid-client-route-owner-direct.js";
@@ -44,7 +44,7 @@ function resolveClientRewrite(
   let matched = false;
 
   for (const rewrite of rewrites) {
-    const pathname = resolveSameOriginPathname(currentHref, basePath);
+    const pathname = resolveSameOriginAppPathname(currentHref, basePath);
     if (pathname === null) return null;
     const url = new URL(currentHref, window.location.href);
     const headers = new Headers({ "user-agent": globalThis.navigator?.userAgent ?? "" });

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -534,6 +534,7 @@ function prefetchUrl(
         }
         const { additionalRscUrls, rscUrl, usesCanonicalPrewarmedRequest } =
           await resolveAppPrefetchRscRequest({
+            canUseCanonicalLoadingShell: autoPrefetch.canUseCanonicalLoadingShell === true,
             fullHref,
             headers,
             interceptionContext,

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -2935,6 +2935,7 @@ const _appRouter: AppRouterInstance = {
       }
       const { additionalRscUrls, rscUrl, usesCanonicalPrewarmedRequest } =
         await resolveAppPrefetchRscRequest({
+          canUseCanonicalLoadingShell: policy.canUseCanonicalLoadingShell === true,
           fullHref,
           headers,
           interceptionContext,

--- a/tests/app-prefetch-rsc-request.test.ts
+++ b/tests/app-prefetch-rsc-request.test.ts
@@ -11,6 +11,7 @@ import {
 import { resolveAppPrefetchRscRequest } from "../packages/vinext/src/shims/internal/app-prefetch-rsc-request.js";
 
 const DEFAULT_OPTIONS = {
+  canUseCanonicalLoadingShell: true,
   interceptionContext: null,
   mountedSlotsHeader: null,
   prefetchInlining: false,
@@ -88,6 +89,32 @@ describe("shared App Router prefetch RSC request resolution", () => {
     expect(headers.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER)).toBe("1");
     expect(headers.get("next-router-state-tree")).toBeNull();
     expect(headers.get("next-url")).toBeNull();
+  });
+
+  it("keeps non-main-tree loading shells contextual", async () => {
+    vi.stubEnv("__VINEXT_CANONICAL_RSC_REQUESTS", "1");
+    const headers = createRscRequestHeaders({
+      nextUrl: "/source",
+      prefetchRouterState: { pathAndSearch: "/source", routeId: "route:/source" },
+      renderMode: APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
+    });
+    headers.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "1");
+    const expectedUrl = await createRscRequestUrl("/parallel", new Headers(headers));
+
+    const resolved = await resolveAppPrefetchRscRequest({
+      ...DEFAULT_OPTIONS,
+      canUseCanonicalLoadingShell: false,
+      fullHref: "/parallel",
+      headers,
+    });
+
+    expect(resolved).toEqual({
+      additionalRscUrls: [],
+      rscUrl: expectedUrl,
+      usesCanonicalPrewarmedRequest: false,
+    });
+    expect(headers.get("next-url")).toBe("/source");
+    expect(new URL(expectedUrl, "http://vinext.local").searchParams.get("_rsc")).not.toBe("");
   });
 
   it.each(CONTEXTUAL_CASES)("keeps the request contextual when %s", async (_label, overrides) => {

--- a/tests/app-rsc-response-finalizer.test.ts
+++ b/tests/app-rsc-response-finalizer.test.ts
@@ -48,6 +48,20 @@ describe("finalizeAppRscResponse — config header application", () => {
     },
   );
 
+  it("does not collapse field-qualified cache directives to no-store", async () => {
+    const cacheControl = 'public, max-age=60, private="set-cookie", no-cache="set-cookie"';
+    const response = new Response("body", { headers: { "Cache-Control": cacheControl } });
+
+    await finalizeAppRscResponse(response, new Request("http://example.com/about"), {
+      basePath: "",
+      configHeaders: [],
+      i18nConfig: null,
+      requestContext: makeRequestContext(),
+    });
+
+    expect(response.headers.get("cache-control")).toBe(cacheControl);
+  });
+
   it("normalizes an adapter-owned cache opt-out after response headers are finalized", async () => {
     const adapter: CdnCacheAdapter = {
       ownsBackgroundRevalidation: false,

--- a/tests/cache-adapters-config.test.ts
+++ b/tests/cache-adapters-config.test.ts
@@ -16,6 +16,7 @@ import {
   findVinextCacheConfigInPlugins,
   loadVinextCacheConfigFromViteConfig,
   generateCacheAdaptersModule,
+  hasBuildIdentityResponseHeader,
   hasVerbatimResponseVary,
   VINEXT_CACHE_CONFIG_PLUGIN_PROPERTY,
   VIRTUAL_CACHE_ADAPTERS,
@@ -277,8 +278,13 @@ describe("cdnAdapter builder + factory", () => {
     expect(path.isAbsolute(descriptor.adapter)).toBe(true);
     expect(descriptor.adapter.endsWith("cdn-adapter.runtime.js")).toBe(true);
     expect(descriptor.options).toBeUndefined();
-    expect(descriptor.capabilities).toEqual({ responseVary: "verbatim" });
+    expect(descriptor.capabilities).toEqual({
+      buildIdentity: "response-header",
+      responseVary: "verbatim",
+    });
+    expect(hasBuildIdentityResponseHeader({ cdn: descriptor })).toBe(true);
     expect(hasVerbatimResponseVary({ cdn: descriptor })).toBe(true);
+    expect(hasBuildIdentityResponseHeader({ cdn: { adapter: "custom-cache" } })).toBe(false);
     expect(hasVerbatimResponseVary({ cdn: { adapter: "url-only-cache" } })).toBe(false);
   });
 

--- a/tests/cache-control.test.ts
+++ b/tests/cache-control.test.ts
@@ -197,6 +197,21 @@ describe("applyCdnResponseHeaders", () => {
     ).toBe(false);
   });
 
+  it("keeps field-qualified private and no-cache policies cacheable", () => {
+    expect(
+      hasExplicitNonCacheableResponsePolicy(
+        new Headers({
+          "Cache-Control": 'public, max-age=60, private="set-cookie", no-cache="set-cookie"',
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      hasExplicitNonCacheableResponsePolicy(
+        new Headers({ "Cache-Control": 'private="set-cookie", no-store' }),
+      ),
+    ).toBe(true);
+  });
+
   it("delegates provider-specific policy interpretation to the active adapter", () => {
     const edge: CdnCacheAdapter = {
       ownsBackgroundRevalidation: false,

--- a/tests/cloudflare-cdn-cache.test.ts
+++ b/tests/cloudflare-cdn-cache.test.ts
@@ -85,13 +85,14 @@ describe("CloudflareCdnCacheAdapter", () => {
   });
 
   it("stamps the application build identity on cacheable and no-store responses", () => {
-    vi.stubEnv("__VINEXT_BUILD_ID", "build-a");
+    vi.stubEnv("__VINEXT_BUILD_ID", "pinned-build");
+    vi.stubEnv("__VINEXT_RSC_BUILD_IDENTITY", "instance-a");
 
     expect(adapter.buildResponseHeaders({ cacheControl: "s-maxage=60" })).toMatchObject({
-      [VINEXT_CDN_BUILD_ID_HEADER]: "build-a",
+      [VINEXT_CDN_BUILD_ID_HEADER]: "instance-a",
     });
     expect(adapter.buildResponseHeaders({ cacheControl: "no-store" })).toMatchObject({
-      [VINEXT_CDN_BUILD_ID_HEADER]: "build-a",
+      [VINEXT_CDN_BUILD_ID_HEADER]: "instance-a",
     });
   });
 

--- a/tests/cloudflare-cdn-cache.test.ts
+++ b/tests/cloudflare-cdn-cache.test.ts
@@ -21,6 +21,7 @@ import {
   finalizeAppPageRscCacheResponse,
 } from "../packages/vinext/src/server/app-page-cache-finalizer.js";
 import { finalizeAppRscResponse } from "../packages/vinext/src/server/app-rsc-response-finalizer.js";
+import { applyCdnResponseIdentityHeaders } from "../packages/vinext/src/server/cache-control.js";
 import type { RequestContext } from "../packages/vinext/src/config/request-context.js";
 import { VINEXT_CDN_BUILD_ID_HEADER } from "../packages/cloudflare/src/cache/cdn-build-id.js";
 
@@ -92,6 +93,20 @@ describe("CloudflareCdnCacheAdapter", () => {
     expect(adapter.buildResponseHeaders({ cacheControl: "no-store" })).toMatchObject({
       [VINEXT_CDN_BUILD_ID_HEADER]: "build-a",
     });
+  });
+
+  it("stamps build identity at the outer response boundary, including redirects", () => {
+    vi.stubEnv("__VINEXT_BUILD_ID", "build-a");
+    setCdnCacheAdapter(adapter);
+
+    const response = applyCdnResponseIdentityHeaders(
+      Response.redirect("https://example.com/target", 307),
+      new Request("https://example.com/source", { headers: { Accept: "text/html" } }),
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe("https://example.com/target");
+    expect(response.headers.get(VINEXT_CDN_BUILD_ID_HEADER)).toBe("build-a");
   });
 
   it("get returns null so the origin always renders fresh", async () => {

--- a/tests/cloudflare-cdn-cache.test.ts
+++ b/tests/cloudflare-cdn-cache.test.ts
@@ -22,6 +22,7 @@ import {
 } from "../packages/vinext/src/server/app-page-cache-finalizer.js";
 import { finalizeAppRscResponse } from "../packages/vinext/src/server/app-rsc-response-finalizer.js";
 import type { RequestContext } from "../packages/vinext/src/config/request-context.js";
+import { VINEXT_CDN_BUILD_ID_HEADER } from "../packages/cloudflare/src/cache/cdn-build-id.js";
 
 const CDN_KEY = Symbol.for("vinext.cdnCacheAdapter");
 
@@ -68,7 +69,10 @@ function finalizePendingDynamicRscResponse(): Response {
 }
 
 beforeEach(resetActiveAdapter);
-afterEach(resetActiveAdapter);
+afterEach(() => {
+  resetActiveAdapter();
+  vi.unstubAllEnvs();
+});
 
 // ─── Adapter behavior ────────────────────────────────────────────────────
 
@@ -77,6 +81,17 @@ describe("CloudflareCdnCacheAdapter", () => {
 
   it("does not own background revalidation (the edge re-requests origin)", () => {
     expect(adapter.ownsBackgroundRevalidation).toBe(false);
+  });
+
+  it("stamps the application build identity on cacheable and no-store responses", () => {
+    vi.stubEnv("__VINEXT_BUILD_ID", "build-a");
+
+    expect(adapter.buildResponseHeaders({ cacheControl: "s-maxage=60" })).toMatchObject({
+      [VINEXT_CDN_BUILD_ID_HEADER]: "build-a",
+    });
+    expect(adapter.buildResponseHeaders({ cacheControl: "no-store" })).toMatchObject({
+      [VINEXT_CDN_BUILD_ID_HEADER]: "build-a",
+    });
   });
 
   it("get returns null so the origin always renders fresh", async () => {

--- a/tests/cloudflare-cdn-warm-deploy.test.ts
+++ b/tests/cloudflare-cdn-warm-deploy.test.ts
@@ -51,6 +51,19 @@ function cacheableHtml(body = "ok"): Response {
   });
 }
 
+function cacheableRsc(body = "flight"): Response {
+  return new Response(body, {
+    headers: {
+      "cache-control": "public, max-age=0, must-revalidate",
+      "cdn-cache-control": "public, max-age=60",
+      "cf-cache-status": "MISS",
+      "content-type": "text/x-component",
+      [VINEXT_RSC_BUILD_ID_HEADER]: "app-build-a",
+      vary: VINEXT_RSC_VARY_HEADER,
+    },
+  });
+}
+
 describe("Cloudflare CDN warmup deploy flow", () => {
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-cdn-warm-deploy-test-"));
@@ -65,6 +78,18 @@ describe("Cloudflare CDN warmup deploy flow", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("recognizes warm plans that contain only canonical RSC requests", async () => {
+    const { hasCdnWarmRequests } = await import("../packages/cloudflare/src/deploy.js");
+
+    expect(hasCdnWarmRequests({ loadingShellPaths: [], paths: [], rscPaths: ["/dashboard"] })).toBe(
+      true,
+    );
+    expect(hasCdnWarmRequests({ loadingShellPaths: ["/dashboard"], paths: [], rscPaths: [] })).toBe(
+      true,
+    );
+    expect(hasCdnWarmRequests({ loadingShellPaths: [], paths: [], rscPaths: [] })).toBe(false);
   });
 
   it("warms the production custom domain through a 0% staged version override", async () => {
@@ -454,7 +479,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     ).toBe("https://my-worker-staging.example.workers.dev");
   });
 
-  it("defers unverifiable HTML warmup until after promotion", async () => {
+  it("skips unverifiable HTML warmup for adapters without build identity", async () => {
     const events: string[] = [];
     writeFile(
       "wrangler.jsonc",
@@ -493,16 +518,8 @@ describe("Cloudflare CDN warmup deploy flow", () => {
 
     await deployWithCdnWarmup(tmpDir, ["/about"], { warmCdnConcurrency: 1 });
 
-    expect(events).toEqual([
-      "upload",
-      "status",
-      "stage",
-      "triggers",
-      "promote",
-      "fetch:https://app.example.com/about",
-    ]);
-    const requestHeaders = new Headers(vi.mocked(fetch).mock.calls[0]![1]?.headers);
-    expect(requestHeaders.has("Cloudflare-Workers-Version-Overrides")).toBe(false);
+    expect(events).toEqual(["upload", "status", "stage", "triggers", "promote"]);
+    expect(fetch).not.toHaveBeenCalled();
   });
 
   it("applies triggers before post-promotion fallback warmup", async () => {
@@ -516,7 +533,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     );
     vi.mocked(fetch).mockImplementation(async (url) => {
       events.push(`fetch:${formatFetchUrl(url)}`);
-      return cacheableHtml();
+      return cacheableRsc();
     });
     execFileSyncMock.mockImplementation((_file: string, args: string[]) => {
       if (args.includes("upload")) {
@@ -545,6 +562,8 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     const { deployWithCdnWarmup } = await import("../packages/cloudflare/src/deploy.js");
 
     await deployWithCdnWarmup(tmpDir, ["/"], {
+      expectedRscBuildId: "app-build-a",
+      rscPaths: ["/"],
       warmCdnConcurrency: 1,
     });
 
@@ -553,7 +572,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       "status",
       "promote",
       "triggers",
-      "fetch:https://app.example.com/",
+      "fetch:https://app.example.com/?_rsc",
     ]);
   });
 

--- a/tests/cloudflare-cdn-warm-deploy.test.ts
+++ b/tests/cloudflare-cdn-warm-deploy.test.ts
@@ -589,9 +589,9 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     });
 
     expect(events.slice(0, 4)).toEqual(["upload", "status", "stage", "triggers"]);
-    expect(events.filter((event) => event === "fetch:staged")).toHaveLength(60);
+    expect(events.filter((event) => event === "fetch:staged")).toHaveLength(7);
     expect(events.slice(-2)).toEqual(["promote", "fetch:promoted"]);
-    expect(delayMock).toHaveBeenCalledTimes(59);
+    expect(delayMock).toHaveBeenCalledTimes(6);
     expect(delayMock).toHaveBeenCalledWith(1_000);
   });
 
@@ -831,6 +831,54 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     ]);
     expect(events.filter((event) => event === "readiness")).toHaveLength(6);
     expect(events.filter((event) => event === "delay:1000")).toHaveLength(5);
+  });
+
+  it("fails no-promote deployment when staged readiness cannot be established", async () => {
+    writeFile(
+      "wrangler.jsonc",
+      JSON.stringify({ name: "my-worker", custom_domains: ["app.example.com"] }),
+    );
+    vi.mocked(fetch).mockResolvedValue(
+      new Response("old", {
+        headers: {
+          "cf-cache-status": "MISS",
+          "content-type": "text/html",
+          [VINEXT_CDN_BUILD_ID_HEADER]: "old-build",
+        },
+      }),
+    );
+    execFileSyncMock.mockImplementation((_file: string, args: string[]) => {
+      if (args.includes("upload")) {
+        return "Uploaded my-worker\nWorker Version ID: 22222222-2222-4222-8222-222222222222\n";
+      }
+      if (args.includes("status")) {
+        return JSON.stringify({
+          versions: [{ version_id: "11111111-1111-4111-8111-111111111111", percentage: 100 }],
+        });
+      }
+      if (args.includes("22222222-2222-4222-8222-222222222222@0%")) {
+        return "Staged version\nhttps://app.example.com\n";
+      }
+      if (args.includes("triggers")) {
+        return "Triggers deployed\n  app.example.com (custom domain)\n";
+      }
+      throw new Error(`Unexpected Wrangler args: ${args.join(" ")}`);
+    });
+    const { deployWithCdnWarmup } = await import("../packages/cloudflare/src/deploy.js");
+
+    await expect(
+      deployWithCdnWarmup(tmpDir, ["/about"], {
+        expectedBuildId: "app-build-a",
+        warmCdnPromote: false,
+        warmCdnRetries: 0,
+      }),
+    ).rejects.toThrow("promotion is disabled");
+    expect(fetch).toHaveBeenCalledTimes(6);
+    expect(
+      (execFileSyncMock.mock.calls as Array<[string, string[]]>).some(([, args]) =>
+        args.includes("22222222-2222-4222-8222-222222222222@100%"),
+      ),
+    ).toBe(false);
   });
 
   it("rejects strict HTML warmup without verifiable build identity before upload", async () => {
@@ -1166,12 +1214,11 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
-  it("explains promoted version state when strict fallback warming fails", async () => {
+  it("does not promote strict warmup when the existing deployment cannot be staged", async () => {
     writeFile(
       "wrangler.jsonc",
       JSON.stringify({ name: "my-worker", custom_domains: ["app.example.com"] }),
     );
-    vi.mocked(fetch).mockResolvedValue(new Response("not ready", { status: 500 }));
     execFileSyncMock.mockImplementation((_file: string, args: string[]) => {
       if (args.includes("upload")) {
         return "Uploaded version 22222222-2222-4222-8222-222222222222\n";
@@ -1184,10 +1231,6 @@ describe("Cloudflare CDN warmup deploy flow", () => {
           ],
         });
       }
-      if (args.includes("deploy") && args.includes("22222222-2222-4222-8222-222222222222@100%")) {
-        return "Deployed version\nhttps://stable.example.workers.dev\n";
-      }
-      if (args.includes("triggers")) return "Triggers deployed\n";
       throw new Error(`Unexpected Wrangler args: ${args.join(" ")}`);
     });
     const { deployWithCdnWarmup } = await import("../packages/cloudflare/src/deploy.js");
@@ -1198,10 +1241,12 @@ describe("Cloudflare CDN warmup deploy flow", () => {
         warmCdnRetries: 0,
         warmCdnStrict: true,
       }),
-    ).rejects.toThrow("already promoted to 100% and its Worker triggers/routes were updated");
+    ).rejects.toThrow("cannot stage the uploaded Worker at 0%");
+    expect(execFileSyncMock).toHaveBeenCalledTimes(2);
+    expect(fetch).not.toHaveBeenCalled();
   });
 
-  it("explains promoted version state when strict fallback has no target URL", async () => {
+  it("does not require a target URL before rejecting unstaged strict warmup", async () => {
     writeFile("wrangler.jsonc", JSON.stringify({ name: "my-worker", workers_dev: false }));
     execFileSyncMock.mockImplementation((_file: string, args: string[]) => {
       if (args.includes("upload")) {
@@ -1228,7 +1273,8 @@ describe("Cloudflare CDN warmup deploy flow", () => {
         expectedBuildId: "app-build-a",
         warmCdnStrict: true,
       }),
-    ).rejects.toThrow("already promoted to 100% and its Worker triggers/routes were updated");
+    ).rejects.toThrow("cannot stage the uploaded Worker at 0%");
+    expect(execFileSyncMock).toHaveBeenCalledTimes(2);
     expect(fetch).not.toHaveBeenCalled();
   });
 });

--- a/tests/cloudflare-cdn-warm-deploy.test.ts
+++ b/tests/cloudflare-cdn-warm-deploy.test.ts
@@ -43,7 +43,11 @@ function formatFetchUrl(url: Parameters<typeof fetch>[0]): string {
 
 function cacheableHtml(body = "ok"): Response {
   return new Response(body, {
-    headers: { "cf-cache-status": "MISS", "content-type": "text/html" },
+    headers: {
+      "cf-cache-status": "MISS",
+      "content-type": "text/html",
+      [VINEXT_CDN_BUILD_ID_HEADER]: "app-build-a",
+    },
   });
 }
 
@@ -416,6 +420,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
 
     await deployWithCdnWarmup(tmpDir, ["/"], {
       env: "staging",
+      expectedBuildId: "app-build-a",
       warmCdnConcurrency: 1,
       warmCdnPromotionDelay: 2_500,
     });
@@ -447,6 +452,57 @@ describe("Cloudflare CDN warmup deploy flow", () => {
         env: "staging",
       }),
     ).toBe("https://my-worker-staging.example.workers.dev");
+  });
+
+  it("defers unverifiable HTML warmup until after promotion", async () => {
+    const events: string[] = [];
+    writeFile(
+      "wrangler.jsonc",
+      JSON.stringify({ name: "my-worker", custom_domains: ["app.example.com"] }),
+    );
+    vi.mocked(fetch).mockImplementation(async (url) => {
+      events.push(`fetch:${formatFetchUrl(url)}`);
+      return cacheableHtml();
+    });
+    execFileSyncMock.mockImplementation((_file: string, args: string[]) => {
+      if (args.includes("upload")) {
+        events.push("upload");
+        return "Uploaded version 22222222-2222-4222-8222-222222222222\n";
+      }
+      if (args.includes("status")) {
+        events.push("status");
+        return JSON.stringify({
+          versions: [{ version_id: "11111111-1111-4111-8111-111111111111", percentage: 100 }],
+        });
+      }
+      if (args.includes("deploy") && args.includes("22222222-2222-4222-8222-222222222222@0%")) {
+        events.push("stage");
+        return "Staged version\nhttps://stable.example.workers.dev\n";
+      }
+      if (args.includes("deploy") && args.includes("22222222-2222-4222-8222-222222222222@100%")) {
+        events.push("promote");
+        return "Deployed version\nhttps://stable.example.workers.dev\n";
+      }
+      if (args.includes("triggers")) {
+        events.push("triggers");
+        return "Triggers deployed\n";
+      }
+      throw new Error(`Unexpected Wrangler args: ${args.join(" ")}`);
+    });
+    const { deployWithCdnWarmup } = await import("../packages/cloudflare/src/deploy.js");
+
+    await deployWithCdnWarmup(tmpDir, ["/about"], { warmCdnConcurrency: 1 });
+
+    expect(events).toEqual([
+      "upload",
+      "status",
+      "stage",
+      "triggers",
+      "promote",
+      "fetch:https://app.example.com/about",
+    ]);
+    const requestHeaders = new Headers(vi.mocked(fetch).mock.calls[0]![1]?.headers);
+    expect(requestHeaders.has("Cloudflare-Workers-Version-Overrides")).toBe(false);
   });
 
   it("applies triggers before post-promotion fallback warmup", async () => {
@@ -539,6 +595,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
 
     await expect(
       deployWithCdnWarmup(tmpDir, ["/about"], {
+        expectedBuildId: "app-build-a",
         warmCdnConcurrency: 1,
         warmCdnPromote: false,
       }),
@@ -552,6 +609,39 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       "fetch:https://app.example.com/about",
     ]);
     expect(delayMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects strict HTML warmup without verifiable build identity before upload", async () => {
+    writeFile(
+      "wrangler.jsonc",
+      JSON.stringify({ name: "my-worker", custom_domains: ["app.example.com"] }),
+    );
+    execFileSyncMock.mockImplementation((_file: string, args: string[]) => {
+      if (args.includes("upload")) {
+        return "Uploaded version 22222222-2222-4222-8222-222222222222\n";
+      }
+      if (args.includes("status")) {
+        return JSON.stringify({
+          versions: [{ version_id: "11111111-1111-4111-8111-111111111111", percentage: 100 }],
+        });
+      }
+      if (args.includes("deploy") && args.includes("22222222-2222-4222-8222-222222222222@0%")) {
+        return "Staged version\nhttps://stable.example.workers.dev\n";
+      }
+      if (args.includes("triggers")) return "Triggers deployed\n";
+      throw new Error(`Unexpected Wrangler args: ${args.join(" ")}`);
+    });
+    const { deployWithCdnWarmup } = await import("../packages/cloudflare/src/deploy.js");
+
+    await expect(
+      deployWithCdnWarmup(tmpDir, ["/about"], {
+        warmCdnConcurrency: 1,
+        warmCdnPromote: false,
+        warmCdnStrict: true,
+      }),
+    ).rejects.toThrow("Strict CDN HTML warmup requires a CDN adapter");
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
   });
 
   it("replaces a stale 0% version and uses the triggers URL for pre-promotion warmup", async () => {
@@ -601,6 +691,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     const { deployWithCdnWarmup } = await import("../packages/cloudflare/src/deploy.js");
 
     const url = await deployWithCdnWarmup(tmpDir, ["/cached/intro"], {
+      expectedBuildId: "app-build-a",
       warmCdnConcurrency: 1,
     });
 
@@ -650,6 +741,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     const { deployWithCdnWarmup } = await import("../packages/cloudflare/src/deploy.js");
 
     await deployWithCdnWarmup(tmpDir, ["/"], {
+      expectedBuildId: "app-build-a",
       name: "cli-worker",
       warmCdnConcurrency: 1,
     });
@@ -693,6 +785,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
 
     await expect(
       deployWithCdnWarmup(tmpDir, ["/"], {
+        expectedBuildId: "app-build-a",
         warmCdnConcurrency: 1,
         warmCdnRetries: 0,
         warmCdnStrict: true,
@@ -831,6 +924,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
 
     await expect(
       deployWithCdnWarmup(tmpDir, ["/"], {
+        expectedBuildId: "app-build-a",
         warmCdnRetries: 0,
         warmCdnStrict: true,
       }),
@@ -859,9 +953,12 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     });
     const { deployWithCdnWarmup } = await import("../packages/cloudflare/src/deploy.js");
 
-    await expect(deployWithCdnWarmup(tmpDir, ["/"], { warmCdnStrict: true })).rejects.toThrow(
-      "already promoted to 100% and its Worker triggers/routes were updated",
-    );
+    await expect(
+      deployWithCdnWarmup(tmpDir, ["/"], {
+        expectedBuildId: "app-build-a",
+        warmCdnStrict: true,
+      }),
+    ).rejects.toThrow("already promoted to 100% and its Worker triggers/routes were updated");
     expect(fetch).not.toHaveBeenCalled();
   });
 });

--- a/tests/cloudflare-cdn-warm-deploy.test.ts
+++ b/tests/cloudflare-cdn-warm-deploy.test.ts
@@ -92,6 +92,29 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     expect(hasCdnWarmRequests({ loadingShellPaths: [], paths: [], rscPaths: [] })).toBe(false);
   });
 
+  it("does not promote when deployment status cannot be read", async () => {
+    writeFile("wrangler.jsonc", JSON.stringify({ name: "my-worker" }));
+    execFileSyncMock.mockImplementation((_file: string, args: string[]) => {
+      if (args.includes("upload")) {
+        return "Uploaded my-worker (1.23 sec)\nWorker Version ID: 22222222-2222-4222-8222-222222222222\n";
+      }
+      if (args.includes("status")) {
+        throw new Error("deployment status unavailable");
+      }
+      throw new Error(`Unexpected Wrangler args: ${args.join(" ")}`);
+    });
+    const { deployWithCdnWarmup } = await import("../packages/cloudflare/src/deploy.js");
+
+    await expect(
+      deployWithCdnWarmup(tmpDir, ["/"], {
+        expectedBuildId: "app-build-a",
+        warmCdnStrict: true,
+      }),
+    ).rejects.toThrow("deployment status unavailable");
+    expect(execFileSyncMock).toHaveBeenCalledTimes(2);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it("warms the production custom domain through a 0% staged version override", async () => {
     const events: string[] = [];
     delayMock.mockImplementation(async (milliseconds: number) => {
@@ -836,6 +859,48 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     for (const [, args] of execFileSyncMock.mock.calls as Array<[string, string[]]>) {
       expect(args).toEqual(expect.arrayContaining(["--name", "cli-worker"]));
     }
+  });
+
+  it("uses Wrangler's uploaded Worker name for a TOML config", async () => {
+    writeFile(
+      "wrangler.toml",
+      ["name = 'toml-worker'", "workers_dev = false", "route = 'app.example.com/*'"].join("\n"),
+    );
+    execFileSyncMock.mockImplementation((_file: string, args: string[]) => {
+      if (args.includes("upload")) {
+        return [
+          "Uploaded toml-worker (1.23 sec)",
+          "Worker Version ID: 22222222-2222-4222-8222-222222222222",
+        ].join("\n");
+      }
+      if (args.includes("status")) {
+        return JSON.stringify({
+          versions: [{ version_id: "11111111-1111-4111-8111-111111111111", percentage: 100 }],
+        });
+      }
+      if (args.includes("deploy") && args.includes("22222222-2222-4222-8222-222222222222@0%")) {
+        return "Staged version\n";
+      }
+      if (args.includes("deploy") && args.includes("22222222-2222-4222-8222-222222222222@100%")) {
+        return "Promoted version\n";
+      }
+      if (args.includes("triggers")) {
+        return "Triggers deployed\n  app.example.com/*\n";
+      }
+      throw new Error(`Unexpected Wrangler args: ${args.join(" ")}`);
+    });
+    const { deployWithCdnWarmup } = await import("../packages/cloudflare/src/deploy.js");
+
+    await deployWithCdnWarmup(tmpDir, ["/"], {
+      expectedBuildId: "app-build-a",
+      warmCdnConcurrency: 1,
+      warmCdnPromotionDelay: 0,
+    });
+
+    const headers = new Headers(vi.mocked(fetch).mock.calls[0]?.[1]?.headers);
+    expect(headers.get("Cloudflare-Workers-Version-Overrides")).toBe(
+      'toml-worker="22222222-2222-4222-8222-222222222222"',
+    );
   });
 
   it("explains staged version cleanup when strict pre-promotion warmup fails", async () => {

--- a/tests/cloudflare-cdn-warm-deploy.test.ts
+++ b/tests/cloudflare-cdn-warm-deploy.test.ts
@@ -41,6 +41,14 @@ function formatFetchUrl(url: Parameters<typeof fetch>[0]): string {
   return url.url;
 }
 
+function isReadinessFetch(url: Parameters<typeof fetch>[0]): boolean {
+  return new URL(formatFetchUrl(url)).searchParams.has("__vinext_cdn_warm_readiness");
+}
+
+function getRealWarmFetchCalls() {
+  return vi.mocked(fetch).mock.calls.filter(([url]) => !isReadinessFetch(url));
+}
+
 function cacheableHtml(body = "ok"): Response {
   return new Response(body, {
     headers: {
@@ -115,6 +123,109 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
+  it("waits for staged build stability before sending each real warm key once", async () => {
+    const events: string[] = [];
+    const readinessHeaders: Headers[] = [];
+    const readinessUrls: string[] = [];
+    let readinessAttempt = 0;
+    delayMock.mockImplementation(async (milliseconds: number) => {
+      events.push(`delay:${milliseconds}`);
+    });
+    writeFile(
+      "wrangler.jsonc",
+      JSON.stringify({ name: "my-worker", custom_domains: ["app.example.com"] }),
+    );
+    vi.mocked(fetch).mockImplementation(async (input, init) => {
+      const url = new URL(formatFetchUrl(input));
+      const isReadinessProbe = url.searchParams.has("__vinext_cdn_warm_readiness");
+      if (isReadinessProbe) {
+        readinessHeaders.push(new Headers(init?.headers));
+        readinessUrls.push(url.href);
+      }
+      const buildId = isReadinessProbe && readinessAttempt++ === 0 ? "old-build" : "app-build-a";
+      events.push(isReadinessProbe ? `readiness:${buildId}` : `warm:${url.pathname}${url.search}`);
+      return new Response("flight", {
+        headers: {
+          "cache-control": "public, max-age=0, must-revalidate",
+          "cdn-cache-control": "public, max-age=60",
+          "cf-cache-status": "MISS",
+          "content-type": "text/x-component",
+          [VINEXT_RSC_BUILD_ID_HEADER]: buildId,
+          vary: VINEXT_RSC_VARY_HEADER,
+        },
+      });
+    });
+    execFileSyncMock.mockImplementation((_file: string, args: string[]) => {
+      if (args.includes("upload")) {
+        return "Uploaded my-worker\nWorker Version ID: 22222222-2222-4222-8222-222222222222\n";
+      }
+      if (args.includes("status")) {
+        return JSON.stringify({
+          versions: [{ version_id: "11111111-1111-4111-8111-111111111111", percentage: 100 }],
+        });
+      }
+      if (args.includes("11111111-1111-4111-8111-111111111111@100%")) {
+        events.push("stage");
+        return "Staged version\nhttps://app.example.com\n";
+      }
+      if (args.includes("22222222-2222-4222-8222-222222222222@100%")) {
+        events.push("promote");
+        return "Deployed version\nhttps://app.example.com\n";
+      }
+      if (args.includes("triggers")) {
+        events.push("triggers");
+        return "Triggers deployed\n  app.example.com (custom domain)\n";
+      }
+      throw new Error(`Unexpected Wrangler args: ${args.join(" ")}`);
+    });
+    const { deployWithCdnWarmup } = await import("../packages/cloudflare/src/deploy.js");
+
+    await deployWithCdnWarmup(tmpDir, [], {
+      expectedRscBuildId: "app-build-a",
+      rscPaths: ["/about"],
+      warmCdnConcurrency: 1,
+      warmCdnPromotionDelay: 0,
+      warmCdnStrict: true,
+    });
+
+    expect(events).toEqual([
+      "stage",
+      "triggers",
+      "readiness:old-build",
+      "delay:1000",
+      "readiness:app-build-a",
+      "delay:1000",
+      "readiness:app-build-a",
+      "delay:1000",
+      "readiness:app-build-a",
+      "delay:1000",
+      "readiness:app-build-a",
+      "delay:1000",
+      "readiness:app-build-a",
+      "delay:1000",
+      "readiness:app-build-a",
+      "warm:/about?_rsc",
+      "promote",
+    ]);
+    expect(
+      vi.mocked(fetch).mock.calls.filter(([input]) => {
+        const url = new URL(formatFetchUrl(input));
+        return url.pathname === "/about" && url.search === "?_rsc";
+      }),
+    ).toHaveLength(1);
+    expect(new Set(readinessUrls).size).toBe(7);
+    expect(readinessUrls.every((url) => new URL(url).searchParams.has("_rsc"))).toBe(true);
+    expect(
+      readinessHeaders.every(
+        (value) =>
+          value.get("accept") === "text/x-component" &&
+          value.get("cache-control") === "no-cache" &&
+          value.get("rsc") === "1" &&
+          value.has("Cloudflare-Workers-Version-Overrides"),
+      ),
+    ).toBe(true);
+  });
+
   it("warms the production custom domain through a 0% staged version override", async () => {
     const events: string[] = [];
     delayMock.mockImplementation(async (milliseconds: number) => {
@@ -128,7 +239,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       }),
     );
     vi.mocked(fetch).mockImplementation(async (url, init) => {
-      events.push(`fetch:${formatFetchUrl(url)}`);
+      events.push(isReadinessFetch(url) ? "readiness" : `fetch:${formatFetchUrl(url)}`);
       const headers = new Headers(init?.headers);
       const isRsc = headers.get("rsc") === "1";
       return new Response(isRsc ? "flight" : "html", {
@@ -214,28 +325,19 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       ]),
       expect.any(Object),
     );
-    expect(fetch).toHaveBeenCalledTimes(4);
-    expect(fetch).toHaveBeenNthCalledWith(
-      1,
+    const warmCalls = getRealWarmFetchCalls();
+    expect(warmCalls).toHaveLength(4);
+    expect(warmCalls[0]).toEqual([
       new URL("https://app.example.com/about?_rsc"),
       expect.any(Object),
-    );
-    expect(fetch).toHaveBeenNthCalledWith(
-      2,
+    ]);
+    expect(warmCalls[1]).toEqual([
       new URL("https://app.example.com/about?_rsc=9qLBDIU2NgN178cB"),
       expect.any(Object),
-    );
-    expect(fetch).toHaveBeenNthCalledWith(
-      3,
-      new URL("https://app.example.com/"),
-      expect.any(Object),
-    );
-    expect(fetch).toHaveBeenNthCalledWith(
-      4,
-      new URL("https://app.example.com/about"),
-      expect.any(Object),
-    );
-    const rscHeaders = new Headers(vi.mocked(fetch).mock.calls[0]![1]?.headers);
+    ]);
+    expect(warmCalls[2]).toEqual([new URL("https://app.example.com/"), expect.any(Object)]);
+    expect(warmCalls[3]).toEqual([new URL("https://app.example.com/about"), expect.any(Object)]);
+    const rscHeaders = new Headers(warmCalls[0]![1]?.headers);
     expect(rscHeaders.get("Cloudflare-Workers-Version-Overrides")).toBe(
       'my-worker="22222222-2222-4222-8222-222222222222"',
     );
@@ -245,14 +347,14 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     expect(rscHeaders.get("next-router-prefetch")).toBeNull();
     expect(rscHeaders.get("next-router-state-tree")).toBeNull();
     expect(rscHeaders.get("next-url")).toBeNull();
-    const loadingHeaders = new Headers(vi.mocked(fetch).mock.calls[1]![1]?.headers);
+    const loadingHeaders = new Headers(warmCalls[1]![1]?.headers);
     expect(loadingHeaders.get("Cloudflare-Workers-Version-Overrides")).toBe(
       'my-worker="22222222-2222-4222-8222-222222222222"',
     );
     expect(loadingHeaders.get("next-router-prefetch")).toBe("1");
     expect(loadingHeaders.get("next-router-segment-prefetch")).toBe("1");
     expect(loadingHeaders.get("x-vinext-rsc-render-mode")).toBe("prefetch-loading-shell");
-    const firstHtmlHeaders = new Headers(vi.mocked(fetch).mock.calls[2]![1]?.headers);
+    const firstHtmlHeaders = new Headers(warmCalls[2]![1]?.headers);
     expect(firstHtmlHeaders.get("Cloudflare-Workers-Version-Overrides")).toBe(
       'my-worker="22222222-2222-4222-8222-222222222222"',
     );
@@ -274,6 +376,17 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       "status",
       "stage",
       "triggers",
+      "readiness",
+      "delay:1000",
+      "readiness",
+      "delay:1000",
+      "readiness",
+      "delay:1000",
+      "readiness",
+      "delay:1000",
+      "readiness",
+      "delay:1000",
+      "readiness",
       "fetch:https://app.example.com/about?_rsc",
       "fetch:https://app.example.com/about?_rsc=9qLBDIU2NgN178cB",
       "fetch:https://app.example.com/",
@@ -281,8 +394,8 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       "delay:15000",
       "promote",
     ]);
-    expect(delayMock).toHaveBeenCalledOnce();
-    expect(delayMock).toHaveBeenCalledWith(15_000);
+    expect(delayMock).toHaveBeenCalledTimes(6);
+    expect(delayMock).toHaveBeenLastCalledWith(15_000);
   });
 
   it.each([
@@ -342,13 +455,15 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       "wrangler.jsonc",
       JSON.stringify({ name: "my-worker", custom_domains: ["app.example.com"] }),
     );
-    vi.mocked(fetch).mockImplementation(async (_url, init) => {
+    vi.mocked(fetch).mockImplementation(async (url, init) => {
       const headers = new Headers(init?.headers);
       const isRsc = headers.get("rsc") === "1";
       const isLoadingShell = headers.has("next-router-segment-prefetch");
       const staged = headers.has("Cloudflare-Workers-Version-Overrides");
       const kind = isLoadingShell ? "loading" : isRsc ? "rsc" : "html";
-      events.push(`fetch:${staged ? "staged" : "promoted"}:${kind}`);
+      events.push(
+        isReadinessFetch(url) ? "readiness" : `fetch:${staged ? "staged" : "promoted"}:${kind}`,
+      );
       return new Response(isRsc ? "flight" : "html", {
         headers: isRsc
           ? {
@@ -407,17 +522,23 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       "status",
       "stage",
       "triggers",
+      "readiness",
+      "readiness",
+      "readiness",
+      "readiness",
+      "readiness",
+      "readiness",
       "fetch:staged:rsc",
       "fetch:staged:loading",
       "fetch:staged:html",
       "promote",
       "fetch:promoted:loading",
     ]);
-    expect(delayMock).toHaveBeenCalledOnce();
-    expect(delayMock).toHaveBeenCalledWith(15_000);
+    expect(delayMock).toHaveBeenCalledTimes(6);
+    expect(delayMock).toHaveBeenLastCalledWith(15_000);
   });
 
-  it("falls back after every staged response comes from the wrong build", async () => {
+  it("falls back when staged Worker readiness never reaches the uploaded build", async () => {
     const events: string[] = [];
     writeFile(
       "wrangler.jsonc",
@@ -467,17 +588,11 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       warmCdnRetries: 1,
     });
 
-    expect(events).toEqual([
-      "upload",
-      "status",
-      "stage",
-      "triggers",
-      "fetch:staged",
-      "fetch:staged",
-      "promote",
-      "fetch:promoted",
-    ]);
-    expect(delayMock).not.toHaveBeenCalled();
+    expect(events.slice(0, 4)).toEqual(["upload", "status", "stage", "triggers"]);
+    expect(events.filter((event) => event === "fetch:staged")).toHaveLength(60);
+    expect(events.slice(-2)).toEqual(["promote", "fetch:promoted"]);
+    expect(delayMock).toHaveBeenCalledTimes(59);
+    expect(delayMock).toHaveBeenCalledWith(1_000);
   });
 
   it("uses the env Worker name and env custom domain for version override warmup", async () => {
@@ -573,7 +688,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       JSON.stringify({ name: "my-worker", custom_domains: ["app.example.com"] }),
     );
     vi.mocked(fetch).mockImplementation(async (url) => {
-      events.push(`fetch:${formatFetchUrl(url)}`);
+      events.push(isReadinessFetch(url) ? "readiness" : `fetch:${formatFetchUrl(url)}`);
       return cacheableHtml();
     });
     execFileSyncMock.mockImplementation((_file: string, args: string[]) => {
@@ -673,7 +788,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       JSON.stringify({ name: "my-worker", custom_domains: ["app.example.com"] }),
     );
     vi.mocked(fetch).mockImplementation(async (url) => {
-      events.push(`fetch:${formatFetchUrl(url)}`);
+      events.push(isReadinessFetch(url) ? "readiness" : `fetch:${formatFetchUrl(url)}`);
       return cacheableHtml();
     });
     execFileSyncMock.mockImplementation((_file: string, args: string[]) => {
@@ -707,14 +822,15 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       }),
     ).resolves.toBe("https://stable.example.workers.dev");
 
-    expect(events).toEqual([
+    expect(events.filter((event) => event !== "readiness" && !event.startsWith("delay:"))).toEqual([
       "upload",
       "status",
       "stage",
       "triggers",
       "fetch:https://app.example.com/about",
     ]);
-    expect(delayMock).not.toHaveBeenCalled();
+    expect(events.filter((event) => event === "readiness")).toHaveLength(6);
+    expect(events.filter((event) => event === "delay:1000")).toHaveLength(5);
   });
 
   it("rejects strict HTML warmup without verifiable build identity before upload", async () => {
@@ -759,7 +875,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       }),
     );
     vi.mocked(fetch).mockImplementation(async (url) => {
-      events.push(`fetch:${formatFetchUrl(url)}`);
+      events.push(isReadinessFetch(url) ? "readiness" : `fetch:${formatFetchUrl(url)}`);
       return cacheableHtml();
     });
     execFileSyncMock.mockImplementation((_file: string, args: string[]) => {
@@ -811,6 +927,12 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       "status",
       "stage",
       "triggers",
+      "readiness",
+      "readiness",
+      "readiness",
+      "readiness",
+      "readiness",
+      "readiness",
       "fetch:https://workers-cache.vinext.workers.dev/cached/intro",
       "promote",
     ]);

--- a/tests/cloudflare-cdn-warm-deploy.test.ts
+++ b/tests/cloudflare-cdn-warm-deploy.test.ts
@@ -83,6 +83,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
         headers: isRsc
           ? {
               "cache-control": "public, max-age=0, must-revalidate",
+              "cdn-cache-control": "public, max-age=60",
               "cf-cache-status": "MISS",
               "content-type": "text/x-component",
               [VINEXT_RSC_BUILD_ID_HEADER]: "build-a",
@@ -242,6 +243,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
         headers: isRsc
           ? {
               "cache-control": "public, max-age=0, must-revalidate",
+              "cdn-cache-control": "public, max-age=60",
               "cf-cache-status": "MISS",
               "content-type": "text/x-component",
               [VINEXT_RSC_BUILD_ID_HEADER]:
@@ -350,6 +352,24 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     for (const [, args] of execFileSyncMock.mock.calls as Array<[string, string[]]>) {
       expect(args).toEqual(expect.arrayContaining(["--env", "staging"]));
     }
+  });
+
+  it("does not inherit the production custom domain for a named environment", async () => {
+    writeFile(
+      "wrangler.jsonc",
+      JSON.stringify({
+        name: "my-worker",
+        custom_domains: ["app.example.com"],
+        env: { staging: { name: "my-worker-staging" } },
+      }),
+    );
+    const { resolveCdnWarmupTargetUrl } = await import("../packages/cloudflare/src/deploy.js");
+
+    expect(
+      resolveCdnWarmupTargetUrl(tmpDir, "https://my-worker-staging.example.workers.dev", {
+        env: "staging",
+      }),
+    ).toBe("https://my-worker-staging.example.workers.dev");
   });
 
   it("applies triggers before post-promotion fallback warmup", async () => {

--- a/tests/cloudflare-cdn-warm-deploy.test.ts
+++ b/tests/cloudflare-cdn-warm-deploy.test.ts
@@ -6,6 +6,7 @@ import {
   VINEXT_RSC_BUILD_ID_HEADER,
   VINEXT_RSC_VARY_HEADER,
 } from "../packages/vinext/src/server/app-rsc-cache-busting.js";
+import { VINEXT_CDN_BUILD_ID_HEADER } from "../packages/cloudflare/src/cache/cdn-build-id.js";
 
 const execFileSyncMock = vi.hoisted(() => vi.fn());
 const delayMock = vi.hoisted(() => vi.fn());
@@ -86,10 +87,15 @@ describe("Cloudflare CDN warmup deploy flow", () => {
               "cdn-cache-control": "public, max-age=60",
               "cf-cache-status": "MISS",
               "content-type": "text/x-component",
+              [VINEXT_CDN_BUILD_ID_HEADER]: "app-build-a",
               [VINEXT_RSC_BUILD_ID_HEADER]: "build-a",
               vary: VINEXT_RSC_VARY_HEADER,
             }
-          : { "cf-cache-status": "MISS", "content-type": "text/html" },
+          : {
+              "cf-cache-status": "MISS",
+              "content-type": "text/html",
+              [VINEXT_CDN_BUILD_ID_HEADER]: "app-build-a",
+            },
       });
     });
     execFileSyncMock.mockImplementation((_file: string, args: string[]) => {
@@ -125,6 +131,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
 
     const url = await deployWithCdnWarmup(tmpDir, ["/", "/about"], {
       deploymentId: "dpl_123",
+      expectedBuildId: "app-build-a",
       expectedRscBuildId: "build-a",
       loadingShellPaths: ["/about"],
       rscPaths: ["/about"],
@@ -163,12 +170,12 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     );
     expect(fetch).toHaveBeenNthCalledWith(
       2,
-      new URL("https://app.example.com/"),
+      new URL("https://app.example.com/about?_rsc=9qLBDIU2NgN178cB"),
       expect.any(Object),
     );
     expect(fetch).toHaveBeenNthCalledWith(
       3,
-      new URL("https://app.example.com/about?_rsc=9qLBDIU2NgN178cB"),
+      new URL("https://app.example.com/"),
       expect.any(Object),
     );
     expect(fetch).toHaveBeenNthCalledWith(
@@ -186,18 +193,18 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     expect(rscHeaders.get("next-router-prefetch")).toBeNull();
     expect(rscHeaders.get("next-router-state-tree")).toBeNull();
     expect(rscHeaders.get("next-url")).toBeNull();
-    const firstHtmlHeaders = new Headers(vi.mocked(fetch).mock.calls[1]![1]?.headers);
-    expect(firstHtmlHeaders.get("Cloudflare-Workers-Version-Overrides")).toBe(
-      'my-worker="22222222-2222-4222-8222-222222222222"',
-    );
-    expect(firstHtmlHeaders.get("accept")).toBe("text/html");
-    const loadingHeaders = new Headers(vi.mocked(fetch).mock.calls[2]![1]?.headers);
+    const loadingHeaders = new Headers(vi.mocked(fetch).mock.calls[1]![1]?.headers);
     expect(loadingHeaders.get("Cloudflare-Workers-Version-Overrides")).toBe(
       'my-worker="22222222-2222-4222-8222-222222222222"',
     );
     expect(loadingHeaders.get("next-router-prefetch")).toBe("1");
     expect(loadingHeaders.get("next-router-segment-prefetch")).toBe("1");
     expect(loadingHeaders.get("x-vinext-rsc-render-mode")).toBe("prefetch-loading-shell");
+    const firstHtmlHeaders = new Headers(vi.mocked(fetch).mock.calls[2]![1]?.headers);
+    expect(firstHtmlHeaders.get("Cloudflare-Workers-Version-Overrides")).toBe(
+      'my-worker="22222222-2222-4222-8222-222222222222"',
+    );
+    expect(firstHtmlHeaders.get("accept")).toBe("text/html");
     expect(execFileSyncMock).toHaveBeenNthCalledWith(
       4,
       process.execPath,
@@ -216,8 +223,8 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       "stage",
       "triggers",
       "fetch:https://app.example.com/about?_rsc",
-      "fetch:https://app.example.com/",
       "fetch:https://app.example.com/about?_rsc=9qLBDIU2NgN178cB",
+      "fetch:https://app.example.com/",
       "fetch:https://app.example.com/about",
       "delay:15000",
       "promote",
@@ -226,9 +233,8 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     expect(delayMock).toHaveBeenCalledWith(15_000);
   });
 
-  it("falls back to post-promotion warming after a non-strict staged failure", async () => {
+  it("does not replay successful staged fills after a non-strict partial failure", async () => {
     const events: string[] = [];
-    let promotedRscAttempts = 0;
     writeFile(
       "wrangler.jsonc",
       JSON.stringify({ name: "my-worker", custom_domains: ["app.example.com"] }),
@@ -236,9 +242,10 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     vi.mocked(fetch).mockImplementation(async (_url, init) => {
       const headers = new Headers(init?.headers);
       const isRsc = headers.get("rsc") === "1";
+      const isLoadingShell = headers.has("next-router-segment-prefetch");
       const staged = headers.has("Cloudflare-Workers-Version-Overrides");
-      events.push(`fetch:${staged ? "staged" : "promoted"}:${isRsc ? "rsc" : "html"}`);
-      if (isRsc && !staged) promotedRscAttempts++;
+      const kind = isLoadingShell ? "loading" : isRsc ? "rsc" : "html";
+      events.push(`fetch:${staged ? "staged" : "promoted"}:${kind}`);
       return new Response(isRsc ? "flight" : "html", {
         headers: isRsc
           ? {
@@ -246,11 +253,15 @@ describe("Cloudflare CDN warmup deploy flow", () => {
               "cdn-cache-control": "public, max-age=60",
               "cf-cache-status": "MISS",
               "content-type": "text/x-component",
-              [VINEXT_RSC_BUILD_ID_HEADER]:
-                staged || promotedRscAttempts === 1 ? "old-build" : "new-build",
+              [VINEXT_CDN_BUILD_ID_HEADER]: "app-build-a",
+              [VINEXT_RSC_BUILD_ID_HEADER]: staged && isLoadingShell ? "old-build" : "new-build",
               vary: VINEXT_RSC_VARY_HEADER,
             }
-          : { "cf-cache-status": "MISS", "content-type": "text/html" },
+          : {
+              "cf-cache-status": "MISS",
+              "content-type": "text/html",
+              [VINEXT_CDN_BUILD_ID_HEADER]: "app-build-a",
+            },
       });
     });
     execFileSyncMock.mockImplementation((_file: string, args: string[]) => {
@@ -281,7 +292,9 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     const { deployWithCdnWarmup } = await import("../packages/cloudflare/src/deploy.js");
 
     await deployWithCdnWarmup(tmpDir, ["/about"], {
+      expectedBuildId: "app-build-a",
       expectedRscBuildId: "new-build",
+      loadingShellPaths: ["/about"],
       rscPaths: ["/about"],
       warmCdnRetries: 1,
     });
@@ -292,11 +305,75 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       "stage",
       "triggers",
       "fetch:staged:rsc",
-      "fetch:staged:rsc",
+      "fetch:staged:loading",
+      "fetch:staged:html",
+      "fetch:staged:loading",
       "promote",
-      "fetch:promoted:rsc",
-      "fetch:promoted:rsc",
-      "fetch:promoted:html",
+      "fetch:promoted:loading",
+    ]);
+    expect(delayMock).toHaveBeenCalledOnce();
+    expect(delayMock).toHaveBeenCalledWith(15_000);
+  });
+
+  it("falls back after every staged response comes from the wrong build", async () => {
+    const events: string[] = [];
+    writeFile(
+      "wrangler.jsonc",
+      JSON.stringify({ name: "my-worker", custom_domains: ["app.example.com"] }),
+    );
+    vi.mocked(fetch).mockImplementation(async (_url, init) => {
+      const staged = new Headers(init?.headers).has("Cloudflare-Workers-Version-Overrides");
+      events.push(`fetch:${staged ? "staged" : "promoted"}`);
+      return new Response("html", {
+        headers: {
+          "cdn-cache-control": "public, max-age=60",
+          "cf-cache-status": "MISS",
+          "content-type": "text/html",
+          [VINEXT_CDN_BUILD_ID_HEADER]: staged ? "old-build" : "new-build",
+        },
+      });
+    });
+    execFileSyncMock.mockImplementation((_file: string, args: string[]) => {
+      if (args.includes("upload")) {
+        events.push("upload");
+        return "Uploaded version 22222222-2222-4222-8222-222222222222\n";
+      }
+      if (args.includes("status")) {
+        events.push("status");
+        return JSON.stringify({
+          versions: [{ version_id: "11111111-1111-4111-8111-111111111111", percentage: 100 }],
+        });
+      }
+      if (args.includes("11111111-1111-4111-8111-111111111111@100%")) {
+        events.push("stage");
+        return "Staged version\nhttps://app.example.com\n";
+      }
+      if (args.includes("22222222-2222-4222-8222-222222222222@100%")) {
+        events.push("promote");
+        return "Deployed version\nhttps://app.example.com\n";
+      }
+      if (args.includes("triggers")) {
+        events.push("triggers");
+        return "Triggers deployed\n";
+      }
+      throw new Error(`Unexpected Wrangler args: ${args.join(" ")}`);
+    });
+    const { deployWithCdnWarmup } = await import("../packages/cloudflare/src/deploy.js");
+
+    await deployWithCdnWarmup(tmpDir, ["/about"], {
+      expectedBuildId: "new-build",
+      warmCdnRetries: 1,
+    });
+
+    expect(events).toEqual([
+      "upload",
+      "status",
+      "stage",
+      "triggers",
+      "fetch:staged",
+      "fetch:staged",
+      "promote",
+      "fetch:promoted",
     ]);
     expect(delayMock).not.toHaveBeenCalled();
   });

--- a/tests/cloudflare-cdn-warm-deploy.test.ts
+++ b/tests/cloudflare-cdn-warm-deploy.test.ts
@@ -152,7 +152,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       }
       if (args.includes("triggers")) {
         events.push("triggers");
-        return "Triggers deployed\n";
+        return "Triggers deployed\n  app.example.com (custom domain)\n";
       }
       throw new Error(`Unexpected Wrangler args: ${args.join(" ")}`);
     });
@@ -262,6 +262,57 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     expect(delayMock).toHaveBeenCalledWith(15_000);
   });
 
+  it.each([
+    ["singular route", { name: "my-worker", workers_dev: false, route: "sub.example.com/*" }],
+    [
+      "routes object with a zone name",
+      {
+        name: "my-worker",
+        workers_dev: false,
+        routes: [{ pattern: "sub.example.com/*", zone_name: "example.com" }],
+      },
+    ],
+  ])("warms the concrete Worker host from a %s", async (_label, config) => {
+    writeFile("wrangler.jsonc", JSON.stringify(config));
+    execFileSyncMock.mockImplementation((_file: string, args: string[]) => {
+      if (args.includes("upload")) {
+        return "Uploaded version 22222222-2222-4222-8222-222222222222\n";
+      }
+      if (args.includes("status")) {
+        return JSON.stringify({
+          versions: [{ version_id: "11111111-1111-4111-8111-111111111111", percentage: 100 }],
+        });
+      }
+      if (args.includes("deploy") && args.includes("22222222-2222-4222-8222-222222222222@0%")) {
+        return "Staged version\nhttps://stable.example.workers.dev\n";
+      }
+      if (args.includes("deploy") && args.includes("22222222-2222-4222-8222-222222222222@100%")) {
+        return "Deployed version\nhttps://stable.example.workers.dev\n";
+      }
+      if (args.includes("triggers")) {
+        return "Triggers deployed\n  sub.example.com/*\n";
+      }
+      throw new Error(`Unexpected Wrangler args: ${args.join(" ")}`);
+    });
+    const { deployWithCdnWarmup } = await import("../packages/cloudflare/src/deploy.js");
+
+    await deployWithCdnWarmup(tmpDir, ["/about"], {
+      expectedBuildId: "app-build-a",
+      warmCdnConcurrency: 1,
+      warmCdnPromotionDelay: 0,
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      new URL("https://sub.example.com/about"),
+      expect.any(Object),
+    );
+    expect(
+      vi
+        .mocked(fetch)
+        .mock.calls.every(([url]) => formatFetchUrl(url).startsWith("https://sub.example.com/")),
+    ).toBe(true);
+  });
+
   it("does not replay successful staged fills after a non-strict partial failure", async () => {
     const events: string[] = [];
     writeFile(
@@ -314,7 +365,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       }
       if (args.includes("triggers")) {
         events.push("triggers");
-        return "Triggers deployed\n";
+        return "Triggers deployed\n  app.example.com (custom domain)\n";
       }
       throw new Error(`Unexpected Wrangler args: ${args.join(" ")}`);
     });
@@ -336,7 +387,6 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       "fetch:staged:rsc",
       "fetch:staged:loading",
       "fetch:staged:html",
-      "fetch:staged:loading",
       "promote",
       "fetch:promoted:loading",
     ]);
@@ -383,7 +433,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       }
       if (args.includes("triggers")) {
         events.push("triggers");
-        return "Triggers deployed\n";
+        return "Triggers deployed\n  app.example.com (custom domain)\n";
       }
       throw new Error(`Unexpected Wrangler args: ${args.join(" ")}`);
     });
@@ -437,7 +487,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
         return "Deployed version\nhttps://stable.example.workers.dev\n";
       }
       if (args.includes("triggers")) {
-        return "Triggers deployed\n";
+        return "Triggers deployed\n  staging.example.com (custom domain)\n";
       }
       throw new Error(`Unexpected Wrangler args: ${args.join(" ")}`);
     });
@@ -479,6 +529,20 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     ).toBe("https://my-worker-staging.example.workers.dev");
   });
 
+  it("does not infer a warmup target from zone-oriented Wrangler config", async () => {
+    writeFile(
+      "wrangler.jsonc",
+      JSON.stringify({
+        name: "my-worker",
+        workers_dev: false,
+        routes: [{ pattern: "sub.example.com/*", zone_name: "example.com" }],
+      }),
+    );
+    const { resolveCdnWarmupTargetUrl } = await import("../packages/cloudflare/src/deploy.js");
+
+    expect(resolveCdnWarmupTargetUrl(tmpDir, null)).toBeNull();
+  });
+
   it("skips unverifiable HTML warmup for adapters without build identity", async () => {
     const events: string[] = [];
     writeFile(
@@ -510,7 +574,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       }
       if (args.includes("triggers")) {
         events.push("triggers");
-        return "Triggers deployed\n";
+        return "Triggers deployed\n  app.example.com (custom domain)\n";
       }
       throw new Error(`Unexpected Wrangler args: ${args.join(" ")}`);
     });
@@ -555,7 +619,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       }
       if (args.includes("triggers")) {
         events.push("triggers");
-        return "Triggers deployed\n";
+        return "Triggers deployed\n  app.example.com (custom domain)\n";
       }
       throw new Error(`Unexpected Wrangler args: ${args.join(" ")}`);
     });
@@ -606,7 +670,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       }
       if (args.includes("triggers")) {
         events.push("triggers");
-        return "Triggers deployed\n";
+        return "Triggers deployed\n  app.example.com (custom domain)\n";
       }
       throw new Error(`Unexpected Wrangler args: ${args.join(" ")}`);
     });

--- a/tests/cloudflare-cdn-warm.test.ts
+++ b/tests/cloudflare-cdn-warm.test.ts
@@ -81,6 +81,7 @@ describe("Cloudflare CDN warmup", () => {
       JSON.stringify({
         basePath: "/docs",
         buildId: "build-a",
+        buildIdentity: "rsc-build-a",
         deploymentId: "dpl_123",
         loadingShellPaths: ["/dashboard"],
         paths: ["/dashboard", "/dynamic", "/pages"],
@@ -97,6 +98,7 @@ describe("Cloudflare CDN warmup", () => {
 
     expect(readPrerenderWarmPlan(tmpDir)).toEqual({
       buildId: "build-a",
+      buildIdentity: "rsc-build-a",
       deploymentId: "dpl_123",
       loadingShellPaths: ["/docs/dashboard/"],
       paths: ["/docs/dashboard/", "/docs/dynamic/", "/docs/pages/"],
@@ -530,6 +532,42 @@ describe("Cloudflare CDN warmup", () => {
     ).rejects.toThrow("response is missing CF-Cache-Status");
   });
 
+  it("rejects HTML variants that the warmer request cannot share with browsers", async () => {
+    const fetchImpl = vi.fn(async () => {
+      const response = cacheableHtml();
+      response.headers.set("vary", `${VINEXT_RSC_VARY_HEADER}, User-Agent`);
+      return response;
+    });
+
+    await expect(
+      warmCdnCache({
+        expectedBuildId: "build-a",
+        fetchImpl: fetchImpl as typeof fetch,
+        paths: ["/browser-specific-html"],
+        strict: true,
+        targetUrl: "https://app.example.com",
+      }),
+    ).rejects.toThrow("response Vary has unsupported field user-agent");
+  });
+
+  it("accepts HTML varied only by framework RSC selector headers", async () => {
+    const fetchImpl = vi.fn(async () => {
+      const response = cacheableHtml();
+      response.headers.set("vary", VINEXT_RSC_VARY_HEADER);
+      return response;
+    });
+
+    await expect(
+      warmCdnCache({
+        expectedBuildId: "build-a",
+        fetchImpl: fetchImpl as typeof fetch,
+        paths: ["/shared-html"],
+        strict: true,
+        targetUrl: "https://app.example.com",
+      }),
+    ).resolves.toMatchObject({ warmed: 1, failed: 0 });
+  });
+
   it("rejects responses rendered by a different application build", async () => {
     const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
       const response =
@@ -780,14 +818,18 @@ describe("Cloudflare CDN warmup", () => {
   });
 
   it("uses the discovery manifest build identity by default", async () => {
-    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile("dist/server/BUILD_ID", "pinned-build\n");
     writeFile(
       "dist/server/vinext-prerender-paths.json",
-      JSON.stringify({ buildId: "build-a", paths: ["/wrong-build"] }),
+      JSON.stringify({
+        buildId: "pinned-build",
+        buildIdentity: "instance-a",
+        paths: ["/wrong-build"],
+      }),
     );
     const fetchImpl = vi.fn(async () => {
       const response = cacheableHtml();
-      response.headers.set(VINEXT_CDN_BUILD_ID_HEADER, "old-build");
+      response.headers.set(VINEXT_CDN_BUILD_ID_HEADER, "old-instance");
       return response;
     });
 
@@ -798,6 +840,36 @@ describe("Cloudflare CDN warmup", () => {
         strict: true,
         targetUrl: "https://app.example.com",
       }),
-    ).rejects.toThrow(`response ${VINEXT_CDN_BUILD_ID_HEADER} does not match build build-a`);
+    ).rejects.toThrow(`response ${VINEXT_CDN_BUILD_ID_HEADER} does not match build instance-a`);
+  });
+
+  it("uses the discovery manifest RSC build identity by default", async () => {
+    writeFile("dist/server/BUILD_ID", "pinned-build\n");
+    writeFile(
+      "dist/server/vinext-prerender-paths.json",
+      JSON.stringify({
+        buildId: "pinned-build",
+        buildIdentity: "instance-a",
+        paths: [],
+        responseVary: "verbatim",
+        rscBuildId: "instance-a",
+        rscPaths: ["/wrong-rsc-build"],
+      }),
+    );
+    const fetchImpl = vi.fn(async () => {
+      const response = cacheableRsc();
+      response.headers.set(VINEXT_RSC_BUILD_ID_HEADER, "old-instance");
+      return response;
+    });
+
+    await expect(
+      warmCdnCacheFromPrerender({
+        fetchImpl: fetchImpl as typeof fetch,
+        root: tmpDir,
+        strict: true,
+        targetUrl: "https://app.example.com",
+        validateBuildIdentity: false,
+      }),
+    ).rejects.toThrow(`response ${VINEXT_RSC_BUILD_ID_HEADER} does not match build instance-a`);
   });
 });

--- a/tests/cloudflare-cdn-warm.test.ts
+++ b/tests/cloudflare-cdn-warm.test.ts
@@ -268,7 +268,7 @@ describe("Cloudflare CDN warmup", () => {
     ).resolves.toEqual({ total: 2, warmed: 0, skipped: 2, failed: 0, failures: [] });
   });
 
-  it("fails contradictory cache policy instead of claiming a warm", async () => {
+  it("uses Cloudflare cache-control precedence when validating admission", async () => {
     const fetchImpl = vi.fn(async () => {
       const response = cacheableRsc();
       response.headers.set("cache-control", "no-store");
@@ -284,7 +284,62 @@ describe("Cloudflare CDN warmup", () => {
         strict: true,
         targetUrl: "https://app.example.com",
       }),
-    ).rejects.toThrow("opts out of caching, but CF-Cache-Status is MISS");
+    ).resolves.toMatchObject({ warmed: 1, failed: 0 });
+  });
+
+  it("fails contradictory effective cache policy instead of claiming a warm", async () => {
+    const fetchImpl = vi.fn(async () => {
+      const response = cacheableRsc();
+      response.headers.set("cdn-cache-control", "no-store");
+      return response;
+    });
+
+    await expect(
+      warmCdnCache({
+        expectedRscBuildId: "rsc-build-a",
+        fetchImpl: fetchImpl as typeof fetch,
+        paths: [],
+        rscPaths: ["/broken"],
+        strict: true,
+        targetUrl: "https://app.example.com",
+      }),
+    ).rejects.toThrow("CDN-Cache-Control opts out of caching, but CF-Cache-Status is MISS");
+  });
+
+  it("rejects stale cache objects and zero-freshness responses", async () => {
+    const staleFetch = vi.fn(async () => {
+      const response = cacheableRsc();
+      response.headers.set("cf-cache-status", "STALE");
+      return response;
+    });
+    await expect(
+      warmCdnCache({
+        expectedRscBuildId: "rsc-build-a",
+        fetchImpl: staleFetch as typeof fetch,
+        paths: [],
+        rscPaths: ["/stale"],
+        strict: true,
+        targetUrl: "https://app.example.com",
+      }),
+    ).rejects.toThrow("CF-Cache-Status is STALE");
+
+    const zeroFreshnessFetch = vi.fn(async () => {
+      const response = cacheableRsc();
+      response.headers.set("cdn-cache-control", "public, max-age=0");
+      return response;
+    });
+    await expect(
+      warmCdnCache({
+        expectedRscBuildId: "rsc-build-a",
+        fetchImpl: zeroFreshnessFetch as typeof fetch,
+        paths: [],
+        rscPaths: ["/immediately-stale"],
+        strict: true,
+        targetUrl: "https://app.example.com",
+      }),
+    ).rejects.toThrow(
+      "CDN-Cache-Control has no positive shared-cache freshness, but CF-Cache-Status is MISS",
+    );
   });
 
   it("requires CDN admission evidence for HTML responses", async () => {

--- a/tests/cloudflare-cdn-warm.test.ts
+++ b/tests/cloudflare-cdn-warm.test.ts
@@ -483,6 +483,34 @@ describe("Cloudflare CDN warmup", () => {
     expect(attempts.get("/later:html")).toBe(2);
   });
 
+  it("keeps the staged propagation budget independent for each failed key", async () => {
+    const attempts = new Map<string, number>();
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const pathname = new URL(requestHref(input)!).pathname;
+      const attempt = (attempts.get(pathname) ?? 0) + 1;
+      attempts.set(pathname, attempt);
+      if (pathname === "/slow" && attempt <= 30) {
+        return new Response("not propagated", { status: 404 });
+      }
+      return cacheableRsc();
+    });
+
+    await expect(
+      warmCdnCache({
+        expectedRscBuildId: "rsc-build-a",
+        fetchImpl: fetchImpl as typeof fetch,
+        paths: [],
+        propagatingTarget: true,
+        retryDelayMs: 0,
+        rscPaths: ["/ready", "/slow"],
+        strict: true,
+        targetUrl: "https://app.example.com",
+      }),
+    ).resolves.toMatchObject({ total: 2, warmed: 2, failed: 0 });
+    expect(attempts.get("/ready")).toBe(1);
+    expect(attempts.get("/slow")).toBe(31);
+  });
+
   it("warms directly from the discovery manifest", async () => {
     writeFile("dist/server/BUILD_ID", "build-a\n");
     writeFile(

--- a/tests/cloudflare-cdn-warm.test.ts
+++ b/tests/cloudflare-cdn-warm.test.ts
@@ -367,6 +367,27 @@ describe("Cloudflare CDN warmup", () => {
     ).rejects.toThrow("response sets a cookie without an observable field-qualified cache policy");
   });
 
+  it("requires an exact set-cookie field name in field-qualified cache policy", async () => {
+    const fetchImpl = vi.fn(async () => {
+      const response = cacheableHtml();
+      response.headers.set(
+        "cdn-cache-control",
+        'public, max-age=60, private="not-set-cookie, x-set-cookie"',
+      );
+      response.headers.set("set-cookie", "session=uncacheable; Path=/");
+      return response;
+    });
+
+    await expect(
+      warmCdnCache({
+        fetchImpl: fetchImpl as typeof fetch,
+        paths: ["/substring-cookie-policy"],
+        strict: true,
+        targetUrl: "https://app.example.com",
+      }),
+    ).rejects.toThrow("response sets a cookie without an observable field-qualified cache policy");
+  });
+
   it("skips hidden Cloudflare-specific cache opt-outs reported as BYPASS", async () => {
     const fetchImpl = vi.fn(async () => {
       const response = cacheableRsc();
@@ -403,6 +424,54 @@ describe("Cloudflare CDN warmup", () => {
         targetUrl: "https://app.example.com",
       }),
     ).rejects.toThrow("CF-Cache-Status is STALE");
+  });
+
+  it("rejects DYNAMIC when the route response itself is cacheable", async () => {
+    const fetchImpl = vi.fn(async () => {
+      const response = cacheableRsc();
+      response.headers.set("cf-cache-status", "DYNAMIC");
+      return response;
+    });
+
+    await expect(
+      warmCdnCache({
+        expectedBuildId: "build-a",
+        expectedRscBuildId: "rsc-build-a",
+        fetchImpl: fetchImpl as typeof fetch,
+        paths: [],
+        rscPaths: ["/request-ineligible"],
+        strict: true,
+        targetUrl: "https://app.example.com",
+      }),
+    ).rejects.toThrow("CF-Cache-Status is DYNAMIC");
+  });
+
+  it("skips DYNAMIC only when the route response opts out of caching", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response("flight", {
+          headers: {
+            "cache-control": "no-store",
+            "cf-cache-status": "DYNAMIC",
+            "content-type": "text/x-component",
+            [VINEXT_CDN_BUILD_ID_HEADER]: "build-a",
+            [VINEXT_RSC_BUILD_ID_HEADER]: "rsc-build-a",
+            vary: VINEXT_RSC_VARY_HEADER,
+          },
+        }),
+    );
+
+    await expect(
+      warmCdnCache({
+        expectedBuildId: "build-a",
+        expectedRscBuildId: "rsc-build-a",
+        fetchImpl: fetchImpl as typeof fetch,
+        paths: [],
+        rscPaths: ["/response-ineligible"],
+        strict: true,
+        targetUrl: "https://app.example.com",
+      }),
+    ).resolves.toMatchObject({ warmed: 0, skipped: 1, failed: 0 });
   });
 
   it("trusts admitted freshness when a higher-priority edge policy is hidden", async () => {
@@ -526,6 +595,30 @@ describe("Cloudflare CDN warmup", () => {
         ["html", 2],
       ]),
     );
+  });
+
+  it("does not retry permanent validation failures from the uploaded build", async () => {
+    const fetchImpl = vi.fn(async () => {
+      const response = cacheableRsc();
+      response.headers.set("vary", `${VINEXT_RSC_VARY_HEADER}, User-Agent`);
+      return response;
+    });
+
+    await expect(
+      warmCdnCache({
+        expectedBuildId: "build-a",
+        expectedRscBuildId: "rsc-build-a",
+        fetchImpl: fetchImpl as typeof fetch,
+        paths: [],
+        propagatingTarget: true,
+        retries: 60,
+        retryDelayMs: 0,
+        rscPaths: ["/invalid-current-build"],
+        strict: true,
+        targetUrl: "https://app.example.com",
+      }),
+    ).rejects.toThrow("response Vary has unsupported field user-agent");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
   it("retries first and later staged-target failures only after the initial queue", async () => {

--- a/tests/cloudflare-cdn-warm.test.ts
+++ b/tests/cloudflare-cdn-warm.test.ts
@@ -132,7 +132,11 @@ describe("Cloudflare CDN warmup", () => {
     writeFile("dist/server/BUILD_ID", "build-a\n");
     writeFile(
       "dist/server/vinext-prerender-paths.json",
-      JSON.stringify({ buildId: "build-a", paths: ["/", "/cached/intro"] }),
+      JSON.stringify({
+        buildId: "build-a",
+        excludedWarmPaths: ["/blog/[slug]"],
+        paths: ["/", "/cached/intro"],
+      }),
     );
     writeFile(
       "dist/server/vinext-prerender.json",
@@ -151,10 +155,7 @@ describe("Cloudflare CDN warmup", () => {
       }),
     );
 
-    expect(readPrerenderWarmPlan(tmpDir, { includeFallbackShells: true }).paths).toEqual([
-      "/",
-      "/blog/[slug]",
-    ]);
+    expect(readPrerenderWarmPlan(tmpDir, { includeFallbackShells: true }).paths).toEqual(["/"]);
   });
 
   it("falls back to discovered paths when fallback shells were not locally rendered", () => {

--- a/tests/cloudflare-cdn-warm.test.ts
+++ b/tests/cloudflare-cdn-warm.test.ts
@@ -307,7 +307,7 @@ describe("Cloudflare CDN warmup", () => {
     ).resolves.toMatchObject({ warmed: 1, failed: 0 });
   });
 
-  it("fails contradictory effective cache policy instead of claiming a warm", async () => {
+  it("trusts Cloudflare admission when a stripped edge policy overrides downstream no-store", async () => {
     const fetchImpl = vi.fn(async () => {
       const response = cacheableRsc();
       response.headers.set("cdn-cache-control", "no-store");
@@ -323,10 +323,71 @@ describe("Cloudflare CDN warmup", () => {
         strict: true,
         targetUrl: "https://app.example.com",
       }),
-    ).rejects.toThrow("CDN-Cache-Control opts out of caching, but CF-Cache-Status is MISS");
+    ).resolves.toMatchObject({ warmed: 1, failed: 0 });
   });
 
-  it("rejects stale cache objects and zero-freshness responses", async () => {
+  it("accepts admitted field-qualified cookie policies and stripped cached cookies", async () => {
+    const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const response =
+        new Headers(init?.headers).get("rsc") === "1" ? cacheableRsc() : cacheableHtml();
+      response.headers.set(
+        "cdn-cache-control",
+        'public, max-age=60, private="set-cookie", no-cache="set-cookie"',
+      );
+      response.headers.set("set-cookie", "session=first-response-only; Path=/");
+      return response;
+    });
+
+    await expect(
+      warmCdnCache({
+        expectedRscBuildId: "rsc-build-a",
+        fetchImpl: fetchImpl as typeof fetch,
+        paths: ["/cookie-policy"],
+        rscPaths: ["/cookie-policy"],
+        strict: true,
+        targetUrl: "https://app.example.com",
+      }),
+    ).resolves.toMatchObject({ warmed: 2, failed: 0 });
+  });
+
+  it("rejects plain Set-Cookie MISS responses without proof the cookie was stripped", async () => {
+    const fetchImpl = vi.fn(async () => {
+      const response = cacheableHtml();
+      response.headers.set("set-cookie", "session=uncacheable; Path=/");
+      return response;
+    });
+
+    await expect(
+      warmCdnCache({
+        fetchImpl: fetchImpl as typeof fetch,
+        paths: ["/plain-cookie"],
+        strict: true,
+        targetUrl: "https://app.example.com",
+      }),
+    ).rejects.toThrow("response sets a cookie without an observable field-qualified cache policy");
+  });
+
+  it("skips hidden Cloudflare-specific cache opt-outs reported as BYPASS", async () => {
+    const fetchImpl = vi.fn(async () => {
+      const response = cacheableRsc();
+      response.headers.set("cf-cache-status", "BYPASS");
+      return response;
+    });
+
+    await expect(
+      warmCdnCache({
+        expectedBuildId: "build-a",
+        expectedRscBuildId: "rsc-build-a",
+        fetchImpl: fetchImpl as typeof fetch,
+        paths: [],
+        rscPaths: ["/hidden-opt-out"],
+        strict: true,
+        targetUrl: "https://app.example.com",
+      }),
+    ).resolves.toMatchObject({ warmed: 0, skipped: 1, failed: 0 });
+  });
+
+  it("rejects cache statuses that cannot prove a reusable fill", async () => {
     const staleFetch = vi.fn(async () => {
       const response = cacheableRsc();
       response.headers.set("cf-cache-status", "STALE");
@@ -342,24 +403,49 @@ describe("Cloudflare CDN warmup", () => {
         targetUrl: "https://app.example.com",
       }),
     ).rejects.toThrow("CF-Cache-Status is STALE");
+  });
 
-    const zeroFreshnessFetch = vi.fn(async () => {
+  it("trusts admitted freshness when a higher-priority edge policy is hidden", async () => {
+    const fetchImpl = vi.fn(async () => {
       const response = cacheableRsc();
-      response.headers.set("cdn-cache-control", "public, max-age=0");
+      response.headers.set("cdn-cache-control", "public, max-age=0, stale-while-revalidate=60");
       return response;
     });
     await expect(
       warmCdnCache({
         expectedRscBuildId: "rsc-build-a",
-        fetchImpl: zeroFreshnessFetch as typeof fetch,
+        fetchImpl: fetchImpl as typeof fetch,
         paths: [],
         rscPaths: ["/immediately-stale"],
         strict: true,
         targetUrl: "https://app.example.com",
       }),
-    ).rejects.toThrow(
-      "CDN-Cache-Control has no positive shared-cache freshness, but CF-Cache-Status is MISS",
-    );
+    ).resolves.toMatchObject({ warmed: 1, failed: 0 });
+  });
+
+  it("skips non-cacheable responses for adapters without build identity", async () => {
+    const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const isRsc = new Headers(init?.headers).get("rsc") === "1";
+      return new Response(isRsc ? "flight" : "html", {
+        headers: {
+          "cache-control": "no-store",
+          "cf-cache-status": "BYPASS",
+          "content-type": isRsc ? "text/x-component" : "text/html",
+          ...(isRsc ? { [VINEXT_RSC_BUILD_ID_HEADER]: "rsc-build-a" } : {}),
+        },
+      });
+    });
+
+    await expect(
+      warmCdnCache({
+        expectedRscBuildId: "rsc-build-a",
+        fetchImpl: fetchImpl as typeof fetch,
+        paths: ["/dynamic"],
+        rscPaths: ["/dynamic"],
+        strict: true,
+        targetUrl: "https://app.example.com",
+      }),
+    ).resolves.toMatchObject({ warmed: 0, skipped: 2, failed: 0 });
   });
 
   it("requires CDN admission evidence for HTML responses", async () => {
@@ -397,6 +483,49 @@ describe("Cloudflare CDN warmup", () => {
       }),
     ).rejects.toThrow(`response ${VINEXT_CDN_BUILD_ID_HEADER} does not match build build-a`);
     expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries old-build BYPASS responses before accepting a staged skip", async () => {
+    const attempts = new Map<string, number>();
+    const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const isRsc = new Headers(init?.headers).get("rsc") === "1";
+      const kind = isRsc ? "rsc" : "html";
+      const attempt = (attempts.get(kind) ?? 0) + 1;
+      attempts.set(kind, attempt);
+      if (attempt === 1) {
+        return new Response(isRsc ? "old-flight" : "old-html", {
+          headers: {
+            "cache-control": "no-store",
+            "cf-cache-status": "BYPASS",
+            "content-type": isRsc ? "text/x-component" : "text/html",
+            [VINEXT_CDN_BUILD_ID_HEADER]: "old-build",
+            ...(isRsc ? { [VINEXT_RSC_BUILD_ID_HEADER]: "old-rsc-build" } : {}),
+          },
+        });
+      }
+      return isRsc ? cacheableRsc() : cacheableHtml();
+    });
+
+    await expect(
+      warmCdnCache({
+        expectedBuildId: "build-a",
+        expectedRscBuildId: "rsc-build-a",
+        fetchImpl: fetchImpl as typeof fetch,
+        paths: ["/became-cacheable"],
+        propagatingTarget: true,
+        retries: 1,
+        retryDelayMs: 0,
+        rscPaths: ["/became-cacheable"],
+        strict: true,
+        targetUrl: "https://app.example.com",
+      }),
+    ).resolves.toMatchObject({ warmed: 2, skipped: 0, failed: 0 });
+    expect(attempts).toEqual(
+      new Map([
+        ["rsc", 2],
+        ["html", 2],
+      ]),
+    );
   });
 
   it("retries first and later staged-target failures only after the initial queue", async () => {
@@ -526,5 +655,56 @@ describe("Cloudflare CDN warmup", () => {
         targetUrl: "https://app.example.com",
       }),
     ).resolves.toMatchObject({ total: 1, warmed: 1, skipped: 0, failed: 0 });
+  });
+
+  it("requires an explicit opt-out for adapters without a build identity header", async () => {
+    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile(
+      "dist/server/vinext-prerender-paths.json",
+      JSON.stringify({ buildId: "build-a", paths: ["/custom-adapter"] }),
+    );
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response("html", {
+          headers: {
+            "cache-control": "public, max-age=0, must-revalidate",
+            "cdn-cache-control": "public, max-age=60",
+            "cf-cache-status": "MISS",
+            "content-type": "text/html",
+          },
+        }),
+    );
+
+    await expect(
+      warmCdnCacheFromPrerender({
+        fetchImpl: fetchImpl as typeof fetch,
+        root: tmpDir,
+        strict: true,
+        targetUrl: "https://app.example.com",
+        validateBuildIdentity: false,
+      }),
+    ).resolves.toMatchObject({ total: 1, warmed: 1, failed: 0 });
+  });
+
+  it("uses the discovery manifest build identity by default", async () => {
+    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile(
+      "dist/server/vinext-prerender-paths.json",
+      JSON.stringify({ buildId: "build-a", paths: ["/wrong-build"] }),
+    );
+    const fetchImpl = vi.fn(async () => {
+      const response = cacheableHtml();
+      response.headers.set(VINEXT_CDN_BUILD_ID_HEADER, "old-build");
+      return response;
+    });
+
+    await expect(
+      warmCdnCacheFromPrerender({
+        fetchImpl: fetchImpl as typeof fetch,
+        root: tmpDir,
+        strict: true,
+        targetUrl: "https://app.example.com",
+      }),
+    ).rejects.toThrow(`response ${VINEXT_CDN_BUILD_ID_HEADER} does not match build build-a`);
   });
 });

--- a/tests/cloudflare-cdn-warm.test.ts
+++ b/tests/cloudflare-cdn-warm.test.ts
@@ -14,6 +14,7 @@ import {
   VINEXT_RSC_BUILD_ID_HEADER,
   VINEXT_RSC_VARY_HEADER,
 } from "../packages/vinext/src/server/app-rsc-cache-busting.js";
+import { VINEXT_CDN_BUILD_ID_HEADER } from "../packages/cloudflare/src/cache/cdn-build-id.js";
 
 let tmpDir: string;
 
@@ -30,6 +31,7 @@ function cacheableRsc(body = "flight"): Response {
       "cdn-cache-control": "public, max-age=60",
       "cf-cache-status": "MISS",
       "content-type": "text/x-component",
+      [VINEXT_CDN_BUILD_ID_HEADER]: "build-a",
       [VINEXT_RSC_BUILD_ID_HEADER]: "rsc-build-a",
       vary: VINEXT_RSC_VARY_HEADER,
     },
@@ -43,6 +45,7 @@ function cacheableHtml(body = "html"): Response {
       "cdn-cache-control": "public, max-age=60",
       "cf-cache-status": "MISS",
       "content-type": "text/html",
+      [VINEXT_CDN_BUILD_ID_HEADER]: "build-a",
     },
   });
 }
@@ -93,6 +96,7 @@ describe("Cloudflare CDN warmup", () => {
     );
 
     expect(readPrerenderWarmPlan(tmpDir)).toEqual({
+      buildId: "build-a",
       deploymentId: "dpl_123",
       loadingShellPaths: ["/docs/dashboard/"],
       paths: ["/docs/dashboard/", "/docs/dynamic/", "/docs/pages/"],
@@ -115,6 +119,7 @@ describe("Cloudflare CDN warmup", () => {
     );
 
     expect(readPrerenderWarmPlan(tmpDir)).toEqual({
+      buildId: "build-a",
       loadingShellPaths: [],
       paths: ["/dashboard"],
       rscPaths: [],
@@ -187,6 +192,7 @@ describe("Cloudflare CDN warmup", () => {
 
     const result = await warmCdnCache({
       deploymentId: "dpl_123",
+      expectedBuildId: "build-a",
       expectedRscBuildId: "rsc-build-a",
       fetchImpl: fetchImpl as typeof fetch,
       loadingShellPaths: ["/search?q=x"],
@@ -195,7 +201,14 @@ describe("Cloudflare CDN warmup", () => {
       targetUrl: "https://app.example.com",
     });
 
-    expect(result).toEqual({ total: 3, warmed: 3, skipped: 0, failed: 0, failures: [] });
+    expect(result).toEqual({
+      total: 3,
+      warmed: 3,
+      skipped: 0,
+      failed: 0,
+      failures: [],
+      retryPlan: { loadingShellPaths: [], paths: [], rscPaths: [] },
+    });
     expect(fetchImpl).toHaveBeenCalledTimes(3);
     const fullCall = fetchImpl.mock.calls.find((call) => {
       const headers = new Headers(call[1]?.headers);
@@ -265,7 +278,14 @@ describe("Cloudflare CDN warmup", () => {
         strict: true,
         targetUrl: "https://app.example.com",
       }),
-    ).resolves.toEqual({ total: 2, warmed: 0, skipped: 2, failed: 0, failures: [] });
+    ).resolves.toEqual({
+      total: 2,
+      warmed: 0,
+      skipped: 2,
+      failed: 0,
+      failures: [],
+      retryPlan: { loadingShellPaths: [], paths: [], rscPaths: [] },
+    });
   });
 
   it("uses Cloudflare cache-control precedence when validating admission", async () => {
@@ -355,7 +375,31 @@ describe("Cloudflare CDN warmup", () => {
     ).rejects.toThrow("response is missing CF-Cache-Status");
   });
 
-  it("retries staged-target failures after the initial queue has completed", async () => {
+  it("rejects responses rendered by a different application build", async () => {
+    const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const response =
+        new Headers(init?.headers).get("rsc") === "1" ? cacheableRsc() : cacheableHtml();
+      response.headers.set(VINEXT_CDN_BUILD_ID_HEADER, "old-build");
+      return response;
+    });
+
+    await expect(
+      warmCdnCache({
+        expectedBuildId: "build-a",
+        expectedRscBuildId: "rsc-build-a",
+        fetchImpl: fetchImpl as typeof fetch,
+        paths: ["/about"],
+        propagatingTarget: true,
+        retries: 0,
+        rscPaths: ["/about"],
+        strict: true,
+        targetUrl: "https://app.example.com",
+      }),
+    ).rejects.toThrow(`response ${VINEXT_CDN_BUILD_ID_HEADER} does not match build build-a`);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries first and later staged-target failures only after the initial queue", async () => {
     const attempts = new Map<string, number>();
     const calls: string[] = [];
     const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -365,7 +409,7 @@ describe("Cloudflare CDN warmup", () => {
       calls.push(key);
       const attempt = (attempts.get(key) ?? 0) + 1;
       attempts.set(key, attempt);
-      if (url.pathname === "/later" && attempt === 1) {
+      if ((url.pathname === "/first" || url.pathname === "/later") && attempt === 1) {
         if (!isRsc) return new Response("not propagated", { status: 500 });
         const stale = cacheableRsc();
         stale.headers.set(VINEXT_RSC_BUILD_ID_HEADER, "stale-rsc-build");
@@ -388,13 +432,15 @@ describe("Cloudflare CDN warmup", () => {
         targetUrl: "https://app.example.com",
       }),
     ).resolves.toMatchObject({ total: 6, warmed: 6, failed: 0 });
-    expect(attempts.get("/first:rsc")).toBe(1);
-    expect(attempts.get("/first:html")).toBe(1);
+    expect(attempts.get("/first:rsc")).toBe(2);
+    expect(attempts.get("/first:html")).toBe(2);
     expect(attempts.get("/later:rsc")).toBe(2);
     expect(attempts.get("/later:html")).toBe(2);
     expect(attempts.get("/tail:rsc")).toBe(1);
     expect(attempts.get("/tail:html")).toBe(1);
     const lastInitialRequest = Math.max(calls.indexOf("/tail:rsc"), calls.indexOf("/tail:html"));
+    expect(calls.lastIndexOf("/first:rsc")).toBeGreaterThan(lastInitialRequest);
+    expect(calls.lastIndexOf("/first:html")).toBeGreaterThan(lastInitialRequest);
     expect(calls.lastIndexOf("/later:rsc")).toBeGreaterThan(lastInitialRequest);
     expect(calls.lastIndexOf("/later:html")).toBeGreaterThan(lastInitialRequest);
   });

--- a/tests/cloudflare-cdn-warm.test.ts
+++ b/tests/cloudflare-cdn-warm.test.ts
@@ -660,6 +660,31 @@ describe("Cloudflare CDN warmup", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
+  it("does not retry a deterministic failure when either build identity matches", async () => {
+    const fetchImpl = vi.fn(async () => {
+      const response = cacheableRsc();
+      response.headers.delete(VINEXT_CDN_BUILD_ID_HEADER);
+      response.headers.set("vary", `${VINEXT_RSC_VARY_HEADER}, User-Agent`);
+      return response;
+    });
+
+    await expect(
+      warmCdnCache({
+        expectedBuildId: "build-a",
+        expectedRscBuildId: "rsc-build-a",
+        fetchImpl: fetchImpl as typeof fetch,
+        paths: [],
+        propagatingTarget: true,
+        retries: 60,
+        retryDelayMs: 0,
+        rscPaths: ["/invalid-current-rsc-build"],
+        strict: true,
+        targetUrl: "https://app.example.com",
+      }),
+    ).rejects.toThrow(`response ${VINEXT_CDN_BUILD_ID_HEADER} does not match build build-a`);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
   it("retries first and later staged-target failures only after the initial queue", async () => {
     const attempts = new Map<string, number>();
     const calls: string[] = [];

--- a/tests/cloudflare-version-deploy.test.ts
+++ b/tests/cloudflare-version-deploy.test.ts
@@ -218,6 +218,7 @@ describe("Cloudflare Wrangler version deployment helpers", () => {
 
     expect(parseWranglerVersionUploadOutput(output)).toMatchObject({
       versionId: "7283300a-90b0-45d6-ba08-7c4b76797f38",
+      workerName: "rsc-prewarm-32362416100",
       previewUrl: "https://7283300a-rsc-prewarm-32362416100.vinext.workers.dev",
     });
   });

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -64,7 +64,10 @@ import {
   resolveStaticAssetSignal,
 } from "../packages/vinext/src/server/worker-utils.js";
 import { domainCandidates, parseWranglerConfig, runTPR } from "../packages/cloudflare/src/tpr.js";
-import { parseWorkerDeploymentUrl } from "../packages/cloudflare/src/worker-deployment-url.js";
+import {
+  parseCdnWarmupDeploymentUrl,
+  parseWorkerDeploymentUrl,
+} from "../packages/cloudflare/src/worker-deployment-url.js";
 
 // ─── Test Helpers ────────────────────────────────────────────────────────────
 
@@ -560,6 +563,21 @@ describe("parseWorkerDeploymentUrl", () => {
   it("does not report an ordinary route pattern as a canonical URL", () => {
     expect(parseWorkerDeploymentUrl("Deployed app triggers\n  app.example.com/*\n")).toBeNull();
   });
+
+  it.each([
+    ["app.example.com/*", "https://app.example.com"],
+    ["https://app.example.com/*", "https://app.example.com"],
+    ["http://app.example.com/*", "http://app.example.com"],
+  ])("uses a concrete catch-all Worker route for CDN warmup: %s", (route, expected) => {
+    expect(parseCdnWarmupDeploymentUrl(`Deployed app triggers\n  ${route}\n`)).toBe(expected);
+  });
+
+  it.each(["*.example.com/*", "app.example.com/api/*", "app.example.com/"])(
+    "rejects a non-canonical Worker route for CDN warmup: %s",
+    (route) => {
+      expect(parseCdnWarmupDeploymentUrl(`Deployed app triggers\n  ${route}\n`)).toBeNull();
+    },
+  );
 
   it("does not report a disabled custom domain", () => {
     expect(

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -572,6 +572,14 @@ describe("parseWorkerDeploymentUrl", () => {
     expect(parseCdnWarmupDeploymentUrl(`Deployed app triggers\n  ${route}\n`)).toBe(expected);
   });
 
+  it("prefers a concrete Worker route over a workers.dev fallback", () => {
+    expect(
+      parseCdnWarmupDeploymentUrl(
+        "Deployed app triggers\n  https://app.account.workers.dev\n  app.example.com/*\n",
+      ),
+    ).toBe("https://app.example.com");
+  });
+
   it.each(["*.example.com/*", "app.example.com/api/*", "app.example.com/"])(
     "rejects a non-canonical Worker route for CDN warmup: %s",
     (route) => {

--- a/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
+++ b/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
@@ -12,7 +12,7 @@ import fs from "node:fs";
 const TARGET_PATH = "/prewarm-target";
 const LOADING_SHELL_RSC_SEARCH = "?_rsc=9qLBDIU2NgN178cB";
 const PROMOTION_STABILITY_WINDOW_MS = 60_000;
-const PROMOTION_READINESS_TIMEOUT_MS = 90_000;
+const PROMOTION_READINESS_TIMEOUT_MS = 120_000;
 const PROMOTION_PROBE_INTERVAL_MS = 1_000;
 const STALE_SEED_RETRY_TIMEOUT_MS = 45_000;
 
@@ -77,7 +77,7 @@ async function observeRsc(page: Page, action: () => Promise<unknown>): Promise<O
   };
 }
 
-function expectCanonical(observed: ObservedRsc): void {
+function expectCanonical(observed: ObservedRsc, rscBuildId: string): void {
   rejectStaleSeedWorker(observed.response);
   console.log(
     `RSC cache trace: url=${observed.url.pathname}${observed.url.search} ` +
@@ -91,22 +91,23 @@ function expectCanonical(observed: ObservedRsc): void {
   expect(observed.headers["next-router-state-tree"]).toBeUndefined();
   expect(observed.headers["next-url"]).toBeUndefined();
   expect(observed.headers["x-vinext-rsc-state-fingerprint"]).toBeUndefined();
+  expect(observed.response.headers()["x-vinext-rsc-build-id"]).toBe(rscBuildId);
   expect(
     observed.response.headers()["cf-cache-status"],
     JSON.stringify({ request: observed.headers, response: observed.response.headers() }),
   ).toBe("HIT");
 }
 
-function expectFull(observed: ObservedRsc): void {
-  expectCanonical(observed);
+function expectFull(observed: ObservedRsc, rscBuildId: string): void {
+  expectCanonical(observed, rscBuildId);
   expect(observed.url.search).toBe("?_rsc");
   expect(observed.headers["next-router-prefetch"]).toBeUndefined();
   expect(observed.headers["next-router-segment-prefetch"]).toBeUndefined();
   expect(observed.headers["x-vinext-rsc-render-mode"]).toBeUndefined();
 }
 
-function expectLoadingShell(observed: ObservedRsc): void {
-  expectCanonical(observed);
+function expectLoadingShell(observed: ObservedRsc, rscBuildId: string): void {
+  expectCanonical(observed, rscBuildId);
   expect(observed.url.search).toBe(LOADING_SHELL_RSC_SEARCH);
   expect(observed.headers["next-router-prefetch"]).toBe("1");
   expect(observed.headers["next-router-segment-prefetch"]).toBe("1");
@@ -167,7 +168,7 @@ test("deploy-prewarmed full and loading RSC variants are reused by browser navig
 }) => {
   test.skip(!baseURL?.startsWith("https://"), "requires a deployed Cloudflare Worker");
   if (!baseURL) throw new Error("deployed test requires a base URL");
-  test.setTimeout(180_000);
+  test.setTimeout(240_000);
 
   const buildId = fs.readFileSync("examples/workers-cache/dist/server/BUILD_ID", "utf-8").trim();
   const rscBuildId = fs
@@ -254,30 +255,33 @@ test("deploy-prewarmed full and loading RSC variants are reused by browser navig
     expect(response?.ok()).toBe(true);
     await expect(page.getByTestId("build-id")).toHaveText(buildId);
   };
+  const expectTargetCommit = async (page: Page) => {
+    await expect(page).toHaveURL(new RegExp(`${TARGET_PATH}$`));
+    await expect(page.getByRole("heading", { name: "Prewarm target" })).toBeVisible();
+    await expect(page.getByTestId("build-id")).toHaveText(buildId);
+  };
 
   for (const source of ["/prewarm/link-a", "/prewarm/link-b"]) {
     await runFresh(async (page) => {
       const shell = await observeRsc(page, async () => {
         await gotoCurrentBuild(page, source);
       });
-      expectLoadingShell(shell);
+      expectLoadingShell(shell, rscBuildId);
 
       const full = await observeRsc(page, () => page.getByTestId("link-prefetch").click());
-      expectFull(full);
-      await expect(page).toHaveURL(new RegExp(`${TARGET_PATH}$`));
-      await expect(page.getByRole("heading", { name: "Prewarm target" })).toBeVisible();
+      expectFull(full, rscBuildId);
+      await expectTargetCommit(page);
     });
   }
 
   await runFresh(async (page) => {
     await gotoCurrentBuild(page, "/prewarm/router");
     const shell = await observeRsc(page, () => page.getByTestId("router-prefetch").click());
-    expectLoadingShell(shell);
+    expectLoadingShell(shell, rscBuildId);
 
     const full = await observeRsc(page, () => page.getByTestId("router-navigate").click());
-    expectFull(full);
-    await expect(page).toHaveURL(new RegExp(`${TARGET_PATH}$`));
-    await expect(page.getByRole("heading", { name: "Prewarm target" })).toBeVisible();
+    expectFull(full, rscBuildId);
+    await expectTargetCommit(page);
   });
 
   await runFresh(async (page) => {
@@ -291,19 +295,18 @@ test("deploy-prewarmed full and loading RSC variants are reused by browser navig
     const full = await observeRsc(page, async () => {
       await gotoCurrentBuild(page, "/prewarm/full");
     });
-    expectFull(full);
+    expectFull(full, rscBuildId);
     expect(targetRscRequests).toBe(1);
     await page.getByTestId("link-prefetch").click();
-    await expect(page).toHaveURL(new RegExp(`${TARGET_PATH}$`));
-    await expect(page.getByRole("heading", { name: "Prewarm target" })).toBeVisible();
+    await expectTargetCommit(page);
     expect(targetRscRequests).toBe(1);
   });
 
   await runFresh(async (page) => {
     await gotoCurrentBuild(page, "/prewarm/soft");
     const full = await observeRsc(page, () => page.getByTestId("soft-navigation").click());
-    expectFull(full);
-    await expect(page).toHaveURL(new RegExp(`${TARGET_PATH}$`));
+    expectFull(full, rscBuildId);
+    await expectTargetCommit(page);
   });
 
   await runFresh(async (page) => {

--- a/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
+++ b/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
@@ -270,6 +270,17 @@ test("deploy-prewarmed full and loading RSC variants are reused by browser navig
   }
 
   await runFresh(async (page) => {
+    await gotoCurrentBuild(page, "/prewarm/router");
+    const shell = await observeRsc(page, () => page.getByTestId("router-prefetch").click());
+    expectLoadingShell(shell);
+
+    const full = await observeRsc(page, () => page.getByTestId("router-navigate").click());
+    expectFull(full);
+    await expect(page).toHaveURL(new RegExp(`${TARGET_PATH}$`));
+    await expect(page.getByRole("heading", { name: "Prewarm target" })).toBeVisible();
+  });
+
+  await runFresh(async (page) => {
     let targetRscRequests = 0;
     page.on("request", (request) => {
       const url = new URL(request.url());
@@ -295,8 +306,16 @@ test("deploy-prewarmed full and loading RSC variants are reused by browser navig
     await expect(page).toHaveURL(new RegExp(`${TARGET_PATH}$`));
   });
 
-  const dynamic = await request.get(`${baseURL}/dynamic?_rsc`, { headers: fullHeaders });
-  expect(dynamic.ok()).toBe(true);
-  expect(dynamic.headers()["cache-control"]).toContain("no-store");
-  expect(dynamic.headers()["cf-cache-status"]).toBe("BYPASS");
+  await runFresh(async (page) => {
+    const dynamicResponsePromise = page.waitForResponse((response) => {
+      const request = response.request();
+      return new URL(response.url()).pathname === "/dynamic" && request.headers().rsc === "1";
+    });
+    await gotoCurrentBuild(page, "/prewarm/dynamic");
+    const dynamic = await dynamicResponsePromise;
+    rejectStaleSeedWorker(dynamic);
+    expect(dynamic.ok()).toBe(true);
+    expect(dynamic.headers()["cache-control"]).toContain("no-store");
+    expect(dynamic.headers()["cf-cache-status"]).toBe("BYPASS");
+  });
 });

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -188,6 +188,12 @@ describe("App Router generated manifest construction", () => {
     expect(code).not.toContain("cookie-secret-canary");
   });
 
+  it("embeds i18n locales used by hybrid App and Pages route ownership", () => {
+    const code = generateBrowserEntry([], null, [], undefined, ["en", "fr"]);
+
+    expect(code).toContain('window.__VINEXT_LOCALES__ = ["en","fr"]');
+  });
+
   it("embeds the Link auto-prefetch route manifest in the browser entry", () => {
     const code = generateBrowserEntry([
       ...minimalAppRoutes,

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -353,10 +353,10 @@ describe("App Router generated manifest construction", () => {
       '{"canPrefetchLoadingShell":false,"patternParts":["blog",":slug"],"isDynamic":true}',
     );
     expect(code).toContain(
-      '{"canPrefetchLoadingShell":true,"patternParts":["docs",":slug"],"isDynamic":true}',
+      '{"canPrefetchLoadingShell":true,"canUseCanonicalLoadingShell":true,"patternParts":["docs",":slug"],"isDynamic":true}',
     );
     expect(code).toContain(
-      '{"canPrefetchLoadingShell":true,"patternParts":["ancestor-loading","slow"],"isDynamic":false}',
+      '{"canPrefetchLoadingShell":true,"canUseCanonicalLoadingShell":true,"patternParts":["ancestor-loading","slow"],"isDynamic":false}',
     );
     expect(code).toContain(
       '{"canPrefetchLoadingShell":false,"patternParts":["teams",":team","dashboard"],"isDynamic":true,"requiresDynamicNavigationRequest":true}',
@@ -410,6 +410,7 @@ describe("App Router generated manifest construction", () => {
     } satisfies AppRoute;
 
     expect(toLinkPrefetchRoute(route).canPrefetchLoadingShell).toBe(true);
+    expect(toLinkPrefetchRoute(route).canUseCanonicalLoadingShell).toBeUndefined();
     expect(
       toLinkPrefetchRoute({
         ...route,
@@ -464,6 +465,7 @@ describe("App Router generated manifest construction", () => {
     } satisfies AppRoute;
 
     expect(toLinkPrefetchRoute(route).canPrefetchLoadingShell).toBe(true);
+    expect(toLinkPrefetchRoute(route).canUseCanonicalLoadingShell).toBeUndefined();
   });
 
   it("marks root-param routes for concrete route-tree prefetching", () => {
@@ -484,6 +486,7 @@ describe("App Router generated manifest construction", () => {
     expect(toLinkPrefetchRoute(route)).toEqual(
       expect.objectContaining({
         canPrefetchLoadingShell: true,
+        canUseCanonicalLoadingShell: true,
         hasRootParams: true,
       }),
     );
@@ -532,6 +535,7 @@ describe("App Router generated manifest construction", () => {
     ]);
     expect(source.canPrefetchLoadingShell).toBe(false);
     expect(target.canPrefetchLoadingShell).toBe(true);
+    expect(target.canUseCanonicalLoadingShell).toBeUndefined();
     expect(unrelated.canPrefetchLoadingShell).toBe(false);
   });
 

--- a/tests/hybrid-client-route-owner.test.ts
+++ b/tests/hybrid-client-route-owner.test.ts
@@ -189,6 +189,26 @@ describe("resolveHybridClientRouteOwner", () => {
     },
   );
 
+  it("matches locale-aware rewrites against the raw App pathname", () => {
+    installWindow({
+      app: [appRoute([":locale", "app-destination"])],
+      locales: ["en", "fr"],
+      pages: [],
+      rewrites: {
+        afterFiles: [],
+        beforeFiles: [
+          {
+            source: "/:nextInternalLocale(en|fr)/source",
+            destination: "/:nextInternalLocale/app-destination",
+          },
+        ],
+        fallback: [],
+      },
+    });
+
+    expect(resolveHybridClientRouteOwner("/fr/source", "")).toBe("app");
+  });
+
   it.each(["beforeFiles", "afterFiles", "fallback"] as const)(
     "returns the %s rewrite destination href",
     (rewritePhase) => {

--- a/tests/hybrid-client-route-owner.test.ts
+++ b/tests/hybrid-client-route-owner.test.ts
@@ -35,14 +35,16 @@ const APP_BASE = "http://localhost/";
 
 type WindowState = {
   app: VinextLinkPrefetchRoute[];
+  locales?: string[];
   pages: VinextPagesLinkPrefetchRoute[];
   rewrites?: ClientRewrites;
 };
 
-function installWindow({ app, pages, rewrites }: WindowState): void {
+function installWindow({ app, locales, pages, rewrites }: WindowState): void {
   (globalThis as any).window = {
     location: { href: APP_BASE, origin: "http://localhost" },
     __VINEXT_LINK_PREFETCH_ROUTES__: app,
+    __VINEXT_LOCALES__: locales,
     __VINEXT_PAGES_LINK_PREFETCH_ROUTES__: pages,
     __VINEXT_CLIENT_REWRITES__: rewrites,
   };
@@ -123,6 +125,30 @@ describe("resolveHybridClientRouteOwner", () => {
     expect(resolveHybridClientRouteOwner("/api/test", "")).toBe("document");
   });
 
+  it("keeps locale-prefixed App pages distinct from unprefixed Pages API routes", () => {
+    // Next.js treats /fr/api/* as a localized page path, not a Pages API path:
+    // test/e2e/i18n-api-support/index.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/i18n-api-support/index.test.ts
+    installWindow({
+      app: [appRoute([":locale", "api", "status"])],
+      locales: ["en", "fr"],
+      pages: [{ ...pagesRoute(["api", "status"], false), documentOnly: true }],
+    });
+
+    expect(resolveHybridClientRouteOwner("/fr/api/status", "")).toBe("app");
+    expect(resolveHybridClientRouteOwner("/api/status", "")).toBe("document");
+  });
+
+  it("still locale-normalizes Pages page matching", () => {
+    installWindow({
+      app: [appRoute([":locale", "dashboard"])],
+      locales: ["en", "fr"],
+      pages: [pagesRoute(["about"], false)],
+    });
+
+    expect(resolveHybridClientRouteOwner("/fr/about", "")).toBe("pages");
+  });
+
   it("applies document ownership only after choosing the most specific route", () => {
     installWindow({
       app: [appRoute(["api", "settings"], false)],
@@ -131,10 +157,10 @@ describe("resolveHybridClientRouteOwner", () => {
     expect(resolveHybridClientRouteOwner("/api/settings", "")).toBe("app");
 
     installWindow({
-      app: [documentRoute(["api", ":slug"])],
-      pages: [pagesRoute(["api", "settings"], false)],
+      app: [documentRoute(["docs", ":slug"])],
+      pages: [pagesRoute(["docs", "settings"], false)],
     });
-    expect(resolveHybridClientRouteOwner("/api/settings", "")).toBe("pages");
+    expect(resolveHybridClientRouteOwner("/docs/settings", "")).toBe("pages");
   });
 
   it.each(["beforeFiles", "afterFiles", "fallback"] as const)(

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -59,7 +59,12 @@ const linkPrefetchRoutes = [
     patternParts: ["same-origin-intent-prefetch-target"],
     isDynamic: false,
   },
-  { canPrefetchLoadingShell: true, patternParts: ["blog", ":slug"], isDynamic: true },
+  {
+    canPrefetchLoadingShell: true,
+    canUseCanonicalLoadingShell: true,
+    patternParts: ["blog", ":slug"],
+    isDynamic: true,
+  },
   { canPrefetchLoadingShell: false, patternParts: ["products", ":id"], isDynamic: true },
   { canPrefetchLoadingShell: false, patternParts: ["clothing", ":product"], isDynamic: true },
   {

--- a/tests/pages-router-app-prefetch-detection.test.ts
+++ b/tests/pages-router-app-prefetch-detection.test.ts
@@ -274,9 +274,13 @@ describe("Pages Router records app routes as detected on prefetch", () => {
     });
   });
 
-  it("strips basePath and locale prefixes before matching App routes", async () => {
+  it("keeps locale prefixes for App matching but strips them from the Pages component key", async () => {
     const fakeWindow = installFakeBrowserGlobals([
-      { canPrefetchLoadingShell: false, patternParts: ["about"], isDynamic: false },
+      {
+        canPrefetchLoadingShell: false,
+        patternParts: [":locale", "about"],
+        isDynamic: true,
+      },
     ]);
     fakeWindow.__VINEXT_LOCALES__ = ["en", "fr"];
     fakeWindow.__VINEXT_DEFAULT_LOCALE__ = "en";

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -261,6 +261,14 @@ describe("prefetch cache eviction", () => {
 
   it("automatic router.prefetch uses the canonical loading-shell variant", async () => {
     vi.stubEnv("__VINEXT_CANONICAL_RSC_REQUESTS", "1");
+    (globalThis as any).window.__VINEXT_LINK_PREFETCH_ROUTES__ = [
+      {
+        canPrefetchLoadingShell: true,
+        canUseCanonicalLoadingShell: true,
+        patternParts: ["dashboard"],
+        isDynamic: false,
+      },
+    ];
     vi.resetModules();
     const navigation = await import("../packages/vinext/src/shims/navigation.js");
     const fetch = vi.fn(

--- a/tests/prerender-paths.test.ts
+++ b/tests/prerender-paths.test.ts
@@ -49,6 +49,18 @@ describe("prerender path manifest", () => {
             { path: ["specific", "value"] },
           ]);
         }
+        if (
+          url.pathname === "/__vinext/prerender/static-params" &&
+          url.searchParams.get("pattern") === "/:locale/about"
+        ) {
+          return Response.json([{ locale: "fr" }]);
+        }
+        if (
+          url.pathname === "/__vinext/prerender/static-params" &&
+          url.searchParams.get("pattern") === "/:locale/api/status"
+        ) {
+          return Response.json([{ locale: "fr" }]);
+        }
         return new Response("null", { headers: { "content-type": "application/json" } });
       }),
     );
@@ -226,6 +238,64 @@ describe("prerender path manifest", () => {
       "/specific/value",
     ]);
     expect(manifest?.loadingShellPaths).toEqual(["/specific/value"]);
+  });
+
+  it("normalizes Pages i18n prefixes before resolving hybrid RSC ownership", async () => {
+    // Next.js normalizes locale prefixes before route matching:
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/base-server.ts
+    // Locale-prefixed paths do not become Pages API requests after stripping:
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/i18n-api-support/index.test.ts
+    writeFile("package.json", JSON.stringify({ type: "module" }));
+    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile("dist/server/RSC_BUILD_ID", "rsc-build-a\n");
+    writeFile("dist/server/index.js", "export default {};\n");
+    writeFile(
+      "app/[locale]/about/page.tsx",
+      [
+        "export function generateStaticParams() { return [{ locale: 'fr' }]; }",
+        "export default function Page() { return null; }",
+      ].join("\n"),
+    );
+    writeFile(
+      "app/[locale]/about/loading.tsx",
+      "export default function Loading() { return null; }\n",
+    );
+    writeFile(
+      "app/[locale]/api/status/page.tsx",
+      [
+        "export function generateStaticParams() { return [{ locale: 'fr' }]; }",
+        "export default function Page() { return null; }",
+      ].join("\n"),
+    );
+    writeFile(
+      "app/[locale]/api/status/loading.tsx",
+      "export default function Loading() { return null; }\n",
+    );
+    writeFile("pages/about.tsx", "export default function Page() { return null; }\n");
+    writeFile(
+      "pages/api/status.ts",
+      "export default function handler(_request, response) { response.end('ok'); }\n",
+    );
+
+    const [{ emitPrerenderPathManifest }, { resolveNextConfig }] = await Promise.all([
+      import("../packages/vinext/src/build/prerender-paths.js"),
+      import("../packages/vinext/src/config/next-config.js"),
+    ]);
+    const nextConfig = await resolveNextConfig(
+      { i18n: { defaultLocale: "en", locales: ["en", "fr"] } },
+      tmpDir,
+    );
+
+    const manifest = await emitPrerenderPathManifest({
+      nextConfig,
+      responseVary: "verbatim",
+      root: tmpDir,
+    });
+
+    expect(manifest?.paths).toEqual(["/fr/api/status", "/fr/about", "/about"]);
+    expect(manifest?.rscPaths).toEqual(["/fr/api/status"]);
+    expect(manifest?.loadingShellPaths).toEqual(["/fr/api/status"]);
+    expect(manifest?.pagesPaths).toEqual(["/about"]);
   });
 
   it("skips dynamic warmup paths when static params discovery aborts", async () => {

--- a/tests/prerender-paths.test.ts
+++ b/tests/prerender-paths.test.ts
@@ -38,6 +38,17 @@ describe("prerender path manifest", () => {
         ) {
           return Response.json([{ slug: "intro" }, { slug: "featured" }]);
         }
+        if (
+          url.pathname === "/__vinext/prerender/static-params" &&
+          url.searchParams.get("pattern") === "/:path+"
+        ) {
+          return Response.json([
+            { path: ["pages-dir", "foobar"] },
+            { path: ["pages-dir", "static"] },
+            { path: ["api", "status"] },
+            { path: ["specific", "value"] },
+          ]);
+        }
         return new Response("null", { headers: { "content-type": "application/json" } });
       }),
     );
@@ -133,6 +144,88 @@ describe("prerender path manifest", () => {
 
     expect(manifest?.rscPaths).toEqual(["/"]);
     expect(manifest?.rscBuildId).toBe("rsc-build-a");
+  });
+
+  it("excludes Pages-owned hybrid paths from App RSC warm discovery", async () => {
+    // Next.js resolves matching Pages and App routes by cross-router specificity:
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/use-params/use-params.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/pages-to-app-routing/pages-to-app-routing.test.ts
+    writeFile("package.json", JSON.stringify({ type: "module" }));
+    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile("dist/server/RSC_BUILD_ID", "rsc-build-a\n");
+    writeFile("dist/server/index.js", "export default {};\n");
+    writeFile(
+      "app/[...path]/page.tsx",
+      [
+        "export function generateStaticParams() { return []; }",
+        "export default function Page() { return null; }",
+      ].join("\n"),
+    );
+    writeFile("app/[...path]/loading.tsx", "export default function Loading() { return null; }\n");
+    writeFile("app/pages-dir/static/page.tsx", "export default function Page() { return null; }\n");
+    writeFile("app/specific/[id]/page.tsx", "export default function Page() { return null; }\n");
+    writeFile(
+      "app/specific/[id]/loading.tsx",
+      "export default function Loading() { return null; }\n",
+    );
+    writeFile("pages/pages-dir/[dynamic].tsx", "export default function Page() { return null; }\n");
+    writeFile(
+      "pages/api/[slug].ts",
+      "export default function handler(_request, response) { response.end('ok'); }\n",
+    );
+
+    const { emitPrerenderPathManifest } =
+      await import("../packages/vinext/src/build/prerender-paths.js");
+
+    const manifest = await emitPrerenderPathManifest({
+      root: tmpDir,
+      responseVary: "verbatim",
+    });
+
+    expect(manifest?.paths).toEqual([
+      "/pages-dir/static",
+      "/pages-dir/foobar",
+      "/api/status",
+      "/specific/value",
+    ]);
+    expect(manifest?.rscPaths).toEqual(["/pages-dir/static", "/specific/value"]);
+    expect(manifest?.loadingShellPaths).toEqual(["/specific/value"]);
+    expect(manifest?.pagesPaths).toEqual([]);
+  });
+
+  it("uses the runtime-best App route for App-only loading-shell discovery", async () => {
+    writeFile("package.json", JSON.stringify({ type: "module" }));
+    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile("dist/server/RSC_BUILD_ID", "rsc-build-a\n");
+    writeFile("dist/server/index.js", "export default {};\n");
+    writeFile(
+      "app/[...path]/page.tsx",
+      [
+        "export function generateStaticParams() { return []; }",
+        "export default function Page() { return null; }",
+      ].join("\n"),
+    );
+    writeFile("app/pages-dir/static/page.tsx", "export default function Page() { return null; }\n");
+    writeFile("app/specific/[id]/page.tsx", "export default function Page() { return null; }\n");
+    writeFile(
+      "app/specific/[id]/loading.tsx",
+      "export default function Loading() { return null; }\n",
+    );
+
+    const { emitPrerenderPathManifest } =
+      await import("../packages/vinext/src/build/prerender-paths.js");
+    const manifest = await emitPrerenderPathManifest({
+      root: tmpDir,
+      responseVary: "verbatim",
+    });
+
+    expect(manifest?.rscPaths).toEqual([
+      "/pages-dir/static",
+      "/pages-dir/foobar",
+      "/api/status",
+      "/specific/value",
+    ]);
+    expect(manifest?.loadingShellPaths).toEqual(["/specific/value"]);
   });
 
   it("skips dynamic warmup paths when static params discovery aborts", async () => {

--- a/tests/prerender-paths.test.ts
+++ b/tests/prerender-paths.test.ts
@@ -450,7 +450,7 @@ describe("prerender path manifest", () => {
     expect(manifest?.paths).toEqual(["/fr/api/status", "/fr/about", "/about"]);
     expect(manifest?.rscPaths).toEqual(["/fr/api/status"]);
     expect(manifest?.loadingShellPaths).toEqual(["/fr/api/status"]);
-    expect(manifest?.pagesPaths).toEqual(["/about"]);
+    expect(manifest?.pagesPaths).toEqual(["/about", "/fr/about"]);
   });
 
   it("skips dynamic warmup paths when static params discovery aborts", async () => {
@@ -603,6 +603,109 @@ describe("prerender path manifest", () => {
 
     expect(manifest?.paths).toEqual(["/pages-only"]);
     expect(manifest?.pagesPaths).toEqual(["/pages-only"]);
+  });
+
+  it("discovers locale-specific Pages Router warmup keys", async () => {
+    // Next.js passes i18n metadata to getStaticPaths and qualifies each
+    // returned pathname with its selected locale:
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/build/static-paths/pages.ts
+    writeFile("package.json", JSON.stringify({ type: "module" }));
+    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile("dist/server/entry.js", "export default {};\n");
+    writeFile("pages/about.tsx", "export default function Page() { return null; }\n");
+    writeFile(
+      "pages/posts/[slug].tsx",
+      [
+        "export function getStaticPaths() { return { paths: [], fallback: false }; }",
+        "export function getStaticProps() { return { props: {}, revalidate: 60 }; }",
+        "export default function Page() { return null; }",
+      ].join("\n"),
+    );
+    vi.mocked(fetch).mockImplementation(async (input) => {
+      const rawUrl =
+        input instanceof URL ? input.href : typeof input === "string" ? input : input.url;
+      const url = new URL(rawUrl);
+      if (url.pathname === "/__vinext/prerender/pages-static-paths") {
+        return Response.json({
+          fallback: false,
+          paths: [
+            { params: { slug: "hello" } },
+            { params: { slug: "bonjour" }, locale: "fr" },
+            "/fr/posts/string-fr",
+            "/posts/string-en",
+          ],
+        });
+      }
+      return new Response("null", { headers: { "content-type": "application/json" } });
+    });
+
+    const [{ emitPrerenderPathManifest }, { resolveNextConfig }, { readPrerenderWarmPlan }] =
+      await Promise.all([
+        import("../packages/vinext/src/build/prerender-paths.js"),
+        import("../packages/vinext/src/config/next-config.js"),
+        import("../packages/cloudflare/src/cdn-warm.js"),
+      ]);
+    const nextConfig = await resolveNextConfig(
+      {
+        basePath: "/docs",
+        i18n: { defaultLocale: "en", locales: ["en", "fr"] },
+        trailingSlash: true,
+      },
+      tmpDir,
+    );
+
+    const manifest = await emitPrerenderPathManifest({ root: tmpDir, nextConfig });
+
+    expect(manifest?.paths).toEqual([
+      "/about",
+      "/fr/about",
+      "/posts/hello",
+      "/fr/posts/bonjour",
+      "/fr/posts/string-fr",
+      "/posts/string-en",
+    ]);
+    expect(manifest?.pagesPaths).toEqual(manifest?.paths);
+    expect(fetch).toHaveBeenCalledWith(
+      "http://127.0.0.1:43210/__vinext/prerender/pages-static-paths?pattern=%2Fposts%2F%3Aslug&locales=%5B%22en%22%2C%22fr%22%5D&defaultLocale=en",
+      expect.any(Object),
+    );
+    expect(readPrerenderWarmPlan(tmpDir).paths).toEqual([
+      "/docs/about/",
+      "/docs/fr/about/",
+      "/docs/posts/hello/",
+      "/docs/fr/posts/bonjour/",
+      "/docs/fr/posts/string-fr/",
+      "/docs/posts/string-en/",
+    ]);
+  });
+
+  it("excludes only the locale-specific Pages key affected by a rewrite", async () => {
+    writeFile("package.json", JSON.stringify({ type: "module" }));
+    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile("dist/server/entry.js", "export default {};\n");
+    writeFile("pages/about.tsx", "export default function Page() { return null; }\n");
+
+    const [{ emitPrerenderPathManifest }, { resolveNextConfig }] = await Promise.all([
+      import("../packages/vinext/src/build/prerender-paths.js"),
+      import("../packages/vinext/src/config/next-config.js"),
+    ]);
+    const nextConfig = await resolveNextConfig(
+      {
+        i18n: { defaultLocale: "en", locales: ["en", "fr"] },
+        rewrites: () => [{ source: "/fr/about", destination: "/other", locale: false }],
+      },
+      tmpDir,
+    );
+
+    const manifest = await emitPrerenderPathManifest({
+      nextConfig,
+      responseVary: "verbatim",
+      root: tmpDir,
+    });
+
+    expect(manifest?.paths).toEqual(["/about"]);
+    expect(manifest?.pagesPaths).toEqual(["/about"]);
+    expect(manifest?.excludedWarmPaths).toEqual(["/fr/about"]);
   });
 
   it("does not reload disk config when supplied resolved config", async () => {

--- a/tests/prerender-paths.test.ts
+++ b/tests/prerender-paths.test.ts
@@ -212,6 +212,44 @@ describe("prerender path manifest", () => {
     expect(manifest?.loadingShellPaths).toEqual(["/safe"]);
   });
 
+  it("excludes warm paths shadowed by configured redirects", async () => {
+    // Next.js applies config redirects before rendering the filesystem route:
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/navigation/navigation.test.ts
+    writeFile("package.json", JSON.stringify({ type: "module" }));
+    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile("dist/server/RSC_BUILD_ID", "rsc-build-a\n");
+    writeFile("dist/server/index.js", "export default {};\n");
+    writeFile(
+      "app/redirect-me/page.tsx",
+      "export const revalidate = 60; export default function Page() {}\n",
+    );
+    writeFile(
+      "app/safe/page.tsx",
+      "export const revalidate = 60; export default function Page() {}\n",
+    );
+
+    const [{ emitPrerenderPathManifest }, { resolveNextConfig }] = await Promise.all([
+      import("../packages/vinext/src/build/prerender-paths.js"),
+      import("../packages/vinext/src/config/next-config.js"),
+    ]);
+    const nextConfig = await resolveNextConfig(
+      {
+        redirects: () => [{ source: "/redirect-me", destination: "/safe", permanent: false }],
+      },
+      tmpDir,
+    );
+
+    const manifest = await emitPrerenderPathManifest({
+      nextConfig,
+      responseVary: "verbatim",
+      root: tmpDir,
+    });
+
+    expect(manifest?.paths).toEqual(["/safe"]);
+    expect(manifest?.excludedWarmPaths).toEqual(["/redirect-me"]);
+    expect(manifest?.rscPaths).toEqual(["/safe"]);
+  });
+
   it("discovers a static child route from parent-layout generateStaticParams", async () => {
     // Next.js supports parent layouts generating params for static child pages:
     // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app-prefetch-static/app/[region]/(default)/layout.js
@@ -453,8 +491,7 @@ describe("prerender path manifest", () => {
     expect(manifest?.pagesPaths).toEqual(["/about", "/fr/about"]);
   });
 
-  it("skips dynamic warmup paths when static params discovery aborts", async () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  it("fails path discovery when generateStaticParams discovery aborts", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => {
@@ -478,13 +515,9 @@ describe("prerender path manifest", () => {
     const { emitPrerenderPathManifest } =
       await import("../packages/vinext/src/build/prerender-paths.js");
 
-    const manifest = await emitPrerenderPathManifest({ root: tmpDir });
-
-    expect(manifest?.paths).toEqual([]);
-    expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining("failed to discover warmup path(s) for /cached/:slug"),
+    await expect(emitPrerenderPathManifest({ root: tmpDir })).rejects.toThrow(
+      "Failed to discover warmup path(s) for /cached/:slug: path discovery timed out after 30000ms",
     );
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining("timed out after 30000ms"));
   });
 
   it("passes a custom RSC bundle path to the path discovery server", async () => {
@@ -632,6 +665,7 @@ describe("prerender path manifest", () => {
             { params: { slug: "hello" } },
             { params: { slug: "bonjour" }, locale: "fr" },
             "/fr/posts/string-fr",
+            "/FR/posts/string-fr-upper",
             "/posts/string-en",
           ],
         });
@@ -662,6 +696,7 @@ describe("prerender path manifest", () => {
       "/posts/hello",
       "/fr/posts/bonjour",
       "/fr/posts/string-fr",
+      "/fr/posts/string-fr-upper",
       "/posts/string-en",
     ]);
     expect(manifest?.pagesPaths).toEqual(manifest?.paths);
@@ -675,8 +710,30 @@ describe("prerender path manifest", () => {
       "/docs/posts/hello/",
       "/docs/fr/posts/bonjour/",
       "/docs/fr/posts/string-fr/",
+      "/docs/fr/posts/string-fr-upper/",
       "/docs/posts/string-en/",
     ]);
+  });
+
+  it("fails path discovery when getStaticPaths returns an HTTP error", async () => {
+    writeFile("package.json", JSON.stringify({ type: "module" }));
+    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile("dist/server/entry.js", "export default {};\n");
+    writeFile(
+      "pages/posts/[slug].tsx",
+      [
+        "export function getStaticPaths() { throw new Error('boom'); }",
+        "export function getStaticProps() { return { props: {}, revalidate: 60 }; }",
+        "export default function Page() { return null; }",
+      ].join("\n"),
+    );
+    vi.mocked(fetch).mockResolvedValue(new Response("getStaticPaths exploded", { status: 500 }));
+    const { emitPrerenderPathManifest } =
+      await import("../packages/vinext/src/build/prerender-paths.js");
+
+    await expect(emitPrerenderPathManifest({ root: tmpDir })).rejects.toThrow(
+      "Failed to discover warmup path(s) for /posts/:slug: path discovery returned HTTP 500",
+    );
   });
 
   it("excludes only the locale-specific Pages key affected by a rewrite", async () => {

--- a/tests/prerender-paths.test.ts
+++ b/tests/prerender-paths.test.ts
@@ -61,6 +61,12 @@ describe("prerender path manifest", () => {
         ) {
           return Response.json([{ locale: "fr" }]);
         }
+        if (
+          url.pathname === "/__vinext/prerender/static-params" &&
+          url.searchParams.get("pattern") === "/:category"
+        ) {
+          return Response.json([{ category: "news" }]);
+        }
         return new Response("null", { headers: { "content-type": "application/json" } });
       }),
     );
@@ -200,9 +206,111 @@ describe("prerender path manifest", () => {
       root: tmpDir,
     });
 
-    expect(manifest?.paths).toEqual(["/rewrite-me", "/safe"]);
+    expect(manifest?.paths).toEqual(["/safe"]);
+    expect(manifest?.excludedWarmPaths).toEqual(["/rewrite-me"]);
     expect(manifest?.rscPaths).toEqual(["/safe"]);
     expect(manifest?.loadingShellPaths).toEqual(["/safe"]);
+  });
+
+  it("discovers a static child route from parent-layout generateStaticParams", async () => {
+    // Next.js supports parent layouts generating params for static child pages:
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app-prefetch-static/app/[region]/(default)/layout.js
+    writeFile("package.json", JSON.stringify({ type: "module" }));
+    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile("dist/server/RSC_BUILD_ID", "rsc-build-a\n");
+    writeFile("dist/server/index.js", "export default {};\n");
+    writeFile(
+      "app/[category]/layout.tsx",
+      [
+        "export function generateStaticParams() { return [{ category: 'news' }]; }",
+        "export default function Layout({ children }) { return children; }",
+      ].join("\n"),
+    );
+    writeFile(
+      "app/[category]/foo/page.tsx",
+      "export const revalidate = 60; export default function Page() {}\n",
+    );
+    writeFile(
+      "app/[category]/foo/loading.tsx",
+      "export default function Loading() { return null; }\n",
+    );
+
+    const { emitPrerenderPathManifest } =
+      await import("../packages/vinext/src/build/prerender-paths.js");
+    const manifest = await emitPrerenderPathManifest({
+      responseVary: "verbatim",
+      root: tmpDir,
+    });
+
+    expect(manifest?.paths).toEqual(["/news/foo"]);
+    expect(manifest?.rscPaths).toEqual(["/news/foo"]);
+    expect(manifest?.loadingShellPaths).toEqual(["/news/foo"]);
+    expect(fetch).toHaveBeenCalledWith(
+      "http://127.0.0.1:43210/__vinext/prerender/static-params?pattern=%2F%3Acategory",
+      expect.any(Object),
+    );
+  });
+
+  it("matches rewrites against the trailing-slash warm URL", async () => {
+    writeFile("package.json", JSON.stringify({ type: "module" }));
+    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile("dist/server/RSC_BUILD_ID", "rsc-build-a\n");
+    writeFile("dist/server/index.js", "export default {};\n");
+    writeFile("app/foo/page.tsx", "export default function Page() {}\n");
+
+    const [{ emitPrerenderPathManifest }, { resolveNextConfig }] = await Promise.all([
+      import("../packages/vinext/src/build/prerender-paths.js"),
+      import("../packages/vinext/src/config/next-config.js"),
+    ]);
+    const nextConfig = await resolveNextConfig(
+      {
+        trailingSlash: true,
+        rewrites: () => [{ source: "/foo/", destination: "/other" }],
+      },
+      tmpDir,
+    );
+    const manifest = await emitPrerenderPathManifest({
+      nextConfig,
+      responseVary: "verbatim",
+      root: tmpDir,
+    });
+
+    expect(manifest?.paths).toEqual([]);
+    expect(manifest?.rscPaths).toEqual([]);
+    expect(manifest?.excludedWarmPaths).toEqual(["/foo"]);
+  });
+
+  it("checks rewrite identity for every configured domain default locale", async () => {
+    writeFile("package.json", JSON.stringify({ type: "module" }));
+    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile("dist/server/RSC_BUILD_ID", "rsc-build-a\n");
+    writeFile("dist/server/index.js", "export default {};\n");
+    writeFile("app/foo/page.tsx", "export default function Page() {}\n");
+
+    const [{ emitPrerenderPathManifest }, { resolveNextConfig }] = await Promise.all([
+      import("../packages/vinext/src/build/prerender-paths.js"),
+      import("../packages/vinext/src/config/next-config.js"),
+    ]);
+    const nextConfig = await resolveNextConfig(
+      {
+        i18n: {
+          defaultLocale: "en",
+          locales: ["en", "fr"],
+          domains: [{ domain: "example.fr", defaultLocale: "fr" }],
+        },
+        rewrites: () => [{ source: "/fr/foo", destination: "/other", locale: false }],
+      },
+      tmpDir,
+    );
+    const manifest = await emitPrerenderPathManifest({
+      nextConfig,
+      responseVary: "verbatim",
+      root: tmpDir,
+    });
+
+    expect(manifest?.paths).toEqual([]);
+    expect(manifest?.rscPaths).toEqual([]);
+    expect(manifest?.excludedWarmPaths).toEqual(["/foo"]);
   });
 
   it("excludes Pages-owned hybrid paths from App RSC warm discovery", async () => {

--- a/tests/prerender-paths.test.ts
+++ b/tests/prerender-paths.test.ts
@@ -99,6 +99,7 @@ describe("prerender path manifest", () => {
 
     expect(manifest).toEqual({
       buildId: "build-a",
+      buildIdentity: "rsc-build-a",
       loadingShellPaths: ["/cached/intro", "/cached/featured"],
       rscBuildId: "rsc-build-a",
       responseVary: "verbatim",

--- a/tests/prerender-paths.test.ts
+++ b/tests/prerender-paths.test.ts
@@ -159,6 +159,52 @@ describe("prerender path manifest", () => {
     expect(manifest?.rscBuildId).toBe("rsc-build-a");
   });
 
+  it("excludes App RSC warm paths affected by configured rewrites", async () => {
+    // Rewrite-aware prefetches can resolve a public URL to a different route:
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/concurrent-navigations/mismatching-prefetch.test.ts
+    writeFile("package.json", JSON.stringify({ type: "module" }));
+    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile("dist/server/RSC_BUILD_ID", "rsc-build-a\n");
+    writeFile("dist/server/index.js", "export default {};\n");
+    writeFile(
+      "app/rewrite-me/page.tsx",
+      "export const revalidate = 60; export default function Page() {}\n",
+    );
+    writeFile("app/rewrite-me/loading.tsx", "export default function Loading() { return null; }\n");
+    writeFile(
+      "app/safe/page.tsx",
+      "export const revalidate = 60; export default function Page() {}\n",
+    );
+    writeFile("app/safe/loading.tsx", "export default function Loading() { return null; }\n");
+
+    const [{ emitPrerenderPathManifest }, { resolveNextConfig }] = await Promise.all([
+      import("../packages/vinext/src/build/prerender-paths.js"),
+      import("../packages/vinext/src/config/next-config.js"),
+    ]);
+    const nextConfig = await resolveNextConfig(
+      {
+        rewrites: () => [
+          {
+            source: "/rewrite-me",
+            destination: "/safe",
+            has: [{ type: "header", key: "x-route-variant", value: "1" }],
+          },
+        ],
+      },
+      tmpDir,
+    );
+
+    const manifest = await emitPrerenderPathManifest({
+      nextConfig,
+      responseVary: "verbatim",
+      root: tmpDir,
+    });
+
+    expect(manifest?.paths).toEqual(["/rewrite-me", "/safe"]);
+    expect(manifest?.rscPaths).toEqual(["/safe"]);
+    expect(manifest?.loadingShellPaths).toEqual(["/safe"]);
+  });
+
   it("excludes Pages-owned hybrid paths from App RSC warm discovery", async () => {
     // Next.js resolves matching Pages and App routes by cross-router specificity:
     // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/use-params/use-params.test.ts

--- a/tests/prerender.test.ts
+++ b/tests/prerender.test.ts
@@ -2194,6 +2194,17 @@ describe("resolveParentParams", () => {
     expect(result).toEqual([{ category: "electronics" }, { category: "clothing" }]);
   });
 
+  it("can include a provider for the last dynamic segment", async () => {
+    const child = mockRoute("/:category/foo");
+    const staticParamsMap: StaticParamsMap = {
+      "/:category": async () => [{ category: "news" }],
+    };
+
+    await expect(
+      resolveParentParams(child, staticParamsMap, { includeLastDynamicSegment: true }),
+    ).resolves.toEqual([{ category: "news" }]);
+  });
+
   it("resolves two levels of parent dynamic segments", async () => {
     const child = mockRoute("/a/:b/c/:d/:e");
     const staticParamsMap: StaticParamsMap = {


### PR DESCRIPTION
## Summary

Consolidates the canonical warmup hardening previously split across #3021–#3040. This range ends at the first clean, self-contained deployed boundary: earlier heads could begin filling cache keys while version-override routing was still mixed, which is fixed by the staged-readiness work included here.

### Response and build validation

- validate effective Cloudflare cache policy, shared freshness, cache admission status, cookies, content type, exact supported `Vary`, and immutable build identity
- expose generic adapter-owned build identity at the outer App and Pages response boundary
- retry only failed staged requests after the initial queue and distinguish transient old-build responses from permanent same-build failures
- keep strict and best-effort warming bound to the uploaded Worker build

### Canonical request ownership

- align concrete App/Pages and hybrid-i18n ownership between browser navigation, runtime routing, and warm discovery
- keep rewrite-affected, parallel/interception-only, and other contextual requests hashed rather than collapsing them into canonical entries
- prove Link, `router.prefetch()`, `router.push()`, explicit full prefetch, and soft navigation reuse on a real deployed Worker
- isolate each deployed proof attempt behind a fresh Worker/cache namespace

### Discovery and staged deployment

- discover child routes using parent-generated params and exclude rewrite/redirect-owned public paths
- discover localized Pages keys with basePath and trailingSlash applied correctly
- warm the concrete production route/custom domain reported by Wrangler without changing TPR parsing
- derive version identity from upload output and fail closed when deployment state is unavailable
- establish stable uploaded-version readiness with unique no-cache probes before sending any canonical cache-fill request
- enforce strict/no-promote staging invariants, configured retry budgets, and complete fail-closed discovery

The three findings raised on #3038 are resolved by #3039 and #3040 within this consolidated range.

## Scope

Only canonical RSC/ISR CDN warm request identity, build-time warm discovery, response validation, and Cloudflare staged deployment. No middleware, TPR, development-mode, cross-version-cache, local page rendering, or generic caching changes.

## Validation

The retained commits keep their focused client, ownership, cache, adapter, discovery, deploy, version, build, and deployed Playwright coverage. This exact head passed all 67 checks, including strict Worker prewarming and browser reuse.

Consolidates #3021 through #3040. Stacked on #3020.