### PR TITLE
chore(ci): lower Big Bonk reasoning effort

### DIFF
--- a/.github/workflows/bigbonk.yml
+++ b/.github/workflows/bigbonk.yml
@@ -47,7 +47,7 @@ jobs:
           oidc_base_url: https://ask-bonk.cloudflare-exponent.workers.dev/auth
           model: "cloudflare-ai-gateway/openai/gpt-5.6-sol"
           mentions: "/bigbonk"
-          variant: "max"
+          variant: "high"
           permissions: write
           opencode_dev: true
           opencode_version: latest


### PR DESCRIPTION
## Summary

- run Big Bonk with the `high` variant instead of `max`
- leave regular Bonk at its existing `high` variant

## Validation

- `git diff --check`