### PR TITLE
fix(metadata): encode metadata social image URLs

### DIFF
--- a/packages/vinext/src/shims/metadata.tsx
+++ b/packages/vinext/src/shims/metadata.tsx
@@ -831,12 +831,21 @@ function resolveSocialImageUrl(
   metadataBase: URL | null | undefined,
 ): string {
   const imageUrl = isSocialImageDescriptor(image) ? image.url : image;
+
+  // Next.js resolves social image URLs through resolveUrl(), which parses
+  // absolute strings before considering metadataBase. Returning the serialized
+  // URL also percent-encodes characters such as spaces in image paths.
+  if (imageUrl instanceof URL) {
+    return imageUrl.href;
+  }
+  try {
+    return new URL(imageUrl).href;
+  } catch {
+    // Relative social image URLs are composed with metadataBase below.
+  }
+
   const metadataRoute = isSocialImageDescriptor(image) && isMetadataRouteSocialImage(image);
-  if (
-    typeof imageUrl === "string" &&
-    !isAbsoluteOrProtocolRelativeUrl(imageUrl) &&
-    (!metadataBase || metadataRoute)
-  ) {
+  if (!isAbsoluteOrProtocolRelativeUrl(imageUrl) && (!metadataBase || metadataRoute)) {
     return resolveMetadataUrl(imageUrl, getSocialImageMetadataBaseFallback(metadataBase));
   }
   return resolveMetadataUrl(imageUrl, metadataBase);

--- a/packages/vinext/src/shims/metadata.tsx
+++ b/packages/vinext/src/shims/metadata.tsx
@@ -11,7 +11,7 @@ import type {
   Viewport as NextViewport,
 } from "@vinext/types/next/upstream/dist/lib/metadata/types/metadata-interface";
 import { makeThenableParams, type ThenableParamsObserver } from "./thenable-params.js";
-import { isAbsoluteOrProtocolRelativeUrl } from "./url-utils.js";
+import { isAbsoluteOrProtocolRelativeUrl, isAbsoluteUrl } from "./url-utils.js";
 
 const USE_CACHE_FUNCTION_SYMBOL = Symbol.for("vinext.useCacheFunction");
 const USE_CACHE_ACCEPTS_SECOND_ARGUMENT_SYMBOL = Symbol.for("vinext.useCacheAcceptsSecondArgument");
@@ -845,10 +845,12 @@ function resolveSocialImageUrl(
   }
 
   const metadataRoute = isSocialImageDescriptor(image) && isMetadataRouteSocialImage(image);
-  if (!isAbsoluteOrProtocolRelativeUrl(imageUrl) && (!metadataBase || metadataRoute)) {
-    return resolveMetadataUrl(imageUrl, getSocialImageMetadataBaseFallback(metadataBase));
-  }
-  return resolveMetadataUrl(imageUrl, metadataBase);
+  const base =
+    !isAbsoluteUrl(imageUrl) && (!metadataBase || metadataRoute)
+      ? getSocialImageMetadataBaseFallback(metadataBase)
+      : metadataBase;
+  // Next.js treats protocol-relative social images as relative paths.
+  return resolveMetadataUrl(imageUrl.replace(/^\/+/, "/"), base);
 }
 
 type MetadataHeadProps = {

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -3024,6 +3024,29 @@ describe("MetadataHead rendering", () => {
     expect(html).toContain('content="https://acme.com/og.png"');
   });
 
+  // Ported from Next.js: packages/next/src/lib/metadata/resolvers/resolve-opengraph.test.ts
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/metadata/resolvers/resolve-opengraph.test.ts
+  it.each([
+    ["without metadataBase", undefined],
+    ["with a cross-origin metadataBase", new URL("https://site.example")],
+  ])("percent-encodes absolute social image URLs %s", (_scenario, metadataBase) => {
+    const imageUrl = "https://cdn.example/path/my image.webp";
+    const encodedImageUrl = "https://cdn.example/path/my%20image.webp";
+    const html = renderToStaticMarkup(
+      React.createElement(MetadataHead, {
+        metadata: {
+          metadataBase,
+          openGraph: { images: [imageUrl] },
+          twitter: { images: [{ url: imageUrl }] },
+        },
+      }),
+    );
+
+    expect(html).toContain(`property="og:image" content="${encodedImageUrl}"`);
+    expect(html).toContain(`name="twitter:image" content="${encodedImageUrl}"`);
+    expect(html).not.toContain(imageUrl);
+  });
+
   it("normalizes root canonical metadataBase URLs without a trailing slash", () => {
     // Ported from Next.js: test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
     // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -3047,6 +3047,25 @@ describe("MetadataHead rendering", () => {
     expect(html).not.toContain(imageUrl);
   });
 
+  // Matches Next.js's resolveUrl path composition for protocol-relative input:
+  // packages/next/src/lib/metadata/resolvers/resolve-url.ts
+  it("resolves protocol-relative social image URLs against metadataBase", () => {
+    const imageUrl = "//cdn.example/path/my image.webp";
+    const encodedImageUrl = "https://site.example/base/cdn.example/path/my%20image.webp";
+    const html = renderToStaticMarkup(
+      React.createElement(MetadataHead, {
+        metadata: {
+          metadataBase: new URL("https://site.example/base"),
+          openGraph: { images: [imageUrl] },
+          twitter: { images: [{ url: imageUrl }] },
+        },
+      }),
+    );
+
+    expect(html).toContain(`property="og:image" content="${encodedImageUrl}"`);
+    expect(html).toContain(`name="twitter:image" content="${encodedImageUrl}"`);
+  });
+
   it("normalizes root canonical metadataBase URLs without a trailing slash", () => {
     // Ported from Next.js: test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
     // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts


### PR DESCRIPTION
Closes #3066

## Overview

Next.js percent-encodes og and twitter image URLs during metadata resolution, while vinext could emit absolute string URLs unchanged when they contained spaces or other characters requiring encoding. This produced invalid metadata URLs and could cause social crawlers or link-preview generators to fail when fetching CMS-provided images.

This PR restores Next.js-compatible URL serialization for social image metadata.

## What changed

In `packages/vinext/src/shims/metadata.tsx`, `resolveSocialImageUrl()` uses `resolveMetadataUrl()` to resolve social image URLs.

https://github.com/cloudflare/vinext/blob/20fdac4cec59fd0f8dcdf490693e5205ccc33dff/packages/vinext/src/shims/metadata.tsx#L835-L842

However, `resolveMetadataUrl()` will return the original URL if there is no `metadataBase` provided.

https://github.com/cloudflare/vinext/blob/20fdac4cec59fd0f8dcdf490693e5205ccc33dff/packages/vinext/src/shims/metadata.tsx#L751-L759

So just pass the social image URL into `new URL()`, and the URL will be encoded automatically. If `new URL()` fails, this means it may be a relative URL, then just pass it to the `resolveMetadataUrl()`.

```ts
try {
  return new URL(imageUrl).href;
} catch {
  // Relative social image URLs are composed with metadataBase below.
}
// ...
```

## Testing

- `pnpm test tests/features.test.ts`