### PR TITLE
fix(cache): honor CDN adapter build identity capability

### DIFF
--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -1043,6 +1043,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
     await emitPrerenderPathManifest({
       root: info.root,
       nextConfig,
+      buildIdentity: hasBuildIdentityHeader ? "response-header" : undefined,
       responseVary: hasStrictResponseVary ? "verbatim" : undefined,
       routeRootConfig: viteConfigMetadata.routeRootConfig,
     });

--- a/packages/vinext/src/build/prerender-paths.ts
+++ b/packages/vinext/src/build/prerender-paths.ts
@@ -72,6 +72,7 @@ type EmitPrerenderPathManifestOptions = {
   routeRootConfig?: VinextRouteRootConfig | null;
   pagesBundlePath?: string;
   rscBundlePath?: string;
+  buildIdentity?: CdnCacheAdapterCapabilities["buildIdentity"];
   responseVary?: CdnCacheAdapterCapabilities["responseVary"];
 };
 
@@ -847,7 +848,9 @@ export async function emitPrerenderPathManifest(
   const manifest: PrerenderPathManifest = {
     ...(config.basePath ? { basePath: config.basePath } : {}),
     buildId: config.buildId,
-    ...(rscBuildId ? { buildIdentity: rscBuildId } : {}),
+    ...(rscBuildId && options.buildIdentity === "response-header"
+      ? { buildIdentity: rscBuildId }
+      : {}),
     ...(config.deploymentId ? { deploymentId: config.deploymentId } : {}),
     ...(pagesDir
       ? {

--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -64,6 +64,7 @@ import {
 } from "./config/prerender.js";
 import {
   findVinextCacheConfigInPlugins,
+  hasBuildIdentityResponseHeader,
   hasVerbatimResponseVary,
   type VinextCacheConfig,
 } from "./cache/cache-adapters-virtual.js";
@@ -729,6 +730,9 @@ async function buildApp() {
     await emitPrerenderPathManifest({
       root,
       nextConfig: resolvedNextConfig,
+      buildIdentity: hasBuildIdentityResponseHeader(buildConfigMetadata.cacheConfig)
+        ? "response-header"
+        : undefined,
       responseVary: hasVerbatimResponseVary(buildConfigMetadata.cacheConfig)
         ? "verbatim"
         : undefined,

--- a/tests/prerender-paths.test.ts
+++ b/tests/prerender-paths.test.ts
@@ -101,7 +101,11 @@ describe("prerender path manifest", () => {
     const { emitPrerenderPathManifest } =
       await import("../packages/vinext/src/build/prerender-paths.js");
 
-    const manifest = await emitPrerenderPathManifest({ root: tmpDir, responseVary: "verbatim" });
+    const manifest = await emitPrerenderPathManifest({
+      root: tmpDir,
+      buildIdentity: "response-header",
+      responseVary: "verbatim",
+    });
 
     expect(manifest).toEqual({
       buildId: "build-a",
@@ -287,6 +291,21 @@ describe("prerender path manifest", () => {
       "http://127.0.0.1:43210/__vinext/prerender/static-params?pattern=%2F%3Acategory",
       expect.any(Object),
     );
+  });
+
+  it("only advertises HTML build identity when the CDN adapter guarantees it", async () => {
+    writeFile("package.json", JSON.stringify({ type: "module" }));
+    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile("dist/server/RSC_BUILD_ID", "rsc-build-a\n");
+    writeFile("dist/server/index.js", "export default {};\n");
+    writeFile("app/page.tsx", "export default function Page() { return null; }\n");
+
+    const { emitPrerenderPathManifest } =
+      await import("../packages/vinext/src/build/prerender-paths.js");
+    const manifest = await emitPrerenderPathManifest({ root: tmpDir, responseVary: "verbatim" });
+
+    expect(manifest?.buildIdentity).toBeUndefined();
+    expect(manifest?.rscBuildId).toBe("rsc-build-a");
   });
 
   it("matches rewrites against the trailing-slash warm URL", async () => {


### PR DESCRIPTION
## Summary

- emit the HTML buildIdentity warm-plan guarantee only when the configured CDN adapter declares response-header support
- pass the adapter capability through both vinext build discovery and Cloudflare deploy discovery
- keep the independent RSC build identity available for canonical RSC validation
- prevent manifest-driven warming with custom strict-Vary adapters from requiring a header they do not promise

## Tests

- vp test run tests/prerender-paths.test.ts tests/cloudflare-cdn-warm-deploy.test.ts tests/deploy-prerender-config.test.ts tests/deploy.test.ts
- vp check packages/vinext/src/build/prerender-paths.ts packages/vinext/src/cli.ts packages/cloudflare/src/deploy.ts tests/prerender-paths.test.ts

Stacked on #3053.