### PR TITLE
fix(cloudflare): support explicit CDN warm targets

### DIFF
--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -67,6 +67,7 @@ jobs:
             working_directory: apps/web
             wrangler_config: dist/server/wrangler.json
             warm_cdn_cache: true
+            warm_cdn_target: https://vinext.dev
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -124,7 +125,13 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: vp exec vinext-cloudflare deploy --skip-build --config ${{ matrix.example.wrangler_config }} --experimental-warm-cdn-cache
+          WARM_CDN_TARGET: ${{ matrix.example.warm_cdn_target }}
+        run: |
+          args=(--skip-build --config "${{ matrix.example.wrangler_config }}" --experimental-warm-cdn-cache)
+          if [[ -n "$WARM_CDN_TARGET" ]]; then
+            args+=(--warm-cdn-target "$WARM_CDN_TARGET")
+          fi
+          vp exec vinext-cloudflare deploy "${args[@]}"
 
       - name: Deploy Preview Version
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository

--- a/packages/cloudflare/src/cli.ts
+++ b/packages/cloudflare/src/cli.ts
@@ -52,6 +52,7 @@ async function deployCommand(): Promise<void> {
     prerenderAll: parsed.prerenderAll,
     prerenderConcurrency: parsed.prerenderConcurrency,
     warmCdnCache: parsed.warmCdnCache,
+    warmCdnTarget: parsed.warmCdnTarget,
     warmCdnConcurrency: parsed.warmCdnConcurrency,
     warmCdnTimeout: parsed.warmCdnTimeout,
     warmCdnRetries: parsed.warmCdnRetries,

--- a/packages/cloudflare/src/deploy-help.ts
+++ b/packages/cloudflare/src/deploy-help.ts
@@ -25,6 +25,9 @@ export function formatDeployHelp(): string {
     --experimental-warm-cdn-cache
                              Upload a Worker version, warm build-discovered paths
                              through the production URL, then promote it (experimental)
+    --warm-cdn-target <origin>
+                             HTTPS origin to use for discovery, probing, and warming
+                             (overrides URLs inferred from Wrangler output)
     --warm-cdn-concurrency <count>
                              Maximum number of CDN warmup requests in parallel (default: 25)
     --warm-cdn-timeout <ms>  Per-request CDN warmup timeout (default: 10000)
@@ -90,6 +93,8 @@ export function formatDeployHelp(): string {
     vinext-cloudflare deploy --dry-run                                 Validate setup without building or deploying
     vinext-cloudflare deploy --name my-app                             Deploy with a custom Worker name
     vinext-cloudflare deploy --experimental-warm-cdn-cache              Warm build-discovered paths during version deploy (experimental)
+    vinext-cloudflare deploy --experimental-warm-cdn-cache --warm-cdn-target https://example.com
+                                                                          Warm an explicit production origin
     vinext-cloudflare deploy --experimental-tpr                        Enable TPR during deploy
     vinext-cloudflare deploy --experimental-tpr --tpr-coverage 95      Cover 95% of traffic
     vinext-cloudflare deploy --experimental-tpr --tpr-limit 500        Cap at 500 pages

--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -121,6 +121,8 @@ export type DeployOptions = {
   prerenderConcurrency?: number;
   /** Warm Cloudflare's CDN cache by requesting build-discovered paths for the uploaded version */
   warmCdnCache?: boolean;
+  /** Explicit production origin to use for CDN discovery, probing, and warming */
+  warmCdnTarget?: string;
   /** Maximum number of CDN warmup requests to issue in parallel */
   warmCdnConcurrency?: number;
   /** Per-request CDN warmup timeout in milliseconds */
@@ -212,6 +214,30 @@ function validatePromotionDelay(value: number, raw = String(value)): number {
   return validateTimerDelay(value, "--warm-cdn-promotion-delay", raw);
 }
 
+function validateCdnWarmTarget(raw: string): string {
+  const value = raw.trim();
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error(`--warm-cdn-target expects an HTTPS origin, but got "${raw}".`);
+  }
+  if (
+    url.protocol !== "https:" ||
+    url.username !== "" ||
+    url.password !== "" ||
+    url.port !== "" ||
+    url.pathname !== "/" ||
+    url.search !== "" ||
+    url.hash !== ""
+  ) {
+    throw new Error(
+      `--warm-cdn-target expects an HTTPS origin without a path, query, credentials, or port, but got "${raw}".`,
+    );
+  }
+  return url.origin;
+}
+
 function formatUnknownError(error: unknown): string {
   if (error instanceof Error && error.message) return error.message;
   return String(error);
@@ -232,6 +258,7 @@ const deployArgOptions = {
   "prerender-all": { type: "boolean", default: false },
   "prerender-concurrency": { type: "string" },
   "experimental-warm-cdn-cache": { type: "boolean", default: false },
+  "warm-cdn-target": { type: "string" },
   "warm-cdn-concurrency": { type: "string" },
   "warm-cdn-timeout": { type: "string" },
   "warm-cdn-retries": { type: "string" },
@@ -260,6 +287,9 @@ export function parseDeployArgs(args: string[]) {
   if (values["warm-cdn-certify"] && !values["experimental-warm-cdn-cache"]) {
     throw new Error("--warm-cdn-certify requires --experimental-warm-cdn-cache.");
   }
+  if (values["warm-cdn-target"] && !values["experimental-warm-cdn-cache"]) {
+    throw new Error("--warm-cdn-target requires --experimental-warm-cdn-cache.");
+  }
 
   function parseIntArg(name: string, raw: string | undefined): number | undefined {
     if (!raw) return undefined;
@@ -286,6 +316,10 @@ export function parseDeployArgs(args: string[]) {
         ? undefined
         : parsePositiveIntegerArg(values["prerender-concurrency"], "--prerender-concurrency"),
     warmCdnCache: values["experimental-warm-cdn-cache"],
+    warmCdnTarget:
+      values["warm-cdn-target"] === undefined
+        ? undefined
+        : validateCdnWarmTarget(values["warm-cdn-target"]),
     warmCdnConcurrency:
       values["warm-cdn-concurrency"] === undefined
         ? undefined
@@ -722,6 +756,7 @@ type CdnWarmDeployOptions = Pick<
   | "name"
   | "config"
   | "verbose"
+  | "warmCdnTarget"
   | "warmCdnConcurrency"
   | "warmCdnTimeout"
   | "warmCdnRetries"
@@ -775,6 +810,9 @@ export async function deployWithCdnWarmup(
   paths: readonly string[],
   options: CdnWarmDeployOptions,
 ): Promise<string> {
+  if (options.warmCdnTarget !== undefined) {
+    options = { ...options, warmCdnTarget: validateCdnWarmTarget(options.warmCdnTarget) };
+  }
   if (options.warmCdnDiscoveryTimeout !== undefined) {
     parsePositiveIntegerArg(
       String(options.warmCdnDiscoveryTimeout),
@@ -1647,14 +1685,14 @@ export function resolveCdnWarmupTargetUrl(root: string, deployedUrl: string | nu
 export function resolveCdnWarmupTargetUrl(
   root: string,
   deployedUrl: string | null,
-  options: Pick<DeployOptions, "preview" | "env" | "config">,
+  options: Pick<DeployOptions, "preview" | "env" | "config" | "warmCdnTarget">,
 ): string | null;
 export function resolveCdnWarmupTargetUrl(
   _root: string,
   deployedUrl: string | null,
-  _options?: Pick<DeployOptions, "preview" | "env" | "config">,
+  options?: Pick<DeployOptions, "preview" | "env" | "config" | "warmCdnTarget">,
 ): string | null {
-  return deployedUrl;
+  return options?.warmCdnTarget ?? deployedUrl;
 }
 
 export function getZeroPercentStagingTraffic(
@@ -1760,6 +1798,11 @@ function withPromotedVersionWarmupNote(error: unknown): Error {
 // ─── Main Entry ──────────────────────────────────────────────────────────────
 
 export async function deploy(options: DeployOptions): Promise<void> {
+  if (options.warmCdnTarget !== undefined && !options.warmCdnCache) {
+    throw new Error("--warm-cdn-target requires --experimental-warm-cdn-cache.");
+  }
+  const warmCdnTarget =
+    options.warmCdnTarget === undefined ? undefined : validateCdnWarmTarget(options.warmCdnTarget);
   const deployEnv = validateWranglerEnvName(
     options.env || (options.preview ? "preview" : "production"),
   );
@@ -1966,6 +2009,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
         });
       },
       warmCdnConcurrency: options.warmCdnConcurrency,
+      warmCdnTarget,
       warmCdnTimeout: options.warmCdnTimeout,
       warmCdnRetries: options.warmCdnRetries,
       warmCdnDiscoveryTimeout: options.warmCdnDiscoveryTimeout,

--- a/tests/cloudflare-cdn-warm-deploy.test.ts
+++ b/tests/cloudflare-cdn-warm-deploy.test.ts
@@ -705,6 +705,51 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     expect(JSON.parse(manifestJson)).toEqual({ buildId: "app-build-a", routes: {}, version: 1 });
   });
 
+  it("uses an explicit warm target for both stages of a cacheability-probed deploy", async () => {
+    writeTwoStageWorkerArtifact();
+    const wrangler = mockTwoStageWrangler();
+    const fetchOrigins: string[] = [];
+    vi.mocked(fetch).mockImplementation(async (input, init) => {
+      fetchOrigins.push(new URL(formatFetchUrl(input)).origin);
+      const headers = new Headers(init?.headers);
+      if (headers.get(VINEXT_CACHEABILITY_PROBE_HEADER) === "1") {
+        return appPageProbeResponse();
+      }
+      if (isReadinessFetch(input)) return readinessResponse();
+      return cacheableHtml();
+    });
+    const { deployWithCdnWarmup } = await import("../packages/cloudflare/src/deploy.js");
+
+    await expect(
+      deployWithCdnWarmup(tmpDir, [], {
+        cacheabilityProbe: true,
+        config: "dist/server/wrangler.json",
+        discoverWarmPlan: async ({ targetUrl }) => {
+          expect(targetUrl).toBe("https://app.example.com");
+          return {
+            appPaths: ["/about"],
+            buildId: "app-build-a",
+            buildIdentity: "app-build-a",
+            loadingShellPaths: [],
+            paths: ["/about"],
+            routePatterns: appPageRoutePatterns(["/about"]),
+            rscPaths: [],
+          };
+        },
+        warmCdnConcurrency: 1,
+        warmCdnPromotionDelay: 0,
+        warmCdnReadinessProbes: 1,
+        warmCdnRetries: 0,
+        warmCdnTarget: "https://app.example.com/",
+      }),
+    ).resolves.toBe("https://my-worker.example.workers.dev");
+
+    expect(wrangler.uploads).toBe(2);
+    expect(wrangler.promoted).toBe(true);
+    expect(fetchOrigins.length).toBeGreaterThan(0);
+    expect(new Set(fetchOrigins)).toEqual(new Set(["https://app.example.com"]));
+  });
+
   it("promotes compact pattern-only admission for zero-path static fallbacks", async () => {
     writeTwoStageWorkerArtifact();
     const wrangler = mockTwoStageWrangler();

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -722,6 +722,7 @@ describe("parseDeployArgs", () => {
       "warmCdnCertify",
       "warmCdnReadinessTimeout",
       "warmCdnReadinessRetries",
+      "warmCdnTarget",
     ]) {
       expect(cliSource).toContain(`${option}: parsed.${option}`);
     }
@@ -745,6 +746,7 @@ describe("parseDeployArgs", () => {
     expect(parsed.dryRun).toBe(false);
     expect(parsed.verbose).toBe(false);
     expect(parsed.warmCdnCache).toBe(false);
+    expect(parsed.warmCdnTarget).toBeUndefined();
     expect(parsed.warmCdnCertify).toBe(false);
     expect(parsed.dangerouslyPromoteOnCdnWarmError).toBe(false);
   });
@@ -752,6 +754,12 @@ describe("parseDeployArgs", () => {
   it("requires CDN warming when certification is requested", () => {
     expect(() => parseDeployArgs(["--warm-cdn-certify"])).toThrow(
       "--warm-cdn-certify requires --experimental-warm-cdn-cache.",
+    );
+  });
+
+  it("requires CDN warming when an explicit warm target is requested", () => {
+    expect(() => parseDeployArgs(["--warm-cdn-target", "https://app.example.com"])).toThrow(
+      "--warm-cdn-target requires --experimental-warm-cdn-cache.",
     );
   });
 
@@ -834,6 +842,7 @@ describe("parseDeployArgs", () => {
   it("parses CDN warmup flags", () => {
     const parsed = parseDeployArgs([
       "--experimental-warm-cdn-cache",
+      "--warm-cdn-target=https://app.example.com/",
       "--warm-cdn-concurrency",
       "6",
       "--warm-cdn-timeout=1500",
@@ -856,6 +865,7 @@ describe("parseDeployArgs", () => {
     ]);
 
     expect(parsed.warmCdnCache).toBe(true);
+    expect(parsed.warmCdnTarget).toBe("https://app.example.com");
     expect(parsed.warmCdnConcurrency).toBe(6);
     expect(parsed.warmCdnTimeout).toBe(1500);
     expect(parsed.warmCdnRetries).toBe(0);
@@ -872,6 +882,19 @@ describe("parseDeployArgs", () => {
     expect(parsed.warmCdnPromote).toBe(false);
     expect(parsed.warmCdnPromotionDelay).toBe(2500);
     expect(parsed.warmCdnIncludeFallbacks).toBe(true);
+  });
+
+  it.each([
+    "http://app.example.com",
+    "https://app.example.com/path",
+    "https://app.example.com?preview=1",
+    "https://user@app.example.com",
+    "https://app.example.com:8443",
+    "not-a-url",
+  ])("rejects invalid CDN warm target %s", (target) => {
+    expect(() =>
+      parseDeployArgs(["--experimental-warm-cdn-cache", "--warm-cdn-target", target]),
+    ).toThrow("--warm-cdn-target expects an HTTPS origin");
   });
 
   it("promotes warmed Worker versions by default", () => {


### PR DESCRIPTION
## Summary

- add `--warm-cdn-target <origin>` to explicitly select the hostname used for staged discovery, cacheability probing, readiness checks, cache fills, and optional certification
- validate that the target is an HTTPS origin without a path, query, credentials, or non-default port
- use the canonical `https://vinext.dev` target for the dashboard-managed web custom domain

## Why

Wrangler's version commands only expose version/deployment metadata and `wrangler triggers deploy` only prints domains declared in the local configuration. A dashboard-managed custom domain is therefore invisible to the existing inference and falls back to `workers.dev`.

CDN cache identity is hostname-specific, so warming the `workers.dev` hostname does not warm the application's custom domain. This was exposed by the production web Worker's intentional redirect from `vinext-web.vinext.workers.dev` to `vinext.dev`.

The explicit target continues to use the Worker version-override header and the existing build/version checks, so a target that does not route to the staged version fails readiness rather than being promoted.

## Next.js parity

This does not change route classification or cache eligibility. It only selects the Cloudflare hostname through which the existing Next.js-compatible classification and warming flow runs.

## Validation

- `vp check`
- `vp test run tests/deploy.test.ts tests/cloudflare-cdn-warm-deploy.test.ts` (409 tests)
- `vp run @vinext/cloudflare#build`
