### PR TITLE
fix(cloudflare): restore web CDN warmup deploy

### DIFF
--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -58,4 +58,7 @@
   "cache": {
     "enabled": true,
   },
+  "version_metadata": {
+    "binding": "CF_VERSION_METADATA",
+  },
 }

--- a/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
@@ -56,14 +56,16 @@ type CdnAdapterOptions = {
   versionMetadataBinding?: string;
 };
 
-function versionValidationFailure(message: string): Response {
-  return new Response(`[vinext] ${message}\n`, {
-    status: 503,
-    headers: {
-      "Cache-Control": "no-store",
-      "Content-Type": "text/plain; charset=utf-8",
+function versionValidationFailure(message: string, status = 500): Response {
+  return Response.json(
+    { error: message },
+    {
+      status,
+      headers: {
+        "Cache-Control": "no-store",
+      },
     },
-  });
+  );
 }
 
 const CACHEABLE_EDGE_DIRECTIVE_RE = /(?:^|,)\s*(?:s-maxage|max-age)\s*=/i;
@@ -209,6 +211,7 @@ export class CloudflareCdnCacheAdapter implements CdnCacheAdapter {
     if (expectedVersionId !== this.versionMetadata.id) {
       return versionValidationFailure(
         `Cloudflare invoked Worker version ${this.versionMetadata.id}, but vinext warmup expected ${expectedVersionId}.`,
+        503,
       );
     }
     return null;

--- a/tests/cloudflare-cdn-cache.test.ts
+++ b/tests/cloudflare-cdn-cache.test.ts
@@ -107,6 +107,7 @@ describe("CloudflareCdnCacheAdapter", () => {
     expect(await routedAdapter.validateRequest?.(matching)).toBeNull();
     const response = await routedAdapter.validateRequest?.(mismatching);
     expect(response?.status).toBe(503);
+    expect(response?.headers.get("Content-Type")).toContain("application/json");
     expect(response?.headers.get("Cache-Control")).toBe("no-store");
     await expect(response?.text()).resolves.toContain(
       "Cloudflare invoked Worker version version-b, but vinext warmup expected version-c",
@@ -135,7 +136,8 @@ describe("CloudflareCdnCacheAdapter", () => {
     });
 
     const response = await routedAdapter.validateRequest?.(request);
-    expect(response?.status).toBe(503);
+    expect(response?.status).toBe(500);
+    expect(response?.headers.get("Content-Type")).toContain("application/json");
     await expect(response?.text()).resolves.toContain(
       `received ${VINEXT_EXPECTED_WORKER_VERSION_HEADER} without Cloudflare-Workers-Version-Overrides`,
     );
@@ -154,10 +156,11 @@ describe("CloudflareCdnCacheAdapter", () => {
     });
 
     const response = await routedAdapter.validateRequest?.(request);
-    expect(response?.status).toBe(503);
-    const body = await response?.text();
-    expect(body).toContain("requires the `CUSTOM_VERSION` version metadata binding");
-    expect(body).toContain("Named environments do not inherit this binding");
+    expect(response?.status).toBe(500);
+    expect(response?.headers.get("Content-Type")).toContain("application/json");
+    const body = (await response?.json()) as { error: string };
+    expect(body.error).toContain("requires the `CUSTOM_VERSION` version metadata binding");
+    expect(body.error).toContain("Named environments do not inherit this binding");
   });
 
   it("does not require version metadata for ordinary requests without an override", async () => {


### PR DESCRIPTION
Fixes the main deployment failure in [run 33555256126](https://github.com/cloudflare/vinext/actions/runs/33555256126/job/100014389954).

## What changed

- add the required `CF_VERSION_METADATA` binding to `apps/web`
- return deterministic staged-warmup configuration failures as HTTP 500 JSON so remote path discovery surfaces them immediately instead of retrying for the full phase deadline
- preserve HTTP 503 retry behavior for genuine Worker-version propagation mismatches

## Why

The merged two-stage warmup pins discovery requests to the staged Worker version. `apps/web` configured the CDN adapter but omitted its version metadata binding, so the adapter returned a plain-text 503. Discovery treated that as transient and retried 111 times before the 120-second deadline.

This protocol is Cloudflare-specific; there is no corresponding Next.js behavior to port.

## Validation

- `vp test run tests/cloudflare-cdn-cache.test.ts tests/prerender-paths.test.ts` (101 tests)
- `vp check packages/cloudflare/src/cache/cdn-adapter.runtime.ts tests/cloudflare-cdn-cache.test.ts apps/web/wrangler.jsonc`
- `vp build` in `apps/web`
- `wrangler deploy --dry-run --config dist/server/wrangler.json` in `apps/web`; generated artifact exposes `env.CF_VERSION_METADATA`
