### PR TITLE
fix(app-router): support soft navigation in static exports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -545,6 +545,10 @@ jobs:
             label: static-export
             shardIndex: 1
             shardTotal: 1
+          - project: static-export-basepath
+            label: static-export-basepath
+            shardIndex: 1
+            shardTotal: 1
           - project: app-with-src
             label: app-with-src
             shardIndex: 1

--- a/examples/static-export/README.md
+++ b/examples/static-export/README.md
@@ -16,14 +16,16 @@ pnpm preview
 ```text
 dist/client/
 ├── index.html
+├── index.txt
 ├── 404.html
 ├── 404/index.html
 ├── catalog/pocket-observatory/index.html
+├── catalog/pocket-observatory/index.txt
 ├── docs/deployment/cloudflare/index.html
 ├── legacy/index.html
 ├── products/atlas/index.html
 ├── robots.txt
-└── assets and static RSC payloads
+└── assets and additional static Flight `.txt` payloads
 ```
 
 Deploy the directory to any static host. The hosting-only `deploy/wrangler.jsonc` uses Cloudflare Workers Static Assets. It lives outside the project root so vinext does not mistake a runtime-free export for a Worker application:
@@ -32,7 +34,7 @@ Deploy the directory to any static host. The hosting-only `deploy/wrangler.jsonc
 pnpm exec wrangler deploy --config deploy/wrangler.jsonc
 ```
 
-`trailingSlash: true` emits directory-style `index.html` files. Its matching `html_handling: "force-trailing-slash"` setting makes the deployed canonical URLs agree with the build output, while `not_found_handling: "404-page"` preserves the generated 404 page and status.
+`trailingSlash: true` emits directory-style `index.html` files plus matching `index.txt` Flight payloads for App Router soft navigation. The `.txt` extension is a portable `text/plain` transport name; the contents are still React Server Component data. The matching `html_handling: "force-trailing-slash"` setting makes the deployed canonical URLs agree with the build output, while `not_found_handling: "404-page"` preserves the generated 404 page and status.
 
 ## Capability tour
 

--- a/examples/static-export/scripts/verify-output.mjs
+++ b/examples/static-export/scripts/verify-output.mjs
@@ -6,13 +6,16 @@ const root = fileURLToPath(new URL("../dist/client/", import.meta.url));
 
 const expected = new Map([
   ["index.html", "Static does not mean inert"],
+  ["index.txt", "Static does not mean inert"],
   ["catalog/pocket-observatory/index.html", "Pocket Observatory"],
+  ["catalog/pocket-observatory/index.txt", "Pocket Observatory"],
   ["catalog/tide-clock/index.html", "Tide Clock"],
   ["catalog/trail-journal/index.html", "Trail Journal"],
   ["docs/building/the-artifact/index.html", "Read the artifact"],
   ["docs/deployment/cloudflare/index.html", "Deploy without a server"],
   ["browser-state/index.html", "Interactivity survives the export"],
   ["search/index.html", "The browser owns the query string"],
+  ["search/index.txt", "The browser owns the query string"],
   ["legacy/index.html", "Two routers, one static artifact"],
   ["products/atlas/index.html", "Atlas Field Kit"],
   ["products/lantern/index.html", "Low-light Lantern"],

--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -1588,7 +1588,9 @@ export async function prerenderApp({
         // Match Next.js's export worker: when trailingSlash is enabled, render
         // the canonical slash form instead of letting the request pipeline
         // return a 308 that the exporter would misclassify as a failed route.
-        // Keep urlPath unchanged for manifest and output-file identity.
+        // Keep urlPath unchanged for route and manifest identity. Exported
+        // artifacts are rooted under basePath alongside the client assets so
+        // an ordinary static host can serve the output tree verbatim.
         // Ported from Next.js: packages/next/src/export/worker.ts
         // https://github.com/vercel/next.js/blob/canary/packages/next/src/export/worker.ts
         const routeRequestPath =
@@ -1707,7 +1709,11 @@ export async function prerenderApp({
         const outputFiles: string[] = [];
 
         // Write HTML
-        const htmlOutputPath = getOutputPath(urlPath, config.trailingSlash);
+        const htmlOutputPath = getOutputPath(
+          urlPath,
+          config.trailingSlash,
+          mode === "export" ? config.basePath : "",
+        );
         const htmlFullPath = path.join(outDir, htmlOutputPath);
         fs.mkdirSync(path.dirname(htmlFullPath), { recursive: true });
         fs.writeFileSync(htmlFullPath, html, "utf-8");
@@ -1719,6 +1725,7 @@ export async function prerenderApp({
         const rscOutputPath = getRscOutputPath(urlPath, {
           mode,
           trailingSlash: config.trailingSlash,
+          basePath: mode === "export" ? config.basePath : "",
         });
         const rscFullPath = path.join(outDir, rscOutputPath);
         fs.mkdirSync(path.dirname(rscFullPath), { recursive: true });

--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -495,8 +495,10 @@ function metadataOutputPath(servedUrl: string): string | null {
 function emitStaticMetadataFiles(
   metadataRoutes: readonly MetadataFileRoute[],
   outDir: string,
+  basePath = "",
 ): string[] {
   const outputFiles: string[] = [];
+  const outputPrefix = basePath.replace(/^\//, "").replace(/\/$/, "");
   for (const route of metadataRoutes) {
     if (route.isDynamic) continue;
 
@@ -504,10 +506,11 @@ function emitStaticMetadataFiles(
     // scanMetadataFiles controls servedUrl; this remains defensive against malformed route data.
     if (!outputPath) continue;
 
-    const fullPath = path.join(outDir, ...outputPath.split("/"));
+    const namespacedOutputPath = outputPrefix ? `${outputPrefix}/${outputPath}` : outputPath;
+    const fullPath = path.join(outDir, ...namespacedOutputPath.split("/"));
     fs.mkdirSync(path.dirname(fullPath), { recursive: true });
     fs.copyFileSync(route.filePath, fullPath);
-    outputFiles.push(outputPath);
+    outputFiles.push(namespacedOutputPath);
   }
   return outputFiles;
 }
@@ -732,7 +735,12 @@ export async function prerenderPages({
       // by getStaticProps. Avoid confusing the framework's own canonical 308
       // with one of those application redirects by requesting the configured
       // trailing-slash form up front, as Next.js's export worker does.
-      const requestPath = config.trailingSlash && !urlPath.endsWith("/") ? `${urlPath}/` : urlPath;
+      const routeRequestPath =
+        config.trailingSlash && !urlPath.endsWith("/") ? `${urlPath}/` : urlPath;
+      const requestPath =
+        config.basePath && routeRequestPath === "/" && !config.trailingSlash
+          ? config.basePath
+          : `${config.basePath ?? ""}${routeRequestPath}`;
       return fetch(`http://127.0.0.1:${port}${requestPath}`, {
         headers: secretHeaders,
         redirect: "manual",
@@ -923,7 +931,11 @@ export async function prerenderPages({
         try {
           const response = await renderPage(urlPath);
           const outputFiles: string[] = [];
-          const htmlOutputPath = getOutputPath(urlPath, config.trailingSlash);
+          const htmlOutputPath = getOutputPath(
+            urlPath,
+            config.trailingSlash,
+            mode === "export" ? config.basePath : "",
+          );
           const htmlFullPath = path.join(outDir, htmlOutputPath);
 
           if (response.status >= 300 && response.status < 400) {
@@ -1595,7 +1607,10 @@ export async function prerenderApp({
         // https://github.com/vercel/next.js/blob/canary/packages/next/src/export/worker.ts
         const routeRequestPath =
           config.trailingSlash && !urlPath.endsWith("/") ? `${urlPath}/` : urlPath;
-        const requestPath = `${config.basePath ?? ""}${routeRequestPath}`;
+        const requestPath =
+          config.basePath && routeRequestPath === "/" && !config.trailingSlash
+            ? config.basePath
+            : `${config.basePath ?? ""}${routeRequestPath}`;
         const htmlRequest = new Request(`http://localhost${requestPath}`, {
           headers: htmlHeaders,
         });
@@ -1806,7 +1821,7 @@ export async function prerenderApp({
 
     const outputFiles =
       mode === "export" && metadataRoutes.length > 0
-        ? emitStaticMetadataFiles(metadataRoutes, outDir)
+        ? emitStaticMetadataFiles(metadataRoutes, outDir, config.basePath)
         : [];
 
     // ── Render 404 page ───────────────────────────────────────────────────────
@@ -1818,7 +1833,9 @@ export async function prerenderApp({
         config.trailingSlash && !NOT_FOUND_SENTINEL_PATH.endsWith("/")
           ? `${NOT_FOUND_SENTINEL_PATH}/`
           : NOT_FOUND_SENTINEL_PATH;
-      const notFoundRequest = new Request(`http://localhost${notFoundPath}`);
+      const notFoundRequest = new Request(
+        `http://localhost${config.basePath ?? ""}${notFoundPath}`,
+      );
       const notFoundRes = await runWithHeadersContext(
         headersContextFromRequest(notFoundRequest),
         () => rscHandler(notFoundRequest),

--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -1591,8 +1591,9 @@ export async function prerenderApp({
         // Keep urlPath unchanged for manifest and output-file identity.
         // Ported from Next.js: packages/next/src/export/worker.ts
         // https://github.com/vercel/next.js/blob/canary/packages/next/src/export/worker.ts
-        const requestPath =
+        const routeRequestPath =
           config.trailingSlash && !urlPath.endsWith("/") ? `${urlPath}/` : urlPath;
+        const requestPath = `${config.basePath ?? ""}${routeRequestPath}`;
         const htmlRequest = new Request(`http://localhost${requestPath}`, {
           headers: htmlHeaders,
         });

--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -1038,7 +1038,7 @@ export async function prerenderPages({
  * Starts a local production server and fetches every static/ISR route via HTTP.
  * Works for both plain Node and Cloudflare Workers builds — the CF Workers bundle
  * (`dist/server/index.js`) is a standard Node-compatible server entry, so no
- * wrangler/miniflare is needed. Writes HTML files, `.rsc` files, and
+ * wrangler/miniflare is needed. Writes HTML files, Flight payloads, and
  * `vinext-prerender.json` to `outDir`.
  *
  * If the bundle does not exist, an error is thrown directing the user to run
@@ -1673,7 +1673,7 @@ export async function prerenderApp({
         // Reconstruct the RSC payload from the inline bootstrap chunks already
         // streamed into the HTML body. The generated RSC entry performs
         // framing-aware hint normalization at the stream source, so the
-        // resulting `.rsc` file contains the same Flight bytes.
+        // resulting Flight artifact contains the same bytes.
         //
         // Falls back to a second invocation with `RSC: 1` when the HTML has
         // no chunk scripts at all — covers cases where middleware
@@ -1712,8 +1712,13 @@ export async function prerenderApp({
         fs.writeFileSync(htmlFullPath, html, "utf-8");
         outputFiles.push(htmlOutputPath);
 
-        // Write RSC payload (.rsc file)
-        const rscOutputPath = getRscOutputPath(urlPath);
+        // Next.js writes export-mode Flight payloads as `.txt` so a plain
+        // static host serves a portable `text/plain` content type. Normal
+        // server prerenders retain vinext's internal `.rsc` artifact shape.
+        const rscOutputPath = getRscOutputPath(urlPath, {
+          mode,
+          trailingSlash: config.trailingSlash,
+        });
         const rscFullPath = path.join(outDir, rscOutputPath);
         fs.mkdirSync(path.dirname(rscFullPath), { recursive: true });
         fs.writeFileSync(rscFullPath, rscData);

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2425,6 +2425,9 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         defines["process.env.__VINEXT_TRAILING_SLASH"] = JSON.stringify(
           nextConfig.trailingSlash ? "true" : "false",
         );
+        // Next.js uses this compile-time value to switch App Router navigation
+        // from header-selected RSC responses to static `.txt` Flight assets.
+        defines["process.env.__NEXT_CONFIG_OUTPUT"] = JSON.stringify(nextConfig.output ?? "");
         // Expose image remote patterns for validation in next/image shim
         defines["process.env.__VINEXT_IMAGE_REMOTE_PATTERNS"] = JSON.stringify(
           JSON.stringify(nextConfig.images?.remotePatterns ?? []),

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1504,6 +1504,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
   // once while generating the RSC entry.
   let devPublicFileRoutes: Set<string> | null = null;
   let publicDirConflictOptions: Parameters<typeof assertNoPublicDirAssetConflict>[0] | null = null;
+  let copyPublicDirIntoStaticExportBasePath = false;
   let rscBuildIdentity: string | undefined;
   let rscCompatibilityId: string | undefined;
   let draftModeSecret = getPagesPreviewModeId();
@@ -3602,6 +3603,16 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
       },
 
       configEnvironment(name, config) {
+        if (name === "client" && nextConfig.output === "export" && nextConfig.basePath) {
+          // Vite normally copies publicDir into the client output root. Static
+          // exports are served verbatim, so files requested below basePath must
+          // live in that same on-disk namespace. Defer the copy to writeBundle,
+          // where we can target dist/client/<basePath> instead.
+          config.build ??= {};
+          copyPublicDirIntoStaticExportBasePath = config.build.copyPublicDir !== false;
+          config.build.copyPublicDir = false;
+        }
+
         if (name !== "client" && config.consumer !== "client") {
           // optimizeDeps runs its own Rolldown pipeline, outside Vite's plugin
           // container. Register only the thin adapter for the same module-
@@ -3837,6 +3848,44 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         handler() {
           if (this.environment?.name !== "client" || !publicDirConflictOptions) return;
           assertNoPublicDirAssetConflict(publicDirConflictOptions);
+        },
+      },
+
+      writeBundle: {
+        sequential: true,
+        order: "post",
+        handler(outputOptions) {
+          if (
+            this.environment?.name !== "client" ||
+            nextConfig.output !== "export" ||
+            !nextConfig.basePath ||
+            !copyPublicDirIntoStaticExportBasePath
+          ) {
+            return;
+          }
+
+          const envConfig = this.environment.config;
+          const publicDir = envConfig.publicDir;
+          if (!publicDir || !fs.existsSync(publicDir)) return;
+
+          // Re-check immediately before the deferred copy, including files
+          // generated after renderStart, so public assets cannot overwrite the
+          // framework's reserved asset namespace.
+          if (publicDirConflictOptions) {
+            assertNoPublicDirAssetConflict(publicDirConflictOptions);
+          }
+
+          const buildRoot = envConfig.root ?? process.cwd();
+          const clientOutDir = outputOptions.dir
+            ? path.resolve(buildRoot, outputOptions.dir)
+            : path.resolve(buildRoot, envConfig.build.outDir);
+          const basePathDir = path.join(clientOutDir, nextConfig.basePath.slice(1));
+          fs.mkdirSync(basePathDir, { recursive: true });
+          fs.cpSync(publicDir, basePathDir, {
+            recursive: true,
+            dereference: true,
+            force: true,
+          });
         },
       },
 

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -204,6 +204,7 @@ import {
   getOptimisticPrefetchSourceKey,
   getOptimisticRouteTemplateKey,
   matchOptimisticRouteManifestRoute,
+  resolveOptimisticNavigationParamsForHref,
   resolveOptimisticNavigationPayload,
   type OptimisticRouteTemplate,
 } from "./app-optimistic-routing.js";
@@ -261,9 +262,11 @@ function toOperationLane(kind: NavigationKind): OperationLane {
 const MAX_VISITED_RESPONSE_CACHE_SIZE = 50;
 const IS_STATIC_EXPORT =
   process.env.NODE_ENV === "production" && process.env.__NEXT_CONFIG_OUTPUT === "export";
+const CLIENT_DEPLOYMENT_VERSION = process.env.__VINEXT_BUILD_ID ?? null;
 // Static asset hosts cannot attach vinext's compatibility header to `.txt`
 // files. The artifact and client bundle are emitted atomically by one build,
-// so export mode uses the Flight payload itself as the compatibility boundary.
+// so export mode validates the deployment version embedded in the Flight
+// payload before committing it instead.
 const CLIENT_RSC_COMPATIBILITY_ID = IS_STATIC_EXPORT ? null : getVinextRscCompatibilityId();
 const optimisticRouteTemplates = new Map<string, OptimisticRouteTemplate>();
 const optimisticRouteTemplateSources = new Set<string>();
@@ -289,12 +292,19 @@ function resolveStaticExportRouteParams(href: string): Record<string, string | s
   const routeManifest = getBrowserRouteManifest();
   if (routeManifest === null) return {};
   return (
-    matchOptimisticRouteManifestRoute({
+    resolveOptimisticNavigationParamsForHref({
       basePath: __basePath,
       href,
       routeManifest,
-    })?.params ?? {}
+    }) ?? {}
   );
+}
+
+function isStaticExportPayloadDeploymentCompatible(elements: AppElements): boolean {
+  if (!IS_STATIC_EXPORT) return true;
+  const deploymentVersion =
+    AppElementsWire.readMetadata(elements).artifactCompatibility.deploymentVersion;
+  return CLIENT_DEPLOYMENT_VERSION !== null && deploymentVersion === CLIENT_DEPLOYMENT_VERSION;
 }
 
 const MAX_HISTORY_STATE_SNAPSHOTS = 50;
@@ -2588,6 +2598,20 @@ function bootstrapHydration(
             signal: navigationAbortHandle.signal,
             supplemental,
           }).then(requireCompleteSupplementalRefresh);
+        }
+
+        // Static hosts cannot supply the compatibility response header used by
+        // server navigation. Match Next.js's export skew protection by checking
+        // the build identity carried in the decoded Flight model before React
+        // can commit a mixed-deployment tree.
+        if (IS_STATIC_EXPORT) {
+          const staticExportElements = await rscPayload;
+          if (!browserNavigationController.isCurrentNavigation(navId)) return;
+          if (!isStaticExportPayloadDeploymentCompatible(staticExportElements)) {
+            performHardNavigationForScrollIntent(currentHref);
+            return;
+          }
+          rscPayload = Promise.resolve(staticExportElements);
         }
 
         if (!browserNavigationController.isCurrentNavigation(navId)) return;

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -259,7 +259,12 @@ function toOperationLane(kind: NavigationKind): OperationLane {
 }
 
 const MAX_VISITED_RESPONSE_CACHE_SIZE = 50;
-const CLIENT_RSC_COMPATIBILITY_ID = getVinextRscCompatibilityId();
+const IS_STATIC_EXPORT =
+  process.env.NODE_ENV === "production" && process.env.__NEXT_CONFIG_OUTPUT === "export";
+// Static asset hosts cannot attach vinext's compatibility header to `.txt`
+// files. The artifact and client bundle are emitted atomically by one build,
+// so export mode uses the Flight payload itself as the compatibility boundary.
+const CLIENT_RSC_COMPATIBILITY_ID = IS_STATIC_EXPORT ? null : getVinextRscCompatibilityId();
 const optimisticRouteTemplates = new Map<string, OptimisticRouteTemplate>();
 const optimisticRouteTemplateSources = new Set<string>();
 const optimisticRouteTemplateLearning = new Map<string, Promise<void>>();
@@ -278,6 +283,18 @@ function markInitialAppRouterBootstrapHydrated(): void {
 
 function getBrowserRouteManifest(): RouteManifest | null {
   return getNavigationRuntime()?.bootstrap.routeManifest ?? null;
+}
+
+function resolveStaticExportRouteParams(href: string): Record<string, string | string[]> {
+  const routeManifest = getBrowserRouteManifest();
+  if (routeManifest === null) return {};
+  return (
+    matchOptimisticRouteManifestRoute({
+      basePath: __basePath,
+      href,
+      routeManifest,
+    })?.params ?? {}
+  );
 }
 
 const MAX_HISTORY_STATE_SNAPSHOTS = 50;
@@ -2094,6 +2111,7 @@ function bootstrapHydration(
           targetPathAndSearch,
         });
         const canUseCanonicalSharedRequest =
+          !IS_STATIC_EXPORT &&
           process.env.__VINEXT_CANONICAL_RSC_REQUESTS === "1" &&
           navigationKind === "navigate" &&
           settledPrefetchedResponse === null &&
@@ -2419,6 +2437,14 @@ function bootstrapHydration(
         if (!browserNavigationController.isCurrentNavigation(navId)) return;
 
         const navContentType = navResponse.headers.get("content-type") ?? "";
+        const isNavigationRscContentType =
+          navContentType.startsWith(VINEXT_RSC_CONTENT_TYPE) ||
+          (IS_STATIC_EXPORT && navContentType.startsWith("text/plain"));
+        // A static host reports the fetched transport URL (`/route/index.txt`),
+        // but that is not a redirect and must never become browser-visible.
+        const navigationResponseUrl = IS_STATIC_EXPORT
+          ? currentHref
+          : (navResponseUrl ?? navResponse.url);
         const streamedRedirectTarget = navResponse.headers.get(VINEXT_RSC_REDIRECT_HEADER);
         const streamedRedirectTypeHeader = navResponse.headers.get(VINEXT_RSC_REDIRECT_TYPE_HEADER);
         const streamedRedirectType =
@@ -2434,12 +2460,12 @@ function bootstrapHydration(
           currentHref,
           effectiveHistoryUpdateMode: currentHistoryMode ?? "replace",
           hasBody: navResponse.body !== null,
-          isRscContentType: navContentType.startsWith(VINEXT_RSC_CONTENT_TYPE),
+          isRscContentType: isNavigationRscContentType,
           origin: window.location.origin,
           redirectDepth: redirectCount,
           requestPreviousNextUrl,
           responseOk: navResponse.ok,
-          responseUrl: navResponseUrl ?? navResponse.url,
+          responseUrl: navigationResponseUrl,
           source: "live",
           streamedRedirectTarget,
           streamedRedirectType,
@@ -2490,10 +2516,11 @@ function bootstrapHydration(
         }
 
         // navParams falls back to {} on a missing or malformed header.
+        const responseParams = parseEncodedJsonHeader<Record<string, string | string[]>>(
+          navResponse.headers.get(VINEXT_PARAMS_HEADER),
+        );
         const navParams: Record<string, string | string[]> =
-          parseEncodedJsonHeader<Record<string, string | string[]>>(
-            navResponse.headers.get(VINEXT_PARAMS_HEADER),
-          ) ?? {};
+          responseParams ?? (IS_STATIC_EXPORT ? resolveStaticExportRouteParams(currentHref) : {});
         // Build snapshot from local params, not latestClientParams
         const navigationSnapshot = createClientNavigationRenderSnapshot(currentHref, navParams);
 
@@ -2639,7 +2666,11 @@ function bootstrapHydration(
           // absent from both caches and an explicit prefetch refetches it.
           const responseSnapshot =
             consumedPrefetchSnapshot ??
-            createCachedRscResponseSnapshot(navResponse, await cacheBufferPromise, navResponseUrl);
+            createCachedRscResponseSnapshot(
+              navResponse,
+              await cacheBufferPromise,
+              navigationResponseUrl,
+            );
           const completedResponseResolvedDynamic =
             responseSnapshot.completedDynamicStaleTimeSeconds !== undefined;
           const cacheRestorable =

--- a/packages/vinext/src/server/app-optimistic-routing.ts
+++ b/packages/vinext/src/server/app-optimistic-routing.ts
@@ -282,6 +282,25 @@ function resolveOptimisticNavigationParams(options: {
   return { navigationParams, routeParams };
 }
 
+export function resolveOptimisticNavigationParamsForHref(options: {
+  basePath: string;
+  href: string;
+  routeManifest: RouteManifest;
+}): Record<string, string | string[]> | null {
+  const urlParts = hrefToRouteParts(options.href, options.basePath);
+  if (urlParts === null) return null;
+
+  const match = matchOptimisticRouteManifestRoute(options);
+  if (match === null) return null;
+
+  return resolveOptimisticNavigationParams({
+    match,
+    rawUrlParts: urlParts.raw,
+    routeManifest: options.routeManifest,
+    urlParts: urlParts.normalized,
+  }).navigationParams;
+}
+
 function collectRenderedBfcacheSegmentIds(
   value: unknown,
   candidates: ReadonlySet<string>,

--- a/packages/vinext/src/server/app-page-render.ts
+++ b/packages/vinext/src/server/app-page-render.ts
@@ -1027,16 +1027,17 @@ export async function renderAppPageLifecycle(
           // Runs after the RSC embed drains, so this peek observes the
           // completed render's minimum. Peek, not consume — the cache-write
           // closure owns the consuming read.
-          // Prerendering drains the captured RSC stream and consumes the
-          // completed request cache life before the HTML stream reaches this
-          // done-script callback. Reuse that captured value here; peeking the
-          // now-cleared request state would omit the client stale claim from
-          // the prerendered HTML even though the seeded cache entry retains it.
+          // During prerendering the done-script callback can run immediately
+          // after the RSC capture drains, before the outer lifecycle performs
+          // its consuming cacheLife read. Use the live non-destructive peek in
+          // that window, then reuse the captured value after the outer read;
+          // peeking only after consumption would omit the client stale claim
+          // even though the seeded cache entry retains it.
           // Runtime renders have not consumed the state yet and still use the
           // non-destructive peek so the cache-write closure remains its owner.
           const requestCacheLife =
             options.isPrerender === true
-              ? requestCacheLifeForPrerender
+              ? (requestCacheLifeForPrerender ?? options.peekRequestCacheLife?.())
               : options.peekRequestCacheLife?.();
           const staleTimeSeconds = resolveClientStaleTimeSeconds(requestCacheLife);
           return {

--- a/packages/vinext/src/server/app-rsc-cache-busting.ts
+++ b/packages/vinext/src/server/app-rsc-cache-busting.ts
@@ -443,7 +443,13 @@ export async function createRscRequestUrl(href: string, headers: Headers): Promi
     // Static hosts cannot select Flight with request headers, so exported App
     // Router navigations address the prebuilt payload directly. The bytes are
     // still RSC; `.txt` supplies a portable MIME type across asset hosts.
-    url.pathname += url.pathname.endsWith("/") ? "index.txt" : ".txt";
+    const basePath = process.env.__NEXT_ROUTER_BASEPATH ?? "";
+    const isBasePathRoot = basePath !== "" && url.pathname === basePath;
+    if (url.pathname.endsWith("/")) {
+      url.pathname += "index.txt";
+    } else {
+      url.pathname += isBasePathRoot ? "/index.txt" : ".txt";
+    }
     return `${url.pathname}${url.search}`;
   }
   const hash = await computeRscCacheBustingSearchParam(headers);

--- a/packages/vinext/src/server/app-rsc-cache-busting.ts
+++ b/packages/vinext/src/server/app-rsc-cache-busting.ts
@@ -433,6 +433,19 @@ function toRscRequestPath(href: string): string {
 
 export async function createRscRequestUrl(href: string, headers: Headers): Promise<string> {
   const url = new URL(toRscRequestPath(href), "http://vinext.local");
+  if (
+    typeof window !== "undefined" &&
+    process.env.NODE_ENV === "production" &&
+    process.env.__NEXT_CONFIG_OUTPUT === "export"
+  ) {
+    // Ported from Next.js:
+    // packages/next/src/client/components/router-reducer/fetch-server-response.ts
+    // Static hosts cannot select Flight with request headers, so exported App
+    // Router navigations address the prebuilt payload directly. The bytes are
+    // still RSC; `.txt` supplies a portable MIME type across asset hosts.
+    url.pathname += url.pathname.endsWith("/") ? "index.txt" : ".txt";
+    return `${url.pathname}${url.search}`;
+  }
   const hash = await computeRscCacheBustingSearchParam(headers);
   setRscCacheBustingSearchParam(url, hash);
   return `${url.pathname}${url.search}`;

--- a/packages/vinext/src/shims/internal/app-prefetch-rsc-request.ts
+++ b/packages/vinext/src/shims/internal/app-prefetch-rsc-request.ts
@@ -39,6 +39,7 @@ export async function resolveAppPrefetchRscRequest({
   rewrittenPrefetchHref,
 }: ResolveAppPrefetchRscRequestOptions): Promise<ResolvedAppPrefetchRscRequest> {
   const canUseCanonicalSharedRequest =
+    process.env.__NEXT_CONFIG_OUTPUT !== "export" &&
     process.env.__VINEXT_CANONICAL_RSC_REQUESTS === "1" &&
     interceptionContext === null &&
     mountedSlotsHeader === null &&

--- a/packages/vinext/src/shims/internal/app-route-prefetch-policy.ts
+++ b/packages/vinext/src/shims/internal/app-route-prefetch-policy.ts
@@ -91,6 +91,13 @@ export function resolveAutoAppRoutePrefetch(href: string): AppRoutePrefetchPolic
   const match = matchRouteWithTrie(routeHref, routes, linkPrefetchRouteTrieCache);
   if (!match) return NO_APP_ROUTE_PREFETCH;
 
+  // Export builds only emit one full-route Flight artifact per pathname; they
+  // have no server that can produce loading-shell, route-tree, or per-segment
+  // variants. Reuse that full payload for every matched App route prefetch.
+  if (process.env.NODE_ENV === "production" && process.env.__NEXT_CONFIG_OUTPUT === "export") {
+    return resolveFullAppRoutePrefetch();
+  }
+
   const route = match.route;
   const requiresRouteTreePrefetch =
     String(process.env.__NEXT_CACHE_COMPONENTS) === "true" && route.hasRootParams === true;

--- a/packages/vinext/src/utils/prerender-output-paths.ts
+++ b/packages/vinext/src/utils/prerender-output-paths.ts
@@ -2,9 +2,17 @@
  * Determine the HTML output file path for a prerendered URL.
  * Respects trailingSlash config.
  */
-export function getOutputPath(urlPath: string, trailingSlash: boolean): string {
-  if (urlPath === "/") return "index.html";
-  const clean = urlPath.replace(/^\//, "");
+export function getOutputPath(urlPath: string, trailingSlash: boolean, basePath = ""): string {
+  if (urlPath === "/" && basePath === "") return "index.html";
+  const outputUrlPath =
+    basePath === ""
+      ? urlPath
+      : urlPath === "/"
+        ? trailingSlash
+          ? `${basePath}/`
+          : basePath
+        : `${basePath}${urlPath}`;
+  const clean = outputUrlPath.replace(/^\//, "");
   if (trailingSlash) return `${clean}/index.html`;
   return `${clean}.html`;
 }
@@ -12,14 +20,18 @@ export function getOutputPath(urlPath: string, trailingSlash: boolean): string {
 /** Determine the Flight payload path for a prerendered App Router URL. */
 export function getRscOutputPath(
   urlPath: string,
-  options: { mode: "default" | "export"; trailingSlash: boolean } = {
+  options: { mode: "default" | "export"; trailingSlash: boolean; basePath?: string } = {
     mode: "default",
     trailingSlash: false,
   },
 ): string {
   if (options.mode === "export") {
-    if (urlPath === "/") return "index.txt";
-    const clean = urlPath.replace(/^\//, "").replace(/\/$/, "");
+    if (urlPath === "/") {
+      const cleanBasePath = options.basePath?.replace(/^\//, "");
+      return cleanBasePath ? `${cleanBasePath}/index.txt` : "index.txt";
+    }
+    const outputUrlPath = options.basePath ? `${options.basePath}${urlPath}` : urlPath;
+    const clean = outputUrlPath.replace(/^\//, "").replace(/\/$/, "");
     return options.trailingSlash ? `${clean}/index.txt` : `${clean}.txt`;
   }
 

--- a/packages/vinext/src/utils/prerender-output-paths.ts
+++ b/packages/vinext/src/utils/prerender-output-paths.ts
@@ -9,12 +9,20 @@ export function getOutputPath(urlPath: string, trailingSlash: boolean): string {
   return `${clean}.html`;
 }
 
-/**
- * Determine the RSC output file path for a prerendered URL.
- * "/blog/hello-world" -> "blog/hello-world.rsc"
- * "/"                 -> "index.rsc"
- */
-export function getRscOutputPath(urlPath: string): string {
+/** Determine the Flight payload path for a prerendered App Router URL. */
+export function getRscOutputPath(
+  urlPath: string,
+  options: { mode: "default" | "export"; trailingSlash: boolean } = {
+    mode: "default",
+    trailingSlash: false,
+  },
+): string {
+  if (options.mode === "export") {
+    if (urlPath === "/") return "index.txt";
+    const clean = urlPath.replace(/^\//, "").replace(/\/$/, "");
+    return options.trailingSlash ? `${clean}/index.txt` : `${clean}.txt`;
+  }
+
   if (urlPath === "/") return "index.rsc";
   return urlPath.replace(/^\//, "") + ".rsc";
 }

--- a/packages/vinext/src/utils/prerender-output-paths.ts
+++ b/packages/vinext/src/utils/prerender-output-paths.ts
@@ -12,7 +12,7 @@ export function getOutputPath(urlPath: string, trailingSlash: boolean, basePath 
           ? `${basePath}/`
           : basePath
         : `${basePath}${urlPath}`;
-  const clean = outputUrlPath.replace(/^\//, "");
+  const clean = outputUrlPath.replace(/^\//, "").replace(/\/$/, "");
   if (trailingSlash) return `${clean}/index.html`;
   return `${clean}.html`;
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -261,7 +261,7 @@ const projectServers = {
     use: { baseURL: "http://localhost:4203/docs" },
     server: {
       command:
-        "npx vp run vinext#build && node ../../../packages/vinext/dist/cli.js build && node ../../../tests/e2e/static-export/serve-static.mjs dist/client 4203 /docs",
+        "npx vp run vinext#build && node ../../../packages/vinext/dist/cli.js build && node ../../../tests/e2e/static-export/serve-static.mjs dist/client 4203",
       cwd: "./tests/fixtures/static-export-basepath",
       port: 4203,
       reuseExistingServer: !process.env.CI,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -256,6 +256,18 @@ const projectServers = {
       timeout: 60_000,
     },
   },
+  "static-export-basepath": {
+    testDir: "./tests/e2e/static-export-basepath",
+    use: { baseURL: "http://localhost:4203/docs" },
+    server: {
+      command:
+        "npx vp run vinext#build && node ../../../packages/vinext/dist/cli.js build && node ../../../tests/e2e/static-export/serve-static.mjs dist/client 4203 /docs",
+      cwd: "./tests/fixtures/static-export-basepath",
+      port: 4203,
+      reuseExistingServer: !process.env.CI,
+      timeout: 60_000,
+    },
+  },
   "app-with-src": {
     testDir: "./tests/e2e/app-with-src",
     use: { baseURL: "http://localhost:4181" },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1898,6 +1898,27 @@ importers:
         specifier: npm:@voidzero-dev/vite-plus-core@0.2.6
         version: '@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0)'
 
+  tests/fixtures/static-export-basepath:
+    dependencies:
+      '@vitejs/plugin-rsc':
+        specifier: 'catalog:'
+        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.7
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.7(react@19.2.7)
+      react-server-dom-webpack:
+        specifier: 'catalog:'
+        version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      vinext:
+        specifier: workspace:*
+        version: link:../../../packages/vinext
+      vite:
+        specifier: npm:@voidzero-dev/vite-plus-core@0.2.6
+        version: '@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0)'
+
   tests/fixtures/use-params-app-pages:
     dependencies:
       '@vitejs/plugin-rsc':

--- a/tests/app-optimistic-routing.test.ts
+++ b/tests/app-optimistic-routing.test.ts
@@ -12,6 +12,7 @@ import {
   getOptimisticPrefetchSourceKey,
   getOptimisticRouteTemplateKey,
   matchOptimisticRouteManifestRoute,
+  resolveOptimisticNavigationParamsForHref,
   resolveOptimisticNavigationPayload,
   type OptimisticRouteTemplate,
 } from "../packages/vinext/src/server/app-optimistic-routing.js";
@@ -359,6 +360,17 @@ describe("App Router optimistic routing", () => {
     });
 
     expect(navigationPayload?.params).toEqual({
+      teamID: "vercel",
+      folder: "other-folder",
+      catchAll: ["sub", "other-folder"],
+    });
+    expect(
+      resolveOptimisticNavigationParamsForHref({
+        basePath: "",
+        href: "/vercel/sub/other-folder",
+        routeManifest,
+      }),
+    ).toEqual({
       teamID: "vercel",
       folder: "other-folder",
       catchAll: ["sub", "other-folder"],

--- a/tests/app-page-render.test.ts
+++ b/tests/app-page-render.test.ts
@@ -1264,6 +1264,75 @@ describe("app page render lifecycle", () => {
     expect(common.isrSet).not.toHaveBeenCalled();
   });
 
+  it("preserves prerender cacheLife metadata when the HTML footer finalizes before the outer read", async () => {
+    const common = createCommonOptions();
+    let requestCacheLife: { stale: number; revalidate: number; expire: number } | null = null;
+    let initialNavigationCacheMetadata: InitialNavigationCacheMetadata | undefined;
+
+    const response = await renderAppPageLifecycle({
+      ...common.options,
+      getRequestCacheLife() {
+        const value = requestCacheLife;
+        requestCacheLife = null;
+        return value;
+      },
+      isPrerender: true,
+      isProduction: false,
+      loadSsrHandler: async () => ({
+        async handleSsr(
+          rscStream: ReadableStream<Uint8Array>,
+          _navContext: unknown,
+          _fontData: unknown,
+          options?: {
+            sideStream?: ReadableStream<Uint8Array>;
+            capturedRscDataRef?: { value: Promise<ArrayBuffer> | null };
+            getInitialNavigationCacheMetadata?: () => InitialNavigationCacheMetadata;
+          },
+        ) {
+          const stream = options?.sideStream ?? rscStream;
+          const capturedRscData = new Response(stream).arrayBuffer();
+          if (options?.capturedRscDataRef) {
+            options.capturedRscDataRef.value = capturedRscData;
+          }
+
+          // The real RSC embed transform finalizes its navigation footer as
+          // soon as this capture drains. That can happen before handleSsr()
+          // returns and before renderAppPageLifecycle performs its consuming
+          // cacheLife read.
+          await capturedRscData;
+          initialNavigationCacheMetadata = options?.getInitialNavigationCacheMetadata?.();
+
+          return {
+            htmlStream: createStream(["<html>page</html>"]),
+            metadataReady: Promise.resolve(),
+            capturedRscData,
+          };
+        },
+      }),
+      peekRequestCacheLife() {
+        return requestCacheLife;
+      },
+      renderToReadableStream() {
+        let sent = false;
+        return new ReadableStream<Uint8Array>({
+          pull(controller) {
+            if (sent) {
+              controller.close();
+              return;
+            }
+            requestCacheLife = { stale: 30, revalidate: 1, expire: 60 };
+            controller.enqueue(new TextEncoder().encode("flight-data"));
+            sent = true;
+          },
+        });
+      },
+      revalidateSeconds: null,
+    });
+
+    expect(initialNavigationCacheMetadata).toEqual({ kind: "static", staleTimeSeconds: 30 });
+    await expect(response.text()).resolves.toBe("<html>page</html>");
+  });
+
   it("preserves prerender cache metadata for the manifest writer after shaping headers", async () => {
     const common = createCommonOptions();
     let requestCacheLife: { revalidate: number; expire: number } | null = null;

--- a/tests/app-prefetch-rsc-request.test.ts
+++ b/tests/app-prefetch-rsc-request.test.ts
@@ -37,6 +37,7 @@ const CONTEXTUAL_CASES: Array<[string, ContextualCaseOverrides]> = [
 
 afterEach(() => {
   vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
 });
 
 describe("shared App Router prefetch RSC request resolution", () => {
@@ -154,6 +155,26 @@ describe("shared App Router prefetch RSC request resolution", () => {
     expect(resolved).toEqual({
       additionalRscUrls: [destinationUrl],
       rscUrl: sourceUrl,
+      usesCanonicalPrewarmedRequest: false,
+    });
+  });
+
+  it("prefers the exported .txt artifact over deploy-warmer request sharing", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("__NEXT_CONFIG_OUTPUT", "export");
+    vi.stubEnv("__VINEXT_CANONICAL_RSC_REQUESTS", "1");
+    vi.stubGlobal("window", {});
+    const headers = createRscRequestHeaders({ nextUrl: "/source" });
+
+    await expect(
+      resolveAppPrefetchRscRequest({
+        ...DEFAULT_OPTIONS,
+        fullHref: "/target/",
+        headers,
+      }),
+    ).resolves.toEqual({
+      additionalRscUrls: [],
+      rscUrl: "/target/index.txt",
       usesCanonicalPrewarmedRequest: false,
     });
   });

--- a/tests/app-rsc-cache-busting.test.ts
+++ b/tests/app-rsc-cache-busting.test.ts
@@ -149,6 +149,27 @@ describe("App Router RSC cache-busting", () => {
     await expect(createRscRequestUrl("/docs/", headers)).resolves.toBe("/docs/?_rsc");
   });
 
+  // Ported from Next.js:
+  // packages/next/src/client/components/router-reducer/fetch-server-response.ts
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+  it("addresses static export Flight payloads as .txt files", async () => {
+    vi.stubGlobal("window", {});
+    try {
+      await withEnvVar("NODE_ENV", "production", async () => {
+        await withEnvVar("__NEXT_CONFIG_OUTPUT", "export", async () => {
+          const headers = createRscRequestHeaders({ routerState: null });
+          await expect(createRscRequestUrl("/", headers)).resolves.toBe("/index.txt");
+          await expect(createRscRequestUrl("/docs/", headers)).resolves.toBe("/docs/index.txt");
+          await expect(createRscRequestUrl("/docs?tab=api", headers)).resolves.toBe(
+            "/docs.txt?tab=api",
+          );
+        });
+      });
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("preserves encoded spaces while adding the RSC cache-busting query", async () => {
     const headers = createRscRequestHeaders();
 

--- a/tests/app-rsc-cache-busting.test.ts
+++ b/tests/app-rsc-cache-busting.test.ts
@@ -163,6 +163,15 @@ describe("App Router RSC cache-busting", () => {
           await expect(createRscRequestUrl("/docs?tab=api", headers)).resolves.toBe(
             "/docs.txt?tab=api",
           );
+          await withEnvVar("__NEXT_ROUTER_BASEPATH", "/docs", async () => {
+            await expect(createRscRequestUrl("/docs", headers)).resolves.toBe("/docs/index.txt");
+            await expect(createRscRequestUrl("/docs?tab=api", headers)).resolves.toBe(
+              "/docs/index.txt?tab=api",
+            );
+            await expect(createRscRequestUrl("/docs/about", headers)).resolves.toBe(
+              "/docs/about.txt",
+            );
+          });
         });
       });
     } finally {

--- a/tests/app-ssr-stream.test.ts
+++ b/tests/app-ssr-stream.test.ts
@@ -430,8 +430,13 @@ async function readSingleTransformChunk(
 
   await writer.write(new TextEncoder().encode(chunk));
   const result = await reader.read();
-  await writer.close();
-  await reader.cancel();
+  const close = writer.close();
+  while (!(await reader.read()).done) {
+    // Drain the transform so its asynchronous flush can finish before the
+    // helper releases the reader. Cancelling here races flush() under Node
+    // 24.20 and can close the controller before it emits the document suffix.
+  }
+  await close;
 
   if (result.done) {
     throw new Error("Expected transform to emit a chunk");

--- a/tests/e2e/static-export-basepath/app-router.spec.ts
+++ b/tests/e2e/static-export-basepath/app-router.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "@playwright/test";
+import { waitForAppRouterHydration } from "../helpers";
+
+const BASE = process.env.VINEXT_E2E_BASE_URL ?? "http://localhost:4203";
+
+test("basePath root soft navigation uses index.txt without trailingSlash", async ({ page }) => {
+  const documentPaths: string[] = [];
+  const flightPaths: string[] = [];
+  page.on("request", (request) => {
+    const pathname = new URL(request.url()).pathname;
+    if (request.resourceType() === "document") documentPaths.push(pathname);
+    if (pathname.endsWith(".txt")) flightPaths.push(pathname);
+  });
+
+  await page.goto(`${BASE}/docs/about`);
+  await waitForAppRouterHydration(page);
+  await page.evaluate(() => Reflect.set(window, "__staticExportSoftNavigation", true));
+  await page.locator('a[href="/docs"]').click();
+  await page.waitForURL(`${BASE}/docs`);
+  await expect(page.getByRole("heading", { name: "BasePath Home" })).toBeVisible();
+
+  expect(flightPaths).toContain("/docs/index.txt");
+  expect(flightPaths).not.toContain("/docs.txt");
+  expect(documentPaths).toEqual(["/docs/about"]);
+  expect(await page.evaluate(() => Reflect.get(window, "__staticExportSoftNavigation"))).toBe(true);
+});

--- a/tests/e2e/static-export-basepath/app-router.spec.ts
+++ b/tests/e2e/static-export-basepath/app-router.spec.ts
@@ -34,3 +34,15 @@ test("serves static metadata and the rendered 404 under basePath", async ({ requ
   expect(missing.status()).toBe(404);
   expect(await missing.text()).toContain("BasePath Not Found");
 });
+
+// Next.js serves public files through the configured basePath and rejects the
+// unprefixed URL:
+// https://github.com/vercel/next.js/blob/canary/test/e2e/basepath/basepath.test.ts
+test("namespaces public files under basePath", async ({ request }) => {
+  const publicFile = await request.get(`${BASE}/docs/public-data.txt`);
+  expect(publicFile.status()).toBe(200);
+  expect(await publicFile.text()).toBe("basePath public data\n");
+
+  const unprefixed = await request.get(`${BASE}/public-data.txt`);
+  expect(unprefixed.status()).toBe(404);
+});

--- a/tests/e2e/static-export-basepath/app-router.spec.ts
+++ b/tests/e2e/static-export-basepath/app-router.spec.ts
@@ -24,3 +24,13 @@ test("basePath root soft navigation uses index.txt without trailingSlash", async
   expect(documentPaths).toEqual(["/docs/about"]);
   expect(await page.evaluate(() => Reflect.get(window, "__staticExportSoftNavigation"))).toBe(true);
 });
+
+test("serves static metadata and the rendered 404 under basePath", async ({ request }) => {
+  const robots = await request.get(`${BASE}/docs/robots.txt`);
+  expect(robots.status()).toBe(200);
+  expect(await robots.text()).toContain("Disallow: /docs/private");
+
+  const missing = await request.get(`${BASE}/docs/missing`);
+  expect(missing.status()).toBe(404);
+  expect(await missing.text()).toContain("BasePath Not Found");
+});

--- a/tests/e2e/static-export/app-router.spec.ts
+++ b/tests/e2e/static-export/app-router.spec.ts
@@ -64,13 +64,47 @@ test.describe("Static Export — App Router", () => {
     await expect(nav.locator('a[href="/blog/getting-started/"]')).toBeVisible();
     await expect(nav.locator('a[href="/old-school/"]')).toBeVisible();
     await expect(nav.locator('a[href="/products/widget/"]')).toBeVisible();
+    await expect(nav.locator('a[href="/missing-static-artifact/"]')).toBeVisible();
   });
 
-  test("client-side navigation works between pages", async ({ page }) => {
+  test("soft navigation fetches the exported Flight text without a document reload", async ({
+    page,
+  }) => {
+    const documentPaths: string[] = [];
+    const flightPaths: string[] = [];
+    page.on("request", (request) => {
+      const pathname = new URL(request.url()).pathname;
+      if (request.resourceType() === "document") documentPaths.push(pathname);
+      if (pathname.endsWith(".txt") && request.headers().rsc === "1") {
+        flightPaths.push(pathname);
+      }
+    });
+
     await page.goto(`${BASE}/`);
+    await waitForAppRouterHydration(page);
+    await page.evaluate(() => Reflect.set(window, "__staticExportSoftNavigation", true));
     await page.locator('a[href="/about/"]').click();
     await page.waitForURL(`${BASE}/about/`);
     await expect(page.locator("h1")).toHaveText("About");
+    await expect(page).toHaveTitle("About — Static Export");
+    expect(await page.evaluate(() => Reflect.get(window, "__staticExportSoftNavigation"))).toBe(
+      true,
+    );
+    expect(flightPaths).toContain("/about/index.txt");
+    expect(documentPaths).toEqual(["/"]);
+  });
+
+  test("soft navigation restores dynamic useParams from the route manifest", async ({ page }) => {
+    await page.goto(`${BASE}/`);
+    await waitForAppRouterHydration(page);
+    await page.evaluate(() => Reflect.set(window, "__staticExportSoftNavigation", true));
+    await page.locator('a[href="/blog/hello-world/"]').click();
+    await page.waitForURL(`${BASE}/blog/hello-world/`);
+    await expect(page.getByTestId("client-slug")).toHaveText("Client slug: hello-world");
+    await expect(page).toHaveTitle("Blog: hello-world");
+    expect(await page.evaluate(() => Reflect.get(window, "__staticExportSoftNavigation"))).toBe(
+      true,
+    );
   });
 
   // Ported from Next.js: test/e2e/app-dir/app-static/app-static.test.ts
@@ -88,14 +122,65 @@ test.describe("Static Export — App Router", () => {
     expect(rscRequests).toBe(0);
   });
 
-  test("useSearchParams reads the query after static-host navigation fallback", async ({
-    page,
-  }) => {
+  test("useSearchParams reads the query after static-host soft navigation", async ({ page }) => {
+    const documentPaths: string[] = [];
+    const flightPaths: string[] = [];
+    page.on("request", (request) => {
+      const pathname = new URL(request.url()).pathname;
+      if (request.resourceType() === "document") documentPaths.push(pathname);
+      if (pathname.endsWith(".txt")) flightPaths.push(pathname);
+    });
     await page.goto(`${BASE}/`);
+    await waitForAppRouterHydration(page);
     await page.evaluate(() => Reflect.set(window, "__staticExportSoftNavigation", true));
     await page.locator('a[href="/search-params/?value=navigated"]').click();
     await page.waitForURL(`${BASE}/search-params/?value=navigated`);
     await expect(page.getByTestId("query-value")).toHaveText("navigated");
+    expect(await page.evaluate(() => Reflect.get(window, "__staticExportSoftNavigation"))).toBe(
+      true,
+    );
+    expect(flightPaths).toContain("/search-params/index.txt");
+    expect(documentPaths).toEqual(["/"]);
+  });
+
+  test("back and forward retain the client document", async ({ page }) => {
+    await page.goto(`${BASE}/`);
+    await waitForAppRouterHydration(page);
+    await page.evaluate(() => Reflect.set(window, "__staticExportSoftNavigation", true));
+    await page.locator('a[href="/about/"]').click();
+    await page.waitForURL(`${BASE}/about/`);
+
+    await page.goBack();
+    await page.waitForURL(`${BASE}/`);
+    await expect(page.locator("h1")).toHaveText("Static Export — App Router");
+    expect(await page.evaluate(() => Reflect.get(window, "__staticExportSoftNavigation"))).toBe(
+      true,
+    );
+
+    await page.goForward();
+    await page.waitForURL(`${BASE}/about/`);
+    await expect(page.locator("h1")).toHaveText("About");
+    expect(await page.evaluate(() => Reflect.get(window, "__staticExportSoftNavigation"))).toBe(
+      true,
+    );
+  });
+
+  test("missing Flight artifacts fall back to the static 404 document", async ({ page }) => {
+    const documentPaths: string[] = [];
+    const flightPaths: string[] = [];
+    page.on("request", (request) => {
+      const pathname = new URL(request.url()).pathname;
+      if (request.resourceType() === "document") documentPaths.push(pathname);
+      if (pathname.endsWith(".txt")) flightPaths.push(pathname);
+    });
+    await page.goto(`${BASE}/`);
+    await waitForAppRouterHydration(page);
+    await page.evaluate(() => Reflect.set(window, "__staticExportSoftNavigation", true));
+    await page.locator('a[href="/missing-static-artifact/"]').click();
+    await page.waitForURL(`${BASE}/missing-static-artifact/`);
+
+    expect(flightPaths).toContain("/missing-static-artifact/index.txt");
+    expect(documentPaths).toContain("/missing-static-artifact/");
     expect(
       await page.evaluate(() => Reflect.get(window, "__staticExportSoftNavigation")),
     ).toBeUndefined();

--- a/tests/e2e/static-export/app-router.spec.ts
+++ b/tests/e2e/static-export/app-router.spec.ts
@@ -94,6 +94,42 @@ test.describe("Static Export — App Router", () => {
     expect(documentPaths).toEqual(["/"]);
   });
 
+  // Ported from Next.js:
+  // test/e2e/app-dir/static-export-skew-trailing-slash/static-export-skew-trailing-slash.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/static-export-skew-trailing-slash/static-export-skew-trailing-slash.test.ts
+  test("deployment-skewed Flight falls back to the canonical static document", async ({ page }) => {
+    const documentPaths: string[] = [];
+    const flightPaths: string[] = [];
+    page.on("request", (request) => {
+      const pathname = new URL(request.url()).pathname;
+      if (request.resourceType() === "document") documentPaths.push(pathname);
+      if (pathname.endsWith(".txt")) flightPaths.push(pathname);
+    });
+    await page.route("**/about/index.txt", async (route) => {
+      const response = await route.fetch();
+      const body = await response.text();
+      const skewedBody = body.replace(
+        /"deploymentVersion":"[^"]*"/,
+        '"deploymentVersion":"foreign-build-id"',
+      );
+      expect(skewedBody).not.toBe(body);
+      await route.fulfill({ response, body: skewedBody });
+    });
+
+    await page.goto(`${BASE}/`);
+    await waitForAppRouterHydration(page);
+    await page.evaluate(() => Reflect.set(window, "__staticExportSoftNavigation", true));
+    await page.locator('a[href="/about/"]').click();
+    await page.waitForURL(`${BASE}/about/`);
+    await expect(page.locator("h1")).toHaveText("About");
+
+    expect(flightPaths).toContain("/about/index.txt");
+    expect(documentPaths).toEqual(["/", "/about/"]);
+    expect(
+      await page.evaluate(() => Reflect.get(window, "__staticExportSoftNavigation")),
+    ).toBeUndefined();
+  });
+
   test("soft navigation restores dynamic useParams from the route manifest", async ({ page }) => {
     await page.goto(`${BASE}/`);
     await waitForAppRouterHydration(page);

--- a/tests/e2e/static-export/serve-static.mjs
+++ b/tests/e2e/static-export/serve-static.mjs
@@ -56,6 +56,7 @@ const MIME_TYPES = {
   ".svg": "image/svg+xml",
   ".ico": "image/x-icon",
   ".rsc": "text/x-component",
+  ".txt": "text/plain; charset=utf-8",
 };
 
 async function tryFile(filePath) {

--- a/tests/e2e/static-export/serve-static.mjs
+++ b/tests/e2e/static-export/serve-static.mjs
@@ -5,7 +5,7 @@
  * and 404 handling. Used by the Playwright webServer config to serve
  * the static export output without requiring external dependencies.
  *
- * Usage: node serve-static.mjs <root-dir> <port>
+ * Usage: node serve-static.mjs <root-dir> <port> [mount-path]
  */
 import { createServer } from "node:http";
 import { readFile, stat } from "node:fs/promises";
@@ -13,18 +13,25 @@ import { join, extname, resolve, sep } from "node:path";
 
 const rawRoot = process.argv[2];
 const rawPort = process.argv[3];
+const rawMountPath = process.argv[4] ?? "";
 
 if (!rawRoot || !rawPort) {
-  console.error("Usage: node serve-static.mjs <root-dir> <port>");
+  console.error("Usage: node serve-static.mjs <root-dir> <port> [mount-path]");
   process.exit(1);
 }
 
 const rootDir = resolve(rawRoot);
 const rootPrefix = rootDir.endsWith(sep) ? rootDir : rootDir + sep;
 const port = parseInt(rawPort, 10);
+const mountPath = rawMountPath === "/" ? "" : rawMountPath.replace(/\/$/, "");
 
 if (!Number.isInteger(port) || port < 1 || port > 65535) {
   console.error(`Invalid port: "${rawPort}". Must be an integer between 1 and 65535.`);
+  process.exit(1);
+}
+
+if (mountPath !== "" && (!mountPath.startsWith("/") || mountPath.includes("?"))) {
+  console.error(`Invalid mount path: "${rawMountPath}". Must be an absolute URL pathname.`);
   process.exit(1);
 }
 
@@ -79,6 +86,20 @@ const server = createServer(async (req, res) => {
   try {
     const parsed = new URL(req.url ?? "/", "http://localhost");
     let pathname = decodeURIComponent(parsed.pathname);
+
+    if (mountPath !== "") {
+      if (pathname !== mountPath && !pathname.startsWith(`${mountPath}/`)) {
+        res.writeHead(404);
+        res.end("Not Found");
+        return;
+      }
+      // vinext writes basePath-prefixed `_next` assets to disk so they can be
+      // served verbatim, while exported page and Flight artifacts stay rooted
+      // at the export directory and are mounted below basePath by the host.
+      if (!pathname.startsWith(`${mountPath}/_next/`)) {
+        pathname = pathname.slice(mountPath.length) || "/";
+      }
+    }
 
     // Directory index
     if (pathname.endsWith("/")) pathname += "index.html";

--- a/tests/e2e/static-export/serve-static.mjs
+++ b/tests/e2e/static-export/serve-static.mjs
@@ -5,7 +5,7 @@
  * and 404 handling. Used by the Playwright webServer config to serve
  * the static export output without requiring external dependencies.
  *
- * Usage: node serve-static.mjs <root-dir> <port> [mount-path]
+ * Usage: node serve-static.mjs <root-dir> <port>
  */
 import { createServer } from "node:http";
 import { readFile, stat } from "node:fs/promises";
@@ -13,25 +13,18 @@ import { join, extname, resolve, sep } from "node:path";
 
 const rawRoot = process.argv[2];
 const rawPort = process.argv[3];
-const rawMountPath = process.argv[4] ?? "";
 
 if (!rawRoot || !rawPort) {
-  console.error("Usage: node serve-static.mjs <root-dir> <port> [mount-path]");
+  console.error("Usage: node serve-static.mjs <root-dir> <port>");
   process.exit(1);
 }
 
 const rootDir = resolve(rawRoot);
 const rootPrefix = rootDir.endsWith(sep) ? rootDir : rootDir + sep;
 const port = parseInt(rawPort, 10);
-const mountPath = rawMountPath === "/" ? "" : rawMountPath.replace(/\/$/, "");
 
 if (!Number.isInteger(port) || port < 1 || port > 65535) {
   console.error(`Invalid port: "${rawPort}". Must be an integer between 1 and 65535.`);
-  process.exit(1);
-}
-
-if (mountPath !== "" && (!mountPath.startsWith("/") || mountPath.includes("?"))) {
-  console.error(`Invalid mount path: "${rawMountPath}". Must be an absolute URL pathname.`);
   process.exit(1);
 }
 
@@ -86,20 +79,6 @@ const server = createServer(async (req, res) => {
   try {
     const parsed = new URL(req.url ?? "/", "http://localhost");
     let pathname = decodeURIComponent(parsed.pathname);
-
-    if (mountPath !== "") {
-      if (pathname !== mountPath && !pathname.startsWith(`${mountPath}/`)) {
-        res.writeHead(404);
-        res.end("Not Found");
-        return;
-      }
-      // vinext writes basePath-prefixed `_next` assets to disk so they can be
-      // served verbatim, while exported page and Flight artifacts stay rooted
-      // at the export directory and are mounted below basePath by the host.
-      if (!pathname.startsWith(`${mountPath}/_next/`)) {
-        pathname = pathname.slice(mountPath.length) || "/";
-      }
-    }
 
     // Directory index
     if (pathname.endsWith("/")) pathname += "index.html";

--- a/tests/fixtures/static-export-basepath/app/about/page.tsx
+++ b/tests/fixtures/static-export-basepath/app/about/page.tsx
@@ -1,0 +1,10 @@
+import Link from "next/link";
+
+export default function AboutPage() {
+  return (
+    <main>
+      <h1>BasePath About</h1>
+      <Link href="/">Home</Link>
+    </main>
+  );
+}

--- a/tests/fixtures/static-export-basepath/app/layout.tsx
+++ b/tests/fixtures/static-export-basepath/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/tests/fixtures/static-export-basepath/app/not-found.tsx
+++ b/tests/fixtures/static-export-basepath/app/not-found.tsx
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return <h1>BasePath Not Found</h1>;
+}

--- a/tests/fixtures/static-export-basepath/app/page.tsx
+++ b/tests/fixtures/static-export-basepath/app/page.tsx
@@ -1,0 +1,10 @@
+import Link from "next/link";
+
+export default function HomePage() {
+  return (
+    <main>
+      <h1>BasePath Home</h1>
+      <Link href="/about">About</Link>
+    </main>
+  );
+}

--- a/tests/fixtures/static-export-basepath/app/robots.txt
+++ b/tests/fixtures/static-export-basepath/app/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /docs/private

--- a/tests/fixtures/static-export-basepath/next.config.mjs
+++ b/tests/fixtures/static-export-basepath/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('vinext').NextConfig} */
+export default {
+  basePath: "/docs",
+  output: "export",
+  trailingSlash: false,
+};

--- a/tests/fixtures/static-export-basepath/package.json
+++ b/tests/fixtures/static-export-basepath/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "fixture-static-export-basepath",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@vitejs/plugin-rsc": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "react-server-dom-webpack": "catalog:",
+    "vinext": "workspace:*",
+    "vite": "catalog:"
+  }
+}

--- a/tests/fixtures/static-export-basepath/public/public-data.txt
+++ b/tests/fixtures/static-export-basepath/public/public-data.txt
@@ -1,0 +1,1 @@
+basePath public data

--- a/tests/fixtures/static-export-basepath/tsconfig.json
+++ b/tests/fixtures/static-export-basepath/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["vite/client", "@vitejs/plugin-rsc/types"]
+  },
+  "include": ["app", "*.ts"]
+}

--- a/tests/fixtures/static-export-basepath/vite.config.ts
+++ b/tests/fixtures/static-export-basepath/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import vinext from "vinext";
+
+export default defineConfig({
+  plugins: [vinext({ appDir: import.meta.dirname })],
+});

--- a/tests/fixtures/static-export/app/about/page.tsx
+++ b/tests/fixtures/static-export/app/about/page.tsx
@@ -1,3 +1,5 @@
+export const metadata = { title: "About — Static Export" };
+
 export default function AboutPage() {
   return (
     <main>

--- a/tests/fixtures/static-export/app/blog/[slug]/client-slug.tsx
+++ b/tests/fixtures/static-export/app/blog/[slug]/client-slug.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import { useParams } from "next/navigation";
+
+export function ClientSlug() {
+  const params = useParams<{ slug: string }>();
+  return <p data-testid="client-slug">Client slug: {params.slug}</p>;
+}

--- a/tests/fixtures/static-export/app/blog/[slug]/page.tsx
+++ b/tests/fixtures/static-export/app/blog/[slug]/page.tsx
@@ -13,6 +13,8 @@ export default async function BlogPost({ params }: { params: Promise<{ slug: str
     <main>
       <h1>Blog Post</h1>
       <p>Slug: {slug}</p>
+      <ClientSlug />
     </main>
   );
 }
+import { ClientSlug } from "./client-slug";

--- a/tests/fixtures/static-export/app/page.tsx
+++ b/tests/fixtures/static-export/app/page.tsx
@@ -25,6 +25,9 @@ export default function HomePage() {
           <li>
             <Link href="/products/widget">Product: widget (Pages Router)</Link>
           </li>
+          <li>
+            <Link href="/missing-static-artifact">Missing route</Link>
+          </li>
         </ul>
       </nav>
     </main>

--- a/tests/link.test.ts
+++ b/tests/link.test.ts
@@ -457,6 +457,39 @@ describe("Link App Router prefetch mode", () => {
     }
   });
 
+  it("uses reusable full-route prefetches for static exports", () => {
+    const originalWindow = globalThis.window;
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("__NEXT_CONFIG_OUTPUT", "export");
+    (globalThis as any).window = {
+      location: {
+        href: "http://localhost/blog",
+        origin: "http://localhost",
+      },
+      __VINEXT_LINK_PREFETCH_ROUTES__: [
+        { canPrefetchLoadingShell: true, patternParts: ["blog", ":slug"], isDynamic: true },
+      ],
+    };
+
+    try {
+      expect(resolveAutoAppRoutePrefetch("/blog/hello-world?from=export")).toEqual({
+        cacheForNavigation: true,
+        dynamicStaleTime: "full-prefetch",
+        fallbackTtl: "static",
+        prefetchShellFirst: true,
+        shouldPrefetch: true,
+      });
+      expect(resolveAutoAppRoutePrefetch("/missing").shouldPrefetch).toBe(false);
+    } finally {
+      if (originalWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = originalWindow;
+      }
+      vi.unstubAllEnvs();
+    }
+  });
+
   it("keeps Cache Components encoded delimiters and fully dynamic roots learning-only", () => {
     const originalWindow = globalThis.window;
     const originalCacheComponents = process.env.__NEXT_CACHE_COMPONENTS;

--- a/tests/prerender.test.ts
+++ b/tests/prerender.test.ts
@@ -109,6 +109,20 @@ describe("getRscOutputPath", () => {
     expect(getRscOutputPath("/target", { mode: "export", trailingSlash: false })).toBe(
       "target.txt",
     );
+    expect(
+      getRscOutputPath("/", {
+        mode: "export",
+        trailingSlash: false,
+        basePath: "/docs",
+      }),
+    ).toBe("docs/index.txt");
+    expect(
+      getRscOutputPath("/target", {
+        mode: "export",
+        trailingSlash: false,
+        basePath: "/docs",
+      }),
+    ).toBe("docs/target.txt");
   });
 
   it("retains .rsc files for server prerenders", () => {
@@ -246,7 +260,7 @@ describe("extractRscPayloadFromPrerenderedHtml", () => {
 });
 
 describe("prerenderApp — RSC extraction", () => {
-  it("requests App pages through basePath while writing basePath-free artifacts", async () => {
+  it("requests App pages through basePath and writes basePath-prefixed export artifacts", async () => {
     const root = tmpDir("vinext-prerender-app-basepath-");
     const outDir = path.join(root, "out");
     const appDir = path.join(root, "app");
@@ -297,8 +311,10 @@ describe("prerenderApp — RSC extraction", () => {
         route: "/",
         status: "rendered",
       });
-      expect(fs.readFileSync(path.join(outDir, "index.txt"), "utf8")).toBe(rscPayload);
-      expect(fs.existsSync(path.join(outDir, "docs", "index.txt"))).toBe(false);
+      expect(fs.readFileSync(path.join(outDir, "docs.html"), "utf8")).toContain("<html><body>");
+      expect(fs.readFileSync(path.join(outDir, "docs", "index.txt"), "utf8")).toBe(rscPayload);
+      expect(fs.existsSync(path.join(outDir, "index.html"))).toBe(false);
+      expect(fs.existsSync(path.join(outDir, "index.txt"))).toBe(false);
     } finally {
       await closeServer(server);
       fs.rmSync(root, { recursive: true, force: true });

--- a/tests/prerender.test.ts
+++ b/tests/prerender.test.ts
@@ -246,6 +246,65 @@ describe("extractRscPayloadFromPrerenderedHtml", () => {
 });
 
 describe("prerenderApp — RSC extraction", () => {
+  it("requests App pages through basePath while writing basePath-free artifacts", async () => {
+    const root = tmpDir("vinext-prerender-app-basepath-");
+    const outDir = path.join(root, "out");
+    const appDir = path.join(root, "app");
+    fs.mkdirSync(appDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(appDir, "page.tsx"),
+      "export const dynamic = 'force-static';\nexport default function Page() { return null; }\n",
+    );
+
+    const requestedPaths: string[] = [];
+    const rscPayload = '0:["$","main",null,{"children":"basePath page"}]\n';
+    const server = createServer((req, res) => {
+      requestedPaths.push(req.url ?? "");
+      if (req.url !== "/docs/") {
+        res.statusCode = 404;
+        res.end("<html>not found</html>");
+        return;
+      }
+      res.setHeader("content-type", "text/html");
+      res.end(
+        "<html><body>" +
+          runtimeRscChunkScript(rscPayload) +
+          runtimeRscDoneScript() +
+          "</body></html>",
+      );
+    });
+
+    const port = await listen(server);
+    try {
+      const { prerenderApp } = await import("../packages/vinext/src/build/prerender.js");
+      const { appRouter } = await import("../packages/vinext/src/routing/app-router.js");
+      const { resolveNextConfig } = await import("../packages/vinext/src/config/next-config.js");
+      const routes = await appRouter(appDir);
+      const config = await resolveNextConfig({ basePath: "/docs" });
+
+      const result = await prerenderApp({
+        mode: "export",
+        rscBundlePath: path.join(root, "dist", "server", "index.js"),
+        routes,
+        outDir,
+        config,
+        _prodServer: { server, port },
+      });
+
+      expect(requestedPaths).toContain("/docs/");
+      expect(requestedPaths).not.toContain("/");
+      expect(findRoute(result.routes, "/")).toMatchObject({
+        route: "/",
+        status: "rendered",
+      });
+      expect(fs.readFileSync(path.join(outDir, "index.txt"), "utf8")).toBe(rscPayload);
+      expect(fs.existsSync(path.join(outDir, "docs", "index.txt"))).toBe(false);
+    } finally {
+      await closeServer(server);
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("requests metadata routes through basePath while writing basePath-free artifacts", async () => {
     const root = tmpDir("vinext-prerender-metadata-basepath-");
     const outDir = path.join(root, "out");

--- a/tests/prerender.test.ts
+++ b/tests/prerender.test.ts
@@ -274,7 +274,7 @@ describe("prerenderApp — RSC extraction", () => {
     const rscPayload = '0:["$","main",null,{"children":"basePath page"}]\n';
     const server = createServer((req, res) => {
       requestedPaths.push(req.url ?? "");
-      if (req.url !== "/docs/") {
+      if (req.url !== "/docs") {
         res.statusCode = 404;
         res.end("<html>not found</html>");
         return;
@@ -305,7 +305,7 @@ describe("prerenderApp — RSC extraction", () => {
         _prodServer: { server, port },
       });
 
-      expect(requestedPaths).toContain("/docs/");
+      expect(requestedPaths).toContain("/docs");
       expect(requestedPaths).not.toContain("/");
       expect(findRoute(result.routes, "/")).toMatchObject({
         route: "/",
@@ -765,6 +765,73 @@ describe("prerenderApp — RSC extraction", () => {
 });
 
 // ─── Pages Router ─────────────────────────────────────────────────────────────
+
+describe("prerenderPages — basePath export", () => {
+  it("requests and writes Pages exports under basePath", async () => {
+    const root = tmpDir("vinext-prerender-pages-basepath-");
+    const outDir = path.join(root, "out");
+    const pagesDir = path.join(root, "pages");
+    fs.mkdirSync(pagesDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(pagesDir, "about.tsx"),
+      "export default function About() { return null; }\n",
+    );
+    fs.writeFileSync(
+      path.join(pagesDir, "index.tsx"),
+      "export default function Home() { return null; }\n",
+    );
+
+    const requestedPaths: string[] = [];
+    const server = createServer((req, res) => {
+      requestedPaths.push(req.url ?? "");
+      if (req.url !== "/docs" && req.url !== "/docs/about") {
+        res.statusCode = 404;
+        res.end("not found");
+        return;
+      }
+      res.setHeader("content-type", "text/html");
+      res.end(`<!DOCTYPE html><html><body>Pages basePath ${req.url}</body></html>`);
+    });
+
+    const port = await listen(server);
+    try {
+      const { prerenderPages } = await import("../packages/vinext/src/build/prerender.js");
+      const { pagesRouter, apiRouter } =
+        await import("../packages/vinext/src/routing/pages-router.js");
+      const { resolveNextConfig } = await import("../packages/vinext/src/config/next-config.js");
+      const routes = await pagesRouter(pagesDir);
+      const apiRoutes = await apiRouter(pagesDir);
+      const config = await resolveNextConfig({ basePath: "/docs", output: "export" });
+
+      const result = await prerenderPages({
+        mode: "export",
+        routes,
+        apiRoutes,
+        pagesDir,
+        outDir,
+        config,
+        _prodServer: { server, port },
+      });
+
+      expect(requestedPaths).toEqual(expect.arrayContaining(["/docs", "/docs/about"]));
+      expect(findRoute(result.routes, "/about")).toMatchObject({
+        route: "/about",
+        status: "rendered",
+        outputFiles: ["docs/about.html"],
+      });
+      expect(fs.readFileSync(path.join(outDir, "docs", "about.html"), "utf8")).toContain(
+        "Pages basePath /docs/about",
+      );
+      expect(fs.readFileSync(path.join(outDir, "docs.html"), "utf8")).toContain(
+        "Pages basePath /docs",
+      );
+      expect(fs.existsSync(path.join(outDir, "about.html"))).toBe(false);
+    } finally {
+      await closeServer(server);
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
 
 describe("prerenderPages — default mode (pages-basic)", () => {
   let outDir: string;

--- a/tests/prerender.test.ts
+++ b/tests/prerender.test.ts
@@ -799,8 +799,9 @@ describe("prerenderPages — basePath export", () => {
         res.end("not found");
         return;
       }
+      const responsePath = req.url === "/docs/about" ? "/docs/about" : "/docs";
       res.setHeader("content-type", "text/html");
-      res.end(`<!DOCTYPE html><html><body>Pages basePath ${req.url}</body></html>`);
+      res.end(`<!DOCTYPE html><html><body>Pages basePath ${responsePath}</body></html>`);
     });
 
     const port = await listen(server);

--- a/tests/prerender.test.ts
+++ b/tests/prerender.test.ts
@@ -26,6 +26,7 @@ import { safeJsonStringify } from "../packages/vinext/src/server/html.js";
 import type { AppRoute } from "../packages/vinext/src/routing/app-router.js";
 import {
   getAppRouteOutputPath,
+  getOutputPath,
   getRscOutputPath,
 } from "../packages/vinext/src/utils/prerender-output-paths.js";
 
@@ -128,6 +129,15 @@ describe("getRscOutputPath", () => {
   it("retains .rsc files for server prerenders", () => {
     expect(getRscOutputPath("/")).toBe("index.rsc");
     expect(getRscOutputPath("/target")).toBe("target.rsc");
+  });
+});
+
+describe("getOutputPath", () => {
+  it("emits canonical basePath keys for both trailingSlash modes", () => {
+    expect(getOutputPath("/", false, "/docs")).toBe("docs.html");
+    expect(getOutputPath("/", true, "/docs")).toBe("docs/index.html");
+    expect(getOutputPath("/about", false, "/docs")).toBe("docs/about.html");
+    expect(getOutputPath("/about", true, "/docs")).toBe("docs/about/index.html");
   });
 });
 

--- a/tests/prerender.test.ts
+++ b/tests/prerender.test.ts
@@ -24,7 +24,10 @@ import {
 import { VINEXT_PRERENDER_SPECULATIVE_HEADER } from "../packages/vinext/src/server/headers.js";
 import { safeJsonStringify } from "../packages/vinext/src/server/html.js";
 import type { AppRoute } from "../packages/vinext/src/routing/app-router.js";
-import { getAppRouteOutputPath } from "../packages/vinext/src/utils/prerender-output-paths.js";
+import {
+  getAppRouteOutputPath,
+  getRscOutputPath,
+} from "../packages/vinext/src/utils/prerender-output-paths.js";
 
 const PAGES_FIXTURE = path.resolve(import.meta.dirname, "./fixtures/pages-basic");
 const APP_FIXTURE = path.resolve(import.meta.dirname, "./fixtures/app-basic");
@@ -93,6 +96,26 @@ function legacyRscDoneScript(): string {
 }
 
 // ─── App Router RSC payload extraction ───────────────────────────────────────
+
+describe("getRscOutputPath", () => {
+  // Ported from Next.js:
+  // test/e2e/app-dir/static-export-skew-trailing-slash/static-export-skew-trailing-slash.test.ts
+  // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/static-export-skew-trailing-slash/static-export-skew-trailing-slash.test.ts
+  it("matches static export HTML layout with text/plain Flight artifacts", () => {
+    expect(getRscOutputPath("/", { mode: "export", trailingSlash: true })).toBe("index.txt");
+    expect(getRscOutputPath("/target", { mode: "export", trailingSlash: true })).toBe(
+      "target/index.txt",
+    );
+    expect(getRscOutputPath("/target", { mode: "export", trailingSlash: false })).toBe(
+      "target.txt",
+    );
+  });
+
+  it("retains .rsc files for server prerenders", () => {
+    expect(getRscOutputPath("/")).toBe("index.rsc");
+    expect(getRscOutputPath("/target")).toBe("target.rsc");
+  });
+});
 
 describe("extractRscPayloadFromPrerenderedHtml", () => {
   function decodeExtractedPayload(html: string): string | null {


### PR DESCRIPTION
## Summary

- emit App Router Flight payloads as `.txt` assets in `output: "export"`, matching Next.js and the configured HTML/trailing-slash layout
- fetch those portable `text/plain` assets for static-export navigation while preserving the visible URL, route params, metadata, and client document state
- force export prefetches onto the available full-route artifact and fall back to the static 404 document when an artifact is missing
- handle deployment skew, parallel-slot params, and `basePath` roots without falling back to a document navigation
- namespace exported HTML, Flight, metadata, 404, and `public/` assets under `basePath` for verbatim static hosts
- extend the static-export fixture and comprehensive example verification

## Next.js parity

This follows Next.js's export transport in `packages/next/src/client/components/router-reducer/fetch-server-response.ts` and its trailing-slash regression in `test/e2e/app-dir/static-export-skew-trailing-slash/static-export-skew-trailing-slash.test.ts`. The `.txt` extension is only a static-host transport name; the contents remain Flight/RSC bytes. Normal vinext server prerenders continue to emit `.rsc`.

## Temporary CI prerequisite

This draft currently carries the two focused commits from #3108 because CI against `main` consistently reproduced the prerender footer and Node stream-test races that PR fixes. They remain separate from the static-export commits and can be dropped once #3108 lands.

## Validation

- `vp check`
- `vp test run tests/app-rsc-cache-busting.test.ts tests/prerender.test.ts` (157 tests)
- `vp test run tests/link.test.ts` (130 tests)
- `vp test run tests/app-prefetch-rsc-request.test.ts tests/app-browser-entry.test.ts` (260 tests)
- `PLAYWRIGHT_PROJECT=static-export pnpm run test:e2e` (23 tests)
- `PLAYWRIGHT_PROJECT=static-export-basepath pnpm run test:e2e` (3 tests)
- `pnpm --dir examples/static-export build && pnpm --dir examples/static-export verify` (50 emitted files)
