### PR TITLE
fix(cache): classify explicit io probes

### DIFF
--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -79,7 +79,10 @@ import {
   resolveDevImageRedirect,
   type ImageConfig,
 } from "./image-optimization.js";
-import { runWithPrerenderWorkUnit } from "./prerender-work-unit-setup.js";
+import {
+  runWithLegacyPagesPrerenderWorkUnit,
+  runWithPrerenderWorkUnit,
+} from "./prerender-work-unit-setup.js";
 import { buildPostMwRequestContext } from "./app-post-middleware-context.js";
 import type { AppRscRenderMode } from "./app-rsc-render-mode.js";
 import type { AppPagePprFallbackCacheShell } from "./app-ppr-fallback-shell.js";
@@ -1484,22 +1487,36 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     matchKind: "dynamic" | "static",
   ): Promise<Response | null> => {
     if (!filesystemRouteEligible) return null;
-    const response =
-      !isInterceptionMatch && (match === null || match.route.isDynamic)
-        ? ((await options.renderPagesFallback?.({
-            appRouteMatch: match ?? null,
-            allowRscDocumentFallback:
-              didMiddlewareRewritePathname || allowInternalRscDocumentFallback,
-            isDataRequest,
-            isRscRequest,
-            matchKind,
-            middlewareContext,
-            pathname: resolvedUrl,
-            pagesDataRequest,
-            request,
-            url,
-          })) ?? null)
-        : null;
+    const renderPagesFallback = options.renderPagesFallback;
+    let response: Response | null = null;
+    if (!isInterceptionMatch && (match === null || match.route.isDynamic) && renderPagesFallback) {
+      // Cache Components is an App Router feature. A hybrid fallback must
+      // retain Pages Router's legacy `io()` semantics during both staged
+      // probing and post-purge admission, matching Next.js.
+      setRouteCacheabilityCacheComponents(false);
+      try {
+        response =
+          (await runWithLegacyPagesPrerenderWorkUnit(() =>
+            renderPagesFallback({
+              appRouteMatch: match ?? null,
+              allowRscDocumentFallback:
+                didMiddlewareRewritePathname || allowInternalRscDocumentFallback,
+              isDataRequest,
+              isRscRequest,
+              matchKind,
+              middlewareContext,
+              pathname: resolvedUrl,
+              pagesDataRequest,
+              request,
+              url,
+            }),
+          )) ?? null;
+      } finally {
+        if (!response) {
+          setRouteCacheabilityCacheComponents(options.createPprFallbackShells !== undefined);
+        }
+      }
+    }
     if (response) preserveRouteCacheabilityResponsePolicy();
     if (!response || !pagesDataRequest || resolvedUrl === originalResolvedUrl) return response;
 

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -110,6 +110,7 @@ import {
 import {
   markRouteCacheabilityDynamic,
   preserveRouteCacheabilityResponsePolicy,
+  setRouteCacheabilityCacheComponents,
 } from "vinext/shims/cacheability-classification";
 
 type AppPageParams = Record<string, string | string[]>;
@@ -1978,6 +1979,8 @@ export function createAppRscHandler<TRoute extends AppRscHandlerRoute>(
       unstableCacheRevalidation: "background",
     });
     let interceptionResponseUncacheable = false;
+
+    setRouteCacheabilityCacheComponents(options.createPprFallbackShells !== undefined);
 
     const responsePromise = runWithRequestContext(requestContext, () =>
       runWithPrerenderWorkUnit(

--- a/packages/vinext/src/server/prerender-work-unit-setup.ts
+++ b/packages/vinext/src/server/prerender-work-unit-setup.ts
@@ -28,6 +28,19 @@ export function runWithPrerenderWorkUnit(
   return fn();
 }
 
+/** Keep Pages Router rendering on its legacy prerender semantics during an App handoff. */
+export function runWithLegacyPagesPrerenderWorkUnit<T>(fn: () => T): T {
+  const store = workUnitAsyncStorage.getStore();
+  if (
+    store?.type !== "prerender" &&
+    store?.type !== "prerender-client" &&
+    store?.type !== "prerender-runtime"
+  ) {
+    return fn();
+  }
+  return workUnitAsyncStorage.run({ type: "prerender-legacy" }, fn);
+}
+
 async function runWithPrerenderWorkUnitOwner(
   fn: () => Promise<Response>,
   options?: { route?: string | (() => string) },

--- a/packages/vinext/src/shims/cache.ts
+++ b/packages/vinext/src/shims/cache.ts
@@ -274,8 +274,10 @@ export function io(): Promise<void> {
       case "prerender-client":
       case "prerender-runtime":
         // Prevent execution past the IO boundary during prerendering.
-        // The hanging promise suspends React's render indefinitely until
-        // the prerender is aborted or completed.
+        // Notify the render owner before returning the hanging promise. The
+        // owner can then finish an authenticated cacheability probe as
+        // dynamic without exposing a catchable framework error to user code.
+        workUnitStore.signalPrerenderBailout?.("`io()`");
         return makeHangingPromise(
           workUnitStore.renderSignal,
           /* route */ workUnitStore.route ?? "unknown",

--- a/packages/vinext/src/shims/cache.ts
+++ b/packages/vinext/src/shims/cache.ts
@@ -21,6 +21,7 @@
 
 import {
   getHeadersAccessPhase,
+  isInsideAnyCacheScope,
   isDraftModeEnabled,
   markDynamicUsage as _markDynamic,
   peekInvalidDynamicUsageError,
@@ -34,7 +35,11 @@ import { encodeCacheTag, encodeCacheTags } from "../utils/encode-cache-tag.js";
 import { getCdnCacheAdapter } from "./cdn-cache.js";
 import { getDataCacheHandler, type CachedFetchValue } from "./cache-handler.js";
 import { getRequestExecutionContext } from "./request-context.js";
-import { isStagedCacheabilityProbeActive } from "./cacheability-classification.js";
+import {
+  isRouteCacheabilityCacheComponentsEnabled,
+  isStagedCacheabilityProbeActive,
+  markRouteCacheabilityDynamic,
+} from "./cacheability-classification.js";
 import { addCollectedRequestTags, getCurrentFetchSoftTags } from "./fetch-cache.js";
 import {
   ACTION_DID_REVALIDATE_DYNAMIC_ONLY,
@@ -266,6 +271,26 @@ const _resolvedIOPromise: Promise<void> = Promise.resolve(undefined);
 export function io(): Promise<void> {
   const workUnitStore = workUnitAsyncStorage.getStore();
 
+  // Vinext's cache scopes use dedicated ALS stores rather than replacing the
+  // outer prerender work unit. Check those owners first so `io()` remains the
+  // same no-op inside public `"use cache"` and `unstable_cache()` that it is in
+  // Next.js, even while a Cache Components prerender owns the outer render.
+  if (_unstableCacheAls.getStore() === true || isInsideAnyCacheScope()) {
+    return _resolvedIOPromise;
+  }
+
+  // Without Cache Components, `io()` is deliberately a no-op during legacy
+  // prerendering and must not demote an otherwise static route.
+  if (workUnitStore?.type === "prerender-legacy") return _resolvedIOPromise;
+
+  // A manifest-certified route can take a different branch after an edge
+  // purge. Runtime admission has no prerender work unit, so preserve the
+  // Cache Components `io()` boundary explicitly and fail closed before the
+  // completed response receives public CDN headers.
+  if (isRouteCacheabilityCacheComponentsEnabled()) {
+    markRouteCacheabilityDynamic("`io()` requires request-time execution");
+  }
+
   if (workUnitStore) {
     switch (workUnitStore.type) {
       case "request":
@@ -287,7 +312,6 @@ export function io(): Promise<void> {
       case "private-cache":
       case "unstable-cache":
       case "generate-static-params":
-      case "prerender-legacy":
         return _resolvedIOPromise;
       default:
         workUnitStore satisfies never;

--- a/packages/vinext/src/shims/cacheability-classification.ts
+++ b/packages/vinext/src/shims/cacheability-classification.ts
@@ -29,6 +29,8 @@ export type RouteCacheabilityState = {
   /** Optional admission budget override used by focused runtime tests. */
   captureBudget?: { maxBytes: number; reservedBytes: number };
   captureDeadlineAt: number;
+  /** Whether this request renders with Next.js Cache Components semantics. */
+  cacheComponents?: boolean;
   complete?: (outcome: RouteCacheabilityOutcome) => void;
   completion?: Promise<RouteCacheabilityOutcome>;
   finalResponseVetoReason?: string;
@@ -67,6 +69,17 @@ export function beginRouteCacheability(kind: "app-page" | "app-route", pattern: 
   if (!state) return false;
   state.route = { kind, pattern };
   return true;
+}
+
+/** Record the route runtime's Cache Components mode for late admission checks. */
+export function setRouteCacheabilityCacheComponents(enabled: boolean): void {
+  const state = readRouteCacheabilityState();
+  if (state) state.cacheComponents = enabled;
+}
+
+/** Whether the active cacheability evaluation uses Cache Components semantics. */
+export function isRouteCacheabilityCacheComponentsEnabled(): boolean {
+  return readRouteCacheabilityState()?.cacheComponents === true;
 }
 
 /** Prevent shared caching when request processing before route dispatch was request-specific. */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -328,7 +328,7 @@ const projectServers = {
     use: { baseURL: "http://localhost:4209" },
     server: {
       command:
-        "(test -e node_modules || test -L node_modules || ln -s ../../../fixtures/ppr-impact-demo/node_modules node_modules) && npx vp run vinext#build && node ../../../../packages/vinext/dist/cli.js build && npx wrangler dev --config dist/server/wrangler.json --port 4209",
+        "(test -e node_modules || test -L node_modules || ln -s ../../../fixtures/ppr-impact-demo/node_modules node_modules) && npx vp run vinext#build && node ../../../../packages/vinext/dist/cli.js build && node ../../../fixtures/ppr-impact-demo/embed-cacheability-manifest.mjs && npx wrangler dev --config dist/server/wrangler.json --port 4209",
       cwd: "./tests/e2e/cacheability-components/fixture",
       port: 4209,
       reuseExistingServer: !process.env.CI,

--- a/tests/cacheability-admission.test.ts
+++ b/tests/cacheability-admission.test.ts
@@ -360,6 +360,7 @@ describe("single-request cacheability admission", () => {
     "keeps a manifest-backed response private after late $name",
     async (testCase) => {
       const { raw } = staticManifestRoute();
+
       const context = createWorkerCacheabilityAdmissionContext(
         { waitUntil() {} },
         request,
@@ -384,6 +385,52 @@ describe("single-request cacheability admission", () => {
       await expect(response.text()).resolves.toBe("late private response");
     },
   );
+
+  it("demotes post-certification io only with Cache Components enabled", async () => {
+    // Next.js makes `io()` dynamic during Cache Components prerenders but a
+    // no-op under legacy prerender ownership.
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/request/io.ts
+    const { io } = await import("../packages/vinext/src/shims/cache.js");
+    const { setRouteCacheabilityCacheComponents } =
+      await import("../packages/vinext/src/shims/cacheability-classification.js");
+    const { runWithExecutionContext } =
+      await import("../packages/vinext/src/shims/request-context.js");
+    const { raw } = staticManifestRoute();
+
+    const render = async (cacheComponents: boolean) => {
+      const context = createWorkerCacheabilityAdmissionContext(
+        { waitUntil() {} },
+        request,
+        raw,
+        "build-a",
+      );
+      const state = cacheabilityState(context);
+      state.route = { kind: "app-page", pattern: "/page" };
+      state.outcome = {
+        cacheable: true,
+        cacheControl: "s-maxage=60, stale-while-revalidate=540",
+      };
+
+      await runWithExecutionContext(context, async () => {
+        setRouteCacheabilityCacheComponents(cacheComponents);
+        await io();
+      });
+      return finalizeWorkerCacheabilityResponse(
+        new Response("conditional", { headers: { "Cache-Control": "no-store" } }),
+        context,
+      );
+    };
+
+    const cacheComponentsResponse = await render(true);
+    expect(cacheComponentsResponse.headers.get("Cache-Control")).toContain("no-store");
+    await expect(cacheComponentsResponse.text()).resolves.toBe("conditional");
+
+    const legacyResponse = await render(false);
+    expect(legacyResponse.headers.get("Cache-Control")).toBe(
+      "s-maxage=60, stale-while-revalidate=540",
+    );
+    await expect(legacyResponse.text()).resolves.toBe("conditional");
+  });
 
   it("does not add admission overhead for adapters that persist completed artifacts", () => {
     const base = { waitUntil() {} };

--- a/tests/cacheability-admission.test.ts
+++ b/tests/cacheability-admission.test.ts
@@ -406,6 +406,7 @@ describe("single-request cacheability admission", () => {
       );
       const state = cacheabilityState(context);
       state.route = { kind: "app-page", pattern: "/page" };
+      state.frameworkResponseCachePolicy = { "cache-control": "no-store" };
       state.outcome = {
         cacheable: true,
         cacheControl: "s-maxage=60, stale-while-revalidate=540",

--- a/tests/e2e/cacheability-components/cacheability-ownership.spec.ts
+++ b/tests/e2e/cacheability-components/cacheability-ownership.spec.ts
@@ -88,6 +88,22 @@ test("preserves Cache Components ownership while probing inside workerd", async 
     });
   }
 
+  // Ported from Next.js: test/e2e/app-dir/io/io.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/io/io.test.ts
+  // Cache Components must not leak through the hybrid handoff: io() remains
+  // a no-op for Pages Router even while the outer App handler owns the probe.
+  expect((await request.delete("/pages-io-state")).status()).toBe(204);
+  const pagesIoProbe = await request.get("/pages-io", { headers });
+  expect(pagesIoProbe.status()).toBe(200);
+  await expect(pagesIoProbe.json()).resolves.toMatchObject({
+    reason: "request did not resolve to a probeable App Page",
+    state: "probe-failed",
+  });
+  const pagesIoState = (await (await request.get("/pages-io-state")).json()) as {
+    renderCount: number;
+  };
+  expect(pagesIoState.renderCount).toBeGreaterThan(0);
+
   const dynamicErrorProbe = await request.get("/dynamic-error", { headers });
   await expect(dynamicErrorProbe.json()).resolves.toMatchObject({
     kind: "app-page",

--- a/tests/e2e/cacheability-components/cacheability-ownership.spec.ts
+++ b/tests/e2e/cacheability-components/cacheability-ownership.spec.ts
@@ -73,6 +73,21 @@ test("preserves Cache Components ownership while probing inside workerd", async 
     version: 1,
   });
 
+  // Ported from Next.js: test/e2e/app-dir/io/io.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/io/io.test.ts
+  // Vinext keeps cache ownership in a separate ALS scope, so both real cache
+  // APIs must still make io() a no-op under the outer prerender owner.
+  for (const path of ["/io-in-use-cache", "/io-in-unstable-cache"]) {
+    const cachedIoProbe = await request.get(path, { headers });
+    await expect(cachedIoProbe.json()).resolves.toMatchObject({
+      kind: "app-page",
+      pattern: path,
+      state: "static-candidate",
+      status: 200,
+      version: 1,
+    });
+  }
+
   const dynamicErrorProbe = await request.get("/dynamic-error", { headers });
   await expect(dynamicErrorProbe.json()).resolves.toMatchObject({
     kind: "app-page",
@@ -119,4 +134,42 @@ test("preserves Cache Components ownership while probing inside workerd", async 
   expect((await request.get("/use-cache-private-in-unstable-cache")).status()).toBe(500);
   const state = await request.get("/use-cache-private-in-unstable-cache/state");
   await expect(state.json()).resolves.toEqual({ privateExecutions: 0 });
+});
+
+test("keeps a conditional io refill private after manifest certification", async ({ request }) => {
+  // Reset reused local workerd state and purge any response retained by a
+  // previous run before warming the manifest-certified static branch.
+  expect((await request.delete("/conditional-io/state")).status()).toBe(204);
+
+  const staticFill = await request.get("/conditional-io", {
+    headers: { Accept: "text/html" },
+  });
+  expect(staticFill.status()).toBe(200);
+  const staticBody = await staticFill.text();
+  expect(staticBody).toContain("conditional-io:static:");
+  expect(staticFill.headers()["cdn-cache-control"]).toContain("public");
+
+  // Simulate application state changing after certification, then purge the
+  // warmed edge entry so the next request performs a real conditional refill.
+  expect((await request.post("/conditional-io/state")).status()).toBe(204);
+
+  const dynamicRefill = await request.get("/conditional-io", {
+    headers: { Accept: "text/html" },
+  });
+  expect(dynamicRefill.status()).toBe(200);
+  const dynamicBody = await dynamicRefill.text();
+  expect(dynamicBody).toContain("conditional-io:dynamic:");
+  expect(dynamicRefill.headers()["cache-control"]).toContain("no-store");
+  expect(dynamicRefill.headers()["cdn-cache-control"]).toBeUndefined();
+
+  // The private refill itself must not warm the edge again.
+  const secondDynamicRefill = await request.get("/conditional-io", {
+    headers: { Accept: "text/html" },
+  });
+  expect(secondDynamicRefill.status()).toBe(200);
+  const secondDynamicBody = await secondDynamicRefill.text();
+  expect(secondDynamicBody).toContain("conditional-io:dynamic:");
+  expect(secondDynamicBody).not.toBe(dynamicBody);
+  expect(secondDynamicRefill.headers()["cache-control"]).toContain("no-store");
+  expect(secondDynamicRefill.headers()["cdn-cache-control"]).toBeUndefined();
 });

--- a/tests/e2e/cacheability-components/cacheability-ownership.spec.ts
+++ b/tests/e2e/cacheability-components/cacheability-ownership.spec.ts
@@ -61,6 +61,18 @@ test("preserves Cache Components ownership while probing inside workerd", async 
   expect(privateRuntime.headers()["cache-control"]).toContain("no-store");
   expect(privateRuntime.headers()["cdn-cache-control"]).toBeUndefined();
 
+  // Ported from Next.js: packages/next/src/server/request/io.ts
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/request/io.ts
+  // The hanging promise must notify the outer probe owner before suspending;
+  // otherwise a Suspense fallback can complete and be certified as static.
+  const explicitIoProbe = await request.get("/explicit-io", { headers });
+  await expect(explicitIoProbe.json()).resolves.toMatchObject({
+    kind: "app-page",
+    pattern: "/explicit-io",
+    state: "dynamic",
+    version: 1,
+  });
+
   const dynamicErrorProbe = await request.get("/dynamic-error", { headers });
   await expect(dynamicErrorProbe.json()).resolves.toMatchObject({
     kind: "app-page",

--- a/tests/e2e/cacheability-components/fixture/app/conditional-io/page.tsx
+++ b/tests/e2e/cacheability-components/fixture/app/conditional-io/page.tsx
@@ -1,0 +1,18 @@
+// `io()` is implemented by vinext for Next.js parity but is not declared by
+// the stable Next.js types installed in this fixture yet.
+// @ts-expect-error -- experimental Next.js Cache Components API
+import { io } from "next/cache";
+import { recordConditionalIoRender, shouldUseConditionalIo } from "./state";
+
+async function establishRouteCacheLife() {
+  "use cache";
+  return null;
+}
+
+export default async function ConditionalIoPage() {
+  const render = recordConditionalIoRender();
+  const dynamic = shouldUseConditionalIo();
+  await establishRouteCacheLife();
+  if (dynamic) await io();
+  return <p>{`conditional-io:${dynamic ? "dynamic" : "static"}:${render}`}</p>;
+}

--- a/tests/e2e/cacheability-components/fixture/app/conditional-io/state.ts
+++ b/tests/e2e/cacheability-components/fixture/app/conditional-io/state.ts
@@ -1,0 +1,18 @@
+// Deliberately isolate-local test state. The workerd regression flips this
+// after certifying the route, purges the cached response, and verifies that a
+// conditional refill cannot regain public cache headers.
+let useIo = false;
+let renders = 0;
+
+export function setConditionalIo(enabled: boolean): void {
+  useIo = enabled;
+  renders = 0;
+}
+
+export function shouldUseConditionalIo(): boolean {
+  return useIo;
+}
+
+export function recordConditionalIoRender(): number {
+  return ++renders;
+}

--- a/tests/e2e/cacheability-components/fixture/app/conditional-io/state/route.ts
+++ b/tests/e2e/cacheability-components/fixture/app/conditional-io/state/route.ts
@@ -1,0 +1,22 @@
+import { getDataCacheHandler } from "vinext/shims/cache-handler";
+import { getCdnCacheAdapter } from "vinext/shims/cdn-cache";
+import { setConditionalIo } from "../state";
+
+const pageTag = "_N_T_/conditional-io/page";
+
+async function setState(enabled: boolean): Promise<Response> {
+  setConditionalIo(enabled);
+  await Promise.all([
+    getDataCacheHandler().revalidateTag(pageTag),
+    getCdnCacheAdapter().revalidateTag(pageTag),
+  ]);
+  return new Response(null, { status: 204 });
+}
+
+export function DELETE() {
+  return setState(false);
+}
+
+export function POST() {
+  return setState(true);
+}

--- a/tests/e2e/cacheability-components/fixture/app/explicit-io/page.tsx
+++ b/tests/e2e/cacheability-components/fixture/app/explicit-io/page.tsx
@@ -1,0 +1,18 @@
+// `io()` is implemented by vinext for Next.js parity but is not declared by
+// the stable Next.js types installed in this fixture yet.
+// @ts-expect-error -- experimental Next.js Cache Components API
+import { io } from "next/cache";
+import { Suspense } from "react";
+
+async function ExplicitIoContent() {
+  await io();
+  return <p>executed past io boundary</p>;
+}
+
+export default function ExplicitIoPage() {
+  return (
+    <Suspense fallback={<p>explicit io fallback</p>}>
+      <ExplicitIoContent />
+    </Suspense>
+  );
+}

--- a/tests/e2e/cacheability-components/fixture/app/io-in-unstable-cache/page.tsx
+++ b/tests/e2e/cacheability-components/fixture/app/io-in-unstable-cache/page.tsx
@@ -1,0 +1,21 @@
+// `io()` is implemented by vinext for Next.js parity but is not declared by
+// the stable Next.js types installed in this fixture yet.
+// @ts-expect-error -- experimental Next.js Cache Components API
+import { io, unstable_cache } from "next/cache";
+
+const readCachedValue = unstable_cache(async () => {
+  await io();
+  return "io resolved inside unstable cache";
+}, ["cacheability-io-inside-unstable-cache"]);
+
+async function establishRouteCacheLife() {
+  "use cache";
+  return null;
+}
+
+export default async function IoInUnstableCachePage() {
+  // Keep the io() call exclusively inside unstable_cache while making the
+  // surrounding route otherwise eligible for a completed public policy.
+  await establishRouteCacheLife();
+  return <p>{await readCachedValue()}</p>;
+}

--- a/tests/e2e/cacheability-components/fixture/app/io-in-use-cache/page.tsx
+++ b/tests/e2e/cacheability-components/fixture/app/io-in-use-cache/page.tsx
@@ -1,0 +1,14 @@
+// `io()` is implemented by vinext for Next.js parity but is not declared by
+// the stable Next.js types installed in this fixture yet.
+// @ts-expect-error -- experimental Next.js Cache Components API
+import { io } from "next/cache";
+
+async function readCachedValue() {
+  "use cache";
+  await io();
+  return "io resolved inside use cache";
+}
+
+export default async function IoInUseCachePage() {
+  return <p>{await readCachedValue()}</p>;
+}

--- a/tests/e2e/cacheability-components/fixture/app/pages-io-state/route.ts
+++ b/tests/e2e/cacheability-components/fixture/app/pages-io-state/route.ts
@@ -1,0 +1,10 @@
+import { readPagesIoRenderCount, resetPagesIoRenderCount } from "../../pages-io-state";
+
+export function DELETE(): Response {
+  resetPagesIoRenderCount();
+  return new Response(null, { status: 204 });
+}
+
+export function GET(): Response {
+  return Response.json({ renderCount: readPagesIoRenderCount() });
+}

--- a/tests/e2e/cacheability-components/fixture/cacheability-manifest.json
+++ b/tests/e2e/cacheability-components/fixture/cacheability-manifest.json
@@ -1,0 +1,14 @@
+{
+  "buildId": "cacheability-components-e2e",
+  "routes": {
+    "[\"app-page\",\"/conditional-io\",\"html\",\"/conditional-io\"]": {
+      "kind": "app-page",
+      "pattern": "/conditional-io",
+      "representation": "html",
+      "requestKey": "/conditional-io",
+      "state": "static-candidate",
+      "status": 200
+    }
+  },
+  "version": 1
+}

--- a/tests/e2e/cacheability-components/fixture/pages-io-state.ts
+++ b/tests/e2e/cacheability-components/fixture/pages-io-state.ts
@@ -1,0 +1,10 @@
+const pagesIoRenderCount = Symbol.for("vinext.test.pagesIoRenderCount");
+const globalState = globalThis as typeof globalThis & { [pagesIoRenderCount]?: number };
+
+export function readPagesIoRenderCount(): number {
+  return globalState[pagesIoRenderCount] ?? 0;
+}
+
+export function resetPagesIoRenderCount(): void {
+  globalState[pagesIoRenderCount] = 0;
+}

--- a/tests/e2e/cacheability-components/fixture/pages/pages-io.tsx
+++ b/tests/e2e/cacheability-components/fixture/pages/pages-io.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+// `io()` is implemented by vinext for Next.js parity but is not declared by
+// the stable Next.js types installed in this fixture yet.
+// @ts-expect-error -- experimental Next.js Cache Components API
+import { io } from "next/cache";
+
+const pagesIoRenderCount = Symbol.for("vinext.test.pagesIoRenderCount");
+const globalState = globalThis as typeof globalThis & { [pagesIoRenderCount]?: number };
+
+export default function PagesIo() {
+  React.use(io());
+  globalState[pagesIoRenderCount] = (globalState[pagesIoRenderCount] ?? 0) + 1;
+  return <p id="pages-io">pages-io:ok</p>;
+}

--- a/tests/e2e/cacheability-components/fixture/tsconfig.json
+++ b/tests/e2e/cacheability-components/fixture/tsconfig.json
@@ -7,7 +7,8 @@
     "strict": true,
     "skipLibCheck": true,
     "paths": {
-      "vinext/shims/cache-handler": ["../../../../packages/vinext/src/shims/cache-handler.ts"]
+      "vinext/shims/cache-handler": ["../../../../packages/vinext/src/shims/cache-handler.ts"],
+      "vinext/shims/cdn-cache": ["../../../../packages/vinext/src/shims/cdn-cache.ts"]
     }
   },
   "include": ["app"]

--- a/tests/e2e/cacheability-components/fixture/wrangler.jsonc
+++ b/tests/e2e/cacheability-components/fixture/wrangler.jsonc
@@ -3,5 +3,6 @@
   "name": "cacheability-components-e2e",
   "compatibility_date": "2026-04-08",
   "compatibility_flags": ["nodejs_compat"],
+  "cache": { "enabled": true },
   "main": "vinext/server/fetch-handler",
 }

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -6204,6 +6204,46 @@ describe("next/cache shim", () => {
     await expect(promise).resolves.toBeUndefined();
   });
 
+  // Ported from Next.js: test/e2e/app-dir/io/io.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/io/io.test.ts
+  it('io resolves inside actual "use cache" and unstable_cache scopes during prerender', async () => {
+    const { io, unstable_cache, setCacheHandler, MemoryCacheHandler } =
+      await import("../packages/vinext/src/shims/cache.js");
+    const { registerCachedFunction } =
+      await import("../packages/vinext/src/shims/cache-runtime.js");
+    const { workUnitAsyncStorage } =
+      await import("../packages/vinext/src/shims/internal/work-unit-async-storage.js");
+
+    setCacheHandler(new MemoryCacheHandler());
+    const controller = new AbortController();
+    const signalPrerenderBailout = vi.fn();
+    const publicCached = registerCachedFunction(async () => {
+      await io();
+      return "public-cache";
+    }, "test:io-inside-public-cache");
+    const unstableCached = unstable_cache(async () => {
+      await io();
+      return "unstable-cache";
+    }, ["io-inside-unstable-cache"]);
+
+    try {
+      await expect(
+        workUnitAsyncStorage.run(
+          {
+            type: "prerender",
+            renderSignal: controller.signal,
+            signalPrerenderBailout,
+          },
+          () => Promise.all([publicCached(), unstableCached()]),
+        ),
+      ).resolves.toEqual(["public-cache", "unstable-cache"]);
+      expect(signalPrerenderBailout).not.toHaveBeenCalled();
+    } finally {
+      controller.abort();
+      setCacheHandler(new MemoryCacheHandler());
+    }
+  });
+
   it("io rejects hanging promise on abort when prerendering", async () => {
     const { io } = await import("../packages/vinext/src/shims/cache.js");
     const { workUnitAsyncStorage } =


### PR DESCRIPTION
Follow-up stack **2/2**. Exact head: `4311d92858fb18d6356fbd16b6de8bde0a14ab98`. Base: #3099 at `7ab2b603d`.

Chain: #3099 → #3097.

This layer closes the explicit `io()` ownership and post-certification admission gap for Cache Components:

- during a staged Cache Components prerender, `io()` notifies the outer render owner before returning its hanging promise, so a surrounding Suspense fallback cannot complete and be certified as static
- `io()` remains a no-op inside `"use cache"` and `unstable_cache()` scopes, matching Next.js even though vinext models those owners in separate async-local state
- legacy prerendering without Cache Components remains eligible; `io()` does not demote those routes
- hybrid Pages Router fallbacks run with legacy prerender ownership and clear the App Cache Components marker, matching Next.js where `io()` is a no-op in Pages GSSP, GSP, and component rendering
- the request records whether Cache Components are enabled, allowing a manifest-certified route that later takes an `io()` branch after an edge purge to fail closed before public CDN policy is restored

The built-workerd regression covers both sides of the lifecycle: authenticated probing classifies direct App `io()` as dynamic while proving a hybrid Pages `React.use(io())` render completes, and a route certified through its static branch remains private when later application state selects `io()` after the warmed edge object is purged. A second request proves the private refill did not re-warm the edge.

This PR deliberately does not instrument `Date`, `Math`, Web Crypto, or Node crypto. Platform-I/O parity is separate from the request-derived cache disclosure fix and requires a design that does not rewrite `node:crypto` imports.

Next.js references:

- https://github.com/vercel/next.js/blob/canary/packages/next/src/server/request/io.ts
- https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/io/io.test.ts

## Review size

Layer-only diff against #3099: **20 files, +425/-23**.

## Validation

- focused cache/admission/runtime tests — **1,551/1,551**
- Cache Components built-workerd E2E — **2/2**
- `vp check`
- `git diff --check`
