### PR TITLE
fix(web): redirect canonical HTTP pages to HTTPS

### DIFF
--- a/apps/web/worker/seo.ts
+++ b/apps/web/worker/seo.ts
@@ -16,7 +16,10 @@ function isPublicDocumentRequest(request: Request, url: URL): boolean {
 export function getCanonicalRedirect(request: Request): Response | null {
   const url = new URL(request.url);
   if (!isPublicDocumentRequest(request, url)) return null;
-  if (url.hostname !== WWW_HOSTNAME && url.hostname !== PRODUCTION_WORKERS_HOSTNAME) return null;
+  const isAlternateHost =
+    url.hostname === WWW_HOSTNAME || url.hostname === PRODUCTION_WORKERS_HOSTNAME;
+  const isInsecureCanonicalUrl = url.hostname === CANONICAL_HOSTNAME && url.protocol === "http:";
+  if (!isAlternateHost && !isInsecureCanonicalUrl) return null;
 
   url.protocol = "https:";
   url.hostname = CANONICAL_HOSTNAME;

--- a/tests/web-seo.test.ts
+++ b/tests/web-seo.test.ts
@@ -54,6 +54,13 @@ describe("vinext.dev canonical host handling", () => {
     },
   );
 
+  it("redirects HTTP documents on the canonical host to HTTPS", () => {
+    const response = getCanonicalRedirect(new Request("http://vinext.dev/benchmarks?view=bundles"));
+
+    expect(response?.status).toBe(308);
+    expect(response?.headers.get("location")).toBe("https://vinext.dev/benchmarks?view=bundles");
+  });
+
   it("keeps the workers.dev API origin available to existing CI uploaders", () => {
     expect(
       getCanonicalRedirect(


### PR DESCRIPTION
## Summary

Google can crawl `http://vinext.dev` as a separate `200` page. The canonical tag points to HTTPS, so Search Console treats the HTTP URL as an alternate instead of following a redirect.

This sends public `GET` and `HEAD` requests on the canonical HTTP host to the same HTTPS path with a `308`. Paths and query strings stay intact, and API behavior is unchanged.

## Testing

- `pnpm exec vp test run tests/web-seo.test.ts`
- `pnpm exec vp check apps/web/worker/seo.ts tests/web-seo.test.ts`