### PR TITLE
fix(cache): certify staged cache fills before promotion

### DIFF
--- a/README.md
+++ b/README.md
@@ -710,8 +710,18 @@ The KV data adapter reads `env[binding]` at runtime, so add the matching KV name
 ```jsonc
 {
   "cache": { "enabled": true },
+  "version_metadata": { "binding": "CF_VERSION_METADATA" },
 }
 ```
+
+The version metadata binding is required for staged discovery and warming to
+verify the uploaded Worker version. Wrangler named environments do not inherit
+`version_metadata`, so repeat it inside each `env.<name>` used for warming.
+
+`vinext-cloudflare deploy --experimental-warm-cdn-cache` performs the two-stage
+upload and makes one final cache-fill request per admitted identity by default.
+Add `--warm-cdn-certify` only to opt into a second, header-only request that
+must prove every planned entry reusable before promotion.
 
 While the data adapter can store entries and serve HIT/STALE itself, the CDN adapter delegates serving to Cloudflare's edge: the origin renders fresh responses and tags them with `Cache-Tag`, and `revalidateTag()` / `revalidatePath()` purge the edge through `ctx.cache.purge({ tags })`. See [examples/workers-cache](examples/workers-cache) for both adapters wired up together.
 

--- a/packages/cloudflare/README.md
+++ b/packages/cloudflare/README.md
@@ -45,6 +45,9 @@ export default defineConfig({
   "cache": {
     "enabled": true,
   },
+  "version_metadata": {
+    "binding": "CF_VERSION_METADATA",
+  },
 }
 ```
 
@@ -53,6 +56,16 @@ import { cdnAdapter } from "@vinext/cloudflare/cache/cdn-adapter";
 
 vinext({ cache: { cdn: cdnAdapter() } });
 ```
+
+The version metadata binding lets staged warmup prove that every discovery,
+probe, and fill request reached the uploaded Worker version. Wrangler named
+environments do not inherit `version_metadata`; repeat the binding inside every
+`env.<name>` used with CDN warming.
+
+Use `--experimental-warm-cdn-cache` for the two-stage deploy. The default flow
+makes one final fill request per admitted identity. Add `--warm-cdn-certify`
+only when you want an opt-in second, header-only request that must prove every
+planned entry reusable before promotion.
 
 ## Deploy
 

--- a/packages/cloudflare/src/cdn-warm.ts
+++ b/packages/cloudflare/src/cdn-warm.ts
@@ -46,6 +46,8 @@ export type CdnWarmOptions = {
   phaseTimeoutMs?: number;
   /** Retry a newly staged version or preview alias until its routing has propagated. */
   propagatingTarget?: boolean;
+  /** Require the response to come from a reusable cache entry, not merely an eligible MISS. */
+  requireCacheHit?: boolean;
   strict?: boolean;
   fetchImpl?: typeof fetch;
 };
@@ -71,6 +73,7 @@ export type CdnWarmResult = {
   skipped: number;
   failed: number;
   failures: Array<{ path: string; error: string }>;
+  warmedPlan: CdnWarmRequestPlan;
   retryPlan: CdnWarmRequestPlan;
 };
 
@@ -441,6 +444,7 @@ const REQUIRED_RSC_VARY_HEADERS = VINEXT_RSC_VARY_HEADER.split(",").map((name) =
   name.trim().toLowerCase(),
 );
 const ADMITTED_CF_CACHE_STATUSES = new Set(["HIT", "MISS", "EXPIRED", "REVALIDATED", "UPDATING"]);
+const REUSABLE_CF_CACHE_STATUSES = new Set(["HIT", "REVALIDATED", "UPDATING"]);
 const NON_CACHEABLE_CF_CACHE_STATUSES = new Set(["BYPASS"]);
 const CDN_CACHE_POLICY_HEADERS = [
   "Cloudflare-CDN-Cache-Control",
@@ -488,7 +492,11 @@ type WarmValidation =
   | { outcome: "skipped"; reason: string }
   | { outcome: "failed"; error: string };
 
-function validateCachePolicy(response: Response, requireCacheStatus: boolean): WarmValidation {
+function validateCachePolicy(
+  response: Response,
+  requireCacheStatus: boolean,
+  requireCacheHit = false,
+): WarmValidation {
   const effectivePolicy = CDN_CACHE_POLICY_HEADERS.map((name) => ({
     name,
     value: response.headers.get(name),
@@ -502,6 +510,13 @@ function validateCachePolicy(response: Response, requireCacheStatus: boolean): W
       : [];
   const hasSetCookie = response.headers.has("Set-Cookie");
   const cacheStatus = response.headers.get("CF-Cache-Status")?.trim().toUpperCase();
+
+  if (requireCacheHit && !REUSABLE_CF_CACHE_STATUSES.has(cacheStatus ?? "")) {
+    return {
+      outcome: "failed",
+      error: `CF-Cache-Status is ${cacheStatus ?? "missing"}; the cache fill is not reusable`,
+    };
+  }
 
   // Cloudflare-CDN-Cache-Control is consumed at the edge and is deliberately
   // not forwarded to clients. A cacheable Cloudflare-specific policy can
@@ -584,6 +599,7 @@ function validateRscWarmResponse(
   response: Response,
   expectedBuildId?: string,
   expectedRscBuildId?: string,
+  requireCacheHit = false,
 ): WarmValidation {
   const buildIdentityValidation = validateBuildIdentity(response, expectedBuildId);
   if (buildIdentityValidation) return buildIdentityValidation;
@@ -612,7 +628,7 @@ function validateRscWarmResponse(
   ) {
     return { outcome: "failed", error: `expected ${VINEXT_RSC_CONTENT_TYPE} response` };
   }
-  const cachePolicyValidation = validateCachePolicy(response, true);
+  const cachePolicyValidation = validateCachePolicy(response, true, requireCacheHit);
   if (cachePolicyValidation.outcome !== "warmed") return cachePolicyValidation;
   if (
     terminalResponse &&
@@ -637,7 +653,11 @@ function validateRscWarmResponse(
   return { outcome: "warmed" };
 }
 
-function validateHtmlWarmResponse(response: Response, expectedBuildId?: string): WarmValidation {
+function validateHtmlWarmResponse(
+  response: Response,
+  expectedBuildId?: string,
+  requireCacheHit = false,
+): WarmValidation {
   const buildIdentityValidation = validateBuildIdentity(response, expectedBuildId);
   if (buildIdentityValidation) return buildIdentityValidation;
   if (response.redirected) {
@@ -649,7 +669,7 @@ function validateHtmlWarmResponse(response: Response, expectedBuildId?: string):
       return { outcome: "failed", error: `HTTP ${response.status}` };
     }
   }
-  const cachePolicyValidation = validateCachePolicy(response, true);
+  const cachePolicyValidation = validateCachePolicy(response, true, requireCacheHit);
   if (cachePolicyValidation.outcome !== "warmed") return cachePolicyValidation;
   const extraVary = (response.headers.get("Vary") ?? "")
     .split(",")
@@ -876,6 +896,7 @@ async function warmOnePath(
     retryDelayMs: number;
     retryNotFound: boolean;
     phaseTimeoutMs?: number;
+    requireCacheHit: boolean;
   },
 ): Promise<
   | { path: string; ok: true; skipped: false }
@@ -908,16 +929,29 @@ async function warmOnePath(
     }
     const attemptTimeoutMs = Math.min(options.timeoutMs, remainingMs);
     try {
-      const { response } = await fetchWithTimeout(
-        options.fetchImpl,
-        url,
-        attemptTimeoutMs,
-        target.headers ?? options.headers,
-        "manual",
-      );
+      const response = options.requireCacheHit
+        ? await fetchHeadersWithTimeout(
+            options.fetchImpl,
+            url,
+            attemptTimeoutMs,
+            target.headers ?? options.headers,
+          )
+        : (
+            await fetchWithTimeout(
+              options.fetchImpl,
+              url,
+              attemptTimeoutMs,
+              target.headers ?? options.headers,
+              "manual",
+            )
+          ).response;
       if (options.deadlineAt !== undefined && Date.now() >= options.deadlineAt) {
         return { path: target.label, ok: false, error: phaseDeadlineError(), retryable: false };
       }
+      // Certification only needs immutable response metadata. A reusable HIT
+      // is already stored at the edge, so downloading it again would double
+      // warmup bandwidth without proving anything more.
+      if (options.requireCacheHit) void response.body?.cancel().catch(() => {});
 
       if (process.env.VINEXT_CDN_WARM_DEBUG === "1") {
         console.log(
@@ -935,6 +969,7 @@ async function warmOnePath(
           response,
           options.expectedBuildId,
           options.expectedRscBuildId,
+          options.requireCacheHit,
         );
         if (validation.outcome === "warmed") {
           return { path: target.label, ok: true, skipped: false };
@@ -943,7 +978,12 @@ async function warmOnePath(
           return { path: target.label, ok: true, skipped: true, reason: validation.reason };
         }
         lastError = validation.error;
-        lastRetryable = shouldRetryValidationFailure(response, target, options);
+        const cacheStatus = response.headers.get("CF-Cache-Status")?.trim().toUpperCase();
+        lastRetryable =
+          (options.requireCacheHit &&
+            ADMITTED_CF_CACHE_STATUSES.has(cacheStatus ?? "") &&
+            !REUSABLE_CF_CACHE_STATUSES.has(cacheStatus ?? "")) ||
+          shouldRetryValidationFailure(response, target, options);
         if (!lastRetryable) break;
         if (!canRetry(attempt)) break;
         if (!(await waitBeforeRetry())) {
@@ -952,7 +992,11 @@ async function warmOnePath(
         continue;
       }
 
-      const validation = validateHtmlWarmResponse(response, options.expectedBuildId);
+      const validation = validateHtmlWarmResponse(
+        response,
+        options.expectedBuildId,
+        options.requireCacheHit,
+      );
       if (validation.outcome === "warmed") {
         return { path: target.label, ok: true, skipped: false };
       }
@@ -960,7 +1004,12 @@ async function warmOnePath(
         return { path: target.label, ok: true, skipped: true, reason: validation.reason };
       }
       lastError = validation.error;
-      lastRetryable = shouldRetryValidationFailure(response, target, options);
+      const cacheStatus = response.headers.get("CF-Cache-Status")?.trim().toUpperCase();
+      lastRetryable =
+        (options.requireCacheHit &&
+          ADMITTED_CF_CACHE_STATUSES.has(cacheStatus ?? "") &&
+          !REUSABLE_CF_CACHE_STATUSES.has(cacheStatus ?? "")) ||
+        shouldRetryValidationFailure(response, target, options);
       if (!lastRetryable) break;
     } catch (error) {
       lastRetryable = true;
@@ -1031,6 +1080,7 @@ export async function warmCdnCache(options: CdnWarmOptions): Promise<CdnWarmResu
       skipped: 0,
       failed: 0,
       failures: [],
+      warmedPlan: { loadingShellPaths: [], paths: [], rscPaths: [] },
       retryPlan: { loadingShellPaths: [], paths: [], rscPaths: [] },
     };
   }
@@ -1063,6 +1113,7 @@ export async function warmCdnCache(options: CdnWarmOptions): Promise<CdnWarmResu
       retryDelayMs: isPropagationRequest ? propagationRetryDelayMs : normalRetryDelayMs,
       retryNotFound: isPropagationRequest,
       phaseTimeoutMs,
+      requireCacheHit: options.requireCacheHit === true,
     });
   };
 
@@ -1145,6 +1196,10 @@ export async function warmCdnCache(options: CdnWarmOptions): Promise<CdnWarmResu
     );
   const failures = failedRequests.map(({ result: { path, error } }) => ({ path, error }));
   const skippedResults = results.filter((result) => result.ok && result.skipped);
+  const warmedRequests = requests.filter((_target, index) => {
+    const result = results[index];
+    return result.ok && !result.skipped;
+  });
   const warmed = results.length - failures.length - skippedResults.length;
 
   console.log(
@@ -1168,6 +1223,17 @@ export async function warmCdnCache(options: CdnWarmOptions): Promise<CdnWarmResu
     skipped: skippedResults.length,
     failed: failures.length,
     failures,
+    warmedPlan: {
+      loadingShellPaths: warmedRequests
+        .filter((target) => target.kind === "rsc-loading-shell")
+        .map((target) => target.sourcePathname),
+      paths: warmedRequests
+        .filter((target) => target.kind === "html")
+        .map((target) => target.sourcePathname),
+      rscPaths: warmedRequests
+        .filter((target) => target.kind === "rsc-full")
+        .map((target) => target.sourcePathname),
+    },
     retryPlan: {
       loadingShellPaths: failedRequests
         .filter(({ target }) => target.kind === "rsc-loading-shell")

--- a/packages/cloudflare/src/cli.ts
+++ b/packages/cloudflare/src/cli.ts
@@ -58,6 +58,7 @@ async function deployCommand(): Promise<void> {
     warmCdnDiscoveryRetries: parsed.warmCdnDiscoveryRetries,
     warmCdnProbeTimeout: parsed.warmCdnProbeTimeout,
     warmCdnProbeRetries: parsed.warmCdnProbeRetries,
+    warmCdnCertify: parsed.warmCdnCertify,
     warmCdnReadinessTimeout: parsed.warmCdnReadinessTimeout,
     warmCdnReadinessRetries: parsed.warmCdnReadinessRetries,
     warmCdnReadinessProbes: parsed.warmCdnReadinessProbes,

--- a/packages/cloudflare/src/deploy-help.ts
+++ b/packages/cloudflare/src/deploy-help.ts
@@ -38,8 +38,9 @@ export function formatDeployHelp(): string {
                              Total cacheability-probe deadline (default: 120000)
     --warm-cdn-probe-retries <n>
                              Cacheability-probe retries (default: 2)
-    --warm-cdn-certify      Re-request warmed entries using headers only and
-                             require reusable CDN hits before promotion
+    --warm-cdn-certify      With --experimental-warm-cdn-cache, re-request warmed
+                             entries using headers only and require every planned
+                             entry to be reusable before promotion
     --warm-cdn-readiness-timeout <ms>
                              Total staged-readiness deadline (default: 120000)
     --warm-cdn-readiness-retries <n>
@@ -50,7 +51,8 @@ export function formatDeployHelp(): string {
     --warm-cdn-readiness-probe-delay <ms>
                              Delay between staged-readiness probes (default: 1000)
     --dangerously-promote-on-cdn-warm-error
-                             Promote even when staged warmup cannot be verified
+                             Promote even when ordinary staged warmup cannot be
+                             verified (never bypasses --warm-cdn-certify)
     --warm-cdn-no-promote    Leave the warmed Worker version staged at 0% traffic;
                              production triggers are still applied before warming
     --warm-cdn-promotion-delay <ms>

--- a/packages/cloudflare/src/deploy-help.ts
+++ b/packages/cloudflare/src/deploy-help.ts
@@ -38,6 +38,8 @@ export function formatDeployHelp(): string {
                              Total cacheability-probe deadline (default: 120000)
     --warm-cdn-probe-retries <n>
                              Cacheability-probe retries (default: 2)
+    --warm-cdn-certify      Re-request warmed entries using headers only and
+                             require reusable CDN hits before promotion
     --warm-cdn-readiness-timeout <ms>
                              Total staged-readiness deadline (default: 120000)
     --warm-cdn-readiness-retries <n>

--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -130,6 +130,8 @@ export type DeployOptions = {
   warmCdnProbeTimeout?: number;
   /** Number of transient staged Worker cacheability probe retries */
   warmCdnProbeRetries?: number;
+  /** Re-request warmed identities and require reusable CDN hits before promotion */
+  warmCdnCertify?: boolean;
   /** Maximum duration of staged Worker readiness verification */
   warmCdnReadinessTimeout?: number;
   /** Number of staged Worker readiness retries */
@@ -231,6 +233,7 @@ const deployArgOptions = {
   "warm-cdn-discovery-retries": { type: "string" },
   "warm-cdn-probe-timeout": { type: "string" },
   "warm-cdn-probe-retries": { type: "string" },
+  "warm-cdn-certify": { type: "boolean", default: false },
   "warm-cdn-readiness-timeout": { type: "string" },
   "warm-cdn-readiness-retries": { type: "string" },
   "warm-cdn-readiness-probes": { type: "string" },
@@ -306,6 +309,7 @@ export function parseDeployArgs(args: string[]) {
       values["warm-cdn-probe-retries"] === undefined
         ? undefined
         : parseNonNegativeIntegerArg(values["warm-cdn-probe-retries"], "--warm-cdn-probe-retries"),
+    warmCdnCertify: values["warm-cdn-certify"],
     warmCdnReadinessTimeout:
       values["warm-cdn-readiness-timeout"] === undefined
         ? undefined
@@ -694,6 +698,7 @@ type CdnWarmDeployOptions = Pick<
   | "warmCdnDiscoveryRetries"
   | "warmCdnProbeTimeout"
   | "warmCdnProbeRetries"
+  | "warmCdnCertify"
   | "warmCdnReadinessTimeout"
   | "warmCdnReadinessRetries"
   | "warmCdnReadinessProbes"
@@ -987,7 +992,7 @@ async function deployUploadedVersionWithCdnWarmup(
               paths: warmResult.retryPlan.paths,
               rscPaths: warmResult.retryPlan.rscPaths,
             };
-            if (hasPreparedWarmPlan && warmResult.warmed > 0) {
+            if (hasPreparedWarmPlan && options.warmCdnCertify && warmResult.warmed > 0) {
               console.log(
                 `  CDN warmup: certifying ${warmResult.warmed} staged cache entr${warmResult.warmed === 1 ? "y" : "ies"} before promotion...`,
               );
@@ -1796,6 +1801,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
       warmCdnDiscoveryRetries: options.warmCdnDiscoveryRetries,
       warmCdnProbeTimeout: options.warmCdnProbeTimeout,
       warmCdnProbeRetries: options.warmCdnProbeRetries,
+      warmCdnCertify: options.warmCdnCertify,
       warmCdnReadinessTimeout: options.warmCdnReadinessTimeout,
       warmCdnReadinessRetries: options.warmCdnReadinessRetries,
       warmCdnReadinessProbes: options.warmCdnReadinessProbes,

--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -251,6 +251,10 @@ const deployArgOptions = {
 export function parseDeployArgs(args: string[]) {
   const { values } = nodeParseArgs({ args, options: deployArgOptions, strict: true });
 
+  if (values["warm-cdn-certify"] && !values["experimental-warm-cdn-cache"]) {
+    throw new Error("--warm-cdn-certify requires --experimental-warm-cdn-cache.");
+  }
+
   function parseIntArg(name: string, raw: string | undefined): number | undefined {
     if (!raw) return undefined;
     const n = parseInt(raw, 10);
@@ -781,6 +785,11 @@ async function deployUploadedVersionWithCdnWarmup(
   paths: readonly string[],
   options: PreparedCdnWarmDeployOptions,
 ): Promise<string> {
+  // Certification is an explicit request to prove every planned cache entry
+  // reusable before promotion. The dangerous override may relax ordinary
+  // warming, but it must never bypass that stronger contract.
+  const allowUnverifiedPromotion =
+    options.dangerouslyPromoteOnCdnWarmError === true && options.warmCdnCertify !== true;
   let deploymentId = options.deploymentId;
   let expectedBuildId = options.expectedBuildId;
   let expectedRscBuildId = options.expectedRscBuildId;
@@ -798,7 +807,7 @@ async function deployUploadedVersionWithCdnWarmup(
 
   const prepareWarmPlan = (plan: CdnWarmRequestPlan): CdnWarmRequestPlan => {
     if (plan.paths.length === 0 || expectedBuildId !== undefined) return plan;
-    if (!options.dangerouslyPromoteOnCdnWarmError) {
+    if (!allowUnverifiedPromotion) {
       throw new Error(
         "CDN HTML warmup requires a CDN adapter that declares build-identity response headers. " +
           "Configure that adapter capability or deploy without --experimental-warm-cdn-cache.",
@@ -859,7 +868,7 @@ async function deployUploadedVersionWithCdnWarmup(
       timeoutMs: options.warmCdnTimeout,
       retries: options.warmCdnRetries,
       requireCacheHit,
-      strict: requireCacheHit || !options.dangerouslyPromoteOnCdnWarmError,
+      strict: requireCacheHit || !allowUnverifiedPromotion,
     });
 
   const wranglerConfig = parseWranglerConfig(root, options.config);
@@ -971,18 +980,25 @@ async function deployUploadedVersionWithCdnWarmup(
               options.warmCdnPromote === false
                 ? " CDN warmup cannot continue because promotion is disabled and the staged version was not warmed."
                 : "";
-            if (!options.dangerouslyPromoteOnCdnWarmError || options.warmCdnPromote === false) {
+            if (!allowUnverifiedPromotion || options.warmCdnPromote === false) {
               throw new Error(`${message}${noPromoteNote}`);
             }
             console.warn(`  ${message} Promoting because the dangerous override is enabled.`);
           } else {
             console.log("  CDN warmup: staged Worker version is stable.");
             const warmResult = await warmUploadedVersion(targetUrl, headers, true, stagedWarmPlan);
+            if (hasPreparedWarmPlan && options.warmCdnCertify) {
+              if (warmResult.warmed !== stagedWarmRequests) {
+                throw new Error(
+                  `CDN warmup cannot certify the staged cache because only ${warmResult.warmed}/${stagedWarmRequests} planned cache entries completed their initial fill.`,
+                );
+              }
+            }
             if (hasPreparedWarmPlan && warmResult.skipped > 0) {
               const message =
                 `Two-stage CDN warming could not fill ${warmResult.skipped}/${warmResult.total} ` +
                 "planned cache entries because Cloudflare refused cache admission.";
-              if (!options.dangerouslyPromoteOnCdnWarmError) {
+              if (!allowUnverifiedPromotion) {
                 throw new Error(message);
               }
               console.warn(`  ${message} Promoting because the dangerous override is enabled.`);
@@ -1021,7 +1037,7 @@ async function deployUploadedVersionWithCdnWarmup(
       const message =
         "CDN warmup failed: pre-traffic warmup needs a production URL and Worker name for version overrides. " +
         "Configure a route/custom domain and Worker name, or deploy without --experimental-warm-cdn-cache.";
-      if (!options.dangerouslyPromoteOnCdnWarmError) {
+      if (!allowUnverifiedPromotion) {
         throw new Error(`${message} ${getStagedVersionCleanupNote()}`);
       }
       console.warn(`  ${message} Promoting because the dangerous override is enabled.`);
@@ -1030,7 +1046,7 @@ async function deployUploadedVersionWithCdnWarmup(
     if (initialWarmRequests > 0) {
       const message =
         "CDN warmup cannot stage the uploaded Worker at 0% because the current deployment is not exactly one version serving 100% traffic.";
-      if (!options.dangerouslyPromoteOnCdnWarmError) {
+      if (!allowUnverifiedPromotion) {
         throw new Error(`${message} No traffic or triggers were changed.`);
       }
       console.warn(`  ${message} Promoting because the dangerous override is enabled.`);
@@ -1171,7 +1187,7 @@ async function deployUploadedVersionWithCdnWarmup(
       } catch (error) {
         throw withPromotedVersionWarmupNote(error);
       }
-    } else if (!options.dangerouslyPromoteOnCdnWarmError) {
+    } else if (!allowUnverifiedPromotion) {
       throw withPromotedVersionWarmupNote(
         new Error(
           "CDN warmup failed: no production URL could be inferred from wrangler config or output. " +
@@ -1791,7 +1807,8 @@ export async function deploy(options: DeployOptions): Promise<void> {
         });
         return readPrerenderWarmPlan(root, {
           includeFallbackShells: options.warmCdnIncludeFallbacks,
-          strict: !options.dangerouslyPromoteOnCdnWarmError,
+          strict:
+            options.warmCdnCertify === true || !options.dangerouslyPromoteOnCdnWarmError,
         });
       },
       warmCdnConcurrency: options.warmCdnConcurrency,

--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -1807,8 +1807,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
         });
         return readPrerenderWarmPlan(root, {
           includeFallbackShells: options.warmCdnIncludeFallbacks,
-          strict:
-            options.warmCdnCertify === true || !options.dangerouslyPromoteOnCdnWarmError,
+          strict: options.warmCdnCertify === true || !options.dangerouslyPromoteOnCdnWarmError,
         });
       },
       warmCdnConcurrency: options.warmCdnConcurrency,

--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -837,6 +837,7 @@ async function deployUploadedVersionWithCdnWarmup(
       paths: remainingWarmPlan.paths,
       rscPaths: remainingWarmPlan.rscPaths,
     },
+    requireCacheHit = false,
   ) =>
     warmCdnCache({
       targetUrl,
@@ -852,7 +853,8 @@ async function deployUploadedVersionWithCdnWarmup(
       phaseTimeoutMs: hasPreparedWarmPlan ? DEFAULT_STAGED_READINESS_PHASE_TIMEOUT_MS : undefined,
       timeoutMs: options.warmCdnTimeout,
       retries: options.warmCdnRetries,
-      strict: !options.dangerouslyPromoteOnCdnWarmError,
+      requireCacheHit,
+      strict: requireCacheHit || !options.dangerouslyPromoteOnCdnWarmError,
     });
 
   const wranglerConfig = parseWranglerConfig(root, options.config);
@@ -866,6 +868,11 @@ async function deployUploadedVersionWithCdnWarmup(
     );
   }
   const stagingTraffic = getZeroPercentStagingTraffic(deploymentStatus, upload.versionId);
+  if (hasPreparedWarmPlan && !stagingTraffic) {
+    throw new Error(
+      "Two-stage CDN warming stopped because Worker deployment traffic changed before the final version could be staged. No final version was promoted.",
+    );
+  }
   let staged: ReturnType<typeof runWranglerVersionDeploy> | null = null;
   let triggersDeployedUrl: string | null = options.triggersDeployedUrl ?? null;
   let stagedCacheFilled = false;
@@ -975,12 +982,31 @@ async function deployUploadedVersionWithCdnWarmup(
               }
               console.warn(`  ${message} Promoting because the dangerous override is enabled.`);
             }
-            stagedCacheFilled = warmResult.warmed > 0;
             remainingWarmPlan = {
               loadingShellPaths: warmResult.retryPlan.loadingShellPaths,
               paths: warmResult.retryPlan.paths,
               rscPaths: warmResult.retryPlan.rscPaths,
             };
+            if (hasPreparedWarmPlan && warmResult.warmed > 0) {
+              console.log(
+                `  CDN warmup: certifying ${warmResult.warmed} staged cache entr${warmResult.warmed === 1 ? "y" : "ies"} before promotion...`,
+              );
+              const certification = await warmUploadedVersion(
+                targetUrl,
+                headers,
+                true,
+                warmResult.warmedPlan,
+                true,
+              );
+              if (certification.warmed !== warmResult.warmed) {
+                throw new Error(
+                  `CDN warmup certified ${certification.warmed}/${warmResult.warmed} staged cache entries as reusable.`,
+                );
+              }
+              stagedCacheFilled = true;
+            } else {
+              stagedCacheFilled = warmResult.warmed > 0;
+            }
           }
         }
       } catch (error) {

--- a/tests/cloudflare-cdn-warm-deploy.test.ts
+++ b/tests/cloudflare-cdn-warm-deploy.test.ts
@@ -659,6 +659,47 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     ).toBe(false);
   });
 
+  it("does not let the dangerous override bypass a failed initial certified fill", async () => {
+    writeTwoStageWorkerArtifact();
+    const wrangler = mockTwoStageWrangler();
+    vi.mocked(fetch).mockImplementation(async (input, init) => {
+      if (new Headers(init?.headers).get(VINEXT_CACHEABILITY_PROBE_HEADER) === "1") {
+        return appPageProbeResponse();
+      }
+      if (isReadinessFetch(input)) return cacheableHtml();
+      return new Response("failed fill", {
+        status: 500,
+        headers: {
+          "cache-control": "no-store",
+          [VINEXT_CDN_BUILD_ID_HEADER]: "app-build-a",
+        },
+      });
+    });
+    const { deployWithCdnWarmup } = await import("../packages/cloudflare/src/deploy.js");
+
+    await expect(
+      deployWithCdnWarmup(tmpDir, [], {
+        cacheabilityProbe: true,
+        config: "dist/server/wrangler.json",
+        discoverWarmPlan: async () => ({
+          appPaths: ["/about"],
+          buildId: "app-build-a",
+          buildIdentity: "app-build-a",
+          loadingShellPaths: [],
+          paths: ["/about"],
+          rscPaths: [],
+        }),
+        dangerouslyPromoteOnCdnWarmError: true,
+        warmCdnCertify: true,
+        warmCdnConcurrency: 1,
+        warmCdnPromotionDelay: 0,
+        warmCdnReadinessProbes: 1,
+        warmCdnRetries: 0,
+      }),
+    ).rejects.toThrow("HTTP 500");
+    expect(wrangler.promoted).toBe(false);
+  });
+
   it("does not overwrite deployment traffic changed before promotion", async () => {
     writeTwoStageWorkerArtifact();
     let uploadCount = 0;

--- a/tests/cloudflare-cdn-warm-deploy.test.ts
+++ b/tests/cloudflare-cdn-warm-deploy.test.ts
@@ -326,7 +326,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     ).toThrow(`the limit is ${MAX_CACHEABILITY_MANIFEST_ROUTES}`);
   });
 
-  it("uploads only static identities, then warms and promotes the final version", async () => {
+  it("uploads only static identities, then warms once and promotes the final version", async () => {
     writeTwoStageWorkerArtifact();
     const events: string[] = [];
     let uploadCount = 0;
@@ -410,7 +410,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       if (isReadinessFetch(input)) events.push("readiness");
       else {
         cacheRequestCount++;
-        events.push(cacheRequestCount === 1 ? "warm" : "certify");
+        events.push(cacheRequestCount === 1 ? "warm" : "unexpected-second-request");
       }
       return cacheableHtml("ok", cacheRequestCount > 1 ? "HIT" : "MISS");
     });
@@ -438,6 +438,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     expect(deployedUrl).toBe("https://my-worker.example.workers.dev");
     expect(uploadCount).toBe(2);
     expect(statusCount).toBe(7);
+    expect(cacheRequestCount).toBe(1);
     expect(events).toEqual([
       "upload-probe",
       "status-1",
@@ -455,7 +456,6 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       "triggers",
       "readiness",
       "warm",
-      "certify",
       "status-7",
       "promote-final",
     ]);
@@ -584,6 +584,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     writeTwoStageWorkerArtifact();
     let uploadCount = 0;
     let statusCount = 0;
+    let finalStaged = false;
     execFileSyncMock.mockImplementation((_file: string, args: string[]) => {
       if (args.includes("upload")) {
         uploadCount++;
@@ -595,16 +596,22 @@ describe("Cloudflare CDN warmup deploy flow", () => {
           versions:
             statusCount === 1
               ? [{ version_id: OLD_VERSION, percentage: 100 }]
-              : [
-                  { version_id: OLD_VERSION, percentage: 100 },
-                  { version_id: PROBE_VERSION, percentage: 0 },
-                ],
+              : finalStaged
+                ? [
+                    { version_id: OLD_VERSION, percentage: 100 },
+                    { version_id: FINAL_VERSION, percentage: 0 },
+                  ]
+                : [
+                    { version_id: OLD_VERSION, percentage: 100 },
+                    { version_id: PROBE_VERSION, percentage: 0 },
+                  ],
         });
       }
       if (args.includes(`${PROBE_VERSION}@0%`)) {
         return "Staged probe version\nhttps://my-worker.example.workers.dev\n";
       }
       if (args.includes(`${FINAL_VERSION}@0%`)) {
+        finalStaged = true;
         return "Staged final version\nhttps://my-worker.example.workers.dev\n";
       }
       if (args.includes(`${FINAL_VERSION}@100%`)) {
@@ -637,6 +644,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
           rscPaths: [],
         }),
         dangerouslyPromoteOnCdnWarmError: true,
+        warmCdnCertify: true,
         warmCdnConcurrency: 1,
         warmCdnPromotionDelay: 0,
         warmCdnReadinessProbes: 1,
@@ -651,7 +659,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     ).toBe(false);
   });
 
-  it("does not overwrite deployment traffic changed during final certification", async () => {
+  it("does not overwrite deployment traffic changed before promotion", async () => {
     writeTwoStageWorkerArtifact();
     let uploadCount = 0;
     let statusCount = 0;
@@ -665,12 +673,17 @@ describe("Cloudflare CDN warmup deploy flow", () => {
         const versions =
           statusCount === 1
             ? [{ version_id: OLD_VERSION, percentage: 100 }]
-            : statusCount === 5
+            : statusCount === 7
               ? [{ version_id: "44444444-4444-4444-8444-444444444444", percentage: 100 }]
-              : [
-                  { version_id: OLD_VERSION, percentage: 100 },
-                  { version_id: PROBE_VERSION, percentage: 0 },
-                ];
+              : statusCount === 6
+                ? [
+                    { version_id: OLD_VERSION, percentage: 100 },
+                    { version_id: FINAL_VERSION, percentage: 0 },
+                  ]
+                : [
+                    { version_id: OLD_VERSION, percentage: 100 },
+                    { version_id: PROBE_VERSION, percentage: 0 },
+                  ];
         return JSON.stringify({ versions });
       }
       if (args.includes(`${PROBE_VERSION}@0%`)) {
@@ -710,13 +723,16 @@ describe("Cloudflare CDN warmup deploy flow", () => {
           paths: ["/about"],
           rscPaths: [],
         }),
+        warmCdnCertify: true,
         warmCdnConcurrency: 1,
         warmCdnPromotionDelay: 0,
         warmCdnReadinessProbes: 1,
         warmCdnRetries: 0,
       }),
-    ).rejects.toThrow("deployment traffic changed during final cache certification");
-    expect(statusCount).toBe(5);
+    ).rejects.toThrow(
+      "deployment traffic or deployment identity changed before the final version could be promoted",
+    );
+    expect(statusCount).toBe(7);
     expect(
       (execFileSyncMock.mock.calls as Array<[string, string[]]>).some(([, args]) =>
         args.includes(`${FINAL_VERSION}@100%`),

--- a/tests/cloudflare-cdn-warm-deploy.test.ts
+++ b/tests/cloudflare-cdn-warm-deploy.test.ts
@@ -54,10 +54,10 @@ function getRealWarmFetchCalls() {
   return vi.mocked(fetch).mock.calls.filter(([url]) => !isReadinessFetch(url));
 }
 
-function cacheableHtml(body = "ok"): Response {
+function cacheableHtml(body = "ok", cacheStatus = "MISS"): Response {
   return new Response(body, {
     headers: {
-      "cf-cache-status": "MISS",
+      "cf-cache-status": cacheStatus,
       "content-type": "text/html",
       [VINEXT_CDN_BUILD_ID_HEADER]: "app-build-a",
     },
@@ -332,6 +332,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     let uploadCount = 0;
     let statusCount = 0;
     let finalStaged = false;
+    let cacheRequestCount = 0;
     let finalManifestSource = "";
     let finalConfig: unknown;
 
@@ -407,8 +408,11 @@ describe("Cloudflare CDN warmup deploy flow", () => {
           : appPageProbeResponse();
       }
       if (isReadinessFetch(input)) events.push("readiness");
-      else events.push("warm");
-      return cacheableHtml();
+      else {
+        cacheRequestCount++;
+        events.push(cacheRequestCount === 1 ? "warm" : "certify");
+      }
+      return cacheableHtml("ok", cacheRequestCount > 1 ? "HIT" : "MISS");
     });
     const { deployWithCdnWarmup } = await import("../packages/cloudflare/src/deploy.js");
 
@@ -451,6 +455,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       "triggers",
       "readiness",
       "warm",
+      "certify",
       "status-7",
       "promote-final",
     ]);
@@ -573,6 +578,150 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     expect(wrangler.promoted).toBe(false);
     expect(wrangler.triggerDeploys).toBe(1);
     expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("does not promote when a staged cache fill cannot be reused", async () => {
+    writeTwoStageWorkerArtifact();
+    let uploadCount = 0;
+    let statusCount = 0;
+    execFileSyncMock.mockImplementation((_file: string, args: string[]) => {
+      if (args.includes("upload")) {
+        uploadCount++;
+        return `Uploaded my-worker\nWorker Version ID: ${uploadCount === 1 ? PROBE_VERSION : FINAL_VERSION}\n`;
+      }
+      if (args.includes("status")) {
+        statusCount++;
+        return JSON.stringify({
+          versions:
+            statusCount === 1
+              ? [{ version_id: OLD_VERSION, percentage: 100 }]
+              : [
+                  { version_id: OLD_VERSION, percentage: 100 },
+                  { version_id: PROBE_VERSION, percentage: 0 },
+                ],
+        });
+      }
+      if (args.includes(`${PROBE_VERSION}@0%`)) {
+        return "Staged probe version\nhttps://my-worker.example.workers.dev\n";
+      }
+      if (args.includes(`${FINAL_VERSION}@0%`)) {
+        return "Staged final version\nhttps://my-worker.example.workers.dev\n";
+      }
+      if (args.includes(`${FINAL_VERSION}@100%`)) {
+        throw new Error("final version must not be promoted");
+      }
+      if (args.includes("triggers")) {
+        return "Triggers deployed\nhttps://my-worker.example.workers.dev\n";
+      }
+      throw new Error(`Unexpected Wrangler args: ${args.join(" ")}`);
+    });
+    vi.mocked(fetch).mockImplementation(async (input, init) => {
+      if (new Headers(init?.headers).get(VINEXT_CACHEABILITY_PROBE_HEADER) === "1") {
+        return appPageProbeResponse();
+      }
+      if (isReadinessFetch(input)) return cacheableHtml();
+      return cacheableHtml();
+    });
+    const { deployWithCdnWarmup } = await import("../packages/cloudflare/src/deploy.js");
+
+    await expect(
+      deployWithCdnWarmup(tmpDir, [], {
+        cacheabilityProbe: true,
+        config: "dist/server/wrangler.json",
+        discoverWarmPlan: async () => ({
+          appPaths: ["/about"],
+          buildId: "app-build-a",
+          buildIdentity: "app-build-a",
+          loadingShellPaths: [],
+          paths: ["/about"],
+          rscPaths: [],
+        }),
+        dangerouslyPromoteOnCdnWarmError: true,
+        warmCdnConcurrency: 1,
+        warmCdnPromotionDelay: 0,
+        warmCdnReadinessProbes: 1,
+        warmCdnRetries: 0,
+      }),
+    ).rejects.toThrow("CF-Cache-Status is MISS; the cache fill is not reusable");
+    expect(uploadCount).toBe(2);
+    expect(
+      (execFileSyncMock.mock.calls as Array<[string, string[]]>).some(([, args]) =>
+        args.includes(`${FINAL_VERSION}@100%`),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not overwrite deployment traffic changed during final certification", async () => {
+    writeTwoStageWorkerArtifact();
+    let uploadCount = 0;
+    let statusCount = 0;
+    execFileSyncMock.mockImplementation((_file: string, args: string[]) => {
+      if (args.includes("upload")) {
+        uploadCount++;
+        return `Uploaded my-worker\nWorker Version ID: ${uploadCount === 1 ? PROBE_VERSION : FINAL_VERSION}\n`;
+      }
+      if (args.includes("status")) {
+        statusCount++;
+        const versions =
+          statusCount === 1
+            ? [{ version_id: OLD_VERSION, percentage: 100 }]
+            : statusCount === 5
+              ? [{ version_id: "44444444-4444-4444-8444-444444444444", percentage: 100 }]
+              : [
+                  { version_id: OLD_VERSION, percentage: 100 },
+                  { version_id: PROBE_VERSION, percentage: 0 },
+                ];
+        return JSON.stringify({ versions });
+      }
+      if (args.includes(`${PROBE_VERSION}@0%`)) {
+        return "Staged probe version\nhttps://my-worker.example.workers.dev\n";
+      }
+      if (args.includes(`${FINAL_VERSION}@0%`)) {
+        return "Staged final version\nhttps://my-worker.example.workers.dev\n";
+      }
+      if (args.includes(`${FINAL_VERSION}@100%`)) {
+        throw new Error("final version must not overwrite the concurrent deployment");
+      }
+      if (args.includes("triggers")) {
+        return "Triggers deployed\nhttps://my-worker.example.workers.dev\n";
+      }
+      throw new Error(`Unexpected Wrangler args: ${args.join(" ")}`);
+    });
+    let cacheRequestCount = 0;
+    vi.mocked(fetch).mockImplementation(async (input, init) => {
+      if (new Headers(init?.headers).get(VINEXT_CACHEABILITY_PROBE_HEADER) === "1") {
+        return appPageProbeResponse();
+      }
+      if (isReadinessFetch(input)) return cacheableHtml();
+      cacheRequestCount++;
+      return cacheableHtml("ok", cacheRequestCount === 1 ? "MISS" : "HIT");
+    });
+    const { deployWithCdnWarmup } = await import("../packages/cloudflare/src/deploy.js");
+
+    await expect(
+      deployWithCdnWarmup(tmpDir, [], {
+        cacheabilityProbe: true,
+        config: "dist/server/wrangler.json",
+        discoverWarmPlan: async () => ({
+          appPaths: ["/about"],
+          buildId: "app-build-a",
+          buildIdentity: "app-build-a",
+          loadingShellPaths: [],
+          paths: ["/about"],
+          rscPaths: [],
+        }),
+        warmCdnConcurrency: 1,
+        warmCdnPromotionDelay: 0,
+        warmCdnReadinessProbes: 1,
+        warmCdnRetries: 0,
+      }),
+    ).rejects.toThrow("deployment traffic changed during final cache certification");
+    expect(statusCount).toBe(5);
+    expect(
+      (execFileSyncMock.mock.calls as Array<[string, string[]]>).some(([, args]) =>
+        args.includes(`${FINAL_VERSION}@100%`),
+      ),
+    ).toBe(false);
   });
 
   it("leaves production triggers untouched when an exact request cannot be classified", async () => {

--- a/tests/cloudflare-cdn-warm.test.ts
+++ b/tests/cloudflare-cdn-warm.test.ts
@@ -215,6 +215,11 @@ describe("Cloudflare CDN warmup", () => {
       skipped: 0,
       failed: 0,
       failures: [],
+      warmedPlan: {
+        loadingShellPaths: ["/search?q=x"],
+        paths: ["/search?q=x"],
+        rscPaths: ["/search?q=x"],
+      },
       retryPlan: { loadingShellPaths: [], paths: [], rscPaths: [] },
     });
     expect(fetchImpl).toHaveBeenCalledTimes(3);
@@ -292,8 +297,95 @@ describe("Cloudflare CDN warmup", () => {
       skipped: 2,
       failed: 0,
       failures: [],
+      warmedPlan: { loadingShellPaths: [], paths: [], rscPaths: [] },
       retryPlan: { loadingShellPaths: [], paths: [], rscPaths: [] },
     });
+  });
+
+  it("does not certify a staged cache fill until the entry is reusable", async () => {
+    let attempt = 0;
+    const fetchImpl = vi.fn(async () => {
+      attempt += 1;
+      const response = cacheableHtml();
+      response.headers.set("cf-cache-status", attempt === 1 ? "MISS" : "HIT");
+      return response;
+    });
+
+    await expect(
+      warmCdnCache({
+        expectedBuildId: "build-a",
+        fetchImpl: fetchImpl as typeof fetch,
+        paths: ["/staged"],
+        propagatingTarget: true,
+        requireCacheHit: true,
+        retries: 1,
+        retryDelayMs: 0,
+        strict: true,
+        targetUrl: "https://app.example.com",
+      }),
+    ).resolves.toMatchObject({ warmed: 1, failed: 0 });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects a cache fill that becomes private during certification", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response("dynamic", {
+          headers: {
+            "cache-control": "no-store",
+            "cf-cache-status": "BYPASS",
+            "content-type": "text/html",
+            [VINEXT_CDN_BUILD_ID_HEADER]: "build-a",
+          },
+        }),
+    );
+
+    await expect(
+      warmCdnCache({
+        expectedBuildId: "build-a",
+        fetchImpl: fetchImpl as typeof fetch,
+        paths: ["/changed"],
+        requireCacheHit: true,
+        strict: true,
+        targetUrl: "https://app.example.com",
+      }),
+    ).rejects.toThrow("CF-Cache-Status is BYPASS; the cache fill is not reusable");
+  });
+
+  it("certifies from response headers without consuming the cached body", async () => {
+    let cancelled = false;
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          new ReadableStream({
+            pull(controller) {
+              controller.enqueue(new Uint8Array([1]));
+            },
+            cancel() {
+              cancelled = true;
+            },
+          }),
+          {
+            headers: {
+              "cf-cache-status": "HIT",
+              "content-type": "text/html",
+              [VINEXT_CDN_BUILD_ID_HEADER]: "build-a",
+            },
+          },
+        ),
+    );
+
+    await expect(
+      warmCdnCache({
+        expectedBuildId: "build-a",
+        fetchImpl: fetchImpl as typeof fetch,
+        paths: ["/cached"],
+        requireCacheHit: true,
+        strict: true,
+        targetUrl: "https://app.example.com",
+      }),
+    ).resolves.toMatchObject({ warmed: 1, failed: 0 });
+    await vi.waitFor(() => expect(cancelled).toBe(true));
   });
 
   it("uses Cloudflare cache-control precedence when validating admission", async () => {

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -717,6 +717,7 @@ describe("parseDeployArgs", () => {
       "warmCdnDiscoveryRetries",
       "warmCdnProbeTimeout",
       "warmCdnProbeRetries",
+      "warmCdnCertify",
       "warmCdnReadinessTimeout",
       "warmCdnReadinessRetries",
     ]) {
@@ -732,6 +733,7 @@ describe("parseDeployArgs", () => {
     expect(parsed.skipBuild).toBe(false);
     expect(parsed.dryRun).toBe(false);
     expect(parsed.warmCdnCache).toBe(false);
+    expect(parsed.warmCdnCertify).toBe(false);
     expect(parsed.dangerouslyPromoteOnCdnWarmError).toBe(false);
   });
 
@@ -816,6 +818,7 @@ describe("parseDeployArgs", () => {
       "--warm-cdn-discovery-retries=7",
       "--warm-cdn-probe-timeout=60000",
       "--warm-cdn-probe-retries=4",
+      "--warm-cdn-certify",
       "--warm-cdn-readiness-timeout=45000",
       "--warm-cdn-readiness-retries=9",
       "--warm-cdn-readiness-probes=8",
@@ -835,6 +838,7 @@ describe("parseDeployArgs", () => {
     expect(parsed.warmCdnDiscoveryRetries).toBe(7);
     expect(parsed.warmCdnProbeTimeout).toBe(60_000);
     expect(parsed.warmCdnProbeRetries).toBe(4);
+    expect(parsed.warmCdnCertify).toBe(true);
     expect(parsed.warmCdnReadinessTimeout).toBe(45_000);
     expect(parsed.warmCdnReadinessRetries).toBe(9);
     expect(parsed.warmCdnReadinessProbes).toBe(8);

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -737,6 +737,12 @@ describe("parseDeployArgs", () => {
     expect(parsed.dangerouslyPromoteOnCdnWarmError).toBe(false);
   });
 
+  it("requires CDN warming when certification is requested", () => {
+    expect(() => parseDeployArgs(["--warm-cdn-certify"])).toThrow(
+      "--warm-cdn-certify requires --experimental-warm-cdn-cache.",
+    );
+  });
+
   it("parses --env with space-separated value", () => {
     expect(parseDeployArgs(["--env", "staging"]).env).toBe("staging");
   });

--- a/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
+++ b/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
@@ -385,7 +385,7 @@ test("deploy-prewarmed App HTML and RSC variants are reused", async ({
 
   // A purge removes the warmed response body, not the manifest embedded in the
   // promoted Worker. The first completed render must therefore be admitted as
-  // a CDN MISS and the next untouched request must reuse that exact entry.
+  // a CDN MISS, and subsequent requests must eventually reuse that exact entry.
   const purgeDeadline = Date.now() + 30_000;
   let coldAfterPurge: APIResponse | undefined;
   do {
@@ -406,9 +406,20 @@ test("deploy-prewarmed App HTML and RSC variants are reused", async ({
   expect(coldHeaders["cdn-cache-control"]).toContain("public");
   expect(await coldAfterPurge!.text()).toContain("Prewarm target");
 
-  const hitAfterPurge = await getResponseAfterPromotion(request, `${baseURL}${TARGET_PATH}`, {
-    accept: "text/html",
-  });
-  expect(hitAfterPurge.headers()["cf-cache-status"]).toBe("HIT");
-  expect(await hitAfterPurge.text()).toContain("Prewarm target");
+  const reuseDeadline = Date.now() + 30_000;
+  let hitAfterPurge: APIResponse | undefined;
+  do {
+    const candidate = await getResponseAfterPromotion(request, `${baseURL}${TARGET_PATH}`, {
+      accept: "text/html",
+    });
+    if (candidate.headers()["cf-cache-status"] === "HIT") {
+      hitAfterPurge = candidate;
+      break;
+    }
+    await candidate.dispose();
+    await new Promise((resolve) => setTimeout(resolve, PROMOTION_PROBE_INTERVAL_MS));
+  } while (Date.now() < reuseDeadline);
+  expect(hitAfterPurge, "cold App HTML cache fill did not become reusable").toBeDefined();
+  expect(hitAfterPurge!.ok(), JSON.stringify(hitAfterPurge!.headers())).toBe(true);
+  expect(await hitAfterPurge!.text()).toContain("Prewarm target");
 });

--- a/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
+++ b/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
@@ -376,4 +376,39 @@ test("deploy-prewarmed App HTML and RSC variants are reused", async ({
     expect(dynamic.headers()["cache-control"]).toContain("no-store");
     expect(dynamic.headers()["cf-cache-status"]).toBe("BYPASS");
   });
+
+  const purgeResponse = await request.post(`${baseURL}/api/revalidate-path`, {
+    data: { path: TARGET_PATH },
+  });
+  expect(purgeResponse.ok()).toBe(true);
+  expect(await purgeResponse.json()).toEqual({ revalidated: true, target: TARGET_PATH });
+
+  // A purge removes the warmed response body, not the manifest embedded in the
+  // promoted Worker. The first completed render must therefore be admitted as
+  // a CDN MISS and the next untouched request must reuse that exact entry.
+  const purgeDeadline = Date.now() + 30_000;
+  let coldAfterPurge: APIResponse | undefined;
+  do {
+    const candidate = await getResponseAfterPromotion(request, `${baseURL}${TARGET_PATH}`, {
+      accept: "text/html",
+    });
+    if (candidate.headers()["cf-cache-status"] !== "HIT") {
+      coldAfterPurge = candidate;
+      break;
+    }
+    await candidate.dispose();
+    await new Promise((resolve) => setTimeout(resolve, PROMOTION_PROBE_INTERVAL_MS));
+  } while (Date.now() < purgeDeadline);
+  expect(coldAfterPurge, "purged App HTML entry remained a CDN HIT").toBeDefined();
+  const coldHeaders = coldAfterPurge!.headers();
+  expect(coldAfterPurge!.ok(), JSON.stringify(coldHeaders)).toBe(true);
+  expect(coldHeaders["cf-cache-status"]).toBe("MISS");
+  expect(coldHeaders["cdn-cache-control"]).toContain("public");
+  expect(await coldAfterPurge!.text()).toContain("Prewarm target");
+
+  const hitAfterPurge = await getResponseAfterPromotion(request, `${baseURL}${TARGET_PATH}`, {
+    accept: "text/html",
+  });
+  expect(hitAfterPurge.headers()["cf-cache-status"]).toBe("HIT");
+  expect(await hitAfterPurge.text()).toContain("Prewarm target");
 });


### PR DESCRIPTION
Capability stack **7/9**. Exact head: `de0d12e4f27aa266418e5e1daa3a2044324da7cb`. Base: #3093.

Full chain: #3108 → #3090 → #3091 → #3092 → #3103 → #3093 → #3094 → #3098 → #3113.

## Summary

Add an **optional** header-only certification pass for successfully warmed cache keys before promotion.

The default two-stage flow issues one cache-fill request per identity. Certification is enabled only with `--warm-cdn-certify`; it then re-requests each warmed identity and accepts only `HIT`, `REVALIDATED`, or `UPDATING` as proof that the entry is reusable. Cached response bodies are cancelled rather than downloaded again, and promotion aborts if deployment traffic changes. The dangerous warmup override cannot bypass an enabled certification pass. `--warm-cdn-certify` is rejected unless `--experimental-warm-cdn-cache` is also supplied, and every planned initial fill must succeed before certification or promotion.

The deployed Cloudflare E2E also purges a warmed App Page and asserts `MISS → HIT`, proving that embedded classification continues to admit safe cold fills after cache loss.

## Why opt-in

Certification gives stronger deployment-time evidence, but doubles requests for warmed identities. Keeping it behind a CLI flag preserves the performance benefit of normal cache warming while allowing stricter deployments to choose the extra verification.

## Review guide

1. `packages/cloudflare/src/cdn-warm.ts` performs header-only cache certification and defines accepted cache states.
2. `packages/cloudflare/src/deploy.ts` gates certification on `warmCdnCertify` and relies on #3093's traffic checks before promotion.
3. `packages/cloudflare/src/cli.ts` and `deploy-help.ts` expose `--warm-cdn-certify`.
4. `tests/cloudflare-cdn-warm.test.ts` covers accepted/rejected cache states without consuming bodies.
5. The Cloudflare README documents the required `version_metadata` binding, including repetition in named Wrangler environments.
6. `tests/cloudflare-cdn-warm-deploy.test.ts` proves one request by default, rejects invalid flag combinations, and requires complete initial-fill success before opt-in certification.
7. `tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts` proves warmed reuse and post-purge admission on the real CDN.

## Review size

Layer-only diff against this PR's base: **10 files, +525/-29**.

## Validation

- default-flow regression proves one final fill request per identity
- certification adds a second, header-only request only with `--warm-cdn-certify`
- current full-stack cumulative changed-file suites — **2,864/2,864**
- current full-stack PPR probe/admission/Pages built-workerd E2E — **8/8**
- current full-stack `vp check` and `git diff --check`
- layer exact-head CI and deploy previews are green
