### PR TITLE
fix(app-router): keep dynamic usage visible across nested request scopes

### DIFF
--- a/packages/vinext/src/server/app-layout-param-observation.ts
+++ b/packages/vinext/src/server/app-layout-param-observation.ts
@@ -12,6 +12,7 @@ import {
 import { peekDynamicUsage, peekRenderRequestApiUsage } from "vinext/shims/headers";
 import {
   isInsideUnifiedScope,
+  isolateDynamicUsage,
   runWithUnifiedStateMutation,
 } from "vinext/shims/unified-request-context";
 import type { RenderRequestApiKind } from "./cache-proof.js";
@@ -187,7 +188,7 @@ export function createAppLayoutParamAccessTracker(): AppLayoutParamAccessTracker
       ctx.currentRequestTags = [];
       ctx.currentFetchSoftTags = [];
       ctx.dynamicFetchUrls = new Set();
-      ctx.dynamicUsageDetected = false;
+      isolateDynamicUsage(ctx);
       ctx.renderRequestApiUsage = new Set();
       ctx.requestScopedCacheLife = null;
       ctx.unstableCacheObservations = new Map();

--- a/packages/vinext/src/shims/headers.ts
+++ b/packages/vinext/src/shims/headers.ts
@@ -21,6 +21,7 @@ import { parseEdgeRequestCookieHeader } from "../utils/parse-cookie.js";
 import {
   isInsideUnifiedScope,
   getRequestContext,
+  isolateDynamicUsage,
   runWithUnifiedStateMutation,
 } from "./unified-request-context.js";
 import { createPprFallbackShellSuspensePromise } from "./ppr-fallback-shell.js";
@@ -248,7 +249,7 @@ export async function runWithIsolatedDynamicUsage<T>(
     let childState: VinextHeadersShimState | null = null;
     return await runWithUnifiedStateMutation(
       (context) => {
-        context.dynamicUsageDetected = false;
+        isolateDynamicUsage(context);
         childState = context;
       },
       () => {
@@ -594,7 +595,7 @@ export function runWithHeadersContext<T>(
   if (isInsideUnifiedScope()) {
     return runWithUnifiedStateMutation((uCtx) => {
       uCtx.headersContext = ctx;
-      uCtx.dynamicUsageDetected = false;
+      isolateDynamicUsage(uCtx);
       uCtx.renderRequestApiUsage = new Set();
       uCtx.connectionProbe = null;
       uCtx.pendingSetCookies = [];

--- a/packages/vinext/src/shims/unified-request-context.ts
+++ b/packages/vinext/src/shims/unified-request-context.ts
@@ -352,6 +352,40 @@ export function runWithRequestContext<T>(
 }
 
 /**
+ * `dynamicUsageDetected` is request-scoped, not scope-scoped: a nested scope's
+ * lazily consumed stream can call cookies()/headers()/noStore() long after its
+ * callback settles, so the child aliases the parent's flag instead of copying
+ * it. Scopes that measure a subtree opt out with `isolateDynamicUsage()`.
+ */
+function aliasDynamicUsageToParent(
+  childCtx: UnifiedRequestContext,
+  parentCtx: UnifiedRequestContext,
+): void {
+  Object.defineProperty(childCtx, "dynamicUsageDetected", {
+    configurable: true,
+    enumerable: true,
+    get: () => parentCtx.dynamicUsageDetected,
+    set: (value: boolean) => {
+      parentCtx.dynamicUsageDetected = value;
+    },
+  });
+}
+
+/**
+ * Give a nested scope its own `dynamicUsageDetected` flag, hidden from the
+ * request. Only for scopes that measure a subtree and report the result
+ * themselves; every other scope must let dynamic usage reach the request.
+ */
+export function isolateDynamicUsage(ctx: UnifiedRequestContext): void {
+  Object.defineProperty(ctx, "dynamicUsageDetected", {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: false,
+  });
+}
+
+/**
  * Run `fn` in a nested unified scope derived from the current request context.
  * Used by legacy runWith* wrappers to reset or override one sub-state while
  * preserving proper async isolation for continuations created inside `fn`.
@@ -393,6 +427,10 @@ export function runWithUnifiedStateMutation<T>(
   // observe those changes too. Keep this enumeration in sync with
   // UnifiedRequestContext: when adding a new reference-typed field, add it
   // here too and verify callers still follow the replace-not-mutate rule.
+  //
+  // `dynamicUsageDetected` is the deliberate exception to copy-by-value: it is
+  // aliased to the parent so cacheability stays a property of the request.
+  aliasDynamicUsageToParent(childCtx, parentCtx);
   mutate(childCtx);
   return _als.run(childCtx, fn);
 }

--- a/tests/root-params.test.ts
+++ b/tests/root-params.test.ts
@@ -9,6 +9,7 @@ import {
   runWithRequestContext,
   createRequestContext,
 } from "../packages/vinext/src/shims/unified-request-context.js";
+import { consumeDynamicUsage, markDynamicUsage } from "../packages/vinext/src/shims/headers.js";
 import { runWithNavigationContext } from "../packages/vinext/src/shims/navigation-state.js";
 import {
   getNavigationContext,
@@ -164,6 +165,27 @@ describe("next/root-params shim", () => {
       langVal: "fr",
       nestedVal: "de",
       langValAfter: "fr",
+    });
+  });
+
+  it("keeps dynamic usage visible to the request after the scope returns", async () => {
+    // handleSsr() renders inside this scope, but the HTML/RSC stream it returns
+    // is consumed later — cookies()/headers() can still fire from that work.
+    await runWithRequestContext(createRequestContext(), async () => {
+      let releaseStreamedWork!: () => void;
+      const streamedWork = new Promise<void>((resolve) => {
+        releaseStreamedWork = resolve;
+      });
+
+      let lateDynamicUsage!: Promise<void>;
+      await runWithRootParamsScope({ lang: "en" }, () => {
+        lateDynamicUsage = streamedWork.then(() => markDynamicUsage());
+      });
+
+      releaseStreamedWork();
+      await lateDynamicUsage;
+
+      expect(consumeDynamicUsage()).toBe(true);
     });
   });
 

--- a/tests/unified-request-context.test.ts
+++ b/tests/unified-request-context.test.ts
@@ -8,7 +8,9 @@ import {
 } from "../packages/vinext/src/shims/unified-request-context.js";
 import {
   consumeRenderRequestApiUsage,
+  markDynamicUsage,
   markRenderRequestApiUsage,
+  runWithIsolatedDynamicUsage,
 } from "../packages/vinext/src/shims/headers.js";
 import {
   getRequestExecutionContext,
@@ -548,6 +550,44 @@ describe("unified-request-context", () => {
           expect(getRequestContext().ssrHeadChildren).toEqual(["<meta data-outer />"]);
         },
       );
+    });
+  });
+
+  describe("dynamic usage across nested scopes", () => {
+    it("keeps a nested scope's late dynamic usage visible to the request", async () => {
+      // Nested scopes wrap lazily consumed streams: the work they spawn keeps
+      // running (and can mark dynamic usage) after their callback settles.
+      await runWithRequestContext(createRequestContext(), async () => {
+        let releaseLateWork!: () => void;
+        const lateWork = new Promise<void>((resolve) => {
+          releaseLateWork = resolve;
+        });
+
+        let lateDynamicUsage!: Promise<void>;
+        await runWithUnifiedStateMutation(
+          () => {},
+          () => {
+            lateDynamicUsage = lateWork.then(() => markDynamicUsage());
+          },
+        );
+
+        expect(getRequestContext().dynamicUsageDetected).toBe(false);
+        releaseLateWork();
+        await lateDynamicUsage;
+        expect(getRequestContext().dynamicUsageDetected).toBe(true);
+      });
+    });
+
+    it("runWithIsolatedDynamicUsage measures a subtree without marking the request", async () => {
+      await runWithRequestContext(createRequestContext(), async () => {
+        const { dynamicDetected } = await runWithIsolatedDynamicUsage(() => {
+          markDynamicUsage();
+          return "measured";
+        });
+
+        expect(dynamicDetected).toBe(true);
+        expect(getRequestContext().dynamicUsageDetected).toBe(false);
+      });
     });
   });
 


### PR DESCRIPTION
## Overview

| | |
| --- | --- |
| Goal | Keep `dynamicUsageDetected` a property of the request, not of whichever nested ALS scope happens to be active. |
| Core change | `runWithUnifiedStateMutation()` aliases the flag to the parent context instead of copying it by value. |
| Key boundary | The unified request context owns the flag. Scopes that measure a subtree opt out through the new `isolateDynamicUsage()`. |
| Expected impact | A `cookies()`, `headers()`, or `noStore()` call that happens inside a nested scope, or in async work that scope spawned, now reaches the cache policy. |

## Why

Cacheability is decided once per request. `consumeDynamicUsage()` is the control that forces `no-store` and skips ISR writes when a render touches request data, so every `markDynamicUsage()` in that request must reach it.

`runWithUnifiedStateMutation()` builds a child scope with `{ ...parentCtx }`. The file already documents the hazard for reference-typed fields, which leak into the parent. `dynamicUsageDetected` is a primitive and has the mirror hazard: the child gets a private copy, and writes to that copy never reach the parent.

Two properties make this observable rather than theoretical:

1. Nested scopes wrap lazily consumed streams. `handleSsr()` runs inside `runWithNavigationContext()` and then inside `runWithRootParamsScope()`, but the HTTP layer pulls the HTML stream after both callbacks settle. `app-page-render.ts` documents this timing where it defers `clearRequestContext()` until the stream drains.
2. The cache decision runs in the outer lifecycle. `renderAppPageLifecycle()` and `finalizeAppPageHtmlCacheResponse()` both call `options.consumeDynamicUsage()` from outside those scopes.

Concretely: a render enters a nested scope, returns a stream handle, and the scope callback settles. The HTTP layer then pulls the body, and a component that runs during that pull calls `cookies()`. The flag is set on the discarded child copy. The outer `consumeDynamicUsage()` returns `false`, and the response is treated as cacheable.

A fix in `runWithRootParamsScope()` alone would be a symptom patch. `runWithNavigationContext()` wraps the same SSR render one level further out and reproduces the identical failure, and seven other wrappers build child scopes the same way.

| Area | Principle / invariant | What this PR changes |
| --- | --- | --- |
| `unified-request-context.ts` | A nested scope shares request-level state and replaces only the slice it overrides. | Aliases `dynamicUsageDetected` to the parent so nested scopes cannot fork it. |
| `headers.ts` | `runWithIsolatedDynamicUsage()` and `runWithHeadersContext()` deliberately start a fresh dynamic-usage measurement. | Both opt out through `isolateDynamicUsage()` and keep their current isolation. |
| `app-layout-param-observation.ts` | The layout probe measures one subtree and folds the result into its own observation. | Opts out through `isolateDynamicUsage()` and keeps its current isolation. |

## What changed

| Scenario | Before | After |
| --- | --- | --- |
| `markDynamicUsage()` inside any nested scope | Marked the child copy only. | Marks the request. |
| `markDynamicUsage()` from async work that outlives the nested scope callback | Lost when the child scope was discarded. | Marks the request. |
| `runWithIsolatedDynamicUsage()` | Measured its subtree without marking the request. | Unchanged. |
| `runWithHeadersContext()` | Started a fresh flag and restored the outer value on exit. | Unchanged. |
| Layout param probe | Isolated its flag and folded the result into the observation. | Unchanged. |
| `runWithConnectionProbe()` | Copied the child flag to the parent when the probe finished. | Unchanged in effect. The copy is now a no-op because both read the same flag. |
| `setHeadersContext()` | Reset the flag on the current state at request entry. | Unchanged. Every call site runs at the outer level. |

<details>
<summary>Maintainer review path</summary>

1. `packages/vinext/src/shims/unified-request-context.ts` for the ownership decision: `aliasDynamicUsageToParent()`, `isolateDynamicUsage()`, and the call added to `runWithUnifiedStateMutation()`.
2. `packages/vinext/src/shims/headers.ts` and `packages/vinext/src/server/app-layout-param-observation.ts` for the three deliberate opt-outs.
3. `tests/unified-request-context.test.ts` for the owning-layer contract in both directions.
4. `tests/root-params.test.ts` for the reported caller.

</details>

<details>
<summary>Validation</summary>

- Added a regression test at the owning layer: late dynamic usage from work that outlives a nested scope callback reaches the request context.
- Added a regression test for the opposite direction: `runWithIsolatedDynamicUsage()` still measures its subtree without marking the request.
- Added a regression test for the reported caller: dynamic usage during work that outlives `runWithRootParamsScope()` reaches `consumeDynamicUsage()`.
- Confirmed the two new failure cases are red on the parent commit and green after the change.
- Existing isolation contracts stay green without modification: the `runWithHeadersContext()` sub-state test in `tests/unified-request-context.test.ts`, and the layout probe test in `tests/app-layout-param-observation.test.ts`.
- Ran 32 targeted suites covering request context, shims, App Router render, dispatch, probe, cache, ISR, prerender, route handlers, and draft mode. 2093 tests passed.
- Ran `vp check`. No formatting, lint, or type errors in 1289 files.

<details>
<summary>Commands and extended results</summary>

```text
vp test run tests/root-params.test.ts tests/unified-request-context.test.ts \
  tests/app-layout-param-observation.test.ts tests/cache-for-request.test.ts
  Test Files  4 passed (4)
       Tests  52 passed (52)

vp test run tests/shims.test.ts tests/app-page-render.test.ts tests/app-page-cache.test.ts \
  tests/app-page-cache-render.test.ts tests/app-page-dispatch.test.ts tests/app-page-probe.test.ts \
  tests/app-page-execution.test.ts tests/app-route-handler-execution.test.ts \
  tests/app-route-handler-cache.test.ts tests/fetch-cache.test.ts tests/app-request-context.test.ts \
  tests/app-prerender-static-params.test.ts tests/cloudflare-cdn-cache.test.ts tests/als-registry.test.ts
  Test Files  14 passed (14)
       Tests  1771 passed (1771)

vp test run tests/isr-cache.test.ts tests/isr-decision.test.ts tests/cache-proof.test.ts \
  tests/cache-control.test.ts tests/app-static-generation.test.ts tests/app-ppr-fallback-shell.test.ts \
  tests/ppr-fallback-shell.test.ts tests/app-visited-response-cache.test.ts tests/page-cache-tags.test.ts \
  tests/prerender-phase.test.ts tests/prerender-route-params.test.ts \
  tests/app-hydration-cache-publication.test.ts tests/nextjs-compat/draft-mode.test.ts \
  tests/app-page-boundary-render.test.ts
  Test Files  14 passed (14)
       Tests  270 passed (270)

vp check
  pass: Found no warnings, lint errors, or type errors in 1289 files
```

</details>
</details>

<details>
<summary>Risk / compatibility</summary>

- Public API: unchanged. `UnifiedRequestContext` keeps the `dynamicUsageDetected` field name and `boolean` type, so no caller or existing test needed updating. `isolateDynamicUsage()` is a new internal export from `vinext/shims/unified-request-context`.
- Behavioural direction: the change can only make more renders classify as dynamic. It cannot cause a render that previously bypassed the cache to start being cached.
- Property descriptor: the alias uses `Object.defineProperty` with `enumerable: true`, so a child context still spreads correctly into further nested scopes. Nested aliases chain up to the nearest isolating ancestor.
- Known limit: this change corrects the scope semantics. It does not add an end-to-end fixture that drives a production route through the previously affected path, so the practical exposure of any specific route configuration is not measured here.

</details>

<details>
<summary>Non-goals</summary>

- Converting `dynamicUsageDetected` into a shared holder object. That is the idiom this file already uses for reference-typed slices, but it renames a field used in about 20 places and in the `createRequestContext()` options, which mixes a mechanical refactor into a behavioural fix.
- Auditing the other primitive fields on `UnifiedRequestContext` for the same copy-by-value question. `phase`, `actionRevalidationKind`, and the `currentFetch*` fields are genuinely scope-local today.

</details>
