### PR TITLE
fix(cloudflare): reject incomplete no-promote CDN warmup

### DIFF
--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -727,11 +727,23 @@ export async function deployWithCdnWarmup(
     );
   }
 
+  const remainingWarmRequests =
+    remainingWarmPlan.paths.length +
+    remainingWarmPlan.rscPaths.length +
+    remainingWarmPlan.loadingShellPaths.length;
+
   if (options.warmCdnPromote === false) {
     if (!staged) {
       throw new Error(
         "CDN warmup cannot skip promotion because the uploaded Worker version could not be staged at 0% traffic. " +
           "The current deployment must have exactly one version serving 100% traffic.",
+      );
+    }
+    if (remainingWarmRequests > 0) {
+      throw withStagedVersionCleanupNote(
+        new Error(
+          `CDN warmup cannot skip promotion because ${remainingWarmRequests} request(s) remain unwarmed.`,
+        ),
       );
     }
     console.log(
@@ -770,10 +782,6 @@ export async function deployWithCdnWarmup(
   } catch (error) {
     throw withPromotedVersionTriggerNote(error);
   }
-  const remainingWarmRequests =
-    remainingWarmPlan.paths.length +
-    remainingWarmPlan.rscPaths.length +
-    remainingWarmPlan.loadingShellPaths.length;
   if (remainingWarmRequests > 0) {
     const targetUrl =
       resolveCdnWarmupTargetUrl(root, triggersDeployedUrl, options) ?? deployed.deployedUrl;

--- a/tests/cloudflare-cdn-warm-deploy.test.ts
+++ b/tests/cloudflare-cdn-warm-deploy.test.ts
@@ -881,6 +881,49 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     ).toBe(false);
   });
 
+  it("fails no-promote deployment when a staged warm request remains unsuccessful", async () => {
+    writeFile(
+      "wrangler.jsonc",
+      JSON.stringify({ name: "my-worker", custom_domains: ["app.example.com"] }),
+    );
+    vi.mocked(fetch).mockImplementation(async (url) => {
+      if (isReadinessFetch(url)) return cacheableHtml();
+      return new Response("unavailable", { status: 503 });
+    });
+    execFileSyncMock.mockImplementation((_file: string, args: string[]) => {
+      if (args.includes("upload")) {
+        return "Uploaded my-worker\nWorker Version ID: 22222222-2222-4222-8222-222222222222\n";
+      }
+      if (args.includes("status")) {
+        return JSON.stringify({
+          versions: [{ version_id: "11111111-1111-4111-8111-111111111111", percentage: 100 }],
+        });
+      }
+      if (args.includes("22222222-2222-4222-8222-222222222222@0%")) {
+        return "Staged version\nhttps://app.example.com\n";
+      }
+      if (args.includes("triggers")) {
+        return "Triggers deployed\n  app.example.com (custom domain)\n";
+      }
+      throw new Error(`Unexpected Wrangler args: ${args.join(" ")}`);
+    });
+    const { deployWithCdnWarmup } = await import("../packages/cloudflare/src/deploy.js");
+
+    await expect(
+      deployWithCdnWarmup(tmpDir, ["/about"], {
+        expectedBuildId: "app-build-a",
+        warmCdnPromote: false,
+        warmCdnRetries: 0,
+      }),
+    ).rejects.toThrow("1 request(s) remain unwarmed");
+    expect(fetch).toHaveBeenCalledTimes(7);
+    expect(
+      (execFileSyncMock.mock.calls as Array<[string, string[]]>).some(([, args]) =>
+        args.includes("22222222-2222-4222-8222-222222222222@100%"),
+      ),
+    ).toBe(false);
+  });
+
   it("rejects strict HTML warmup without verifiable build identity before upload", async () => {
     writeFile(
       "wrangler.jsonc",


### PR DESCRIPTION
## Summary

- reject `--warm-cdn-no-promote` when any staged warm request remains unsuccessful
- keep the uploaded version staged at 0% and report the existing cleanup guidance instead of returning false success
- cover readiness-success plus real-request-failure without promoting

## Scope

This is a focused follow-up from the cumulative RSC/ISR CDN prewarming review. It changes only no-promote completion semantics and its focused deploy test.

## Validation

- 26 Cloudflare warm-deploy tests passed
- targeted format, lint, and type checks passed