### PR TITLE
feat(rsc): remove hard RSDW requirement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -553,6 +553,14 @@ jobs:
             label: app-with-src
             shardIndex: 1
             shardTotal: 1
+          - project: app-rsdw-override-prod
+            label: app-rsdw-override-prod
+            shardIndex: 1
+            shardTotal: 1
+          - project: app-rsc-isolated-standalone
+            label: app-rsc-isolated-standalone
+            shardIndex: 1
+            shardTotal: 1
           - project: standalone-output
             label: standalone-output
             shardIndex: 1

--- a/README.md
+++ b/README.md
@@ -74,9 +74,12 @@ npm install -D vite @vitejs/plugin-react
 If you're using the App Router, also install:
 
 ```bash
-npm install react-server-dom-webpack
 npm install -D @vitejs/plugin-rsc
 ```
+
+`@vitejs/plugin-rsc` includes the React Flight runtime used by default. Projects
+that intentionally use a different React release channel can install the
+matching `react-server-dom-webpack` version as an explicit runtime override.
 
 Replace `next` with `vinext` in your scripts:
 
@@ -768,7 +771,7 @@ Analysis of the build output shows two main factors:
 1. **Tree-shaking**: Vite/Rolldown produces a smaller React+ReactDOM bundle than Next.js/Turbopack. Rolldown's more aggressive dead-code elimination accounts for roughly half the overall difference.
 2. **Framework overhead**: Next.js ships more client-side infrastructure (router, Turbopack runtime loader, prefetching, error handling) than vinext's lighter client runtime.
 
-Both frameworks ship the same app code and the same RSC client runtime (`react-server-dom-webpack`). The difference is in how much of React's internals survive tree-shaking and how much framework plumbing each tool adds.
+Both frameworks ship the same app code and the React Flight client runtime. Vinext receives that runtime from `@vitejs/plugin-rsc`; Next.js carries its own compiled copy. The difference is in how much of React's internals survive tree-shaking and how much framework plumbing each tool adds.
 
 </details>
 
@@ -892,7 +895,7 @@ Or add it to your `package.json` as a file dependency:
 }
 ```
 
-vinext has peer dependencies on `react ^19.2.6`, `react-dom ^19.2.6`, `react-server-dom-webpack ^19.2.6`, and `vite ^8.0.0`. Then replace `next` with `vinext` in your scripts and run as normal.
+vinext has peer dependencies on `react ^19.2.6`, `react-dom ^19.2.6`, and `vite ^8.0.0`. App Router projects also use the optional `@vitejs/plugin-rsc` peer, which provides the default Flight runtime. Its vendored runtime requires React 19.2.8 or newer; `vinext init` upgrades older stable React versions unless the project declares a matching `react-server-dom-webpack` override. Then replace `next` with `vinext` in your scripts and run as normal.
 
 ## Contributing
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -36,7 +36,6 @@
     "@vitejs/plugin-rsc": "catalog:",
     "drizzle-kit": "catalog:",
     "postcss": "catalog:",
-    "react-server-dom-webpack": "catalog:",
     "tailwindcss": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:",

--- a/benchmarks/vinext/package.json
+++ b/benchmarks/vinext/package.json
@@ -11,7 +11,6 @@
     "@vitejs/plugin-react": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "react-server-dom-webpack": "catalog:",
     "vinext": "workspace:*"
   },
   "devDependencies": {

--- a/examples/app-router-cloudflare/package.json
+++ b/examples/app-router-cloudflare/package.json
@@ -15,7 +15,6 @@
     "vinext": "workspace:*",
     "@vinext/cloudflare": "workspace:*",
     "@vitejs/plugin-rsc": "catalog:",
-    "react-server-dom-webpack": "catalog:",
     "@cloudflare/vite-plugin": "catalog:",
     "wrangler": "catalog:"
   },

--- a/examples/app-router-playground/package.json
+++ b/examples/app-router-playground/package.json
@@ -20,7 +20,6 @@
     "ms": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "react-server-dom-webpack": "catalog:",
     "recma-codehike": "catalog:",
     "remark-codehike": "catalog:",
     "use-count-up": "catalog:",

--- a/examples/benchmarks/package.json
+++ b/examples/benchmarks/package.json
@@ -13,7 +13,6 @@
     "vite": "catalog:",
     "vinext": "workspace:*",
     "@vitejs/plugin-rsc": "catalog:",
-    "react-server-dom-webpack": "catalog:",
     "@cloudflare/vite-plugin": "catalog:",
     "@cloudflare/kumo": "catalog:",
     "@phosphor-icons/react": "catalog:",

--- a/examples/fumadocs-docs-template/package.json
+++ b/examples/fumadocs-docs-template/package.json
@@ -31,7 +31,6 @@
     "@vitejs/plugin-react": "catalog:",
     "@vitejs/plugin-rsc": "catalog:",
     "postcss": "catalog:",
-    "react-server-dom-webpack": "catalog:",
     "tailwindcss": "catalog:",
     "typescript": "catalog:",
     "vinext": "workspace:*",

--- a/examples/hackernews/package.json
+++ b/examples/hackernews/package.json
@@ -17,7 +17,6 @@
     "vite": "catalog:",
     "vinext": "workspace:*",
     "@vitejs/plugin-rsc": "catalog:",
-    "react-server-dom-webpack": "catalog:",
     "@cloudflare/vite-plugin": "catalog:",
     "wrangler": "catalog:"
   },

--- a/examples/nextra-docs-template/package.json
+++ b/examples/nextra-docs-template/package.json
@@ -11,7 +11,6 @@
     "@vitejs/plugin-react": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "react-server-dom-webpack": "catalog:",
     "vinext": "workspace:*"
   },
   "devDependencies": {

--- a/examples/static-export/package.json
+++ b/examples/static-export/package.json
@@ -12,7 +12,6 @@
     "@vitejs/plugin-rsc": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "react-server-dom-webpack": "catalog:",
     "vinext": "workspace:*",
     "vite": "catalog:",
     "wrangler": "catalog:"

--- a/examples/tpr-demo/package.json
+++ b/examples/tpr-demo/package.json
@@ -14,7 +14,6 @@
     "@vitejs/plugin-rsc": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "react-server-dom-webpack": "catalog:",
     "vite": "catalog:",
     "vinext": "workspace:*"
   },

--- a/examples/workers-cache/package.json
+++ b/examples/workers-cache/package.json
@@ -15,7 +15,6 @@
     "vinext": "workspace:*",
     "@vinext/cloudflare": "workspace:*",
     "@vitejs/plugin-rsc": "catalog:",
-    "react-server-dom-webpack": "catalog:",
     "@cloudflare/vite-plugin": "catalog:",
     "wrangler": "catalog:"
   },

--- a/packages/vinext/package.json
+++ b/packages/vinext/package.json
@@ -196,7 +196,6 @@
     "am-i-vibing": "catalog:",
     "image-size": "catalog:",
     "pathslash": "catalog:",
-    "react-server-dom-webpack": "catalog:",
     "vite": "catalog:",
     "vite-plus": "catalog:"
   },
@@ -204,9 +203,8 @@
     "@mdx-js/rollup": "^3.0.0",
     "@vitejs/plugin-react": "^5.1.4 || ^6.0.0",
     "@vitejs/plugin-rsc": "^0.5.34",
-    "react": "^19.2.6",
-    "react-dom": "^19.2.6",
-    "react-server-dom-webpack": "^19.2.6",
+    "react": "^19.2.6 || >=19.3.0-0 <19.4.0 || >=0.0.0-0 <0.0.1",
+    "react-dom": "^19.2.6 || >=19.3.0-0 <19.4.0 || >=0.0.0-0 <0.0.1",
     "vite": "^8.0.0"
   },
   "peerDependenciesMeta": {
@@ -214,9 +212,6 @@
       "optional": true
     },
     "@vitejs/plugin-rsc": {
-      "optional": true
-    },
-    "react-server-dom-webpack": {
       "optional": true
     }
   },

--- a/packages/vinext/src/build/client-build-config.ts
+++ b/packages/vinext/src/build/client-build-config.ts
@@ -213,13 +213,14 @@ export function createClientCodeSplittingConfig(
  * Splitting React into its own (CSS-free) chunk means global-not-found imports
  * the framework chunk instead of the layout-bearing entry chunk, so it no
  * longer inherits the root layout's CSS. The match list mirrors the client
- * build's `framework` chunk, plus `react-server-dom-webpack` for the RSC flight
- * runtime that the server environment bundles.
+ * build's `framework` chunk, plus both plugin-rsc's vendored Flight runtime and
+ * its explicit `react-server-dom-webpack` override path.
  *
  * Uses `[\\/]` rather than `/` for the path separator so it matches on Windows
  * too, per the rolldown `codeSplitting` docs.
  */
 const FRAMEWORK_PACKAGES = ["react", "react-dom", "scheduler", "react-server-dom-webpack"] as const;
+const VENDORED_RSC_RUNTIME_PATH = "@vitejs/plugin-rsc/dist/vendor/react-server-dom/";
 
 /**
  * Regex matching any {@link FRAMEWORK_PACKAGES} package inside `node_modules`.
@@ -227,11 +228,14 @@ const FRAMEWORK_PACKAGES = ["react", "react-dom", "scheduler", "react-server-dom
  * predicate can't drift.
  */
 export const RSC_FRAMEWORK_CHUNK_TEST = new RegExp(
-  `[\\\\/]node_modules[\\\\/](${FRAMEWORK_PACKAGES.join("|")})[\\\\/]`,
+  `[\\\\/]node_modules[\\\\/](?:${FRAMEWORK_PACKAGES.join("|")})[\\\\/]|` +
+    `[\\\\/]node_modules[\\\\/]@vitejs[\\\\/]plugin-rsc[\\\\/]dist[\\\\/]vendor[\\\\/]react-server-dom[\\\\/]`,
 );
 
 export function isRscFrameworkModule(id: string): boolean {
   if (!id.includes("node_modules")) return false;
+  const normalizedId = toSlash(id);
+  if (normalizedId.includes(`/node_modules/${VENDORED_RSC_RUNTIME_PATH}`)) return true;
   const pkg = getPackageName(id);
   return pkg !== null && (FRAMEWORK_PACKAGES as readonly string[]).includes(pkg);
 }

--- a/packages/vinext/src/check.ts
+++ b/packages/vinext/src/check.ts
@@ -1318,7 +1318,7 @@ export function formatReport(result: CheckResult, opts?: { calledFromInit?: bool
     lines.push("  Or manually:");
     lines.push(`    1. Add \x1b[36m"type": "module"\x1b[0m to package.json`);
     lines.push(
-      `    2. Install: \x1b[36m${detectPackageManager(process.cwd())} vinext vite @vitejs/plugin-react${hasAppRouter ? " @vitejs/plugin-rsc react-server-dom-webpack" : ""}\x1b[0m`,
+      `    2. Install: \x1b[36m${detectPackageManager(process.cwd())} vinext vite @vitejs/plugin-react${hasAppRouter ? " @vitejs/plugin-rsc" : ""}\x1b[0m`,
     );
     lines.push(`    3. Create vite.config.ts (see docs)`);
     lines.push(`    4. Run: \x1b[36mnpx vite dev\x1b[0m`);

--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -24,6 +24,7 @@ import { execFileSync } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import {
   detectPackageManager,
+  detectPackageManagerProductionCommand,
   ensureViteConfigCompatibility,
   hasAppDir,
   hasViteConfig,
@@ -577,15 +578,14 @@ async function buildApp() {
     ? vite.createLogger("info", { allowClearScreen: false })
     : createBuildLogger(vite);
 
-  // For App Router: upgrade React if needed for react-server-dom-webpack compatibility.
-  // Without this, builds with older React versions can produce a Worker that crashes at
-  // runtime with "Cannot read properties of undefined (reading 'moduleMap')".
+  // Keep App Router's React pair compatible with its Flight runtime. Stable
+  // React uses plugin-rsc's vendor; prereleases need a matching RSDW override.
   if (isApp) {
     const reactUpgrade = getReactUpgradeDeps(process.cwd());
     if (reactUpgrade.length > 0) {
-      const installCmd = detectPackageManager(process.cwd()).replace(/ -D$/, "");
+      const installCmd = detectPackageManagerProductionCommand(process.cwd());
       const [pm, ...pmArgs] = installCmd.split(" ");
-      console.log("  Upgrading React for RSC compatibility...");
+      console.log("  Installing dependencies for RSC compatibility...");
       execFileSync(pm, [...pmArgs, ...reactUpgrade], {
         cwd: process.cwd(),
         stdio: "inherit",

--- a/packages/vinext/src/global.d.ts
+++ b/packages/vinext/src/global.d.ts
@@ -224,7 +224,7 @@ declare global {
    * inlined Flight payload kind.
    * Each `<script>` calls `self.__VINEXT_RSC_CHUNKS__.push(chunk)`.
    * The browser RSC entry monkey-patches this array's `push` method to feed a
-   * `ReadableStream` that is consumed by `react-server-dom-webpack`.
+   * `ReadableStream` that is consumed by the plugin-rsc Flight runtime.
    */
   // oxlint-disable-next-line no-var
   var __VINEXT_RSC_CHUNKS__: (string | [3, string])[] | undefined;

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1825,6 +1825,14 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         const runtimePackage = source.startsWith(PLUGIN_RSC_VENDOR_RUNTIME)
           ? PLUGIN_RSC_VENDOR_RUNTIME
           : RSDW_RUNTIME;
+        // Let the selected runtime keep its bare package specifier so Vite can
+        // serve the matching optimizeDeps output in development. Only redirect
+        // references to the non-selected runtime onto the selected package root.
+        if (runtimePackage === rscRuntimePackage) return;
+        if (this.environment?.name === "client") {
+          const target = replaceRscRuntimeSpecifier(source, rscRuntimePackage);
+          return this.resolve(target, importer, { ...resolveOptions, skipSelf: true });
+        }
         const subpath = source.slice(runtimePackage.length).replace(/^\//, "");
         const target = subpath ? path.join(rscRuntimeRoot, subpath) : rscRuntimeRoot;
         return this.resolve(target, importer, { ...resolveOptions, skipSelf: true });
@@ -7470,6 +7478,25 @@ export const loadServerActionClient = ${
   } else if (manualUseCachePluginPromise) {
     plugins.push(rscRuntimeResolverPlugin);
     plugins.push(manualUseCachePluginPromise);
+    plugins.push(
+      applyOnlyToAppRouter(
+        createActionOwnerManifestPlugin({
+          canonicalizeModuleId: canonicalize,
+          async getManager(config) {
+            const rscPluginModule = await rscPluginModulePromise;
+            return rscPluginModule?.getPluginApi(config)?.manager;
+          },
+          getRoutes: () => rscActionOwnerRoutes ?? [],
+          getSharedRoots: () => rscActionOwnerSharedRoots,
+          onComplete() {
+            rscActionOwnerRoutes = null;
+            rscActionOwnerSharedRoots = [];
+          },
+        }),
+      ),
+    );
+    plugins.push(applyOnlyToAppRouter(createRscReferenceValidationNormalizerPlugin()));
+    plugins.push(applyOnlyToAppRouter(createRscClientReferenceLoadersPlugin()));
   }
 
   return plugins;

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2355,7 +2355,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         }
 
         if (hasAppDir) {
-          if (!explicitProjectRoot && autoRsc) {
+          if (!explicitProjectRoot) {
             const configuredRscPath = resolveDependencyFromRoot(root, "@vitejs/plugin-rsc");
             if (configuredRscPath && !sameResolvedModule(resolvedRscPath, configuredRscPath)) {
               throw new Error(

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1807,6 +1807,12 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
     }).then(applyOnlyToAppRouter);
   }
 
+  const getRscManager = (plugins: readonly Plugin[]): object | null => {
+    const minimalPlugin = plugins.find((plugin) => plugin.name === "rsc:minimal");
+    const api = minimalPlugin?.api as { manager?: unknown } | undefined;
+    return api?.manager !== null && typeof api?.manager === "object" ? api.manager : null;
+  };
+
   const rscRuntimeResolverPlugin: Plugin = {
     name: "vinext:rsc-runtime-root",
     enforce: "pre",
@@ -1834,11 +1840,29 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         return this.resolve(target, importer, { ...resolveOptions, skipSelf: true });
       },
     },
-    configResolved(config) {
+    async configResolved(config) {
       // Auto mode normalizes the RSC config hook result before Vite computes
       // optimizer metadata. Manual rsc() runs after vinext by contract, so its
       // final merged config needs one last normalization here.
-      if (!autoRsc) pinRscRuntimeConfig(config, rscRuntimePackage);
+      if (!autoRsc) {
+        const configuredManager = getRscManager(config.plugins);
+        if (configuredManager && rscPluginModulePromise) {
+          const resolvedRscModule = await rscPluginModulePromise;
+          const resolvedManager = getRscManager(resolvedRscModule.default());
+          if (
+            resolvedManager &&
+            Object.getPrototypeOf(configuredManager).constructor !==
+              Object.getPrototypeOf(resolvedManager).constructor
+          ) {
+            throw new Error(
+              "vinext: The manually registered @vitejs/plugin-rsc was created by a different module copy than vinext resolved.\n" +
+                `Import rsc() from the dependency graph rooted at ${JSON.stringify(root)}, ` +
+                "or remove rsc: false and the explicit rsc() call so vinext can register it.",
+            );
+          }
+        }
+        pinRscRuntimeConfig(config, rscRuntimePackage);
+      }
     },
   };
 

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -146,9 +146,14 @@ import { matchesRewriteSource, proxyExternalRequest } from "./config/config-matc
 import { encodeMiddlewareRequestHeaders } from "./utils/middleware-request-headers.js";
 import {
   detectPackageManager,
+  detectPackageManagerProductionCommand,
   formatMissingCloudflarePluginError,
   hasWranglerConfig,
 } from "./utils/project.js";
+import {
+  getReactUpgradeDeps,
+  resolveReactServerDomWebpackOverride,
+} from "./utils/react-version.js";
 import {
   hasReactCompilerPlugin,
   isReactCompilerPlugin,
@@ -391,12 +396,21 @@ function hasServerOnlyMarkerImport(code: string): boolean {
 
 const __dirname = import.meta.dirname;
 type VitePluginReactModule = typeof import("@vitejs/plugin-react");
+const PLUGIN_RSC_VENDOR_RUNTIME = "@vitejs/plugin-rsc/vendor/react-server-dom";
+const RSDW_RUNTIME = "react-server-dom-webpack";
+
+function resolveDependencyFromRoot(projectRoot: string, specifier: string): string | null {
+  try {
+    const projectRequire = createRequire(path.join(path.resolve(projectRoot), "package.json"));
+    return projectRequire.resolve(specifier);
+  } catch {
+    return null;
+  }
+}
 
 function resolveOptionalDependency(projectRoot: string, specifier: string): string | null {
-  try {
-    const projectRequire = createRequire(path.join(projectRoot, "package.json"));
-    return projectRequire.resolve(specifier);
-  } catch {}
+  const projectResolution = resolveDependencyFromRoot(projectRoot, specifier);
+  if (projectResolution) return projectResolution;
 
   try {
     const selfRequire = createRequire(import.meta.url);
@@ -404,6 +418,53 @@ function resolveOptionalDependency(projectRoot: string, specifier: string): stri
   } catch {}
 
   return null;
+}
+
+function resolvePluginRscVendorRuntimeRoot(resolvedPluginPath: string | null): string | null {
+  if (!resolvedPluginPath) return null;
+  try {
+    const clientEntry = createRequire(resolvedPluginPath).resolve(
+      `${PLUGIN_RSC_VENDOR_RUNTIME}/client.browser`,
+    );
+    return path.dirname(clientEntry);
+  } catch {
+    return null;
+  }
+}
+
+function sameResolvedModule(left: string | null, right: string | null): boolean {
+  if (!left || !right) return left === right;
+  return (tryRealpathSync(left) ?? left) === (tryRealpathSync(right) ?? right);
+}
+
+function replaceRscRuntimeSpecifier(specifier: string, runtimePackage: string): string {
+  for (const packageName of [PLUGIN_RSC_VENDOR_RUNTIME, RSDW_RUNTIME]) {
+    if (specifier === packageName) return runtimePackage;
+    if (specifier.startsWith(`${packageName}/`)) {
+      return `${runtimePackage}/${specifier.slice(packageName.length + 1)}`;
+    }
+  }
+  return specifier;
+}
+
+function pinRscRuntimeConfig(
+  config: UserConfig | ResolvedConfig | null | void,
+  runtimePackage: string,
+): void {
+  if (!config?.environments) return;
+  for (const environment of Object.values(config.environments)) {
+    const include = environment?.optimizeDeps?.include;
+    if (include) {
+      environment.optimizeDeps!.include = include.map((specifier: string) =>
+        replaceRscRuntimeSpecifier(specifier, runtimePackage),
+      );
+    }
+    const noExternal = environment?.resolve?.noExternal;
+    if (!Array.isArray(noExternal)) continue;
+    const filtered = noExternal.filter((specifier) => specifier !== RSDW_RUNTIME);
+    if (runtimePackage === RSDW_RUNTIME) filtered.push(RSDW_RUNTIME);
+    environment.resolve!.noExternal = [...new Set(filtered)];
+  }
 }
 
 function resolveShimModulePath(shimsDir: string, moduleName: string): string {
@@ -1282,6 +1343,13 @@ function getClientOutputConfig(assetsDir: string, preserveAppRouteBoundaries = f
 
 export type VinextOptions = {
   /**
+   * Project root used to resolve vinext's optional Vite plugin peers before
+   * Vite runs config hooks. Set this when invoking Vite programmatically with
+   * a `root` that differs from `process.cwd()` and may have a distinct
+   * dependency graph.
+   */
+  projectRoot?: string;
+  /**
    * Base directory containing the app/ and pages/ directories.
    * Can be an absolute path or a path relative to the Vite root.
    *
@@ -1616,10 +1684,57 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
   }
 
   // Auto-register @vitejs/plugin-rsc when App Router is detected.
-  // Check eagerly at call time using the same heuristic as config().
-  // Must mirror the full detection logic: check {base}/app then {base}/src/app.
+  // Plugin `apply` receives Vite's configured root before config hooks run, so
+  // use it instead of process.cwd() for programmatic/custom-root Vite callers.
   const autoRsc = options.rsc !== false;
-  const earlyBaseDir = options.appDir ?? process.cwd();
+  const appRouterPluginApplies = (config: UserConfig): boolean => {
+    if (options.disableAppRouter) return false;
+    const configuredRoot = path.resolve(config.root ?? process.cwd());
+    if (options.appDir) {
+      const baseDir = path.isAbsolute(options.appDir)
+        ? options.appDir
+        : path.resolve(configuredRoot, options.appDir);
+      return fs.existsSync(path.join(baseDir, "app"));
+    }
+    return (
+      fs.existsSync(path.join(configuredRoot, "app")) ||
+      fs.existsSync(path.join(configuredRoot, "src", "app"))
+    );
+  };
+  const applyOnlyToAppRouter = (plugin: Plugin): Plugin => {
+    const originalApply = plugin.apply;
+    return {
+      ...plugin,
+      apply(config, env) {
+        if (!appRouterPluginApplies(config)) return false;
+        if (!originalApply) return true;
+        if (typeof originalApply === "string") return originalApply === env.command;
+        return originalApply(config, env);
+      },
+    };
+  };
+  let rscRuntimePackage = PLUGIN_RSC_VENDOR_RUNTIME;
+  const pinRscRuntimePlugin = (plugin: Plugin): Plugin => {
+    if (plugin.name !== "rsc" || !plugin.config) return plugin;
+    const originalConfig = plugin.config;
+    const originalHandler =
+      typeof originalConfig === "function" ? originalConfig : originalConfig.handler;
+    const handler = async function (
+      this: ThisParameterType<typeof originalHandler>,
+      config: UserConfig,
+      env: Parameters<typeof originalHandler>[1],
+    ) {
+      const result = await originalHandler.call(this, config, env);
+      pinRscRuntimeConfig(result, rscRuntimePackage);
+      return result;
+    };
+    return {
+      ...plugin,
+      config: typeof originalConfig === "function" ? handler : { ...originalConfig, handler },
+    } as Plugin;
+  };
+  const explicitProjectRoot = options.projectRoot ? path.resolve(options.projectRoot) : null;
+  const earlyBaseDir = explicitProjectRoot ?? path.resolve(options.appDir ?? process.cwd());
   const earlyAppDirExists =
     !options.disableAppRouter &&
     (fs.existsSync(path.join(earlyBaseDir, "app")) ||
@@ -1639,27 +1754,21 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
   // consistent resolution.
   let resolvedReactPath: string | null = null;
   let resolvedRscPath: string | null = null;
+  let rscRuntimeRoot: string | null = null;
   let rscPluginModulePromise: Promise<typeof import("@vitejs/plugin-rsc")> | null = null;
   // Prefer the user's project graph so vinext shares the app's Vite/plugin
   // instances. In source/workspace development, test fixtures may not declare
   // peer deps explicitly, so fall back to vinext's own install location.
   resolvedReactPath = resolveOptionalDependency(earlyBaseDir, "@vitejs/plugin-react");
   resolvedRscPath = resolveOptionalDependency(earlyBaseDir, "@vitejs/plugin-rsc");
+  const pluginRscVendorRuntimeRoot = resolvePluginRscVendorRuntimeRoot(resolvedRscPath);
 
   // If app/ exists and auto-RSC is enabled, create a lazy Promise that
   // resolves to the configured RSC plugin array. Vite's asyncFlatten
   // will resolve this before processing the plugin list.
   let rscPluginPromise: Promise<Plugin[]> | null = null;
   let manualUseCachePluginPromise: Promise<Plugin> | null = null;
-  if (earlyAppDirExists && autoRsc) {
-    if (!resolvedRscPath) {
-      throw new Error(
-        "vinext: App Router detected but @vitejs/plugin-rsc is not installed.\n" +
-          "Run: " +
-          detectPackageManager(process.cwd()) +
-          " @vitejs/plugin-rsc",
-      );
-    }
+  if (autoRsc && resolvedRscPath) {
     const rscImport = import(pathToFileURL(resolvedRscPath).href);
     rscPluginModulePromise = rscImport;
     rscPluginPromise = rscImport
@@ -1684,14 +1793,14 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           throw new Error("vinext: Failed to locate @vitejs/plugin-rsc use-server plugin.");
         }
         plugins.splice(useServerIndex, 0, useCachePlugin);
-        return plugins;
+        return plugins.map((plugin) => applyOnlyToAppRouter(pinRscRuntimePlugin(plugin)));
       })
       .catch((cause) => {
         throw new Error("vinext: Failed to load @vitejs/plugin-rsc.", {
           cause,
         });
       });
-  } else if (earlyAppDirExists && resolvedRscPath) {
+  } else if (!autoRsc && earlyAppDirExists && resolvedRscPath) {
     rscPluginModulePromise = import(pathToFileURL(resolvedRscPath).href);
     manualUseCachePluginPromise = createUseCacheCallablePlugin({
       projectRoot: earlyBaseDir,
@@ -1701,6 +1810,33 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
       allowMissingRsc: true,
     });
   }
+
+  const rscRuntimeResolverPlugin: Plugin = {
+    name: "vinext:rsc-runtime-root",
+    enforce: "pre",
+    apply: appRouterPluginApplies,
+    resolveId: {
+      order: "pre",
+      filter: {
+        id: /^(?:@vitejs\/plugin-rsc\/vendor\/react-server-dom|react-server-dom-webpack)(?:\/|$)/,
+      },
+      async handler(source, importer, resolveOptions) {
+        if (!rscRuntimeRoot) return;
+        const runtimePackage = source.startsWith(PLUGIN_RSC_VENDOR_RUNTIME)
+          ? PLUGIN_RSC_VENDOR_RUNTIME
+          : RSDW_RUNTIME;
+        const subpath = source.slice(runtimePackage.length).replace(/^\//, "");
+        const target = subpath ? path.join(rscRuntimeRoot, subpath) : rscRuntimeRoot;
+        return this.resolve(target, importer, { ...resolveOptions, skipSelf: true });
+      },
+    },
+    configResolved(config) {
+      // Auto mode normalizes the RSC config hook result before Vite computes
+      // optimizer metadata. Manual rsc() runs after vinext by contract, so its
+      // final merged config needs one last normalization here.
+      if (!autoRsc) pinRscRuntimeConfig(config, rscRuntimePackage);
+    },
+  };
 
   async function resolveHasServerActions(
     config: Pick<ResolvedConfig, "command" | "plugins">,
@@ -2137,7 +2273,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
 
       async config(config, env) {
         isServeCommand = env.command === "serve";
-        root = toSlash(config.root ?? process.cwd());
+        root = toSlash(path.resolve(config.root ?? process.cwd()));
         const userResolve = config.resolve as UserResolveConfigWithTsconfigPaths | undefined;
         let tsconfigPathAliases: Record<string, string> = {};
         let sassTsconfigPathAliases: SassTsconfigPathAlias[] = [];
@@ -2203,6 +2339,44 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         appDir = path.join(baseDir, "app");
         hasPagesDir = fs.existsSync(pagesDir);
         hasAppDir = !options.disableAppRouter && fs.existsSync(appDir);
+
+        if (!explicitProjectRoot && options.react !== false) {
+          const configuredReactPath = resolveDependencyFromRoot(root, "@vitejs/plugin-react");
+          if (configuredReactPath && !sameResolvedModule(resolvedReactPath, configuredReactPath)) {
+            throw new Error(
+              "vinext: @vitejs/plugin-react resolves differently from the configured Vite root.\n" +
+                `Pass projectRoot: ${JSON.stringify(root)} to vinext() when using a programmatic custom root.`,
+            );
+          }
+        }
+
+        if (hasAppDir) {
+          if (!explicitProjectRoot && autoRsc) {
+            const configuredRscPath = resolveDependencyFromRoot(root, "@vitejs/plugin-rsc");
+            if (configuredRscPath && !sameResolvedModule(resolvedRscPath, configuredRscPath)) {
+              throw new Error(
+                "vinext: @vitejs/plugin-rsc resolves differently from the configured Vite root.\n" +
+                  `Pass projectRoot: ${JSON.stringify(root)} to vinext() when using a programmatic custom root.`,
+              );
+            }
+          }
+          if (autoRsc && !rscPluginPromise) {
+            throw new Error(
+              "vinext: App Router detected but @vitejs/plugin-rsc is not installed.\n" +
+                `Run: ${detectPackageManager(root)} @vitejs/plugin-rsc`,
+            );
+          }
+          const compatibilityDeps = getReactUpgradeDeps(root, pluginRscVendorRuntimeRoot);
+          if (compatibilityDeps.length > 0) {
+            throw new Error(
+              "vinext: React is incompatible with the selected App Router Flight runtime.\n" +
+                `Run: ${detectPackageManagerProductionCommand(root)} ${compatibilityDeps.join(" ")}`,
+            );
+          }
+          const overrideRuntimeRoot = resolveReactServerDomWebpackOverride(root);
+          rscRuntimePackage = overrideRuntimeRoot ? RSDW_RUNTIME : PLUGIN_RSC_VENDOR_RUNTIME;
+          rscRuntimeRoot = overrideRuntimeRoot ?? pluginRscVendorRuntimeRoot;
+        }
 
         // Route scans are cached at module scope so the generated entries and
         // request handlers can share them. A Vite restart can create a new
@@ -3043,6 +3217,11 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 ...tsconfigPathAliases,
                 ...nextConfig.aliases,
                 ...nextShimMap,
+                ...(rscRuntimeRoot
+                  ? {
+                      [PLUGIN_RSC_VENDOR_RUNTIME]: rscRuntimeRoot,
+                    }
+                  : {}),
                 "vinext/server/pages-client-assets": _pagesClientAssetsPath,
               },
               tsconfigPathAliases,
@@ -3354,11 +3533,10 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
               optimizeDeps: {
                 exclude: mergeOptimizeDepsExclude(incomingExclude, VINEXT_OPTIMIZE_DEPS_EXCLUDE),
                 entries: optimizeEntries,
-                // plugin-rsc pre-includes server.edge, but not its vendored
-                // static.edge import, which it rewrites to this package specifier.
-                // Prebundle both so they share the large development renderer
-                // instead of transforming its raw CJS source on the first request.
-                include: [...new Set([...incomingInclude, "react-server-dom-webpack/static.edge"])],
+                // plugin-rsc owns the Flight-runtime includes. It selects its
+                // vendored runtime by default and an explicitly installed
+                // react-server-dom-webpack package as an opt-in override.
+                ...(incomingInclude.length > 0 ? { include: incomingInclude } : {}),
                 ...depOptimizeNodeEnvOptions,
               },
               build: {
@@ -7266,29 +7444,31 @@ export const loadServerActionClient = ${
 
   // Append auto-injected RSC plugins if applicable
   if (rscPluginPromise) {
+    // Run before plugin-rsc's own cwd-based override resolver so the resolved
+    // Vite root, not an unrelated parent workspace, selects the Flight runtime.
+    plugins.push(rscRuntimeResolverPlugin);
     plugins.push(rscPluginPromise);
-  }
-  if (earlyAppDirExists) {
     plugins.push(
-      createActionOwnerManifestPlugin({
-        canonicalizeModuleId: canonicalize,
-        async getManager(config) {
-          const rscPluginModule = await rscPluginModulePromise;
-          return rscPluginModule?.getPluginApi(config)?.manager;
-        },
-        getRoutes: () => rscActionOwnerRoutes ?? [],
-        getSharedRoots: () => rscActionOwnerSharedRoots,
-        onComplete() {
-          rscActionOwnerRoutes = null;
-          rscActionOwnerSharedRoots = [];
-        },
-      }),
+      applyOnlyToAppRouter(
+        createActionOwnerManifestPlugin({
+          canonicalizeModuleId: canonicalize,
+          async getManager(config) {
+            const rscPluginModule = await rscPluginModulePromise;
+            return rscPluginModule?.getPluginApi(config)?.manager;
+          },
+          getRoutes: () => rscActionOwnerRoutes ?? [],
+          getSharedRoots: () => rscActionOwnerSharedRoots,
+          onComplete() {
+            rscActionOwnerRoutes = null;
+            rscActionOwnerSharedRoots = [];
+          },
+        }),
+      ),
     );
-  }
-  if (rscPluginPromise) {
-    plugins.push(createRscReferenceValidationNormalizerPlugin());
-    plugins.push(createRscClientReferenceLoadersPlugin());
+    plugins.push(applyOnlyToAppRouter(createRscReferenceValidationNormalizerPlugin()));
+    plugins.push(applyOnlyToAppRouter(createRscClientReferenceLoadersPlugin()));
   } else if (manualUseCachePluginPromise) {
+    plugins.push(rscRuntimeResolverPlugin);
     plugins.push(manualUseCachePluginPromise);
   }
 

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1735,10 +1735,6 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
   };
   const explicitProjectRoot = options.projectRoot ? path.resolve(options.projectRoot) : null;
   const earlyBaseDir = explicitProjectRoot ?? path.resolve(options.appDir ?? process.cwd());
-  const earlyAppDirExists =
-    !options.disableAppRouter &&
-    (fs.existsSync(path.join(earlyBaseDir, "app")) ||
-      fs.existsSync(path.join(earlyBaseDir, "src", "app")));
 
   // IMPORTANT: Resolve @vitejs/plugin-rsc subpath imports from the user's
   // project root, not from vinext's own package location. When vinext is
@@ -1800,7 +1796,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           cause,
         });
       });
-  } else if (!autoRsc && earlyAppDirExists && resolvedRscPath) {
+  } else if (!autoRsc && resolvedRscPath) {
     rscPluginModulePromise = import(pathToFileURL(resolvedRscPath).href);
     manualUseCachePluginPromise = createUseCacheCallablePlugin({
       projectRoot: earlyBaseDir,
@@ -1808,7 +1804,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
       getAppDir: () => appDir,
       matchesPageExtension: (fileName) => fileMatcher.extensionRegex.test(fileName),
       allowMissingRsc: true,
-    });
+    }).then(applyOnlyToAppRouter);
   }
 
   const rscRuntimeResolverPlugin: Plugin = {

--- a/packages/vinext/src/init.ts
+++ b/packages/vinext/src/init.ts
@@ -25,6 +25,7 @@ import {
   renameCJSConfigs,
   detectPackageManager,
   detectPackageManagerName,
+  detectPackageManagerProductionCommand,
   findViteConfigPath,
   hasViteConfig,
 } from "./utils/project.js";
@@ -223,7 +224,6 @@ export function getInitDependencyGroups(
   const dependencies = ["vinext"];
   const devDependencies = ["vite", "@vitejs/plugin-react"];
   if (isAppRouter) {
-    dependencies.push("react-server-dom-webpack");
     devDependencies.push("@vitejs/plugin-rsc");
   }
   if (platform === "cloudflare") {
@@ -291,6 +291,8 @@ function addDependencyEntries(root: string, deps: string[], { dev }: { dev: bool
   const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8")) as {
     dependencies?: Record<string, string>;
     devDependencies?: Record<string, string>;
+    optionalDependencies?: Record<string, string>;
+    peerDependencies?: Record<string, string>;
   };
   const targetKey = dev ? "devDependencies" : "dependencies";
   const target = (pkg[targetKey] ??= {});
@@ -298,6 +300,7 @@ function addDependencyEntries(root: string, deps: string[], { dev }: { dev: bool
 
   for (const dep of deps) {
     const { name, version, hasExplicitVersion } = parseDependencySpecifier(dep);
+    let changed = false;
     const existingTarget =
       pkg.dependencies?.[name] !== undefined
         ? pkg.dependencies
@@ -306,13 +309,27 @@ function addDependencyEntries(root: string, deps: string[], { dev }: { dev: bool
           : undefined;
 
     if (existingTarget) {
-      if (!hasExplicitVersion || existingTarget[name] === version) continue;
-      existingTarget[name] = version;
-      added.push(name);
+      if (hasExplicitVersion && existingTarget[name] !== version) {
+        existingTarget[name] = version;
+        changed = true;
+      }
+      if (!dev) {
+        for (const section of [pkg.optionalDependencies, pkg.peerDependencies]) {
+          if (section?.[name] !== undefined) {
+            delete section[name];
+            changed = true;
+          }
+        }
+      }
+      if (changed) added.push(name);
       continue;
     }
 
     target[name] = version;
+    if (!dev) {
+      delete pkg.optionalDependencies?.[name];
+      delete pkg.peerDependencies?.[name];
+    }
     added.push(name);
   }
 
@@ -323,20 +340,7 @@ function addDependencyEntries(root: string, deps: string[], { dev }: { dev: bool
   return added;
 }
 
-/**
- * Check if react/react-dom need upgrading for react-server-dom-webpack compatibility.
- *
- * react-server-dom-webpack versions are pinned to match their React version
- * (e.g. rsdw@19.2.6 requires react@^19.2.6). When a project has an older
- * React (e.g. create-next-app ships react@19.2.3), we need to upgrade
- * react/react-dom BEFORE installing rsdw to avoid peer-dep conflicts.
- *
- * Uses createRequire to resolve react's package.json through Node's module
- * resolution, which works correctly across all package managers (npm, pnpm,
- * yarn, Yarn PnP) and monorepo layouts with hoisting/symlinking.
- *
- * Returns ["react@latest", "react-dom@latest"] if upgrade is needed, [] otherwise.
- */
+/** Install dependency specs using the project's package manager. */
 async function installDeps(
   root: string,
   deps: string[],
@@ -348,9 +352,10 @@ async function installDeps(
 ): Promise<string> {
   if (deps.length === 0) return "";
 
-  const baseCmd = detectPackageManager(root);
-  // Strip " -D" for non-dev installs (keeps deps in "dependencies", not "devDependencies")
-  const installCmd = dev ? baseCmd : baseCmd.replace(/ -D$/, "");
+  // npm and pnpm otherwise preserve an existing optional/peer classification.
+  // Force runtime packages into dependencies so plugin-rsc's framework crawl
+  // can see an explicit RSDW override.
+  const installCmd = dev ? detectPackageManager(root) : detectPackageManagerProductionCommand(root);
   const depsStr = deps.join(" ");
 
   return (
@@ -602,11 +607,28 @@ export async function init(options: InitOptions): Promise<InitResult> {
   const dependencyEntriesAdded: string[] = [];
   const devDependencyEntriesAdded: string[] = [];
 
-  // For App Router: react-server-dom-webpack requires react/react-dom versions
-  // to match exactly (e.g. rsdw@19.2.6 needs react@^19.2.6). If the installed
-  // React is too old (common with create-next-app), upgrade it first as a
-  // regular dependency to avoid ERESOLVE peer-dep conflicts.
-  if (isApp && missingDependencies.includes("react-server-dom-webpack")) {
+  // Install plugin-rsc first so compatibility checks read the exact vendored
+  // Flight version selected by this project instead of guessing which React
+  // release a future plugin version will carry.
+  const missingRscPluginIndex = missingDevDependencies.indexOf("@vitejs/plugin-rsc");
+  if (isApp && shouldInstall && missingRscPluginIndex !== -1) {
+    console.log(`  ${terminalStyle.cyan(terminalStyle.bold("Installing devDependencies:"))}`);
+    console.log(formatList(["@vitejs/plugin-rsc"], "    "));
+    try {
+      const installOutput = await installDeps(root, ["@vitejs/plugin-rsc"], exec);
+      devDependencyEntriesAdded.push("@vitejs/plugin-rsc");
+      if (isApproveBuildsError(installOutput)) dependencyInstallNeedsApproval = true;
+    } catch (error) {
+      if (pmName !== "pnpm" || !isApproveBuildsError(error)) throw error;
+      dependencyInstallNeedsApproval = true;
+    }
+    missingDevDependencies.splice(missingRscPluginIndex, 1);
+    console.log();
+  }
+
+  // Keep App Router's React pair compatible with its Flight runtime. Stable
+  // React uses plugin-rsc's vendor; prereleases need a matching RSDW override.
+  if (isApp) {
     const reactUpgrade = getReactUpgradeDeps(root);
     if (reactUpgrade.length > 0) {
       console.log(`  ${terminalStyle.cyan(terminalStyle.bold("Upgrading dependencies:"))}`);

--- a/packages/vinext/src/server/app-rsc-redirect-flight.ts
+++ b/packages/vinext/src/server/app-rsc-redirect-flight.ts
@@ -64,7 +64,7 @@ export type RedirectFlightStreamRenderer = (
  * Builds an RSC flight payload that encodes a `redirect()` as a React error
  * carrying the canonical `NEXT_REDIRECT;<type>;<url>;<status>;` digest. We
  * render a tiny element that throws immediately; `renderToReadableStream`'s
- * `onError` returns the digest, react-server-dom-webpack serializes the error
+ * `onError` returns the digest, the plugin-rsc Flight runtime serializes the error
  * into the stream, and the client's `RedirectErrorBoundary` decodes it via
  * `getURLFromRedirectError` / `getRedirectTypeFromError`. The HTTP response
  * stays 200 because the redirect rides in the flight body, not the status line.

--- a/packages/vinext/src/utils/project.ts
+++ b/packages/vinext/src/utils/project.ts
@@ -237,6 +237,14 @@ export function detectPackageManager(root: string): string {
   return `${pm} add -D`;
 }
 
+/** Return a command that moves named packages into regular dependencies. */
+export function detectPackageManagerProductionCommand(root: string): string {
+  const pm = detectPackageManagerName(root);
+  if (pm === "npm") return "npm install --save-prod";
+  if (pm === "pnpm") return "pnpm add --save-prod";
+  return `${pm} add`;
+}
+
 // ─── Node Modules Resolution ─────────────────────────────────────────────────
 
 /**
@@ -586,9 +594,6 @@ export function getMissingDeps(
   }
   if (info.isAppRouter && !info.hasRscPlugin) {
     missing.push({ name: "@vitejs/plugin-rsc", version: "latest" });
-  }
-  if (info.isAppRouter && !_isResolvable(info.root, "react-server-dom-webpack")) {
-    missing.push({ name: "react-server-dom-webpack", version: "latest" });
   }
   if (info.hasMDX && !_isResolvable(info.root, "@mdx-js/rollup")) {
     missing.push({ name: "@mdx-js/rollup", version: "latest" });

--- a/packages/vinext/src/utils/react-version.ts
+++ b/packages/vinext/src/utils/react-version.ts
@@ -1,37 +1,211 @@
 import fs from "node:fs";
-import path from "pathslash";
 import { createRequire } from "node:module";
+import path from "pathslash";
 
-type DependencyUpgradeRecommendation = {
-  minimumVersion: [major: number, minor: number, patch: number];
-  upgrades: string[];
+type DependencyMap = Record<string, string>;
+type ProjectPackageJson = {
+  dependencies?: DependencyMap;
+  devDependencies?: DependencyMap;
+  optionalDependencies?: DependencyMap;
+  peerDependencies?: DependencyMap;
 };
 
-function getDependencyUpgradeDeps(
-  root: string,
-  recommendations: Record<string, DependencyUpgradeRecommendation>,
-): string[] {
-  const req = createRequire(path.join(root, "package.json"));
-  for (const [dependency, recommendation] of Object.entries(recommendations)) {
-    try {
-      const version = findPackageVersion(req.resolve(dependency), dependency);
-      if (version && isVersionBelow(version, recommendation.minimumVersion)) {
-        return recommendation.upgrades;
-      }
-    } catch {
-      continue;
-    }
+type InstalledPackage = {
+  root: string;
+  version: string;
+};
+
+const RSDW_PACKAGE = "react-server-dom-webpack";
+const PLUGIN_RSC_VENDOR_CLIENT = "@vitejs/plugin-rsc/vendor/react-server-dom/client.browser";
+const EXACT_VERSION_RE = /^=?([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)$/;
+
+function readProjectPackage(root: string): ProjectPackageJson | null {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8"));
+  } catch {
+    return null;
   }
-  return [];
 }
 
-export function getReactUpgradeDeps(root: string): string[] {
-  return getDependencyUpgradeDeps(root, {
-    react: {
-      minimumVersion: [19, 2, 6],
-      upgrades: ["react@latest", "react-dom@latest"],
-    },
-  });
+function getDeclaredVersion(pkg: ProjectPackageJson | null, dependency: string): string | null {
+  if (!pkg) return null;
+  return (
+    pkg.dependencies?.[dependency] ??
+    pkg.devDependencies?.[dependency] ??
+    pkg.optionalDependencies?.[dependency] ??
+    pkg.peerDependencies?.[dependency] ??
+    null
+  );
+}
+
+function parseExactVersion(specifier: string | null): string | null {
+  if (!specifier) return null;
+  return EXACT_VERSION_RE.exec(specifier)?.[1] ?? null;
+}
+
+function getInstalledPackage(
+  root: string,
+  dependency: string,
+  packageName = dependency,
+): InstalledPackage | null {
+  const req = createRequire(path.join(root, "package.json"));
+  try {
+    return findPackage(req.resolve(dependency), packageName);
+  } catch {
+    return null;
+  }
+}
+
+function parseVersionTuple(version: string): [major: number, minor: number, patch: number] | null {
+  const match = /^(\d+)\.(\d+)\.(\d+)/.exec(version);
+  return match ? [Number(match[1]), Number(match[2]), Number(match[3])] : null;
+}
+
+function compareVersionTuples(
+  left: [number, number, number],
+  right: [number, number, number],
+): number {
+  for (let index = 0; index < left.length; index++) {
+    if (left[index] !== right[index]) return left[index] - right[index];
+  }
+  return 0;
+}
+
+function getVendoredReactVersion(
+  root: string,
+  vendoredRuntimeRoot?: string | null,
+): [major: number, minor: number, patch: number] | null {
+  let version: string | null = null;
+  if (vendoredRuntimeRoot) {
+    try {
+      const pkg = JSON.parse(
+        fs.readFileSync(path.join(vendoredRuntimeRoot, "package.json"), "utf8"),
+      );
+      version = typeof pkg.version === "string" ? pkg.version : null;
+    } catch {
+      // Fall through to root-based package resolution.
+    }
+  }
+  version ??= getInstalledPackage(root, PLUGIN_RSC_VENDOR_CLIENT, RSDW_PACKAGE)?.version ?? null;
+  if (!version) {
+    try {
+      const resolvedEntry = createRequire(import.meta.url).resolve(PLUGIN_RSC_VENDOR_CLIENT);
+      version = findPackage(resolvedEntry, RSDW_PACKAGE)?.version ?? null;
+    } catch {
+      // The optional RSC plugin may not be installed yet during `vinext init`.
+    }
+  }
+  return parseVersionTuple(version ?? "");
+}
+
+function getEffectiveVersion(
+  installed: InstalledPackage | null,
+  pkg: ProjectPackageJson | null,
+  dependency: string,
+): string | null {
+  return installed?.version ?? parseExactVersion(getDeclaredVersion(pkg, dependency));
+}
+
+/**
+ * Return dependencies needed to align React with the App Router Flight runtime.
+ *
+ * Stable React uses plugin-rsc's vendored runtime by default. Prerelease React
+ * needs the exact matching RSDW release because its internal protocol may
+ * differ from the stable vendor. An explicit app-level RSDW declaration opts
+ * into plugin-rsc's override path, but the installed React, ReactDOM, and RSDW
+ * versions must still form an exact release trio.
+ */
+export function getReactUpgradeDeps(root: string, vendoredRuntimeRoot?: string | null): string[] {
+  const pkg = readProjectPackage(root);
+  const declaredRsdwSpecifier =
+    pkg?.dependencies?.[RSDW_PACKAGE] ?? pkg?.devDependencies?.[RSDW_PACKAGE] ?? null;
+  const rsdwIsShadowed = pkg?.optionalDependencies?.[RSDW_PACKAGE] !== undefined;
+
+  const installedReact = getInstalledPackage(root, "react");
+  const installedReactDom = getInstalledPackage(root, "react-dom");
+  const reactVersion = getEffectiveVersion(installedReact, pkg, "react");
+  const reactDomVersion = getEffectiveVersion(installedReactDom, pkg, "react-dom");
+
+  if (declaredRsdwSpecifier !== null) {
+    const installedRsdw = getInstalledPackage(root, RSDW_PACKAGE);
+    const targetVersion =
+      parseExactVersion(declaredRsdwSpecifier) ??
+      installedRsdw?.version ??
+      reactVersion ??
+      reactDomVersion;
+
+    // A non-exact declaration with no installed packages cannot be aligned to
+    // a release yet, but it must still be installed instead of being mistaken
+    // for a usable override.
+    if (!targetVersion) {
+      return [`${RSDW_PACKAGE}@${declaredRsdwSpecifier}`];
+    }
+
+    const upgrades: string[] = [];
+    if (reactVersion !== targetVersion) upgrades.push(`react@${targetVersion}`);
+    if (reactDomVersion !== targetVersion) upgrades.push(`react-dom@${targetVersion}`);
+    if (installedRsdw?.version !== targetVersion || rsdwIsShadowed) {
+      upgrades.push(`${RSDW_PACKAGE}@${targetVersion}`);
+    }
+    return upgrades;
+  }
+
+  if (!reactVersion) return [];
+
+  const prereleaseVersion = [reactVersion, reactDomVersion].find((version) =>
+    version?.includes("-"),
+  );
+  if (prereleaseVersion) {
+    if (
+      reactVersion !== prereleaseVersion ||
+      (reactDomVersion !== null && reactDomVersion !== prereleaseVersion)
+    ) {
+      return [
+        `react@${prereleaseVersion}`,
+        `react-dom@${prereleaseVersion}`,
+        `${RSDW_PACKAGE}@${prereleaseVersion}`,
+      ];
+    }
+    return [`${RSDW_PACKAGE}@${prereleaseVersion}`];
+  }
+
+  const vendoredReactVersion = getVendoredReactVersion(root, vendoredRuntimeRoot);
+  if (reactDomVersion && reactVersion !== reactDomVersion) {
+    const reactTuple = parseVersionTuple(reactVersion);
+    const reactDomTuple = parseVersionTuple(reactDomVersion);
+    const targetVersion =
+      reactTuple && reactDomTuple && compareVersionTuples(reactTuple, reactDomTuple) < 0
+        ? reactDomVersion
+        : reactVersion;
+    const targetTuple = parseVersionTuple(targetVersion);
+    if (
+      vendoredReactVersion &&
+      (!targetTuple || compareVersionTuples(targetTuple, vendoredReactVersion) < 0)
+    ) {
+      return ["react@latest", "react-dom@latest"];
+    }
+    const upgrades: string[] = [];
+    if (reactVersion !== targetVersion) upgrades.push(`react@${targetVersion}`);
+    if (reactDomVersion !== targetVersion) upgrades.push(`react-dom@${targetVersion}`);
+    return upgrades;
+  }
+
+  return vendoredReactVersion &&
+    (isVersionBelow(reactVersion, vendoredReactVersion) ||
+      (reactDomVersion !== null && isVersionBelow(reactDomVersion, vendoredReactVersion)))
+    ? ["react@latest", "react-dom@latest"]
+    : [];
+}
+
+/** Resolve the installed, validated app-level RSDW override package root. */
+export function resolveReactServerDomWebpackOverride(root: string): string | null {
+  const pkg = readProjectPackage(root);
+  const hasExplicitOverride =
+    pkg?.dependencies?.[RSDW_PACKAGE] !== undefined ||
+    pkg?.devDependencies?.[RSDW_PACKAGE] !== undefined;
+  if (!hasExplicitOverride || pkg?.optionalDependencies?.[RSDW_PACKAGE] !== undefined) return null;
+  if (getReactUpgradeDeps(root).length > 0) return null;
+  return getInstalledPackage(root, RSDW_PACKAGE)?.root ?? null;
 }
 
 function isVersionBelow(version: string, minimum: [number, number, number]): boolean {
@@ -42,15 +216,15 @@ function isVersionBelow(version: string, minimum: [number, number, number]): boo
   return false;
 }
 
-/** Walk up from a resolved module entry to find its package version. */
-function findPackageVersion(resolvedEntry: string, packageName: string): string | null {
+/** Walk up from a resolved module entry to find its package root and version. */
+function findPackage(resolvedEntry: string, packageName: string): InstalledPackage | null {
   let dir = path.dirname(resolvedEntry);
   while (dir !== path.dirname(dir)) {
     const candidate = path.join(dir, "package.json");
     try {
-      const pkg = JSON.parse(fs.readFileSync(candidate, "utf-8"));
-      if (pkg.name === packageName) {
-        return pkg.version ?? null;
+      const pkg = JSON.parse(fs.readFileSync(candidate, "utf8"));
+      if (pkg.name === packageName && typeof pkg.version === "string") {
+        return { root: dir, version: pkg.version };
       }
     } catch {
       // no package.json at this level, keep walking up

--- a/packages/vinext/src/utils/react-version.ts
+++ b/packages/vinext/src/utils/react-version.ts
@@ -17,6 +17,10 @@ type InstalledPackage = {
 
 const RSDW_PACKAGE = "react-server-dom-webpack";
 const PLUGIN_RSC_VENDOR_CLIENT = "@vitejs/plugin-rsc/vendor/react-server-dom/client.browser";
+// @vitejs/plugin-rsc 0.5.34, vinext's minimum supported release, vendors this
+// React Flight version. Keep the floor available when `vinext init --install=false`
+// runs before the optional plugin has been installed.
+const MINIMUM_PLUGIN_RSC_VENDOR_REACT_VERSION: [number, number, number] = [19, 2, 8];
 const EXACT_VERSION_RE = /^=?([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)$/;
 
 function readProjectPackage(root: string): ProjectPackageJson | null {
@@ -86,8 +90,12 @@ function getVendoredReactVersion(
       // Fall through to root-based package resolution.
     }
   }
-  version ??= getInstalledPackage(root, PLUGIN_RSC_VENDOR_CLIENT, RSDW_PACKAGE)?.version ?? null;
-  if (!version) {
+  // An explicit null lets callers and tests represent a plugin that is known
+  // to be unavailable. Undefined retains the normal project/self lookup.
+  if (!version && vendoredRuntimeRoot !== null) {
+    version = getInstalledPackage(root, PLUGIN_RSC_VENDOR_CLIENT, RSDW_PACKAGE)?.version ?? null;
+  }
+  if (!version && vendoredRuntimeRoot !== null) {
     try {
       const resolvedEntry = createRequire(import.meta.url).resolve(PLUGIN_RSC_VENDOR_CLIENT);
       version = findPackage(resolvedEntry, RSDW_PACKAGE)?.version ?? null;
@@ -95,7 +103,7 @@ function getVendoredReactVersion(
       // The optional RSC plugin may not be installed yet during `vinext init`.
     }
   }
-  return parseVersionTuple(version ?? "");
+  return parseVersionTuple(version ?? "") ?? MINIMUM_PLUGIN_RSC_VENDOR_REACT_VERSION;
 }
 
 function getEffectiveVersion(

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from "@playwright/test";
 
 const appRouterBrowserSpecificTests = "**/app-router/**/*.browser.spec.ts";
+const appWithSrcPort = Number(process.env.VINEXT_APP_WITH_SRC_PORT ?? 4181);
+const appRouterIsrPort = Number(process.env.VINEXT_APP_ROUTER_ISR_PORT ?? 4198);
+const isolatedRscStandalonePort = Number(process.env.VINEXT_ISOLATED_RSC_STANDALONE_PORT ?? 4205);
 const appRouterServer = {
   command: "npx vp dev --port 4174",
   cwd: "./tests/fixtures/app-basic",
@@ -62,12 +65,11 @@ const projectServers = {
       "app-router-prod/static-hydration.spec.ts",
       "app-router-prod/use-cache.spec.ts",
     ],
-    use: { baseURL: "http://localhost:4198" },
+    use: { baseURL: `http://localhost:${appRouterIsrPort}` },
     server: {
-      command:
-        "npx vp run vinext#build && node ../../../packages/vinext/dist/cli.js build && node ../../../packages/vinext/dist/cli.js start --port 4198",
+      command: `npx vp run vinext#build && node ../../../packages/vinext/dist/cli.js build && node ../../../packages/vinext/dist/cli.js start --port ${appRouterIsrPort}`,
       cwd: "./tests/fixtures/app-basic",
-      port: 4198,
+      port: appRouterIsrPort,
       reuseExistingServer: !process.env.CI,
       timeout: 120_000,
     },
@@ -270,13 +272,37 @@ const projectServers = {
   },
   "app-with-src": {
     testDir: "./tests/e2e/app-with-src",
-    use: { baseURL: "http://localhost:4181" },
+    use: { baseURL: `http://localhost:${appWithSrcPort}` },
     server: {
-      command: "npx vp dev --port 4181",
+      command: `npx vp dev --port ${appWithSrcPort}`,
       cwd: "./tests/fixtures/app-with-src",
-      port: 4181,
+      port: appWithSrcPort,
       reuseExistingServer: !process.env.CI,
       timeout: 30_000,
+    },
+  },
+  "app-rsdw-override-prod": {
+    testDir: "./tests/e2e/app-rsdw-override",
+    use: { baseURL: "http://localhost:4204" },
+    server: {
+      command:
+        "npx vp run vinext#build && node ../../../packages/vinext/dist/cli.js build && node ../../../packages/vinext/dist/cli.js start --port 4204",
+      cwd: "./tests/fixtures/app-with-src",
+      port: 4204,
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+    },
+  },
+  "app-rsc-isolated-standalone": {
+    testDir: "./tests/e2e/app-rsc-isolated-standalone",
+    use: { baseURL: `http://localhost:${isolatedRscStandalonePort}` },
+    server: {
+      command: `node tests/e2e/app-rsc-isolated-standalone/setup-and-start.mjs ${isolatedRscStandalonePort}`,
+      cwd: ".",
+      port: isolatedRscStandalonePort,
+      reuseExistingServer: !process.env.CI,
+      timeout: 180_000,
+      gracefulShutdown: { signal: "SIGTERM" as const, timeout: 10_000 },
     },
   },
   "standalone-output": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,14 +184,14 @@ catalogs:
       specifier: 8.5.10
       version: 8.5.10
     react:
-      specifier: ^19.2.7
-      version: 19.2.7
+      specifier: ^19.2.8
+      version: 19.2.8
     react-dom:
-      specifier: ^19.2.7
-      version: 19.2.7
+      specifier: ^19.2.8
+      version: 19.2.8
     react-server-dom-webpack:
-      specifier: ^19.2.7
-      version: 19.2.7
+      specifier: ^19.2.8
+      version: 19.2.8
     recma-codehike:
       specifier: 0.0.1
       version: 0.0.1
@@ -258,7 +258,7 @@ importers:
     dependencies:
       '@mdx-js/react':
         specifier: 'catalog:'
-        version: 3.1.1(@types/react@19.2.16)(react@19.2.7)
+        version: 3.1.1(@types/react@19.2.16)(react@19.2.8)
       '@mdx-js/rollup':
         specifier: 'catalog:'
         version: 3.1.1(rollup@4.62.2)
@@ -274,7 +274,7 @@ importers:
         version: 1.60.0
       '@sentry/nextjs':
         specifier: 'catalog:'
-        version: 10.62.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0))(react@19.2.7)
+        version: 10.62.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.100.0))(react@19.2.8)
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.2
@@ -286,7 +286,7 @@ importers:
         version: 19.2.3(@types/react@19.2.16)
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
-        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       '@vitest/coverage-istanbul':
         specifier: 'catalog:'
         version: 4.1.10(vitest@4.1.10)
@@ -298,7 +298,7 @@ importers:
         version: 2.14.6(@types/node@25.9.2)(typescript@7.0.2)
       next:
         specifier: 'catalog:'
-        version: 16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0)
+        version: 16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.100.0)
       oxc-transform-react:
         specifier: 'catalog:'
         version: 0.145.0
@@ -310,10 +310,10 @@ importers:
         version: 1.60.0
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       sass:
         specifier: 'catalog:'
         version: 1.100.0
@@ -334,10 +334,10 @@ importers:
     dependencies:
       '@cloudflare/kumo':
         specifier: 'catalog:'
-        version: 2.2.0(@date-fns/tz@1.4.1)(@phosphor-icons/react@2.1.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.16)(date-fns@4.1.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.3.6)
+        version: 2.2.0(@date-fns/tz@1.4.1)(@phosphor-icons/react@2.1.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/react@19.2.16)(date-fns@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.3.6)
       '@phosphor-icons/react':
         specifier: 'catalog:'
-        version: 2.1.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 2.1.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@vinext/cloudflare':
         specifier: workspace:*
         version: link:../../packages/cloudflare
@@ -346,13 +346,13 @@ importers:
         version: 0.45.2(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.1)(better-sqlite3@12.6.2)(kysely@0.28.15)
       next:
         specifier: 'catalog:'
-        version: 16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0)
+        version: 16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.100.0)
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       shiki:
         specifier: 'catalog:'
         version: 4.0.2
@@ -383,16 +383,13 @@ importers:
         version: 6.1.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(oxc-transform-react@0.145.0)
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
-        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       drizzle-kit:
         specifier: 'catalog:'
         version: 0.31.10
       postcss:
         specifier: 'catalog:'
         version: 8.5.10
-      react-server-dom-webpack:
-        specifier: 'catalog:'
-        version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       tailwindcss:
         specifier: 'catalog:'
         version: 4.1.4
@@ -413,20 +410,17 @@ importers:
         version: 6.1.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(oxc-transform-react@0.145.0)
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
-      react-server-dom-webpack:
-        specifier: 'catalog:'
-        version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       vinext:
         specifier: workspace:*
         version: link:../../packages/vinext
     devDependencies:
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
-        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       vite:
         specifier: npm:@voidzero-dev/vite-plus-core@0.2.6
         version: '@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0)'
@@ -447,16 +441,13 @@ importers:
         version: 6.1.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(oxc-transform-react@0.145.0)
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
-        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
-      react-server-dom-webpack:
-        specifier: 'catalog:'
-        version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       vinext:
         specifier: workspace:*
         version: link:../../packages/vinext
@@ -484,10 +475,10 @@ importers:
         version: nitro-nightly@3.0.1-20260512-093145-0498ce70(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(better-sqlite3@12.6.2)(chokidar@5.0.0)(dotenv@16.6.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.1)(better-sqlite3@12.6.2)(kysely@0.28.15))(jiti@2.7.0)(lru-cache@11.5.1)(miniflare@4.20260401.0)(rollup@4.62.2)
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       vinext:
         specifier: workspace:*
         version: link:../../packages/vinext
@@ -503,13 +494,13 @@ importers:
     dependencies:
       '@heroicons/react':
         specifier: 'catalog:'
-        version: 2.2.0(react@19.2.7)
+        version: 2.2.0(react@19.2.8)
       '@mdx-js/loader':
         specifier: 'catalog:'
         version: 3.1.0
       '@next/mdx':
         specifier: 'catalog:'
-        version: 16.2.7(@mdx-js/loader@3.1.0)(@mdx-js/react@3.1.1(@types/react@19.2.16)(react@19.2.7))
+        version: 16.2.7(@mdx-js/loader@3.1.0)(@mdx-js/react@3.1.1(@types/react@19.2.16)(react@19.2.8))
       '@types/mdx':
         specifier: 'catalog:'
         version: 2.0.13
@@ -533,13 +524,10 @@ importers:
         version: 3.0.0-canary.1
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
-      react-server-dom-webpack:
-        specifier: 'catalog:'
-        version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       recma-codehike:
         specifier: 'catalog:'
         version: 0.0.1(zod@3.24.3)
@@ -548,7 +536,7 @@ importers:
         version: 0.0.1(zod@3.24.3)
       use-count-up:
         specifier: 'catalog:'
-        version: 3.0.1(react@19.2.7)
+        version: 3.0.1(react@19.2.8)
       vinext:
         specifier: workspace:*
         version: link:../../packages/vinext
@@ -582,7 +570,7 @@ importers:
         version: 19.2.3(@types/react@19.2.16)
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
-        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       postcss:
         specifier: 'catalog:'
         version: 8.5.10
@@ -606,13 +594,13 @@ importers:
     dependencies:
       '@cloudflare/kumo':
         specifier: 'catalog:'
-        version: 2.2.0(@date-fns/tz@1.4.1)(@phosphor-icons/react@2.1.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.16)(date-fns@4.1.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.3.6)
+        version: 2.2.0(@date-fns/tz@1.4.1)(@phosphor-icons/react@2.1.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/react@19.2.16)(date-fns@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.3.6)
       '@cloudflare/vite-plugin':
         specifier: 'catalog:'
         version: 1.31.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(workerd@1.20260401.1)(wrangler@4.80.0)
       '@phosphor-icons/react':
         specifier: 'catalog:'
-        version: 2.1.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 2.1.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tailwindcss/vite':
         specifier: 'catalog:'
         version: 4.2.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))
@@ -621,16 +609,13 @@ importers:
         version: 6.1.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(oxc-transform-react@0.145.0)
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
-        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
-      react-server-dom-webpack:
-        specifier: 'catalog:'
-        version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       tailwindcss:
         specifier: 'catalog:'
         version: 4.1.4
@@ -655,25 +640,25 @@ importers:
         version: 0.72.0
       fumadocs-core:
         specifier: 'catalog:'
-        version: 16.7.9(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.7))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.3.6)
+        version: 16.7.9(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.8))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.100.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.3.6)
       fumadocs-mdx:
         specifier: 'catalog:'
-        version: 14.2.10(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.16)(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(fumadocs-core@16.7.9(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.7))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.3.6))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0))(react@19.2.7)
+        version: 14.2.10(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.16)(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(fumadocs-core@16.7.9(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.8))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.100.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.3.6))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.100.0))(react@19.2.8)
       fumadocs-ui:
         specifier: 'catalog:'
-        version: 16.7.9(@takumi-rs/image-response@0.72.0)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(fumadocs-core@16.7.9(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.7))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.3.6))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(shiki@4.0.2)(tailwindcss@4.1.4)
+        version: 16.7.9(@takumi-rs/image-response@0.72.0)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(fumadocs-core@16.7.9(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.8))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.100.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.3.6))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.100.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(shiki@4.0.2)(tailwindcss@4.1.4)
       lucide-react:
         specifier: 'catalog:'
-        version: 0.577.0(react@19.2.7)
+        version: 0.577.0(react@19.2.8)
       next:
         specifier: 'catalog:'
-        version: 16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0)
+        version: 16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.100.0)
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       tailwind-merge:
         specifier: 'catalog:'
         version: 3.5.0
@@ -704,13 +689,10 @@ importers:
         version: 6.1.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(oxc-transform-react@0.145.0)
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
-        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       postcss:
         specifier: 'catalog:'
         version: 8.5.10
-      react-server-dom-webpack:
-        specifier: 'catalog:'
-        version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       tailwindcss:
         specifier: 'catalog:'
         version: 4.1.4
@@ -737,19 +719,16 @@ importers:
         version: 6.1.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(oxc-transform-react@0.145.0)
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
-        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       ms:
         specifier: 'catalog:'
         version: 3.0.0-canary.1
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
-      react-server-dom-webpack:
-        specifier: 'catalog:'
-        version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       sanitize-html:
         specifier: 'catalog:'
         version: 2.17.3
@@ -780,13 +759,10 @@ importers:
         version: 6.1.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(oxc-transform-react@0.145.0)
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
-      react-server-dom-webpack:
-        specifier: 'catalog:'
-        version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       vinext:
         specifier: workspace:*
         version: link:../../packages/vinext
@@ -808,7 +784,7 @@ importers:
         version: 19.2.3(@types/react@19.2.16)
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
-        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -832,10 +808,10 @@ importers:
         version: 6.1.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(oxc-transform-react@0.145.0)
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       vinext:
         specifier: workspace:*
         version: link:../../packages/vinext
@@ -863,13 +839,13 @@ importers:
         version: 24.2.3(typescript@7.0.2)
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       react-i18next:
         specifier: ^15.7.4
-        version: 15.7.4(i18next@24.2.3(typescript@7.0.2))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@7.0.2)
+        version: 15.7.4(i18next@24.2.3(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2)
       vinext:
         specifier: workspace:*
         version: link:../../packages/vinext
@@ -888,7 +864,7 @@ importers:
         version: 19.2.16
       next:
         specifier: 'catalog:'
-        version: 16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0)
+        version: 16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.100.0)
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
@@ -903,13 +879,13 @@ importers:
         version: 6.1.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(oxc-transform-react@0.145.0)
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       swr:
         specifier: 'catalog:'
-        version: 2.4.0(react@19.2.7)
+        version: 2.4.0(react@19.2.8)
       vinext:
         specifier: workspace:*
         version: link:../../packages/vinext
@@ -943,16 +919,13 @@ importers:
     dependencies:
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
-        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
-      react-server-dom-webpack:
-        specifier: 'catalog:'
-        version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       vinext:
         specifier: workspace:*
         version: link:../../packages/vinext
@@ -983,16 +956,13 @@ importers:
         version: 6.1.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(oxc-transform-react@0.145.0)
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
-        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
-      react-server-dom-webpack:
-        specifier: 'catalog:'
-        version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       vinext:
         specifier: workspace:*
         version: link:../../packages/vinext
@@ -1029,16 +999,13 @@ importers:
         version: 6.1.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(oxc-transform-react@0.145.0)
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
-        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
-      react-server-dom-webpack:
-        specifier: 'catalog:'
-        version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       vinext:
         specifier: workspace:*
         version: link:../../packages/vinext
@@ -1095,7 +1062,7 @@ importers:
     dependencies:
       '@unpic/react':
         specifier: 'catalog:'
-        version: 1.0.2(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 1.0.2(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.100.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@vercel/og':
         specifier: 'catalog:'
         version: 0.8.6
@@ -1132,7 +1099,7 @@ importers:
         version: 6.1.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(oxc-transform-react@0.145.0)
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
-        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       am-i-vibing:
         specifier: 'catalog:'
         version: 0.5.0
@@ -1142,9 +1109,6 @@ importers:
       pathslash:
         specifier: 'catalog:'
         version: 0.1.0
-      react-server-dom-webpack:
-        specifier: 'catalog:'
-        version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       vite-plus:
         specifier: 'catalog:'
         version: 0.2.6(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-istanbul@4.1.10(vitest@4.1.10))(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(esbuild@0.27.3)(jiti@2.7.0)(msw@2.14.6(@types/node@25.9.2)(typescript@7.0.2))(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0)
@@ -1155,7 +1119,7 @@ importers:
     dependencies:
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
-        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       fake-context-lib:
         specifier: file:./__test_packages__/fake-context-lib
         version: file:tests/fixtures/app-basic/__test_packages__/fake-context-lib
@@ -1167,13 +1131,10 @@ importers:
         version: file:tests/fixtures/app-basic/__test_packages__/fake-css-module-lib
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
-      react-server-dom-webpack:
-        specifier: 'catalog:'
-        version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       vinext:
         specifier: workspace:*
         version: link:../../../packages/vinext
@@ -1189,16 +1150,13 @@ importers:
     dependencies:
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
-        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
-      react-server-dom-webpack:
-        specifier: 'catalog:'
-        version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       vinext:
         specifier: workspace:*
         version: link:../../../packages/vinext
@@ -1214,16 +1172,13 @@ importers:
     dependencies:
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
-        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
-      react-server-dom-webpack:
-        specifier: 'catalog:'
-        version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       vinext:
         specifier: workspace:*
         version: link:../../../packages/vinext
@@ -1247,16 +1202,16 @@ importers:
     dependencies:
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
-        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       react-server-dom-webpack:
         specifier: 'catalog:'
-        version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       vinext:
         specifier: workspace:*
         version: link:../../../packages/vinext
@@ -1281,16 +1236,13 @@ importers:
         version: 6.1.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(oxc-transform-react@0.145.0)
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
-        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
-      react-server-dom-webpack:
-        specifier: 'catalog:'
-        version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       vinext:
         specifier: workspace:*
         version: link:../../../packages/vinext
@@ -1312,22 +1264,19 @@ importers:
         version: 1.31.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(workerd@1.20260401.1)(wrangler@4.80.0)
       '@sentry/nextjs':
         specifier: 'catalog:'
-        version: 10.62.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0))(react@19.2.7)
+        version: 10.62.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.100.0))(react@19.2.8)
       '@vitejs/plugin-react':
         specifier: 'catalog:'
         version: 6.1.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(oxc-transform-react@0.145.0)
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
-        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
-      react-server-dom-webpack:
-        specifier: 'catalog:'
-        version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       vinext:
         specifier: workspace:*
         version: link:../../../packages/vinext
@@ -1349,16 +1298,16 @@ importers:
         version: 1.31.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(workerd@1.20260401.1)(wrangler@4.80.0)
       '@sentry/nextjs':
         specifier: 'catalog:'
-        version: 10.62.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0))(react@19.2.7)
+        version: 10.62.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.100.0))(react@19.2.8)
       '@vitejs/plugin-react':
         specifier: 'catalog:'
         version: 6.1.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(oxc-transform-react@0.145.0)
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       vinext:
         specifier: workspace:*
         version: link:../../../packages/vinext
@@ -1384,22 +1333,19 @@ importers:
         version: 1.9.1
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
-        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       better-auth:
         specifier: 'catalog:'
-        version: 1.5.6(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.1)(better-sqlite3@12.6.2)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.1)(better-sqlite3@12.6.2)(kysely@0.28.15))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10)
+        version: 1.5.6(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.1)(better-sqlite3@12.6.2)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.1)(better-sqlite3@12.6.2)(kysely@0.28.15))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.100.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
       better-sqlite3:
         specifier: 'catalog:'
         version: 12.6.2
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
-      react-server-dom-webpack:
-        specifier: 'catalog:'
-        version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       vinext:
         specifier: workspace:*
         version: link:../../../../packages/vinext
@@ -1415,19 +1361,16 @@ importers:
     dependencies:
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
-        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       next-intl:
         specifier: 'catalog:'
-        version: 4.11.1(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0))(react@19.2.7)(typescript@7.0.2)
+        version: 4.11.1(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.100.0))(react@19.2.8)(typescript@7.0.2)
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
-      react-server-dom-webpack:
-        specifier: 'catalog:'
-        version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       vinext:
         specifier: workspace:*
         version: link:../../../../packages/vinext
@@ -1443,19 +1386,16 @@ importers:
     dependencies:
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
-        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       next-themes:
         specifier: 'catalog:'
-        version: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
-      react-server-dom-webpack:
-        specifier: 'catalog:'
-        version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       vinext:
         specifier: workspace:*
         version: link:../../../../packages/vinext
@@ -1471,19 +1411,16 @@ importers:
     dependencies:
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
-        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       next-view-transitions:
         specifier: 'catalog:'
-        version: 0.3.5(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 0.3.5(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.100.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
-      react-server-dom-webpack:
-        specifier: 'catalog:'
-        version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       vinext:
         specifier: workspace:*
         version: link:../../../../packages/vinext
@@ -1499,19 +1436,16 @@ importers:
     dependencies:
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
-        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       nuqs:
         specifier: 'catalog:'
-        version: 2.8.8(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0))(react@19.2.7)
+        version: 2.8.8(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.100.0))(react@19.2.8)
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
-      react-server-dom-webpack:
-        specifier: 'catalog:'
-        version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       vinext:
         specifier: workspace:*
         version: link:../../../../packages/vinext
@@ -1527,16 +1461,16 @@ importers:
     dependencies:
       '@radix-ui/react-dialog':
         specifier: 'catalog:'
-        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@radix-ui/react-dropdown-menu':
         specifier: 'catalog:'
-        version: 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@radix-ui/react-slot':
         specifier: 'catalog:'
-        version: 1.2.4(@types/react@19.2.16)(react@19.2.7)
+        version: 1.2.4(@types/react@19.2.16)(react@19.2.8)
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
-        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       class-variance-authority:
         specifier: 'catalog:'
         version: 0.7.1
@@ -1545,13 +1479,10 @@ importers:
         version: 2.1.1
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
-      react-server-dom-webpack:
-        specifier: 'catalog:'
-        version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       tailwind-merge:
         specifier: 'catalog:'
         version: 3.5.0
@@ -1570,10 +1501,10 @@ importers:
     dependencies:
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       validator:
         specifier: 'catalog:'
         version: 13.15.26
@@ -1592,7 +1523,7 @@ importers:
     dependencies:
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
-        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       app-cjs-esm-package:
         specifier: file:./__test_packages__/app-cjs-esm-package
         version: file:tests/fixtures/esm-externals/__test_packages__/app-cjs-esm-package
@@ -1631,13 +1562,10 @@ importers:
         version: file:tests/fixtures/esm-externals/__test_packages__/optimized-esm-package
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
-      react-server-dom-webpack:
-        specifier: 'catalog:'
-        version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       shared-condition-package:
         specifier: file:./__test_packages__/shared-condition-package
         version: file:tests/fixtures/esm-externals/__test_packages__/shared-condition-package
@@ -1656,16 +1584,13 @@ importers:
     dependencies:
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
-        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
-      react-server-dom-webpack:
-        specifier: 'catalog:'
-        version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       vinext:
         specifier: workspace:*
         version: link:../../../packages/vinext
@@ -1681,16 +1606,13 @@ importers:
     dependencies:
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
-        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
-      react-server-dom-webpack:
-        specifier: 'catalog:'
-        version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       vinext:
         specifier: workspace:*
         version: link:../../../packages/vinext
@@ -1706,16 +1628,13 @@ importers:
     dependencies:
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
-        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
-      react-server-dom-webpack:
-        specifier: 'catalog:'
-        version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       vinext:
         specifier: workspace:*
         version: link:../../../packages/vinext
@@ -1741,10 +1660,10 @@ importers:
     dependencies:
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       vinext:
         specifier: workspace:*
         version: link:../../../packages/vinext
@@ -1760,10 +1679,10 @@ importers:
     dependencies:
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       vinext:
         specifier: workspace:*
         version: link:../../../packages/vinext
@@ -1781,10 +1700,10 @@ importers:
     dependencies:
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       vinext:
         specifier: workspace:*
         version: link:../../../packages/vinext
@@ -1803,16 +1722,13 @@ importers:
         version: 1.31.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(workerd@1.20260401.1)(wrangler@4.80.0)
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
-        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
-      react-server-dom-webpack:
-        specifier: 'catalog:'
-        version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       vinext:
         specifier: workspace:*
         version: link:../../../packages/vinext
@@ -1836,16 +1752,13 @@ importers:
     dependencies:
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
-        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
-      react-server-dom-webpack:
-        specifier: 'catalog:'
-        version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       vinext:
         specifier: workspace:*
         version: link:../../../packages/vinext
@@ -1861,10 +1774,10 @@ importers:
     dependencies:
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       shiki:
         specifier: 'catalog:'
         version: 4.0.2
@@ -1883,16 +1796,13 @@ importers:
     dependencies:
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
-        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
-      react-server-dom-webpack:
-        specifier: 'catalog:'
-        version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       vinext:
         specifier: workspace:*
         version: link:../../../packages/vinext
@@ -1904,16 +1814,13 @@ importers:
     dependencies:
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
-        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
-      react-server-dom-webpack:
-        specifier: 'catalog:'
-        version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       vinext:
         specifier: workspace:*
         version: link:../../../packages/vinext
@@ -1925,16 +1832,13 @@ importers:
     dependencies:
       '@vitejs/plugin-rsc':
         specifier: 'catalog:'
-        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       react:
         specifier: 'catalog:'
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: 'catalog:'
-        version: 19.2.7(react@19.2.7)
-      react-server-dom-webpack:
-        specifier: 'catalog:'
-        version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       vinext:
         specifier: workspace:*
         version: link:../../../packages/vinext
@@ -7769,10 +7673,10 @@ packages:
     peerDependencies:
       react: '>=16.8.0'
 
-  react-dom@19.2.7:
-    resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
+  react-dom@19.2.8:
+    resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
     peerDependencies:
-      react: ^19.2.7
+      react: ^19.2.8
 
   react-i18next@15.7.4:
     resolution: {integrity: sha512-nyU8iKNrI5uDJch0z9+Y5XEr34b0wkyYj3Rp+tfbahxtlswxSCjcUL9H0nqXo9IR3/t5Y5PKIA3fx3MfUyR9Xw==}
@@ -7819,12 +7723,12 @@ packages:
       '@types/react':
         optional: true
 
-  react-server-dom-webpack@19.2.7:
-    resolution: {integrity: sha512-bYfuvqPJnHB4CHo2Ze7fQyJAO77TUu1W/aKFt81ICXbLiOTg5jHaO/NPDlpvGWUALoEGaGb7Oi1uXAaO+Bw6jw==}
+  react-server-dom-webpack@19.2.8:
+    resolution: {integrity: sha512-rFO1VJZ+cH9ZH6hGy9+qmIsmZHZpCMKJZXhWHqT71UnSfg+w+W+gwrwp58MVzMqdFquG8GF1c6C8q0OGphkEdg==}
     engines: {node: '>=0.10.0'}
     peerDependencies:
-      react: ^19.2.7
-      react-dom: ^19.2.7
+      react: ^19.2.8
+      react-dom: ^19.2.8
       webpack: ^5.59.0
 
   react-style-singleton@2.2.3:
@@ -7837,8 +7741,8 @@ packages:
       '@types/react':
         optional: true
 
-  react@19.2.7:
-    resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
+  react@19.2.8:
+    resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
     engines: {node: '>=0.10.0'}
 
   read-yaml-file@1.1.0:
@@ -8781,28 +8685,28 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@base-ui/react@1.4.1(@date-fns/tz@1.4.1)(@types/react@19.2.16)(date-fns@4.1.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@base-ui/react@1.4.1(@date-fns/tz@1.4.1)(@types/react@19.2.16)(date-fns@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@babel/runtime': 7.29.2
-      '@base-ui/utils': 0.2.8(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@base-ui/utils': 0.2.8(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@floating-ui/utils': 0.2.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      use-sync-external-store: 1.6.0(react@19.2.7)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      use-sync-external-store: 1.6.0(react@19.2.8)
     optionalDependencies:
       '@date-fns/tz': 1.4.1
       '@types/react': 19.2.16
       date-fns: 4.1.0
 
-  '@base-ui/utils@0.2.8(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@base-ui/utils@0.2.8(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@floating-ui/utils': 0.2.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
       reselect: 5.1.1
-      use-sync-external-store: 1.6.0(react@19.2.7)
+      use-sync-external-store: 1.6.0(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.16
 
@@ -9005,17 +8909,17 @@ snapshots:
       human-id: 4.2.0
       prettier: 2.8.8
 
-  '@cloudflare/kumo@2.2.0(@date-fns/tz@1.4.1)(@phosphor-icons/react@2.1.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.16)(date-fns@4.1.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.3.6)':
+  '@cloudflare/kumo@2.2.0(@date-fns/tz@1.4.1)(@phosphor-icons/react@2.1.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/react@19.2.16)(date-fns@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.3.6)':
     dependencies:
-      '@base-ui/react': 1.4.1(@date-fns/tz@1.4.1)(@types/react@19.2.16)(date-fns@4.1.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@phosphor-icons/react': 2.1.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@base-ui/react': 1.4.1(@date-fns/tz@1.4.1)(@types/react@19.2.16)(date-fns@4.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@phosphor-icons/react': 2.1.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@shikijs/langs': 4.0.2
       '@shikijs/themes': 4.0.2
       clsx: 2.1.1
-      motion: 12.38.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react: 19.2.7
-      react-day-picker: 9.13.2(react@19.2.7)
-      react-dom: 19.2.7(react@19.2.7)
+      motion: 12.38.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react: 19.2.8
+      react-day-picker: 9.13.2(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
       shiki: 4.0.2
       tailwind-merge: 3.5.0
     optionalDependencies:
@@ -9333,11 +9237,11 @@ snapshots:
       '@floating-ui/core': 1.7.5
       '@floating-ui/utils': 0.2.11
 
-  '@floating-ui/react-dom@2.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@floating-ui/react-dom@2.1.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@floating-ui/dom': 1.7.6
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
 
   '@floating-ui/utils@0.2.11': {}
 
@@ -9380,9 +9284,9 @@ snapshots:
     optionalDependencies:
       tailwindcss: 4.1.4
 
-  '@heroicons/react@2.2.0(react@19.2.7)':
+  '@heroicons/react@2.2.0(react@19.2.8)':
     dependencies:
-      react: 19.2.7
+      react: 19.2.8
 
   '@img/colour@1.0.0': {}
 
@@ -9593,11 +9497,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@mdx-js/react@3.1.1(@types/react@19.2.16)(react@19.2.7)':
+  '@mdx-js/react@3.1.1(@types/react@19.2.16)(react@19.2.8)':
     dependencies:
       '@types/mdx': 2.0.13
       '@types/react': 19.2.16
-      react: 19.2.7
+      react: 19.2.8
 
   '@mdx-js/rollup@3.1.1(rollup@4.62.2)':
     dependencies:
@@ -9627,12 +9531,12 @@ snapshots:
 
   '@next/env@16.2.7': {}
 
-  '@next/mdx@16.2.7(@mdx-js/loader@3.1.0)(@mdx-js/react@3.1.1(@types/react@19.2.16)(react@19.2.7))':
+  '@next/mdx@16.2.7(@mdx-js/loader@3.1.0)(@mdx-js/react@3.1.1(@types/react@19.2.16)(react@19.2.8))':
     dependencies:
       source-map: 0.7.6
     optionalDependencies:
       '@mdx-js/loader': 3.1.0
-      '@mdx-js/react': 3.1.1(@types/react@19.2.16)(react@19.2.7)
+      '@mdx-js/react': 3.1.1(@types/react@19.2.16)(react@19.2.8)
 
   '@next/swc-darwin-arm64@16.2.7':
     optional: true
@@ -10106,10 +10010,10 @@ snapshots:
       '@parcel/watcher-win32-ia32': 2.5.6
       '@parcel/watcher-win32-x64': 2.5.6
 
-  '@phosphor-icons/react@2.1.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@phosphor-icons/react@2.1.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
 
   '@playwright/test@1.60.0':
     dependencies:
@@ -10133,393 +10037,393 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
-  '@radix-ui/react-accordion@1.2.12(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@radix-ui/react-accordion@1.2.12(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.16)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.16)(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.16
       '@types/react-dom': 19.2.3(@types/react@19.2.16)
 
-  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.16
       '@types/react-dom': 19.2.3(@types/react@19.2.16)
 
-  '@radix-ui/react-collapsible@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@radix-ui/react-collapsible@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.16)(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.16
       '@types/react-dom': 19.2.3(@types/react@19.2.16)
 
-  '@radix-ui/react-collection@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@radix-ui/react-collection@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.16)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.16)(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.16
       '@types/react-dom': 19.2.3(@types/react@19.2.16)
 
-  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.16)(react@19.2.7)':
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.16)(react@19.2.8)':
     dependencies:
-      react: 19.2.7
+      react: 19.2.8
     optionalDependencies:
       '@types/react': 19.2.16
 
-  '@radix-ui/react-context@1.1.2(@types/react@19.2.16)(react@19.2.7)':
+  '@radix-ui/react-context@1.1.2(@types/react@19.2.16)(react@19.2.8)':
     dependencies:
-      react: 19.2.7
+      react: 19.2.8
     optionalDependencies:
       '@types/react': 19.2.16
 
-  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.16)(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.16)(react@19.2.8)
       aria-hidden: 1.2.6
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      react-remove-scroll: 2.7.2(@types/react@19.2.16)(react@19.2.7)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-remove-scroll: 2.7.2(@types/react@19.2.16)(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.16
       '@types/react-dom': 19.2.3(@types/react@19.2.16)
 
-  '@radix-ui/react-direction@1.1.1(@types/react@19.2.16)(react@19.2.7)':
+  '@radix-ui/react-direction@1.1.1(@types/react@19.2.16)(react@19.2.8)':
     dependencies:
-      react: 19.2.7
+      react: 19.2.8
     optionalDependencies:
       '@types/react': 19.2.16
 
-  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.16)(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.16
       '@types/react-dom': 19.2.3(@types/react@19.2.16)
 
-  '@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.16)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.16)(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.16
       '@types/react-dom': 19.2.3(@types/react@19.2.16)
 
-  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.16)(react@19.2.7)':
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.16)(react@19.2.8)':
     dependencies:
-      react: 19.2.7
+      react: 19.2.8
     optionalDependencies:
       '@types/react': 19.2.16
 
-  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.16)(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.16
       '@types/react-dom': 19.2.3(@types/react@19.2.16)
 
-  '@radix-ui/react-id@1.1.1(@types/react@19.2.16)(react@19.2.7)':
+  '@radix-ui/react-id@1.1.1(@types/react@19.2.16)(react@19.2.8)':
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      react: 19.2.7
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.16)(react@19.2.8)
+      react: 19.2.8
     optionalDependencies:
       '@types/react': 19.2.16
 
-  '@radix-ui/react-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@radix-ui/react-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.16)(react@19.2.7)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.16)(react@19.2.8)
       aria-hidden: 1.2.6
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      react-remove-scroll: 2.7.2(@types/react@19.2.16)(react@19.2.7)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-remove-scroll: 2.7.2(@types/react@19.2.16)(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.16
       '@types/react-dom': 19.2.3(@types/react@19.2.16)
 
-  '@radix-ui/react-navigation-menu@1.2.14(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@radix-ui/react-navigation-menu@1.2.14(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.16
       '@types/react-dom': 19.2.3(@types/react@19.2.16)
 
-  '@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.16)(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.16)(react@19.2.8)
       aria-hidden: 1.2.6
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      react-remove-scroll: 2.7.2(@types/react@19.2.16)(react@19.2.7)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-remove-scroll: 2.7.2(@types/react@19.2.16)(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.16
       '@types/react-dom': 19.2.3(@types/react@19.2.16)
 
-  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.16)(react@19.2.7)
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.16)(react@19.2.8)
       '@radix-ui/rect': 1.1.1
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.16
       '@types/react-dom': 19.2.3(@types/react@19.2.16)
 
-  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.16)(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.16
       '@types/react-dom': 19.2.3(@types/react@19.2.16)
 
-  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.16)(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.16
       '@types/react-dom': 19.2.3(@types/react@19.2.16)
 
-  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.16)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.16)(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.16
       '@types/react-dom': 19.2.3(@types/react@19.2.16)
 
-  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.16)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.16)(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.16
       '@types/react-dom': 19.2.3(@types/react@19.2.16)
 
-  '@radix-ui/react-scroll-area@1.2.10(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@radix-ui/react-scroll-area@1.2.10(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@radix-ui/number': 1.1.1
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.16)(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.16
       '@types/react-dom': 19.2.3(@types/react@19.2.16)
 
-  '@radix-ui/react-slot@1.2.3(@types/react@19.2.16)(react@19.2.7)':
+  '@radix-ui/react-slot@1.2.3(@types/react@19.2.16)(react@19.2.8)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.16)(react@19.2.7)
-      react: 19.2.7
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.16)(react@19.2.8)
+      react: 19.2.8
     optionalDependencies:
       '@types/react': 19.2.16
 
-  '@radix-ui/react-slot@1.2.4(@types/react@19.2.16)(react@19.2.7)':
+  '@radix-ui/react-slot@1.2.4(@types/react@19.2.16)(react@19.2.8)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.16)(react@19.2.7)
-      react: 19.2.7
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.16)(react@19.2.8)
+      react: 19.2.8
     optionalDependencies:
       '@types/react': 19.2.16
 
-  '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.16)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.16)(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.16
       '@types/react-dom': 19.2.3(@types/react@19.2.16)
 
-  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.16)(react@19.2.7)':
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.16)(react@19.2.8)':
     dependencies:
-      react: 19.2.7
+      react: 19.2.8
     optionalDependencies:
       '@types/react': 19.2.16
 
-  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.16)(react@19.2.7)':
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.16)(react@19.2.8)':
     dependencies:
-      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      react: 19.2.7
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.16)(react@19.2.8)
+      react: 19.2.8
     optionalDependencies:
       '@types/react': 19.2.16
 
-  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.16)(react@19.2.7)':
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.16)(react@19.2.8)':
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      react: 19.2.7
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.16)(react@19.2.8)
+      react: 19.2.8
     optionalDependencies:
       '@types/react': 19.2.16
 
-  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.16)(react@19.2.7)':
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.16)(react@19.2.8)':
     dependencies:
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      react: 19.2.7
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.16)(react@19.2.8)
+      react: 19.2.8
     optionalDependencies:
       '@types/react': 19.2.16
 
-  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.16)(react@19.2.7)':
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.16)(react@19.2.8)':
     dependencies:
-      react: 19.2.7
+      react: 19.2.8
     optionalDependencies:
       '@types/react': 19.2.16
 
-  '@radix-ui/react-use-previous@1.1.1(@types/react@19.2.16)(react@19.2.7)':
+  '@radix-ui/react-use-previous@1.1.1(@types/react@19.2.16)(react@19.2.8)':
     dependencies:
-      react: 19.2.7
+      react: 19.2.8
     optionalDependencies:
       '@types/react': 19.2.16
 
-  '@radix-ui/react-use-rect@1.1.1(@types/react@19.2.16)(react@19.2.7)':
+  '@radix-ui/react-use-rect@1.1.1(@types/react@19.2.16)(react@19.2.8)':
     dependencies:
       '@radix-ui/rect': 1.1.1
-      react: 19.2.7
+      react: 19.2.8
     optionalDependencies:
       '@types/react': 19.2.16
 
-  '@radix-ui/react-use-size@1.1.1(@types/react@19.2.16)(react@19.2.7)':
+  '@radix-ui/react-use-size@1.1.1(@types/react@19.2.16)(react@19.2.8)':
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      react: 19.2.7
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.16)(react@19.2.8)
+      react: 19.2.8
     optionalDependencies:
       '@types/react': 19.2.16
 
-  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.16
       '@types/react-dom': 19.2.3(@types/react@19.2.16)
@@ -10757,7 +10661,7 @@ snapshots:
     dependencies:
       '@sentry/core': 10.62.0
 
-  '@sentry/nextjs@10.62.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0))(react@19.2.7)':
+  '@sentry/nextjs@10.62.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.100.0))(react@19.2.8)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@rollup/plugin-commonjs': 28.0.1(rollup@4.62.2)
@@ -10767,10 +10671,10 @@ snapshots:
       '@sentry/core': 10.62.0
       '@sentry/node': 10.62.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))
       '@sentry/opentelemetry': 10.62.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))
-      '@sentry/react': 10.62.0(react@19.2.7)
+      '@sentry/react': 10.62.0(react@19.2.8)
       '@sentry/vercel-edge': 10.62.0
       '@sentry/webpack-plugin': 5.3.0
-      next: 16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0)
+      next: 16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.100.0)
       rollup: 4.62.2
       stacktrace-parser: 0.1.11
     transitivePeerDependencies:
@@ -10818,11 +10722,11 @@ snapshots:
       '@sentry/conventions': 0.12.0
       '@sentry/core': 10.62.0
 
-  '@sentry/react@10.62.0(react@19.2.7)':
+  '@sentry/react@10.62.0(react@19.2.8)':
     dependencies:
       '@sentry/browser': 10.62.0
       '@sentry/core': 10.62.0
-      react: 19.2.7
+      react: 19.2.8
 
   '@sentry/replay-canvas@10.62.0':
     dependencies:
@@ -11315,13 +11219,13 @@ snapshots:
     dependencies:
       unpic: 4.2.2
 
-  '@unpic/react@1.0.2(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@unpic/react@1.0.2(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.100.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@unpic/core': 1.0.3
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
-      next: 16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0)
+      next: 16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.100.0)
 
   '@vercel/og@0.8.6':
     dependencies:
@@ -11335,21 +11239,21 @@ snapshots:
     optionalDependencies:
       oxc-transform-react: 0.145.0
 
-  '@vitejs/plugin-rsc@0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+  '@vitejs/plugin-rsc@0.5.34(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       es-module-lexer: 2.3.1
       estree-walker: 3.0.3
       magic-string: 0.30.21
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
       srvx: 0.12.5
       strip-literal: 3.1.0
       turbo-stream: 3.2.0
       vite: '@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0)'
       vitefu: 1.1.3(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))
     optionalDependencies:
-      react-server-dom-webpack: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react-server-dom-webpack: 19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
 
   '@vitest/browser-preview@4.1.10(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(msw@2.14.6(@types/node@25.9.2)(typescript@7.0.2))(vitest@4.1.10)':
     dependencies:
@@ -11620,7 +11524,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.25: {}
 
-  better-auth@1.5.6(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.1)(better-sqlite3@12.6.2)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.1)(better-sqlite3@12.6.2)(kysely@0.28.15))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10):
+  better-auth@1.5.6(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.1)(better-sqlite3@12.6.2)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.1)(better-sqlite3@12.6.2)(kysely@0.28.15))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.100.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10):
     dependencies:
       '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.15)(nanostores@1.2.0)
       '@better-auth/drizzle-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.1)(better-sqlite3@12.6.2)(kysely@0.28.15))
@@ -11643,9 +11547,9 @@ snapshots:
       better-sqlite3: 12.6.2
       drizzle-kit: 0.31.10
       drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260313.1)(@opentelemetry/api@1.9.1)(better-sqlite3@12.6.2)(kysely@0.28.15)
-      next: 16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      next: 16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.100.0)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
       vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/browser-preview@4.1.10)(@vitest/coverage-istanbul@4.1.10(vitest@4.1.10))(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(msw@2.14.6(@types/node@25.9.2)(typescript@7.0.2))
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
@@ -12163,14 +12067,14 @@ snapshots:
     dependencies:
       fd-package-json: 2.0.0
 
-  framer-motion@12.38.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  framer-motion@12.38.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       motion-dom: 12.38.0
       motion-utils: 12.36.0
       tslib: 2.8.1
     optionalDependencies:
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
 
   fs-constants@1.0.0: {}
 
@@ -12192,7 +12096,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  fumadocs-core@16.7.9(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.7))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.3.6):
+  fumadocs-core@16.7.9(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.8))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.100.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.3.6):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.2
       '@orama/orama': 3.1.18
@@ -12223,22 +12127,22 @@ snapshots:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       '@types/react': 19.2.16
-      lucide-react: 0.577.0(react@19.2.7)
-      next: 16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      lucide-react: 0.577.0(react@19.2.8)
+      next: 16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.100.0)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
       zod: 4.3.6
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@14.2.10(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.16)(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(fumadocs-core@16.7.9(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.7))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.3.6))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0))(react@19.2.7):
+  fumadocs-mdx@14.2.10(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.16)(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(fumadocs-core@16.7.9(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.8))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.100.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.3.6))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.100.0))(react@19.2.8):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.27.3
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.7.9(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.7))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.3.6)
+      fumadocs-core: 16.7.9(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.8))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.100.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.3.6)
       js-yaml: 4.1.1
       mdast-util-mdx: 3.0.0
       mdast-util-to-markdown: 2.1.2
@@ -12255,34 +12159,34 @@ snapshots:
       '@types/mdast': 4.0.4
       '@types/mdx': 2.0.13
       '@types/react': 19.2.16
-      next: 16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0)
-      react: 19.2.7
+      next: 16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.100.0)
+      react: 19.2.8
       vite: '@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.27.3)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0)'
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-ui@16.7.9(@takumi-rs/image-response@0.72.0)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(fumadocs-core@16.7.9(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.7))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.3.6))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(shiki@4.0.2)(tailwindcss@4.1.4):
+  fumadocs-ui@16.7.9(@takumi-rs/image-response@0.72.0)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(fumadocs-core@16.7.9(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.8))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.100.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.3.6))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.100.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(shiki@4.0.2)(tailwindcss@4.1.4):
     dependencies:
       '@fumadocs/tailwind': 0.0.3(tailwindcss@4.1.4)
-      '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-navigation-menu': 1.2.14(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-scroll-area': 1.2.10(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.16)(react@19.2.7)
-      '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-navigation-menu': 1.2.14(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-scroll-area': 1.2.10(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.16)(react@19.2.8)
+      '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.7.9(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.7))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.3.6)
-      lucide-react: 1.7.0(react@19.2.7)
-      motion: 12.38.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      next-themes: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      react-medium-image-zoom: 5.4.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react-remove-scroll: 2.7.2(@types/react@19.2.16)(react@19.2.7)
+      fumadocs-core: 16.7.9(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.16)(lucide-react@0.577.0(react@19.2.8))(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.100.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.3.6)
+      lucide-react: 1.7.0(react@19.2.8)
+      motion: 12.38.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next-themes: 0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-medium-image-zoom: 5.4.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react-remove-scroll: 2.7.2(@types/react@19.2.16)(react@19.2.8)
       rehype-raw: 7.0.0
       scroll-into-view-if-needed: 3.1.0
       tailwind-merge: 3.5.0
@@ -12291,7 +12195,7 @@ snapshots:
       '@takumi-rs/image-response': 0.72.0
       '@types/mdx': 2.0.13
       '@types/react': 19.2.16
-      next: 16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0)
+      next: 16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.100.0)
       shiki: 4.0.2
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
@@ -12812,13 +12716,13 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  lucide-react@0.577.0(react@19.2.7):
+  lucide-react@0.577.0(react@19.2.8):
     dependencies:
-      react: 19.2.7
+      react: 19.2.8
 
-  lucide-react@1.7.0(react@19.2.7):
+  lucide-react@1.7.0(react@19.2.8):
     dependencies:
-      react: 19.2.7
+      react: 19.2.8
 
   lz-string@1.5.0: {}
 
@@ -13312,13 +13216,13 @@ snapshots:
 
   motion-utils@12.36.0: {}
 
-  motion@12.38.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  motion@12.38.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
-      framer-motion: 12.38.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      framer-motion: 12.38.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       tslib: 2.8.1
     optionalDependencies:
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
 
   mri@1.2.0: {}
 
@@ -13367,44 +13271,44 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.11.1: {}
 
-  next-intl@4.11.1(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0))(react@19.2.7)(typescript@7.0.2):
+  next-intl@4.11.1(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.100.0))(react@19.2.8)(typescript@7.0.2):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.2
       '@parcel/watcher': 2.5.6
       '@swc/core': 1.15.11
       icu-minify: 4.11.1
       negotiator: 1.0.0
-      next: 16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0)
+      next: 16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.100.0)
       next-intl-swc-plugin-extractor: 4.11.1
       po-parser: 2.1.1
-      react: 19.2.7
-      use-intl: 4.11.1(react@19.2.7)
+      react: 19.2.8
+      use-intl: 4.11.1(react@19.2.8)
     optionalDependencies:
       typescript: 7.0.2
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  next-themes@0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next-themes@0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
 
-  next-view-transitions@0.3.5(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next-view-transitions@0.3.5(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.100.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
-      next: 16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      next: 16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.100.0)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
 
-  next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0):
+  next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.100.0):
     dependencies:
       '@next/env': 16.2.7
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.25
       caniuse-lite: 1.0.30001791
       postcss: 8.4.31
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      styled-jsx: 5.1.6(react@19.2.7)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      styled-jsx: 5.1.6(react@19.2.8)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.7
       '@next/swc-darwin-x64': 16.2.7
@@ -13490,12 +13394,12 @@ snapshots:
 
   npm-to-yarn@3.0.1: {}
 
-  nuqs@2.8.8(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0))(react@19.2.7):
+  nuqs@2.8.8(next@16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.100.0))(react@19.2.8):
     dependencies:
       '@standard-schema/spec': 1.0.0
-      react: 19.2.7
+      react: 19.2.8
     optionalDependencies:
-      next: 16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.100.0)
+      next: 16.2.7(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.100.0)
 
   obug@2.1.1: {}
 
@@ -13815,71 +13719,71 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  react-day-picker@9.13.2(react@19.2.7):
+  react-day-picker@9.13.2(react@19.2.8):
     dependencies:
       '@date-fns/tz': 1.4.1
       date-fns: 4.1.0
       date-fns-jalali: 4.1.0-0
-      react: 19.2.7
+      react: 19.2.8
 
-  react-dom@19.2.7(react@19.2.7):
+  react-dom@19.2.8(react@19.2.8):
     dependencies:
-      react: 19.2.7
+      react: 19.2.8
       scheduler: 0.27.0
 
-  react-i18next@15.7.4(i18next@24.2.3(typescript@7.0.2))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@7.0.2):
+  react-i18next@15.7.4(i18next@24.2.3(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2):
     dependencies:
       '@babel/runtime': 7.29.2
       html-parse-stringify: 3.1.0
       i18next: 24.2.3(typescript@7.0.2)
-      react: 19.2.7
+      react: 19.2.8
     optionalDependencies:
-      react-dom: 19.2.7(react@19.2.7)
+      react-dom: 19.2.8(react@19.2.8)
       typescript: 7.0.2
 
   react-is@17.0.2: {}
 
-  react-medium-image-zoom@5.4.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  react-medium-image-zoom@5.4.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
 
-  react-remove-scroll-bar@2.3.8(@types/react@19.2.16)(react@19.2.7):
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.16)(react@19.2.8):
     dependencies:
-      react: 19.2.7
-      react-style-singleton: 2.2.3(@types/react@19.2.16)(react@19.2.7)
+      react: 19.2.8
+      react-style-singleton: 2.2.3(@types/react@19.2.16)(react@19.2.8)
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.16
 
-  react-remove-scroll@2.7.2(@types/react@19.2.16)(react@19.2.7):
+  react-remove-scroll@2.7.2(@types/react@19.2.16)(react@19.2.8):
     dependencies:
-      react: 19.2.7
-      react-remove-scroll-bar: 2.3.8(@types/react@19.2.16)(react@19.2.7)
-      react-style-singleton: 2.2.3(@types/react@19.2.16)(react@19.2.7)
+      react: 19.2.8
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.16)(react@19.2.8)
+      react-style-singleton: 2.2.3(@types/react@19.2.16)(react@19.2.8)
       tslib: 2.8.1
-      use-callback-ref: 1.3.3(@types/react@19.2.16)(react@19.2.7)
-      use-sidecar: 1.1.3(@types/react@19.2.16)(react@19.2.7)
+      use-callback-ref: 1.3.3(@types/react@19.2.16)(react@19.2.8)
+      use-sidecar: 1.1.3(@types/react@19.2.16)(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.16
 
-  react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       acorn-loose: 8.5.2
       neo-async: 2.6.2
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
       webpack-sources: 3.3.4
 
-  react-style-singleton@2.2.3(@types/react@19.2.16)(react@19.2.7):
+  react-style-singleton@2.2.3(@types/react@19.2.16)(react@19.2.8):
     dependencies:
       get-nonce: 1.0.1
-      react: 19.2.7
+      react: 19.2.8
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.16
 
-  react@19.2.7: {}
+  react@19.2.8: {}
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -14290,10 +14194,10 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  styled-jsx@5.1.6(react@19.2.7):
+  styled-jsx@5.1.6(react@19.2.8):
     dependencies:
       client-only: 0.0.1
-      react: 19.2.7
+      react: 19.2.8
 
   supports-color@10.2.2: {}
 
@@ -14301,11 +14205,11 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  swr@2.4.0(react@19.2.7):
+  swr@2.4.0(react@19.2.8):
     dependencies:
       dequal: 2.0.3
-      react: 19.2.7
-      use-sync-external-store: 1.6.0(react@19.2.7)
+      react: 19.2.8
+      use-sync-external-store: 1.6.0(react@19.2.8)
 
   tagged-tag@1.0.0: {}
 
@@ -14499,41 +14403,41 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
-  use-callback-ref@1.3.3(@types/react@19.2.16)(react@19.2.7):
+  use-callback-ref@1.3.3(@types/react@19.2.16)(react@19.2.8):
     dependencies:
-      react: 19.2.7
+      react: 19.2.8
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.16
 
-  use-count-up@3.0.1(react@19.2.7):
+  use-count-up@3.0.1(react@19.2.8):
     dependencies:
-      react: 19.2.7
-      use-elapsed-time: 3.0.2(react@19.2.7)
+      react: 19.2.8
+      use-elapsed-time: 3.0.2(react@19.2.8)
 
-  use-elapsed-time@3.0.2(react@19.2.7):
+  use-elapsed-time@3.0.2(react@19.2.8):
     dependencies:
-      react: 19.2.7
+      react: 19.2.8
 
-  use-intl@4.11.1(react@19.2.7):
+  use-intl@4.11.1(react@19.2.8):
     dependencies:
       '@formatjs/fast-memoize': 3.1.1
       '@schummar/icu-type-parser': 1.21.5
       icu-minify: 4.11.1
       intl-messageformat: 11.1.2
-      react: 19.2.7
+      react: 19.2.8
 
-  use-sidecar@1.1.3(@types/react@19.2.16)(react@19.2.7):
+  use-sidecar@1.1.3(@types/react@19.2.16)(react@19.2.8):
     dependencies:
       detect-node-es: 1.1.0
-      react: 19.2.7
+      react: 19.2.8
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.16
 
-  use-sync-external-store@1.6.0(react@19.2.7):
+  use-sync-external-store@1.6.0(react@19.2.8):
     dependencies:
-      react: 19.2.7
+      react: 19.2.8
 
   util-deprecate@1.0.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -76,9 +76,9 @@ catalog:
   pathslash: ^0.1.0
   playwright: ^1.60.0
   postcss: 8.5.10
-  react: ^19.2.7
-  react-dom: ^19.2.7
-  react-server-dom-webpack: ^19.2.7
+  react: ^19.2.8
+  react-dom: ^19.2.8
+  react-server-dom-webpack: ^19.2.8
   sass: 1.100.0
   server-only: ^0.0.1
   shiki: 4.0.2

--- a/scripts/e2e-deploy.sh
+++ b/scripts/e2e-deploy.sh
@@ -509,12 +509,11 @@ fs.writeFileSync(
 pkg.devDependencies = pkg.devDependencies || {}
 pkg.devDependencies.vinext = 'file:.vinext-local-package'
 
-// App Router fixtures need React to satisfy the same peer range as the
-// injected react-server-dom-webpack. If they install an older React pair first,
-// `vinext build` runs its RSC compatibility upgrade and pays for a second
-// package-manager install inside every throwaway test app. Normalize the temp
-// manifest before the first install so the final dependency graph is unchanged
-// but setup is single-pass.
+// App Router fixtures need React to match plugin-rsc's vendored Flight runtime.
+// If they install an older React pair first, `vinext build` runs its RSC
+// compatibility upgrade and pays for a second package-manager install inside
+// every throwaway test app. Normalize the temp manifest before the first install
+// so the final dependency graph is unchanged but setup is single-pass.
 function hasAppRouterDir(root) {
   return fs.existsSync(path.join(root, 'app')) || fs.existsSync(path.join(root, 'src', 'app'))
 }
@@ -575,7 +574,6 @@ for (const dep of [
   'vite',
   '@vitejs/plugin-react',
   '@vitejs/plugin-rsc',
-  'react-server-dom-webpack',
   '@mdx-js/rollup',
   '@mdx-js/react',
   'ipaddr.js',

--- a/tests/action-runtime-security.test.ts
+++ b/tests/action-runtime-security.test.ts
@@ -254,7 +254,9 @@ export default function Page() {
     const builder = await createBuilder({
       root: fixtureRoot,
       configFile: false,
-      plugins: [vinext({ appDir: fixtureRoot, rsc: false }), rsc({ entries: RSC_ENTRIES })],
+      // Keep appDir implicit so this also verifies manual RSC helper plugins
+      // follow a programmatic Vite root outside process.cwd().
+      plugins: [vinext({ rsc: false }), rsc({ entries: RSC_ENTRIES })],
       logLevel: "silent",
     });
     await builder.buildApp();

--- a/tests/app-router-dev-server.test.ts
+++ b/tests/app-router-dev-server.test.ts
@@ -2102,13 +2102,16 @@ describe("App Router integration", () => {
     }
   });
 
-  it("includes the static RSC renderer in startup dependency optimization", async () => {
+  it("uses plugin-rsc's vendored static renderer when no RSDW override is installed", async () => {
     const rscEnvironment = server.environments.rsc;
     await rscEnvironment.waitForRequestsIdle();
 
-    const optimizedDependencies =
-      rscEnvironment.depsOptimizer?.metadata.depInfoList.map((dep) => dep.id) ?? [];
-    expect(optimizedDependencies).toContain("react-server-dom-webpack/static.edge");
+    const optimizedDependencies = rscEnvironment.depsOptimizer?.metadata.depInfoList ?? [];
+    const staticRenderer = optimizedDependencies.find((dep) => dep.id.endsWith("/static.edge"));
+    expect(staticRenderer?.id).toBe("@vitejs/plugin-rsc/vendor/react-server-dom/static.edge");
+    expect(staticRenderer?.src).toContain(
+      "@vitejs/plugin-rsc/dist/vendor/react-server-dom/static.edge.js",
+    );
   });
 
   // ── CSRF protection for server actions ───────────────────────────────

--- a/tests/app-router-rsc-plugin.test.ts
+++ b/tests/app-router-rsc-plugin.test.ts
@@ -186,20 +186,19 @@ describe("RSC plugin auto-registration", () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-no-app-"));
     try {
       // Empty directory — no app/ or src/app/.
-      const plugins = vinext({ appDir: tmpDir, react: false });
-
-      const resolvedPlugins = (
-        await Promise.all(
-          plugins.map(async (plugin) => {
-            if (plugin && typeof (plugin as any).then === "function") {
-              return await (plugin as Promise<any>);
-            }
-            return plugin;
-          }),
-        )
-      ).flat();
-
-      const hasRscPlugin = resolvedPlugins.some((p) => p && (p as any).name === "rsc");
+      // RSC plugins are prepared eagerly so they can honor a programmatic Vite
+      // root, then filtered by `apply` once that root is known.
+      const { resolveConfig } = await import("vite");
+      const config = await resolveConfig(
+        {
+          root: tmpDir,
+          configFile: false,
+          plugins: vinext({ appDir: tmpDir, react: false }),
+        },
+        "serve",
+        "development",
+      );
+      const hasRscPlugin = config.plugins.some((plugin) => plugin.name === "rsc");
       expect(hasRscPlugin).toBe(false);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/tests/build-optimization.test.ts
+++ b/tests/build-optimization.test.ts
@@ -3924,6 +3924,7 @@ describe("RSC framework package matching", () => {
     "/app/node_modules/react-dom/server.js",
     "/app/node_modules/scheduler/index.js",
     "/app/node_modules/react-server-dom-webpack/client.js",
+    "/app/node_modules/@vitejs/plugin-rsc/dist/vendor/react-server-dom/client.edge.js",
     // pnpm-style nested path.
     "/app/node_modules/.pnpm/react@19.0.0/node_modules/react/index.js",
   ];

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -1696,7 +1696,7 @@ describe("formatReport", () => {
     expect(report).toContain('"type": "module"');
     expect(report).toContain("@vitejs/plugin-react");
     expect(report).toContain("@vitejs/plugin-rsc");
-    expect(report).toContain("react-server-dom-webpack");
+    expect(report).not.toContain("react-server-dom-webpack");
     expect(report).toContain("vite.config.ts");
     expect(report).toContain("npx vite dev");
   });

--- a/tests/create-vinext-app.test.ts
+++ b/tests/create-vinext-app.test.ts
@@ -208,10 +208,11 @@ describe("createVinextApp", () => {
     );
 
     expect(readPkg(appPath).packageManager).toMatch(/^pnpm(?:@|$)/);
-    expect(calls).toContain("pnpm add vinext @vinext/cloudflare");
+    expect(calls).toContain("pnpm add -D @vitejs/plugin-rsc");
+    expect(calls).toContain("pnpm add --save-prod vinext @vinext/cloudflare");
     expect(calls.some((command) => command.includes("react-server-dom-webpack"))).toBe(false);
     expect(calls).toContain(
-      "pnpm add -D vite @vitejs/plugin-react @vitejs/plugin-rsc @cloudflare/vite-plugin wrangler",
+      "pnpm add -D vite @vitejs/plugin-react @cloudflare/vite-plugin wrangler",
     );
     expect(calls.some((command) => command.split(/\s+/).includes("next"))).toBe(false);
     expect(calls.some((command) => command.includes("typegen"))).toBe(false);

--- a/tests/create-vinext-app.test.ts
+++ b/tests/create-vinext-app.test.ts
@@ -154,9 +154,9 @@ describe("createVinextApp", () => {
       react: "latest",
       "react-dom": "latest",
       vinext: "latest",
-      "react-server-dom-webpack": "latest",
       "@vinext/cloudflare": "latest",
     });
+    expect(pkg.dependencies).not.toHaveProperty("react-server-dom-webpack");
     expect(pkg.dependencies).not.toHaveProperty("next");
     expect(readFile(appPath, "tsconfig.json")).not.toContain('"name": "next"');
     expect(pkg.scripts).not.toHaveProperty("postinstall");
@@ -208,7 +208,8 @@ describe("createVinextApp", () => {
     );
 
     expect(readPkg(appPath).packageManager).toMatch(/^pnpm(?:@|$)/);
-    expect(calls).toContain("pnpm add vinext react-server-dom-webpack @vinext/cloudflare");
+    expect(calls).toContain("pnpm add vinext @vinext/cloudflare");
+    expect(calls.some((command) => command.includes("react-server-dom-webpack"))).toBe(false);
     expect(calls).toContain(
       "pnpm add -D vite @vitejs/plugin-react @vitejs/plugin-rsc @cloudflare/vite-plugin wrangler",
     );
@@ -322,8 +323,8 @@ describe("createVinextApp", () => {
     const pkg = readPkg(appPath);
     expect(pkg.dependencies).toMatchObject({
       vinext: "latest",
-      "react-server-dom-webpack": "latest",
     });
+    expect(pkg.dependencies).not.toHaveProperty("react-server-dom-webpack");
     expect(pkg.dependencies).not.toHaveProperty("@vinext/cloudflare");
     expect(pkg.devDependencies).not.toHaveProperty("@cloudflare/vite-plugin");
     expect(pkg.devDependencies).not.toHaveProperty("wrangler");

--- a/tests/css-url-assets.test.ts
+++ b/tests/css-url-assets.test.ts
@@ -319,7 +319,7 @@ describe.each(["plain", "cloudflare"] as const)(
       // Build an isolated copy so the client output (which vinext writes to
       // <root>/dist/client) lands in a temp dir instead of the committed fixture.
       // Borrow app-basic's node_modules for the RSC/React-server deps the App
-      // Router build needs (@vitejs/plugin-rsc, react-server-dom-webpack, …).
+      // Router build needs (@vitejs/plugin-rsc and its vendored Flight runtime).
       tmpDir = await createIsolatedFixture(
         APP_CSS_FIXTURE,
         "vinext-css-url-app-",

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -23,6 +23,7 @@ import {
 import {
   detectPackageManager,
   detectPackageManagerName,
+  detectPackageManagerProductionCommand,
   detectProject,
   findInNodeModules,
   formatMissingCloudflarePluginError,
@@ -2241,7 +2242,7 @@ describe("getMissingDeps", () => {
     expect(missing).not.toContainEqual(expect.objectContaining({ name: "@vitejs/plugin-rsc" }));
   });
 
-  it("reports missing react-server-dom-webpack for App Router", () => {
+  it("does not require react-server-dom-webpack for App Router", () => {
     mkdir(tmpDir, "app");
     const info = detectProject(tmpDir);
     info.hasCloudflarePlugin = true;
@@ -2253,7 +2254,9 @@ describe("getMissingDeps", () => {
     // on filesystem isolation in tmpdir.)
     const notResolvable = () => false;
     const missing = getMissingDeps(info, notResolvable);
-    expect(missing).toContainEqual(expect.objectContaining({ name: "react-server-dom-webpack" }));
+    expect(missing).not.toContainEqual(
+      expect.objectContaining({ name: "react-server-dom-webpack" }),
+    );
   });
 
   it("does not require react-server-dom-webpack for Pages Router", () => {
@@ -3207,18 +3210,21 @@ describe("detectPackageManager", () => {
     writeFile(tmpDir, "pnpm-lock.yaml", "");
     expect(detectPackageManager(tmpDir)).toBe("pnpm add -D");
     expect(detectPackageManagerName(tmpDir)).toBe("pnpm");
+    expect(detectPackageManagerProductionCommand(tmpDir)).toBe("pnpm add --save-prod");
   });
 
   it("detects yarn from yarn.lock", () => {
     writeFile(tmpDir, "yarn.lock", "");
     expect(detectPackageManager(tmpDir)).toBe("yarn add -D");
     expect(detectPackageManagerName(tmpDir)).toBe("yarn");
+    expect(detectPackageManagerProductionCommand(tmpDir)).toBe("yarn add");
   });
 
   it("detects bun from bun.lock (text format, Bun v1.0+)", () => {
     writeFile(tmpDir, "bun.lock", "");
     expect(detectPackageManager(tmpDir)).toBe("bun add -D");
     expect(detectPackageManagerName(tmpDir)).toBe("bun");
+    expect(detectPackageManagerProductionCommand(tmpDir)).toBe("bun add");
   });
 
   it("detects bun from bun.lockb (legacy binary format)", () => {
@@ -3235,6 +3241,7 @@ describe("detectPackageManager", () => {
     try {
       expect(detectPackageManager(tmpDir)).toBe("npm install -D");
       expect(detectPackageManagerName(tmpDir)).toBe("npm");
+      expect(detectPackageManagerProductionCommand(tmpDir)).toBe("npm install --save-prod");
     } finally {
       if (savedUA !== undefined) process.env.npm_config_user_agent = savedUA;
     }

--- a/tests/e2e/app-router/navigation-flows.spec.ts
+++ b/tests/e2e/app-router/navigation-flows.spec.ts
@@ -1,9 +1,54 @@
+import fs from "node:fs";
+import path from "node:path";
 import { test, expect } from "@playwright/test";
 import { disableDevErrorOverlay, waitForAppRouterHydration } from "../helpers";
 
 const BASE = "http://localhost:4174";
+const APP_FIXTURE = path.resolve(process.cwd(), "tests/fixtures/app-basic");
 
 test.describe("App Router navigation flows", () => {
+  test("uses plugin-rsc's vendored Flight runtime without a direct RSDW dependency", async ({
+    page,
+    request,
+  }) => {
+    const manifest = JSON.parse(fs.readFileSync(path.join(APP_FIXTURE, "package.json"), "utf8"));
+    expect(manifest.dependencies).not.toHaveProperty("react-server-dom-webpack");
+    expect(fs.existsSync(path.join(APP_FIXTURE, "node_modules/react-server-dom-webpack"))).toBe(
+      false,
+    );
+
+    const vendoredRuntime = JSON.parse(
+      fs.readFileSync(
+        path.join(
+          APP_FIXTURE,
+          "node_modules/@vitejs/plugin-rsc/dist/vendor/react-server-dom/package.json",
+        ),
+        "utf8",
+      ),
+    );
+    const react = JSON.parse(
+      fs.readFileSync(path.join(APP_FIXTURE, "node_modules/react/package.json"), "utf8"),
+    );
+    expect(vendoredRuntime.version).toBe(react.version);
+
+    await page.goto(`${BASE}/`);
+    await waitForAppRouterHydration(page);
+    await page.evaluate(() => {
+      Reflect.set(window, "__VINEXT_VENDORED_RSC_CANARY__", true);
+    });
+    await page.click('a[href="/about"]');
+    await expect(page.locator("h1")).toHaveText("About");
+    expect(await page.evaluate(() => Reflect.get(window, "__VINEXT_VENDORED_RSC_CANARY__"))).toBe(
+      true,
+    );
+
+    const flight = await request.get(`${BASE}/blog/vendored-runtime.rsc`, {
+      headers: { Accept: "text/x-component", RSC: "1" },
+    });
+    expect(flight.status()).toBe(200);
+    expect(await flight.text()).toContain("vendored-runtime");
+  });
+
   test("multi-page navigation chain without reload", async ({ page }) => {
     await page.goto(`${BASE}/`);
     await expect(page.locator("h1")).toHaveText("Welcome to App Router");

--- a/tests/e2e/app-rsc-isolated-standalone/basic.spec.ts
+++ b/tests/e2e/app-rsc-isolated-standalone/basic.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "@playwright/test";
+import { waitForAppRouterHydration } from "../helpers";
+
+test("runs a relocated App Router standalone artifact from a genuinely RSDW-free install", async ({
+  page,
+  request,
+}) => {
+  await page.goto("/");
+  await expect(page.locator("h1")).toHaveText("RSDW-free standalone");
+  await waitForAppRouterHydration(page);
+
+  await page.locator("#counter").click();
+  await expect(page.locator("#counter")).toHaveText("count:1");
+
+  await page.getByRole("link", { name: "About" }).click();
+  await expect(page.locator("h1")).toHaveText("Isolated about");
+
+  await page.getByRole("link", { name: "Home" }).click();
+  await page.locator("#action").click();
+  await expect(page.locator("#action-result")).toHaveText("action:isolated");
+
+  const flight = await request.get("/.rsc", {
+    headers: { Accept: "text/x-component", RSC: "1" },
+  });
+  expect(flight.status()).toBe(200);
+  expect(await flight.text()).toContain("RSDW-free standalone");
+});

--- a/tests/e2e/app-rsc-isolated-standalone/setup-and-start.mjs
+++ b/tests/e2e/app-rsc-isolated-standalone/setup-and-start.mjs
@@ -1,0 +1,155 @@
+import { spawn, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const port = Number(process.argv[2]);
+if (!Number.isInteger(port) || port <= 0) {
+  throw new Error("Usage: setup-and-start.mjs <port>");
+}
+
+const repoRoot = path.resolve(import.meta.dirname, "../../..");
+const tempRoot = await mkdtemp(path.join(os.tmpdir(), "vinext-rsdw-free-standalone-"));
+const packRoot = path.join(tempRoot, "packages");
+const appRoot = path.join(tempRoot, "app");
+const relocatedRoot = path.join(tempRoot, "relocated");
+process.on("exit", () => fs.rmSync(tempRoot, { recursive: true, force: true }));
+
+function run(command, args, cwd) {
+  const result = spawnSync(command, args, {
+    cwd,
+    stdio: "inherit",
+    env: process.env,
+    shell: process.platform === "win32",
+  });
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args.join(" ")} exited with status ${result.status}`);
+  }
+}
+
+async function write(relativePath, contents) {
+  const outputPath = path.join(appRoot, relativePath);
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, contents);
+}
+
+async function findPackageDirectories(root, packageName) {
+  const matches = [];
+  for (const entry of await readdir(root, { withFileTypes: true })) {
+    const entryPath = path.join(root, entry.name);
+    if (entry.name === packageName) matches.push(entryPath);
+    if (entry.isDirectory())
+      matches.push(...(await findPackageDirectories(entryPath, packageName)));
+  }
+  return matches;
+}
+
+await mkdir(packRoot, { recursive: true });
+run("vp", ["pm", "pack", "--pack-destination", packRoot], path.join(repoRoot, "packages/types"));
+const vinextPackageRoot = path.join(repoRoot, "packages/vinext");
+const vinextReadmePath = path.join(vinextPackageRoot, "README.md");
+const vinextReadme = await readFile(vinextReadmePath);
+try {
+  run("vp", ["pm", "pack", "--pack-destination", packRoot], vinextPackageRoot);
+} finally {
+  await writeFile(vinextReadmePath, vinextReadme);
+}
+
+const tarballs = await readdir(packRoot);
+const typesTarball = tarballs.find((entry) => entry.startsWith("vinext-types-"));
+const vinextTarball = tarballs.find(
+  (entry) => entry.startsWith("vinext-") && !entry.startsWith("vinext-types-"),
+);
+if (!typesTarball || !vinextTarball) {
+  throw new Error(
+    `Expected packed vinext and @vinext/types tarballs, found: ${tarballs.join(", ")}`,
+  );
+}
+
+await write(
+  "package.json",
+  `${JSON.stringify(
+    {
+      name: "vinext-rsdw-free-standalone-e2e",
+      private: true,
+      type: "module",
+      version: "0.0.0",
+      dependencies: {
+        "@vinext/types": pathToFileURL(path.join(packRoot, typesTarball)).href,
+        react: "19.2.8",
+        "react-dom": "19.2.8",
+        vinext: pathToFileURL(path.join(packRoot, vinextTarball)).href,
+      },
+      devDependencies: {
+        "@vitejs/plugin-react": "6.1.0",
+        "@vitejs/plugin-rsc": "0.5.34",
+        vite: "8.0.0",
+      },
+    },
+    null,
+    2,
+  )}\n`,
+);
+await write("next.config.mjs", 'export default { output: "standalone" };\n');
+await write(
+  "vite.config.ts",
+  'import { defineConfig } from "vite";\nimport vinext from "vinext";\nexport default defineConfig({ plugins: [vinext()] });\n',
+);
+await write(
+  "app/layout.tsx",
+  "export default function Layout({ children }: { children: React.ReactNode }) { return <html><body>{children}</body></html>; }\n",
+);
+await write(
+  "app/actions.ts",
+  '"use server";\nexport async function isolatedEcho(value: string) { return `action:${value}`; }\n',
+);
+await write(
+  "app/client-probe.tsx",
+  '"use client";\nimport { useState } from "react";\nimport { isolatedEcho } from "./actions";\nexport function ClientProbe() { const [count, setCount] = useState(0); const [result, setResult] = useState(""); return <><button id="counter" onClick={() => setCount((value) => value + 1)}>count:{count}</button><button id="action" onClick={async () => setResult(await isolatedEcho("isolated"))}>run action</button><output id="action-result">{result}</output></>; }\n',
+);
+await write(
+  "app/page.tsx",
+  'import Link from "next/link";\nimport { ClientProbe } from "./client-probe";\nexport default function Page() { return <main><h1>RSDW-free standalone</h1><ClientProbe /><Link href="/about">About</Link></main>; }\n',
+);
+await write(
+  "app/about/page.tsx",
+  'import Link from "next/link";\nexport default function About() { return <main><h1>Isolated about</h1><Link href="/">Home</Link></main>; }\n',
+);
+
+run(
+  "npm",
+  ["install", "--ignore-scripts", "--no-audit", "--no-fund", "--package-lock=false"],
+  appRoot,
+);
+
+const rsdwPackages = await findPackageDirectories(
+  path.join(appRoot, "node_modules"),
+  "react-server-dom-webpack",
+);
+if (rsdwPackages.length > 0) {
+  throw new Error(`The isolated install unexpectedly contains RSDW: ${rsdwPackages.join(", ")}`);
+}
+
+run(process.execPath, [path.join(appRoot, "node_modules/vinext/dist/cli.js"), "build"], appRoot);
+fs.cpSync(path.join(appRoot, "dist/standalone"), relocatedRoot, { recursive: true });
+await rm(appRoot, { recursive: true, force: true });
+
+const server = spawn(process.execPath, [path.join(relocatedRoot, "server.js")], {
+  cwd: relocatedRoot,
+  stdio: "inherit",
+  env: { ...process.env, PORT: String(port) },
+});
+
+let forwardedSignal = null;
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.once(signal, () => {
+    forwardedSignal = signal;
+    server.kill(signal);
+  });
+}
+
+server.on("exit", (code, signal) => {
+  process.exit(code ?? (signal === forwardedSignal ? 0 : 1));
+});

--- a/tests/e2e/app-rsdw-override/override.spec.ts
+++ b/tests/e2e/app-rsdw-override/override.spec.ts
@@ -1,0 +1,38 @@
+import fs from "node:fs";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import { waitForAppRouterHydration } from "../helpers";
+
+const APP_FIXTURE = path.resolve(process.cwd(), "tests/fixtures/app-with-src");
+
+test("builds and hydrates with an explicitly installed RSDW runtime override", async ({
+  page,
+  request,
+}) => {
+  const manifest = JSON.parse(fs.readFileSync(path.join(APP_FIXTURE, "package.json"), "utf8"));
+  expect(manifest.dependencies).toHaveProperty("react-server-dom-webpack");
+  expect(fs.existsSync(path.join(APP_FIXTURE, "node_modules/react-server-dom-webpack"))).toBe(true);
+
+  for (const environment of ["client", "ssr", "rsc"]) {
+    const moduleIds = JSON.parse(
+      fs.readFileSync(path.join(APP_FIXTURE, "dist", `rsc-runtime-${environment}.json`), "utf8"),
+    ) as string[];
+    expect(moduleIds.length).toBeGreaterThan(0);
+    expect(moduleIds.every((id) => id.includes("react-server-dom-webpack"))).toBe(true);
+    expect(moduleIds.some((id) => id.includes("@vitejs/plugin-rsc/dist/vendor"))).toBe(false);
+  }
+
+  await page.goto("/");
+  await expect(page.locator("#app-with-src-home")).toBeVisible();
+  await waitForAppRouterHydration(page);
+  await page.getByTestId("override-action").click();
+  await expect(page.getByTestId("override-action-result")).toHaveText(
+    "server-action:override-runtime",
+  );
+
+  const flight = await request.get("/.rsc", {
+    headers: { Accept: "text/x-component", RSC: "1" },
+  });
+  expect(flight.status()).toBe(200);
+  expect(await flight.text()).toContain("App With Src");
+});

--- a/tests/e2e/app-with-src/dev-overlay-recovery.spec.ts
+++ b/tests/e2e/app-with-src/dev-overlay-recovery.spec.ts
@@ -1,7 +1,10 @@
+import fs from "node:fs";
+import path from "node:path";
 import { test, expect } from "@playwright/test";
 import { waitForAppRouterHydration } from "../helpers";
 
-const BASE = "http://localhost:4181";
+const BASE = `http://localhost:${process.env.VINEXT_APP_WITH_SRC_PORT ?? 4181}`;
+const APP_FIXTURE = path.resolve(process.cwd(), "tests/fixtures/app-with-src");
 
 // app-with-src is a bare-bones fixture: no global-error.tsx, no route-level
 // error.tsx. That means a thrown error in /dev-overlay-recovery walks past
@@ -11,6 +14,33 @@ const BASE = "http://localhost:4181";
 // catches via the user boundary first; this spec covers the gap.
 
 test.describe("Dev recovery boundary (no global-error.tsx)", () => {
+  test("keeps an explicitly installed RSDW package as a supported runtime override", async ({
+    page,
+  }) => {
+    const manifest = JSON.parse(fs.readFileSync(path.join(APP_FIXTURE, "package.json"), "utf8"));
+    expect(manifest.dependencies).toHaveProperty("react-server-dom-webpack");
+    expect(fs.existsSync(path.join(APP_FIXTURE, "node_modules/react-server-dom-webpack"))).toBe(
+      true,
+    );
+
+    await page.goto(`${BASE}/`);
+    await expect(page.locator("#app-with-src-home")).toBeVisible();
+    await waitForAppRouterHydration(page);
+
+    const optimizerMetadata = JSON.parse(
+      fs.readFileSync(path.join(APP_FIXTURE, "node_modules/.vite/deps_rsc/_metadata.json"), "utf8"),
+    );
+    expect(Object.keys(optimizerMetadata.optimized)).toContain(
+      "react-server-dom-webpack/static.edge",
+    );
+    expect(Object.keys(optimizerMetadata.optimized)).not.toContain(
+      "@vitejs/plugin-rsc/vendor/react-server-dom/static.edge",
+    );
+    expect(optimizerMetadata.optimized["react-server-dom-webpack/static.edge"].src).toContain(
+      "react-server-dom-webpack",
+    );
+  });
+
   test("soft-nav to a broken route still updates the URL", async ({ page }) => {
     await page.goto(`${BASE}/`);
     await expect(page.locator("#app-with-src-home")).toBeVisible();

--- a/tests/e2e/app-with-src/runtime-error-sourcemap.spec.ts
+++ b/tests/e2e/app-with-src/runtime-error-sourcemap.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 
-const BASE = "http://localhost:4181";
+const BASE = `http://localhost:${process.env.VINEXT_APP_WITH_SRC_PORT ?? 4181}`;
 // Keep in sync with the throw in source-mapped-runtime-error.tsx.
 const EXPECTED_THROW_LINE = 33;
 

--- a/tests/fixtures/app-basic/package.json
+++ b/tests/fixtures/app-basic/package.json
@@ -9,7 +9,6 @@
     "fake-css-module-lib": "file:./__test_packages__/fake-css-module-lib",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "react-server-dom-webpack": "catalog:",
     "vinext": "workspace:*",
     "vite": "catalog:"
   },

--- a/tests/fixtures/app-bfcache/package.json
+++ b/tests/fixtures/app-bfcache/package.json
@@ -6,7 +6,6 @@
     "@vitejs/plugin-rsc": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "react-server-dom-webpack": "catalog:",
     "vinext": "workspace:*",
     "vite": "catalog:"
   },

--- a/tests/fixtures/app-cjs-violation/package.json
+++ b/tests/fixtures/app-cjs-violation/package.json
@@ -6,7 +6,6 @@
     "@vitejs/plugin-rsc": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "react-server-dom-webpack": "catalog:",
     "vinext": "workspace:*",
     "vite": "catalog:"
   },

--- a/tests/fixtures/app-with-src/src/app/action-button.tsx
+++ b/tests/fixtures/app-with-src/src/app/action-button.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { roundTripAction } from "./actions";
+
+export function ActionButton() {
+  const [result, setResult] = useState("idle");
+  const [isPending, startTransition] = useTransition();
+
+  return (
+    <div>
+      <button
+        data-testid="override-action"
+        disabled={isPending}
+        onClick={() => {
+          startTransition(async () => {
+            setResult(await roundTripAction("override-runtime"));
+          });
+        }}
+      >
+        Run action
+      </button>
+      <output data-testid="override-action-result">{result}</output>
+    </div>
+  );
+}

--- a/tests/fixtures/app-with-src/src/app/actions.ts
+++ b/tests/fixtures/app-with-src/src/app/actions.ts
@@ -1,0 +1,5 @@
+"use server";
+
+export async function roundTripAction(value: string): Promise<string> {
+  return `server-action:${value}`;
+}

--- a/tests/fixtures/app-with-src/src/app/page.tsx
+++ b/tests/fixtures/app-with-src/src/app/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { ActionButton } from "./action-button";
 
 export default function HomePage() {
   return (
@@ -7,6 +8,7 @@ export default function HomePage() {
       <Link href="/dev-overlay-recovery" data-testid="link-to-recovery">
         Recovery
       </Link>
+      <ActionButton />
     </>
   );
 }

--- a/tests/fixtures/app-with-src/vite.config.ts
+++ b/tests/fixtures/app-with-src/vite.config.ts
@@ -1,6 +1,32 @@
-import { defineConfig } from "vite";
+import fs from "node:fs";
+import path from "node:path";
+import { defineConfig, type Plugin } from "vite";
 import vinext from "vinext";
 
+function recordRscRuntimeProvenance(): Plugin {
+  return {
+    name: "app-with-src:rsc-runtime-provenance",
+    apply: "build",
+    enforce: "post",
+    generateBundle(_options, bundle) {
+      const runtimeModuleIds = Object.values(bundle).flatMap((output) =>
+        output.type === "chunk"
+          ? output.moduleIds.filter((id) => id.includes("react-server-dom"))
+          : [],
+      );
+      if (runtimeModuleIds.length === 0) return;
+
+      const outputPath = path.join(
+        import.meta.dirname,
+        "dist",
+        `rsc-runtime-${this.environment.name}.json`,
+      );
+      fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+      fs.writeFileSync(outputPath, `${JSON.stringify(runtimeModuleIds.sort(), null, 2)}\n`);
+    },
+  };
+}
+
 export default defineConfig({
-  plugins: [vinext({ appDir: `${import.meta.dirname}/src` })],
+  plugins: [vinext({ appDir: `${import.meta.dirname}/src` }), recordRscRuntimeProvenance()],
 });

--- a/tests/fixtures/cf-app-basic/package.json
+++ b/tests/fixtures/cf-app-basic/package.json
@@ -9,7 +9,6 @@
     "@vitejs/plugin-rsc": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "react-server-dom-webpack": "catalog:",
     "vinext": "workspace:*",
     "vite": "catalog:",
     "wrangler": "catalog:"

--- a/tests/fixtures/cf-sentry-app/package.json
+++ b/tests/fixtures/cf-sentry-app/package.json
@@ -9,7 +9,6 @@
     "@vitejs/plugin-rsc": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "react-server-dom-webpack": "catalog:",
     "vinext": "workspace:*",
     "vite": "catalog:",
     "wrangler": "catalog:"

--- a/tests/fixtures/ecosystem/better-auth/package.json
+++ b/tests/fixtures/ecosystem/better-auth/package.json
@@ -9,8 +9,7 @@
     "better-auth": "catalog:",
     "better-sqlite3": "catalog:",
     "vinext": "workspace:*",
-    "@vitejs/plugin-rsc": "catalog:",
-    "react-server-dom-webpack": "catalog:"
+    "@vitejs/plugin-rsc": "catalog:"
   },
   "devDependencies": {
     "vite": "catalog:",

--- a/tests/fixtures/ecosystem/next-intl/package.json
+++ b/tests/fixtures/ecosystem/next-intl/package.json
@@ -14,8 +14,7 @@
     "react-dom": "catalog:",
     "next-intl": "catalog:",
     "vinext": "workspace:*",
-    "@vitejs/plugin-rsc": "catalog:",
-    "react-server-dom-webpack": "catalog:"
+    "@vitejs/plugin-rsc": "catalog:"
   },
   "devDependencies": {
     "vite": "catalog:",

--- a/tests/fixtures/ecosystem/next-themes/package.json
+++ b/tests/fixtures/ecosystem/next-themes/package.json
@@ -7,8 +7,7 @@
     "react-dom": "catalog:",
     "next-themes": "catalog:",
     "vinext": "workspace:*",
-    "@vitejs/plugin-rsc": "catalog:",
-    "react-server-dom-webpack": "catalog:"
+    "@vitejs/plugin-rsc": "catalog:"
   },
   "devDependencies": {
     "vite": "catalog:",

--- a/tests/fixtures/ecosystem/next-view-transitions/package.json
+++ b/tests/fixtures/ecosystem/next-view-transitions/package.json
@@ -7,8 +7,7 @@
     "react-dom": "catalog:",
     "next-view-transitions": "catalog:",
     "vinext": "workspace:*",
-    "@vitejs/plugin-rsc": "catalog:",
-    "react-server-dom-webpack": "catalog:"
+    "@vitejs/plugin-rsc": "catalog:"
   },
   "devDependencies": {
     "vite": "catalog:",

--- a/tests/fixtures/ecosystem/nuqs/package.json
+++ b/tests/fixtures/ecosystem/nuqs/package.json
@@ -7,8 +7,7 @@
     "react-dom": "catalog:",
     "nuqs": "catalog:",
     "vinext": "workspace:*",
-    "@vitejs/plugin-rsc": "catalog:",
-    "react-server-dom-webpack": "catalog:"
+    "@vitejs/plugin-rsc": "catalog:"
   },
   "devDependencies": {
     "vite": "catalog:",

--- a/tests/fixtures/ecosystem/shadcn/package.json
+++ b/tests/fixtures/ecosystem/shadcn/package.json
@@ -12,8 +12,7 @@
     "clsx": "catalog:",
     "tailwind-merge": "catalog:",
     "vinext": "workspace:*",
-    "@vitejs/plugin-rsc": "catalog:",
-    "react-server-dom-webpack": "catalog:"
+    "@vitejs/plugin-rsc": "catalog:"
   },
   "devDependencies": {
     "vite": "catalog:",

--- a/tests/fixtures/esm-externals/package.json
+++ b/tests/fixtures/esm-externals/package.json
@@ -18,7 +18,6 @@
     "optimized-esm-package": "file:./__test_packages__/optimized-esm-package",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "react-server-dom-webpack": "catalog:",
     "shared-condition-package": "file:./__test_packages__/shared-condition-package",
     "vinext": "workspace:*",
     "vite": "catalog:"

--- a/tests/fixtures/font-google-multiple/package.json
+++ b/tests/fixtures/font-google-multiple/package.json
@@ -6,7 +6,6 @@
     "@vitejs/plugin-rsc": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "react-server-dom-webpack": "catalog:",
     "vinext": "workspace:*",
     "vite": "catalog:"
   },

--- a/tests/fixtures/global-not-found-basic/package.json
+++ b/tests/fixtures/global-not-found-basic/package.json
@@ -6,7 +6,6 @@
     "@vitejs/plugin-rsc": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "react-server-dom-webpack": "catalog:",
     "vinext": "workspace:*",
     "vite": "catalog:"
   },

--- a/tests/fixtures/global-not-found-css-order/package.json
+++ b/tests/fixtures/global-not-found-css-order/package.json
@@ -6,7 +6,6 @@
     "@vitejs/plugin-rsc": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "react-server-dom-webpack": "catalog:",
     "vinext": "workspace:*",
     "vite": "catalog:"
   },

--- a/tests/fixtures/ppr-impact-demo/package.json
+++ b/tests/fixtures/ppr-impact-demo/package.json
@@ -12,7 +12,6 @@
     "@vitejs/plugin-rsc": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "react-server-dom-webpack": "catalog:",
     "vinext": "workspace:*",
     "vite": "catalog:",
     "wrangler": "catalog:"

--- a/tests/fixtures/root-layout-redirect/package.json
+++ b/tests/fixtures/root-layout-redirect/package.json
@@ -6,7 +6,6 @@
     "@vitejs/plugin-rsc": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "react-server-dom-webpack": "catalog:",
     "vinext": "workspace:*",
     "vite": "catalog:"
   },

--- a/tests/fixtures/static-export-basepath/package.json
+++ b/tests/fixtures/static-export-basepath/package.json
@@ -6,7 +6,6 @@
     "@vitejs/plugin-rsc": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "react-server-dom-webpack": "catalog:",
     "vinext": "workspace:*",
     "vite": "catalog:"
   }

--- a/tests/fixtures/static-export/package.json
+++ b/tests/fixtures/static-export/package.json
@@ -6,7 +6,6 @@
     "@vitejs/plugin-rsc": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "react-server-dom-webpack": "catalog:",
     "vinext": "workspace:*",
     "vite": "catalog:"
   }

--- a/tests/fixtures/use-params-app-pages/package.json
+++ b/tests/fixtures/use-params-app-pages/package.json
@@ -6,7 +6,6 @@
     "@vitejs/plugin-rsc": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "react-server-dom-webpack": "catalog:",
     "vinext": "workspace:*",
     "vite": "catalog:"
   },

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -491,6 +491,16 @@ describe("getReactUpgradeDeps", () => {
     expect(deps).toEqual(["react@latest", "react-dom@latest"]);
   });
 
+  it("uses the minimum vendor floor when plugin-rsc is not installed yet", () => {
+    setupProject(tmpDir, { router: "app" });
+    setupFakeReact(tmpDir, "19.2.7");
+
+    // null models a published vinext install where the optional plugin cannot
+    // resolve; the source workspace's devDependency must not satisfy this test.
+    const deps = getReactUpgradeDeps(tmpDir, null);
+    expect(deps).toEqual(["react@latest", "react-dom@latest"]);
+  });
+
   it("returns empty array when React is new enough", () => {
     setupProject(tmpDir, { router: "app" });
     setupFakeReact(tmpDir, "19.2.8");

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -373,13 +373,13 @@ describe("addScripts", () => {
 // ─── Unit Tests: getInitDeps / isDepInstalled ────────────────────────────────
 
 describe("getInitDeps", () => {
-  it("returns vinext + vite + @vitejs/plugin-react + App Router deps for App Router", () => {
+  it("uses plugin-rsc's vendored Flight runtime for App Router by default", () => {
     const deps = getInitDeps(true, "cloudflare");
     expect(deps).toContain("vinext");
     expect(deps).toContain("vite");
     expect(deps).toContain("@vitejs/plugin-react");
     expect(deps).toContain("@vitejs/plugin-rsc");
-    expect(deps).toContain("react-server-dom-webpack");
+    expect(deps).not.toContain("react-server-dom-webpack");
   });
 
   it("returns vinext + vite + @vitejs/plugin-react for Pages Router", () => {
@@ -416,10 +416,76 @@ function setupFakeReact(dir: string, version: string): void {
   fs.writeFileSync(path.join(reactDir, "index.js"), "");
 }
 
+function setupFakeReactDom(dir: string, version: string): void {
+  const reactDomDir = path.join(dir, "node_modules", "react-dom");
+  fs.mkdirSync(reactDomDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(reactDomDir, "package.json"),
+    JSON.stringify({ name: "react-dom", version, main: "index.js" }),
+  );
+  fs.writeFileSync(path.join(reactDomDir, "index.js"), "");
+}
+
+function setupFakePluginRscVendor(dir: string, version: string): void {
+  const pluginDir = path.join(dir, "node_modules", "@vitejs", "plugin-rsc");
+  const vendorDir = path.join(pluginDir, "dist", "vendor", "react-server-dom");
+  fs.mkdirSync(vendorDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(pluginDir, "package.json"),
+    JSON.stringify({
+      name: "@vitejs/plugin-rsc",
+      version: "0.0.0-test",
+      exports: { "./*": "./dist/*.js" },
+    }),
+  );
+  fs.writeFileSync(path.join(vendorDir, "client.browser.js"), "");
+  fs.writeFileSync(
+    path.join(vendorDir, "package.json"),
+    JSON.stringify({ name: "react-server-dom-webpack", version }),
+  );
+}
+
+function setupFakeRsdw(
+  dir: string,
+  version: string,
+  {
+    declared = true,
+    section = "dependencies",
+  }: {
+    declared?: boolean;
+    section?: "dependencies" | "devDependencies" | "optionalDependencies" | "peerDependencies";
+  } = {},
+): void {
+  const rsdwDir = path.join(dir, "node_modules", "react-server-dom-webpack");
+  fs.mkdirSync(rsdwDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(rsdwDir, "package.json"),
+    JSON.stringify({ name: "react-server-dom-webpack", version, main: "index.js" }),
+  );
+  fs.writeFileSync(path.join(rsdwDir, "index.js"), "");
+  if (declared) {
+    const packagePath = path.join(dir, "package.json");
+    const pkg = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+    pkg[section] ??= {};
+    pkg[section]["react-server-dom-webpack"] = version;
+    fs.writeFileSync(packagePath, `${JSON.stringify(pkg, null, 2)}\n`);
+  }
+}
+
 describe("getReactUpgradeDeps", () => {
-  it("returns react@latest + react-dom@latest when React is below the RSDW security floor", () => {
+  it("allows matching React 19.2.7 and RSDW overrides through vinext's peer range", () => {
+    const pkg = JSON.parse(
+      fs.readFileSync(path.resolve(import.meta.dirname, "../packages/vinext/package.json"), "utf8"),
+    );
+    const expectedRange = "^19.2.6 || >=19.3.0-0 <19.4.0 || >=0.0.0-0 <0.0.1";
+
+    expect(pkg.peerDependencies.react).toBe(expectedRange);
+    expect(pkg.peerDependencies["react-dom"]).toBe(expectedRange);
+  });
+
+  it("returns react@latest + react-dom@latest when React is below the vendored RSC runtime", () => {
     setupProject(tmpDir, { router: "app" });
-    setupFakeReact(tmpDir, "19.2.5");
+    setupFakeReact(tmpDir, "19.2.7");
 
     const deps = getReactUpgradeDeps(tmpDir);
     expect(deps).toEqual(["react@latest", "react-dom@latest"]);
@@ -427,10 +493,52 @@ describe("getReactUpgradeDeps", () => {
 
   it("returns empty array when React is new enough", () => {
     setupProject(tmpDir, { router: "app" });
-    setupFakeReact(tmpDir, "19.2.6");
+    setupFakeReact(tmpDir, "19.2.8");
 
     const deps = getReactUpgradeDeps(tmpDir);
     expect(deps).toEqual([]);
+  });
+
+  it("aligns ReactDOM with React when only ReactDOM is below the vendored runtime", () => {
+    setupProject(tmpDir, { router: "app" });
+    setupFakeReact(tmpDir, "19.2.8");
+    setupFakeReactDom(tmpDir, "19.2.7");
+
+    const deps = getReactUpgradeDeps(tmpDir);
+    expect(deps).toEqual(["react-dom@19.2.8"]);
+  });
+
+  it("aligns stable ReactDOM to a newer React patch", () => {
+    setupProject(tmpDir, { router: "app" });
+    setupFakeReact(tmpDir, "19.2.9");
+    setupFakeReactDom(tmpDir, "19.2.8");
+
+    expect(getReactUpgradeDeps(tmpDir)).toEqual(["react-dom@19.2.9"]);
+  });
+
+  it("aligns stable React to a newer ReactDOM patch", () => {
+    setupProject(tmpDir, { router: "app" });
+    setupFakeReact(tmpDir, "19.2.8");
+    setupFakeReactDom(tmpDir, "19.2.9");
+
+    expect(getReactUpgradeDeps(tmpDir)).toEqual(["react@19.2.9"]);
+  });
+
+  it("upgrades both mismatched stable packages when both remain below the vendor floor", () => {
+    setupProject(tmpDir, { router: "app" });
+    setupFakeReact(tmpDir, "19.2.7");
+    setupFakeReactDom(tmpDir, "19.2.6");
+
+    expect(getReactUpgradeDeps(tmpDir)).toEqual(["react@latest", "react-dom@latest"]);
+  });
+
+  it("reads the compatibility floor from the installed plugin-rsc vendor", () => {
+    setupProject(tmpDir, { router: "app" });
+    setupFakeReact(tmpDir, "19.2.8");
+    setupFakeReactDom(tmpDir, "19.2.8");
+    setupFakePluginRscVendor(tmpDir, "19.2.9");
+
+    expect(getReactUpgradeDeps(tmpDir)).toEqual(["react@latest", "react-dom@latest"]);
   });
 
   it("returns empty array when React is a newer minor version", () => {
@@ -441,6 +549,119 @@ describe("getReactUpgradeDeps", () => {
     expect(deps).toEqual([]);
   });
 
+  it("requires an exact RSDW override for prerelease React", () => {
+    setupProject(tmpDir, { router: "app" });
+    setupFakeReact(tmpDir, "19.3.0-canary-test");
+
+    const deps = getReactUpgradeDeps(tmpDir);
+    expect(deps).toEqual(["react-server-dom-webpack@19.3.0-canary-test"]);
+  });
+
+  it("aligns mismatched prerelease React and ReactDOM with the exact RSDW override", () => {
+    setupProject(tmpDir, { router: "app" });
+    setupFakeReact(tmpDir, "19.3.0-canary-react");
+    setupFakeReactDom(tmpDir, "19.3.0-canary-react-dom");
+
+    const deps = getReactUpgradeDeps(tmpDir);
+    expect(deps).toEqual([
+      "react@19.3.0-canary-react",
+      "react-dom@19.3.0-canary-react",
+      "react-server-dom-webpack@19.3.0-canary-react",
+    ]);
+  });
+
+  it("preserves an explicitly installed experimental React and RSDW pair", () => {
+    setupProject(tmpDir, { router: "app" });
+    setupFakeReact(tmpDir, "0.0.0-experimental-test");
+    setupFakeReactDom(tmpDir, "0.0.0-experimental-test");
+    setupFakeRsdw(tmpDir, "0.0.0-experimental-test");
+
+    const deps = getReactUpgradeDeps(tmpDir);
+    expect(deps).toEqual([]);
+  });
+
+  it("preserves an explicitly installed stable RSDW override", () => {
+    setupProject(tmpDir, { router: "app" });
+    setupFakeReact(tmpDir, "19.2.7");
+    setupFakeReactDom(tmpDir, "19.2.7");
+    setupFakeRsdw(tmpDir, "19.2.7");
+
+    const deps = getReactUpgradeDeps(tmpDir);
+    expect(deps).toEqual([]);
+  });
+
+  it("reinstalls an explicit RSDW override shadowed by optionalDependencies", () => {
+    setupProject(tmpDir, { router: "app" });
+    setupFakeReact(tmpDir, "19.2.7");
+    setupFakeReactDom(tmpDir, "19.2.7");
+    setupFakeRsdw(tmpDir, "19.2.7");
+    const packagePath = path.join(tmpDir, "package.json");
+    const pkg = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+    pkg.optionalDependencies = { "react-server-dom-webpack": "19.2.7" };
+    fs.writeFileSync(packagePath, `${JSON.stringify(pkg, null, 2)}\n`);
+
+    const deps = getReactUpgradeDeps(tmpDir);
+    expect(deps).toEqual(["react-server-dom-webpack@19.2.7"]);
+  });
+
+  it("aligns an explicit stable override with incompatible installed React packages", () => {
+    setupProject(tmpDir, { router: "app" });
+    setupFakeReact(tmpDir, "18.3.1");
+    setupFakeReactDom(tmpDir, "18.3.1");
+    setupFakeRsdw(tmpDir, "19.2.8");
+
+    const deps = getReactUpgradeDeps(tmpDir);
+    expect(deps).toEqual(["react@19.2.8", "react-dom@19.2.8"]);
+  });
+
+  it("aligns an explicit override with a different installed canary pair", () => {
+    setupProject(tmpDir, { router: "app" });
+    setupFakeReact(tmpDir, "19.3.0-canary-react");
+    setupFakeReactDom(tmpDir, "19.3.0-canary-react");
+    setupFakeRsdw(tmpDir, "19.3.0-canary-rsdw");
+
+    const deps = getReactUpgradeDeps(tmpDir);
+    expect(deps).toEqual(["react@19.3.0-canary-rsdw", "react-dom@19.3.0-canary-rsdw"]);
+  });
+
+  it("installs an explicitly declared but missing RSDW override", () => {
+    setupProject(tmpDir, {
+      router: "app",
+      extraPkg: {
+        dependencies: {
+          react: "19.2.8",
+          "react-dom": "19.2.8",
+          "react-server-dom-webpack": "19.2.8",
+        },
+      },
+    });
+    setupFakeReact(tmpDir, "19.2.8");
+    setupFakeReactDom(tmpDir, "19.2.8");
+
+    const deps = getReactUpgradeDeps(tmpDir);
+    expect(deps).toEqual(["react-server-dom-webpack@19.2.8"]);
+  });
+
+  it("does not treat an undeclared hoisted RSDW package as an explicit override", () => {
+    setupProject(tmpDir, { router: "app" });
+    setupFakeReact(tmpDir, "19.2.7");
+    setupFakeRsdw(tmpDir, "19.2.7", { declared: false });
+
+    const deps = getReactUpgradeDeps(tmpDir);
+    expect(deps).toEqual(["react@latest", "react-dom@latest"]);
+  });
+
+  for (const section of ["optionalDependencies", "peerDependencies"] as const) {
+    it(`does not treat an RSDW ${section} declaration as a plugin-rsc override`, () => {
+      setupProject(tmpDir, { router: "app" });
+      setupFakeReact(tmpDir, "19.2.7");
+      setupFakeRsdw(tmpDir, "19.2.7", { section });
+
+      const deps = getReactUpgradeDeps(tmpDir);
+      expect(deps).toEqual(["react@latest", "react-dom@latest"]);
+    });
+  }
+
   it("returns upgrade deps when React major is below 19", () => {
     setupProject(tmpDir, { router: "app" });
     setupFakeReact(tmpDir, "18.3.1");
@@ -449,10 +670,35 @@ describe("getReactUpgradeDeps", () => {
     expect(deps).toEqual(["react@latest", "react-dom@latest"]);
   });
 
-  it("returns empty array when node_modules/react does not exist", () => {
+  it("returns empty array when node_modules and exact manifest versions do not exist", () => {
     setupProject(tmpDir, { router: "app" });
     const deps = getReactUpgradeDeps(tmpDir);
     expect(deps).toEqual([]);
+  });
+
+  it("uses exact stable manifest versions when node_modules does not exist", () => {
+    setupProject(tmpDir, {
+      router: "app",
+      extraPkg: { dependencies: { react: "19.2.7", "react-dom": "19.2.7" } },
+    });
+
+    const deps = getReactUpgradeDeps(tmpDir);
+    expect(deps).toEqual(["react@latest", "react-dom@latest"]);
+  });
+
+  it("uses exact canary manifest versions when node_modules does not exist", () => {
+    setupProject(tmpDir, {
+      router: "app",
+      extraPkg: {
+        dependencies: {
+          react: "19.3.0-canary-test",
+          "react-dom": "19.3.0-canary-test",
+        },
+      },
+    });
+
+    const deps = getReactUpgradeDeps(tmpDir);
+    expect(deps).toEqual(["react-server-dom-webpack@19.3.0-canary-test"]);
   });
 });
 
@@ -1159,10 +1405,9 @@ describe("init — dependency installation", () => {
       },
     });
 
-    expect(
-      commands.some((cmd) => cmd.includes("react-server-dom-webpack") && !cmd.includes("-D")),
-    ).toBe(true);
-    expect(result.installedDeps).toContain("react-server-dom-webpack");
+    expect(commands.some((cmd) => cmd.includes("vinext") && !cmd.includes("-D"))).toBe(true);
+    expect(commands.some((cmd) => cmd.includes("react-server-dom-webpack"))).toBe(false);
+    expect(result.installedDeps).not.toContain("react-server-dom-webpack");
     expect(output).toContain("pnpm approve-builds");
   });
 
@@ -1204,16 +1449,16 @@ describe("init — dependency installation", () => {
 
     expect(result.installedDeps).toContain("@vitejs/plugin-react");
     expect(result.installedDeps).toContain("@vitejs/plugin-rsc");
-    expect(result.installedDeps).toContain("react-server-dom-webpack");
+    expect(result.installedDeps).not.toContain("react-server-dom-webpack");
   });
 
-  it("detects missing react-server-dom-webpack for App Router", async () => {
+  it("does not require react-server-dom-webpack for App Router", async () => {
     setupProject(tmpDir, { router: "app" });
 
     const { result } = await runInit(tmpDir);
 
     expect(result.installedDeps).toContain("@vitejs/plugin-react");
-    expect(result.installedDeps).toContain("react-server-dom-webpack");
+    expect(result.installedDeps).not.toContain("react-server-dom-webpack");
   });
 
   it("does not require @vitejs/plugin-rsc for Pages Router", async () => {
@@ -1234,7 +1479,7 @@ describe("init — dependency installation", () => {
     expect(result.installedDeps).not.toContain("react-server-dom-webpack");
   });
 
-  it("upgrades React before installing dev deps when React is too old (App Router)", async () => {
+  it("installs plugin-rsc before upgrading React to its vendored floor", async () => {
     setupProject(tmpDir, { router: "app" });
     setupFakeReact(tmpDir, "19.2.3");
 
@@ -1248,32 +1493,37 @@ describe("init — dependency installation", () => {
     // The React upgrade should NOT use -D flag (keeps them in dependencies)
     expect(reactUpgradeCall!.cmd).not.toContain("-D");
 
-    // The second exec call should install runtime framework deps (without -D).
+    // The runtime framework deps still install without -D.
     const runtimeDepsCall = execCalls.find(
-      (c) => c.cmd.includes("react-server-dom-webpack") && !c.cmd.includes("-D"),
+      (c) =>
+        c.cmd.includes("vinext") && c.cmd.includes("@vinext/cloudflare") && !c.cmd.includes("-D"),
     );
     expect(runtimeDepsCall).toBeDefined();
 
     // The dev deps install should still use -D.
-    const devDepsCall = execCalls.find(
-      (c) =>
-        c.cmd.includes("@vitejs/plugin-react") &&
-        c.cmd.includes("@vitejs/plugin-rsc") &&
-        c.cmd.includes("-D"),
+    const pluginRscCall = execCalls.find(
+      (c) => c.cmd.includes("@vitejs/plugin-rsc") && c.cmd.includes("-D"),
     );
+    const devDepsCall = execCalls.find(
+      (c) => c.cmd.includes("@vitejs/plugin-react") && c.cmd.includes("-D"),
+    );
+    expect(pluginRscCall).toBeDefined();
     expect(devDepsCall).toBeDefined();
 
-    // React upgrade should come before framework deps that peer on React.
+    // The active vendor is installed before validation, then runtime and
+    // remaining development dependencies follow the compatibility update.
+    const pluginRscIdx = execCalls.indexOf(pluginRscCall!);
     const upgradeIdx = execCalls.indexOf(reactUpgradeCall!);
     const runtimeDepsIdx = execCalls.indexOf(runtimeDepsCall!);
     const devDepsIdx = execCalls.indexOf(devDepsCall!);
+    expect(pluginRscIdx).toBeLessThan(upgradeIdx);
     expect(upgradeIdx).toBeLessThan(runtimeDepsIdx);
     expect(runtimeDepsIdx).toBeLessThan(devDepsIdx);
   });
 
   it("does not upgrade React when version is already compatible", async () => {
     setupProject(tmpDir, { router: "app" });
-    setupFakeReact(tmpDir, "19.2.6");
+    setupFakeReact(tmpDir, "19.2.8");
 
     const { execCalls } = await runInit(tmpDir);
 
@@ -1281,6 +1531,52 @@ describe("init — dependency installation", () => {
     const reactUpgradeCall = execCalls.find((c) => c.cmd.includes("react@latest"));
     expect(reactUpgradeCall).toBeUndefined();
   });
+
+  it("installs plugin-rsc before reading its vendored React floor", async () => {
+    setupProject(tmpDir, { router: "app" });
+    setupFakeReact(tmpDir, "19.2.8");
+    setupFakeReactDom(tmpDir, "19.2.8");
+    const commands: string[] = [];
+
+    await runInit(tmpDir, {
+      _exec: (command) => {
+        commands.push(command);
+        if (command.includes("@vitejs/plugin-rsc")) {
+          setupFakePluginRscVendor(tmpDir, "19.2.9");
+        }
+      },
+    });
+    const pluginInstallIndex = commands.findIndex((command) =>
+      command.includes("@vitejs/plugin-rsc"),
+    );
+    const reactUpgradeIndex = commands.findIndex(
+      (command) => command.includes("react@latest") && command.includes("react-dom@latest"),
+    );
+
+    expect(pluginInstallIndex).toBeGreaterThanOrEqual(0);
+    expect(reactUpgradeIndex).toBeGreaterThan(pluginInstallIndex);
+  });
+
+  for (const section of ["optionalDependencies", "peerDependencies"] as const) {
+    it(`forces a prerelease RSDW ${section} declaration into npm dependencies`, async () => {
+      setupProject(tmpDir, {
+        router: "app",
+        extraPkg: {
+          [section]: { "react-server-dom-webpack": "19.3.0-canary-test" },
+        },
+      });
+      setupFakeReact(tmpDir, "19.3.0-canary-test");
+
+      const { execCalls } = await runInit(tmpDir);
+      const compatibilityInstall = execCalls.find((call) =>
+        call.cmd.includes("react-server-dom-webpack@19.3.0-canary-test"),
+      );
+
+      expect(compatibilityInstall?.cmd).toBe(
+        "npm install --save-prod react-server-dom-webpack@19.3.0-canary-test",
+      );
+    });
+  }
 
   function withUserAgent<T>(value: string | undefined, run: () => Promise<T>): Promise<T> {
     const previous = process.env.npm_config_user_agent;
@@ -1324,9 +1620,9 @@ describe("init — dependency installation", () => {
     expect(execCalls).toEqual([]);
     expect(pkg.dependencies).toMatchObject({
       vinext: "latest",
-      "react-server-dom-webpack": "latest",
       "@vinext/cloudflare": "latest",
     });
+    expect(pkg.dependencies).not.toHaveProperty("react-server-dom-webpack");
     expect(pkg.devDependencies).toMatchObject({
       vite: "latest",
       "@vitejs/plugin-react": "latest",
@@ -1353,6 +1649,101 @@ describe("init — dependency installation", () => {
     expect(output).toContain(
       "Added dependencies to dependencies:\n      - react\n      - react-dom",
     );
+  });
+
+  it("updates exact old React manifest entries without node_modules or installing", async () => {
+    setupProject(tmpDir, {
+      router: "app",
+      extraPkg: { dependencies: { react: "19.2.7", "react-dom": "19.2.7" } },
+    });
+
+    const { execCalls } = await runInit(tmpDir, { install: false });
+    const pkg = readPkg(tmpDir) as { dependencies?: Record<string, string> };
+
+    expect(execCalls).toEqual([]);
+    expect(pkg.dependencies).toMatchObject({ react: "latest", "react-dom": "latest" });
+  });
+
+  it("adds a matching canary RSDW from exact manifest entries without node_modules", async () => {
+    setupProject(tmpDir, {
+      router: "app",
+      extraPkg: {
+        dependencies: {
+          react: "19.3.0-canary-test",
+          "react-dom": "19.3.0-canary-test",
+        },
+      },
+    });
+
+    const { execCalls } = await runInit(tmpDir, { install: false });
+    const pkg = readPkg(tmpDir) as { dependencies?: Record<string, string> };
+
+    expect(execCalls).toEqual([]);
+    expect(pkg.dependencies?.["react-server-dom-webpack"]).toBe("19.3.0-canary-test");
+  });
+
+  it("adds a matching RSDW override for prerelease React without installing", async () => {
+    setupProject(tmpDir, { router: "app" });
+    setupFakeReact(tmpDir, "19.3.0-canary-test");
+
+    const { result, execCalls } = await runInit(tmpDir, { install: false });
+    const pkg = readPkg(tmpDir) as {
+      dependencies?: Record<string, string>;
+    };
+
+    expect(execCalls).toEqual([]);
+    expect(pkg.dependencies?.["react-server-dom-webpack"]).toBe("19.3.0-canary-test");
+    expect(result.installedDeps).toContain("react-server-dom-webpack");
+  });
+
+  for (const section of ["optionalDependencies", "peerDependencies"] as const) {
+    it(`reclassifies a prerelease RSDW ${section} declaration without installing`, async () => {
+      setupProject(tmpDir, {
+        router: "app",
+        extraPkg: {
+          [section]: { "react-server-dom-webpack": "19.3.0-canary-test" },
+        },
+      });
+      setupFakeReact(tmpDir, "19.3.0-canary-test");
+
+      const { result, execCalls } = await runInit(tmpDir, { install: false });
+      const pkg = readPkg(tmpDir) as {
+        dependencies?: Record<string, string>;
+        optionalDependencies?: Record<string, string>;
+        peerDependencies?: Record<string, string>;
+      };
+
+      expect(execCalls).toEqual([]);
+      expect(pkg.dependencies?.["react-server-dom-webpack"]).toBe("19.3.0-canary-test");
+      expect(pkg[section]).not.toHaveProperty("react-server-dom-webpack");
+      expect(result.installedDeps).toContain("react-server-dom-webpack");
+    });
+  }
+
+  it("removes an optional RSDW declaration shadowing an existing dependency", async () => {
+    setupProject(tmpDir, {
+      router: "app",
+      extraPkg: {
+        dependencies: {
+          react: "19.2.7",
+          "react-dom": "19.2.7",
+          "react-server-dom-webpack": "19.2.7",
+        },
+        optionalDependencies: { "react-server-dom-webpack": "19.2.7" },
+      },
+    });
+    setupFakeReact(tmpDir, "19.2.7");
+
+    const { result, execCalls } = await runInit(tmpDir, { install: false });
+    const pkg = readPkg(tmpDir) as {
+      dependencies?: Record<string, string>;
+      optionalDependencies?: Record<string, string>;
+    };
+
+    expect(execCalls).toEqual([]);
+    expect(pkg.dependencies?.["react-server-dom-webpack"]).toBe("19.2.7");
+    expect(pkg.optionalDependencies).not.toHaveProperty("react-server-dom-webpack");
+    expect(result.installedDeps).toContain("react-server-dom-webpack");
   });
 
   it("calls exec with bun when bun.lock exists", async () => {

--- a/tests/react-rsc-compatibility.test.ts
+++ b/tests/react-rsc-compatibility.test.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs";
+import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { createServer, resolveConfig } from "vite";
 import rsc from "@vitejs/plugin-rsc";
@@ -10,6 +12,47 @@ import { RSC_ENTRIES } from "./helpers.js";
 const APP_WITH_SRC_ROOT = path.resolve(import.meta.dirname, "fixtures/app-with-src");
 const APP_BASIC_ROOT = path.resolve(import.meta.dirname, "fixtures/app-basic");
 const RSDW_VENDOR_ALIAS = "@vitejs/plugin-rsc/vendor/react-server-dom";
+const testRequire = createRequire(import.meta.url);
+const realRscPackageJson = testRequire.resolve("@vitejs/plugin-rsc/package.json");
+const realRscRoot = path.dirname(realRscPackageJson);
+const realRscDependencyRoot = path.resolve(realRscRoot, "../..");
+const realRscDependencies = Object.keys(
+  JSON.parse(fs.readFileSync(realRscPackageJson, "utf8")).dependencies as Record<string, string>,
+);
+
+function resolvePackageRoot(req: NodeJS.Require, packageName: string): string {
+  let current = path.dirname(req.resolve(packageName));
+  while (current !== path.dirname(current)) {
+    try {
+      const pkg = JSON.parse(fs.readFileSync(path.join(current, "package.json"), "utf8"));
+      if (pkg.name === packageName) return current;
+    } catch {}
+    current = path.dirname(current);
+  }
+  throw new Error(`Unable to resolve package root for ${packageName}`);
+}
+
+function linkPackage(root: string, packageName: string, packageRoot: string): void {
+  const target = path.join(root, "node_modules", packageName);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.symlinkSync(packageRoot, target, "junction");
+}
+
+function installDistinctRscPluginCopy(root: string): string {
+  const pluginRoot = path.join(root, "node_modules", "@vitejs", "plugin-rsc");
+  const nestedNodeModules = path.join(realRscRoot, "node_modules");
+  fs.mkdirSync(path.dirname(pluginRoot), { recursive: true });
+  fs.cpSync(realRscRoot, pluginRoot, {
+    recursive: true,
+    filter(source) {
+      return source !== nestedNodeModules && !source.startsWith(`${nestedNodeModules}${path.sep}`);
+    },
+  });
+  for (const dependency of [...realRscDependencies, "vite"]) {
+    linkPackage(root, dependency, fs.realpathSync(path.join(realRscDependencyRoot, dependency)));
+  }
+  return path.join(pluginRoot, "dist", "index.js");
+}
 
 describe("App Router React/RSC compatibility validation", () => {
   let root: string;
@@ -66,18 +109,7 @@ describe("App Router React/RSC compatibility validation", () => {
 
   for (const rscMode of ["auto", "manual"] as const) {
     it(`requires projectRoot when a custom root resolves a distinct RSC plugin copy in ${rscMode} mode`, async () => {
-      const pluginRoot = path.join(root, "node_modules", "@vitejs", "plugin-rsc");
-      fs.mkdirSync(path.join(pluginRoot, "dist"), { recursive: true });
-      fs.writeFileSync(
-        path.join(pluginRoot, "package.json"),
-        JSON.stringify({
-          name: "@vitejs/plugin-rsc",
-          version: "0.0.0-distinct-test",
-          type: "module",
-          exports: { ".": "./dist/index.js" },
-        }),
-      );
-      fs.writeFileSync(path.join(pluginRoot, "dist", "index.js"), "export default () => [];\n");
+      installDistinctRscPluginCopy(root);
 
       const plugins =
         rscMode === "auto"
@@ -88,6 +120,56 @@ describe("App Router React/RSC compatibility validation", () => {
       ).rejects.toThrow(`Pass projectRoot: ${JSON.stringify(root)} to vinext()`);
     });
   }
+
+  it("validates the registered manual RSC plugin copy after applying projectRoot", async () => {
+    const distinctRscEntry = installDistinctRscPluginCopy(root);
+    const reactVersion = JSON.parse(
+      fs.readFileSync(path.join(resolvePackageRoot(testRequire, "react"), "package.json"), "utf8"),
+    ).version;
+    fs.writeFileSync(
+      path.join(root, "package.json"),
+      JSON.stringify({
+        name: "react-rsc-compat-test",
+        private: true,
+        dependencies: { react: reactVersion, "react-dom": reactVersion },
+      }),
+    );
+    fs.rmSync(path.join(root, "node_modules", "react"), { recursive: true, force: true });
+    linkPackage(root, "react", resolvePackageRoot(testRequire, "react"));
+    linkPackage(root, "react-dom", resolvePackageRoot(testRequire, "react-dom"));
+
+    await expect(
+      resolveConfig(
+        {
+          root,
+          configFile: false,
+          plugins: [
+            vinext({ projectRoot: root, react: false, rsc: false }),
+            rsc({ entries: RSC_ENTRIES }),
+          ],
+        },
+        "build",
+        "production",
+      ),
+    ).rejects.toThrow(
+      "manually registered @vitejs/plugin-rsc was created by a different module copy",
+    );
+
+    const rootRsc = (await import(pathToFileURL(distinctRscEntry).href)).default;
+    const config = await resolveConfig(
+      {
+        root,
+        configFile: false,
+        plugins: [
+          vinext({ projectRoot: root, react: false, rsc: false }),
+          rootRsc({ entries: RSC_ENTRIES }),
+        ],
+      },
+      "build",
+      "production",
+    );
+    expect(config.plugins.some((plugin) => plugin.name === "rsc:minimal")).toBe(true);
+  });
 
   it("aliases the active RSC plugin vendor to an override from a relative custom root", async () => {
     const config = await resolveConfig(

--- a/tests/react-rsc-compatibility.test.ts
+++ b/tests/react-rsc-compatibility.test.ts
@@ -64,28 +64,30 @@ describe("App Router React/RSC compatibility validation", () => {
     ).rejects.toThrow("npm install --save-prod react-server-dom-webpack@19.3.0-canary-test");
   });
 
-  it("requires projectRoot when a custom root resolves a distinct RSC plugin copy", async () => {
-    const pluginRoot = path.join(root, "node_modules", "@vitejs", "plugin-rsc");
-    fs.mkdirSync(path.join(pluginRoot, "dist"), { recursive: true });
-    fs.writeFileSync(
-      path.join(pluginRoot, "package.json"),
-      JSON.stringify({
-        name: "@vitejs/plugin-rsc",
-        version: "0.0.0-distinct-test",
-        type: "module",
-        exports: { ".": "./dist/index.js" },
-      }),
-    );
-    fs.writeFileSync(path.join(pluginRoot, "dist", "index.js"), "export default () => [];\n");
+  for (const rscMode of ["auto", "manual"] as const) {
+    it(`requires projectRoot when a custom root resolves a distinct RSC plugin copy in ${rscMode} mode`, async () => {
+      const pluginRoot = path.join(root, "node_modules", "@vitejs", "plugin-rsc");
+      fs.mkdirSync(path.join(pluginRoot, "dist"), { recursive: true });
+      fs.writeFileSync(
+        path.join(pluginRoot, "package.json"),
+        JSON.stringify({
+          name: "@vitejs/plugin-rsc",
+          version: "0.0.0-distinct-test",
+          type: "module",
+          exports: { ".": "./dist/index.js" },
+        }),
+      );
+      fs.writeFileSync(path.join(pluginRoot, "dist", "index.js"), "export default () => [];\n");
 
-    await expect(
-      resolveConfig(
-        { root, configFile: false, plugins: vinext({ react: false }) },
-        "build",
-        "production",
-      ),
-    ).rejects.toThrow(`Pass projectRoot: ${JSON.stringify(root)} to vinext()`);
-  });
+      const plugins =
+        rscMode === "auto"
+          ? vinext({ react: false })
+          : [vinext({ react: false, rsc: false }), rsc({ entries: RSC_ENTRIES })];
+      await expect(
+        resolveConfig({ root, configFile: false, plugins }, "build", "production"),
+      ).rejects.toThrow(`Pass projectRoot: ${JSON.stringify(root)} to vinext()`);
+    });
+  }
 
   it("aliases the active RSC plugin vendor to an override from a relative custom root", async () => {
     const config = await resolveConfig(

--- a/tests/react-rsc-compatibility.test.ts
+++ b/tests/react-rsc-compatibility.test.ts
@@ -1,0 +1,199 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { createServer, resolveConfig } from "vite";
+import rsc from "@vitejs/plugin-rsc";
+import vinext from "../packages/vinext/src/index.js";
+import { RSC_ENTRIES } from "./helpers.js";
+
+const APP_WITH_SRC_ROOT = path.resolve(import.meta.dirname, "fixtures/app-with-src");
+const APP_BASIC_ROOT = path.resolve(import.meta.dirname, "fixtures/app-basic");
+const RSDW_VENDOR_ALIAS = "@vitejs/plugin-rsc/vendor/react-server-dom";
+
+describe("App Router React/RSC compatibility validation", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-react-rsc-compat-"));
+    fs.mkdirSync(path.join(root, "app"), { recursive: true });
+    fs.writeFileSync(path.join(root, "app", "page.tsx"), "export default function Page() {}\n");
+    fs.writeFileSync(
+      path.join(root, "package.json"),
+      JSON.stringify({
+        name: "react-rsc-compat-test",
+        private: true,
+        dependencies: { react: "19.3.0-canary-test", "react-dom": "19.3.0-canary-test" },
+      }),
+    );
+    const reactDir = path.join(root, "node_modules", "react");
+    fs.mkdirSync(reactDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(reactDir, "package.json"),
+      JSON.stringify({ name: "react", version: "19.3.0-canary-test", main: "index.js" }),
+    );
+    fs.writeFileSync(path.join(reactDir, "index.js"), "");
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  for (const command of ["serve", "build"] as const) {
+    it(`rejects incompatible prerelease React in direct Vite ${command}`, async () => {
+      await expect(
+        resolveConfig(
+          { root, plugins: vinext({ react: false, rsc: false }) },
+          command,
+          command === "build" ? "production" : "development",
+        ),
+      ).rejects.toThrow("npm install --save-prod react-server-dom-webpack@19.3.0-canary-test");
+    });
+  }
+
+  it("rejects incompatible prerelease React with a relative Vite root", async () => {
+    await expect(
+      resolveConfig(
+        {
+          root: path.relative(process.cwd(), root),
+          plugins: vinext({ react: false, rsc: false }),
+        },
+        "serve",
+        "development",
+      ),
+    ).rejects.toThrow("npm install --save-prod react-server-dom-webpack@19.3.0-canary-test");
+  });
+
+  it("requires projectRoot when a custom root resolves a distinct RSC plugin copy", async () => {
+    const pluginRoot = path.join(root, "node_modules", "@vitejs", "plugin-rsc");
+    fs.mkdirSync(path.join(pluginRoot, "dist"), { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginRoot, "package.json"),
+      JSON.stringify({
+        name: "@vitejs/plugin-rsc",
+        version: "0.0.0-distinct-test",
+        type: "module",
+        exports: { ".": "./dist/index.js" },
+      }),
+    );
+    fs.writeFileSync(path.join(pluginRoot, "dist", "index.js"), "export default () => [];\n");
+
+    await expect(
+      resolveConfig(
+        { root, configFile: false, plugins: vinext({ react: false }) },
+        "build",
+        "production",
+      ),
+    ).rejects.toThrow(`Pass projectRoot: ${JSON.stringify(root)} to vinext()`);
+  });
+
+  it("aliases the active RSC plugin vendor to an override from a relative custom root", async () => {
+    const config = await resolveConfig(
+      {
+        root: path.relative(process.cwd(), APP_WITH_SRC_ROOT),
+        configFile: false,
+        plugins: vinext({ appDir: path.join(APP_WITH_SRC_ROOT, "src"), react: false }),
+      },
+      "build",
+      "production",
+    );
+
+    expect(config.plugins.some((plugin) => plugin.name === "rsc:minimal")).toBe(true);
+    const runtimeAlias = config.resolve.alias.find((entry) => entry.find === RSDW_VENDOR_ALIAS);
+    expect(runtimeAlias?.replacement).toContain("/node_modules/react-server-dom-webpack");
+  });
+
+  it("auto-registers RSC and pins the vendor for a custom root without an override", async () => {
+    const config = await resolveConfig(
+      {
+        root: path.relative(process.cwd(), APP_BASIC_ROOT),
+        configFile: false,
+        plugins: vinext({ projectRoot: APP_BASIC_ROOT, react: false }),
+      },
+      "build",
+      "production",
+    );
+
+    expect(config.plugins.some((plugin) => plugin.name === "rsc:minimal")).toBe(true);
+    const runtimeAlias = config.resolve.alias.find((entry) => entry.find === RSDW_VENDOR_ALIAS);
+    expect(runtimeAlias?.replacement).toContain("plugin-rsc");
+    expect(runtimeAlias?.replacement).toContain("/vendor/react-server-dom");
+  });
+
+  it("pins a child without an override to the vendor when its parent declares RSDW", async () => {
+    const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(APP_WITH_SRC_ROOT);
+    let server: Awaited<ReturnType<typeof createServer>> | null = null;
+    try {
+      const config = await resolveConfig(
+        {
+          root: APP_BASIC_ROOT,
+          configFile: false,
+          plugins: vinext({ projectRoot: APP_BASIC_ROOT, react: false }),
+        },
+        "build",
+        "production",
+      );
+
+      expect(config.plugins.some((plugin) => plugin.name === "rsc:minimal")).toBe(true);
+      const runtimeAlias = config.resolve.alias.find((entry) => entry.find === RSDW_VENDOR_ALIAS);
+      expect(runtimeAlias?.replacement).toContain("plugin-rsc");
+      expect(runtimeAlias?.replacement).toContain("/vendor/react-server-dom");
+      expect(runtimeAlias?.replacement).not.toContain("/node_modules/react-server-dom-webpack");
+
+      for (const environment of Object.values(config.environments)) {
+        const includes = environment.optimizeDeps.include ?? [];
+        expect(includes.some((id) => id.startsWith("react-server-dom-webpack/"))).toBe(false);
+        expect(includes.some((id) => id.startsWith(`${RSDW_VENDOR_ALIAS}/`))).toBe(true);
+      }
+
+      server = await createServer({
+        root: APP_BASIC_ROOT,
+        cacheDir: path.join(root, "auto-runtime-cache"),
+        configFile: false,
+        plugins: vinext({ projectRoot: APP_BASIC_ROOT }),
+        server: { host: "127.0.0.1", port: 0 },
+      });
+      await server.listen();
+      const address = server.httpServer?.address();
+      if (!address || typeof address === "string") throw new Error("Expected a local dev address");
+      const response = await fetch(`http://127.0.0.1:${address.port}/`);
+      expect(response.status).toBe(200);
+      expect(await response.text()).toContain("Welcome to App Router");
+    } finally {
+      await server?.close();
+      cwdSpy.mockRestore();
+    }
+  }, 30_000);
+
+  it("pins a manually registered RSC plugin to the child vendor runtime", async () => {
+    const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(APP_WITH_SRC_ROOT);
+    let server: Awaited<ReturnType<typeof createServer>> | null = null;
+    try {
+      server = await createServer({
+        root: APP_BASIC_ROOT,
+        cacheDir: path.join(root, "manual-runtime-cache"),
+        configFile: false,
+        plugins: [
+          vinext({ projectRoot: APP_BASIC_ROOT, rsc: false }),
+          rsc({ entries: RSC_ENTRIES }),
+        ],
+        server: { host: "127.0.0.1", port: 0 },
+      });
+      for (const environment of Object.values(server.config.environments)) {
+        const includes = environment.optimizeDeps.include ?? [];
+        expect(includes.some((id) => id.startsWith("react-server-dom-webpack/"))).toBe(false);
+        expect(includes.some((id) => id.startsWith(`${RSDW_VENDOR_ALIAS}/`))).toBe(true);
+      }
+
+      await server.listen();
+      const address = server.httpServer?.address();
+      if (!address || typeof address === "string") throw new Error("Expected a local dev address");
+      const response = await fetch(`http://127.0.0.1:${address.port}/`);
+      expect(response.status).toBe(200);
+      expect(await response.text()).toContain("Welcome to App Router");
+    } finally {
+      await server?.close();
+      cwdSpy.mockRestore();
+    }
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary

- use the Flight runtime vendored by `@vitejs/plugin-rsc` by default
- preserve an explicitly declared, version-aligned `react-server-dom-webpack` override
- make init, custom-root resolution, optimizer configuration, standalone output, fixtures, examples, and documentation follow the new dependency model
- add isolated default-runtime and explicit-override production E2E coverage, including hydration, navigation, Flight, relocation, and Server Actions

## Validation

- `vp test run tests/init.test.ts tests/react-rsc-compatibility.test.ts tests/app-router-rsc-plugin.test.ts`
- `vp test run tests/app-router-dev-server.test.ts tests/pages-router.test.ts tests/build-optimization.test.ts tests/deploy.test.ts`
- `PLAYWRIGHT_PROJECT=app-rsdw-override-prod pnpm run test:e2e`
- `PLAYWRIGHT_PROJECT=app-rsc-isolated-standalone pnpm run test:e2e`
- `vp check`
- repeated independent review until clean

## Diff size

Most touched files are one-line dependency removals across App Router examples and fixtures. The shared lockfile and isolated E2E setup account for most changed lines; runtime behavior is concentrated in the RSC plugin/configuration and React compatibility helpers.