### PR TITLE
feat(cache): probe App Page cacheability on staged Workers

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -6304,6 +6304,13 @@ export const loadServerActionClient = ${
         // compute `'/nodejs'` correctly instead of `''` (issue #1365).
         serverDefines["process.env.NEXT_RUNTIME"] = JSON.stringify("nodejs");
 
+        // Next evaluates App Page prerenders with NEXT_PHASE set to
+        // phase-production-build, then evaluates ISR regeneration in the
+        // production-server phase. A staged probe shares a Worker bundle with
+        // ordinary requests, so defer this one value to the request-scoped
+        // server-global accessor instead of baking one phase into the bundle.
+        serverDefines["process.env.NEXT_PHASE"] = "globalThis.__VINEXT_NEXT_PHASE";
+
         // On-demand ISR revalidation secret — baked SERVER-ONLY (the `client`
         // early-return above guarantees it never reaches the browser bundle) so
         // every server bundle, and therefore every Workers isolate, shares the

--- a/packages/vinext/src/server/app-middleware.ts
+++ b/packages/vinext/src/server/app-middleware.ts
@@ -52,11 +52,15 @@ export type ApplyAppMiddlewareResult =
   | {
       kind: "continue";
       cleanPathname: string;
+      /** Present on real middleware results; optional for older generated callers. */
+      matched?: boolean;
       rewritten: boolean;
       search: string | null;
     }
   | {
       kind: "response";
+      /** Present on real middleware results; optional for older generated callers. */
+      matched?: boolean;
       response: Response;
     };
 
@@ -270,6 +274,7 @@ export async function applyAppMiddleware(
   options: ApplyAppMiddlewareOptions,
 ): Promise<ApplyAppMiddlewareResult> {
   const forwarded = applyForwardedMiddlewareContext(options.request, options.context);
+  let matched = forwarded.applied;
   let cleanPathname = options.cleanPathname;
   let rewritten = false;
   let search: string | null = null;
@@ -282,6 +287,7 @@ export async function applyAppMiddleware(
           if (options.middlewareRequest) cancelRequestBody(options.middlewareRequest);
           return {
             kind: "response",
+            matched,
             response: validationResponseWithMiddlewareHeaders(validationResponse, options.context),
           };
         }
@@ -289,6 +295,7 @@ export async function applyAppMiddleware(
         const externalRequest = options.externalRewriteRequest ?? options.request;
         return {
           kind: "response",
+          matched,
           response: await proxyExternalMiddlewareRewrite(
             externalRequest,
             forwarded.rewriteUrl,
@@ -325,6 +332,9 @@ export async function applyAppMiddleware(
         isProxy: options.isProxy,
         module: options.module,
         normalizedPathname: cleanPathname,
+        onMatch() {
+          matched = true;
+        },
         requestBodyAlreadyIsolated: true,
         request: middlewareRequest,
         trailingSlash: options.trailingSlash,
@@ -339,12 +349,12 @@ export async function applyAppMiddleware(
     if (!result.continue) {
       cancelRequestBody(options.request);
       if (result.redirectUrl) {
-        return { kind: "response", response: responseFromMiddlewareRedirect(result) };
+        return { kind: "response", matched, response: responseFromMiddlewareRedirect(result) };
       }
       if (result.response) {
-        return { kind: "response", response: result.response };
+        return { kind: "response", matched, response: result.response };
       }
-      return { kind: "response", response: internalServerErrorResponse() };
+      return { kind: "response", matched, response: internalServerErrorResponse() };
     }
 
     if (result.responseHeaders) {
@@ -364,12 +374,14 @@ export async function applyAppMiddleware(
         if (validationResponse) {
           return {
             kind: "response",
+            matched,
             response: validationResponseWithMiddlewareHeaders(validationResponse, options.context),
           };
         }
         const externalRequest = options.externalRewriteRequest ?? options.request;
         return {
           kind: "response",
+          matched,
           response: await proxyExternalMiddlewareRewrite(
             externalRequest,
             result.rewriteUrl,
@@ -396,5 +408,5 @@ export async function applyAppMiddleware(
     processMiddlewareHeaders(options.context.headers);
   }
 
-  return { kind: "continue", cleanPathname, rewritten, search };
+  return { kind: "continue", cleanPathname, matched, rewritten, search };
 }

--- a/packages/vinext/src/server/app-page-cache-finalizer.ts
+++ b/packages/vinext/src/server/app-page-cache-finalizer.ts
@@ -1,5 +1,11 @@
 import type { AppRscRenderMode } from "./app-rsc-render-mode.js";
-import { applyCdnResponseHeaders, NO_STORE_CACHE_CONTROL } from "./cache-control.js";
+import {
+  applyCdnResponseHeaders,
+  buildRevalidateCacheControl,
+  hasExplicitNonCacheableResponsePolicy,
+  NO_STORE_CACHE_CONTROL,
+  STATIC_CACHE_CONTROL,
+} from "./cache-control.js";
 import { setCacheStateHeaders } from "./cache-headers.js";
 import { NEXTJS_CACHE_HEADER, VINEXT_CACHE_HEADER } from "./headers.js";
 import {
@@ -12,6 +18,12 @@ import type { RenderObservation } from "./cache-proof.js";
 import { resolveClientStaleTimeSeconds } from "../utils/cache-control-metadata.js";
 import { readStreamAsText } from "../utils/text-stream.js";
 import { markFrameworkLinkHeaders } from "./app-response-header-provenance.js";
+import { deferUntilStreamConsumed } from "./defer-until-stream-consumed.js";
+import {
+  deferRouteCacheability,
+  isRouteCacheabilityProbe,
+  type RouteCacheabilityOutcome,
+} from "vinext/shims/cacheability-classification";
 
 type AppPageDebugLogger = (event: string, detail: string) => void;
 type AppPageRscCacheKeyBuilder = (
@@ -157,10 +169,86 @@ function resolveAppPageCacheControl(options: {
   });
 }
 
+function appPageCacheControlHeader(cacheControl: CacheControlMetadata): string {
+  return cacheControl.revalidate === Infinity
+    ? STATIC_CACHE_CONTROL
+    : buildRevalidateCacheControl(cacheControl.revalidate, cacheControl.expire);
+}
+
+function finalizeProbeAppPageResponse(
+  response: Response,
+  options: {
+    capturedDynamicUsageBeforeContextCleanup?: () => boolean;
+    consumeDynamicUsage: () => boolean;
+    consumeRenderObservationState?: () => AppPageRenderObservationState;
+    getPageTags: () => string[];
+    getRequestCacheLife?: () => AppPageRequestCacheLife | null;
+    expireSeconds?: number;
+    revalidateSeconds: number | null;
+  },
+): Response | null {
+  if (!isRouteCacheabilityProbe()) return null;
+  const complete = deferRouteCacheability();
+  if (!complete) return response;
+
+  let completed = false;
+  const finish = (): void => {
+    if (completed) return;
+    completed = true;
+
+    let outcome: RouteCacheabilityOutcome;
+    if (
+      options.capturedDynamicUsageBeforeContextCleanup?.() === true ||
+      options.consumeDynamicUsage()
+    ) {
+      outcome = {
+        cacheable: false,
+        dynamicUsage: true,
+        reason: "dynamic API used during render",
+      };
+    } else if (
+      response.headers.has("set-cookie") ||
+      hasExplicitNonCacheableResponsePolicy(response.headers)
+    ) {
+      outcome = { cacheable: false, reason: "response explicitly opts out of shared caching" };
+    } else {
+      const cacheControl = resolveAppPageCacheControl({
+        expireSeconds: options.expireSeconds,
+        requestCacheLife: options.getRequestCacheLife?.(),
+        revalidateSeconds: options.revalidateSeconds,
+      });
+      outcome = cacheControl
+        ? {
+            cacheable: true,
+            cacheControl: appPageCacheControlHeader(cacheControl),
+            tags: options.getPageTags(),
+          }
+        : { cacheable: false, reason: "render did not produce a cache policy" };
+    }
+    options.consumeRenderObservationState?.();
+    complete(outcome);
+  };
+
+  if (!response.body) {
+    finish();
+    return response;
+  }
+  return new Response(deferUntilStreamConsumed(response.body, finish), {
+    headers: response.headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
+}
+
 export function finalizeAppPageHtmlCacheResponse(
   response: Response,
   options: FinalizeAppPageHtmlCacheResponseOptions,
 ): Response {
+  const probeResponse = finalizeProbeAppPageResponse(response, options);
+  if (probeResponse) {
+    void options.capturedRscDataPromise?.catch(() => {});
+    return probeResponse;
+  }
   if (!response.body) {
     return response;
   }
@@ -262,6 +350,11 @@ export function finalizeAppPageRscCacheResponse(
   response: Response,
   options: ScheduleAppPageRscCacheWriteOptions,
 ): Response {
+  const probeResponse = finalizeProbeAppPageResponse(response, options);
+  if (probeResponse) {
+    void options.capturedRscDataPromise?.catch(() => {});
+    return probeResponse;
+  }
   // Persisting to the ISR store and finalizing the client-facing headers are
   // independent decisions. Mounted-slot and unverified-interception variants
   // are deliberately never stored, but a fresh MISS stream can still reach a

--- a/packages/vinext/src/server/app-page-dispatch.ts
+++ b/packages/vinext/src/server/app-page-dispatch.ts
@@ -92,6 +92,11 @@ import {
   isAppLayoutObservationUnsafeForStaticReuse,
   type AppLayoutParamAccessTracker,
 } from "./app-layout-param-observation.js";
+import {
+  beginRouteCacheability,
+  isRouteCacheabilityIdentityProbe,
+  isRouteCacheabilityProbe,
+} from "vinext/shims/cacheability-classification";
 
 type AppPageParams = Record<string, string | string[]>;
 type AppPageElement = ReactNode | Readonly<Record<string, ReactNode>>;
@@ -632,6 +637,11 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
   options: DispatchAppPageOptions<TRoute>,
 ): Promise<Response> {
   const route = options.route;
+  beginRouteCacheability("app-page", route.pattern);
+  if (isRouteCacheabilityIdentityProbe()) {
+    options.clearRequestContext();
+    return new Response(null, { status: 204 });
+  }
   const dynamicConfig = options.dynamicConfig;
   const currentRevalidateSeconds = options.revalidateSeconds;
   const interceptionId = options.isRscRequest
@@ -711,6 +721,7 @@ async function dispatchAppPageInner<TRoute extends AppPageDispatchRoute>(
   }
 
   if (
+    !isRouteCacheabilityProbe() &&
     options.bypassInterceptionContextCache !== true &&
     shouldReadAppPageCache({
       isDraftMode,

--- a/packages/vinext/src/server/app-router-entry.ts
+++ b/packages/vinext/src/server/app-router-entry.ts
@@ -52,6 +52,7 @@ import {
   isOpenRedirectShaped,
 } from "./request-pipeline.js";
 import {
+  VINEXT_CACHEABILITY_PROBE_HEADER,
   VINEXT_PRERENDER_ROUTE_PARAMS_HEADER,
   VINEXT_PRERENDER_SECRET_HEADER,
   VINEXT_REVALIDATE_HOST_HEADER,
@@ -107,7 +108,24 @@ async function handleRequest(
     : createWorkerRevalidationContext(platformCtx, (internalRequest, internalCtx) =>
         handleRequest(internalRequest, env, internalCtx),
       );
-  const ctx = createWorkerPrerenderDiscoveryContext(requestCtx, request, __rscPrerenderSecret);
+  let ctx = createWorkerPrerenderDiscoveryContext(requestCtx, request, __rscPrerenderSecret);
+  let finalizeCacheabilityResponse:
+    | ((response: Response, ctx: ExecutionContextLike) => Promise<Response>)
+    | undefined;
+  if (request.headers.has(VINEXT_CACHEABILITY_PROBE_HEADER)) {
+    // Keep the capture/classification runtime out of every ordinary request.
+    // Authentication still happens before internal headers are removed below.
+    const cacheability = await import("./cacheability-request.js");
+    const probeContext = cacheability.createWorkerCacheabilityContext(
+      ctx,
+      request,
+      __rscPrerenderSecret,
+    );
+    if (probeContext !== ctx) {
+      ctx = probeContext;
+      finalizeCacheabilityResponse = cacheability.finalizeWorkerCacheabilityResponse;
+    }
+  }
 
   // Register config-driven cache adapters before any rendering touches the cache.
   registerConfiguredCacheAdapters(env as Record<string, unknown> | undefined);
@@ -204,12 +222,15 @@ async function handleRequest(
       });
       if (assetResponse) response = assetResponse;
     }
-    return finalizeMissingStaticAssetResponse(response, missingBuildAsset);
+    response = finalizeMissingStaticAssetResponse(response, missingBuildAsset);
+    return finalizeCacheabilityResponse ? finalizeCacheabilityResponse(response, ctx) : response;
   }
 
   if (result === null || result === undefined) {
-    return missingBuildAsset ? notFoundStaticAssetResponse() : notFoundResponse();
+    const response = missingBuildAsset ? notFoundStaticAssetResponse() : notFoundResponse();
+    return finalizeCacheabilityResponse ? finalizeCacheabilityResponse(response, ctx) : response;
   }
 
-  return new Response(String(result), { status: 200 });
+  const response = new Response(String(result), { status: 200 });
+  return finalizeCacheabilityResponse ? finalizeCacheabilityResponse(response, ctx) : response;
 }

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -107,6 +107,7 @@ import {
   type AppRouteTreePrefetchRoute,
   type PrefetchInliningConfig,
 } from "./app-route-tree-prefetch.js";
+import { markRouteCacheabilityDynamic } from "vinext/shims/cacheability-classification";
 
 type AppPageParams = Record<string, string | string[]>;
 type RequestContext = ReturnType<typeof requestContextFromRequest>;
@@ -898,6 +899,13 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
       request: userlandRequest,
       validateExternalRewriteRequest: () => validateClaimedOutsideBasePathRsc(true),
     });
+    if (middlewareResult.matched) {
+      // Next.js runs matched middleware before serving a page response. A CDN
+      // HIT in front of this Worker would skip that request-specific boundary,
+      // so this architecture must remain private until middleware is isolated
+      // into an uncached outer stage.
+      markRouteCacheabilityDynamic("middleware matched this request");
+    }
     if (middlewareResult.kind === "response") {
       if (request.body && !request.body.locked) {
         void request.body.cancel().catch(() => {});
@@ -1250,6 +1258,9 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
       ) {
         void sourceRequest.body.cancel().catch(() => {});
       }
+    }
+    if (sourceMiddlewareResult.matched) {
+      markRouteCacheabilityDynamic("middleware matched this request");
     }
     if (sourceMiddlewareResult.kind === "response") {
       options.clearRequestContext();

--- a/packages/vinext/src/server/cacheability-limits.ts
+++ b/packages/vinext/src/server/cacheability-limits.ts
@@ -1,0 +1,5 @@
+/** Maximum response body that an authenticated cacheability probe will drain. */
+export const CACHEABILITY_PROBE_BODY_LIMIT = 4 * 1024 * 1024;
+
+/** Leave headroom below the deploy-side request timeout for a fail-closed envelope. */
+export const CACHEABILITY_PROBE_TIMEOUT_MS = 20_000;

--- a/packages/vinext/src/server/cacheability-request.ts
+++ b/packages/vinext/src/server/cacheability-request.ts
@@ -1,0 +1,188 @@
+import type { ExecutionContextLike } from "vinext/shims/request-context";
+import {
+  CACHEABILITY_REQUEST_STATE,
+  type RouteCacheabilityOutcome,
+  type RouteCacheabilityState,
+} from "vinext/shims/cacheability-classification";
+import { NO_STORE_CACHE_CONTROL } from "./cache-control.js";
+import { VINEXT_CACHEABILITY_PROBE_HEADER, VINEXT_PRERENDER_SECRET_HEADER } from "./headers.js";
+import { workerCapabilityMatches } from "./worker-prerender-discovery.js";
+import {
+  CACHEABILITY_PROBE_BODY_LIMIT,
+  CACHEABILITY_PROBE_TIMEOUT_MS,
+} from "./cacheability-limits.js";
+
+export type CacheabilityProbeRouteState =
+  | "dynamic"
+  | "probe-failed"
+  | "runtime-check"
+  | "static-candidate";
+
+export type CacheabilityProbeResult = {
+  cacheControl?: string;
+  kind?: "app-page";
+  pattern?: string;
+  reason?: string;
+  state: CacheabilityProbeRouteState;
+  status: number;
+  version: 1;
+};
+
+export function createWorkerCacheabilityContext(
+  base: ExecutionContextLike,
+  request: Request,
+  expectedSecret: string | null | undefined,
+): ExecutionContextLike {
+  const requestedMode = request.headers.get(VINEXT_CACHEABILITY_PROBE_HEADER);
+  if (requestedMode !== "1" && requestedMode !== "identity") return base;
+  if (
+    !expectedSecret ||
+    !workerCapabilityMatches(
+      request.headers.get(VINEXT_PRERENDER_SECRET_HEADER) ?? "",
+      expectedSecret,
+    )
+  ) {
+    return base;
+  }
+
+  const state: RouteCacheabilityState = {
+    captureDeadlineAt: Date.now() + CACHEABILITY_PROBE_TIMEOUT_MS,
+    mode: requestedMode === "identity" ? "identity" : "probe",
+  };
+  return Object.assign(Object.create(Object.getPrototypeOf(base)), base, {
+    [CACHEABILITY_REQUEST_STATE]: state,
+  });
+}
+
+function readState(ctx: ExecutionContextLike): RouteCacheabilityState | null {
+  return (
+    (Reflect.get(ctx, CACHEABILITY_REQUEST_STATE) as RouteCacheabilityState | undefined) ?? null
+  );
+}
+
+function probeResponse(
+  state: RouteCacheabilityState,
+  routeState: CacheabilityProbeRouteState,
+  outcome: RouteCacheabilityOutcome,
+  status: number,
+): Response {
+  const body: CacheabilityProbeResult = {
+    cacheControl: outcome.cacheControl,
+    kind: state.route?.kind,
+    pattern: state.route?.pattern,
+    reason: outcome.reason,
+    state: routeState,
+    status,
+    version: 1,
+  };
+  return Response.json(body, {
+    headers: { "Cache-Control": NO_STORE_CACHE_CONTROL },
+  });
+}
+
+async function drainProbeBody(response: Response, deadlineAt: number): Promise<string | null> {
+  if (!response.body) return null;
+  const reader = response.body.getReader();
+  let total = 0;
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    while (true) {
+      const remaining = deadlineAt - Date.now();
+      if (remaining <= 0) return "response body did not complete before the probe deadline";
+      const result = await Promise.race([
+        reader.read(),
+        new Promise<never>((_, reject) => {
+          timeout = setTimeout(
+            () => reject(new Error("response body did not complete before the probe deadline")),
+            remaining,
+          );
+        }),
+      ]);
+      if (timeout !== undefined) {
+        clearTimeout(timeout);
+        timeout = undefined;
+      }
+      if (result.done) return null;
+      total += result.value.byteLength;
+      if (total > CACHEABILITY_PROBE_BODY_LIMIT) {
+        return `response body exceeded ${CACHEABILITY_PROBE_BODY_LIMIT} bytes`;
+      }
+    }
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout);
+    await reader.cancel().catch(() => {});
+    reader.releaseLock();
+  }
+}
+
+export async function finalizeWorkerCacheabilityResponse(
+  response: Response,
+  ctx: ExecutionContextLike,
+): Promise<Response> {
+  const state = readState(ctx);
+  if (!state) return response;
+
+  if (state.mode === "identity") {
+    await response.body?.cancel().catch(() => {});
+    return probeResponse(
+      state,
+      state.route ? "runtime-check" : "probe-failed",
+      state.route
+        ? { cacheable: false }
+        : { cacheable: false, reason: "request did not resolve to a probeable App Page" },
+      response.status,
+    );
+  }
+
+  if (!state.route) {
+    await response.body?.cancel().catch(() => {});
+    return probeResponse(
+      state,
+      "probe-failed",
+      { cacheable: false, reason: "request did not resolve to a probeable App Page" },
+      response.status,
+    );
+  }
+
+  if (response.status >= 500) {
+    await response.body?.cancel().catch(() => {});
+    return probeResponse(
+      state,
+      "probe-failed",
+      { cacheable: false, reason: `route returned HTTP ${response.status}` },
+      response.status,
+    );
+  }
+
+  const drainFailure = await drainProbeBody(response, state.captureDeadlineAt);
+  if (drainFailure) {
+    return probeResponse(
+      state,
+      "probe-failed",
+      { cacheable: false, classificationFailure: true, reason: drainFailure },
+      response.status,
+    );
+  }
+
+  const outcome = state.completion ? await state.completion : state.outcome;
+  if (!outcome) {
+    return probeResponse(
+      state,
+      "dynamic",
+      { cacheable: false, reason: "completed render did not produce a reusable cache policy" },
+      response.status,
+    );
+  }
+  return probeResponse(
+    state,
+    outcome.cacheable
+      ? "static-candidate"
+      : outcome.classificationFailure
+        ? "probe-failed"
+        : "dynamic",
+    outcome,
+    response.status,
+  );
+}

--- a/packages/vinext/src/server/cacheability-request.ts
+++ b/packages/vinext/src/server/cacheability-request.ts
@@ -12,13 +12,13 @@ import {
   CACHEABILITY_PROBE_TIMEOUT_MS,
 } from "./cacheability-limits.js";
 
-export type CacheabilityProbeRouteState =
+type CacheabilityProbeRouteState =
   | "dynamic"
   | "probe-failed"
   | "runtime-check"
   | "static-candidate";
 
-export type CacheabilityProbeResult = {
+type CacheabilityProbeResult = {
   cacheControl?: string;
   kind?: "app-page";
   pattern?: string;

--- a/packages/vinext/src/server/headers.ts
+++ b/packages/vinext/src/server/headers.ts
@@ -37,6 +37,9 @@ export const VINEXT_TIMING_HEADER = "x-vinext-timing";
 /** Expected Worker version asserted by vinext staged warmup requests. */
 export const VINEXT_EXPECTED_WORKER_VERSION_HEADER = "X-Vinext-Expected-Worker-Version";
 
+/** Authenticated staged-Worker request asking for a completed App Page classification. */
+export const VINEXT_CACHEABILITY_PROBE_HEADER = "X-Vinext-Cacheability-Probe";
+
 export {
   VINEXT_MW_CTX_HEADER,
   VINEXT_PRERENDER_ROUTE_PARAMS_HEADER,
@@ -268,6 +271,7 @@ export const INTERNAL_HEADERS = [
 
 /** Vinext-only internal headers stripped alongside Next.js protocol internals. */
 export const VINEXT_INTERNAL_HEADERS = [
+  VINEXT_CACHEABILITY_PROBE_HEADER.toLowerCase(),
   VINEXT_EXPECTED_WORKER_VERSION_HEADER.toLowerCase(),
   VINEXT_PRERENDER_ROUTE_PARAMS_HEADER,
   VINEXT_PRERENDER_SPECULATIVE_HEADER,

--- a/packages/vinext/src/server/middleware-runtime.ts
+++ b/packages/vinext/src/server/middleware-runtime.ts
@@ -82,6 +82,8 @@ type ExecuteMiddlewareOptions = {
   isProxy: boolean;
   module: MiddlewareModule;
   normalizedPathname?: string;
+  /** Called only after the configured matcher accepts this request. */
+  onMatch?: () => void;
   /**
    * The caller already created an isolated body branch for middleware. This
    * lets App Router normalize that branch's URL and headers without adding a
@@ -448,6 +450,8 @@ export async function executeMiddleware(
   if (!encodedMatches && !decodedMatches) {
     return { continue: true };
   }
+
+  options.onMatch?.();
 
   const nextRequest = createNextRequest(
     options.request,

--- a/packages/vinext/src/server/server-globals.ts
+++ b/packages/vinext/src/server/server-globals.ts
@@ -62,7 +62,10 @@ export function installServerGlobals(): void {
       get() {
         const context = getRequestExecutionContext();
         const state = context ? Reflect.get(context, CACHEABILITY_REQUEST_STATE) : undefined;
-        if (Reflect.get(state ?? {}, "mode") === "probe") {
+        if (
+          context?.isPrerenderPathDiscovery === true ||
+          Reflect.get(state ?? {}, "mode") === "probe"
+        ) {
           return PHASE_PRODUCTION_BUILD;
         }
         return Reflect.get(process.env, "NEXT_PHASE");

--- a/packages/vinext/src/server/server-globals.ts
+++ b/packages/vinext/src/server/server-globals.ts
@@ -8,6 +8,10 @@
  * body would run after static user imports have already evaluated.
  */
 import { AsyncLocalStorage } from "node:async_hooks";
+import { getRequestExecutionContext } from "vinext/shims/request-context";
+
+const CACHEABILITY_REQUEST_STATE = Symbol.for("vinext.cacheabilityRequestState");
+const PHASE_PRODUCTION_BUILD = "phase-production-build";
 
 type BrowserGlobalName = "window" | "document";
 
@@ -48,6 +52,21 @@ export function installServerGlobals(): void {
       configurable: true,
       value: AsyncLocalStorage,
       writable: true,
+    });
+  }
+
+  const nextPhaseDescriptor = Object.getOwnPropertyDescriptor(globalThis, "__VINEXT_NEXT_PHASE");
+  if (!nextPhaseDescriptor || nextPhaseDescriptor.configurable) {
+    Object.defineProperty(globalThis, "__VINEXT_NEXT_PHASE", {
+      configurable: true,
+      get() {
+        const context = getRequestExecutionContext();
+        const state = context ? Reflect.get(context, CACHEABILITY_REQUEST_STATE) : undefined;
+        if (Reflect.get(state ?? {}, "mode") === "probe") {
+          return PHASE_PRODUCTION_BUILD;
+        }
+        return Reflect.get(process.env, "NEXT_PHASE");
+      },
     });
   }
 }

--- a/packages/vinext/src/server/worker-prerender-discovery.ts
+++ b/packages/vinext/src/server/worker-prerender-discovery.ts
@@ -41,7 +41,11 @@ export function createWorkerPrerenderDiscoveryContext(
   // Ordinary traffic never carries this capability. Reject it before URL
   // parsing so staged discovery adds no URL work to the common request path.
   const providedSecret = request.headers.get(VINEXT_PRERENDER_SECRET_HEADER);
-  if (!expectedSecret || !providedSecret || !workerCapabilityMatches(providedSecret, expectedSecret)) {
+  if (
+    !expectedSecret ||
+    !providedSecret ||
+    !workerCapabilityMatches(providedSecret, expectedSecret)
+  ) {
     return base;
   }
 

--- a/packages/vinext/src/server/worker-prerender-discovery.ts
+++ b/packages/vinext/src/server/worker-prerender-discovery.ts
@@ -16,7 +16,7 @@ export function isWorkerPrerenderDiscoveryPath(pathname: string): boolean {
   return PRERENDER_DISCOVERY_PATHS.has(pathname);
 }
 
-function secretsMatch(provided: string, expected: string): boolean {
+export function workerCapabilityMatches(provided: string, expected: string): boolean {
   // The generated secret is fixed-width hex, so always scan the full expected
   // value and fold the length mismatch into the result. Do not use ordinary
   // string equality for this externally supplied capability.
@@ -41,7 +41,7 @@ export function createWorkerPrerenderDiscoveryContext(
   // Ordinary traffic never carries this capability. Reject it before URL
   // parsing so staged discovery adds no URL work to the common request path.
   const providedSecret = request.headers.get(VINEXT_PRERENDER_SECRET_HEADER);
-  if (!expectedSecret || !providedSecret || !secretsMatch(providedSecret, expectedSecret)) {
+  if (!expectedSecret || !providedSecret || !workerCapabilityMatches(providedSecret, expectedSecret)) {
     return base;
   }
 

--- a/packages/vinext/src/shims/cache.ts
+++ b/packages/vinext/src/shims/cache.ts
@@ -33,6 +33,7 @@ import { encodeCacheTag, encodeCacheTags } from "../utils/encode-cache-tag.js";
 import { getCdnCacheAdapter } from "./cdn-cache.js";
 import { getDataCacheHandler, type CachedFetchValue } from "./cache-handler.js";
 import { getRequestExecutionContext } from "./request-context.js";
+import { isStagedCacheabilityProbeActive } from "./cacheability-classification.js";
 import { addCollectedRequestTags, getCurrentFetchSoftTags } from "./fetch-cache.js";
 import {
   ACTION_DID_REVALIDATE_DYNAMIC_ONLY,
@@ -96,6 +97,10 @@ function scheduleRevalidation(promise: Promise<void>): undefined {
  * @param profile - cacheLife profile name (e.g. 'max', 'hours') or inline { expire: number }
  */
 export function revalidateTag(tag: string, profile?: string | { expire?: number }): undefined {
+  if (isStagedCacheabilityProbeActive()) {
+    _markDynamic();
+    return undefined;
+  }
   // Resolve the profile to durations for the handler
   let durations: { expire?: number } | undefined;
   if (typeof profile === "string") {
@@ -151,6 +156,10 @@ async function _invalidateEncodedTag(
  * layout/page hierarchy tags, so only no-type invalidation applies there.
  */
 export function revalidatePath(path: string, type?: "page" | "layout"): undefined {
+  if (isStagedCacheabilityProbeActive()) {
+    _markDynamic();
+    return undefined;
+  }
   markActionRevalidation(ACTION_DID_REVALIDATE_STATIC_AND_DYNAMIC);
   // Strip trailing slash so root "/" becomes "" — avoids double-slash in _N_T_//layout
   const stem = path.endsWith("/") ? path.slice(0, -1) : path;

--- a/packages/vinext/src/shims/cacheability-classification.ts
+++ b/packages/vinext/src/shims/cacheability-classification.ts
@@ -1,0 +1,75 @@
+import { getRequestExecutionContext } from "./request-context.js";
+
+export const CACHEABILITY_REQUEST_STATE = Symbol.for("vinext.cacheabilityRequestState");
+
+export type RouteCacheabilityOutcome = {
+  cacheControl?: string;
+  cacheable: boolean;
+  classificationFailure?: boolean;
+  dynamicUsage?: boolean;
+  reason?: string;
+  tags?: readonly string[];
+};
+
+export type RouteCacheabilityState = {
+  captureDeadlineAt: number;
+  complete?: (outcome: RouteCacheabilityOutcome) => void;
+  completion?: Promise<RouteCacheabilityOutcome>;
+  mode: "identity" | "probe";
+  outcome?: RouteCacheabilityOutcome;
+  route?: {
+    kind: "app-page";
+    pattern: string;
+  };
+};
+
+export function readRouteCacheabilityState(): RouteCacheabilityState | null {
+  const context = getRequestExecutionContext();
+  if (!context) return null;
+  return (
+    (Reflect.get(context, CACHEABILITY_REQUEST_STATE) as RouteCacheabilityState | undefined) ?? null
+  );
+}
+
+export function beginRouteCacheability(kind: "app-page", pattern: string): boolean {
+  const state = readRouteCacheabilityState();
+  if (!state) return false;
+  state.route = { kind, pattern };
+  return true;
+}
+
+/** True only for an authenticated probe that must render the matched App Page. */
+export function isRouteCacheabilityProbe(): boolean {
+  return readRouteCacheabilityState()?.mode === "probe";
+}
+
+/** True for the authenticated routing pass that must not evaluate user components. */
+export function isRouteCacheabilityIdentityProbe(): boolean {
+  return readRouteCacheabilityState()?.mode === "identity";
+}
+
+/** True for every side-effect-free staged Worker observation request. */
+export function isStagedCacheabilityProbeActive(): boolean {
+  const mode = readRouteCacheabilityState()?.mode;
+  return mode === "probe" || mode === "identity";
+}
+
+export function deferRouteCacheability(): ((outcome: RouteCacheabilityOutcome) => void) | null {
+  const state = readRouteCacheabilityState();
+  if (!state?.route || state.completion) return null;
+
+  state.completion = new Promise<RouteCacheabilityOutcome>((resolve) => {
+    state.complete = (outcome) => {
+      state.outcome = outcome;
+      resolve(outcome);
+    };
+  });
+  return (outcome) => state.complete?.(outcome);
+}
+
+export function recordRouteCacheability(outcome: RouteCacheabilityOutcome): void {
+  const state = readRouteCacheabilityState();
+  if (!state?.route) return;
+  state.outcome = outcome;
+  state.complete?.(outcome);
+}

--- a/packages/vinext/src/shims/cacheability-classification.ts
+++ b/packages/vinext/src/shims/cacheability-classification.ts
@@ -15,6 +15,7 @@ export type RouteCacheabilityState = {
   captureDeadlineAt: number;
   complete?: (outcome: RouteCacheabilityOutcome) => void;
   completion?: Promise<RouteCacheabilityOutcome>;
+  forcedDynamicReason?: string;
   mode: "identity" | "probe";
   outcome?: RouteCacheabilityOutcome;
   route?: {
@@ -36,6 +37,13 @@ export function beginRouteCacheability(kind: "app-page", pattern: string): boole
   if (!state) return false;
   state.route = { kind, pattern };
   return true;
+}
+
+/** Prevent shared caching when request processing before route dispatch was request-specific. */
+export function markRouteCacheabilityDynamic(reason: string): void {
+  const state = readRouteCacheabilityState();
+  if (!state) return;
+  state.forcedDynamicReason = reason;
 }
 
 /** True only for an authenticated probe that must render the matched App Page. */
@@ -60,8 +68,15 @@ export function deferRouteCacheability(): ((outcome: RouteCacheabilityOutcome) =
 
   state.completion = new Promise<RouteCacheabilityOutcome>((resolve) => {
     state.complete = (outcome) => {
-      state.outcome = outcome;
-      resolve(outcome);
+      const resolvedOutcome = state.forcedDynamicReason
+        ? {
+            cacheable: false,
+            dynamicUsage: true,
+            reason: state.forcedDynamicReason,
+          }
+        : outcome;
+      state.outcome = resolvedOutcome;
+      resolve(resolvedOutcome);
     };
   });
   return (outcome) => state.complete?.(outcome);
@@ -70,6 +85,13 @@ export function deferRouteCacheability(): ((outcome: RouteCacheabilityOutcome) =
 export function recordRouteCacheability(outcome: RouteCacheabilityOutcome): void {
   const state = readRouteCacheabilityState();
   if (!state?.route) return;
-  state.outcome = outcome;
-  state.complete?.(outcome);
+  const resolvedOutcome = state.forcedDynamicReason
+    ? {
+        cacheable: false,
+        dynamicUsage: true,
+        reason: state.forcedDynamicReason,
+      }
+    : outcome;
+  state.outcome = resolvedOutcome;
+  state.complete?.(resolvedOutcome);
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -316,11 +316,11 @@ const projectServers = {
     use: { baseURL: "http://localhost:4187" },
     server: {
       command:
-        "npx vp run vinext#build && node ../../../packages/vinext/dist/cli.js build && node ../../../packages/vinext/dist/cli.js start --port 4187",
+        "npx vp run vinext#build && npx vp build && npx wrangler dev --config dist/server/wrangler.json --port 4187",
       cwd: "./tests/fixtures/ppr-impact-demo",
       port: 4187,
       reuseExistingServer: !process.env.CI,
-      timeout: 90_000,
+      timeout: 120_000,
     },
   },
   "app-front-redirect-issue": {

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -690,8 +690,8 @@ describe("createAppRscHandler", () => {
       async runMiddleware({ cleanPathname }) {
         middlewarePaths.push(cleanPathname);
         return cleanPathname.startsWith("/feed/secret")
-          ? { kind: "response", response: new Response("denied", { status: 401 }) }
-          : { kind: "continue", cleanPathname, rewritten: false, search: null };
+          ? { kind: "response", matched: true, response: new Response("denied", { status: 401 }) }
+          : { kind: "continue", cleanPathname, matched: true, rewritten: false, search: null };
       },
     });
 
@@ -1918,7 +1918,7 @@ describe("createAppRscHandler", () => {
         } else {
           getHeadersContext()?.headers.set("x-source", "added");
         }
-        return { kind: "continue", cleanPathname, rewritten: false, search: null };
+        return { kind: "continue", cleanPathname, matched: true, rewritten: false, search: null };
       },
     });
 
@@ -2043,7 +2043,7 @@ describe("createAppRscHandler", () => {
         pathname === "/photos/1" ? { params: {}, route: targetRoute } : null,
       async runMiddleware({ cleanPathname }) {
         middlewarePaths.push(cleanPathname);
-        return { kind: "continue", cleanPathname, rewritten: false, search: null };
+        return { kind: "continue", cleanPathname, matched: true, rewritten: false, search: null };
       },
     });
 
@@ -4455,7 +4455,7 @@ describe("createAppRscHandler", () => {
         matchRoute,
         async runMiddleware({ cleanPathname }) {
           middlewarePaths.push(cleanPathname);
-          return { kind: "continue", cleanPathname, rewritten: false, search: null };
+          return { kind: "continue", cleanPathname, matched: true, rewritten: false, search: null };
         },
       });
       const headers = createRscRequestHeaders({ interceptionContext: "/feed" });

--- a/tests/compiler-define.test.ts
+++ b/tests/compiler-define.test.ts
@@ -170,12 +170,14 @@ describe("compiler.define forwarding to Vite", () => {
       expect(rscResult?.define).toEqual({
         MY_SERVER_VARIABLE: '"server"',
         "process.env.MY_MAGIC_SERVER_EXPR": '"serverbarbaz"',
+        "process.env.NEXT_PHASE": "globalThis.__VINEXT_NEXT_PHASE",
         "process.env.NEXT_RUNTIME": '"nodejs"',
         ...previewDefines,
       });
       expect(ssrResult?.define).toEqual({
         MY_SERVER_VARIABLE: '"server"',
         "process.env.MY_MAGIC_SERVER_EXPR": '"serverbarbaz"',
+        "process.env.NEXT_PHASE": "globalThis.__VINEXT_NEXT_PHASE",
         "process.env.NEXT_RUNTIME": '"nodejs"',
         ...previewDefines,
       });
@@ -345,6 +347,7 @@ describe("compiler.define forwarding to Vite", () => {
       expect(rscResult?.define?.["process.env.NEXT_RUNTIME"]).toBe('"nodejs"');
       expect(Object.keys(rscResult!.define!)).toEqual([
         "process.env.NEXT_RUNTIME",
+        "process.env.NEXT_PHASE",
         ...PREVIEW_DEFINE_NAMES,
       ]);
       getPreviewDefines(rscResult?.define);

--- a/tests/e2e/ppr-impact-demo/cacheability-probe.spec.ts
+++ b/tests/e2e/ppr-impact-demo/cacheability-probe.spec.ts
@@ -25,6 +25,37 @@ test("classifies completed App Page renders inside workerd", async ({ request })
   });
   expect(staticProbe.headers()["cache-control"]).toContain("no-store");
 
+  const fullRscProbe = await request.get("/cacheability/static?_rsc", {
+    headers: { ...headers, Accept: "text/x-component", RSC: "1" },
+  });
+  expect(fullRscProbe.ok()).toBe(true);
+  await expect(fullRscProbe.json()).resolves.toMatchObject({
+    kind: "app-page",
+    pattern: "/cacheability/static",
+    state: "static-candidate",
+    status: 200,
+    version: 1,
+  });
+
+  const loadingShellProbe = await request.get("/cacheability/static?_rsc=9qLBDIU2NgN178cB", {
+    headers: {
+      ...headers,
+      Accept: "text/x-component",
+      RSC: "1",
+      "Next-Router-Prefetch": "1",
+      "Next-Router-Segment-Prefetch": "1",
+      "X-Vinext-Rsc-Render-Mode": "prefetch-loading-shell",
+    },
+  });
+  expect(loadingShellProbe.ok()).toBe(true);
+  await expect(loadingShellProbe.json()).resolves.toMatchObject({
+    kind: "app-page",
+    pattern: "/cacheability/static",
+    state: "static-candidate",
+    status: 200,
+    version: 1,
+  });
+
   const dynamicProbe = await request.get("/cacheability/dynamic", { headers });
   expect(dynamicProbe.ok()).toBe(true);
   await expect(dynamicProbe.json()).resolves.toMatchObject({

--- a/tests/e2e/ppr-impact-demo/cacheability-probe.spec.ts
+++ b/tests/e2e/ppr-impact-demo/cacheability-probe.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "@playwright/test";
+import fs from "node:fs";
+
+const probeHeader = "X-Vinext-Cacheability-Probe";
+const secretHeader = "X-Vinext-Prerender-Secret";
+
+function prerenderSecret(): string {
+  const manifest = JSON.parse(
+    fs.readFileSync("tests/fixtures/ppr-impact-demo/dist/server/vinext-server.json", "utf8"),
+  ) as { prerenderSecret: string };
+  return manifest.prerenderSecret;
+}
+
+test("classifies completed App Page renders inside workerd", async ({ request }) => {
+  const headers = { [probeHeader]: "1", [secretHeader]: prerenderSecret() };
+
+  const staticProbe = await request.get("/cacheability/static", { headers });
+  expect(staticProbe.ok()).toBe(true);
+  await expect(staticProbe.json()).resolves.toMatchObject({
+    kind: "app-page",
+    pattern: "/cacheability/static",
+    state: "static-candidate",
+    status: 200,
+    version: 1,
+  });
+  expect(staticProbe.headers()["cache-control"]).toContain("no-store");
+
+  const dynamicProbe = await request.get("/cacheability/dynamic", { headers });
+  expect(dynamicProbe.ok()).toBe(true);
+  await expect(dynamicProbe.json()).resolves.toMatchObject({
+    kind: "app-page",
+    pattern: "/cacheability/dynamic",
+    state: "dynamic",
+    status: 200,
+    version: 1,
+  });
+
+  const identityProbe = await request.get("/cacheability/static", {
+    headers: { ...headers, [probeHeader]: "identity" },
+  });
+  await expect(identityProbe.json()).resolves.toMatchObject({
+    kind: "app-page",
+    pattern: "/cacheability/static",
+    state: "runtime-check",
+    version: 1,
+  });
+
+  // Ported from Next.js:
+  // test/e2e/app-dir/app-static/app/gen-params-dynamic-revalidate/[slug]/page.js
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app-static/app/gen-params-dynamic-revalidate/%5Bslug%5D/page.js
+  const phaseProbe = await request.get("/cacheability/prerender-phase/known", { headers });
+  await expect(phaseProbe.json()).resolves.toMatchObject({
+    kind: "app-page",
+    pattern: "/cacheability/prerender-phase/:slug",
+    state: "static-candidate",
+    version: 1,
+  });
+});
+
+test("rejects forged probes without exposing capability headers to user code", async ({
+  request,
+}) => {
+  const response = await request.get("/cacheability/dynamic", {
+    headers: { [probeHeader]: "1", [secretHeader]: "wrong-secret" },
+  });
+  expect(response.ok()).toBe(true);
+  expect(response.headers()["content-type"]).toContain("text/html");
+  const body = await response.text();
+  expect(body).toContain("probe=<!-- -->none");
+  expect(body).toContain(";secret=<!-- -->none");
+
+  const ordinaryPhaseResponse = await request.get("/cacheability/prerender-phase/known");
+  expect(await ordinaryPhaseResponse.text()).toContain("phase=<!-- -->runtime");
+});

--- a/tests/e2e/ppr-impact-demo/cacheability-probe.spec.ts
+++ b/tests/e2e/ppr-impact-demo/cacheability-probe.spec.ts
@@ -14,6 +14,15 @@ function prerenderSecret(): string {
 test("classifies completed App Page renders inside workerd", async ({ request }) => {
   const headers = { [probeHeader]: "1", [secretHeader]: prerenderSecret() };
 
+  // Next.js evaluates generateStaticParams during phase-production-build:
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/build/index.ts
+  const discovery = await request.get(
+    "/__vinext/prerender/static-params?pattern=%2Fcacheability%2Fprerender-phase%2F%3Aslug",
+    { headers: { [secretHeader]: prerenderSecret() } },
+  );
+  expect(discovery.ok()).toBe(true);
+  await expect(discovery.json()).resolves.toEqual([{ slug: "known" }]);
+
   const staticProbe = await request.get("/cacheability/static", { headers });
   expect(staticProbe.ok()).toBe(true);
   await expect(staticProbe.json()).resolves.toMatchObject({

--- a/tests/e2e/ppr-impact-demo/cacheability-probe.spec.ts
+++ b/tests/e2e/ppr-impact-demo/cacheability-probe.spec.ts
@@ -35,6 +35,20 @@ test("classifies completed App Page renders inside workerd", async ({ request })
     version: 1,
   });
 
+  // Next.js keeps middleware in front of page serving on every request:
+  // test/e2e/middleware-static-files/index.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-static-files/index.test.ts
+  const middlewareProbe = await request.get("/cacheability/middleware", { headers });
+  expect(middlewareProbe.ok()).toBe(true);
+  await expect(middlewareProbe.json()).resolves.toMatchObject({
+    kind: "app-page",
+    pattern: "/cacheability/middleware",
+    reason: "middleware matched this request",
+    state: "dynamic",
+    status: 200,
+    version: 1,
+  });
+
   const identityProbe = await request.get("/cacheability/static", {
     headers: { ...headers, [probeHeader]: "identity" },
   });

--- a/tests/fixtures/ppr-impact-demo/app/cacheability/dynamic/page.tsx
+++ b/tests/fixtures/ppr-impact-demo/app/cacheability/dynamic/page.tsx
@@ -1,0 +1,13 @@
+import { headers } from "next/headers";
+
+export const revalidate = 60;
+
+export default async function DynamicCacheabilityPage() {
+  const requestHeaders = await headers();
+  return (
+    <p id="cacheability-result">
+      probe={requestHeaders.get("x-vinext-cacheability-probe") ?? "none"};secret=
+      {requestHeaders.get("x-vinext-prerender-secret") ?? "none"}
+    </p>
+  );
+}

--- a/tests/fixtures/ppr-impact-demo/app/cacheability/middleware/page.tsx
+++ b/tests/fixtures/ppr-impact-demo/app/cacheability/middleware/page.tsx
@@ -1,0 +1,3 @@
+export default function MiddlewareCacheabilityPage() {
+  return <p>Middleware cacheability probe</p>;
+}

--- a/tests/fixtures/ppr-impact-demo/app/cacheability/prerender-phase/[slug]/page.tsx
+++ b/tests/fixtures/ppr-impact-demo/app/cacheability/prerender-phase/[slug]/page.tsx
@@ -1,0 +1,22 @@
+import { headers } from "next/headers";
+
+export const revalidate = 3;
+
+export function generateStaticParams() {
+  return [{ slug: "known" }];
+}
+
+export default async function PrerenderPhasePage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const isProductionBuild = process.env.NEXT_PHASE === "phase-production-build";
+  if (!isProductionBuild) await headers();
+  return (
+    <p id="cacheability-result">
+      phase={isProductionBuild ? "build" : "runtime"};{slug}
+    </p>
+  );
+}

--- a/tests/fixtures/ppr-impact-demo/app/cacheability/prerender-phase/[slug]/page.tsx
+++ b/tests/fixtures/ppr-impact-demo/app/cacheability/prerender-phase/[slug]/page.tsx
@@ -3,7 +3,7 @@ import { headers } from "next/headers";
 export const revalidate = 3;
 
 export function generateStaticParams() {
-  return [{ slug: "known" }];
+  return process.env.NEXT_PHASE === "phase-production-build" ? [{ slug: "known" }] : [];
 }
 
 export default async function PrerenderPhasePage({

--- a/tests/fixtures/ppr-impact-demo/app/cacheability/static/page.tsx
+++ b/tests/fixtures/ppr-impact-demo/app/cacheability/static/page.tsx
@@ -1,0 +1,5 @@
+export const revalidate = 60;
+
+export default function StaticCacheabilityPage() {
+  return <p id="cacheability-result">static page</p>;
+}

--- a/tests/fixtures/ppr-impact-demo/middleware.ts
+++ b/tests/fixtures/ppr-impact-demo/middleware.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+
+export function middleware() {
+  const response = NextResponse.next();
+  response.headers.set("X-Cacheability-Middleware", "matched");
+  return response;
+}
+
+export const config = { matcher: "/cacheability/middleware" };

--- a/tests/fixtures/ppr-impact-demo/proxy.ts
+++ b/tests/fixtures/ppr-impact-demo/proxy.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 
-export function middleware() {
+export function proxy() {
   const response = NextResponse.next();
   response.headers.set("X-Cacheability-Middleware", "matched");
   return response;

--- a/tests/middleware-runtime.test.ts
+++ b/tests/middleware-runtime.test.ts
@@ -433,6 +433,30 @@ describe("middleware redirect protocol", () => {
     expect((capturedRequest as NextRequest & { __isData?: boolean }).__isData).toBeUndefined();
   });
 
+  it("reports whether the configured matcher accepted the request", async () => {
+    const onMatch = vi.fn();
+    const module = {
+      config: { matcher: "/matched/:path*" },
+      default: () => undefined,
+    };
+
+    await executeMiddleware({
+      isProxy: false,
+      module,
+      onMatch,
+      request: new Request("http://localhost:3000/not-matched"),
+    });
+    expect(onMatch).not.toHaveBeenCalled();
+
+    await executeMiddleware({
+      isProxy: false,
+      module,
+      onMatch,
+      request: new Request("http://localhost:3000/matched/page"),
+    });
+    expect(onMatch).toHaveBeenCalledOnce();
+  });
+
   it("relativizes the Location header for same-host redirects", async () => {
     const module = {
       default: (req: Request) => {

--- a/tests/request-pipeline.test.ts
+++ b/tests/request-pipeline.test.ts
@@ -23,6 +23,7 @@ import {
   applyConfigHeadersToResponse,
 } from "../packages/vinext/src/server/config-headers.js";
 import {
+  VINEXT_CACHEABILITY_PROBE_HEADER,
   VINEXT_EXPECTED_WORKER_VERSION_HEADER,
   VINEXT_PRERENDER_CACHE_LIFE_HEADER,
   VINEXT_PRERENDER_ROUTE_PARAMS_HEADER,
@@ -871,6 +872,7 @@ describe("filterInternalHeaders", () => {
   it("strips vinext-only internal headers without extending Next.js INTERNAL_HEADERS", () => {
     const headers = new Headers({
       "cloudflare-workers-version-overrides": 'downstream="version-id"',
+      [VINEXT_CACHEABILITY_PROBE_HEADER]: "forged",
       [VINEXT_EXPECTED_WORKER_VERSION_HEADER]: "expected-version",
       [VINEXT_PRERENDER_CACHE_LIFE_HEADER]: "forged",
       [VINEXT_PRERENDER_ROUTE_PARAMS_HEADER]: "forged",
@@ -885,6 +887,7 @@ describe("filterInternalHeaders", () => {
     expect(INTERNAL_HEADERS).not.toContain(VINEXT_PRERENDER_SPECULATIVE_HEADER);
     expect(INTERNAL_HEADERS).not.toContain(VINEXT_PRERENDER_CACHE_LIFE_HEADER);
     expect(VINEXT_INTERNAL_HEADERS).toEqual([
+      VINEXT_CACHEABILITY_PROBE_HEADER.toLowerCase(),
       VINEXT_EXPECTED_WORKER_VERSION_HEADER.toLowerCase(),
       VINEXT_PRERENDER_ROUTE_PARAMS_HEADER,
       VINEXT_PRERENDER_SPECULATIVE_HEADER,
@@ -895,6 +898,7 @@ describe("filterInternalHeaders", () => {
       expect(name).toBe(name.toLowerCase());
     }
     expect(result.has(VINEXT_PRERENDER_ROUTE_PARAMS_HEADER)).toBe(false);
+    expect(result.has(VINEXT_CACHEABILITY_PROBE_HEADER)).toBe(false);
     expect(result.has(VINEXT_EXPECTED_WORKER_VERSION_HEADER)).toBe(false);
     expect(result.has(VINEXT_PRERENDER_SPECULATIVE_HEADER)).toBe(false);
     expect(result.has(VINEXT_PRERENDER_CACHE_LIFE_HEADER)).toBe(false);


### PR DESCRIPTION
Capability stack **3/9**. Exact head: `16340739a0a09f558eb06946d2ac2568c2123b05`. Base: #3090.

Full chain: #3108 → #3090 → #3091 → #3092 → #3103 → #3093 → #3094 → #3098 → #3113.

## Summary

- add authenticated identity and completed-response cacheability probe modes for App Pages
- decide cacheability only after the response body reaches clean EOF
- bound probe capture by time and size
- expose Next.js's production-build phase during staged discovery/probing while leaving ordinary ISR requests in the production-server phase
- classify dynamic APIs, revalidation mutations, errors, redirects, incomplete responses, timeouts, oversized responses, and middleware-eligible routes as unsafe
- dynamically load probe-only runtime code only for authenticated internal requests

## Safety and Next.js parity

- `revalidate` alone does not override dynamic runtime usage
- middleware eligibility is treated conservatively because a CDN hit in front of the Worker would skip middleware
- forged or stale capabilities cannot create a static classification
- internal capability headers are removed before user code
- production-build phase behavior follows Next.js App Router static-generation coverage

This layer covers App Pages. #3092 consumes probe results for ordinary CDN admission; #3098 extends the protocol to Pages Router.

## Review guide

1. `cacheability-request.ts` authenticates probes and drains bounded responses.
2. `cacheability-classification.ts` records request-scoped route outcomes.
3. `middleware-runtime.ts` reports middleware participation without changing middleware behavior.
4. `app-page-cache-finalizer.ts` publishes the completed render outcome.
5. `cacheability-probe.spec.ts` exercises the built Worker under workerd.

## Review size

Layer-only diff against this PR's base: **25 files, +717/-18**.

## Validation

- layer exact-head CI is green
- prior cumulative focused validation through #3098 — **2,024/2,024**
- current full-stack cumulative changed-file suites — **2,864/2,864**
- current full-stack PPR probe/admission/Pages built-workerd E2E — **8/8**
- current full-stack `vp check` and `git diff --check`
