### PR TITLE
fix(cache): gate CDN admission on probed routes

### DIFF
--- a/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
@@ -267,6 +267,11 @@ export class CloudflareCdnCacheAdapter implements CdnCacheAdapter {
       "CDN-Cache-Control": toEdgeCacheControl(input.cacheControl),
       "Cloudflare-CDN-Cache-Control": null,
       "Cache-Tag": input.tags ? formatCacheTag(input.tags) : null,
+      // Workers Cache is consulted before the Worker runs. Vary the reusable
+      // anonymous response by Cookie so a draft/preview request cannot consume
+      // that HIT before vinext validates its signed bypass cookie. The draft
+      // response itself remains no-store once the Worker handles the miss.
+      Vary: "Cookie",
     };
 
     return headers;

--- a/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
@@ -267,11 +267,6 @@ export class CloudflareCdnCacheAdapter implements CdnCacheAdapter {
       "CDN-Cache-Control": toEdgeCacheControl(input.cacheControl),
       "Cloudflare-CDN-Cache-Control": null,
       "Cache-Tag": input.tags ? formatCacheTag(input.tags) : null,
-      // Workers Cache is consulted before the Worker runs. Vary the reusable
-      // anonymous response by Cookie so a draft/preview request cannot consume
-      // that HIT before vinext validates its signed bypass cookie. The draft
-      // response itself remains no-store once the Worker handles the miss.
-      Vary: "Cookie",
     };
 
     return headers;

--- a/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
@@ -180,6 +180,8 @@ function formatCacheTag(tags: readonly string[]): string | null {
 }
 
 export class CloudflareCdnCacheAdapter implements CdnCacheAdapter {
+  readonly requiresCompletedResponseAdmission = true;
+
   constructor(
     private readonly versionMetadata?: WorkerVersionMetadata,
     private readonly versionMetadataBinding = DEFAULT_VERSION_METADATA_BINDING,
@@ -237,6 +239,14 @@ export class CloudflareCdnCacheAdapter implements CdnCacheAdapter {
   }
 
   buildResponseHeaders(input: CdnCacheableHeaderInput): CdnResponseHeaders {
+    // App Page MISS streams may discover request-bound dynamic APIs after the
+    // response object is created. Only the outer Worker admission boundary may
+    // replace this private policy after clean EOF; without that proof, the CDN
+    // must fail closed.
+    if (input.pendingDynamicCheck) {
+      return clearCloudflareCdnResponseHeaders(NO_STORE);
+    }
+
     // No cacheable policy → nobody stores it.
     if (!input.cacheControl) {
       return clearCloudflareCdnResponseHeaders(NO_STORE);

--- a/packages/vinext/src/config/config-matchers.ts
+++ b/packages/vinext/src/config/config-matchers.ts
@@ -835,6 +835,7 @@ export function matchRedirect(
   redirects: NextRedirect[],
   ctx: RequestContext,
   basePathState: BasePathMatchState = _BASEPATH_DEFAULT,
+  onRuleSourceMatch?: (rule: NextRedirect) => void,
 ): { destination: string; permanent: boolean } | null {
   if (redirects.length === 0) return null;
 
@@ -875,6 +876,7 @@ export function matchRedirect(
         if (entry.originalIndex >= localeMatchIndex) continue; // already have a better match
         const redirect = entry.redirect;
         if (!shouldEvaluateRule(redirect.basePath, basePathState)) continue;
+        onRuleSourceMatch?.(redirect);
         const conditionParams =
           redirect.has || redirect.missing
             ? collectConditionParams(redirect.has, redirect.missing, ctx)
@@ -906,6 +908,7 @@ export function matchRedirect(
           if (!entry.altRe.test(localePart)) continue;
           const redirect = entry.redirect;
           if (!shouldEvaluateRule(redirect.basePath, basePathState)) continue;
+          onRuleSourceMatch?.(redirect);
           const conditionParams =
             redirect.has || redirect.missing
               ? collectConditionParams(redirect.has, redirect.missing, ctx)
@@ -936,6 +939,7 @@ export function matchRedirect(
     if (!shouldEvaluateRule(redirect.basePath, basePathState)) continue;
     const params = matchConfigPattern(pathname, redirect.source);
     if (params) {
+      onRuleSourceMatch?.(redirect);
       const conditionParams =
         redirect.has || redirect.missing
           ? collectConditionParams(redirect.has, redirect.missing, ctx)
@@ -968,11 +972,13 @@ export function matchRewrite(
   ctx: RequestContext,
   basePathState: BasePathMatchState = _BASEPATH_DEFAULT,
   paramsPathname: string = pathname,
+  onRuleSourceMatch?: (rule: NextRewrite) => void,
 ): string | null {
   for (const rewrite of rewrites) {
     if (!shouldEvaluateRule(rewrite.basePath, basePathState)) continue;
     const matchedParams = matchConfigPattern(pathname, rewrite.source);
     if (matchedParams) {
+      onRuleSourceMatch?.(rewrite);
       // App request routing matches against a segment-normalized pathname but
       // Next.js prepareDestination substitutes the encoded source captures.
       // Prefer those captures when the caller retained the encoded pathname.
@@ -1384,7 +1390,7 @@ export function matchHeaders(
   headers: NextHeader[],
   ctx: RequestContext,
   basePathState: BasePathMatchState = _BASEPATH_DEFAULT,
-  onRuleMatch?: (rule: NextHeader) => void,
+  onRuleSourceMatch?: (rule: NextHeader) => void,
 ): Array<{ key: string; value: string }> {
   const pathnameHadTrailingSlash = pathname.length > 1 && pathname.endsWith("/");
   pathname = stripTrailingSlashForConfigMatch(pathname);
@@ -1401,12 +1407,12 @@ export function matchHeaders(
       safeRegExp("^" + escapeHeaderSource(source) + "$", "i"),
     );
     if (sourceRegex && sourceRegex.test(pathname)) {
+      onRuleSourceMatch?.(rule);
       if (rule.has || rule.missing) {
         if (!checkHasConditions(rule.has, rule.missing, ctx)) {
           continue;
         }
       }
-      onRuleMatch?.(rule);
       result.push(...rule.headers);
     }
   }

--- a/packages/vinext/src/config/config-matchers.ts
+++ b/packages/vinext/src/config/config-matchers.ts
@@ -1384,6 +1384,7 @@ export function matchHeaders(
   headers: NextHeader[],
   ctx: RequestContext,
   basePathState: BasePathMatchState = _BASEPATH_DEFAULT,
+  onRuleMatch?: (rule: NextHeader) => void,
 ): Array<{ key: string; value: string }> {
   const pathnameHadTrailingSlash = pathname.length > 1 && pathname.endsWith("/");
   pathname = stripTrailingSlashForConfigMatch(pathname);
@@ -1405,6 +1406,7 @@ export function matchHeaders(
           continue;
         }
       }
+      onRuleMatch?.(rule);
       result.push(...rule.headers);
     }
   }

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -301,6 +301,8 @@ import ${JSON.stringify(appRouteRequestBuiltInsPath)};`
     : ""
 }
 import ${JSON.stringify(serverGlobalsPath)};
+import __cacheabilityManifest from "virtual:vinext-cacheability-manifest";
+export { __cacheabilityManifest };
 import {
   renderToReadableStream as _renderToReadableStream,
   ${

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1099,6 +1099,9 @@ const RESOLVED_PAGES_CLIENT_ASSETS = VIRTUAL_PREFIX + VIRTUAL_PAGES_CLIENT_ASSET
 // Virtual module IDs for App Router entries
 const VIRTUAL_RSC_ENTRY = "virtual:vinext-rsc-entry";
 const RESOLVED_RSC_ENTRY = VIRTUAL_PREFIX + VIRTUAL_RSC_ENTRY;
+const VIRTUAL_CACHEABILITY_MANIFEST = "virtual:vinext-cacheability-manifest";
+const RESOLVED_CACHEABILITY_MANIFEST = VIRTUAL_PREFIX + VIRTUAL_CACHEABILITY_MANIFEST;
+const CACHEABILITY_MANIFEST_MODULE = "__vinext_cacheability_manifest.js";
 const VIRTUAL_APP_SSR_ENTRY = "virtual:vinext-app-ssr-entry";
 const RESOLVED_APP_SSR_ENTRY = VIRTUAL_PREFIX + VIRTUAL_APP_SSR_ENTRY;
 const VIRTUAL_APP_BROWSER_ENTRY = "virtual:vinext-app-browser-entry";
@@ -3901,6 +3904,12 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           }
           // App Router virtual modules
           if (cleanId === VIRTUAL_RSC_ENTRY) return RESOLVED_RSC_ENTRY;
+          if (cleanId === VIRTUAL_CACHEABILITY_MANIFEST) {
+            if (this.environment?.name === "rsc" && this.environment.config?.command === "build") {
+              return { id: `./${CACHEABILITY_MANIFEST_MODULE}`, external: true };
+            }
+            return RESOLVED_CACHEABILITY_MANIFEST;
+          }
           if (cleanId === VIRTUAL_APP_SSR_ENTRY) return RESOLVED_APP_SSR_ENTRY;
           if (cleanId === VIRTUAL_APP_BROWSER_ENTRY) return RESOLVED_APP_BROWSER_ENTRY;
           if (cleanId === VIRTUAL_APP_CAPABILITIES) return RESOLVED_APP_CAPABILITIES;
@@ -4005,6 +4014,9 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             return `export default ${JSON.stringify(metadata)};`;
           }
           // App Router virtual modules
+          if (id === RESOLVED_CACHEABILITY_MANIFEST) {
+            return "export default null;";
+          }
           if (id === RESOLVED_RSC_ENTRY && hasAppDir) {
             const routes = await appRouter(appDir, nextConfig?.pageExtensions, fileMatcher);
             const metaRoutes = scanMetadataFiles(appDir);
@@ -4391,6 +4403,19 @@ export const loadServerActionClient = ${
             optimizerConditions.filter((condition) => condition !== "browser");
         }
         return null;
+      },
+    },
+    {
+      name: "vinext:cacheability-manifest-asset",
+      apply: "build",
+
+      generateBundle() {
+        if (this.environment?.name !== "rsc") return;
+        this.emitFile({
+          type: "asset",
+          fileName: CACHEABILITY_MANIFEST_MODULE,
+          source: "export default null;\n",
+        });
       },
     },
     {

--- a/packages/vinext/src/server/app-middleware.ts
+++ b/packages/vinext/src/server/app-middleware.ts
@@ -54,6 +54,8 @@ export type ApplyAppMiddlewareResult =
       cleanPathname: string;
       /** Present on real middleware results; optional for older generated callers. */
       matched?: boolean;
+      /** True when this pathname can match middleware for some request context. */
+      pathnameEligible?: boolean;
       rewritten: boolean;
       search: string | null;
     }
@@ -61,6 +63,8 @@ export type ApplyAppMiddlewareResult =
       kind: "response";
       /** Present on real middleware results; optional for older generated callers. */
       matched?: boolean;
+      /** True when this pathname can match middleware for some request context. */
+      pathnameEligible?: boolean;
       response: Response;
     };
 
@@ -275,6 +279,7 @@ export async function applyAppMiddleware(
 ): Promise<ApplyAppMiddlewareResult> {
   const forwarded = applyForwardedMiddlewareContext(options.request, options.context);
   let matched = forwarded.applied;
+  let pathnameEligible = forwarded.applied;
   let cleanPathname = options.cleanPathname;
   let rewritten = false;
   let search: string | null = null;
@@ -288,6 +293,7 @@ export async function applyAppMiddleware(
           return {
             kind: "response",
             matched,
+            pathnameEligible,
             response: validationResponseWithMiddlewareHeaders(validationResponse, options.context),
           };
         }
@@ -296,6 +302,7 @@ export async function applyAppMiddleware(
         return {
           kind: "response",
           matched,
+          pathnameEligible,
           response: await proxyExternalMiddlewareRewrite(
             externalRequest,
             forwarded.rewriteUrl,
@@ -335,6 +342,9 @@ export async function applyAppMiddleware(
         onMatch() {
           matched = true;
         },
+        onPathMatch() {
+          pathnameEligible = true;
+        },
         requestBodyAlreadyIsolated: true,
         request: middlewareRequest,
         trailingSlash: options.trailingSlash,
@@ -349,12 +359,22 @@ export async function applyAppMiddleware(
     if (!result.continue) {
       cancelRequestBody(options.request);
       if (result.redirectUrl) {
-        return { kind: "response", matched, response: responseFromMiddlewareRedirect(result) };
+        return {
+          kind: "response",
+          matched,
+          pathnameEligible,
+          response: responseFromMiddlewareRedirect(result),
+        };
       }
       if (result.response) {
-        return { kind: "response", matched, response: result.response };
+        return { kind: "response", matched, pathnameEligible, response: result.response };
       }
-      return { kind: "response", matched, response: internalServerErrorResponse() };
+      return {
+        kind: "response",
+        matched,
+        pathnameEligible,
+        response: internalServerErrorResponse(),
+      };
     }
 
     if (result.responseHeaders) {
@@ -375,6 +395,7 @@ export async function applyAppMiddleware(
           return {
             kind: "response",
             matched,
+            pathnameEligible,
             response: validationResponseWithMiddlewareHeaders(validationResponse, options.context),
           };
         }
@@ -382,6 +403,7 @@ export async function applyAppMiddleware(
         return {
           kind: "response",
           matched,
+          pathnameEligible,
           response: await proxyExternalMiddlewareRewrite(
             externalRequest,
             result.rewriteUrl,
@@ -408,5 +430,12 @@ export async function applyAppMiddleware(
     processMiddlewareHeaders(options.context.headers);
   }
 
-  return { kind: "continue", cleanPathname, matched, rewritten, search };
+  return {
+    kind: "continue",
+    cleanPathname,
+    matched,
+    pathnameEligible,
+    rewritten,
+    search,
+  };
 }

--- a/packages/vinext/src/server/app-page-cache-finalizer.ts
+++ b/packages/vinext/src/server/app-page-cache-finalizer.ts
@@ -21,7 +21,7 @@ import { markFrameworkLinkHeaders } from "./app-response-header-provenance.js";
 import { deferUntilStreamConsumed } from "./defer-until-stream-consumed.js";
 import {
   deferRouteCacheability,
-  isRouteCacheabilityProbe,
+  isRouteCacheabilityEvaluation,
   type RouteCacheabilityOutcome,
 } from "vinext/shims/cacheability-classification";
 
@@ -175,7 +175,7 @@ function appPageCacheControlHeader(cacheControl: CacheControlMetadata): string {
     : buildRevalidateCacheControl(cacheControl.revalidate, cacheControl.expire);
 }
 
-function finalizeProbeAppPageResponse(
+function finalizeEvaluatedAppPageResponse(
   response: Response,
   options: {
     capturedDynamicUsageBeforeContextCleanup?: () => boolean;
@@ -187,7 +187,7 @@ function finalizeProbeAppPageResponse(
     revalidateSeconds: number | null;
   },
 ): Response | null {
-  if (!isRouteCacheabilityProbe()) return null;
+  if (!isRouteCacheabilityEvaluation()) return null;
   const complete = deferRouteCacheability();
   if (!complete) return response;
 
@@ -244,7 +244,7 @@ export function finalizeAppPageHtmlCacheResponse(
   response: Response,
   options: FinalizeAppPageHtmlCacheResponseOptions,
 ): Response {
-  const probeResponse = finalizeProbeAppPageResponse(response, options);
+  const probeResponse = finalizeEvaluatedAppPageResponse(response, options);
   if (probeResponse) {
     void options.capturedRscDataPromise?.catch(() => {});
     return probeResponse;
@@ -350,7 +350,7 @@ export function finalizeAppPageRscCacheResponse(
   response: Response,
   options: ScheduleAppPageRscCacheWriteOptions,
 ): Response {
-  const probeResponse = finalizeProbeAppPageResponse(response, options);
+  const probeResponse = finalizeEvaluatedAppPageResponse(response, options);
   if (probeResponse) {
     void options.capturedRscDataPromise?.catch(() => {});
     return probeResponse;

--- a/packages/vinext/src/server/app-page-cache-finalizer.ts
+++ b/packages/vinext/src/server/app-page-cache-finalizer.ts
@@ -20,6 +20,7 @@ import { readStreamAsText } from "../utils/text-stream.js";
 import { markFrameworkLinkHeaders } from "./app-response-header-provenance.js";
 import { deferUntilStreamConsumed } from "./defer-until-stream-consumed.js";
 import {
+  captureRouteCacheabilityResponsePolicy,
   deferRouteCacheability,
   isRouteCacheabilityEvaluation,
   type RouteCacheabilityOutcome,
@@ -192,6 +193,7 @@ function finalizeEvaluatedAppPageResponse(
   if (!isRouteCacheabilityEvaluation()) return null;
   const complete = deferRouteCacheability();
   if (!complete) return response;
+  captureRouteCacheabilityResponsePolicy(response.headers);
 
   let completed = false;
   const finish = (): void => {

--- a/packages/vinext/src/server/app-page-cache-finalizer.ts
+++ b/packages/vinext/src/server/app-page-cache-finalizer.ts
@@ -43,6 +43,16 @@ type BuildAppPageCacheRenderObservation = (input: {
   state: AppPageRenderObservationState;
 }) => RenderObservation;
 
+type FinalizeAppPageCacheabilityEvaluationOptions = {
+  capturedDynamicUsageBeforeContextCleanup?: () => boolean;
+  consumeDynamicUsage: () => boolean;
+  consumeRenderObservationState?: () => AppPageRenderObservationState;
+  getPageTags: () => string[];
+  getRequestCacheLife?: () => AppPageRequestCacheLife | null;
+  expireSeconds?: number;
+  revalidateSeconds: number | null;
+};
+
 type FinalizeAppPageHtmlCacheResponseOptions = {
   capturedDynamicUsageBeforeContextCleanup?: () => boolean;
   capturedRscDataPromise: Promise<ArrayBuffer> | null;
@@ -177,15 +187,7 @@ function appPageCacheControlHeader(cacheControl: CacheControlMetadata): string {
 
 function finalizeEvaluatedAppPageResponse(
   response: Response,
-  options: {
-    capturedDynamicUsageBeforeContextCleanup?: () => boolean;
-    consumeDynamicUsage: () => boolean;
-    consumeRenderObservationState?: () => AppPageRenderObservationState;
-    getPageTags: () => string[];
-    getRequestCacheLife?: () => AppPageRequestCacheLife | null;
-    expireSeconds?: number;
-    revalidateSeconds: number | null;
-  },
+  options: FinalizeAppPageCacheabilityEvaluationOptions,
 ): Response | null {
   if (!isRouteCacheabilityEvaluation()) return null;
   const complete = deferRouteCacheability();
@@ -238,6 +240,17 @@ function finalizeEvaluatedAppPageResponse(
     status: response.status,
     statusText: response.statusText,
   });
+}
+
+/**
+ * Complete probe/admission classification for an App Page response that does
+ * not enter the ISR cache-write path. Ordinary requests pass through unchanged.
+ */
+export function finalizeAppPageCacheabilityEvaluationResponse(
+  response: Response,
+  options: FinalizeAppPageCacheabilityEvaluationOptions,
+): Response {
+  return finalizeEvaluatedAppPageResponse(response, options) ?? response;
 }
 
 export function finalizeAppPageHtmlCacheResponse(

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -8,6 +8,7 @@ import { resolveClientStaleTimeSeconds } from "../utils/cache-control-metadata.j
 import { AppElementsWire, isAppElementsRecord, type AppOutgoingElements } from "./app-elements.js";
 import { hasDigest } from "./app-rsc-errors.js";
 import {
+  finalizeAppPageCacheabilityEvaluationResponse,
   finalizeAppPageHtmlCacheResponse,
   finalizeAppPageRscCacheResponse,
 } from "./app-page-cache-finalizer.js";
@@ -1297,7 +1298,7 @@ export async function renderAppPageLifecycle(
     });
   }
 
-  return buildAppPageHtmlResponse(safeHtmlStream, {
+  const response = buildAppPageHtmlResponse(safeHtmlStream, {
     cacheTags: options.isPrerender === true ? options.getPageTags() : undefined,
     draftCookie,
     linkHeader,
@@ -1306,6 +1307,25 @@ export async function renderAppPageLifecycle(
     policy: htmlResponsePolicy,
     requestCacheLife: requestCacheLifeForPrerender,
     timing: htmlResponseTiming,
+  });
+  return finalizeAppPageCacheabilityEvaluationResponse(response, {
+    capturedDynamicUsageBeforeContextCleanup() {
+      return dynamicUsedBeforeContextCleanup;
+    },
+    consumeDynamicUsage: consumeRenderDynamicUsage,
+    consumeRenderObservationState: options.consumeRenderObservationState,
+    getPageTags() {
+      return options.getPageTags();
+    },
+    getRequestCacheLife() {
+      return readRequestCacheLifeForCachePolicy(options);
+    },
+    expireSeconds,
+    revalidateSeconds: resolveAppPageCacheWriteRevalidateSeconds({
+      isDynamicError: options.isDynamicError,
+      isForceStatic: options.isForceStatic,
+      revalidateSeconds,
+    }),
   });
 }
 

--- a/packages/vinext/src/server/app-route-handler-dispatch.ts
+++ b/packages/vinext/src/server/app-route-handler-dispatch.ts
@@ -44,6 +44,10 @@ import {
 } from "./app-route-handler-execution.js";
 import { isKnownDynamicAppRoute, isValidHTTPMethod } from "./app-route-handler-runtime.js";
 import {
+  beginRouteCacheability,
+  getRouteCacheabilityDynamicReason,
+} from "vinext/shims/cacheability-classification";
+import {
   applyRouteHandlerMiddlewareContext,
   finalizeRouteHandlerResponse,
   type RouteHandlerMiddlewareContext,
@@ -169,6 +173,9 @@ export async function dispatchAppRouteHandler(
   const { route } = options;
   const handler = route.routeHandler;
   const method = options.request.method.toUpperCase();
+  if (method === "GET" || method === "HEAD") {
+    beginRouteCacheability("app-route", route.pattern);
+  }
   const revalidateSeconds = getAppRouteHandlerRevalidateSeconds(handler);
   const isDevelopment = options.isDevelopment ?? process.env.NODE_ENV === "development";
   const isProduction = options.isProduction ?? process.env.NODE_ENV === "production";
@@ -240,6 +247,7 @@ export async function dispatchAppRouteHandler(
 
   if (
     revalidateSeconds !== null &&
+    !getRouteCacheabilityDynamicReason() &&
     shouldReadAppRouteHandlerCache({
       dynamicConfig: handler.dynamic,
       handlerFn: resolvedHandlerFn,

--- a/packages/vinext/src/server/app-route-handler-execution.ts
+++ b/packages/vinext/src/server/app-route-handler-execution.ts
@@ -9,10 +9,7 @@ import type { CachedRouteValue } from "vinext/shims/cache-handler";
 import type { NextRequest } from "vinext/shims/server";
 import { _drainPendingRevalidations } from "vinext/shims/cache-request-state";
 import { runWithRootParamsUsage } from "vinext/shims/root-params";
-import {
-  applyCdnResponseHeaders,
-  NEVER_CACHE_CONTROL,
-} from "./cache-control.js";
+import { applyCdnResponseHeaders, NEVER_CACHE_CONTROL } from "./cache-control.js";
 import { isrCacheControl, type IsrWritePolicy } from "./isr-cache.js";
 import {
   createStaticGenerationHeadersContext,

--- a/packages/vinext/src/server/app-route-handler-execution.ts
+++ b/packages/vinext/src/server/app-route-handler-execution.ts
@@ -40,6 +40,8 @@ import {
 import {
   getRouteCacheabilityCaptureOptions,
   getRouteCacheabilityDynamicReason,
+  isRouteCacheabilityEvaluation,
+  markRouteCacheabilityFinalResponseUncacheable,
 } from "vinext/shims/cacheability-classification";
 import {
   CACHEABILITY_PROBE_BODY_LIMIT,
@@ -325,6 +327,7 @@ export async function executeAppRouteHandler(
         isProduction: options.isProduction,
         method: options.method,
         revalidateSeconds: options.revalidateSeconds,
+        requiresCompletedResponseAdmission: isRouteCacheabilityEvaluation(),
       })
     ) {
       const completed = await completeAppRouteHandlerResponse(response);
@@ -339,8 +342,16 @@ export async function executeAppRouteHandler(
 
     const requestCacheabilityVeto = getRouteCacheabilityDynamicReason();
     const responseMustStayPrivate = Boolean(
-      dynamicUsedInHandler || requestCacheabilityVeto || cleanupDeferredToBody,
+      options.handler.dynamic === "force-dynamic" ||
+      dynamicUsedInHandler ||
+      requestCacheabilityVeto ||
+      cleanupDeferredToBody,
     );
+    if (responseMustStayPrivate) {
+      markRouteCacheabilityFinalResponseUncacheable(
+        "Route Handler did not complete as a reusable static response",
+      );
+    }
 
     if (dynamicUsedInHandler) {
       markKnownDynamicAppRoute(options.routePattern);

--- a/packages/vinext/src/server/app-route-handler-execution.ts
+++ b/packages/vinext/src/server/app-route-handler-execution.ts
@@ -9,7 +9,11 @@ import type { CachedRouteValue } from "vinext/shims/cache-handler";
 import type { NextRequest } from "vinext/shims/server";
 import { _drainPendingRevalidations } from "vinext/shims/cache-request-state";
 import { runWithRootParamsUsage } from "vinext/shims/root-params";
-import { applyCdnResponseHeaders, NEVER_CACHE_CONTROL } from "./cache-control.js";
+import {
+  applyCdnResponseHeaders,
+  isNonCacheableCacheControl,
+  NEVER_CACHE_CONTROL,
+} from "./cache-control.js";
 import { isrCacheControl, type IsrWritePolicy } from "./isr-cache.js";
 import {
   createStaticGenerationHeadersContext,
@@ -448,7 +452,14 @@ export async function executeAppRouteHandler(
       ),
       shouldApplyDraftPolicy,
     );
-    if (responseMustStayPrivate) {
+    // Outside probe/admission, preserve an explicit handler-owned opt-out as
+    // Next.js does. During CDN evaluation the adapter must own the fail-closed
+    // policy so provider-specific public headers cannot survive alongside it.
+    const preserveHandlerNonCacheablePolicy =
+      !isRouteCacheabilityEvaluation() &&
+      handlerSetCacheControl &&
+      isNonCacheableCacheControl(finalized.headers.get("Cache-Control") ?? "");
+    if (responseMustStayPrivate && !preserveHandlerNonCacheablePolicy) {
       const headers = new Headers(finalized.headers);
       applyCdnResponseHeaders(headers, { cacheControl: NEVER_CACHE_CONTROL });
       finalized = new Response(finalized.body, {

--- a/packages/vinext/src/server/app-route-handler-execution.ts
+++ b/packages/vinext/src/server/app-route-handler-execution.ts
@@ -11,7 +11,6 @@ import { _drainPendingRevalidations } from "vinext/shims/cache-request-state";
 import { runWithRootParamsUsage } from "vinext/shims/root-params";
 import {
   applyCdnResponseHeaders,
-  isNonCacheableCacheControl,
   NEVER_CACHE_CONTROL,
 } from "./cache-control.js";
 import { isrCacheControl, type IsrWritePolicy } from "./isr-cache.js";
@@ -452,14 +451,11 @@ export async function executeAppRouteHandler(
       ),
       shouldApplyDraftPolicy,
     );
-    // Outside probe/admission, preserve an explicit handler-owned opt-out as
-    // Next.js does. During CDN evaluation the adapter must own the fail-closed
-    // policy so provider-specific public headers cannot survive alongside it.
-    const preserveHandlerNonCacheablePolicy =
-      !isRouteCacheabilityEvaluation() &&
-      handlerSetCacheControl &&
-      isNonCacheableCacheControl(finalized.headers.get("Cache-Control") ?? "");
-    if (responseMustStayPrivate && !preserveHandlerNonCacheablePolicy) {
+    // Next.js preserves a Route Handler's explicit Cache-Control even when the
+    // handler used request data. During CDN probe/admission the adapter still
+    // owns fail-closed policy until the completed response is authorized.
+    const preserveHandlerPolicy = !isRouteCacheabilityEvaluation() && handlerSetCacheControl;
+    if (responseMustStayPrivate && !preserveHandlerPolicy) {
       const headers = new Headers(finalized.headers);
       applyCdnResponseHeaders(headers, { cacheControl: NEVER_CACHE_CONTROL });
       finalized = new Response(finalized.body, {

--- a/packages/vinext/src/server/app-route-handler-execution.ts
+++ b/packages/vinext/src/server/app-route-handler-execution.ts
@@ -19,6 +19,7 @@ import {
   isPossibleAppRouteActionRequest,
   resolveAppRouteHandlerSpecialError,
   shouldApplyAppRouteHandlerRevalidateHeader,
+  shouldCompleteAppRouteHandlerResponse,
   shouldWriteAppRouteHandlerCache,
   type AppRouteHandlerModule,
 } from "./app-route-handler-policy.js";
@@ -36,6 +37,14 @@ import {
   createTrackedAppRouteRequest,
   markKnownDynamicAppRoute,
 } from "./app-route-handler-runtime.js";
+import {
+  getRouteCacheabilityCaptureOptions,
+  getRouteCacheabilityDynamicReason,
+} from "vinext/shims/cacheability-classification";
+import {
+  CACHEABILITY_PROBE_BODY_LIMIT,
+  CACHEABILITY_PROBE_TIMEOUT_MS,
+} from "./cacheability-limits.js";
 
 export type AppRouteParams = Record<string, string | string[]>;
 export type AppRouteDynamicUsageFn = () => boolean;
@@ -89,9 +98,92 @@ type RunAppRouteHandlerOptions = {
 };
 
 type RunAppRouteHandlerResult = {
+  didAccessDynamicRequest: () => boolean;
   dynamicUsedInHandler: boolean;
   response: Response;
 };
+
+type CompletedAppRouteHandlerResponse = {
+  completed: boolean;
+  response: Response;
+};
+
+async function completeAppRouteHandlerResponse(
+  response: Response,
+): Promise<CompletedAppRouteHandlerResponse> {
+  // Match Next.js static App Route generation: resolve only after clean EOF,
+  // then rebuild the response from the completed body. Besides making the ISR
+  // artifact deterministic, this keeps request tracking active for stream
+  // pulls and turns a late body failure into the normal Route Handler error
+  // path before cacheable response headers are applied.
+  // Workers cannot safely buffer an unbounded or never-ending response. Reuse
+  // admission's isolate-wide bounded capture and fall back to private streaming
+  // when the response exceeds either the size or completion deadline.
+  const { captureCacheabilityAdmissionBody } = await import("./cacheability-request.js");
+  const captureOptions = getRouteCacheabilityCaptureOptions();
+  const captured = await captureCacheabilityAdmissionBody(
+    response.body,
+    captureOptions?.captureDeadlineAt ?? Date.now() + CACHEABILITY_PROBE_TIMEOUT_MS,
+    CACHEABILITY_PROBE_BODY_LIMIT,
+    captureOptions?.captureBudget,
+  );
+  const completed = new Response(captured.body, {
+    headers: response.headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
+  copyLinkHeaderProvenance(response.headers, completed.headers);
+  return { completed: captured.kind === "captured", response: completed };
+}
+
+function deferAppRouteHandlerCleanup(response: Response, cleanup: () => Promise<void>): Response {
+  if (!response.body) {
+    void cleanup();
+    return response;
+  }
+
+  const reader = response.body.getReader();
+  let cleaned = false;
+  const cleanOnce = async () => {
+    if (cleaned) return;
+    cleaned = true;
+    reader.releaseLock();
+    await cleanup();
+  };
+  const body = new ReadableStream<Uint8Array>(
+    {
+      async pull(controller) {
+        try {
+          const result = await reader.read();
+          if (result.done) {
+            await cleanOnce();
+            controller.close();
+          } else {
+            controller.enqueue(result.value);
+          }
+        } catch (error) {
+          await cleanOnce();
+          controller.error(error);
+        }
+      },
+      async cancel(reason) {
+        try {
+          await reader.cancel(reason);
+        } finally {
+          await cleanOnce();
+        }
+      },
+    },
+    { highWaterMark: 0 },
+  );
+  const deferred = new Response(body, {
+    headers: response.headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
+  copyLinkHeaderProvenance(response.headers, deferred.headers);
+  return deferred;
+}
 
 export function applyDraftModeCachePolicy(response: Response, isDraftMode: boolean): Response {
   if (!isDraftMode) return response;
@@ -184,8 +276,10 @@ export async function runAppRouteHandler(
       }),
   );
 
+  const dynamicUsedInContext = options.consumeDynamicUsage();
   return {
-    dynamicUsedInHandler: options.consumeDynamicUsage(),
+    didAccessDynamicRequest: () => trackedRequest.didAccessDynamicRequest(),
+    dynamicUsedInHandler: trackedRequest.didAccessDynamicRequest() || dynamicUsedInContext,
     response,
   };
 }
@@ -194,6 +288,7 @@ export async function executeAppRouteHandler(
   options: ExecuteAppRouteHandlerOptions,
 ): Promise<Response> {
   const previousHeadersPhase = options.setHeadersAccessPhase("route-handler");
+  let cleanupDeferredToBody = false;
   const middlewareMergeOptions = {
     appendResponseLink:
       options.handler.runtime === "edge" || options.handler.runtime === "experimental-edge",
@@ -212,16 +307,48 @@ export async function executeAppRouteHandler(
       // finalization clears the request context.
       await _drainPendingRevalidations();
     }
-    const { dynamicUsedInHandler, response } = handlerResult;
+    let { dynamicUsedInHandler, response } = handlerResult;
     assertSupportedAppRouteHandlerResponse(response);
     const handlerSetCacheControl = response.headers.has("cache-control");
+
+    const draftModeBeforeCompletion =
+      options.getActiveDraftModeState?.() ?? options.isDraftMode === true;
+    const handlerDraftCookieBeforeCompletion =
+      options.getDraftModeCookieHeader() ?? options.initialDraftModeCookie;
+    if (
+      shouldCompleteAppRouteHandlerResponse({
+        dynamicConfig: options.handler.dynamic,
+        dynamicUsedInHandler,
+        handlerSetCacheControl,
+        isAutoHead: options.isAutoHead,
+        isDraftMode: draftModeBeforeCompletion || handlerDraftCookieBeforeCompletion != null,
+        isProduction: options.isProduction,
+        method: options.method,
+        revalidateSeconds: options.revalidateSeconds,
+      })
+    ) {
+      const completed = await completeAppRouteHandlerResponse(response);
+      response = completed.response;
+      cleanupDeferredToBody = !completed.completed;
+      const dynamicUsedDuringCompletion = options.consumeDynamicUsage();
+      dynamicUsedInHandler =
+        handlerResult.didAccessDynamicRequest() ||
+        dynamicUsedDuringCompletion ||
+        dynamicUsedInHandler;
+    }
+
+    const requestCacheabilityVeto = getRouteCacheabilityDynamicReason();
+    const responseMustStayPrivate = Boolean(
+      dynamicUsedInHandler || requestCacheabilityVeto || cleanupDeferredToBody,
+    );
 
     if (dynamicUsedInHandler) {
       markKnownDynamicAppRoute(options.routePattern);
     }
 
     const pendingCookies = options.getAndClearPendingCookies();
-    const handlerDraftCookie = options.getDraftModeCookieHeader();
+    const handlerDraftCookie =
+      options.getDraftModeCookieHeader() ?? handlerDraftCookieBeforeCompletion;
     const draftCookie = handlerDraftCookie ?? options.initialDraftModeCookie;
     const activeDraftMode = options.getActiveDraftModeState?.() ?? options.isDraftMode === true;
     const shouldApplyDraftPolicy = activeDraftMode || draftCookie != null;
@@ -242,7 +369,7 @@ export async function executeAppRouteHandler(
 
     if (
       shouldApplyAppRouteHandlerRevalidateHeader({
-        dynamicUsedInHandler,
+        dynamicUsedInHandler: responseMustStayPrivate,
         handlerSetCacheControl,
         isAutoHead: options.isAutoHead,
         isDraftMode: shouldApplyDraftPolicy,
@@ -265,7 +392,7 @@ export async function executeAppRouteHandler(
     if (
       shouldWriteAppRouteHandlerCache({
         dynamicConfig: options.handler.dynamic,
-        dynamicUsedInHandler,
+        dynamicUsedInHandler: responseMustStayPrivate,
         handlerSetCacheControl,
         isAutoHead: options.isAutoHead,
         isDraftMode: shouldApplyDraftPolicy,
@@ -298,9 +425,7 @@ export async function executeAppRouteHandler(
       options.executionContext?.waitUntil(routeWritePromise);
     }
 
-    options.clearRequestContext();
-
-    return applyDraftModeCachePolicy(
+    let finalized = applyDraftModeCachePolicy(
       applyRouteHandlerMiddlewareContext(
         finalizeRouteHandlerResponse(response, {
           pendingCookies,
@@ -312,6 +437,31 @@ export async function executeAppRouteHandler(
       ),
       shouldApplyDraftPolicy,
     );
+    if (responseMustStayPrivate) {
+      const headers = new Headers(finalized.headers);
+      applyCdnResponseHeaders(headers, { cacheControl: NEVER_CACHE_CONTROL });
+      finalized = new Response(finalized.body, {
+        headers,
+        status: finalized.status,
+        statusText: finalized.statusText,
+      });
+      copyLinkHeaderProvenance(response.headers, finalized.headers);
+    }
+
+    if (!cleanupDeferredToBody) {
+      options.clearRequestContext();
+      return finalized;
+    }
+
+    return deferAppRouteHandlerCleanup(finalized, async () => {
+      try {
+        await _drainPendingRevalidations();
+        options.consumeDynamicUsage();
+      } finally {
+        options.clearRequestContext();
+        options.setHeadersAccessPhase(previousHeadersPhase);
+      }
+    });
   } catch (error) {
     const pendingCookies = options.getAndClearPendingCookies();
     const handlerDraftCookie = options.getDraftModeCookieHeader();
@@ -382,6 +532,6 @@ export async function executeAppRouteHandler(
       shouldApplyDraftPolicy,
     );
   } finally {
-    options.setHeadersAccessPhase(previousHeadersPhase);
+    if (!cleanupDeferredToBody) options.setHeadersAccessPhase(previousHeadersPhase);
   }
 }

--- a/packages/vinext/src/server/app-route-handler-policy.ts
+++ b/packages/vinext/src/server/app-route-handler-policy.ts
@@ -45,6 +45,7 @@ type AppRouteHandlerResponseCacheOptions = {
   isProduction: boolean;
   method: string;
   revalidateSeconds: number | null;
+  requiresCompletedResponseAdmission?: boolean;
 };
 
 type AppRouteHandlerSpecialError =
@@ -170,8 +171,8 @@ export function shouldCompleteAppRouteHandlerResponse(
 ): boolean {
   return (
     options.isProduction &&
-    options.revalidateSeconds !== null &&
-    options.revalidateSeconds > 0 &&
+    ((options.revalidateSeconds !== null && options.revalidateSeconds > 0) ||
+      options.requiresCompletedResponseAdmission === true) &&
     options.dynamicConfig !== "force-dynamic" &&
     !options.isDraftMode &&
     !options.dynamicUsedInHandler &&

--- a/packages/vinext/src/server/app-route-handler-policy.ts
+++ b/packages/vinext/src/server/app-route-handler-policy.ts
@@ -10,6 +10,7 @@ export { isPossibleAppRouteActionRequest } from "./app-action-request.js";
 export type AppRouteHandlerModule = {
   dynamic?: string;
   fetchCache?: unknown;
+  generateStaticParams?: unknown;
   revalidate?: unknown;
   runtime?: string;
 } & RouteHandlerModule;
@@ -62,7 +63,7 @@ type AppRouteHandlerSpecialErrorOptions = {
 };
 
 export function getAppRouteHandlerRevalidateSeconds(
-  handler: Pick<AppRouteHandlerModule, "revalidate">,
+  handler: Pick<AppRouteHandlerModule, "dynamic" | "generateStaticParams" | "revalidate">,
 ): number | null {
   // 0 is a meaningful value ("never cache") and must be preserved so the
   // header path can emit a no-store Cache-Control.
@@ -70,10 +71,24 @@ export function getAppRouteHandlerRevalidateSeconds(
   // parity) — return Infinity to signal the cache-later path.
   const { revalidate } = handler;
   if (revalidate === false) return Infinity;
-  if (typeof revalidate !== "number" || !Number.isFinite(revalidate) || revalidate < 0) {
+  if (typeof revalidate === "number" && Number.isFinite(revalidate) && revalidate >= 0) {
+    return revalidate;
+  }
+  if (revalidate !== undefined) {
     return null;
   }
-  return revalidate;
+
+  // Ported from Next.js static eligibility:
+  // packages/next/src/server/route-modules/app-route/helpers/is-static-gen-enabled.ts
+  if (
+    handler.dynamic === "force-static" ||
+    handler.dynamic === "error" ||
+    typeof handler.generateStaticParams === "function"
+  ) {
+    return Infinity;
+  }
+
+  return null;
 }
 
 export function hasAppRouteHandlerDefaultExport(handler: RouteHandlerModule): boolean {
@@ -141,6 +156,26 @@ export function shouldApplyAppRouteHandlerRevalidateHeader(
     !options.dynamicUsedInHandler &&
     (options.method === "GET" || options.isAutoHead) &&
     !options.handlerSetCacheControl
+  );
+}
+
+/**
+ * Next.js consumes the full body before completing static generation for an
+ * App Route. Keep that completion boundary for every response that can still
+ * receive a public framework cache policy, including
+ * `revalidate = false` (represented by Infinity).
+ */
+export function shouldCompleteAppRouteHandlerResponse(
+  options: AppRouteHandlerResponseCacheOptions,
+): boolean {
+  return (
+    options.isProduction &&
+    options.revalidateSeconds !== null &&
+    options.revalidateSeconds > 0 &&
+    options.dynamicConfig !== "force-dynamic" &&
+    !options.isDraftMode &&
+    !options.dynamicUsedInHandler &&
+    (options.method === "GET" || options.isAutoHead)
   );
 }
 

--- a/packages/vinext/src/server/app-router-entry.ts
+++ b/packages/vinext/src/server/app-router-entry.ts
@@ -147,8 +147,8 @@ async function handleRequest(
     getCdnCacheAdapter().requiresCompletedResponseAdmission === true;
   if (
     !finalizeCacheabilityResponse &&
-    isPotentialCompletedAdmissionRequest(request) &&
-    (__rscCacheabilityManifest || requiresCompletedResponseAdmission)
+    (__rscCacheabilityManifest || requiresCompletedResponseAdmission) &&
+    isPotentialCompletedAdmissionRequest(request)
   ) {
     const cacheability = await import("./cacheability-request.js");
     const admissionContext = cacheability.createWorkerCacheabilityAdmissionContext(

--- a/packages/vinext/src/server/app-router-entry.ts
+++ b/packages/vinext/src/server/app-router-entry.ts
@@ -26,6 +26,7 @@ import "./server-globals.js";
 import rscHandler, {
   __assetPrefix as __rscAssetPrefix,
   __basePath as __rscBasePath,
+  __cacheabilityManifest as __rscCacheabilityManifest,
   __imageAllowedWidths as __rscImageAllowedWidths,
   __imageConfig as __rscImageConfig,
   __prerenderSecret as __rscPrerenderSecret,
@@ -123,6 +124,19 @@ async function handleRequest(
     );
     if (probeContext !== ctx) {
       ctx = probeContext;
+      finalizeCacheabilityResponse = cacheability.finalizeWorkerCacheabilityResponse;
+    }
+  }
+  if (!finalizeCacheabilityResponse && __rscCacheabilityManifest) {
+    const cacheability = await import("./cacheability-request.js");
+    const admissionContext = cacheability.createWorkerCacheabilityAdmissionContext(
+      ctx,
+      request,
+      __rscCacheabilityManifest,
+      process.env.__VINEXT_BUILD_ID,
+    );
+    if (admissionContext !== ctx) {
+      ctx = admissionContext;
       finalizeCacheabilityResponse = cacheability.finalizeWorkerCacheabilityResponse;
     }
   }

--- a/packages/vinext/src/server/app-router-entry.ts
+++ b/packages/vinext/src/server/app-router-entry.ts
@@ -56,7 +56,6 @@ import {
 import {
   NEXT_ACTION_HEADER,
   RSC_ACTION_HEADER,
-  RSC_HEADER,
   VINEXT_CACHEABILITY_PROBE_HEADER,
   VINEXT_PRERENDER_ROUTE_PARAMS_HEADER,
   VINEXT_PRERENDER_SECRET_HEADER,
@@ -93,9 +92,7 @@ function isPotentialCompletedAdmissionRequest(request: Request): boolean {
   if (request.method !== "GET" && request.method !== "HEAD") return false;
   if (request.headers.has(NEXT_ACTION_HEADER) || request.headers.has(RSC_ACTION_HEADER))
     return false;
-  if (request.headers.get(RSC_HEADER) === "1") return true;
-  if (request.headers.get("Accept")?.toLowerCase().includes("text/html")) return true;
-  return new URL(request.url).pathname.endsWith(".rsc");
+  return true;
 }
 
 export default {

--- a/packages/vinext/src/server/app-router-entry.ts
+++ b/packages/vinext/src/server/app-router-entry.ts
@@ -32,6 +32,7 @@ import rscHandler, {
   __prerenderSecret as __rscPrerenderSecret,
 } from "virtual:vinext-rsc-entry";
 import { runWithExecutionContext, type ExecutionContextLike } from "vinext/shims/request-context";
+import { getCdnCacheAdapter } from "vinext/shims/cdn-cache";
 // @ts-expect-error -- virtual module resolved by vinext at build time
 import { registerConfiguredCacheAdapters } from "virtual:vinext-cache-adapters";
 import { applyCdnResponseIdentityHeaders, validateCdnRequest } from "./cache-control.js";
@@ -53,6 +54,9 @@ import {
   isOpenRedirectShaped,
 } from "./request-pipeline.js";
 import {
+  NEXT_ACTION_HEADER,
+  RSC_ACTION_HEADER,
+  RSC_HEADER,
   VINEXT_CACHEABILITY_PROBE_HEADER,
   VINEXT_PRERENDER_ROUTE_PARAMS_HEADER,
   VINEXT_PRERENDER_SECRET_HEADER,
@@ -85,6 +89,15 @@ type WorkerAssetEnv = {
   };
 };
 
+function isPotentialCompletedAdmissionRequest(request: Request): boolean {
+  if (request.method !== "GET" && request.method !== "HEAD") return false;
+  if (request.headers.has(NEXT_ACTION_HEADER) || request.headers.has(RSC_ACTION_HEADER))
+    return false;
+  if (request.headers.get(RSC_HEADER) === "1") return true;
+  if (request.headers.get("Accept")?.toLowerCase().includes("text/html")) return true;
+  return new URL(request.url).pathname.endsWith(".rsc");
+}
+
 export default {
   async fetch(
     request: Request,
@@ -109,6 +122,9 @@ async function handleRequest(
     : createWorkerRevalidationContext(platformCtx, (internalRequest, internalCtx) =>
         handleRequest(internalRequest, env, internalCtx),
       );
+  // Registration must precede admission setup: the active adapter declares
+  // whether a completed response is required before public cache headers.
+  registerConfiguredCacheAdapters(env as Record<string, unknown> | undefined);
   let ctx = createWorkerPrerenderDiscoveryContext(requestCtx, request, __rscPrerenderSecret);
   let finalizeCacheabilityResponse:
     | ((response: Response, ctx: ExecutionContextLike) => Promise<Response>)
@@ -127,13 +143,20 @@ async function handleRequest(
       finalizeCacheabilityResponse = cacheability.finalizeWorkerCacheabilityResponse;
     }
   }
-  if (!finalizeCacheabilityResponse && __rscCacheabilityManifest) {
+  const requiresCompletedResponseAdmission =
+    getCdnCacheAdapter().requiresCompletedResponseAdmission === true;
+  if (
+    !finalizeCacheabilityResponse &&
+    isPotentialCompletedAdmissionRequest(request) &&
+    (__rscCacheabilityManifest || requiresCompletedResponseAdmission)
+  ) {
     const cacheability = await import("./cacheability-request.js");
     const admissionContext = cacheability.createWorkerCacheabilityAdmissionContext(
       ctx,
       request,
       __rscCacheabilityManifest,
       process.env.__VINEXT_BUILD_ID,
+      requiresCompletedResponseAdmission,
     );
     if (admissionContext !== ctx) {
       ctx = admissionContext;
@@ -141,8 +164,8 @@ async function handleRequest(
     }
   }
 
-  // Register config-driven cache adapters before any rendering touches the cache.
-  registerConfiguredCacheAdapters(env as Record<string, unknown> | undefined);
+  // Register the image adapter before rendering can touch it. Cache adapters
+  // were registered above because cacheability admission depends on them.
   registerConfiguredImageOptimizer(env as Record<string, unknown> | undefined);
 
   const cdnValidationResponse = await validateCdnRequest(request);

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -107,7 +107,10 @@ import {
   type AppRouteTreePrefetchRoute,
   type PrefetchInliningConfig,
 } from "./app-route-tree-prefetch.js";
-import { markRouteCacheabilityDynamic } from "vinext/shims/cacheability-classification";
+import {
+  markRouteCacheabilityDynamic,
+  preserveRouteCacheabilityResponsePolicy,
+} from "vinext/shims/cacheability-classification";
 
 type AppPageParams = Record<string, string | string[]>;
 type RequestContext = ReturnType<typeof requestContextFromRequest>;
@@ -1496,6 +1499,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
             url,
           })) ?? null)
         : null;
+    if (response) preserveRouteCacheabilityResponsePolicy();
     if (!response || !pagesDataRequest || resolvedUrl === originalResolvedUrl) return response;
 
     const headers = new Headers(response.headers);

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -120,18 +120,29 @@ type RootParamNamesMap = AppPrerenderRootParamNamesMap;
 
 type AppRscMiddlewareContext = AppMiddlewareContext;
 
-function rewriteUsesUnkeyedRequestCondition(rewrite: NextRewrite): boolean {
-  return [...(rewrite.has ?? []), ...(rewrite.missing ?? [])].some(
-    (condition) => condition.type === "header" || condition.type === "cookie",
+function ruleUsesUnkeyedRequestCondition(rule: NextRedirect | NextRewrite): boolean {
+  return [...(rule.has ?? []), ...(rule.missing ?? [])].some(
+    (condition) =>
+      condition.type === "header" || condition.type === "cookie" || condition.type === "host",
   );
 }
 
 function markConditionalRewriteCacheability(rewrite: NextRewrite): void {
-  if (rewriteUsesUnkeyedRequestCondition(rewrite)) {
-    // Query values are already part of the public CDN key and hostnames are
-    // isolated by the platform. Headers and cookies are neither, so a rewrite
-    // selected by either cannot publish its destination under the source URL.
-    markRouteCacheabilityDynamic("next.config rewrite depends on request headers or cookies");
+  if (ruleUsesUnkeyedRequestCondition(rewrite)) {
+    // Query values are already part of the public Workers Cache key. Headers,
+    // cookies, and hostnames are not, so a rewrite selected by any of them
+    // cannot publish its destination under the source URL.
+    markRouteCacheabilityDynamic(
+      "next.config rewrite depends on request headers, cookies, or hostnames",
+    );
+  }
+}
+
+function markConditionalRedirectCacheability(redirect: NextRedirect): void {
+  if (ruleUsesUnkeyedRequestCondition(redirect)) {
+    markRouteCacheabilityDynamic(
+      "next.config redirect depends on request headers, cookies, or hostnames",
+    );
   }
 }
 
@@ -505,6 +516,7 @@ async function applyRewrite(
     options.requestContext,
     options.basePathState,
     options.paramsPathname,
+    markConditionalRewriteCacheability,
   );
   if (!rewritten) return null;
 
@@ -847,6 +859,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
         options.configRedirects,
         preMiddlewareRequestContext,
         basePathState,
+        markConditionalRedirectCacheability,
       )
     : null;
   if (configMatchers && redirect) {
@@ -983,7 +996,6 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     );
     if (beforeFilesRewrite instanceof Response) return beforeFilesRewrite;
     if (beforeFilesRewrite) {
-      markConditionalRewriteCacheability(rewrite);
       resolvedUrl = mergeRewriteQuery(resolvedUrl, beforeFilesRewrite);
       cleanPathname = pathnameForResolvedUrl(resolvedUrl);
       cleanPathnameIsRequestPathname = false;
@@ -1024,7 +1036,6 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
       );
       if (rewritten instanceof Response) return rewritten;
       if (!rewritten) continue;
-      markConditionalRewriteCacheability(rewrite);
       resolvedUrl = mergeRewriteQuery(resolvedUrl, rewritten);
       cleanPathname = pathnameForResolvedUrl(resolvedUrl);
       cleanPathnameIsRequestPathname = false;
@@ -1054,7 +1065,6 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
         );
         if (rewritten instanceof Response) return rewritten;
         if (!rewritten) continue;
-        markConditionalRewriteCacheability(rewrite);
         resolvedUrl = mergeRewriteQuery(resolvedUrl, rewritten);
         cleanPathname = pathnameForResolvedUrl(resolvedUrl);
         cleanPathnameIsRequestPathname = false;
@@ -1527,7 +1537,6 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
         return afterFilesRewrite;
       }
       if (!afterFilesRewrite) continue;
-      markConditionalRewriteCacheability(rewrite);
       resolvedUrl = mergeRewriteQuery(resolvedUrl, afterFilesRewrite);
       cleanPathname = pathnameForResolvedUrl(resolvedUrl);
       cleanPathnameIsRequestPathname = false;
@@ -1582,7 +1591,6 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
         return fallbackRewrite;
       }
       if (!fallbackRewrite) continue;
-      markConditionalRewriteCacheability(rewrite);
       resolvedUrl = mergeRewriteQuery(resolvedUrl, fallbackRewrite);
       cleanPathname = pathnameForResolvedUrl(resolvedUrl);
       cleanPathnameIsRequestPathname = false;

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -120,6 +120,21 @@ type RootParamNamesMap = AppPrerenderRootParamNamesMap;
 
 type AppRscMiddlewareContext = AppMiddlewareContext;
 
+function rewriteUsesUnkeyedRequestCondition(rewrite: NextRewrite): boolean {
+  return [...(rewrite.has ?? []), ...(rewrite.missing ?? [])].some(
+    (condition) => condition.type === "header" || condition.type === "cookie",
+  );
+}
+
+function markConditionalRewriteCacheability(rewrite: NextRewrite): void {
+  if (rewriteUsesUnkeyedRequestCondition(rewrite)) {
+    // Query values are already part of the public CDN key and hostnames are
+    // isolated by the platform. Headers and cookies are neither, so a rewrite
+    // selected by either cannot publish its destination under the source URL.
+    markRouteCacheabilityDynamic("next.config rewrite depends on request headers or cookies");
+  }
+}
+
 function haveSameRequestCookies(
   first: ReadonlyMap<string, string>,
   second: ReadonlyMap<string, string>,
@@ -964,6 +979,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     );
     if (beforeFilesRewrite instanceof Response) return beforeFilesRewrite;
     if (beforeFilesRewrite) {
+      markConditionalRewriteCacheability(rewrite);
       resolvedUrl = mergeRewriteQuery(resolvedUrl, beforeFilesRewrite);
       cleanPathname = pathnameForResolvedUrl(resolvedUrl);
       cleanPathnameIsRequestPathname = false;
@@ -1004,6 +1020,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
       );
       if (rewritten instanceof Response) return rewritten;
       if (!rewritten) continue;
+      markConditionalRewriteCacheability(rewrite);
       resolvedUrl = mergeRewriteQuery(resolvedUrl, rewritten);
       cleanPathname = pathnameForResolvedUrl(resolvedUrl);
       cleanPathnameIsRequestPathname = false;
@@ -1033,6 +1050,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
         );
         if (rewritten instanceof Response) return rewritten;
         if (!rewritten) continue;
+        markConditionalRewriteCacheability(rewrite);
         resolvedUrl = mergeRewriteQuery(resolvedUrl, rewritten);
         cleanPathname = pathnameForResolvedUrl(resolvedUrl);
         cleanPathnameIsRequestPathname = false;
@@ -1501,6 +1519,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
         return afterFilesRewrite;
       }
       if (!afterFilesRewrite) continue;
+      markConditionalRewriteCacheability(rewrite);
       resolvedUrl = mergeRewriteQuery(resolvedUrl, afterFilesRewrite);
       cleanPathname = pathnameForResolvedUrl(resolvedUrl);
       cleanPathnameIsRequestPathname = false;
@@ -1555,6 +1574,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
         return fallbackRewrite;
       }
       if (!fallbackRewrite) continue;
+      markConditionalRewriteCacheability(rewrite);
       resolvedUrl = mergeRewriteQuery(resolvedUrl, fallbackRewrite);
       cleanPathname = pathnameForResolvedUrl(resolvedUrl);
       cleanPathnameIsRequestPathname = false;

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -914,12 +914,16 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
       request: userlandRequest,
       validateExternalRewriteRequest: () => validateClaimedOutsideBasePathRsc(true),
     });
-    if (middlewareResult.matched) {
+    if (middlewareResult.pathnameEligible) {
       // Next.js runs matched middleware before serving a page response. A CDN
       // HIT in front of this Worker would skip that request-specific boundary,
       // so this architecture must remain private until middleware is isolated
       // into an uncached outer stage.
-      markRouteCacheabilityDynamic("middleware matched this request");
+      markRouteCacheabilityDynamic(
+        middlewareResult.matched
+          ? "middleware matched this request"
+          : "middleware is eligible for this pathname",
+      );
     }
     if (middlewareResult.kind === "response") {
       if (request.body && !request.body.locked) {
@@ -1277,8 +1281,12 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
         void sourceRequest.body.cancel().catch(() => {});
       }
     }
-    if (sourceMiddlewareResult.matched) {
-      markRouteCacheabilityDynamic("middleware matched this request");
+    if (sourceMiddlewareResult.pathnameEligible) {
+      markRouteCacheabilityDynamic(
+        sourceMiddlewareResult.matched
+          ? "middleware matched this request"
+          : "middleware is eligible for this pathname",
+      );
     }
     if (sourceMiddlewareResult.kind === "response") {
       options.clearRequestContext();

--- a/packages/vinext/src/server/app-rsc-response-finalizer.ts
+++ b/packages/vinext/src/server/app-rsc-response-finalizer.ts
@@ -13,6 +13,7 @@ import { hasBasePath, stripBasePath } from "../utils/base-path.js";
 import { normalizeDefaultLocalePathname } from "./pages-i18n.js";
 import { sanitizeMethodNotAllowedHeaders } from "./http-error-responses.js";
 import { hasPostConfigLinkHeaders } from "./app-response-header-provenance.js";
+import { captureRouteCacheabilityResponsePolicy } from "vinext/shims/cacheability-classification";
 
 type FinalizeAppRscResponseOptions = {
   basePath: string;
@@ -123,6 +124,11 @@ export async function finalizeAppRscResponse(
   // already applied. Redirects are already skipped above.
   if (!response.headers.has("Cache-Control")) {
     applyCdnResponseHeaders(response.headers, { cacheControl: "" });
+    // This is the adapter's fail-closed provisional policy, not an
+    // application opt-out. Admission may replace it only after the body has
+    // completed and the render has proved reusable. Capture before config
+    // headers run so any later private/no-store override still vetoes.
+    captureRouteCacheabilityResponsePolicy(response.headers);
   }
 
   if (configHeadersAlreadyApplied.has(response)) {

--- a/packages/vinext/src/server/cache-control.ts
+++ b/packages/vinext/src/server/cache-control.ts
@@ -3,6 +3,7 @@ import {
   isNonCacheableCacheControl,
   type CdnCacheableHeaderInput,
 } from "vinext/shims/cdn-cache";
+import { mergeVaryHeader } from "./middleware-response-headers.js";
 
 export { isNonCacheableCacheControl } from "vinext/shims/cdn-cache";
 
@@ -73,6 +74,10 @@ export function applyCdnResponseHeaders(headers: Headers, input: CdnCacheableHea
     // origin-managed adapter), in which case the header should stay absent
     // rather than being emitted as a blank value.
     if (value === "") continue;
+    if (name.toLowerCase() === "vary") {
+      mergeVaryHeader(headers, value);
+      continue;
+    }
     headers.set(name, value);
   }
   if (useNextDeployPolicy) {

--- a/packages/vinext/src/server/cache-control.ts
+++ b/packages/vinext/src/server/cache-control.ts
@@ -3,7 +3,6 @@ import {
   isNonCacheableCacheControl,
   type CdnCacheableHeaderInput,
 } from "vinext/shims/cdn-cache";
-import { mergeVaryHeader } from "./middleware-response-headers.js";
 
 export { isNonCacheableCacheControl } from "vinext/shims/cdn-cache";
 
@@ -74,10 +73,6 @@ export function applyCdnResponseHeaders(headers: Headers, input: CdnCacheableHea
     // origin-managed adapter), in which case the header should stay absent
     // rather than being emitted as a blank value.
     if (value === "") continue;
-    if (name.toLowerCase() === "vary") {
-      mergeVaryHeader(headers, value);
-      continue;
-    }
     headers.set(name, value);
   }
   if (useNextDeployPolicy) {

--- a/packages/vinext/src/server/cacheability-limits.ts
+++ b/packages/vinext/src/server/cacheability-limits.ts
@@ -1,5 +1,8 @@
 /** Maximum response body that an authenticated cacheability probe will drain. */
 export const CACHEABILITY_PROBE_BODY_LIMIT = 4 * 1024 * 1024;
 
+/** Maximum completed-response capture retained across concurrent isolate requests. */
+export const CACHEABILITY_ADMISSION_ISOLATE_BODY_LIMIT = 16 * 1024 * 1024;
+
 /** Leave headroom below the deploy-side request timeout for a fail-closed envelope. */
 export const CACHEABILITY_PROBE_TIMEOUT_MS = 20_000;

--- a/packages/vinext/src/server/cacheability-manifest.ts
+++ b/packages/vinext/src/server/cacheability-manifest.ts
@@ -1,0 +1,189 @@
+import {
+  NEXT_ACTION_HEADER,
+  NEXT_ROUTER_PREFETCH_HEADER,
+  NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
+  NEXT_ROUTER_STATE_TREE_HEADER,
+  NEXT_URL_HEADER,
+  RSC_ACTION_HEADER,
+  RSC_HEADER,
+  VINEXT_INTERCEPTION_CONTEXT_HEADER,
+  VINEXT_INTERCEPTION_ID_HEADER,
+  VINEXT_MOUNTED_SLOTS_HEADER,
+  VINEXT_RSC_RENDER_MODE_HEADER,
+  VINEXT_RSC_STATE_FINGERPRINT_HEADER,
+} from "./headers.js";
+import { APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL } from "./app-rsc-render-mode.js";
+
+export type CacheabilityRepresentation = "html" | "rsc-full" | "rsc-loading-shell";
+type CacheabilityManifestRouteState =
+  | "static-candidate"
+  | "runtime-check"
+  | "dynamic"
+  | "probe-failed";
+
+export type CacheabilityManifestRoute = {
+  kind: "app-page";
+  pattern: string;
+  representation: CacheabilityRepresentation;
+  requestKey: string;
+  state: CacheabilityManifestRouteState;
+  status: number;
+};
+
+export type CacheabilityManifest = {
+  buildId: string;
+  routes: Record<string, CacheabilityManifestRoute>;
+  version: 1;
+};
+
+export function cacheabilityManifestRouteKey(
+  kind: CacheabilityManifestRoute["kind"],
+  pattern: string,
+  representation: CacheabilityRepresentation,
+  requestKey: string,
+): string {
+  return JSON.stringify([kind, pattern, representation, requestKey]);
+}
+
+function isRepresentation(value: unknown): value is CacheabilityRepresentation {
+  return value === "html" || value === "rsc-full" || value === "rsc-loading-shell";
+}
+
+function isRouteState(value: unknown): value is CacheabilityManifestRouteState {
+  return (
+    value === "static-candidate" ||
+    value === "runtime-check" ||
+    value === "dynamic" ||
+    value === "probe-failed"
+  );
+}
+
+function parseRoute(key: string, value: unknown): CacheabilityManifestRoute | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const route = value as Record<string, unknown>;
+  if (
+    route.kind !== "app-page" ||
+    typeof route.pattern !== "string" ||
+    !route.pattern.startsWith("/") ||
+    !isRepresentation(route.representation) ||
+    typeof route.requestKey !== "string" ||
+    !route.requestKey.startsWith("/") ||
+    !isRouteState(route.state) ||
+    !Number.isInteger(route.status) ||
+    (route.status as number) < 100 ||
+    (route.status as number) > 599
+  ) {
+    return null;
+  }
+  const parsed: CacheabilityManifestRoute = {
+    kind: "app-page",
+    pattern: route.pattern,
+    representation: route.representation,
+    requestKey: route.requestKey,
+    state: route.state,
+    status: route.status as number,
+  };
+  return key ===
+    cacheabilityManifestRouteKey(
+      parsed.kind,
+      parsed.pattern,
+      parsed.representation,
+      parsed.requestKey,
+    )
+    ? parsed
+    : null;
+}
+
+export function parseCacheabilityManifest(
+  value: string | null | undefined,
+  expectedBuildId: string | null | undefined,
+): CacheabilityManifest | null {
+  if (!value || !expectedBuildId) return null;
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+    const record = parsed as Record<string, unknown>;
+    if (
+      record.version !== 1 ||
+      record.buildId !== expectedBuildId ||
+      !record.routes ||
+      typeof record.routes !== "object" ||
+      Array.isArray(record.routes)
+    ) {
+      return null;
+    }
+
+    const routes: Record<string, CacheabilityManifestRoute> = {};
+    for (const [key, routeValue] of Object.entries(record.routes)) {
+      const route = parseRoute(key, routeValue);
+      if (!route) return null;
+      routes[key] = route;
+    }
+    return { buildId: expectedBuildId, routes, version: 1 };
+  } catch {
+    return null;
+  }
+}
+
+const CONTEXTUAL_RSC_HEADERS = [
+  NEXT_ROUTER_STATE_TREE_HEADER,
+  NEXT_URL_HEADER,
+  VINEXT_INTERCEPTION_CONTEXT_HEADER,
+  VINEXT_INTERCEPTION_ID_HEADER,
+  VINEXT_MOUNTED_SLOTS_HEADER,
+  VINEXT_RSC_STATE_FINGERPRINT_HEADER,
+] as const;
+
+export function cacheabilityRequestIdentity(request: Request): {
+  representation: CacheabilityRepresentation;
+  requestKey: string;
+} | null {
+  if (request.method !== "GET" && request.method !== "HEAD") return null;
+  if (request.headers.has(NEXT_ACTION_HEADER) || request.headers.has(RSC_ACTION_HEADER))
+    return null;
+
+  const url = new URL(request.url);
+  const requestKey = `${url.pathname}${url.search}`;
+  const isRsc = request.headers.get(RSC_HEADER) === "1" || url.pathname.endsWith(".rsc");
+  if (!isRsc) {
+    const accept = request.headers.get("Accept")?.toLowerCase() ?? "";
+    return accept.includes("text/html") ? { representation: "html", requestKey } : null;
+  }
+
+  if (CONTEXTUAL_RSC_HEADERS.some((header) => request.headers.has(header))) return null;
+  const renderMode = request.headers.get(VINEXT_RSC_RENDER_MODE_HEADER);
+  if (renderMode === APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL) {
+    if (
+      request.headers.get(NEXT_ROUTER_PREFETCH_HEADER) !== "1" ||
+      request.headers.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER) !== "1"
+    ) {
+      return null;
+    }
+    return { representation: "rsc-loading-shell", requestKey };
+  }
+  if (
+    renderMode !== null ||
+    request.headers.has(NEXT_ROUTER_PREFETCH_HEADER) ||
+    request.headers.has(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER)
+  ) {
+    return null;
+  }
+  return { representation: "rsc-full", requestKey };
+}
+
+export function findCacheabilityManifestRoute(
+  manifest: CacheabilityManifest,
+  pattern: string,
+  identity: { representation: CacheabilityRepresentation; requestKey: string },
+): CacheabilityManifestRoute | null {
+  return (
+    manifest.routes[
+      cacheabilityManifestRouteKey(
+        "app-page",
+        pattern,
+        identity.representation,
+        identity.requestKey,
+      )
+    ] ?? null
+  );
+}

--- a/packages/vinext/src/server/cacheability-request.ts
+++ b/packages/vinext/src/server/cacheability-request.ts
@@ -413,7 +413,7 @@ function hasStrictFinalResponseVeto(response: Response, state: RouteCacheability
     const value = response.headers.get(name);
     if (
       value !== null &&
-      value !== state.initialResponseCachePolicy?.[name] &&
+      value !== state.frameworkResponseCachePolicy?.[name] &&
       isNonCacheableCacheControl(value)
     ) {
       return true;

--- a/packages/vinext/src/server/cacheability-request.ts
+++ b/packages/vinext/src/server/cacheability-request.ts
@@ -4,13 +4,20 @@ import {
   type RouteCacheabilityOutcome,
   type RouteCacheabilityState,
 } from "vinext/shims/cacheability-classification";
-import { NO_STORE_CACHE_CONTROL } from "./cache-control.js";
+import { applyCdnResponseHeaders, NO_STORE_CACHE_CONTROL } from "./cache-control.js";
 import { VINEXT_CACHEABILITY_PROBE_HEADER, VINEXT_PRERENDER_SECRET_HEADER } from "./headers.js";
 import { workerCapabilityMatches } from "./worker-prerender-discovery.js";
 import {
   CACHEABILITY_PROBE_BODY_LIMIT,
   CACHEABILITY_PROBE_TIMEOUT_MS,
 } from "./cacheability-limits.js";
+import {
+  cacheabilityRequestIdentity,
+  findCacheabilityManifestRoute,
+  parseCacheabilityManifest,
+  type CacheabilityManifest,
+  type CacheabilityManifestRoute,
+} from "./cacheability-manifest.js";
 
 type CacheabilityProbeRouteState =
   | "dynamic"
@@ -48,6 +55,40 @@ export function createWorkerCacheabilityContext(
   const state: RouteCacheabilityState = {
     captureDeadlineAt: Date.now() + CACHEABILITY_PROBE_TIMEOUT_MS,
     mode: requestedMode === "identity" ? "identity" : "probe",
+  };
+  return Object.assign(Object.create(Object.getPrototypeOf(base)), base, {
+    [CACHEABILITY_REQUEST_STATE]: state,
+  });
+}
+
+let cachedManifest:
+  | { buildId: string; manifest: CacheabilityManifest | null; raw: string }
+  | undefined;
+
+function readBoundManifest(raw: string, buildId: string): CacheabilityManifest | null {
+  if (cachedManifest?.raw === raw && cachedManifest.buildId === buildId) {
+    return cachedManifest.manifest;
+  }
+  const manifest = parseCacheabilityManifest(raw, buildId);
+  cachedManifest = { buildId, manifest, raw };
+  return manifest;
+}
+
+export function createWorkerCacheabilityAdmissionContext(
+  base: ExecutionContextLike,
+  request: Request,
+  rawManifest: string | null | undefined,
+  buildId: string | null | undefined,
+): ExecutionContextLike {
+  if (!rawManifest || !buildId) return base;
+  const manifest = readBoundManifest(rawManifest, buildId);
+  const identity = cacheabilityRequestIdentity(request);
+  if (!manifest || !identity) return base;
+
+  const state: RouteCacheabilityState = {
+    admission: { manifest, ...identity },
+    captureDeadlineAt: Date.now() + CACHEABILITY_PROBE_TIMEOUT_MS,
+    mode: "admit",
   };
   return Object.assign(Object.create(Object.getPrototypeOf(base)), base, {
     [CACHEABILITY_REQUEST_STATE]: state,
@@ -117,12 +158,204 @@ async function drainProbeBody(response: Response, deadlineAt: number): Promise<s
   }
 }
 
+type CapturedAdmissionBody =
+  | { body: Uint8Array<ArrayBuffer> | null; kind: "captured" }
+  | { body: ReadableStream<Uint8Array>; kind: "fallback" };
+
+async function readBeforeDeadline<T>(
+  promise: Promise<T>,
+  deadlineAt: number,
+): Promise<{ kind: "timeout" } | { kind: "value"; value: T }> {
+  const remaining = deadlineAt - Date.now();
+  if (remaining <= 0) return { kind: "timeout" };
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise.then((value) => ({ kind: "value" as const, value })),
+      new Promise<{ kind: "timeout" }>((resolve) => {
+        timeout = setTimeout(() => resolve({ kind: "timeout" }), remaining);
+      }),
+    ]);
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout);
+  }
+}
+
+function continueCapturedBody(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  captured: Uint8Array[],
+  pendingRead?: Promise<ReadableStreamReadResult<Uint8Array>>,
+): ReadableStream<Uint8Array> {
+  let index = 0;
+  let released = false;
+  const release = () => {
+    if (released) return;
+    released = true;
+    reader.releaseLock();
+  };
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      if (index < captured.length) {
+        controller.enqueue(captured[index++]);
+        return;
+      }
+      try {
+        const result = await (pendingRead ?? reader.read());
+        pendingRead = undefined;
+        if (result.done) {
+          release();
+          controller.close();
+        } else {
+          controller.enqueue(result.value);
+        }
+      } catch (error) {
+        release();
+        controller.error(error);
+      }
+    },
+    async cancel(reason) {
+      try {
+        await reader.cancel(reason);
+      } finally {
+        release();
+      }
+    },
+  });
+}
+
+export async function captureCacheabilityAdmissionBody(
+  body: ReadableStream<Uint8Array> | null,
+  deadlineAt: number,
+  limit = CACHEABILITY_PROBE_BODY_LIMIT,
+): Promise<CapturedAdmissionBody> {
+  if (!body) return { body: null, kind: "captured" };
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const pendingRead = reader.read();
+      const deadlineResult = await readBeforeDeadline(pendingRead, deadlineAt);
+      if (deadlineResult.kind === "timeout") {
+        return {
+          body: continueCapturedBody(reader, chunks, pendingRead),
+          kind: "fallback",
+        };
+      }
+      const result = deadlineResult.value;
+      if (result.done) {
+        reader.releaseLock();
+        const captured = new Uint8Array(total);
+        let offset = 0;
+        for (const chunk of chunks) {
+          captured.set(chunk, offset);
+          offset += chunk.byteLength;
+        }
+        return { body: captured, kind: "captured" };
+      }
+      chunks.push(result.value);
+      total += result.value.byteLength;
+      if (total > limit) {
+        return { body: continueCapturedBody(reader, chunks), kind: "fallback" };
+      }
+    }
+  } catch (error) {
+    await reader.cancel(error).catch(() => {});
+    reader.releaseLock();
+    throw error;
+  }
+}
+
+function responseWithCachePolicy(
+  response: Response,
+  body: BodyInit | null,
+  outcome: RouteCacheabilityOutcome | null,
+): Response {
+  const headers = new Headers(response.headers);
+  applyCdnResponseHeaders(
+    headers,
+    outcome?.cacheable === true && outcome.cacheControl
+      ? { cacheControl: outcome.cacheControl, tags: outcome.tags }
+      : { cacheControl: NO_STORE_CACHE_CONTROL },
+  );
+  return new Response(body, {
+    headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
+}
+
+function staticToDynamicResponse(route: CacheabilityManifestRoute): Response {
+  const headers = new Headers({ "Content-Type": "text/plain; charset=utf-8" });
+  applyCdnResponseHeaders(headers, { cacheControl: NO_STORE_CACHE_CONTROL });
+  return new Response(
+    `[vinext] Route ${route.pattern} changed from static to dynamic after deployment.`,
+    { headers, status: 500 },
+  );
+}
+
+function cacheabilityEvaluationFailureResponse(route: CacheabilityManifestRoute): Response {
+  const headers = new Headers({ "Content-Type": "text/plain; charset=utf-8" });
+  applyCdnResponseHeaders(headers, { cacheControl: NO_STORE_CACHE_CONTROL });
+  return new Response(`[vinext] Route ${route.pattern} failed during cacheability evaluation.`, {
+    headers,
+    status: 500,
+  });
+}
+
+async function finalizeWorkerCacheabilityAdmission(
+  response: Response,
+  state: RouteCacheabilityState,
+): Promise<Response> {
+  const admission = state.admission;
+  if (!admission || !state.route) return responseWithCachePolicy(response, response.body, null);
+  const manifest = admission.manifest as CacheabilityManifest;
+  const manifestRoute = findCacheabilityManifestRoute(manifest, state.route.pattern, {
+    representation: admission.representation as Parameters<
+      typeof findCacheabilityManifestRoute
+    >[2]["representation"],
+    requestKey: admission.requestKey,
+  });
+  if (
+    !manifestRoute ||
+    manifestRoute.state === "dynamic" ||
+    manifestRoute.state === "probe-failed" ||
+    manifestRoute.status !== response.status ||
+    response.status >= 500
+  ) {
+    return responseWithCachePolicy(response, response.body, null);
+  }
+
+  let captured: CapturedAdmissionBody;
+  try {
+    captured = await captureCacheabilityAdmissionBody(response.body, state.captureDeadlineAt);
+  } catch {
+    return cacheabilityEvaluationFailureResponse(manifestRoute);
+  }
+  if (captured.kind === "fallback") {
+    return responseWithCachePolicy(response, captured.body, null);
+  }
+
+  const outcome = state.completion ? await state.completion : (state.outcome ?? null);
+  if (outcome?.cacheable !== true || !outcome.cacheControl) {
+    return manifestRoute.state === "static-candidate" &&
+      (outcome === null || outcome.dynamicUsage === true)
+      ? staticToDynamicResponse(manifestRoute)
+      : responseWithCachePolicy(response, captured.body, null);
+  }
+  return responseWithCachePolicy(response, captured.body, outcome);
+}
+
 export async function finalizeWorkerCacheabilityResponse(
   response: Response,
   ctx: ExecutionContextLike,
 ): Promise<Response> {
   const state = readState(ctx);
   if (!state) return response;
+
+  if (state.mode === "admit") {
+    return finalizeWorkerCacheabilityAdmission(response, state);
+  }
 
   if (state.mode === "identity") {
     await response.body?.cancel().catch(() => {});

--- a/packages/vinext/src/server/cacheability-request.ts
+++ b/packages/vinext/src/server/cacheability-request.ts
@@ -388,6 +388,40 @@ function responseWithCachePolicy(
   });
 }
 
+function inferFinalAppPageCacheability(
+  response: Response,
+  state: RouteCacheabilityState,
+): RouteCacheabilityOutcome | null {
+  if (!state.frameworkResponseCachePolicy) return null;
+
+  // Config headers run after the framework snapshots its provisional policy.
+  // Match Next.js by honoring a later explicit public policy instead of
+  // replacing it with the renderer-derived default during admission.
+  const changedPolicy = (
+    ["cloudflare-cdn-cache-control", "cdn-cache-control", "cache-control"] as const
+  ).find((name) => {
+    const value = response.headers.get(name);
+    return value !== null && value !== state.frameworkResponseCachePolicy?.[name];
+  });
+  if (!changedPolicy) return null;
+
+  const cacheControl = response.headers.get(changedPolicy)!;
+  if (isNonCacheableCacheControl(cacheControl)) return { cacheable: false };
+  const cacheTag = response.headers.get("Cache-Tag");
+  return {
+    cacheable: true,
+    cacheControl,
+    ...(cacheTag
+      ? {
+          tags: cacheTag
+            .split(",")
+            .map((tag) => tag.trim())
+            .filter(Boolean),
+        }
+      : {}),
+  };
+}
+
 function staticToDynamicResponse(route: CacheabilityManifestRoute): Response {
   const headers = new Headers({ "Content-Type": "text/plain; charset=utf-8" });
   applyCdnResponseHeaders(headers, { cacheControl: NO_STORE_CACHE_CONTROL });
@@ -503,7 +537,10 @@ async function finalizeWorkerCacheabilityAdmission(
     return responseWithCachePolicy(response, captured.body, null);
   }
 
-  const outcome = state.completion ? await state.completion : (state.outcome ?? null);
+  let outcome = state.completion ? await state.completion : (state.outcome ?? null);
+  if (state.route.kind === "app-page") {
+    outcome = inferFinalAppPageCacheability(response, state) ?? outcome;
+  }
   if (outcome?.cacheable !== true || !outcome.cacheControl) {
     // Next.js throws a static-to-dynamic error only when the runtime render
     // actually observed dynamic usage. An absent outcome can also mean the

--- a/packages/vinext/src/server/cacheability-request.ts
+++ b/packages/vinext/src/server/cacheability-request.ts
@@ -426,6 +426,12 @@ async function finalizeWorkerCacheabilityAdmission(
   response: Response,
   state: RouteCacheabilityState,
 ): Promise<Response> {
+  // This layer classifies App Pages only. Hybrid routing can hand the request
+  // to Pages Router after admission begins; retain the Pages response and its
+  // independently computed cache policy until Pages probing is introduced by
+  // its own stack layer.
+  if (state.preserveResponseCachePolicy) return response;
+
   const admission = state.admission;
   if (
     !admission ||

--- a/packages/vinext/src/server/cacheability-request.ts
+++ b/packages/vinext/src/server/cacheability-request.ts
@@ -1,10 +1,15 @@
 import type { ExecutionContextLike } from "vinext/shims/request-context";
 import {
   CACHEABILITY_REQUEST_STATE,
+  CACHEABILITY_POLICY_HEADERS,
   type RouteCacheabilityOutcome,
   type RouteCacheabilityState,
 } from "vinext/shims/cacheability-classification";
-import { applyCdnResponseHeaders, NO_STORE_CACHE_CONTROL } from "./cache-control.js";
+import {
+  applyCdnResponseHeaders,
+  isNonCacheableCacheControl,
+  NO_STORE_CACHE_CONTROL,
+} from "./cache-control.js";
 import {
   VINEXT_CACHEABILITY_PROBE_HEADER,
   VINEXT_PRERENDER_SECRET_HEADER,
@@ -401,6 +406,22 @@ function cacheabilityEvaluationFailureResponse(pattern: string): Response {
   });
 }
 
+function hasStrictFinalResponseVeto(response: Response, state: RouteCacheabilityState): boolean {
+  if (state.finalResponseVetoReason || response.headers.has("set-cookie")) return true;
+
+  for (const name of CACHEABILITY_POLICY_HEADERS) {
+    const value = response.headers.get(name);
+    if (
+      value !== null &&
+      value !== state.initialResponseCachePolicy?.[name] &&
+      isNonCacheableCacheControl(value)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
 async function finalizeWorkerCacheabilityAdmission(
   response: Response,
   state: RouteCacheabilityState,
@@ -437,6 +458,9 @@ async function finalizeWorkerCacheabilityAdmission(
   }
 
   if (state.forcedDynamicReason) {
+    return responseWithCachePolicy(response, response.body, null);
+  }
+  if (hasStrictFinalResponseVeto(response, state)) {
     return responseWithCachePolicy(response, response.body, null);
   }
   if (hasUnsupportedCacheabilityVary(response.headers)) {

--- a/packages/vinext/src/server/cacheability-request.ts
+++ b/packages/vinext/src/server/cacheability-request.ts
@@ -8,6 +8,7 @@ import { applyCdnResponseHeaders, NO_STORE_CACHE_CONTROL } from "./cache-control
 import { VINEXT_CACHEABILITY_PROBE_HEADER, VINEXT_PRERENDER_SECRET_HEADER } from "./headers.js";
 import { workerCapabilityMatches } from "./worker-prerender-discovery.js";
 import {
+  CACHEABILITY_ADMISSION_ISOLATE_BODY_LIMIT,
   CACHEABILITY_PROBE_BODY_LIMIT,
   CACHEABILITY_PROBE_TIMEOUT_MS,
 } from "./cacheability-limits.js";
@@ -79,14 +80,26 @@ export function createWorkerCacheabilityAdmissionContext(
   request: Request,
   rawManifest: string | null | undefined,
   buildId: string | null | undefined,
+  requiresCompletedResponseAdmission = rawManifest != null,
 ): ExecutionContextLike {
-  if (!rawManifest || !buildId) return base;
-  const manifest = readBoundManifest(rawManifest, buildId);
   const identity = cacheabilityRequestIdentity(request);
-  if (!manifest || !identity) return base;
+  if (!rawManifest) {
+    if (!requiresCompletedResponseAdmission || !identity) return base;
+    const state: RouteCacheabilityState = {
+      admission: { policy: "runtime", ...identity },
+      captureDeadlineAt: Date.now() + CACHEABILITY_PROBE_TIMEOUT_MS,
+      mode: "admit",
+    };
+    return Object.assign(Object.create(Object.getPrototypeOf(base)), base, {
+      [CACHEABILITY_REQUEST_STATE]: state,
+    });
+  }
+
+  const manifest = buildId ? readBoundManifest(rawManifest, buildId) : null;
 
   const state: RouteCacheabilityState = {
-    admission: { manifest, ...identity },
+    admission:
+      manifest && identity ? { manifest, policy: "manifest", ...identity } : { policy: "deny" },
     captureDeadlineAt: Date.now() + CACHEABILITY_PROBE_TIMEOUT_MS,
     mode: "admit",
   };
@@ -159,8 +172,48 @@ async function drainProbeBody(response: Response, deadlineAt: number): Promise<s
 }
 
 type CapturedAdmissionBody =
-  | { body: Uint8Array<ArrayBuffer> | null; kind: "captured" }
+  | { body: ReadableStream<Uint8Array> | null; kind: "captured" }
   | { body: ReadableStream<Uint8Array>; kind: "fallback" };
+
+export type CacheabilityAdmissionCaptureBudget = {
+  maxBytes: number;
+  reservedBytes: number;
+};
+
+const isolateCaptureBudget: CacheabilityAdmissionCaptureBudget = {
+  maxBytes: CACHEABILITY_ADMISSION_ISOLATE_BODY_LIMIT,
+  reservedBytes: 0,
+};
+
+export function createCacheabilityAdmissionCaptureBudget(
+  maxBytes: number,
+): CacheabilityAdmissionCaptureBudget {
+  return { maxBytes, reservedBytes: 0 };
+}
+
+type CapturedChunk = { reserved: boolean; value: Uint8Array };
+
+function reserveChunk(budget: CacheabilityAdmissionCaptureBudget, byteLength: number): boolean {
+  if (byteLength > budget.maxBytes - budget.reservedBytes) return false;
+  budget.reservedBytes += byteLength;
+  return true;
+}
+
+function releaseChunk(budget: CacheabilityAdmissionCaptureBudget, chunk: CapturedChunk): void {
+  if (!chunk.reserved) return;
+  chunk.reserved = false;
+  budget.reservedBytes -= chunk.value.byteLength;
+}
+
+function releaseChunks(
+  budget: CacheabilityAdmissionCaptureBudget,
+  chunks: CapturedChunk[],
+  start = 0,
+): void {
+  for (let index = start; index < chunks.length; index++) {
+    releaseChunk(budget, chunks[index]);
+  }
+}
 
 async function readBeforeDeadline<T>(
   promise: Promise<T>,
@@ -183,7 +236,8 @@ async function readBeforeDeadline<T>(
 
 function continueCapturedBody(
   reader: ReadableStreamDefaultReader<Uint8Array>,
-  captured: Uint8Array[],
+  captured: CapturedChunk[],
+  budget: CacheabilityAdmissionCaptureBudget,
   pendingRead?: Promise<ReadableStreamReadResult<Uint8Array>>,
 ): ReadableStream<Uint8Array> {
   let index = 0;
@@ -193,44 +247,75 @@ function continueCapturedBody(
     released = true;
     reader.releaseLock();
   };
-  return new ReadableStream<Uint8Array>({
-    async pull(controller) {
-      if (index < captured.length) {
-        controller.enqueue(captured[index++]);
-        return;
-      }
-      try {
-        const result = await (pendingRead ?? reader.read());
-        pendingRead = undefined;
-        if (result.done) {
-          release();
-          controller.close();
-        } else {
-          controller.enqueue(result.value);
+  return new ReadableStream<Uint8Array>(
+    {
+      async pull(controller) {
+        if (index < captured.length) {
+          const chunk = captured[index++];
+          controller.enqueue(chunk.value);
+          releaseChunk(budget, chunk);
+          return;
         }
-      } catch (error) {
-        release();
-        controller.error(error);
-      }
+        try {
+          const result = await (pendingRead ?? reader.read());
+          pendingRead = undefined;
+          if (result.done) {
+            release();
+            controller.close();
+          } else {
+            controller.enqueue(result.value);
+          }
+        } catch (error) {
+          release();
+          controller.error(error);
+        }
+      },
+      async cancel(reason) {
+        try {
+          await reader.cancel(reason);
+        } finally {
+          releaseChunks(budget, captured, index);
+          release();
+        }
+      },
     },
-    async cancel(reason) {
-      try {
-        await reader.cancel(reason);
-      } finally {
-        release();
-      }
+    { highWaterMark: 0 },
+  );
+}
+
+function replayCapturedBody(
+  captured: CapturedChunk[],
+  budget: CacheabilityAdmissionCaptureBudget,
+): ReadableStream<Uint8Array> {
+  let index = 0;
+  return new ReadableStream<Uint8Array>(
+    {
+      pull(controller) {
+        if (index >= captured.length) {
+          controller.close();
+          return;
+        }
+        const chunk = captured[index++];
+        controller.enqueue(chunk.value);
+        releaseChunk(budget, chunk);
+      },
+      cancel() {
+        releaseChunks(budget, captured, index);
+      },
     },
-  });
+    { highWaterMark: 0 },
+  );
 }
 
 export async function captureCacheabilityAdmissionBody(
   body: ReadableStream<Uint8Array> | null,
   deadlineAt: number,
   limit = CACHEABILITY_PROBE_BODY_LIMIT,
+  budget = isolateCaptureBudget,
 ): Promise<CapturedAdmissionBody> {
   if (!body) return { body: null, kind: "captured" };
   const reader = body.getReader();
-  const chunks: Uint8Array[] = [];
+  const chunks: CapturedChunk[] = [];
   let total = 0;
   try {
     while (true) {
@@ -238,29 +323,27 @@ export async function captureCacheabilityAdmissionBody(
       const deadlineResult = await readBeforeDeadline(pendingRead, deadlineAt);
       if (deadlineResult.kind === "timeout") {
         return {
-          body: continueCapturedBody(reader, chunks, pendingRead),
+          body: continueCapturedBody(reader, chunks, budget, pendingRead),
           kind: "fallback",
         };
       }
       const result = deadlineResult.value;
       if (result.done) {
         reader.releaseLock();
-        const captured = new Uint8Array(total);
-        let offset = 0;
-        for (const chunk of chunks) {
-          captured.set(chunk, offset);
-          offset += chunk.byteLength;
-        }
-        return { body: captured, kind: "captured" };
+        return { body: replayCapturedBody(chunks, budget), kind: "captured" };
       }
-      chunks.push(result.value);
-      total += result.value.byteLength;
-      if (total > limit) {
-        return { body: continueCapturedBody(reader, chunks), kind: "fallback" };
+      const nextTotal = total + result.value.byteLength;
+      const withinResponseLimit = nextTotal <= limit;
+      const reserved = withinResponseLimit && reserveChunk(budget, result.value.byteLength);
+      chunks.push({ reserved, value: result.value });
+      total = nextTotal;
+      if (!reserved) {
+        return { body: continueCapturedBody(reader, chunks, budget), kind: "fallback" };
       }
     }
   } catch (error) {
     await reader.cancel(error).catch(() => {});
+    releaseChunks(budget, chunks);
     reader.releaseLock();
     throw error;
   }
@@ -294,10 +377,10 @@ function staticToDynamicResponse(route: CacheabilityManifestRoute): Response {
   );
 }
 
-function cacheabilityEvaluationFailureResponse(route: CacheabilityManifestRoute): Response {
+function cacheabilityEvaluationFailureResponse(pattern: string): Response {
   const headers = new Headers({ "Content-Type": "text/plain; charset=utf-8" });
   applyCdnResponseHeaders(headers, { cacheControl: NO_STORE_CACHE_CONTROL });
-  return new Response(`[vinext] Route ${route.pattern} failed during cacheability evaluation.`, {
+  return new Response(`[vinext] Route ${pattern} failed during cacheability evaluation.`, {
     headers,
     status: 500,
   });
@@ -308,21 +391,37 @@ async function finalizeWorkerCacheabilityAdmission(
   state: RouteCacheabilityState,
 ): Promise<Response> {
   const admission = state.admission;
-  if (!admission || !state.route) return responseWithCachePolicy(response, response.body, null);
-  const manifest = admission.manifest as CacheabilityManifest;
-  const manifestRoute = findCacheabilityManifestRoute(manifest, state.route.pattern, {
-    representation: admission.representation as Parameters<
-      typeof findCacheabilityManifestRoute
-    >[2]["representation"],
-    requestKey: admission.requestKey,
-  });
   if (
-    !manifestRoute ||
-    manifestRoute.state === "dynamic" ||
-    manifestRoute.state === "probe-failed" ||
-    manifestRoute.status !== response.status ||
+    !admission ||
+    admission.policy === "deny" ||
+    !admission.representation ||
+    !admission.requestKey ||
+    !state.route ||
     response.status >= 500
   ) {
+    return responseWithCachePolicy(response, response.body, null);
+  }
+
+  let manifestRoute: CacheabilityManifestRoute | null = null;
+  if (admission.policy === "manifest") {
+    const manifest = admission.manifest as CacheabilityManifest;
+    manifestRoute = findCacheabilityManifestRoute(manifest, state.route.pattern, {
+      representation: admission.representation as Parameters<
+        typeof findCacheabilityManifestRoute
+      >[2]["representation"],
+      requestKey: admission.requestKey,
+    });
+    if (
+      !manifestRoute ||
+      manifestRoute.state === "dynamic" ||
+      manifestRoute.state === "probe-failed" ||
+      manifestRoute.status !== response.status
+    ) {
+      return responseWithCachePolicy(response, response.body, null);
+    }
+  }
+
+  if (state.forcedDynamicReason) {
     return responseWithCachePolicy(response, response.body, null);
   }
 
@@ -330,7 +429,7 @@ async function finalizeWorkerCacheabilityAdmission(
   try {
     captured = await captureCacheabilityAdmissionBody(response.body, state.captureDeadlineAt);
   } catch {
-    return cacheabilityEvaluationFailureResponse(manifestRoute);
+    return cacheabilityEvaluationFailureResponse(state.route.pattern);
   }
   if (captured.kind === "fallback") {
     return responseWithCachePolicy(response, captured.body, null);
@@ -338,7 +437,7 @@ async function finalizeWorkerCacheabilityAdmission(
 
   const outcome = state.completion ? await state.completion : (state.outcome ?? null);
   if (outcome?.cacheable !== true || !outcome.cacheControl) {
-    return manifestRoute.state === "static-candidate" &&
+    return manifestRoute?.state === "static-candidate" &&
       (outcome === null || outcome.dynamicUsage === true)
       ? staticToDynamicResponse(manifestRoute)
       : responseWithCachePolicy(response, captured.body, null);

--- a/packages/vinext/src/server/cacheability-request.ts
+++ b/packages/vinext/src/server/cacheability-request.ts
@@ -37,7 +37,7 @@ type CacheabilityProbeRouteState =
 
 type CacheabilityProbeResult = {
   cacheControl?: string;
-  kind?: "app-page";
+  kind?: "app-page" | "app-route";
   pattern?: string;
   reason?: string;
   state: CacheabilityProbeRouteState;
@@ -104,9 +104,9 @@ export function createWorkerCacheabilityAdmissionContext(
 ): ExecutionContextLike {
   const identity = cacheabilityRequestIdentity(request);
   if (!rawManifest) {
-    if (!requiresCompletedResponseAdmission || !identity) return base;
+    if (!requiresCompletedResponseAdmission) return base;
     const state: RouteCacheabilityState = {
-      admission: { policy: "runtime", ...identity },
+      admission: identity ? { policy: "runtime", ...identity } : { policy: "deny" },
       captureDeadlineAt: Date.now() + CACHEABILITY_PROBE_TIMEOUT_MS,
       mode: "admit",
     };
@@ -431,6 +431,21 @@ async function finalizeWorkerCacheabilityAdmission(
   // independently computed cache policy until Pages probing is introduced by
   // its own stack layer.
   if (state.preserveResponseCachePolicy) return response;
+
+  // Route Handlers prove body completion inside their execution boundary.
+  // This outer state still carries middleware/config routing vetoes that were
+  // observed before dispatch and must win over a handler's public policy.
+  if (state.route?.kind === "app-route") {
+    if (
+      response.status >= 500 ||
+      state.forcedDynamicReason ||
+      hasStrictFinalResponseVeto(response, state) ||
+      hasUnsupportedCacheabilityVary(response.headers)
+    ) {
+      return responseWithCachePolicy(response, response.body, null);
+    }
+    return response;
+  }
 
   const admission = state.admission;
   if (

--- a/packages/vinext/src/server/cacheability-request.ts
+++ b/packages/vinext/src/server/cacheability-request.ts
@@ -5,7 +5,11 @@ import {
   type RouteCacheabilityState,
 } from "vinext/shims/cacheability-classification";
 import { applyCdnResponseHeaders, NO_STORE_CACHE_CONTROL } from "./cache-control.js";
-import { VINEXT_CACHEABILITY_PROBE_HEADER, VINEXT_PRERENDER_SECRET_HEADER } from "./headers.js";
+import {
+  VINEXT_CACHEABILITY_PROBE_HEADER,
+  VINEXT_PRERENDER_SECRET_HEADER,
+  VINEXT_RSC_VARY_HEADER,
+} from "./headers.js";
 import { workerCapabilityMatches } from "./worker-prerender-discovery.js";
 import {
   CACHEABILITY_ADMISSION_ISOLATE_BODY_LIMIT,
@@ -35,6 +39,17 @@ type CacheabilityProbeResult = {
   status: number;
   version: 1;
 };
+
+const SUPPORTED_CACHEABILITY_VARY_FIELDS = new Set(
+  VINEXT_RSC_VARY_HEADER.split(",").map((name) => name.trim().toLowerCase()),
+);
+
+function hasUnsupportedCacheabilityVary(headers: Headers): boolean {
+  return (headers.get("Vary") ?? "").split(",").some((name) => {
+    const normalized = name.trim().toLowerCase();
+    return normalized.length > 0 && !SUPPORTED_CACHEABILITY_VARY_FIELDS.has(normalized);
+  });
+}
 
 export function createWorkerCacheabilityContext(
   base: ExecutionContextLike,
@@ -424,10 +439,18 @@ async function finalizeWorkerCacheabilityAdmission(
   if (state.forcedDynamicReason) {
     return responseWithCachePolicy(response, response.body, null);
   }
+  if (hasUnsupportedCacheabilityVary(response.headers)) {
+    return responseWithCachePolicy(response, response.body, null);
+  }
 
   let captured: CapturedAdmissionBody;
   try {
-    captured = await captureCacheabilityAdmissionBody(response.body, state.captureDeadlineAt);
+    captured = await captureCacheabilityAdmissionBody(
+      response.body,
+      state.captureDeadlineAt,
+      CACHEABILITY_PROBE_BODY_LIMIT,
+      state.captureBudget ?? isolateCaptureBudget,
+    );
   } catch {
     return cacheabilityEvaluationFailureResponse(state.route.pattern);
   }
@@ -437,10 +460,18 @@ async function finalizeWorkerCacheabilityAdmission(
 
   const outcome = state.completion ? await state.completion : (state.outcome ?? null);
   if (outcome?.cacheable !== true || !outcome.cacheControl) {
-    return manifestRoute?.state === "static-candidate" &&
-      (outcome === null || outcome.dynamicUsage === true)
-      ? staticToDynamicResponse(manifestRoute)
-      : responseWithCachePolicy(response, captured.body, null);
+    // Next.js throws a static-to-dynamic error only when the runtime render
+    // actually observed dynamic usage. An absent outcome can also mean the
+    // renderer deliberately bypassed its cache-write path (notably draft mode
+    // and nonce-bearing HTML), in which case the completed response must stay
+    // private without being replaced by a 500.
+    if (manifestRoute?.state === "static-candidate" && outcome?.dynamicUsage === true) {
+      // The replacement 500 does not consume the captured replay stream. Its
+      // cancellation releases the isolate-wide byte reservation immediately.
+      await captured.body?.cancel().catch(() => {});
+      return staticToDynamicResponse(manifestRoute);
+    }
+    return responseWithCachePolicy(response, captured.body, null);
   }
   return responseWithCachePolicy(response, captured.body, outcome);
 }

--- a/packages/vinext/src/server/config-headers.ts
+++ b/packages/vinext/src/server/config-headers.ts
@@ -5,8 +5,22 @@ import {
   type RequestContext,
 } from "../config/config-matchers.js";
 import type { HeaderRecord } from "./request-pipeline.js";
+import { markRouteCacheabilityDynamic } from "vinext/shims/cacheability-classification";
 
 const ADDITIVE_CONFIG_HEADER_NAMES = new Set(["set-cookie", "vary"]);
+
+function markConditionalConfigHeaderCacheability(rule: NextHeader): void {
+  if (
+    [...(rule.has ?? []), ...(rule.missing ?? [])].some(
+      (condition) => condition.type === "header" || condition.type === "cookie",
+    )
+  ) {
+    // Query values are already part of the public CDN key and hostnames are
+    // isolated by the platform. Headers and cookies are neither, so a response
+    // header selected by either cannot be shared safely under the request URL.
+    markRouteCacheabilityDynamic("next.config headers depend on request headers or cookies");
+  }
+}
 
 type ApplyConfigHeadersOptions = {
   configHeaders: NextHeader[];
@@ -89,6 +103,7 @@ export function applyConfigHeadersToResponse(
       options.configHeaders,
       options.requestContext,
       options.basePathState,
+      markConditionalConfigHeaderCacheability,
     ),
   );
   for (const header of matched) {
@@ -120,6 +135,7 @@ export function applyConfigHeadersToHeaderRecord(
       options.configHeaders,
       options.requestContext,
       options.basePathState,
+      markConditionalConfigHeaderCacheability,
     ),
   );
   for (const header of matched) {

--- a/packages/vinext/src/server/config-headers.ts
+++ b/packages/vinext/src/server/config-headers.ts
@@ -18,13 +18,16 @@ const CACHEABILITY_POLICY_HEADER_NAMES = new Set<string>(CACHEABILITY_POLICY_HEA
 function markConditionalConfigHeaderCacheability(rule: NextHeader): void {
   if (
     [...(rule.has ?? []), ...(rule.missing ?? [])].some(
-      (condition) => condition.type === "header" || condition.type === "cookie",
+      (condition) =>
+        condition.type === "header" || condition.type === "cookie" || condition.type === "host",
     )
   ) {
-    // Query values are already part of the public CDN key and hostnames are
-    // isolated by the platform. Headers and cookies are neither, so a response
-    // header selected by either cannot be shared safely under the request URL.
-    markRouteCacheabilityDynamic("next.config headers depend on request headers or cookies");
+    // Query values are already part of the public Workers Cache key. Headers,
+    // cookies, and hostnames are not, so a response header selected by any of
+    // them cannot be shared safely under the request URL.
+    markRouteCacheabilityDynamic(
+      "next.config headers depend on request headers, cookies, or hostnames",
+    );
   }
 }
 

--- a/packages/vinext/src/server/config-headers.ts
+++ b/packages/vinext/src/server/config-headers.ts
@@ -5,9 +5,15 @@ import {
   type RequestContext,
 } from "../config/config-matchers.js";
 import type { HeaderRecord } from "./request-pipeline.js";
-import { markRouteCacheabilityDynamic } from "vinext/shims/cacheability-classification";
+import {
+  CACHEABILITY_POLICY_HEADERS,
+  markRouteCacheabilityDynamic,
+  markRouteCacheabilityFinalResponseUncacheable,
+} from "vinext/shims/cacheability-classification";
+import { isNonCacheableCacheControl } from "vinext/shims/cdn-cache";
 
 const ADDITIVE_CONFIG_HEADER_NAMES = new Set(["set-cookie", "vary"]);
+const CACHEABILITY_POLICY_HEADER_NAMES = new Set<string>(CACHEABILITY_POLICY_HEADERS);
 
 function markConditionalConfigHeaderCacheability(rule: NextHeader): void {
   if (
@@ -19,6 +25,23 @@ function markConditionalConfigHeaderCacheability(rule: NextHeader): void {
     // isolated by the platform. Headers and cookies are neither, so a response
     // header selected by either cannot be shared safely under the request URL.
     markRouteCacheabilityDynamic("next.config headers depend on request headers or cookies");
+  }
+}
+
+function markExplicitConfigResponseVeto(
+  matched: ReadonlyArray<{ key: string; value: string }>,
+): void {
+  for (const header of matched) {
+    const name = header.key.toLowerCase();
+    if (name === "set-cookie") {
+      markRouteCacheabilityFinalResponseUncacheable("next.config headers set a cookie");
+      continue;
+    }
+    if (CACHEABILITY_POLICY_HEADER_NAMES.has(name) && isNonCacheableCacheControl(header.value)) {
+      markRouteCacheabilityFinalResponseUncacheable(
+        `next.config headers set a non-cacheable ${header.key} policy`,
+      );
+    }
   }
 }
 
@@ -106,6 +129,7 @@ export function applyConfigHeadersToResponse(
       markConditionalConfigHeaderCacheability,
     ),
   );
+  markExplicitConfigResponseVeto(matched);
   for (const header of matched) {
     const lowerName = header.key.toLowerCase();
     if (lowerName === "link") {
@@ -138,6 +162,7 @@ export function applyConfigHeadersToHeaderRecord(
       markConditionalConfigHeaderCacheability,
     ),
   );
+  markExplicitConfigResponseVeto(matched);
   for (const header of matched) {
     const lowerName = header.key.toLowerCase();
     if (lowerName === "set-cookie") {

--- a/packages/vinext/src/server/middleware-matcher.ts
+++ b/packages/vinext/src/server/middleware-matcher.ts
@@ -75,6 +75,49 @@ export function matchesMiddleware(
   return false;
 }
 
+/**
+ * Whether a pathname can reach middleware, ignoring request-specific
+ * `has`/`missing` conditions. This is deliberately separate from
+ * `matchesMiddleware`: ordinary middleware execution must still evaluate the
+ * full request, while cacheability certification needs a stable answer for
+ * every request that can share the pathname's cache entry.
+ */
+export function matchesMiddlewarePathname(
+  pathname: string,
+  matcher: MatcherConfig | undefined,
+  i18nConfig?: NextI18nConfig | null,
+  localeContext?: MiddlewareLocaleMatchContext,
+): boolean {
+  if (!matcher) {
+    return true;
+  }
+
+  if (typeof matcher === "string") {
+    return matchMatcherPattern(pathname, matcher, i18nConfig, localeContext);
+  }
+  if (!Array.isArray(matcher)) {
+    return true;
+  }
+
+  for (const item of matcher) {
+    if (typeof item === "string") {
+      if (matchMatcherPattern(pathname, item, i18nConfig, localeContext)) {
+        return true;
+      }
+      continue;
+    }
+
+    if (!isValidMiddlewareMatcherObjectConfig(item)) {
+      return true;
+    }
+    if (matchObjectMatcher(pathname, item, i18nConfig, localeContext)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 function matchMatcherPattern(
   pathname: string,
   pattern: string,

--- a/packages/vinext/src/server/middleware-runtime.ts
+++ b/packages/vinext/src/server/middleware-runtime.ts
@@ -17,6 +17,7 @@ import {
 } from "./headers.js";
 import {
   matchesMiddleware,
+  matchesMiddlewarePathname,
   type MatcherConfig,
   type MiddlewareLocaleMatchContext,
 } from "./middleware-matcher.js";
@@ -36,6 +37,8 @@ export type MiddlewareModule = Record<string, unknown>;
 
 export type MiddlewareResult = {
   continue: boolean;
+  /** True when this pathname can match middleware for some request context. */
+  pathnameEligible?: boolean;
   redirectUrl?: string;
   redirectStatus?: number;
   rewriteUrl?: string;
@@ -84,6 +87,8 @@ type ExecuteMiddlewareOptions = {
   normalizedPathname?: string;
   /** Called only after the configured matcher accepts this request. */
   onMatch?: () => void;
+  /** Called when the pathname matches, before request `has`/`missing` checks. */
+  onPathMatch?: () => void;
   /**
    * The caller already created an isolated body branch for middleware. This
    * lets App Router normalize that branch's URL and headers without adding a
@@ -426,6 +431,18 @@ export async function executeMiddleware(
             };
     }
   }
+  const encodedPathMatches =
+    encodedMatchPathname !== null &&
+    matchesMiddlewarePathname(encodedMatchPathname, matcher, options.i18nConfig, localeContext);
+  const decodedPathMatches =
+    !encodedPathMatches &&
+    decodedMatchPathname !== null &&
+    decodedMatchPathname !== encodedMatchPathname &&
+    matchesMiddlewarePathname(decodedMatchPathname, matcher, options.i18nConfig, localeContext);
+  if (encodedPathMatches || decodedPathMatches) {
+    options.onPathMatch?.();
+  }
+
   const encodedMatches =
     encodedMatchPathname !== null &&
     matchesMiddleware(
@@ -643,6 +660,17 @@ export async function executeMiddleware(
 export async function runGeneratedMiddleware(
   options: RunGeneratedMiddlewareOptions,
 ): Promise<MiddlewareResult> {
-  const run = () => executeMiddleware(options);
+  let pathnameEligible = false;
+  const run = async () => {
+    const result = await executeMiddleware({
+      ...options,
+      onPathMatch() {
+        pathnameEligible = true;
+        options.onPathMatch?.();
+      },
+    });
+    if (pathnameEligible) result.pathnameEligible = true;
+    return result;
+  };
   return options.ctx ? runWithExecutionContext(options.ctx, run) : run();
 }

--- a/packages/vinext/src/shims/cacheability-classification.ts
+++ b/packages/vinext/src/shims/cacheability-classification.ts
@@ -13,9 +13,10 @@ export type RouteCacheabilityOutcome = {
 
 export type RouteCacheabilityState = {
   admission?: {
-    manifest: unknown;
-    representation: string;
-    requestKey: string;
+    manifest?: unknown;
+    policy: "deny" | "manifest" | "runtime";
+    representation?: string;
+    requestKey?: string;
   };
   captureDeadlineAt: number;
   complete?: (outcome: RouteCacheabilityOutcome) => void;

--- a/packages/vinext/src/shims/cacheability-classification.ts
+++ b/packages/vinext/src/shims/cacheability-classification.ts
@@ -33,7 +33,7 @@ export type RouteCacheabilityState = {
   completion?: Promise<RouteCacheabilityOutcome>;
   finalResponseVetoReason?: string;
   forcedDynamicReason?: string;
-  initialResponseCachePolicy?: Partial<Record<CacheabilityPolicyHeader, string>>;
+  frameworkResponseCachePolicy?: Partial<Record<CacheabilityPolicyHeader, string>>;
   mode: "admit" | "identity" | "probe";
   outcome?: RouteCacheabilityOutcome;
   route?: {
@@ -71,17 +71,23 @@ export function markRouteCacheabilityFinalResponseUncacheable(reason: string): v
   state.finalResponseVetoReason ??= reason;
 }
 
-/** Record renderer-owned policy so admission can identify policy added later. */
+/** Record framework-owned policy so admission can identify policy added later. */
 export function captureRouteCacheabilityResponsePolicy(headers: Headers): void {
   const state = readRouteCacheabilityState();
-  if (!state || state.mode !== "admit" || state.initialResponseCachePolicy) return;
+  if (!state || state.mode !== "admit") return;
 
   const policy: Partial<Record<CacheabilityPolicyHeader, string>> = {};
   for (const name of CACHEABILITY_POLICY_HEADERS) {
     const value = headers.get(name);
     if (value !== null) policy[name] = value;
   }
-  state.initialResponseCachePolicy = policy;
+  // Framework response shaping has more than one trusted phase. In
+  // particular, the App Page renderer can leave Cache-Control absent before
+  // the outer response finalizer applies the adapter's provisional no-store
+  // default. Keep the latest trusted snapshot; configurable response headers
+  // run after the final capture and remain visible to the strict admission
+  // comparison below.
+  state.frameworkResponseCachePolicy = policy;
 }
 
 /** True only for an authenticated probe that must render the matched App Page. */

--- a/packages/vinext/src/shims/cacheability-classification.ts
+++ b/packages/vinext/src/shims/cacheability-classification.ts
@@ -36,11 +36,19 @@ export type RouteCacheabilityState = {
   frameworkResponseCachePolicy?: Partial<Record<CacheabilityPolicyHeader, string>>;
   mode: "admit" | "identity" | "probe";
   outcome?: RouteCacheabilityOutcome;
+  preserveResponseCachePolicy?: boolean;
   route?: {
     kind: "app-page";
     pattern: string;
   };
 };
+
+/** Preserve the existing policy when hybrid routing hands the request to Pages Router. */
+export function preserveRouteCacheabilityResponsePolicy(): void {
+  const state = readRouteCacheabilityState();
+  if (!state || state.mode !== "admit") return;
+  state.preserveResponseCachePolicy = true;
+}
 
 export function readRouteCacheabilityState(): RouteCacheabilityState | null {
   const context = getRequestExecutionContext();

--- a/packages/vinext/src/shims/cacheability-classification.ts
+++ b/packages/vinext/src/shims/cacheability-classification.ts
@@ -38,7 +38,7 @@ export type RouteCacheabilityState = {
   outcome?: RouteCacheabilityOutcome;
   preserveResponseCachePolicy?: boolean;
   route?: {
-    kind: "app-page";
+    kind: "app-page" | "app-route";
     pattern: string;
   };
 };
@@ -58,7 +58,7 @@ export function readRouteCacheabilityState(): RouteCacheabilityState | null {
   );
 }
 
-export function beginRouteCacheability(kind: "app-page", pattern: string): boolean {
+export function beginRouteCacheability(kind: "app-page" | "app-route", pattern: string): boolean {
   const state = readRouteCacheabilityState();
   if (!state) return false;
   state.route = { kind, pattern };
@@ -70,6 +70,22 @@ export function markRouteCacheabilityDynamic(reason: string): void {
   const state = readRouteCacheabilityState();
   if (!state) return;
   state.forcedDynamicReason = reason;
+}
+
+/** Read a request-specific routing veto without making the route globally dynamic. */
+export function getRouteCacheabilityDynamicReason(): string | null {
+  return readRouteCacheabilityState()?.forcedDynamicReason ?? null;
+}
+
+/** Reuse the active request's bounded response-capture envelope when available. */
+export function getRouteCacheabilityCaptureOptions(): Pick<
+  RouteCacheabilityState,
+  "captureBudget" | "captureDeadlineAt"
+> | null {
+  const state = readRouteCacheabilityState();
+  return state
+    ? { captureBudget: state.captureBudget, captureDeadlineAt: state.captureDeadlineAt }
+    : null;
 }
 
 /** Keep a completed response private without treating it as static-to-dynamic. */

--- a/packages/vinext/src/shims/cacheability-classification.ts
+++ b/packages/vinext/src/shims/cacheability-classification.ts
@@ -2,6 +2,14 @@ import { getRequestExecutionContext } from "./request-context.js";
 
 export const CACHEABILITY_REQUEST_STATE = Symbol.for("vinext.cacheabilityRequestState");
 
+export const CACHEABILITY_POLICY_HEADERS = [
+  "cache-control",
+  "cdn-cache-control",
+  "cloudflare-cdn-cache-control",
+] as const;
+
+type CacheabilityPolicyHeader = (typeof CACHEABILITY_POLICY_HEADERS)[number];
+
 export type RouteCacheabilityOutcome = {
   cacheControl?: string;
   cacheable: boolean;
@@ -23,7 +31,9 @@ export type RouteCacheabilityState = {
   captureDeadlineAt: number;
   complete?: (outcome: RouteCacheabilityOutcome) => void;
   completion?: Promise<RouteCacheabilityOutcome>;
+  finalResponseVetoReason?: string;
   forcedDynamicReason?: string;
+  initialResponseCachePolicy?: Partial<Record<CacheabilityPolicyHeader, string>>;
   mode: "admit" | "identity" | "probe";
   outcome?: RouteCacheabilityOutcome;
   route?: {
@@ -52,6 +62,26 @@ export function markRouteCacheabilityDynamic(reason: string): void {
   const state = readRouteCacheabilityState();
   if (!state) return;
   state.forcedDynamicReason = reason;
+}
+
+/** Keep a completed response private without treating it as static-to-dynamic. */
+export function markRouteCacheabilityFinalResponseUncacheable(reason: string): void {
+  const state = readRouteCacheabilityState();
+  if (!state || state.mode !== "admit") return;
+  state.finalResponseVetoReason ??= reason;
+}
+
+/** Record renderer-owned policy so admission can identify policy added later. */
+export function captureRouteCacheabilityResponsePolicy(headers: Headers): void {
+  const state = readRouteCacheabilityState();
+  if (!state || state.mode !== "admit" || state.initialResponseCachePolicy) return;
+
+  const policy: Partial<Record<CacheabilityPolicyHeader, string>> = {};
+  for (const name of CACHEABILITY_POLICY_HEADERS) {
+    const value = headers.get(name);
+    if (value !== null) policy[name] = value;
+  }
+  state.initialResponseCachePolicy = policy;
 }
 
 /** True only for an authenticated probe that must render the matched App Page. */

--- a/packages/vinext/src/shims/cacheability-classification.ts
+++ b/packages/vinext/src/shims/cacheability-classification.ts
@@ -12,11 +12,16 @@ export type RouteCacheabilityOutcome = {
 };
 
 export type RouteCacheabilityState = {
+  admission?: {
+    manifest: unknown;
+    representation: string;
+    requestKey: string;
+  };
   captureDeadlineAt: number;
   complete?: (outcome: RouteCacheabilityOutcome) => void;
   completion?: Promise<RouteCacheabilityOutcome>;
   forcedDynamicReason?: string;
-  mode: "identity" | "probe";
+  mode: "admit" | "identity" | "probe";
   outcome?: RouteCacheabilityOutcome;
   route?: {
     kind: "app-page";
@@ -49,6 +54,12 @@ export function markRouteCacheabilityDynamic(reason: string): void {
 /** True only for an authenticated probe that must render the matched App Page. */
 export function isRouteCacheabilityProbe(): boolean {
   return readRouteCacheabilityState()?.mode === "probe";
+}
+
+/** True when the outer Worker must decide cache admission after clean EOF. */
+export function isRouteCacheabilityEvaluation(): boolean {
+  const mode = readRouteCacheabilityState()?.mode;
+  return mode === "probe" || mode === "admit";
 }
 
 /** True for the authenticated routing pass that must not evaluate user components. */

--- a/packages/vinext/src/shims/cacheability-classification.ts
+++ b/packages/vinext/src/shims/cacheability-classification.ts
@@ -18,6 +18,8 @@ export type RouteCacheabilityState = {
     representation?: string;
     requestKey?: string;
   };
+  /** Optional admission budget override used by focused runtime tests. */
+  captureBudget?: { maxBytes: number; reservedBytes: number };
   captureDeadlineAt: number;
   complete?: (outcome: RouteCacheabilityOutcome) => void;
   completion?: Promise<RouteCacheabilityOutcome>;

--- a/packages/vinext/src/shims/cdn-cache.ts
+++ b/packages/vinext/src/shims/cdn-cache.ts
@@ -101,6 +101,14 @@ export function isNonCacheableCacheControl(cacheControl: string): boolean {
 // equivalent and stay CDN-specific.
 export type CdnCacheAdapter = {
   /**
+   * Fresh App Page responses must reach clean EOF before this adapter may emit
+   * shared-cache headers. Used by edge adapters whose cache sits in front of
+   * the Worker; origin-managed adapters can stream privately and persist only
+   * the completed artifact.
+   */
+  readonly requiresCompletedResponseAdmission?: boolean;
+
+  /**
    * Validate provider-specific request routing before the application handles
    * the request. Returning a response short-circuits the request pipeline;
    * returning `null` continues normally.

--- a/packages/vinext/src/virtual-vinext-rsc-entry.d.ts
+++ b/packages/vinext/src/virtual-vinext-rsc-entry.d.ts
@@ -16,6 +16,7 @@ declare module "virtual:vinext-rsc-entry" {
   export default rscHandler;
   export const __assetPrefix: string;
   export const __basePath: string;
+  export const __cacheabilityManifest: string | null;
   export const __hasPagesDir: boolean;
   export const __imageAllowedWidths: number[];
   export const __prerenderSecret: string;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -316,7 +316,7 @@ const projectServers = {
     use: { baseURL: "http://localhost:4187" },
     server: {
       command:
-        "npx vp run vinext#build && npx vp build && npx wrangler dev --config dist/server/wrangler.json --port 4187",
+        "npx vp run vinext#build && npx vp build && node embed-cacheability-manifest.mjs && npx wrangler dev --config dist/server/wrangler.json --port 4187",
       cwd: "./tests/fixtures/ppr-impact-demo",
       port: 4187,
       reuseExistingServer: !process.env.CI,

--- a/tests/app-route-handler-execution.test.ts
+++ b/tests/app-route-handler-execution.test.ts
@@ -532,7 +532,7 @@ describe("app route handler execution helpers", () => {
     await expect(response.json()).resolves.toEqual({ ping: "from-header" });
   });
 
-  it("completes a statically eligible custom-cache response before preserving its policy", async () => {
+  it("preserves a handler-owned public policy outside CDN admission", async () => {
     const dynamicUsage = createDynamicUsageState();
     const response = await executeAppRouteHandler({
       buildPageCacheTags() {
@@ -591,7 +591,7 @@ describe("app route handler execution helpers", () => {
       },
     });
 
-    expect(response.headers.get("cache-control")).toContain("no-store");
+    expect(response.headers.get("cache-control")).toBe("public, s-maxage=60");
     await expect(response.text()).resolves.toBe("tenant-a");
   });
 

--- a/tests/app-route-handler-execution.test.ts
+++ b/tests/app-route-handler-execution.test.ts
@@ -25,6 +25,12 @@ import {
   createRequestContext,
   runWithRequestContext,
 } from "../packages/vinext/src/shims/unified-request-context.js";
+import { runWithExecutionContext } from "../packages/vinext/src/shims/request-context.js";
+import { createWorkerCacheabilityAdmissionContext } from "../packages/vinext/src/server/cacheability-request.js";
+import {
+  CACHEABILITY_REQUEST_STATE,
+  type RouteCacheabilityState,
+} from "../packages/vinext/src/shims/cacheability-classification.js";
 
 // The fetch-cache shim captures `originalFetch` from globalThis at import
 // time, so stub fetch BEFORE importing it (same pattern as
@@ -520,10 +526,145 @@ describe("app route handler execution helpers", () => {
     });
 
     expect(isKnownDynamicAppRoute(routePattern)).toBe(true);
-    expect(response.headers.get("cache-control")).toBeNull();
+    expect(response.headers.get("cache-control")).toContain("no-store");
     expect(response.headers.get("x-vinext-cache")).toBeNull();
     expect(wroteCache).toBe(false);
     await expect(response.json()).resolves.toEqual({ ping: "from-header" });
+  });
+
+  it("completes a statically eligible custom-cache response before preserving its policy", async () => {
+    const dynamicUsage = createDynamicUsageState();
+    const response = await executeAppRouteHandler({
+      buildPageCacheTags() {
+        return [];
+      },
+      cleanPathname: "/api/custom-cache-late-dynamic",
+      clearRequestContext() {},
+      consumeDynamicUsage: dynamicUsage.consumeDynamicUsage,
+      executionContext: null,
+      getAndClearPendingCookies() {
+        return [];
+      },
+      getCollectedFetchTags() {
+        return [];
+      },
+      getDraftModeCookieHeader() {
+        return null;
+      },
+      handler: { dynamic: "auto", revalidate: 60 },
+      handlerFn(request) {
+        return new Response(
+          new ReadableStream<Uint8Array>(
+            {
+              pull(controller) {
+                controller.enqueue(
+                  new TextEncoder().encode(request.headers.get("x-tenant") ?? "missing"),
+                );
+                controller.close();
+              },
+            },
+            { highWaterMark: 0 },
+          ),
+          { headers: { "Cache-Control": "public, s-maxage=60" } },
+        );
+      },
+      isAutoHead: false,
+      isProduction: true,
+      isrRouteKey(pathname) {
+        return pathname;
+      },
+      async isrSet() {
+        throw new Error("dynamic response must not be persisted");
+      },
+      markDynamicUsage: dynamicUsage.markDynamicUsage,
+      method: "GET",
+      middlewareContext: { headers: null, status: null },
+      params: null,
+      reportRequestError() {},
+      request: new Request("https://example.com/api/custom-cache-late-dynamic", {
+        headers: { "x-tenant": "tenant-a" },
+      }),
+      revalidateSeconds: 60,
+      routePattern: "/api/custom-cache-late-dynamic",
+      setHeadersAccessPhase() {
+        return "render";
+      },
+    });
+
+    expect(response.headers.get("cache-control")).toContain("no-store");
+    await expect(response.text()).resolves.toBe("tenant-a");
+  });
+
+  it("falls back to private streaming and defers cleanup when bounded completion overflows", async () => {
+    const request = new Request("https://example.com/api/large", {
+      headers: { Accept: "*/*" },
+    });
+    const context = createWorkerCacheabilityAdmissionContext(
+      { waitUntil() {} },
+      request,
+      null,
+      "build-a",
+      true,
+    );
+    const state = Reflect.get(context, CACHEABILITY_REQUEST_STATE) as RouteCacheabilityState;
+    state.captureBudget = { maxBytes: 1, reservedBytes: 0 };
+    let cleared = false;
+    const phaseCalls: string[] = [];
+
+    const response = await runWithExecutionContext(context, () =>
+      executeAppRouteHandler({
+        buildPageCacheTags() {
+          return [];
+        },
+        cleanPathname: "/api/large",
+        clearRequestContext() {
+          cleared = true;
+        },
+        consumeDynamicUsage() {
+          return false;
+        },
+        executionContext: null,
+        getAndClearPendingCookies() {
+          return [];
+        },
+        getCollectedFetchTags() {
+          return [];
+        },
+        getDraftModeCookieHeader() {
+          return null;
+        },
+        handler: { dynamic: "auto", revalidate: 60 },
+        handlerFn() {
+          return new Response("large");
+        },
+        isAutoHead: false,
+        isProduction: true,
+        isrRouteKey(pathname) {
+          return pathname;
+        },
+        async isrSet() {
+          throw new Error("overflow response must not be persisted");
+        },
+        markDynamicUsage() {},
+        method: "GET",
+        middlewareContext: { headers: null, status: null },
+        params: null,
+        reportRequestError() {},
+        request,
+        revalidateSeconds: 60,
+        routePattern: "/api/large",
+        setHeadersAccessPhase(phase) {
+          phaseCalls.push(phase);
+          return "render";
+        },
+      }),
+    );
+
+    expect(cleared).toBe(false);
+    expect(response.headers.get("cache-control")).toContain("no-store");
+    await expect(response.text()).resolves.toBe("large");
+    expect(cleared).toBe(true);
+    expect(phaseCalls).toEqual(["route-handler", "render"]);
   });
 
   it("applies the draft cache policy to responses with immutable headers", async () => {
@@ -743,7 +884,7 @@ describe("app route handler execution helpers", () => {
       expect(fetchMock.mock.calls[0]?.[1]?.cache).toBe("no-store");
       expect(isKnownDynamicAppRoute(routePattern)).toBe(true);
       expect(wroteCache).toBe(false);
-      expect(response.headers.get("cache-control")).toBeNull();
+      expect(response.headers.get("cache-control")).toContain("no-store");
       expect(response.headers.get("x-vinext-cache")).toBeNull();
       await expect(response.json()).resolves.toEqual({ ok: true });
     } finally {

--- a/tests/app-route-handler-execution.test.ts
+++ b/tests/app-route-handler-execution.test.ts
@@ -595,6 +595,83 @@ describe("app route handler execution helpers", () => {
     await expect(response.text()).resolves.toBe("tenant-a");
   });
 
+  it("completes an otherwise dynamic GET before adapter admission", async () => {
+    const request = new Request("https://example.com/api/config-cache", {
+      headers: { "x-tenant": "tenant-a" },
+    });
+    const context = createWorkerCacheabilityAdmissionContext(
+      { waitUntil() {} },
+      request,
+      null,
+      "build-a",
+      true,
+    );
+    const state = Reflect.get(context, CACHEABILITY_REQUEST_STATE) as RouteCacheabilityState;
+    const dynamicUsage = createDynamicUsageState();
+
+    const response = await runWithExecutionContext(context, () =>
+      executeAppRouteHandler({
+        buildPageCacheTags() {
+          return [];
+        },
+        cleanPathname: "/api/config-cache",
+        clearRequestContext() {},
+        consumeDynamicUsage: dynamicUsage.consumeDynamicUsage,
+        executionContext: null,
+        getAndClearPendingCookies() {
+          return [];
+        },
+        getCollectedFetchTags() {
+          return [];
+        },
+        getDraftModeCookieHeader() {
+          return null;
+        },
+        handler: { dynamic: "auto" },
+        handlerFn(trackedRequest) {
+          return new Response(
+            new ReadableStream<Uint8Array>(
+              {
+                pull(controller) {
+                  controller.enqueue(
+                    new TextEncoder().encode(trackedRequest.headers.get("x-tenant") ?? "missing"),
+                  );
+                  controller.close();
+                },
+              },
+              { highWaterMark: 0 },
+            ),
+          );
+        },
+        isAutoHead: false,
+        isProduction: true,
+        isrRouteKey(pathname) {
+          return pathname;
+        },
+        async isrSet() {
+          throw new Error("dynamic response must not be persisted");
+        },
+        markDynamicUsage: dynamicUsage.markDynamicUsage,
+        method: "GET",
+        middlewareContext: { headers: null, status: null },
+        params: null,
+        reportRequestError() {},
+        request,
+        revalidateSeconds: null,
+        routePattern: "/api/config-cache",
+        setHeadersAccessPhase() {
+          return "render";
+        },
+      }),
+    );
+
+    expect(state.finalResponseVetoReason).toContain(
+      "did not complete as a reusable static response",
+    );
+    expect(response.headers.get("cache-control")).toContain("no-store");
+    await expect(response.text()).resolves.toBe("tenant-a");
+  });
+
   it("falls back to private streaming and defers cleanup when bounded completion overflows", async () => {
     const request = new Request("https://example.com/api/large", {
       headers: { Accept: "*/*" },

--- a/tests/app-route-handler-policy.test.ts
+++ b/tests/app-route-handler-policy.test.ts
@@ -6,6 +6,7 @@ import {
   resolveAppRouteHandlerMethod,
   resolveAppRouteHandlerSpecialError,
   shouldApplyAppRouteHandlerRevalidateHeader,
+  shouldCompleteAppRouteHandlerResponse,
   shouldReadAppRouteHandlerCache,
   shouldWriteAppRouteHandlerCache,
 } from "../packages/vinext/src/server/app-route-handler-policy.js";
@@ -72,6 +73,21 @@ describe("app route handler policy helpers", () => {
     // unless the handler set its own. Gating this off would leave the
     // response with no Cache-Control and expose it to heuristic caching.
     expect(shouldApplyAppRouteHandlerRevalidateHeader(writeBase)).toBe(true);
+  });
+
+  it("completes GET bodies when the CDN adapter requires response admission", () => {
+    expect(
+      shouldCompleteAppRouteHandlerResponse({
+        dynamicConfig: "auto",
+        dynamicUsedInHandler: false,
+        handlerSetCacheControl: false,
+        isAutoHead: false,
+        isProduction: true,
+        method: "GET",
+        revalidateSeconds: null,
+        requiresCompletedResponseAdmission: true,
+      }),
+    ).toBe(true);
   });
 
   it("detects invalid default-export route handlers", () => {

--- a/tests/app-route-handler-policy.test.ts
+++ b/tests/app-route-handler-policy.test.ts
@@ -24,6 +24,22 @@ describe("app route handler policy helpers", () => {
     expect(getAppRouteHandlerRevalidateSeconds({ revalidate: false })).toBe(Infinity);
   });
 
+  // Ported from Next.js:
+  // packages/next/src/server/route-modules/app-route/helpers/is-static-gen-enabled.ts
+  it("recognizes every App Route static-generation opt-in", () => {
+    expect(getAppRouteHandlerRevalidateSeconds({ dynamic: "force-static" })).toBe(Infinity);
+    expect(getAppRouteHandlerRevalidateSeconds({ dynamic: "error" })).toBe(Infinity);
+    expect(
+      getAppRouteHandlerRevalidateSeconds({
+        generateStaticParams() {
+          return [{ slug: "one" }];
+        },
+      }),
+    ).toBe(Infinity);
+    expect(getAppRouteHandlerRevalidateSeconds({ dynamic: "force-dynamic" })).toBeNull();
+    expect(getAppRouteHandlerRevalidateSeconds({})).toBeNull();
+  });
+
   it("treats revalidate = 0 as never-cache for route handler ISR read/write gates", () => {
     const readBase = {
       dynamicConfig: "auto",

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -38,6 +38,11 @@ import {
   headers as requestHeaders,
 } from "../packages/vinext/src/shims/headers.js";
 import { readStaticFileSignal } from "../packages/vinext/src/server/static-file-signal.js";
+import { runWithExecutionContext } from "../packages/vinext/src/shims/request-context.js";
+import {
+  CACHEABILITY_REQUEST_STATE,
+  type RouteCacheabilityState,
+} from "../packages/vinext/src/shims/cacheability-classification.js";
 
 type TestRoute = {
   __loadPage?: unknown;
@@ -202,6 +207,58 @@ describe("createAppRscHandler", () => {
     expect(response.status).toBe(200);
     expect(await response.text()).toBe("page");
   });
+
+  it.each([
+    {
+      condition: { type: "cookie" as const, key: "tenant" },
+      expectedReason: "next.config rewrite depends on request headers or cookies",
+      requestUrl: "https://example.test/docs/account",
+      requestHeaders: { Cookie: "tenant=alice" },
+    },
+    {
+      condition: { type: "query" as const, key: "tenant" },
+      expectedReason: undefined,
+      requestUrl: "https://example.test/docs/account?tenant=alice",
+      requestHeaders: undefined,
+    },
+  ])(
+    "keeps $condition.type-conditioned rewrite cacheability aligned with the public key",
+    async ({ condition, expectedReason, requestHeaders, requestUrl }) => {
+      // Cookie-conditioned rewrites are exercised by Next.js here:
+      // test/e2e/custom-routes/custom-routes.test.ts
+      // https://github.com/vercel/next.js/blob/canary/test/e2e/custom-routes/custom-routes.test.ts
+      const handler = createHandler({
+        configHeaders: [],
+        configRewrites: {
+          beforeFiles: [
+            {
+              source: "/account",
+              destination: "/about",
+              has: [condition],
+            },
+          ],
+          afterFiles: [],
+          fallback: [],
+        },
+      });
+      const state: RouteCacheabilityState = {
+        captureDeadlineAt: Date.now() + 1_000,
+        mode: "admit",
+      };
+      const context = {
+        [CACHEABILITY_REQUEST_STATE]: state,
+        waitUntil() {},
+      };
+
+      const response = await runWithExecutionContext(context, () =>
+        handler(new Request(requestUrl, { headers: requestHeaders }), null),
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe("page");
+      expect(state.forcedDynamicReason).toBe(expectedReason);
+    },
+  );
 
   it.each(["afterFiles", "fallback"] as const)(
     "allows out-of-basePath %s rewrites to reach Pages routes",

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -211,19 +211,35 @@ describe("createAppRscHandler", () => {
   it.each([
     {
       condition: { type: "cookie" as const, key: "tenant" },
-      expectedReason: "next.config rewrite depends on request headers or cookies",
+      expectedReason: "next.config rewrite depends on request headers, cookies, or hostnames",
+      expectedStatus: 200,
       requestUrl: "https://example.test/docs/account",
       requestHeaders: { Cookie: "tenant=alice" },
     },
     {
+      condition: { type: "cookie" as const, key: "tenant" },
+      expectedReason: "next.config rewrite depends on request headers, cookies, or hostnames",
+      expectedStatus: 404,
+      requestUrl: "https://example.test/docs/account",
+      requestHeaders: undefined,
+    },
+    {
+      condition: { type: "host" as const, key: "host", value: "example\\.test" },
+      expectedReason: "next.config rewrite depends on request headers, cookies, or hostnames",
+      expectedStatus: 200,
+      requestUrl: "https://example.test/docs/account",
+      requestHeaders: undefined,
+    },
+    {
       condition: { type: "query" as const, key: "tenant" },
       expectedReason: undefined,
+      expectedStatus: 200,
       requestUrl: "https://example.test/docs/account?tenant=alice",
       requestHeaders: undefined,
     },
   ])(
     "keeps $condition.type-conditioned rewrite cacheability aligned with the public key",
-    async ({ condition, expectedReason, requestHeaders, requestUrl }) => {
+    async ({ condition, expectedReason, expectedStatus, requestHeaders, requestUrl }) => {
       // Cookie-conditioned rewrites are exercised by Next.js here:
       // test/e2e/custom-routes/custom-routes.test.ts
       // https://github.com/vercel/next.js/blob/canary/test/e2e/custom-routes/custom-routes.test.ts
@@ -254,8 +270,8 @@ describe("createAppRscHandler", () => {
         handler(new Request(requestUrl, { headers: requestHeaders }), null),
       );
 
-      expect(response.status).toBe(200);
-      expect(await response.text()).toBe("page");
+      expect(response.status).toBe(expectedStatus);
+      if (expectedStatus === 200) expect(await response.text()).toBe("page");
       expect(state.forcedDynamicReason).toBe(expectedReason);
     },
   );
@@ -294,19 +310,35 @@ describe("createAppRscHandler", () => {
   it.each([
     {
       condition: { type: "cookie" as const, key: "tenant" },
-      expectedReason: "next.config headers depend on request headers or cookies",
+      expectedReason: "next.config headers depend on request headers, cookies, or hostnames",
+      expectedHeader: "alice",
       requestUrl: "https://example.test/docs/about",
       requestHeaders: { Cookie: "tenant=alice" },
     },
     {
+      condition: { type: "cookie" as const, key: "tenant" },
+      expectedReason: "next.config headers depend on request headers, cookies, or hostnames",
+      expectedHeader: null,
+      requestUrl: "https://example.test/docs/about",
+      requestHeaders: undefined,
+    },
+    {
+      condition: { type: "host" as const, key: "host", value: "example\\.test" },
+      expectedReason: "next.config headers depend on request headers, cookies, or hostnames",
+      expectedHeader: "alice",
+      requestUrl: "https://example.test/docs/about",
+      requestHeaders: undefined,
+    },
+    {
       condition: { type: "query" as const, key: "tenant" },
       expectedReason: undefined,
+      expectedHeader: "alice",
       requestUrl: "https://example.test/docs/about?tenant=alice",
       requestHeaders: undefined,
     },
   ])(
     "keeps $condition.type-conditioned config header cacheability aligned with the public key",
-    async ({ condition, expectedReason, requestHeaders, requestUrl }) => {
+    async ({ condition, expectedHeader, expectedReason, requestHeaders, requestUrl }) => {
       const handler = createHandler({
         configHeaders: [
           {
@@ -330,10 +362,41 @@ describe("createAppRscHandler", () => {
       );
 
       expect(response.status).toBe(200);
-      expect(response.headers.get("X-Tenant")).toBe("alice");
+      expect(response.headers.get("X-Tenant")).toBe(expectedHeader);
       expect(state.forcedDynamicReason).toBe(expectedReason);
     },
   );
+
+  it("keeps a condition-miss redirect pathname private", async () => {
+    const handler = createHandler({
+      configRedirects: [
+        {
+          source: "/about",
+          destination: "/account",
+          permanent: false,
+          has: [{ type: "cookie", key: "tenant" }],
+        },
+      ],
+    });
+    const state: RouteCacheabilityState = {
+      captureDeadlineAt: Date.now() + 1_000,
+      mode: "admit",
+    };
+    const context = {
+      [CACHEABILITY_REQUEST_STATE]: state,
+      waitUntil() {},
+    };
+
+    const response = await runWithExecutionContext(context, () =>
+      handler(new Request("https://example.test/docs/about"), null),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("page");
+    expect(state.forcedDynamicReason).toBe(
+      "next.config redirect depends on request headers, cookies, or hostnames",
+    );
+  });
 
   it("passes source config headers into Server Action execution", async () => {
     let sourceConfigHeader: string | null | undefined;

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -4660,9 +4660,20 @@ describe("createAppRscHandler", () => {
       renderPagesFallback,
     });
 
-    const response = await handler(new Request("https://example.test/docs/about"), null);
+    const state: RouteCacheabilityState = {
+      captureDeadlineAt: Date.now() + 1_000,
+      mode: "admit",
+    };
+    const context = {
+      [CACHEABILITY_REQUEST_STATE]: state,
+      waitUntil() {},
+    };
+    const response = await runWithExecutionContext(context, () =>
+      handler(new Request("https://example.test/docs/about"), null),
+    );
 
     expect(await response.text()).toBe("pages:/about");
+    expect(state.preserveResponseCachePolicy).toBe(true);
     expect(renderPagesFallback).toHaveBeenCalledWith(
       expect.objectContaining({
         matchKind: "static",

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -291,6 +291,50 @@ describe("createAppRscHandler", () => {
     },
   );
 
+  it.each([
+    {
+      condition: { type: "cookie" as const, key: "tenant" },
+      expectedReason: "next.config headers depend on request headers or cookies",
+      requestUrl: "https://example.test/docs/about",
+      requestHeaders: { Cookie: "tenant=alice" },
+    },
+    {
+      condition: { type: "query" as const, key: "tenant" },
+      expectedReason: undefined,
+      requestUrl: "https://example.test/docs/about?tenant=alice",
+      requestHeaders: undefined,
+    },
+  ])(
+    "keeps $condition.type-conditioned config header cacheability aligned with the public key",
+    async ({ condition, expectedReason, requestHeaders, requestUrl }) => {
+      const handler = createHandler({
+        configHeaders: [
+          {
+            source: "/about",
+            has: [condition],
+            headers: [{ key: "X-Tenant", value: "alice" }],
+          },
+        ],
+      });
+      const state: RouteCacheabilityState = {
+        captureDeadlineAt: Date.now() + 1_000,
+        mode: "admit",
+      };
+      const context = {
+        [CACHEABILITY_REQUEST_STATE]: state,
+        waitUntil() {},
+      };
+
+      const response = await runWithExecutionContext(context, () =>
+        handler(new Request(requestUrl, { headers: requestHeaders }), null),
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("X-Tenant")).toBe("alice");
+      expect(state.forcedDynamicReason).toBe(expectedReason);
+    },
+  );
+
   it("passes source config headers into Server Action execution", async () => {
     let sourceConfigHeader: string | null | undefined;
     const handleServerActionRequest: NonNullable<

--- a/tests/app-rsc-response-finalizer.test.ts
+++ b/tests/app-rsc-response-finalizer.test.ts
@@ -16,6 +16,12 @@ import {
   type CdnResponseHeaders,
 } from "../packages/vinext/src/shims/cdn-cache.js";
 import { createStaticFileSignal } from "../packages/vinext/src/server/request-pipeline.js";
+import { createWorkerCacheabilityAdmissionContext } from "../packages/vinext/src/server/cacheability-request.js";
+import {
+  CACHEABILITY_REQUEST_STATE,
+  type RouteCacheabilityState,
+} from "../packages/vinext/src/shims/cacheability-classification.js";
+import { runWithExecutionContext } from "../packages/vinext/src/shims/request-context.js";
 
 afterEach(() => setCdnCacheAdapter(new DefaultCdnCacheAdapter()));
 
@@ -92,6 +98,55 @@ describe("finalizeAppRscResponse — config header application", () => {
 
     expect(response.headers.get("cache-control")).toBe("no-store, must-revalidate");
     expect(response.headers.get("x-example-edge-policy")).toBeNull();
+  });
+
+  it("records the adapter's provisional policy before config headers run", async () => {
+    const adapter: CdnCacheAdapter = {
+      ownsBackgroundRevalidation: true,
+      async get() {
+        return null;
+      },
+      async set() {},
+      buildResponseHeaders({ cacheControl }): CdnResponseHeaders {
+        return { "Cache-Control": cacheControl || "no-store" };
+      },
+      hasExplicitNonCacheableResponsePolicy(headers) {
+        return headers.get("Cache-Control")?.includes("no-store") === true;
+      },
+      async revalidateTag() {},
+    };
+    setCdnCacheAdapter(adapter);
+    const request = new Request("http://example.com/about", {
+      headers: { Accept: "text/html" },
+    });
+    const executionContext = createWorkerCacheabilityAdmissionContext(
+      { waitUntil() {} },
+      request,
+      null,
+      "build-a",
+      true,
+    );
+
+    await runWithExecutionContext(executionContext, () =>
+      finalizeAppRscResponse(new Response("body"), request, {
+        basePath: "",
+        configHeaders: [
+          {
+            source: "/about",
+            headers: [{ key: "Cache-Control", value: "private, no-store" }],
+          },
+        ],
+        i18nConfig: null,
+        requestContext: makeRequestContext(),
+      }),
+    );
+
+    const state = Reflect.get(
+      executionContext,
+      CACHEABILITY_REQUEST_STATE,
+    ) as RouteCacheabilityState;
+    expect(state.frameworkResponseCachePolicy).toEqual({ "cache-control": "no-store" });
+    expect(state.finalResponseVetoReason).toContain("next.config headers set a non-cacheable");
   });
 
   it("applies a matching config header to a 200 response", async () => {

--- a/tests/cacheability-admission.test.ts
+++ b/tests/cacheability-admission.test.ts
@@ -126,7 +126,7 @@ describe("single-request cacheability admission", () => {
       cacheable: true,
       cacheControl: "s-maxage=60, stale-while-revalidate=540",
     };
-    state.initialResponseCachePolicy = { "cache-control": "no-store" };
+    state.frameworkResponseCachePolicy = { "cache-control": "no-store" };
 
     const response = await finalizeWorkerCacheabilityResponse(
       new Response("static", { headers: { "Cache-Control": "no-store" } }),
@@ -225,7 +225,7 @@ describe("single-request cacheability admission", () => {
 
   const lateFinalPolicyCases: Array<{
     finalHeaders: Record<string, string>;
-    initialPolicy: NonNullable<RouteCacheabilityState["initialResponseCachePolicy"]>;
+    initialPolicy: NonNullable<RouteCacheabilityState["frameworkResponseCachePolicy"]>;
     name: string;
   }> = [
     {
@@ -262,7 +262,7 @@ describe("single-request cacheability admission", () => {
       );
       const state = cacheabilityState(context);
       state.route = { kind: "app-page", pattern: "/page" };
-      state.initialResponseCachePolicy = testCase.initialPolicy;
+      state.frameworkResponseCachePolicy = testCase.initialPolicy;
       state.outcome = {
         cacheable: true,
         cacheControl: "s-maxage=60, stale-while-revalidate=540",

--- a/tests/cacheability-admission.test.ts
+++ b/tests/cacheability-admission.test.ts
@@ -136,6 +136,34 @@ describe("single-request cacheability admission", () => {
     await expect(response.text()).resolves.toBe("static");
   });
 
+  it("honors a final public App Page cache policy", async () => {
+    // Ported from Next.js:
+    // test/e2e/app-dir/custom-cache-control/custom-cache-control.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/custom-cache-control/custom-cache-control.test.ts
+    const context = createWorkerCacheabilityAdmissionContext(
+      { waitUntil() {} },
+      request,
+      null,
+      "build-a",
+      true,
+    );
+    const state = cacheabilityState(context);
+    state.route = { kind: "app-page", pattern: "/page" };
+    state.outcome = {
+      cacheable: true,
+      cacheControl: "s-maxage=120, stale-while-revalidate=31535880",
+    };
+    state.frameworkResponseCachePolicy = { "cache-control": "no-store" };
+
+    const response = await finalizeWorkerCacheabilityResponse(
+      new Response("static", { headers: { "Cache-Control": "s-maxage=30" } }),
+      context,
+    );
+
+    expect(response.headers.get("Cache-Control")).toBe("s-maxage=30");
+    await expect(response.text()).resolves.toBe("static");
+  });
+
   it("keeps a completed dynamic response private without a build manifest", async () => {
     const context = createWorkerCacheabilityAdmissionContext(
       { waitUntil() {} },

--- a/tests/cacheability-admission.test.ts
+++ b/tests/cacheability-admission.test.ts
@@ -223,6 +223,62 @@ describe("single-request cacheability admission", () => {
     await expect(response.text()).resolves.toContain("changed from static to dynamic");
   });
 
+  const lateFinalPolicyCases: Array<{
+    finalHeaders: Record<string, string>;
+    initialPolicy: NonNullable<RouteCacheabilityState["initialResponseCachePolicy"]>;
+    name: string;
+  }> = [
+    {
+      finalHeaders: { "Set-Cookie": "session=private; Path=/; HttpOnly" },
+      initialPolicy: {},
+      name: "Set-Cookie",
+    },
+    {
+      finalHeaders: { "Cache-Control": "private, no-store" },
+      initialPolicy: { "cache-control": "public, s-maxage=60" },
+      name: "Cache-Control",
+    },
+    {
+      finalHeaders: { "CDN-Cache-Control": "private, no-store" },
+      initialPolicy: { "cdn-cache-control": "public, s-maxage=60" },
+      name: "CDN-Cache-Control",
+    },
+    {
+      finalHeaders: { "Cloudflare-CDN-Cache-Control": "private, no-store" },
+      initialPolicy: { "cloudflare-cdn-cache-control": "public, s-maxage=60" },
+      name: "Cloudflare-CDN-Cache-Control",
+    },
+  ];
+
+  it.each(lateFinalPolicyCases)(
+    "keeps a manifest-backed response private after late $name",
+    async (testCase) => {
+      const { raw } = staticManifestRoute();
+      const context = createWorkerCacheabilityAdmissionContext(
+        { waitUntil() {} },
+        request,
+        raw,
+        "build-a",
+      );
+      const state = cacheabilityState(context);
+      state.route = { kind: "app-page", pattern: "/page" };
+      state.initialResponseCachePolicy = testCase.initialPolicy;
+      state.outcome = {
+        cacheable: true,
+        cacheControl: "s-maxage=60, stale-while-revalidate=540",
+      };
+
+      const response = await finalizeWorkerCacheabilityResponse(
+        new Response("late private response", { headers: testCase.finalHeaders }),
+        context,
+      );
+
+      expect(state.finalResponseVetoReason).toBeUndefined();
+      expect(response.headers.get("Cache-Control")).toContain("no-store");
+      await expect(response.text()).resolves.toBe("late private response");
+    },
+  );
+
   it("does not add admission overhead for adapters that persist completed artifacts", () => {
     const base = { waitUntil() {} };
     expect(createWorkerCacheabilityAdmissionContext(base, request, null, "build-a", false)).toBe(

--- a/tests/cacheability-admission.test.ts
+++ b/tests/cacheability-admission.test.ts
@@ -9,6 +9,10 @@ import {
   CACHEABILITY_REQUEST_STATE,
   type RouteCacheabilityState,
 } from "../packages/vinext/src/shims/cacheability-classification.js";
+import {
+  cacheabilityManifestRouteKey,
+  type CacheabilityManifestRoute,
+} from "../packages/vinext/src/server/cacheability-manifest.js";
 
 const encoder = new TextEncoder();
 
@@ -86,6 +90,27 @@ function cacheabilityState(context: object): RouteCacheabilityState {
   return Reflect.get(context, CACHEABILITY_REQUEST_STATE) as RouteCacheabilityState;
 }
 
+function staticManifestRoute(): { raw: string; route: CacheabilityManifestRoute } {
+  const route: CacheabilityManifestRoute = {
+    kind: "app-page",
+    pattern: "/page",
+    representation: "html",
+    requestKey: "/page",
+    state: "static-candidate",
+    status: 200,
+  };
+  const key = cacheabilityManifestRouteKey(
+    route.kind,
+    route.pattern,
+    route.representation,
+    route.requestKey,
+  );
+  return {
+    raw: JSON.stringify({ buildId: "build-a", routes: { [key]: route }, version: 1 }),
+    route,
+  };
+}
+
 describe("single-request cacheability admission", () => {
   const request = new Request("https://example.com/page", {
     headers: { Accept: "text/html" },
@@ -125,6 +150,76 @@ describe("single-request cacheability admission", () => {
     const response = await finalizeWorkerCacheabilityResponse(new Response("dynamic"), context);
     expect(response.headers.get("Cache-Control")).toContain("no-store");
     await expect(response.text()).resolves.toBe("dynamic");
+  });
+
+  it("keeps responses with unsupported Vary fields private", async () => {
+    const context = createWorkerCacheabilityAdmissionContext(
+      { waitUntil() {} },
+      request,
+      null,
+      "build-a",
+      true,
+    );
+    const state = cacheabilityState(context);
+    state.route = { kind: "app-page", pattern: "/page" };
+    state.outcome = {
+      cacheable: true,
+      cacheControl: "s-maxage=60, stale-while-revalidate=540",
+    };
+
+    const response = await finalizeWorkerCacheabilityResponse(
+      new Response("contextual", { headers: { Vary: "RSC, Cookie" } }),
+      context,
+    );
+
+    expect(response.headers.get("Cache-Control")).toContain("no-store");
+    await expect(response.text()).resolves.toBe("contextual");
+  });
+
+  it("serves an intentionally private certified response without treating it as static-to-dynamic", async () => {
+    // Next.js bypasses the Full Route Cache in draft mode. The HTML renderer
+    // intentionally returns no-store without opening a cache-write completion,
+    // so an absent outcome is not evidence that a dynamic API was used.
+    // Ported from Next.js: test/e2e/app-dir/app-static/app-static.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/app-static/app-static.test.ts
+    const { raw } = staticManifestRoute();
+    const context = createWorkerCacheabilityAdmissionContext(
+      { waitUntil() {} },
+      request,
+      raw,
+      "build-a",
+    );
+    const state = cacheabilityState(context);
+    state.route = { kind: "app-page", pattern: "/page" };
+
+    const response = await finalizeWorkerCacheabilityResponse(
+      new Response("draft", { headers: { "Cache-Control": "no-store" } }),
+      context,
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toContain("no-store");
+    await expect(response.text()).resolves.toBe("draft");
+  });
+
+  it("still rejects an observed static-to-dynamic transition", async () => {
+    const { raw } = staticManifestRoute();
+    const context = createWorkerCacheabilityAdmissionContext(
+      { waitUntil() {} },
+      request,
+      raw,
+      "build-a",
+    );
+    const state = cacheabilityState(context);
+    const captureBudget = createCacheabilityAdmissionCaptureBudget(7);
+    state.captureBudget = captureBudget;
+    state.route = { kind: "app-page", pattern: "/page" };
+    state.outcome = { cacheable: false, dynamicUsage: true };
+
+    const response = await finalizeWorkerCacheabilityResponse(new Response("dynamic"), context);
+    expect(response.status).toBe(500);
+    expect(response.headers.get("Cache-Control")).toContain("no-store");
+    expect(captureBudget.reservedBytes).toBe(0);
+    await expect(response.text()).resolves.toContain("changed from static to dynamic");
   });
 
   it("does not add admission overhead for adapters that persist completed artifacts", () => {

--- a/tests/cacheability-admission.test.ts
+++ b/tests/cacheability-admission.test.ts
@@ -126,6 +126,7 @@ describe("single-request cacheability admission", () => {
       cacheable: true,
       cacheControl: "s-maxage=60, stale-while-revalidate=540",
     };
+    state.initialResponseCachePolicy = { "cache-control": "no-store" };
 
     const response = await finalizeWorkerCacheabilityResponse(
       new Response("static", { headers: { "Cache-Control": "no-store" } }),

--- a/tests/cacheability-admission.test.ts
+++ b/tests/cacheability-admission.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vite-plus/test";
+import { captureCacheabilityAdmissionBody } from "../packages/vinext/src/server/cacheability-request.js";
+
+const encoder = new TextEncoder();
+
+describe("cacheability admission capture", () => {
+  it("preserves all bytes when the bounded capture limit is exceeded", async () => {
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode("first"));
+        controller.enqueue(encoder.encode("second"));
+        controller.close();
+      },
+    });
+
+    const captured = await captureCacheabilityAdmissionBody(body, Date.now() + 1_000, 5);
+    expect(captured.kind).toBe("fallback");
+    await expect(new Response(captured.body).text()).resolves.toBe("firstsecond");
+  });
+
+  it("falls back to the private stream without cancelling a slow response", async () => {
+    const body = new ReadableStream<Uint8Array>({
+      async start(controller) {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        controller.enqueue(encoder.encode("slow"));
+        controller.close();
+      },
+    });
+
+    const captured = await captureCacheabilityAdmissionBody(body, Date.now() + 5);
+    expect(captured.kind).toBe("fallback");
+    await expect(new Response(captured.body).text()).resolves.toBe("slow");
+  });
+});

--- a/tests/cacheability-admission.test.ts
+++ b/tests/cacheability-admission.test.ts
@@ -153,6 +153,25 @@ describe("single-request cacheability admission", () => {
     await expect(response.text()).resolves.toBe("dynamic");
   });
 
+  it("preserves an independently classified hybrid Pages response", async () => {
+    const context = createWorkerCacheabilityAdmissionContext(
+      { waitUntil() {} },
+      request,
+      null,
+      "build-a",
+      true,
+    );
+    cacheabilityState(context).preserveResponseCachePolicy = true;
+
+    const response = await finalizeWorkerCacheabilityResponse(
+      new Response("pages", { headers: { "Cache-Control": "public, s-maxage=300" } }),
+      context,
+    );
+
+    expect(response.headers.get("Cache-Control")).toBe("public, s-maxage=300");
+    await expect(response.text()).resolves.toBe("pages");
+  });
+
   it("keeps responses with unsupported Vary fields private", async () => {
     const context = createWorkerCacheabilityAdmissionContext(
       { waitUntil() {} },

--- a/tests/cacheability-admission.test.ts
+++ b/tests/cacheability-admission.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from "vite-plus/test";
-import { captureCacheabilityAdmissionBody } from "../packages/vinext/src/server/cacheability-request.js";
+import {
+  captureCacheabilityAdmissionBody,
+  createCacheabilityAdmissionCaptureBudget,
+  createWorkerCacheabilityAdmissionContext,
+  finalizeWorkerCacheabilityResponse,
+} from "../packages/vinext/src/server/cacheability-request.js";
+import {
+  CACHEABILITY_REQUEST_STATE,
+  type RouteCacheabilityState,
+} from "../packages/vinext/src/shims/cacheability-classification.js";
 
 const encoder = new TextEncoder();
 
@@ -30,5 +39,98 @@ describe("cacheability admission capture", () => {
     const captured = await captureCacheabilityAdmissionBody(body, Date.now() + 5);
     expect(captured.kind).toBe("fallback");
     await expect(new Response(captured.body).text()).resolves.toBe("slow");
+  });
+
+  it("bounds completed captures across concurrent isolate requests", async () => {
+    const budget = createCacheabilityAdmissionCaptureBudget(5);
+    const first = await captureCacheabilityAdmissionBody(
+      new Response("first").body,
+      Date.now() + 1_000,
+      10,
+      budget,
+    );
+    expect(first.kind).toBe("captured");
+    expect(budget.reservedBytes).toBe(5);
+
+    const second = await captureCacheabilityAdmissionBody(
+      new Response("second").body,
+      Date.now() + 1_000,
+      10,
+      budget,
+    );
+    expect(second.kind).toBe("fallback");
+    await expect(new Response(second.body).text()).resolves.toBe("second");
+    expect(budget.reservedBytes).toBe(5);
+
+    await expect(new Response(first.body).text()).resolves.toBe("first");
+    expect(budget.reservedBytes).toBe(0);
+  });
+
+  it("releases the isolate reservation when a captured response is cancelled", async () => {
+    const budget = createCacheabilityAdmissionCaptureBudget(5);
+    const captured = await captureCacheabilityAdmissionBody(
+      new Response("first").body,
+      Date.now() + 1_000,
+      10,
+      budget,
+    );
+    expect(captured.kind).toBe("captured");
+    expect(budget.reservedBytes).toBe(5);
+
+    await captured.body?.cancel();
+    expect(budget.reservedBytes).toBe(0);
+  });
+});
+
+function cacheabilityState(context: object): RouteCacheabilityState {
+  return Reflect.get(context, CACHEABILITY_REQUEST_STATE) as RouteCacheabilityState;
+}
+
+describe("single-request cacheability admission", () => {
+  const request = new Request("https://example.com/page", {
+    headers: { Accept: "text/html" },
+  });
+
+  it("admits a completed static response without a build manifest", async () => {
+    const base = { waitUntil() {} };
+    const context = createWorkerCacheabilityAdmissionContext(base, request, null, "build-a", true);
+    expect(context).not.toBe(base);
+    const state = cacheabilityState(context);
+    state.route = { kind: "app-page", pattern: "/page" };
+    state.outcome = {
+      cacheable: true,
+      cacheControl: "s-maxage=60, stale-while-revalidate=540",
+    };
+
+    const response = await finalizeWorkerCacheabilityResponse(
+      new Response("static", { headers: { "Cache-Control": "no-store" } }),
+      context,
+    );
+    expect(response.headers.get("Cache-Control")).toBe("s-maxage=60, stale-while-revalidate=540");
+    await expect(response.text()).resolves.toBe("static");
+  });
+
+  it("keeps a completed dynamic response private without a build manifest", async () => {
+    const context = createWorkerCacheabilityAdmissionContext(
+      { waitUntil() {} },
+      request,
+      null,
+      "build-a",
+      true,
+    );
+    const state = cacheabilityState(context);
+    state.route = { kind: "app-page", pattern: "/page" };
+    state.outcome = { cacheable: false, dynamicUsage: true };
+
+    const response = await finalizeWorkerCacheabilityResponse(new Response("dynamic"), context);
+    expect(response.headers.get("Cache-Control")).toContain("no-store");
+    await expect(response.text()).resolves.toBe("dynamic");
+  });
+
+  it("does not add admission overhead for adapters that persist completed artifacts", () => {
+    const base = { waitUntil() {} };
+    expect(createWorkerCacheabilityAdmissionContext(base, request, null, "build-a", false)).toBe(
+      base,
+    );
   });
 });

--- a/tests/cacheability-admission.test.ts
+++ b/tests/cacheability-admission.test.ts
@@ -153,6 +153,65 @@ describe("single-request cacheability admission", () => {
     await expect(response.text()).resolves.toBe("dynamic");
   });
 
+  it.each([undefined, "*/*", "application/json"])(
+    "creates fail-closed request state without an HTML Accept header (%s)",
+    (accept) => {
+      const base = { waitUntil() {} };
+      const headers = new Headers();
+      if (accept !== undefined) headers.set("Accept", accept);
+      const context = createWorkerCacheabilityAdmissionContext(
+        base,
+        new Request("https://example.com/page", { headers }),
+        null,
+        "build-a",
+        true,
+      );
+
+      expect(context).not.toBe(base);
+      expect(cacheabilityState(context).admission).toEqual({ policy: "deny" });
+    },
+  );
+
+  it("applies a pre-dispatch veto to an otherwise public Route Handler response", async () => {
+    const context = createWorkerCacheabilityAdmissionContext(
+      { waitUntil() {} },
+      new Request("https://example.com/api/data", { headers: { Accept: "*/*" } }),
+      null,
+      "build-a",
+      true,
+    );
+    const state = cacheabilityState(context);
+    state.route = { kind: "app-route", pattern: "/api/data" };
+    state.forcedDynamicReason = "middleware is eligible for this pathname";
+
+    const response = await finalizeWorkerCacheabilityResponse(
+      new Response("private", { headers: { "Cache-Control": "public, s-maxage=60" } }),
+      context,
+    );
+
+    expect(response.headers.get("Cache-Control")).toContain("no-store");
+    await expect(response.text()).resolves.toBe("private");
+  });
+
+  it("preserves a safely completed Route Handler public policy", async () => {
+    const context = createWorkerCacheabilityAdmissionContext(
+      { waitUntil() {} },
+      new Request("https://example.com/api/data", { headers: { Accept: "*/*" } }),
+      null,
+      "build-a",
+      true,
+    );
+    cacheabilityState(context).route = { kind: "app-route", pattern: "/api/data" };
+
+    const response = await finalizeWorkerCacheabilityResponse(
+      new Response("public", { headers: { "Cache-Control": "public, s-maxage=60" } }),
+      context,
+    );
+
+    expect(response.headers.get("Cache-Control")).toBe("public, s-maxage=60");
+    await expect(response.text()).resolves.toBe("public");
+  });
+
   it("preserves an independently classified hybrid Pages response", async () => {
     const context = createWorkerCacheabilityAdmissionContext(
       { waitUntil() {} },

--- a/tests/cacheability-manifest.test.ts
+++ b/tests/cacheability-manifest.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  cacheabilityManifestRouteKey,
+  cacheabilityRequestIdentity,
+  findCacheabilityManifestRoute,
+  parseCacheabilityManifest,
+  type CacheabilityManifestRoute,
+} from "../packages/vinext/src/server/cacheability-manifest.js";
+
+const route: CacheabilityManifestRoute = {
+  kind: "app-page",
+  pattern: "/products/:id",
+  representation: "html",
+  requestKey: "/products/one?currency=gbp",
+  state: "static-candidate",
+  status: 200,
+};
+const key = cacheabilityManifestRouteKey(
+  route.kind,
+  route.pattern,
+  route.representation,
+  route.requestKey,
+);
+
+describe("cacheability manifest", () => {
+  it("accepts only the expected build and exact route key", () => {
+    const raw = JSON.stringify({ buildId: "build-a", routes: { [key]: route }, version: 1 });
+    const manifest = parseCacheabilityManifest(raw, "build-a");
+    expect(manifest).not.toBeNull();
+    expect(
+      findCacheabilityManifestRoute(manifest!, "/products/:id", {
+        representation: "html",
+        requestKey: "/products/one?currency=gbp",
+      }),
+    ).toEqual(route);
+    expect(
+      findCacheabilityManifestRoute(manifest!, "/products/:id", {
+        representation: "html",
+        requestKey: "/products/two?currency=gbp",
+      }),
+    ).toBeNull();
+    expect(parseCacheabilityManifest(raw, "build-b")).toBeNull();
+  });
+
+  it("rejects malformed routes instead of partially trusting a manifest", () => {
+    expect(
+      parseCacheabilityManifest(
+        JSON.stringify({
+          buildId: "build-a",
+          routes: { [key]: { ...route, requestKey: "/different" } },
+          version: 1,
+        }),
+        "build-a",
+      ),
+    ).toBeNull();
+  });
+
+  it("keeps HTML query variants and RSC representations distinct", () => {
+    expect(
+      cacheabilityRequestIdentity(
+        new Request("https://example.com/products/one?currency=gbp", {
+          headers: { Accept: "text/html" },
+        }),
+      ),
+    ).toEqual({ representation: "html", requestKey: "/products/one?currency=gbp" });
+    expect(
+      cacheabilityRequestIdentity(
+        new Request("https://example.com/products/one?_rsc", {
+          headers: { Accept: "text/x-component", RSC: "1" },
+        }),
+      ),
+    ).toEqual({ representation: "rsc-full", requestKey: "/products/one?_rsc" });
+  });
+
+  it("fails closed for contextual RSC and action requests", () => {
+    expect(
+      cacheabilityRequestIdentity(
+        new Request("https://example.com/products/one?_rsc", {
+          headers: { "Next-Router-State-Tree": "opaque", RSC: "1" },
+        }),
+      ),
+    ).toBeNull();
+    expect(
+      cacheabilityRequestIdentity(
+        new Request("https://example.com/products/one", {
+          method: "POST",
+          headers: { "Next-Action": "action-id" },
+        }),
+      ),
+    ).toBeNull();
+  });
+});

--- a/tests/cloudflare-cdn-cache.test.ts
+++ b/tests/cloudflare-cdn-cache.test.ts
@@ -214,15 +214,17 @@ describe("CloudflareCdnCacheAdapter", () => {
     });
   });
 
-  it("uses max-age (not s-maxage) and public on the edge directive, even pending-dynamic", () => {
+  it("fails closed while an App Page render still has a pending dynamic check", () => {
     const headers = adapter.buildResponseHeaders({
       cacheControl: "s-maxage=60, stale-while-revalidate=540",
       pendingDynamicCheck: true,
     });
-    // Edge caches + SWRs via CDN-Cache-Control; the browser always revalidates.
-    // An already-valued stale-while-revalidate is passed through unchanged.
-    expect(headers["CDN-Cache-Control"]).toBe("public, max-age=60, stale-while-revalidate=540");
-    expect(headers["Cache-Control"]).toBe("public, max-age=0, must-revalidate");
+    expect(headers).toEqual({
+      "Cache-Control": "no-store",
+      "CDN-Cache-Control": null,
+      "Cloudflare-CDN-Cache-Control": null,
+      "Cache-Tag": null,
+    });
   });
 
   it("adds a Cache-Tag header from the page tags", () => {
@@ -320,7 +322,7 @@ describe("CloudflareCdnCacheAdapter", () => {
     expect(response.headers.get("CDN-Cache-Control")).toBeNull();
   });
 
-  it("replaces Cloudflare headers on pending HTML and still skips a late-dynamic cache write", async () => {
+  it("keeps pending HTML private and skips a late-dynamic cache write", async () => {
     setCdnCacheAdapter(new CloudflareCdnCacheAdapter());
     const pendingCacheWrites: Promise<void>[] = [];
     const isrSet = vi.fn();
@@ -359,12 +361,10 @@ describe("CloudflareCdnCacheAdapter", () => {
       },
     );
 
-    expect(response.headers.get("Cache-Control")).toBe("public, max-age=0, must-revalidate");
-    expect(response.headers.get("CDN-Cache-Control")).toBe(
-      "public, max-age=60, stale-while-revalidate=31536000",
-    );
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("CDN-Cache-Control")).toBeNull();
     expect(response.headers.get("Cloudflare-CDN-Cache-Control")).toBeNull();
-    expect(response.headers.get("Cache-Tag")).toBe("/dynamic-html");
+    expect(response.headers.get("Cache-Tag")).toBeNull();
     await expect(response.text()).resolves.toBe("<h1>personalized</h1>");
     await Promise.all(pendingCacheWrites);
     expect(isrSet).not.toHaveBeenCalled();
@@ -495,14 +495,14 @@ describe("CloudflareCdnCacheAdapter", () => {
     await expect(response.text()).resolves.toBe("dynamic-slot-flight");
   });
 
-  it("applies the Cloudflare pending edge policy in a separate adapter case", async () => {
+  it("keeps a pending RSC response out of the Cloudflare edge cache", async () => {
     setCdnCacheAdapter(new CloudflareCdnCacheAdapter());
     const response = finalizePendingDynamicRscResponse();
 
-    expect(response.headers.get("Cache-Control")).toBe("public, max-age=0, must-revalidate");
-    expect(response.headers.get("CDN-Cache-Control")).toBe("public, max-age=60");
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("CDN-Cache-Control")).toBeNull();
     expect(response.headers.get("Cloudflare-CDN-Cache-Control")).toBeNull();
-    expect(response.headers.get("Cache-Tag")).toBe("/dashboard");
+    expect(response.headers.get("Cache-Tag")).toBeNull();
     expect(response.headers.get("X-Vinext-Cache")).toBe("MISS");
     await expect(response.text()).resolves.toBe("pending-dynamic-flight");
   });

--- a/tests/cloudflare-cdn-cache.test.ts
+++ b/tests/cloudflare-cdn-cache.test.ts
@@ -23,7 +23,10 @@ import {
   finalizeAppPageRscCacheResponse,
 } from "../packages/vinext/src/server/app-page-cache-finalizer.js";
 import { finalizeAppRscResponse } from "../packages/vinext/src/server/app-rsc-response-finalizer.js";
-import { applyCdnResponseIdentityHeaders } from "../packages/vinext/src/server/cache-control.js";
+import {
+  applyCdnResponseHeaders,
+  applyCdnResponseIdentityHeaders,
+} from "../packages/vinext/src/server/cache-control.js";
 import type { RequestContext } from "../packages/vinext/src/config/request-context.js";
 import { VINEXT_CDN_BUILD_ID_HEADER } from "../packages/cloudflare/src/cache/cdn-build-id.js";
 import { VINEXT_EXPECTED_WORKER_VERSION_HEADER } from "../packages/cloudflare/src/version-headers.js";
@@ -211,7 +214,17 @@ describe("CloudflareCdnCacheAdapter", () => {
       "CDN-Cache-Control": "public, max-age=60, stale-while-revalidate=31536000",
       "Cloudflare-CDN-Cache-Control": null,
       "Cache-Tag": null,
+      Vary: "Cookie",
     });
+  });
+
+  it("preserves existing variants while isolating cookie-bearing requests", () => {
+    setCdnCacheAdapter(adapter);
+    const headers = new Headers({ Vary: "RSC, Next-Router-State-Tree" });
+
+    applyCdnResponseHeaders(headers, { cacheControl: "s-maxage=60" });
+
+    expect(headers.get("Vary")).toBe("RSC, Next-Router-State-Tree, Cookie");
   });
 
   it("fails closed while an App Page render still has a pending dynamic check", () => {

--- a/tests/cloudflare-cdn-cache.test.ts
+++ b/tests/cloudflare-cdn-cache.test.ts
@@ -23,10 +23,7 @@ import {
   finalizeAppPageRscCacheResponse,
 } from "../packages/vinext/src/server/app-page-cache-finalizer.js";
 import { finalizeAppRscResponse } from "../packages/vinext/src/server/app-rsc-response-finalizer.js";
-import {
-  applyCdnResponseHeaders,
-  applyCdnResponseIdentityHeaders,
-} from "../packages/vinext/src/server/cache-control.js";
+import { applyCdnResponseIdentityHeaders } from "../packages/vinext/src/server/cache-control.js";
 import type { RequestContext } from "../packages/vinext/src/config/request-context.js";
 import { VINEXT_CDN_BUILD_ID_HEADER } from "../packages/cloudflare/src/cache/cdn-build-id.js";
 import { VINEXT_EXPECTED_WORKER_VERSION_HEADER } from "../packages/cloudflare/src/version-headers.js";
@@ -214,17 +211,7 @@ describe("CloudflareCdnCacheAdapter", () => {
       "CDN-Cache-Control": "public, max-age=60, stale-while-revalidate=31536000",
       "Cloudflare-CDN-Cache-Control": null,
       "Cache-Tag": null,
-      Vary: "Cookie",
     });
-  });
-
-  it("preserves existing variants while isolating cookie-bearing requests", () => {
-    setCdnCacheAdapter(adapter);
-    const headers = new Headers({ Vary: "RSC, Next-Router-State-Tree" });
-
-    applyCdnResponseHeaders(headers, { cacheControl: "s-maxage=60" });
-
-    expect(headers.get("Vary")).toBe("RSC, Next-Router-State-Tree, Cookie");
   });
 
   it("fails closed while an App Page render still has a pending dynamic check", () => {

--- a/tests/e2e/cloudflare-workers/route-handler-draft-cache.spec.ts
+++ b/tests/e2e/cloudflare-workers/route-handler-draft-cache.spec.ts
@@ -61,7 +61,12 @@ test.describe("Cloudflare route-handler draft-mode cache isolation", () => {
     });
     expect(forged.status()).toBe(200);
     expect(await forged.json()).toMatchObject({ draftMode: false });
-    expect(forged.headers()["cache-control"]).not.toContain("no-store");
+    // This fixture has pathname-eligible middleware. A CDN HIT would bypass
+    // that boundary, so even an anonymous Route Handler response must remain
+    // private until middleware is isolated into an uncached outer stage.
+    expect(forged.headers()["cache-control"]).toContain("no-store");
+    expect(forged.headers()["cdn-cache-control"]).toBeUndefined();
+    expect(forged.headers()["x-vinext-cache"]).toBeUndefined();
 
     await setDraftMode(request, true);
     const draftFirstScenario = `draft-first-${Date.now()}`;
@@ -77,6 +82,8 @@ test.describe("Cloudflare route-handler draft-mode cache isolation", () => {
     expect(draftFirst.cacheTag).toBeUndefined();
     expect(anonymousAfterDraft.payload.draftMode).toBe(false);
     expect(anonymousAfterDraft.payload.token).not.toBe(draftFirst.payload.token);
+    expect(anonymousAfterDraft.cacheControl).toContain("no-store");
+    expect(anonymousAfterDraft.cacheState).toBeUndefined();
 
     const publicFirstScenario = `public-first-${Date.now()}`;
     const anonymousFirst = await readDraftIsrRoute(request, publicFirstScenario);
@@ -153,5 +160,45 @@ test.describe("Cloudflare route-handler draft-mode cache isolation", () => {
     expect(second.headers()["cache-control"]).toContain("no-store");
 
     await setDraftMode(request, false);
+  });
+
+  test("completes static-candidate route handler streams before CDN admission", async ({
+    request,
+  }) => {
+    // Next.js drains a statically eligible Route Handler response before
+    // finalizing static generation. Ported from:
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/route-modules/app-route/module.ts#L700-L734
+    const dynamicResponse = await request.get(`${BASE_URL}/api/late-dynamic-stream`, {
+      headers: { "x-tenant": "tenant-a" },
+    });
+    expect(dynamicResponse.status()).toBe(200);
+    expect(await dynamicResponse.text()).toBe("tenant-a");
+    expect(dynamicResponse.headers()["cache-control"] ?? "").not.toContain("public");
+    expect(dynamicResponse.headers()["cache-control"]).toContain("no-store");
+    expect(dynamicResponse.headers()["cdn-cache-control"]).toBeUndefined();
+    expect(dynamicResponse.headers()["cloudflare-cdn-cache-control"]).toBeUndefined();
+    expect(dynamicResponse.headers()["cache-tag"]).toBeUndefined();
+    expect(dynamicResponse.headers()["x-vinext-cache"]).toBeUndefined();
+
+    const errorResponse = await request.get(`${BASE_URL}/api/late-error-stream`);
+    expect(errorResponse.status()).toBe(500);
+    expect(errorResponse.headers()["cache-control"] ?? "").not.toContain("public");
+    expect(errorResponse.headers()["cdn-cache-control"]).toBeUndefined();
+    expect(errorResponse.headers()["cloudflare-cdn-cache-control"]).toBeUndefined();
+    expect(errorResponse.headers()["cache-tag"]).toBeUndefined();
+    expect(errorResponse.headers()["x-vinext-cache"]).toBeUndefined();
+  });
+
+  test("streams oversized static candidates privately instead of buffering without a bound", async ({
+    request,
+  }) => {
+    const response = await request.get(`${BASE_URL}/api/large-static-stream`);
+    expect(response.status()).toBe(200);
+    expect((await response.body()).byteLength).toBe(4 * 1024 * 1024 + 1);
+    expect(response.headers()["cache-control"]).toContain("no-store");
+    expect(response.headers()["cdn-cache-control"]).toBeUndefined();
+    expect(response.headers()["cloudflare-cdn-cache-control"]).toBeUndefined();
+    expect(response.headers()["cache-tag"]).toBeUndefined();
+    expect(response.headers()["x-vinext-cache"]).toBeUndefined();
   });
 });

--- a/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
+++ b/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
@@ -162,7 +162,7 @@ async function waitForStablePromotion({
   );
 }
 
-test("deploy-prewarmed Pages HTML and RSC variants are reused", async ({
+test("deploy-prewarmed App HTML and RSC variants are reused", async ({
   baseURL,
   browser,
   playwright,
@@ -224,10 +224,10 @@ test("deploy-prewarmed Pages HTML and RSC variants are reused", async ({
   expect(pagesResponse.ok(), JSON.stringify(pagesResponseHeaders)).toBe(true);
   expect(pagesResponseHeaders["content-type"]).toContain("text/html");
   expect(pagesResponseHeaders["x-vinext-build-id"]).toBe(rscBuildId);
-  expect(
-    pagesResponseHeaders["cf-cache-status"],
-    `Pages response headers: ${JSON.stringify(pagesResponseHeaders)}`,
-  ).toBe("HIT");
+  // This layer only probes App Pages. Pages Router keeps its existing
+  // route-owned cache policy, but is deliberately not prewarmed yet.
+  expect(pagesResponseHeaders["cache-control"]).toContain("public");
+  expect(pagesResponseHeaders["cf-cache-status"]).toBe("MISS");
   expect(await pagesResponse.text()).toContain("Pages prewarm target");
 
   const appHtmlResponse = await getResponseAfterPromotion(

--- a/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
+++ b/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
@@ -225,9 +225,9 @@ test("deploy-prewarmed App HTML and RSC variants are reused", async ({
   expect(pagesResponseHeaders["content-type"]).toContain("text/html");
   expect(pagesResponseHeaders["x-vinext-build-id"]).toBe(rscBuildId);
   // This layer only probes App Pages. Pages Router keeps its existing
-  // route-owned cache policy, but is deliberately not prewarmed yet.
+  // route-owned cache policy. Existing path discovery may already have filled
+  // this entry, so its current CDN residency is not part of this assertion.
   expect(pagesResponseHeaders["cache-control"]).toContain("public");
-  expect(pagesResponseHeaders["cf-cache-status"]).toBe("MISS");
   expect(await pagesResponse.text()).toContain("Pages prewarm target");
 
   const appHtmlResponse = await getResponseAfterPromotion(

--- a/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
+++ b/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
@@ -243,7 +243,29 @@ test("deploy-prewarmed App HTML and RSC variants are reused", async ({
     appHtmlResponseHeaders["cf-cache-status"],
     `App HTML response headers: ${JSON.stringify(appHtmlResponseHeaders)}`,
   ).toBe("HIT");
+  expect(appHtmlResponseHeaders.vary?.split(/\s*,\s*/i)).toContain("Cookie");
   expect(await appHtmlResponse.text()).toContain("Prewarm target");
+
+  // Workers Cache is consulted before Worker code can validate Next.js's
+  // signed draft cookie. The cached anonymous response must therefore vary by
+  // Cookie; otherwise a valid draft request could consume this HIT without
+  // entering vinext and leak the public page into preview mode.
+  const cookieIsolatedHtmlResponse = await getResponseAfterPromotion(
+    request,
+    `${baseURL}${TARGET_PATH}`,
+    {
+      ...htmlHeaders,
+      Cookie: `__prerender_bypass=invalid-${Date.now()}`,
+    },
+  );
+  const cookieIsolatedHtmlHeaders = cookieIsolatedHtmlResponse.headers();
+  expect(cookieIsolatedHtmlResponse.ok(), JSON.stringify(cookieIsolatedHtmlHeaders)).toBe(true);
+  expect(
+    cookieIsolatedHtmlHeaders["cf-cache-status"],
+    `cookie-isolated App HTML response headers: ${JSON.stringify(cookieIsolatedHtmlHeaders)}`,
+  ).toBe("MISS");
+  expect(cookieIsolatedHtmlHeaders.vary?.split(/\s*,\s*/i)).toContain("Cookie");
+  expect(await cookieIsolatedHtmlResponse.text()).toContain("Prewarm target");
 
   const fullResponse = await getResponseAfterPromotion(
     request,

--- a/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
+++ b/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
@@ -243,29 +243,7 @@ test("deploy-prewarmed App HTML and RSC variants are reused", async ({
     appHtmlResponseHeaders["cf-cache-status"],
     `App HTML response headers: ${JSON.stringify(appHtmlResponseHeaders)}`,
   ).toBe("HIT");
-  expect(appHtmlResponseHeaders.vary?.split(/\s*,\s*/i)).toContain("Cookie");
   expect(await appHtmlResponse.text()).toContain("Prewarm target");
-
-  // Workers Cache is consulted before Worker code can validate Next.js's
-  // signed draft cookie. The cached anonymous response must therefore vary by
-  // Cookie; otherwise a valid draft request could consume this HIT without
-  // entering vinext and leak the public page into preview mode.
-  const cookieIsolatedHtmlResponse = await getResponseAfterPromotion(
-    request,
-    `${baseURL}${TARGET_PATH}`,
-    {
-      ...htmlHeaders,
-      Cookie: `__prerender_bypass=invalid-${Date.now()}`,
-    },
-  );
-  const cookieIsolatedHtmlHeaders = cookieIsolatedHtmlResponse.headers();
-  expect(cookieIsolatedHtmlResponse.ok(), JSON.stringify(cookieIsolatedHtmlHeaders)).toBe(true);
-  expect(
-    cookieIsolatedHtmlHeaders["cf-cache-status"],
-    `cookie-isolated App HTML response headers: ${JSON.stringify(cookieIsolatedHtmlHeaders)}`,
-  ).toBe("MISS");
-  expect(cookieIsolatedHtmlHeaders.vary?.split(/\s*,\s*/i)).toContain("Cookie");
-  expect(await cookieIsolatedHtmlResponse.text()).toContain("Prewarm target");
 
   const fullResponse = await getResponseAfterPromotion(
     request,

--- a/tests/e2e/ppr-impact-demo/cacheability-admission.spec.ts
+++ b/tests/e2e/ppr-impact-demo/cacheability-admission.spec.ts
@@ -37,6 +37,25 @@ test("admits only exact manifest-backed App Page responses after clean EOF", asy
   expect(runtimeCheck.status()).toBe(200);
   expect(runtimeCheck.headers()["cdn-cache-control"]).toContain("public");
 
+  const lateCookie = await request.get("/cacheability/static?late-policy=set-cookie", {
+    headers: { Accept: "text/html" },
+  });
+  expect(lateCookie.status()).toBe(200);
+  expect(lateCookie.headers()["set-cookie"]).toContain("late-config=cookie");
+  expect(lateCookie.headers()["cache-control"]).toContain("no-store");
+  expect(lateCookie.headers()["cdn-cache-control"]).toBeUndefined();
+  expect(lateCookie.headers()["cloudflare-cdn-cache-control"]).toBeUndefined();
+
+  for (const policy of ["cache-control", "cdn-cache-control", "cloudflare-cdn-cache-control"]) {
+    const latePrivatePolicy = await request.get(`/cacheability/static?late-policy=${policy}`, {
+      headers: { Accept: "text/html" },
+    });
+    expect(latePrivatePolicy.status()).toBe(200);
+    expect(latePrivatePolicy.headers()["cache-control"]).toContain("no-store");
+    expect(latePrivatePolicy.headers()["cdn-cache-control"]).toBeUndefined();
+    expect(latePrivatePolicy.headers()["cloudflare-cdn-cache-control"]).toBeUndefined();
+  }
+
   const unlistedQuery = await request.get("/cacheability/static?unlisted=1", {
     headers: { Accept: "text/html" },
   });

--- a/tests/e2e/ppr-impact-demo/cacheability-admission.spec.ts
+++ b/tests/e2e/ppr-impact-demo/cacheability-admission.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "@playwright/test";
+
+test("admits only exact manifest-backed App Page responses after clean EOF", async ({
+  request,
+}) => {
+  const certified = await request.get("/cacheability/static", {
+    headers: { Accept: "text/html" },
+  });
+  expect(certified.status()).toBe(200);
+  expect(await certified.text()).toContain("static page");
+  expect(certified.headers()["cdn-cache-control"]).toContain("public");
+  expect(certified.headers()["cache-control"]).toContain("must-revalidate");
+
+  const runtimeCheck = await request.get("/cacheability/static?runtime=1", {
+    headers: { Accept: "text/html" },
+  });
+  expect(runtimeCheck.status()).toBe(200);
+  expect(runtimeCheck.headers()["cdn-cache-control"]).toContain("public");
+
+  const unlistedQuery = await request.get("/cacheability/static?unlisted=1", {
+    headers: { Accept: "text/html" },
+  });
+  expect(unlistedQuery.status()).toBe(200);
+  expect(unlistedQuery.headers()["cache-control"]).toContain("no-store");
+  expect(unlistedQuery.headers()["cdn-cache-control"]).toBeUndefined();
+
+  const knownDynamic = await request.get("/cacheability/dynamic", {
+    headers: { Accept: "text/html" },
+  });
+  expect(knownDynamic.status()).toBe(200);
+  expect(knownDynamic.headers()["cache-control"]).toContain("no-store");
+  expect(knownDynamic.headers()["cdn-cache-control"]).toBeUndefined();
+
+  const staticToDynamic = await request.get("/cacheability/static-to-dynamic/runtime", {
+    headers: { Accept: "text/html", "X-Probe-Value": "private-value" },
+  });
+  expect(staticToDynamic.status()).toBe(500);
+  expect(await staticToDynamic.text()).toContain("changed from static to dynamic");
+  expect(staticToDynamic.headers()["cache-control"]).toContain("no-store");
+  expect(staticToDynamic.headers()["cdn-cache-control"]).toBeUndefined();
+
+  const uncertifiedRsc = await request.get("/cacheability/static?_rsc", {
+    headers: { Accept: "text/x-component", RSC: "1" },
+  });
+  expect(uncertifiedRsc.status()).toBe(200);
+  expect(uncertifiedRsc.headers()["cache-control"]).toContain("no-store");
+  expect(uncertifiedRsc.headers()["cdn-cache-control"]).toBeUndefined();
+});

--- a/tests/e2e/ppr-impact-demo/cacheability-admission.spec.ts
+++ b/tests/e2e/ppr-impact-demo/cacheability-admission.spec.ts
@@ -11,6 +11,26 @@ test("admits only exact manifest-backed App Page responses after clean EOF", asy
   expect(certified.headers()["cdn-cache-control"]).toContain("public");
   expect(certified.headers()["cache-control"]).toContain("must-revalidate");
 
+  const certifiedFullRsc = await request.get("/cacheability/static?_rsc", {
+    headers: { Accept: "text/x-component", RSC: "1" },
+  });
+  expect(certifiedFullRsc.status()).toBe(200);
+  expect(certifiedFullRsc.headers()["content-type"]).toContain("text/x-component");
+  expect(certifiedFullRsc.headers()["cdn-cache-control"]).toContain("public");
+
+  const certifiedLoadingShell = await request.get("/cacheability/static?_rsc=9qLBDIU2NgN178cB", {
+    headers: {
+      Accept: "text/x-component",
+      RSC: "1",
+      "Next-Router-Prefetch": "1",
+      "Next-Router-Segment-Prefetch": "1",
+      "X-Vinext-Rsc-Render-Mode": "prefetch-loading-shell",
+    },
+  });
+  expect(certifiedLoadingShell.status()).toBe(200);
+  expect(certifiedLoadingShell.headers()["content-type"]).toContain("text/x-component");
+  expect(certifiedLoadingShell.headers()["cdn-cache-control"]).toContain("public");
+
   const runtimeCheck = await request.get("/cacheability/static?runtime=1", {
     headers: { Accept: "text/html" },
   });
@@ -39,7 +59,7 @@ test("admits only exact manifest-backed App Page responses after clean EOF", asy
   expect(staticToDynamic.headers()["cache-control"]).toContain("no-store");
   expect(staticToDynamic.headers()["cdn-cache-control"]).toBeUndefined();
 
-  const uncertifiedRsc = await request.get("/cacheability/static?_rsc", {
+  const uncertifiedRsc = await request.get("/cacheability/prerender-phase/known?_rsc", {
     headers: { Accept: "text/x-component", RSC: "1" },
   });
   expect(uncertifiedRsc.status()).toBe(200);

--- a/tests/e2e/ppr-impact-demo/cacheability-probe.spec.ts
+++ b/tests/e2e/ppr-impact-demo/cacheability-probe.spec.ts
@@ -89,6 +89,39 @@ test("classifies completed App Page renders inside workerd", async ({ request })
     version: 1,
   });
 
+  // Next.js first matches the pathname regexp and only then evaluates
+  // request-specific `has`/`missing` conditions:
+  // packages/next/src/shared/lib/router/utils/middleware-route-matcher.ts
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/middleware-route-matcher.ts
+  // A condition-free staged probe must therefore not certify a pathname that
+  // a later cookie- or header-bearing request can send through middleware.
+  for (const { conditionHeaders, pathname } of [
+    {
+      conditionHeaders: { Cookie: "cacheability-middleware=1" },
+      pathname: "/cacheability/conditional-middleware-cookie",
+    },
+    {
+      conditionHeaders: { "X-Cacheability-Middleware": "enabled" },
+      pathname: "/cacheability/conditional-middleware-header",
+    },
+  ]) {
+    const conditionMiss = await request.get(pathname);
+    expect(conditionMiss.headers()["x-cacheability-middleware"]).toBeUndefined();
+    const conditionHit = await request.get(pathname, { headers: conditionHeaders });
+    expect(conditionHit.headers()["x-cacheability-middleware"]).toBe("matched");
+
+    const conditionalMiddlewareProbe = await request.get(pathname, { headers });
+    expect(conditionalMiddlewareProbe.ok()).toBe(true);
+    await expect(conditionalMiddlewareProbe.json()).resolves.toMatchObject({
+      kind: "app-page",
+      pattern: pathname,
+      reason: "middleware is eligible for this pathname",
+      state: "dynamic",
+      status: 200,
+      version: 1,
+    });
+  }
+
   const identityProbe = await request.get("/cacheability/static", {
     headers: { ...headers, [probeHeader]: "identity" },
   });

--- a/tests/fixtures/app-basic/app/api/custom-cache/route.ts
+++ b/tests/fixtures/app-basic/app/api/custom-cache/route.ts
@@ -5,8 +5,11 @@
  */
 export const revalidate = 60;
 
-export async function GET() {
-  return new Response(JSON.stringify({ ok: true }), {
+// Ported from Next.js:
+// test/e2e/vary-header/app/app/normal/route.js
+// A request API read does not override an explicit response cache policy.
+export async function GET(request: Request) {
+  return new Response(JSON.stringify({ ok: true, userAgent: request.headers.get("user-agent") }), {
     headers: { "Cache-Control": "public, max-age=300", "Content-Type": "application/json" },
   });
 }

--- a/tests/fixtures/cf-app-basic/app/api/large-static-stream/route.ts
+++ b/tests/fixtures/cf-app-basic/app/api/large-static-stream/route.ts
@@ -1,0 +1,18 @@
+export const revalidate = 60;
+
+const BODY_SIZE = 4 * 1024 * 1024 + 1;
+
+export function GET() {
+  return new Response(
+    new ReadableStream<Uint8Array>(
+      {
+        pull(controller) {
+          controller.enqueue(new Uint8Array(BODY_SIZE).fill(97));
+          controller.close();
+        },
+      },
+      { highWaterMark: 0 },
+    ),
+    { headers: { "Content-Type": "application/octet-stream" } },
+  );
+}

--- a/tests/fixtures/cf-app-basic/app/api/late-dynamic-stream/route.ts
+++ b/tests/fixtures/cf-app-basic/app/api/late-dynamic-stream/route.ts
@@ -1,0 +1,22 @@
+export const revalidate = 60;
+
+export function GET(request: Request) {
+  const encoder = new TextEncoder();
+  return new Response(
+    new ReadableStream<Uint8Array>(
+      {
+        pull(controller) {
+          controller.enqueue(encoder.encode(request.headers.get("x-tenant") ?? "missing"));
+          controller.close();
+        },
+      },
+      { highWaterMark: 0 },
+    ),
+    {
+      headers: {
+        "Cache-Control": "public, s-maxage=60",
+        "Content-Type": "text/plain",
+      },
+    },
+  );
+}

--- a/tests/fixtures/cf-app-basic/app/api/late-error-stream/route.ts
+++ b/tests/fixtures/cf-app-basic/app/api/late-error-stream/route.ts
@@ -1,0 +1,15 @@
+export const revalidate = 60;
+
+export function GET() {
+  return new Response(
+    new ReadableStream<Uint8Array>(
+      {
+        pull(controller) {
+          controller.error(new Error("late route body failure"));
+        },
+      },
+      { highWaterMark: 0 },
+    ),
+    { headers: { "Content-Type": "text/plain" } },
+  );
+}

--- a/tests/fixtures/ppr-impact-demo/app/cacheability/conditional-middleware-cookie/page.tsx
+++ b/tests/fixtures/ppr-impact-demo/app/cacheability/conditional-middleware-cookie/page.tsx
@@ -1,0 +1,5 @@
+export const revalidate = 60;
+
+export default function ConditionalCookieMiddlewareCacheabilityPage() {
+  return <p id="cacheability-result">conditional cookie middleware page</p>;
+}

--- a/tests/fixtures/ppr-impact-demo/app/cacheability/conditional-middleware-header/page.tsx
+++ b/tests/fixtures/ppr-impact-demo/app/cacheability/conditional-middleware-header/page.tsx
@@ -1,0 +1,5 @@
+export const revalidate = 60;
+
+export default function ConditionalHeaderMiddlewareCacheabilityPage() {
+  return <p id="cacheability-result">conditional header middleware page</p>;
+}

--- a/tests/fixtures/ppr-impact-demo/app/cacheability/dynamic/page.tsx
+++ b/tests/fixtures/ppr-impact-demo/app/cacheability/dynamic/page.tsx
@@ -1,7 +1,5 @@
 import { headers } from "next/headers";
 
-export const revalidate = 60;
-
 export default async function DynamicCacheabilityPage() {
   const requestHeaders = await headers();
   return (

--- a/tests/fixtures/ppr-impact-demo/app/cacheability/dynamic/page.tsx
+++ b/tests/fixtures/ppr-impact-demo/app/cacheability/dynamic/page.tsx
@@ -1,5 +1,7 @@
 import { headers } from "next/headers";
 
+export const revalidate = 60;
+
 export default async function DynamicCacheabilityPage() {
   const requestHeaders = await headers();
   return (

--- a/tests/fixtures/ppr-impact-demo/app/cacheability/prerender-phase/[slug]/page.tsx
+++ b/tests/fixtures/ppr-impact-demo/app/cacheability/prerender-phase/[slug]/page.tsx
@@ -1,7 +1,5 @@
 import { headers } from "next/headers";
 
-export const revalidate = 3;
-
 export function generateStaticParams() {
   return process.env.NEXT_PHASE === "phase-production-build" ? [{ slug: "known" }] : [];
 }

--- a/tests/fixtures/ppr-impact-demo/app/cacheability/prerender-phase/[slug]/page.tsx
+++ b/tests/fixtures/ppr-impact-demo/app/cacheability/prerender-phase/[slug]/page.tsx
@@ -1,5 +1,7 @@
 import { headers } from "next/headers";
 
+export const revalidate = 3;
+
 export function generateStaticParams() {
   return process.env.NEXT_PHASE === "phase-production-build" ? [{ slug: "known" }] : [];
 }

--- a/tests/fixtures/ppr-impact-demo/app/cacheability/static-to-dynamic/[slug]/page.tsx
+++ b/tests/fixtures/ppr-impact-demo/app/cacheability/static-to-dynamic/[slug]/page.tsx
@@ -1,0 +1,13 @@
+import { headers } from "next/headers";
+
+export const revalidate = 60;
+
+export default async function StaticToDynamicCacheabilityPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const requestHeaders = await headers();
+  return <p>{`${slug}:${requestHeaders.get("x-probe-value") ?? "none"}`}</p>;
+}

--- a/tests/fixtures/ppr-impact-demo/app/cacheability/static-to-dynamic/[slug]/page.tsx
+++ b/tests/fixtures/ppr-impact-demo/app/cacheability/static-to-dynamic/[slug]/page.tsx
@@ -1,5 +1,7 @@
 import { headers } from "next/headers";
 
+export const revalidate = 60;
+
 export default async function StaticToDynamicCacheabilityPage({
   params,
 }: {

--- a/tests/fixtures/ppr-impact-demo/app/cacheability/static-to-dynamic/[slug]/page.tsx
+++ b/tests/fixtures/ppr-impact-demo/app/cacheability/static-to-dynamic/[slug]/page.tsx
@@ -1,7 +1,5 @@
 import { headers } from "next/headers";
 
-export const revalidate = 60;
-
 export default async function StaticToDynamicCacheabilityPage({
   params,
 }: {

--- a/tests/fixtures/ppr-impact-demo/app/cacheability/static/page.tsx
+++ b/tests/fixtures/ppr-impact-demo/app/cacheability/static/page.tsx
@@ -1,5 +1,7 @@
-export const revalidate = 60;
+import { cacheLife } from "next/cache";
 
-export default function StaticCacheabilityPage() {
+export default async function StaticCacheabilityPage() {
+  "use cache";
+  cacheLife("minutes");
   return <p id="cacheability-result">static page</p>;
 }

--- a/tests/fixtures/ppr-impact-demo/app/cacheability/static/page.tsx
+++ b/tests/fixtures/ppr-impact-demo/app/cacheability/static/page.tsx
@@ -1,7 +1,5 @@
-import { cacheLife } from "next/cache";
+export const revalidate = 60;
 
-export default async function StaticCacheabilityPage() {
-  "use cache";
-  cacheLife("minutes");
+export default function StaticCacheabilityPage() {
   return <p id="cacheability-result">static page</p>;
 }

--- a/tests/fixtures/ppr-impact-demo/cacheability-manifest.json
+++ b/tests/fixtures/ppr-impact-demo/cacheability-manifest.json
@@ -1,0 +1,38 @@
+{
+  "buildId": "ppr-impact-demo-cacheability",
+  "routes": {
+    "[\"app-page\",\"/cacheability/dynamic\",\"html\",\"/cacheability/dynamic\"]": {
+      "kind": "app-page",
+      "pattern": "/cacheability/dynamic",
+      "representation": "html",
+      "requestKey": "/cacheability/dynamic",
+      "state": "dynamic",
+      "status": 200
+    },
+    "[\"app-page\",\"/cacheability/static\",\"html\",\"/cacheability/static\"]": {
+      "kind": "app-page",
+      "pattern": "/cacheability/static",
+      "representation": "html",
+      "requestKey": "/cacheability/static",
+      "state": "static-candidate",
+      "status": 200
+    },
+    "[\"app-page\",\"/cacheability/static\",\"html\",\"/cacheability/static?runtime=1\"]": {
+      "kind": "app-page",
+      "pattern": "/cacheability/static",
+      "representation": "html",
+      "requestKey": "/cacheability/static?runtime=1",
+      "state": "runtime-check",
+      "status": 200
+    },
+    "[\"app-page\",\"/cacheability/static-to-dynamic/:slug\",\"html\",\"/cacheability/static-to-dynamic/runtime\"]": {
+      "kind": "app-page",
+      "pattern": "/cacheability/static-to-dynamic/:slug",
+      "representation": "html",
+      "requestKey": "/cacheability/static-to-dynamic/runtime",
+      "state": "static-candidate",
+      "status": 200
+    }
+  },
+  "version": 1
+}

--- a/tests/fixtures/ppr-impact-demo/cacheability-manifest.json
+++ b/tests/fixtures/ppr-impact-demo/cacheability-manifest.json
@@ -25,6 +25,38 @@
       "state": "runtime-check",
       "status": 200
     },
+    "[\"app-page\",\"/cacheability/static\",\"html\",\"/cacheability/static?late-policy=set-cookie\"]": {
+      "kind": "app-page",
+      "pattern": "/cacheability/static",
+      "representation": "html",
+      "requestKey": "/cacheability/static?late-policy=set-cookie",
+      "state": "static-candidate",
+      "status": 200
+    },
+    "[\"app-page\",\"/cacheability/static\",\"html\",\"/cacheability/static?late-policy=cache-control\"]": {
+      "kind": "app-page",
+      "pattern": "/cacheability/static",
+      "representation": "html",
+      "requestKey": "/cacheability/static?late-policy=cache-control",
+      "state": "static-candidate",
+      "status": 200
+    },
+    "[\"app-page\",\"/cacheability/static\",\"html\",\"/cacheability/static?late-policy=cdn-cache-control\"]": {
+      "kind": "app-page",
+      "pattern": "/cacheability/static",
+      "representation": "html",
+      "requestKey": "/cacheability/static?late-policy=cdn-cache-control",
+      "state": "static-candidate",
+      "status": 200
+    },
+    "[\"app-page\",\"/cacheability/static\",\"html\",\"/cacheability/static?late-policy=cloudflare-cdn-cache-control\"]": {
+      "kind": "app-page",
+      "pattern": "/cacheability/static",
+      "representation": "html",
+      "requestKey": "/cacheability/static?late-policy=cloudflare-cdn-cache-control",
+      "state": "static-candidate",
+      "status": 200
+    },
     "[\"app-page\",\"/cacheability/static\",\"rsc-full\",\"/cacheability/static?_rsc\"]": {
       "kind": "app-page",
       "pattern": "/cacheability/static",

--- a/tests/fixtures/ppr-impact-demo/cacheability-manifest.json
+++ b/tests/fixtures/ppr-impact-demo/cacheability-manifest.json
@@ -25,6 +25,22 @@
       "state": "runtime-check",
       "status": 200
     },
+    "[\"app-page\",\"/cacheability/static\",\"rsc-full\",\"/cacheability/static?_rsc\"]": {
+      "kind": "app-page",
+      "pattern": "/cacheability/static",
+      "representation": "rsc-full",
+      "requestKey": "/cacheability/static?_rsc",
+      "state": "static-candidate",
+      "status": 200
+    },
+    "[\"app-page\",\"/cacheability/static\",\"rsc-loading-shell\",\"/cacheability/static?_rsc=9qLBDIU2NgN178cB\"]": {
+      "kind": "app-page",
+      "pattern": "/cacheability/static",
+      "representation": "rsc-loading-shell",
+      "requestKey": "/cacheability/static?_rsc=9qLBDIU2NgN178cB",
+      "state": "static-candidate",
+      "status": 200
+    },
     "[\"app-page\",\"/cacheability/static-to-dynamic/:slug\",\"html\",\"/cacheability/static-to-dynamic/runtime\"]": {
       "kind": "app-page",
       "pattern": "/cacheability/static-to-dynamic/:slug",

--- a/tests/fixtures/ppr-impact-demo/embed-cacheability-manifest.mjs
+++ b/tests/fixtures/ppr-impact-demo/embed-cacheability-manifest.mjs
@@ -1,0 +1,7 @@
+import fs from "node:fs";
+
+const manifest = fs.readFileSync("cacheability-manifest.json", "utf8");
+fs.writeFileSync(
+  "dist/server/__vinext_cacheability_manifest.js",
+  `export default ${JSON.stringify(manifest)};\n`,
+);

--- a/tests/fixtures/ppr-impact-demo/next.config.ts
+++ b/tests/fixtures/ppr-impact-demo/next.config.ts
@@ -2,4 +2,26 @@ import type { NextConfig } from "vinext";
 
 export default {
   generateBuildId: () => "ppr-impact-demo-cacheability",
+  headers: async () => [
+    {
+      source: "/cacheability/static",
+      has: [{ type: "query", key: "late-policy", value: "set-cookie" }],
+      headers: [{ key: "Set-Cookie", value: "late-config=cookie; Path=/; HttpOnly" }],
+    },
+    {
+      source: "/cacheability/static",
+      has: [{ type: "query", key: "late-policy", value: "cache-control" }],
+      headers: [{ key: "Cache-Control", value: "private" }],
+    },
+    {
+      source: "/cacheability/static",
+      has: [{ type: "query", key: "late-policy", value: "cdn-cache-control" }],
+      headers: [{ key: "CDN-Cache-Control", value: "no-store" }],
+    },
+    {
+      source: "/cacheability/static",
+      has: [{ type: "query", key: "late-policy", value: "cloudflare-cdn-cache-control" }],
+      headers: [{ key: "Cloudflare-CDN-Cache-Control", value: "private" }],
+    },
+  ],
 } satisfies NextConfig;

--- a/tests/fixtures/ppr-impact-demo/next.config.ts
+++ b/tests/fixtures/ppr-impact-demo/next.config.ts
@@ -2,4 +2,5 @@ import type { NextConfig } from "vinext";
 
 export default {
   cacheComponents: true,
+  generateBuildId: () => "ppr-impact-demo-cacheability",
 } satisfies NextConfig;

--- a/tests/fixtures/ppr-impact-demo/next.config.ts
+++ b/tests/fixtures/ppr-impact-demo/next.config.ts
@@ -1,6 +1,5 @@
 import type { NextConfig } from "vinext";
 
 export default {
-  cacheComponents: true,
   generateBuildId: () => "ppr-impact-demo-cacheability",
 } satisfies NextConfig;

--- a/tests/fixtures/ppr-impact-demo/proxy.ts
+++ b/tests/fixtures/ppr-impact-demo/proxy.ts
@@ -6,4 +6,16 @@ export function proxy() {
   return response;
 }
 
-export const config = { matcher: "/cacheability/middleware" };
+export const config = {
+  matcher: [
+    "/cacheability/middleware",
+    {
+      source: "/cacheability/conditional-middleware-cookie",
+      has: [{ type: "cookie", key: "cacheability-middleware" }],
+    },
+    {
+      source: "/cacheability/conditional-middleware-header",
+      has: [{ type: "header", key: "x-cacheability-middleware", value: "enabled" }],
+    },
+  ],
+};

--- a/tests/fixtures/ppr-impact-demo/vite.config.ts
+++ b/tests/fixtures/ppr-impact-demo/vite.config.ts
@@ -1,10 +1,11 @@
 import { cloudflare } from "@cloudflare/vite-plugin";
 import { defineConfig } from "vite";
 import vinext from "vinext";
+import { cdnAdapter } from "../../../packages/cloudflare/src/cache/cdn-adapter.js";
 
 export default defineConfig({
   plugins: [
-    vinext({ prerender: { routes: "*" } }),
+    vinext({ cache: { cdn: cdnAdapter() }, prerender: { routes: "*" } }),
     cloudflare({
       viteEnvironment: {
         name: "rsc",

--- a/tests/middleware-runtime.test.ts
+++ b/tests/middleware-runtime.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vite-plus/test";
-import { executeMiddleware } from "../packages/vinext/src/server/middleware-runtime.js";
+import {
+  executeMiddleware,
+  runGeneratedMiddleware,
+} from "../packages/vinext/src/server/middleware-runtime.js";
 import type { NextRequest } from "../packages/vinext/src/shims/server.js";
 
 describe("middleware pathname matching", () => {
@@ -455,6 +458,75 @@ describe("middleware redirect protocol", () => {
       request: new Request("http://localhost:3000/matched/page"),
     });
     expect(onMatch).toHaveBeenCalledOnce();
+  });
+
+  it("reports pathname eligibility before request matcher conditions", async () => {
+    const onMatch = vi.fn();
+    const onPathMatch = vi.fn();
+    const module = {
+      config: {
+        matcher: [
+          {
+            source: "/conditional/:path*",
+            has: [{ type: "cookie", key: "middleware-user" }],
+          },
+        ],
+      },
+      default: () => undefined,
+    };
+
+    await executeMiddleware({
+      isProxy: false,
+      module,
+      onMatch,
+      onPathMatch,
+      request: new Request("http://localhost:3000/not-conditional"),
+    });
+    expect(onPathMatch).not.toHaveBeenCalled();
+    expect(onMatch).not.toHaveBeenCalled();
+
+    await executeMiddleware({
+      isProxy: false,
+      module,
+      onMatch,
+      onPathMatch,
+      request: new Request("http://localhost:3000/conditional/page"),
+    });
+    expect(onPathMatch).toHaveBeenCalledOnce();
+    expect(onMatch).not.toHaveBeenCalled();
+
+    await executeMiddleware({
+      isProxy: false,
+      module,
+      onMatch,
+      onPathMatch,
+      request: new Request("http://localhost:3000/conditional/page", {
+        headers: { Cookie: "middleware-user=1" },
+      }),
+    });
+    expect(onPathMatch).toHaveBeenCalledTimes(2);
+    expect(onMatch).toHaveBeenCalledOnce();
+  });
+
+  it("returns pathname eligibility from the generated middleware boundary", async () => {
+    const result = await runGeneratedMiddleware({
+      isProxy: false,
+      module: {
+        config: {
+          matcher: [
+            {
+              source: "/conditional/:path*",
+              has: [{ type: "header", key: "x-middleware-user" }],
+            },
+          ],
+        },
+        default: () => undefined,
+      },
+      request: new Request("http://localhost:3000/conditional/page"),
+    });
+
+    expect(result.continue).toBe(true);
+    expect(result.pathnameEligible).toBe(true);
   });
 
   it("relativizes the Location header for same-host redirects", async () => {


### PR DESCRIPTION
Capability stack **4/9**. Exact head: `f50e5a1d7526ec067df7306085c5f05d253e457d`. Base: #3091.

Full chain: #3108 → #3090 → #3091 → #3092 → #3103 → #3093 → #3094 → #3098 → #3113.

## Summary

- emit an inert cacheability-manifest ESM module in App Router Worker builds
- admit exact manifest identities only after the ordinary response completes cleanly
- preserve a safe no-manifest fallback by buffering one bounded cold response to EOF before applying its proven static policy
- apply the same completed-response boundary to potentially cacheable App Route Handlers, matching Next.js response draining before static completion
- convert late Route Handler stream errors into uncached 500 responses and observe dynamic request reads made during stream consumption
- keep the Cloudflare adapter's provisional responses private until the outer admission boundary completes
- preserve independently classified Pages Router responses when hybrid routing hands off outside the App-only admission layer
- preserve every explicit handler-owned public or private cache policy on ordinary origin-managed requests, matching Next.js, while retaining adapter-owned fail-closed policy during CDN probe/admission
- cap capture at 4 MiB per response and 16 MiB across concurrent isolate requests
- replay captured chunks without allocating a second contiguous body

## Fail-closed behavior

- an identity absent from a present manifest is `no-store`
- malformed, wrong-build, dynamic, contextual RSC, slow, oversized, incomplete, or middleware-eligible requests remain private
- middleware `has`/`missing` conditions are evaluated by pathname eligibility, not only by the probe request's current headers
- conditional redirects, rewrites, and response headers cannot become shared responses
- framework-owned provisional `no-store` may be replaced after proof, while application/config/private policy remains an absolute veto
- a final ordinary response is revalidated independently of the earlier probe
- CDN purge is safe because every refill repeats completed-response admission

The manifest is a Worker module asset containing classification only—never response bodies. Origin-managed/KV adapters retain their existing streaming path.

## Next.js reference

Next.js drains cacheable App Route Handler responses before resolving static generation (`packages/next/src/server/route-modules/app-route/module.ts`). The built-workerd regression here covers late stream request reads and late stream failure at that same completion boundary.

## Review guide

1. `cacheability-manifest.ts` validates the embedded artifact.
2. `cacheability-request.ts` owns exact matching, capture limits, and admission.
3. `app-route-handler-execution.ts` completes potentially cacheable Route Handler bodies before public admission.
4. `app-router-entry.ts` gates obvious non-page requests before loading admission code.
5. `cdn-adapter.runtime.ts` fails closed while classification is pending.
6. The built-workerd suites prove App Page and Route Handler completion behavior.

This PR does not alter cache keys, response `Vary`, Worker entrypoints, or request routing. Existing framework and adapter `Vary` replacement semantics are unchanged.

## Review size

Layer-only diff against this PR's base: **47 files, +2,723/-76**.

## Validation

- current full-stack cumulative changed-file suites — **2,864/2,864**
- current full-stack PPR probe/admission/Pages built-workerd E2E — **8/8**
- current full-stack `vp check` and `git diff --check`
- layer exact-head CI and deploy previews are green
