### PR TITLE
fix(app-router): validate interception context identity

### DIFF
--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -792,6 +792,7 @@ const __appRscHandler = createAppRscHandler({
   isDev: process.env.NODE_ENV !== "production",
   draftModeSecret: __draftModeSecret,
   dispatchMatchedPage({
+    bypassInterceptionContextCache,
     clientReuseManifest,
     cleanPathname,
     displayPathname,
@@ -854,6 +855,7 @@ const __appRscHandler = createAppRscHandler({
     const _asyncRouteParams = makeThenableParams(params);
     return __dispatchAppPage({
       basePath: __basePath,
+      bypassInterceptionContextCache,
       ensureRouteLoaded: __ensureRouteLoaded,
       clientTraceMetadata: __clientTraceMetadata,
       reactMaxHeadersLength: __reactMaxHeadersLength,
@@ -944,7 +946,11 @@ const __appRscHandler = createAppRscHandler({
         });
       },
       async probePage(probeSearchParams = searchParams) {
-        const __probeIntercept = findIntercept(interceptionPathname, interceptionContext);
+        const __probeIntercept = findIntercept(
+          interceptionPathname,
+          interceptionContext,
+          interceptionId,
+        );
         // The intercepting-route page module is lazy (page: null + __pageLoader).
         // Resolve it before probing so buildAppPageProbes inspects the real page
         // component for dynamic bailout — matching the render path, which also
@@ -965,7 +971,11 @@ const __appRscHandler = createAppRscHandler({
         }));
       },
       renderErrorBoundaryPage(renderErr, errorOrigin) {
-        const __activeIntercept = findIntercept(interceptionPathname, interceptionContext);
+        const __activeIntercept = findIntercept(
+          interceptionPathname,
+          interceptionContext,
+          interceptionId,
+        );
         return __fallbackRenderer.renderErrorBoundary(route, renderErr, isRscRequest, request, params, scriptNonce, middlewareContext, {
           isEdgeRuntime: __isEdgeRuntime(__segmentConfig.runtime),
           sourcePageSegments: __activeIntercept?.slotKey === __SIBLING_PAGE_INTERCEPT_SLOT_KEY
@@ -974,7 +984,11 @@ const __appRscHandler = createAppRscHandler({
         }, errorOrigin);
       },
       renderHttpAccessFallbackPage(statusCode, opts, currentMiddlewareContext) {
-        const __activeIntercept = findIntercept(interceptionPathname, interceptionContext);
+        const __activeIntercept = findIntercept(
+          interceptionPathname,
+          interceptionContext,
+          interceptionId,
+        );
         return __fallbackRenderer.renderHttpAccessFallback(route, statusCode, isRscRequest, request, opts, scriptNonce, currentMiddlewareContext, {
           isEdgeRuntime: __isEdgeRuntime(__segmentConfig.runtime),
           routePathname: cleanPathname,
@@ -1388,7 +1402,11 @@ const __appRscHandler = createAppRscHandler({
         params[name] = intercept.sourceMatchedParams[name];
       }
     }
-    return { route, params };
+    return {
+      interceptionSourceIsConcrete: intercept.sourceRouteIsConcrete,
+      route,
+      params,
+    };
   },
   ${
     middlewarePath

--- a/packages/vinext/src/server/app-page-cache-finalizer.ts
+++ b/packages/vinext/src/server/app-page-cache-finalizer.ts
@@ -56,6 +56,7 @@ type FinalizeAppPageHtmlCacheResponseOptions = {
 };
 
 type ScheduleAppPageRscCacheWriteOptions = {
+  bypassInterceptionContextCache?: boolean;
   capturedRscDataPromise: Promise<ArrayBuffer> | null;
   cleanPathname: string;
   consumeDynamicUsage: () => boolean;
@@ -92,14 +93,15 @@ function applyUncacheableRscVariantNoStoreHeaders(
   headers: Headers,
   options: { omitCacheState?: boolean } = {},
 ): void {
-  // Mounted-slot RSC payloads deliberately bypass the slot-blind persistent
-  // cache. Make that same bypass explicit to
-  // every CDN adapter: an edge-managed adapter may intentionally cache
-  // pending-dynamic responses, so that generic signal is not strong enough.
+  // Request-specific RSC payloads deliberately bypass persistent caches. Make
+  // that bypass explicit to every CDN adapter: an edge-managed adapter may
+  // intentionally cache pending-dynamic responses, so that generic signal is
+  // not strong enough.
   // The active adapter clears any stale provider-specific headers that it owns.
   applyCdnResponseHeaders(headers, { cacheControl: NO_STORE_CACHE_CONTROL });
   // Dynamic and draft responses intentionally have no cache state. Do not
-  // manufacture a MISS solely because the request carried mounted slots.
+  // manufacture a MISS solely because the request carried an uncacheable
+  // selector variant.
   finalizePendingCacheStateHeaders(headers, {
     ...options,
     preserveMissingCacheState: true,
@@ -261,14 +263,15 @@ export function finalizeAppPageRscCacheResponse(
   options: ScheduleAppPageRscCacheWriteOptions,
 ): Response {
   // Persisting to the ISR store and finalizing the client-facing headers are
-  // independent decisions. Mounted-slot variants are deliberately never stored
-  // (their RSC key is slot-blind), but a fresh MISS stream can still reach a
+  // independent decisions. Mounted-slot and unverified-interception variants
+  // are deliberately never stored, but a fresh MISS stream can still reach a
   // dynamic API after the cache policy was chosen, so shared caches must not
-  // keep it either way. An explicit no-store policy is required for mounted
-  // slots because edge-managed adapters may cache pending-dynamic responses.
+  // keep it either way. An explicit no-store policy is required because
+  // edge-managed adapters may cache pending-dynamic responses.
   scheduleAppPageRscCacheWrite(options);
 
-  const isUncacheableVariant = Boolean(options.mountedSlotsHeader);
+  const isUncacheableVariant =
+    Boolean(options.mountedSlotsHeader) || options.bypassInterceptionContextCache === true;
   if (options.preserveClientResponseHeaders === true && !isUncacheableVariant) {
     return response;
   }
@@ -295,7 +298,12 @@ export function scheduleAppPageRscCacheWrite(
   options: ScheduleAppPageRscCacheWriteOptions,
 ): boolean {
   const capturedRscDataPromise = options.capturedRscDataPromise;
-  if (!capturedRscDataPromise || options.dynamicUsedDuringBuild || options.mountedSlotsHeader) {
+  if (
+    !capturedRscDataPromise ||
+    options.dynamicUsedDuringBuild ||
+    options.mountedSlotsHeader ||
+    options.bypassInterceptionContextCache === true
+  ) {
     return false;
   }
 

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -273,6 +273,8 @@ export type AppPagePprState = PprFallbackShellState;
 export type DispatchAppPageOptions<TRoute extends AppPageDispatchRoute> = {
   /** Configured basePath (e.g. "/blog"). Used to prefix redirect Locations. */
   basePath?: string;
+  /** Bypass shared RSC caches when the client-supplied interception context was not verified. */
+  bypassInterceptionContextCache?: boolean;
   /**
    * Allow-list of OpenTelemetry propagation keys (from
    * `experimental.clientTraceMetadata`) to surface as `<meta>` tags in the
@@ -709,6 +711,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
   }
 
   if (
+    options.bypassInterceptionContextCache !== true &&
     shouldReadAppPageCache({
       isDraftMode,
       isForceDynamic,
@@ -1105,6 +1108,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
 
   return renderAppPageLifecycle({
     basePath: options.basePath,
+    bypassInterceptionContextCache: options.bypassInterceptionContextCache,
     clientTraceMetadata: options.clientTraceMetadata,
     reactMaxHeadersLength: options.reactMaxHeadersLength,
     cleanPathname: options.cleanPathname,

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -100,6 +100,7 @@ type AppPageRequestCacheLife = {
 
 type RenderAppPageLifecycleOptions = {
   basePath?: string;
+  bypassInterceptionContextCache?: boolean;
   /**
    * Allow-list of OpenTelemetry propagation keys to emit as `<meta>` tags in
    * the SSR head. From `experimental.clientTraceMetadata` in `next.config`.
@@ -715,6 +716,8 @@ export async function renderAppPageLifecycle(
     });
   const shouldBypassRscCacheForSkipTransport =
     options.isRscRequest && isSkipTransportEnabled(skipDisposition);
+  const shouldBypassRscCache =
+    shouldBypassRscCacheForSkipTransport || options.bypassInterceptionContextCache === true;
   const dynamicStaleTimeSeconds =
     options.dynamicStaleTimeSeconds ?? resolveConfiguredDynamicStaleTimeSeconds();
   const outgoingElement = AppElementsWire.encodeOutgoingPayload({
@@ -772,7 +775,7 @@ export async function renderAppPageLifecycle(
     (revalidateSeconds === null || (revalidateSeconds > 0 && revalidateSeconds !== Infinity)) &&
     !options.isDraftMode &&
     !options.isForceDynamic &&
-    !shouldBypassRscCacheForSkipTransport;
+    !shouldBypassRscCache;
   const shouldCaptureRscForCacheMetadata =
     (options.isProduction || options.isPrerender === true) && mayResolveCacheLifeAfterHeaders;
   const createBufferedRscStream = (close: boolean): ReadableStream<Uint8Array> =>
@@ -822,7 +825,6 @@ export async function renderAppPageLifecycle(
     // When skip transport is enabled, omit cacheState because the response is a
     // per-client payload, not a shared-cache MISS/HIT artifact. The absence also
     // keeps finalizeAppPageRscCacheResponse from overwriting no-store.
-    const shouldBypassRscCache = shouldBypassRscCacheForSkipTransport;
     const rscResponsePolicy = shouldBypassRscCache
       ? { cacheControl: NO_STORE_CACHE_CONTROL }
       : resolveAppPageRscResponsePolicy({
@@ -836,7 +838,12 @@ export async function renderAppPageLifecycle(
           revalidateSeconds,
         });
     if (shouldBypassRscCache) {
-      options.isrDebug?.("RSC cache write skipped (skip transport payload)", options.cleanPathname);
+      options.isrDebug?.(
+        options.bypassInterceptionContextCache === true
+          ? "RSC cache write skipped (unverified interception context)"
+          : "RSC cache write skipped (skip transport payload)",
+        options.cleanPathname,
+      );
     }
     const shouldEmitDynamicStaleTime =
       dynamicStaleTimeSeconds !== undefined &&
@@ -932,6 +939,7 @@ export async function renderAppPageLifecycle(
     return finalizeAppPageRscCacheResponse(devRscResponse, {
       capturedRscDataPromise:
         options.isProduction && shouldCaptureRscForCacheMetadata ? capturedRscDataRef.value : null,
+      bypassInterceptionContextCache: options.bypassInterceptionContextCache,
       cleanPathname: options.cleanPathname,
       consumeDynamicUsage: finalizeRenderDynamicUsage,
       consumeRenderObservationState: options.consumeRenderObservationState,

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -1575,9 +1575,12 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
             interceptionIdHeader,
           ) ?? null)
         : null;
-    const hasVerifiedFinalInterceptionSource = provesConcreteInterceptionSource(
-      finalInterceptionSourceMatch,
-    );
+    const hasVerifiedFinalInterceptionSource =
+      hasVerifiedInterceptionSource &&
+      interceptionSourceMatch !== null &&
+      provesConcreteInterceptionSource(finalInterceptionSourceMatch) &&
+      finalInterceptionSourceMatch?.route === interceptionSourceMatch.route &&
+      haveSamePageParams(finalInterceptionSourceMatch.params, interceptionSourceMatch.params);
     if (interceptionIdHeader !== null && !hasVerifiedFinalInterceptionSource) {
       options.clearRequestContext();
       setInterceptionResponseUncacheable(true);

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -1144,13 +1144,19 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     setInterceptionResponseUncacheable(true);
     return badRequestResponse();
   }
-  const bypassInterceptionContextCache =
-    hasRawInterceptionContext && !hasVerifiedInterceptionSource;
+  let bypassInterceptionContextCache = hasRawInterceptionContext && !hasVerifiedInterceptionSource;
   if (interceptionContextHeader !== null) {
     // Replace any direct-target proof after rewrites. Exact graph ownership is
     // the only point where the source identity is safe for shared variants.
     setInterceptionResponseUncacheable(bypassInterceptionContextCache);
   }
+  let interceptionCacheProofInvalidated = false;
+  const invalidateInterceptionCacheProof = (): void => {
+    if (!hasRawInterceptionContext) return;
+    interceptionCacheProofInvalidated = true;
+    bypassInterceptionContextCache = true;
+    setInterceptionResponseUncacheable(true);
+  };
   if (
     interceptionSourceMatch !== null &&
     interceptionSourcePathname !== null &&
@@ -1476,11 +1482,15 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
         },
         matchPathname(cleanPathname),
       );
-      if (afterFilesRewrite instanceof Response) return afterFilesRewrite;
+      if (afterFilesRewrite instanceof Response) {
+        invalidateInterceptionCacheProof();
+        return afterFilesRewrite;
+      }
       if (!afterFilesRewrite) continue;
       resolvedUrl = mergeRewriteQuery(resolvedUrl, afterFilesRewrite);
       cleanPathname = pathnameForResolvedUrl(resolvedUrl);
       cleanPathnameIsRequestPathname = false;
+      invalidateInterceptionCacheProof();
       filesystemRouteEligible = true;
       const claimedRscCacheBustingRedirect = await validateClaimedOutsideBasePathRsc();
       if (claimedRscCacheBustingRedirect) return claimedRscCacheBustingRedirect;
@@ -1526,11 +1536,15 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
         },
         matchPathname(cleanPathname),
       );
-      if (fallbackRewrite instanceof Response) return fallbackRewrite;
+      if (fallbackRewrite instanceof Response) {
+        invalidateInterceptionCacheProof();
+        return fallbackRewrite;
+      }
       if (!fallbackRewrite) continue;
       resolvedUrl = mergeRewriteQuery(resolvedUrl, fallbackRewrite);
       cleanPathname = pathnameForResolvedUrl(resolvedUrl);
       cleanPathnameIsRequestPathname = false;
+      invalidateInterceptionCacheProof();
       filesystemRouteEligible = true;
       const claimedRscCacheBustingRedirect = await validateClaimedOutsideBasePathRsc();
       if (claimedRscCacheBustingRedirect) return claimedRscCacheBustingRedirect;
@@ -1547,6 +1561,30 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
       }
       if (match) break;
     }
+  }
+
+  if (interceptionCacheProofInvalidated && interceptionContextHeader !== null) {
+    const finalInterceptionTargetPathname = cleanPathnameIsRequestPathname
+      ? requestCleanPathname
+      : cleanPathname;
+    const finalInterceptionSourceMatch =
+      filesystemRouteEligible && match !== null
+        ? (options.matchInterceptRoute?.(
+            finalInterceptionTargetPathname,
+            interceptionContextHeader,
+            interceptionIdHeader,
+          ) ?? null)
+        : null;
+    const hasVerifiedFinalInterceptionSource = provesConcreteInterceptionSource(
+      finalInterceptionSourceMatch,
+    );
+    if (interceptionIdHeader !== null && !hasVerifiedFinalInterceptionSource) {
+      options.clearRequestContext();
+      setInterceptionResponseUncacheable(true);
+      return badRequestResponse();
+    }
+    bypassInterceptionContextCache = !hasVerifiedFinalInterceptionSource;
+    setInterceptionResponseUncacheable(bypassInterceptionContextCache);
   }
 
   if (!filesystemRouteEligible) {

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -27,6 +27,7 @@ import {
   VINEXT_PRERENDER_SPECULATIVE_HEADER,
   VINEXT_PRERENDER_STATIC_PARAMS_PATH,
   VINEXT_REVALIDATE_HOST_HEADER,
+  VINEXT_INTERCEPTION_CONTEXT_HEADER,
   VINEXT_INTERCEPTION_ID_HEADER,
 } from "./headers.js";
 import { ensureFetchPatch, setCurrentFetchSoftTags } from "vinext/shims/fetch-cache";
@@ -151,6 +152,13 @@ function haveSamePageParams(first: AppPageParams, second: AppPageParams): boolea
   return true;
 }
 
+function hasUrlParserDotSegment(pathname: string): boolean {
+  return pathname.split("/").some((segment) => {
+    const decodedDots = segment.replaceAll(/%2e/gi, ".");
+    return decodedDots === "." || decodedDots === "..";
+  });
+}
+
 type RunAppMiddlewareOptions = {
   cleanPathname: string;
   context: AppRscMiddlewareContext;
@@ -178,6 +186,7 @@ type AppRscHandlerRoute = {
 };
 
 type AppRscRouteMatch<TRoute> = {
+  interceptionSourceIsConcrete?: boolean;
   params: AppPageParams;
   route: TRoute;
 };
@@ -204,6 +213,7 @@ function applyMiddlewareContextToResponse(
 }
 
 type DispatchMatchedPageOptions<TRoute> = {
+  bypassInterceptionContextCache: boolean;
   clientReuseManifest: ClientReuseManifestParseResult;
   cleanPathname: string;
   displayPathname: string;
@@ -573,7 +583,7 @@ function requestWithoutRscSuffix(request: Request): Request {
   return cloneRequestWithUrl(request, url.toString());
 }
 
-function markInvalidInterceptionIdResponseUncacheable(response: Response): Response {
+function markUnverifiedInterceptionResponseUncacheable(response: Response): Response {
   const applyNoStore = (headers: Headers): void => {
     applyCdnResponseHeaders(headers, { cacheControl: NEVER_CACHE_CONTROL });
   };
@@ -604,7 +614,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
   pagesDataRequest: Request | null,
   dispatchInternalRequest: (request: Request) => Promise<Response>,
   allowInternalRscDocumentFallback: boolean,
-  markInterceptionIdRejected: () => void,
+  setInterceptionResponseUncacheable: (uncacheable: boolean) => void,
 ): Promise<Response> {
   const handlerStart = process.env.NODE_ENV !== "production" ? performance.now() : 0;
 
@@ -624,8 +634,11 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     ].some((rule) => rule.basePath === false);
   const normalized = normalizeRscRequest(request, options.basePath, canHandleOutsideBasePath);
   if (normalized instanceof Response) {
-    if (request.headers.has(VINEXT_INTERCEPTION_ID_HEADER)) {
-      markInterceptionIdRejected();
+    if (
+      request.headers.has(VINEXT_INTERCEPTION_CONTEXT_HEADER) ||
+      request.headers.has(VINEXT_INTERCEPTION_ID_HEADER)
+    ) {
+      setInterceptionResponseUncacheable(true);
     }
     return normalized;
   }
@@ -640,6 +653,44 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     clientReuseManifest,
     hadBasePath,
   } = normalized;
+  const hasRawInterceptionContext =
+    isRscRequest && request.headers.has(VINEXT_INTERCEPTION_CONTEXT_HEADER);
+  if (hasRawInterceptionContext) {
+    // Header normalization deliberately treats malformed/oversized values as
+    // absent for progressive enhancement, but the raw value still contributes
+    // to the RSC URL hash. Keep those attacker-selected variants out of every
+    // shared cache even when routing proceeds as a direct request.
+    setInterceptionResponseUncacheable(true);
+  }
+  // Validate the client-supplied source pathname immediately after request
+  // normalization, before redirects, middleware, rewrites, or cache-busting
+  // responses can observe a structurally different identity. Keep the raw
+  // header for the route matcher's deliberate one-decode contract, while
+  // carrying the decoded canonical pathname for middleware authorization.
+  let interceptionSourcePathname: string | null = null;
+  if (isRscRequest && interceptionContextHeader !== null) {
+    try {
+      if (!isInterceptionMatchedUrlPath(interceptionContextHeader)) {
+        throw new Error("Invalid interception source pathname");
+      }
+      const decodedInterceptionSourcePathname =
+        normalizePathnameForRouteMatchStrict(interceptionContextHeader);
+      if (/[\t\n\r]/.test(decodedInterceptionSourcePathname)) {
+        throw new Error("Interception source contains a stripped URL character");
+      }
+      if (hasUrlParserDotSegment(decodedInterceptionSourcePathname)) {
+        throw new Error("Interception source contains a URL dot segment");
+      }
+      interceptionSourcePathname = normalizePath(decodedInterceptionSourcePathname);
+      if (interceptionSourcePathname !== decodedInterceptionSourcePathname) {
+        throw new Error("Non-canonical interception source pathname");
+      }
+    } catch {
+      options.clearRequestContext();
+      setInterceptionResponseUncacheable(true);
+      return badRequestResponse();
+    }
+  }
   const { requestCleanPathname } = normalized;
   let { pathname, cleanPathname } = normalized;
   let resolvedUrl = cleanPathname + url.search;
@@ -664,12 +715,13 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     interceptionIdHeader !== null &&
     (!isRscRequest ||
       interceptionContextHeader === null ||
+      (request.method !== "GET" && request.method !== "HEAD") ||
       !options.hasInterceptionId(interceptionIdHeader))
   ) {
     // Reject attacker-selected selector values before middleware, redirects,
     // or other early responders can attach a cacheable policy. Exact
     // source/target verification still happens after rewrites below.
-    markInterceptionIdRejected();
+    setInterceptionResponseUncacheable(true);
     return badRequestResponse();
   }
 
@@ -683,6 +735,36 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
       request,
     });
     if (selectorCacheBustingRedirect) return selectorCacheBustingRedirect;
+  }
+
+  const provesConcreteInterceptionSource = (
+    sourceMatch: AppRscRouteMatch<TRoute> | null,
+  ): boolean => {
+    if (sourceMatch === null) return false;
+    if (sourceMatch.interceptionSourceIsConcrete !== undefined) {
+      return sourceMatch.interceptionSourceIsConcrete;
+    }
+    // Backward-compatible fallback for custom/older entry glue. Route identity
+    // proves existence without decoding the already-once-decoded context again
+    // for a parameter comparison.
+    return (
+      interceptionSourcePathname !== null &&
+      options.matchRoute(interceptionSourcePathname)?.route === sourceMatch.route
+    );
+  };
+  const directInterceptionSourceMatch =
+    hadBasePath && hasRawInterceptionContext && interceptionContextHeader !== null
+      ? (options.matchInterceptRoute?.(
+          requestCleanPathname,
+          interceptionContextHeader,
+          interceptionIdHeader,
+        ) ?? null)
+      : null;
+  if (provesConcreteInterceptionSource(directInterceptionSourceMatch)) {
+    // Direct targets with a concrete source can be proven before config
+    // redirects or middleware. If routing later changes the target, the
+    // post-rewrite proof below replaces this state before page dispatch.
+    setInterceptionResponseUncacheable(false);
   }
 
   if (
@@ -1042,37 +1124,32 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
   // a client header, so authorize it before anything downstream renders from it.
   // Skipped when the source resolves to the route already matched and authorized
   // for this request, which is also the case where interception does not fire.
-  let interceptionSourcePathname: string | null = null;
-  if (filesystemRouteEligible && isRscRequest && interceptionContextHeader !== null) {
-    try {
-      if (!isInterceptionMatchedUrlPath(interceptionContextHeader)) {
-        throw new Error("Invalid interception source pathname");
-      }
-      interceptionSourcePathname = normalizePath(
-        normalizePathnameForRouteMatchStrict(interceptionContextHeader),
-      );
-    } catch {
-      options.clearRequestContext();
-      if (interceptionIdHeader !== null) markInterceptionIdRejected();
-      return badRequestResponse();
-    }
-  }
   const interceptionSourceMatch =
-    interceptionSourcePathname !== null && interceptionContextHeader !== null
+    filesystemRouteEligible &&
+    interceptionSourcePathname !== null &&
+    interceptionContextHeader !== null
       ? (options.matchInterceptRoute?.(
           preActionRoutePathname,
           interceptionContextHeader,
           interceptionIdHeader,
         ) ?? null)
       : null;
-  if (interceptionIdHeader !== null && interceptionSourceMatch === null) {
+  const hasVerifiedInterceptionSource = provesConcreteInterceptionSource(interceptionSourceMatch);
+  if (interceptionIdHeader !== null && !hasVerifiedInterceptionSource) {
     // The supplemental-refresh selector is an untrusted request header. Only
     // graph-owned identities that match this exact target and source may reach
     // rendering or shared caches; otherwise arbitrary short values can create
     // unbounded `_rsc` and Vary variants.
     options.clearRequestContext();
-    markInterceptionIdRejected();
+    setInterceptionResponseUncacheable(true);
     return badRequestResponse();
+  }
+  const bypassInterceptionContextCache =
+    hasRawInterceptionContext && !hasVerifiedInterceptionSource;
+  if (interceptionContextHeader !== null) {
+    // Replace any direct-target proof after rewrites. Exact graph ownership is
+    // the only point where the source identity is safe for shared variants.
+    setInterceptionResponseUncacheable(bypassInterceptionContextCache);
   }
   if (
     interceptionSourceMatch !== null &&
@@ -1608,6 +1685,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
   }
 
   const pageResponse = await options.dispatchMatchedPage({
+    bypassInterceptionContextCache,
     clientReuseManifest,
     cleanPathname,
     displayPathname: canonicalPathname,
@@ -1804,7 +1882,7 @@ export function createAppRscHandler<TRoute extends AppRscHandlerRoute>(
       executionContext,
       unstableCacheRevalidation: "background",
     });
-    let interceptionIdRejected = false;
+    let interceptionResponseUncacheable = false;
 
     const responsePromise = runWithRequestContext(requestContext, () =>
       runWithPrerenderWorkUnit(
@@ -1829,8 +1907,8 @@ export function createAppRscHandler<TRoute extends AppRscHandlerRoute>(
               pagesDataRequest,
               (internalRequest) => appRscHandler(internalRequest, ctx, true),
               allowInternalRscDocumentFallback,
-              () => {
-                interceptionIdRejected = true;
+              (uncacheable) => {
+                interceptionResponseUncacheable = uncacheable;
               },
             );
           } catch (error) {
@@ -1847,8 +1925,8 @@ export function createAppRscHandler<TRoute extends AppRscHandlerRoute>(
             middlewareHeaders: middlewareContext.headers,
             requestContext: preMiddlewareRequestContext,
           });
-          return interceptionIdRejected
-            ? markInvalidInterceptionIdResponseUncacheable(response)
+          return interceptionResponseUncacheable
+            ? markUnverifiedInterceptionResponseUncacheable(response)
             : response;
         },
         { route: () => new URL(request.url).pathname },

--- a/packages/vinext/src/server/app-rsc-route-matching.ts
+++ b/packages/vinext/src/server/app-rsc-route-matching.ts
@@ -105,6 +105,7 @@ type AppRscRouteForMatching = {
 
 type AppRscInterceptMatch = AppRscInterceptLookupEntry & {
   matchedParams: AppRscRouteParams;
+  sourceRouteIsConcrete: boolean;
   sourceMatchedParams: AppRscRouteParams;
 };
 
@@ -306,6 +307,7 @@ export function createAppRscRouteMatcher<Route extends AppRscRouteForMatching>(
         return {
           ...entry,
           page: entry.__loadState.page,
+          sourceRouteIsConcrete: concreteSourceRoute !== null,
           sourceRouteIndex: concreteSourceRouteIndex,
           matchedParams: mergeMatchedParams(sourceParams, params),
           sourceMatchedParams: matchedSourceParams ?? createRouteParams(),

--- a/packages/vinext/src/server/normalize-path.ts
+++ b/packages/vinext/src/server/normalize-path.ts
@@ -49,6 +49,7 @@ export function isInterceptionMatchedUrlPath(value: string): boolean {
     !value.startsWith("//") &&
     !value.includes("?") &&
     !value.includes("#") &&
+    !value.includes("\\") &&
     !value.includes("\0")
   );
 }

--- a/tests/app-page-dispatch.test.ts
+++ b/tests/app-page-dispatch.test.ts
@@ -282,6 +282,7 @@ function createRoute(overrides: Partial<TestRoute> = {}): TestRoute {
 
 type CreateDispatchOptionsOverrides = {
   buildPageElement?: DispatchOptions["buildPageElement"];
+  bypassInterceptionContextCache?: DispatchOptions["bypassInterceptionContextCache"];
   cleanPathname?: string;
   clearRequestContext?: DispatchOptions["clearRequestContext"];
   dynamicConfig?: DispatchOptions["dynamicConfig"];
@@ -345,6 +346,7 @@ function createDispatchOptions(overrides: CreateDispatchOptionsOverrides = {}) {
     }));
   const options: DispatchOptions = {
     buildPageElement,
+    bypassInterceptionContextCache: overrides.bypassInterceptionContextCache,
     cleanPathname: overrides.cleanPathname ?? "/posts/hello",
     clearRequestContext,
     createRscOnErrorHandler() {
@@ -2469,6 +2471,47 @@ describe("app page dispatch", () => {
     });
     expect(options.isrGet).not.toHaveBeenCalled();
     expect(options.isrSet).not.toHaveBeenCalled();
+  });
+
+  it("bypasses shared caches for an unverified interception context", async () => {
+    const isrGet = vi.fn(async () =>
+      buildISRCacheEntry(
+        buildCachedAppPageValue(
+          "",
+          new TextEncoder().encode("cached-flight").buffer,
+          undefined,
+          buildQueryInvariantRenderObservation(),
+        ),
+      ),
+    );
+    const isrSet = vi.fn<DispatchOptions["isrSet"]>(async () => {});
+    const waitUntilPromises: Promise<unknown>[] = [];
+    const executionContext = {
+      waitUntil(promise) {
+        waitUntilPromises.push(promise);
+      },
+    } satisfies ExecutionContextLike;
+    const { options } = createDispatchOptions({
+      bypassInterceptionContextCache: true,
+      interceptionContext: "/attacker-selected",
+      isProduction: true,
+      isRscRequest: true,
+      isrGet,
+      isrSet,
+      renderToReadableStream: () => createStream(["fresh-flight"]),
+      revalidateSeconds: 60,
+    });
+
+    const response = await runWithExecutionContext(executionContext, () =>
+      dispatchAppPage(options),
+    );
+
+    expect(response.headers.get("cache-control")).toBe("no-store, must-revalidate");
+    expect(response.headers.get("x-vinext-cache")).toBeNull();
+    await expect(response.text()).resolves.toBe("fresh-flight");
+    await Promise.all(waitUntilPromises.splice(0));
+    expect(isrGet).not.toHaveBeenCalled();
+    expect(isrSet).not.toHaveBeenCalled();
   });
 
   it("uses a verified interception id in the persistent RSC cache key", async () => {

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -681,8 +681,11 @@ describe("createAppRscHandler", () => {
       dispatchMatchedPage,
       matchInterceptRoute: (_pathname, sourcePathname) =>
         sourcePathname === "/feed/secret" ? { route: sourceRoute, params: {} } : null,
-      matchRoute: (pathname: string) =>
-        pathname === "/photos/1" ? { params: {}, route: targetRoute } : null,
+      matchRoute: (pathname: string) => {
+        if (pathname === "/photos/1") return { params: {}, route: targetRoute };
+        if (pathname === "/feed/secret") return { params: {}, route: sourceRoute };
+        return null;
+      },
       async runMiddleware({ cleanPathname }) {
         middlewarePaths.push(cleanPathname);
         return cleanPathname.startsWith("/feed/secret")
@@ -715,8 +718,11 @@ describe("createAppRscHandler", () => {
       dispatchMatchedPage,
       matchInterceptRoute: (_pathname, sourcePathname) =>
         sourcePathname === "/%66eed/secret" ? { route: sourceRoute, params: {} } : null,
-      matchRoute: (pathname: string) =>
-        pathname === "/photos/1" ? { params: {}, route: targetRoute } : null,
+      matchRoute: (pathname: string) => {
+        if (pathname === "/photos/1") return { params: {}, route: targetRoute };
+        if (pathname === "/feed/secret") return { params: {}, route: sourceRoute };
+        return null;
+      },
       middlewareModule: {
         config: { matcher: "/feed/:path*" },
         default(request: NextRequest) {
@@ -733,6 +739,102 @@ describe("createAppRscHandler", () => {
     expect(response.status).toBe(401);
     expect(middlewarePaths).toEqual(["/feed/secret"]);
     expect(dispatchMatchedPage).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "/feed/..",
+    "/feed/%2e%2e",
+    "/feed/./secret",
+    "/feed//secret",
+    "/feed/secret/../../../x",
+    "/feed/..\\secret",
+    "/feed\\..\\secret",
+    "/feed\\secret",
+    "/feed/%09../secret",
+    "/feed/%0a../secret",
+    "/feed/%0d../secret",
+    "/feed/%252e%252e/secret",
+  ])("rejects non-canonical interception source %s before route matching", async (source) => {
+    const targetRoute = createPageRoute({ pattern: "/photos/1", routeSegments: ["photos", "1"] });
+    const sourceRoute = createPageRoute({
+      isDynamic: true,
+      params: ["path"],
+      pattern: "/feed/:path*",
+      routeSegments: ["feed", "[[...path]]"],
+    });
+    const matcher = createAppRscRouteMatcher([
+      {
+        params: ["path"],
+        pattern: "/feed/:path*",
+        patternParts: ["feed", ":path*"],
+        slots: {
+          modal: {
+            intercepts: [
+              {
+                sourceMatchPattern: "/feed",
+                targetPattern: "/photos/:id",
+                interceptLayouts: [],
+                page: { default() {} },
+                params: ["id"],
+              },
+            ],
+          },
+        },
+      },
+    ]);
+    const matchInterceptRoute = vi.fn((pathname: string, sourcePathname: string) => {
+      const intercept = matcher.findIntercept(pathname, sourcePathname);
+      return intercept ? { route: sourceRoute, params: intercept.sourceMatchedParams } : null;
+    });
+    const runMiddleware = vi.fn(async ({ cleanPathname }: { cleanPathname: string }) => ({
+      kind: "continue" as const,
+      cleanPathname,
+      rewritten: false,
+      search: null,
+    }));
+    const dispatchMatchedPage = vi.fn(async () => new Response("secret"));
+    const handler = createHandler({
+      configHeaders: [
+        {
+          source: "/photos/:path*",
+          headers: [{ key: "Cache-Control", value: "public, max-age=3600" }],
+        },
+      ],
+      dispatchMatchedPage,
+      matchInterceptRoute,
+      matchRoute: (pathname: string) =>
+        pathname === "/photos/1" ? { params: {}, route: targetRoute } : null,
+      runMiddleware,
+    });
+
+    const headers = createRscRequestHeaders({ interceptionContext: source });
+    const rscUrl = await createRscRequestUrl("/docs/photos/1", headers);
+    const response = await handler(new Request(`https://example.test${rscUrl}`, { headers }), null);
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("cache-control")).toBe(
+      "private, no-cache, no-store, max-age=0, must-revalidate",
+    );
+    expect(runMiddleware).not.toHaveBeenCalled();
+    expect(matchInterceptRoute).not.toHaveBeenCalled();
+    expect(dispatchMatchedPage).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-canonical interception sources before config redirects", async () => {
+    const handler = createHandler({
+      configHeaders: [],
+      configRedirects: [{ source: "/photos/:id", destination: "/viewer/:id", permanent: false }],
+    });
+    const headers = createRscRequestHeaders({ interceptionContext: "/feed/.." });
+    const rscUrl = await createRscRequestUrl("/docs/photos/1", headers);
+
+    const response = await handler(new Request(`https://example.test${rscUrl}`, { headers }), null);
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("location")).toBeNull();
+    expect(response.headers.get("cache-control")).toBe(
+      "private, no-cache, no-store, max-age=0, must-revalidate",
+    );
   });
 
   it("rejects interception sources containing a raw query delimiter", async () => {
@@ -781,7 +883,7 @@ describe("createAppRscHandler", () => {
     const response = await handler(new Request(`https://example.test${rscUrl}`, { headers }), null);
 
     expect(response.status).toBe(400);
-    expect(middlewarePaths).toEqual(["/photos/1"]);
+    expect(middlewarePaths).toEqual([]);
     expect(dispatchMatchedPage).not.toHaveBeenCalled();
   });
 
@@ -805,6 +907,186 @@ describe("createAppRscHandler", () => {
     expect(matchInterceptRoute).toHaveBeenCalledWith("/photos/1", "/%2561dmin", null);
     expect(dispatchMatchedPage).toHaveBeenCalledWith(
       expect.objectContaining({ interceptionContext: "/%2561dmin" }),
+    );
+  });
+
+  it("bypasses shared caches for an unverified canonical interception context", async () => {
+    const targetRoute = createPageRoute({ pattern: "/photos/1", routeSegments: ["photos", "1"] });
+    const matchInterceptRoute = vi.fn(() => null);
+    const dispatchMatchedPage = vi.fn(
+      async () =>
+        new Response("page", {
+          headers: { "Cache-Control": "public, max-age=3600" },
+        }),
+    );
+    const handler = createHandler({
+      configHeaders: [],
+      dispatchMatchedPage,
+      matchInterceptRoute,
+      matchRoute: (pathname: string) =>
+        pathname === "/photos/1" ? { params: {}, route: targetRoute } : null,
+    });
+    const headers = createRscRequestHeaders({ interceptionContext: "/attacker-selected" });
+    const rscUrl = await createRscRequestUrl("/docs/photos/1", headers);
+
+    const response = await handler(new Request(`https://example.test${rscUrl}`, { headers }), null);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe(
+      "private, no-cache, no-store, max-age=0, must-revalidate",
+    );
+    expect(dispatchMatchedPage).toHaveBeenCalledWith(
+      expect.objectContaining({ bypassInterceptionContextCache: true }),
+    );
+  });
+
+  it("marks early redirects for unverified canonical interception contexts no-store", async () => {
+    const handler = createHandler({
+      configHeaders: [
+        {
+          source: "/photos/:path*",
+          headers: [{ key: "Cache-Control", value: "public, max-age=3600" }],
+        },
+      ],
+      configRedirects: [{ source: "/photos/:id", destination: "/viewer/:id", permanent: false }],
+    });
+    const headers = createRscRequestHeaders({ interceptionContext: "/attacker-selected" });
+    const rscUrl = await createRscRequestUrl("/docs/photos/1", headers);
+
+    const response = await handler(new Request(`https://example.test${rscUrl}`, { headers }), null);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toContain("/docs/viewer/1");
+    expect(response.headers.get("cache-control")).toBe(
+      "private, no-cache, no-store, max-age=0, must-revalidate",
+    );
+  });
+
+  it("bypasses shared caches when interception-context normalization drops a raw value", async () => {
+    const targetRoute = createPageRoute({ pattern: "/photos/1", routeSegments: ["photos", "1"] });
+    const dispatchMatchedPage = vi.fn(
+      async () =>
+        new Response("page", {
+          headers: { "Cache-Control": "public, max-age=3600" },
+        }),
+    );
+    const handler = createHandler({
+      configHeaders: [],
+      dispatchMatchedPage,
+      matchRoute: (pathname: string) =>
+        pathname === "/photos/1" ? { params: {}, route: targetRoute } : null,
+    });
+    const headers = createRscRequestHeaders({ interceptionContext: "not-a-path" });
+    const rscUrl = await createRscRequestUrl("/docs/photos/1", headers);
+
+    const response = await handler(new Request(`https://example.test${rscUrl}`, { headers }), null);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe(
+      "private, no-cache, no-store, max-age=0, must-revalidate",
+    );
+    expect(dispatchMatchedPage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bypassInterceptionContextCache: true,
+        interceptionContext: null,
+      }),
+    );
+  });
+
+  it("keeps verified canonical interception contexts cacheable", async () => {
+    const targetRoute = createPageRoute({ pattern: "/photos/1", routeSegments: ["photos", "1"] });
+    const sourceRoute = createPageRoute({ pattern: "/feed", routeSegments: ["feed"] });
+    const dispatchMatchedPage = vi.fn(
+      async () =>
+        new Response("page", {
+          headers: { "Cache-Control": "public, max-age=3600" },
+        }),
+    );
+    const handler = createHandler({
+      configHeaders: [],
+      dispatchMatchedPage,
+      matchInterceptRoute: (_pathname, sourcePathname) =>
+        sourcePathname === "/feed" ? { route: sourceRoute, params: {} } : null,
+      matchRoute: (pathname: string) => {
+        if (pathname === "/photos/1") return { params: {}, route: targetRoute };
+        if (pathname === "/feed") return { params: {}, route: sourceRoute };
+        return null;
+      },
+    });
+    const headers = createRscRequestHeaders({ interceptionContext: "/feed" });
+    const rscUrl = await createRscRequestUrl("/docs/photos/1", headers);
+
+    const response = await handler(new Request(`https://example.test${rscUrl}`, { headers }), null);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("public, max-age=3600");
+    expect(dispatchMatchedPage).toHaveBeenCalledWith(
+      expect.objectContaining({ bypassInterceptionContextCache: false }),
+    );
+  });
+
+  it("keeps nonexistent interception descendants out of shared caches", async () => {
+    const targetRoute = createPageRoute({ pattern: "/photos/1", routeSegments: ["photos", "1"] });
+    const sourceRoute = createPageRoute({ pattern: "/feed", routeSegments: ["feed"] });
+    const matcher = createAppRscRouteMatcher([
+      {
+        params: [],
+        pattern: "/feed",
+        patternParts: ["feed"],
+        slots: {
+          modal: {
+            intercepts: [
+              {
+                sourceMatchPattern: "/feed",
+                targetPattern: "/photos/:id",
+                interceptLayouts: [],
+                page: { default() {} },
+                params: ["id"],
+              },
+            ],
+          },
+        },
+      },
+    ]);
+    const dispatchMatchedPage = vi.fn(
+      async () =>
+        new Response("page", {
+          headers: { "Cache-Control": "public, max-age=3600" },
+        }),
+    );
+    const handler = createHandler({
+      configHeaders: [],
+      dispatchMatchedPage,
+      matchInterceptRoute(pathname, sourcePathname) {
+        const intercept = matcher.findIntercept(pathname, sourcePathname);
+        return intercept
+          ? {
+              interceptionSourceIsConcrete: intercept.sourceRouteIsConcrete,
+              route: sourceRoute,
+              params: intercept.sourceMatchedParams,
+            }
+          : null;
+      },
+      matchRoute(pathname) {
+        if (pathname === "/photos/1") return { params: {}, route: targetRoute };
+        if (pathname === "/feed") return { params: {}, route: sourceRoute };
+        return null;
+      },
+    });
+    const headers = createRscRequestHeaders({ interceptionContext: "/feed/attacker-selected" });
+    const rscUrl = await createRscRequestUrl("/docs/photos/1", headers);
+
+    const response = await handler(new Request(`https://example.test${rscUrl}`, { headers }), null);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe(
+      "private, no-cache, no-store, max-age=0, must-revalidate",
+    );
+    expect(dispatchMatchedPage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bypassInterceptionContextCache: true,
+        interceptionContext: "/feed/attacker-selected",
+      }),
     );
   });
 
@@ -913,13 +1195,51 @@ describe("createAppRscHandler", () => {
     expect(dispatchMatchedPage).not.toHaveBeenCalled();
   });
 
-  it("preserves a cacheable middleware 400 for a graph-owned id", async () => {
+  it("does not cache middleware responses when graph ownership is not target-specific", async () => {
     const interceptionId = "interception:slot:modal:/feed:/feed->/photos/:id";
     const dispatchMatchedPage = vi.fn(async () => new Response("page"));
     const handler = createHandler({
       configHeaders: [],
       dispatchMatchedPage,
       hasInterceptionId: (requestedId) => requestedId === interceptionId,
+      async runMiddleware() {
+        return {
+          kind: "response",
+          response: new Response("middleware", {
+            status: 400,
+            headers: { "Cache-Control": "public, max-age=3600" },
+          }),
+        };
+      },
+    });
+
+    const headers = createRscRequestHeaders({
+      interceptionContext: "/feed",
+      interceptionId,
+    });
+    const rscUrl = await createRscRequestUrl("/docs/photos/1", headers);
+    const response = await handler(new Request(`https://example.test${rscUrl}`, { headers }), null);
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe("middleware");
+    expect(response.headers.get("cache-control")).toBe(
+      "private, no-cache, no-store, max-age=0, must-revalidate",
+    );
+    expect(dispatchMatchedPage).not.toHaveBeenCalled();
+  });
+
+  it("preserves cacheable middleware responses after exact interception proof", async () => {
+    const interceptionId = "interception:slot:modal:/feed:/feed->/photos/:id";
+    const sourceRoute = createPageRoute({ pattern: "/feed", routeSegments: ["feed"] });
+    const dispatchMatchedPage = vi.fn(async () => new Response("page"));
+    const handler = createHandler({
+      configHeaders: [],
+      dispatchMatchedPage,
+      hasInterceptionId: (requestedId) => requestedId === interceptionId,
+      matchInterceptRoute: (_pathname, sourcePathname, requestedId) =>
+        sourcePathname === "/feed" && requestedId === interceptionId
+          ? { interceptionSourceIsConcrete: true, route: sourceRoute, params: {} }
+          : null,
       async runMiddleware() {
         return {
           kind: "response",
@@ -993,13 +1313,50 @@ describe("createAppRscHandler", () => {
     expect(dispatchMatchedPage).not.toHaveBeenCalled();
   });
 
+  it.each(["POST", "PUT"])(
+    "rejects interception ids on %s requests before action or route dispatch",
+    async (method) => {
+      const interceptionId = "interception:slot:modal:/feed:/feed->/photos/:id";
+      const dispatchMatchedPage = vi.fn(async () => new Response("page"));
+      const dispatchMatchedRouteHandler = vi.fn(async () => new Response("route"));
+      const handleServerActionRequest = vi.fn(async () => new Response("action"));
+      const handler = createHandler({
+        configHeaders: [],
+        dispatchMatchedPage,
+        dispatchMatchedRouteHandler,
+        handleServerActionRequest,
+        hasInterceptionId: (requestedId) => requestedId === interceptionId,
+      });
+      const headers = createRscRequestHeaders({
+        interceptionContext: "/feed",
+        interceptionId,
+      });
+      const rscUrl = await createRscRequestUrl("/docs/photos/1", headers);
+
+      const response = await handler(
+        new Request(`https://example.test${rscUrl}`, { headers, method }),
+        null,
+      );
+
+      expect(response.status).toBe(400);
+      expect(response.headers.get("cache-control")).toBe(
+        "private, no-cache, no-store, max-age=0, must-revalidate",
+      );
+      expect(handleServerActionRequest).not.toHaveBeenCalled();
+      expect(dispatchMatchedRouteHandler).not.toHaveBeenCalled();
+      expect(dispatchMatchedPage).not.toHaveBeenCalled();
+    },
+  );
+
   it("allows an exact graph-owned interception id", async () => {
     const sourceRoute = createPageRoute({ pattern: "/feed", routeSegments: ["feed"] });
     const interceptionId = "interception:slot:modal:/feed:/feed->/photos/:id";
     const dispatchMatchedPage = vi.fn(async () => new Response("intercepted"));
     const matchInterceptRoute = vi.fn(
       (_pathname: string, _sourcePathname: string, requestedId?: string | null) =>
-        requestedId === interceptionId ? { route: sourceRoute, params: {} } : null,
+        requestedId === interceptionId
+          ? { interceptionSourceIsConcrete: true, route: sourceRoute, params: {} }
+          : null,
     );
     const handler = createHandler({
       configHeaders: [
@@ -1025,6 +1382,84 @@ describe("createAppRscHandler", () => {
     expect(response.headers.get("cache-control")).toBe("public, max-age=3600");
     expect(dispatchMatchedPage).toHaveBeenCalledWith(
       expect.objectContaining({ interceptionContext: "/feed", interceptionId }),
+    );
+  });
+
+  it("preserves one-decode dynamic source params in concrete interception proof", async () => {
+    const targetRoute = createPageRoute({ pattern: "/photos/1", routeSegments: ["photos", "1"] });
+    const sourceRoute = createPageRoute({
+      isDynamic: true,
+      params: ["slug"],
+      pattern: "/feed/:slug",
+      routeSegments: ["feed", "[slug]"],
+    });
+    const matcher = createAppRscRouteMatcher([
+      {
+        params: ["slug"],
+        pattern: "/feed/:slug",
+        patternParts: ["feed", ":slug"],
+        slots: {
+          modal: {
+            id: "slot:modal:/feed/:slug",
+            intercepts: [
+              {
+                sourceMatchPattern: "/feed/:slug",
+                targetPattern: "/photos/:id",
+                interceptLayouts: [],
+                page: { default() {} },
+                params: ["id"],
+              },
+            ],
+          },
+        },
+      },
+    ]);
+    const sourceContext = "/feed/%2561";
+    const initialIntercept = matcher.findIntercept("/photos/1", sourceContext);
+    expect(initialIntercept).toMatchObject({
+      sourceMatchedParams: { slug: "%61" },
+      sourceRouteIsConcrete: true,
+    });
+    const interceptionId = initialIntercept!.interceptionId;
+    expect(interceptionId).not.toBeNull();
+    const dispatchMatchedPage = vi.fn(
+      async () =>
+        new Response("page", {
+          headers: { "Cache-Control": "public, max-age=3600" },
+        }),
+    );
+    const handler = createHandler({
+      configHeaders: [],
+      dispatchMatchedPage,
+      hasInterceptionId: (requestedId) => matcher.hasInterceptionId(requestedId),
+      matchInterceptRoute(pathname, sourcePathname, requestedId) {
+        const intercept = matcher.findIntercept(pathname, sourcePathname, requestedId);
+        return intercept
+          ? {
+              interceptionSourceIsConcrete: intercept.sourceRouteIsConcrete,
+              route: sourceRoute,
+              params: intercept.sourceMatchedParams,
+            }
+          : null;
+      },
+      matchRoute: (pathname) =>
+        pathname === "/photos/1" ? { params: {}, route: targetRoute } : null,
+    });
+    const headers = createRscRequestHeaders({
+      interceptionContext: sourceContext,
+      interceptionId,
+    });
+    const rscUrl = await createRscRequestUrl("/docs/photos/1", headers);
+
+    const response = await handler(new Request(`https://example.test${rscUrl}`, { headers }), null);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("public, max-age=3600");
+    expect(dispatchMatchedPage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bypassInterceptionContextCache: false,
+        interceptionId,
+      }),
     );
   });
 

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -4306,6 +4306,89 @@ describe("createAppRscHandler", () => {
     );
   });
 
+  it.each([
+    { label: "context-only requests", interceptionId: null, expectedStatus: 200 },
+    {
+      label: "selector-bearing requests",
+      interceptionId: "interception:slot:modal:/feed:/feed->/blog/:slug",
+      expectedStatus: 400,
+    },
+  ])(
+    "revalidates interception proof after afterFiles rewrites for $label",
+    async ({ expectedStatus, interceptionId }) => {
+      const routes = {
+        about: createPageRoute({ pattern: "/about", routeSegments: ["about"] }),
+        blog: createPageRoute({
+          isDynamic: true,
+          pattern: "/blog/:slug",
+          routeSegments: ["blog", "[slug]"],
+        }),
+        feed: createPageRoute({ pattern: "/feed", routeSegments: ["feed"] }),
+      };
+      const matchInterceptRoute = vi.fn(
+        (pathname: string, sourcePathname: string, requestedId?: string | null) =>
+          pathname === "/blog/legacy" &&
+          sourcePathname === "/feed" &&
+          requestedId === interceptionId
+            ? { interceptionSourceIsConcrete: true, params: {}, route: routes.feed }
+            : null,
+      );
+      const dispatchMatchedPage = vi.fn(
+        async () =>
+          new Response("page", {
+            headers: { "Cache-Control": "public, max-age=3600" },
+          }),
+      );
+      const emptyParams: Record<string, string | string[]> = {};
+      const blogParams: Record<string, string | string[]> = { slug: "legacy" };
+      const matchRoute: HandlerOptions["matchRoute"] = (pathname) => {
+        if (pathname === "/about") return { params: emptyParams, route: routes.about };
+        if (pathname === "/blog/legacy") {
+          return { params: blogParams, route: routes.blog };
+        }
+        return null;
+      };
+      const handler = createHandler({
+        configHeaders: [],
+        configRewrites: {
+          beforeFiles: [],
+          afterFiles: [{ source: "/blog/legacy", destination: "/about" }],
+          fallback: [],
+        },
+        dispatchMatchedPage,
+        hasInterceptionId: (requestedId) => requestedId === interceptionId,
+        matchInterceptRoute,
+        matchRoute,
+      });
+      const headers = createRscRequestHeaders({
+        interceptionContext: "/feed",
+        interceptionId,
+      });
+      const rscUrl = await createRscRequestUrl("/docs/blog/legacy", headers);
+
+      const response = await handler(
+        new Request(`https://example.test${rscUrl}`, { headers }),
+        null,
+      );
+
+      expect(response.status).toBe(expectedStatus);
+      expect(response.headers.get("cache-control")).toBe(
+        "private, no-cache, no-store, max-age=0, must-revalidate",
+      );
+      expect(matchInterceptRoute).toHaveBeenCalledWith("/about", "/feed", interceptionId);
+      if (interceptionId === null) {
+        expect(dispatchMatchedPage).toHaveBeenCalledWith(
+          expect.objectContaining({
+            bypassInterceptionContextCache: true,
+            cleanPathname: "/about",
+          }),
+        );
+      } else {
+        expect(dispatchMatchedPage).not.toHaveBeenCalled();
+      }
+    },
+  );
+
   it("lets a static Pages route win before afterFiles rewrites", async () => {
     const dynamicRoute = createPageRoute({
       isDynamic: true,

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -4389,6 +4389,94 @@ describe("createAppRscHandler", () => {
     },
   );
 
+  it.each([
+    {
+      expectedBypass: true,
+      expectedCacheControl: "private, no-cache, no-store, max-age=0, must-revalidate",
+      expectedMiddlewarePaths: ["/blog/legacy"],
+      initialSourceMatch: false,
+      label: "newly discovered sources",
+    },
+    {
+      expectedBypass: false,
+      expectedCacheControl: "public, max-age=3600",
+      expectedMiddlewarePaths: ["/blog/legacy", "/feed"],
+      initialSourceMatch: true,
+      label: "previously authorized sources",
+    },
+  ])(
+    "restores cacheability after late rewrites only for $label",
+    async ({
+      expectedBypass,
+      expectedCacheControl,
+      expectedMiddlewarePaths,
+      initialSourceMatch,
+    }) => {
+      const routes = {
+        about: createPageRoute({ pattern: "/about", routeSegments: ["about"] }),
+        blog: createPageRoute({
+          isDynamic: true,
+          pattern: "/blog/:slug",
+          routeSegments: ["blog", "[slug]"],
+        }),
+        feed: createPageRoute({ pattern: "/feed", routeSegments: ["feed"] }),
+      };
+      const matchInterceptRoute = vi.fn((pathname: string, sourcePathname: string) =>
+        sourcePathname === "/feed" && (pathname === "/about" || initialSourceMatch)
+          ? { interceptionSourceIsConcrete: true, params: {}, route: routes.feed }
+          : null,
+      );
+      const middlewarePaths: string[] = [];
+      const dispatchMatchedPage = vi.fn(
+        async () =>
+          new Response("page", {
+            headers: { "Cache-Control": "public, max-age=3600" },
+          }),
+      );
+      const emptyParams: Record<string, string | string[]> = {};
+      const blogParams: Record<string, string | string[]> = { slug: "legacy" };
+      const matchRoute: HandlerOptions["matchRoute"] = (pathname) => {
+        if (pathname === "/about") return { params: emptyParams, route: routes.about };
+        if (pathname === "/blog/legacy") {
+          return { params: blogParams, route: routes.blog };
+        }
+        return null;
+      };
+      const handler = createHandler({
+        configHeaders: [],
+        configRewrites: {
+          beforeFiles: [],
+          afterFiles: [{ source: "/blog/legacy", destination: "/about" }],
+          fallback: [],
+        },
+        dispatchMatchedPage,
+        matchInterceptRoute,
+        matchRoute,
+        async runMiddleware({ cleanPathname }) {
+          middlewarePaths.push(cleanPathname);
+          return { kind: "continue", cleanPathname, rewritten: false, search: null };
+        },
+      });
+      const headers = createRscRequestHeaders({ interceptionContext: "/feed" });
+      const rscUrl = await createRscRequestUrl("/docs/blog/legacy", headers);
+
+      const response = await handler(
+        new Request(`https://example.test${rscUrl}`, { headers }),
+        null,
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("cache-control")).toBe(expectedCacheControl);
+      expect(middlewarePaths).toEqual(expectedMiddlewarePaths);
+      expect(dispatchMatchedPage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          bypassInterceptionContextCache: expectedBypass,
+          cleanPathname: "/about",
+        }),
+      );
+    },
+  );
+
   it("lets a static Pages route win before afterFiles rewrites", async () => {
     const dynamicRoute = createPageRoute({
       isDynamic: true,

--- a/tests/app-rsc-route-matching.test.ts
+++ b/tests/app-rsc-route-matching.test.ts
@@ -708,6 +708,7 @@ describe("App RSC route matching", () => {
 
       // A Route Handler descendant falls back to the slot owner (index 0).
       expect(matcher.findIntercept("/hidden", "/feed/admin")).toMatchObject({
+        sourceRouteIsConcrete: false,
         sourceRouteIndex: 0,
       });
       // A lazy Route Handler is classified the same before its first load.
@@ -732,6 +733,7 @@ describe("App RSC route matching", () => {
       });
       // Page descendants still resolve concretely, preserving their params.
       expect(matcher.findIntercept("/hidden", "/feed/recent")).toMatchObject({
+        sourceRouteIsConcrete: true,
         sourceRouteIndex: 2,
         sourceMatchedParams: { tab: "recent" },
       });
@@ -821,16 +823,19 @@ describe("App RSC route matching", () => {
       ]);
 
       expect(matcher.findIntercept("/en/hidden", "/en/feed/admin")).toMatchObject({
+        sourceRouteIsConcrete: false,
         sourceRouteIndex: 0,
         sourceMatchedParams: { locale: "en" },
       });
       // A descendant with no concrete route at all takes the same fallback.
       expect(matcher.findIntercept("/en/hidden", "/en/feed/unknown/deep")).toMatchObject({
+        sourceRouteIsConcrete: false,
         sourceRouteIndex: 0,
         sourceMatchedParams: { locale: "en" },
       });
       // An exact source still matches the owner directly.
       expect(matcher.findIntercept("/en/hidden", "/en/feed")).toMatchObject({
+        sourceRouteIsConcrete: true,
         sourceRouteIndex: 0,
         sourceMatchedParams: { locale: "en" },
       });

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -1098,9 +1098,14 @@ describe("App Router entry templates", () => {
     expect(code).toContain(
       "const intercept = findIntercept(pathname, sourcePathname, interceptionId)",
     );
+    expect(code).toContain("interceptionSourceIsConcrete: intercept.sourceRouteIsConcrete");
+    expect(
+      code.match(
+        /findIntercept\(\s*interceptionPathname,\s*interceptionContext,\s*interceptionId,?\s*\)/g,
+      ),
+    ).toHaveLength(3);
     expect(code).toContain("const route = routes[intercept.sourceRouteIndex]");
     expect(code).toContain("intercept.sourceMatchedParams");
-    expect(code).toContain("return { route, params }");
   });
 
   it("installs server globals before App Router user modules are imported", () => {

--- a/tests/fixtures/interception-source-authz/app/feed/@modal/(...)photos/[id]/page.tsx
+++ b/tests/fixtures/interception-source-authz/app/feed/@modal/(...)photos/[id]/page.tsx
@@ -1,0 +1,4 @@
+export default async function PhotoModal({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  return <p>Intercepted photo {id}</p>;
+}

--- a/tests/fixtures/interception-source-authz/app/feed/@modal/default.tsx
+++ b/tests/fixtures/interception-source-authz/app/feed/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function DefaultModal() {
+  return null;
+}

--- a/tests/fixtures/interception-source-authz/app/feed/[...rest]/page.tsx
+++ b/tests/fixtures/interception-source-authz/app/feed/[...rest]/page.tsx
@@ -1,0 +1,3 @@
+export default function GuardedFeedPage() {
+  return <p>SECRET-FEED-CONTENT</p>;
+}

--- a/tests/fixtures/interception-source-authz/app/feed/layout.tsx
+++ b/tests/fixtures/interception-source-authz/app/feed/layout.tsx
@@ -1,0 +1,14 @@
+export default function FeedLayout({
+  children,
+  modal,
+}: {
+  children: React.ReactNode;
+  modal: React.ReactNode;
+}) {
+  return (
+    <main>
+      {children}
+      {modal}
+    </main>
+  );
+}

--- a/tests/fixtures/interception-source-authz/app/feed/page.tsx
+++ b/tests/fixtures/interception-source-authz/app/feed/page.tsx
@@ -1,0 +1,3 @@
+export default function FeedPage() {
+  return <p>Feed</p>;
+}

--- a/tests/fixtures/interception-source-authz/app/layout.tsx
+++ b/tests/fixtures/interception-source-authz/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/tests/fixtures/interception-source-authz/app/photos/[id]/page.tsx
+++ b/tests/fixtures/interception-source-authz/app/photos/[id]/page.tsx
@@ -1,0 +1,4 @@
+export default async function PhotoPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  return <p>Photo {id}</p>;
+}

--- a/tests/fixtures/interception-source-authz/middleware.ts
+++ b/tests/fixtures/interception-source-authz/middleware.ts
@@ -1,0 +1,12 @@
+import type { NextRequest } from "next/server";
+
+export function middleware(_request: NextRequest) {
+  return new Response("Blocked by middleware", {
+    status: 403,
+    headers: { "x-auth-guard": "blocked" },
+  });
+}
+
+export const config = {
+  matcher: ["/feed/:path*"],
+};

--- a/tests/fixtures/interception-source-authz/package.json
+++ b/tests/fixtures/interception-source-authz/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "interception-source-authz-fixture",
+  "private": true,
+  "type": "module"
+}

--- a/tests/interception-source-authz-integration.test.ts
+++ b/tests/interception-source-authz-integration.test.ts
@@ -1,0 +1,118 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { createBuilder } from "vite";
+import { afterAll, beforeAll, describe, expect, it } from "vite-plus/test";
+import vinext from "../packages/vinext/src/index.js";
+import { createIsolatedFixture, startFixtureServer } from "./helpers.js";
+
+const FIXTURE_DIR = path.resolve(import.meta.dirname, "./fixtures/interception-source-authz");
+const GUARDED_MARKER = "SECRET-FEED-CONTENT";
+
+type StartedServer = {
+  baseUrl: string;
+  close(): Promise<void>;
+};
+
+function interceptionHeaders(source: string): Record<string, string> {
+  return {
+    Accept: "text/x-component",
+    RSC: "1",
+    "X-Vinext-Interception-Context": source,
+  };
+}
+
+async function startDevServer(root: string): Promise<StartedServer> {
+  const { server, baseUrl } = await startFixtureServer(root, { appRouter: true });
+  return {
+    baseUrl,
+    close: () => server.close(),
+  };
+}
+
+async function startProductionServer(root: string): Promise<StartedServer> {
+  const builder = await createBuilder({
+    root,
+    configFile: false,
+    plugins: [vinext({ appDir: root })],
+    logLevel: "silent",
+  });
+  await builder.buildApp();
+
+  const { startProdServer } = await import("../packages/vinext/src/server/prod-server.js");
+  const { server } = await startProdServer({
+    host: "127.0.0.1",
+    port: 0,
+    outDir: path.join(root, "dist"),
+    noCompression: true,
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    server.close();
+    throw new Error("Production server did not bind to a TCP port");
+  }
+
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}
+
+async function expectInterceptionSourceAuthorization(baseUrl: string): Promise<void> {
+  const direct = await fetch(`${baseUrl}/feed/secret`);
+  expect(direct.status).toBe(403);
+  expect(direct.headers.get("x-auth-guard")).toBe("blocked");
+  expect(await direct.text()).not.toContain(GUARDED_MARKER);
+
+  const control = await fetch(`${baseUrl}/photos/1`, {
+    headers: interceptionHeaders("/feed/secret"),
+  });
+  expect(control.status).toBe(403);
+  expect(control.headers.get("x-auth-guard")).toBe("blocked");
+  expect(await control.text()).not.toContain(GUARDED_MARKER);
+
+  const traversal = await fetch(`${baseUrl}/photos/1`, {
+    headers: interceptionHeaders("/feed/.."),
+  });
+  const traversalBody = await traversal.text();
+  expect({
+    status: traversal.status,
+    authGuard: traversal.headers.get("x-auth-guard"),
+    exposedGuardedContent: traversalBody.includes(GUARDED_MARKER),
+  }).toEqual({
+    status: 400,
+    authGuard: null,
+    exposedGuardedContent: false,
+  });
+}
+
+describe.each([
+  ["development", startDevServer],
+  ["production", startProductionServer],
+] as const)("interception source authorization (%s)", (_mode, startServer) => {
+  let fixtureRoot = "";
+  let server: StartedServer | undefined;
+
+  beforeAll(async () => {
+    fixtureRoot = await createIsolatedFixture(FIXTURE_DIR, "vinext-interception-authz-");
+    server = await startServer(fixtureRoot);
+  }, 120_000);
+
+  afterAll(async () => {
+    await server?.close();
+    if (fixtureRoot) await fs.rm(fixtureRoot, { recursive: true, force: true });
+  });
+
+  // Interception routes paired with middleware mirror the Next.js topology in:
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/interception-dynamic-segment-middleware/interception-dynamic-segment-middleware.test.ts
+  // The forged source-context request is vinext-specific. The fixture mirrors
+  // the reported application and request boundary:
+  // /photos/[id] is intercepted from /feed/@modal/(...)photos/[id], while
+  // middleware guards /feed/:path* and /feed/[...rest] exposes a marker.
+  it("does not authorize and render different interception source paths", async () => {
+    if (!server) throw new Error("Interception authorization fixture server did not start");
+    await expectInterceptionSourceAuthorization(server.baseUrl);
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary

- validate client-provided App Router interception source paths before redirects and middleware
- distinguish concrete source-route proof from compatible render fallbacks, keeping unverified variants out of CDN and ISR caches
- revalidate interception proof after late rewrites and retain cacheability only for previously authorized sources
- restrict exact interception selectors to read requests and propagate them consistently through probes and error rendering
- add an isolated real-HTTP regression for a middleware-guarded interception source in development and production

## Next.js parity

- preserves the raw one-decode matching contract for encoded dynamic parameters
- retains context-only fail-open rendering while preventing unverified shared-cache admission
- applies through the shared App Router handler across dev, production, Node, and Workers
- mirrors Next.js interception-plus-middleware routing while validating vinext's additional source-context header at its trust boundary

## Validation

- `vp check` on all changed files
- targeted unit, integration, and App Router interception/middleware E2E coverage
- the new real-HTTP regression fails on current `origin/main` in both dev and production (200 with guarded content exposed) and passes on this branch (400 with no guarded content)
- `vp run vinext#build`