### PR TITLE
perf(server): avoid base64 fallback for split UTF-8 Flight chunks

### DIFF
--- a/packages/vinext/src/server/app-ssr-stream.ts
+++ b/packages/vinext/src/server/app-ssr-stream.ts
@@ -119,6 +119,39 @@ function createNextFlightCleanupScript(): string {
   return 'self.addEventListener("DOMContentLoaded",()=>{if(self.__next_f?.push===Array.prototype.push)self.__next_f.length=0},{once:true})';
 }
 
+const EMPTY_BYTES = new Uint8Array();
+
+function getIncompleteUtf8Tail(previousTail: Uint8Array, chunk: Uint8Array): Uint8Array {
+  const previousTailLength = previousTail.byteLength;
+  const totalLength = previousTailLength + chunk.byteLength;
+  if (totalLength === 0) return EMPTY_BYTES;
+
+  const byteAt = (index: number): number =>
+    index < previousTailLength ? previousTail[index] : chunk[index - previousTailLength];
+
+  // A UTF-8 sequence has at most three continuation bytes, so only the
+  // combined suffix can still be buffered by the streaming decoder.
+  let leadIndex = totalLength - 1;
+  for (let continuationBytes = 0; continuationBytes < 3 && leadIndex >= 0; continuationBytes++) {
+    const byte = byteAt(leadIndex);
+    if (byte < 0x80 || byte > 0xbf) break;
+    leadIndex--;
+  }
+
+  if (leadIndex < 0) return EMPTY_BYTES;
+
+  const leadByte = byteAt(leadIndex);
+  const expectedLength = leadByte >= 0xf0 ? 4 : leadByte >= 0xe0 ? 3 : leadByte >= 0xc2 ? 2 : 1;
+  const availableLength = totalLength - leadIndex;
+  if (availableLength >= expectedLength) return EMPTY_BYTES;
+
+  const tail = new Uint8Array(availableLength);
+  for (let index = 0; index < availableLength; index++) {
+    tail[index] = byteAt(leadIndex + index);
+  }
+  return tail;
+}
+
 /**
  * Create a helper that progressively embeds RSC chunks as inline <script> tags.
  * The browser entry turns the embedded chunks back into Uint8Array data.
@@ -132,8 +165,37 @@ export function createRscEmbedTransform(
   const reader = embedStream.getReader();
   let pendingChunks: RscEmbeddedChunk[] = [];
   const rawChunks: Uint8Array[] = [];
+  // `ignoreBOM: true` preserves BOM bytes as decoded text so valid UTF-8
+  // round-trips losslessly through the embedded text transport.
+  let textDecoder = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true });
+  // TextDecoder buffers incomplete UTF-8 tails internally. Keep the same raw
+  // bytes here so a later fatal decode or EOF can still fall back losslessly.
+  let undecodedBytes: Uint8Array = EMPTY_BYTES;
   let reading = false;
   let mirroredNextFlightBootstrap = false;
+
+  function commitDecodedText(text: string): void {
+    if (text.length === 0) return;
+    pendingChunks.push(text);
+  }
+
+  function commitUndecodedBytes(bytes: Uint8Array): void {
+    if (bytes.byteLength === 0) {
+      const isBuildTimePrerender =
+        typeof process !== "undefined" && process.env.VINEXT_PRERENDER === "1";
+      if (process.env.NODE_ENV !== "production" || isBuildTimePrerender) {
+        throw new Error("[vinext] UTF-8 decoder rejected input without buffered bytes");
+      }
+      // The raw capture is preserved separately. Reset the unaccounted inline
+      // decoder state and let the already-streaming document finish.
+      undecodedBytes = EMPTY_BYTES;
+      textDecoder = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true });
+      return;
+    }
+    pendingChunks.push([RSC_EMBEDDED_BINARY_CHUNK, bytesToBase64(bytes)]);
+    undecodedBytes = EMPTY_BYTES;
+    textDecoder = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true });
+  }
 
   async function pumpReader(): Promise<void> {
     if (reading) return;
@@ -143,17 +205,32 @@ export function createRscEmbedTransform(
         const result = await reader.read();
         if (result.done) break;
         rawChunks.push(result.value);
+        let decodedText: string;
         try {
-          const decoder = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true });
-          const text = decoder.decode(result.value);
-          pendingChunks.push(text);
+          decodedText = textDecoder.decode(result.value, { stream: true });
         } catch {
-          pendingChunks.push([RSC_EMBEDDED_BINARY_CHUNK, bytesToBase64(result.value)]);
+          commitUndecodedBytes(
+            undecodedBytes.byteLength === 0
+              ? result.value
+              : concatUint8Arrays([undecodedBytes, result.value]),
+          );
+          continue;
         }
+        commitDecodedText(decodedText);
+        undecodedBytes = getIncompleteUtf8Tail(undecodedBytes, result.value);
       }
+      let decodedText: string;
+      try {
+        decodedText = textDecoder.decode();
+      } catch {
+        commitUndecodedBytes(undecodedBytes);
+        return;
+      }
+      commitDecodedText(decodedText);
+      undecodedBytes = EMPTY_BYTES;
     } catch (error) {
       if (process.env.NODE_ENV !== "production") {
-        console.warn("[vinext] RSC embed stream read error:", error);
+        console.warn("[vinext] RSC embed stream processing error:", error);
       }
       throw error;
     } finally {

--- a/tests/app-ssr-stream.test.ts
+++ b/tests/app-ssr-stream.test.ts
@@ -94,6 +94,26 @@ function createByteStream(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
   });
 }
 
+function readEmbeddedRscChunks(html: string): RscEmbeddedChunk[] {
+  const self: Record<PropertyKey, unknown> = { addEventListener() {} };
+  const context = createContext({ self });
+
+  for (const scriptSource of html
+    .slice("<script>".length, -"</script>".length)
+    .split("</script><script>")) {
+    runInContext(scriptSource, context);
+  }
+
+  const navigationRuntime = self[Symbol.for("vinext.navigationRuntime")] as {
+    bootstrap: { rsc: { rsc: RscEmbeddedChunk[] } };
+  };
+  return navigationRuntime.bootstrap.rsc.rsc;
+}
+
+function decodeEmbeddedRscChunks(chunks: RscEmbeddedChunk[]): Uint8Array {
+  return concatUint8Arrays(chunks.map(decodeRscEmbeddedChunk));
+}
+
 function createNoopRscEmbedTransform() {
   return {
     flush: () => "",
@@ -305,36 +325,58 @@ describe("createRscEmbedTransform raw buffer (#981)", () => {
 
     const transform = createRscEmbedTransform(createByteStream(flightChunks));
     const finalScripts = await transform.finalize();
-    const self: Record<PropertyKey, unknown> = {};
-    const context = createContext({ self });
-
-    for (const scriptSource of finalScripts
-      .slice("<script>".length, -"</script>".length)
-      .split("</script><script>")) {
-      runInContext(scriptSource, context);
-    }
-
-    const navigationRuntime = self[Symbol.for("vinext.navigationRuntime")] as {
-      bootstrap: { rsc: { rsc: RscEmbeddedChunk[] } };
-    };
-    const embeddedChunks = navigationRuntime.bootstrap.rsc.rsc.map(decodeRscEmbeddedChunk);
-    const embeddedBytes = concatUint8Arrays(embeddedChunks);
+    const embeddedBytes = decodeEmbeddedRscChunks(readEmbeddedRscChunks(finalScripts));
 
     expect(embeddedBytes).toEqual(expectedBytes);
+  });
+
+  it.each(["中文", "😀"])("embeds %s as text across every UTF-8 byte split", async (text) => {
+    const bytes = new TextEncoder().encode(text);
+
+    for (let split = 1; split < bytes.byteLength; split++) {
+      const transform = createRscEmbedTransform(
+        createByteStream([bytes.slice(0, split), bytes.slice(split)]),
+      );
+      const embeddedChunks = readEmbeddedRscChunks(await transform.finalize());
+
+      expect(
+        embeddedChunks.every((chunk) => typeof chunk === "string"),
+        `split at byte ${split}`,
+      ).toBe(true);
+      expect(decodeEmbeddedRscChunks(embeddedChunks), `split at byte ${split}`).toEqual(bytes);
+    }
+  });
+
+  it("embeds a four-byte emoji as text across byte-at-a-time chunks", async () => {
+    const bytes = new TextEncoder().encode("😀");
+    const transform = createRscEmbedTransform(
+      createByteStream(Array.from(bytes, (byte) => Uint8Array.of(byte))),
+    );
+
+    const embeddedChunks = readEmbeddedRscChunks(await transform.finalize());
+
+    expect(embeddedChunks.every((chunk) => typeof chunk === "string")).toBe(true);
+    expect(decodeEmbeddedRscChunks(embeddedChunks)).toEqual(bytes);
   });
 
   it("embeds non-UTF-8 RSC chunks as base64 binary chunks", async () => {
     // Ported from Next.js: test/e2e/app-dir/binary/rsc-binary.test.ts
     // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/binary/rsc-binary.test.ts
-    const transform = createRscEmbedTransform(
-      createByteStream([new Uint8Array([0xff, 0, 1, 2, 3])]),
-      { mirrorNextFlight: true },
-    );
+    const binaryBytes = new Uint8Array([0xff, 0, 1, 2, 3]);
+    const trailingTextBytes = new TextEncoder().encode("中文");
+    const transform = createRscEmbedTransform(createByteStream([binaryBytes, trailingTextBytes]), {
+      mirrorNextFlight: true,
+    });
 
     const finalScripts = await transform.finalize();
+    const embeddedChunks = readEmbeddedRscChunks(finalScripts);
 
     expect(finalScripts).toContain('.rsc.push([3,"/wABAgM="])');
     expect(finalScripts).toContain('self.__next_f.push([3,"/wABAgM="])');
+    expect(finalScripts).toContain('.rsc.push("中文")');
+    expect(decodeEmbeddedRscChunks(embeddedChunks)).toEqual(
+      concatUint8Arrays([binaryBytes, trailingTextBytes]),
+    );
   });
 
   it("does not lose incomplete UTF-8 bytes before a binary chunk", async () => {
@@ -343,9 +385,20 @@ describe("createRscEmbedTransform raw buffer (#981)", () => {
     );
 
     const finalScripts = await transform.finalize();
+    const embeddedChunks = readEmbeddedRscChunks(finalScripts);
 
-    expect(finalScripts).toContain('.rsc.push([3,"QcM="])');
-    expect(finalScripts).toContain('.rsc.push([3,"/w=="])');
+    expect(embeddedChunks).toEqual(["A", [3, "w/8="]]);
+    expect(decodeEmbeddedRscChunks(embeddedChunks)).toEqual(new Uint8Array([0x41, 0xc3, 0xff]));
+  });
+
+  it("does not lose an incomplete UTF-8 sequence at EOF", async () => {
+    const bytes = new Uint8Array([0x41, 0xf0, 0x9f, 0x98]);
+    const transform = createRscEmbedTransform(createByteStream([bytes]));
+
+    const embeddedChunks = readEmbeddedRscChunks(await transform.finalize());
+
+    expect(embeddedChunks).toEqual(["A", [3, "8J+Y"]]);
+    expect(decodeEmbeddedRscChunks(embeddedChunks)).toEqual(bytes);
   });
 });
 


### PR DESCRIPTION
## Summary

RSC streams can split a valid UTF-8 code point across upstream chunks. `createRscEmbedTransform` currently decodes each chunk independently with a fatal decoder, so split CJK or emoji bytes are classified as binary and embedded as Base64.

This change keeps one streaming fatal decoder for the embed stream and tracks the raw bytes that the decoder has not released yet. Valid split text stays in text chunks, while invalid binary data and incomplete UTF-8 at EOF still use the existing `[3, base64]` representation without losing bytes. The decoder is reset after binary fallback so later text can be decoded normally.

This follows the streaming decode used by the [Next.js Web Flight transport](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/use-flight-response.tsx), with explicit raw-byte retention for lossless error and EOF fallback.

## Coverage

- CJK and emoji split at every UTF-8 byte boundary
- invalid binary followed by valid text
- incomplete UTF-8 followed by binary data
- incomplete UTF-8 at EOF
- existing BOM preservation

## Application result

Measured on a blog page with 108 RSC chunks:

- Base64 chunks: 54 → 0
- raw RSC script size: -36,108 bytes (-9.1%)
- separately gzipped size: about 36.9 KB smaller

## Verification

- `vp test run tests/app-ssr-stream.test.ts -t "createRscEmbedTransform raw buffer"`
- `vp check`
- `vp run vinext#build`