### PR TITLE
test(cloudflare): prove prewarmed App HTML cache reuse

### DIFF
--- a/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
+++ b/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
@@ -202,6 +202,17 @@ test("deploy-prewarmed Pages HTML and RSC variants are reused", async ({
   ).toBe("HIT");
   expect(await pagesResponse.text()).toContain("Pages prewarm target");
 
+  const appHtmlResponse = await getResponseAfterPromotion(request, `${baseURL}${TARGET_PATH}`);
+  const appHtmlResponseHeaders = appHtmlResponse.headers();
+  expect(appHtmlResponse.ok(), JSON.stringify(appHtmlResponseHeaders)).toBe(true);
+  expect(appHtmlResponseHeaders["content-type"]).toContain("text/html");
+  expect(appHtmlResponseHeaders["x-vinext-build-id"]).toBe(rscBuildId);
+  expect(
+    appHtmlResponseHeaders["cf-cache-status"],
+    `App HTML response headers: ${JSON.stringify(appHtmlResponseHeaders)}`,
+  ).toBe("HIT");
+  expect(await appHtmlResponse.text()).toContain("Prewarm target");
+
   const fullResponse = await getResponseAfterPromotion(
     request,
     `${baseURL}${TARGET_PATH}?_rsc`,


### PR DESCRIPTION
## Summary

- require the first post-promotion App Router HTML request to be a CDN `HIT`
- bind the response to the exact uploaded build and expected page body
- keep the assertion ahead of all RSC browser traffic so the test cannot fill the key itself

## Scope

This is the final narrow deployed-proof follow-up from the cumulative RSC/ISR CDN prewarming review. It changes no production behavior.

## Validation

- targeted format, lint, and type checks passed
- the deployed Worker proof runs in this PR CI