### PR TITLE
fix(metadata): prevent layout title template from applying to the same route-layer page

### DIFF
--- a/packages/vinext/src/server/app-page-head.ts
+++ b/packages/vinext/src/server/app-page-head.ts
@@ -775,8 +775,23 @@ function prepareAppPageHeadInner<TModule extends AppPageHeadModule>(
     // with no title suppression.
     // Reference: https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/metadata/resolve-metadata.ts
     const primaryPageHasTitle = pageMetadata != null && pageMetadata.title !== undefined;
+    const hasPrimaryPageLayer =
+      options.pageModule != null &&
+      options.routeSegments != null &&
+      options.layoutTreePositions != null;
     const metadataEntries: MetadataMergeEntry[] = [
-      ...layoutMetadataResults.filter(isPresent).map((entry) => ({ metadata: entry })),
+      ...layoutMetadataResults.flatMap((metadata, index) => {
+        if (!metadata) return [];
+
+        const isSameLayerAsPage =
+          hasPrimaryPageLayer && layoutInputs[index]?.treePosition === routeSegments.length;
+        return [
+          {
+            metadata,
+            ...(isSameLayerAsPage ? { stashesTitleTemplate: false } : {}),
+          },
+        ];
+      }),
       ...(pageMetadata ? [{ isPage: true, metadata: pageMetadata }] : []),
       ...parallelMetadataResults
         .filter(isPresent)

--- a/packages/vinext/src/server/app-page-head.ts
+++ b/packages/vinext/src/server/app-page-head.ts
@@ -170,7 +170,7 @@ type AppPageSearchParamsCollection = {
 };
 
 type ResolvedParallelRouteMetadata = {
-  metadataResults: (Metadata | null)[];
+  metadataEntries: MetadataMergeEntry[];
   metadataSources: AppPageHeadSource[];
 };
 
@@ -505,7 +505,7 @@ async function resolveParallelRouteMetadata<TModule extends AppPageHeadModule>(
 ): Promise<ResolvedParallelRouteMetadata> {
   const params = parallelRoute.params ?? fallbackParams;
   const routeSegments = parallelRoute.routeSegments ?? fallbackRouteSegments;
-  const metadataResults: (Metadata | null)[] = [];
+  const metadataEntries: MetadataMergeEntry[] = [];
   const metadataSources: AppPageHeadSource[] = [];
   let accumulatedMetadata = parent;
   const layoutModules = getParallelRouteModules(parallelRoute);
@@ -522,7 +522,17 @@ async function resolveParallelRouteMetadata<TModule extends AppPageHeadModule>(
       undefined,
       accumulatedMetadata,
     );
-    metadataResults.push(layoutMetadata);
+    if (layoutMetadata) {
+      const isSameLayerAsPage =
+        parallelRoute.pageModule != null &&
+        parallelRoute.routeSegments != null &&
+        parallelRoute.layoutTreePositions != null &&
+        layoutTreePositions[index] === routeSegments.length;
+      metadataEntries.push({
+        metadata: layoutMetadata,
+        ...(isSameLayerAsPage ? { stashesTitleTemplate: false } : {}),
+      });
+    }
     // Parallel route metadata sources are scoped to the active slot branch because
     // the route tree input does not carry per-layout segment positions inside that branch.
     metadataSources.push({ metadata: layoutMetadata, routeSegments });
@@ -543,12 +553,12 @@ async function resolveParallelRouteMetadata<TModule extends AppPageHeadModule>(
       accumulatedMetadata,
       searchParamsObserver,
     );
-    metadataResults.push(pageMetadata);
+    if (pageMetadata) metadataEntries.push({ metadata: pageMetadata });
     // Keep the page source scoped to the same active slot branch as its layouts.
     metadataSources.push({ metadata: pageMetadata, routeSegments });
   }
 
-  return { metadataResults, metadataSources };
+  return { metadataEntries, metadataSources };
 }
 
 function resolveParallelRouteViewport<TModule extends AppPageHeadModule>(
@@ -761,7 +771,7 @@ function prepareAppPageHeadInner<TModule extends AppPageHeadModule>(
     pageMetadataPromise,
     parallelRouteMetadataPromise,
   ]).then(async ([layoutMetadataResults, pageMetadata, parallelRouteMetadata]) => {
-    const parallelMetadataResults = parallelRouteMetadata.flatMap((head) => head.metadataResults);
+    const parallelMetadataEntries = parallelRouteMetadata.flatMap((head) => head.metadataEntries);
     const parallelMetadataSources = parallelRouteMetadata.flatMap((head) => head.metadataSources);
 
     // Active parallel slot metadata is suppressed from contributing the primary
@@ -793,9 +803,10 @@ function prepareAppPageHeadInner<TModule extends AppPageHeadModule>(
         ];
       }),
       ...(pageMetadata ? [{ isPage: true, metadata: pageMetadata }] : []),
-      ...parallelMetadataResults
-        .filter(isPresent)
-        .map((entry) => ({ contributesTitle: !primaryPageHasTitle, metadata: entry })),
+      ...parallelMetadataEntries.map((entry) => ({
+        ...entry,
+        contributesTitle: !primaryPageHasTitle,
+      })),
     ];
 
     const resolvedMetadataBase =

--- a/packages/vinext/src/server/app-page-head.ts
+++ b/packages/vinext/src/server/app-page-head.ts
@@ -170,8 +170,12 @@ type AppPageSearchParamsCollection = {
 };
 
 type ResolvedParallelRouteMetadata = {
-  metadataEntries: MetadataMergeEntry[];
+  metadataItems: AppPageMetadataItem[];
   metadataSources: AppPageHeadSource[];
+};
+
+type AppPageMetadataItem = Omit<MetadataMergeEntry, "metadata"> & {
+  metadata: Metadata | null;
 };
 
 type PreparedViewportBranch = {
@@ -495,6 +499,35 @@ function parallelRouteHasDynamicMetadata<TModule extends AppPageHeadModule>(
   );
 }
 
+function createBranchMetadataItems(
+  layoutMetadata: readonly (Metadata | null)[],
+  layoutTreePositions: readonly number[],
+  routeSegmentCount: number,
+  pageMetadata: Metadata | null,
+  hasPage: boolean,
+): AppPageMetadataItem[] {
+  const items: AppPageMetadataItem[] = [];
+  let treePosition = 0;
+
+  for (const [index, metadata] of layoutMetadata.entries()) {
+    const layoutTreePosition = layoutTreePositions[index] ?? 0;
+    while (treePosition < layoutTreePosition) {
+      items.push({ metadata: null });
+      treePosition++;
+    }
+    items.push({ metadata });
+    treePosition = Math.max(treePosition, layoutTreePosition + 1);
+  }
+
+  while (treePosition <= routeSegmentCount) {
+    items.push({ metadata: null });
+    treePosition++;
+  }
+  if (hasPage) items.push({ metadata: pageMetadata });
+
+  return items;
+}
+
 async function resolveParallelRouteMetadata<TModule extends AppPageHeadModule>(
   parallelRoute: AppPageHeadParallelRoute<TModule>,
   fallbackParams: AppPageParams,
@@ -505,7 +538,7 @@ async function resolveParallelRouteMetadata<TModule extends AppPageHeadModule>(
 ): Promise<ResolvedParallelRouteMetadata> {
   const params = parallelRoute.params ?? fallbackParams;
   const routeSegments = parallelRoute.routeSegments ?? fallbackRouteSegments;
-  const metadataEntries: MetadataMergeEntry[] = [];
+  const layoutMetadataResults: (Metadata | null)[] = [];
   const metadataSources: AppPageHeadSource[] = [];
   let accumulatedMetadata = parent;
   const layoutModules = getParallelRouteModules(parallelRoute);
@@ -522,17 +555,7 @@ async function resolveParallelRouteMetadata<TModule extends AppPageHeadModule>(
       undefined,
       accumulatedMetadata,
     );
-    if (layoutMetadata) {
-      const isSameLayerAsPage =
-        parallelRoute.pageModule != null &&
-        parallelRoute.routeSegments != null &&
-        parallelRoute.layoutTreePositions != null &&
-        layoutTreePositions[index] === routeSegments.length;
-      metadataEntries.push({
-        metadata: layoutMetadata,
-        ...(isSameLayerAsPage ? { stashesTitleTemplate: false } : {}),
-      });
-    }
+    layoutMetadataResults.push(layoutMetadata);
     // Parallel route metadata sources are scoped to the active slot branch because
     // the route tree input does not carry per-layout segment positions inside that branch.
     metadataSources.push({ metadata: layoutMetadata, routeSegments });
@@ -545,20 +568,29 @@ async function resolveParallelRouteMetadata<TModule extends AppPageHeadModule>(
     }
   }
 
+  let pageMetadata: Metadata | null = null;
   if (parallelRoute.pageModule) {
-    const pageMetadata = await resolveModuleMetadata(
+    pageMetadata = await resolveModuleMetadata(
       parallelRoute.pageModule,
       params,
       pageSearchParams,
       accumulatedMetadata,
       searchParamsObserver,
     );
-    if (pageMetadata) metadataEntries.push({ metadata: pageMetadata });
     // Keep the page source scoped to the same active slot branch as its layouts.
     metadataSources.push({ metadata: pageMetadata, routeSegments });
   }
 
-  return { metadataEntries, metadataSources };
+  return {
+    metadataItems: createBranchMetadataItems(
+      layoutMetadataResults,
+      layoutTreePositions,
+      routeSegments.length,
+      pageMetadata,
+      parallelRoute.pageModule != null,
+    ),
+    metadataSources,
+  };
 }
 
 function resolveParallelRouteViewport<TModule extends AppPageHeadModule>(
@@ -771,7 +803,6 @@ function prepareAppPageHeadInner<TModule extends AppPageHeadModule>(
     pageMetadataPromise,
     parallelRouteMetadataPromise,
   ]).then(async ([layoutMetadataResults, pageMetadata, parallelRouteMetadata]) => {
-    const parallelMetadataEntries = parallelRouteMetadata.flatMap((head) => head.metadataEntries);
     const parallelMetadataSources = parallelRouteMetadata.flatMap((head) => head.metadataSources);
 
     // Active parallel slot metadata is suppressed from contributing the primary
@@ -785,29 +816,35 @@ function prepareAppPageHeadInner<TModule extends AppPageHeadModule>(
     // with no title suppression.
     // Reference: https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/metadata/resolve-metadata.ts
     const primaryPageHasTitle = pageMetadata != null && pageMetadata.title !== undefined;
-    const hasPrimaryPageLayer =
-      options.pageModule != null &&
-      options.routeSegments != null &&
-      options.layoutTreePositions != null;
-    const metadataEntries: MetadataMergeEntry[] = [
-      ...layoutMetadataResults.flatMap((metadata, index) => {
-        if (!metadata) return [];
-
-        const isSameLayerAsPage =
-          hasPrimaryPageLayer && layoutInputs[index]?.treePosition === routeSegments.length;
-        return [
-          {
-            metadata,
-            ...(isSameLayerAsPage ? { stashesTitleTemplate: false } : {}),
-          },
-        ];
-      }),
-      ...(pageMetadata ? [{ isPage: true, metadata: pageMetadata }] : []),
-      ...parallelMetadataEntries.map((entry) => ({
-        ...entry,
-        contributesTitle: !primaryPageHasTitle,
-      })),
+    const metadataItems: AppPageMetadataItem[] = [
+      ...createBranchMetadataItems(
+        layoutMetadataResults,
+        layoutSourcePositions,
+        routeSegments.length,
+        pageMetadata,
+        options.pageModule != null,
+      ),
+      ...parallelRouteMetadata.flatMap((head) =>
+        head.metadataItems.map((item) => ({
+          ...item,
+          contributesTitle: !primaryPageHasTitle,
+        })),
+      ),
     ];
+    // Next.js stops carrying title templates forward for only the final two
+    // items in the globally flattened loader-tree order (the leaf layout/page).
+    const firstUnstashedIndex = metadataItems.length - 2;
+    const metadataEntries = metadataItems.flatMap<MetadataMergeEntry>((item, index) =>
+      item.metadata
+        ? [
+            {
+              ...item,
+              metadata: item.metadata,
+              ...(index >= firstUnstashedIndex ? { stashesTitleTemplate: false } : {}),
+            },
+          ]
+        : [],
+    );
 
     const resolvedMetadataBase =
       metadataEntries.length > 0 ? mergeMetadataEntries(metadataEntries) : null;

--- a/packages/vinext/src/shims/metadata.tsx
+++ b/packages/vinext/src/shims/metadata.tsx
@@ -345,13 +345,19 @@ export type MetadataMergeEntry = {
   contributesTitle?: boolean;
   isPage?: boolean;
   metadata: Metadata;
+  /**
+   * Whether this entry's `title.template` becomes the parent template for later entries.
+   * Setting this to false keeps the current title contribution while preventing its
+   * template from wrapping a title from the same route-tree layer.
+   */
+  stashesTitleTemplate?: boolean;
 };
 
 /**
  * Merge metadata from multiple sources (layouts + page).
  *
  * The list is ordered [rootLayout, nestedLayout, ..., page].
- * Title template from layouts applies to the page title but NOT to
+ * Title templates from ancestor layouts apply to child titles but NOT to
  * the segment that defines the template itself. `title.absolute`
  * skips all templates. `title.default` is the fallback when no
  * child provides a title.
@@ -516,7 +522,7 @@ export function postProcessMetadata(merged: Metadata): Metadata {
  * Merge metadata from multiple sources (layouts + page).
  *
  * The list is ordered [rootLayout, nestedLayout, ..., page].
- * Title template from layouts applies to the page title but NOT to
+ * Title templates from ancestor layouts apply to child titles but NOT to
  * the segment that defines the template itself. `title.absolute`
  * skips all templates. `title.default` is the fallback when no
  * child provides a title.
@@ -536,6 +542,7 @@ export function mergeMetadataEntries(entries: readonly MetadataMergeEntry[]): Me
     const meta = entry.metadata;
     const isPage = Boolean(entry.isPage);
     const contributesTitle = entry.contributesTitle !== false;
+    const stashesTitleTemplate = entry.stashesTitleTemplate !== false;
 
     // Merge non-title keys
     for (const key of Object.keys(meta)) {
@@ -561,6 +568,7 @@ export function mergeMetadataEntries(entries: readonly MetadataMergeEntry[]): Me
     // title.default is wrapped by the ancestor template, not by its own template.
     if (
       contributesTitle &&
+      stashesTitleTemplate &&
       !isPage &&
       meta.title &&
       typeof meta.title === "object" &&

--- a/tests/app-page-head.test.ts
+++ b/tests/app-page-head.test.ts
@@ -222,6 +222,38 @@ describe("app page head resolution", () => {
     expect(pageParentImages).toEqual(["/root-og.png", "/nested-og.png"]);
   });
 
+  it("does not apply a leaf layout title template to its same-layer page", async () => {
+    // Ported from Next.js: test/e2e/app-dir/metadata/metadata.test.ts
+    // https://github.com/vercel/next.js/blob/v16.3.2/test/e2e/app-dir/metadata/metadata.test.ts#L37-L47
+    const leafLayout = {
+      async generateMetadata() {
+        return {
+          title: {
+            default: "My Website",
+            template: "%s | My Website",
+          },
+        };
+      },
+    };
+    const page = {
+      async generateMetadata() {
+        return { title: "Hello World" };
+      },
+    };
+
+    const result = await resolveAppPageHead<Record<string, unknown>>({
+      layoutModules: [{}, leafLayout],
+      layoutTreePositions: [0, 1],
+      metadataRoutes: [],
+      pageModule: page,
+      params: { lang: "en" },
+      routePath: "/[lang]",
+      routeSegments: ["[lang]"],
+    });
+
+    expect(result.metadata?.title).toBe("Hello World"); // instead of `"Hello World | My Website"`
+  });
+
   it("resolves viewport descriptors with parent chaining", async () => {
     // Matches Next.js's sequential parent resolution in accumulateViewport:
     // https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/metadata/resolve-metadata.ts

--- a/tests/app-page-head.test.ts
+++ b/tests/app-page-head.test.ts
@@ -1128,6 +1128,30 @@ describe("app page head resolution", () => {
     expect(result.metadata?.title).toBe("first page - @bar");
   });
 
+  it("does not apply a parallel leaf layout title template to its same-layer page", async () => {
+    // Matches Next.js's leaf layout/page title-template handling inside an active slot:
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/metadata/resolve-metadata.ts
+    const result = await resolveAppPageHead<Record<string, unknown>>({
+      layoutModules: [],
+      layoutTreePositions: [],
+      metadataRoutes: [],
+      pageModule: {},
+      parallelRoutes: [
+        {
+          layoutModules: [{ metadata: { title: { default: "Slot", template: "%s | Slot" } } }],
+          layoutTreePositions: [1],
+          pageModule: { metadata: { title: "Slot page" } },
+          routeSegments: ["foo"],
+        },
+      ],
+      params: {},
+      routePath: "/foo",
+      routeSegments: ["foo"],
+    });
+
+    expect(result.metadata?.title).toBe("Slot page");
+  });
+
   it("uses parallel layout title when neither primary page nor slot page set a title", async () => {
     // Ported from Next.js: test/e2e/app-dir/metadata-streaming-parallel-routes/metadata-streaming-parallel-routes.test.ts
     //

--- a/tests/app-page-head.test.ts
+++ b/tests/app-page-head.test.ts
@@ -1152,6 +1152,29 @@ describe("app page head resolution", () => {
     expect(result.metadata?.title).toBe("Slot page");
   });
 
+  it("retains a primary leaf template when later parallel metadata items follow it", async () => {
+    const result = await resolveAppPageHead<Record<string, unknown>>({
+      layoutModules: [
+        {},
+        { metadata: { title: { default: "Dashboard", template: "%s | Dashboard" } } },
+      ],
+      layoutTreePositions: [0, 1],
+      metadataRoutes: [],
+      pageModule: {},
+      parallelRoutes: [
+        {
+          pageModule: { metadata: { title: "Modal" } },
+          routeSegments: ["foo"],
+        },
+      ],
+      params: {},
+      routePath: "/foo",
+      routeSegments: ["foo"],
+    });
+
+    expect(result.metadata?.title).toBe("Modal | Dashboard");
+  });
+
   it("uses parallel layout title when neither primary page nor slot page set a title", async () => {
     // Ported from Next.js: test/e2e/app-dir/metadata-streaming-parallel-routes/metadata-streaming-parallel-routes.test.ts
     //

--- a/tests/e2e/app-router/nextjs-compat/metadata.spec.ts
+++ b/tests/e2e/app-router/nextjs-compat/metadata.spec.ts
@@ -104,10 +104,10 @@ test.describe("Next.js compat: metadata (browser)", () => {
   });
 
   // Next.js: 'should support title template'
-  // Source: metadata.test.ts#L34-L38
-  test("title template applies correctly", async ({ page }) => {
+  // Source: https://github.com/vercel/next.js/blob/v16.3.2/test/e2e/app-dir/metadata/metadata.test.ts#L37-L47
+  test("leaf layout title template does not apply to its same-layer page", async ({ page }) => {
     await page.goto(`${BASE}/nextjs-compat/metadata-title-template`);
-    await expect(page).toHaveTitle("Page | Layout");
+    await expect(page).toHaveTitle("Page");
   });
 
   test("title template applies to child page", async ({ page }) => {

--- a/tests/nextjs-compat/metadata.test.ts
+++ b/tests/nextjs-compat/metadata.test.ts
@@ -55,17 +55,15 @@ describe("Next.js compat: metadata", () => {
 
   // ── Title template ───────────────────────────────────────────
   // Next.js: 'should support title template'
-  // Source: https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/metadata/metadata.test.ts#L34-L38
+  // Source: https://github.com/vercel/next.js/blob/v16.3.2/test/e2e/app-dir/metadata/metadata.test.ts#L37-L47
 
-  it("should apply title template from layout", async () => {
+  it("should not apply a leaf layout title template to its same-layer page", async () => {
     const { html } = await fetchHtml(baseUrl, "/nextjs-compat/metadata-title-template");
-    // Layout has template "%s | Layout", page has title "Page"
-    // Result should be "Page | Layout"
-    expect(html).toContain("<title>Page | Layout</title>");
+    expect(html).toContain("<title>Page</title>");
   });
 
   // Next.js: 'should support stashed title in one layer'
-  // Source: https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/metadata/metadata.test.ts#L40-L44
+  // Source: https://github.com/vercel/next.js/blob/v16.3.2/test/e2e/app-dir/metadata/metadata.test.ts#L43-L47
 
   it("should apply title template to child page", async () => {
     const { html } = await fetchHtml(baseUrl, "/nextjs-compat/metadata-title-template/child");


### PR DESCRIPTION
Closes #3065

## Overview

This PR fixes an App Router metadata compatibility issue where vinext applied a leaf layout's `title.template` to a page on the same route-tree layer. Next.js only propagates that template to deeper child routes.

This restores SSR output parity with Next.js, avoiding related SEO and accessibility regressions.

## What changed

Added a field `stashesTitleTemplate` in `MetadataMergeEntry` to mark the entries on the same route-tree layer, preventing them from applying the layout's title template.

In `packages/vinext/src/server/app-page-head.ts`, filter the same route-layer pages.

```ts
const metadataEntries: MetadataMergeEntry[] = [
  ...layoutMetadataResults.flatMap((metadata, index) => {
    if (!metadata) return [];

    const isSameLayerAsPage =
      hasPrimaryPageLayer && layoutInputs[index]?.treePosition === routeSegments.length;
    return [
      {
        metadata,
        ...(isSameLayerAsPage ? { stashesTitleTemplate: false } : {}),
      },
    ];
  }),
  // ...other entries
];
```

## Testing

- `pnpm test tests/app-page-head.test.ts tests/nextjs-compat/metadata.test.ts`
- `playwright test tests/e2e/app-router/nextjs-compat/metadata.spec.ts --project=app-router`