### PR TITLE
fix(router): serve localized CDN warm paths case-insensitively

### DIFF
--- a/packages/vinext/src/server/pages-i18n.ts
+++ b/packages/vinext/src/server/pages-i18n.ts
@@ -113,8 +113,10 @@ export function extractLocaleFromUrl(
   const parts = pathname.split("/").filter(Boolean);
   const query = url.includes("?") ? url.slice(url.indexOf("?")) : "";
 
-  if (parts.length > 0 && i18nConfig.locales.includes(parts[0])) {
-    const locale = parts[0];
+  const locale = i18nConfig.locales.find(
+    (candidate) => candidate.toLowerCase() === parts[0]?.toLowerCase(),
+  );
+  if (locale) {
     const rest = "/" + parts.slice(1).join("/");
     return { locale, url: (rest || "/") + query, hadPrefix: true };
   }

--- a/tests/pages-i18n.test.ts
+++ b/tests/pages-i18n.test.ts
@@ -72,6 +72,14 @@ describe("Pages i18n domain helpers", () => {
     expect(addLocalePrefix("/FR/about", "fr", "en")).toBe("/FR/about");
   });
 
+  it("routes locale prefixes case-insensitively using the configured locale", () => {
+    expect(resolvePagesI18nRequest("/FR/about", i18n)).toMatchObject({
+      hadPrefix: true,
+      locale: "fr",
+      url: "/about",
+    });
+  });
+
   it("does not let NEXT_LOCALE override the current domain default locale", () => {
     expect(
       getLocaleRedirect({


### PR DESCRIPTION
## Summary

- match Pages locale prefixes case-insensitively at runtime, as Next.js does
- return the canonical configured locale while preserving the request pathname spelling
- ensure localized getStaticPaths warm keys such as /FR/... reach the same Pages ISR route that discovery validated

## Tests

- vp test run tests/pages-i18n.test.ts tests/prerender-paths.test.ts
- vp check packages/vinext/src/server/pages-i18n.ts tests/pages-i18n.test.ts

Stacked on #3052.