### PR TITLE
feat(cloudflare): isolate Workers Cache with staged entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -705,11 +705,17 @@ The KV data adapter reads `env[binding]` at runtime, so add the matching KV name
 
 `binding` defaults to `VINEXT_KV_CACHE`, so `kvDataAdapter()` with no options works as long as that's your binding name. Other options: `appPrefix` (namespace cache keys to isolate multiple apps in one KV namespace), `ttlSeconds` (default KV `expirationTtl`, default 30 days), and `tagCacheTtlMs` (in-memory tag-invalidation cache TTL, default 5s).
 
-`cdnAdapter()` takes no options, but the Workers Cache only exposes `ctx.cache` when `cache.enabled` is set in `wrangler.jsonc`:
+When `cdnAdapter()` is used in a Cloudflare build, vinext emits two Worker
+entrypoints and configures Workers Cache only on the response entrypoint. The
+default entrypoint keeps caching disabled so middleware and request-time routing
+run on every request. Do not enable Workers Cache on the default entrypoint in
+your source `wrangler.jsonc`; the generated `dist/server/wrangler.json` contains
+the per-entrypoint cache settings.
+
+Version metadata is still required for staged discovery and warming:
 
 ```jsonc
 {
-  "cache": { "enabled": true },
   "version_metadata": { "binding": "CF_VERSION_METADATA" },
 }
 ```
@@ -725,12 +731,16 @@ must prove every planned entry reusable before promotion.
 
 While the data adapter can store entries and serve HIT/STALE itself, the CDN adapter delegates serving to Cloudflare's edge: the origin renders fresh responses and tags them with `Cache-Tag`, and `revalidateTag()` / `revalidatePath()` purge the edge through `ctx.cache.purge({ tags })`. See [examples/workers-cache](examples/workers-cache) for both adapters wired up together.
 
-Keep Cloudflare's incoming cache key query-sensitive when using `cdnAdapter()`.
-The two-stage cacheability manifest authorizes exact pathname + query
-identities, and a Cache Rule that ignores or normalizes query strings can serve
-an edge HIT before the Worker has a chance to enforce that identity.
+The response entrypoint adds a transport-only digest of the complete stage
+identity to its Workers Cache URL. That internal key is independent of zone
+Cache Rules and prevents distinct query, representation, rewrite, or
+interception identities from colliding.
 
-Each builder returns a plain, serializable `{ adapter, options }` descriptor — **it never touches the Workers runtime**, so nothing throws at build or dev time when bindings aren't available. The actual adapter (and its `env` binding lookup) is instantiated lazily on the first request.
+Adapter declarations do not access the Workers runtime, so nothing throws at
+config-evaluation or dev time when bindings are unavailable. Builders may also
+provide platform-specific output hooks; `cdnAdapter()` uses one to configure
+the Cloudflare entrypoints after the application build. Runtime adapters (and
+their `env` binding lookups) are instantiated lazily on the first request.
 
 Registration is wired into **every router and runtime** — App Router and Pages Router, on Cloudflare Workers as well as the Node.js server (`vinext start`) and dev. It self-guards (instantiated once per isolate) and is resilient: if an adapter can't initialize on a given runtime (e.g. a KV binding doesn't exist on the Node server), vinext logs a warning and falls back to the default handler instead of failing requests.
 

--- a/examples/workers-cache/README.md
+++ b/examples/workers-cache/README.md
@@ -47,9 +47,9 @@ Cache Rules.
 ## How vinext wires it up
 
 1. **`vite.config.ts`** declares the adapters via `vinext({ cache })` (see
-   above). The descriptors are plain serializable values — they don't touch
-   the Workers runtime at build/dev time; the adapters instantiate lazily on
-   the first request.
+   above). The declarations do not touch the Workers runtime during config
+   evaluation. The Cloudflare build hook emits the staged Worker configuration,
+   and runtime adapters instantiate lazily on the first request.
 
 2. **`wrangler.jsonc`** binds the KV namespace:
 

--- a/examples/workers-cache/README.md
+++ b/examples/workers-cache/README.md
@@ -27,9 +27,9 @@ vinext({
 the Cloudflare build. The KV adapter still needs a matching
 `VINEXT_KV_CACHE` namespace binding in `wrangler.jsonc`.
 
-The incoming Cloudflare cache key must retain the full query string. A Cache
-Rule that ignores or normalizes query parameters can collapse distinct
-manifest identities before the Worker runs.
+The adapter adds a transport-only URL digest so distinct response-stage
+identities cannot collide. Workers Cache owns this key independently of zone
+Cache Rules.
 
 ## What's in the box
 

--- a/examples/workers-cache/README.md
+++ b/examples/workers-cache/README.md
@@ -55,9 +55,7 @@ Cache Rules.
 
    ```jsonc
    {
-     "kv_namespaces": [
-       { "binding": "VINEXT_KV_CACHE", "id": "<your-kv-namespace-id>" }
-     ]
+     "kv_namespaces": [{ "binding": "VINEXT_KV_CACHE", "id": "<your-kv-namespace-id>" }],
    }
    ```
 
@@ -69,7 +67,7 @@ Cache Rules.
 
    ```jsonc
    {
-     "main": "vinext/server/fetch-handler"
+     "main": "vinext/server/fetch-handler",
    }
    ```
 
@@ -81,8 +79,8 @@ Cache Rules.
    The handler also passes the Worker's `env` so `kvDataAdapter()` can resolve
    its KV binding. No manual registration.
 
-4. **ISR responses** carry `CDN-Cache-Control: public, max-age=N,
-   stale-while-revalidate=M` (for the edge) plus a browser-facing
+4. **ISR responses** carry `Cloudflare-CDN-Cache-Control: public, max-age=N,
+stale-while-revalidate=M` (for the edge) plus a browser-facing
    `Cache-Control: public, max-age=0, must-revalidate`, and a `Cache-Tag`
    header listing both the bare path (`/cached/intro`) and Next.js's internal
    `_N_T_<path>` form. The Workers Cache reads these to cache and tag-purge.
@@ -102,7 +100,7 @@ Then open http://localhost:5173 and click into any of the demo routes.
 > **Note:** dev runs on `@cloudflare/vite-plugin` (miniflare), so the
 > `VINEXT_KV_CACHE` namespace is emulated locally and `kvDataAdapter()`
 > works. The edge CDN layer (`cf-cache-status`, background revalidation)
-> only runs on Cloudflare's edge — locally the `CDN-Cache-Control` /
+> only runs on Cloudflare's edge — locally the `Cloudflare-CDN-Cache-Control` /
 > `Cache-Tag` headers `cdnAdapter()` emits are what drive it once deployed.
 
 ## Deploying

--- a/examples/workers-cache/README.md
+++ b/examples/workers-cache/README.md
@@ -23,9 +23,9 @@ vinext({
 });
 ```
 
-The Workers Cache only exposes `ctx.cache` when `cache.enabled: true` is set
-in `wrangler.jsonc`, and the KV adapter needs a matching `VINEXT_KV_CACHE`
-namespace binding — both are configured there.
+`cdnAdapter()` generates the per-entrypoint Workers Cache configuration during
+the Cloudflare build. The KV adapter still needs a matching
+`VINEXT_KV_CACHE` namespace binding in `wrangler.jsonc`.
 
 The incoming Cloudflare cache key must retain the full query string. A Cache
 Rule that ignores or normalizes query parameters can collapse distinct
@@ -51,11 +51,10 @@ manifest identities before the Worker runs.
    the Workers runtime at build/dev time; the adapters instantiate lazily on
    the first request.
 
-2. **`wrangler.jsonc`** enables the platform cache and binds the KV namespace:
+2. **`wrangler.jsonc`** binds the KV namespace:
 
    ```jsonc
    {
-     "cache": { "enabled": true },
      "kv_namespaces": [
        { "binding": "VINEXT_KV_CACHE", "id": "<your-kv-namespace-id>" }
      ]
@@ -74,10 +73,13 @@ manifest identities before the Worker runs.
    }
    ```
 
-   The handler registers the configured adapters on the first request —
-   passing the Worker's `env` so `kvDataAdapter()` can resolve its KV binding —
-   then threads the request's `ExecutionContext` through ALS so `cdnAdapter()`
-   can reach `ctx.cache` at revalidation time. No manual registration.
+   When `cdnAdapter()` is configured, vinext asks the Cloudflare build for two
+   Worker entrypoints. The default entrypoint runs routing and middleware with
+   caching disabled; `VinextCachedResponse` lazily loads the render stage with
+   Workers Cache enabled. The generated `dist/server/wrangler.json` contains
+   those settings, so existing applications do not need a source-config edit.
+   The handler also passes the Worker's `env` so `kvDataAdapter()` can resolve
+   its KV binding. No manual registration.
 
 4. **ISR responses** carry `CDN-Cache-Control: public, max-age=N,
    stale-while-revalidate=M` (for the edge) plus a browser-facing

--- a/examples/workers-cache/app/api/draft-enable/route.ts
+++ b/examples/workers-cache/app/api/draft-enable/route.ts
@@ -1,0 +1,6 @@
+import { draftMode } from "next/headers";
+
+export async function GET() {
+  (await draftMode()).enable();
+  return Response.json({ enabled: true });
+}

--- a/examples/workers-cache/app/prewarm-target/page.tsx
+++ b/examples/workers-cache/app/prewarm-target/page.tsx
@@ -1,9 +1,12 @@
+import { draftMode } from "next/headers";
+
 export const revalidate = 300;
 
-export default function PrewarmTargetPage() {
+export default async function PrewarmTargetPage() {
   return (
     <main>
       <output data-testid="build-id">{process.env.__VINEXT_BUILD_ID}</output>
+      <output data-testid="draft-mode">{String((await draftMode()).isEnabled)}</output>
       <h1>Prewarm target</h1>
     </main>
   );

--- a/examples/workers-cache/app/vary/route.ts
+++ b/examples/workers-cache/app/vary/route.ts
@@ -1,0 +1,11 @@
+export const dynamic = "force-dynamic";
+
+export function GET(request: Request): Response {
+  const variant = request.headers.get("x-cache-variant") ?? "missing";
+  return new Response(variant, {
+    headers: {
+      "Cache-Control": "public, s-maxage=300",
+      Vary: "x-cache-variant",
+    },
+  });
+}

--- a/examples/workers-cache/middleware.ts
+++ b/examples/workers-cache/middleware.ts
@@ -1,0 +1,12 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+export function middleware(request: NextRequest) {
+  const response = NextResponse.next();
+  response.headers.set(
+    "x-workers-cache-visitor",
+    request.headers.get("x-test-visitor-id") ?? "anonymous",
+  );
+  return response;
+}
+
+export const config = { matcher: ["/prewarm-target", "/pages-prewarm"] };

--- a/examples/workers-cache/pages/pages-prewarm.tsx
+++ b/examples/workers-cache/pages/pages-prewarm.tsx
@@ -1,7 +1,12 @@
-export async function getStaticProps() {
-  return { props: {}, revalidate: 300 };
+export async function getStaticProps(context: { draftMode?: boolean }) {
+  return { props: { draftMode: context.draftMode === true }, revalidate: 300 };
 }
 
-export default function PagesPrewarmTarget() {
-  return <h1>Pages prewarm target</h1>;
+export default function PagesPrewarmTarget({ draftMode }: { draftMode: boolean }) {
+  return (
+    <main>
+      <output data-testid="draft-mode">{String(draftMode)}</output>
+      <h1>Pages prewarm target</h1>
+    </main>
+  );
 }

--- a/examples/workers-cache/wrangler.jsonc
+++ b/examples/workers-cache/wrangler.jsonc
@@ -25,9 +25,6 @@
       "enabled": true,
     },
   },
-  "cache": {
-    "enabled": true,
-  },
   "version_metadata": {
     "binding": "CF_VERSION_METADATA",
   },

--- a/packages/cloudflare/README.md
+++ b/packages/cloudflare/README.md
@@ -9,8 +9,8 @@ This package provides Cloudflare-specific cache and image backends for vinext:
   data cache (`fetch`, `"use cache"`, `unstable_cache`) with a Workers KV
   namespace.
 - **`cdnAdapter()`** (`@vinext/cloudflare/cache/cdn-adapter`) — delegates
-  page-level ISR serving and revalidation to Cloudflare Workers Cache. This is
-  opt-in and requires Workers Cache to be enabled in Wrangler config.
+  page-level ISR serving and revalidation to Cloudflare Workers Cache through
+  an automatically generated cache-enabled response entrypoint.
 - **`imagesOptimizer()`** (`@vinext/cloudflare/images/images-optimizer`) — backs
   `next/image` transformations with a Cloudflare Images binding.
 
@@ -37,14 +37,17 @@ export default defineConfig({
 
 ### Workers Cache
 
-`cdnAdapter()` is optional. Only configure it when Workers Cache is enabled in
-`wrangler.jsonc`:
+`cdnAdapter()` is optional. Configuring it asks the Cloudflare build for two
+Worker entrypoints: the default entrypoint runs middleware and request-time
+routing with caching disabled, while `VinextCachedResponse` lazily loads the
+render stage with Workers Cache enabled. These settings are written to the
+generated `dist/server/wrangler.json`; do not enable Workers Cache on the
+default entrypoint in your source config.
+
+Version metadata is still required for staged warmup:
 
 ```jsonc
 {
-  "cache": {
-    "enabled": true,
-  },
   "version_metadata": {
     "binding": "CF_VERSION_METADATA",
   },
@@ -67,9 +70,9 @@ makes one final fill request per admitted identity. Add `--warm-cdn-certify`
 only when you want an opt-in second, header-only request that must prove every
 planned entry reusable before promotion.
 
-Do not configure a Cache Rule that ignores or normalizes query strings for
-these responses. The two-stage cacheability manifest authorizes the full
-pathname + query identity, but an edge HIT happens before Worker admission.
+The response entrypoint hashes the complete transport identity into its
+Workers Cache URL, independently of zone Cache Rules, so distinct query and
+representation variants cannot collide.
 
 ## Deploy
 

--- a/packages/cloudflare/src/cache/cdn-adapter-config.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter-config.ts
@@ -1,0 +1,88 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const RESPONSE_STAGE_EXPORT = "VinextCachedResponse";
+const CTX_EXPORTS_DEFAULT_DATE = "2025-11-17";
+
+type WranglerWorkerExport = {
+  cache?: { enabled: boolean };
+  type?: string;
+  [key: string]: unknown;
+};
+
+type WranglerOutputConfig = {
+  compatibility_date?: string;
+  compatibility_flags?: string[];
+  exports?: Record<string, WranglerWorkerExport>;
+  [key: string]: unknown;
+};
+
+/** Add the per-entrypoint Workers Cache policy to an emitted Wrangler config. */
+export function configureWorkersCacheEntrypoints(
+  config: WranglerOutputConfig,
+): WranglerOutputConfig {
+  const configuredExports = config.exports ?? {};
+  const compatibilityFlags = config.compatibility_flags ?? [];
+  if (compatibilityFlags.includes("disable_ctx_exports")) {
+    throw new Error(
+      "[vinext] cdnAdapter() requires ctx.exports, but the generated Wrangler config explicitly disables it with disable_ctx_exports.",
+    );
+  }
+
+  // Workerd rejects enable_ctx_exports once the feature is already enabled by
+  // the compatibility date. Add it only for older output configs, and remove
+  // a now-redundant flag when an app has advanced its date.
+  const requiresCtxExportsFlag =
+    config.compatibility_date === undefined || config.compatibility_date < CTX_EXPORTS_DEFAULT_DATE;
+  const configuredCompatibilityFlags = requiresCtxExportsFlag
+    ? compatibilityFlags.includes("enable_ctx_exports")
+      ? compatibilityFlags
+      : [...compatibilityFlags, "enable_ctx_exports"]
+    : compatibilityFlags.filter((flag) => flag !== "enable_ctx_exports");
+  for (const name of ["default", RESPONSE_STAGE_EXPORT]) {
+    const existing = configuredExports[name];
+    if (existing?.type !== undefined && existing.type !== "worker") {
+      throw new Error(
+        `[vinext] cdnAdapter() cannot configure the reserved Worker export ${JSON.stringify(name)} because it is already declared as ${JSON.stringify(existing.type)}.`,
+      );
+    }
+  }
+
+  return {
+    ...config,
+    compatibility_flags: configuredCompatibilityFlags,
+    exports: {
+      ...configuredExports,
+      default: {
+        ...configuredExports.default,
+        type: "worker",
+        cache: { enabled: false },
+      },
+      [RESPONSE_STAGE_EXPORT]: {
+        ...configuredExports[RESPONSE_STAGE_EXPORT],
+        type: "worker",
+        cache: { enabled: true },
+      },
+    },
+  };
+}
+
+/** Finalize the Cloudflare Vite plugin's generated deployment config. */
+export async function finalizeWorkersCacheBuildOutput({
+  outDir,
+}: {
+  outDir: string;
+  root: string;
+}): Promise<void> {
+  const configPath = path.join(outDir, "wrangler.json");
+  let source: string;
+  try {
+    source = await fs.readFile(configPath, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw error;
+  }
+
+  const configured = configureWorkersCacheEntrypoints(JSON.parse(source) as WranglerOutputConfig);
+  await fs.writeFile(configPath, `${JSON.stringify(configured)}\n`);
+}

--- a/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
@@ -11,14 +11,14 @@
  *   traffic and revalidates in the background (the `UPDATING` cache status).
  * - `set` is a no-op: the platform caches the *response* based on its
  *   cache headers, so there is nothing to persist at the origin.
- * - `buildResponseHeaders` emits the SWR policy as `CDN-Cache-Control`
+ * - `buildResponseHeaders` emits the SWR policy as `Cloudflare-CDN-Cache-Control`
  *   (`public, max-age=…, stale-while-revalidate=…`) so the edge caches and
  *   revalidates, while the browser-facing `Cache-Control` is
  *   `public, max-age=0, must-revalidate` so a browser never serves a stored copy
  *   without revalidating against the edge. A `Cache-Tag` header lets entries be
  *   purged by tag. Note the edge directive uses `max-age` (not `s-maxage`):
  *   the framework computes the policy with `s-maxage` for shared caches, but
- *   `CDN-Cache-Control` is already CDN-scoped so `max-age` is the correct knob
+ *   `Cloudflare-CDN-Cache-Control` is already CDN-scoped so `max-age` is the correct knob
  *   for the edge to honor max-age + stale-while-revalidate.
  * - `revalidateTag` purges the edge via the request context's `cache.purge({ tags })`.
  *
@@ -142,7 +142,7 @@ const UNBOUNDED_SWR_SECONDS = 31_536_000; // 1 year
 /**
  * Convert the framework's shared-cache policy into a CDN-scoped one:
  * `s-maxage=…` → `max-age=…` (the edge honors `max-age` inside
- * `CDN-Cache-Control`), give a value-less `stale-while-revalidate` an explicit
+ * `Cloudflare-CDN-Cache-Control`), give a value-less `stale-while-revalidate` an explicit
  * seconds value (Cloudflare ignores the bare directive), and ensure a leading
  * `public`.
  */
@@ -267,13 +267,16 @@ export class CloudflareCdnCacheAdapter implements CdnCacheAdapter {
       return clearCloudflareCdnResponseHeaders(input.cacheControl);
     }
 
-    // SWR policy on CDN-Cache-Control (edge caches + revalidates); the browser
-    // is told to revalidate every reuse so it never serves a stale stored copy.
+    // Use Cloudflare's consumed edge-only header rather than CDN-Cache-Control.
+    // The latter is forwarded to downstream CDNs, where the private inner
+    // cache key and request-stage personalization are no longer available.
+    // The browser is told to revalidate every reuse so it never serves a stale
+    // stored copy.
     const headers: CdnResponseHeaders = {
       ...getBuildIdentityResponseHeader(),
       "Cache-Control": BROWSER_REVALIDATE,
-      "CDN-Cache-Control": toEdgeCacheControl(input.cacheControl),
-      "Cloudflare-CDN-Cache-Control": null,
+      "CDN-Cache-Control": null,
+      "Cloudflare-CDN-Cache-Control": toEdgeCacheControl(input.cacheControl),
       "Cache-Tag": input.tags ? formatCacheTag(input.tags) : null,
     };
 

--- a/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
@@ -42,7 +42,7 @@ import {
 } from "vinext/shims/cdn-cache";
 import type { CacheHandlerValue, IncrementalCacheValue } from "vinext/shims/cache";
 import { getRequestExecutionContext } from "vinext/shims/request-context";
-import { VINEXT_CDN_BUILD_ID_HEADER } from "./cdn-build-id.js";
+import { getVinextCdnBuildIdentity, VINEXT_CDN_BUILD_ID_HEADER } from "./cdn-build-id.js";
 import { VINEXT_EXPECTED_WORKER_VERSION_HEADER } from "../version-headers.js";
 
 const DEFAULT_VERSION_METADATA_BINDING = "CF_VERSION_METADATA";
@@ -72,7 +72,7 @@ const CACHEABLE_EDGE_DIRECTIVE_RE = /(?:^|,)\s*(?:s-maxage|max-age)\s*=/i;
 const EDGE_POLICY_HEADERS = ["CDN-Cache-Control", "Cloudflare-CDN-Cache-Control"] as const;
 
 function getBuildIdentityResponseHeader(): CdnResponseHeaders {
-  const buildId = process.env.__VINEXT_RSC_BUILD_IDENTITY ?? process.env.__VINEXT_BUILD_ID;
+  const buildId = getVinextCdnBuildIdentity();
   return buildId ? { [VINEXT_CDN_BUILD_ID_HEADER]: buildId } : {};
 }
 

--- a/packages/cloudflare/src/cache/cdn-adapter.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.ts
@@ -73,6 +73,7 @@ export function cdnAdapter(options?: CdnAdapterOptions) {
     capabilities: {
       buildIdentity: "response-header" as const,
       responsePolicyHeaderNames: ["CDN-Cache-Control", "Cloudflare-CDN-Cache-Control"] as const,
+      requestRouting: "uncached-stage" as const,
       responseVary: "verbatim" as const,
       routeCacheability: "probe-manifest" as const,
     },

--- a/packages/cloudflare/src/cache/cdn-adapter.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.ts
@@ -65,10 +65,7 @@ export function cdnAdapter(options?: CdnAdapterOptions) {
         if (cleanId !== CLOUDFLARE_WORKER_ENTRY_ID) {
           return null;
         }
-        // The deploy pipeline replaces this tiny external asset after probing.
-        // Keep it directly reachable from Worker main without importing the
-        // response stage or application graph on a cache HIT.
-        return `${code}\nimport "virtual:vinext-cacheability-manifest";\nexport { VinextCachedResponse } from ${JSON.stringify(workerEntry)};\n`;
+        return `${code}\nexport { VinextCachedResponse } from ${JSON.stringify(workerEntry)};\n`;
       },
       finalizeBuildOutput: finalizeWorkersCacheBuildOutput,
       type: "multi-stage" as const,

--- a/packages/cloudflare/src/cache/cdn-adapter.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.ts
@@ -1,6 +1,9 @@
 import { fileURLToPath } from "node:url";
+import { finalizeWorkersCacheBuildOutput } from "./cdn-adapter-config.js";
 
 export const DEFAULT_CDN_VERSION_METADATA_BINDING = "CF_VERSION_METADATA";
+
+const CLOUDFLARE_WORKER_ENTRY_ID = "virtual:cloudflare/worker-entry";
 
 /** Options accepted by {@link cdnAdapter}, forwarded to the runtime factory. */
 export type CdnAdapterOptions = {
@@ -13,16 +16,16 @@ export type CdnAdapterOptions = {
  * Cloudflare Workers Cache.
  *
  * Unlike the data adapter (which stores cache entries in a durable store and
- * serves HIT/STALE itself), this adapter delegates serving to Cloudflare's
- * edge cache.
+ * serves HIT/STALE itself), this adapter delegates serving to Workers Cache on
+ * a named Worker entrypoint. The default entrypoint always runs middleware and
+ * request-time routing before dispatching the cacheable response stage.
  *
- * Workers Cache must be enabled in your Wrangler config for this to work.
+ * The emitted Wrangler configuration enables Workers Cache only for that
+ * response-stage export, so cache hits do not start the application stage.
+ * Version metadata is still required for cache warming:
  * ```jsonc
  * // wrangler.jsonc
  * {
- *   "cache": {
- *     "enabled": true,
- *   },
  *   "version_metadata": {
  *     "binding": "CF_VERSION_METADATA"
  *   }
@@ -45,9 +48,28 @@ export function cdnAdapter(options?: CdnAdapterOptions) {
       "[vinext] cdnAdapter({ versionMetadataBinding }) must be a non-empty string binding name.",
     );
   }
+  const workerEntry = fileURLToPath(import.meta.resolve("./cdn-adapter.worker.js"));
   return {
     adapter: fileURLToPath(import.meta.resolve("./cdn-adapter.runtime.js")),
     options,
+    output: {
+      entry: workerEntry,
+      matchesBuild({ plugins }: { plugins: readonly { name?: string }[] }) {
+        return plugins.some(
+          ({ name }) =>
+            name === "vite-plugin-cloudflare" || name?.startsWith("vite-plugin-cloudflare:"),
+        );
+      },
+      transformHostEntry({ code, id }: { code: string; id: string }) {
+        const cleanId = id.charCodeAt(0) === 0 ? id.slice(1) : id;
+        if (cleanId !== CLOUDFLARE_WORKER_ENTRY_ID) {
+          return null;
+        }
+        return `${code}\nexport { VinextCachedResponse } from ${JSON.stringify(workerEntry)};\n`;
+      },
+      finalizeBuildOutput: finalizeWorkersCacheBuildOutput,
+      type: "multi-stage" as const,
+    },
     capabilities: {
       buildIdentity: "response-header" as const,
       responsePolicyHeaderNames: ["CDN-Cache-Control", "Cloudflare-CDN-Cache-Control"] as const,

--- a/packages/cloudflare/src/cache/cdn-adapter.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.ts
@@ -34,9 +34,9 @@ export type CdnAdapterOptions = {
  * Wrangler does not inherit `version_metadata` into named environments. Repeat
  * the binding in every `env.<name>` used for CDN warmup.
  *
- * Cache Rules must preserve the full query string in the incoming cache key.
- * Two-stage admission certifies exact pathname + search identities, while an
- * edge HIT is served before the Worker can reject a differently keyed request.
+ * The adapter adds a transport-only URL digest so distinct response-stage
+ * identities cannot collide. Workers Cache owns this key independently of
+ * zone Cache Rules.
  */
 export function cdnAdapter(options?: CdnAdapterOptions) {
   if (

--- a/packages/cloudflare/src/cache/cdn-adapter.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.ts
@@ -65,7 +65,10 @@ export function cdnAdapter(options?: CdnAdapterOptions) {
         if (cleanId !== CLOUDFLARE_WORKER_ENTRY_ID) {
           return null;
         }
-        return `${code}\nexport { VinextCachedResponse } from ${JSON.stringify(workerEntry)};\n`;
+        // The deploy pipeline replaces this tiny external asset after probing.
+        // Keep it directly reachable from Worker main without importing the
+        // response stage or application graph on a cache HIT.
+        return `${code}\nimport "virtual:vinext-cacheability-manifest";\nexport { VinextCachedResponse } from ${JSON.stringify(workerEntry)};\n`;
       },
       finalizeBuildOutput: finalizeWorkersCacheBuildOutput,
       type: "multi-stage" as const,

--- a/packages/cloudflare/src/cache/cdn-adapter.worker.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.worker.ts
@@ -47,6 +47,13 @@ const RESPONSE_STAGE_EXPORT = "VinextCachedResponse";
 const AUTHORIZATION_TRANSPORT_HEADER = "x-vinext-internal-authorization";
 const REQUEST_CF_TRANSPORT_HEADER = "x-vinext-internal-request-cf";
 const CLOUDFLARE_EDGE_POLICY_HEADER = "Cloudflare-CDN-Cache-Control";
+const RESPONSE_STAGE_WIRE_CACHE = {
+  bypass: "vinext-cloudflare-v1:bypass",
+  shared: "vinext-cloudflare-v1:shared",
+} as const;
+
+type ResponseStageWireCache =
+  (typeof RESPONSE_STAGE_WIRE_CACHE)[keyof typeof RESPONSE_STAGE_WIRE_CACHE];
 
 function isResponseStageReadinessRequest(request: Request): boolean {
   return (
@@ -365,8 +372,30 @@ function getResponseStageInvocation(value: unknown): CloudflareResponseStageInvo
   }
   const options = Reflect.get(value, "options");
   if (!options || typeof options !== "object") return null;
-  const cache = Reflect.get(options, "cache");
-  if (cache !== "shared" && cache !== "bypass") return null;
+  const wireCache = Reflect.get(options, "cache");
+  let cache: VinextResponseStageDispatchOptions["cache"];
+  if (
+    expectedResponseStageBuildIdentity !== undefined &&
+    wireCache === RESPONSE_STAGE_WIRE_CACHE.shared
+  ) {
+    cache = "shared";
+  } else if (
+    expectedResponseStageBuildIdentity !== undefined &&
+    wireCache === RESPONSE_STAGE_WIRE_CACHE.bypass
+  ) {
+    cache = "bypass";
+  } else if (
+    expectedResponseStageBuildIdentity === undefined &&
+    getVinextCdnBuildIdentity() === null &&
+    (wireCache === "shared" || wireCache === "bypass")
+  ) {
+    // Preserve direct source consumers and unit tests. Every built stage must
+    // use the versioned discriminator so either side of a rolling deployment
+    // rejects a pre-protocol peer before render or cache admission.
+    cache = wireCache;
+  } else {
+    return null;
+  }
   const requestUrl = Reflect.get(value, "requestUrl");
   if (typeof requestUrl !== "string") return null;
   const requestMethod = Reflect.get(value, "requestMethod");
@@ -380,7 +409,7 @@ function getResponseStageInvocation(value: unknown): CloudflareResponseStageInvo
     ...(typeof expectedResponseStageBuildIdentity === "string"
       ? { expectedResponseStageBuildIdentity }
       : {}),
-    options: options as VinextResponseStageDispatchOptions,
+    options: { ...options, cache } as VinextResponseStageDispatchOptions,
     props: Reflect.get(value, "props"),
     requestMethod,
     requestUrl,
@@ -422,7 +451,10 @@ export class VinextCachedResponse extends WorkerEntrypoint<unknown, unknown> {
     const invocation = getResponseStageInvocation(context.props);
     if (!invocation) {
       return stampResponseStageBuildIdentity(
-        new Response("Invalid vinext response-stage invocation", { status: 400 }),
+        new Response("Invalid vinext response-stage invocation", {
+          status: 400,
+          headers: { "Cache-Control": "no-store" },
+        }),
       );
     }
     if (
@@ -480,7 +512,16 @@ export default {
       }
       if (!requiresEntrypoint) usedSharedResponseStage = true;
       try {
-        const serializedInvocation = JSON.stringify(invocation);
+        const serializedInvocation = JSON.stringify({
+          ...invocation,
+          options:
+            expectedResponseStageBuildIdentity === null
+              ? options
+              : {
+                  ...options,
+                  cache: RESPONSE_STAGE_WIRE_CACHE[options.cache] satisfies ResponseStageWireCache,
+                },
+        });
         const binding = getResponseStageBinding(stageContext, serializedInvocation);
         if (!binding) {
           return requiresEntrypoint

--- a/packages/cloudflare/src/cache/cdn-adapter.worker.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.worker.ts
@@ -42,6 +42,7 @@ type RestoredResponseStageRequest = {
 const RESPONSE_STAGE_EXPORT = "VinextCachedResponse";
 const AUTHORIZATION_TRANSPORT_HEADER = "x-vinext-internal-authorization";
 const REQUEST_CF_TRANSPORT_HEADER = "x-vinext-internal-request-cf";
+const CLOUDFLARE_EDGE_POLICY_HEADER = "Cloudflare-CDN-Cache-Control";
 
 function withWorkerHostRuntime(
   context: CloudflareStageContext | undefined,
@@ -225,6 +226,23 @@ function preventRequestCfResponseCaching(response: Response): Response {
   });
 }
 
+/**
+ * Cloudflare consumes its private cache policy before returning a cached
+ * entrypoint response. Strip it here as well for uncached/local fallbacks so
+ * the outer gateway never forwards an inner shared-cache policy after adding
+ * request-specific middleware or routing headers.
+ */
+function finalizeGatewayResponse(response: Response): Response {
+  if (!response.headers.has(CLOUDFLARE_EDGE_POLICY_HEADER)) return response;
+  const headers = new Headers(response.headers);
+  headers.delete(CLOUDFLARE_EDGE_POLICY_HEADER);
+  return new Response(response.body, {
+    headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
+}
+
 function withResponseStagePurge(context: CloudflareStageContext): CloudflareStageContext {
   const factory = context.exports?.[RESPONSE_STAGE_EXPORT];
   if (typeof factory !== "function") return context;
@@ -345,6 +363,8 @@ export default {
         : invokeResponseStage(stageRequest, env, stageContext, invocation);
     };
     const { handleRequestStage } = await loadVinextRequestStage<unknown, CloudflareStageContext>();
-    return handleRequestStage(request, env, stageContext, dispatchResponseStage);
+    return finalizeGatewayResponse(
+      await handleRequestStage(request, env, stageContext, dispatchResponseStage),
+    );
   },
 };

--- a/packages/cloudflare/src/cache/cdn-adapter.worker.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.worker.ts
@@ -34,6 +34,7 @@ type CloudflareResponseStageInvocation = {
 type CachePurgeOptions = { tags: string[] };
 
 const RESPONSE_STAGE_EXPORT = "VinextCachedResponse";
+const REQUEST_CF_TRANSPORT_HEADER = "x-vinext-internal-request-cf";
 
 function withWorkerHostRuntime(
   context: CloudflareStageContext | undefined,
@@ -104,12 +105,48 @@ async function createCacheFacingRequest(
   request: Request,
   serializedInvocation: string,
 ): Promise<Request> {
-  const bytes = new TextEncoder().encode(`${request.url}\0${serializedInvocation}`);
+  let serializedRequestCf: string | null = null;
+  const requestCf = Reflect.get(request, "cf");
+  if (requestCf !== undefined) {
+    try {
+      const json = JSON.stringify(requestCf);
+      if (json !== undefined) serializedRequestCf = encodeURIComponent(json);
+    } catch {
+      // A non-serializable platform extension cannot safely cross the stage.
+    }
+  }
+  const bytes = new TextEncoder().encode(
+    `${request.url}\0${serializedInvocation}\0${serializedRequestCf ?? ""}`,
+  );
   const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", bytes));
   const key = [...digest].map((byte) => byte.toString(16).padStart(2, "0")).join("");
   const url = new URL(request.url);
   url.searchParams.set("__vinext_cache_key", key);
-  return new Request(url, request);
+  const headers = new Headers(request.headers);
+  headers.delete(REQUEST_CF_TRANSPORT_HEADER);
+  if (serializedRequestCf !== null) {
+    headers.set(REQUEST_CF_TRANSPORT_HEADER, serializedRequestCf);
+  }
+  return new Request(new Request(url, request), { headers });
+}
+
+function restoreResponseStageRequest(request: Request, requestUrl: string): Request {
+  const headers = new Headers(request.headers);
+  const serializedRequestCf = headers.get(REQUEST_CF_TRANSPORT_HEADER);
+  headers.delete(REQUEST_CF_TRANSPORT_HEADER);
+  const restored = new Request(new Request(requestUrl, request), { headers });
+  if (serializedRequestCf !== null) {
+    try {
+      Object.defineProperty(restored, "cf", {
+        configurable: true,
+        enumerable: true,
+        value: JSON.parse(decodeURIComponent(serializedRequestCf)),
+      });
+    } catch {
+      // Malformed internal metadata is stripped rather than exposed to userland.
+    }
+  }
+  return restored;
 }
 
 function withResponseStagePurge(context: CloudflareStageContext): CloudflareStageContext {
@@ -184,7 +221,7 @@ export class VinextCachedResponse extends WorkerEntrypoint<unknown, unknown> {
       return new Response("Invalid vinext response-stage invocation", { status: 400 });
     }
     return invokeResponseStage(
-      new Request(invocation.requestUrl, request),
+      restoreResponseStageRequest(request, invocation.requestUrl),
       this.env,
       context,
       invocation,

--- a/packages/cloudflare/src/cache/cdn-adapter.worker.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.worker.ts
@@ -9,6 +9,7 @@ import type {
 import { loadVinextRequestStage } from "vinext/server/request-stage";
 import { loadVinextResponseStage } from "vinext/server/response-stage";
 import { isNonCacheableCacheControl } from "vinext/shims/cdn-cache";
+import { getVinextCdnBuildIdentity, VINEXT_CDN_BUILD_ID_HEADER } from "./cdn-build-id.js";
 
 type StageBinding = {
   fetch(request: Request): Promise<Response> | Response;
@@ -58,6 +59,41 @@ function responseStageUnavailable(): Response {
     status: 503,
     headers: { "Cache-Control": "no-store" },
   });
+}
+
+/** Stamp the entrypoint that actually produced a response, before Workers Cache stores it. */
+function stampResponseStageBuildIdentity(response: Response): Response {
+  const buildIdentity = getVinextCdnBuildIdentity();
+  // Direct source consumers and unit tests do not pass through vinext's build
+  // defines. Production multi-stage output always has this opaque identity.
+  if (!buildIdentity) return response;
+  try {
+    response.headers.set(VINEXT_CDN_BUILD_ID_HEADER, buildIdentity);
+    return response;
+  } catch {
+    const headers = new Headers(response.headers);
+    headers.set(VINEXT_CDN_BUILD_ID_HEADER, buildIdentity);
+    return new Response(response.body, {
+      headers,
+      status: response.status,
+      statusText: response.statusText,
+    });
+  }
+}
+
+/** Reject a response routed to an entrypoint from another propagating build. */
+function validateResponseStageBuildIdentity(response: Response): Response {
+  const expectedBuildIdentity = getVinextCdnBuildIdentity();
+  if (
+    !expectedBuildIdentity ||
+    response.headers.get(VINEXT_CDN_BUILD_ID_HEADER) === expectedBuildIdentity
+  ) {
+    return response;
+  }
+  // The stale response must not continue producing bytes after the gateway has
+  // replaced it. Cancellation is best-effort and must not delay the 503.
+  void response.body?.cancel().catch(() => {});
+  return responseStageUnavailable();
 }
 
 function stripUntrustedTransportHeaders(request: Request): Request {
@@ -171,8 +207,9 @@ async function createCacheFacingRequest(
   // https://developers.cloudflare.com/workers/cache/#what-gets-cached
   const authorizationIdentity =
     authorization === null ? "absent" : `present:${authorization.length}:${authorization}`;
+  const responseStageBuildIdentity = getVinextCdnBuildIdentity() ?? "";
   const bytes = new TextEncoder().encode(
-    `${request.url}\0${serializedInvocation}\0${authorizationIdentity}`,
+    `${request.url}\0${serializedInvocation}\0${authorizationIdentity}\0${responseStageBuildIdentity}`,
   );
   const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", bytes));
   const key = [...digest].map((byte) => byte.toString(16).padStart(2, "0")).join("");
@@ -370,7 +407,9 @@ export class VinextCachedResponse extends WorkerEntrypoint<unknown, unknown> {
     const context = withWorkerHostRuntime(this.ctx, this.env);
     const invocation = getResponseStageInvocation(context.props);
     if (!invocation) {
-      return new Response("Invalid vinext response-stage invocation", { status: 400 });
+      return stampResponseStageBuildIdentity(
+        new Response("Invalid vinext response-stage invocation", { status: 400 }),
+      );
     }
     const restored = restoreResponseStageRequest(
       request,
@@ -378,7 +417,9 @@ export class VinextCachedResponse extends WorkerEntrypoint<unknown, unknown> {
       invocation.requestMethod,
     );
     const response = await invokeResponseStage(restored.request, this.env, context, invocation);
-    return restored.didAccessRequestCf() ? preventRequestCfResponseCaching(response) : response;
+    return stampResponseStageBuildIdentity(
+      restored.didAccessRequestCf() ? preventRequestCfResponseCaching(response) : response,
+    );
   }
 
   async purge(options: CachePurgeOptions): Promise<unknown> {
@@ -425,7 +466,7 @@ export default {
         const entrypointRequest = requiresEntrypoint
           ? stageRequest
           : await createCacheFacingRequest(stageRequest, serializedInvocation);
-        return await binding.fetch(entrypointRequest);
+        return validateResponseStageBuildIdentity(await binding.fetch(entrypointRequest));
       } catch (error) {
         if (requiresEntrypoint) return responseStageUnavailable();
         throw error;

--- a/packages/cloudflare/src/cache/cdn-adapter.worker.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.worker.ts
@@ -115,9 +115,10 @@ async function createCacheFacingRequest(
       // A non-serializable platform extension cannot safely cross the stage.
     }
   }
-  const bytes = new TextEncoder().encode(
-    `${request.url}\0${serializedInvocation}\0${serializedRequestCf ?? ""}`,
-  );
+  // Incoming `request.cf` describes the caller/connection, not the public
+  // representation. Keep it available to a cold response-stage render without
+  // fragmenting warmed cache entries by colo, geography, TCP RTT, or bot data.
+  const bytes = new TextEncoder().encode(`${request.url}\0${serializedInvocation}`);
   const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", bytes));
   const key = [...digest].map((byte) => byte.toString(16).padStart(2, "0")).join("");
   const url = new URL(request.url);
@@ -127,7 +128,17 @@ async function createCacheFacingRequest(
   if (serializedRequestCf !== null) {
     headers.set(REQUEST_CF_TRANSPORT_HEADER, serializedRequestCf);
   }
-  return new Request(new Request(url, request), { headers });
+  const init = {
+    // Explicitly replace inherited inbound `cf` metadata. In workerd,
+    // Request-from-Request construction otherwise preserves values such as a
+    // caller-supplied cacheKey. The response stage receives the original
+    // platform metadata through the authenticated internal header above.
+    cf: { vary: { default: { action: "passthrough" } } },
+    headers,
+  } satisfies RequestInit & {
+    cf: { vary: { default: { action: "passthrough" } } };
+  };
+  return new Request(new Request(url, request), init);
 }
 
 function restoreResponseStageRequest(request: Request, requestUrl: string): Request {

--- a/packages/cloudflare/src/cache/cdn-adapter.worker.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.worker.ts
@@ -44,6 +44,28 @@ const AUTHORIZATION_TRANSPORT_HEADER = "x-vinext-internal-authorization";
 const REQUEST_CF_TRANSPORT_HEADER = "x-vinext-internal-request-cf";
 const CLOUDFLARE_EDGE_POLICY_HEADER = "Cloudflare-CDN-Cache-Control";
 
+function stripUntrustedTransportHeaders(request: Request): Request {
+  if (
+    !request.headers.has(AUTHORIZATION_TRANSPORT_HEADER) &&
+    !request.headers.has(REQUEST_CF_TRANSPORT_HEADER)
+  ) {
+    return request;
+  }
+  const headers = new Headers(request.headers);
+  headers.delete(AUTHORIZATION_TRANSPORT_HEADER);
+  headers.delete(REQUEST_CF_TRANSPORT_HEADER);
+  const sanitized = new Request(request, { headers });
+  const requestCf = Reflect.get(request, "cf");
+  if (requestCf !== undefined) {
+    Object.defineProperty(sanitized, "cf", {
+      configurable: true,
+      enumerable: true,
+      value: requestCf,
+    });
+  }
+  return sanitized;
+}
+
 function withWorkerHostRuntime(
   context: CloudflareStageContext | undefined,
   env?: unknown,
@@ -341,6 +363,7 @@ export default {
     env: unknown,
     context: CloudflareStageContext | undefined,
   ): Promise<Response> {
+    request = stripUntrustedTransportHeaders(request);
     const stageContext = withResponseStagePurge(withWorkerHostRuntime(context, env));
     const dispatchResponseStage: VinextResponseStageTransport = async (
       stageRequest,

--- a/packages/cloudflare/src/cache/cdn-adapter.worker.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.worker.ts
@@ -1,4 +1,5 @@
 import { WorkerEntrypoint } from "cloudflare:workers";
+import { VINEXT_PRERENDER_READINESS_PATH } from "vinext/internal/server/headers";
 import type {
   VinextAssetFetcher,
   VinextRequestStageTransport,
@@ -44,6 +45,20 @@ const RESPONSE_STAGE_EXPORT = "VinextCachedResponse";
 const AUTHORIZATION_TRANSPORT_HEADER = "x-vinext-internal-authorization";
 const REQUEST_CF_TRANSPORT_HEADER = "x-vinext-internal-request-cf";
 const CLOUDFLARE_EDGE_POLICY_HEADER = "Cloudflare-CDN-Cache-Control";
+
+function isResponseStageReadinessRequest(request: Request): boolean {
+  return (
+    request.url.includes(VINEXT_PRERENDER_READINESS_PATH) &&
+    new URL(request.url).pathname === VINEXT_PRERENDER_READINESS_PATH
+  );
+}
+
+function responseStageUnavailable(): Response {
+  return new Response(null, {
+    status: 503,
+    headers: { "Cache-Control": "no-store" },
+  });
+}
 
 function stripUntrustedTransportHeaders(request: Request): Request {
   if (
@@ -390,15 +405,27 @@ export default {
         requestMethod: stageRequest.method,
         requestUrl: stageRequest.url,
       };
-      if (options.cache === "bypass") {
+      const requiresEntrypoint = isResponseStageReadinessRequest(stageRequest);
+      if (options.cache === "bypass" && !requiresEntrypoint) {
         return invokeResponseStage(stageRequest, env, stageContext, invocation);
       }
-      usedSharedResponseStage = true;
-      const serializedInvocation = JSON.stringify(invocation);
-      const binding = getResponseStageBinding(stageContext, serializedInvocation);
-      return binding
-        ? await binding.fetch(await createCacheFacingRequest(stageRequest, serializedInvocation))
-        : invokeResponseStage(stageRequest, env, stageContext, invocation);
+      if (!requiresEntrypoint) usedSharedResponseStage = true;
+      try {
+        const serializedInvocation = JSON.stringify(invocation);
+        const binding = getResponseStageBinding(stageContext, serializedInvocation);
+        if (!binding) {
+          return requiresEntrypoint
+            ? responseStageUnavailable()
+            : invokeResponseStage(stageRequest, env, stageContext, invocation);
+        }
+        const entrypointRequest = requiresEntrypoint
+          ? stageRequest
+          : await createCacheFacingRequest(stageRequest, serializedInvocation);
+        return await binding.fetch(entrypointRequest);
+      } catch (error) {
+        if (requiresEntrypoint) return responseStageUnavailable();
+        throw error;
+      }
     };
     const { handleRequestStage } = await loadVinextRequestStage<unknown, CloudflareStageContext>();
     return finalizeGatewayResponse(

--- a/packages/cloudflare/src/cache/cdn-adapter.worker.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.worker.ts
@@ -40,6 +40,7 @@ type RestoredResponseStageRequest = {
 };
 
 const RESPONSE_STAGE_EXPORT = "VinextCachedResponse";
+const AUTHORIZATION_TRANSPORT_HEADER = "x-vinext-internal-authorization";
 const REQUEST_CF_TRANSPORT_HEADER = "x-vinext-internal-request-cf";
 
 function withWorkerHostRuntime(
@@ -111,6 +112,7 @@ async function createCacheFacingRequest(
   request: Request,
   serializedInvocation: string,
 ): Promise<Request> {
+  const authorization = request.headers.get("Authorization");
   let serializedRequestCf: string | null = null;
   const requestCf = Reflect.get(request, "cf");
   if (requestCf !== undefined) {
@@ -124,13 +126,26 @@ async function createCacheFacingRequest(
   // Incoming `request.cf` describes the caller/connection, not the public
   // representation. Keep it available to a cold response-stage render without
   // fragmenting warmed cache entries by colo, geography, TCP RTT, or bot data.
-  const bytes = new TextEncoder().encode(`${request.url}\0${serializedInvocation}`);
+  // Workers Cache automatically bypasses requests carrying Authorization, so
+  // transport that value under a private header and partition the opaque URL
+  // key by its digest instead.
+  // https://developers.cloudflare.com/workers/cache/#what-gets-cached
+  const authorizationIdentity =
+    authorization === null ? "absent" : `present:${authorization.length}:${authorization}`;
+  const bytes = new TextEncoder().encode(
+    `${request.url}\0${serializedInvocation}\0${authorizationIdentity}`,
+  );
   const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", bytes));
   const key = [...digest].map((byte) => byte.toString(16).padStart(2, "0")).join("");
   const url = new URL(request.url);
   url.searchParams.set("__vinext_cache_key", key);
   const headers = new Headers(request.headers);
+  headers.delete("Authorization");
+  headers.delete(AUTHORIZATION_TRANSPORT_HEADER);
   headers.delete(REQUEST_CF_TRANSPORT_HEADER);
+  if (authorization !== null) {
+    headers.set(AUTHORIZATION_TRANSPORT_HEADER, encodeURIComponent(authorization));
+  }
   if (serializedRequestCf !== null) {
     headers.set(REQUEST_CF_TRANSPORT_HEADER, serializedRequestCf);
   }
@@ -153,8 +168,18 @@ function restoreResponseStageRequest(
   requestMethod: string,
 ): RestoredResponseStageRequest {
   const headers = new Headers(request.headers);
+  const serializedAuthorization = headers.get(AUTHORIZATION_TRANSPORT_HEADER);
   const serializedRequestCf = headers.get(REQUEST_CF_TRANSPORT_HEADER);
+  headers.delete("Authorization");
+  headers.delete(AUTHORIZATION_TRANSPORT_HEADER);
   headers.delete(REQUEST_CF_TRANSPORT_HEADER);
+  if (serializedAuthorization !== null) {
+    try {
+      headers.set("Authorization", decodeURIComponent(serializedAuthorization));
+    } catch {
+      // Malformed internal metadata is stripped rather than exposed to userland.
+    }
+  }
   let requestCf: unknown;
   if (serializedRequestCf !== null) {
     try {

--- a/packages/cloudflare/src/cache/cdn-adapter.worker.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.worker.ts
@@ -1,0 +1,227 @@
+import { WorkerEntrypoint } from "cloudflare:workers";
+import type {
+  VinextAssetFetcher,
+  VinextRequestStageTransport,
+  VinextResponseStageDispatchOptions,
+  VinextResponseStageTransport,
+} from "vinext/server/multi-stage";
+import { loadVinextRequestStage } from "vinext/server/request-stage";
+import { loadVinextResponseStage } from "vinext/server/response-stage";
+
+type StageBinding = {
+  fetch(request: Request): Promise<Response> | Response;
+  purge?(options: CachePurgeOptions): unknown;
+};
+
+type StageBindingFactory = (options: { props: unknown }) => StageBinding;
+
+type CloudflareStageContext = {
+  assets?: VinextAssetFetcher;
+  cache?: unknown;
+  exports?: Record<string, unknown>;
+  props?: unknown;
+  hostRuntime?: "worker";
+  passThroughOnException?(): void;
+  waitUntil?(promise: Promise<unknown>): void;
+};
+
+type CloudflareResponseStageInvocation = {
+  options: VinextResponseStageDispatchOptions;
+  props: unknown;
+  requestUrl: string;
+};
+
+type CachePurgeOptions = { tags: string[] };
+
+const RESPONSE_STAGE_EXPORT = "VinextCachedResponse";
+
+function withWorkerHostRuntime(
+  context: CloudflareStageContext | undefined,
+  env?: unknown,
+): CloudflareStageContext {
+  const candidateAssets =
+    env && typeof env === "object" && Reflect.has(env, "ASSETS")
+      ? Reflect.get(env, "ASSETS")
+      : undefined;
+  const assets =
+    candidateAssets &&
+    (typeof candidateAssets === "object" || typeof candidateAssets === "function") &&
+    Reflect.has(candidateAssets, "fetch") &&
+    typeof Reflect.get(candidateAssets, "fetch") === "function"
+      ? (candidateAssets as VinextAssetFetcher)
+      : context?.assets;
+
+  return {
+    ...(assets === undefined ? {} : { assets }),
+    ...(context?.cache === undefined ? {} : { cache: context.cache }),
+    ...(context?.exports === undefined ? {} : { exports: context.exports }),
+    hostRuntime: "worker",
+    ...(typeof context?.passThroughOnException === "function"
+      ? { passThroughOnException: () => context.passThroughOnException?.() }
+      : {}),
+    ...(context?.props === undefined ? {} : { props: context.props }),
+    ...(typeof context?.waitUntil === "function"
+      ? { waitUntil: (promise: Promise<unknown>) => context.waitUntil?.(promise) }
+      : {}),
+  };
+}
+
+function hasFetch(value: unknown): value is StageBinding {
+  return (
+    value !== null &&
+    (typeof value === "object" || typeof value === "function") &&
+    "fetch" in value &&
+    typeof value.fetch === "function"
+  );
+}
+
+function hasPurge(value: unknown): value is Required<Pick<StageBinding, "purge">> {
+  return (
+    value !== null &&
+    (typeof value === "object" || typeof value === "function") &&
+    "purge" in value &&
+    typeof value.purge === "function"
+  );
+}
+
+function getResponseStageBinding(
+  context: CloudflareStageContext,
+  serializedInvocation: string,
+): StageBinding | null {
+  const binding = context.exports?.[RESPONSE_STAGE_EXPORT];
+  if (typeof binding !== "function") return null;
+
+  // Configurable-entrypoint props cross a Workers RPC boundary. Some vinext
+  // route metadata objects intentionally use null prototypes, which are valid
+  // in-process but are not supported by Workers RPC serialization. Normalize
+  // the transport contract to plain JSON data at the adapter boundary.
+  const props = JSON.parse(serializedInvocation) as CloudflareResponseStageInvocation;
+  const target = (binding as StageBindingFactory)({ props });
+  return hasFetch(target) ? target : null;
+}
+
+async function createCacheFacingRequest(
+  request: Request,
+  serializedInvocation: string,
+): Promise<Request> {
+  const bytes = new TextEncoder().encode(`${request.url}\0${serializedInvocation}`);
+  const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", bytes));
+  const key = [...digest].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+  const url = new URL(request.url);
+  url.searchParams.set("__vinext_cache_key", key);
+  return new Request(url, request);
+}
+
+function withResponseStagePurge(context: CloudflareStageContext): CloudflareStageContext {
+  const factory = context.exports?.[RESPONSE_STAGE_EXPORT];
+  if (typeof factory !== "function") return context;
+  const fallback = context.cache;
+  return {
+    ...context,
+    cache: {
+      purge(options: CachePurgeOptions) {
+        const target = (factory as StageBindingFactory)({ props: {} });
+        if (hasPurge(target)) return target.purge(options);
+        return hasPurge(fallback) ? fallback.purge(options) : undefined;
+      },
+    },
+  };
+}
+
+function getResponseStageInvocation(value: unknown): CloudflareResponseStageInvocation | null {
+  if (!value || typeof value !== "object") return null;
+  const options = Reflect.get(value, "options");
+  if (!options || typeof options !== "object") return null;
+  const cache = Reflect.get(options, "cache");
+  if (cache !== "shared" && cache !== "bypass") return null;
+  const requestUrl = Reflect.get(value, "requestUrl");
+  if (typeof requestUrl !== "string") return null;
+  try {
+    new URL(requestUrl);
+  } catch {
+    return null;
+  }
+  return {
+    options: options as VinextResponseStageDispatchOptions,
+    props: Reflect.get(value, "props"),
+    requestUrl,
+  };
+}
+
+async function invokeResponseStage(
+  request: Request,
+  env: unknown,
+  context: CloudflareStageContext,
+  invocation: CloudflareResponseStageInvocation,
+): Promise<Response> {
+  const dispatchResponseStage: VinextResponseStageTransport = (stageRequest, props, options) =>
+    invokeResponseStage(stageRequest, env, context, {
+      options,
+      props,
+      requestUrl: stageRequest.url,
+    });
+  const dispatchRequestStage: VinextRequestStageTransport = async (stageRequest) => {
+    const { handleRequestStage } = await loadVinextRequestStage<unknown, CloudflareStageContext>();
+    return handleRequestStage(stageRequest, env, context, dispatchResponseStage);
+  };
+  const { handleResponseStage } = await loadVinextResponseStage<unknown, CloudflareStageContext>();
+  return handleResponseStage(
+    request,
+    env,
+    context,
+    invocation.props,
+    dispatchRequestStage,
+    invocation.options,
+  );
+}
+
+/** Cache-bearing entrypoint. Workers Cache HITs bypass this class entirely. */
+export class VinextCachedResponse extends WorkerEntrypoint<unknown, unknown> {
+  async fetch(request: Request): Promise<Response> {
+    const context = withWorkerHostRuntime(this.ctx, this.env);
+    const invocation = getResponseStageInvocation(context.props);
+    if (!invocation) {
+      return new Response("Invalid vinext response-stage invocation", { status: 400 });
+    }
+    return invokeResponseStage(
+      new Request(invocation.requestUrl, request),
+      this.env,
+      context,
+      invocation,
+    );
+  }
+
+  async purge(options: CachePurgeOptions): Promise<unknown> {
+    const cache = Reflect.get(this.ctx, "cache");
+    if (!hasPurge(cache)) return undefined;
+    return cache.purge(options);
+  }
+}
+
+/** Uncached gateway: request routing and middleware always execute here. */
+export default {
+  async fetch(
+    request: Request,
+    env: unknown,
+    context: CloudflareStageContext | undefined,
+  ): Promise<Response> {
+    const stageContext = withResponseStagePurge(withWorkerHostRuntime(context, env));
+    const dispatchResponseStage: VinextResponseStageTransport = async (
+      stageRequest,
+      props,
+      options,
+    ) => {
+      const invocation = { options, props, requestUrl: stageRequest.url };
+      if (options.cache === "bypass") {
+        return invokeResponseStage(stageRequest, env, stageContext, invocation);
+      }
+      const serializedInvocation = JSON.stringify(invocation);
+      const binding = getResponseStageBinding(stageContext, serializedInvocation);
+      return binding
+        ? await binding.fetch(await createCacheFacingRequest(stageRequest, serializedInvocation))
+        : invokeResponseStage(stageRequest, env, stageContext, invocation);
+    };
+    const { handleRequestStage } = await loadVinextRequestStage<unknown, CloudflareStageContext>();
+    return handleRequestStage(request, env, stageContext, dispatchResponseStage);
+  },
+};

--- a/packages/cloudflare/src/cache/cdn-adapter.worker.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.worker.ts
@@ -29,6 +29,7 @@ type CloudflareStageContext = {
 };
 
 type CloudflareResponseStageInvocation = {
+  expectedResponseStageBuildIdentity?: string;
   options: VinextResponseStageDispatchOptions;
   props: unknown;
   requestMethod: string;
@@ -352,6 +353,16 @@ function withResponseStagePurge(context: CloudflareStageContext): CloudflareStag
 
 function getResponseStageInvocation(value: unknown): CloudflareResponseStageInvocation | null {
   if (!value || typeof value !== "object") return null;
+  const expectedResponseStageBuildIdentity = Reflect.get(
+    value,
+    "expectedResponseStageBuildIdentity",
+  );
+  if (
+    expectedResponseStageBuildIdentity !== undefined &&
+    typeof expectedResponseStageBuildIdentity !== "string"
+  ) {
+    return null;
+  }
   const options = Reflect.get(value, "options");
   if (!options || typeof options !== "object") return null;
   const cache = Reflect.get(options, "cache");
@@ -366,6 +377,9 @@ function getResponseStageInvocation(value: unknown): CloudflareResponseStageInvo
     return null;
   }
   return {
+    ...(typeof expectedResponseStageBuildIdentity === "string"
+      ? { expectedResponseStageBuildIdentity }
+      : {}),
     options: options as VinextResponseStageDispatchOptions,
     props: Reflect.get(value, "props"),
     requestMethod,
@@ -411,6 +425,12 @@ export class VinextCachedResponse extends WorkerEntrypoint<unknown, unknown> {
         new Response("Invalid vinext response-stage invocation", { status: 400 }),
       );
     }
+    if (
+      invocation.expectedResponseStageBuildIdentity !== undefined &&
+      invocation.expectedResponseStageBuildIdentity !== getVinextCdnBuildIdentity()
+    ) {
+      return stampResponseStageBuildIdentity(responseStageUnavailable());
+    }
     const restored = restoreResponseStageRequest(
       request,
       invocation.requestUrl,
@@ -444,7 +464,11 @@ export default {
       props,
       options,
     ) => {
+      const expectedResponseStageBuildIdentity = getVinextCdnBuildIdentity();
       const invocation = {
+        ...(expectedResponseStageBuildIdentity === null
+          ? {}
+          : { expectedResponseStageBuildIdentity }),
         options,
         props,
         requestMethod: stageRequest.method,

--- a/packages/cloudflare/src/cache/cdn-adapter.worker.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.worker.ts
@@ -28,6 +28,7 @@ type CloudflareStageContext = {
 type CloudflareResponseStageInvocation = {
   options: VinextResponseStageDispatchOptions;
   props: unknown;
+  requestMethod: string;
   requestUrl: string;
 };
 
@@ -141,21 +142,37 @@ async function createCacheFacingRequest(
   return new Request(new Request(url, request), init);
 }
 
-function restoreResponseStageRequest(request: Request, requestUrl: string): Request {
+function restoreResponseStageRequest(
+  request: Request,
+  requestUrl: string,
+  requestMethod: string,
+): Request {
   const headers = new Headers(request.headers);
   const serializedRequestCf = headers.get(REQUEST_CF_TRANSPORT_HEADER);
   headers.delete(REQUEST_CF_TRANSPORT_HEADER);
-  const restored = new Request(new Request(requestUrl, request), { headers });
+  let requestCf: unknown;
   if (serializedRequestCf !== null) {
     try {
-      Object.defineProperty(restored, "cf", {
-        configurable: true,
-        enumerable: true,
-        value: JSON.parse(decodeURIComponent(serializedRequestCf)),
-      });
+      requestCf = JSON.parse(decodeURIComponent(serializedRequestCf));
     } catch {
       // Malformed internal metadata is stripped rather than exposed to userland.
     }
+  }
+  const init = {
+    headers,
+    method: requestMethod,
+    ...(requestCf === undefined ? {} : { cf: requestCf }),
+  } satisfies RequestInit & { cf?: unknown };
+  const restored = new Request(new Request(requestUrl, request), init);
+  // Node's Request ignores the Workers-only RequestInit.cf member. Preserve a
+  // shadow there for tests and non-Workers hosts; workerd already exposes the
+  // value installed through RequestInit.cf.
+  if (requestCf !== undefined && Reflect.get(restored, "cf") === undefined) {
+    Object.defineProperty(restored, "cf", {
+      configurable: true,
+      enumerable: true,
+      value: requestCf,
+    });
   }
   return restored;
 }
@@ -184,6 +201,8 @@ function getResponseStageInvocation(value: unknown): CloudflareResponseStageInvo
   if (cache !== "shared" && cache !== "bypass") return null;
   const requestUrl = Reflect.get(value, "requestUrl");
   if (typeof requestUrl !== "string") return null;
+  const requestMethod = Reflect.get(value, "requestMethod");
+  if (typeof requestMethod !== "string" || requestMethod.length === 0) return null;
   try {
     new URL(requestUrl);
   } catch {
@@ -192,6 +211,7 @@ function getResponseStageInvocation(value: unknown): CloudflareResponseStageInvo
   return {
     options: options as VinextResponseStageDispatchOptions,
     props: Reflect.get(value, "props"),
+    requestMethod,
     requestUrl,
   };
 }
@@ -206,6 +226,7 @@ async function invokeResponseStage(
     invokeResponseStage(stageRequest, env, context, {
       options,
       props,
+      requestMethod: stageRequest.method,
       requestUrl: stageRequest.url,
     });
   const dispatchRequestStage: VinextRequestStageTransport = async (stageRequest) => {
@@ -232,7 +253,7 @@ export class VinextCachedResponse extends WorkerEntrypoint<unknown, unknown> {
       return new Response("Invalid vinext response-stage invocation", { status: 400 });
     }
     return invokeResponseStage(
-      restoreResponseStageRequest(request, invocation.requestUrl),
+      restoreResponseStageRequest(request, invocation.requestUrl, invocation.requestMethod),
       this.env,
       context,
       invocation,
@@ -259,7 +280,12 @@ export default {
       props,
       options,
     ) => {
-      const invocation = { options, props, requestUrl: stageRequest.url };
+      const invocation = {
+        options,
+        props,
+        requestMethod: stageRequest.method,
+        requestUrl: stageRequest.url,
+      };
       if (options.cache === "bypass") {
         return invokeResponseStage(stageRequest, env, stageContext, invocation);
       }

--- a/packages/cloudflare/src/cache/cdn-adapter.worker.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.worker.ts
@@ -7,6 +7,7 @@ import type {
 } from "vinext/server/multi-stage";
 import { loadVinextRequestStage } from "vinext/server/request-stage";
 import { loadVinextResponseStage } from "vinext/server/response-stage";
+import { isNonCacheableCacheControl } from "vinext/shims/cdn-cache";
 
 type StageBinding = {
   fetch(request: Request): Promise<Response> | Response;
@@ -254,10 +255,22 @@ function preventRequestCfResponseCaching(response: Response): Response {
  * the outer gateway never forwards an inner shared-cache policy after adding
  * request-specific middleware or routing headers.
  */
-function finalizeGatewayResponse(response: Response): Response {
-  if (!response.headers.has(CLOUDFLARE_EDGE_POLICY_HEADER)) return response;
+function finalizeGatewayResponse(response: Response, usedSharedResponseStage: boolean): Response {
+  const cacheControl = response.headers.get("Cache-Control");
+  if (
+    !response.headers.has(CLOUDFLARE_EDGE_POLICY_HEADER) &&
+    (!usedSharedResponseStage || (cacheControl && isNonCacheableCacheControl(cacheControl)))
+  ) {
+    return response;
+  }
   const headers = new Headers(response.headers);
   headers.delete(CLOUDFLARE_EDGE_POLICY_HEADER);
+  if (usedSharedResponseStage) {
+    headers.delete("CDN-Cache-Control");
+    if (!cacheControl || !isNonCacheableCacheControl(cacheControl)) {
+      headers.set("Cache-Control", "private, max-age=0, must-revalidate");
+    }
+  }
   return new Response(response.body, {
     headers,
     status: response.status,
@@ -365,6 +378,7 @@ export default {
   ): Promise<Response> {
     request = stripUntrustedTransportHeaders(request);
     const stageContext = withResponseStagePurge(withWorkerHostRuntime(context, env));
+    let usedSharedResponseStage = false;
     const dispatchResponseStage: VinextResponseStageTransport = async (
       stageRequest,
       props,
@@ -379,6 +393,7 @@ export default {
       if (options.cache === "bypass") {
         return invokeResponseStage(stageRequest, env, stageContext, invocation);
       }
+      usedSharedResponseStage = true;
       const serializedInvocation = JSON.stringify(invocation);
       const binding = getResponseStageBinding(stageContext, serializedInvocation);
       return binding
@@ -388,6 +403,7 @@ export default {
     const { handleRequestStage } = await loadVinextRequestStage<unknown, CloudflareStageContext>();
     return finalizeGatewayResponse(
       await handleRequestStage(request, env, stageContext, dispatchResponseStage),
+      usedSharedResponseStage,
     );
   },
 };

--- a/packages/cloudflare/src/cache/cdn-adapter.worker.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.worker.ts
@@ -34,6 +34,11 @@ type CloudflareResponseStageInvocation = {
 
 type CachePurgeOptions = { tags: string[] };
 
+type RestoredResponseStageRequest = {
+  didAccessRequestCf(): boolean;
+  request: Request;
+};
+
 const RESPONSE_STAGE_EXPORT = "VinextCachedResponse";
 const REQUEST_CF_TRANSPORT_HEADER = "x-vinext-internal-request-cf";
 
@@ -146,7 +151,7 @@ function restoreResponseStageRequest(
   request: Request,
   requestUrl: string,
   requestMethod: string,
-): Request {
+): RestoredResponseStageRequest {
   const headers = new Headers(request.headers);
   const serializedRequestCf = headers.get(REQUEST_CF_TRANSPORT_HEADER);
   headers.delete(REQUEST_CF_TRANSPORT_HEADER);
@@ -158,23 +163,41 @@ function restoreResponseStageRequest(
       // Malformed internal metadata is stripped rather than exposed to userland.
     }
   }
-  const init = {
+  const restored = new Request(new Request(requestUrl, request), {
     headers,
     method: requestMethod,
-    ...(requestCf === undefined ? {} : { cf: requestCf }),
-  } satisfies RequestInit & { cf?: unknown };
-  const restored = new Request(new Request(requestUrl, request), init);
-  // Node's Request ignores the Workers-only RequestInit.cf member. Preserve a
-  // shadow there for tests and non-Workers hosts; workerd already exposes the
-  // value installed through RequestInit.cf.
-  if (requestCf !== undefined && Reflect.get(restored, "cf") === undefined) {
+  });
+  let didAccessRequestCf = false;
+  if (requestCf !== undefined) {
+    // Keep provider metadata available to user code without making it part of
+    // the shared cache identity. Core request reconstruction preserves this
+    // accessor lazily, so only an application read flips the admission veto.
     Object.defineProperty(restored, "cf", {
       configurable: true,
       enumerable: true,
-      value: requestCf,
+      get() {
+        didAccessRequestCf = true;
+        return requestCf;
+      },
     });
   }
-  return restored;
+  return {
+    didAccessRequestCf: () => didAccessRequestCf,
+    request: restored,
+  };
+}
+
+function preventRequestCfResponseCaching(response: Response): Response {
+  const headers = new Headers(response.headers);
+  headers.set("Cache-Control", "no-store");
+  headers.delete("CDN-Cache-Control");
+  headers.delete("Cloudflare-CDN-Cache-Control");
+  headers.delete("Cache-Tag");
+  return new Response(response.body, {
+    headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
 }
 
 function withResponseStagePurge(context: CloudflareStageContext): CloudflareStageContext {
@@ -252,12 +275,13 @@ export class VinextCachedResponse extends WorkerEntrypoint<unknown, unknown> {
     if (!invocation) {
       return new Response("Invalid vinext response-stage invocation", { status: 400 });
     }
-    return invokeResponseStage(
-      restoreResponseStageRequest(request, invocation.requestUrl, invocation.requestMethod),
-      this.env,
-      context,
-      invocation,
+    const restored = restoreResponseStageRequest(
+      request,
+      invocation.requestUrl,
+      invocation.requestMethod,
     );
+    const response = await invokeResponseStage(restored.request, this.env, context, invocation);
+    return restored.didAccessRequestCf() ? preventRequestCfResponseCaching(response) : response;
   }
 
   async purge(options: CachePurgeOptions): Promise<unknown> {

--- a/packages/cloudflare/src/cache/cdn-adapter.worker.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.worker.ts
@@ -272,16 +272,20 @@ function preventRequestCfResponseCaching(response: Response): Response {
  */
 function finalizeGatewayResponse(response: Response, usedSharedResponseStage: boolean): Response {
   const cacheControl = response.headers.get("Cache-Control");
-  if (
-    !response.headers.has(CLOUDFLARE_EDGE_POLICY_HEADER) &&
-    (!usedSharedResponseStage || (cacheControl && isNonCacheableCacheControl(cacheControl)))
-  ) {
+  const hasSharedResponseMetadata =
+    usedSharedResponseStage &&
+    (response.headers.has("CDN-Cache-Control") ||
+      response.headers.has("Cache-Tag") ||
+      !cacheControl ||
+      !isNonCacheableCacheControl(cacheControl));
+  if (!response.headers.has(CLOUDFLARE_EDGE_POLICY_HEADER) && !hasSharedResponseMetadata) {
     return response;
   }
   const headers = new Headers(response.headers);
   headers.delete(CLOUDFLARE_EDGE_POLICY_HEADER);
   if (usedSharedResponseStage) {
     headers.delete("CDN-Cache-Control");
+    headers.delete("Cache-Tag");
     if (!cacheControl || !isNonCacheableCacheControl(cacheControl)) {
       headers.set("Cache-Control", "private, max-age=0, must-revalidate");
     }

--- a/packages/cloudflare/src/cache/cdn-build-id.ts
+++ b/packages/cloudflare/src/cache/cdn-build-id.ts
@@ -1,2 +1,7 @@
 /** Build identity stamped by the Cloudflare CDN adapter on page responses. */
 export const VINEXT_CDN_BUILD_ID_HEADER = "X-Vinext-Build-Id";
+
+/** Opaque identity shared by every server entry emitted by one vinext build. */
+export function getVinextCdnBuildIdentity(): string | null {
+  return process.env.__VINEXT_RSC_BUILD_IDENTITY || process.env.__VINEXT_BUILD_ID || null;
+}

--- a/packages/cloudflare/src/cacheability-artifact.ts
+++ b/packages/cloudflare/src/cacheability-artifact.ts
@@ -179,14 +179,51 @@ function assertManifestModuleReachable(configPath: string): void {
   if (!fs.existsSync(mainPath) || !fs.lstatSync(mainPath).isFile()) {
     throw new Error("Two-stage CDN warming could not find the generated Wrangler main module.");
   }
-  if (
-    !hasStaticModuleSpecifier(
-      fs.readFileSync(mainPath, "utf8"),
-      `./${CACHEABILITY_MANIFEST_MODULE}`,
-    )
-  ) {
+  const viteManifestPath = path.join(serverDirectory, ".vite", "manifest.json");
+  let viteManifest: Record<string, { dynamicImports?: unknown; file?: unknown; imports?: unknown }>;
+  try {
+    viteManifest = JSON.parse(fs.readFileSync(viteManifestPath, "utf8"));
+  } catch (cause) {
+    throw new Error("Two-stage CDN warming could not read the generated Vite manifest.", {
+      cause,
+    });
+  }
+  const normalizedMain = main.replace(/^\.\//, "");
+  const entryKey = Object.entries(viteManifest).find(
+    ([, entry]) => entry?.file === normalizedMain,
+  )?.[0];
+  const queue = entryKey ? [entryKey] : [];
+  const visited = new Set<string>();
+  let reachable = false;
+  while (queue.length > 0 && !reachable) {
+    const key = queue.shift()!;
+    if (visited.has(key)) continue;
+    visited.add(key);
+    const entry = viteManifest[key];
+    if (!entry || typeof entry.file !== "string") continue;
+    const modulePath = path.resolve(serverDirectory, entry.file);
+    if (fs.existsSync(modulePath) && fs.lstatSync(modulePath).isFile()) {
+      const relativeManifest = path
+        .relative(
+          path.dirname(modulePath),
+          path.join(serverDirectory, CACHEABILITY_MANIFEST_MODULE),
+        )
+        .split(path.sep)
+        .join("/");
+      const specifier = relativeManifest.startsWith(".")
+        ? relativeManifest
+        : `./${relativeManifest}`;
+      reachable = hasStaticModuleSpecifier(fs.readFileSync(modulePath, "utf8"), specifier);
+    }
+    for (const references of [entry.imports, entry.dynamicImports]) {
+      if (Array.isArray(references)) {
+        queue.push(...references.filter((value): value is string => typeof value === "string"));
+      }
+    }
+  }
+  if (!reachable) {
     throw new Error(
-      `Two-stage CDN warming requires the generated Worker main module to import ${CACHEABILITY_MANIFEST_MODULE}.`,
+      `Two-stage CDN warming requires the generated Worker graph to statically import ${CACHEABILITY_MANIFEST_MODULE}.`,
     );
   }
 }

--- a/packages/cloudflare/src/cacheability-probe.ts
+++ b/packages/cloudflare/src/cacheability-probe.ts
@@ -36,6 +36,7 @@ type ProbePayload = {
   pattern?: string;
   reason?: string;
   rendererStatic?: boolean;
+  routePathname?: string;
   state?: string;
   status?: number;
   version?: number;
@@ -356,26 +357,26 @@ export async function probeStagedWorkerCacheability(options: {
   let staticPathCount = 0;
   let dynamicPathCount = 0;
 
+  type ConcretePathResult = {
+    rendererStatic: boolean;
+    representation: CdnWarmTarget["kind"];
+    state: Exclude<ProbeRouteState, "probe-failed">;
+    terminal: boolean;
+  };
   type PatternClassification = {
     canPrune: boolean;
     groups: ConcretePathGroup[];
     key: string;
     resultKeys: Set<string>;
     pruned: boolean;
-    results: Map<
-      string,
-      {
-        rendererStatic: boolean;
-        representation: CdnWarmTarget["kind"];
-        state: Exclude<ProbeRouteState, "probe-failed">;
-      }
-    >;
+    results: Map<string, ConcretePathResult>;
     route: NonNullable<CdnWarmTarget["route"]>;
     splitRepresentations: boolean;
   };
   type ConcretePathGroup = {
     pattern: PatternClassification;
     primary: CdnWarmTarget;
+    result?: ConcretePathResult;
     resultKey: string;
     routePathname: string;
     targets: CdnWarmTarget[];
@@ -530,6 +531,21 @@ export async function probeStagedWorkerCacheability(options: {
     return pattern;
   };
 
+  const updateGroupRoutePathname = (group: ConcretePathGroup, routePathname: string): void => {
+    const normalized = normalizeCacheabilityRoutePathname(routePathname);
+    if (normalized === group.routePathname) return;
+    const pattern = group.pattern;
+    const previousResultKey = group.resultKey;
+    group.routePathname = normalized;
+    group.resultKey = pattern.splitRepresentations
+      ? `${group.primary.kind}\0${normalized}`
+      : normalized;
+    if (!pattern.groups.some((candidate) => candidate.resultKey === previousResultKey)) {
+      pattern.resultKeys.delete(previousResultKey);
+    }
+    pattern.resultKeys.add(group.resultKey);
+  };
+
   const classifyConcretePath = async (group: ConcretePathGroup): Promise<void> => {
     if (group.pattern.pruned) {
       skippedPathCount += 1;
@@ -577,6 +593,11 @@ export async function probeStagedWorkerCacheability(options: {
       !isProbeRouteState(result.state) ||
       (result.scope !== undefined && result.scope !== "identity" && result.scope !== "pattern") ||
       (result.scope === "pattern" && result.state !== "dynamic") ||
+      (result.routePathname !== undefined &&
+        (typeof result.routePathname !== "string" ||
+          !result.routePathname.startsWith("/") ||
+          result.routePathname.includes("?") ||
+          result.routePathname.includes("#"))) ||
       (result.terminal !== undefined && result.terminal !== true) ||
       (result.terminal === true &&
         (result.state !== "dynamic" ||
@@ -613,9 +634,35 @@ export async function probeStagedWorkerCacheability(options: {
         reportProgress();
         return;
       }
+      if (result.routePathname === undefined) {
+        failures.push(`${target.label}: probe resolved without a concrete route pathname`);
+        completedPathCount += 1;
+        reportProgress();
+        return;
+      }
       moveGroupToResolvedRoute(group, { kind: result.kind, pattern: result.pattern });
     }
+    if (result.routePathname !== undefined) {
+      updateGroupRoutePathname(group, result.routePathname);
+    }
 
+    const classification: ConcretePathResult = {
+      rendererStatic: result.rendererStatic === true,
+      representation: target.kind,
+      state: result.state,
+      terminal: result.terminal === true,
+    };
+    group.result = classification;
+    const previousClassification = group.pattern.results.get(group.resultKey);
+    if (
+      !previousClassification ||
+      (previousClassification.state === "static-candidate" && classification.state === "dynamic") ||
+      (previousClassification.state === classification.state &&
+        previousClassification.rendererStatic &&
+        !classification.rendererStatic)
+    ) {
+      group.pattern.results.set(group.resultKey, classification);
+    }
     const patternIsDefinitelyDynamic =
       result.state === "dynamic" && result.scope === "pattern" && group.pattern.canPrune;
     if (patternIsDefinitelyDynamic) {
@@ -625,12 +672,6 @@ export async function probeStagedWorkerCacheability(options: {
       reportProgress();
       return;
     }
-
-    group.pattern.results.set(group.resultKey, {
-      rendererStatic: result.rendererStatic === true,
-      representation: target.kind,
-      state: result.state,
-    });
     if (result.state === "static-candidate") {
       staticPathCount += 1;
     } else {
@@ -728,7 +769,7 @@ export async function probeStagedWorkerCacheability(options: {
     const rendererStaticTargets = new Map<string, CdnWarmTarget>();
     const runtimePathSet = new Set<string>();
     for (const group of pattern.groups) {
-      const result = pattern.results.get(group.resultKey);
+      const result = group.result;
       if (result?.state === "static-candidate") {
         if (result.rendererStatic) {
           const previous = rendererStaticTargets.get(group.routePathname);
@@ -743,7 +784,7 @@ export async function probeStagedWorkerCacheability(options: {
         continue;
       }
 
-      runtimePathSet.add(group.routePathname);
+      if (result?.terminal !== true) runtimePathSet.add(group.routePathname);
       // A representation-specific response policy can make an RSC/data
       // sibling reusable even when the representative HTML render is private.
       // The final completed render decides admission without another probe.
@@ -755,7 +796,9 @@ export async function probeStagedWorkerCacheability(options: {
     }
     const staticPaths: CacheabilityManifestRoute["staticPaths"] = {};
     for (const [routePathname, staticTarget] of rendererStaticTargets) {
-      runtimePathSet.delete(routePathname);
+      // Conflicting observations for one resolved route identity must retain
+      // runtime admission rather than certifying the static observation.
+      if (runtimePathSet.has(routePathname)) continue;
       const paths = staticPaths[staticTarget.kind] ?? [];
       paths.push(routePathname);
       staticPaths[staticTarget.kind] = paths;

--- a/packages/cloudflare/src/cacheability-probe.ts
+++ b/packages/cloudflare/src/cacheability-probe.ts
@@ -15,6 +15,7 @@ import type { PrerenderRoutePattern } from "vinext/internal/build/prerender-path
 import {
   VINEXT_CACHEABILITY_PROBE_HEADER,
   VINEXT_CACHEABILITY_PROBE_QUERY_PARAM,
+  VINEXT_CACHEABILITY_PROBE_ROUTE_HEADER,
   VINEXT_PRERENDER_SECRET_HEADER,
 } from "vinext/internal/server/headers";
 import { VINEXT_CDN_BUILD_ID_HEADER } from "./cache/cdn-build-id.js";
@@ -196,6 +197,12 @@ async function probeTarget(options: {
   const headers = new Headers(options.headers);
   for (const [name, value] of new Headers(options.target.headers)) headers.set(name, value);
   headers.set(VINEXT_CACHEABILITY_PROBE_HEADER, "1");
+  if (options.target.route) {
+    headers.set(
+      VINEXT_CACHEABILITY_PROBE_ROUTE_HEADER,
+      JSON.stringify([options.target.route.kind, options.target.route.pattern]),
+    );
+  }
   headers.set(VINEXT_PRERENDER_SECRET_HEADER, options.secret);
 
   let reason = "probe failed";

--- a/packages/cloudflare/src/cacheability-probe.ts
+++ b/packages/cloudflare/src/cacheability-probe.ts
@@ -41,6 +41,7 @@ type ProbePayload = {
   version?: number;
   phaseTimedOut?: boolean;
   scope?: "identity" | "pattern";
+  terminal?: true;
 };
 
 export type CacheabilityProbeProgress = {
@@ -359,7 +360,7 @@ export async function probeStagedWorkerCacheability(options: {
     canPrune: boolean;
     groups: ConcretePathGroup[];
     key: string;
-    pathnames: Set<string>;
+    resultKeys: Set<string>;
     pruned: boolean;
     results: Map<
       string,
@@ -370,10 +371,12 @@ export async function probeStagedWorkerCacheability(options: {
       }
     >;
     route: NonNullable<CdnWarmTarget["route"]>;
+    splitRepresentations: boolean;
   };
   type ConcretePathGroup = {
     pattern: PatternClassification;
     primary: CdnWarmTarget;
+    resultKey: string;
     routePathname: string;
     targets: CdnWarmTarget[];
   };
@@ -382,7 +385,7 @@ export async function probeStagedWorkerCacheability(options: {
     return target.kind === "html" ? 0 : target.kind === "rsc-full" ? 1 : 2;
   };
   const patterns = new Map<string, PatternClassification>();
-  const targetsByConcretePath = new Map<string, CdnWarmTarget[]>();
+  const routableTargets: CdnWarmTarget[] = [];
   let missingRouteMetadata = 0;
   for (const target of options.targets) {
     if (!target.route) {
@@ -394,46 +397,65 @@ export async function probeStagedWorkerCacheability(options: {
       canPrune: true,
       groups: [],
       key,
-      pathnames: new Set<string>(),
+      resultKeys: new Set<string>(),
       pruned: false,
       results: new Map(),
       route: target.route,
+      splitRepresentations: false,
     };
+    pattern.splitRepresentations ||=
+      target.route.cacheabilityProbe?.requestStageMayTerminate === true;
     pattern.canPrune &&=
       target.route.cacheabilityProbe?.canPrunePattern === true &&
-      target.route.cacheabilityProbe.routeMayResolve !== true;
+      target.route.cacheabilityProbe.routeMayResolve !== true &&
+      target.route.cacheabilityProbe.requestStageMayTerminate !== true;
     patterns.set(key, pattern);
-
-    const routePathname =
-      target.route.cacheabilityProbe?.concretePathname ??
-      cacheabilityRoutePathname(target.pathname, target.kind);
-    pattern.pathnames.add(routePathname);
-    const concreteKey = `${key}\0${routePathname}`;
-    const groupTargets = targetsByConcretePath.get(concreteKey) ?? [];
-    groupTargets.push(target);
-    targetsByConcretePath.set(concreteKey, groupTargets);
+    routableTargets.push(target);
   }
   if (missingRouteMetadata > 0) {
     failures.push(
       `${missingRouteMetadata} warm target${missingRouteMetadata === 1 ? " is" : "s are"} missing route-pattern metadata`,
     );
   }
-  const groups: ConcretePathGroup[] = Array.from(
-    targetsByConcretePath,
-    ([concreteKey, groupTargets]) => {
-      const route = groupTargets[0].route!;
-      const key = cacheabilityManifestRouteKey(route.kind, route.pattern);
-      const pattern = patterns.get(key)!;
-      const routePathname = concreteKey.slice(key.length + 1);
-      groupTargets.sort((first, second) => {
-        const preference = targetPreference(first) - targetPreference(second);
-        return preference || first.sourcePathname.localeCompare(second.sourcePathname);
-      });
-      const group = { pattern, primary: groupTargets[0], routePathname, targets: groupTargets };
-      pattern.groups.push(group);
-      return group;
-    },
-  );
+  const targetGroups = new Map<
+    string,
+    {
+      pattern: PatternClassification;
+      resultKey: string;
+      routePathname: string;
+      targets: CdnWarmTarget[];
+    }
+  >();
+  for (const target of routableTargets) {
+    const route = target.route!;
+    const key = cacheabilityManifestRouteKey(route.kind, route.pattern);
+    const pattern = patterns.get(key)!;
+    const routePathname =
+      route.cacheabilityProbe?.concretePathname ??
+      cacheabilityRoutePathname(target.pathname, target.kind);
+    const resultKey = pattern.splitRepresentations
+      ? `${target.kind}\0${routePathname}`
+      : routePathname;
+    pattern.resultKeys.add(resultKey);
+    const concreteKey = `${key}\0${resultKey}`;
+    const group = targetGroups.get(concreteKey) ?? {
+      pattern,
+      resultKey,
+      routePathname,
+      targets: [],
+    };
+    group.targets.push(target);
+    targetGroups.set(concreteKey, group);
+  }
+  const groups: ConcretePathGroup[] = Array.from(targetGroups.values(), (targetGroup) => {
+    targetGroup.targets.sort((first, second) => {
+      const preference = targetPreference(first) - targetPreference(second);
+      return preference || first.sourcePathname.localeCompare(second.sourcePathname);
+    });
+    const group = { ...targetGroup, primary: targetGroup.targets[0] };
+    targetGroup.pattern.groups.push(group);
+    return group;
+  });
 
   const reportProgress = (): void => {
     options.onProgress?.({
@@ -481,14 +503,16 @@ export async function probeStagedWorkerCacheability(options: {
         canPrune: false,
         groups: [],
         key,
-        pathnames: new Set<string>(),
+        resultKeys: new Set<string>(),
         pruned: false,
         results: new Map(),
         route,
+        splitRepresentations: previousPattern.splitRepresentations,
       };
       patterns.set(key, pattern);
     }
     pattern.canPrune = false;
+    pattern.splitRepresentations ||= previousPattern.splitRepresentations;
     // A direct destination probe may have provisionally pruned this pattern
     // before the routed source completed. Its retained concrete observation is
     // authoritative once another public path joins the resolved route.
@@ -497,13 +521,11 @@ export async function probeStagedWorkerCacheability(options: {
 
     const previousGroupIndex = previousPattern.groups.indexOf(group);
     if (previousGroupIndex !== -1) previousPattern.groups.splice(previousGroupIndex, 1);
-    if (
-      !previousPattern.groups.some((candidate) => candidate.routePathname === group.routePathname)
-    ) {
-      previousPattern.pathnames.delete(group.routePathname);
+    if (!previousPattern.groups.some((candidate) => candidate.resultKey === group.resultKey)) {
+      previousPattern.resultKeys.delete(group.resultKey);
     }
     pattern.groups.push(group);
-    pattern.pathnames.add(group.routePathname);
+    pattern.resultKeys.add(group.resultKey);
     group.pattern = pattern;
     return pattern;
   };
@@ -555,6 +577,11 @@ export async function probeStagedWorkerCacheability(options: {
       !isProbeRouteState(result.state) ||
       (result.scope !== undefined && result.scope !== "identity" && result.scope !== "pattern") ||
       (result.scope === "pattern" && result.state !== "dynamic") ||
+      (result.terminal !== undefined && result.terminal !== true) ||
+      (result.terminal === true &&
+        (result.state !== "dynamic" ||
+          result.scope !== "identity" ||
+          !group.pattern.splitRepresentations)) ||
       (result.rendererStatic !== undefined && typeof result.rendererStatic !== "boolean") ||
       !Number.isInteger(result.status) ||
       result.status! < 100 ||
@@ -589,11 +616,6 @@ export async function probeStagedWorkerCacheability(options: {
       moveGroupToResolvedRoute(group, { kind: result.kind, pattern: result.pattern });
     }
 
-    group.pattern.results.set(group.routePathname, {
-      rendererStatic: result.rendererStatic === true,
-      representation: target.kind,
-      state: result.state,
-    });
     const patternIsDefinitelyDynamic =
       result.state === "dynamic" && result.scope === "pattern" && group.pattern.canPrune;
     if (patternIsDefinitelyDynamic) {
@@ -604,6 +626,11 @@ export async function probeStagedWorkerCacheability(options: {
       return;
     }
 
+    group.pattern.results.set(group.resultKey, {
+      rendererStatic: result.rendererStatic === true,
+      representation: target.kind,
+      state: result.state,
+    });
     if (result.state === "static-candidate") {
       staticPathCount += 1;
     } else {
@@ -698,15 +725,16 @@ export async function probeStagedWorkerCacheability(options: {
       dynamic += 1;
     }
 
-    const staticPaths: CacheabilityManifestRoute["staticPaths"] = {};
+    const rendererStaticTargets = new Map<string, CdnWarmTarget>();
     const runtimePathSet = new Set<string>();
     for (const group of pattern.groups) {
-      const result = pattern.results.get(group.routePathname);
+      const result = pattern.results.get(group.resultKey);
       if (result?.state === "static-candidate") {
         if (result.rendererStatic) {
-          const paths = staticPaths[result.representation] ?? [];
-          paths.push(group.routePathname);
-          staticPaths[result.representation] = paths;
+          const previous = rendererStaticTargets.get(group.routePathname);
+          if (!previous || targetPreference(group.primary) < targetPreference(previous)) {
+            rendererStaticTargets.set(group.routePathname, group.primary);
+          }
         } else {
           runtimePathSet.add(group.routePathname);
         }
@@ -725,9 +753,17 @@ export async function probeStagedWorkerCacheability(options: {
         speculativeTargets.push(...pairedTargets);
       }
     }
+    const staticPaths: CacheabilityManifestRoute["staticPaths"] = {};
+    for (const [routePathname, staticTarget] of rendererStaticTargets) {
+      runtimePathSet.delete(routePathname);
+      const paths = staticPaths[staticTarget.kind] ?? [];
+      paths.push(routePathname);
+      staticPaths[staticTarget.kind] = paths;
+    }
     for (const paths of Object.values(staticPaths)) paths?.sort();
     const allObservedPathsStatic =
-      pattern.results.size === pattern.pathnames.size && runtimePathSet.size === 0;
+      pattern.results.size === pattern.resultKeys.size &&
+      Array.from(pattern.results.values()).every((result) => result.state === "static-candidate");
     const allObservedPathsStaticallyGenerated =
       allObservedPathsStatic &&
       Array.from(pattern.results.values()).every((result) => result.rendererStatic);
@@ -739,7 +775,7 @@ export async function probeStagedWorkerCacheability(options: {
       normalizeCacheabilityRoutePathname(pattern.route.pattern) === soleGroup.routePathname;
     let route: CacheabilityManifestRoute;
     if (literalPatternNamesSolePath) {
-      const result = pattern.results.get(soleGroup.routePathname);
+      const result = pattern.results.get(soleGroup.resultKey);
       route =
         result?.state === "static-candidate"
           ? pattern.route.kind === "app-route"

--- a/packages/cloudflare/src/cacheability-probe.ts
+++ b/packages/cloudflare/src/cacheability-probe.ts
@@ -200,7 +200,7 @@ async function probeTarget(options: {
   if (options.target.route) {
     headers.set(
       VINEXT_CACHEABILITY_PROBE_ROUTE_HEADER,
-      JSON.stringify([options.target.route.kind, options.target.route.pattern]),
+      encodeURIComponent(JSON.stringify([options.target.route.kind, options.target.route.pattern])),
     );
   }
   headers.set(VINEXT_PRERENDER_SECRET_HEADER, options.secret);

--- a/packages/cloudflare/src/cacheability-probe.ts
+++ b/packages/cloudflare/src/cacheability-probe.ts
@@ -392,7 +392,9 @@ export async function probeStagedWorkerCacheability(options: {
       results: new Map(),
       route: target.route,
     };
-    pattern.canPrune &&= target.route.cacheabilityProbe?.canPrunePattern === true;
+    pattern.canPrune &&=
+      target.route.cacheabilityProbe?.canPrunePattern === true &&
+      target.route.cacheabilityProbe.routeMayResolve !== true;
     patterns.set(key, pattern);
 
     const routePathname =
@@ -460,6 +462,41 @@ export async function probeStagedWorkerCacheability(options: {
     return true;
   };
 
+  const moveGroupToResolvedRoute = (
+    group: ConcretePathGroup,
+    route: Pick<PrerenderRoutePattern, "kind" | "pattern">,
+  ): PatternClassification => {
+    const previousPattern = group.pattern;
+    const key = cacheabilityManifestRouteKey(route.kind, route.pattern);
+    let pattern = patterns.get(key);
+    if (!pattern) {
+      pattern = {
+        canPrune: false,
+        groups: [],
+        key,
+        pathnames: new Set<string>(),
+        pruned: false,
+        results: new Map(),
+        route,
+      };
+      patterns.set(key, pattern);
+    }
+    pattern.canPrune = false;
+    if (pattern === previousPattern) return pattern;
+
+    const previousGroupIndex = previousPattern.groups.indexOf(group);
+    if (previousGroupIndex !== -1) previousPattern.groups.splice(previousGroupIndex, 1);
+    if (
+      !previousPattern.groups.some((candidate) => candidate.routePathname === group.routePathname)
+    ) {
+      previousPattern.pathnames.delete(group.routePathname);
+    }
+    pattern.groups.push(group);
+    pattern.pathnames.add(group.routePathname);
+    group.pattern = pattern;
+    return pattern;
+  };
+
   const classifyConcretePath = async (group: ConcretePathGroup): Promise<void> => {
     if (group.pattern.pruned) {
       skippedPathCount += 1;
@@ -523,15 +560,22 @@ export async function probeStagedWorkerCacheability(options: {
       reportProgress();
       return;
     }
-    if (
-      !target.route ||
-      result.kind !== target.route.kind ||
-      result.pattern !== target.route.pattern
-    ) {
-      failures.push(`${target.label}: probe resolved to unexpected route ${result.pattern ?? ""}`);
+    if (!target.route) {
+      failures.push(`${target.label}: probe resolved without route metadata`);
       completedPathCount += 1;
       reportProgress();
       return;
+    }
+    if (result.kind !== target.route.kind || result.pattern !== target.route.pattern) {
+      if (target.route.cacheabilityProbe?.routeMayResolve !== true) {
+        failures.push(
+          `${target.label}: probe resolved to unexpected route ${result.pattern ?? ""}`,
+        );
+        completedPathCount += 1;
+        reportProgress();
+        return;
+      }
+      moveGroupToResolvedRoute(group, { kind: result.kind, pattern: result.pattern });
     }
 
     const patternIsDefinitelyDynamic =

--- a/packages/cloudflare/src/cacheability-probe.ts
+++ b/packages/cloudflare/src/cacheability-probe.ts
@@ -195,7 +195,6 @@ async function probeTarget(options: {
 }): Promise<ProbePayload> {
   const headers = new Headers(options.headers);
   for (const [name, value] of new Headers(options.target.headers)) headers.set(name, value);
-  headers.set("Cache-Control", "no-cache");
   headers.set(VINEXT_CACHEABILITY_PROBE_HEADER, "1");
   headers.set(VINEXT_PRERENDER_SECRET_HEADER, options.secret);
 

--- a/packages/cloudflare/src/cacheability-probe.ts
+++ b/packages/cloudflare/src/cacheability-probe.ts
@@ -482,6 +482,10 @@ export async function probeStagedWorkerCacheability(options: {
       patterns.set(key, pattern);
     }
     pattern.canPrune = false;
+    // A direct destination probe may have provisionally pruned this pattern
+    // before the routed source completed. Its retained concrete observation is
+    // authoritative once another public path joins the resolved route.
+    pattern.pruned = false;
     if (pattern === previousPattern) return pattern;
 
     const previousGroupIndex = previousPattern.groups.indexOf(group);
@@ -578,6 +582,11 @@ export async function probeStagedWorkerCacheability(options: {
       moveGroupToResolvedRoute(group, { kind: result.kind, pattern: result.pattern });
     }
 
+    group.pattern.results.set(group.routePathname, {
+      rendererStatic: result.rendererStatic === true,
+      representation: target.kind,
+      state: result.state,
+    });
     const patternIsDefinitelyDynamic =
       result.state === "dynamic" && result.scope === "pattern" && group.pattern.canPrune;
     if (patternIsDefinitelyDynamic) {
@@ -588,11 +597,6 @@ export async function probeStagedWorkerCacheability(options: {
       return;
     }
 
-    group.pattern.results.set(group.routePathname, {
-      rendererStatic: result.rendererStatic === true,
-      representation: target.kind,
-      state: result.state,
-    });
     if (result.state === "static-candidate") {
       staticPathCount += 1;
     } else {

--- a/packages/cloudflare/src/cdn-warm.ts
+++ b/packages/cloudflare/src/cdn-warm.ts
@@ -57,6 +57,8 @@ export type CdnWarmOptions = {
   phaseTimeoutMs?: number;
   /** Retry a newly staged version or preview alias until its routing has propagated. */
   propagatingTarget?: boolean;
+  /** @internal Matching skipped targets that may be transient while a staged version propagates. */
+  retrySkippedTargetKeys?: ReadonlySet<string>;
   /** Require the response to come from a reusable cache entry, not merely an eligible MISS. */
   requireCacheHit?: boolean;
   strict?: boolean;
@@ -445,6 +447,10 @@ export type CdnWarmTarget = {
   sourcePathname: string;
   route?: PrerenderRoutePattern;
 };
+
+function cdnWarmTargetKey(target: Pick<CdnWarmTarget, "kind" | "sourcePathname">): string {
+  return `${target.kind}\0${target.sourcePathname}`;
+}
 
 export async function createCdnWarmTargets(
   options: Pick<
@@ -1056,6 +1062,7 @@ async function warmOnePath(
     retryPropagationFailures: boolean;
     retryDelayMs: number;
     retryNotFound: boolean;
+    retrySkipped: boolean;
     phaseTimeoutMs?: number;
     requireCacheHit: boolean;
   },
@@ -1067,6 +1074,7 @@ async function warmOnePath(
   const url = buildWarmupUrl(options.targetUrl, target.pathname);
   let lastError = "request failed before the first attempt";
   let lastRetryable = true;
+  let lastSkippedReason: string | null = null;
 
   const phaseDeadlineError = () =>
     `CDN warmup exceeded its ${options.phaseTimeoutMs}ms phase deadline`;
@@ -1136,8 +1144,18 @@ async function warmOnePath(
           return { path: target.label, ok: true, skipped: false };
         }
         if (validation.outcome === "skipped") {
-          return { path: target.label, ok: true, skipped: true, reason: validation.reason };
+          if (!options.retrySkipped) {
+            return { path: target.label, ok: true, skipped: true, reason: validation.reason };
+          }
+          lastSkippedReason = validation.reason;
+          lastRetryable = true;
+          if (!canRetry(attempt)) break;
+          if (!(await waitBeforeRetry())) {
+            return { path: target.label, ok: false, error: phaseDeadlineError(), retryable: false };
+          }
+          continue;
         }
+        lastSkippedReason = null;
         lastError = validation.error;
         const cacheStatus = response.headers.get("CF-Cache-Status")?.trim().toUpperCase();
         lastRetryable =
@@ -1165,8 +1183,18 @@ async function warmOnePath(
         return { path: target.label, ok: true, skipped: false };
       }
       if (validation.outcome === "skipped") {
-        return { path: target.label, ok: true, skipped: true, reason: validation.reason };
+        if (!options.retrySkipped) {
+          return { path: target.label, ok: true, skipped: true, reason: validation.reason };
+        }
+        lastSkippedReason = validation.reason;
+        lastRetryable = true;
+        if (!canRetry(attempt)) break;
+        if (!(await waitBeforeRetry())) {
+          return { path: target.label, ok: false, error: phaseDeadlineError(), retryable: false };
+        }
+        continue;
       }
+      lastSkippedReason = null;
       lastError = validation.error;
       const cacheStatus = response.headers.get("CF-Cache-Status")?.trim().toUpperCase();
       lastRetryable =
@@ -1176,6 +1204,7 @@ async function warmOnePath(
         shouldRetryValidationFailure(response, target, options);
       if (!lastRetryable) break;
     } catch (error) {
+      lastSkippedReason = null;
       lastRetryable = true;
       if (error instanceof DOMException && error.name === "AbortError") {
         lastError =
@@ -1192,7 +1221,9 @@ async function warmOnePath(
     }
   }
 
-  return { path: target.label, ok: false, error: lastError, retryable: lastRetryable };
+  return lastSkippedReason === null
+    ? { path: target.label, ok: false, error: lastError, retryable: lastRetryable }
+    : { path: target.label, ok: true, skipped: true, reason: lastSkippedReason };
 }
 
 async function runWithConcurrency<T, R>(
@@ -1224,9 +1255,9 @@ export async function warmCdnCache(options: CdnWarmOptions): Promise<CdnWarmResu
   const timeoutMs = Math.max(1, options.timeoutMs ?? DEFAULT_CDN_WARM_TIMEOUT_MS);
   const hasVersionOverride = new Headers(options.headers).has(WORKER_VERSION_OVERRIDE_HEADER);
   const propagatingTarget = options.propagatingTarget ?? hasVersionOverride;
-  // A propagating target gives every key one initial attempt, then retries only
-  // failed keys after the queue completes. Build identity validation prevents
-  // an old Worker response from being mistaken for a successful fill.
+  // A propagating target gives every key one initial attempt, then retries
+  // unresolved keys after the queue completes. Build identity validation
+  // prevents an old Worker response from being mistaken for a successful fill.
   const concurrency = Math.max(1, options.concurrency ?? DEFAULT_CDN_WARM_CONCURRENCY);
   const normalRetries = Math.max(0, options.retries ?? 1);
   const propagationRetries = Math.max(0, options.retries ?? 60);
@@ -1279,6 +1310,9 @@ export async function warmCdnCache(options: CdnWarmOptions): Promise<CdnWarmResu
       retryNotFound: isPropagationRequest,
       phaseTimeoutMs,
       requireCacheHit: options.requireCacheHit === true,
+      retrySkipped:
+        isPropagationRequest &&
+        options.retrySkippedTargetKeys?.has(cdnWarmTargetKey(target)) === true,
     });
   };
 
@@ -1298,43 +1332,33 @@ export async function warmCdnCache(options: CdnWarmOptions): Promise<CdnWarmResu
     const results = await runWithConcurrency(targets, concurrency, (target) =>
       warmRequest(target, "propagation-pass"),
     );
-    const failed = targets
+    const retryable = targets
       .map((target, index) => ({ index, result: results[index], target }))
-      .filter(
-        (
-          entry,
-        ): entry is {
-          index: number;
-          result: { path: string; ok: false; error: string; retryable: boolean };
-          target: CdnWarmTarget;
-        } => !entry.result.ok,
+      .filter(({ result, target }) =>
+        result.ok
+          ? result.skipped && options.retrySkippedTargetKeys?.has(cdnWarmTargetKey(target)) === true
+          : result.retryable,
       );
-    const retryableFailed = failed.filter(({ result }) => result.retryable);
-    if (retryableFailed.length === 0 || propagationRetries === 0) return results;
+    if (retryable.length === 0 || propagationRetries === 0) return results;
 
     progress.finish();
     console.log(
-      `  CDN warmup: retrying ${retryableFailed.length} failed request(s) after completing the initial pass...`,
+      `  CDN warmup: retrying ${retryable.length} unresolved request(s) after completing the initial pass...`,
     );
     let completedRetries = 0;
-    progress.update(0, retryableFailed.length, "starting retry pass", "Retrying CDN cache");
+    progress.update(0, retryable.length, "starting retry pass", "Retrying CDN cache");
     const retried = await runWithConcurrency(
-      retryableFailed.map(({ target }) => target),
+      retryable.map(({ target }) => target),
       concurrency,
       async (target) => {
         const result = await warmTarget(target, "propagation-retry");
         completedRetries++;
-        progress.update(
-          completedRetries,
-          retryableFailed.length,
-          target.label,
-          "Retrying CDN cache",
-        );
+        progress.update(completedRetries, retryable.length, target.label, "Retrying CDN cache");
         return result;
       },
     );
     progress.finish();
-    for (const [retryIndex, { index }] of retryableFailed.entries()) {
+    for (const [retryIndex, { index }] of retryable.entries()) {
       results[index] = retried[retryIndex];
     }
     return results;

--- a/packages/cloudflare/src/cdn-warm.ts
+++ b/packages/cloudflare/src/cdn-warm.ts
@@ -203,7 +203,9 @@ function readPrerenderPathManifest(manifestPath: string): PrerenderPathManifest 
                   typeof route.cacheabilityProbe.canPrunePattern === "boolean" &&
                   (route.cacheabilityProbe.concretePathname === undefined ||
                     (typeof route.cacheabilityProbe.concretePathname === "string" &&
-                      route.cacheabilityProbe.concretePathname.startsWith("/"))))),
+                      route.cacheabilityProbe.concretePathname.startsWith("/"))) &&
+                  (route.cacheabilityProbe.routeMayResolve === undefined ||
+                    typeof route.cacheabilityProbe.routeMayResolve === "boolean"))),
           ))) ||
       (manifest.loadingShellPaths !== undefined &&
         (!Array.isArray(manifest.loadingShellPaths) ||

--- a/packages/cloudflare/src/cdn-warm.ts
+++ b/packages/cloudflare/src/cdn-warm.ts
@@ -205,7 +205,9 @@ function readPrerenderPathManifest(manifestPath: string): PrerenderPathManifest 
                     (typeof route.cacheabilityProbe.concretePathname === "string" &&
                       route.cacheabilityProbe.concretePathname.startsWith("/"))) &&
                   (route.cacheabilityProbe.routeMayResolve === undefined ||
-                    typeof route.cacheabilityProbe.routeMayResolve === "boolean"))),
+                    typeof route.cacheabilityProbe.routeMayResolve === "boolean") &&
+                  (route.cacheabilityProbe.requestStageMayTerminate === undefined ||
+                    typeof route.cacheabilityProbe.requestStageMayTerminate === "boolean"))),
           ))) ||
       (manifest.loadingShellPaths !== undefined &&
         (!Array.isArray(manifest.loadingShellPaths) ||

--- a/packages/cloudflare/src/cloudflare-workers.d.ts
+++ b/packages/cloudflare/src/cloudflare-workers.d.ts
@@ -1,0 +1,13 @@
+declare module "cloudflare:workers" {
+  /** Runtime base class supplied by Cloudflare Workers for named entrypoints. */
+  export abstract class WorkerEntrypoint<Env = unknown, Props = unknown> {
+    protected ctx: {
+      readonly cache?: unknown;
+      readonly props: Props;
+      waitUntil(promise: Promise<unknown>): void;
+    };
+    protected env: Env;
+    constructor(ctx: unknown, env: Env);
+    fetch?(request: Request): Response | Promise<Response>;
+  }
+}

--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -807,6 +807,23 @@ function cdnWarmTargetKey(target: Pick<CdnWarmTarget, "kind" | "sourcePathname">
   return `${target.kind}\0${target.sourcePathname}`;
 }
 
+function requiredCdnWarmTargetKeys(
+  plan: CdnWarmRequestPlan,
+  optionalTargetKeys: ReadonlySet<string> | undefined,
+): ReadonlySet<string> {
+  const keys = new Set([
+    ...plan.paths.map((pathname) => `html\0${pathname}`),
+    ...plan.pagesDataPaths.map((pathname) => `pages-data\0${pathname}`),
+    ...(plan.routeHandlerPaths ?? []).map((pathname) => `app-route\0${pathname}`),
+    ...plan.rscPaths.map((pathname) => `rsc-full\0${pathname}`),
+    ...plan.loadingShellPaths.map((pathname) => `rsc-loading-shell\0${pathname}`),
+  ]);
+  if (optionalTargetKeys) {
+    for (const key of optionalTargetKeys) keys.delete(key);
+  }
+  return keys;
+}
+
 export async function deployWithCdnWarmup(
   root: string,
   paths: readonly string[],
@@ -975,6 +992,10 @@ async function deployUploadedVersionWithCdnWarmup(
       concurrency: options.warmCdnConcurrency,
       timeoutMs: options.warmCdnTimeout,
       retries: options.warmCdnRetries,
+      retrySkippedTargetKeys:
+        propagatingTarget && hasPreparedWarmPlan
+          ? requiredCdnWarmTargetKeys(plan, options.optionalWarmTargetKeys)
+          : undefined,
       requireCacheHit,
       strict: requireCacheHit || !allowUnverifiedPromotion,
     });

--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -37,6 +37,7 @@ import {
   formatVinextPrerenderLabel,
   getConfiguredCdnResponsePolicyHeaderNames,
   hasBuildIdentityResponseHeader,
+  hasUncachedRequestRouting,
   hasVerbatimResponseVary,
   requiresRouteCacheabilityProbeManifest,
   resolveVinextPrerenderDecision,
@@ -1902,6 +1903,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
     nextOutput: nextConfig.output,
   });
   const hasStrictResponseVary = hasVerbatimResponseVary(viteConfigMetadata.cacheConfig);
+  const hasStagedRequestRouting = hasUncachedRequestRouting(viteConfigMetadata.cacheConfig);
   const hasBuildIdentityHeader = hasBuildIdentityResponseHeader(viteConfigMetadata.cacheConfig);
   const needsCacheabilityProbeManifest = projectRequiresRouteCacheabilityProbeManifest(
     info,
@@ -1921,6 +1923,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
       root: info.root,
       nextConfig,
       buildIdentity: hasBuildIdentityHeader ? "response-header" : undefined,
+      requestRouting: hasStagedRequestRouting ? "uncached-stage" : undefined,
       responseVary: hasStrictResponseVary ? "verbatim" : undefined,
       responsePolicyHeaderNames: getConfiguredCdnResponsePolicyHeaderNames(
         viteConfigMetadata.cacheConfig,
@@ -1996,6 +1999,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
           root: info.root,
           nextConfig,
           buildIdentity: hasBuildIdentityHeader ? "response-header" : undefined,
+          requestRouting: hasStagedRequestRouting ? "uncached-stage" : undefined,
           responseVary: hasStrictResponseVary ? "verbatim" : undefined,
           responsePolicyHeaderNames: getConfiguredCdnResponsePolicyHeaderNames(
             viteConfigMetadata.cacheConfig,

--- a/packages/cloudflare/tsconfig.json
+++ b/packages/cloudflare/tsconfig.json
@@ -2,7 +2,9 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "paths": {
+      "vinext": ["../vinext/src/index.ts"],
       "vinext/internal/*": ["../vinext/src/*"],
+      "vinext/server/*": ["../vinext/src/server/*"],
       "vinext/shims/*": ["../vinext/src/shims/*"],
       "@vinext/cloudflare/cache/*": ["./src/cache/*"],
       "@vinext/cloudflare/images/*": ["./src/images/*"]

--- a/tests/app-route-handler-response.test.ts
+++ b/tests/app-route-handler-response.test.ts
@@ -417,14 +417,15 @@ describe("route handler responses route through the CDN cache adapter", () => {
     delete (globalThis as Record<PropertyKey, unknown>)[CDN_KEY];
   });
 
-  it("emits CDN-Cache-Control + Cache-Tag on a fresh response when an edge adapter is active", () => {
+  it("emits Cloudflare-CDN-Cache-Control + Cache-Tag with an edge adapter", () => {
     setCdnCacheAdapter(new CloudflareCdnCacheAdapter());
     const response = new Response("fresh");
 
     applyRouteHandlerRevalidateHeader(response, 60, 600, ["_N_T_/api/feed", "posts"]);
 
     expect(response.headers.get("Cache-Control")).toBe("public, max-age=0, must-revalidate");
-    expect(response.headers.get("CDN-Cache-Control")).toBe(
+    expect(response.headers.get("CDN-Cache-Control")).toBeNull();
+    expect(response.headers.get("Cloudflare-CDN-Cache-Control")).toBe(
       "public, max-age=60, stale-while-revalidate=540",
     );
     expect(response.headers.get("Cache-Tag")).toBe("_N_T_/api/feed,posts");
@@ -440,5 +441,6 @@ describe("route handler responses route through the CDN cache adapter", () => {
       "private, no-cache, no-store, max-age=0, must-revalidate",
     );
     expect(response.headers.get("CDN-Cache-Control")).toBeNull();
+    expect(response.headers.get("Cloudflare-CDN-Cache-Control")).toBeNull();
   });
 });

--- a/tests/cache-adapters-build.test.ts
+++ b/tests/cache-adapters-build.test.ts
@@ -15,6 +15,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { createBuilder } from "vite";
 import { afterEach, describe, expect, it } from "vite-plus/test";
+import { cdnAdapter } from "../packages/cloudflare/src/cache/cdn-adapter.js";
 import vinext from "../packages/vinext/src/index.js";
 
 const tmpDirs: string[] = [];

--- a/tests/cache-adapters-build.test.ts
+++ b/tests/cache-adapters-build.test.ts
@@ -94,7 +94,7 @@ function readStaticJavaScriptClosure(entryPath: string): string {
     const source = fs.readFileSync(filePath, "utf8");
     output += source;
     for (const match of source.matchAll(
-      /(?:import|export)\s*(?:[^"']*?\sfrom\s*)?["']([^"']+)["']/g,
+      /(?:import|export)\s*(?:[^"']*?\bfrom\s*)?["']([^"']+)["']/g,
     )) {
       const specifier = match[1];
       if (!specifier?.startsWith(".")) continue;
@@ -307,9 +307,25 @@ export default createAdapter;
     const workerPath = path.join(root, "dist/server/index.js");
     const worker = fs.readFileSync(workerPath, "utf8");
     expect(worker).toMatch(/export\s*\{[^}]*\b(?:[A-Za-z_$][\w$]*\s+as\s+)?VinextCachedResponse\b/);
-    expect(worker).toMatch(/import\s*["']\.\/__vinext_cacheability_manifest\.js["']/);
+    expect(worker).not.toMatch(/import\s*["']\.\/__vinext_cacheability_manifest\.js["']/);
     expect(readTextFilesRecursive(path.join(root, "dist/server"))).toContain(RESPONSE_STAGE_MARKER);
     expect(readStaticJavaScriptClosure(workerPath)).not.toContain(RESPONSE_STAGE_MARKER);
+    expect(readStaticJavaScriptClosure(workerPath)).not.toContain(
+      "__vinext_cacheability_manifest.js",
+    );
+    const viteManifest = JSON.parse(
+      fs.readFileSync(path.join(root, "dist/server/.vite/manifest.json"), "utf8"),
+    );
+    const responseStageEntry = Object.entries(viteManifest).find(
+      ([key, entry]) =>
+        key.endsWith("virtual:vinext-response-stage") ||
+        (entry as { src?: string }).src?.endsWith("virtual:vinext-response-stage"),
+    )?.[1] as { file: string } | undefined;
+    expect(responseStageEntry).toBeDefined();
+    const responseStagePath = path.join(root, "dist/server", responseStageEntry!.file);
+    expect(readStaticJavaScriptClosure(responseStagePath)).toContain(
+      "__vinext_cacheability_manifest.js",
+    );
     const wrangler = JSON.parse(
       fs.readFileSync(path.join(root, "dist/server/wrangler.json"), "utf8"),
     );

--- a/tests/cache-adapters-build.test.ts
+++ b/tests/cache-adapters-build.test.ts
@@ -251,6 +251,89 @@ export default createAdapter;
     ).toContain("__VINEXT_PREGENERATED_CONCRETE_PATHS");
   }, 60_000);
 
+  it("preserves the CDN response entrypoint through Cloudflare's virtual host entry", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-cdn-entrypoint-build-"));
+    tmpDirs.push(root);
+    writeCloudflareAppFixture(root, "vinext-cdn-entrypoint-build");
+    fs.rmSync(path.join(root, "node_modules"));
+    fs.symlinkSync(
+      path.resolve(import.meta.dirname, "fixtures/cf-app-basic/node_modules"),
+      path.join(root, "node_modules"),
+      "junction",
+    );
+    writeFixtureFile(
+      root,
+      "worker/index.ts",
+      'import handler from "vinext/server/fetch-handler";\n\nexport default handler;\n',
+    );
+
+    const { cloudflare } = (await import(pathToFileURL(cfPluginPath).href)) as {
+      cloudflare: CloudflarePluginFactory;
+    };
+    const builder = await createBuilder({
+      root,
+      configFile: false,
+      plugins: [
+        vinext({ appDir: root, cache: { cdn: cdnAdapter() } }),
+        cloudflare({ viteEnvironment: { name: "rsc", childEnvironments: ["ssr"] } }),
+      ],
+      logLevel: "silent",
+    });
+
+    await builder.buildApp();
+
+    const worker = fs.readFileSync(path.join(root, "dist/server/index.js"), "utf8");
+    expect(worker).toMatch(/export\s*\{[^}]*\b(?:[A-Za-z_$][\w$]*\s+as\s+)?VinextCachedResponse\b/);
+    const wrangler = JSON.parse(
+      fs.readFileSync(path.join(root, "dist/server/wrangler.json"), "utf8"),
+    );
+    expect(wrangler.exports).toMatchObject({
+      default: { type: "worker", cache: { enabled: false } },
+      VinextCachedResponse: { type: "worker", cache: { enabled: true } },
+    });
+  }, 60_000);
+
+  it("keeps the adapter-owned response entrypoint when a custom Worker uses its reserved export", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-cdn-entrypoint-collision-"));
+    tmpDirs.push(root);
+    writeCloudflareAppFixture(root, "vinext-cdn-entrypoint-collision");
+    fs.rmSync(path.join(root, "node_modules"));
+    fs.symlinkSync(
+      path.resolve(import.meta.dirname, "fixtures/cf-app-basic/node_modules"),
+      path.join(root, "node_modules"),
+      "junction",
+    );
+    writeFixtureFile(
+      root,
+      "worker/index.ts",
+      [
+        'import handler from "vinext/server/fetch-handler";',
+        'export class VinextCachedResponse { marker = "CUSTOM_RESERVED_EXPORT_MARKER"; }',
+        "export default handler;",
+        "",
+      ].join("\n"),
+    );
+
+    const { cloudflare } = (await import(pathToFileURL(cfPluginPath).href)) as {
+      cloudflare: CloudflarePluginFactory;
+    };
+    const builder = await createBuilder({
+      root,
+      configFile: false,
+      plugins: [
+        vinext({ appDir: root, cache: { cdn: cdnAdapter() } }),
+        cloudflare({ viteEnvironment: { name: "rsc", childEnvironments: ["ssr"] } }),
+      ],
+      logLevel: "silent",
+    });
+
+    await builder.buildApp();
+
+    const buildOutput = readTextFilesRecursive(path.join(root, "dist/server"));
+    expect(buildOutput).toContain("Invalid vinext response-stage invocation");
+    expect(buildOutput).not.toContain("CUSTOM_RESERVED_EXPORT_MARKER");
+  }, 60_000);
+
   it("keeps the data adapter out of the emitted request-stage graph", async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-cache-adapter-stages-"));
     tmpDirs.push(root);

--- a/tests/cache-adapters-build.test.ts
+++ b/tests/cache-adapters-build.test.ts
@@ -30,6 +30,9 @@ type CloudflarePluginFactory = (opts?: {
   viteEnvironment?: { name: string; childEnvironments?: string[] };
 }) => import("vite").Plugin;
 
+const LOCAL_ADAPTER_MARKER = "__VINEXT_LOCAL_DATA_ADAPTER_MARKER__";
+const RESPONSE_STAGE_MARKER = "__VINEXT_RESPONSE_STAGE_USER_CODE_MARKER__";
+
 function writeFixtureFile(root: string, filePath: string, content: string) {
   const absPath = path.join(root, filePath);
   fs.mkdirSync(path.dirname(absPath), { recursive: true });
@@ -79,6 +82,27 @@ function readStaticEntryClosure(root: string, entryKey: string): string {
     }
   }
 
+  return output;
+}
+
+function readStaticJavaScriptClosure(entryPath: string): string {
+  const visited = new Set<string>();
+  let output = "";
+  const visit = (filePath: string) => {
+    if (visited.has(filePath)) return;
+    visited.add(filePath);
+    const source = fs.readFileSync(filePath, "utf8");
+    output += source;
+    for (const match of source.matchAll(
+      /(?:import|export)\s*(?:[^"']*?\sfrom\s*)?["']([^"']+)["']/g,
+    )) {
+      const specifier = match[1];
+      if (!specifier?.startsWith(".")) continue;
+      const dependency = path.resolve(path.dirname(filePath), specifier);
+      if (fs.existsSync(dependency) && fs.statSync(dependency).isFile()) visit(dependency);
+    }
+  };
+  visit(entryPath);
   return output;
 }
 
@@ -141,7 +165,7 @@ function writeCloudflareAppFixture(root: string, name: string) {
     root,
     "app/page.tsx",
     `export default function HomePage() {
-  return <main>home</main>;
+  return <main>home ${RESPONSE_STAGE_MARKER}</main>;
 }
 `,
   );
@@ -159,8 +183,6 @@ function writeCloudflareAppFixture(root: string, name: string) {
     `import handler from ${JSON.stringify(workerEntryPath)};\n\nexport default handler;\n`,
   );
 }
-
-const LOCAL_ADAPTER_MARKER = "__VINEXT_LOCAL_DATA_ADAPTER_MARKER__";
 
 describe("config-driven cache adapter — local file by absolute path", () => {
   afterEach(() => {
@@ -282,8 +304,12 @@ export default createAdapter;
 
     await builder.buildApp();
 
-    const worker = fs.readFileSync(path.join(root, "dist/server/index.js"), "utf8");
+    const workerPath = path.join(root, "dist/server/index.js");
+    const worker = fs.readFileSync(workerPath, "utf8");
     expect(worker).toMatch(/export\s*\{[^}]*\b(?:[A-Za-z_$][\w$]*\s+as\s+)?VinextCachedResponse\b/);
+    expect(worker).toMatch(/import\s*["']\.\/__vinext_cacheability_manifest\.js["']/);
+    expect(readTextFilesRecursive(path.join(root, "dist/server"))).toContain(RESPONSE_STAGE_MARKER);
+    expect(readStaticJavaScriptClosure(workerPath)).not.toContain(RESPONSE_STAGE_MARKER);
     const wrangler = JSON.parse(
       fs.readFileSync(path.join(root, "dist/server/wrangler.json"), "utf8"),
     );
@@ -291,6 +317,7 @@ export default createAdapter;
       default: { type: "worker", cache: { enabled: false } },
       VinextCachedResponse: { type: "worker", cache: { enabled: true } },
     });
+    expect(wrangler.cache).toBeUndefined();
   }, 60_000);
 
   it("keeps the adapter-owned response entrypoint when a custom Worker uses its reserved export", async () => {

--- a/tests/cache-adapters-config.test.ts
+++ b/tests/cache-adapters-config.test.ts
@@ -317,6 +317,33 @@ describe("cdnAdapter builder + factory", () => {
     expect(path.isAbsolute(descriptor.adapter)).toBe(true);
     expect(descriptor.adapter.endsWith("cdn-adapter.runtime.js")).toBe(true);
     expect(descriptor.options).toBeUndefined();
+    expect(descriptor.output.type).toBe("multi-stage");
+    expect(path.isAbsolute(descriptor.output.entry)).toBe(true);
+    expect(descriptor.output.entry.endsWith("cdn-adapter.worker.js")).toBe(true);
+    expect(
+      descriptor.output.transformHostEntry({
+        code: 'import handler from "vinext/server/fetch-handler";\nexport default handler;',
+        id: "\0virtual:cloudflare/worker-entry",
+      }),
+    ).toContain(`export { VinextCachedResponse } from ${JSON.stringify(descriptor.output.entry)};`);
+    expect(
+      descriptor.output.transformHostEntry({
+        code: "export default { fetch() {} };",
+        id: "/app/unrelated.ts",
+      }),
+    ).toBeNull();
+    expect(
+      descriptor.output.transformHostEntry({
+        code: 'export default function Docs() { return "vinext/server/fetch-handler"; }',
+        id: "/app/page.tsx",
+      }),
+    ).toBeNull();
+    expect(
+      descriptor.output.transformHostEntry({
+        code: '// import handler from "vinext/server/fetch-handler";\nexport default {};',
+        id: "/app/page.ts",
+      }),
+    ).toBeNull();
     expect(descriptor.capabilities).toEqual({
       buildIdentity: "response-header",
       responsePolicyHeaderNames: ["CDN-Cache-Control", "Cloudflare-CDN-Cache-Control"],

--- a/tests/cache-adapters-config.test.ts
+++ b/tests/cache-adapters-config.test.ts
@@ -347,18 +347,12 @@ describe("cdnAdapter builder + factory", () => {
     expect(descriptor.capabilities).toEqual({
       buildIdentity: "response-header",
       responsePolicyHeaderNames: ["CDN-Cache-Control", "Cloudflare-CDN-Cache-Control"],
+      requestRouting: "uncached-stage",
       responseVary: "verbatim",
       routeCacheability: "probe-manifest",
     });
     expect(hasBuildIdentityResponseHeader({ cdn: descriptor })).toBe(true);
-    expect(
-      hasUncachedRequestRouting({
-        cdn: {
-          adapter: "staged-cache",
-          capabilities: { requestRouting: "uncached-stage" },
-        },
-      }),
-    ).toBe(true);
+    expect(hasUncachedRequestRouting({ cdn: descriptor })).toBe(true);
     expect(hasVerbatimResponseVary({ cdn: descriptor })).toBe(true);
     expect(hasBuildIdentityResponseHeader({ cdn: { adapter: "custom-cache" } })).toBe(false);
     expect(hasUncachedRequestRouting({ cdn: { adapter: "url-only-cache" } })).toBe(false);

--- a/tests/cloudflare-cacheability-probe.test.ts
+++ b/tests/cloudflare-cacheability-probe.test.ts
@@ -661,7 +661,7 @@ describe("staged Worker cacheability probes", () => {
     ]);
   });
 
-  it("records a rewrite source under the route resolved by the request stage", async () => {
+  it("records a rewrite source under the concrete route resolved by the request stage", async () => {
     const root = createProbeRoot();
     const source = {
       ...target("/rewrite-me"),
@@ -682,6 +682,7 @@ describe("staged Worker cacheability probes", () => {
           kind: "app-page",
           pattern: "/safe",
           rendererStatic: true,
+          routePathname: "/safe",
           state: "static-candidate",
           status: 200,
           version: 1,
@@ -700,8 +701,98 @@ describe("staged Worker cacheability probes", () => {
       kind: "app-page",
       pattern: "/safe",
       state: "runtime-check",
-      staticPaths: { html: ["/rewrite-me", "/safe"] },
+      staticPaths: { html: ["/safe"] },
       unknownState: "static-candidate",
+    });
+  });
+
+  it("records a rewritten App runtime path without a direct destination target", async () => {
+    const root = createProbeRoot();
+    const source = {
+      ...target("/latest"),
+      route: {
+        cacheabilityProbe: { canPrunePattern: true, routeMayResolve: true },
+        kind: "app-page" as const,
+        pattern: "/latest",
+      },
+    };
+    const result = await probeStagedWorkerCacheability({
+      buildId: "application-build",
+      fetchImpl: async () =>
+        Response.json({
+          kind: "app-page",
+          pattern: "/posts/:slug",
+          rendererStatic: false,
+          routePathname: "/posts/one",
+          state: "static-candidate",
+          status: 200,
+          version: 1,
+        }),
+      retries: 0,
+      root,
+      targetUrl: "https://example.com",
+      targets: [source],
+    });
+
+    expect(result.failures).toEqual([]);
+    expect(result.cacheableTargets).toEqual([source]);
+    expect(
+      result.manifest.routes[cacheabilityManifestRouteKey("app-page", "/posts/:slug")],
+    ).toEqual({
+      kind: "app-page",
+      pattern: "/posts/:slug",
+      runtimePaths: ["/posts/one"],
+      state: "runtime-check",
+    });
+  });
+
+  it("records rewritten Pages HTML and data under the resolved GSSP path", async () => {
+    const root = createProbeRoot();
+    const route = {
+      cacheabilityProbe: { canPrunePattern: true, routeMayResolve: true },
+      kind: "pages-page" as const,
+      pattern: "/latest",
+    };
+    const html = { ...target("/latest"), route };
+    const data = {
+      headers: { Accept: "application/json" },
+      kind: "pages-data" as const,
+      label: "/_next/data/build/latest.json (Pages data)",
+      pathname: "/_next/data/build/latest.json",
+      route: {
+        ...route,
+        cacheabilityProbe: { ...route.cacheabilityProbe, concretePathname: "/latest" },
+      },
+      sourcePathname: "/_next/data/build/latest.json",
+    };
+    const result = await probeStagedWorkerCacheability({
+      buildId: "application-build",
+      fetchImpl: async () =>
+        Response.json({
+          kind: "pages-page",
+          pattern: "/posts/:slug",
+          rendererStatic: false,
+          routePathname: "/posts/one",
+          state: "static-candidate",
+          status: 200,
+          version: 1,
+        }),
+      retries: 0,
+      root,
+      targetUrl: "https://example.com",
+      targets: [data, html],
+    });
+
+    expect(result.failures).toEqual([]);
+    expect(result.cacheableTargets).toEqual([html, data]);
+    expect(result.speculativeTargets).toEqual([data]);
+    expect(
+      result.manifest.routes[cacheabilityManifestRouteKey("pages-page", "/posts/:slug")],
+    ).toEqual({
+      kind: "pages-page",
+      pattern: "/posts/:slug",
+      runtimePaths: ["/posts/one"],
+      state: "runtime-check",
     });
   });
 
@@ -798,6 +889,7 @@ describe("staged Worker cacheability probes", () => {
             kind: "app-page",
             pattern: "/safe",
             rendererStatic: pathname === "/rewrite-me",
+            routePathname: "/safe",
             ...(pathname === "/safe" ? { scope: "pattern" } : {}),
             state: pathname === "/safe" ? "dynamic" : "static-candidate",
             status: 200,
@@ -817,7 +909,6 @@ describe("staged Worker cacheability probes", () => {
         pattern: "/safe",
         runtimePaths: ["/safe"],
         state: "runtime-check",
-        staticPaths: { html: ["/rewrite-me"] },
       });
     }
   });

--- a/tests/cloudflare-cacheability-probe.test.ts
+++ b/tests/cloudflare-cacheability-probe.test.ts
@@ -555,6 +555,54 @@ describe("staged Worker cacheability probes", () => {
     expect(result.cacheableTargets).toEqual([]);
   });
 
+  it("regroups resolved routes independently of probe completion order", async () => {
+    const source = {
+      ...target("/rewrite-me"),
+      route: {
+        cacheabilityProbe: { canPrunePattern: true, routeMayResolve: true },
+        kind: "app-page" as const,
+        pattern: "/rewrite-me",
+      },
+    };
+    const direct = { ...target("/safe"), route: optimizableRoute("/safe") };
+
+    for (const delayedPathname of ["/rewrite-me", "/safe"]) {
+      const result = await probeStagedWorkerCacheability({
+        buildId: "application-build",
+        concurrency: 2,
+        fetchImpl: async (input) => {
+          const pathname = new URL(input instanceof Request ? input.url : String(input)).pathname;
+          if (pathname === delayedPathname) {
+            await new Promise((resolve) => setTimeout(resolve, 10));
+          }
+          return Response.json({
+            kind: "app-page",
+            pattern: "/safe",
+            rendererStatic: pathname === "/rewrite-me",
+            ...(pathname === "/safe" ? { scope: "pattern" } : {}),
+            state: pathname === "/safe" ? "dynamic" : "static-candidate",
+            status: 200,
+            version: 1,
+          });
+        },
+        retries: 0,
+        root: createProbeRoot(),
+        targetUrl: "https://example.com",
+        targets: [source, direct],
+      });
+
+      expect(result.failures).toEqual([]);
+      expect(result.cacheableTargets).toEqual([source]);
+      expect(result.manifest.routes[cacheabilityManifestRouteKey("app-page", "/safe")]).toEqual({
+        kind: "app-page",
+        pattern: "/safe",
+        runtimePaths: ["/safe"],
+        state: "runtime-check",
+        staticPaths: { html: ["/rewrite-me"] },
+      });
+    }
+  });
+
   it("does not prune siblings when a config cache policy varies within the route pattern", async () => {
     const root = createProbeRoot();
     const route = {

--- a/tests/cloudflare-cacheability-probe.test.ts
+++ b/tests/cloudflare-cacheability-probe.test.ts
@@ -13,6 +13,7 @@ import {
 import {
   VINEXT_CACHEABILITY_PROBE_HEADER,
   VINEXT_CACHEABILITY_PROBE_QUERY_PARAM,
+  VINEXT_CACHEABILITY_PROBE_ROUTE_HEADER,
   VINEXT_PRERENDER_SECRET_HEADER,
 } from "../packages/vinext/src/server/headers.js";
 
@@ -78,6 +79,10 @@ describe("staged Worker cacheability probes", () => {
       urls.push(url);
       const headers = new Headers(init?.headers);
       expect(headers.get(VINEXT_CACHEABILITY_PROBE_HEADER)).toBe("1");
+      expect(JSON.parse(headers.get(VINEXT_CACHEABILITY_PROBE_ROUTE_HEADER)!)).toEqual([
+        "app-page",
+        "/cached/:slug",
+      ]);
       expect(headers.get(VINEXT_PRERENDER_SECRET_HEADER)).toBe("probe-secret");
       expect(headers.get("Cache-Control")).toBeNull();
 

--- a/tests/cloudflare-cacheability-probe.test.ts
+++ b/tests/cloudflare-cacheability-probe.test.ts
@@ -79,10 +79,9 @@ describe("staged Worker cacheability probes", () => {
       urls.push(url);
       const headers = new Headers(init?.headers);
       expect(headers.get(VINEXT_CACHEABILITY_PROBE_HEADER)).toBe("1");
-      expect(JSON.parse(headers.get(VINEXT_CACHEABILITY_PROBE_ROUTE_HEADER)!)).toEqual([
-        "app-page",
-        "/cached/:slug",
-      ]);
+      expect(
+        JSON.parse(decodeURIComponent(headers.get(VINEXT_CACHEABILITY_PROBE_ROUTE_HEADER)!)),
+      ).toEqual(["app-page", "/cached/:slug"]);
       expect(headers.get(VINEXT_PRERENDER_SECRET_HEADER)).toBe("probe-secret");
       expect(headers.get("Cache-Control")).toBeNull();
 
@@ -535,6 +534,52 @@ describe("staged Worker cacheability probes", () => {
       staticPaths: { html: ["/rewrite-me", "/safe"] },
       unknownState: "static-candidate",
     });
+  });
+
+  it("encodes Unicode route patterns into ByteString probe headers", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-cacheability-probe-unicode-"));
+    roots.push(root);
+    fs.mkdirSync(path.join(root, "dist", "server"), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, "dist", "server", "vinext-server.json"),
+      JSON.stringify({ prerenderSecret: "probe-secret" }),
+    );
+
+    const fetchImpl = vi.fn<typeof fetch>(async (_input, init) => {
+      const encodedRoute = new Headers(init?.headers).get(VINEXT_CACHEABILITY_PROBE_ROUTE_HEADER);
+      expect(encodedRoute).toContain("%E4%BD%A0%E5%A5%BD");
+      expect(JSON.parse(decodeURIComponent(encodedRoute!))).toEqual(["app-page", "/你好"]);
+      return Response.json({
+        kind: "app-page",
+        pattern: "/你好",
+        scope: "identity",
+        state: "dynamic",
+        status: 200,
+        version: 1,
+      });
+    });
+    const route = optimizableRoute("/你好");
+    const result = await probeStagedWorkerCacheability({
+      buildId: "application-build",
+      fetchImpl,
+      retries: 0,
+      root,
+      targetUrl: "https://example.com",
+      targets: [
+        {
+          headers: { Accept: "text/html" },
+          kind: "html",
+          label: "/你好",
+          pathname: "/你好",
+          route,
+          sourcePathname: "/你好",
+        },
+      ],
+    });
+
+    expect(result.failures).toEqual([]);
+    expect(result.dynamic).toBe(1);
+    expect(fetchImpl).toHaveBeenCalledOnce();
   });
 
   it("rejects an unexpected resolved route without rewrite metadata", async () => {

--- a/tests/cloudflare-cacheability-probe.test.ts
+++ b/tests/cloudflare-cacheability-probe.test.ts
@@ -488,6 +488,73 @@ describe("staged Worker cacheability probes", () => {
     ]);
   });
 
+  it("records a rewrite source under the route resolved by the request stage", async () => {
+    const root = createProbeRoot();
+    const source = {
+      ...target("/rewrite-me"),
+      route: {
+        cacheabilityProbe: { canPrunePattern: true, routeMayResolve: true },
+        kind: "app-page" as const,
+        pattern: "/rewrite-me",
+      },
+    };
+    const direct = {
+      ...target("/safe"),
+      route: optimizableRoute("/safe"),
+    };
+    const result = await probeStagedWorkerCacheability({
+      buildId: "application-build",
+      fetchImpl: async () =>
+        Response.json({
+          kind: "app-page",
+          pattern: "/safe",
+          rendererStatic: true,
+          state: "static-candidate",
+          status: 200,
+          version: 1,
+        }),
+      retries: 0,
+      root,
+      targetUrl: "https://example.com",
+      targets: [source, direct],
+    });
+
+    expect(result.failures).toEqual([]);
+    expect(result).toMatchObject({ classified: 1, probed: 2 });
+    expect(result.cacheableTargets).toEqual([source, direct]);
+    expect(result.manifest.routes[cacheabilityManifestRouteKey("app-page", "/safe")]).toEqual({
+      allowUnknown: true,
+      kind: "app-page",
+      pattern: "/safe",
+      state: "runtime-check",
+      staticPaths: { html: ["/rewrite-me", "/safe"] },
+      unknownState: "static-candidate",
+    });
+  });
+
+  it("rejects an unexpected resolved route without rewrite metadata", async () => {
+    const root = createProbeRoot();
+    const result = await probeStagedWorkerCacheability({
+      buildId: "application-build",
+      fetchImpl: async () =>
+        Response.json({
+          kind: "app-page",
+          pattern: "/unexpected",
+          rendererStatic: true,
+          state: "static-candidate",
+          status: 200,
+          version: 1,
+        }),
+      retries: 0,
+      root,
+      targetUrl: "https://example.com",
+      targets: [target("/expected")],
+    });
+
+    expect(result.failures).toEqual(["/expected: probe resolved to unexpected route /unexpected"]);
+    expect(result.cacheableTargets).toEqual([]);
+  });
+
   it("does not prune siblings when a config cache policy varies within the route pattern", async () => {
     const root = createProbeRoot();
     const route = {

--- a/tests/cloudflare-cacheability-probe.test.ts
+++ b/tests/cloudflare-cacheability-probe.test.ts
@@ -287,6 +287,175 @@ describe("staged Worker cacheability probes", () => {
     ]);
   });
 
+  it("probes App representations independently when the request stage may terminate", async () => {
+    const root = createProbeRoot();
+    const route = {
+      cacheabilityProbe: { canPrunePattern: true, requestStageMayTerminate: true },
+      kind: "app-page" as const,
+      pattern: "/conditional",
+    };
+    const html = { ...target("/conditional"), route };
+    const rsc = {
+      headers: { Accept: "text/x-component", RSC: "1" },
+      kind: "rsc-full" as const,
+      label: "/conditional (RSC full)",
+      pathname: "/conditional?_rsc",
+      route,
+      sourcePathname: "/conditional",
+    };
+    const fetchImpl = vi.fn<typeof fetch>(async (_input, init) => {
+      const isRsc = new Headers(init?.headers).get("RSC") === "1";
+      return Response.json({
+        kind: "app-page",
+        pattern: route.pattern,
+        ...(isRsc
+          ? { rendererStatic: true, state: "static-candidate" }
+          : { scope: "identity", state: "dynamic", terminal: true }),
+        status: isRsc ? 200 : 307,
+        version: 1,
+      });
+    });
+
+    const result = await probeStagedWorkerCacheability({
+      buildId: "application-build",
+      fetchImpl,
+      retries: 0,
+      root,
+      targetUrl: "https://example.com",
+      targets: [rsc, html],
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(result).toMatchObject({ classified: 1, dynamic: 1, probed: 2, skipped: 0 });
+    expect(result.failures).toEqual([]);
+    expect(result.cacheableTargets).toEqual([rsc]);
+    expect(result.speculativeTargets).toEqual([]);
+    const manifestRoute = Object.values(result.manifest.routes)[0];
+    expect(cacheabilityManifestRouteState(manifestRoute, "/conditional", "rsc-full")).toBe(
+      "static-candidate",
+    );
+  });
+
+  it("probes Pages HTML and data independently when the request stage may terminate", async () => {
+    const root = createProbeRoot();
+    const route = {
+      cacheabilityProbe: { canPrunePattern: true, requestStageMayTerminate: true },
+      kind: "pages-page" as const,
+      pattern: "/posts/:slug",
+    };
+    const html = {
+      headers: { Accept: "text/html" },
+      kind: "html" as const,
+      label: "/posts/one",
+      pathname: "/posts/one",
+      route,
+      sourcePathname: "/posts/one",
+    };
+    const data = {
+      headers: { Accept: "application/json" },
+      kind: "pages-data" as const,
+      label: "/_next/data/build/posts/one.json (Pages data)",
+      pathname: "/_next/data/build/posts/one.json",
+      route: {
+        ...route,
+        cacheabilityProbe: { ...route.cacheabilityProbe, concretePathname: "/posts/one" },
+      },
+      sourcePathname: "/_next/data/build/posts/one.json",
+    };
+    const fetchImpl = vi.fn<typeof fetch>(async (_input, init) => {
+      const isData = new Headers(init?.headers).get("Accept") === "application/json";
+      return Response.json({
+        kind: "pages-page",
+        pattern: route.pattern,
+        ...(isData
+          ? { rendererStatic: true, state: "static-candidate" }
+          : { scope: "identity", state: "dynamic", terminal: true }),
+        status: isData ? 200 : 307,
+        version: 1,
+      });
+    });
+
+    const result = await probeStagedWorkerCacheability({
+      buildId: "application-build",
+      fetchImpl,
+      retries: 0,
+      root,
+      targetUrl: "https://example.com",
+      targets: [data, html],
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(result.cacheableTargets).toEqual([data]);
+    expect(result.speculativeTargets).toEqual([]);
+  });
+
+  it("does not prune a terminal-capable pattern from one representation", async () => {
+    const root = createProbeRoot();
+    const route = {
+      cacheabilityProbe: { canPrunePattern: true, requestStageMayTerminate: true },
+      kind: "app-page" as const,
+      pattern: "/posts/:slug",
+    };
+    const first = { ...target("/posts/one"), route };
+    const second = { ...target("/posts/two"), route };
+    const fetchImpl = vi.fn<typeof fetch>(async (input) => {
+      const pathname = new URL(input instanceof Request ? input.url : String(input)).pathname;
+      return Response.json({
+        kind: "app-page",
+        pattern: route.pattern,
+        rendererStatic: pathname.endsWith("/two"),
+        scope: pathname.endsWith("/one") ? "pattern" : undefined,
+        state: pathname.endsWith("/one") ? "dynamic" : "static-candidate",
+        status: 200,
+        version: 1,
+      });
+    });
+
+    const result = await probeStagedWorkerCacheability({
+      buildId: "application-build",
+      concurrency: 1,
+      fetchImpl,
+      retries: 0,
+      root,
+      targetUrl: "https://example.com",
+      targets: [first, second],
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(result).toMatchObject({ dynamic: 1, probed: 2, skipped: 0 });
+    expect(result.cacheableTargets).toEqual([second]);
+  });
+
+  it.each([
+    ["false", { scope: "identity", state: "dynamic", terminal: false }],
+    ["non-dynamic", { rendererStatic: true, state: "static-candidate", terminal: true }],
+  ])("rejects an invalid %s terminal probe signal", async (_label, probeResult) => {
+    const root = createProbeRoot();
+    const route = {
+      cacheabilityProbe: { canPrunePattern: true, requestStageMayTerminate: true },
+      kind: "app-page" as const,
+      pattern: "/conditional",
+    };
+    const result = await probeStagedWorkerCacheability({
+      buildId: "application-build",
+      fetchImpl: async () =>
+        Response.json({
+          kind: "app-page",
+          pattern: route.pattern,
+          ...probeResult,
+          status: 200,
+          version: 1,
+        }),
+      retries: 0,
+      root,
+      targetUrl: "https://example.com",
+      targets: [{ ...target("/conditional"), route }],
+    });
+
+    expect(result.failures).toEqual(["/conditional: probe returned an invalid envelope"]);
+    expect(result.cacheableTargets).toEqual([]);
+  });
+
   it("leaves representation-specific statuses to the final completed render", async () => {
     const root = createProbeRoot();
     const route = { kind: "app-page" as const, pattern: "/missing" };

--- a/tests/cloudflare-cacheability-probe.test.ts
+++ b/tests/cloudflare-cacheability-probe.test.ts
@@ -79,6 +79,7 @@ describe("staged Worker cacheability probes", () => {
       const headers = new Headers(init?.headers);
       expect(headers.get(VINEXT_CACHEABILITY_PROBE_HEADER)).toBe("1");
       expect(headers.get(VINEXT_PRERENDER_SECRET_HEADER)).toBe("probe-secret");
+      expect(headers.get("Cache-Control")).toBeNull();
 
       if (urls.length <= 2) {
         return new Response(

--- a/tests/cloudflare-cdn-cache.test.ts
+++ b/tests/cloudflare-cdn-cache.test.ts
@@ -219,15 +219,15 @@ describe("CloudflareCdnCacheAdapter", () => {
     await expect(adapter.set("k", null)).resolves.toBeUndefined();
   });
 
-  it("carries SWR on CDN-Cache-Control (public + max-age) and revalidates the browser", () => {
+  it("carries SWR on Cloudflare's consumed edge policy and revalidates the browser", () => {
     // A value-less `stale-while-revalidate` is normalized to an explicit window
     // (Cloudflare ignores the bare directive — RFC 5861 requires a value).
     expect(
       adapter.buildResponseHeaders({ cacheControl: "s-maxage=60, stale-while-revalidate" }),
     ).toEqual({
       "Cache-Control": "public, max-age=0, must-revalidate",
-      "CDN-Cache-Control": "public, max-age=60, stale-while-revalidate=31536000",
-      "Cloudflare-CDN-Cache-Control": null,
+      "CDN-Cache-Control": null,
+      "Cloudflare-CDN-Cache-Control": "public, max-age=60, stale-while-revalidate=31536000",
       "Cache-Tag": null,
     });
   });
@@ -252,7 +252,8 @@ describe("CloudflareCdnCacheAdapter", () => {
     });
     expect(headers["Cache-Tag"]).toBe("/blog,_N_T_/blog,posts");
     expect(headers["Cache-Control"]).toBe("public, max-age=0, must-revalidate");
-    expect(headers["CDN-Cache-Control"]).toBe("public, max-age=60");
+    expect(headers["CDN-Cache-Control"]).toBeNull();
+    expect(headers["Cloudflare-CDN-Cache-Control"]).toBe("public, max-age=60");
   });
 
   it("skips tags containing the comma separator or that are too long", () => {

--- a/tests/cloudflare-cdn-warm-deploy.test.ts
+++ b/tests/cloudflare-cdn-warm-deploy.test.ts
@@ -115,7 +115,18 @@ function writeTwoStageWorkerArtifact(): void {
     "dist/server/wrangler.json",
     JSON.stringify({ main: "index.js", name: "my-worker", workers_dev: true }),
   );
-  writeFile("dist/server/index.js", `import "./${CACHEABILITY_MANIFEST_MODULE}";\n`);
+  writeFile("dist/server/index.js", 'void import("./response-stage.js");\n');
+  writeFile("dist/server/response-stage.js", `import "./${CACHEABILITY_MANIFEST_MODULE}";\n`);
+  writeFile(
+    "dist/server/.vite/manifest.json",
+    JSON.stringify({
+      "virtual:cloudflare/worker-entry": {
+        dynamicImports: ["virtual:vinext-response-stage"],
+        file: "index.js",
+      },
+      "virtual:vinext-response-stage": { file: "response-stage.js" },
+    }),
+  );
   writeFile(`dist/server/${CACHEABILITY_MANIFEST_MODULE}`, "export default null;\n");
   writeFile(
     "dist/server/vinext-server.json",
@@ -304,6 +315,13 @@ describe("Cloudflare CDN warmup deploy flow", () => {
   it("rejects a generated artifact whose Worker main cannot reach the manifest module", () => {
     writeTwoStageWorkerArtifact();
     writeFile("dist/server/index.js", "export default { fetch() {} };\n");
+    writeFile(
+      "dist/server/.vite/manifest.json",
+      JSON.stringify({
+        "virtual:cloudflare/worker-entry": { file: "index.js" },
+        "virtual:vinext-response-stage": { file: "response-stage.js" },
+      }),
+    );
 
     expect(() =>
       writeCacheabilityManifestArtifact(tmpDir, "dist/server/wrangler.json", {
@@ -311,7 +329,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
         routes: {},
         version: 1,
       }),
-    ).toThrow(`Worker main module to import ${CACHEABILITY_MANIFEST_MODULE}`);
+    ).toThrow(`Worker graph to statically import ${CACHEABILITY_MANIFEST_MODULE}`);
   });
 
   it.each([
@@ -335,7 +353,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     ],
   ])("rejects a manifest filename mentioned only by a %s", (_label, mainSource) => {
     writeTwoStageWorkerArtifact();
-    writeFile("dist/server/index.js", mainSource);
+    writeFile("dist/server/response-stage.js", mainSource);
 
     expect(() =>
       writeCacheabilityManifestArtifact(tmpDir, "dist/server/wrangler.json", {
@@ -343,7 +361,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
         routes: {},
         version: 1,
       }),
-    ).toThrow(`Worker main module to import ${CACHEABILITY_MANIFEST_MODULE}`);
+    ).toThrow(`Worker graph to statically import ${CACHEABILITY_MANIFEST_MODULE}`);
   });
 
   it.each([
@@ -357,7 +375,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     ],
   ])("accepts a manifest reached by a %s", (_label, mainSource) => {
     writeTwoStageWorkerArtifact();
-    writeFile("dist/server/index.js", mainSource);
+    writeFile("dist/server/response-stage.js", mainSource);
 
     expect(
       writeCacheabilityManifestArtifact(tmpDir, "dist/server/wrangler.json", {

--- a/tests/cloudflare-cdn-warm-deploy.test.ts
+++ b/tests/cloudflare-cdn-warm-deploy.test.ts
@@ -1350,6 +1350,53 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     },
   );
 
+  it("retries a required prepared fill while entrypoint cache config propagates", async () => {
+    writeTwoStageWorkerArtifact();
+    const wrangler = mockTwoStageWrangler();
+    let fillCalls = 0;
+    vi.mocked(fetch).mockImplementation(async (input, init) => {
+      if (new Headers(init?.headers).get(VINEXT_CACHEABILITY_PROBE_HEADER) === "1") {
+        return appPageProbeResponse();
+      }
+      if (isReadinessFetch(input)) return readinessResponse();
+      fillCalls++;
+      if (fillCalls === 1) {
+        return new Response("cache config still propagating", {
+          headers: {
+            "cache-control": "no-store",
+            "cf-cache-status": "BYPASS",
+            "content-type": "text/html",
+            [VINEXT_CDN_BUILD_ID_HEADER]: "app-build-a",
+          },
+        });
+      }
+      return cacheableHtml();
+    });
+    const { deployWithCdnWarmup } = await import("../packages/cloudflare/src/deploy.js");
+
+    await expect(
+      deployWithCdnWarmup(tmpDir, [], {
+        cacheabilityProbe: true,
+        config: "dist/server/wrangler.json",
+        discoverWarmPlan: async () => ({
+          appPaths: ["/about"],
+          buildId: "app-build-a",
+          buildIdentity: "app-build-a",
+          loadingShellPaths: [],
+          paths: ["/about"],
+          routePatterns: appPageRoutePatterns(["/about"]),
+          rscPaths: [],
+        }),
+        warmCdnConcurrency: 1,
+        warmCdnPromotionDelay: 0,
+        warmCdnReadinessProbes: 1,
+        warmCdnRetries: 1,
+      }),
+    ).resolves.toBe("https://my-worker.example.workers.dev");
+    expect(fillCalls).toBe(2);
+    expect(wrangler.promoted).toBe(true);
+  });
+
   it("lets prepared cache fills exceed the readiness window while requests keep completing", async () => {
     writeTwoStageWorkerArtifact();
     let now = 0;

--- a/tests/cloudflare-cdn-warm.test.ts
+++ b/tests/cloudflare-cdn-warm.test.ts
@@ -384,6 +384,47 @@ describe("Cloudflare CDN warmup", () => {
     expect(result.skippedTargets).toHaveLength(2);
   });
 
+  it("retries required staged BYPASS responses without delaying optional representations", async () => {
+    const attempts = new Map<string, number>();
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const pathname = new URL(requestHref(input)!).pathname;
+      const attempt = (attempts.get(pathname) ?? 0) + 1;
+      attempts.set(pathname, attempt);
+      if (pathname === "/required" && attempt > 1) return cacheableHtml("required");
+      return new Response("private", {
+        headers: {
+          "cache-control": "no-store",
+          "cf-cache-status": "BYPASS",
+          "content-type": "text/html",
+          [VINEXT_CDN_BUILD_ID_HEADER]: "build-a",
+        },
+      });
+    });
+
+    const result = await warmCdnCache({
+      expectedBuildId: "build-a",
+      fetchImpl: fetchImpl as typeof fetch,
+      paths: ["/required", "/optional"],
+      propagatingTarget: true,
+      retries: 2,
+      retryDelayMs: 0,
+      retrySkippedTargetKeys: new Set(["html\0/required"]),
+      strict: true,
+      targetUrl: "https://app.example.com",
+    });
+
+    expect(result).toMatchObject({ failed: 0, skipped: 1, warmed: 1 });
+    expect(attempts).toEqual(
+      new Map([
+        ["/required", 2],
+        ["/optional", 1],
+      ]),
+    );
+    expect(result.skippedTargets.map(({ sourcePathname }) => sourcePathname)).toEqual([
+      "/optional",
+    ]);
+  });
+
   it("rejects a Pages data response with a non-JSON representation", async () => {
     await expect(
       warmCdnCache({

--- a/tests/cloudflare-cdn-warm.test.ts
+++ b/tests/cloudflare-cdn-warm.test.ts
@@ -219,6 +219,31 @@ describe("Cloudflare CDN warmup", () => {
     );
   });
 
+  it("rejects non-boolean request-stage termination metadata", () => {
+    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile(
+      "dist/server/vinext-prerender-paths.json",
+      JSON.stringify({
+        buildId: "build-a",
+        paths: ["/conditional"],
+        routePatterns: {
+          "/conditional": {
+            cacheabilityProbe: {
+              canPrunePattern: true,
+              requestStageMayTerminate: "true",
+            },
+            kind: "app-page",
+            pattern: "/conditional",
+          },
+        },
+      }),
+    );
+
+    expect(() => readPrerenderWarmPlan(tmpDir, { strict: true })).toThrow(
+      "prerender path manifest not found",
+    );
+  });
+
   it("warms canonical RSC, HTML, and Pages data with browser-identical requests", async () => {
     const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
       const headers = new Headers(init?.headers);

--- a/tests/cloudflare-cdn-worker.test.ts
+++ b/tests/cloudflare-cdn-worker.test.ts
@@ -79,6 +79,83 @@ function pagesPageProps(
   };
 }
 
+type PreFixResponseStageInvocation = {
+  options: { cache: "shared" | "bypass" };
+  props: unknown;
+  requestMethod: string;
+  requestUrl: string;
+};
+
+/** Snapshot of the response-stage parser immediately before the wire-version fix. */
+function getPreFixResponseStageInvocation(value: unknown): PreFixResponseStageInvocation | null {
+  if (!value || typeof value !== "object") return null;
+  const options = Reflect.get(value, "options");
+  if (!options || typeof options !== "object") return null;
+  const cache = Reflect.get(options, "cache");
+  if (cache !== "shared" && cache !== "bypass") return null;
+  const requestUrl = Reflect.get(value, "requestUrl");
+  if (typeof requestUrl !== "string") return null;
+  const requestMethod = Reflect.get(value, "requestMethod");
+  if (typeof requestMethod !== "string" || requestMethod.length === 0) return null;
+  try {
+    new URL(requestUrl);
+  } catch {
+    return null;
+  }
+  return {
+    options: options as PreFixResponseStageInvocation["options"],
+    props: Reflect.get(value, "props"),
+    requestMethod,
+    requestUrl,
+  };
+}
+
+/** Local pre-fix entrypoint used to exercise a real rolling-deploy boundary. */
+class PreFixVinextCachedResponse {
+  constructor(
+    private readonly props: unknown,
+    private readonly buildIdentity: string,
+  ) {}
+
+  async fetch(request: Request): Promise<Response> {
+    const invocation = getPreFixResponseStageInvocation(this.props);
+    if (!invocation) {
+      return this.stamp(new Response("Invalid vinext response-stage invocation", { status: 400 }));
+    }
+    const restored = new Request(new Request(invocation.requestUrl, request), {
+      method: invocation.requestMethod,
+    });
+    const response = await stages.response(
+      restored,
+      {},
+      { hostRuntime: "worker" },
+      invocation.props,
+      async () => new Response(null, { status: 501 }),
+      invocation.options,
+    );
+    return this.stamp(response);
+  }
+
+  private stamp(response: Response): Response {
+    const headers = new Headers(response.headers);
+    headers.set(VINEXT_CDN_BUILD_ID_HEADER, this.buildIdentity);
+    return new Response(response.body, {
+      headers,
+      status: response.status,
+      statusText: response.statusText,
+    });
+  }
+}
+
+function isWorkersCacheAdmissible(response: Response): boolean {
+  // This deliberately models only the RFC admission decision needed by this
+  // regression, not every feature of Workers Cache.
+  return (
+    response.status === 200 &&
+    response.headers.get("Cloudflare-CDN-Cache-Control")?.includes("public") === true
+  );
+}
+
 describe("Cloudflare CDN multi-stage Worker facade", () => {
   beforeEach(() => {
     stages.request.mockReset();
@@ -131,9 +208,11 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
         }),
       );
 
-      const response = await createEntrypoint(responseStageInvocation({ kind: "app-page" })).fetch(
-        new Request("https://example.com/page"),
-      );
+      const response = await createEntrypoint({
+        ...responseStageInvocation({ kind: "app-page" }),
+        expectedResponseStageBuildIdentity: "current-stage",
+        options: { cache: "vinext-cloudflare-v1:shared" },
+      }).fetch(new Request("https://example.com/page"));
 
       expect(response.status).toBe(status);
       expect(response.headers.get(VINEXT_CDN_BUILD_ID_HEADER)).toBe("current-stage");
@@ -208,12 +287,16 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
     await vi.waitFor(() => expect(cancel).toHaveBeenCalledOnce());
   });
 
-  it("rejects a stale named stage before Workers Cache can admit its response", async () => {
+  it("makes a pre-fix named stage fail before render or Workers Cache admission", async () => {
     // No Next.js test port applies: propagation between named Worker
     // entrypoints and Workers Cache admission is Cloudflare-specific.
     vi.stubEnv("__VINEXT_RSC_BUILD_IDENTITY", "current-stage");
     const cachedResponses = new Map<string, Response>();
-    const coldResponseMetadata: { cacheControl: string | null; identity: string | null }[] = [];
+    const coldResponseMetadata: {
+      edgeCacheControl: string | null;
+      identity: string | null;
+      status: number;
+    }[] = [];
     const renderedBy: string[] = [];
     let coldDispatch = 0;
     const binding = vi.fn(({ props }: { props: unknown }) => ({
@@ -223,19 +306,16 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
         const cached = cachedResponses.get(request.url);
         if (cached) return cached.clone();
 
-        const responseStageIdentity = coldDispatch++ === 0 ? "previous-stage" : "current-stage";
-        process.env.__VINEXT_RSC_BUILD_IDENTITY = responseStageIdentity;
-        let response: Response;
-        try {
-          response = await createEntrypoint(props).fetch(request);
-        } finally {
-          process.env.__VINEXT_RSC_BUILD_IDENTITY = "current-stage";
-        }
+        const response =
+          coldDispatch++ === 0
+            ? await new PreFixVinextCachedResponse(props, "previous-stage").fetch(request)
+            : await createEntrypoint(props).fetch(request);
         coldResponseMetadata.push({
-          cacheControl: response.headers.get("Cache-Control"),
+          edgeCacheControl: response.headers.get("Cloudflare-CDN-Cache-Control"),
           identity: response.headers.get(VINEXT_CDN_BUILD_ID_HEADER),
+          status: response.status,
         });
-        if (!response.headers.get("Cache-Control")?.includes("no-store")) {
+        if (isWorkersCacheAdmissible(response)) {
           cachedResponses.set(request.url, response.clone());
         }
         return response;
@@ -245,9 +325,8 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
       dispatch(request, { kind: "app-page" }, { cache: "shared" }),
     );
     stages.response.mockImplementation(() => {
-      const responseStageIdentity = process.env.__VINEXT_RSC_BUILD_IDENTITY!;
-      renderedBy.push(responseStageIdentity);
-      return new Response(`rendered by ${responseStageIdentity}`, {
+      renderedBy.push("current-stage");
+      return new Response("rendered by current-stage", {
         headers: { "Cloudflare-CDN-Cache-Control": "public, max-age=300" },
       });
     });
@@ -258,8 +337,9 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
     expect(first.headers.get("Cache-Control")).toBe("no-store");
     expect(cachedResponses).toHaveProperty("size", 0);
     expect(coldResponseMetadata).toEqual([
-      { cacheControl: "no-store", identity: "previous-stage" },
+      { edgeCacheControl: null, identity: "previous-stage", status: 400 },
     ]);
+    expect(renderedBy).toEqual([]);
 
     const retry = await worker.fetch(new Request("https://example.com/page"), {}, context);
     expect(retry.status).toBe(200);
@@ -267,8 +347,12 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
     expect(renderedBy).toEqual(["current-stage"]);
     expect(cachedResponses).toHaveProperty("size", 1);
     expect(coldResponseMetadata).toEqual([
-      { cacheControl: "no-store", identity: "previous-stage" },
-      { cacheControl: null, identity: "current-stage" },
+      { edgeCacheControl: null, identity: "previous-stage", status: 400 },
+      {
+        edgeCacheControl: "public, max-age=300",
+        identity: "current-stage",
+        status: 200,
+      },
     ]);
 
     const hit = await worker.fetch(new Request("https://example.com/page"), {}, context);
@@ -322,6 +406,7 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
     const response = await createEntrypoint({
       ...responseStageInvocation({ kind: "app-page" }),
       expectedResponseStageBuildIdentity: "current-stage",
+      options: { cache: "vinext-cloudflare-v1:shared" },
     }).fetch(new Request("https://example.com/page"));
 
     expect(response.status).toBe(503);
@@ -339,6 +424,7 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
       }).fetch(new Request("https://example.com/page"));
 
       expect(response.status).toBe(400);
+      expect(response.headers.get("Cache-Control")).toBe("no-store");
       expect(stages.response).not.toHaveBeenCalled();
     },
   );
@@ -350,7 +436,70 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
       requestUrl: "https://example.com/page",
     }).fetch(new Request("https://example.com/page"));
     expect(response.status).toBe(400);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
     expect(stages.response).not.toHaveBeenCalled();
+  });
+
+  it("rejects unversioned cache intent when an expected identity is present", async () => {
+    vi.stubEnv("__VINEXT_RSC_BUILD_IDENTITY", "current-stage");
+    const response = await createEntrypoint({
+      ...responseStageInvocation({ kind: "app-page" }),
+      expectedResponseStageBuildIdentity: "current-stage",
+    }).fetch(new Request("https://example.com/page"));
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(stages.response).not.toHaveBeenCalled();
+  });
+
+  it("rejects versioned wire cache intent without an expected identity", async () => {
+    const response = await createEntrypoint({
+      ...responseStageInvocation({ kind: "app-page" }),
+      options: { cache: "vinext-cloudflare-v1:shared" },
+    }).fetch(new Request("https://example.com/page"));
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(stages.response).not.toHaveBeenCalled();
+  });
+
+  it("makes a built stage reject pre-fix gateway props before render or cache admission", async () => {
+    vi.stubEnv("__VINEXT_RSC_BUILD_IDENTITY", "current-stage");
+
+    // This is the exact configurable-entrypoint shape serialized by the
+    // immediately preceding gateway implementation.
+    const response = await createEntrypoint(responseStageInvocation({ kind: "app-page" })).fetch(
+      new Request("https://example.com/page"),
+    );
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(isWorkersCacheAdmissible(response)).toBe(false);
+    expect(stages.response).not.toHaveBeenCalled();
+  });
+
+  it("normalizes wire cache intent before nested response-stage dispatch", async () => {
+    vi.stubEnv("__VINEXT_RSC_BUILD_IDENTITY", "current-stage");
+    stages.response
+      .mockImplementationOnce((_request, _env, _context, _props, dispatchRequestStage) =>
+        dispatchRequestStage(new Request("https://example.com/nested")),
+      )
+      .mockResolvedValueOnce(new Response("nested response"));
+    stages.request.mockImplementation((request, _env, _context, dispatchResponseStage) =>
+      dispatchResponseStage(request, { kind: "app-page" }, { cache: "shared" }),
+    );
+
+    const response = await createEntrypoint({
+      ...responseStageInvocation({ kind: "app-page" }),
+      expectedResponseStageBuildIdentity: "current-stage",
+      options: { cache: "vinext-cloudflare-v1:shared" },
+    }).fetch(new Request("https://example.com/page"));
+
+    await expect(response.text()).resolves.toBe("nested response");
+    expect(stages.response.mock.calls.map((call) => call[5])).toEqual([
+      { cache: "shared" },
+      { cache: "shared" },
+    ]);
   });
 
   it("dispatches shared work through ctx.exports", async () => {
@@ -776,7 +925,7 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
     expect(binding).toHaveBeenCalledWith({
       props: {
         expectedResponseStageBuildIdentity: "current-stage",
-        options: { cache: "bypass" },
+        options: { cache: "vinext-cloudflare-v1:bypass" },
         props: { kind: "pages-prerender-discovery" },
         requestMethod: "GET",
         requestUrl: request.url,
@@ -784,6 +933,7 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
     });
     expect(stages.response).toHaveBeenCalledOnce();
     expect((stages.response.mock.calls[0]![0] as Request).url).toBe(request.url);
+    expect(stages.response.mock.calls[0]![5]).toEqual({ cache: "bypass" });
   });
 
   it("fails readiness closed when the named response entrypoint is unavailable", async () => {

--- a/tests/cloudflare-cdn-worker.test.ts
+++ b/tests/cloudflare-cdn-worker.test.ts
@@ -495,6 +495,38 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
     expect(stages.response).toHaveBeenCalledOnce();
   });
 
+  it("strips forged transport metadata from bypass and fallback renders", async () => {
+    for (const cache of ["bypass", "shared"] as const) {
+      stages.request.mockImplementation((request, _env, _ctx, dispatch) =>
+        dispatch(request, { route: "/private" }, { cache }),
+      );
+      stages.response.mockImplementation((request) =>
+        Response.json({
+          authorizationTransport: request.headers.get("x-vinext-internal-authorization"),
+          requestCfTransport: request.headers.get("x-vinext-internal-request-cf"),
+        }),
+      );
+
+      const response = await worker.fetch(
+        new Request("https://example.com/private", {
+          headers: {
+            "x-vinext-internal-authorization": "forged-authorization",
+            "x-vinext-internal-request-cf": "forged-request-cf",
+          },
+        }),
+        {},
+        {},
+      );
+
+      await expect(response.json()).resolves.toEqual({
+        authorizationTransport: null,
+        requestCfTransport: null,
+      });
+      stages.request.mockReset();
+      stages.response.mockReset();
+    }
+  });
+
   it("falls back to an uncached render when loopback exports are unavailable", async () => {
     stages.response.mockResolvedValue(new Response("rendered"));
     stages.request.mockImplementation((_request, _env, _ctx, dispatch) =>

--- a/tests/cloudflare-cdn-worker.test.ts
+++ b/tests/cloudflare-cdn-worker.test.ts
@@ -48,8 +48,12 @@ function createEntrypoint(props: unknown, env: unknown = { binding: "value" }) {
   }) as VinextCachedResponse;
 }
 
-function responseStageInvocation(props: unknown, requestUrl = "https://example.com/page") {
-  return { options: { cache: "shared" }, props, requestUrl };
+function responseStageInvocation(
+  props: unknown,
+  requestUrl = "https://example.com/page",
+  requestMethod = "GET",
+) {
+  return { options: { cache: "shared" }, props, requestMethod, requestUrl };
 }
 
 function pagesPageProps(
@@ -148,6 +152,7 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
       props: {
         options: { cache: "shared" },
         props: { params: { slug: "page" }, route: "/page" },
+        requestMethod: "GET",
         requestUrl: "https://example.com/render",
       },
     });
@@ -279,6 +284,31 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
 
     expect(seen).toHaveLength(4);
     expect(new Set(seen)).toHaveProperty("size", 4);
+  });
+
+  it("partitions and restores HEAD when Workers Cache invokes the entrypoint as GET", async () => {
+    const cacheFacingUrls: string[] = [];
+    const binding = vi.fn(({ props }: { props: unknown }) => ({
+      fetch(request: Request) {
+        cacheFacingUrls.push(request.url);
+        // Workers Cache shares GET/HEAD entries and a cold HEAD reaches the
+        // Worker as GET. Configurable-entrypoint props retain the caller's
+        // logical method across that platform conversion.
+        return createEntrypoint(props).fetch(new Request(request, { method: "GET" }));
+      },
+    }));
+    stages.request.mockImplementation((request, _env, _ctx, dispatch) =>
+      dispatch(request, { kind: "app-route-handler" }, { cache: "shared" }),
+    );
+    stages.response.mockImplementation((request) => new Response(request.method));
+
+    const context = { exports: { VinextCachedResponse: binding } };
+    await worker.fetch(new Request("https://example.com/route"), {}, context);
+    await worker.fetch(new Request("https://example.com/route", { method: "HEAD" }), {}, context);
+
+    expect(cacheFacingUrls).toHaveLength(2);
+    expect(cacheFacingUrls[0]).not.toBe(cacheFacingUrls[1]);
+    expect(stages.response.mock.calls.map(([request]) => request.method)).toEqual(["GET", "HEAD"]);
   });
 
   it("renders bypass work without consulting the cached entrypoint", async () => {

--- a/tests/cloudflare-cdn-worker.test.ts
+++ b/tests/cloudflare-cdn-worker.test.ts
@@ -586,13 +586,26 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
   });
 
   it("falls back to an uncached render when loopback exports are unavailable", async () => {
-    stages.response.mockResolvedValue(new Response("rendered"));
+    stages.response.mockResolvedValue(
+      new Response("rendered", {
+        headers: {
+          "Cache-Control": "public, max-age=300",
+          "CDN-Cache-Control": "public, s-maxage=300",
+          "Cloudflare-CDN-Cache-Control": "public, s-maxage=300",
+          "Cache-Tag": "private-fallback",
+        },
+      }),
+    );
     stages.request.mockImplementation((_request, _env, _ctx, dispatch) =>
       dispatch(new Request("https://example.com/render"), {}, { cache: "shared" }),
     );
 
     const response = await worker.fetch(new Request("https://example.com/page"), {}, {});
     expect(await response.text()).toBe("rendered");
+    expect(response.headers.get("Cache-Control")).toBe("private, max-age=0, must-revalidate");
+    expect(response.headers.get("CDN-Cache-Control")).toBeNull();
+    expect(response.headers.get("Cloudflare-CDN-Cache-Control")).toBeNull();
+    expect(response.headers.get("Cache-Tag")).toBeNull();
     expect(stages.response).toHaveBeenCalledOnce();
   });
 

--- a/tests/cloudflare-cdn-worker.test.ts
+++ b/tests/cloudflare-cdn-worker.test.ts
@@ -13,6 +13,8 @@ import {
   PAGES_RESPONSE_STAGE_PROTOCOL_VERSION,
   type WorkerResponseStageProps,
 } from "../packages/vinext/src/server/worker-stages.js";
+import { cloneRequestWithUrl } from "../packages/vinext/src/server/request-pipeline.js";
+import { NextRequest } from "../packages/vinext/src/shims/server.js";
 
 type PagesPageResponseStageProps = Extract<WorkerResponseStageProps, { kind: "pages-page" }>;
 
@@ -217,6 +219,74 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
       expect(Reflect.get(renderedRequest, "cf")).toEqual(requestCf);
       expect(renderedRequest.headers.has("x-vinext-internal-request-cf")).toBe(false);
     }
+  });
+
+  it("forces a shared response private when application code reads request.cf", async () => {
+    const binding = vi.fn(({ props }: { props: unknown }) => ({
+      fetch(request: Request) {
+        return createEntrypoint(props).fetch(request);
+      },
+    }));
+    stages.request.mockImplementation((request, _env, _ctx, dispatch) =>
+      dispatch(request, { kind: "app-route-handler" }, { cache: "shared" }),
+    );
+    stages.response.mockImplementation((request) => {
+      // Match the framework reconstruction used by Pages Edge APIs and App
+      // Route Handlers before user code reads the platform extension.
+      const rebuilt = cloneRequestWithUrl(request, `${request.url}?resolved=1`);
+      const nextRequest = new NextRequest(rebuilt);
+      const country = Reflect.get(nextRequest, "cf")?.country;
+      return Response.json(
+        { country },
+        {
+          headers: {
+            "Cache-Control": "max-age=0, must-revalidate",
+            "CDN-Cache-Control": "public, s-maxage=300",
+            "Cloudflare-CDN-Cache-Control": "public, s-maxage=300",
+            "Cache-Tag": "geo-response",
+          },
+        },
+      );
+    });
+    const source = new Request("https://example.com/geo");
+    Object.defineProperty(source, "cf", {
+      configurable: true,
+      enumerable: true,
+      value: { country: "GB" },
+    });
+
+    const response = await worker.fetch(source, {}, { exports: { VinextCachedResponse: binding } });
+
+    await expect(response.json()).resolves.toEqual({ country: "GB" });
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("CDN-Cache-Control")).toBeNull();
+    expect(response.headers.get("Cloudflare-CDN-Cache-Control")).toBeNull();
+    expect(response.headers.get("Cache-Tag")).toBeNull();
+  });
+
+  it("retains public policy when transported request.cf remains unread", async () => {
+    const binding = vi.fn(({ props }: { props: unknown }) => ({
+      fetch(request: Request) {
+        return createEntrypoint(props).fetch(request);
+      },
+    }));
+    stages.request.mockImplementation((request, _env, _ctx, dispatch) =>
+      dispatch(request, { kind: "app-route-handler" }, { cache: "shared" }),
+    );
+    stages.response.mockResolvedValue(
+      new Response("public", { headers: { "CDN-Cache-Control": "public, s-maxage=300" } }),
+    );
+    const source = new Request("https://example.com/public");
+    Object.defineProperty(source, "cf", {
+      configurable: true,
+      enumerable: true,
+      value: { country: "GB" },
+    });
+
+    const response = await worker.fetch(source, {}, { exports: { VinextCachedResponse: binding } });
+
+    expect(response.headers.get("CDN-Cache-Control")).toBe("public, s-maxage=300");
+    await expect(response.text()).resolves.toBe("public");
   });
 
   it("strips forged request.cf transport metadata when no platform metadata exists", async () => {

--- a/tests/cloudflare-cdn-worker.test.ts
+++ b/tests/cloudflare-cdn-worker.test.ts
@@ -9,6 +9,7 @@ import {
 import worker, {
   VinextCachedResponse,
 } from "../packages/cloudflare/src/cache/cdn-adapter.worker.js";
+import { VINEXT_CDN_BUILD_ID_HEADER } from "../packages/cloudflare/src/cache/cdn-build-id.js";
 import {
   PAGES_RESPONSE_STAGE_PROTOCOL_VERSION,
   type WorkerResponseStageProps,
@@ -86,6 +87,7 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
   });
 
   it("exports the cached stage as a named WorkerEntrypoint class", () => {
@@ -116,6 +118,120 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
     expect(renderedProps).toEqual(props);
     expect(reverseTransport).toEqual(expect.any(Function));
     expect(options).toEqual({ cache: "shared" });
+  });
+
+  it.each([200, 204, 404, 503])(
+    "stamps named-stage identity on every %s response before cache admission",
+    async (status) => {
+      vi.stubEnv("__VINEXT_RSC_BUILD_IDENTITY", "current-stage");
+      stages.response.mockResolvedValue(
+        new Response(status === 204 ? null : "rendered", {
+          status,
+          headers: { [VINEXT_CDN_BUILD_ID_HEADER]: "forged-stage" },
+        }),
+      );
+
+      const response = await createEntrypoint(responseStageInvocation({ kind: "app-page" })).fetch(
+        new Request("https://example.com/page"),
+      );
+
+      expect(response.status).toBe(status);
+      expect(response.headers.get(VINEXT_CDN_BUILD_ID_HEADER)).toBe("current-stage");
+    },
+  );
+
+  it.each([
+    ["missing", null, 503],
+    ["different", "previous-stage", 503],
+    ["matching", "current-stage", 200],
+  ] as const)(
+    "%s named-stage identity is validated before the request stage stamps its own identity",
+    async (_label, responseStageIdentity, expectedStatus) => {
+      vi.stubEnv("__VINEXT_RSC_BUILD_IDENTITY", "current-stage");
+      const binding = vi.fn(() => ({
+        fetch() {
+          return new Response("response-stage body", {
+            headers:
+              responseStageIdentity === null
+                ? undefined
+                : { [VINEXT_CDN_BUILD_ID_HEADER]: responseStageIdentity },
+          });
+        },
+      }));
+      stages.request.mockImplementation(async (request, _env, _ctx, dispatch) => {
+        const response = await dispatch(request, { kind: "app-page" }, { cache: "shared" });
+        const headers = new Headers(response.headers);
+        // App and Pages request stages apply this public identity after the
+        // response transport returns. It must not hide an inner mismatch.
+        headers.set(VINEXT_CDN_BUILD_ID_HEADER, "current-stage");
+        return new Response(response.body, { headers, status: response.status });
+      });
+
+      const response = await worker.fetch(
+        new Request("https://example.com/page", { headers: { Accept: "text/html" } }),
+        {},
+        { exports: { VinextCachedResponse: binding } },
+      );
+
+      expect(response.status).toBe(expectedStatus);
+      expect(response.headers.get(VINEXT_CDN_BUILD_ID_HEADER)).toBe("current-stage");
+      expect(response.headers.get("Cache-Control")).toBe(
+        expectedStatus === 503 ? "no-store" : "private, max-age=0, must-revalidate",
+      );
+      await expect(response.text()).resolves.toBe(
+        expectedStatus === 503 ? "" : "response-stage body",
+      );
+    },
+  );
+
+  it("cancels a response from a mismatched named stage", async () => {
+    vi.stubEnv("__VINEXT_RSC_BUILD_IDENTITY", "current-stage");
+    const cancel = vi.fn();
+    const binding = vi.fn(() => ({
+      fetch() {
+        return new Response(new ReadableStream({ cancel }), {
+          headers: { [VINEXT_CDN_BUILD_ID_HEADER]: "previous-stage" },
+        });
+      },
+    }));
+    stages.request.mockImplementation((request, _env, _ctx, dispatch) =>
+      dispatch(request, { kind: "app-page" }, { cache: "shared" }),
+    );
+
+    const response = await worker.fetch(
+      new Request("https://example.com/page"),
+      {},
+      { exports: { VinextCachedResponse: binding } },
+    );
+
+    expect(response.status).toBe(503);
+    await vi.waitFor(() => expect(cancel).toHaveBeenCalledOnce());
+  });
+
+  it("partitions cache-facing keys by the opaque response-stage build identity", async () => {
+    const cacheFacingUrls: string[] = [];
+    const binding = vi.fn(() => ({
+      fetch(request: Request) {
+        cacheFacingUrls.push(request.url);
+        return new Response("cached", {
+          headers: {
+            [VINEXT_CDN_BUILD_ID_HEADER]: process.env.__VINEXT_RSC_BUILD_IDENTITY!,
+          },
+        });
+      },
+    }));
+    stages.request.mockImplementation((request, _env, _ctx, dispatch) =>
+      dispatch(request, { kind: "app-page", buildId: "pinned-build" }, { cache: "shared" }),
+    );
+
+    const context = { exports: { VinextCachedResponse: binding } };
+    vi.stubEnv("__VINEXT_RSC_BUILD_IDENTITY", "stage-a");
+    await worker.fetch(new Request("https://example.com/page"), {}, context);
+    vi.stubEnv("__VINEXT_RSC_BUILD_IDENTITY", "stage-b");
+    await worker.fetch(new Request("https://example.com/page"), {}, context);
+
+    expect(cacheFacingUrls).toHaveLength(2);
+    expect(cacheFacingUrls[0]).not.toBe(cacheFacingUrls[1]);
   });
 
   it("retains Cloudflare's private policy on the cache-bearing entrypoint", async () => {

--- a/tests/cloudflare-cdn-worker.test.ts
+++ b/tests/cloudflare-cdn-worker.test.ts
@@ -208,6 +208,76 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
     await vi.waitFor(() => expect(cancel).toHaveBeenCalledOnce());
   });
 
+  it("rejects a stale named stage before Workers Cache can admit its response", async () => {
+    // No Next.js test port applies: propagation between named Worker
+    // entrypoints and Workers Cache admission is Cloudflare-specific.
+    vi.stubEnv("__VINEXT_RSC_BUILD_IDENTITY", "current-stage");
+    const cachedResponses = new Map<string, Response>();
+    const coldResponseMetadata: { cacheControl: string | null; identity: string | null }[] = [];
+    const renderedBy: string[] = [];
+    let coldDispatch = 0;
+    const binding = vi.fn(({ props }: { props: unknown }) => ({
+      async fetch(request: Request) {
+        // The adapter's URL digest already covers the serialized configurable
+        // entrypoint props, including the expected response-stage identity.
+        const cached = cachedResponses.get(request.url);
+        if (cached) return cached.clone();
+
+        const responseStageIdentity = coldDispatch++ === 0 ? "previous-stage" : "current-stage";
+        process.env.__VINEXT_RSC_BUILD_IDENTITY = responseStageIdentity;
+        let response: Response;
+        try {
+          response = await createEntrypoint(props).fetch(request);
+        } finally {
+          process.env.__VINEXT_RSC_BUILD_IDENTITY = "current-stage";
+        }
+        coldResponseMetadata.push({
+          cacheControl: response.headers.get("Cache-Control"),
+          identity: response.headers.get(VINEXT_CDN_BUILD_ID_HEADER),
+        });
+        if (!response.headers.get("Cache-Control")?.includes("no-store")) {
+          cachedResponses.set(request.url, response.clone());
+        }
+        return response;
+      },
+    }));
+    stages.request.mockImplementation((request, _env, _ctx, dispatch) =>
+      dispatch(request, { kind: "app-page" }, { cache: "shared" }),
+    );
+    stages.response.mockImplementation(() => {
+      const responseStageIdentity = process.env.__VINEXT_RSC_BUILD_IDENTITY!;
+      renderedBy.push(responseStageIdentity);
+      return new Response(`rendered by ${responseStageIdentity}`, {
+        headers: { "Cloudflare-CDN-Cache-Control": "public, max-age=300" },
+      });
+    });
+    const context = { exports: { VinextCachedResponse: binding } };
+
+    const first = await worker.fetch(new Request("https://example.com/page"), {}, context);
+    expect(first.status).toBe(503);
+    expect(first.headers.get("Cache-Control")).toBe("no-store");
+    expect(cachedResponses).toHaveProperty("size", 0);
+    expect(coldResponseMetadata).toEqual([
+      { cacheControl: "no-store", identity: "previous-stage" },
+    ]);
+
+    const retry = await worker.fetch(new Request("https://example.com/page"), {}, context);
+    expect(retry.status).toBe(200);
+    await expect(retry.text()).resolves.toBe("rendered by current-stage");
+    expect(renderedBy).toEqual(["current-stage"]);
+    expect(cachedResponses).toHaveProperty("size", 1);
+    expect(coldResponseMetadata).toEqual([
+      { cacheControl: "no-store", identity: "previous-stage" },
+      { cacheControl: null, identity: "current-stage" },
+    ]);
+
+    const hit = await worker.fetch(new Request("https://example.com/page"), {}, context);
+    expect(hit.status).toBe(200);
+    await expect(hit.text()).resolves.toBe("rendered by current-stage");
+    expect(renderedBy).toEqual(["current-stage"]);
+    expect(coldDispatch).toBe(2);
+  });
+
   it("partitions cache-facing keys by the opaque response-stage build identity", async () => {
     const cacheFacingUrls: string[] = [];
     const binding = vi.fn(() => ({
@@ -247,6 +317,31 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
 
     expect(response.headers.get("Cloudflare-CDN-Cache-Control")).toBe("public, max-age=300");
   });
+
+  it("rejects an expected build identity when the named stage has no identity", async () => {
+    const response = await createEntrypoint({
+      ...responseStageInvocation({ kind: "app-page" }),
+      expectedResponseStageBuildIdentity: "current-stage",
+    }).fetch(new Request("https://example.com/page"));
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get(VINEXT_CDN_BUILD_ID_HEADER)).toBeNull();
+    expect(stages.response).not.toHaveBeenCalled();
+  });
+
+  it.each([null, 42, {}])(
+    "rejects malformed expected response-stage identity %j",
+    async (expectedResponseStageBuildIdentity) => {
+      const response = await createEntrypoint({
+        ...responseStageInvocation({ kind: "app-page" }),
+        expectedResponseStageBuildIdentity,
+      }).fetch(new Request("https://example.com/page"));
+
+      expect(response.status).toBe(400);
+      expect(stages.response).not.toHaveBeenCalled();
+    },
+  );
 
   it("rejects malformed configurable entrypoint props", async () => {
     const response = await createEntrypoint({
@@ -652,6 +747,7 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
   it("requires the named response entrypoint for readiness bypasses", async () => {
     // No Next.js test port applies: ctx.exports propagation is a Cloudflare
     // deployment boundary.
+    vi.stubEnv("__VINEXT_RSC_BUILD_IDENTITY", "current-stage");
     const binding = vi.fn(({ props }: { props: unknown }) => ({
       fetch(request: Request) {
         return createEntrypoint(props).fetch(request);
@@ -679,6 +775,7 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
     expect(response.status).toBe(204);
     expect(binding).toHaveBeenCalledWith({
       props: {
+        expectedResponseStageBuildIdentity: "current-stage",
         options: { cache: "bypass" },
         props: { kind: "pages-prerender-discovery" },
         requestMethod: "GET",

--- a/tests/cloudflare-cdn-worker.test.ts
+++ b/tests/cloudflare-cdn-worker.test.ts
@@ -118,6 +118,20 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
     expect(options).toEqual({ cache: "shared" });
   });
 
+  it("retains Cloudflare's private policy on the cache-bearing entrypoint", async () => {
+    stages.response.mockResolvedValue(
+      new Response("rendered", {
+        headers: { "Cloudflare-CDN-Cache-Control": "public, max-age=300" },
+      }),
+    );
+
+    const response = await createEntrypoint(responseStageInvocation({ kind: "app-page" })).fetch(
+      new Request("https://example.com/page"),
+    );
+
+    expect(response.headers.get("Cloudflare-CDN-Cache-Control")).toBe("public, max-age=300");
+  });
+
   it("rejects malformed configurable entrypoint props", async () => {
     const response = await createEntrypoint({
       options: { cache: "invalid" },
@@ -164,6 +178,39 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
       /^https:\/\/example\.com\/render\?__vinext_cache_key=[0-9a-f]{64}$/,
     );
     expect(stages.response).not.toHaveBeenCalled();
+  });
+
+  it("does not expose the inner Cloudflare cache policy after gateway personalization", async () => {
+    const binding = vi.fn(() => ({
+      fetch: vi.fn().mockResolvedValue(
+        new Response("shared", {
+          headers: {
+            "Cache-Control": "public, max-age=0, must-revalidate",
+            "Cloudflare-CDN-Cache-Control": "public, max-age=300",
+          },
+        }),
+      ),
+    }));
+    stages.request.mockImplementation(async (request, _env, _ctx, dispatch) => {
+      const response = await dispatch(request, { kind: "app-page" }, { cache: "shared" });
+      const headers = new Headers(response.headers);
+      headers.set("x-user-variant", request.headers.get("x-user-variant") ?? "missing");
+      return new Response(response.body, { headers, status: response.status });
+    });
+
+    const response = await worker.fetch(
+      new Request("https://example.com/page", {
+        headers: { "x-user-variant": "alice" },
+      }),
+      {},
+      { exports: { VinextCachedResponse: binding } },
+    );
+
+    expect(response.headers.get("x-user-variant")).toBe("alice");
+    expect(response.headers.get("Cache-Control")).toBe("public, max-age=0, must-revalidate");
+    expect(response.headers.get("Cloudflare-CDN-Cache-Control")).toBeNull();
+    expect(response.headers.get("CDN-Cache-Control")).toBeNull();
+    await expect(response.text()).resolves.toBe("shared");
   });
 
   it("keeps Authorization off Workers Cache while restoring and partitioning cold renders", async () => {

--- a/tests/cloudflare-cdn-worker.test.ts
+++ b/tests/cloudflare-cdn-worker.test.ts
@@ -176,11 +176,11 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
     expect(renderedRequest.url).toBe("https://tenant.example/original?view=one");
   });
 
-  it("partitions by request.cf without letting it replace the cache-facing URL", async () => {
-    let cacheFacingRequest: Request | undefined;
+  it("preserves request.cf on misses without fragmenting or replacing the cache key", async () => {
+    const cacheFacingRequests: Request[] = [];
     const binding = vi.fn(({ props }: { props: unknown }) => ({
       async fetch(request: Request) {
-        cacheFacingRequest = request;
+        cacheFacingRequests.push(request);
         return createEntrypoint(props).fetch(request);
       },
     }));
@@ -188,23 +188,30 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
       dispatch(request, { kind: "app-route-handler" }, { cache: "shared" }),
     );
     stages.response.mockResolvedValue(new Response("rendered"));
-    const source = new Request("https://example.com/geo", {
-      headers: { "x-vinext-internal-request-cf": "forged" },
-    });
-    const requestCf = { cacheKey: "attacker-controlled", colo: "LHR", country: "GB" };
-    Object.defineProperty(source, "cf", { enumerable: true, value: requestCf });
+    const requestCfValues = [
+      { cacheKey: "attacker-controlled", clientTcpRtt: 12, colo: "LHR", country: "GB" },
+      { cacheKey: "other-attacker-key", clientTcpRtt: 87, colo: "SJC", country: "US" },
+    ];
+    for (const requestCf of requestCfValues) {
+      const source = new Request("https://example.com/geo", {
+        headers: { "x-vinext-internal-request-cf": "forged" },
+      });
+      Object.defineProperty(source, "cf", { enumerable: true, value: requestCf });
+      await worker.fetch(source, {}, { exports: { VinextCachedResponse: binding } });
+    }
 
-    await worker.fetch(source, {}, { exports: { VinextCachedResponse: binding } });
-
-    expect(cacheFacingRequest?.url).toMatch(
+    expect(cacheFacingRequests[0]?.url).toMatch(
       /^https:\/\/example\.com\/geo\?__vinext_cache_key=[0-9a-f]{64}$/,
     );
-    expect(Reflect.get(cacheFacingRequest!, "cf")).toBeUndefined();
-    expect(cacheFacingRequest?.headers.get("x-vinext-internal-request-cf")).not.toBe("forged");
-    const renderedRequest = stages.response.mock.calls[0]![0] as Request;
-    expect(renderedRequest.url).toBe(source.url);
-    expect(Reflect.get(renderedRequest, "cf")).toEqual(requestCf);
-    expect(renderedRequest.headers.has("x-vinext-internal-request-cf")).toBe(false);
+    expect(cacheFacingRequests[1]?.url).toBe(cacheFacingRequests[0]?.url);
+    expect(cacheFacingRequests[0]?.headers.get("x-vinext-internal-request-cf")).not.toBe("forged");
+    expect(cacheFacingRequests[1]?.headers.get("x-vinext-internal-request-cf")).not.toBe("forged");
+    for (const [index, requestCf] of requestCfValues.entries()) {
+      const renderedRequest = stages.response.mock.calls[index]![0] as Request;
+      expect(renderedRequest.url).toBe("https://example.com/geo");
+      expect(Reflect.get(renderedRequest, "cf")).toEqual(requestCf);
+      expect(renderedRequest.headers.has("x-vinext-internal-request-cf")).toBe(false);
+    }
   });
 
   it("strips forged request.cf transport metadata when no platform metadata exists", async () => {

--- a/tests/cloudflare-cdn-worker.test.ts
+++ b/tests/cloudflare-cdn-worker.test.ts
@@ -1,0 +1,328 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import {
+  configureWorkersCacheEntrypoints,
+  finalizeWorkersCacheBuildOutput,
+} from "../packages/cloudflare/src/cache/cdn-adapter-config.js";
+import worker, {
+  VinextCachedResponse,
+} from "../packages/cloudflare/src/cache/cdn-adapter.worker.js";
+import {
+  PAGES_RESPONSE_STAGE_PROTOCOL_VERSION,
+  type PagesPageResponseStageProps,
+} from "../packages/vinext/src/server/worker-stages.js";
+
+const stages = vi.hoisted(() => ({
+  request: vi.fn(),
+  response: vi.fn(),
+}));
+
+vi.mock("cloudflare:workers", () => ({
+  WorkerEntrypoint: class<Env, Props> {
+    protected ctx: { props: Props };
+    protected env: Env;
+
+    constructor(ctx: { props: Props }, env: Env) {
+      this.ctx = ctx;
+      this.env = env;
+    }
+  },
+}));
+
+vi.mock("virtual:vinext-request-stage", () => ({
+  handleRequestStage: stages.request,
+}));
+
+vi.mock("virtual:vinext-response-stage", () => ({
+  handleResponseStage: stages.response,
+}));
+
+function createEntrypoint(props: unknown, env: unknown = { binding: "value" }) {
+  return Object.assign(Object.create(VinextCachedResponse.prototype), {
+    ctx: { props },
+    env,
+  }) as VinextCachedResponse;
+}
+
+function responseStageInvocation(props: unknown, requestUrl = "https://example.com/page") {
+  return { options: { cache: "shared" }, props, requestUrl };
+}
+
+function pagesPageProps(
+  resolvedUrl: string,
+  renderOptions: PagesPageResponseStageProps["renderOptions"],
+): PagesPageResponseStageProps {
+  return {
+    buildId: "test-build",
+    kind: "pages-page",
+    protocolVersion: PAGES_RESPONSE_STAGE_PROTOCOL_VERSION,
+    requestHost: "example.com",
+    renderOptions,
+    resolvedUrl,
+    stagedHeaders: null,
+  };
+}
+
+describe("Cloudflare CDN multi-stage Worker facade", () => {
+  beforeEach(() => {
+    stages.request.mockReset();
+    stages.response.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("exports the cached stage as a named WorkerEntrypoint class", () => {
+    expect(typeof VinextCachedResponse).toBe("function");
+    expect(typeof VinextCachedResponse.prototype.fetch).toBe("function");
+  });
+
+  it("lazily invokes the response stage from named-entrypoint props", async () => {
+    const request = new Request("https://example.com/page");
+    const props = { kind: "pages-page", resolvedUrl: "/page" };
+    const response = new Response("rendered");
+    stages.response.mockResolvedValue(response);
+
+    const result = await createEntrypoint(responseStageInvocation(props)).fetch(request);
+
+    expect(result).toBe(response);
+    const [
+      renderedRequest,
+      renderedEnv,
+      renderedContext,
+      renderedProps,
+      reverseTransport,
+      options,
+    ] = stages.response.mock.calls[0]!;
+    expect((renderedRequest as Request).url).toBe(request.url);
+    expect(renderedEnv).toEqual({ binding: "value" });
+    expect(renderedContext).toEqual(expect.objectContaining({ hostRuntime: "worker" }));
+    expect(renderedProps).toEqual(props);
+    expect(reverseTransport).toEqual(expect.any(Function));
+    expect(options).toEqual({ cache: "shared" });
+  });
+
+  it("rejects malformed configurable entrypoint props", async () => {
+    const response = await createEntrypoint({
+      options: { cache: "invalid" },
+      props: {},
+      requestUrl: "https://example.com/page",
+    }).fetch(new Request("https://example.com/page"));
+    expect(response.status).toBe(400);
+    expect(stages.response).not.toHaveBeenCalled();
+  });
+
+  it("dispatches shared work through ctx.exports", async () => {
+    const cachedResponse = new Response("cached");
+    const fetch = vi.fn().mockResolvedValue(cachedResponse);
+    const binding = vi.fn(() => ({ fetch }));
+    const params = Object.assign(Object.create(null) as Record<string, string>, { slug: "page" });
+    stages.request.mockImplementation((_request, _env, _ctx, dispatch) =>
+      dispatch(
+        new Request("https://example.com/render"),
+        { params, route: "/page" },
+        { cache: "shared" },
+      ),
+    );
+
+    const result = await worker.fetch(
+      new Request("https://example.com/page"),
+      {},
+      {
+        exports: { VinextCachedResponse: binding },
+      },
+    );
+
+    expect(result).toBe(cachedResponse);
+    expect(binding).toHaveBeenCalledWith({
+      props: {
+        options: { cache: "shared" },
+        props: { params: { slug: "page" }, route: "/page" },
+        requestUrl: "https://example.com/render",
+      },
+    });
+    expect(fetch).toHaveBeenCalledOnce();
+    const cacheRequest = fetch.mock.calls[0]![0] as Request;
+    expect(cacheRequest.url).toMatch(
+      /^https:\/\/example\.com\/render\?__vinext_cache_key=[0-9a-f]{64}$/,
+    );
+    expect(stages.response).not.toHaveBeenCalled();
+  });
+
+  it("keys cached dispatches by route metadata and restores the user-facing URL", async () => {
+    const cachedEntrypoint = createEntrypoint(
+      responseStageInvocation(
+        { kind: "app-page", resolvedUrl: "/rewritten" },
+        "https://tenant.example/original?view=one",
+      ),
+    );
+    stages.response.mockResolvedValue(new Response("rendered"));
+
+    await cachedEntrypoint.fetch(
+      new Request("https://tenant.example/original?view=one&__vinext_cache_key=transport-digest"),
+    );
+
+    const renderedRequest = stages.response.mock.calls[0]![0] as Request;
+    expect(renderedRequest.url).toBe("https://tenant.example/original?view=one");
+  });
+
+  it("uses distinct cache-facing URLs for Pages HTML, data, and rewrite identities", async () => {
+    const seen: string[] = [];
+    const binding = vi.fn(() => ({
+      fetch(request: Request) {
+        seen.push(request.url);
+        return new Response("cached");
+      },
+    }));
+    stages.request.mockImplementation(async (_request, _env, _ctx, dispatch) => {
+      await dispatch(
+        new Request("https://example.com/page"),
+        pagesPageProps("/page", { isDataReq: false }),
+        { cache: "shared" },
+      );
+      await dispatch(
+        new Request("https://example.com/page"),
+        pagesPageProps("/page", { isDataReq: true }),
+        { cache: "shared" },
+      );
+      await dispatch(
+        new Request("https://example.com/page"),
+        pagesPageProps("/rewritten-a", { isDataReq: false }),
+        { cache: "shared" },
+      );
+      return dispatch(
+        new Request("https://example.com/page"),
+        pagesPageProps("/rewritten-b", { isDataReq: false }),
+        { cache: "shared" },
+      );
+    });
+
+    await worker.fetch(
+      new Request("https://example.com/page"),
+      {},
+      {
+        exports: { VinextCachedResponse: binding },
+      },
+    );
+
+    expect(seen).toHaveLength(4);
+    expect(new Set(seen)).toHaveProperty("size", 4);
+  });
+
+  it("renders bypass work without consulting the cached entrypoint", async () => {
+    const rendered = new Response("private");
+    const binding = vi.fn();
+    stages.response.mockResolvedValue(rendered);
+    stages.request.mockImplementation((_request, _env, _ctx, dispatch) =>
+      dispatch(
+        new Request("https://example.com/render"),
+        { route: "/private" },
+        { cache: "bypass" },
+      ),
+    );
+
+    const result = await worker.fetch(
+      new Request("https://example.com/private"),
+      {},
+      {
+        exports: { VinextCachedResponse: binding },
+      },
+    );
+
+    expect(result).toBe(rendered);
+    expect(binding).not.toHaveBeenCalled();
+    expect(stages.response).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to an uncached render when loopback exports are unavailable", async () => {
+    stages.response.mockResolvedValue(new Response("rendered"));
+    stages.request.mockImplementation((_request, _env, _ctx, dispatch) =>
+      dispatch(new Request("https://example.com/render"), {}, { cache: "shared" }),
+    );
+
+    const response = await worker.fetch(new Request("https://example.com/page"), {}, {});
+    expect(await response.text()).toBe("rendered");
+    expect(stages.response).toHaveBeenCalledOnce();
+  });
+
+  it("routes gateway purges through the cache-bearing entrypoint", async () => {
+    const purge = vi.fn().mockResolvedValue({ success: true });
+    const defaultPurge = vi.fn();
+    const binding = vi.fn(() => ({ fetch: vi.fn(), purge }));
+    stages.request.mockImplementation((_request, _env, context) =>
+      context.cache.purge({ tags: ["encoded-tag"] }).then(() => new Response("purged")),
+    );
+
+    const response = await worker.fetch(
+      new Request("https://example.com/revalidate"),
+      {},
+      {
+        cache: { purge: defaultPurge },
+        exports: { VinextCachedResponse: binding },
+      },
+    );
+
+    expect(await response.text()).toBe("purged");
+    expect(binding).toHaveBeenCalledWith({ props: {} });
+    expect(purge).toHaveBeenCalledWith({ tags: ["encoded-tag"] });
+    expect(defaultPurge).not.toHaveBeenCalled();
+  });
+});
+
+describe("Workers Cache deployment configuration", () => {
+  it("disables caching on the gateway and enables only the response entrypoint", () => {
+    expect(configureWorkersCacheEntrypoints({ name: "app" })).toMatchObject({
+      compatibility_flags: ["enable_ctx_exports"],
+      name: "app",
+      exports: {
+        default: { type: "worker", cache: { enabled: false } },
+        VinextCachedResponse: { type: "worker", cache: { enabled: true } },
+      },
+    });
+  });
+
+  it("preserves unrelated exports and rejects reserved non-Worker exports", () => {
+    expect(
+      configureWorkersCacheEntrypoints({ exports: { Counter: { type: "durable_object" } } }),
+    ).toMatchObject({ exports: { Counter: { type: "durable_object" } } });
+    expect(() =>
+      configureWorkersCacheEntrypoints({
+        exports: { VinextCachedResponse: { type: "durable_object" } },
+      }),
+    ).toThrow(/reserved Worker export/);
+  });
+
+  it("preserves compatibility flags and rejects an explicit ctx.exports opt-out", () => {
+    expect(
+      configureWorkersCacheEntrypoints({
+        compatibility_date: "2025-11-16",
+        compatibility_flags: ["nodejs_compat", "enable_ctx_exports"],
+      }).compatibility_flags,
+    ).toEqual(["nodejs_compat", "enable_ctx_exports"]);
+    expect(
+      configureWorkersCacheEntrypoints({
+        compatibility_date: "2025-11-17",
+        compatibility_flags: ["nodejs_compat", "enable_ctx_exports"],
+      }).compatibility_flags,
+    ).toEqual(["nodejs_compat"]);
+    expect(() =>
+      configureWorkersCacheEntrypoints({ compatibility_flags: ["disable_ctx_exports"] }),
+    ).toThrow(/requires ctx\.exports/);
+  });
+
+  it("updates the generated Wrangler config without changing the source config", async () => {
+    const outDir = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-cdn-output-"));
+    try {
+      await fs.writeFile(path.join(outDir, "wrangler.json"), JSON.stringify({ name: "app" }));
+      await finalizeWorkersCacheBuildOutput({ outDir, root: outDir });
+      const config = JSON.parse(await fs.readFile(path.join(outDir, "wrangler.json"), "utf8"));
+      expect(config.exports.default.cache.enabled).toBe(false);
+      expect(config.exports.VinextCachedResponse.cache.enabled).toBe(true);
+    } finally {
+      await fs.rm(outDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/cloudflare-cdn-worker.test.ts
+++ b/tests/cloudflare-cdn-worker.test.ts
@@ -176,6 +176,61 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
     expect(renderedRequest.url).toBe("https://tenant.example/original?view=one");
   });
 
+  it("partitions by request.cf without letting it replace the cache-facing URL", async () => {
+    let cacheFacingRequest: Request | undefined;
+    const binding = vi.fn(({ props }: { props: unknown }) => ({
+      async fetch(request: Request) {
+        cacheFacingRequest = request;
+        return createEntrypoint(props).fetch(request);
+      },
+    }));
+    stages.request.mockImplementation((request, _env, _ctx, dispatch) =>
+      dispatch(request, { kind: "app-route-handler" }, { cache: "shared" }),
+    );
+    stages.response.mockResolvedValue(new Response("rendered"));
+    const source = new Request("https://example.com/geo", {
+      headers: { "x-vinext-internal-request-cf": "forged" },
+    });
+    const requestCf = { cacheKey: "attacker-controlled", colo: "LHR", country: "GB" };
+    Object.defineProperty(source, "cf", { enumerable: true, value: requestCf });
+
+    await worker.fetch(source, {}, { exports: { VinextCachedResponse: binding } });
+
+    expect(cacheFacingRequest?.url).toMatch(
+      /^https:\/\/example\.com\/geo\?__vinext_cache_key=[0-9a-f]{64}$/,
+    );
+    expect(Reflect.get(cacheFacingRequest!, "cf")).toBeUndefined();
+    expect(cacheFacingRequest?.headers.get("x-vinext-internal-request-cf")).not.toBe("forged");
+    const renderedRequest = stages.response.mock.calls[0]![0] as Request;
+    expect(renderedRequest.url).toBe(source.url);
+    expect(Reflect.get(renderedRequest, "cf")).toEqual(requestCf);
+    expect(renderedRequest.headers.has("x-vinext-internal-request-cf")).toBe(false);
+  });
+
+  it("strips forged request.cf transport metadata when no platform metadata exists", async () => {
+    const binding = vi.fn(({ props }: { props: unknown }) => ({
+      fetch(request: Request) {
+        return createEntrypoint(props).fetch(request);
+      },
+    }));
+    stages.request.mockImplementation((request, _env, _ctx, dispatch) =>
+      dispatch(request, { kind: "app-route-handler" }, { cache: "shared" }),
+    );
+    stages.response.mockResolvedValue(new Response("rendered"));
+
+    await worker.fetch(
+      new Request("https://example.com/geo", {
+        headers: { "x-vinext-internal-request-cf": encodeURIComponent('{"country":"forged"}') },
+      }),
+      {},
+      { exports: { VinextCachedResponse: binding } },
+    );
+
+    const renderedRequest = stages.response.mock.calls[0]![0] as Request;
+    expect(Reflect.get(renderedRequest, "cf")).toBeUndefined();
+    expect(renderedRequest.headers.has("x-vinext-internal-request-cf")).toBe(false);
+  });
+
   it("uses distinct cache-facing URLs for Pages HTML, data, and rewrite identities", async () => {
     const seen: string[] = [];
     const binding = vi.fn(() => ({

--- a/tests/cloudflare-cdn-worker.test.ts
+++ b/tests/cloudflare-cdn-worker.test.ts
@@ -497,6 +497,62 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
     expect(stages.response).toHaveBeenCalledOnce();
   });
 
+  it("requires the named response entrypoint for readiness bypasses", async () => {
+    // No Next.js test port applies: ctx.exports propagation is a Cloudflare
+    // deployment boundary.
+    const binding = vi.fn(({ props }: { props: unknown }) => ({
+      fetch(request: Request) {
+        return createEntrypoint(props).fetch(request);
+      },
+    }));
+    stages.request.mockImplementation((request, _env, _ctx, dispatch) =>
+      dispatch(request, { kind: "pages-prerender-discovery" }, { cache: "bypass" }),
+    );
+    stages.response.mockResolvedValue(
+      new Response(null, {
+        status: 204,
+        headers: { "Cache-Control": "no-store", "X-Vinext-Prerender-Readiness": "1" },
+      }),
+    );
+    const request = new Request(
+      "https://example.com/__vinext/prerender/readiness?attempt=entrypoint",
+    );
+
+    const response = await worker.fetch(
+      request,
+      {},
+      { exports: { VinextCachedResponse: binding } },
+    );
+
+    expect(response.status).toBe(204);
+    expect(binding).toHaveBeenCalledWith({
+      props: {
+        options: { cache: "bypass" },
+        props: { kind: "pages-prerender-discovery" },
+        requestMethod: "GET",
+        requestUrl: request.url,
+      },
+    });
+    expect(stages.response).toHaveBeenCalledOnce();
+    expect((stages.response.mock.calls[0]![0] as Request).url).toBe(request.url);
+  });
+
+  it("fails readiness closed when the named response entrypoint is unavailable", async () => {
+    stages.request.mockImplementation((request, _env, _ctx, dispatch) =>
+      dispatch(request, { kind: "pages-prerender-discovery" }, { cache: "bypass" }),
+    );
+
+    const response = await worker.fetch(
+      new Request("https://example.com/__vinext/prerender/readiness?attempt=missing"),
+      {},
+      {},
+    );
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(stages.response).not.toHaveBeenCalled();
+  });
+
   it("strips forged transport metadata from bypass and fallback renders", async () => {
     for (const cache of ["bypass", "shared"] as const) {
       stages.request.mockImplementation((request, _env, _ctx, dispatch) =>

--- a/tests/cloudflare-cdn-worker.test.ts
+++ b/tests/cloudflare-cdn-worker.test.ts
@@ -181,6 +181,42 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
     expect(stages.response).not.toHaveBeenCalled();
   });
 
+  it("partitions shared dispatches by public request authority", async () => {
+    const cacheFacingRequests: Request[] = [];
+    const binding = vi.fn(({ props }: { props: unknown }) => ({
+      fetch(request: Request) {
+        cacheFacingRequests.push(request);
+        return createEntrypoint(props).fetch(request);
+      },
+    }));
+    stages.request.mockImplementation((request, _env, _ctx, dispatch) =>
+      dispatch(request, { kind: "app-page" }, { cache: "shared" }),
+    );
+    stages.response.mockImplementation((request) => Response.json({ url: request.url }));
+
+    const responses = [];
+    for (const url of ["https://tenant-a.example/page", "https://tenant-b.example/page"]) {
+      responses.push(
+        await worker.fetch(new Request(url), {}, { exports: { VinextCachedResponse: binding } }),
+      );
+    }
+
+    expect(cacheFacingRequests).toHaveLength(2);
+    expect(cacheFacingRequests[0]?.url).toMatch(
+      /^https:\/\/tenant-a\.example\/page\?__vinext_cache_key=[0-9a-f]{64}$/,
+    );
+    expect(cacheFacingRequests[1]?.url).toMatch(
+      /^https:\/\/tenant-b\.example\/page\?__vinext_cache_key=[0-9a-f]{64}$/,
+    );
+    expect(cacheFacingRequests[0]?.url).not.toBe(cacheFacingRequests[1]?.url);
+    await expect(responses[0]?.json()).resolves.toEqual({
+      url: "https://tenant-a.example/page",
+    });
+    await expect(responses[1]?.json()).resolves.toEqual({
+      url: "https://tenant-b.example/page",
+    });
+  });
+
   it("does not expose the inner Cloudflare cache policy after gateway personalization", async () => {
     const binding = vi.fn(() => ({
       fetch: vi.fn().mockResolvedValue(

--- a/tests/cloudflare-cdn-worker.test.ts
+++ b/tests/cloudflare-cdn-worker.test.ts
@@ -11,8 +11,10 @@ import worker, {
 } from "../packages/cloudflare/src/cache/cdn-adapter.worker.js";
 import {
   PAGES_RESPONSE_STAGE_PROTOCOL_VERSION,
-  type PagesPageResponseStageProps,
+  type WorkerResponseStageProps,
 } from "../packages/vinext/src/server/worker-stages.js";
+
+type PagesPageResponseStageProps = Extract<WorkerResponseStageProps, { kind: "pages-page" }>;
 
 const stages = vi.hoisted(() => ({
   request: vi.fn(),

--- a/tests/cloudflare-cdn-worker.test.ts
+++ b/tests/cloudflare-cdn-worker.test.ts
@@ -166,6 +166,48 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
     expect(stages.response).not.toHaveBeenCalled();
   });
 
+  it("keeps Authorization off Workers Cache while restoring and partitioning cold renders", async () => {
+    const cacheFacingRequests: Request[] = [];
+    const binding = vi.fn(({ props }: { props: unknown }) => ({
+      fetch(request: Request) {
+        cacheFacingRequests.push(request);
+        return createEntrypoint(props).fetch(request);
+      },
+    }));
+    stages.request.mockImplementation((request, _env, _ctx, dispatch) =>
+      dispatch(request, { kind: "app-route-handler" }, { cache: "shared" }),
+    );
+    stages.response.mockImplementation((request) =>
+      Response.json({ authorization: request.headers.get("Authorization") }),
+    );
+
+    for (const authorization of ["Bearer first", "Bearer second"]) {
+      await worker.fetch(
+        new Request("https://example.com/authenticated", {
+          headers: {
+            Authorization: authorization,
+            "x-vinext-internal-authorization": "forged",
+          },
+        }),
+        {},
+        { exports: { VinextCachedResponse: binding } },
+      );
+    }
+
+    expect(cacheFacingRequests).toHaveLength(2);
+    expect(cacheFacingRequests[0]?.headers.get("Authorization")).toBeNull();
+    expect(cacheFacingRequests[1]?.headers.get("Authorization")).toBeNull();
+    expect(cacheFacingRequests[0]?.url).not.toBe(cacheFacingRequests[1]?.url);
+    expect(
+      stages.response.mock.calls.map(([request]) =>
+        (request as Request).headers.get("Authorization"),
+      ),
+    ).toEqual(["Bearer first", "Bearer second"]);
+    for (const [request] of stages.response.mock.calls) {
+      expect((request as Request).headers.has("x-vinext-internal-authorization")).toBe(false);
+    }
+  });
+
   it("keys cached dispatches by route metadata and restores the user-facing URL", async () => {
     const cachedEntrypoint = createEntrypoint(
       responseStageInvocation(

--- a/tests/cloudflare-cdn-worker.test.ts
+++ b/tests/cloudflare-cdn-worker.test.ts
@@ -58,6 +58,11 @@ function pagesPageProps(
 ): PagesPageResponseStageProps {
   return {
     buildId: "test-build",
+    cacheability: {
+      policyHeaders: null,
+      probeMode: null,
+      resolvedRoutePathname: new URL(resolvedUrl, "https://example.com").pathname,
+    },
     kind: "pages-page",
     protocolVersion: PAGES_RESPONSE_STAGE_PROTOCOL_VERSION,
     requestHost: "example.com",

--- a/tests/cloudflare-cdn-worker.test.ts
+++ b/tests/cloudflare-cdn-worker.test.ts
@@ -163,7 +163,8 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
       },
     );
 
-    expect(result).toBe(cachedResponse);
+    await expect(result.text()).resolves.toBe("cached");
+    expect(result.headers.get("Cache-Control")).toBe("private, max-age=0, must-revalidate");
     expect(binding).toHaveBeenCalledWith({
       props: {
         options: { cache: "shared" },
@@ -207,7 +208,7 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
     );
 
     expect(response.headers.get("x-user-variant")).toBe("alice");
-    expect(response.headers.get("Cache-Control")).toBe("public, max-age=0, must-revalidate");
+    expect(response.headers.get("Cache-Control")).toBe("private, max-age=0, must-revalidate");
     expect(response.headers.get("Cloudflare-CDN-Cache-Control")).toBeNull();
     expect(response.headers.get("CDN-Cache-Control")).toBeNull();
     await expect(response.text()).resolves.toBe("shared");
@@ -353,7 +354,7 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
     expect(response.headers.get("Cache-Tag")).toBeNull();
   });
 
-  it("retains public policy when transported request.cf remains unread", async () => {
+  it("keeps the gateway private when transported request.cf remains unread", async () => {
     const binding = vi.fn(({ props }: { props: unknown }) => ({
       fetch(request: Request) {
         return createEntrypoint(props).fetch(request);
@@ -374,7 +375,8 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
 
     const response = await worker.fetch(source, {}, { exports: { VinextCachedResponse: binding } });
 
-    expect(response.headers.get("CDN-Cache-Control")).toBe("public, s-maxage=300");
+    expect(response.headers.get("Cache-Control")).toBe("private, max-age=0, must-revalidate");
+    expect(response.headers.get("CDN-Cache-Control")).toBeNull();
     await expect(response.text()).resolves.toBe("public");
   });
 

--- a/tests/e2e/cloudflare-workers/route-handler-draft-cache.spec.ts
+++ b/tests/e2e/cloudflare-workers/route-handler-draft-cache.spec.ts
@@ -267,6 +267,19 @@ test.describe("Cloudflare route-handler draft-mode cache isolation", () => {
     expect(second.body).toContain("middleware-cookie:visitor-b");
   });
 
+  test("bypasses the shared response stage for middleware request-header overrides", async ({
+    request,
+  }) => {
+    const slug = `request-header-${Date.now()}`;
+    for (const visitorId of ["visitor-a", "visitor-b"]) {
+      const response = await request.get(`${BASE_URL}/api/cdn-stage-middleware-header/${slug}`, {
+        headers: { "x-test-visitor-id": visitorId },
+      });
+      expect(response.status()).toBe(200);
+      expect(await response.text()).toBe(visitorId);
+    }
+  });
+
   test("does not cache late request-dependent App responses", async ({ request }) => {
     for (const route of ["cdn-stage-late", "api/cdn-stage-late-route"]) {
       const slug = `${route.replaceAll("/", "-")}-${Date.now()}`;
@@ -287,7 +300,7 @@ test.describe("Cloudflare Pages-only completed-response admission", () => {
   test.beforeAll(async () => {
     test.setTimeout(90_000);
     pagesServer = spawn(
-      "../../../node_modules/.bin/vp build --config vite.pages-cdn-cache.config.ts && npx wrangler dev --config dist/server/wrangler.json --port 4196",
+      "../../../node_modules/.bin/vp build --config vite.pages-cdn-cache.config.ts && npx wrangler dev --config dist/cf_app_basic/wrangler.json --port 4196",
       { cwd: FIXTURE_DIR, shell: true, stdio: "inherit" },
     );
     for (let attempt = 0; attempt < 240; attempt++) {
@@ -311,7 +324,10 @@ test.describe("Cloudflare Pages-only completed-response admission", () => {
     request,
   }) => {
     expect(
-      fs.readFileSync(`${FIXTURE_DIR}/dist/server/__vinext_cacheability_manifest.js`, "utf8"),
+      fs.readFileSync(
+        `${FIXTURE_DIR}/dist/cf_app_basic/__vinext_cacheability_manifest.js`,
+        "utf8",
+      ),
     ).toBe("export default null;\n");
 
     const response = await request.get(`${pagesBaseUrl}/pages-about`, {
@@ -334,5 +350,27 @@ test.describe("Cloudflare Pages-only completed-response admission", () => {
       expect(response.headers()["cache-control"], accept ?? "missing Accept").toContain("no-store");
       expect(response.headers()["cdn-cache-control"], accept ?? "missing Accept").toBeUndefined();
     }
+  });
+
+  test("admits explicitly public Pages API responses", async ({ request }) => {
+    const response = await request.get(`${pagesBaseUrl}/api/cdn-public`);
+
+    expect(response.status()).toBe(200);
+    expect(await response.json()).toEqual({ public: true });
+    expect(response.headers()["cache-control"]).toBe("public, max-age=0, must-revalidate");
+    expect(response.headers()["cdn-cache-control"]).toBe("public, max-age=60");
+  });
+
+  test("keeps public Pages Edge API responses private after request.cf access", async ({
+    request,
+  }) => {
+    const response = await request.get(`${pagesBaseUrl}/api/cdn-request-cf`);
+
+    expect(response.status()).toBe(200);
+    expect(await response.json()).toEqual({ hasCf: true });
+    expect(response.headers()["cache-control"]).toContain("no-store");
+    expect(response.headers()["cdn-cache-control"]).toBeUndefined();
+    expect(response.headers()["cloudflare-cdn-cache-control"]).toBeUndefined();
+    expect(response.headers()["cache-tag"]).toBeUndefined();
   });
 });

--- a/tests/e2e/cloudflare-workers/route-handler-draft-cache.spec.ts
+++ b/tests/e2e/cloudflare-workers/route-handler-draft-cache.spec.ts
@@ -186,7 +186,7 @@ test.describe("Cloudflare route-handler draft-mode cache isolation", () => {
     // Next.js even when the handler observed request headers while streaming.
     expect(dynamicResponse.headers()["cache-control"]).toContain("public");
     expect(dynamicResponse.headers()["cache-control"]).toContain("max-age=0");
-    expect(dynamicResponse.headers()["cdn-cache-control"]).toBe("public, max-age=60");
+    expect(dynamicResponse.headers()["cdn-cache-control"]).toBeUndefined();
     expect(dynamicResponse.headers()["cloudflare-cdn-cache-control"]).toBeUndefined();
     expect(dynamicResponse.headers()["cache-tag"]).toBeUndefined();
     expect(dynamicResponse.headers()["x-vinext-cache"]).toBeUndefined();

--- a/tests/e2e/cloudflare-workers/route-handler-draft-cache.spec.ts
+++ b/tests/e2e/cloudflare-workers/route-handler-draft-cache.spec.ts
@@ -324,10 +324,7 @@ test.describe("Cloudflare Pages-only completed-response admission", () => {
     request,
   }) => {
     expect(
-      fs.readFileSync(
-        `${FIXTURE_DIR}/dist/cf_app_basic/__vinext_cacheability_manifest.js`,
-        "utf8",
-      ),
+      fs.readFileSync(`${FIXTURE_DIR}/dist/cf_app_basic/__vinext_cacheability_manifest.js`, "utf8"),
     ).toBe("export default null;\n");
 
     const response = await request.get(`${pagesBaseUrl}/pages-about`, {

--- a/tests/e2e/cloudflare-workers/route-handler-draft-cache.spec.ts
+++ b/tests/e2e/cloudflare-workers/route-handler-draft-cache.spec.ts
@@ -182,9 +182,9 @@ test.describe("Cloudflare route-handler draft-mode cache isolation", () => {
     });
     expect(dynamicResponse.status()).toBe(200);
     expect(await dynamicResponse.text()).toBe("tenant-a");
-    // Explicit response policy wins after the clean body has completed, matching
-    // Next.js even when the handler observed request headers while streaming.
-    expect(dynamicResponse.headers()["cache-control"]).toContain("public");
+    // The explicit response policy admits the completed body in the named
+    // entrypoint; the uncached gateway remains private for outer composition.
+    expect(dynamicResponse.headers()["cache-control"]).toContain("private");
     expect(dynamicResponse.headers()["cache-control"]).toContain("max-age=0");
     expect(dynamicResponse.headers()["cdn-cache-control"]).toBeUndefined();
     expect(dynamicResponse.headers()["cloudflare-cdn-cache-control"]).toBeUndefined();
@@ -354,7 +354,7 @@ test.describe("Cloudflare Pages-only completed-response admission", () => {
 
     expect(response.status()).toBe(200);
     expect(await response.json()).toEqual({ public: true });
-    expect(response.headers()["cache-control"]).toBe("public, max-age=0, must-revalidate");
+    expect(response.headers()["cache-control"]).toBe("private, max-age=0, must-revalidate");
     expect(response.headers()["cdn-cache-control"]).toBeUndefined();
     expect(response.headers()["cloudflare-cdn-cache-control"]).toBeUndefined();
   });

--- a/tests/e2e/cloudflare-workers/route-handler-draft-cache.spec.ts
+++ b/tests/e2e/cloudflare-workers/route-handler-draft-cache.spec.ts
@@ -73,12 +73,9 @@ test.describe("Cloudflare route-handler draft-mode cache isolation", () => {
     });
     expect(forged.status()).toBe(200);
     expect(await forged.json()).toMatchObject({ draftMode: false });
-    // This fixture has pathname-eligible middleware. A CDN HIT would bypass
-    // that boundary, so even an anonymous Route Handler response must remain
-    // private until middleware is isolated into an uncached outer stage.
     expect(forged.headers()["cache-control"]).toContain("no-store");
     expect(forged.headers()["cdn-cache-control"]).toBeUndefined();
-    expect(forged.headers()["x-vinext-cache"]).toBeUndefined();
+    expect(forged.headers()["x-vinext-cache"]).toBe("MISS");
 
     await setDraftMode(request, true);
     const draftFirstScenario = `draft-first-${Date.now()}`;
@@ -95,7 +92,7 @@ test.describe("Cloudflare route-handler draft-mode cache isolation", () => {
     expect(anonymousAfterDraft.payload.draftMode).toBe(false);
     expect(anonymousAfterDraft.payload.token).not.toBe(draftFirst.payload.token);
     expect(anonymousAfterDraft.cacheControl).toContain("no-store");
-    expect(anonymousAfterDraft.cacheState).toBeUndefined();
+    expect(anonymousAfterDraft.cacheState).toBe("MISS");
 
     const publicFirstScenario = `public-first-${Date.now()}`;
     const anonymousFirst = await readDraftIsrRoute(request, publicFirstScenario);
@@ -185,9 +182,11 @@ test.describe("Cloudflare route-handler draft-mode cache isolation", () => {
     });
     expect(dynamicResponse.status()).toBe(200);
     expect(await dynamicResponse.text()).toBe("tenant-a");
-    expect(dynamicResponse.headers()["cache-control"] ?? "").not.toContain("public");
-    expect(dynamicResponse.headers()["cache-control"]).toContain("no-store");
-    expect(dynamicResponse.headers()["cdn-cache-control"]).toBeUndefined();
+    // Explicit response policy wins after the clean body has completed, matching
+    // Next.js even when the handler observed request headers while streaming.
+    expect(dynamicResponse.headers()["cache-control"]).toContain("public");
+    expect(dynamicResponse.headers()["cache-control"]).toContain("max-age=0");
+    expect(dynamicResponse.headers()["cdn-cache-control"]).toBe("public, max-age=60");
     expect(dynamicResponse.headers()["cloudflare-cdn-cache-control"]).toBeUndefined();
     expect(dynamicResponse.headers()["cache-tag"]).toBeUndefined();
     expect(dynamicResponse.headers()["x-vinext-cache"]).toBeUndefined();
@@ -206,7 +205,7 @@ test.describe("Cloudflare route-handler draft-mode cache isolation", () => {
   }) => {
     const response = await request.get(`${BASE_URL}/api/large-static-stream`);
     expect(response.status()).toBe(200);
-    expect((await response.body()).byteLength).toBe(4 * 1024 * 1024 + 1);
+    expect((await response.body()).byteLength).toBe(16 * 1024 * 1024 + 1);
     expect(response.headers()["cache-control"]).toContain("no-store");
     expect(response.headers()["cdn-cache-control"]).toBeUndefined();
     expect(response.headers()["cloudflare-cdn-cache-control"]).toBeUndefined();
@@ -308,7 +307,9 @@ test.describe("Cloudflare Pages-only completed-response admission", () => {
     pagesServer.kill();
   });
 
-  test("fails closed without an embedded two-stage manifest", async ({ request }) => {
+  test("clears inner CDN policy when outer config keeps a response private", async ({
+    request,
+  }) => {
     expect(
       fs.readFileSync(`${FIXTURE_DIR}/dist/server/__vinext_cacheability_manifest.js`, "utf8"),
     ).toBe("export default null;\n");

--- a/tests/e2e/cloudflare-workers/route-handler-draft-cache.spec.ts
+++ b/tests/e2e/cloudflare-workers/route-handler-draft-cache.spec.ts
@@ -355,7 +355,8 @@ test.describe("Cloudflare Pages-only completed-response admission", () => {
     expect(response.status()).toBe(200);
     expect(await response.json()).toEqual({ public: true });
     expect(response.headers()["cache-control"]).toBe("public, max-age=0, must-revalidate");
-    expect(response.headers()["cdn-cache-control"]).toBe("public, max-age=60");
+    expect(response.headers()["cdn-cache-control"]).toBeUndefined();
+    expect(response.headers()["cloudflare-cdn-cache-control"]).toBeUndefined();
   });
 
   test("keeps public Pages Edge API responses private after request.cf access", async ({

--- a/tests/e2e/cloudflare-workers/route-handler-draft-cache.spec.ts
+++ b/tests/e2e/cloudflare-workers/route-handler-draft-cache.spec.ts
@@ -43,6 +43,17 @@ async function readDraftIsrRoute(request: APIRequestContext, scenario: string) {
   };
 }
 
+async function readPersonalized(request: APIRequestContext, pathname: string, visitorId: string) {
+  const response = await request.get(`${BASE_URL}${pathname}`, {
+    headers: { "x-test-visitor-id": visitorId },
+  });
+  expect(response.status()).toBe(200);
+  return {
+    body: await response.text(),
+    visitor: response.headers()["x-cdn-stage-visitor"],
+  };
+}
+
 test.describe("Cloudflare route-handler draft-mode cache isolation", () => {
   test.beforeAll(async () => {
     server = spawn(
@@ -213,6 +224,47 @@ test.describe("Cloudflare route-handler draft-mode cache isolation", () => {
       expect(response.status(), accept ?? "missing Accept").toBe(200);
       expect(response.headers()["cache-control"], accept ?? "missing Accept").toContain("no-store");
       expect(response.headers()["cdn-cache-control"], accept ?? "missing Accept").toBeUndefined();
+    }
+  });
+
+  test("runs middleware above App and Pages response stages", async ({ request }) => {
+    // Local Miniflare executes the named response entrypoint but does not emulate
+    // the deployed Worker-front cache. Deployed HIT reuse is covered by
+    // rsc-prewarm.spec.ts in the workers-cache preview workflow.
+    for (const route of ["cdn-stage-app", "cdn-stage-pages"]) {
+      const slug = `${route}-${Date.now()}`;
+      const first = await readPersonalized(request, `/${route}/${slug}`, "visitor-a");
+      const second = await readPersonalized(request, `/${route}/${slug}`, "visitor-b");
+
+      expect(first.visitor).toBe("visitor-a");
+      expect(second.visitor).toBe("visitor-b");
+      expect(first.body).toContain(
+        `${route === "cdn-stage-app" ? "App" : "Pages"} CDN response stage`,
+      );
+      expect(second.body).toContain(
+        `${route === "cdn-stage-app" ? "App" : "Pages"} CDN response stage`,
+      );
+    }
+  });
+
+  test("bypasses the shared response stage for middleware cookie overlays", async ({ request }) => {
+    const slug = `cookie-${Date.now()}`;
+    const first = await readPersonalized(request, `/cdn-stage-cookie/${slug}`, "visitor-a");
+    const second = await readPersonalized(request, `/cdn-stage-cookie/${slug}`, "visitor-b");
+
+    expect(first.body).toContain("middleware-cookie:visitor-a");
+    expect(second.body).toContain("middleware-cookie:visitor-b");
+  });
+
+  test("does not cache late request-dependent App responses", async ({ request }) => {
+    for (const route of ["cdn-stage-late", "api/cdn-stage-late-route"]) {
+      const slug = `${route.replaceAll("/", "-")}-${Date.now()}`;
+      const first = await readPersonalized(request, `/${route}/${slug}`, "visitor-a");
+      const second = await readPersonalized(request, `/${route}/${slug}`, "visitor-b");
+
+      expect(first.body).toContain("visitor-a");
+      expect(second.body).toContain("visitor-b");
+      expect(second.body).not.toBe(first.body);
     }
   });
 });

--- a/tests/e2e/cloudflare-workers/route-handler-draft-cache.spec.ts
+++ b/tests/e2e/cloudflare-workers/route-handler-draft-cache.spec.ts
@@ -247,6 +247,18 @@ test.describe("Cloudflare route-handler draft-mode cache isolation", () => {
     }
   });
 
+  test("routes revalidatePath through the cache-bearing response entrypoint", async ({
+    request,
+  }) => {
+    const slug = `purge-${Date.now()}`;
+    const pathname = `/cdn-stage-app/${slug}`;
+    const purge = await request.post(`${BASE_URL}/api/cdn-stage-revalidate`, {
+      data: { pathname },
+    });
+    expect(purge.status()).toBe(200);
+    expect(await purge.json()).toEqual({ revalidated: pathname });
+  });
+
   test("bypasses the shared response stage for middleware cookie overlays", async ({ request }) => {
     const slug = `cookie-${Date.now()}`;
     const first = await readPersonalized(request, `/cdn-stage-cookie/${slug}`, "visitor-a");

--- a/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
+++ b/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
@@ -215,11 +215,10 @@ test("deploy-prewarmed App, Pages, and RSC variants are reused", async ({
   expect(mismatchedOverride.headers()["cache-control"]).toBe("no-store");
   expect(await mismatchedOverride.text()).toContain("Cloudflare invoked Worker version");
 
-  const pagesResponse = await getResponseAfterPromotion(
-    request,
-    `${baseURL}${PAGES_TARGET_PATH}`,
-    { ...htmlHeaders, "x-test-visitor-id": "visitor-a" },
-  );
+  const pagesResponse = await getResponseAfterPromotion(request, `${baseURL}${PAGES_TARGET_PATH}`, {
+    ...htmlHeaders,
+    "x-test-visitor-id": "visitor-a",
+  });
   const pagesResponseHeaders = pagesResponse.headers();
   expect(pagesResponse.ok(), JSON.stringify(pagesResponseHeaders)).toBe(true);
   expect(pagesResponseHeaders["content-type"]).toContain("text/html");
@@ -248,11 +247,10 @@ test("deploy-prewarmed App, Pages, and RSC variants are reused", async ({
   expect(secondPagesResponseHeaders["x-workers-cache-visitor"]).toBe("visitor-b");
   expect(await secondPagesResponse.text()).toBe(pagesBody);
 
-  const appHtmlResponse = await getResponseAfterPromotion(
-    request,
-    `${baseURL}${TARGET_PATH}`,
-    { ...htmlHeaders, "x-test-visitor-id": "visitor-a" },
-  );
+  const appHtmlResponse = await getResponseAfterPromotion(request, `${baseURL}${TARGET_PATH}`, {
+    ...htmlHeaders,
+    "x-test-visitor-id": "visitor-a",
+  });
   const appHtmlResponseHeaders = appHtmlResponse.headers();
   expect(appHtmlResponse.ok(), JSON.stringify(appHtmlResponseHeaders)).toBe(true);
   expect(appHtmlResponseHeaders["content-type"]).toContain("text/html");
@@ -279,6 +277,40 @@ test("deploy-prewarmed App, Pages, and RSC variants are reused", async ({
   ).toBe("HIT");
   expect(secondAppHtmlResponseHeaders["x-workers-cache-visitor"]).toBe("visitor-b");
   expect(await secondAppHtmlResponse.text()).toBe(appHtmlBody);
+
+  // Next.js skips its shared response cache in draft mode. This must be
+  // decided in the uncached request entrypoint because a named-entrypoint HIT
+  // cannot inspect the draft cookie before replaying anonymous bytes.
+  const draftRequest = await playwright.request.newContext();
+  try {
+    const enableDraft = await draftRequest.get(`${baseURL}/api/draft-enable`);
+    expect(enableDraft.ok()).toBe(true);
+    expect(enableDraft.headers()["set-cookie"]).toContain("__prerender_bypass=");
+    expect(enableDraft.headers()["cache-control"]).toContain("no-store");
+
+    for (const pathname of [TARGET_PATH, PAGES_TARGET_PATH]) {
+      const draftResponse = await draftRequest.get(`${baseURL}${pathname}`, {
+        headers: htmlHeaders,
+      });
+      const draftHeaders = draftResponse.headers();
+      expect(draftResponse.ok(), JSON.stringify(draftHeaders)).toBe(true);
+      expect(draftHeaders["cf-cache-status"]).not.toBe("HIT");
+      expect(draftHeaders["cache-control"]).toContain("no-store");
+      expect(await draftResponse.text()).toContain(
+        '<output data-testid="draft-mode">true</output>',
+      );
+    }
+  } finally {
+    await draftRequest.dispose();
+  }
+
+  const anonymousAfterDraft = await getResponseAfterPromotion(
+    request,
+    `${baseURL}${TARGET_PATH}`,
+    htmlHeaders,
+  );
+  expect(anonymousAfterDraft.headers()["cf-cache-status"]).toBe("HIT");
+  expect(await anonymousAfterDraft.text()).toBe(appHtmlBody);
 
   const fullResponse = await getResponseAfterPromotion(request, `${baseURL}${TARGET_PATH}?_rsc`, {
     ...fullHeaders,

--- a/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
+++ b/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
@@ -223,7 +223,9 @@ test("deploy-prewarmed App, Pages, and RSC variants are reused", async ({
   expect(pagesResponse.ok(), JSON.stringify(pagesResponseHeaders)).toBe(true);
   expect(pagesResponseHeaders["content-type"]).toContain("text/html");
   expect(pagesResponseHeaders["x-vinext-build-id"]).toBe(rscBuildId);
-  expect(pagesResponseHeaders["cache-control"]).toContain("public");
+  expect(pagesResponseHeaders["cache-control"]).toBe("private, max-age=0, must-revalidate");
+  expect(pagesResponseHeaders["cdn-cache-control"]).toBeUndefined();
+  expect(pagesResponseHeaders["cloudflare-cdn-cache-control"]).toBeUndefined();
   expect(
     pagesResponseHeaders["cf-cache-status"],
     `Pages response headers: ${JSON.stringify(pagesResponseHeaders)}`,

--- a/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
+++ b/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
@@ -218,7 +218,7 @@ test("deploy-prewarmed App, Pages, and RSC variants are reused", async ({
   const pagesResponse = await getResponseAfterPromotion(
     request,
     `${baseURL}${PAGES_TARGET_PATH}`,
-    htmlHeaders,
+    { ...htmlHeaders, "x-test-visitor-id": "visitor-a" },
   );
   const pagesResponseHeaders = pagesResponse.headers();
   expect(pagesResponse.ok(), JSON.stringify(pagesResponseHeaders)).toBe(true);
@@ -229,12 +229,29 @@ test("deploy-prewarmed App, Pages, and RSC variants are reused", async ({
     pagesResponseHeaders["cf-cache-status"],
     `Pages response headers: ${JSON.stringify(pagesResponseHeaders)}`,
   ).toBe("HIT");
-  expect(await pagesResponse.text()).toContain("Pages prewarm target");
+  expect(pagesResponseHeaders["x-workers-cache-visitor"]).toBe("visitor-a");
+  const pagesBody = await pagesResponse.text();
+  expect(pagesBody).toContain("Pages prewarm target");
+
+  const secondPagesResponse = await getResponseAfterPromotion(
+    request,
+    `${baseURL}${PAGES_TARGET_PATH}`,
+    { ...htmlHeaders, "x-test-visitor-id": "visitor-b" },
+  );
+  const secondPagesResponseHeaders = secondPagesResponse.headers();
+  expect(secondPagesResponse.ok(), JSON.stringify(secondPagesResponseHeaders)).toBe(true);
+  expect(secondPagesResponseHeaders["x-vinext-build-id"]).toBe(rscBuildId);
+  expect(
+    secondPagesResponseHeaders["cf-cache-status"],
+    `Second Pages response headers: ${JSON.stringify(secondPagesResponseHeaders)}`,
+  ).toBe("HIT");
+  expect(secondPagesResponseHeaders["x-workers-cache-visitor"]).toBe("visitor-b");
+  expect(await secondPagesResponse.text()).toBe(pagesBody);
 
   const appHtmlResponse = await getResponseAfterPromotion(
     request,
     `${baseURL}${TARGET_PATH}`,
-    htmlHeaders,
+    { ...htmlHeaders, "x-test-visitor-id": "visitor-a" },
   );
   const appHtmlResponseHeaders = appHtmlResponse.headers();
   expect(appHtmlResponse.ok(), JSON.stringify(appHtmlResponseHeaders)).toBe(true);
@@ -244,13 +261,29 @@ test("deploy-prewarmed App, Pages, and RSC variants are reused", async ({
     appHtmlResponseHeaders["cf-cache-status"],
     `App HTML response headers: ${JSON.stringify(appHtmlResponseHeaders)}`,
   ).toBe("HIT");
-  expect(await appHtmlResponse.text()).toContain("Prewarm target");
+  expect(appHtmlResponseHeaders["x-workers-cache-visitor"]).toBe("visitor-a");
+  const appHtmlBody = await appHtmlResponse.text();
+  expect(appHtmlBody).toContain("Prewarm target");
 
-  const fullResponse = await getResponseAfterPromotion(
+  const secondAppHtmlResponse = await getResponseAfterPromotion(
     request,
-    `${baseURL}${TARGET_PATH}?_rsc`,
-    fullHeaders,
+    `${baseURL}${TARGET_PATH}`,
+    { ...htmlHeaders, "x-test-visitor-id": "visitor-b" },
   );
+  const secondAppHtmlResponseHeaders = secondAppHtmlResponse.headers();
+  expect(secondAppHtmlResponse.ok(), JSON.stringify(secondAppHtmlResponseHeaders)).toBe(true);
+  expect(secondAppHtmlResponseHeaders["x-vinext-build-id"]).toBe(rscBuildId);
+  expect(
+    secondAppHtmlResponseHeaders["cf-cache-status"],
+    `Second App HTML response headers: ${JSON.stringify(secondAppHtmlResponseHeaders)}`,
+  ).toBe("HIT");
+  expect(secondAppHtmlResponseHeaders["x-workers-cache-visitor"]).toBe("visitor-b");
+  expect(await secondAppHtmlResponse.text()).toBe(appHtmlBody);
+
+  const fullResponse = await getResponseAfterPromotion(request, `${baseURL}${TARGET_PATH}?_rsc`, {
+    ...fullHeaders,
+    "x-test-visitor-id": "visitor-a",
+  });
   const fullResponseHeaders = fullResponse.headers();
   expect(fullResponse.ok(), JSON.stringify(fullResponseHeaders)).toBe(true);
   expect(fullResponseHeaders["content-type"]).toContain("text/x-component");
@@ -259,9 +292,25 @@ test("deploy-prewarmed App, Pages, and RSC variants are reused", async ({
     fullResponseHeaders["cf-cache-status"],
     `full RSC response headers: ${JSON.stringify(fullResponseHeaders)}`,
   ).toBe("HIT");
+  expect(fullResponseHeaders["x-workers-cache-visitor"]).toBe("visitor-a");
   const fullBody = await fullResponse.text();
   expect(fullBody).toContain(buildId);
   expect(fullBody).toContain("Prewarm target");
+
+  const secondFullResponse = await getResponseAfterPromotion(
+    request,
+    `${baseURL}${TARGET_PATH}?_rsc`,
+    { ...fullHeaders, "x-test-visitor-id": "visitor-b" },
+  );
+  const secondFullResponseHeaders = secondFullResponse.headers();
+  expect(secondFullResponse.ok(), JSON.stringify(secondFullResponseHeaders)).toBe(true);
+  expect(secondFullResponseHeaders["x-vinext-rsc-build-id"]).toBe(rscBuildId);
+  expect(
+    secondFullResponseHeaders["cf-cache-status"],
+    `Second full RSC response headers: ${JSON.stringify(secondFullResponseHeaders)}`,
+  ).toBe("HIT");
+  expect(secondFullResponseHeaders["x-workers-cache-visitor"]).toBe("visitor-b");
+  expect(await secondFullResponse.text()).toBe(fullBody);
 
   const shellResponse = await getResponseAfterPromotion(
     request,

--- a/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
+++ b/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
@@ -500,7 +500,8 @@ test("deploy-prewarmed App, Pages, and RSC variants are reused", async ({
   const coldHeaders = coldAfterPurge!.headers();
   expect(coldAfterPurge!.ok(), JSON.stringify(coldHeaders)).toBe(true);
   expect(coldHeaders["cf-cache-status"]).toBe("MISS");
-  expect(coldHeaders["cdn-cache-control"]).toContain("public");
+  expect(coldHeaders["cdn-cache-control"]).toBeUndefined();
+  expect(coldHeaders["cloudflare-cdn-cache-control"]).toBeUndefined();
   expect(await coldAfterPurge!.text()).toContain("Prewarm target");
 
   const reuseDeadline = Date.now() + 30_000;

--- a/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
+++ b/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
@@ -312,6 +312,21 @@ test("deploy-prewarmed App, Pages, and RSC variants are reused", async ({
   expect(anonymousAfterDraft.headers()["cf-cache-status"]).toBe("HIT");
   expect(await anonymousAfterDraft.text()).toBe(appHtmlBody);
 
+  for (const variant of ["alpha", "beta"]) {
+    const first = await getResponseAfterPromotion(request, `${baseURL}/vary`, {
+      "x-cache-variant": variant,
+    });
+    expect(first.ok(), JSON.stringify(first.headers())).toBe(true);
+    expect(await first.text()).toBe(variant);
+    expect(first.headers()["vary"]?.toLowerCase()).toContain("x-cache-variant");
+
+    const cached = await getResponseAfterPromotion(request, `${baseURL}/vary`, {
+      "x-cache-variant": variant,
+    });
+    expect(cached.headers()["cf-cache-status"], JSON.stringify(cached.headers())).toBe("HIT");
+    expect(await cached.text()).toBe(variant);
+  }
+
   const fullResponse = await getResponseAfterPromotion(request, `${baseURL}${TARGET_PATH}?_rsc`, {
     ...fullHeaders,
     "x-test-visitor-id": "visitor-a",

--- a/tests/e2e/ppr-impact-demo/cacheability-admission.spec.ts
+++ b/tests/e2e/ppr-impact-demo/cacheability-admission.spec.ts
@@ -1,4 +1,10 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type APIResponse } from "@playwright/test";
+
+function expectGatewayCachePolicy(response: APIResponse): void {
+  expect(response.headers()["cache-control"]).toContain("must-revalidate");
+  expect(response.headers()["cdn-cache-control"]).toBeUndefined();
+  expect(response.headers()["cloudflare-cdn-cache-control"]).toBeUndefined();
+}
 
 test("admits pattern-backed App responses only after each clean EOF", async ({ request }) => {
   const certified = await request.get("/cacheability/static", {
@@ -6,15 +12,14 @@ test("admits pattern-backed App responses only after each clean EOF", async ({ r
   });
   expect(certified.status()).toBe(200);
   expect(await certified.text()).toContain("static page");
-  expect(certified.headers()["cdn-cache-control"]).toContain("public");
-  expect(certified.headers()["cache-control"]).toContain("must-revalidate");
+  expectGatewayCachePolicy(certified);
 
   const certifiedFullRsc = await request.get("/cacheability/static?_rsc", {
     headers: { Accept: "text/x-component", RSC: "1" },
   });
   expect(certifiedFullRsc.status()).toBe(200);
   expect(certifiedFullRsc.headers()["content-type"]).toContain("text/x-component");
-  expect(certifiedFullRsc.headers()["cdn-cache-control"]).toContain("public");
+  expectGatewayCachePolicy(certifiedFullRsc);
 
   const certifiedLoadingShell = await request.get("/cacheability/static?_rsc=9qLBDIU2NgN178cB", {
     headers: {
@@ -27,13 +32,13 @@ test("admits pattern-backed App responses only after each clean EOF", async ({ r
   });
   expect(certifiedLoadingShell.status()).toBe(200);
   expect(certifiedLoadingShell.headers()["content-type"]).toContain("text/x-component");
-  expect(certifiedLoadingShell.headers()["cdn-cache-control"]).toContain("public");
+  expectGatewayCachePolicy(certifiedLoadingShell);
 
   const runtimeCheck = await request.get("/cacheability/static?runtime=1", {
     headers: { Accept: "text/html" },
   });
   expect(runtimeCheck.status()).toBe(200);
-  expect(runtimeCheck.headers()["cdn-cache-control"]).toContain("public");
+  expectGatewayCachePolicy(runtimeCheck);
 
   const lateCookie = await request.get("/cacheability/static?late-policy=set-cookie", {
     headers: { Accept: "text/html" },
@@ -49,7 +54,7 @@ test("admits pattern-backed App responses only after each clean EOF", async ({ r
       headers: { Accept: "text/html" },
     });
     expect(latePrivatePolicy.status()).toBe(200);
-    expect(latePrivatePolicy.headers()["cache-control"]).toContain("no-store");
+    expect(latePrivatePolicy.headers()["cache-control"]).toMatch(/(?:private|no-store)/);
     expect(latePrivatePolicy.headers()["cdn-cache-control"]).toBeUndefined();
     expect(latePrivatePolicy.headers()["cloudflare-cdn-cache-control"]).toBeUndefined();
   }
@@ -58,8 +63,7 @@ test("admits pattern-backed App responses only after each clean EOF", async ({ r
     headers: { Accept: "text/html" },
   });
   expect(unlistedQuery.status()).toBe(200);
-  expect(unlistedQuery.headers()["cdn-cache-control"]).toContain("public");
-  expect(unlistedQuery.headers()["cache-control"]).toContain("must-revalidate");
+  expectGatewayCachePolicy(unlistedQuery);
 
   const knownDynamic = await request.get("/cacheability/dynamic", {
     headers: { Accept: "text/html" },
@@ -72,7 +76,7 @@ test("admits pattern-backed App responses only after each clean EOF", async ({ r
     headers: { Accept: "text/html" },
   });
   expect(configPublicDynamic.status()).toBe(200);
-  expect(configPublicDynamic.headers()["cdn-cache-control"]).toContain("max-age=32");
+  expectGatewayCachePolicy(configPublicDynamic);
 
   const configPrivateDynamic = await request.get("/cacheability/config-public-dynamic?preview=1", {
     headers: { Accept: "text/html" },
@@ -92,14 +96,14 @@ test("admits pattern-backed App responses only after each clean EOF", async ({ r
     headers: { Accept: "text/html" },
   });
   expect(publicConfigPattern.status()).toBe(200);
-  expect(publicConfigPattern.headers()["cdn-cache-control"]).toContain("max-age=33");
+  expectGatewayCachePolicy(publicConfigPattern);
 
   const publicConfigRepresentation = await request.get(
     "/cacheability/config-public-representation",
     { headers: { Accept: "text/html" } },
   );
   expect(publicConfigRepresentation.status()).toBe(200);
-  expect(publicConfigRepresentation.headers()["cdn-cache-control"]).toContain("max-age=34");
+  expectGatewayCachePolicy(publicConfigRepresentation);
 
   const privateConfigRepresentation = await request.get(
     "/cacheability/config-public-representation?_rsc",
@@ -119,7 +123,7 @@ test("admits pattern-backed App responses only after each clean EOF", async ({ r
     headers: { Accept: "text/html" },
   });
   expect(staticPatternSibling.status()).toBe(200);
-  expect(staticPatternSibling.headers()["cdn-cache-control"]).toContain("public");
+  expectGatewayCachePolicy(staticPatternSibling);
 
   const dynamicPatternSibling = await request.get("/cacheability/pattern-runtime-dynamic/dynamic", {
     headers: { Accept: "text/html" },
@@ -147,7 +151,7 @@ test("admits pattern-backed App responses only after each clean EOF", async ({ r
     { headers: { Accept: "text/html" } },
   );
   expect(allStaticFallback.status()).toBe(200);
-  expect(allStaticFallback.headers()["cdn-cache-control"]).toContain("public");
+  expectGatewayCachePolicy(allStaticFallback);
   const allStaticFallbackBody = await allStaticFallback.text();
   expect(allStaticFallbackBody).toContain("runtime static ");
   expect(allStaticFallbackBody).toContain("runtime-fallback</main>");
@@ -156,7 +160,7 @@ test("admits pattern-backed App responses only after each clean EOF", async ({ r
     headers: { Accept: "text/html" },
   });
   expect(emptyStaticFallback.status()).toBe(200);
-  expect(emptyStaticFallback.headers()["cdn-cache-control"]).toContain("public");
+  expectGatewayCachePolicy(emptyStaticFallback);
   expect(await emptyStaticFallback.text()).toContain("empty fallback on-demand</main>");
 
   const staticToDynamic = await request.get("/cacheability/static-to-dynamic/runtime", {
@@ -185,13 +189,13 @@ test("admits pattern-backed App responses only after each clean EOF", async ({ r
   const certifiedRouteHandler = await request.get("/cacheability/route-handler-static");
   expect(certifiedRouteHandler.status()).toBe(200);
   await expect(certifiedRouteHandler.json()).resolves.toEqual({ kind: "static-route-handler" });
-  expect(certifiedRouteHandler.headers()["cdn-cache-control"]).toContain("public");
+  expectGatewayCachePolicy(certifiedRouteHandler);
   expect(certifiedRouteHandler.headers()["vary"]?.toLowerCase()).toContain("user-agent");
 
   const largeRouteHandler = await request.get("/cacheability/route-handler-large");
   expect(largeRouteHandler.status()).toBe(200);
   expect((await largeRouteHandler.body()).byteLength).toBe(4 * 1024 * 1024 + 1);
-  expect(largeRouteHandler.headers()["cdn-cache-control"]).toContain("public");
+  expectGatewayCachePolicy(largeRouteHandler);
 
   const cachedLargeRouteHandler = await request.get("/cacheability/route-handler-large");
   expect(cachedLargeRouteHandler.status()).toBe(200);
@@ -205,13 +209,13 @@ test("admits pattern-backed App responses only after each clean EOF", async ({ r
     kind: "static-empty",
     slug: "on-demand",
   });
-  expect(emptyStaticRouteHandler.headers()["cdn-cache-control"]).toContain("public");
+  expectGatewayCachePolicy(emptyStaticRouteHandler);
 
   const unlistedRouteHandlerQuery = await request.get(
     "/cacheability/route-handler-static?user=one",
   );
   expect(unlistedRouteHandlerQuery.status()).toBe(200);
-  expect(unlistedRouteHandlerQuery.headers()["cdn-cache-control"]).toContain("public");
+  expectGatewayCachePolicy(unlistedRouteHandlerQuery);
 
   // Next.js does not statically generate a GET+POST Route Handler, so this
   // route is intentionally absent from the probe manifest. Its handler-owned
@@ -220,7 +224,7 @@ test("admits pattern-backed App responses only after each clean EOF", async ({ r
   await expect(explicitMixedRouteHandler.json()).resolves.toEqual({
     kind: "explicit-mixed-route-handler",
   });
-  expect(explicitMixedRouteHandler.headers()["cache-control"]).toBe("public, s-maxage=60");
+  expectGatewayCachePolicy(explicitMixedRouteHandler);
 
   // `revalidate` alone is framework policy, not an explicit response-level
   // opt-in, and must not bypass the route's manifest absence.
@@ -247,8 +251,7 @@ test("admits pattern-backed App responses only after each clean EOF", async ({ r
   await expect(explicitDynamicRouteHandler.json()).resolves.toEqual({
     value: "explicitly-public",
   });
-  expect(explicitDynamicRouteHandler.headers()["cdn-cache-control"]).toBe("public, max-age=60");
-  expect(explicitDynamicRouteHandler.headers()["cache-control"]).toContain("must-revalidate");
+  expectGatewayCachePolicy(explicitDynamicRouteHandler);
 
   const lateConfigPublicFailure = await request.get(
     "/cacheability/route-handler-config-public-late-error",

--- a/tests/e2e/ppr-impact-demo/cacheability-probe.spec.ts
+++ b/tests/e2e/ppr-impact-demo/cacheability-probe.spec.ts
@@ -213,7 +213,10 @@ test("classifies completed App Page renders inside workerd", async ({ request })
     version: 1,
   });
 
-  // Next.js keeps middleware in front of page serving on every request:
+  // Next.js keeps middleware in front of page serving on every request. The
+  // staged probe classifies only the reusable render below that boundary, so
+  // this route remains dynamic for its own missing cache policy, not merely
+  // because middleware matched:
   // test/e2e/middleware-static-files/index.test.ts
   // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-static-files/index.test.ts
   const middlewareProbe = await request.get("/cacheability/middleware", { headers });
@@ -221,7 +224,7 @@ test("classifies completed App Page renders inside workerd", async ({ request })
   await expect(middlewareProbe.json()).resolves.toMatchObject({
     kind: "app-page",
     pattern: "/cacheability/middleware",
-    reason: "middleware matched this request",
+    reason: "render did not produce a cache policy",
     state: "dynamic",
     status: 200,
     version: 1,
@@ -231,8 +234,8 @@ test("classifies completed App Page renders inside workerd", async ({ request })
   // request-specific `has`/`missing` conditions:
   // packages/next/src/shared/lib/router/utils/middleware-route-matcher.ts
   // https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/middleware-route-matcher.ts
-  // A condition-free staged probe must therefore not certify a pathname that
-  // a later cookie- or header-bearing request can send through middleware.
+  // The uncached request stage evaluates those request-specific conditions on
+  // every request, while the probe certifies the reusable render beneath it.
   for (const { conditionHeaders, pathname } of [
     {
       conditionHeaders: { Cookie: "cacheability-middleware=1" },
@@ -253,8 +256,7 @@ test("classifies completed App Page renders inside workerd", async ({ request })
     await expect(conditionalMiddlewareProbe.json()).resolves.toMatchObject({
       kind: "app-page",
       pattern: pathname,
-      reason: "middleware is eligible for this pathname",
-      state: "dynamic",
+      state: "static-candidate",
       status: 200,
       version: 1,
     });

--- a/tests/e2e/ppr-impact-demo/pages-cacheability.spec.ts
+++ b/tests/e2e/ppr-impact-demo/pages-cacheability.spec.ts
@@ -1,9 +1,20 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type APIResponse } from "@playwright/test";
 import fs from "node:fs";
 
 const probeHeader = "X-Vinext-Cacheability-Probe";
 const secretHeader = "X-Vinext-Prerender-Secret";
 const buildId = "ppr-impact-demo-cacheability";
+
+function expectGatewayRevalidation(response: APIResponse, label: string): void {
+  expect(response.headers()["cache-control"], label).toContain("max-age=0");
+  expect(response.headers()["cache-control"], label).toContain("must-revalidate");
+  expect(response.headers()["cdn-cache-control"], label).toBeUndefined();
+}
+
+function expectPrivateGateway(response: APIResponse, label: string): void {
+  expect(response.headers()["cache-control"], label).toMatch(/(?:private|no-store)/);
+  expect(response.headers()["cdn-cache-control"], label).toBeUndefined();
+}
 
 function prerenderSecret(): string {
   const manifest = JSON.parse(
@@ -89,20 +100,13 @@ test("classifies Pages Router data contracts inside the staged Worker", async ({
     version: 1,
   });
 
-  for (const [pathname, reason] of [
-    ["/cacheability-pages/middleware", "middleware is eligible for this pathname"],
-    [
-      "/cacheability-pages/config-header",
-      "next.config headers depend on request headers, cookies, or hostnames",
-    ],
-    [
-      "/cacheability-pages/conditional-redirect",
-      "next.config redirect depends on request headers, cookies, or hostnames",
-    ],
-    [
-      "/cacheability-pages/conditional-rewrite",
-      "next.config rewrite depends on request headers, cookies, or hostnames",
-    ],
+  // Middleware and request-conditioned config rules execute in the uncached
+  // request stage. Probe the reusable Pages render beneath those rules.
+  for (const pathname of [
+    "/cacheability-pages/middleware",
+    "/cacheability-pages/config-header",
+    "/cacheability-pages/conditional-redirect",
+    "/cacheability-pages/conditional-rewrite",
   ] as const) {
     const response = await request.get(pathname, {
       headers: { ...headers, Accept: "text/html" },
@@ -111,8 +115,7 @@ test("classifies Pages Router data contracts inside the staged Worker", async ({
     await expect(response.json(), pathname).resolves.toMatchObject({
       kind: "pages-page",
       pattern: pathname,
-      reason,
-      state: "dynamic",
+      state: "static-candidate",
       status: 200,
       version: 1,
     });
@@ -130,7 +133,7 @@ test("admits pattern-backed Pages Router responses after each completed render",
   ]) {
     const response = await request.get(pathname, { headers: { Accept: "text/html" } });
     expect(response.status(), pathname).toBe(200);
-    expect(response.headers()["cdn-cache-control"], pathname).toContain("max-age=60");
+    expectGatewayRevalidation(response, pathname);
   }
 
   for (const pathname of [
@@ -142,7 +145,7 @@ test("admits pattern-backed Pages Router responses after each completed render",
     const response = await request.get(pathname, { headers: { Accept: "application/json" } });
     expect(response.status(), pathname).toBe(200);
     expect(response.headers()["content-type"], pathname).toContain("application/json");
-    expect(response.headers()["cdn-cache-control"], pathname).toContain("max-age=60");
+    expectGatewayRevalidation(response, pathname);
   }
 
   for (const pathname of [
@@ -153,7 +156,7 @@ test("admits pattern-backed Pages Router responses after each completed render",
       headers: { Accept: pathname.includes("/_next/data/") ? "application/json" : "text/html" },
     });
     expect(response.status(), pathname).toBe(200);
-    expect(response.headers()["cdn-cache-control"], pathname).toContain("max-age=36");
+    expectGatewayRevalidation(response, pathname);
   }
 
   for (const pathname of [
@@ -178,16 +181,14 @@ test("keeps middleware cookie variants private", async ({ request }) => {
   });
   expect(middlewarePublic.status()).toBe(200);
   expect(middlewarePublic.headers()["x-cacheability-middleware"]).toBeUndefined();
-  expect(middlewarePublic.headers()["cache-control"]).toContain("no-store");
-  expect(middlewarePublic.headers()["cdn-cache-control"]).toBeUndefined();
+  expectPrivateGateway(middlewarePublic, "public middleware variant");
 
   const middlewarePrivate = await request.get("/cacheability-pages/middleware", {
     headers: { Accept: "text/html", Cookie: "variant=private" },
   });
   expect(middlewarePrivate.status()).toBe(200);
   expect(middlewarePrivate.headers()["x-cacheability-middleware"]).toBe("matched");
-  expect(middlewarePrivate.headers()["cache-control"]).toContain("no-store");
-  expect(middlewarePrivate.headers()["cdn-cache-control"]).toBeUndefined();
+  expectPrivateGateway(middlewarePrivate, "private middleware variant");
 
   const dataPath = `/_next/data/${buildId}/cacheability-pages/middleware.json`;
   for (const cookie of [undefined, "variant=private"]) {
@@ -198,8 +199,7 @@ test("keeps middleware cookie variants private", async ({ request }) => {
       },
     });
     expect(response.status(), cookie ?? "public").toBe(200);
-    expect(response.headers()["cache-control"], cookie ?? "public").toContain("no-store");
-    expect(response.headers()["cdn-cache-control"], cookie ?? "public").toBeUndefined();
+    expectPrivateGateway(response, cookie ?? "public");
   }
 });
 
@@ -209,16 +209,14 @@ test("keeps config-header cookie variants private", async ({ request }) => {
   });
   expect(configPublic.status()).toBe(200);
   expect(configPublic.headers()["x-cacheability-config"]).toBeUndefined();
-  expect(configPublic.headers()["cache-control"]).toContain("no-store");
-  expect(configPublic.headers()["cdn-cache-control"]).toBeUndefined();
+  expectPrivateGateway(configPublic, "public config variant");
 
   const configPrivate = await request.get("/cacheability-pages/config-header", {
     headers: { Accept: "text/html", Cookie: "variant=private" },
   });
   expect(configPrivate.status()).toBe(200);
   expect(configPrivate.headers()["x-cacheability-config"]).toBe("private");
-  expect(configPrivate.headers()["cache-control"]).toContain("no-store");
-  expect(configPrivate.headers()["cdn-cache-control"]).toBeUndefined();
+  expectPrivateGateway(configPrivate, "private config variant");
 
   const dataPath = `/_next/data/${buildId}/cacheability-pages/config-header.json`;
   for (const cookie of [undefined, "variant=private"]) {
@@ -229,8 +227,7 @@ test("keeps config-header cookie variants private", async ({ request }) => {
       },
     });
     expect(response.status(), cookie ?? "public").toBe(200);
-    expect(response.headers()["cache-control"], cookie ?? "public").toContain("no-store");
-    expect(response.headers()["cdn-cache-control"], cookie ?? "public").toBeUndefined();
+    expectPrivateGateway(response, cookie ?? "public");
   }
 });
 

--- a/tests/fetch-handler.test.ts
+++ b/tests/fetch-handler.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { createServer, type ViteDevServer } from "vite-plus";
 import { describe, expect, it } from "vite-plus/test";
+import { cdnAdapter } from "../packages/cloudflare/src/cache/cdn-adapter.js";
 import { resolveRuntimeEntryModule } from "../packages/vinext/src/entries/runtime-entry-module.js";
 import vinext, { type VinextOptions } from "../packages/vinext/src/index.js";
 
@@ -42,6 +43,21 @@ function loadUnifiedFetchHandler(
   options: Parameters<typeof loadVirtualModule>[2] = {},
 ): Promise<string> {
   return loadVirtualModule(root, "virtual:vinext-worker-entry", options);
+}
+
+async function resolveWithCdnOutput(root: string, id: string): Promise<string | undefined> {
+  const server = await createServer({
+    root,
+    configFile: false,
+    plugins: [vinext({ cache: { cdn: cdnAdapter() } }), { name: "vite-plugin-cloudflare" }],
+    server: { port: 0 },
+    logLevel: "silent",
+  });
+  try {
+    return (await server.pluginContainer.resolveId(id))?.id;
+  } finally {
+    await server.close();
+  }
 }
 
 describe("unified Worker fetch handler", () => {
@@ -116,6 +132,53 @@ describe("unified Worker fetch handler", () => {
       fs.rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it("lets the Cloudflare CDN adapter select its multi-stage Worker facade", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-fetch-handler-cdn-"));
+    try {
+      fs.mkdirSync(path.join(root, "app"), { recursive: true });
+      fs.writeFileSync(
+        path.join(root, "app/page.tsx"),
+        "export default function Page() { return <div>app</div>; }\n",
+      );
+
+      const descriptor = cdnAdapter();
+      await expect(
+        loadUnifiedFetchHandler(root, {
+          cache: { cdn: descriptor },
+          hostPluginName: "vite-plugin-cloudflare",
+        }),
+      ).resolves.toBe(
+        [
+          `export { default } from ${JSON.stringify(descriptor.output.entry)};`,
+          `export * from ${JSON.stringify(descriptor.output.entry)};`,
+          "",
+        ].join("\n"),
+      );
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it.each(["app-router-entry", "pages-router-entry"])(
+    "routes a direct %s main through the Cloudflare facade",
+    async (entryName) => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-direct-router-cdn-"));
+      try {
+        fs.mkdirSync(path.join(root, "app"), { recursive: true });
+        fs.writeFileSync(
+          path.join(root, "app/page.tsx"),
+          "export default function Page() { return <div>app</div>; }\n",
+        );
+
+        await expect(resolveWithCdnOutput(root, `vinext/server/${entryName}`)).resolves.toBe(
+          "\0virtual:vinext-worker-entry",
+        );
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    },
+  );
 
   it.each(["app-router-entry", "pages-router-entry"])(
     "routes a direct %s main through the selected facade",

--- a/tests/fixtures/cf-app-basic/app/api/cdn-stage-late-route/[slug]/route.ts
+++ b/tests/fixtures/cf-app-basic/app/api/cdn-stage-late-route/[slug]/route.ts
@@ -1,0 +1,18 @@
+export const revalidate = false;
+
+export function GET(request: Request) {
+  return new Response(
+    new ReadableStream({
+      async pull(controller) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+        const visitorId = request.headers.get("x-test-visitor-id") ?? "anonymous";
+        const renderToken = crypto.randomUUID();
+        controller.enqueue(
+          new TextEncoder().encode(`late-route-visitor:${visitorId}; render-token:${renderToken}`),
+        );
+        controller.close();
+      },
+    }),
+    { headers: { "Content-Type": "text/plain" } },
+  );
+}

--- a/tests/fixtures/cf-app-basic/app/api/cdn-stage-middleware-header/[slug]/route.ts
+++ b/tests/fixtures/cf-app-basic/app/api/cdn-stage-middleware-header/[slug]/route.ts
@@ -1,0 +1,5 @@
+export function GET(request: Request) {
+  return new Response(request.headers.get("x-from-middleware") ?? "missing", {
+    headers: { "Cache-Control": "public, s-maxage=60" },
+  });
+}

--- a/tests/fixtures/cf-app-basic/app/api/cdn-stage-revalidate/route.ts
+++ b/tests/fixtures/cf-app-basic/app/api/cdn-stage-revalidate/route.ts
@@ -1,0 +1,7 @@
+import { revalidatePath } from "next/cache";
+
+export async function POST(request: Request) {
+  const { pathname } = (await request.json()) as { pathname: string };
+  revalidatePath(pathname);
+  return Response.json({ revalidated: pathname });
+}

--- a/tests/fixtures/cf-app-basic/app/api/large-static-stream/route.ts
+++ b/tests/fixtures/cf-app-basic/app/api/large-static-stream/route.ts
@@ -1,6 +1,6 @@
 export const revalidate = 60;
 
-const BODY_SIZE = 4 * 1024 * 1024 + 1;
+const BODY_SIZE = 16 * 1024 * 1024 + 1;
 
 export function GET() {
   return new Response(

--- a/tests/fixtures/cf-app-basic/app/cdn-stage-app/[slug]/page.tsx
+++ b/tests/fixtures/cf-app-basic/app/cdn-stage-app/[slug]/page.tsx
@@ -1,0 +1,11 @@
+export const revalidate = 60;
+
+export default async function CdnStageAppPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const renderToken = crypto.randomUUID();
+  return (
+    <main data-render-token={renderToken} data-slug={slug}>
+      App CDN response stage render-token:{renderToken}
+    </main>
+  );
+}

--- a/tests/fixtures/cf-app-basic/app/cdn-stage-cookie/[slug]/page.tsx
+++ b/tests/fixtures/cf-app-basic/app/cdn-stage-cookie/[slug]/page.tsx
@@ -1,0 +1,11 @@
+import { cookies } from "next/headers";
+
+export default async function CdnStageCookiePage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const cookie = (await cookies()).get("stage-cookie")?.value ?? "missing";
+  return <main>{`middleware-cookie:${cookie}; slug:${slug}`}</main>;
+}

--- a/tests/fixtures/cf-app-basic/app/cdn-stage-late/[slug]/page.tsx
+++ b/tests/fixtures/cf-app-basic/app/cdn-stage-late/[slug]/page.tsx
@@ -1,0 +1,32 @@
+import { Suspense } from "react";
+import { headers } from "next/headers";
+
+// Default-static pages use an infinite revalidation interval internally. This
+// exercises the client-header-preservation path as well as ordinary ISR.
+export const revalidate = false;
+
+async function LateDynamicContent({ slug }: { slug: string }) {
+  // Ensure the response stream has started before dynamic request state is
+  // accessed. The completed response must not be promoted to a shared cache.
+  await new Promise((resolve) => setTimeout(resolve, 25));
+  const visitorId = (await headers()).get("x-test-visitor-id") ?? "anonymous";
+  const renderToken = crypto.randomUUID();
+
+  return (
+    <span data-render-token={renderToken}>
+      {`late-dynamic-visitor:${visitorId}; slug:${slug}; render-token:${renderToken}`}
+    </span>
+  );
+}
+
+export default async function CdnStageLatePage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+
+  return (
+    <main>
+      <Suspense fallback={<span>loading-late-dynamic-content</span>}>
+        <LateDynamicContent slug={slug} />
+      </Suspense>
+    </main>
+  );
+}

--- a/tests/fixtures/cf-app-basic/middleware.ts
+++ b/tests/fixtures/cf-app-basic/middleware.ts
@@ -30,13 +30,23 @@ export async function middleware(request: NextRequest) {
     (await draftMode()).enable();
   }
   const headers = new Headers(request.headers);
-  headers.set("x-from-middleware", "hello-from-middleware");
-  const response = NextResponse.next({ request: { headers } });
+  const testsMiddlewareRequestHeaders =
+    request.nextUrl.pathname.startsWith("/api/dump-headers") ||
+    request.nextUrl.pathname.startsWith("/api/cdn-stage-middleware-header/");
+  if (request.nextUrl.pathname.startsWith("/api/cdn-stage-middleware-header/")) {
+    headers.set("x-from-middleware", visitorId);
+  } else {
+    headers.set("x-from-middleware", "hello-from-middleware");
+  }
+  const response = testsMiddlewareRequestHeaders
+    ? NextResponse.next({ request: { headers } })
+    : NextResponse.next();
   if (
     request.nextUrl.pathname.startsWith("/cdn-stage-app/") ||
     request.nextUrl.pathname.startsWith("/cdn-stage-cookie/") ||
     request.nextUrl.pathname.startsWith("/cdn-stage-late/") ||
     request.nextUrl.pathname.startsWith("/api/cdn-stage-late-route/") ||
+    request.nextUrl.pathname.startsWith("/api/cdn-stage-middleware-header/") ||
     request.nextUrl.pathname.startsWith("/cdn-stage-pages/")
   ) {
     response.headers.set("x-cdn-stage-visitor", visitorId);

--- a/tests/fixtures/cf-app-basic/middleware.ts
+++ b/tests/fixtures/cf-app-basic/middleware.ts
@@ -8,6 +8,13 @@ import { NextResponse, type NextRequest } from "next/server";
  * for #1520.
  */
 export async function middleware(request: NextRequest) {
+  const visitorId = request.headers.get("x-test-visitor-id") ?? "anonymous";
+  if (request.nextUrl.pathname.startsWith("/cdn-stage-cookie/")) {
+    const response = NextResponse.next();
+    response.cookies.set("stage-cookie", visitorId);
+    response.headers.set("x-cdn-stage-visitor", visitorId);
+    return response;
+  }
   if (request.nextUrl.pathname === "/%61dmin") {
     return NextResponse.rewrite(new URL("/admin", request.url));
   }
@@ -24,5 +31,15 @@ export async function middleware(request: NextRequest) {
   }
   const headers = new Headers(request.headers);
   headers.set("x-from-middleware", "hello-from-middleware");
-  return NextResponse.next({ request: { headers } });
+  const response = NextResponse.next({ request: { headers } });
+  if (
+    request.nextUrl.pathname.startsWith("/cdn-stage-app/") ||
+    request.nextUrl.pathname.startsWith("/cdn-stage-cookie/") ||
+    request.nextUrl.pathname.startsWith("/cdn-stage-late/") ||
+    request.nextUrl.pathname.startsWith("/api/cdn-stage-late-route/") ||
+    request.nextUrl.pathname.startsWith("/cdn-stage-pages/")
+  ) {
+    response.headers.set("x-cdn-stage-visitor", visitorId);
+  }
+  return response;
 }

--- a/tests/fixtures/cf-app-basic/pages/api/cdn-public.ts
+++ b/tests/fixtures/cf-app-basic/pages/api/cdn-public.ts
@@ -1,0 +1,6 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export default function handler(_request: NextApiRequest, response: NextApiResponse) {
+  response.setHeader("Cache-Control", "public, s-maxage=60");
+  response.json({ public: true });
+}

--- a/tests/fixtures/cf-app-basic/pages/api/cdn-request-cf.ts
+++ b/tests/fixtures/cf-app-basic/pages/api/cdn-request-cf.ts
@@ -1,0 +1,11 @@
+export const config = {
+  runtime: "edge",
+};
+
+export default function handler(request: Request) {
+  const cf = Reflect.get(request, "cf");
+  return Response.json(
+    { hasCf: cf !== undefined },
+    { headers: { "Cache-Control": "public, s-maxage=60" } },
+  );
+}

--- a/tests/fixtures/cf-app-basic/pages/cdn-stage-pages/[slug].tsx
+++ b/tests/fixtures/cf-app-basic/pages/cdn-stage-pages/[slug].tsx
@@ -1,0 +1,38 @@
+type Props = {
+  revalidateReason: string;
+  renderToken: string;
+  slug: string;
+};
+
+export default function CdnStagePagesPage({ revalidateReason, renderToken, slug }: Props) {
+  return (
+    <main
+      data-render-token={renderToken}
+      data-revalidate-reason={revalidateReason}
+      data-slug={slug}
+    >
+      Pages CDN response stage render-token:{renderToken}
+    </main>
+  );
+}
+
+export function getStaticPaths() {
+  return { fallback: "blocking", paths: [] };
+}
+
+export async function getStaticProps({
+  params,
+  revalidateReason,
+}: {
+  params: { slug: string };
+  revalidateReason?: string;
+}) {
+  return {
+    props: {
+      revalidateReason: revalidateReason ?? "unknown",
+      renderToken: crypto.randomUUID(),
+      slug: params.slug,
+    },
+    revalidate: 60,
+  };
+}


### PR DESCRIPTION
## Summary

- make the default Worker entrypoint an uncached gateway that always runs middleware and routing
- add a cache-enabled `VinextCachedResponse` Worker entrypoint for reusable render responses
- configure per-entrypoint Workers Cache settings in generated Wrangler output
- use adapter-owned `ctx.exports` dispatch while keeping ordinary bypass work local and uncached
- lazy-load both stages so an edge HIT does not evaluate the Worker and a miss does not eagerly load the render graph
- carry the gateway build identity into configurable-entrypoint props and reject stale stages before rendering or cache admission
- version the Cloudflare wire cache discriminator so both old-stage/new-gateway and new-stage/old-gateway rollout pairings fail closed before admission
- route readiness through the response entrypoint and retry required transient BYPASS results within the existing bounded propagation window
- preserve custom Worker entrypoints, revalidation purges, static assets, and existing app configuration

## Stack

1. tooling baseline (#3082)
2. transport-neutral worker stages (#3083)
3. **This PR:** Cloudflare Workers Cache entrypoint isolation (#3079)
4. independently deployed HTTP stages (#3084)
5. Workers Cache tag parity (#3085)

## Validation

- Cloudflare warmup/deploy/worker tests: 170 passed
- rolling-deploy cache emulation covers both pre-protocol directions, retry fill, and subsequent HIT
- readiness and nested dispatch wire normalization covered
- full `vp check` and Knip: passed at the stack head
- `vinext` and `@vinext/cloudflare` builds: passed
- deployed Workers Cache run 33597158196: 12 warmed, 0 skipped, 0 failed; browser RSC requests were HITs