### PR TITLE
test(stream): drain transforms before releasing readers

### DIFF
--- a/tests/app-ssr-stream.test.ts
+++ b/tests/app-ssr-stream.test.ts
@@ -430,8 +430,13 @@ async function readSingleTransformChunk(
 
   await writer.write(new TextEncoder().encode(chunk));
   const result = await reader.read();
-  await writer.close();
-  await reader.cancel();
+  const close = writer.close();
+  while (!(await reader.read()).done) {
+    // Drain the transform so its asynchronous flush can finish before the
+    // helper releases the reader. Cancelling here races flush() under Node
+    // 24.20 and can close the controller before it emits the document suffix.
+  }
+  await close;
 
   if (result.done) {
     throw new Error("Expected transform to emit a chunk");


### PR DESCRIPTION
## Summary

- drain the transform to completion in the single-chunk test helper instead of cancelling while asynchronous `flush()` is still running
- avoid the deterministic `ERR_INVALID_STATE: Unable to enqueue` failure introduced by Node 24.20 stream cancellation timing

This is a test-harness compatibility prerequisite and intentionally contains no production cacheability changes.

## Validation

- failing test reproduced under Node 24.20.0 before this change
- `PATH=/tmp/node-v24.20.0/bin:$PATH vp test run tests/app-ssr-stream.test.ts` (47/47)
- `vp run check`
- `git diff --check`