### PR TITLE
fix(cloudflare): verify Worker version IDs during CDN warmup

### DIFF
--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -150,11 +150,59 @@ jobs:
           --warm-cdn-strict
 
       - name: Verify deploy-prewarmed RSC browser reuse
+        id: verify-rsc-prewarm
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && matrix.example.name == 'workers-cache'
+        continue-on-error: true
         env:
           PLAYWRIGHT_PROJECT: cloudflare-workers
           VINEXT_E2E_BASE_URL: https://rsc-prewarm-${{ github.run_id }}-${{ github.run_attempt }}.vinext.workers.dev
         run: vp exec playwright test tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
+
+      # A Playwright retry against the same keys could pass because the failed
+      # first attempt filled them. Repeat the deployment under a fresh hostname.
+      - name: Seed fresh Worker for RSC prewarm verification retry
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && matrix.example.name == 'workers-cache' && steps.verify-rsc-prewarm.outcome == 'failure'
+        working-directory: ${{ matrix.example.working_directory }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: >-
+          vp exec wrangler deploy
+          --config ../../tests/fixtures/rsc-prewarm-seed/wrangler.jsonc
+          --name rsc-prewarm-${{ github.run_id }}-${{ github.run_attempt }}-retry
+
+      - name: Retry deploy and RSC prewarm with fresh Worker
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && matrix.example.name == 'workers-cache' && steps.verify-rsc-prewarm.outcome == 'failure'
+        working-directory: ${{ matrix.example.working_directory }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          VINEXT_CDN_WARM_DEBUG: "1"
+        run: >-
+          vp exec vinext-cloudflare deploy
+          --skip-build
+          --config ${{ matrix.example.wrangler_config }}
+          --name rsc-prewarm-${{ github.run_id }}-${{ github.run_attempt }}-retry
+          --experimental-warm-cdn-cache
+          --warm-cdn-strict
+
+      - name: Retry deploy-prewarmed RSC browser reuse with fresh Worker
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && matrix.example.name == 'workers-cache' && steps.verify-rsc-prewarm.outcome == 'failure'
+        env:
+          PLAYWRIGHT_PROJECT: cloudflare-workers
+          VINEXT_E2E_BASE_URL: https://rsc-prewarm-${{ github.run_id }}-${{ github.run_attempt }}-retry.vinext.workers.dev
+        run: vp exec playwright test tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
+
+      - name: Delete RSC prewarm retry Worker
+        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && matrix.example.name == 'workers-cache' && steps.verify-rsc-prewarm.outcome == 'failure'
+        working-directory: ${{ matrix.example.working_directory }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: >-
+          vp exec wrangler delete rsc-prewarm-${{ github.run_id }}-${{ github.run_attempt }}-retry
+          --config ${{ matrix.example.wrangler_config }}
+          --force
 
       - name: Delete RSC prewarm test Worker
         if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && matrix.example.name == 'workers-cache'

--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -147,7 +147,6 @@ jobs:
           --config ${{ matrix.example.wrangler_config }}
           --name rsc-prewarm-${{ github.run_id }}-${{ github.run_attempt }}
           --experimental-warm-cdn-cache
-          --warm-cdn-strict
 
       - name: Verify deploy-prewarmed RSC browser reuse
         id: verify-rsc-prewarm
@@ -184,7 +183,6 @@ jobs:
           --config ${{ matrix.example.wrangler_config }}
           --name rsc-prewarm-${{ github.run_id }}-${{ github.run_attempt }}-retry
           --experimental-warm-cdn-cache
-          --warm-cdn-strict
 
       - name: Retry deploy-prewarmed RSC browser reuse with fresh Worker
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && matrix.example.name == 'workers-cache' && steps.verify-rsc-prewarm.outcome == 'failure'

--- a/examples/workers-cache/wrangler.jsonc
+++ b/examples/workers-cache/wrangler.jsonc
@@ -28,5 +28,8 @@
   "cache": {
     "enabled": true,
   },
+  "version_metadata": {
+    "binding": "CF_VERSION_METADATA",
+  },
   "kv_namespaces": [{ "binding": "VINEXT_KV_CACHE", "id": "b38f84f642aa4bd4ba17a37bb516f0b5" }],
 }

--- a/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
@@ -43,6 +43,7 @@ import {
 import type { CacheHandlerValue, IncrementalCacheValue } from "vinext/shims/cache";
 import { getRequestExecutionContext } from "vinext/shims/request-context";
 import { VINEXT_CDN_BUILD_ID_HEADER } from "./cdn-build-id.js";
+import { VINEXT_EXPECTED_WORKER_VERSION_HEADER } from "../version-headers.js";
 
 const DEFAULT_VERSION_METADATA_BINDING = "CF_VERSION_METADATA";
 const WORKER_VERSION_OVERRIDE_HEADER = "Cloudflare-Workers-Version-Overrides";
@@ -54,47 +55,6 @@ type WorkerVersionMetadata = {
 type CdnAdapterOptions = {
   versionMetadataBinding?: string;
 };
-
-function parseVersionOverrideIds(value: string): string[] | null {
-  const ids: string[] = [];
-  let index = 0;
-
-  while (index < value.length) {
-    while (value[index] === " " || value[index] === "\t") index++;
-    const equals = value.indexOf("=", index);
-    if (equals <= index || value.slice(index, equals).includes(",")) return null;
-    index = equals + 1;
-    while (value[index] === " " || value[index] === "\t") index++;
-    if (value[index] !== '"') return null;
-    index++;
-
-    let id = "";
-    let closed = false;
-    while (index < value.length) {
-      const character = value[index++];
-      if (character === '"') {
-        closed = true;
-        break;
-      }
-      if (character === "\\") {
-        const escaped = value[index++];
-        if (escaped !== '"' && escaped !== "\\") return null;
-        id += escaped;
-        continue;
-      }
-      id += character;
-    }
-    if (!closed || id.length === 0) return null;
-    ids.push(id);
-
-    while (value[index] === " " || value[index] === "\t") index++;
-    if (index === value.length) break;
-    if (value[index] !== ",") return null;
-    index++;
-  }
-
-  return ids.length > 0 ? ids : null;
-}
 
 function versionValidationFailure(message: string): Response {
   return new Response(`[vinext] ${message}\n`, {
@@ -226,8 +186,14 @@ export class CloudflareCdnCacheAdapter implements CdnCacheAdapter {
   ) {}
 
   validateRequest(request: Request): Response | null {
-    const override = request.headers.get(WORKER_VERSION_OVERRIDE_HEADER);
-    if (override === null) return null;
+    const expectedVersionId = request.headers.get(VINEXT_EXPECTED_WORKER_VERSION_HEADER);
+    if (expectedVersionId === null) return null;
+
+    if (!request.headers.has(WORKER_VERSION_OVERRIDE_HEADER)) {
+      return versionValidationFailure(
+        `received ${VINEXT_EXPECTED_WORKER_VERSION_HEADER} without ${WORKER_VERSION_OVERRIDE_HEADER}.`,
+      );
+    }
 
     if (!this.versionMetadata) {
       return versionValidationFailure(
@@ -236,15 +202,9 @@ export class CloudflareCdnCacheAdapter implements CdnCacheAdapter {
       );
     }
 
-    const requestedVersionIds = parseVersionOverrideIds(override);
-    if (!requestedVersionIds) {
+    if (expectedVersionId !== this.versionMetadata.id) {
       return versionValidationFailure(
-        `could not validate malformed ${WORKER_VERSION_OVERRIDE_HEADER} request header.`,
-      );
-    }
-    if (!requestedVersionIds.includes(this.versionMetadata.id)) {
-      return versionValidationFailure(
-        `Cloudflare invoked Worker version ${this.versionMetadata.id}, but the request override targeted ${requestedVersionIds.join(", ")}.`,
+        `Cloudflare invoked Worker version ${this.versionMetadata.id}, but vinext warmup expected ${expectedVersionId}.`,
       );
     }
     return null;

--- a/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
@@ -198,7 +198,8 @@ export class CloudflareCdnCacheAdapter implements CdnCacheAdapter {
     if (!this.versionMetadata) {
       return versionValidationFailure(
         `Cloudflare CDN prewarming requires the \`${this.versionMetadataBinding}\` version metadata binding. ` +
-          `Add "version_metadata": { "binding": "${this.versionMetadataBinding}" } to wrangler.jsonc.`,
+          `Add "version_metadata": { "binding": "${this.versionMetadataBinding}" } to the active Wrangler environment. ` +
+          `Named environments do not inherit this binding from the top level.`,
       );
     }
 

--- a/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
@@ -44,6 +44,68 @@ import type { CacheHandlerValue, IncrementalCacheValue } from "vinext/shims/cach
 import { getRequestExecutionContext } from "vinext/shims/request-context";
 import { VINEXT_CDN_BUILD_ID_HEADER } from "./cdn-build-id.js";
 
+const DEFAULT_VERSION_METADATA_BINDING = "CF_VERSION_METADATA";
+const WORKER_VERSION_OVERRIDE_HEADER = "Cloudflare-Workers-Version-Overrides";
+
+type WorkerVersionMetadata = {
+  id: string;
+};
+
+type CdnAdapterOptions = {
+  versionMetadataBinding?: string;
+};
+
+function parseVersionOverrideIds(value: string): string[] | null {
+  const ids: string[] = [];
+  let index = 0;
+
+  while (index < value.length) {
+    while (value[index] === " " || value[index] === "\t") index++;
+    const equals = value.indexOf("=", index);
+    if (equals <= index || value.slice(index, equals).includes(",")) return null;
+    index = equals + 1;
+    while (value[index] === " " || value[index] === "\t") index++;
+    if (value[index] !== '"') return null;
+    index++;
+
+    let id = "";
+    let closed = false;
+    while (index < value.length) {
+      const character = value[index++];
+      if (character === '"') {
+        closed = true;
+        break;
+      }
+      if (character === "\\") {
+        const escaped = value[index++];
+        if (escaped !== '"' && escaped !== "\\") return null;
+        id += escaped;
+        continue;
+      }
+      id += character;
+    }
+    if (!closed || id.length === 0) return null;
+    ids.push(id);
+
+    while (value[index] === " " || value[index] === "\t") index++;
+    if (index === value.length) break;
+    if (value[index] !== ",") return null;
+    index++;
+  }
+
+  return ids.length > 0 ? ids : null;
+}
+
+function versionValidationFailure(message: string): Response {
+  return new Response(`[vinext] ${message}\n`, {
+    status: 503,
+    headers: {
+      "Cache-Control": "no-store",
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  });
+}
+
 const CACHEABLE_EDGE_DIRECTIVE_RE = /(?:^|,)\s*(?:s-maxage|max-age)\s*=/i;
 const EDGE_POLICY_HEADERS = ["CDN-Cache-Control", "Cloudflare-CDN-Cache-Control"] as const;
 
@@ -158,6 +220,36 @@ function formatCacheTag(tags: readonly string[]): string | null {
 }
 
 export class CloudflareCdnCacheAdapter implements CdnCacheAdapter {
+  constructor(
+    private readonly versionMetadata?: WorkerVersionMetadata,
+    private readonly versionMetadataBinding = DEFAULT_VERSION_METADATA_BINDING,
+  ) {}
+
+  validateRequest(request: Request): Response | null {
+    const override = request.headers.get(WORKER_VERSION_OVERRIDE_HEADER);
+    if (override === null) return null;
+
+    if (!this.versionMetadata) {
+      return versionValidationFailure(
+        `Cloudflare CDN prewarming requires the \`${this.versionMetadataBinding}\` version metadata binding. ` +
+          `Add "version_metadata": { "binding": "${this.versionMetadataBinding}" } to wrangler.jsonc.`,
+      );
+    }
+
+    const requestedVersionIds = parseVersionOverrideIds(override);
+    if (!requestedVersionIds) {
+      return versionValidationFailure(
+        `could not validate malformed ${WORKER_VERSION_OVERRIDE_HEADER} request header.`,
+      );
+    }
+    if (!requestedVersionIds.includes(this.versionMetadata.id)) {
+      return versionValidationFailure(
+        `Cloudflare invoked Worker version ${this.versionMetadata.id}, but the request override targeted ${requestedVersionIds.join(", ")}.`,
+      );
+    }
+    return null;
+  }
+
   // The Cloudflare edge revalidates by re-requesting the origin (UPDATING),
   // so the origin must not also run in-process background regeneration.
   readonly ownsBackgroundRevalidation = false;
@@ -228,6 +320,23 @@ export class CloudflareCdnCacheAdapter implements CdnCacheAdapter {
 }
 
 // Config-driven adapter factory (default export).
-const createCloudflareCdnCacheAdapter = (): CdnCacheAdapter => new CloudflareCdnCacheAdapter();
+const createCloudflareCdnCacheAdapter = ({
+  env,
+  options,
+}: {
+  env?: Record<string, unknown>;
+  options?: CdnAdapterOptions;
+} = {}): CdnCacheAdapter => {
+  const binding = options?.versionMetadataBinding ?? DEFAULT_VERSION_METADATA_BINDING;
+  const candidate = env?.[binding];
+  const versionMetadata =
+    candidate &&
+    typeof candidate === "object" &&
+    "id" in candidate &&
+    typeof candidate.id === "string"
+      ? { id: candidate.id }
+      : undefined;
+  return new CloudflareCdnCacheAdapter(versionMetadata, binding);
+};
 
 export default createCloudflareCdnCacheAdapter;

--- a/packages/cloudflare/src/cache/cdn-adapter.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.ts
@@ -28,6 +28,8 @@ export type CdnAdapterOptions = {
  *   }
  * }
  * ```
+ * Wrangler does not inherit `version_metadata` into named environments. Repeat
+ * the binding in every `env.<name>` used for CDN warmup.
  */
 export function cdnAdapter(options?: CdnAdapterOptions) {
   if (

--- a/packages/cloudflare/src/cache/cdn-adapter.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.ts
@@ -1,5 +1,13 @@
 import { fileURLToPath } from "node:url";
 
+export const DEFAULT_CDN_VERSION_METADATA_BINDING = "CF_VERSION_METADATA";
+
+/** Options accepted by {@link cdnAdapter}, forwarded to the runtime factory. */
+export type CdnAdapterOptions = {
+  /** Version metadata binding used to verify version-overridden requests. */
+  versionMetadataBinding?: string;
+};
+
 /**
  * Cloudflare CDN cache adapter - edge-managed page-level ISR backed by the
  * Cloudflare Workers Cache.
@@ -15,10 +23,22 @@ import { fileURLToPath } from "node:url";
  *   "cache": {
  *     "enabled": true,
  *   },
+ *   "version_metadata": {
+ *     "binding": "CF_VERSION_METADATA"
+ *   }
  * }
  * ```
  */
-export function cdnAdapter(options?: Record<string, never>) {
+export function cdnAdapter(options?: CdnAdapterOptions) {
+  if (
+    options?.versionMetadataBinding !== undefined &&
+    (typeof options.versionMetadataBinding !== "string" ||
+      options.versionMetadataBinding.length === 0)
+  ) {
+    throw new TypeError(
+      "[vinext] cdnAdapter({ versionMetadataBinding }) must be a non-empty string binding name.",
+    );
+  }
   return {
     adapter: fileURLToPath(import.meta.resolve("./cdn-adapter.runtime.js")),
     options,

--- a/packages/cloudflare/src/cdn-warm.ts
+++ b/packages/cloudflare/src/cdn-warm.ts
@@ -778,6 +778,7 @@ async function warmOnePath(
     headers?: HeadersInit;
     expectedBuildId?: string;
     expectedRscBuildId?: string;
+    revalidateCachedResponse: boolean;
     retryPropagationFailures: boolean;
     retryDelayMs: number;
     retryNotFound: boolean;
@@ -800,11 +801,20 @@ async function warmOnePath(
 
   for (let attempt = 0; attempt <= options.retries; attempt++) {
     try {
+      const requestHeaders = new Headers(target.headers ?? options.headers);
+      if (options.revalidateCachedResponse) {
+        // A staged request can be answered by an existing old-build CDN object
+        // before the version-overridden Worker runs. Revalidate only failed
+        // keys; this keeps the canonical URL/cache key unchanged while forcing
+        // Cloudflare to replace the stale object with the uploaded build.
+        requestHeaders.set("Cache-Control", "no-cache");
+        requestHeaders.set("Pragma", "no-cache");
+      }
       const { response } = await fetchWithTimeout(
         options.fetchImpl,
         url,
         options.timeoutMs,
-        target.headers ?? options.headers,
+        requestHeaders,
         "manual",
       );
 
@@ -982,6 +992,7 @@ export async function warmCdnCache(options: CdnWarmOptions): Promise<CdnWarmResu
       headers: options.headers,
       expectedBuildId: options.expectedBuildId,
       expectedRscBuildId: options.expectedRscBuildId,
+      revalidateCachedResponse: retryMode === "propagation-retry",
       retryPropagationFailures: isPropagationRequest,
       retryDelayMs: isPropagationRequest ? propagationRetryDelayMs : normalRetryDelayMs,
       retryNotFound: isPropagationRequest,

--- a/packages/cloudflare/src/cdn-warm.ts
+++ b/packages/cloudflare/src/cdn-warm.ts
@@ -613,6 +613,7 @@ function validateReadinessResponse(
     return `response ${VINEXT_RSC_BUILD_ID_HEADER} does not match build ${expectedRscBuildId}`;
   }
   if (response.redirected) return "redirected response";
+  if (response.status >= 500) return `HTTP ${response.status}`;
   if (
     response.status >= 200 &&
     response.status < 300 &&

--- a/packages/cloudflare/src/cdn-warm.ts
+++ b/packages/cloudflare/src/cdn-warm.ts
@@ -353,7 +353,7 @@ class CdnWarmProgress {
   private readonly isTTY = process.stderr.isTTY;
   private lastLineLength = 0;
 
-  update(completed: number, total: number, label: string): void {
+  update(completed: number, total: number, label: string, phase = "Warming CDN cache"): void {
     if (!this.isTTY) return;
     const percent = total > 0 ? Math.floor((completed / total) * 100) : 0;
     const filled = Math.floor(percent / 5);
@@ -361,14 +361,15 @@ class CdnWarmProgress {
     const maxLabelLength = 40;
     const shortLabel =
       label.length > maxLabelLength ? `…${label.slice(-(maxLabelLength - 1))}` : label;
-    const line = `Warming CDN cache... ${bar} ${String(completed).padStart(String(total).length)}/${total} ${shortLabel}`;
+    const line = `${phase}... ${bar} ${String(completed).padStart(String(total).length)}/${total} ${shortLabel}`;
     process.stderr.write(`\r${line.padEnd(this.lastLineLength)}`);
     this.lastLineLength = line.length;
   }
 
   finish(): void {
-    if (!this.isTTY) return;
+    if (!this.isTTY || this.lastLineLength === 0) return;
     process.stderr.write(`\r${" ".repeat(this.lastLineLength)}\r`);
+    this.lastLineLength = 0;
   }
 }
 
@@ -1002,15 +1003,10 @@ export async function warmCdnCache(options: CdnWarmOptions): Promise<CdnWarmResu
   const warmRequest = async (
     target: WarmTarget,
     retryMode: WarmRetryMode = "normal",
-    countCompletion = true,
   ): Promise<Awaited<ReturnType<typeof warmOnePath>>> => {
     const result = await warmTarget(target, retryMode);
-    if (countCompletion) completedRequests++;
-    progress.update(
-      completedRequests,
-      requests.length,
-      countCompletion ? target.label : `retrying ${target.label}`,
-    );
+    completedRequests++;
+    progress.update(completedRequests, requests.length, target.label);
     return result;
   };
 
@@ -1038,11 +1034,24 @@ export async function warmCdnCache(options: CdnWarmOptions): Promise<CdnWarmResu
     console.log(
       `  CDN warmup: retrying ${retryableFailed.length} failed request(s) after completing the initial pass...`,
     );
+    let completedRetries = 0;
+    progress.update(0, retryableFailed.length, "starting retry pass", "Retrying CDN cache");
     const retried = await runWithConcurrency(
       retryableFailed.map(({ target }) => target),
       concurrency,
-      (target) => warmRequest(target, "propagation-retry", false),
+      async (target) => {
+        const result = await warmTarget(target, "propagation-retry");
+        completedRetries++;
+        progress.update(
+          completedRetries,
+          retryableFailed.length,
+          target.label,
+          "Retrying CDN cache",
+        );
+        return result;
+      },
     );
+    progress.finish();
     for (const [retryIndex, { index }] of retryableFailed.entries()) {
       results[index] = retried[retryIndex];
     }

--- a/packages/cloudflare/src/cdn-warm.ts
+++ b/packages/cloudflare/src/cdn-warm.ts
@@ -779,7 +779,6 @@ async function warmOnePath(
     headers?: HeadersInit;
     expectedBuildId?: string;
     expectedRscBuildId?: string;
-    revalidateCachedResponse: boolean;
     retryPropagationFailures: boolean;
     retryDelayMs: number;
     retryNotFound: boolean;
@@ -802,20 +801,11 @@ async function warmOnePath(
 
   for (let attempt = 0; attempt <= options.retries; attempt++) {
     try {
-      const requestHeaders = new Headers(target.headers ?? options.headers);
-      if (options.revalidateCachedResponse) {
-        // A staged request can be answered by an existing old-build CDN object
-        // before the version-overridden Worker runs. Revalidate only failed
-        // keys; this keeps the canonical URL/cache key unchanged while forcing
-        // Cloudflare to replace the stale object with the uploaded build.
-        requestHeaders.set("Cache-Control", "no-cache");
-        requestHeaders.set("Pragma", "no-cache");
-      }
       const { response } = await fetchWithTimeout(
         options.fetchImpl,
         url,
         options.timeoutMs,
-        requestHeaders,
+        target.headers ?? options.headers,
         "manual",
       );
 
@@ -993,7 +983,6 @@ export async function warmCdnCache(options: CdnWarmOptions): Promise<CdnWarmResu
       headers: options.headers,
       expectedBuildId: options.expectedBuildId,
       expectedRscBuildId: options.expectedRscBuildId,
-      revalidateCachedResponse: retryMode === "propagation-retry",
       retryPropagationFailures: isPropagationRequest,
       retryDelayMs: isPropagationRequest ? propagationRetryDelayMs : normalRetryDelayMs,
       retryNotFound: isPropagationRequest,

--- a/packages/cloudflare/src/cli.ts
+++ b/packages/cloudflare/src/cli.ts
@@ -56,7 +56,7 @@ async function deployCommand(): Promise<void> {
     warmCdnRetries: parsed.warmCdnRetries,
     warmCdnReadinessProbes: parsed.warmCdnReadinessProbes,
     warmCdnReadinessProbeDelay: parsed.warmCdnReadinessProbeDelay,
-    warmCdnStrict: parsed.warmCdnStrict,
+    dangerouslyPromoteOnCdnWarmError: parsed.dangerouslyPromoteOnCdnWarmError,
     warmCdnPromote: parsed.warmCdnPromote,
     warmCdnPromotionDelay: parsed.warmCdnPromotionDelay,
     warmCdnIncludeFallbacks: parsed.warmCdnIncludeFallbacks,

--- a/packages/cloudflare/src/cli.ts
+++ b/packages/cloudflare/src/cli.ts
@@ -54,6 +54,8 @@ async function deployCommand(): Promise<void> {
     warmCdnConcurrency: parsed.warmCdnConcurrency,
     warmCdnTimeout: parsed.warmCdnTimeout,
     warmCdnRetries: parsed.warmCdnRetries,
+    warmCdnReadinessProbes: parsed.warmCdnReadinessProbes,
+    warmCdnReadinessProbeDelay: parsed.warmCdnReadinessProbeDelay,
     warmCdnStrict: parsed.warmCdnStrict,
     warmCdnPromote: parsed.warmCdnPromote,
     warmCdnPromotionDelay: parsed.warmCdnPromotionDelay,

--- a/packages/cloudflare/src/deploy-help.ts
+++ b/packages/cloudflare/src/deploy-help.ts
@@ -34,7 +34,8 @@ export function formatDeployHelp(): string {
                              required before warming (default: 6)
     --warm-cdn-readiness-probe-delay <ms>
                              Delay between staged-readiness probes (default: 1000)
-    --warm-cdn-strict        Fail deploy when any CDN warmup request fails
+    --dangerously-promote-on-cdn-warm-error
+                             Promote even when staged warmup cannot be verified
     --warm-cdn-no-promote    Leave the warmed Worker version staged at 0% traffic
     --warm-cdn-promotion-delay <ms>
                              Delay before promotion after warmup (default: 15000)

--- a/packages/cloudflare/src/deploy-help.ts
+++ b/packages/cloudflare/src/deploy-help.ts
@@ -29,6 +29,11 @@ export function formatDeployHelp(): string {
     --warm-cdn-timeout <ms>  Per-request CDN warmup timeout (default: 10000)
     --warm-cdn-retries <n>   Retries per failed CDN warmup request (default: 1;
                              staged-version propagation default: 60)
+    --warm-cdn-readiness-probes <count>
+                             Consecutive successful staged-readiness probes
+                             required before warming (default: 6)
+    --warm-cdn-readiness-probe-delay <ms>
+                             Delay between staged-readiness probes (default: 1000)
     --warm-cdn-strict        Fail deploy when any CDN warmup request fails
     --warm-cdn-no-promote    Leave the warmed Worker version staged at 0% traffic
     --warm-cdn-promotion-delay <ms>

--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -46,6 +46,7 @@ import {
   type ProjectInfo,
 } from "vinext/internal/utils/project";
 import { parseWranglerConfig, runTPR } from "./tpr.js";
+import { VINEXT_EXPECTED_WORKER_VERSION_HEADER } from "./version-headers.js";
 import {
   readPrerenderWarmPlan,
   waitForCdnWarmTargetReadiness,
@@ -109,8 +110,8 @@ export type DeployOptions = {
   warmCdnReadinessProbes?: number;
   /** Delay between staged Worker readiness probes in milliseconds */
   warmCdnReadinessProbeDelay?: number;
-  /** Fail deployment if any CDN warmup request fails */
-  warmCdnStrict?: boolean;
+  /** Promote even when staged CDN warmup cannot be completed */
+  dangerouslyPromoteOnCdnWarmError?: boolean;
   /** Promote the warmed Worker version to 100% traffic (default: true) */
   warmCdnPromote?: boolean;
   /** Delay between successful warmup and promotion in milliseconds */
@@ -200,7 +201,7 @@ const deployArgOptions = {
   "warm-cdn-retries": { type: "string" },
   "warm-cdn-readiness-probes": { type: "string" },
   "warm-cdn-readiness-probe-delay": { type: "string" },
-  "warm-cdn-strict": { type: "boolean", default: false },
+  "dangerously-promote-on-cdn-warm-error": { type: "boolean", default: false },
   "warm-cdn-no-promote": { type: "boolean", default: false },
   "warm-cdn-promotion-delay": { type: "string" },
   "warm-cdn-include-fallbacks": { type: "boolean", default: false },
@@ -267,7 +268,7 @@ export function parseDeployArgs(args: string[]) {
             "--warm-cdn-readiness-probe-delay",
             values["warm-cdn-readiness-probe-delay"],
           ),
-    warmCdnStrict: values["warm-cdn-strict"],
+    dangerouslyPromoteOnCdnWarmError: values["dangerously-promote-on-cdn-warm-error"],
     warmCdnPromote: !values["warm-cdn-no-promote"],
     warmCdnPromotionDelay:
       values["warm-cdn-promotion-delay"] === undefined
@@ -624,7 +625,7 @@ export async function deployWithCdnWarmup(
     | "warmCdnRetries"
     | "warmCdnReadinessProbes"
     | "warmCdnReadinessProbeDelay"
-    | "warmCdnStrict"
+    | "dangerouslyPromoteOnCdnWarmError"
     | "warmCdnPromote"
     | "warmCdnPromotionDelay"
   > &
@@ -642,20 +643,14 @@ export async function deployWithCdnWarmup(
   if (options.warmCdnPromotionDelay !== undefined) {
     validatePromotionDelay(options.warmCdnPromotionDelay);
   }
-  if (options.warmCdnStrict && paths.length > 0 && options.expectedBuildId === undefined) {
-    throw new Error(
-      "Strict CDN HTML warmup requires a CDN adapter that declares build-identity response headers. " +
-        "Configure that adapter capability or rerun without --warm-cdn-strict.",
-    );
-  }
   if (
-    options.warmCdnPromote === false &&
+    !options.dangerouslyPromoteOnCdnWarmError &&
     paths.length > 0 &&
     options.expectedBuildId === undefined
   ) {
     throw new Error(
-      "CDN warmup cannot skip promotion because the discovered HTML requests cannot be verified. " +
-        "Configure a CDN adapter that declares build-identity response headers.",
+      "CDN HTML warmup requires a CDN adapter that declares build-identity response headers. " +
+        "Configure that adapter capability or deploy without --experimental-warm-cdn-cache.",
     );
   }
   const upload = runWranglerVersionUpload(root, options);
@@ -682,7 +677,7 @@ export async function deployWithCdnWarmup(
       concurrency: options.warmCdnConcurrency,
       timeoutMs: options.warmCdnTimeout,
       retries: options.warmCdnRetries,
-      strict: options.warmCdnStrict,
+      strict: !options.dangerouslyPromoteOnCdnWarmError,
     });
 
   const wranglerConfig = parseWranglerConfig(root, options.config);
@@ -755,14 +750,14 @@ export async function deployWithCdnWarmup(
           });
           if (!readiness.ready) {
             const message = `CDN warmup could not verify staged Worker readiness: ${readiness.error}.`;
-            if (options.warmCdnStrict || options.warmCdnPromote === false) {
-              const noPromoteNote =
-                options.warmCdnPromote === false
-                  ? " CDN warmup cannot continue because promotion is disabled and the staged version was not warmed."
-                  : "";
+            const noPromoteNote =
+              options.warmCdnPromote === false
+                ? " CDN warmup cannot continue because promotion is disabled and the staged version was not warmed."
+                : "";
+            if (!options.dangerouslyPromoteOnCdnWarmError || options.warmCdnPromote === false) {
               throw new Error(`${message}${noPromoteNote}`);
             }
-            console.warn(`  ${message} Warming after promotion instead.`);
+            console.warn(`  ${message} Promoting because the dangerous override is enabled.`);
           } else {
             console.log("  CDN warmup: staged Worker version is stable.");
             const warmResult = await warmUploadedVersion(targetUrl, headers, true, stagedWarmPlan);
@@ -777,18 +772,23 @@ export async function deployWithCdnWarmup(
       } catch (error) {
         throw withStagedVersionCleanupNote(error);
       }
-    } else if (options.warmCdnStrict) {
-      throw new Error(
+    } else if (initialWarmRequests > 0) {
+      const message =
         "CDN warmup failed: pre-traffic warmup needs a production URL and Worker name for version overrides. " +
-          "Configure a route/custom domain and Worker name, or rerun without --warm-cdn-strict. " +
-          getStagedVersionCleanupNote(),
-      );
+        "Configure a route/custom domain and Worker name, or deploy without --experimental-warm-cdn-cache.";
+      if (!options.dangerouslyPromoteOnCdnWarmError) {
+        throw new Error(`${message} ${getStagedVersionCleanupNote()}`);
+      }
+      console.warn(`  ${message} Promoting because the dangerous override is enabled.`);
     }
   } else {
-    if (options.warmCdnStrict && initialWarmRequests > 0) {
-      throw new Error(
-        "Strict CDN warmup cannot stage the uploaded Worker at 0% because the current deployment is not exactly one version serving 100% traffic. No traffic or triggers were changed.",
-      );
+    if (initialWarmRequests > 0) {
+      const message =
+        "CDN warmup cannot stage the uploaded Worker at 0% because the current deployment is not exactly one version serving 100% traffic.";
+      if (!options.dangerouslyPromoteOnCdnWarmError) {
+        throw new Error(`${message} No traffic or triggers were changed.`);
+      }
+      console.warn(`  ${message} Promoting because the dangerous override is enabled.`);
     }
     console.warn(
       "  CDN warmup: pre-traffic version override skipped because the current deployment is not one version serving 100% traffic.",
@@ -859,16 +859,16 @@ export async function deployWithCdnWarmup(
       } catch (error) {
         throw withPromotedVersionWarmupNote(error);
       }
-    } else if (options.warmCdnStrict) {
+    } else if (!options.dangerouslyPromoteOnCdnWarmError) {
       throw withPromotedVersionWarmupNote(
         new Error(
           "CDN warmup failed: no production URL could be inferred from wrangler config or output. " +
-            "Configure a route/custom domain, ensure Wrangler prints a workers.dev URL, or rerun without --warm-cdn-strict.",
+            "Configure a route/custom domain, ensure Wrangler prints a workers.dev URL, or deploy without --experimental-warm-cdn-cache.",
         ),
       );
     } else {
       console.warn(
-        "  CDN warmup skipped: no production URL could be inferred from wrangler config or output.",
+        "  CDN warmup skipped: no production URL could be inferred after promotion; the dangerous override was enabled.",
       );
     }
   }
@@ -947,6 +947,7 @@ export function buildVersionOverrideHeaders(
   if (!workerName) return undefined;
   return {
     "Cloudflare-Workers-Version-Overrides": `${workerName}=${quoteStructuredHeaderString(versionId)}`,
+    [VINEXT_EXPECTED_WORKER_VERSION_HEADER]: versionId,
   };
 }
 
@@ -1167,7 +1168,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
   if (options.warmCdnCache) {
     const warmPlan = readPrerenderWarmPlan(root, {
       includeFallbackShells: options.warmCdnIncludeFallbacks,
-      strict: options.warmCdnStrict,
+      strict: !options.dangerouslyPromoteOnCdnWarmError,
     });
     if (hasCdnWarmRequests(warmPlan)) {
       url = await deployWithCdnWarmup(root, warmPlan.paths, {
@@ -1182,7 +1183,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
         warmCdnRetries: options.warmCdnRetries,
         warmCdnReadinessProbes: options.warmCdnReadinessProbes,
         warmCdnReadinessProbeDelay: options.warmCdnReadinessProbeDelay,
-        warmCdnStrict: options.warmCdnStrict,
+        dangerouslyPromoteOnCdnWarmError: options.dangerouslyPromoteOnCdnWarmError,
         warmCdnPromote: options.warmCdnPromote,
         warmCdnPromotionDelay: options.warmCdnPromotionDelay,
       });

--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -105,6 +105,10 @@ export type DeployOptions = {
   warmCdnTimeout?: number;
   /** Number of CDN warmup retries for transient failures */
   warmCdnRetries?: number;
+  /** Consecutive successful probes required before warming the staged Worker */
+  warmCdnReadinessProbes?: number;
+  /** Delay between staged Worker readiness probes in milliseconds */
+  warmCdnReadinessProbeDelay?: number;
   /** Fail deployment if any CDN warmup request fails */
   warmCdnStrict?: boolean;
   /** Promote the warmed Worker version to 100% traffic (default: true) */
@@ -156,16 +160,20 @@ function parseNonNegativeIntegerArg(raw: string, flag: string): number {
 
 const MAX_NODE_TIMER_DELAY_MS = 2_147_483_647;
 
-function validatePromotionDelay(value: number, raw = String(value)): number {
+function validateTimerDelay(value: number, flag: string, raw = String(value)): number {
   if (!Number.isInteger(value) || value < 0) {
-    throw new Error(`--warm-cdn-promotion-delay expects a non-negative integer, but got "${raw}".`);
+    throw new Error(`${flag} expects a non-negative integer, but got "${raw}".`);
   }
   if (value > MAX_NODE_TIMER_DELAY_MS) {
     throw new Error(
-      `--warm-cdn-promotion-delay must not exceed ${MAX_NODE_TIMER_DELAY_MS} milliseconds, but got "${raw}".`,
+      `${flag} must not exceed ${MAX_NODE_TIMER_DELAY_MS} milliseconds, but got "${raw}".`,
     );
   }
   return value;
+}
+
+function validatePromotionDelay(value: number, raw = String(value)): number {
+  return validateTimerDelay(value, "--warm-cdn-promotion-delay", raw);
 }
 
 function formatUnknownError(error: unknown): string {
@@ -190,6 +198,8 @@ const deployArgOptions = {
   "warm-cdn-concurrency": { type: "string" },
   "warm-cdn-timeout": { type: "string" },
   "warm-cdn-retries": { type: "string" },
+  "warm-cdn-readiness-probes": { type: "string" },
+  "warm-cdn-readiness-probe-delay": { type: "string" },
   "warm-cdn-strict": { type: "boolean", default: false },
   "warm-cdn-no-promote": { type: "boolean", default: false },
   "warm-cdn-promotion-delay": { type: "string" },
@@ -239,6 +249,24 @@ export function parseDeployArgs(args: string[]) {
       values["warm-cdn-retries"] === undefined
         ? undefined
         : parseNonNegativeIntegerArg(values["warm-cdn-retries"], "--warm-cdn-retries"),
+    warmCdnReadinessProbes:
+      values["warm-cdn-readiness-probes"] === undefined
+        ? undefined
+        : parsePositiveIntegerArg(
+            values["warm-cdn-readiness-probes"],
+            "--warm-cdn-readiness-probes",
+          ),
+    warmCdnReadinessProbeDelay:
+      values["warm-cdn-readiness-probe-delay"] === undefined
+        ? undefined
+        : validateTimerDelay(
+            parseNonNegativeIntegerArg(
+              values["warm-cdn-readiness-probe-delay"],
+              "--warm-cdn-readiness-probe-delay",
+            ),
+            "--warm-cdn-readiness-probe-delay",
+            values["warm-cdn-readiness-probe-delay"],
+          ),
     warmCdnStrict: values["warm-cdn-strict"],
     warmCdnPromote: !values["warm-cdn-no-promote"],
     warmCdnPromotionDelay:
@@ -594,6 +622,8 @@ export async function deployWithCdnWarmup(
     | "warmCdnConcurrency"
     | "warmCdnTimeout"
     | "warmCdnRetries"
+    | "warmCdnReadinessProbes"
+    | "warmCdnReadinessProbeDelay"
     | "warmCdnStrict"
     | "warmCdnPromote"
     | "warmCdnPromotionDelay"
@@ -603,6 +633,12 @@ export async function deployWithCdnWarmup(
       "deploymentId" | "expectedBuildId" | "expectedRscBuildId" | "loadingShellPaths" | "rscPaths"
     >,
 ): Promise<string> {
+  if (options.warmCdnReadinessProbes !== undefined) {
+    parsePositiveIntegerArg(String(options.warmCdnReadinessProbes), "--warm-cdn-readiness-probes");
+  }
+  if (options.warmCdnReadinessProbeDelay !== undefined) {
+    validateTimerDelay(options.warmCdnReadinessProbeDelay, "--warm-cdn-readiness-probe-delay");
+  }
   if (options.warmCdnPromotionDelay !== undefined) {
     validatePromotionDelay(options.warmCdnPromotionDelay);
   }
@@ -712,6 +748,8 @@ export async function deployWithCdnWarmup(
             deploymentId: options.deploymentId,
             expectedBuildId: options.expectedBuildId,
             expectedRscBuildId: options.expectedRscBuildId,
+            probeIntervalMs: options.warmCdnReadinessProbeDelay,
+            requiredConsecutiveSuccesses: options.warmCdnReadinessProbes,
             retries: options.warmCdnRetries,
             timeoutMs: options.warmCdnTimeout,
           });
@@ -1142,6 +1180,8 @@ export async function deploy(options: DeployOptions): Promise<void> {
         warmCdnConcurrency: options.warmCdnConcurrency,
         warmCdnTimeout: options.warmCdnTimeout,
         warmCdnRetries: options.warmCdnRetries,
+        warmCdnReadinessProbes: options.warmCdnReadinessProbes,
+        warmCdnReadinessProbeDelay: options.warmCdnReadinessProbeDelay,
         warmCdnStrict: options.warmCdnStrict,
         warmCdnPromote: options.warmCdnPromote,
         warmCdnPromotionDelay: options.warmCdnPromotionDelay,

--- a/packages/cloudflare/src/version-headers.ts
+++ b/packages/cloudflare/src/version-headers.ts
@@ -1,2 +1,1 @@
-/** Expected Worker version asserted by vinext staged warmup requests. */
-export const VINEXT_EXPECTED_WORKER_VERSION_HEADER = "X-Vinext-Expected-Worker-Version";
+export { VINEXT_EXPECTED_WORKER_VERSION_HEADER } from "vinext/internal/server/headers";

--- a/packages/cloudflare/src/version-headers.ts
+++ b/packages/cloudflare/src/version-headers.ts
@@ -1,0 +1,2 @@
+/** Expected Worker version asserted by vinext staged warmup requests. */
+export const VINEXT_EXPECTED_WORKER_VERSION_HEADER = "X-Vinext-Expected-Worker-Version";

--- a/packages/vinext/src/init-cloudflare.ts
+++ b/packages/vinext/src/init-cloudflare.ts
@@ -22,6 +22,7 @@ const DEFAULT_CLOUDFLARE_INIT_OPTIONS: CloudflareInitOptions = {
   cdnCache: "workers-cache",
   imageOptimization: "cloudflare-images",
 };
+const DEFAULT_VERSION_METADATA_BINDING = "CF_VERSION_METADATA";
 
 export type CloudflarePlatformSetupContext = {
   root: string;
@@ -60,6 +61,9 @@ export function validateCloudflarePlatformSetup(
   const imagesBinding = updatedWranglerCode
     ? getWranglerImagesBinding(updatedWranglerCode)
     : "IMAGES";
+  const versionMetadataBinding = updatedWranglerCode
+    ? getWranglerVersionMetadataBinding(updatedWranglerCode)
+    : DEFAULT_VERSION_METADATA_BINDING;
 
   if (context.existingViteConfigPath) {
     updateViteConfigForCloudflare(
@@ -70,6 +74,7 @@ export function validateCloudflarePlatformSetup(
         nativeModulesToStub: projectInfo.nativeModulesToStub,
         cache: cloudflare,
         imagesBinding,
+        versionMetadataBinding,
         prerender: context.prerender,
       },
     );
@@ -85,7 +90,15 @@ export function setupCloudflarePlatform(
     .map((fileName) => path.join(context.root, fileName))
     .find((candidate) => fs.existsSync(candidate));
   const wranglerCode = wranglerPath ? fs.readFileSync(wranglerPath, "utf-8") : undefined;
-  const imagesBinding = wranglerCode ? getWranglerImagesBinding(wranglerCode) : "IMAGES";
+  const updatedWranglerCode = wranglerCode
+    ? updateWranglerConfigForCloudflare(wranglerCode, cloudflare, { root: context.root })
+    : undefined;
+  const imagesBinding = updatedWranglerCode
+    ? getWranglerImagesBinding(updatedWranglerCode)
+    : "IMAGES";
+  const versionMetadataBinding = updatedWranglerCode
+    ? getWranglerVersionMetadataBinding(updatedWranglerCode)
+    : DEFAULT_VERSION_METADATA_BINDING;
 
   let generatedViteConfig = false;
   let skippedViteConfig = false;
@@ -99,6 +112,7 @@ export function setupCloudflarePlatform(
         nativeModulesToStub: projectInfo.nativeModulesToStub,
         cache: cloudflare,
         imagesBinding,
+        versionMetadataBinding,
         prerender: context.prerender,
       },
     );
@@ -110,8 +124,20 @@ export function setupCloudflarePlatform(
     }
   } else {
     const configContent = context.isAppRouter
-      ? generateAppRouterViteConfig(projectInfo, cloudflare, imagesBinding, context.prerender)
-      : generatePagesRouterViteConfig(projectInfo, cloudflare, imagesBinding, context.prerender);
+      ? generateAppRouterViteConfig(
+          projectInfo,
+          cloudflare,
+          imagesBinding,
+          context.prerender,
+          versionMetadataBinding,
+        )
+      : generatePagesRouterViteConfig(
+          projectInfo,
+          cloudflare,
+          imagesBinding,
+          context.prerender,
+          versionMetadataBinding,
+        );
     fs.writeFileSync(path.join(context.root, "vite.config.ts"), configContent, "utf-8");
     generatedViteConfig = true;
   }
@@ -124,12 +150,9 @@ export function setupCloudflarePlatform(
       "utf-8",
     );
     generatedPlatformFiles.push("wrangler.jsonc");
-  } else if (wranglerCode) {
-    const updatedConfig = updateWranglerConfigForCloudflare(wranglerCode, cloudflare, {
-      root: context.root,
-    });
-    if (updatedConfig !== wranglerCode) {
-      fs.writeFileSync(wranglerPath, updatedConfig, "utf-8");
+  } else if (wranglerCode && updatedWranglerCode) {
+    if (updatedWranglerCode !== wranglerCode) {
+      fs.writeFileSync(wranglerPath, updatedWranglerCode, "utf-8");
       generatedPlatformFiles.push(path.basename(wranglerPath));
     }
   }
@@ -198,7 +221,10 @@ export function generateWranglerConfig(
     },
   };
 
-  if (options.cdnCache === "workers-cache") config.cache = { enabled: true };
+  if (options.cdnCache === "workers-cache") {
+    config.cache = { enabled: true };
+    config.version_metadata = { binding: DEFAULT_VERSION_METADATA_BINDING };
+  }
 
   if (options.imageOptimization === "cloudflare-images") {
     config.images = { binding: "IMAGES" };
@@ -415,6 +441,26 @@ export function updateWranglerConfigForCloudflare(
         output = `${output.slice(0, cacheProperty.valueStart)}${updatedCache}${output.slice(cacheProperty.valueEnd)}`;
       }
     }
+    const versionMetadataProperty = findTopLevelJsonProperty(output, "version_metadata");
+    if (!versionMetadataProperty) {
+      output = appendTopLevelJsonProperty(
+        output,
+        `  "version_metadata": { "binding": "${DEFAULT_VERSION_METADATA_BINDING}" }`,
+      );
+    } else {
+      const versionMetadata = JSON.parse(
+        stripJsonComments(
+          output.slice(versionMetadataProperty.valueStart, versionMetadataProperty.valueEnd),
+        ),
+      ) as { binding?: unknown } | null;
+      if (
+        !versionMetadata ||
+        typeof versionMetadata.binding !== "string" ||
+        versionMetadata.binding.length === 0
+      ) {
+        output = `${output.slice(0, versionMetadataProperty.valueStart)}{ "binding": "${DEFAULT_VERSION_METADATA_BINDING}" }${output.slice(versionMetadataProperty.valueEnd)}`;
+      }
+    }
   }
   if (options.imageOptimization === "cloudflare-images") {
     const imagesProperty = findTopLevelJsonProperty(output, "images");
@@ -461,6 +507,19 @@ export function getWranglerImagesBinding(code: string): string {
     : "IMAGES";
 }
 
+export function getWranglerVersionMetadataBinding(code: string): string {
+  const property = findTopLevelJsonProperty(code, "version_metadata");
+  if (!property) return DEFAULT_VERSION_METADATA_BINDING;
+  const versionMetadata = JSON.parse(
+    stripJsonComments(code.slice(property.valueStart, property.valueEnd)),
+  ) as { binding?: unknown } | null;
+  return versionMetadata &&
+    typeof versionMetadata.binding === "string" &&
+    versionMetadata.binding.length > 0
+    ? versionMetadata.binding
+    : DEFAULT_VERSION_METADATA_BINDING;
+}
+
 function cacheImports(options: CloudflareInitOptions): string[] {
   const imports: string[] = [];
   if (options.dataCache === "kv") {
@@ -481,12 +540,19 @@ function vinextExpression(
   imageBinding = "imagesOptimizer",
   imagesBinding = "IMAGES",
   prerender = false,
+  versionMetadataBinding = DEFAULT_VERSION_METADATA_BINDING,
 ): string {
   const cacheEntries: string[] = [];
   if (options.dataCache === "kv") {
     cacheEntries.push("data: kvDataAdapter()");
   }
-  if (options.cdnCache === "workers-cache") cacheEntries.push("cdn: cdnAdapter()");
+  if (options.cdnCache === "workers-cache") {
+    const adapterOptions =
+      versionMetadataBinding === DEFAULT_VERSION_METADATA_BINDING
+        ? ""
+        : `{ versionMetadataBinding: ${JSON.stringify(versionMetadataBinding)} }`;
+    cacheEntries.push(`cdn: cdnAdapter(${adapterOptions})`);
+  }
   const optionEntries: string[] = [];
   if (cacheEntries.length > 0) {
     optionEntries.push(`cache: { ${cacheEntries.join(", ")} }`);
@@ -510,6 +576,7 @@ export function generateAppRouterViteConfig(
   options: CloudflareInitOptions = DEFAULT_CLOUDFLARE_INIT_OPTIONS,
   imagesBinding = "IMAGES",
   prerender = false,
+  versionMetadataBinding = DEFAULT_VERSION_METADATA_BINDING,
 ): string {
   const imports: string[] = [
     `import { defineConfig } from "vite";`,
@@ -528,7 +595,14 @@ export function generateAppRouterViteConfig(
     plugins.push(`    // vinext auto-injects @mdx-js/rollup with plugins from next.config`);
   }
   plugins.push(
-    `    ${vinextExpression(options, "vinext", "imagesOptimizer", imagesBinding, prerender).replace(/\n/g, "\n    ")},`,
+    `    ${vinextExpression(
+      options,
+      "vinext",
+      "imagesOptimizer",
+      imagesBinding,
+      prerender,
+      versionMetadataBinding,
+    ).replace(/\n/g, "\n    ")},`,
   );
 
   plugins.push(`    cloudflare({
@@ -569,6 +643,7 @@ export function generatePagesRouterViteConfig(
   options: CloudflareInitOptions = DEFAULT_CLOUDFLARE_INIT_OPTIONS,
   imagesBinding = "IMAGES",
   prerender = false,
+  versionMetadataBinding = DEFAULT_VERSION_METADATA_BINDING,
 ): string {
   const imports: string[] = [
     `import { defineConfig } from "vite";`,
@@ -600,7 +675,14 @@ export function generatePagesRouterViteConfig(
 
 export default defineConfig({
   plugins: [
-    ${vinextExpression(options, "vinext", "imagesOptimizer", imagesBinding, prerender).replace(/\n/g, "\n    ")},
+    ${vinextExpression(
+      options,
+      "vinext",
+      "imagesOptimizer",
+      imagesBinding,
+      prerender,
+      versionMetadataBinding,
+    ).replace(/\n/g, "\n    ")},
     cloudflare(),
   ],${resolveBlock}
 });
@@ -1104,23 +1186,28 @@ function findPluginCall(
   );
 }
 
-function hasVinextCacheSlot(
+function getVinextCacheSlot(
   call: (ESTree.CallExpression & AstNode) | undefined,
   name: "data" | "cdn",
-): boolean {
+): AstProperty | undefined {
   const firstArgument = call?.arguments[0];
   if (
     !firstArgument ||
     firstArgument.type === "SpreadElement" ||
     firstArgument.type !== "ObjectExpression"
   ) {
-    return false;
+    return undefined;
   }
   const cache = findProperty(firstArgument as AstObject, "cache");
-  return (
-    cache?.value.type === "ObjectExpression" &&
-    Boolean(findProperty(cache.value as AstObject, name))
-  );
+  if (cache?.value.type !== "ObjectExpression") return undefined;
+  return findProperty(cache.value as AstObject, name);
+}
+
+function hasVinextCacheSlot(
+  call: (ESTree.CallExpression & AstNode) | undefined,
+  name: "data" | "cdn",
+): boolean {
+  return Boolean(getVinextCacheSlot(call, name));
 }
 
 function getVinextImageOptimizer(
@@ -1442,6 +1529,7 @@ export function updateViteConfigForCloudflare(
     nativeModulesToStub: string[];
     cache?: CloudflareInitOptions;
     imagesBinding?: string;
+    versionMetadataBinding?: string;
     prerender?: boolean;
   },
 ): string {
@@ -1504,21 +1592,41 @@ export function updateViteConfigForCloudflare(
         );
     cacheAdditions.push({ name: "data", expression: `${binding}()` });
   }
-  if (
-    configureCaches &&
-    cacheOptions.cdnCache === "workers-cache" &&
-    !hasVinextCacheSlot(existingVinextCall, "cdn")
-  ) {
+  if (configureCaches && cacheOptions.cdnCache === "workers-cache") {
     const imported = "cdnAdapter";
     const source = "@vinext/cloudflare/cache/cdn-adapter";
     const existing = commonJs
       ? findRequiredBinding(program, source, imported)
       : findImportedBinding(program, source, imported);
-    const local = existing ?? allocateBinding(bindings, imported);
-    const binding = commonJs
-      ? ensureNamedRequire(program, output, source, imported, local)
-      : ensureNamedImport(program, output, source, imported, local);
-    cacheAdditions.push({ name: "cdn", expression: `${binding}()` });
+    const existingCdnSlot = getVinextCacheSlot(existingVinextCall, "cdn");
+    const existingUsesCloudflareAdapter = Boolean(
+      existing &&
+      existingCdnSlot?.value.type === "CallExpression" &&
+      existingCdnSlot.value.callee.type === "Identifier" &&
+      existingCdnSlot.value.callee.name === existing,
+    );
+    // An existing custom CDN adapter is user-owned; init must not replace it.
+    if (!existingCdnSlot || existingUsesCloudflareAdapter) {
+      const local = existing ?? allocateBinding(bindings, imported);
+      const binding = commonJs
+        ? ensureNamedRequire(program, output, source, imported, local)
+        : ensureNamedImport(program, output, source, imported, local);
+      const adapterOptions =
+        options.versionMetadataBinding &&
+        options.versionMetadataBinding !== DEFAULT_VERSION_METADATA_BINDING
+          ? `{ versionMetadataBinding: ${JSON.stringify(options.versionMetadataBinding)} }`
+          : "";
+      const expression = `${binding}(${adapterOptions})`;
+      if (existingCdnSlot) {
+        output.overwrite(
+          (existingCdnSlot.value as AstNode).start,
+          (existingCdnSlot.value as AstNode).end,
+          expression,
+        );
+      } else {
+        cacheAdditions.push({ name: "cdn", expression });
+      }
+    }
   }
   let imageOptimizerExpression: string | undefined;
   if (cacheOptions.imageOptimization === "cloudflare-images") {
@@ -1564,6 +1672,7 @@ export function updateViteConfigForCloudflare(
                   "imagesOptimizer",
                 options.imagesBinding,
                 options.prerender,
+                options.versionMetadataBinding,
               )
             : `${vinextBinding}()`,
         binding: vinextBinding,

--- a/packages/vinext/src/server/app-router-entry.ts
+++ b/packages/vinext/src/server/app-router-entry.ts
@@ -32,7 +32,7 @@ import rscHandler, {
 import { runWithExecutionContext, type ExecutionContextLike } from "vinext/shims/request-context";
 // @ts-expect-error -- virtual module resolved by vinext at build time
 import { registerConfiguredCacheAdapters } from "virtual:vinext-cache-adapters";
-import { applyCdnResponseIdentityHeaders } from "./cache-control.js";
+import { applyCdnResponseIdentityHeaders, validateCdnRequest } from "./cache-control.js";
 // @ts-expect-error -- virtual module resolved by vinext at build time
 import { registerConfiguredImageOptimizer } from "virtual:vinext-image-adapters";
 import {
@@ -105,6 +105,9 @@ async function handleRequest(
   // Register config-driven cache adapters before any rendering touches the cache.
   registerConfiguredCacheAdapters(env as Record<string, unknown> | undefined);
   registerConfiguredImageOptimizer(env as Record<string, unknown> | undefined);
+
+  const cdnValidationResponse = await validateCdnRequest(request);
+  if (cdnValidationResponse) return cdnValidationResponse;
 
   const url = new URL(request.url);
 

--- a/packages/vinext/src/server/cache-control.ts
+++ b/packages/vinext/src/server/cache-control.ts
@@ -39,6 +39,11 @@ export function hasExplicitNonCacheableResponsePolicy(headers: Headers): boolean
   return Boolean(cacheControl && isNonCacheableCacheControl(cacheControl));
 }
 
+/** Delegate provider-specific request routing validation to the CDN adapter. */
+export async function validateCdnRequest(request: Request): Promise<Response | null> {
+  return (await getCdnCacheAdapter().validateRequest?.(request)) ?? null;
+}
+
 /**
  * Route a cacheable response's headers through the active CDN cache adapter and
  * apply the result to `headers`. The default adapter yields a single

--- a/packages/vinext/src/server/headers.ts
+++ b/packages/vinext/src/server/headers.ts
@@ -37,6 +37,9 @@ export const VINEXT_STATIC_FILE_HEADER = "x-vinext-static-file";
 /** Timing metrics: `handlerStart,compileMs,renderMs`. */
 export const VINEXT_TIMING_HEADER = "x-vinext-timing";
 
+/** Expected Worker version asserted by vinext staged warmup requests. */
+export const VINEXT_EXPECTED_WORKER_VERSION_HEADER = "X-Vinext-Expected-Worker-Version";
+
 export {
   VINEXT_MW_CTX_HEADER,
   VINEXT_PRERENDER_ROUTE_PARAMS_HEADER,
@@ -268,6 +271,7 @@ export const INTERNAL_HEADERS = [
 
 /** Vinext-only internal headers stripped alongside Next.js protocol internals. */
 export const VINEXT_INTERNAL_HEADERS = [
+  VINEXT_EXPECTED_WORKER_VERSION_HEADER.toLowerCase(),
   VINEXT_PRERENDER_ROUTE_PARAMS_HEADER,
   VINEXT_PRERENDER_SPECULATIVE_HEADER,
   VINEXT_PRERENDER_CACHE_LIFE_HEADER,

--- a/packages/vinext/src/server/pages-router-entry.ts
+++ b/packages/vinext/src/server/pages-router-entry.ts
@@ -43,7 +43,7 @@ import { normalizePathnameForRouteMatchStrict } from "../routing/utils.js";
 
 // @ts-expect-error -- virtual module resolved by vinext at build time
 import { registerConfiguredCacheAdapters } from "virtual:vinext-cache-adapters";
-import { applyCdnResponseIdentityHeaders } from "./cache-control.js";
+import { applyCdnResponseIdentityHeaders, validateCdnRequest } from "./cache-control.js";
 // @ts-expect-error -- virtual module resolved by vinext at build time
 import { registerConfiguredImageOptimizer } from "virtual:vinext-image-adapters";
 // @ts-expect-error -- virtual module resolved by vinext at build time
@@ -122,6 +122,9 @@ async function handleRequest(
   registerConfiguredImageOptimizer(env);
 
   try {
+    const cdnValidationResponse = await validateCdnRequest(request);
+    if (cdnValidationResponse) return cdnValidationResponse;
+
     const url = new URL(request.url);
     let pathname = url.pathname;
 

--- a/packages/vinext/src/shims/cdn-cache.ts
+++ b/packages/vinext/src/shims/cdn-cache.ts
@@ -101,6 +101,16 @@ export function isNonCacheableCacheControl(cacheControl: string): boolean {
 // equivalent and stay CDN-specific.
 export type CdnCacheAdapter = {
   /**
+   * Validate provider-specific request routing before the application handles
+   * the request. Returning a response short-circuits the request pipeline;
+   * returning `null` continues normally.
+   *
+   * Core deliberately passes the untouched request and does not interpret any
+   * provider headers or bindings itself.
+   */
+  validateRequest?(request: Request): Response | null | Promise<Response | null>;
+
+  /**
    * Read a page-level artifact. Returning a value lets the origin serve it
    * (HIT/STALE); returning `null` makes the origin render fresh.
    *

--- a/tests/__snapshots__/init.test.ts.snap
+++ b/tests/__snapshots__/init.test.ts.snap
@@ -70,6 +70,9 @@ export default defineConfig({
   "cache": {
     "enabled": true
   },
+  "version_metadata": {
+    "binding": "CF_VERSION_METADATA"
+  },
   "images": {
     "binding": "IMAGES"
   },
@@ -188,6 +191,9 @@ export default defineConfig({
   },
   "cache": {
     "enabled": true
+  },
+  "version_metadata": {
+    "binding": "CF_VERSION_METADATA"
   },
   "images": {
     "binding": "IMAGES"

--- a/tests/cache-adapters-config.test.ts
+++ b/tests/cache-adapters-config.test.ts
@@ -23,7 +23,7 @@ import {
 } from "../packages/vinext/src/cache/cache-adapters-virtual.js";
 import { generateRscEntry } from "../packages/vinext/src/entries/app-rsc-entry.js";
 import { generateServerEntry } from "../packages/vinext/src/entries/pages-server-entry.js";
-import { readPagesRouterEntrySource } from "./worker-entry-source.js";
+import { readAppRouterEntrySource, readPagesRouterEntrySource } from "./worker-entry-source.js";
 import { resolveNextConfig } from "../packages/vinext/src/config/next-config.js";
 import { createValidFileMatcher } from "../packages/vinext/src/routing/file-matcher.js";
 import { kvDataAdapter } from "../packages/cloudflare/src/cache/kv-data-adapter.js";
@@ -269,6 +269,16 @@ describe("registration is wired into every router/runtime entry", () => {
     const code = readPagesRouterEntrySource();
     expect(code).toContain('from "virtual:vinext-cache-adapters"');
     expect(code).toContain("registerConfiguredCacheAdapters(env)");
+    expect(code).toContain("await validateCdnRequest(request)");
+  });
+
+  it("App Router worker entry validates CDN routing after registering with env", () => {
+    const code = readAppRouterEntrySource();
+    expect(code).toContain("registerConfiguredCacheAdapters(env");
+    expect(code).toContain("await validateCdnRequest(request)");
+    expect(code.indexOf("registerConfiguredCacheAdapters(env")).toBeLessThan(
+      code.indexOf("await validateCdnRequest(request)"),
+    );
   });
 });
 
@@ -293,5 +303,14 @@ describe("cdnAdapter builder + factory", () => {
     expect(adapter).toBeInstanceOf(CloudflareCdnCacheAdapter);
     // Edge adapter does not own in-process background regeneration.
     expect(adapter.ownsBackgroundRevalidation).toBe(false);
+  });
+
+  it("forwards a custom version metadata binding", () => {
+    expect(cdnAdapter({ versionMetadataBinding: "CUSTOM_VERSION" }).options).toEqual({
+      versionMetadataBinding: "CUSTOM_VERSION",
+    });
+    expect(() => cdnAdapter({ versionMetadataBinding: "" })).toThrow(
+      "must be a non-empty string binding name",
+    );
   });
 });

--- a/tests/cache-control.test.ts
+++ b/tests/cache-control.test.ts
@@ -6,6 +6,7 @@ import {
   buildRevalidateCacheControl,
   hasExplicitNonCacheableResponsePolicy,
   shouldUseNextDeployCacheControl,
+  validateCdnRequest,
 } from "../packages/vinext/src/server/cache-control.js";
 import {
   setCdnCacheAdapter,
@@ -240,5 +241,30 @@ describe("applyCdnResponseHeaders", () => {
     expect(
       hasExplicitNonCacheableResponsePolicy(new Headers({ "X-Example-Edge-Policy": "no-store" })),
     ).toBe(true);
+  });
+
+  it("delegates request routing validation without interpreting provider headers", async () => {
+    const rejected = new Response("retry", { status: 503 });
+    const request = new Request("https://example.com/page", {
+      headers: { "X-Provider-Version": "version-b" },
+    });
+    const edge: CdnCacheAdapter = {
+      ownsBackgroundRevalidation: false,
+      async get() {
+        return null;
+      },
+      async set() {},
+      buildResponseHeaders() {
+        return {};
+      },
+      validateRequest(received) {
+        expect(received).toBe(request);
+        return rejected;
+      },
+      async revalidateTag() {},
+    };
+    setCdnCacheAdapter(edge);
+
+    await expect(validateCdnRequest(request)).resolves.toBe(rejected);
   });
 });

--- a/tests/cloudflare-cdn-cache.test.ts
+++ b/tests/cloudflare-cdn-cache.test.ts
@@ -9,7 +9,9 @@
  *    explicitly configured.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vite-plus/test";
-import { CloudflareCdnCacheAdapter } from "../packages/cloudflare/src/cache/cdn-adapter.runtime.js";
+import createCloudflareCdnCacheAdapter, {
+  CloudflareCdnCacheAdapter,
+} from "../packages/cloudflare/src/cache/cdn-adapter.runtime.js";
 import {
   getCdnCacheAdapter,
   setCdnCacheAdapter,
@@ -82,6 +84,51 @@ describe("CloudflareCdnCacheAdapter", () => {
 
   it("does not own background revalidation (the edge re-requests origin)", () => {
     expect(adapter.ownsBackgroundRevalidation).toBe(false);
+  });
+
+  it("accepts a version override only in the Worker version it targets", async () => {
+    const routedAdapter = createCloudflareCdnCacheAdapter({
+      env: { CF_VERSION_METADATA: { id: "version-b", tag: "", timestamp: "" } },
+    });
+    const matching = new Request("https://example.com/page", {
+      headers: {
+        "Cloudflare-Workers-Version-Overrides": 'upstream="version-a", app="version-b"',
+      },
+    });
+    const mismatching = new Request("https://example.com/page", {
+      headers: { "Cloudflare-Workers-Version-Overrides": 'app="version-c"' },
+    });
+
+    expect(await routedAdapter.validateRequest?.(matching)).toBeNull();
+    const response = await routedAdapter.validateRequest?.(mismatching);
+    expect(response?.status).toBe(503);
+    expect(response?.headers.get("Cache-Control")).toBe("no-store");
+    await expect(response?.text()).resolves.toContain(
+      "Cloudflare invoked Worker version version-b, but the request override targeted version-c",
+    );
+  });
+
+  it("fails an override loudly when its configured version metadata binding is missing", async () => {
+    const routedAdapter = createCloudflareCdnCacheAdapter({
+      env: {},
+      options: { versionMetadataBinding: "CUSTOM_VERSION" },
+    });
+    const request = new Request("https://example.com/page", {
+      headers: { "Cloudflare-Workers-Version-Overrides": 'app="version-b"' },
+    });
+
+    const response = await routedAdapter.validateRequest?.(request);
+    expect(response?.status).toBe(503);
+    await expect(response?.text()).resolves.toContain(
+      "requires the `CUSTOM_VERSION` version metadata binding",
+    );
+  });
+
+  it("does not require version metadata for ordinary requests without an override", async () => {
+    const routedAdapter = createCloudflareCdnCacheAdapter();
+    expect(
+      await routedAdapter.validateRequest?.(new Request("https://example.com/page")),
+    ).toBeNull();
   });
 
   it("stamps the application build identity on cacheable and no-store responses", () => {

--- a/tests/cloudflare-cdn-cache.test.ts
+++ b/tests/cloudflare-cdn-cache.test.ts
@@ -155,9 +155,9 @@ describe("CloudflareCdnCacheAdapter", () => {
 
     const response = await routedAdapter.validateRequest?.(request);
     expect(response?.status).toBe(503);
-    await expect(response?.text()).resolves.toContain(
-      "requires the `CUSTOM_VERSION` version metadata binding",
-    );
+    const body = await response?.text();
+    expect(body).toContain("requires the `CUSTOM_VERSION` version metadata binding");
+    expect(body).toContain("Named environments do not inherit this binding");
   });
 
   it("does not require version metadata for ordinary requests without an override", async () => {

--- a/tests/cloudflare-cdn-cache.test.ts
+++ b/tests/cloudflare-cdn-cache.test.ts
@@ -26,6 +26,7 @@ import { finalizeAppRscResponse } from "../packages/vinext/src/server/app-rsc-re
 import { applyCdnResponseIdentityHeaders } from "../packages/vinext/src/server/cache-control.js";
 import type { RequestContext } from "../packages/vinext/src/config/request-context.js";
 import { VINEXT_CDN_BUILD_ID_HEADER } from "../packages/cloudflare/src/cache/cdn-build-id.js";
+import { VINEXT_EXPECTED_WORKER_VERSION_HEADER } from "../packages/cloudflare/src/version-headers.js";
 
 const CDN_KEY = Symbol.for("vinext.cdnCacheAdapter");
 
@@ -86,17 +87,21 @@ describe("CloudflareCdnCacheAdapter", () => {
     expect(adapter.ownsBackgroundRevalidation).toBe(false);
   });
 
-  it("accepts a version override only in the Worker version it targets", async () => {
+  it("accepts a staged warmup only in its expected Worker version", async () => {
     const routedAdapter = createCloudflareCdnCacheAdapter({
       env: { CF_VERSION_METADATA: { id: "version-b", tag: "", timestamp: "" } },
     });
     const matching = new Request("https://example.com/page", {
       headers: {
         "Cloudflare-Workers-Version-Overrides": 'upstream="version-a", app="version-b"',
+        [VINEXT_EXPECTED_WORKER_VERSION_HEADER]: "version-b",
       },
     });
     const mismatching = new Request("https://example.com/page", {
-      headers: { "Cloudflare-Workers-Version-Overrides": 'app="version-c"' },
+      headers: {
+        "Cloudflare-Workers-Version-Overrides": 'app="version-c"',
+        [VINEXT_EXPECTED_WORKER_VERSION_HEADER]: "version-c",
+      },
     });
 
     expect(await routedAdapter.validateRequest?.(matching)).toBeNull();
@@ -104,7 +109,35 @@ describe("CloudflareCdnCacheAdapter", () => {
     expect(response?.status).toBe(503);
     expect(response?.headers.get("Cache-Control")).toBe("no-store");
     await expect(response?.text()).resolves.toContain(
-      "Cloudflare invoked Worker version version-b, but the request override targeted version-c",
+      "Cloudflare invoked Worker version version-b, but vinext warmup expected version-c",
+    );
+  });
+
+  it("ignores version overrides that are not vinext staged warmup assertions", async () => {
+    const routedAdapter = createCloudflareCdnCacheAdapter({
+      env: { CF_VERSION_METADATA: { id: "version-a", tag: "", timestamp: "" } },
+    });
+    const downstreamOnly = new Request("https://example.com/page", {
+      headers: {
+        "Cloudflare-Workers-Version-Overrides": 'downstream="version-b"',
+      },
+    });
+
+    expect(await routedAdapter.validateRequest?.(downstreamOnly)).toBeNull();
+  });
+
+  it("rejects a vinext version assertion without a Cloudflare version override", async () => {
+    const routedAdapter = createCloudflareCdnCacheAdapter({
+      env: { CF_VERSION_METADATA: { id: "version-a", tag: "", timestamp: "" } },
+    });
+    const request = new Request("https://example.com/page", {
+      headers: { [VINEXT_EXPECTED_WORKER_VERSION_HEADER]: "version-a" },
+    });
+
+    const response = await routedAdapter.validateRequest?.(request);
+    expect(response?.status).toBe(503);
+    await expect(response?.text()).resolves.toContain(
+      `received ${VINEXT_EXPECTED_WORKER_VERSION_HEADER} without Cloudflare-Workers-Version-Overrides`,
     );
   });
 
@@ -114,7 +147,10 @@ describe("CloudflareCdnCacheAdapter", () => {
       options: { versionMetadataBinding: "CUSTOM_VERSION" },
     });
     const request = new Request("https://example.com/page", {
-      headers: { "Cloudflare-Workers-Version-Overrides": 'app="version-b"' },
+      headers: {
+        "Cloudflare-Workers-Version-Overrides": 'app="version-b"',
+        [VINEXT_EXPECTED_WORKER_VERSION_HEADER]: "version-b",
+      },
     });
 
     const response = await routedAdapter.validateRequest?.(request);

--- a/tests/cloudflare-cdn-warm-deploy.test.ts
+++ b/tests/cloudflare-cdn-warm-deploy.test.ts
@@ -7,6 +7,7 @@ import {
   VINEXT_RSC_VARY_HEADER,
 } from "../packages/vinext/src/server/app-rsc-cache-busting.js";
 import { VINEXT_CDN_BUILD_ID_HEADER } from "../packages/cloudflare/src/cache/cdn-build-id.js";
+import { VINEXT_EXPECTED_WORKER_VERSION_HEADER } from "../packages/cloudflare/src/version-headers.js";
 
 const execFileSyncMock = vi.hoisted(() => vi.fn());
 const delayMock = vi.hoisted(() => vi.fn());
@@ -127,7 +128,6 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     await expect(
       deployWithCdnWarmup(tmpDir, ["/"], {
         expectedBuildId: "app-build-a",
-        warmCdnStrict: true,
       }),
     ).rejects.toThrow("deployment status unavailable");
     expect(execFileSyncMock).toHaveBeenCalledTimes(2);
@@ -198,7 +198,6 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       warmCdnPromotionDelay: 0,
       warmCdnReadinessProbeDelay: 250,
       warmCdnReadinessProbes: 3,
-      warmCdnStrict: true,
     });
 
     expect(events).toEqual([
@@ -228,7 +227,9 @@ describe("Cloudflare CDN warmup deploy flow", () => {
           value.get("accept") === "text/x-component" &&
           value.get("cache-control") === "no-cache" &&
           value.get("rsc") === "1" &&
-          value.has("Cloudflare-Workers-Version-Overrides"),
+          value.has("Cloudflare-Workers-Version-Overrides") &&
+          value.get(VINEXT_EXPECTED_WORKER_VERSION_HEADER) ===
+            "22222222-2222-4222-8222-222222222222",
       ),
     ).toBe(true);
   });
@@ -348,6 +349,9 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     expect(rscHeaders.get("Cloudflare-Workers-Version-Overrides")).toBe(
       'my-worker="22222222-2222-4222-8222-222222222222"',
     );
+    expect(rscHeaders.get(VINEXT_EXPECTED_WORKER_VERSION_HEADER)).toBe(
+      "22222222-2222-4222-8222-222222222222",
+    );
     expect(rscHeaders.get("accept")).toBe("text/x-component");
     expect(rscHeaders.get("rsc")).toBe("1");
     expect(rscHeaders.get("x-deployment-id")).toBe("dpl_123");
@@ -456,7 +460,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     ).toBe(true);
   });
 
-  it("does not replay successful staged fills after a non-strict partial failure", async () => {
+  it("does not promote after a partial staged warmup failure", async () => {
     const events: string[] = [];
     writeFile(
       "wrangler.jsonc",
@@ -516,36 +520,22 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     });
     const { deployWithCdnWarmup } = await import("../packages/cloudflare/src/deploy.js");
 
-    await deployWithCdnWarmup(tmpDir, ["/about"], {
-      expectedBuildId: "app-build-a",
-      expectedRscBuildId: "new-build",
-      loadingShellPaths: ["/about"],
-      rscPaths: ["/about"],
-      warmCdnRetries: 1,
-    });
+    await expect(
+      deployWithCdnWarmup(tmpDir, ["/about"], {
+        expectedBuildId: "app-build-a",
+        expectedRscBuildId: "new-build",
+        loadingShellPaths: ["/about"],
+        rscPaths: ["/about"],
+        warmCdnRetries: 1,
+      }),
+    ).rejects.toThrow("response X-Vinext-RSC-Build-Id does not match build new-build");
 
-    expect(events).toEqual([
-      "upload",
-      "status",
-      "stage",
-      "triggers",
-      "readiness",
-      "readiness",
-      "readiness",
-      "readiness",
-      "readiness",
-      "readiness",
-      "fetch:staged:rsc",
-      "fetch:staged:loading",
-      "fetch:staged:html",
-      "promote",
-      "fetch:promoted:loading",
-    ]);
-    expect(delayMock).toHaveBeenCalledTimes(6);
-    expect(delayMock).toHaveBeenLastCalledWith(15_000);
+    expect(events).not.toContain("promote");
+    expect(events).not.toContain("fetch:promoted:loading");
+    expect(events.filter((event) => event === "fetch:staged:loading")).toHaveLength(1);
   });
 
-  it("falls back when staged Worker readiness never reaches the uploaded build", async () => {
+  it("promotes after failed staged readiness only with the dangerous override", async () => {
     const events: string[] = [];
     writeFile(
       "wrangler.jsonc",
@@ -591,6 +581,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     const { deployWithCdnWarmup } = await import("../packages/cloudflare/src/deploy.js");
 
     await deployWithCdnWarmup(tmpDir, ["/about"], {
+      dangerouslyPromoteOnCdnWarmError: true,
       expectedBuildId: "new-build",
       warmCdnRetries: 1,
     });
@@ -650,6 +641,9 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     expect(new Headers(firstInit.headers).get("Cloudflare-Workers-Version-Overrides")).toBe(
       'my-worker-staging-custom="22222222-2222-4222-8222-222222222222"',
     );
+    expect(new Headers(firstInit.headers).get(VINEXT_EXPECTED_WORKER_VERSION_HEADER)).toBe(
+      "22222222-2222-4222-8222-222222222222",
+    );
     expect(delayMock).toHaveBeenCalledWith(2_500);
     for (const [, args] of execFileSyncMock.mock.calls as Array<[string, string[]]>) {
       expect(args).toEqual(expect.arrayContaining(["--env", "staging"]));
@@ -688,7 +682,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     expect(resolveCdnWarmupTargetUrl(tmpDir, null)).toBeNull();
   });
 
-  it("skips unverifiable HTML warmup for adapters without build identity", async () => {
+  it("skips unverifiable HTML only with the dangerous override", async () => {
     const events: string[] = [];
     writeFile(
       "wrangler.jsonc",
@@ -725,7 +719,10 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     });
     const { deployWithCdnWarmup } = await import("../packages/cloudflare/src/deploy.js");
 
-    await deployWithCdnWarmup(tmpDir, ["/about"], { warmCdnConcurrency: 1 });
+    await deployWithCdnWarmup(tmpDir, ["/about"], {
+      dangerouslyPromoteOnCdnWarmError: true,
+      warmCdnConcurrency: 1,
+    });
 
     expect(events).toEqual(["upload", "status", "stage", "triggers", "promote"]);
     expect(fetch).not.toHaveBeenCalled();
@@ -738,7 +735,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       deployWithCdnWarmup(tmpDir, ["/about"], {
         warmCdnPromote: false,
       }),
-    ).rejects.toThrow("discovered HTML requests cannot be verified");
+    ).rejects.toThrow("CDN HTML warmup requires a CDN adapter");
     expect(execFileSyncMock).not.toHaveBeenCalled();
     expect(fetch).not.toHaveBeenCalled();
   });
@@ -783,6 +780,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     const { deployWithCdnWarmup } = await import("../packages/cloudflare/src/deploy.js");
 
     await deployWithCdnWarmup(tmpDir, ["/"], {
+      dangerouslyPromoteOnCdnWarmError: true,
       expectedRscBuildId: "app-build-a",
       rscPaths: ["/"],
       warmCdnConcurrency: 1,
@@ -934,7 +932,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
         warmCdnPromote: false,
         warmCdnRetries: 0,
       }),
-    ).rejects.toThrow("1 request(s) remain unwarmed");
+    ).rejects.toThrow("CDN warmup failed for 1/1 request(s)");
     expect(fetch).toHaveBeenCalledTimes(7);
     expect(
       (execFileSyncMock.mock.calls as Array<[string, string[]]>).some(([, args]) =>
@@ -943,7 +941,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     ).toBe(false);
   });
 
-  it("rejects strict HTML warmup without verifiable build identity before upload", async () => {
+  it("rejects HTML warmup without verifiable build identity before upload", async () => {
     writeFile(
       "wrangler.jsonc",
       JSON.stringify({ name: "my-worker", custom_domains: ["app.example.com"] }),
@@ -969,9 +967,8 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       deployWithCdnWarmup(tmpDir, ["/about"], {
         warmCdnConcurrency: 1,
         warmCdnPromote: false,
-        warmCdnStrict: true,
       }),
-    ).rejects.toThrow("Strict CDN HTML warmup requires a CDN adapter");
+    ).rejects.toThrow("CDN HTML warmup requires a CDN adapter");
     expect(execFileSyncMock).not.toHaveBeenCalled();
     expect(fetch).not.toHaveBeenCalled();
   });
@@ -1135,7 +1132,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     );
   });
 
-  it("explains staged version cleanup when strict pre-promotion warmup fails", async () => {
+  it("explains staged version cleanup when pre-promotion warmup fails", async () => {
     writeFile(
       "wrangler.jsonc",
       JSON.stringify({
@@ -1168,7 +1165,6 @@ describe("Cloudflare CDN warmup deploy flow", () => {
         expectedBuildId: "app-build-a",
         warmCdnConcurrency: 1,
         warmCdnRetries: 0,
-        warmCdnStrict: true,
       }),
     ).rejects.toThrow("may remain staged at 0%");
   });
@@ -1202,6 +1198,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
 
     await expect(
       deployWithCdnWarmup(tmpDir, ["/"], {
+        expectedBuildId: "app-build-a",
         warmCdnConcurrency: 1,
       }),
     ).rejects.toThrow("may remain staged at 0%");
@@ -1233,9 +1230,12 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     });
     const { deployWithCdnWarmup } = await import("../packages/cloudflare/src/deploy.js");
 
-    await expect(deployWithCdnWarmup(tmpDir, ["/"], { warmCdnConcurrency: 1 })).rejects.toThrow(
-      "may remain staged at 0%",
-    );
+    await expect(
+      deployWithCdnWarmup(tmpDir, ["/"], {
+        expectedBuildId: "app-build-a",
+        warmCdnConcurrency: 1,
+      }),
+    ).rejects.toThrow("may remain staged at 0%");
   });
 
   it("explains promoted version state when fallback trigger deployment fails", async () => {
@@ -1270,13 +1270,15 @@ describe("Cloudflare CDN warmup deploy flow", () => {
 
     await expect(
       deployWithCdnWarmup(tmpDir, ["/"], {
+        dangerouslyPromoteOnCdnWarmError: true,
+        expectedBuildId: "app-build-a",
         warmCdnConcurrency: 1,
       }),
     ).rejects.toThrow("may already be promoted to 100%");
     expect(fetch).not.toHaveBeenCalled();
   });
 
-  it("does not promote strict warmup when the existing deployment cannot be staged", async () => {
+  it("does not promote warmup when the existing deployment cannot be staged", async () => {
     writeFile(
       "wrangler.jsonc",
       JSON.stringify({ name: "my-worker", custom_domains: ["app.example.com"] }),
@@ -1301,14 +1303,13 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       deployWithCdnWarmup(tmpDir, ["/"], {
         expectedBuildId: "app-build-a",
         warmCdnRetries: 0,
-        warmCdnStrict: true,
       }),
     ).rejects.toThrow("cannot stage the uploaded Worker at 0%");
     expect(execFileSyncMock).toHaveBeenCalledTimes(2);
     expect(fetch).not.toHaveBeenCalled();
   });
 
-  it("does not require a target URL before rejecting unstaged strict warmup", async () => {
+  it("does not require a target URL before rejecting unstaged warmup", async () => {
     writeFile("wrangler.jsonc", JSON.stringify({ name: "my-worker", workers_dev: false }));
     execFileSyncMock.mockImplementation((_file: string, args: string[]) => {
       if (args.includes("upload")) {
@@ -1333,7 +1334,6 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     await expect(
       deployWithCdnWarmup(tmpDir, ["/"], {
         expectedBuildId: "app-build-a",
-        warmCdnStrict: true,
       }),
     ).rejects.toThrow("cannot stage the uploaded Worker at 0%");
     expect(execFileSyncMock).toHaveBeenCalledTimes(2);

--- a/tests/cloudflare-cdn-warm-deploy.test.ts
+++ b/tests/cloudflare-cdn-warm-deploy.test.ts
@@ -134,7 +134,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
-  it("waits for staged build stability before sending each real warm key once", async () => {
+  it("honors custom staged-readiness probe count and delay before warming", async () => {
     const events: string[] = [];
     const readinessHeaders: Headers[] = [];
     const readinessUrls: string[] = [];
@@ -196,6 +196,8 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       rscPaths: ["/about"],
       warmCdnConcurrency: 1,
       warmCdnPromotionDelay: 0,
+      warmCdnReadinessProbeDelay: 250,
+      warmCdnReadinessProbes: 3,
       warmCdnStrict: true,
     });
 
@@ -203,17 +205,11 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       "stage",
       "triggers",
       "readiness:old-build",
-      "delay:1000",
+      "delay:250",
       "readiness:app-build-a",
-      "delay:1000",
+      "delay:250",
       "readiness:app-build-a",
-      "delay:1000",
-      "readiness:app-build-a",
-      "delay:1000",
-      "readiness:app-build-a",
-      "delay:1000",
-      "readiness:app-build-a",
-      "delay:1000",
+      "delay:250",
       "readiness:app-build-a",
       "warm:/about?_rsc",
       "promote",
@@ -224,7 +220,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
         return url.pathname === "/about" && url.search === "?_rsc";
       }),
     ).toHaveLength(1);
-    expect(new Set(readinessUrls).size).toBe(7);
+    expect(new Set(readinessUrls).size).toBe(4);
     expect(readinessUrls.every((url) => new URL(url).searchParams.has("_rsc"))).toBe(true);
     expect(
       readinessHeaders.every(

--- a/tests/cloudflare-cdn-warm.test.ts
+++ b/tests/cloudflare-cdn-warm.test.ts
@@ -1008,7 +1008,7 @@ describe("Cloudflare CDN warmup", () => {
     );
   });
 
-  it("revalidates isolated stale-build entries after a large successful staged pass", async () => {
+  it("retries isolated stale-build responses after a large successful staged pass", async () => {
     const rscPaths = Array.from({ length: 4_528 }, (_, index) => `/archive/${index}`);
     const stalePaths = new Set(rscPaths.slice(-12));
     const requestHeaders = new Map<string, Headers[]>();
@@ -1054,14 +1054,15 @@ describe("Cloudflare CDN warmup", () => {
       const [initialHeaders, retryHeaders] = requestHeaders.get(pathname)!;
       expect(initialHeaders.get("cache-control")).toBeNull();
       expect(initialHeaders.get("pragma")).toBeNull();
-      expect(retryHeaders.get("cache-control")).toBe("no-cache");
-      expect(retryHeaders.get("pragma")).toBe("no-cache");
+      expect(retryHeaders.get("cache-control")).toBeNull();
+      expect(retryHeaders.get("pragma")).toBeNull();
       expect(retryHeaders.get("accept")).toBe("text/x-component");
       expect(retryHeaders.get("rsc")).toBe("1");
+      expect([...retryHeaders]).toEqual([...initialHeaders]);
     }
   });
 
-  it("still fails strict warmup when targeted revalidation returns the stale build", async () => {
+  it("still fails strict warmup when a targeted retry returns the stale build", async () => {
     const seenHeaders: Headers[] = [];
     const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
       seenHeaders.push(new Headers(init?.headers));
@@ -1088,8 +1089,8 @@ describe("Cloudflare CDN warmup", () => {
 
     expect(seenHeaders).toHaveLength(2);
     expect(seenHeaders[0].get("cache-control")).toBeNull();
-    expect(seenHeaders[1].get("cache-control")).toBe("no-cache");
-    expect(seenHeaders[1].get("pragma")).toBe("no-cache");
+    expect(seenHeaders[1].get("cache-control")).toBeNull();
+    expect(seenHeaders[1].get("pragma")).toBeNull();
   });
 
   it("warms directly from the discovery manifest", async () => {

--- a/tests/cloudflare-cdn-warm.test.ts
+++ b/tests/cloudflare-cdn-warm.test.ts
@@ -955,6 +955,59 @@ describe("Cloudflare CDN warmup", () => {
     expect(attempts.get("/slow")).toBe(31);
   });
 
+  it("reports targeted retries with their own progress total", async () => {
+    const originalIsTTY = Object.getOwnPropertyDescriptor(process.stderr, "isTTY");
+    Object.defineProperty(process.stderr, "isTTY", { configurable: true, value: true });
+    const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const attempts = new Map<string, number>();
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const pathname = new URL(requestHref(input)!).pathname;
+      const attempt = (attempts.get(pathname) ?? 0) + 1;
+      attempts.set(pathname, attempt);
+      if (pathname === "/stale" && attempt === 1) {
+        const stale = cacheableRsc();
+        stale.headers.set(VINEXT_CDN_BUILD_ID_HEADER, "old-build");
+        stale.headers.set(VINEXT_RSC_BUILD_ID_HEADER, "old-rsc-build");
+        return stale;
+      }
+      return cacheableRsc();
+    });
+
+    let progressWrites: string[];
+    try {
+      await expect(
+        warmCdnCache({
+          concurrency: 1,
+          expectedBuildId: "build-a",
+          expectedRscBuildId: "rsc-build-a",
+          fetchImpl: fetchImpl as typeof fetch,
+          paths: [],
+          propagatingTarget: true,
+          retries: 1,
+          retryDelayMs: 0,
+          rscPaths: ["/ready", "/stale"],
+          strict: true,
+          targetUrl: "https://app.example.com",
+        }),
+      ).resolves.toMatchObject({ total: 2, warmed: 2, failed: 0 });
+      progressWrites = stderrWrite.mock.calls.map(([chunk]) => String(chunk));
+    } finally {
+      stderrWrite.mockRestore();
+      if (originalIsTTY) Object.defineProperty(process.stderr, "isTTY", originalIsTTY);
+      else delete (process.stderr as unknown as { isTTY?: boolean }).isTTY;
+    }
+
+    expect(progressWrites).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("Warming CDN cache... [████████████████████] 2/2 /stale"),
+        expect.stringContaining(
+          "Retrying CDN cache... [                    ] 0/1 starting retry pass",
+        ),
+        expect.stringContaining("Retrying CDN cache... [████████████████████] 1/1 /stale"),
+      ]),
+    );
+  });
+
   it("revalidates isolated stale-build entries after a large successful staged pass", async () => {
     const rscPaths = Array.from({ length: 4_528 }, (_, index) => `/archive/${index}`);
     const stalePaths = new Set(rscPaths.slice(-12));

--- a/tests/cloudflare-cdn-warm.test.ts
+++ b/tests/cloudflare-cdn-warm.test.ts
@@ -654,6 +654,34 @@ describe("Cloudflare CDN warmup", () => {
     ).resolves.toEqual({ ready: true });
   });
 
+  it("rejects an exact-build server error as staged-version readiness", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response("version validation failed", {
+          status: 503,
+          headers: {
+            "cache-control": "no-store",
+            [VINEXT_CDN_BUILD_ID_HEADER]: "build-a",
+          },
+        }),
+    );
+
+    await expect(
+      waitForCdnWarmTargetReadiness({
+        expectedBuildId: "build-a",
+        fetchImpl: fetchImpl as typeof fetch,
+        maxAttempts: 1,
+        plan: { loadingShellPaths: [], paths: ["/"], rscPaths: [] },
+        probeIntervalMs: 0,
+        requiredConsecutiveSuccesses: 1,
+        targetUrl: "https://app.example.com",
+      }),
+    ).resolves.toEqual({
+      error: "HTTP 503; uploaded build was not stable for 1 consecutive probe(s)",
+      ready: false,
+    });
+  });
+
   it("does not skip a non-success response from a different build", async () => {
     const fetchImpl = vi.fn(
       async () =>

--- a/tests/cloudflare-cdn-warm.test.ts
+++ b/tests/cloudflare-cdn-warm.test.ts
@@ -955,6 +955,90 @@ describe("Cloudflare CDN warmup", () => {
     expect(attempts.get("/slow")).toBe(31);
   });
 
+  it("revalidates isolated stale-build entries after a large successful staged pass", async () => {
+    const rscPaths = Array.from({ length: 4_528 }, (_, index) => `/archive/${index}`);
+    const stalePaths = new Set(rscPaths.slice(-12));
+    const requestHeaders = new Map<string, Headers[]>();
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = new URL(requestHref(input)!);
+      expect(url.search).toBe("?_rsc");
+      const pathname = url.pathname;
+      const headers = new Headers(init?.headers);
+      const headersForPath = requestHeaders.get(pathname) ?? [];
+      headersForPath.push(headers);
+      requestHeaders.set(pathname, headersForPath);
+
+      if (stalePaths.has(pathname) && headersForPath.length === 1) {
+        const stale = cacheableRsc("stale flight");
+        stale.headers.set(VINEXT_CDN_BUILD_ID_HEADER, "old-build");
+        stale.headers.set(VINEXT_RSC_BUILD_ID_HEADER, "old-rsc-build");
+        return stale;
+      }
+      return cacheableRsc();
+    });
+
+    await expect(
+      warmCdnCache({
+        concurrency: 25,
+        expectedBuildId: "build-a",
+        expectedRscBuildId: "rsc-build-a",
+        fetchImpl: fetchImpl as typeof fetch,
+        paths: [],
+        propagatingTarget: true,
+        retries: 1,
+        retryDelayMs: 0,
+        rscPaths,
+        strict: true,
+        targetUrl: "https://app.example.com",
+      }),
+    ).resolves.toMatchObject({ total: 4_528, warmed: 4_528, failed: 0 });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(4_540);
+    for (const pathname of rscPaths.slice(0, -12)) {
+      expect(requestHeaders.get(pathname)).toHaveLength(1);
+    }
+    for (const pathname of stalePaths) {
+      const [initialHeaders, retryHeaders] = requestHeaders.get(pathname)!;
+      expect(initialHeaders.get("cache-control")).toBeNull();
+      expect(initialHeaders.get("pragma")).toBeNull();
+      expect(retryHeaders.get("cache-control")).toBe("no-cache");
+      expect(retryHeaders.get("pragma")).toBe("no-cache");
+      expect(retryHeaders.get("accept")).toBe("text/x-component");
+      expect(retryHeaders.get("rsc")).toBe("1");
+    }
+  });
+
+  it("still fails strict warmup when targeted revalidation returns the stale build", async () => {
+    const seenHeaders: Headers[] = [];
+    const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seenHeaders.push(new Headers(init?.headers));
+      const stale = cacheableRsc("stale flight");
+      stale.headers.set(VINEXT_CDN_BUILD_ID_HEADER, "old-build");
+      stale.headers.set(VINEXT_RSC_BUILD_ID_HEADER, "old-rsc-build");
+      return stale;
+    });
+
+    await expect(
+      warmCdnCache({
+        expectedBuildId: "build-a",
+        expectedRscBuildId: "rsc-build-a",
+        fetchImpl: fetchImpl as typeof fetch,
+        paths: [],
+        propagatingTarget: true,
+        retries: 1,
+        retryDelayMs: 0,
+        rscPaths: ["/persistently-stale"],
+        strict: true,
+        targetUrl: "https://app.example.com",
+      }),
+    ).rejects.toThrow(`response ${VINEXT_CDN_BUILD_ID_HEADER} does not match build build-a`);
+
+    expect(seenHeaders).toHaveLength(2);
+    expect(seenHeaders[0].get("cache-control")).toBeNull();
+    expect(seenHeaders[1].get("cache-control")).toBe("no-cache");
+    expect(seenHeaders[1].get("pragma")).toBe("no-cache");
+  });
+
   it("warms directly from the discovery manifest", async () => {
     writeFile("dist/server/BUILD_ID", "build-a\n");
     writeFile(

--- a/tests/deploy-prerender-config.test.ts
+++ b/tests/deploy-prerender-config.test.ts
@@ -273,7 +273,12 @@ describe("deploy prerender config wiring", () => {
     );
     const { deploy } = await import("../packages/cloudflare/src/deploy.js");
 
-    await deploy({ root: tmpDir, skipBuild: true, warmCdnCache: true });
+    await deploy({
+      root: tmpDir,
+      skipBuild: true,
+      warmCdnCache: true,
+      dangerouslyPromoteOnCdnWarmError: true,
+    });
 
     expect(fs.readFileSync(path.join(tmpDir, "config-load-count.txt"), "utf8")).toBe("1");
     expect(fs.existsSync(path.join(tmpDir, "dist/server/vinext-prerender-paths.json"))).toBe(true);

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -793,6 +793,9 @@ describe("parseDeployArgs", () => {
       "--warm-cdn-timeout=1500",
       "--warm-cdn-retries",
       "0",
+      "--warm-cdn-readiness-probes=8",
+      "--warm-cdn-readiness-probe-delay",
+      "750",
       "--warm-cdn-strict",
       "--warm-cdn-no-promote",
       "--warm-cdn-promotion-delay=2500",
@@ -803,6 +806,8 @@ describe("parseDeployArgs", () => {
     expect(parsed.warmCdnConcurrency).toBe(6);
     expect(parsed.warmCdnTimeout).toBe(1500);
     expect(parsed.warmCdnRetries).toBe(0);
+    expect(parsed.warmCdnReadinessProbes).toBe(8);
+    expect(parsed.warmCdnReadinessProbeDelay).toBe(750);
     expect(parsed.warmCdnStrict).toBe(true);
     expect(parsed.warmCdnPromote).toBe(false);
     expect(parsed.warmCdnPromotionDelay).toBe(2500);
@@ -817,12 +822,30 @@ describe("parseDeployArgs", () => {
     expect(parseDeployArgs(["--warm-cdn-promotion-delay=0"]).warmCdnPromotionDelay).toBe(0);
   });
 
+  it("allows the staged-readiness probe delay to be set to zero", () => {
+    expect(parseDeployArgs(["--warm-cdn-readiness-probe-delay=0"]).warmCdnReadinessProbeDelay).toBe(
+      0,
+    );
+  });
+
   it("throws for invalid CDN warmup numeric flags", () => {
     expect(() => parseDeployArgs(["--warm-cdn-concurrency=0"])).toThrow(
       '--warm-cdn-concurrency expects a positive integer, but got "0".',
     );
     expect(() => parseDeployArgs(["--warm-cdn-retries=-1"])).toThrow(
       '--warm-cdn-retries expects a non-negative integer, but got "-1".',
+    );
+    expect(() => parseDeployArgs(["--warm-cdn-readiness-probes=0"])).toThrow(
+      '--warm-cdn-readiness-probes expects a positive integer, but got "0".',
+    );
+    expect(() => parseDeployArgs(["--warm-cdn-readiness-probes=1.5"])).toThrow(
+      '--warm-cdn-readiness-probes expects a positive integer, but got "1.5".',
+    );
+    expect(() => parseDeployArgs(["--warm-cdn-readiness-probe-delay=-1"])).toThrow(
+      '--warm-cdn-readiness-probe-delay expects a non-negative integer, but got "-1".',
+    );
+    expect(() => parseDeployArgs(["--warm-cdn-readiness-probe-delay=2147483648"])).toThrow(
+      '--warm-cdn-readiness-probe-delay must not exceed 2147483647 milliseconds, but got "2147483648".',
     );
     expect(() => parseDeployArgs(["--warm-cdn-promotion-delay=-1"])).toThrow(
       '--warm-cdn-promotion-delay expects a non-negative integer, but got "-1".',

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -713,7 +713,7 @@ describe("parseDeployArgs", () => {
     expect(parsed.skipBuild).toBe(false);
     expect(parsed.dryRun).toBe(false);
     expect(parsed.warmCdnCache).toBe(false);
-    expect(parsed.warmCdnStrict).toBe(false);
+    expect(parsed.dangerouslyPromoteOnCdnWarmError).toBe(false);
   });
 
   it("parses --env with space-separated value", () => {
@@ -796,7 +796,7 @@ describe("parseDeployArgs", () => {
       "--warm-cdn-readiness-probes=8",
       "--warm-cdn-readiness-probe-delay",
       "750",
-      "--warm-cdn-strict",
+      "--dangerously-promote-on-cdn-warm-error",
       "--warm-cdn-no-promote",
       "--warm-cdn-promotion-delay=2500",
       "--warm-cdn-include-fallbacks",
@@ -808,7 +808,7 @@ describe("parseDeployArgs", () => {
     expect(parsed.warmCdnRetries).toBe(0);
     expect(parsed.warmCdnReadinessProbes).toBe(8);
     expect(parsed.warmCdnReadinessProbeDelay).toBe(750);
-    expect(parsed.warmCdnStrict).toBe(true);
+    expect(parsed.dangerouslyPromoteOnCdnWarmError).toBe(true);
     expect(parsed.warmCdnPromote).toBe(false);
     expect(parsed.warmCdnPromotionDelay).toBe(2500);
     expect(parsed.warmCdnIncludeFallbacks).toBe(true);

--- a/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
+++ b/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
@@ -8,6 +8,7 @@ import {
   type Response,
 } from "@playwright/test";
 import fs from "node:fs";
+import { VINEXT_EXPECTED_WORKER_VERSION_HEADER } from "../../../packages/cloudflare/src/version-headers.js";
 
 const TARGET_PATH = "/prewarm-target";
 const PAGES_TARGET_PATH = "/pages-prewarm";
@@ -192,9 +193,18 @@ test("deploy-prewarmed Pages HTML and RSC variants are reused", async ({
   await waitForStablePromotion({ baseURL, buildId, playwright, rscBuildId });
 
   const workerName = new URL(baseURL).hostname.split(".")[0];
+  const downstreamOnlyOverride = await request.get(`${baseURL}/api/prewarm-version?downstream=1`, {
+    headers: {
+      "Cloudflare-Workers-Version-Overrides":
+        'unrelated-downstream="00000000-0000-4000-8000-000000000000"',
+    },
+  });
+  expect(downstreamOnlyOverride.ok()).toBe(true);
+
   const mismatchedOverride = await request.get(`${baseURL}/api/prewarm-version?mismatch=1`, {
     headers: {
       "Cloudflare-Workers-Version-Overrides": `${workerName}="00000000-0000-4000-8000-000000000000"`,
+      [VINEXT_EXPECTED_WORKER_VERSION_HEADER]: "00000000-0000-4000-8000-000000000000",
     },
   });
   expect(mismatchedOverride.status()).toBe(503);

--- a/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
+++ b/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
@@ -191,6 +191,16 @@ test("deploy-prewarmed Pages HTML and RSC variants are reused", async ({
   // without touching either canonical cache entry before its HIT assertion.
   await waitForStablePromotion({ baseURL, buildId, playwright, rscBuildId });
 
+  const workerName = new URL(baseURL).hostname.split(".")[0];
+  const mismatchedOverride = await request.get(`${baseURL}/api/prewarm-version?mismatch=1`, {
+    headers: {
+      "Cloudflare-Workers-Version-Overrides": `${workerName}="00000000-0000-4000-8000-000000000000"`,
+    },
+  });
+  expect(mismatchedOverride.status()).toBe(503);
+  expect(mismatchedOverride.headers()["cache-control"]).toBe("no-store");
+  expect(await mismatchedOverride.text()).toContain("Cloudflare invoked Worker version");
+
   const pagesResponse = await getResponseAfterPromotion(request, `${baseURL}${PAGES_TARGET_PATH}`);
   const pagesResponseHeaders = pagesResponse.headers();
   expect(pagesResponse.ok(), JSON.stringify(pagesResponseHeaders)).toBe(true);

--- a/tests/fixtures/rsc-prewarm-seed/wrangler.jsonc
+++ b/tests/fixtures/rsc-prewarm-seed/wrangler.jsonc
@@ -16,6 +16,7 @@
     },
   ],
   "cache": { "enabled": true },
+  "version_metadata": { "binding": "CF_VERSION_METADATA" },
   "preview_urls": true,
   "workers_dev": true,
 }

--- a/tests/init-cloudflare.test.ts
+++ b/tests/init-cloudflare.test.ts
@@ -4,6 +4,7 @@ import {
   generateAppRouterViteConfig,
   generatePagesRouterViteConfig,
   getWranglerImagesBinding,
+  getWranglerVersionMetadataBinding,
   updateViteConfigForCloudflare,
   updateWranglerConfigForCloudflare,
 } from "../packages/vinext/src/init-cloudflare.js";
@@ -626,6 +627,7 @@ export default { plugins: [vinext({ imageOptimization: true })] };
       cache: { enabled: true },
       images: { binding: "IMAGES" },
       kv_namespaces: [{ binding: "VINEXT_KV_CACHE" }],
+      version_metadata: { binding: "CF_VERSION_METADATA" },
     });
   });
 
@@ -658,7 +660,68 @@ export default { plugins: [vinext({ imageOptimization: true })] };
       main: "vinext/server/fetch-handler",
       assets: { directory: "dist/client", not_found_handling: "none", binding: "ASSETS" },
       cache: { enabled: true },
+      version_metadata: { binding: "CF_VERSION_METADATA" },
     });
+  });
+
+  it("preserves a custom Wrangler version metadata binding for the CDN adapter", () => {
+    const input = `{ "version_metadata": { "binding": "CUSTOM_VERSION" } }\n`;
+    const output = updateWranglerConfigForCloudflare(input, {
+      dataCache: "none",
+      cdnCache: "workers-cache",
+      imageOptimization: "none",
+    });
+
+    expect(getWranglerVersionMetadataBinding(output)).toBe("CUSTOM_VERSION");
+    expect(
+      generateAppRouterViteConfig(
+        undefined,
+        {
+          dataCache: "none",
+          cdnCache: "workers-cache",
+          imageOptimization: "none",
+        },
+        "IMAGES",
+        false,
+        "CUSTOM_VERSION",
+      ),
+    ).toContain('cdnAdapter({ versionMetadataBinding: "CUSTOM_VERSION" })');
+  });
+
+  it("aligns an existing Cloudflare CDN adapter with a custom version metadata binding", () => {
+    const input = `import { defineConfig } from "vite";
+import vinext from "vinext";
+import { cdnAdapter } from "@vinext/cloudflare/cache/cdn-adapter";
+
+export default defineConfig({
+  plugins: [vinext({ cache: { cdn: cdnAdapter() } })],
+});
+`;
+    const output = updateViteConfigForCloudflare("vite.config.ts", input, {
+      isAppRouter: false,
+      nativeModulesToStub: [],
+      cache: {
+        dataCache: "none",
+        cdnCache: "workers-cache",
+        imageOptimization: "none",
+      },
+      versionMetadataBinding: "CUSTOM_VERSION",
+    });
+
+    expectValidConfig(output);
+    expect(output).toContain('cdn: cdnAdapter({ versionMetadataBinding: "CUSTOM_VERSION" })');
+    expect(
+      updateViteConfigForCloudflare("vite.config.ts", output, {
+        isAppRouter: false,
+        nativeModulesToStub: [],
+        cache: {
+          dataCache: "none",
+          cdnCache: "workers-cache",
+          imageOptimization: "none",
+        },
+        versionMetadataBinding: "CUSTOM_VERSION",
+      }),
+    ).toBe(output);
   });
 
   it("preserves a custom Wrangler Images binding for the Vite adapter", () => {

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -540,6 +540,7 @@ describe("init — basic functionality", () => {
     expect(JSON.parse(readFile(tmpDir, "wrangler.jsonc"))).toMatchObject({
       cache: { enabled: true },
       main: "vinext/server/fetch-handler",
+      version_metadata: { binding: "CF_VERSION_METADATA" },
     });
   });
 

--- a/tests/request-pipeline.test.ts
+++ b/tests/request-pipeline.test.ts
@@ -23,6 +23,7 @@ import {
   applyConfigHeadersToResponse,
 } from "../packages/vinext/src/server/config-headers.js";
 import {
+  VINEXT_EXPECTED_WORKER_VERSION_HEADER,
   VINEXT_PRERENDER_CACHE_LIFE_HEADER,
   VINEXT_PRERENDER_ROUTE_PARAMS_HEADER,
   VINEXT_PRERENDER_SPECULATIVE_HEADER,
@@ -866,6 +867,8 @@ describe("filterInternalHeaders", () => {
 
   it("strips vinext-only internal headers without extending Next.js INTERNAL_HEADERS", () => {
     const headers = new Headers({
+      "cloudflare-workers-version-overrides": 'downstream="version-id"',
+      [VINEXT_EXPECTED_WORKER_VERSION_HEADER]: "expected-version",
       [VINEXT_PRERENDER_CACHE_LIFE_HEADER]: "forged",
       [VINEXT_PRERENDER_ROUTE_PARAMS_HEADER]: "forged",
       [VINEXT_PRERENDER_SPECULATIVE_HEADER]: "forged",
@@ -879,6 +882,7 @@ describe("filterInternalHeaders", () => {
     expect(INTERNAL_HEADERS).not.toContain(VINEXT_PRERENDER_SPECULATIVE_HEADER);
     expect(INTERNAL_HEADERS).not.toContain(VINEXT_PRERENDER_CACHE_LIFE_HEADER);
     expect(VINEXT_INTERNAL_HEADERS).toEqual([
+      VINEXT_EXPECTED_WORKER_VERSION_HEADER.toLowerCase(),
       VINEXT_PRERENDER_ROUTE_PARAMS_HEADER,
       VINEXT_PRERENDER_SPECULATIVE_HEADER,
       VINEXT_PRERENDER_CACHE_LIFE_HEADER,
@@ -888,9 +892,11 @@ describe("filterInternalHeaders", () => {
       expect(name).toBe(name.toLowerCase());
     }
     expect(result.has(VINEXT_PRERENDER_ROUTE_PARAMS_HEADER)).toBe(false);
+    expect(result.has(VINEXT_EXPECTED_WORKER_VERSION_HEADER)).toBe(false);
     expect(result.has(VINEXT_PRERENDER_SPECULATIVE_HEADER)).toBe(false);
     expect(result.has(VINEXT_PRERENDER_CACHE_LIFE_HEADER)).toBe(false);
     expect(result.has(VINEXT_REVALIDATE_HOST_HEADER)).toBe(false);
+    expect(result.get("cloudflare-workers-version-overrides")).toBe('downstream="version-id"');
     expect(result.get("user-agent")).toBe("test");
   });
 

--- a/tests/worker-entry-source.ts
+++ b/tests/worker-entry-source.ts
@@ -1,5 +1,14 @@
 import fs from "node:fs";
 
+export function readAppRouterEntrySource(): string {
+  const sourceUrl = new URL("../packages/vinext/src/server/app-router-entry.ts", import.meta.url);
+  if (fs.existsSync(sourceUrl)) return fs.readFileSync(sourceUrl, "utf-8");
+  return fs.readFileSync(
+    new URL("../packages/vinext/src/server/app-router-entry.js", import.meta.url),
+    "utf-8",
+  );
+}
+
 export function readPagesRouterEntrySource(): string {
   const sourceUrl = new URL("../packages/vinext/src/server/pages-router-entry.ts", import.meta.url);
   if (fs.existsSync(sourceUrl)) return fs.readFileSync(sourceUrl, "utf-8");


### PR DESCRIPTION
## Summary

- keep initial and retried CDN warm requests browser-cache-identical; retries do not add `Cache-Control: no-cache` or `Pragma: no-cache`
- send a vinext-owned `X-Vinext-Expected-Worker-Version` assertion alongside Cloudflare's version override during staged warmup
- add a provider-neutral `CdnCacheAdapter.validateRequest(request)` hook which App and Pages Worker entries invoke before application routing
- make the Cloudflare adapter compare the vinext assertion with the executing Worker's version metadata binding
- return a non-cacheable HTTP 503 when the expected and executing versions differ or the configured metadata binding is missing, allowing the warmup retry flow to retry without populating cache
- ignore ordinary/downstream-only `Cloudflare-Workers-Version-Overrides` dictionaries that do not carry vinext's assertion
- make warmup fail closed by default and remove `--warm-cdn-strict`
- add `--dangerously-promote-on-cdn-warm-error` as the explicit escape hatch which may promote after failed staged readiness/warmup and retry unresolved paths after promotion
- default the metadata binding to `CF_VERSION_METADATA`, customizable with `cdnAdapter({ versionMetadataBinding: "CUSTOM_VERSION" })`
- scaffold and repair the top-level `version_metadata` during `vinext init --platform=cloudflare`, preserving custom binding names; Wrangler named environments remain user-managed and must repeat this non-inheritable binding
- retain deferred retries, retry progress, readiness controls, promotion controls, and browser-identical canonical warm requests

## Runtime flow

1. The deploy command sends `Cloudflare-Workers-Version-Overrides` and `X-Vinext-Expected-Worker-Version` with the uploaded version ID.
2. Core passes the untouched request to the configured CDN adapter without interpreting provider headers or bindings.
3. The Cloudflare adapter compares the expected version with `env[versionMetadataBinding].id`.
4. A mismatch returns `503` with `Cache-Control: no-store`, preventing the wrong Worker invocation from rendering or populating cache.
5. The warmer retries the same canonical URL with the same request headers.
6. Without the dangerous escape hatch, any unverifiable readiness or failed warm request leaves the uploaded version staged instead of promoting it.

Ordinary requests and version-override dictionaries intended only for downstream Workers are unaffected.

## Configuration

Default init output:

```jsonc
"version_metadata": { "binding": "CF_VERSION_METADATA" }
```

Custom binding:

```ts
cdnAdapter({ versionMetadataBinding: "CUSTOM_VERSION" })
```

```jsonc
"version_metadata": { "binding": "CUSTOM_VERSION" }
```

Wrangler does not inherit `version_metadata` into named environments. Repeat the same binding under every `env.<name>` used for CDN warmup.

Dangerous fallback:

```sh
vinext-cloudflare deploy --experimental-warm-cdn-cache --dangerously-promote-on-cdn-warm-error
```

## Regression coverage

- matching/mismatched version assertions and missing metadata bindings
- downstream-only override dictionaries continue normally
- vinext assertions without Cloudflare overrides fail closed
- default partial warmup failure does not promote
- dangerous readiness failure promotes and retries after promotion
- App and Pages Worker entries validate after adapter registration and before routing
- init generation, repair, custom binding alignment, and idempotency
- 4,528-request retry regression keeps initial and retry request headers identical
- deployed Cloudflare E2E checks downstream-only override handling, mismatch rejection, and prewarmed HTML/RSC browser reuse

## Validation

- 635 focused adapter, warmup, deploy, cache, and init tests passed
- `vp check` passed with no formatting, lint, or type errors
- `vp run vinext#build`
- `vp run @vinext/cloudflare#build`
- `vp run workers-cache#build`; emitted Worker contains the version assertion validator and version metadata binding

This is Cloudflare deployment and cache orchestration; there is no equivalent Next.js behavior to port.

Stacked on #3057.
