### PR TITLE
fix(cloudflare): enforce no-promote CDN warmup contract

### DIFF
--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -592,6 +592,16 @@ export async function deployWithCdnWarmup(
         "Configure that adapter capability or rerun without --warm-cdn-strict.",
     );
   }
+  if (
+    options.warmCdnPromote === false &&
+    paths.length > 0 &&
+    options.expectedBuildId === undefined
+  ) {
+    throw new Error(
+      "CDN warmup cannot skip promotion because the discovered HTML requests cannot be verified. " +
+        "Configure a CDN adapter that declares build-identity response headers.",
+    );
+  }
   const upload = runWranglerVersionUpload(root, options);
   const warmUploadedVersion = (
     targetUrl: string,
@@ -1116,6 +1126,11 @@ export async function deploy(options: DeployOptions): Promise<void> {
         warmCdnPromotionDelay: options.warmCdnPromotionDelay,
       });
     } else {
+      if (options.warmCdnPromote === false) {
+        throw new Error(
+          "CDN warmup cannot skip promotion because no build-discovered requests were found to warm.",
+        );
+      }
       console.log("\n  CDN warmup skipped: no build-discovered paths found.");
       url = await runWranglerDeploy(root, wranglerOptions);
     }

--- a/tests/cloudflare-cdn-warm-deploy.test.ts
+++ b/tests/cloudflare-cdn-warm-deploy.test.ts
@@ -724,6 +724,18 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
+  it("rejects no-promote HTML warmup without verifiable build identity before upload", async () => {
+    const { deployWithCdnWarmup } = await import("../packages/cloudflare/src/deploy.js");
+
+    await expect(
+      deployWithCdnWarmup(tmpDir, ["/about"], {
+        warmCdnPromote: false,
+      }),
+    ).rejects.toThrow("discovered HTML requests cannot be verified");
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it("applies triggers before post-promotion fallback warmup", async () => {
     const events: string[] = [];
     writeFile(

--- a/tests/deploy-prerender-config.test.ts
+++ b/tests/deploy-prerender-config.test.ts
@@ -414,4 +414,19 @@ describe("deploy prerender config wiring", () => {
       "deploy",
     ]);
   });
+
+  it("rejects no-promote warmup when discovery finds no requests", async () => {
+    writeApiOnlyProject();
+    const { deploy } = await import("../packages/cloudflare/src/deploy.js");
+
+    await expect(
+      deploy({
+        root: tmpDir,
+        skipBuild: true,
+        warmCdnCache: true,
+        warmCdnPromote: false,
+      }),
+    ).rejects.toThrow("no build-discovered requests were found to warm");
+    expect(spawn).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

- reject `--warm-cdn-no-promote` when discovery finds no requests instead of silently running an ordinary deployment
- reject no-promote HTML warming before upload when the adapter cannot verify response build identity
- preserve normal best-effort promotion behavior when no-promote is not requested

## Scope

This is a narrow exact-head review follow-up for the CDN prewarming promotion-control flag. It does not change cache admission, routing, middleware, or general deployment behavior.

## Validation

- 39 focused deploy tests passed
- targeted format, lint, and type checks passed