### PR TITLE
fix(build): discover dynamic MDX CDN warm paths

### DIFF
--- a/packages/vinext/src/build/prerender-paths.ts
+++ b/packages/vinext/src/build/prerender-paths.ts
@@ -17,12 +17,7 @@ import {
   normalizeStaticPathsEntry,
   type StaticPathsEntry,
 } from "../routing/route-pattern.js";
-import {
-  getAppRouteRenderEntryPath,
-  classifyAppRoute,
-  classifyPagesRoute,
-  hasNamedExport,
-} from "./report.js";
+import { getAppRouteRenderEntryPath, classifyAppRoute, classifyPagesRoute } from "./report.js";
 import { buildUrlFromParams, resolveParentParams, type StaticParamsMap } from "./prerender.js";
 import { readPrerenderSecret } from "./server-manifest.js";
 import { startProdServer } from "../server/prod-server.js";
@@ -260,7 +255,7 @@ async function fetchDiscoveryEndpoint(
     });
     const text = await res.text();
     if (!res.ok) throw new Error(`path discovery returned HTTP ${res.status}`);
-    if (text === "null") return null;
+    if (res.status === 204) return null;
     return text;
   } catch (error) {
     if (error instanceof Error && error.name === "AbortError") {
@@ -269,15 +264,6 @@ async function fetchDiscoveryEndpoint(
     throw error;
   } finally {
     clearTimeout(timeout);
-  }
-}
-
-function fileHasNamedExport(filePath: string | null | undefined, name: string): boolean {
-  if (!filePath) return false;
-  try {
-    return hasNamedExport(fs.readFileSync(filePath, "utf-8"), name);
-  } catch {
-    return false;
   }
 }
 
@@ -317,11 +303,6 @@ function resolveConfiguredRouteDirs(
   };
 }
 
-function appRouteMayHaveGenerateStaticParams(route: Awaited<ReturnType<typeof appRouter>>[number]) {
-  if (fileHasNamedExport(route.pagePath, "generateStaticParams")) return true;
-  return route.layouts.some((layoutPath) => fileHasNamedExport(layoutPath, "generateStaticParams"));
-}
-
 async function shouldStartPathDiscoveryServer(options: {
   appDir: string | null;
   pagesDir: string | null;
@@ -329,20 +310,12 @@ async function shouldStartPathDiscoveryServer(options: {
 }): Promise<boolean> {
   if (options.appDir) {
     const routes = await appRouter(options.appDir, options.pageExtensions);
-    if (routes.some((route) => route.isDynamic && appRouteMayHaveGenerateStaticParams(route))) {
-      return true;
-    }
+    if (routes.some((route) => route.isDynamic)) return true;
   }
 
   if (options.pagesDir) {
     const routes = await pagesRouter(options.pagesDir, options.pageExtensions);
-    if (
-      routes.some(
-        (route) => route.isDynamic && fileHasNamedExport(route.filePath, "getStaticPaths"),
-      )
-    ) {
-      return true;
-    }
+    if (routes.some((route) => route.isDynamic)) return true;
   }
 
   return false;
@@ -397,7 +370,6 @@ async function collectPagesPaths(options: {
       continue;
     }
 
-    if (!fileHasNamedExport(route.filePath, "getStaticPaths")) continue;
     if (!options.baseUrl) continue;
 
     try {
@@ -411,7 +383,7 @@ async function collectPagesPaths(options: {
         options.secretHeaders,
       );
       if (text === null) {
-        throw new Error(`Invalid value returned from getStaticPaths for ${route.pattern}.`);
+        continue;
       }
 
       const pathsResult = validatePagesStaticPathsResult(JSON.parse(text), route.pattern);
@@ -574,7 +546,6 @@ async function collectAppPaths(options: {
       continue;
     }
 
-    if (!appRouteMayHaveGenerateStaticParams(route)) continue;
     try {
       const generateStaticParams = staticParamsMap[route.pattern];
       if (typeof generateStaticParams !== "function") continue;

--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -755,7 +755,7 @@ export async function prerenderPages({
                 );
                 return { paths: [], fallback: false };
               }
-              if (text === "null") return { paths: [], fallback: false };
+              if (res.status === 204 || text === "null") return { paths: [], fallback: false };
               return JSON.parse(text) as {
                 paths: Array<StaticPathsEntry>;
                 fallback: unknown;
@@ -1183,7 +1183,7 @@ export async function prerenderApp({
               );
               return null;
             }
-            if (text === "null") return null;
+            if (res.status === 204 || text === "null") return null;
             return JSON.parse(text) as Record<string, string | string[]>[];
           })();
           // Only cache on success — a rejected or error promise must not poison

--- a/packages/vinext/src/server/app-prerender-endpoints.ts
+++ b/packages/vinext/src/server/app-prerender-endpoints.ts
@@ -137,10 +137,7 @@ function jsonResponse(body: unknown, status = 200): Response {
 }
 
 function jsonNullResponse(): Response {
-  return new Response("null", {
-    headers: JSON_HEADERS,
-    status: 200,
-  });
+  return new Response(null, { status: 204 });
 }
 
 function parseParentParams(raw: string | null): RootParams {

--- a/packages/vinext/src/server/app-prerender-endpoints.ts
+++ b/packages/vinext/src/server/app-prerender-endpoints.ts
@@ -90,6 +90,7 @@ async function handleStaticParamsEndpoint(
       pattern,
       rootParamNamesByPattern: options.rootParamNamesByPattern ?? {},
     });
+    if (result === null) return jsonNullResponse();
     return jsonResponse(result);
   } catch (error) {
     return jsonResponse({ error: String(error) }, 500);

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -2027,8 +2027,8 @@ async function startPagesRouterServer(options: PagesRouterServerOptions) {
       const route = pageRoutes?.find((r) => r.pattern === pattern);
       const fn = route?.module?.getStaticPaths;
       if (typeof fn !== "function") {
-        res.writeHead(200, { "Content-Type": "application/json" });
-        res.end("null");
+        res.writeHead(204);
+        res.end();
         return;
       }
       try {

--- a/tests/app-prerender-endpoints.test.ts
+++ b/tests/app-prerender-endpoints.test.ts
@@ -248,13 +248,13 @@ describe("App prerender endpoint helpers", () => {
       },
     );
 
-    expect(staticParamsResponse?.status).toBe(200);
-    await expect(staticParamsResponse?.text()).resolves.toBe("null");
-    expect(pagesResponse?.status).toBe(200);
-    await expect(pagesResponse?.text()).resolves.toBe("null");
+    expect(staticParamsResponse?.status).toBe(204);
+    await expect(staticParamsResponse?.text()).resolves.toBe("");
+    expect(pagesResponse?.status).toBe(204);
+    await expect(pagesResponse?.text()).resolves.toBe("");
   });
 
-  it("returns JSON null when the Pages Router loader returns a non-route shape", async () => {
+  it("returns no content when the Pages Router loader returns a non-route shape", async () => {
     const response = await handleAppPrerenderEndpoint(
       new Request("http://localhost/__vinext/prerender/pages-static-paths?pattern=/missing"),
       {
@@ -265,8 +265,8 @@ describe("App prerender endpoint helpers", () => {
       },
     );
 
-    expect(response?.status).toBe(200);
-    await expect(response?.text()).resolves.toBe("null");
+    expect(response?.status).toBe(204);
+    await expect(response?.text()).resolves.toBe("");
   });
 
   it("returns explicit endpoint errors for missing query fields and thrown user functions", async () => {

--- a/tests/app-prerender-endpoints.test.ts
+++ b/tests/app-prerender-endpoints.test.ts
@@ -229,7 +229,7 @@ describe("App prerender endpoint helpers", () => {
     });
   });
 
-  it("returns JSON null when the requested prerender function is absent", async () => {
+  it("returns no content when the requested prerender function is absent", async () => {
     const staticParamsResponse = await handleAppPrerenderEndpoint(
       new Request("http://localhost/__vinext/prerender/static-params?pattern=/missing"),
       {
@@ -252,6 +252,20 @@ describe("App prerender endpoint helpers", () => {
     await expect(staticParamsResponse?.text()).resolves.toBe("");
     expect(pagesResponse?.status).toBe(204);
     await expect(pagesResponse?.text()).resolves.toBe("");
+  });
+
+  it("returns no content when a lazy App route resolves without a generator", async () => {
+    const response = await handleAppPrerenderEndpoint(
+      new Request("http://localhost/__vinext/prerender/static-params?pattern=/dynamic/:slug"),
+      {
+        isPrerenderEnabled: () => true,
+        pathname: "/__vinext/prerender/static-params",
+        staticParamsMap: { "/dynamic/:slug": async () => null },
+      },
+    );
+
+    expect(response?.status).toBe(204);
+    await expect(response?.text()).resolves.toBe("");
   });
 
   it("returns no content when the Pages Router loader returns a non-route shape", async () => {

--- a/tests/prerender-paths.test.ts
+++ b/tests/prerender-paths.test.ts
@@ -67,7 +67,7 @@ describe("prerender path manifest", () => {
         ) {
           return Response.json([{ category: "news" }]);
         }
-        return new Response("null", { headers: { "content-type": "application/json" } });
+        return new Response(null, { status: 204 });
       }),
     );
   });
@@ -291,6 +291,64 @@ describe("prerender path manifest", () => {
       "http://127.0.0.1:43210/__vinext/prerender/static-params?pattern=%2F%3Acategory",
       expect.any(Object),
     );
+  });
+
+  it("discovers dynamic App MDX paths from the built runtime", async () => {
+    writeFile("package.json", JSON.stringify({ type: "module" }));
+    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile("dist/server/RSC_BUILD_ID", "rsc-build-a\n");
+    writeFile("dist/server/index.js", "export default {};\n");
+    writeFile(
+      "app/[slug]/page.mdx",
+      'export function generateStaticParams() { return [{ slug: "hello" }] }\n\n# Hello\n',
+    );
+    vi.mocked(fetch).mockResolvedValue(Response.json([{ slug: "hello" }]));
+
+    const [{ emitPrerenderPathManifest }, { resolveNextConfig }] = await Promise.all([
+      import("../packages/vinext/src/build/prerender-paths.js"),
+      import("../packages/vinext/src/config/next-config.js"),
+    ]);
+    const nextConfig = await resolveNextConfig(
+      { pageExtensions: ["tsx", "ts", "jsx", "js", "mdx"] },
+      tmpDir,
+    );
+    const manifest = await emitPrerenderPathManifest({
+      root: tmpDir,
+      nextConfig,
+      responseVary: "verbatim",
+    });
+
+    expect(manifest?.paths).toEqual(["/hello"]);
+    expect(manifest?.rscPaths).toEqual(["/hello"]);
+  });
+
+  it("discovers dynamic Pages MDX paths from the built runtime", async () => {
+    writeFile("package.json", JSON.stringify({ type: "module" }));
+    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile("dist/server/entry.js", "export default {};\n");
+    writeFile(
+      "pages/[slug].mdx",
+      [
+        'export function getStaticPaths() { return { paths: ["/hello"], fallback: false } }',
+        "export function getStaticProps() { return { props: {}, revalidate: 60 } }",
+        "",
+        "# Hello",
+      ].join("\n"),
+    );
+    vi.mocked(fetch).mockResolvedValue(Response.json({ fallback: false, paths: ["/hello"] }));
+
+    const [{ emitPrerenderPathManifest }, { resolveNextConfig }] = await Promise.all([
+      import("../packages/vinext/src/build/prerender-paths.js"),
+      import("../packages/vinext/src/config/next-config.js"),
+    ]);
+    const nextConfig = await resolveNextConfig(
+      { pageExtensions: ["tsx", "ts", "jsx", "js", "mdx"] },
+      tmpDir,
+    );
+    const manifest = await emitPrerenderPathManifest({ root: tmpDir, nextConfig });
+
+    expect(manifest?.paths).toEqual(["/hello"]);
+    expect(manifest?.pagesPaths).toEqual(["/hello"]);
   });
 
   it("only advertises HTML build identity when the CDN adapter guarantees it", async () => {
@@ -528,7 +586,7 @@ describe("prerender path manifest", () => {
       if (url.pathname === "/__vinext/prerender/pages-static-paths") {
         return Response.json({ fallback: false, paths: ["/health", "/specific/value"] });
       }
-      return new Response("null", { headers: { "content-type": "application/json" } });
+      return new Response(null, { status: 204 });
     });
 
     const { emitPrerenderPathManifest } =
@@ -753,7 +811,7 @@ describe("prerender path manifest", () => {
           ],
         });
       }
-      return new Response("null", { headers: { "content-type": "application/json" } });
+      return new Response(null, { status: 204 });
     });
 
     const [{ emitPrerenderPathManifest }, { resolveNextConfig }, { readPrerenderWarmPlan }] =


### PR DESCRIPTION
## Summary

- ask the built runtime about every dynamic App and Pages route instead of parsing raw source for generator exports
- distinguish a missing generator with a no-content internal response so an invalid null getStaticPaths result still fails closed
- include dynamic MDX generateStaticParams and getStaticPaths results in CDN warm discovery without rendering page responses locally

## Tests

- vp test run tests/prerender-paths.test.ts tests/app-prerender-endpoints.test.ts tests/prerender.test.ts
- vp check packages/vinext/src/build/prerender-paths.ts packages/vinext/src/build/prerender.ts packages/vinext/src/server/app-prerender-endpoints.ts packages/vinext/src/server/prod-server.ts tests/prerender-paths.test.ts tests/app-prerender-endpoints.test.ts

Stacked on #3055.