### PR TITLE
fix(build): preserve encoded Pages CDN warm keys

### DIFF
--- a/packages/vinext/src/build/prerender-paths.ts
+++ b/packages/vinext/src/build/prerender-paths.ts
@@ -12,7 +12,11 @@ import {
   matchAppRoute,
 } from "../routing/app-router.js";
 import { apiRouter, matchRoute, pagesRouter } from "../routing/pages-router.js";
-import { normalizeStaticPathsEntry, type StaticPathsEntry } from "../routing/route-pattern.js";
+import {
+  normalizeStaticPathname,
+  normalizeStaticPathsEntry,
+  type StaticPathsEntry,
+} from "../routing/route-pattern.js";
 import {
   getAppRouteRenderEntryPath,
   classifyAppRoute,
@@ -386,12 +390,9 @@ async function collectPagesPaths(options: {
         const validatedItem = validatePagesStaticPathsEntry(item, route.pattern);
         let itemToNormalize = validatedItem;
         let locale = options.i18n?.defaultLocale;
-        let explicitLocalePrefix: string | undefined;
         if (options.i18n && typeof validatedItem === "string") {
           const localeInfo = extractPagesStaticPathLocale(validatedItem, options.i18n);
           itemToNormalize = localeInfo.url;
-          locale = localeInfo.locale;
-          explicitLocalePrefix = localeInfo.explicitLocalePrefix;
         } else if (
           options.i18n &&
           validatedItem &&
@@ -410,12 +411,15 @@ async function collectPagesPaths(options: {
         if ("error" in normalized) {
           throw new Error(normalized.error);
         }
-        const pathname = buildUrlFromParams(route.pattern, normalized.params);
-        addPath(
-          paths,
-          seen,
-          localizePagesPath(pathname, locale, options.i18n, explicitLocalePrefix),
-        );
+        const pathname =
+          typeof validatedItem === "string"
+            ? normalizeStaticPathname(validatedItem)
+            : localizePagesPath(
+                buildUrlFromParams(route.pattern, normalized.params),
+                locale,
+                options.i18n,
+              );
+        addPath(paths, seen, pathname);
       }
     } catch (error) {
       throwDiscoveryFailure(route.pattern, error);
@@ -429,11 +433,7 @@ function localizePagesPath(
   pathname: string,
   locale: string | undefined,
   i18n: ResolvedNextConfig["i18n"],
-  explicitLocalePrefix?: string,
 ): string {
-  if (explicitLocalePrefix) {
-    return pathname === "/" ? `/${explicitLocalePrefix}` : `/${explicitLocalePrefix}${pathname}`;
-  }
   if (!i18n || !locale || locale === i18n.defaultLocale) return pathname;
   return pathname === "/" ? `/${locale}` : `/${locale}${pathname}`;
 }

--- a/tests/cloudflare-cdn-warm.test.ts
+++ b/tests/cloudflare-cdn-warm.test.ts
@@ -73,6 +73,10 @@ describe("Cloudflare CDN warmup", () => {
     expect(buildWarmupUrl("https://app.example.com", "/search?q=x").href).toBe(
       "https://app.example.com/search?q=x",
     );
+    expect(buildWarmupUrl("https://app.example.com", "/posts/%7Euser").pathname).toBe(
+      "/posts/%7Euser",
+    );
+    expect(buildWarmupUrl("https://app.example.com", "/posts/a%2fb").pathname).toBe("/posts/a%2fb");
   });
 
   it("reads only build-discovered paths and does not require local prerender output", () => {

--- a/tests/prerender-paths.test.ts
+++ b/tests/prerender-paths.test.ts
@@ -701,6 +701,8 @@ describe("prerender path manifest", () => {
             "/FR/posts/string-fr-upper",
             "/en/posts/string-en-explicit",
             "/posts/string-en",
+            "/posts/%7Euser/",
+            "/posts/a%2fb/",
           ],
         });
       }
@@ -733,6 +735,8 @@ describe("prerender path manifest", () => {
       "/FR/posts/string-fr-upper",
       "/en/posts/string-en-explicit",
       "/posts/string-en",
+      "/posts/%7Euser",
+      "/posts/a%2fb",
     ]);
     expect(manifest?.pagesPaths).toEqual(manifest?.paths);
     expect(fetch).toHaveBeenCalledWith(
@@ -748,6 +752,8 @@ describe("prerender path manifest", () => {
       "/docs/FR/posts/string-fr-upper/",
       "/docs/en/posts/string-en-explicit/",
       "/docs/posts/string-en/",
+      "/docs/posts/%7Euser/",
+      "/docs/posts/a%2fb/",
     ]);
   });
 


### PR DESCRIPTION
## Summary

- preserve the validated original spelling of string entries returned by Pages Router getStaticPaths
- continue matching those entries against the route and locale before adding them to the warm plan
- keep object-form params on the existing canonical encoding path
- prevent percent-encoding case and unreserved-character normalization from warming a different Workers cache key

## Tests

- vp test run tests/prerender-paths.test.ts tests/cloudflare-cdn-warm.test.ts
- vp check packages/vinext/src/build/prerender-paths.ts tests/prerender-paths.test.ts

Stacked on #3050.