### PR TITLE
fix(cache): preserve prerender metadata across completion races

### DIFF
--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -1027,16 +1027,17 @@ export async function renderAppPageLifecycle(
           // Runs after the RSC embed drains, so this peek observes the
           // completed render's minimum. Peek, not consume — the cache-write
           // closure owns the consuming read.
-          // Prerendering drains the captured RSC stream and consumes the
-          // completed request cache life before the HTML stream reaches this
-          // done-script callback. Reuse that captured value here; peeking the
-          // now-cleared request state would omit the client stale claim from
-          // the prerendered HTML even though the seeded cache entry retains it.
+          // During prerendering the done-script callback can run immediately
+          // after the RSC capture drains, before the outer lifecycle performs
+          // its consuming cacheLife read. Use the live non-destructive peek in
+          // that window, then reuse the captured value after the outer read;
+          // peeking only after consumption would omit the client stale claim
+          // even though the seeded cache entry retains it.
           // Runtime renders have not consumed the state yet and still use the
           // non-destructive peek so the cache-write closure remains its owner.
           const requestCacheLife =
             options.isPrerender === true
-              ? requestCacheLifeForPrerender
+              ? (requestCacheLifeForPrerender ?? options.peekRequestCacheLife?.())
               : options.peekRequestCacheLife?.();
           const staleTimeSeconds = resolveClientStaleTimeSeconds(requestCacheLife);
           return {

--- a/tests/app-page-render.test.ts
+++ b/tests/app-page-render.test.ts
@@ -1264,6 +1264,75 @@ describe("app page render lifecycle", () => {
     expect(common.isrSet).not.toHaveBeenCalled();
   });
 
+  it("preserves prerender cacheLife metadata when the HTML footer finalizes before the outer read", async () => {
+    const common = createCommonOptions();
+    let requestCacheLife: { stale: number; revalidate: number; expire: number } | null = null;
+    let initialNavigationCacheMetadata: InitialNavigationCacheMetadata | undefined;
+
+    const response = await renderAppPageLifecycle({
+      ...common.options,
+      getRequestCacheLife() {
+        const value = requestCacheLife;
+        requestCacheLife = null;
+        return value;
+      },
+      isPrerender: true,
+      isProduction: false,
+      loadSsrHandler: async () => ({
+        async handleSsr(
+          rscStream: ReadableStream<Uint8Array>,
+          _navContext: unknown,
+          _fontData: unknown,
+          options?: {
+            sideStream?: ReadableStream<Uint8Array>;
+            capturedRscDataRef?: { value: Promise<ArrayBuffer> | null };
+            getInitialNavigationCacheMetadata?: () => InitialNavigationCacheMetadata;
+          },
+        ) {
+          const stream = options?.sideStream ?? rscStream;
+          const capturedRscData = new Response(stream).arrayBuffer();
+          if (options?.capturedRscDataRef) {
+            options.capturedRscDataRef.value = capturedRscData;
+          }
+
+          // The real RSC embed transform finalizes its navigation footer as
+          // soon as this capture drains. That can happen before handleSsr()
+          // returns and before renderAppPageLifecycle performs its consuming
+          // cacheLife read.
+          await capturedRscData;
+          initialNavigationCacheMetadata = options?.getInitialNavigationCacheMetadata?.();
+
+          return {
+            htmlStream: createStream(["<html>page</html>"]),
+            metadataReady: Promise.resolve(),
+            capturedRscData,
+          };
+        },
+      }),
+      peekRequestCacheLife() {
+        return requestCacheLife;
+      },
+      renderToReadableStream() {
+        let sent = false;
+        return new ReadableStream<Uint8Array>({
+          pull(controller) {
+            if (sent) {
+              controller.close();
+              return;
+            }
+            requestCacheLife = { stale: 30, revalidate: 1, expire: 60 };
+            controller.enqueue(new TextEncoder().encode("flight-data"));
+            sent = true;
+          },
+        });
+      },
+      revalidateSeconds: null,
+    });
+
+    expect(initialNavigationCacheMetadata).toEqual({ kind: "static", staleTimeSeconds: 30 });
+    await expect(response.text()).resolves.toBe("<html>page</html>");
+  });
+
   it("preserves prerender cache metadata for the manifest writer after shaping headers", async () => {
     const common = createCommonOptions();
     let requestCacheLife: { revalidate: number; expire: number } | null = null;

--- a/tests/app-ssr-stream.test.ts
+++ b/tests/app-ssr-stream.test.ts
@@ -430,8 +430,13 @@ async function readSingleTransformChunk(
 
   await writer.write(new TextEncoder().encode(chunk));
   const result = await reader.read();
-  await writer.close();
-  await reader.cancel();
+  const close = writer.close();
+  while (!(await reader.read()).done) {
+    // Drain the transform so its asynchronous flush can finish before the
+    // helper releases the reader. Cancelling here races flush() under Node
+    // 24.20 and can close the controller before it emits the document suffix.
+  }
+  await close;
 
   if (result.done) {
     throw new Error("Expected transform to emit a chunk");


### PR DESCRIPTION
Capability stack **1/9**. Exact head: `1fd53d7b899a4e34cb0dbf49b99168936a942b6a`. Base: `main`.

Full chain: #3108 → #3090 → #3091 → #3092 → #3103 → #3093 → #3094 → #3098 → #3113.

## Summary

This keeps two independent completion-ordering fixes outside the cacheability implementation layers:

- drain the single-chunk stream-test transform before releasing its reader, preventing Node 24.20 cancellation from racing asynchronous `flush()`
- preserve prerender cache-life metadata when the HTML navigation footer finalizes before the outer render lifecycle consumes that metadata
- add a deterministic regression for the prerender ordering

Without the stale-time fix, prerendered HTML can omit `staleTimeSeconds` even though the prerender manifest records the correct value.

No staged probing, cacheability manifest, CDN-admission behavior, or warming behavior is introduced here. #3090 begins the capability itself.

## Review size

Layer-only diff against this PR's base: **3 files, +83/-8**.

## Validation

- layer exact-head CI is green
- prior cumulative focused validation through #3098 — **2,024/2,024**
- current full-stack cumulative changed-file suites — **2,864/2,864**
- current full-stack PPR probe/admission/Pages built-workerd E2E — **8/8**
- current full-stack `vp check` and `git diff --check`
