### PR TITLE
test(cloudflare): prove deployed Pages CDN prewarming

### DIFF
--- a/examples/workers-cache/pages/pages-prewarm.tsx
+++ b/examples/workers-cache/pages/pages-prewarm.tsx
@@ -1,0 +1,7 @@
+export async function getStaticProps() {
+  return { props: {}, revalidate: 300 };
+}
+
+export default function PagesPrewarmTarget() {
+  return <h1>Pages prewarm target</h1>;
+}

--- a/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
+++ b/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
@@ -10,6 +10,7 @@ import {
 import fs from "node:fs";
 
 const TARGET_PATH = "/prewarm-target";
+const PAGES_TARGET_PATH = "/pages-prewarm";
 const LOADING_SHELL_RSC_SEARCH = "?_rsc=9qLBDIU2NgN178cB";
 const PROMOTION_STABILITY_WINDOW_MS = 60_000;
 const PROMOTION_READINESS_TIMEOUT_MS = 120_000;
@@ -32,10 +33,10 @@ function rejectStaleSeedWorker(response: Response | null): void {
   }
 }
 
-async function getCanonicalRscAfterPromotion(
+async function getResponseAfterPromotion(
   request: APIRequestContext,
   url: string,
-  headers: Record<string, string>,
+  headers: Record<string, string> = {},
 ): Promise<APIResponse> {
   const deadline = Date.now() + STALE_SEED_RETRY_TIMEOUT_MS;
   let lastSeedStatus: number | undefined;
@@ -51,7 +52,7 @@ async function getCanonicalRscAfterPromotion(
   } while (Date.now() < deadline);
 
   throw new Error(
-    `stale seed Worker remained reachable for canonical RSC request: ${lastSeedStatus ?? "unknown status"}`,
+    `stale seed Worker remained reachable for prewarmed request: ${lastSeedStatus ?? "unknown status"}`,
   );
 }
 
@@ -160,7 +161,7 @@ async function waitForStablePromotion({
   );
 }
 
-test("deploy-prewarmed full and loading RSC variants are reused by browser navigation", async ({
+test("deploy-prewarmed Pages HTML and RSC variants are reused", async ({
   baseURL,
   browser,
   playwright,
@@ -190,7 +191,18 @@ test("deploy-prewarmed full and loading RSC variants are reused by browser navig
   // without touching either canonical cache entry before its HIT assertion.
   await waitForStablePromotion({ baseURL, buildId, playwright, rscBuildId });
 
-  const fullResponse = await getCanonicalRscAfterPromotion(
+  const pagesResponse = await getResponseAfterPromotion(request, `${baseURL}${PAGES_TARGET_PATH}`);
+  const pagesResponseHeaders = pagesResponse.headers();
+  expect(pagesResponse.ok(), JSON.stringify(pagesResponseHeaders)).toBe(true);
+  expect(pagesResponseHeaders["content-type"]).toContain("text/html");
+  expect(pagesResponseHeaders["x-vinext-build-id"]).toBe(rscBuildId);
+  expect(
+    pagesResponseHeaders["cf-cache-status"],
+    `Pages response headers: ${JSON.stringify(pagesResponseHeaders)}`,
+  ).toBe("HIT");
+  expect(await pagesResponse.text()).toContain("Pages prewarm target");
+
+  const fullResponse = await getResponseAfterPromotion(
     request,
     `${baseURL}${TARGET_PATH}?_rsc`,
     fullHeaders,
@@ -207,7 +219,7 @@ test("deploy-prewarmed full and loading RSC variants are reused by browser navig
   expect(fullBody).toContain(buildId);
   expect(fullBody).toContain("Prewarm target");
 
-  const shellResponse = await getCanonicalRscAfterPromotion(
+  const shellResponse = await getResponseAfterPromotion(
     request,
     `${baseURL}${TARGET_PATH}${LOADING_SHELL_RSC_SEARCH}`,
     shellHeaders,


### PR DESCRIPTION
## Summary

- add one non-conflicting Pages ISR route to the existing hybrid workers-cache fixture
- require the staged deploy warmup to discover and fill that HTML key
- assert the first post-promotion Pages request is an untouched CDN HIT from the exact uploaded build before running the existing RSC browser proof

## Scope

This reuses the existing Worker, seed deployment, strict warm command, production hostname, promotion readiness check, and Playwright job. It does not add a second deploy flow or change production behavior.

## Validation

- workers-cache hybrid App/Pages production build passed locally
- 20 focused discovery tests passed
- vp check passed
- deployed strict warm/HIT proof runs in this PR CI