### PR TITLE
fix(build): exclude unsafe Pages CDN warm paths

### DIFF
--- a/packages/vinext/src/build/prerender-paths.ts
+++ b/packages/vinext/src/build/prerender-paths.ts
@@ -199,6 +199,13 @@ function validatePagesStaticPathsEntry(entry: StaticPathsEntry, pattern: string)
         `The provided path \`${entry}\` from getStaticPaths does not match the route pattern \`${pattern}\`.`,
       );
     }
+    try {
+      for (const segment of entry.split("/")) decodeURIComponent(segment);
+    } catch {
+      throw new Error(
+        `The provided path \`${entry}\` from getStaticPaths contains malformed percent-encoding.`,
+      );
+    }
     return entry;
   }
   if (!entry || typeof entry !== "object" || Array.isArray(entry)) return entry;
@@ -427,6 +434,22 @@ async function collectPagesPaths(options: {
   }
 
   return paths;
+}
+
+async function excludePagesApiWarmPaths(options: {
+  i18n: ResolvedNextConfig["i18n"];
+  pagesDir: string;
+  pageExtensions: readonly string[];
+  paths: readonly string[];
+}): Promise<string[]> {
+  const apiRoutes = await apiRouter(options.pagesDir, options.pageExtensions);
+  return options.paths.filter((pathname) => {
+    const pagesPathname = options.i18n
+      ? extractLocaleFromUrl(pathname, options.i18n).url
+      : pathname;
+    if (pagesPathname !== "/api" && !pagesPathname.startsWith("/api/")) return true;
+    return matchRoute(pagesPathname, apiRoutes) === null;
+  });
 }
 
 function localizePagesPath(
@@ -796,6 +819,15 @@ export async function emitPrerenderPathManifest(
   const configuredPagesWarmPaths = discoveredPagesPaths.filter(
     (pathname) => !excludedWarmPathSet.has(pathname),
   );
+  const resolvedPagesWarmPaths =
+    !appDir && pagesDir
+      ? await excludePagesApiWarmPaths({
+          i18n: config.i18n,
+          pagesDir,
+          pageExtensions: config.pageExtensions,
+          paths: configuredPagesWarmPaths,
+        })
+      : configuredPagesWarmPaths;
   const configuredCandidatePaths = paths.filter((pathname) => !excludedWarmPathSet.has(pathname));
   const appOwnedWarmPaths = appDir
     ? await resolveAppWarmPaths({
@@ -810,7 +842,7 @@ export async function emitPrerenderPathManifest(
         loadingShellPaths: discoveredLoadingShellPaths,
         rscPaths: discoveredAppPaths,
       };
-  const warmPaths = appDir ? appOwnedWarmPaths.htmlPaths : configuredPagesWarmPaths;
+  const warmPaths = appDir ? appOwnedWarmPaths.htmlPaths : resolvedPagesWarmPaths;
 
   const manifest: PrerenderPathManifest = {
     ...(config.basePath ? { basePath: config.basePath } : {}),
@@ -819,7 +851,7 @@ export async function emitPrerenderPathManifest(
     ...(config.deploymentId ? { deploymentId: config.deploymentId } : {}),
     ...(pagesDir
       ? {
-          pagesPaths: configuredPagesWarmPaths,
+          pagesPaths: resolvedPagesWarmPaths,
         }
       : {}),
     ...(excludedWarmPathSet.size > 0 ? { excludedWarmPaths: Array.from(excludedWarmPathSet) } : {}),

--- a/tests/prerender-paths.test.ts
+++ b/tests/prerender-paths.test.ts
@@ -671,6 +671,34 @@ describe("prerender path manifest", () => {
     expect(manifest?.pagesPaths).toEqual(["/pages-only"]);
   });
 
+  it("excludes Pages API handlers from Pages-only concrete warm paths", async () => {
+    writeFile("package.json", JSON.stringify({ type: "module" }));
+    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile("dist/server/entry.js", "export default {};\n");
+    writeFile(
+      "pages/[...slug].tsx",
+      [
+        "export function getStaticPaths() { return { paths: [], fallback: false }; }",
+        "export function getStaticProps() { return { props: {}, revalidate: 60 }; }",
+        "export default function Page() { return null; }",
+      ].join("\n"),
+    );
+    writeFile(
+      "pages/api/[...slug].ts",
+      "export default function handler(_request, response) { response.end('ok'); }\n",
+    );
+    vi.mocked(fetch).mockResolvedValue(
+      Response.json({ fallback: false, paths: ["/page/foo", "/api/foo"] }),
+    );
+
+    const { emitPrerenderPathManifest } =
+      await import("../packages/vinext/src/build/prerender-paths.js");
+    const manifest = await emitPrerenderPathManifest({ root: tmpDir });
+
+    expect(manifest?.paths).toEqual(["/page/foo"]);
+    expect(manifest?.pagesPaths).toEqual(["/page/foo"]);
+  });
+
   it("discovers locale-specific Pages Router warmup keys", async () => {
     // Next.js passes i18n metadata to getStaticPaths and qualifies each
     // returned pathname with its selected locale:
@@ -813,6 +841,7 @@ describe("prerender path manifest", () => {
     ["a query-bearing string path", "/posts/[slug].tsx", "/posts/query?x=1"],
     ["a relative string path", "/posts/[slug].tsx", "posts/x"],
     ["a double-slash string path", "/posts/[slug].tsx", "/posts//x"],
+    ["malformed percent-encoding", "/posts/[slug].tsx", "/posts/%ZZ/"],
   ])("fails path discovery for getStaticPaths entry with %s", async (_name, file, entry) => {
     writeFile("package.json", JSON.stringify({ type: "module" }));
     writeFile("dist/server/BUILD_ID", "build-a\n");


### PR DESCRIPTION
## Summary

- exclude concrete Pages-only warm paths when a real Pages API route owns the request
- reject malformed percent-encoding from string getStaticPaths entries during discovery
- prevent deploy warming from invoking API handlers or requesting paths the runtime rejects

## Tests

- vp test run tests/prerender-paths.test.ts
- vp check packages/vinext/src/build/prerender-paths.ts tests/prerender-paths.test.ts

Stacked on #3051.