### PR TITLE
fix(ci): sync interception fixture lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1729,6 +1729,8 @@ importers:
 
   tests/fixtures/hybrid-i18n-api-handoff: {}
 
+  tests/fixtures/interception-source-authz: {}
+
   tests/fixtures/middleware-matcher-auth: {}
 
   tests/fixtures/og-font-package: {}


### PR DESCRIPTION
## Summary

- add the `tests/fixtures/interception-source-authz` workspace importer generated by pnpm
- keep repository setup from dirtying `pnpm-lock.yaml` before Big Bonk checks out a pull-request branch

The fixture was added in #3078, but its empty workspace importer was not committed. Because Big Bonk runs `vp install` on `main` before its action switches to the requested PR branch, that drift made the checkout abort with `pnpm-lock.yaml` local changes.

## Validation

- `vp install` from a clean current `origin/main` reproduced the two-line lockfile drift
- after this commit, `vp install` reports `Already up to date` and leaves the worktree clean
- `git diff --check`