### PR TITLE
fix(cloudflare): preserve Workers Cache tag parity

### DIFF
--- a/examples/workers-cache/README.md
+++ b/examples/workers-cache/README.md
@@ -85,7 +85,11 @@ stale-while-revalidate=M` (for the edge) plus a browser-facing
    header containing Cloudflare-safe fixed-size digests of both the bare path
    (`/cached/intro`) and Next.js's internal `_N_T_<path>` form. The Workers
    Cache reads these to cache and tag-purge without losing Next.js's
-   case-sensitive tag semantics.
+   case-sensitive tag semantics. Because Workers Cache requires every `Vary`
+   variant of a URL to use the same cache tags, vinext conservatively leaves a
+   tagged response uncached when it declares an application-defined `Vary`
+   field; use a separate URL or response-stage identity when those variants
+   need both caching and tag invalidation.
 
 5. **`revalidateTag` / `revalidatePath`** in your route handlers fan out to
    both the KV data cache and `ctx.cache.purge(...)` on the platform layer.

--- a/examples/workers-cache/README.md
+++ b/examples/workers-cache/README.md
@@ -82,8 +82,10 @@ Cache Rules.
 4. **ISR responses** carry `Cloudflare-CDN-Cache-Control: public, max-age=N,
 stale-while-revalidate=M` (for the edge) plus a browser-facing
    `Cache-Control: public, max-age=0, must-revalidate`, and a `Cache-Tag`
-   header listing both the bare path (`/cached/intro`) and Next.js's internal
-   `_N_T_<path>` form. The Workers Cache reads these to cache and tag-purge.
+   header containing Cloudflare-safe fixed-size digests of both the bare path
+   (`/cached/intro`) and Next.js's internal `_N_T_<path>` form. The Workers
+   Cache reads these to cache and tag-purge without losing Next.js's
+   case-sensitive tag semantics.
 
 5. **`revalidateTag` / `revalidatePath`** in your route handlers fan out to
    both the KV data cache and `ctx.cache.purge(...)` on the platform layer.

--- a/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
@@ -171,14 +171,9 @@ function toEdgeCacheControl(cacheControl: string): string {
  */
 const MAX_CACHE_TAG_BYTES = 16 * 1024;
 const CACHE_TAG_PREFIX = "vinext-";
-const ENCODED_CACHE_TAG_RE = /^vinext-[0-9a-f]{32}$/;
 
 /** Encode a case-sensitive Next.js tag into a fixed Workers Cache tag. */
 export function encodeCloudflareCacheTag(tag: string): string {
-  // Completed-response admission may feed the adapter tags recovered from its
-  // own provisional Cache-Tag header. Preserve that representation so the
-  // admitted header and a later purge use the same platform tag.
-  if (ENCODED_CACHE_TAG_RE.test(tag)) return tag;
   // Two domain-separated 64-bit rounds keep accidental collisions negligible
   // while staying synchronous for the response-header interface.
   return `${CACHE_TAG_PREFIX}${fnv1a64(`0:${tag}`)}${fnv1a64(`1:${tag}`)}`;

--- a/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
@@ -280,22 +280,18 @@ export class CloudflareCdnCacheAdapter implements CdnCacheAdapter {
     // cache key and request-stage personalization are no longer available.
     // The browser is told to revalidate every reuse so it never serves a stale
     // stored copy.
-    const headers: CdnResponseHeaders = {
+    const cacheTag = input.tags?.length ? formatCacheTag(input.tags) : null;
+    if (input.tags?.length && !cacheTag) {
+      return clearCloudflareCdnResponseHeaders(NO_STORE);
+    }
+
+    return {
       ...getBuildIdentityResponseHeader(),
       "Cache-Control": BROWSER_REVALIDATE,
       "CDN-Cache-Control": null,
       "Cloudflare-CDN-Cache-Control": toEdgeCacheControl(input.cacheControl),
-      "Cache-Tag": input.tags ? formatCacheTag(input.tags) : null,
+      "Cache-Tag": cacheTag,
     };
-
-    if (input.tags && input.tags.length > 0) {
-      const cacheTag = formatCacheTag(input.tags);
-      if (!cacheTag) {
-        return clearCloudflareCdnResponseHeaders(NO_STORE);
-      }
-      headers["Cache-Tag"] = cacheTag;
-    }
-    return headers;
   }
 
   hasExplicitNonCacheableResponsePolicy(headers: Headers): boolean {

--- a/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
@@ -22,11 +22,9 @@
  *   for the edge to honor max-age + stale-while-revalidate.
  * - `revalidateTag` purges the edge via the request context's `cache.purge({ tags })`.
  *
- * Tag alignment: the tags emitted in `Cache-Tag` come from the page's render
- * tags (already canonicalised via `encodeCacheTag`), and the framework's
- * `revalidateTag` / `revalidatePath` pass the same canonical form to this
- * adapter's `revalidateTag`, so a purge targets exactly the responses that
- * carried the tag.
+ * Tags use fixed-size lowercase digests before emission and purge because
+ * Workers Cache tags are case-insensitive printable ASCII, while Next.js tags
+ * are case-sensitive arbitrary strings.
  *
  * The default export is the adapter factory the generated
  * `virtual:vinext-cache-adapters` registration imports; configure it from
@@ -42,8 +40,19 @@ import {
 } from "vinext/shims/cdn-cache";
 import type { CacheHandlerValue, IncrementalCacheValue } from "vinext/shims/cache";
 import { getRequestExecutionContext } from "vinext/shims/request-context";
+import { fnv1a64 } from "vinext/internal/utils/hash";
 import { getVinextCdnBuildIdentity, VINEXT_CDN_BUILD_ID_HEADER } from "./cdn-build-id.js";
 import { VINEXT_EXPECTED_WORKER_VERSION_HEADER } from "../version-headers.js";
+
+type WorkersCachePurgeError = {
+  code: number;
+  message: string;
+};
+
+type WorkersCachePurgeResult = {
+  errors: WorkersCachePurgeError[];
+  success: boolean;
+};
 
 const DEFAULT_VERSION_METADATA_BINDING = "CF_VERSION_METADATA";
 const WORKER_VERSION_OVERRIDE_HEADER = "Cloudflare-Workers-Version-Overrides";
@@ -105,7 +114,9 @@ function hasExplicitCloudflareNonCacheableResponsePolicy(headers: Headers): bool
 
 /** The request-context cache surface this adapter relies on (narrowed from `unknown`). */
 type WorkersCacheLike = {
-  purge(options: { tags: string[] }): Promise<unknown>;
+  // Miniflare currently resolves undefined; production Workers returns the
+  // documented result object.
+  purge(options: { tags: string[] }): Promise<WorkersCachePurgeResult | undefined>;
 };
 
 function getWorkersCache(): WorkersCacheLike | null {
@@ -155,30 +166,32 @@ function toEdgeCacheControl(cacheControl: string): string {
 }
 
 /**
- * Cloudflare's `Cache-Tag` header budget is 16 KB total with each tag capped at
- * 1024 bytes. Keep a conservative ceiling so a page with a large tag set never
- * produces an oversized (silently-dropped) header.
+ * Cloudflare's `Cache-Tag` header budget is 16 KB total. Fixed-size digests let
+ * the full Next.js tag set fit without dropping valid long or Unicode tags.
  */
-const MAX_CACHE_TAG_BYTES = 8 * 1024;
-const MAX_SINGLE_TAG_BYTES = 1024;
+const MAX_CACHE_TAG_BYTES = 16 * 1024;
+const CACHE_TAG_PREFIX = "vinext-";
+const ENCODED_CACHE_TAG_RE = /^vinext-[0-9a-f]{32}$/;
+
+/** Encode a case-sensitive Next.js tag into a fixed Workers Cache tag. */
+export function encodeCloudflareCacheTag(tag: string): string {
+  // Completed-response admission may feed the adapter tags recovered from its
+  // own provisional Cache-Tag header. Preserve that representation so the
+  // admitted header and a later purge use the same platform tag.
+  if (ENCODED_CACHE_TAG_RE.test(tag)) return tag;
+  // Two domain-separated 64-bit rounds keep accidental collisions negligible
+  // while staying synchronous for the response-header interface.
+  return `${CACHE_TAG_PREFIX}${fnv1a64(`0:${tag}`)}${fnv1a64(`1:${tag}`)}`;
+}
 
 /**
- * Build a `Cache-Tag` header value from canonicalised tags. Tags containing a
- * comma (the header separator) or exceeding the per-tag size are skipped, and
- * the whole value is bounded to stay within Cloudflare's limit.
+ * Build a complete `Cache-Tag` header value from canonicalised tags. Returning
+ * null makes the response uncacheable rather than caching with incomplete
+ * invalidation metadata.
  */
 function formatCacheTag(tags: readonly string[]): string | null {
-  const parts: string[] = [];
-  let total = 0;
-  for (const tag of tags) {
-    if (!tag || tag.includes(",") || tag.length > MAX_SINGLE_TAG_BYTES) continue;
-    // +1 accounts for the joining comma.
-    const next = total + tag.length + (parts.length > 0 ? 1 : 0);
-    if (next > MAX_CACHE_TAG_BYTES) break;
-    parts.push(tag);
-    total = next;
-  }
-  return parts.length > 0 ? parts.join(",") : null;
+  const value = tags.map(encodeCloudflareCacheTag).join(",");
+  return value && value.length <= MAX_CACHE_TAG_BYTES ? value : null;
 }
 
 export class CloudflareCdnCacheAdapter implements CdnCacheAdapter {
@@ -280,6 +293,13 @@ export class CloudflareCdnCacheAdapter implements CdnCacheAdapter {
       "Cache-Tag": input.tags ? formatCacheTag(input.tags) : null,
     };
 
+    if (input.tags && input.tags.length > 0) {
+      const cacheTag = formatCacheTag(input.tags);
+      if (!cacheTag) {
+        return clearCloudflareCdnResponseHeaders(NO_STORE);
+      }
+      headers["Cache-Tag"] = cacheTag;
+    }
     return headers;
   }
 
@@ -293,11 +313,15 @@ export class CloudflareCdnCacheAdapter implements CdnCacheAdapter {
     if (!cache) return; // no host cache in the request context (e.g. Node dev)
 
     const tagList = (Array.isArray(tags) ? tags : [tags]).filter(
-      (t): t is string => typeof t === "string" && t.length > 0,
+      (t): t is string => typeof t === "string",
     );
     if (tagList.length === 0) return;
 
-    await cache.purge({ tags: tagList });
+    const result = await cache.purge({ tags: tagList.map(encodeCloudflareCacheTag) });
+    if (result?.success === false) {
+      const errors = result.errors.map(({ code, message }) => `${code}: ${message}`).join(", ");
+      throw new Error(`[vinext] Workers Cache purge failed${errors ? `: ${errors}` : ""}`);
+    }
   }
 }
 

--- a/packages/cloudflare/src/cache/cdn-adapter.worker.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.worker.ts
@@ -1,5 +1,8 @@
 import { WorkerEntrypoint } from "cloudflare:workers";
-import { VINEXT_PRERENDER_READINESS_PATH } from "vinext/internal/server/headers";
+import {
+  VINEXT_PRERENDER_READINESS_PATH,
+  VINEXT_RSC_VARY_HEADER,
+} from "vinext/internal/server/headers";
 import type {
   VinextAssetFetcher,
   VinextRequestStageTransport,
@@ -54,6 +57,9 @@ const RESPONSE_STAGE_WIRE_CACHE = {
 
 type ResponseStageWireCache =
   (typeof RESPONSE_STAGE_WIRE_CACHE)[keyof typeof RESPONSE_STAGE_WIRE_CACHE];
+const FRAMEWORK_RESPONSE_VARY_FIELDS = new Set(
+  VINEXT_RSC_VARY_HEADER.split(",").map((name) => name.trim().toLowerCase()),
+);
 
 function isResponseStageReadinessRequest(request: Request): boolean {
   return (
@@ -296,7 +302,7 @@ function restoreResponseStageRequest(
   };
 }
 
-function preventRequestCfResponseCaching(response: Response): Response {
+function preventResponseCaching(response: Response): Response {
   const headers = new Headers(response.headers);
   headers.set("Cache-Control", "no-store");
   headers.delete("CDN-Cache-Control");
@@ -340,6 +346,15 @@ function finalizeGatewayResponse(response: Response, usedSharedResponseStage: bo
     status: response.status,
     statusText: response.statusText,
   });
+}
+
+function hasTaggedCustomVary(response: Response): boolean {
+  if (!response.headers.get("Cache-Tag")) return false;
+  const varyFields = (response.headers.get("Vary") ?? "")
+    .split(",")
+    .map((name) => name.trim().toLowerCase())
+    .filter(Boolean);
+  return varyFields.some((name) => !FRAMEWORK_RESPONSE_VARY_FIELDS.has(name));
 }
 
 function withResponseStagePurge(context: CloudflareStageContext): CloudflareStageContext {
@@ -469,8 +484,16 @@ export class VinextCachedResponse extends WorkerEntrypoint<unknown, unknown> {
       invocation.requestMethod,
     );
     const response = await invokeResponseStage(restored.request, this.env, context, invocation);
+    // Workers Cache variants share one purge identity and therefore must carry
+    // exactly the same Cache-Tag values. Application-defined Vary fields can
+    // also influence cacheTag() calls, and this boundary cannot prove that the
+    // resulting tag set is invariant across variants, so fail closed. The RSC
+    // selectors are already partitioned by the response-stage invocation.
+    // https://developers.cloudflare.com/workers/cache/#content-negotiation-with-vary
     return stampResponseStageBuildIdentity(
-      restored.didAccessRequestCf() ? preventRequestCfResponseCaching(response) : response,
+      restored.didAccessRequestCf() || hasTaggedCustomVary(response)
+        ? preventResponseCaching(response)
+        : response,
     );
   }
 

--- a/packages/vinext/src/server/cache-control.ts
+++ b/packages/vinext/src/server/cache-control.ts
@@ -3,6 +3,7 @@ import {
   isNonCacheableCacheControl,
   type CdnCacheableHeaderInput,
 } from "vinext/shims/cdn-cache";
+import { recordRouteCacheabilityCdnTags } from "vinext/shims/cacheability-classification";
 
 export { isNonCacheableCacheControl } from "vinext/shims/cdn-cache";
 
@@ -82,6 +83,7 @@ export async function validateCdnRequest(request: Request): Promise<Response | n
  * owns before applying that map.
  */
 export function applyCdnResponseHeaders(headers: Headers, input: CdnCacheableHeaderInput): void {
+  recordRouteCacheabilityCdnTags(input.tags);
   headers.delete("Cache-Control");
   const useNextDeployPolicy =
     shouldUseNextDeployCacheControl() && isSharedCacheControl(input.cacheControl);

--- a/packages/vinext/src/server/cacheability-request.ts
+++ b/packages/vinext/src/server/cacheability-request.ts
@@ -612,18 +612,10 @@ function inferFinalAppPageCacheability(
 
   const cacheControl = response.headers.get(changedPolicy)!;
   if (isNonCacheableCacheControl(cacheControl)) return { cacheable: false };
-  const cacheTag = response.headers.get("Cache-Tag");
   return {
     cacheable: true,
     cacheControl,
-    ...(cacheTag
-      ? {
-          tags: cacheTag
-            .split(",")
-            .map((tag) => tag.trim())
-            .filter(Boolean),
-        }
-      : {}),
+    ...(state.cdnCacheTags ? { tags: state.cdnCacheTags } : {}),
   };
 }
 
@@ -638,18 +630,10 @@ function inferPagesPageCacheability(
   if (!cacheControl || isNonCacheableCacheControl(cacheControl)) {
     return { cacheable: false };
   }
-  const cacheTag = response.headers.get("Cache-Tag");
   return {
     cacheable: true,
     cacheControl,
-    ...(cacheTag
-      ? {
-          tags: cacheTag
-            .split(",")
-            .map((tag) => tag.trim())
-            .filter(Boolean),
-        }
-      : {}),
+    ...(state.cdnCacheTags ? { tags: state.cdnCacheTags } : {}),
   };
 }
 

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -1075,11 +1075,15 @@ export function createPagesPageHandler(
           } else if (isStaticPropsRoute) {
             if (isrRevalidateSeconds !== null) {
               const headers = new Headers(init.headers);
+              const stem = isrCachePathname.endsWith("/")
+                ? isrCachePathname.slice(0, -1)
+                : isrCachePathname;
               applyCdnResponseHeaders(headers, {
                 cacheControl: buildMissIsrCacheControl(
                   isrRevalidateSeconds,
                   vinextConfig.expireTime,
                 ),
+                tags: [encodeCacheTag(`_N_T_${stem || "/"}`)],
               });
               for (const [key, value] of headers) {
                 init.headers[key] = value;

--- a/packages/vinext/src/shims/cacheability-classification.ts
+++ b/packages/vinext/src/shims/cacheability-classification.ts
@@ -27,6 +27,8 @@ export type RouteCacheabilityState = {
   captureDeadlineAt: number;
   complete?: (outcome: RouteCacheabilityOutcome) => void;
   completion?: Promise<RouteCacheabilityOutcome>;
+  /** Canonical framework tags most recently handed to the active CDN adapter. */
+  cdnCacheTags?: readonly string[];
   completedResponseBody?: boolean;
   /** Whether admission must translate a completed response through the active adapter. */
   applyCompletedResponsePolicy?: boolean;
@@ -55,6 +57,14 @@ export type RouteCacheabilityState = {
     pattern: string;
   };
 };
+
+/** Retain canonical tags across completed-response admission and adapter header shaping. */
+export function recordRouteCacheabilityCdnTags(tags: readonly string[] | undefined): void {
+  if (tags === undefined) return;
+  const state = readRouteCacheabilityState();
+  if (state?.mode !== "admit") return;
+  state.cdnCacheTags = [...tags];
+}
 
 /** Preserve the existing policy when hybrid routing hands the request to Pages Router. */
 export function preserveRouteCacheabilityResponsePolicy(): void {

--- a/tests/app-route-handler-response.test.ts
+++ b/tests/app-route-handler-response.test.ts
@@ -10,7 +10,10 @@ import {
   markRouteHandlerCacheMiss,
 } from "../packages/vinext/src/server/app-route-handler-response.js";
 import { setCdnCacheAdapter } from "../packages/vinext/src/shims/cdn-cache.js";
-import { CloudflareCdnCacheAdapter } from "../packages/cloudflare/src/cache/cdn-adapter.runtime.js";
+import {
+  CloudflareCdnCacheAdapter,
+  encodeCloudflareCacheTag,
+} from "../packages/cloudflare/src/cache/cdn-adapter.runtime.js";
 import { hasPostConfigLinkHeaders } from "../packages/vinext/src/server/app-response-header-provenance.js";
 
 function buildCachedRouteValue(
@@ -428,7 +431,9 @@ describe("route handler responses route through the CDN cache adapter", () => {
     expect(response.headers.get("Cloudflare-CDN-Cache-Control")).toBe(
       "public, max-age=60, stale-while-revalidate=540",
     );
-    expect(response.headers.get("Cache-Tag")).toBe("_N_T_/api/feed,posts");
+    expect(response.headers.get("Cache-Tag")).toBe(
+      ["_N_T_/api/feed", "posts"].map(encodeCloudflareCacheTag).join(","),
+    );
   });
 
   it("does not promote a revalidate=0 (non-cacheable) response to the edge", () => {

--- a/tests/cacheability-admission.test.ts
+++ b/tests/cacheability-admission.test.ts
@@ -18,6 +18,8 @@ import {
   DefaultCdnCacheAdapter,
   setCdnCacheAdapter,
 } from "../packages/vinext/src/shims/cdn-cache.js";
+import { runWithExecutionContext } from "../packages/vinext/src/shims/request-context.js";
+import { applyCdnResponseHeaders } from "../packages/vinext/src/server/cache-control.js";
 import { CloudflareCdnCacheAdapter } from "../packages/cloudflare/src/cache/cdn-adapter.runtime.js";
 
 const encoder = new TextEncoder();
@@ -168,6 +170,64 @@ function staticAppRouteManifest(): { raw: string; route: CacheabilityManifestRou
 describe("single-request cacheability admission", () => {
   const request = new Request("https://example.com/page", {
     headers: { Accept: "text/html" },
+  });
+
+  it("retains canonical adapter tag inputs across completed-response admission", async () => {
+    const calls: string[][] = [];
+    const adapter = {
+      buildResponseHeaders({
+        cacheControl,
+        tags,
+      }: {
+        cacheControl: string;
+        tags?: readonly string[];
+      }) {
+        if (tags) calls.push([...tags]);
+        return {
+          "Cache-Control": cacheControl,
+          "Cache-Tag": tags?.map((tag) => `platform:${tag}`).join(",") ?? null,
+        };
+      },
+      async get() {
+        return null;
+      },
+      ownsBackgroundRevalidation: false,
+      async revalidateTag() {},
+      requiresCompletedResponseAdmission: true,
+      async set() {},
+    };
+    setCdnCacheAdapter(adapter);
+    try {
+      const context = createWorkerCacheabilityAdmissionContext(
+        { waitUntil() {} },
+        request,
+        null,
+        "build-a",
+        true,
+      );
+      const state = cacheabilityState(context);
+      state.route = { kind: "pages-page", pattern: "/page" };
+      const headers = new Headers();
+      await runWithExecutionContext(context, () =>
+        applyCdnResponseHeaders(headers, {
+          cacheControl: "s-maxage=60",
+          tags: ["posts", "platform:posts"],
+        }),
+      );
+
+      const response = await finalizeWorkerCacheabilityResponse(
+        new Response("static", { headers }),
+        context,
+      );
+
+      expect(calls).toEqual([
+        ["posts", "platform:posts"],
+        ["posts", "platform:posts"],
+      ]);
+      expect(response.headers.get("Cache-Tag")).toBe("platform:posts,platform:platform:posts");
+    } finally {
+      setCdnCacheAdapter(new DefaultCdnCacheAdapter());
+    }
   });
 
   it("admits a completed static response without a build manifest", async () => {

--- a/tests/cloudflare-cdn-cache.test.ts
+++ b/tests/cloudflare-cdn-cache.test.ts
@@ -25,6 +25,11 @@ import {
 } from "../packages/vinext/src/server/app-page-cache-finalizer.js";
 import { finalizeAppRscResponse } from "../packages/vinext/src/server/app-rsc-response-finalizer.js";
 import { applyCdnResponseIdentityHeaders } from "../packages/vinext/src/server/cache-control.js";
+import { withResponseStageCacheability } from "../packages/vinext/src/server/response-stage-cacheability.js";
+import {
+  CACHEABILITY_REQUEST_STATE,
+  type RouteCacheabilityState,
+} from "../packages/vinext/src/shims/cacheability-classification.js";
 import type { RequestContext } from "../packages/vinext/src/config/request-context.js";
 import { VINEXT_CDN_BUILD_ID_HEADER } from "../packages/cloudflare/src/cache/cdn-build-id.js";
 import { VINEXT_EXPECTED_WORKER_VERSION_HEADER } from "../packages/cloudflare/src/version-headers.js";
@@ -283,6 +288,48 @@ describe("CloudflareCdnCacheAdapter", () => {
   it("does not re-encode tags recovered during completed-response admission", () => {
     const encoded = encodeCloudflareCacheTag("posts");
     expect(encodeCloudflareCacheTag(encoded)).toBe(encoded);
+  });
+
+  it("keeps admitted response tags aligned with later purge tags", async () => {
+    setCdnCacheAdapter(adapter);
+    const encoded = encodeCloudflareCacheTag("posts");
+    const response = await withResponseStageCacheability(
+      {
+        buildId: "build-a",
+        cache: "shared",
+        context: { waitUntil() {} },
+        rawManifest: null,
+        registerCacheAdapters() {},
+        request: new Request("https://example.com/posts", {
+          headers: { Accept: "text/html" },
+        }),
+        resolvedRoutePathname: "/posts",
+      },
+      async (context) => {
+        const state = Reflect.get(context, CACHEABILITY_REQUEST_STATE) as RouteCacheabilityState;
+        state.route = { kind: "pages-page", pattern: "/posts" };
+        const headers = new Headers();
+        for (const [name, value] of Object.entries(
+          adapter.buildResponseHeaders({
+            cacheControl: "s-maxage=60",
+            tags: ["posts"],
+          }),
+        )) {
+          if (value !== null && value !== undefined) headers.set(name, value);
+        }
+        return new Response("posts", {
+          headers,
+        });
+      },
+    );
+
+    expect(response.headers.get("Cache-Tag")).toBe(encoded);
+
+    const purge = vi.fn(async () => ({ errors: [], success: true }));
+    await runWithExecutionContext({ waitUntil() {}, cache: { purge } }, () =>
+      adapter.revalidateTag("posts"),
+    );
+    expect(purge).toHaveBeenCalledWith({ tags: [encoded] });
   });
 
   it("makes a response uncacheable rather than emitting incomplete tag metadata", () => {

--- a/tests/cloudflare-cdn-cache.test.ts
+++ b/tests/cloudflare-cdn-cache.test.ts
@@ -10,6 +10,7 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vite-plus/test";
 import createCloudflareCdnCacheAdapter, {
+  encodeCloudflareCacheTag,
   CloudflareCdnCacheAdapter,
 } from "../packages/cloudflare/src/cache/cdn-adapter.runtime.js";
 import {
@@ -250,18 +251,52 @@ describe("CloudflareCdnCacheAdapter", () => {
       cacheControl: "s-maxage=60",
       tags: ["/blog", "_N_T_/blog", "posts"],
     });
-    expect(headers["Cache-Tag"]).toBe("/blog,_N_T_/blog,posts");
+    expect(headers["Cache-Tag"]).toBe(
+      ["/blog", "_N_T_/blog", "posts"].map(encodeCloudflareCacheTag).join(","),
+    );
     expect(headers["Cache-Control"]).toBe("public, max-age=0, must-revalidate");
     expect(headers["CDN-Cache-Control"]).toBeNull();
     expect(headers["Cloudflare-CDN-Cache-Control"]).toBe("public, max-age=60");
   });
 
-  it("skips tags containing the comma separator or that are too long", () => {
+  it("preserves an empty Next.js tag in response invalidation metadata", () => {
+    const tags = ["", "posts"];
+    const headers = adapter.buildResponseHeaders({ cacheControl: "s-maxage=60", tags });
+    expect(headers["Cache-Tag"]).toBe(tags.map(encodeCloudflareCacheTag).join(","));
+  });
+
+  it("encodes the complete Next-valid set of long Unicode and case-sensitive tags", () => {
+    const tags = [
+      "é".repeat(128),
+      "Product List",
+      "product list",
+      ...Array.from({ length: 125 }, (_, index) => `tag-${index}-${"x".repeat(240)}`),
+    ];
     const headers = adapter.buildResponseHeaders({
       cacheControl: "s-maxage=60",
-      tags: ["a,b", "x".repeat(2000), "ok"],
+      tags,
     });
-    expect(headers["Cache-Tag"]).toBe("ok");
+    expect(headers["Cache-Tag"]).toBe(tags.map(encodeCloudflareCacheTag).join(","));
+    expect(headers["Cache-Tag"]?.split(",")).toHaveLength(128);
+  });
+
+  it("does not re-encode tags recovered during completed-response admission", () => {
+    const encoded = encodeCloudflareCacheTag("posts");
+    expect(encodeCloudflareCacheTag(encoded)).toBe(encoded);
+  });
+
+  it("makes a response uncacheable rather than emitting incomplete tag metadata", () => {
+    expect(
+      adapter.buildResponseHeaders({
+        cacheControl: "s-maxage=60",
+        tags: Array.from({ length: 500 }, (_, index) => `tag-${index}`),
+      }),
+    ).toEqual({
+      "Cache-Control": "no-store",
+      "CDN-Cache-Control": null,
+      "Cloudflare-CDN-Cache-Control": null,
+      "Cache-Tag": null,
+    });
   });
 
   it("returns no-store and clears owned headers when there is no cacheable policy", () => {
@@ -527,19 +562,29 @@ describe("CloudflareCdnCacheAdapter", () => {
   });
 
   it("revalidateTag purges the Workers Cache by tag via ctx.cache.purge", async () => {
-    const purge = vi.fn(async () => {});
+    const purge = vi.fn(async () => ({ errors: [], success: true }));
     await runWithExecutionContext({ waitUntil() {}, cache: { purge } }, async () => {
       await adapter.revalidateTag(["posts", "_N_T_/blog"]);
     });
-    expect(purge).toHaveBeenCalledWith({ tags: ["posts", "_N_T_/blog"] });
+    expect(purge).toHaveBeenCalledWith({
+      tags: ["posts", "_N_T_/blog"].map(encodeCloudflareCacheTag),
+    });
   });
 
   it("revalidateTag normalizes a single tag to an array", async () => {
-    const purge = vi.fn(async () => {});
+    const purge = vi.fn(async () => ({ errors: [], success: true }));
     await runWithExecutionContext({ waitUntil() {}, cache: { purge } }, async () => {
       await adapter.revalidateTag("posts");
     });
-    expect(purge).toHaveBeenCalledWith({ tags: ["posts"] });
+    expect(purge).toHaveBeenCalledWith({ tags: [encodeCloudflareCacheTag("posts")] });
+  });
+
+  it("revalidateTag purges an empty Next.js tag", async () => {
+    const purge = vi.fn(async () => ({ errors: [], success: true }));
+    await runWithExecutionContext({ waitUntil() {}, cache: { purge } }, async () => {
+      await adapter.revalidateTag("");
+    });
+    expect(purge).toHaveBeenCalledWith({ tags: [encodeCloudflareCacheTag("")] });
   });
 
   it("revalidateTag is a no-op when the Workers Cache is absent (e.g. Node dev)", async () => {
@@ -548,11 +593,23 @@ describe("CloudflareCdnCacheAdapter", () => {
   });
 
   it("revalidateTag does not purge for an empty tag set", async () => {
-    const purge = vi.fn(async () => {});
+    const purge = vi.fn(async () => ({ errors: [], success: true }));
     await runWithExecutionContext({ waitUntil() {}, cache: { purge } }, async () => {
       await adapter.revalidateTag([]);
     });
     expect(purge).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a resolved Workers Cache purge failure", async () => {
+    const purge = vi.fn(async () => ({
+      errors: [{ code: 10000, message: "rate limited" }],
+      success: false,
+    }));
+    await expect(
+      runWithExecutionContext({ waitUntil() {}, cache: { purge } }, () =>
+        adapter.revalidateTag("posts"),
+      ),
+    ).rejects.toThrow("Workers Cache purge failed: 10000: rate limited");
   });
 });
 

--- a/tests/cloudflare-cdn-cache.test.ts
+++ b/tests/cloudflare-cdn-cache.test.ts
@@ -24,7 +24,10 @@ import {
   finalizeAppPageRscCacheResponse,
 } from "../packages/vinext/src/server/app-page-cache-finalizer.js";
 import { finalizeAppRscResponse } from "../packages/vinext/src/server/app-rsc-response-finalizer.js";
-import { applyCdnResponseIdentityHeaders } from "../packages/vinext/src/server/cache-control.js";
+import {
+  applyCdnResponseHeaders,
+  applyCdnResponseIdentityHeaders,
+} from "../packages/vinext/src/server/cache-control.js";
 import { withResponseStageCacheability } from "../packages/vinext/src/server/response-stage-cacheability.js";
 import {
   CACHEABILITY_REQUEST_STATE,
@@ -285,9 +288,20 @@ describe("CloudflareCdnCacheAdapter", () => {
     expect(headers["Cache-Tag"]?.split(",")).toHaveLength(128);
   });
 
-  it("does not re-encode tags recovered during completed-response admission", () => {
+  it("does not alias a raw tag that resembles an encoded platform tag", () => {
     const encoded = encodeCloudflareCacheTag("posts");
-    expect(encodeCloudflareCacheTag(encoded)).toBe(encoded);
+    expect(encodeCloudflareCacheTag(encoded)).not.toBe(encoded);
+  });
+
+  it("purges digest-shaped raw tags independently from their source tags", async () => {
+    const encoded = encodeCloudflareCacheTag("posts");
+    const purge = vi.fn(async () => ({ errors: [], success: true }));
+    await runWithExecutionContext({ waitUntil() {}, cache: { purge } }, async () => {
+      await adapter.revalidateTag(["posts", encoded]);
+    });
+    expect(purge).toHaveBeenCalledWith({
+      tags: [encoded, encodeCloudflareCacheTag(encoded)],
+    });
   });
 
   it("keeps admitted response tags aligned with later purge tags", async () => {
@@ -309,14 +323,12 @@ describe("CloudflareCdnCacheAdapter", () => {
         const state = Reflect.get(context, CACHEABILITY_REQUEST_STATE) as RouteCacheabilityState;
         state.route = { kind: "pages-page", pattern: "/posts" };
         const headers = new Headers();
-        for (const [name, value] of Object.entries(
-          adapter.buildResponseHeaders({
+        await runWithExecutionContext(context, () =>
+          applyCdnResponseHeaders(headers, {
             cacheControl: "s-maxage=60",
             tags: ["posts"],
           }),
-        )) {
-          if (value !== null && value !== undefined) headers.set(name, value);
-        }
+        );
         return new Response("posts", {
           headers,
         });

--- a/tests/cloudflare-cdn-worker.test.ts
+++ b/tests/cloudflare-cdn-worker.test.ts
@@ -14,6 +14,7 @@ import {
   PAGES_RESPONSE_STAGE_PROTOCOL_VERSION,
   type WorkerResponseStageProps,
 } from "../packages/vinext/src/server/worker-stages.js";
+import { VINEXT_RSC_VARY_HEADER } from "../packages/vinext/src/server/headers.js";
 import { cloneRequestWithUrl } from "../packages/vinext/src/server/request-pipeline.js";
 import { NextRequest } from "../packages/vinext/src/shims/server.js";
 
@@ -774,6 +775,71 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
     expect(response.headers.get("Cache-Control")).toBe("private, max-age=0, must-revalidate");
     expect(response.headers.get("CDN-Cache-Control")).toBeNull();
     await expect(response.text()).resolves.toBe("public");
+  });
+
+  it("keeps tagged responses with custom Vary fields private", async () => {
+    stages.response.mockResolvedValue(
+      new Response("variant", {
+        headers: {
+          "Cache-Control": "public, max-age=0, must-revalidate",
+          "CDN-Cache-Control": "public, max-age=300",
+          "Cache-Tag": "variant-specific-tag",
+          Vary: "RSC, Accept-Language",
+        },
+      }),
+    );
+
+    const response = await createEntrypoint(responseStageInvocation({ kind: "app-page" })).fetch(
+      new Request("https://example.com/page", {
+        headers: { "Accept-Language": "en" },
+      }),
+    );
+
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("CDN-Cache-Control")).toBeNull();
+    expect(response.headers.get("Cloudflare-CDN-Cache-Control")).toBeNull();
+    expect(response.headers.get("Cache-Tag")).toBeNull();
+    expect(response.headers.get("Vary")).toBe("RSC, Accept-Language");
+    await expect(response.text()).resolves.toBe("variant");
+  });
+
+  it("retains tagged responses with framework-owned RSC variance", async () => {
+    stages.response.mockResolvedValue(
+      new Response("flight", {
+        headers: {
+          "CDN-Cache-Control": "public, max-age=300",
+          "Cache-Tag": "page-tag",
+          Vary: VINEXT_RSC_VARY_HEADER,
+        },
+      }),
+    );
+
+    const response = await createEntrypoint(responseStageInvocation({ kind: "app-page" })).fetch(
+      new Request("https://example.com/page", { headers: { RSC: "1" } }),
+    );
+
+    expect(response.headers.get("CDN-Cache-Control")).toBe("public, max-age=300");
+    expect(response.headers.get("Cache-Tag")).toBe("page-tag");
+  });
+
+  it("retains untagged responses with application-defined variance", async () => {
+    stages.response.mockResolvedValue(
+      new Response("localized", {
+        headers: {
+          "CDN-Cache-Control": "public, max-age=300",
+          Vary: "Accept-Language",
+        },
+      }),
+    );
+
+    const response = await createEntrypoint(responseStageInvocation({ kind: "app-route" })).fetch(
+      new Request("https://example.com/localized", {
+        headers: { "Accept-Language": "en" },
+      }),
+    );
+
+    expect(response.headers.get("CDN-Cache-Control")).toBe("public, max-age=300");
+    expect(response.headers.get("Vary")).toBe("Accept-Language");
   });
 
   it("strips forged request.cf transport metadata when no platform metadata exists", async () => {

--- a/tests/e2e/ppr-impact-demo/cacheability-admission.spec.ts
+++ b/tests/e2e/ppr-impact-demo/cacheability-admission.spec.ts
@@ -189,7 +189,12 @@ test("admits pattern-backed App responses only after each clean EOF", async ({ r
   const certifiedRouteHandler = await request.get("/cacheability/route-handler-static");
   expect(certifiedRouteHandler.status()).toBe(200);
   await expect(certifiedRouteHandler.json()).resolves.toEqual({ kind: "static-route-handler" });
-  expectGatewayCachePolicy(certifiedRouteHandler);
+  // Tagged Workers Cache entries must use one stable Vary shape. Preserve the
+  // handler's custom variant response, but do not admit it under shared tags.
+  expect(certifiedRouteHandler.headers()["cache-control"]).toContain("no-store");
+  expect(certifiedRouteHandler.headers()["cdn-cache-control"]).toBeUndefined();
+  expect(certifiedRouteHandler.headers()["cloudflare-cdn-cache-control"]).toBeUndefined();
+  expect(certifiedRouteHandler.headers()["cache-tag"]).toBeUndefined();
   expect(certifiedRouteHandler.headers()["vary"]?.toLowerCase()).toContain("user-agent");
 
   const largeRouteHandler = await request.get("/cacheability/route-handler-large");
@@ -215,7 +220,10 @@ test("admits pattern-backed App responses only after each clean EOF", async ({ r
     "/cacheability/route-handler-static?user=one",
   );
   expect(unlistedRouteHandlerQuery.status()).toBe(200);
-  expectGatewayCachePolicy(unlistedRouteHandlerQuery);
+  expect(unlistedRouteHandlerQuery.headers()["cache-control"]).toContain("no-store");
+  expect(unlistedRouteHandlerQuery.headers()["cdn-cache-control"]).toBeUndefined();
+  expect(unlistedRouteHandlerQuery.headers()["cloudflare-cdn-cache-control"]).toBeUndefined();
+  expect(unlistedRouteHandlerQuery.headers()["cache-tag"]).toBeUndefined();
 
   // Next.js does not statically generate a GET+POST Route Handler, so this
   // route is intentionally absent from the probe manifest. Its handler-owned

--- a/tests/pages-page-handler.test.ts
+++ b/tests/pages-page-handler.test.ts
@@ -461,6 +461,49 @@ describe("createPagesPageHandler — _next/data", () => {
     expect(ct).toContain("application/json");
   });
 
+  it("uses the HTML path tag for cacheable static-props data responses", async () => {
+    const cacheInputs: Array<{ cacheControl: string; tags?: readonly string[] }> = [];
+    setCdnCacheAdapter({
+      ownsBackgroundRevalidation: false,
+      async get() {
+        return null;
+      },
+      async set() {},
+      async revalidateTag() {},
+      buildResponseHeaders(input) {
+        cacheInputs.push(input);
+        return {
+          "Cache-Control": "public, max-age=0, must-revalidate",
+          "X-Example-Cache-Tag": input.tags?.join(",") ?? null,
+          "X-Example-Edge-Policy": input.cacheControl,
+        };
+      },
+    });
+    const handler = createPagesPageHandler(
+      makeOpts({
+        pageRoutes: [
+          makeRoute(
+            "/about",
+            makePageModule({
+              getStaticProps: async () => ({ props: {}, revalidate: 60 }),
+            }),
+          ),
+        ],
+      }),
+    );
+    const dataUrl = "/_next/data/test-build-id/about.json";
+
+    const response = await handler(makeRequest(dataUrl), dataUrl, null, null, null);
+
+    expect(response.status).toBe(200);
+    expect(cacheInputs).toEqual([
+      expect.objectContaining({
+        tags: ["_N_T_/about"],
+      }),
+    ]);
+    expect(response.headers.get("X-Example-Cache-Tag")).toBe("_N_T_/about");
+  });
+
   it("preserves no-middleware trailingSlash data request resolvedUrl and asPath", async () => {
     // Next.js derives Pages data resolvedUrl/asPath from the parsed data
     // pathname. The trailingSlash data-path adjustment is middleware-only.


### PR DESCRIPTION
## Summary

- encode case-sensitive Next.js cache tags as fixed-size Cloudflare-safe digests
- keep complete invalidation metadata or make an oversized response uncacheable
- preserve empty, Unicode, long, and case-distinct Next.js tags across staged responses
- surface Workers Cache purge failures

## Stack

1. tooling baseline (#3082)
2. transport-neutral worker stages (#3083)
3. Cloudflare Workers Cache entrypoint isolation (#3079)
4. independently deployed HTTP stages (#3084)
5. **This PR:** Workers Cache tag parity (#3085)

## Validation

- Cloudflare cache/facade coverage: 49 passed
- full `vp check` and Knip: passed
- `vinext` and `@vinext/cloudflare` builds: passed