### PR TITLE
fix(cloudflare): harden post-deploy readiness checks

### DIFF
--- a/packages/cloudflare/src/cdn-warm.ts
+++ b/packages/cloudflare/src/cdn-warm.ts
@@ -406,6 +406,7 @@ async function fetchHeadersWithTimeout(
   url: URL,
   timeoutMs: number,
   headers?: HeadersInit,
+  method: "GET" | "POST" = "GET",
 ): Promise<Response> {
   const controller = new AbortController();
   const requestHeaders = new Headers(headers);
@@ -420,7 +421,7 @@ async function fetchHeadersWithTimeout(
     });
     return await Promise.race([
       fetchImpl(url, {
-        method: "GET",
+        method,
         redirect: "manual",
         headers: requestHeaders,
         signal: controller.signal,
@@ -698,9 +699,10 @@ function validateBuildIdentity(
     expectedBuildId !== undefined &&
     response.headers.get(VINEXT_CDN_BUILD_ID_HEADER) !== expectedBuildId
   ) {
+    const actualBuildId = response.headers.get(VINEXT_CDN_BUILD_ID_HEADER) ?? "missing";
     return {
       outcome: "failed",
-      error: `response ${VINEXT_CDN_BUILD_ID_HEADER} does not match build ${expectedBuildId}`,
+      error: `response ${VINEXT_CDN_BUILD_ID_HEADER} does not match build ${expectedBuildId} (received ${actualBuildId})`,
     };
   }
   return null;
@@ -951,6 +953,7 @@ export async function waitForCdnWarmTargetReadiness(
         url,
         Math.min(timeoutMs, remainingMs),
         headers,
+        useReadinessEndpoint ? "POST" : "GET",
       );
       const validationError = useReadinessEndpoint
         ? validatePrerenderReadinessResponse(response, options.expectedBuildId)

--- a/packages/vinext/src/server/worker-prerender-discovery.ts
+++ b/packages/vinext/src/server/worker-prerender-discovery.ts
@@ -47,7 +47,7 @@ export function createWorkerPrerenderReadinessResponse(
 
   if (
     ctx.isPrerenderPathDiscovery !== true ||
-    request.method !== "GET" ||
+    (request.method !== "GET" && request.method !== "POST") ||
     !request.headers.has(VINEXT_EXPECTED_WORKER_VERSION_HEADER)
   ) {
     // This namespace is framework-owned. Never let a failed capability check

--- a/tests/cloudflare-cdn-warm-deploy.test.ts
+++ b/tests/cloudflare-cdn-warm-deploy.test.ts
@@ -507,6 +507,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       const isRsc = headers.get("RSC") === "1";
       if (isReadinessFetch(input)) {
         expect(pathname).toBe("/__vinext/prerender/readiness");
+        expect(init?.method).toBe("POST");
         expect(headers.get("accept")).toBe("text/html");
         expect(headers.get("rsc")).toBeNull();
         expect(headers.get("x-vinext-prerender-secret")).toBe("test-prerender-secret");

--- a/tests/cloudflare-cdn-warm.test.ts
+++ b/tests/cloudflare-cdn-warm.test.ts
@@ -822,6 +822,7 @@ describe("Cloudflare CDN warmup", () => {
       const headers = new Headers(init?.headers);
       expect(url.pathname).toBe("/__vinext/prerender/readiness");
       expect(url.searchParams.has("__vinext_cdn_warm_readiness")).toBe(true);
+      expect(init?.method).toBe("POST");
       expect(headers.get("accept")).toBe("text/html");
       expect(headers.get("rsc")).toBeNull();
       expect(headers.get("x-vinext-prerender-secret")).toBe("build-secret");

--- a/tests/e2e/app-router/server-actions.spec.ts
+++ b/tests/e2e/app-router/server-actions.spec.ts
@@ -506,16 +506,16 @@ test.describe("Data-returning server actions", () => {
     await expect(page.locator("h1")).toHaveText("Action Form Preserved Test");
     await waitForAppRouterHydration(page);
 
-    const renderCount = async () =>
-      parseInt(
-        (await page.locator('[data-testid="server-render-count"]').textContent())!.split(": ")[1],
-        10,
-      );
-    const renderCountBefore = await renderCount();
-
     // Type an edit, then move focus away to trigger the blur action.
     await page.fill("#edit-input", "pending-edit");
+    const actionResponsePromise = page.waitForResponse(
+      (response) =>
+        response.request().method() === "POST" &&
+        new URL(response.url()).pathname === "/action-form-preserved" &&
+        response.headers()["content-type"]?.startsWith("text/x-component") === true,
+    );
     await page.click("#blur-target");
+    const actionResponse = await actionResponsePromise;
 
     // The action's return value surfaces through client state...
     await expect(page.locator('[data-testid="action-result"]')).toHaveText(
@@ -526,7 +526,11 @@ test.describe("Data-returning server actions", () => {
     // ...and the pending edit survives because the server tree was not re-applied.
     await expect(page.locator("#edit-input")).toHaveValue("pending-edit");
 
-    // The page did not re-render on the server.
-    expect(await renderCount()).toBe(renderCountBefore);
+    // Omitting a page root is the stable protocol proof that the server skipped
+    // the rerender. A module-level counter can reset when another parallel dev
+    // test invalidates the Vite module graph.
+    const actionPayload = (await actionResponse.body()).toString("utf8");
+    expect(actionPayload).toContain('"returnValue"');
+    expect(actionPayload).not.toContain('"root"');
   });
 });

--- a/tests/fixtures/app-basic/app/action-form-preserved/page.tsx
+++ b/tests/fixtures/app-basic/app/action-form-preserved/page.tsx
@@ -1,16 +1,9 @@
 import ActionFormPreservedForm from "./form";
 
-// Module-level counter: advances on every server render of this page. If a
-// data-returning server action wrongly commits a visible router update, the
-// page re-renders and this counter moves — the e2e asserts it stays flat.
-let serverRenderCount = 0;
-
 export default function ActionFormPreservedPage() {
-  serverRenderCount++;
   return (
     <div>
       <h1>Action Form Preserved Test</h1>
-      <p data-testid="server-render-count">Server render count: {serverRenderCount}</p>
       <ActionFormPreservedForm />
     </div>
   );

--- a/tests/web-seo.test.ts
+++ b/tests/web-seo.test.ts
@@ -72,6 +72,13 @@ describe("vinext.dev canonical host handling", () => {
         new Request("https://vinext-web.vinext.workers.dev/benchmarks", { method: "POST" }),
       ),
     ).toBeNull();
+    expect(
+      getCanonicalRedirect(
+        new Request("https://vinext-web.vinext.workers.dev/__vinext/prerender/readiness", {
+          method: "POST",
+        }),
+      ),
+    ).toBeNull();
   });
 
   it("marks preview aliases as non-indexable without buffering the response body", async () => {

--- a/tests/worker-prerender-discovery.test.ts
+++ b/tests/worker-prerender-discovery.test.ts
@@ -68,4 +68,17 @@ describe("Worker prerender path discovery authorization", () => {
     expect(unauthorized?.status).toBe(404);
     expect(unauthorized?.headers.get("cache-control")).toBe("no-store");
   });
+
+  it("accepts POST readiness probes so custom entries do not treat them as public documents", () => {
+    const request = new Request("https://example.com/__vinext/prerender/readiness", {
+      method: "POST",
+      headers: {
+        "x-vinext-expected-worker-version": "version-a",
+        "x-vinext-prerender-secret": "build-secret",
+      },
+    });
+    const authorized = createWorkerPrerenderDiscoveryContext(base, request, "build-secret");
+
+    expect(createWorkerPrerenderReadinessResponse(authorized, request)?.status).toBe(204);
+  });
 });


### PR DESCRIPTION
## Summary

Fix both regressions first exposed by the post-merge `main` runs after #3135:

- send the authenticated, version-pinned vinext readiness probe as `POST`, so custom Worker wrappers do not mistake the internal capability check for an ordinary public document and redirect it before vinext can verify the build
- replace the Server Action E2E's module-level render counter with the actual wire contract: a data-returning, non-revalidating action returns `returnValue` without a replacement `root`
- report the received build ID (`missing` when absent) in readiness failures so any future routing interception is immediately diagnosable

Ordinary CDN warming requests remain `GET`; only the secret-gated internal readiness endpoint changes method. The readiness handler continues accepting `GET` for compatibility.

## Root causes

The failed `Deploy web` job reached the new 0% version, but `apps/web` canonicalized document `GET`s before delegating to vinext. A version-pinned `GET` therefore returned a cached 308 without `X-Vinext-Build-Id`; a version-pinned `POST` reaches the vinext readiness endpoint and remains `no-store`.

The failed App Router shard used mutable module state as its oracle. Parallel dev tests can invalidate/reload Vite module instances, so the counter could independently move or reset. The replacement assertion observes the Server Action response itself and matches Next.js' bail-out behavior in `server-action-reducer.ts`: no redirect + no revalidation + no flight data does not apply a replacement tree.

## Validation

- `vp test run tests/cloudflare-cdn-warm.test.ts tests/cloudflare-cdn-warm-deploy.test.ts tests/worker-prerender-discovery.test.ts tests/app-router-worker-entry.test.ts tests/pages-router-worker-entry.test.ts tests/web-seo.test.ts` (139 passed)
- `PLAYWRIGHT_PROJECT=app-router vp exec playwright test tests/e2e/app-router/server-actions.spec.ts --grep "preserves form edits without re-rendering" --repeat-each=10` (10/10 passed)
- `vp check` on all 8 changed files
- `git diff --check`

## Next.js parity

Next.js current reducer explicitly resolves the action result without applying router state when the action did not redirect, did not revalidate, and returned no flight data:
https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
