### PR TITLE
fix(cloudflare): finalize CDN version metadata output

### DIFF
--- a/examples/workers-cache/wrangler.jsonc
+++ b/examples/workers-cache/wrangler.jsonc
@@ -28,8 +28,5 @@
   "cache": {
     "enabled": true,
   },
-  "version_metadata": {
-    "binding": "CF_VERSION_METADATA",
-  },
   "kv_namespaces": [{ "binding": "VINEXT_KV_CACHE", "id": "b38f84f642aa4bd4ba17a37bb516f0b5" }],
 }

--- a/packages/cloudflare/src/cache/cdn-adapter-config.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter-config.ts
@@ -1,0 +1,117 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+type WranglerOutputConfig = {
+  version_metadata?: unknown;
+  [key: string]: unknown;
+};
+
+type VersionMetadataOptions = {
+  binding: string;
+  bindingIsExplicit: boolean;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function configureCdnVersionMetadata(
+  config: WranglerOutputConfig,
+  options: VersionMetadataOptions,
+): WranglerOutputConfig {
+  if (!Object.hasOwn(config, "version_metadata")) {
+    return {
+      ...config,
+      version_metadata: { binding: options.binding },
+    };
+  }
+
+  if (!isRecord(config.version_metadata)) {
+    throw new Error(
+      "[vinext] The generated Wrangler config has an invalid version_metadata value.",
+    );
+  }
+
+  const existingBinding = config.version_metadata.binding;
+  if (typeof existingBinding !== "string" || existingBinding.length === 0) {
+    throw new Error(
+      "[vinext] The generated Wrangler config has an invalid version_metadata.binding value.",
+    );
+  }
+  if (existingBinding === options.binding) return config;
+
+  if (!options.bindingIsExplicit) {
+    throw new Error(
+      `[vinext] cdnAdapter() uses the default version metadata binding ${JSON.stringify(options.binding)}, but the generated Wrangler config already declares ${JSON.stringify(existingBinding)}. Align the Wrangler binding or configure cdnAdapter({ versionMetadataBinding: ${JSON.stringify(existingBinding)} }).`,
+    );
+  }
+
+  return {
+    ...config,
+    version_metadata: { binding: options.binding },
+  };
+}
+
+type DeployRedirect = {
+  configPath?: unknown;
+};
+
+/**
+ * Add the CDN adapter's version metadata binding to the Cloudflare Vite
+ * plugin's primary generated deployment config.
+ */
+export async function finalizeCdnAdapterBuildOutput({
+  root,
+  outDir,
+  binding,
+  bindingIsExplicit,
+}: {
+  root: string;
+  outDir: string;
+  binding: string;
+  bindingIsExplicit: boolean;
+}): Promise<void> {
+  const redirectPath = path.join(root, ".wrangler", "deploy", "config.json");
+  let redirectSource: string;
+  try {
+    redirectSource = await fs.readFile(redirectPath, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw error;
+  }
+
+  let redirect: DeployRedirect;
+  try {
+    redirect = JSON.parse(redirectSource) as DeployRedirect;
+  } catch (cause) {
+    throw new Error(`[vinext] Could not parse ${redirectPath}.`, { cause });
+  }
+  if (typeof redirect.configPath !== "string" || redirect.configPath.length === 0) {
+    throw new Error(`[vinext] ${redirectPath} does not identify a generated Wrangler config.`);
+  }
+
+  const generatedConfigPath = path.resolve(path.dirname(redirectPath), redirect.configPath);
+  const currentOutputConfigPath = path.resolve(outDir, "wrangler.json");
+  if (generatedConfigPath !== currentOutputConfigPath) return;
+
+  let generatedConfig: WranglerOutputConfig;
+  try {
+    const parsed = JSON.parse(await fs.readFile(generatedConfigPath, "utf8")) as unknown;
+    if (!isRecord(parsed)) {
+      throw new TypeError("the root value must be an object");
+    }
+    generatedConfig = parsed;
+  } catch (cause) {
+    throw new Error(
+      `[vinext] Could not read the generated Wrangler config at ${generatedConfigPath}.`,
+      { cause },
+    );
+  }
+
+  const configured = configureCdnVersionMetadata(generatedConfig, {
+    binding,
+    bindingIsExplicit,
+  });
+  if (configured === generatedConfig) return;
+  await fs.writeFile(generatedConfigPath, `${JSON.stringify(configured, null, 2)}\n`);
+}

--- a/packages/cloudflare/src/cache/cdn-adapter-config.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter-config.ts
@@ -52,48 +52,36 @@ export function configureCdnVersionMetadata(
   };
 }
 
-type DeployRedirect = {
-  configPath?: unknown;
-};
-
 /**
  * Add the CDN adapter's version metadata binding to the Cloudflare Vite
  * plugin's primary generated deployment config.
  */
 export async function finalizeCdnAdapterBuildOutput({
-  root,
   outDir,
+  isPrimaryServerOutput,
   binding,
   bindingIsExplicit,
 }: {
-  root: string;
   outDir: string;
+  isPrimaryServerOutput: boolean;
   binding: string;
   bindingIsExplicit: boolean;
 }): Promise<void> {
-  const redirectPath = path.join(root, ".wrangler", "deploy", "config.json");
-  let redirectSource: string;
-  try {
-    redirectSource = await fs.readFile(redirectPath, "utf8");
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
-    throw error;
-  }
+  // Cloudflare builds may contain additional server-consumed environments.
+  // Only the bundle containing vinext's actual server entry owns the CDN
+  // adapter and its version metadata binding.
+  if (!isPrimaryServerOutput) return;
 
-  let redirect: DeployRedirect;
-  try {
-    redirect = JSON.parse(redirectSource) as DeployRedirect;
-  } catch (cause) {
-    throw new Error(`[vinext] Could not parse ${redirectPath}.`, { cause });
-  }
-  if (typeof redirect.configPath !== "string" || redirect.configPath.length === 0) {
-    throw new Error(`[vinext] ${redirectPath} does not identify a generated Wrangler config.`);
-  }
+  await configureGeneratedCdnVersionMetadata(path.resolve(outDir, "wrangler.json"), {
+    binding,
+    bindingIsExplicit,
+  });
+}
 
-  const generatedConfigPath = path.resolve(path.dirname(redirectPath), redirect.configPath);
-  const currentOutputConfigPath = path.resolve(outDir, "wrangler.json");
-  if (generatedConfigPath !== currentOutputConfigPath) return;
-
+async function configureGeneratedCdnVersionMetadata(
+  generatedConfigPath: string,
+  options: VersionMetadataOptions,
+): Promise<void> {
   let generatedConfig: WranglerOutputConfig;
   try {
     const parsed = JSON.parse(await fs.readFile(generatedConfigPath, "utf8")) as unknown;
@@ -108,10 +96,7 @@ export async function finalizeCdnAdapterBuildOutput({
     );
   }
 
-  const configured = configureCdnVersionMetadata(generatedConfig, {
-    binding,
-    bindingIsExplicit,
-  });
+  const configured = configureCdnVersionMetadata(generatedConfig, options);
   if (configured === generatedConfig) return;
   await fs.writeFile(generatedConfigPath, `${JSON.stringify(configured, null, 2)}\n`);
 }

--- a/packages/cloudflare/src/cache/cdn-adapter.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.ts
@@ -1,4 +1,5 @@
 import { fileURLToPath } from "node:url";
+import { finalizeCdnAdapterBuildOutput } from "./cdn-adapter-config.js";
 
 export const DEFAULT_CDN_VERSION_METADATA_BINDING = "CF_VERSION_METADATA";
 
@@ -45,9 +46,28 @@ export function cdnAdapter(options?: CdnAdapterOptions) {
       "[vinext] cdnAdapter({ versionMetadataBinding }) must be a non-empty string binding name.",
     );
   }
+  const versionMetadataBinding =
+    options?.versionMetadataBinding ?? DEFAULT_CDN_VERSION_METADATA_BINDING;
+  const bindingIsExplicit = options?.versionMetadataBinding !== undefined;
   return {
     adapter: fileURLToPath(import.meta.resolve("./cdn-adapter.runtime.js")),
     options,
+    output: {
+      matchesBuild({ plugins }: { plugins: readonly { name?: string }[] }) {
+        return plugins.some(
+          ({ name }) =>
+            name === "vite-plugin-cloudflare" || name?.startsWith("vite-plugin-cloudflare:"),
+        );
+      },
+      finalizeBuildOutput({ root, outDir }: { root: string; outDir: string }) {
+        return finalizeCdnAdapterBuildOutput({
+          root,
+          outDir,
+          binding: versionMetadataBinding,
+          bindingIsExplicit,
+        });
+      },
+    },
     capabilities: {
       buildIdentity: "response-header" as const,
       responseVary: "verbatim" as const,

--- a/packages/cloudflare/src/cache/cdn-adapter.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.ts
@@ -59,10 +59,16 @@ export function cdnAdapter(options?: CdnAdapterOptions) {
             name === "vite-plugin-cloudflare" || name?.startsWith("vite-plugin-cloudflare:"),
         );
       },
-      finalizeBuildOutput({ root, outDir }: { root: string; outDir: string }) {
+      finalizeBuildOutput({
+        outDir,
+        isPrimaryServerOutput,
+      }: {
+        outDir: string;
+        isPrimaryServerOutput: boolean;
+      }) {
         return finalizeCdnAdapterBuildOutput({
-          root,
           outDir,
+          isPrimaryServerOutput,
           binding: versionMetadataBinding,
           bindingIsExplicit,
         });

--- a/packages/cloudflare/src/deploy-config.ts
+++ b/packages/cloudflare/src/deploy-config.ts
@@ -1,11 +1,16 @@
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import type { VinextCacheConfig } from "vinext/internal/cache-adapters";
 import { findViteConfigPath } from "vinext/internal/utils/project";
 import {
   DEFAULT_KV_DATA_CACHE_BINDING,
   type KvDataAdapterOptions,
 } from "./cache/kv-data-adapter.js";
+import {
+  DEFAULT_CDN_VERSION_METADATA_BINDING,
+  type CdnAdapterOptions,
+} from "./cache/cdn-adapter.js";
 
 function escapeRegExp(value: string): string {
   return value.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&");
@@ -115,6 +120,38 @@ export type ResolvedKvDataAdapterConfig = {
   appPrefix?: string;
   ttlSeconds?: number;
 };
+
+export type ResolvedCdnAdapterConfig = {
+  versionMetadataBinding: string;
+};
+
+function isCloudflareCdnAdapterPath(adapter: string): boolean {
+  const normalized = adapter.replace(/\\/g, "/");
+  const bundledRuntime = fileURLToPath(
+    new URL("./cache/cdn-adapter.runtime.js", import.meta.url),
+  ).replace(/\\/g, "/");
+  return (
+    normalized === "@vinext/cloudflare/cache/cdn-adapter.runtime" ||
+    normalized === "@vinext/cloudflare/cache/cdn-adapter.runtime.js" ||
+    normalized === bundledRuntime
+  );
+}
+
+export function resolveCdnAdapterConfig(
+  cache: VinextCacheConfig | null | undefined,
+): ResolvedCdnAdapterConfig | null {
+  const cdn = cache?.cdn;
+  if (!cdn?.adapter || !isCloudflareCdnAdapterPath(cdn.adapter)) return null;
+
+  const options = cdn.options as CdnAdapterOptions | undefined;
+  return {
+    versionMetadataBinding:
+      typeof options?.versionMetadataBinding === "string" &&
+      options.versionMetadataBinding.length > 0
+        ? options.versionMetadataBinding
+        : DEFAULT_CDN_VERSION_METADATA_BINDING,
+  };
+}
 
 function isCloudflareKvDataAdapterPath(adapter: string): boolean {
   const normalized = adapter.replace(/\\/g, "/");

--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -66,12 +66,14 @@ import {
 import {
   formatMissingCacheAdapterError,
   formatImageOptimizationHint,
+  resolveCdnAdapterConfig,
   resolveKvDataAdapterConfig,
   viteConfigHasCacheAdapter,
   viteConfigHasCloudflarePlugin,
   viteConfigHasImageAdapter,
   workerEntryHasCacheHandler,
 } from "./deploy-config.js";
+import { assertCdnVersionMetadataConfig } from "./wrangler-version-metadata.js";
 import {
   runWranglerDeploymentStatus,
   runWranglerTriggersDeploy,
@@ -166,6 +168,20 @@ export type DeployOptions = {
 };
 
 type ProjectViteApi = Pick<typeof import("vite"), "createBuilder" | "loadConfigFromFile">;
+
+type ProjectWranglerApi = {
+  unstable_readConfig(
+    args: { config?: string; env?: string },
+    options: {
+      hideWarnings: true;
+      preserveOriginalMain: true;
+      useRedirectIfAvailable: true;
+    },
+  ): {
+    configPath?: string;
+    version_metadata?: { binding: string };
+  };
+};
 
 type DeployViteConfigMetadata = {
   cacheConfig: VinextCacheConfig | null;
@@ -457,6 +473,18 @@ async function loadProjectViteApi(root: string): Promise<ProjectViteApi> {
   return (await import(/* @vite-ignore */ viteUrl)) as ProjectViteApi;
 }
 
+async function loadProjectWranglerApi(root: string): Promise<ProjectWranglerApi> {
+  const req = createRequire(path.join(root, "package.json"));
+  let wranglerPath: string;
+  try {
+    wranglerPath = req.resolve("wrangler");
+  } catch {
+    const cloudflarePluginPath = req.resolve("@cloudflare/vite-plugin");
+    wranglerPath = createRequire(cloudflarePluginPath).resolve("wrangler");
+  }
+  return (await import(/* @vite-ignore */ pathToFileURL(wranglerPath).href)) as ProjectWranglerApi;
+}
+
 async function loadDeployViteConfigMetadata(root: string): Promise<DeployViteConfigMetadata> {
   const vite = await loadProjectViteApi(root);
   const loaded = await vite.loadConfigFromFile(
@@ -466,9 +494,9 @@ async function loadDeployViteConfigMetadata(root: string): Promise<DeployViteCon
   );
   const plugins = loaded?.config.plugins;
   return {
-    cacheConfig: viteConfigHasCacheAdapter(root)
-      ? await findVinextCacheConfigInPlugins(plugins)
-      : null,
+    // The executed Vite config is authoritative. Source scans cannot see
+    // imported or composed cache objects and must not suppress valid metadata.
+    cacheConfig: await findVinextCacheConfigInPlugins(plugins),
     nextConfig: await findVinextNextConfigInPlugins(plugins),
     prerenderConfig: await findVinextPrerenderConfigInPlugins(plugins),
     routeRootConfig: await findVinextRouteRootConfigInPlugins(plugins),
@@ -1883,6 +1911,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
   const viteConfigMetadata = await withCloudflareEnv(buildEnv, () =>
     loadDeployViteConfigMetadata(info.root),
   );
+  const cdnAdapterConfig = resolveCdnAdapterConfig(viteConfigMetadata.cacheConfig);
   const nextConfig = await withCloudflareEnv(buildEnv, async () => {
     const inlineNextConfig = viteConfigMetadata.nextConfig;
     const rawNextConfig = inlineNextConfig
@@ -1907,12 +1936,35 @@ export async function deploy(options: DeployOptions): Promise<void> {
     viteConfigMetadata.cacheConfig,
   );
   const shouldEmitPrerenderPathManifest = !options.skipBuild && prerenderDecision;
-
   // Step 5: Build
   if (!options.skipBuild) {
     await runBuild(info, buildEnv);
   } else {
     console.log("\n  Skipping build (--skip-build)");
+  }
+
+  if (options.warmCdnCache && cdnAdapterConfig) {
+    const wrangler = await loadProjectWranglerApi(info.root);
+    const previousCwd = process.cwd();
+    try {
+      // Wrangler resolves its generated deploy redirect relative to cwd.
+      process.chdir(info.root);
+      const config = wrangler.unstable_readConfig(
+        { config: options.config, env: buildEnv },
+        {
+          hideWarnings: true,
+          preserveOriginalMain: true,
+          useRedirectIfAvailable: true,
+        },
+      );
+      assertCdnVersionMetadataConfig({
+        binding: cdnAdapterConfig.versionMetadataBinding,
+        configuredBinding: config.version_metadata?.binding,
+        configPath: config.configPath,
+      });
+    } finally {
+      process.chdir(previousCwd);
+    }
   }
 
   if (shouldEmitPrerenderPathManifest) {

--- a/packages/cloudflare/src/wrangler-version-metadata.ts
+++ b/packages/cloudflare/src/wrangler-version-metadata.ts
@@ -1,0 +1,19 @@
+export function assertCdnVersionMetadataConfig({
+  binding,
+  configuredBinding,
+  configPath,
+}: {
+  binding: string;
+  configuredBinding: string | undefined;
+  configPath: string | undefined;
+}): void {
+  if (configuredBinding === binding) return;
+
+  const location = configPath ? ` in ${configPath}` : "";
+  const found = configuredBinding
+    ? ` declares ${JSON.stringify(configuredBinding)} instead`
+    : " does not declare version_metadata";
+  throw new Error(
+    `[vinext] Cloudflare CDN warmup requires version metadata binding ${JSON.stringify(binding)}, but the effective Wrangler config${location}${found}. Deploy the generated Wrangler config finalized by cdnAdapter(), or add the binding to this effective config and align cdnAdapter({ versionMetadataBinding }) when using a custom name.`,
+  );
+}

--- a/packages/vinext/src/cache/cache-adapters-virtual.ts
+++ b/packages/vinext/src/cache/cache-adapters-virtual.ts
@@ -53,7 +53,11 @@ export type CacheAdapterBuildOutput = {
   /** Whether this adapter owns output for the resolved build platform. */
   matchesBuild?: (build: { plugins: readonly { name?: string }[] }) => boolean;
   /** Finalize an emitted directory after other platform output hooks. */
-  finalizeBuildOutput?: (output: { root: string; outDir: string }) => Promise<void> | void;
+  finalizeBuildOutput?: (output: {
+    root: string;
+    outDir: string;
+    isPrimaryServerOutput: boolean;
+  }) => Promise<void> | void;
 };
 
 export type CacheAdapterDescriptor<O extends Record<string, unknown> = Record<string, unknown>> = {

--- a/packages/vinext/src/cache/cache-adapters-virtual.ts
+++ b/packages/vinext/src/cache/cache-adapters-virtual.ts
@@ -49,6 +49,13 @@ export type CdnCacheAdapterCapabilities = {
   routeCacheability?: "probe-manifest";
 };
 
+export type CacheAdapterBuildOutput = {
+  /** Whether this adapter owns output for the resolved build platform. */
+  matchesBuild?: (build: { plugins: readonly { name?: string }[] }) => boolean;
+  /** Finalize an emitted directory after other platform output hooks. */
+  finalizeBuildOutput?: (output: { root: string; outDir: string }) => Promise<void> | void;
+};
+
 export type CacheAdapterDescriptor<O extends Record<string, unknown> = Record<string, unknown>> = {
   /**
    * Module specifier (or absolute path, e.g. from `require.resolve(...)`) whose
@@ -57,6 +64,8 @@ export type CacheAdapterDescriptor<O extends Record<string, unknown> = Record<st
   adapter: string;
   /** JSON-serializable options forwarded to the factory at runtime. */
   options?: O;
+  /** Optional adapter-owned finalization for platform-generated build output. */
+  output?: CacheAdapterBuildOutput;
   /** Build-time cache semantics used by shared request protocol code. */
   capabilities?: CdnCacheAdapterCapabilities;
 };

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1530,6 +1530,17 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
   let rscClassificationManifest: RouteClassificationManifest | null = null;
   let rscActionOwnerRoutes: Awaited<ReturnType<typeof appRouter>> | null = null;
   let rscActionOwnerSharedRoots: string[] = [];
+  const serverEntryKindsByEnvironment = new Map<string, Set<string>>();
+
+  function recordServerEntryLoad(environmentName: string | undefined, id: string): void {
+    if (!environmentName) return;
+    let entries = serverEntryKindsByEnvironment.get(environmentName);
+    if (!entries) {
+      entries = new Set();
+      serverEntryKindsByEnvironment.set(environmentName, entries);
+    }
+    entries.add(id);
+  }
 
   // Resolve shim paths - works both from source (.ts) and built (.js).
   const shimsDir = path.resolve(__dirname, "shims");
@@ -4033,6 +4044,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           }
           // Pages Router virtual modules
           if (id === RESOLVED_SERVER_ENTRY) {
+            recordServerEntryLoad(this.environment?.name, id);
             return await generateServerEntry(
               this.environment.config.publicDir === "" ? false : this.environment.config.publicDir,
             );
@@ -4077,6 +4089,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             return "export default null;";
           }
           if (id === RESOLVED_RSC_ENTRY && hasAppDir) {
+            recordServerEntryLoad(this.environment?.name, id);
             const routes = await appRouter(appDir, nextConfig?.pageExtensions, fileMatcher);
             const metaRoutes = scanMetadataFiles(appDir);
             const hasServerActions = await resolveHasServerActions(this.environment.config);
@@ -4171,6 +4184,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             return generateImageAdaptersModule(options.images);
           }
           if (id === RESOLVED_APP_SSR_ENTRY && hasAppDir) {
+            recordServerEntryLoad(this.environment?.name, id);
             return generateSsrEntry(hasPagesDir);
           }
           if (id === RESOLVED_APP_BROWSER_ENTRY && hasAppDir) {
@@ -7341,9 +7355,19 @@ export const loadServerActionClient = ${
           const build = { plugins: config.plugins };
           const buildRoot = config.root ?? process.cwd();
           const outDir = path.resolve(buildRoot, outputOptions.dir);
+          const loadedEntries = serverEntryKindsByEnvironment.get(this.environment?.name ?? "");
+          const isPrimaryServerOutput = Boolean(
+            loadedEntries?.has(RESOLVED_RSC_ENTRY) ||
+            (loadedEntries?.has(RESOLVED_SERVER_ENTRY) &&
+              !loadedEntries.has(RESOLVED_APP_SSR_ENTRY)),
+          );
           for (const output of cacheAdapterBuildOutputs) {
             if (output.matchesBuild && !output.matchesBuild(build)) continue;
-            await output.finalizeBuildOutput?.({ root: buildRoot, outDir });
+            await output.finalizeBuildOutput?.({
+              root: buildRoot,
+              outDir,
+              isPrimaryServerOutput,
+            });
           }
         },
       },

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -1460,6 +1460,9 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
   const { supportsNativeTypeofWindowFolding: useNativeTypeofWindowFolding } =
     assertSupportedViteVersion();
   const prerenderConfig = normalizeVinextPrerenderConfig(options.prerender);
+  const cacheAdapterBuildOutputs = [options.cache?.data?.output, options.cache?.cdn?.output].filter(
+    (output) => output !== undefined,
+  );
   let root: string;
   let pagesDir: string;
   let canonicalPagesDir: string;
@@ -7321,6 +7324,31 @@ export const loadServerActionClient = ${
       },
     },
   ];
+
+  if (cacheAdapterBuildOutputs.length > 0) {
+    plugins.push({
+      name: "vinext:cache-adapter-build-output",
+      apply: "build",
+      enforce: "post",
+      writeBundle: {
+        sequential: true,
+        order: "post",
+        async handler(outputOptions) {
+          if (!outputOptions.dir) return;
+          const config = this.environment?.config;
+          if (!config) return;
+
+          const build = { plugins: config.plugins };
+          const buildRoot = config.root ?? process.cwd();
+          const outDir = path.resolve(buildRoot, outputOptions.dir);
+          for (const output of cacheAdapterBuildOutputs) {
+            if (output.matchesBuild && !output.matchesBuild(build)) continue;
+            await output.finalizeBuildOutput?.({ root: buildRoot, outDir });
+          }
+        },
+      },
+    });
+  }
 
   // Append auto-injected RSC plugins if applicable
   if (rscPluginPromise) {

--- a/tests/cdn-adapter-build.test.ts
+++ b/tests/cdn-adapter-build.test.ts
@@ -24,6 +24,7 @@ describe("Cloudflare CDN adapter build output", () => {
     root = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-cdn-adapter-build-"));
     await fs.symlink(CLOUDFLARE_NODE_MODULES, path.join(root, "node_modules"), "dir");
     await fs.mkdir(path.join(root, "app"), { recursive: true });
+    await fs.mkdir(path.join(root, "pages"), { recursive: true });
     await fs.writeFile(
       path.join(root, "package.json"),
       JSON.stringify({ name: "cdn-adapter-build", type: "module" }),
@@ -35,6 +36,10 @@ describe("Cloudflare CDN adapter build output", () => {
     await fs.writeFile(
       path.join(root, "app/page.tsx"),
       "export default function Page() { return <main>home</main>; }\n",
+    );
+    await fs.writeFile(
+      path.join(root, "pages/legacy.tsx"),
+      "export default function LegacyPage() { return <main>legacy</main>; }\n",
     );
     await fs.writeFile(
       path.join(root, "wrangler.jsonc"),
@@ -109,4 +114,50 @@ describe("Cloudflare CDN adapter build output", () => {
       process.chdir(previousCwd);
     }
   });
+
+  it("adds the binding to a Pages Router primary output", async () => {
+    const pagesRoot = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-cdn-adapter-pages-"));
+    try {
+      await fs.symlink(CLOUDFLARE_NODE_MODULES, path.join(pagesRoot, "node_modules"), "dir");
+      await fs.mkdir(path.join(pagesRoot, "pages"), { recursive: true });
+      await fs.writeFile(
+        path.join(pagesRoot, "package.json"),
+        JSON.stringify({ name: "cdn-adapter-pages", type: "module" }),
+      );
+      await fs.writeFile(
+        path.join(pagesRoot, "pages/index.tsx"),
+        "export default function Page() { return <main>home</main>; }\n",
+      );
+      await fs.writeFile(
+        path.join(pagesRoot, "wrangler.jsonc"),
+        JSON.stringify({
+          name: "cdn-adapter-pages",
+          compatibility_date: "2026-09-02",
+          compatibility_flags: ["nodejs_compat"],
+          main: "vinext/server/fetch-handler",
+          assets: { not_found_handling: "none", binding: "ASSETS" },
+        }),
+      );
+
+      const { cloudflare } = (await import(pathToFileURL(CLOUDFLARE_PLUGIN_PATH).href)) as {
+        cloudflare: () => import("vite").Plugin;
+      };
+      const builder = await createBuilder({
+        root: pagesRoot,
+        configFile: false,
+        logLevel: "silent",
+        plugins: [vinext({ appDir: pagesRoot, cache: { cdn: cdnAdapter() } }), cloudflare()],
+      });
+      await builder.buildApp();
+
+      const redirect = JSON.parse(
+        await fs.readFile(path.join(pagesRoot, ".wrangler/deploy/config.json"), "utf8"),
+      ) as { configPath: string };
+      const generatedPath = path.resolve(pagesRoot, ".wrangler/deploy", redirect.configPath);
+      const generated = JSON.parse(await fs.readFile(generatedPath, "utf8"));
+      expect(generated.version_metadata).toEqual({ binding: "CF_VERSION_METADATA" });
+    } finally {
+      await fs.rm(pagesRoot, { recursive: true, force: true });
+    }
+  }, 120_000);
 });

--- a/tests/cdn-adapter-build.test.ts
+++ b/tests/cdn-adapter-build.test.ts
@@ -1,0 +1,112 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { pathToFileURL } from "node:url";
+import { createBuilder } from "vite";
+import { afterAll, beforeAll, describe, expect, it } from "vite-plus/test";
+import { cdnAdapter } from "../packages/cloudflare/src/cache/cdn-adapter.js";
+import vinext from "../packages/vinext/src/index.js";
+
+const CLOUDFLARE_NODE_MODULES = path.resolve(
+  import.meta.dirname,
+  "fixtures/cf-app-basic/node_modules",
+);
+const CLOUDFLARE_PLUGIN_PATH = path.join(
+  CLOUDFLARE_NODE_MODULES,
+  "@cloudflare/vite-plugin/dist/index.mjs",
+);
+
+describe("Cloudflare CDN adapter build output", () => {
+  let root: string;
+
+  beforeAll(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-cdn-adapter-build-"));
+    await fs.symlink(CLOUDFLARE_NODE_MODULES, path.join(root, "node_modules"), "dir");
+    await fs.mkdir(path.join(root, "app"), { recursive: true });
+    await fs.writeFile(
+      path.join(root, "package.json"),
+      JSON.stringify({ name: "cdn-adapter-build", type: "module" }),
+    );
+    await fs.writeFile(
+      path.join(root, "app/layout.tsx"),
+      "export default function Layout({ children }) { return <html><body>{children}</body></html>; }\n",
+    );
+    await fs.writeFile(
+      path.join(root, "app/page.tsx"),
+      "export default function Page() { return <main>home</main>; }\n",
+    );
+    await fs.writeFile(
+      path.join(root, "wrangler.jsonc"),
+      JSON.stringify({
+        name: "cdn-adapter-build",
+        compatibility_date: "2026-09-02",
+        compatibility_flags: ["nodejs_compat"],
+        main: "vinext/server/fetch-handler",
+        assets: { not_found_handling: "none", binding: "ASSETS" },
+      }),
+    );
+
+    const { cloudflare } = (await import(pathToFileURL(CLOUDFLARE_PLUGIN_PATH).href)) as {
+      cloudflare: (options: {
+        viteEnvironment: { name: string; childEnvironments: string[] };
+      }) => import("vite").Plugin;
+    };
+    const builder = await createBuilder({
+      root,
+      configFile: false,
+      logLevel: "silent",
+      plugins: [
+        vinext({ appDir: root, cache: { cdn: cdnAdapter() } }),
+        cloudflare({ viteEnvironment: { name: "rsc", childEnvironments: ["ssr"] } }),
+      ],
+    });
+    await builder.buildApp();
+  }, 120_000);
+
+  afterAll(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it("makes the emitted Wrangler config directly deployable without changing source config", async () => {
+    const source = JSON.parse(await fs.readFile(path.join(root, "wrangler.jsonc"), "utf8"));
+    const generated = JSON.parse(
+      await fs.readFile(path.join(root, "dist/server/wrangler.json"), "utf8"),
+    );
+
+    expect(source.version_metadata).toBeUndefined();
+    expect(generated.version_metadata).toEqual({ binding: "CF_VERSION_METADATA" });
+  });
+
+  it("is the effective config selected by Wrangler's deploy redirect", async () => {
+    const wranglerPath = createRequire(path.join(root, "package.json")).resolve("wrangler");
+    const wrangler = (await import(pathToFileURL(wranglerPath).href)) as {
+      unstable_readConfig(
+        args: Record<string, never>,
+        options: {
+          hideWarnings: true;
+          preserveOriginalMain: true;
+          useRedirectIfAvailable: true;
+        },
+      ): { configPath?: string; version_metadata?: { binding: string } };
+    };
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(root);
+      const config = wrangler.unstable_readConfig(
+        {},
+        {
+          hideWarnings: true,
+          preserveOriginalMain: true,
+          useRedirectIfAvailable: true,
+        },
+      );
+      expect(await fs.realpath(path.resolve(root, config.configPath ?? ""))).toBe(
+        await fs.realpath(path.join(root, "dist/server/wrangler.json")),
+      );
+      expect(config.version_metadata).toEqual({ binding: "CF_VERSION_METADATA" });
+    } finally {
+      process.chdir(previousCwd);
+    }
+  });
+});

--- a/tests/cdn-adapter-config.test.ts
+++ b/tests/cdn-adapter-config.test.ts
@@ -1,0 +1,226 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import vinext from "../packages/vinext/src/index.js";
+import {
+  configureCdnVersionMetadata,
+  finalizeCdnAdapterBuildOutput,
+} from "../packages/cloudflare/src/cache/cdn-adapter-config.js";
+import {
+  cdnAdapter,
+  DEFAULT_CDN_VERSION_METADATA_BINDING,
+} from "../packages/cloudflare/src/cache/cdn-adapter.js";
+import { resolveCdnAdapterConfig } from "../packages/cloudflare/src/deploy-config.js";
+import { assertCdnVersionMetadataConfig } from "../packages/cloudflare/src/wrangler-version-metadata.js";
+
+let root: string;
+
+function writeJson(relativePath: string, value: unknown): string {
+  const filePath = path.join(root, relativePath);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(value));
+  return filePath;
+}
+
+function writeGeneratedConfig(
+  relativePath = "dist/server/wrangler.json",
+  config: Record<string, unknown> = { name: "test-worker", main: "index.js" },
+): string {
+  const configPath = writeJson(relativePath, config);
+  writeJson(".wrangler/deploy/config.json", {
+    configPath: path.relative(path.join(root, ".wrangler/deploy"), configPath),
+  });
+  return configPath;
+}
+
+describe("Cloudflare CDN adapter generated config", () => {
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-cdn-adapter-config-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("adds the default binding to the primary generated config only", async () => {
+    const sourcePath = writeJson("wrangler.jsonc", { name: "source-worker" });
+    const generatedPath = writeGeneratedConfig();
+    const auxiliaryPath = writeJson("dist/auxiliary/wrangler.json", {
+      name: "auxiliary-worker",
+    });
+
+    await finalizeCdnAdapterBuildOutput({
+      root,
+      outDir: path.dirname(auxiliaryPath),
+      binding: DEFAULT_CDN_VERSION_METADATA_BINDING,
+      bindingIsExplicit: false,
+    });
+    await finalizeCdnAdapterBuildOutput({
+      root,
+      outDir: path.dirname(generatedPath),
+      binding: DEFAULT_CDN_VERSION_METADATA_BINDING,
+      bindingIsExplicit: false,
+    });
+
+    expect(JSON.parse(fs.readFileSync(generatedPath, "utf8")).version_metadata).toEqual({
+      binding: DEFAULT_CDN_VERSION_METADATA_BINDING,
+    });
+    expect(JSON.parse(fs.readFileSync(auxiliaryPath, "utf8")).version_metadata).toBeUndefined();
+    expect(fs.readFileSync(sourcePath, "utf8")).toBe('{"name":"source-worker"}');
+  });
+
+  it("leaves an already matching generated config byte-for-byte unchanged", async () => {
+    const generatedPath = writeGeneratedConfig("dist/server/wrangler.json", {
+      name: "test-worker",
+      version_metadata: { binding: DEFAULT_CDN_VERSION_METADATA_BINDING },
+    });
+    const before = fs.readFileSync(generatedPath, "utf8");
+
+    await finalizeCdnAdapterBuildOutput({
+      root,
+      outDir: path.dirname(generatedPath),
+      binding: DEFAULT_CDN_VERSION_METADATA_BINDING,
+      bindingIsExplicit: false,
+    });
+
+    expect(fs.readFileSync(generatedPath, "utf8")).toBe(before);
+  });
+
+  it("rejects an existing custom binding when cdnAdapter uses its default", async () => {
+    const generatedPath = writeGeneratedConfig("dist/server/wrangler.json", {
+      name: "test-worker",
+      version_metadata: { binding: "EXISTING_VERSION" },
+    });
+
+    await expect(
+      finalizeCdnAdapterBuildOutput({
+        root,
+        outDir: path.dirname(generatedPath),
+        binding: DEFAULT_CDN_VERSION_METADATA_BINDING,
+        bindingIsExplicit: false,
+      }),
+    ).rejects.toThrow('configure cdnAdapter({ versionMetadataBinding: "EXISTING_VERSION" })');
+    expect(JSON.parse(fs.readFileSync(generatedPath, "utf8")).version_metadata).toEqual({
+      binding: "EXISTING_VERSION",
+    });
+  });
+
+  it("lets an explicit adapter binding replace a generated binding", () => {
+    expect(
+      configureCdnVersionMetadata(
+        { version_metadata: { binding: "EXISTING_VERSION" } },
+        { binding: "CUSTOM_VERSION", bindingIsExplicit: true },
+      ),
+    ).toEqual({ version_metadata: { binding: "CUSTOM_VERSION" } });
+  });
+
+  it("rejects malformed generated metadata instead of silently replacing it", () => {
+    for (const version_metadata of [null, [], {}, { binding: "" }, { binding: 42 }]) {
+      expect(() =>
+        configureCdnVersionMetadata(
+          { version_metadata },
+          { binding: DEFAULT_CDN_VERSION_METADATA_BINDING, bindingIsExplicit: false },
+        ),
+      ).toThrow(/invalid version_metadata/);
+    }
+  });
+
+  it("exposes finalization only for Cloudflare builds", () => {
+    const output = cdnAdapter().output;
+    expect(output.matchesBuild({ plugins: [{ name: "vite-plugin-cloudflare" }] })).toBe(true);
+    expect(output.matchesBuild({ plugins: [{ name: "vite-plugin-cloudflare:deploy" }] })).toBe(
+      true,
+    );
+    expect(output.matchesBuild({ plugins: [{ name: "another-platform" }] })).toBe(false);
+  });
+});
+
+describe("vinext cache adapter output hook", () => {
+  it("runs matching adapter finalizers with the emitted output directory", async () => {
+    const finalizeBuildOutput = vi.fn();
+    const plugins = vinext({
+      disableAppRouter: true,
+      react: false,
+      rsc: false,
+      cache: {
+        cdn: {
+          adapter: "test-adapter",
+          output: {
+            matchesBuild: ({ plugins }) => plugins.some(({ name }) => name === "test-platform"),
+            finalizeBuildOutput,
+          },
+        },
+      },
+    });
+    const plugin = plugins.find(
+      (candidate) =>
+        candidate &&
+        typeof candidate === "object" &&
+        "name" in candidate &&
+        candidate.name === "vinext:cache-adapter-build-output",
+    );
+    expect(plugin).toBeDefined();
+    if (!plugin || typeof plugin !== "object" || !("writeBundle" in plugin)) return;
+
+    const hook =
+      typeof plugin.writeBundle === "function" ? plugin.writeBundle : plugin.writeBundle?.handler;
+    expect(hook).toBeTypeOf("function");
+    await hook?.call(
+      {
+        environment: {
+          config: {
+            root: "/project",
+            plugins: [{ name: "test-platform" }],
+          },
+        },
+      } as never,
+      { dir: "dist/server" } as never,
+      {},
+    );
+
+    expect(finalizeBuildOutput).toHaveBeenCalledOnce();
+    expect(finalizeBuildOutput).toHaveBeenCalledWith({
+      root: "/project",
+      outDir: path.resolve("/project/dist/server"),
+    });
+  });
+});
+
+describe("CDN version metadata deploy validation", () => {
+  it("resolves the built-in adapter's default and custom bindings", () => {
+    expect(resolveCdnAdapterConfig({ cdn: cdnAdapter() })).toEqual({
+      versionMetadataBinding: DEFAULT_CDN_VERSION_METADATA_BINDING,
+    });
+    expect(
+      resolveCdnAdapterConfig({
+        cdn: cdnAdapter({ versionMetadataBinding: "CUSTOM_VERSION" }),
+      }),
+    ).toEqual({ versionMetadataBinding: "CUSTOM_VERSION" });
+    expect(resolveCdnAdapterConfig({ cdn: { adapter: "custom-adapter" } })).toBeNull();
+  });
+
+  it("rejects missing or conflicting effective deploy bindings", () => {
+    expect(() =>
+      assertCdnVersionMetadataConfig({
+        binding: DEFAULT_CDN_VERSION_METADATA_BINDING,
+        configuredBinding: undefined,
+        configPath: "dist/server/wrangler.json",
+      }),
+    ).toThrow("does not declare version_metadata");
+    expect(() =>
+      assertCdnVersionMetadataConfig({
+        binding: DEFAULT_CDN_VERSION_METADATA_BINDING,
+        configuredBinding: "OTHER_VERSION",
+        configPath: "dist/server/wrangler.json",
+      }),
+    ).toThrow('declares "OTHER_VERSION" instead');
+    expect(() =>
+      assertCdnVersionMetadataConfig({
+        binding: DEFAULT_CDN_VERSION_METADATA_BINDING,
+        configuredBinding: DEFAULT_CDN_VERSION_METADATA_BINDING,
+        configPath: "dist/server/wrangler.json",
+      }),
+    ).not.toThrow();
+  });
+});

--- a/tests/cdn-adapter-config.test.ts
+++ b/tests/cdn-adapter-config.test.ts
@@ -51,14 +51,14 @@ describe("Cloudflare CDN adapter generated config", () => {
     });
 
     await finalizeCdnAdapterBuildOutput({
-      root,
       outDir: path.dirname(auxiliaryPath),
+      isPrimaryServerOutput: false,
       binding: DEFAULT_CDN_VERSION_METADATA_BINDING,
       bindingIsExplicit: false,
     });
     await finalizeCdnAdapterBuildOutput({
-      root,
       outDir: path.dirname(generatedPath),
+      isPrimaryServerOutput: true,
       binding: DEFAULT_CDN_VERSION_METADATA_BINDING,
       bindingIsExplicit: false,
     });
@@ -70,6 +70,94 @@ describe("Cloudflare CDN adapter generated config", () => {
     expect(fs.readFileSync(sourcePath, "utf8")).toBe('{"name":"source-worker"}');
   });
 
+  it("uses the primary vinext server output when the deploy redirect is absent", async () => {
+    const generatedPath = writeJson("dist/server/wrangler.json", {
+      name: "test-worker",
+      main: "index.js",
+    });
+
+    await finalizeCdnAdapterBuildOutput({
+      outDir: path.dirname(generatedPath),
+      isPrimaryServerOutput: true,
+      binding: DEFAULT_CDN_VERSION_METADATA_BINDING,
+      bindingIsExplicit: false,
+    });
+
+    expect(JSON.parse(fs.readFileSync(generatedPath, "utf8")).version_metadata).toEqual({
+      binding: DEFAULT_CDN_VERSION_METADATA_BINDING,
+    });
+  });
+
+  it("does not treat an auxiliary output as the deploy target when the redirect is absent", async () => {
+    const auxiliaryPath = writeJson("dist/auxiliary/wrangler.json", {
+      name: "auxiliary-worker",
+      main: "index.js",
+    });
+    const before = fs.readFileSync(auxiliaryPath, "utf8");
+
+    await finalizeCdnAdapterBuildOutput({
+      outDir: path.dirname(auxiliaryPath),
+      isPrimaryServerOutput: false,
+      binding: DEFAULT_CDN_VERSION_METADATA_BINDING,
+      bindingIsExplicit: false,
+    });
+
+    expect(fs.readFileSync(auxiliaryPath, "utf8")).toBe(before);
+  });
+
+  it("uses the primary output directly when the deploy redirect is stale", async () => {
+    const auxiliaryPath = writeGeneratedConfig("dist/auxiliary/wrangler.json", {
+      name: "auxiliary-worker",
+      main: "index.js",
+    });
+    const primaryPath = writeJson("dist/server/wrangler.json", {
+      name: "primary-worker",
+      main: "index.js",
+    });
+
+    await finalizeCdnAdapterBuildOutput({
+      outDir: path.dirname(primaryPath),
+      isPrimaryServerOutput: true,
+      binding: DEFAULT_CDN_VERSION_METADATA_BINDING,
+      bindingIsExplicit: false,
+    });
+
+    expect(JSON.parse(fs.readFileSync(primaryPath, "utf8")).version_metadata).toEqual({
+      binding: DEFAULT_CDN_VERSION_METADATA_BINDING,
+    });
+    expect(JSON.parse(fs.readFileSync(auxiliaryPath, "utf8")).version_metadata).toBeUndefined();
+  });
+
+  it("fails when the primary vinext output has no generated Wrangler config", async () => {
+    const outDir = path.join(root, "dist/server");
+
+    await expect(
+      finalizeCdnAdapterBuildOutput({
+        outDir,
+        isPrimaryServerOutput: true,
+        binding: DEFAULT_CDN_VERSION_METADATA_BINDING,
+        bindingIsExplicit: false,
+      }),
+    ).rejects.toThrow(
+      `Could not read the generated Wrangler config at ${path.join(outDir, "wrangler.json")}`,
+    );
+  });
+
+  it("rejects a malformed generated config in the primary output", async () => {
+    const generatedPath = path.join(root, "dist/server/wrangler.json");
+    fs.mkdirSync(path.dirname(generatedPath), { recursive: true });
+    fs.writeFileSync(generatedPath, "not json");
+
+    await expect(
+      finalizeCdnAdapterBuildOutput({
+        outDir: path.dirname(generatedPath),
+        isPrimaryServerOutput: true,
+        binding: DEFAULT_CDN_VERSION_METADATA_BINDING,
+        bindingIsExplicit: false,
+      }),
+    ).rejects.toThrow(`Could not read the generated Wrangler config at ${generatedPath}`);
+  });
+
   it("leaves an already matching generated config byte-for-byte unchanged", async () => {
     const generatedPath = writeGeneratedConfig("dist/server/wrangler.json", {
       name: "test-worker",
@@ -78,8 +166,8 @@ describe("Cloudflare CDN adapter generated config", () => {
     const before = fs.readFileSync(generatedPath, "utf8");
 
     await finalizeCdnAdapterBuildOutput({
-      root,
       outDir: path.dirname(generatedPath),
+      isPrimaryServerOutput: true,
       binding: DEFAULT_CDN_VERSION_METADATA_BINDING,
       bindingIsExplicit: false,
     });
@@ -95,8 +183,8 @@ describe("Cloudflare CDN adapter generated config", () => {
 
     await expect(
       finalizeCdnAdapterBuildOutput({
-        root,
         outDir: path.dirname(generatedPath),
+        isPrimaryServerOutput: true,
         binding: DEFAULT_CDN_VERSION_METADATA_BINDING,
         bindingIsExplicit: false,
       }),
@@ -137,7 +225,7 @@ describe("Cloudflare CDN adapter generated config", () => {
 });
 
 describe("vinext cache adapter output hook", () => {
-  it("runs matching adapter finalizers with the emitted output directory", async () => {
+  it("does not infer primary ownership from a wrapped bundle facade", async () => {
     const finalizeBuildOutput = vi.fn();
     const plugins = vinext({
       disableAppRouter: true,
@@ -166,23 +254,32 @@ describe("vinext cache adapter output hook", () => {
     const hook =
       typeof plugin.writeBundle === "function" ? plugin.writeBundle : plugin.writeBundle?.handler;
     expect(hook).toBeTypeOf("function");
+    const context = {
+      environment: {
+        name: "rsc",
+        config: {
+          root: "/project",
+          plugins: [{ name: "test-platform" }],
+        },
+      },
+    } as never;
     await hook?.call(
+      context,
+      { dir: "dist/server" } as never,
       {
-        environment: {
-          config: {
-            root: "/project",
-            plugins: [{ name: "test-platform" }],
-          },
+        "index.js": {
+          type: "chunk",
+          isEntry: true,
+          facadeModuleId: "\0virtual:cloudflare/worker-entry",
         },
       } as never,
-      { dir: "dist/server" } as never,
-      {},
     );
 
     expect(finalizeBuildOutput).toHaveBeenCalledOnce();
     expect(finalizeBuildOutput).toHaveBeenCalledWith({
       root: "/project",
       outDir: path.resolve("/project/dist/server"),
+      isPrimaryServerOutput: false,
     });
   });
 });

--- a/tests/deploy-prerender-config.test.ts
+++ b/tests/deploy-prerender-config.test.ts
@@ -1,12 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import fs from "node:fs";
 import path from "node:path";
+import { createRequire } from "node:module";
+import { pathToFileURL } from "node:url";
 import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
 import { execFileSync, spawn, type ChildProcess } from "node:child_process";
 
 const runPrerenderMock = vi.hoisted(() => vi.fn(async () => ({ routes: [] })));
 const emitPrerenderPathManifestMock = vi.hoisted(() => vi.fn());
+const realWranglerUrl = pathToFileURL(
+  createRequire(path.join(process.cwd(), "examples/app-router-cloudflare/package.json")).resolve(
+    "wrangler",
+  ),
+).href;
 
 vi.mock("vinext/internal/build/run-prerender", () => ({
   runPrerender: runPrerenderMock,
@@ -164,18 +171,27 @@ function writeApiOnlyProject(): void {
     "export function cloudflare() { return { name: 'test-cloudflare-plugin' }; }\n",
   );
   writeFile(
+    "node_modules/wrangler/package.json",
+    JSON.stringify({ name: "wrangler", type: "module", main: "index.js" }),
+  );
+  writeFile(
+    "node_modules/wrangler/index.js",
+    `export * from ${JSON.stringify(realWranglerUrl)};\n`,
+  );
+  writeFile(
     "wrangler.jsonc",
-    '{"name":"test-worker","main":"vinext/server/app-router-entry","assets":{"directory":"dist/client"}}\n',
+    '{"name":"test-worker","main":"vinext/server/app-router-entry","assets":{"directory":"dist/client"},"version_metadata":{"binding":"CF_VERSION_METADATA"}}\n',
   );
   writeFile(
     "vite.config.ts",
     [
       'import { defineConfig } from "vite";',
       'import { cloudflare } from "@cloudflare/vite-plugin";',
+      'import { cdnAdapter } from "../packages/cloudflare/src/cache/cdn-adapter";',
       'import vinext from "../packages/vinext/src/index";',
       "",
       "export default defineConfig({",
-      "  plugins: [vinext(), cloudflare()],",
+      "  plugins: [vinext({ cache: { cdn: { adapter: cdnAdapter().adapter } } }), cloudflare()],",
       "});",
       "",
     ].join("\n"),
@@ -195,6 +211,21 @@ describe("deploy prerender config wiring", () => {
 
   afterEach(() => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("rejects a missing CDN version binding before uploading", async () => {
+    writeApiOnlyProject();
+    writeFile(
+      "wrangler.jsonc",
+      '{"name":"test-worker","main":"vinext/server/app-router-entry","assets":{"directory":"dist/client"}}\n',
+    );
+    const { deploy } = await import("../packages/cloudflare/src/deploy.js");
+
+    await expect(deploy({ root: tmpDir, skipBuild: true, warmCdnCache: true })).rejects.toThrow(
+      "does not declare version_metadata",
+    );
+    expect(execFileSync).not.toHaveBeenCalled();
+    expect(spawn).not.toHaveBeenCalled();
   });
 
   it("runs prerender during deploy when vinext config uses the true shorthand", async () => {


### PR DESCRIPTION
## Summary

Make the Cloudflare CDN adapter ensure its required Worker version metadata binding is present in the generated deployment artifact at build time.

- Keep `vinext init --cdn-cache=workers-cache` proactive: new projects still receive `cache.enabled`, `version_metadata`, and matching `cdnAdapter()` configuration in source.
- Add a small platform-neutral cache-adapter build-output finalizer seam in vinext core.
- Track the Vite environment that actually loads the vinext App or Pages server entry before Cloudflare wraps and tree-shakes the final bundle.
- Let `cdnAdapter()` update only that primary environment's generated `wrangler.json` directly, without relying on `.wrangler/deploy/config.json` for selection.
- Leave source Wrangler configs and auxiliary/SSR Worker outputs untouched.
- Validate the effective Wrangler config read-only before a two-stage warm upload.

## Conflict behavior

- Missing generated binding: add the adapter binding.
- Matching binding: no-op without rewriting the file.
- Different binding with default `cdnAdapter()`: fail with guidance to align Wrangler or explicitly select the existing name.
- Different binding with `cdnAdapter({ versionMetadataBinding })`: the explicit adapter choice wins in generated output.
- Missing or malformed primary generated config: fail the build clearly.

This changes deployment configuration only; it does not alter Next.js route cacheability or runtime behavior.

## Validation

- 562 focused build, adapter, deploy, and initializer tests pass.
- Real Cloudflare `createBuilder().buildApp()` coverage proves generated binding injection for hybrid App+Pages and pure Pages builds, including exclusion of the App SSR child environment.
- Missing and stale `.wrangler/deploy/config.json` coverage proves the generated primary `dist` config is the source of truth.
- `vinext init` regression coverage proves new Workers Cache projects still receive the binding proactively and custom binding names remain aligned.
- The `workers-cache` example deliberately omits source `version_metadata`; a real build leaves source unchanged and emits `CF_VERSION_METADATA` in `dist/server/wrangler.json`.
- `vp check` on all changed source and test files.
- `git diff --check`.
- `vp run vinext#build`.
- `vp run @vinext/cloudflare#build`.
- Independent behavior, safety, and test-coverage reviews: clean.
