### PR TITLE
refactor(cache): isolate response-stage admission

### DIFF
--- a/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
@@ -183,6 +183,7 @@ function formatCacheTag(tags: readonly string[]): string | null {
 
 export class CloudflareCdnCacheAdapter implements CdnCacheAdapter {
   readonly requiresCompletedResponseAdmission = true;
+  readonly responsePolicyHeaderNames = EDGE_POLICY_HEADERS;
   readonly responseVary = "verbatim" as const;
 
   constructor(

--- a/packages/vinext/src/server/app-route-handler-execution.ts
+++ b/packages/vinext/src/server/app-route-handler-execution.ts
@@ -11,6 +11,7 @@ import { _drainPendingRevalidations } from "vinext/shims/cache-request-state";
 import { runWithRootParamsUsage } from "vinext/shims/root-params";
 import {
   applyCdnResponseHeaders,
+  getCdnResponsePolicyHeaderNames,
   hasExplicitNonCacheableResponsePolicy,
   NEVER_CACHE_CONTROL,
 } from "./cache-control.js";
@@ -44,7 +45,6 @@ import {
 import {
   getRouteCacheabilityCaptureOptions,
   getRouteCacheabilityDynamicReason,
-  CACHEABILITY_POLICY_HEADERS,
   isRouteCacheabilityEvaluation,
   markRouteCacheabilityExplicitResponsePolicy,
   markRouteCacheabilityResponseBodyComplete,
@@ -119,7 +119,7 @@ type CompletedAppRouteHandlerResponse = {
 function hasExplicitCacheableResponsePolicy(headers: Headers): boolean {
   return (
     !hasExplicitNonCacheableResponsePolicy(headers) &&
-    CACHEABILITY_POLICY_HEADERS.some((name) => headers.has(name))
+    [...getCdnResponsePolicyHeaderNames()].some((name) => headers.has(name))
   );
 }
 
@@ -323,7 +323,7 @@ export async function executeAppRouteHandler(
     }
     let { dynamicUsedInHandler, response } = handlerResult;
     assertSupportedAppRouteHandlerResponse(response);
-    const handlerSetCachePolicy = CACHEABILITY_POLICY_HEADERS.some((name) =>
+    const handlerSetCachePolicy = [...getCdnResponsePolicyHeaderNames()].some((name) =>
       response.headers.has(name),
     );
     const hasExplicitCacheablePolicy = hasExplicitCacheableResponsePolicy(response.headers);

--- a/packages/vinext/src/server/cache-control.ts
+++ b/packages/vinext/src/server/cache-control.ts
@@ -39,6 +39,33 @@ export function hasExplicitNonCacheableResponsePolicy(headers: Headers): boolean
   return Boolean(cacheControl && isNonCacheableCacheControl(cacheControl));
 }
 
+/** Lowercase response-policy names owned by core and the active adapter. */
+export function getCdnResponsePolicyHeaderNames(): ReadonlySet<string> {
+  return new Set([
+    "cache-control",
+    ...(getCdnCacheAdapter().responsePolicyHeaderNames ?? []).map((name) => name.toLowerCase()),
+  ]);
+}
+
+/** Capture only cache-policy provenance from an outer composition stage. */
+function captureCdnResponsePolicyHeaders(headers: Headers): Headers {
+  const policy = new Headers();
+  for (const name of getCdnResponsePolicyHeaderNames()) {
+    const value = headers.get(name);
+    if (value !== null) policy.set(name, value);
+  }
+  return policy;
+}
+
+/** Capture policy values that were added above an already-transported baseline. */
+export function captureCdnResponsePolicyOverrides(headers: Headers, baseline: Headers): Headers {
+  const overrides = captureCdnResponsePolicyHeaders(headers);
+  for (const [name, value] of overrides) {
+    if (baseline.get(name) === value) overrides.delete(name);
+  }
+  return overrides;
+}
+
 /** Delegate provider-specific request routing validation to the CDN adapter. */
 export async function validateCdnRequest(request: Request): Promise<Response | null> {
   return (await getCdnCacheAdapter().validateRequest?.(request)) ?? null;
@@ -77,6 +104,50 @@ export function applyCdnResponseHeaders(headers: Headers, input: CdnCacheableHea
   }
   if (useNextDeployPolicy) {
     headers.set("Cache-Control", BROWSER_REVALIDATE_CACHE_CONTROL);
+  }
+}
+
+/**
+ * Reconcile request-stage policy composed above a reusable response artifact.
+ * A newly applied private policy must clear any cacheable provider headers that
+ * belonged to the inner artifact before the final response leaves the gateway.
+ * `outerPolicyHeaders` contains only policy set by the uncached request stage,
+ * so an identical inner value cannot hide explicit outer provenance.
+ */
+export function reconcileCdnResponseHeadersAfterOuterPolicy(
+  headers: Headers,
+  outerPolicyHeaders: Headers,
+): void {
+  // Set-Cookie is additive and therefore is not part of the policy-only
+  // provenance snapshot. It can still be introduced by the uncached request
+  // stage after a shared artifact returns, and the completed response must not
+  // retain that artifact's shared-cache policy.
+  if (headers.has("set-cookie")) {
+    applyCdnResponseHeaders(headers, { cacheControl: NO_STORE_CACHE_CONTROL });
+    return;
+  }
+  const cacheControl = outerPolicyHeaders.get("cache-control");
+  if (cacheControl !== null) {
+    applyCdnResponseHeaders(headers, { cacheControl });
+    // Preserve any explicit provider-specific policy authored alongside the
+    // generic middleware policy after the adapter has derived its defaults.
+    for (const name of getCdnResponsePolicyHeaderNames()) {
+      if (name === "cache-control") continue;
+      const value = outerPolicyHeaders.get(name);
+      if (value !== null) headers.set(name, value);
+    }
+    return;
+  }
+  for (const name of getCdnResponsePolicyHeaderNames()) {
+    const value = outerPolicyHeaders.get(name);
+    if (value !== null && isNonCacheableCacheControl(value)) {
+      headers.set(name, value);
+      applyCdnResponseHeaders(headers, { cacheControl: value });
+      return;
+    }
+  }
+  if (hasExplicitNonCacheableResponsePolicy(outerPolicyHeaders)) {
+    applyCdnResponseHeaders(headers, { cacheControl: NO_STORE_CACHE_CONTROL });
   }
 }
 

--- a/packages/vinext/src/server/cacheability-manifest.ts
+++ b/packages/vinext/src/server/cacheability-manifest.ts
@@ -237,7 +237,10 @@ const CONTEXTUAL_RSC_HEADERS = [
   VINEXT_RSC_STATE_FINGERPRINT_HEADER,
 ] as const;
 
-export function cacheabilityRequestIdentity(request: Request): {
+export function cacheabilityRequestIdentity(
+  request: Request,
+  trustedRepresentation?: CacheabilityRepresentation,
+): {
   representation: CacheabilityRepresentation;
   requestKey: string;
 } | null {
@@ -247,6 +250,7 @@ export function cacheabilityRequestIdentity(request: Request): {
 
   const url = new URL(request.url);
   const requestKey = `${url.pathname}${url.search}`;
+  if (trustedRepresentation) return { representation: trustedRepresentation, requestKey };
   if (/(?:^|\/)_next\/data\/[^/]+\/.+\.json$/.test(url.pathname)) {
     return { representation: "pages-data", requestKey };
   }

--- a/packages/vinext/src/server/cacheability-request.ts
+++ b/packages/vinext/src/server/cacheability-request.ts
@@ -8,12 +8,14 @@ import {
 import {
   applyCdnResponseBuildIdentityHeaders,
   applyCdnResponseHeaders,
+  getCdnResponsePolicyHeaderNames,
   hasExplicitNonCacheableResponsePolicy,
   isNonCacheableCacheControl,
   NO_STORE_CACHE_CONTROL,
 } from "./cache-control.js";
 import {
   VINEXT_CACHEABILITY_PROBE_HEADER,
+  VINEXT_CACHEABILITY_PROBE_ROUTE_HEADER,
   VINEXT_PRERENDER_SECRET_HEADER,
   VINEXT_RSC_VARY_HEADER,
 } from "./headers.js";
@@ -31,8 +33,10 @@ import {
   parseCacheabilityManifest,
   type CacheabilityManifest,
   type CacheabilityManifestRoute,
+  type CacheabilityRouteKind,
   type CacheabilityRepresentation,
 } from "./cacheability-manifest.js";
+import { applyResponseStagePolicyHeaders } from "./response-stage-policy.js";
 
 type CacheabilityProbeRouteState =
   | "dynamic"
@@ -42,14 +46,18 @@ type CacheabilityProbeRouteState =
 
 type CacheabilityProbeResult = {
   cacheControl?: string;
-  kind?: "app-page" | "app-route" | "pages-page";
+  kind?: "app-page" | "app-route" | "pages-api" | "pages-page";
   pattern?: string;
   reason?: string;
   /** The renderer itself completed with a reusable static policy. */
   rendererStatic?: boolean;
+  /** Concrete pathname resolved by request-stage routing before rendering. */
+  routePathname?: string;
   scope?: "identity" | "pattern";
   state: CacheabilityProbeRouteState;
   status: number;
+  /** Routing completed without invoking the reusable response stage. */
+  terminal?: true;
   version: 1;
 };
 
@@ -72,14 +80,48 @@ function cacheabilityVaryRejectionReason(
     : null;
 }
 
-export function createWorkerCacheabilityContext(
-  base: ExecutionContextLike,
+export type WorkerCacheabilityProbeMode = "identity" | "probe";
+
+export type WorkerCacheabilityProbeRoute = {
+  kind: CacheabilityRouteKind;
+  pattern: string;
+};
+
+/** Encode the trusted route identity carried by a staged probe request. */
+export function serializeWorkerCacheabilityProbeRoute(route: WorkerCacheabilityProbeRoute): string {
+  return encodeURIComponent(JSON.stringify([route.kind, route.pattern]));
+}
+
+/** Read route identity only after the surrounding probe request is authenticated. */
+export function readWorkerCacheabilityProbeRoute(
+  request: Request,
+): WorkerCacheabilityProbeRoute | null {
+  const raw = request.headers.get(VINEXT_CACHEABILITY_PROBE_ROUTE_HEADER);
+  if (!raw) return null;
+  try {
+    const value = JSON.parse(decodeURIComponent(raw)) as unknown;
+    if (!Array.isArray(value) || value.length !== 2) return null;
+    const [kind, pattern] = value;
+    if (
+      (kind !== "app-page" && kind !== "app-route" && kind !== "pages-page") ||
+      typeof pattern !== "string" ||
+      !pattern.startsWith("/")
+    ) {
+      return null;
+    }
+    return { kind, pattern };
+  } catch {
+    return null;
+  }
+}
+
+/** Authenticate and read the cacheability probe mode before internal headers are filtered. */
+export function readWorkerCacheabilityProbeMode(
   request: Request,
   expectedSecret: string | null | undefined,
-  responseVary?: "verbatim",
-): ExecutionContextLike {
+): WorkerCacheabilityProbeMode | null {
   const requestedMode = request.headers.get(VINEXT_CACHEABILITY_PROBE_HEADER);
-  if (requestedMode !== "1" && requestedMode !== "identity") return base;
+  if (requestedMode !== "1" && requestedMode !== "identity") return null;
   if (
     !expectedSecret ||
     !workerCapabilityMatches(
@@ -87,17 +129,39 @@ export function createWorkerCacheabilityContext(
       expectedSecret,
     )
   ) {
-    return base;
+    return null;
   }
 
+  return requestedMode === "identity" ? "identity" : "probe";
+}
+
+/** Create probe state from a mode that was authenticated at the request boundary. */
+export function createWorkerCacheabilityProbeContext(
+  base: ExecutionContextLike,
+  mode: WorkerCacheabilityProbeMode,
+  responseVary?: "verbatim",
+  resolvedRoutePathname?: string,
+): ExecutionContextLike {
   const state: RouteCacheabilityState = {
     captureDeadlineAt: Date.now() + CACHEABILITY_PROBE_TIMEOUT_MS,
-    mode: requestedMode === "identity" ? "identity" : "probe",
+    mode,
+    responsePolicyHeaderNames: [...getCdnResponsePolicyHeaderNames()],
     responseVary,
+    resolvedRoutePathname,
   };
   return Object.assign(Object.create(Object.getPrototypeOf(base)), base, {
     [CACHEABILITY_REQUEST_STATE]: state,
   });
+}
+
+export function createWorkerCacheabilityContext(
+  base: ExecutionContextLike,
+  request: Request,
+  expectedSecret: string | null | undefined,
+  responseVary?: "verbatim",
+): ExecutionContextLike {
+  const mode = readWorkerCacheabilityProbeMode(request, expectedSecret);
+  return mode ? createWorkerCacheabilityProbeContext(base, mode, responseVary) : base;
 }
 
 let cachedManifest:
@@ -120,8 +184,17 @@ export function createWorkerCacheabilityAdmissionContext(
   buildId: string | null | undefined,
   requiresCompletedResponseAdmission = rawManifest != null,
   responseVary?: "verbatim",
+  resolvedRoutePathname?: string,
+  trustedRepresentation?: CacheabilityRepresentation,
+  options?: { applyCompletedResponsePolicy?: boolean },
 ): ExecutionContextLike {
-  const identity = cacheabilityRequestIdentity(request);
+  const identity = cacheabilityRequestIdentity(request, trustedRepresentation);
+  const routePathname = identity
+    ? cacheabilityRoutePathname(
+        resolvedRoutePathname ?? new URL(request.url).pathname,
+        identity.representation,
+      )
+    : undefined;
   if (!rawManifest) {
     if (!requiresCompletedResponseAdmission) return base;
     const state: RouteCacheabilityState = {
@@ -129,14 +202,13 @@ export function createWorkerCacheabilityAdmissionContext(
         ? {
             policy: "runtime",
             ...identity,
-            routePathname: cacheabilityRoutePathname(
-              new URL(request.url).pathname,
-              identity.representation,
-            ),
+            routePathname,
           }
         : { policy: "deny" },
       captureDeadlineAt: Date.now() + CACHEABILITY_PROBE_TIMEOUT_MS,
       mode: "admit",
+      applyCompletedResponsePolicy: options?.applyCompletedResponsePolicy,
+      responsePolicyHeaderNames: [...getCdnResponsePolicyHeaderNames()],
       responseVary,
     };
     return Object.assign(Object.create(Object.getPrototypeOf(base)), base, {
@@ -153,14 +225,13 @@ export function createWorkerCacheabilityAdmissionContext(
             manifest,
             policy: "manifest",
             ...identity,
-            routePathname: cacheabilityRoutePathname(
-              new URL(request.url).pathname,
-              identity.representation,
-            ),
+            routePathname,
           }
         : { policy: "deny" },
     captureDeadlineAt: Date.now() + CACHEABILITY_PROBE_TIMEOUT_MS,
     mode: "admit",
+    applyCompletedResponsePolicy: options?.applyCompletedResponsePolicy,
+    responsePolicyHeaderNames: [...getCdnResponsePolicyHeaderNames()],
     responseVary,
   };
   return Object.assign(Object.create(Object.getPrototypeOf(base)), base, {
@@ -189,6 +260,40 @@ function resolveCacheabilityRepresentation(
   return routeKind === "app-route" ? "app-route" : "html";
 }
 
+/** Apply request-stage-vetted positive config policy inside the admission boundary. */
+export function applyResponseStageCachePolicy(
+  response: Response,
+  ctx: ExecutionContextLike,
+  policyHeaders: ReadonlyArray<readonly [string, string]> | null | undefined,
+): Response {
+  if (!policyHeaders?.length) return response;
+  const state = readState(ctx);
+  if (state) state.explicitConfigCachePolicy = true;
+
+  try {
+    applyResponseStagePolicyHeaders(response.headers, policyHeaders);
+    return response;
+  } catch {
+    const headers = new Headers(response.headers);
+    applyResponseStagePolicyHeaders(headers, policyHeaders);
+    return new Response(response.body, {
+      headers,
+      status: response.status,
+      statusText: response.statusText,
+    });
+  }
+}
+
+/** Record policy that a renderer applied before producing its response. */
+export function recordResponseStageCachePolicy(
+  ctx: ExecutionContextLike,
+  policyHeaders: ReadonlyArray<readonly [string, string]> | null | undefined,
+): void {
+  if (!policyHeaders?.length) return;
+  const state = readState(ctx);
+  if (state) state.explicitConfigCachePolicy = true;
+}
+
 function probeResponse(
   state: RouteCacheabilityState,
   routeState: CacheabilityProbeRouteState,
@@ -202,11 +307,44 @@ function probeResponse(
     pattern: state.route?.pattern,
     reason: outcome.reason,
     ...(rendererStatic !== undefined ? { rendererStatic } : {}),
+    ...(state.resolvedRoutePathname ? { routePathname: state.resolvedRoutePathname } : {}),
     ...(routeState === "dynamic"
       ? { scope: state.patternDynamicReason ? ("pattern" as const) : ("identity" as const) }
       : {}),
     state: routeState,
     status,
+    version: 1,
+  };
+  return applyCdnResponseBuildIdentityHeaders(
+    Response.json(body, {
+      headers: { "Cache-Control": NO_STORE_CACHE_CONTROL },
+    }),
+  );
+}
+
+/**
+ * Convert an authenticated probe that terminated in request routing into a
+ * valid identity-scoped dynamic result. Middleware redirects, custom responses,
+ * and external rewrites never reach the reusable response stage.
+ */
+export function finalizeRequestStageCacheabilityProbe(
+  response: Response,
+  options: {
+    mode: WorkerCacheabilityProbeMode | null;
+    responseStageDispatched: boolean;
+    route: WorkerCacheabilityProbeRoute | null;
+  },
+): Response {
+  if (!options.mode || options.responseStageDispatched || !options.route) return response;
+  void response.body?.cancel().catch(() => {});
+  const body: CacheabilityProbeResult = {
+    kind: options.route.kind,
+    pattern: options.route.pattern,
+    reason: "request routing completed without response-stage rendering",
+    scope: "identity",
+    state: "dynamic",
+    status: response.status,
+    terminal: true,
     version: 1,
   };
   return applyCdnResponseBuildIdentityHeaders(
@@ -476,54 +614,39 @@ function inferFinalAppPageCacheability(
   // Config headers run after the framework snapshots its provisional policy.
   // Match Next.js by honoring a later explicit public policy instead of
   // replacing it with the renderer-derived default during admission.
-  const changedPolicy = (
-    ["cloudflare-cdn-cache-control", "cdn-cache-control", "cache-control"] as const
-  ).find((name) => {
-    const value = response.headers.get(name);
-    return (
-      value !== null &&
-      (state.explicitConfigCachePolicy || value !== state.frameworkResponseCachePolicy?.[name])
-    );
-  });
+  const changedPolicy = [...(state.responsePolicyHeaderNames ?? CACHEABILITY_POLICY_HEADERS)]
+    .reverse()
+    .find((name) => {
+      const value = response.headers.get(name);
+      return (
+        value !== null &&
+        (state.explicitConfigCachePolicy || value !== state.frameworkResponseCachePolicy?.[name])
+      );
+    });
   if (!changedPolicy) return null;
 
   const cacheControl = response.headers.get(changedPolicy)!;
   if (isNonCacheableCacheControl(cacheControl)) return { cacheable: false };
-  const cacheTag = response.headers.get("Cache-Tag");
   return {
     cacheable: true,
     cacheControl,
-    ...(cacheTag
-      ? {
-          tags: cacheTag
-            .split(",")
-            .map((tag) => tag.trim())
-            .filter(Boolean),
-        }
-      : {}),
   };
 }
 
-function inferPagesPageCacheability(response: Response): RouteCacheabilityOutcome {
-  const cacheControl =
-    response.headers.get("Cloudflare-CDN-Cache-Control") ??
-    response.headers.get("CDN-Cache-Control") ??
-    response.headers.get("Cache-Control");
+function inferPagesPageCacheability(
+  response: Response,
+  state: RouteCacheabilityState,
+): RouteCacheabilityOutcome {
+  const cacheControl = [...(state.responsePolicyHeaderNames ?? CACHEABILITY_POLICY_HEADERS)]
+    .reverse()
+    .map((name) => response.headers.get(name))
+    .find((value) => value !== null);
   if (!cacheControl || isNonCacheableCacheControl(cacheControl)) {
     return { cacheable: false };
   }
-  const cacheTag = response.headers.get("Cache-Tag");
   return {
     cacheable: true,
     cacheControl,
-    ...(cacheTag
-      ? {
-          tags: cacheTag
-            .split(",")
-            .map((tag) => tag.trim())
-            .filter(Boolean),
-        }
-      : {}),
   };
 }
 
@@ -541,7 +664,7 @@ function completedRouteOutcome(
     if (response.headers.has("set-cookie")) {
       return { cacheable: false, reason: "response sets a cookie" };
     }
-    return inferPagesPageCacheability(response);
+    return inferPagesPageCacheability(response, state);
   }
   if (state.route?.kind === "app-page") {
     return inferFinalAppPageCacheability(response, state) ?? rendererOutcome;
@@ -559,7 +682,7 @@ function completedRouteOutcome(
   // Ported from Next.js:
   // test/e2e/getserversideprops/test/index.test.ts
   // test/e2e/app-dir/custom-cache-control/custom-cache-control.test.ts
-  const responseOutcome = inferPagesPageCacheability(response);
+  const responseOutcome = inferPagesPageCacheability(response, state);
   return responseOutcome.cacheable ? responseOutcome : (rendererOutcome ?? responseOutcome);
 }
 
@@ -584,7 +707,7 @@ function cacheabilityEvaluationFailureResponse(pattern: string): Response {
 function hasStrictFinalResponseVeto(response: Response, state: RouteCacheabilityState): boolean {
   if (state.finalResponseVetoReason || response.headers.has("set-cookie")) return true;
 
-  for (const name of CACHEABILITY_POLICY_HEADERS) {
+  for (const name of state.responsePolicyHeaderNames ?? CACHEABILITY_POLICY_HEADERS) {
     const value = response.headers.get(name);
     if (
       value !== null &&
@@ -609,16 +732,14 @@ async function finalizeWorkerCacheabilityAdmission(
 
   const admission = state.admission;
 
-  // Route Handlers normally prove body completion inside their execution
-  // boundary, so the outer Worker does not buffer them a second time. Config
-  // headers run later, however, and can make an otherwise dynamic response
-  // public. Capture only that unproven final-public case before it can escape.
-  // A manifest-bearing deployment normally authorizes the route pattern. An
-  // unlisted Route Handler can still opt in with an explicit application or
-  // config cache policy, but only after this finalizer has checked the fully
-  // completed response.
-  if (state.route?.kind === "app-route") {
+  // App Route Handlers normally prove body completion inside their execution
+  // boundary, while Pages APIs arrive here with their stream still live.
+  // Config or application headers can explicitly publish either response.
+  // Require a clean completed body before an unlisted endpoint can enter the
+  // shared cache.
+  if (state.route?.kind === "app-route" || state.route?.kind === "pages-api") {
     let manifestRoute: CacheabilityManifestRoute | null = null;
+    const responseOutcome = inferPagesPageCacheability(response, state);
     const representation = admission?.representation
       ? resolveCacheabilityRepresentation(
           admission.representation as CacheabilityRepresentation,
@@ -626,11 +747,13 @@ async function finalizeWorkerCacheabilityAdmission(
         )
       : null;
     const hasExplicitRuntimePolicy =
-      state.explicitResponseCachePolicy === true || state.explicitConfigCachePolicy === true;
+      state.explicitResponseCachePolicy === true ||
+      state.explicitConfigCachePolicy === true ||
+      (state.route.kind === "pages-api" && responseOutcome.cacheable);
     if (!admission || admission.policy === "deny" || !representation || !admission.requestKey) {
       return responseWithCachePolicy(response, response.body, null);
     }
-    if (admission.policy === "manifest") {
+    if (admission.policy === "manifest" && state.route.kind === "app-route") {
       const manifest = admission.manifest as CacheabilityManifest;
       manifestRoute = findCacheabilityManifestRoute(
         manifest,
@@ -657,11 +780,14 @@ async function finalizeWorkerCacheabilityAdmission(
       return responseWithCachePolicy(response, response.body, null);
     }
 
-    const outcome = inferPagesPageCacheability(response);
+    const outcome = responseOutcome;
     if (!outcome.cacheable || !outcome.cacheControl) {
       return responseWithCachePolicy(response, response.body, null);
     }
-    if (state.completedResponseBody) return response;
+    if (state.completedResponseBody) {
+      if (!state.applyCompletedResponsePolicy) return response;
+      return responseWithCachePolicy(response, response.body, outcome);
+    }
 
     let captured: CapturedAdmissionBody;
     try {

--- a/packages/vinext/src/server/cacheability-request.ts
+++ b/packages/vinext/src/server/cacheability-request.ts
@@ -247,7 +247,7 @@ function readState(ctx: ExecutionContextLike): RouteCacheabilityState | null {
 
 function resolveCacheabilityRepresentation(
   representation: CacheabilityRepresentation,
-  routeKind: "app-page" | "app-route" | "pages-page",
+  routeKind: "app-page" | "app-route" | "pages-api" | "pages-page",
 ): CacheabilityRepresentation {
   // Accept describes the representation a caller would prefer; it does not
   // determine whether the resolved pathname belongs to an App Page or a Route
@@ -257,7 +257,7 @@ function resolveCacheabilityRepresentation(
   if (representation !== "html" && representation !== "app-route") {
     return representation;
   }
-  return routeKind === "app-route" ? "app-route" : "html";
+  return routeKind === "app-route" || routeKind === "pages-api" ? "app-route" : "html";
 }
 
 /** Apply request-stage-vetted positive config policy inside the admission boundary. */

--- a/packages/vinext/src/server/config-headers.ts
+++ b/packages/vinext/src/server/config-headers.ts
@@ -6,15 +6,49 @@ import {
 } from "../config/config-matchers.js";
 import type { HeaderRecord } from "./request-pipeline.js";
 import {
-  CACHEABILITY_POLICY_HEADERS,
   markRouteCacheabilityDynamic,
   markRouteCacheabilityExplicitConfigPolicy,
   markRouteCacheabilityFinalResponseUncacheable,
 } from "vinext/shims/cacheability-classification";
 import { isNonCacheableCacheControl } from "vinext/shims/cdn-cache";
+import { getCdnResponsePolicyHeaderNames } from "./cache-control.js";
+import { mergeVaryHeader } from "./middleware-response-headers.js";
 
 const ADDITIVE_CONFIG_HEADER_NAMES = new Set(["set-cookie", "vary"]);
-const CACHEABILITY_POLICY_HEADER_NAMES = new Set<string>(CACHEABILITY_POLICY_HEADERS);
+
+export type ResponseStageCachePolicyOptions = {
+  basePathState?: BasePathMatchState;
+  configHeaders: NextHeader[];
+  pathname: string;
+  requestContext: RequestContext;
+};
+
+/**
+ * Resolve positive config cache policy that must accompany an inner artifact.
+ * The request stage evaluates every condition. Shared stage transports must key
+ * the complete serialized props, so the matched policy partitions the artifact
+ * without exposing request-only header, cookie, or host values to the renderer.
+ */
+export function resolveResponseStageCachePolicy({
+  basePathState,
+  configHeaders,
+  pathname,
+  requestContext,
+}: ResponseStageCachePolicyOptions): Array<[string, string]> | null {
+  const matched = retainLastSingularConfigValues(
+    matchHeaders(pathname, configHeaders, requestContext, basePathState),
+  );
+  const policy = matched
+    .filter((header) => {
+      const name = header.key.toLowerCase();
+      return (
+        name === "vary" ||
+        (getCdnResponsePolicyHeaderNames().has(name) && !isNonCacheableCacheControl(header.value))
+      );
+    })
+    .map((header) => [header.key, header.value] as [string, string]);
+  return policy.length > 0 ? policy : null;
+}
 
 function markConditionalConfigHeaderCacheability(rule: NextHeader): void {
   if (
@@ -23,9 +57,10 @@ function markConditionalConfigHeaderCacheability(rule: NextHeader): void {
         condition.type === "header" || condition.type === "cookie" || condition.type === "host",
     )
   ) {
-    // Query values are already part of the public Workers Cache key. Headers,
-    // cookies, and hostnames are not, so a response header selected by any of
-    // them cannot be shared safely under the request URL.
+    // Legacy single-stage admission keys the public request rather than a
+    // serialized stage envelope, so these conditions still require a veto.
+    // Multi-stage callers set recordCacheability=false and carry the matched
+    // policy in identity-keyed response-stage props instead.
     markRouteCacheabilityDynamic(
       "next.config headers depend on request headers, cookies, or hostnames",
     );
@@ -41,10 +76,10 @@ function markExplicitConfigResponseVeto(
       markRouteCacheabilityFinalResponseUncacheable("next.config headers set a cookie");
       continue;
     }
-    if (CACHEABILITY_POLICY_HEADER_NAMES.has(name)) {
+    if (getCdnResponsePolicyHeaderNames().has(name)) {
       markRouteCacheabilityExplicitConfigPolicy();
     }
-    if (CACHEABILITY_POLICY_HEADER_NAMES.has(name) && isNonCacheableCacheControl(header.value)) {
+    if (getCdnResponsePolicyHeaderNames().has(name) && isNonCacheableCacheControl(header.value)) {
       markRouteCacheabilityFinalResponseUncacheable(
         `next.config headers set a non-cacheable ${header.key} policy`,
       );
@@ -68,6 +103,8 @@ type ApplyConfigHeadersOptions = {
   appendToPostConfigLink?: boolean;
   /** Middleware response headers run after config and therefore suppress config values. */
   middlewareHeaders?: Headers | null;
+  /** Whether this composition participates in response-cache admission. */
+  recordCacheability?: boolean;
 };
 
 function retainLastSingularConfigValues(
@@ -133,10 +170,10 @@ export function applyConfigHeadersToResponse(
       options.configHeaders,
       options.requestContext,
       options.basePathState,
-      markConditionalConfigHeaderCacheability,
+      options.recordCacheability === false ? undefined : markConditionalConfigHeaderCacheability,
     ),
   );
-  markExplicitConfigResponseVeto(matched);
+  if (options.recordCacheability !== false) markExplicitConfigResponseVeto(matched);
   for (const header of matched) {
     const lowerName = header.key.toLowerCase();
     if (lowerName === "link") {
@@ -155,6 +192,8 @@ export function applyConfigHeadersToResponse(
       // authoritative even when this config field may replace a renderer-owned
       // default (notably Cache-Control).
       continue;
+    } else if (lowerName === "vary") {
+      mergeVaryHeader(responseHeaders, header.value);
     } else if (ADDITIVE_CONFIG_HEADER_NAMES.has(lowerName)) {
       responseHeaders.append(header.key, header.value);
     } else if (options.overwriteExisting?.has(lowerName) || !responseHeaders.has(lowerName)) {
@@ -174,10 +213,10 @@ export function applyConfigHeadersToHeaderRecord(
       options.configHeaders,
       options.requestContext,
       options.basePathState,
-      markConditionalConfigHeaderCacheability,
+      options.recordCacheability === false ? undefined : markConditionalConfigHeaderCacheability,
     ),
   );
-  markExplicitConfigResponseVeto(matched);
+  if (options.recordCacheability !== false) markExplicitConfigResponseVeto(matched);
   for (const header of matched) {
     const lowerName = header.key.toLowerCase();
     if (lowerName === "set-cookie") {

--- a/packages/vinext/src/server/headers.ts
+++ b/packages/vinext/src/server/headers.ts
@@ -40,6 +40,9 @@ export const VINEXT_EXPECTED_WORKER_VERSION_HEADER = "X-Vinext-Expected-Worker-V
 /** Authenticated staged-Worker request asking for a completed App Page classification. */
 export const VINEXT_CACHEABILITY_PROBE_HEADER = "X-Vinext-Cacheability-Probe";
 
+/** Trusted route expected by an authenticated staged cacheability probe. */
+export const VINEXT_CACHEABILITY_PROBE_ROUTE_HEADER = "X-Vinext-Cacheability-Probe-Route";
+
 /**
  * Per-attempt cache buster used while a newly staged Worker version propagates.
  * Authenticated probe requests remove it before middleware or route code runs.
@@ -284,6 +287,7 @@ export const INTERNAL_HEADERS = [
 /** Vinext-only internal headers stripped alongside Next.js protocol internals. */
 export const VINEXT_INTERNAL_HEADERS = [
   VINEXT_CACHEABILITY_PROBE_HEADER.toLowerCase(),
+  VINEXT_CACHEABILITY_PROBE_ROUTE_HEADER.toLowerCase(),
   VINEXT_EXPECTED_WORKER_VERSION_HEADER.toLowerCase(),
   VINEXT_PRERENDER_ROUTE_PARAMS_HEADER,
   VINEXT_PRERENDER_SPECULATIVE_HEADER,

--- a/packages/vinext/src/server/isr-cache.ts
+++ b/packages/vinext/src/server/isr-cache.ts
@@ -32,10 +32,7 @@ import {
 } from "./app-rsc-render-mode.js";
 import { normalizeAppPageInterceptionProofPathname } from "./app-page-render-identity.js";
 import type { RenderObservation } from "./cache-proof.js";
-import {
-  PRERENDER_REVALIDATE_HEADER,
-  PRERENDER_REVALIDATE_ONLY_GENERATED_HEADER,
-} from "../utils/protocol-headers.js";
+import { PRERENDER_REVALIDATE_ONLY_GENERATED_HEADER } from "../utils/protocol-headers.js";
 export { normalizeMountedSlotsHeader };
 
 /**
@@ -56,7 +53,12 @@ export { normalizeMountedSlotsHeader };
  * isolates) with a constant-time comparison, and only the matching value (sent
  * by our own `res.revalidate()`) is honored.
  */
-export { PRERENDER_REVALIDATE_HEADER };
+export {
+  getRevalidateSecret,
+  isOnDemandRevalidateRequest,
+  isRevalidateSecret,
+  PRERENDER_REVALIDATE_HEADER,
+} from "./revalidation-request.js";
 
 /**
  * Companion header to {@link PRERENDER_REVALIDATE_HEADER}. When set,
@@ -67,88 +69,6 @@ export { PRERENDER_REVALIDATE_HEADER };
  * `.nextjs-ref/packages/next/src/lib/constants.ts`.
  */
 export { PRERENDER_REVALIDATE_ONLY_GENERATED_HEADER };
-
-/**
- * Build-time secret that authenticates on-demand revalidation requests, the
- * vinext analog of Next.js's prerender-manifest `previewModeId`.
- *
- * `res.revalidate()` loops back into the server via an internal `fetch()`. On
- * Cloudflare Workers that loopback can land on a *different* isolate than the
- * sender, so a per-process random secret would mismatch across isolates and
- * false-reject legitimate revalidations (and, symmetrically, two isolates with
- * independently-rolled secrets could never agree). The fix mirrors Next.js's
- * `previewModeId`: the secret is generated once at BUILD time and baked
- * (server-only — never into the client bundle) into every server bundle via the
- * `__VINEXT_REVALIDATE_SECRET` Vite `define`, so it is byte-for-byte identical in
- * every isolate. See `vinext build` CLI (`__VINEXT_SHARED_REVALIDATE_SECRET`) and
- * the `vinext:compiler-define-server` plugin. The sender attaches it as the
- * {@link PRERENDER_REVALIDATE_HEADER} value; the receiver authorizes a request
- * only when the incoming value equals this secret (see
- * {@link isOnDemandRevalidateRequest}).
- *
- * When the build-time define is absent — dev mode, and any path that doesn't
- * run through `vinext build` — we fall back to a lazily-generated random secret.
- * Those paths are single-process, but Vite can evaluate this module separately
- * in its RSC and SSR module graphs. Store the fallback on `globalThis` under a
- * registry symbol so every module copy in the process reads the same value.
- */
-const _DEV_REVALIDATE_SECRET_KEY = Symbol.for("vinext.isrCache.devRevalidateSecret");
-
-export function getRevalidateSecret(): string {
-  // Production: the build baked the shared secret into every server bundle.
-  // `process.env.__VINEXT_REVALIDATE_SECRET` is statically inlined by Vite's
-  // `define`, so this is a constant string identical across all isolates.
-  const baked = process.env.__VINEXT_REVALIDATE_SECRET;
-  if (baked) return baked;
-
-  // Dev/standalone fallback: no build-time define. Generate a single
-  // process-shared secret lazily. 32 random bytes (256 bits) hex-encoded match
-  // the build-time secret's entropy. Web Crypto's `getRandomValues` works in
-  // both Node and the Workers/edge runtime.
-  const globals = globalThis as unknown as Record<PropertyKey, unknown>;
-  const existing = globals[_DEV_REVALIDATE_SECRET_KEY];
-  if (typeof existing === "string") return existing;
-
-  const bytes = new Uint8Array(32);
-  crypto.getRandomValues(bytes);
-  const secret = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
-  globals[_DEV_REVALIDATE_SECRET_KEY] = secret;
-  return secret;
-}
-
-/**
- * Constant-time string equality. Avoids leaking secret length / prefix via
- * early-exit timing on the on-demand revalidation auth check. Returns false
- * for length mismatch (the only safe option without revealing the secret
- * length, and equality is impossible anyway).
- */
-function safeEqual(a: string, b: string): boolean {
-  if (a.length !== b.length) return false;
-  let mismatch = 0;
-  for (let i = 0; i < a.length; i++) {
-    mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i);
-  }
-  return mismatch === 0;
-}
-
-export function isRevalidateSecret(value: string | null | undefined): boolean {
-  if (typeof value !== "string" || value.length === 0) return false;
-  return safeEqual(value, getRevalidateSecret());
-}
-
-/**
- * Authorize an incoming request as an on-demand revalidation trigger. Mirrors
- * Next.js's `checkIsOnDemandRevalidate`: the {@link PRERENDER_REVALIDATE_HEADER}
- * value must *equal* the process revalidate secret. Header presence alone is
- * NOT sufficient — see the security note on {@link PRERENDER_REVALIDATE_HEADER}.
- */
-export function isOnDemandRevalidateRequest(
-  headerValue: string | string[] | null | undefined,
-): boolean {
-  // Reject arrays (duplicate headers) and absent values outright.
-  if (typeof headerValue !== "string") return false;
-  return isRevalidateSecret(headerValue);
-}
 
 export type ISRCacheEntry = {
   value: CacheHandlerValue;

--- a/packages/vinext/src/server/prerender-route-params.ts
+++ b/packages/vinext/src/server/prerender-route-params.ts
@@ -1,4 +1,8 @@
-import { VINEXT_PRERENDER_ROUTE_PARAMS_HEADER, VINEXT_PRERENDER_SECRET_HEADER } from "./headers.js";
+import {
+  VINEXT_PRERENDER_ROUTE_PARAMS_HEADER,
+  VINEXT_PRERENDER_SECRET_HEADER,
+  VINEXT_PRERENDER_SPECULATIVE_HEADER,
+} from "./headers.js";
 import { isUnknownRecord } from "../utils/record.js";
 
 export type PrerenderRouteParams = Record<string, string | string[]>;
@@ -7,6 +11,12 @@ export type PrerenderRouteParamsPayload = {
   fallbackParamNames?: readonly string[];
   params: PrerenderRouteParams;
   routePattern: string;
+};
+
+/** Prerender-only request state authenticated at the public request boundary. */
+export type TrustedPrerenderState = {
+  routeParams: PrerenderRouteParamsPayload | null;
+  speculative: boolean;
 };
 
 type PrerenderRouteParamsRouteMatch =
@@ -55,6 +65,17 @@ function isPrerenderRouteParamsPayload(value: unknown): value is PrerenderRouteP
   );
 }
 
+export function isTrustedPrerenderState(value: unknown): value is TrustedPrerenderState {
+  if (!isUnknownRecord(value)) return false;
+  const keys = Object.keys(value);
+  return (
+    keys.length === 2 &&
+    keys.every((key) => key === "routeParams" || key === "speculative") &&
+    (value.routeParams === null || isPrerenderRouteParamsPayload(value.routeParams)) &&
+    typeof value.speculative === "boolean"
+  );
+}
+
 // A payload with no dynamic params serializes to `null`, which is
 // indistinguishable from an absent header on the read side. This is intentional:
 // the only producer, `encodePrerenderRouteParams`, already returns `null` for
@@ -93,6 +114,20 @@ export function readTrustedPrerenderRouteParamsFromHeaders(
     throw new Error("[vinext] Invalid internal prerender route params header.");
   }
   return params;
+}
+
+/** Authenticate prerender params and mode once before crossing a stage transport. */
+export function readTrustedPrerenderStateFromHeaders(
+  headers: Headers,
+  expectedSecret: string,
+): TrustedPrerenderState | null {
+  if (process.env.VINEXT_PRERENDER !== "1") return null;
+  const secret = headers.get(VINEXT_PRERENDER_SECRET_HEADER);
+  if (!expectedSecret || secret === null || secret !== expectedSecret) return null;
+  return {
+    routeParams: readTrustedPrerenderRouteParamsFromHeaders(headers, expectedSecret),
+    speculative: headers.get(VINEXT_PRERENDER_SPECULATIVE_HEADER) === "1",
+  };
 }
 
 // Convenience wrapper for reads that happen AFTER the prerender secret has

--- a/packages/vinext/src/server/request-pipeline.ts
+++ b/packages/vinext/src/server/request-pipeline.ts
@@ -525,6 +525,11 @@ function getRequestCf(request: Request): unknown {
  * must restore it explicitly.
  */
 export function attachRequestCfMetadata(target: Request, source: Request): Request {
+  const ownDescriptor = Object.getOwnPropertyDescriptor(source, "cf");
+  if (ownDescriptor) {
+    Object.defineProperty(target, "cf", ownDescriptor);
+    return target;
+  }
   const cf = getRequestCf(source);
   if (cf !== undefined) {
     Object.defineProperty(target, "cf", {

--- a/packages/vinext/src/server/response-stage-cacheability.ts
+++ b/packages/vinext/src/server/response-stage-cacheability.ts
@@ -1,0 +1,84 @@
+import type { ExecutionContextLike } from "vinext/shims/request-context";
+import { getCdnCacheAdapter } from "vinext/shims/cdn-cache";
+import type { VinextResponseStageDispatchOptions } from "./multi-stage.js";
+import type { WorkerCacheabilityProbeMode } from "./cacheability-request.js";
+import type { CacheabilityRepresentation } from "./cacheability-manifest.js";
+
+export type ResponseStageCacheabilityOptions = {
+  buildId: string | null | undefined;
+  cache: VinextResponseStageDispatchOptions["cache"];
+  context: ExecutionContextLike;
+  probeMode?: WorkerCacheabilityProbeMode | null;
+  policyHeaders?: ReadonlyArray<readonly [string, string]> | null;
+  /** The renderer receives policy before user Pages code and applies it itself. */
+  policyHeadersAppliedBeforeRender?: boolean;
+  rawManifest: string | null | undefined;
+  /** The trusted route target after request-stage rewrites. */
+  resolvedRoutePathname?: string;
+  /** Trusted representation retained when request-stage normalization changes the URL shape. */
+  representation?: CacheabilityRepresentation;
+  /** Generated adapter registration, deferred until the response stage executes. */
+  registerCacheAdapters(): void;
+  request: Request;
+};
+
+/**
+ * Run a response-stage render behind completed-response cache admission.
+ *
+ * Adapter registration and cacheability state live here so a shared transport
+ * hit can avoid loading the response stage and its application graph entirely.
+ */
+export async function withResponseStageCacheability(
+  options: ResponseStageCacheabilityOptions,
+  render: (context: ExecutionContextLike) => Promise<Response>,
+): Promise<Response> {
+  options.registerCacheAdapters();
+  const adapter = getCdnCacheAdapter();
+
+  let context = options.context;
+  if (options.probeMode) {
+    const cacheability = await import("./cacheability-request.js");
+    context = cacheability.createWorkerCacheabilityProbeContext(
+      context,
+      options.probeMode,
+      adapter.responseVary,
+      options.resolvedRoutePathname,
+    );
+    if (options.policyHeadersAppliedBeforeRender) {
+      cacheability.recordResponseStageCachePolicy(context, options.policyHeaders);
+    }
+    const rendered = await render(context);
+    const response = options.policyHeadersAppliedBeforeRender
+      ? rendered
+      : cacheability.applyResponseStageCachePolicy(rendered, context, options.policyHeaders);
+    return cacheability.finalizeWorkerCacheabilityResponse(response, context);
+  }
+
+  const requiresAdmission =
+    options.cache === "shared" &&
+    (options.rawManifest != null || adapter.requiresCompletedResponseAdmission === true);
+  if (requiresAdmission) {
+    const cacheability = await import("./cacheability-request.js");
+    context = cacheability.createWorkerCacheabilityAdmissionContext(
+      context,
+      options.request,
+      options.rawManifest,
+      options.buildId,
+      adapter.requiresCompletedResponseAdmission === true,
+      adapter.responseVary,
+      options.resolvedRoutePathname,
+      options.representation,
+      { applyCompletedResponsePolicy: true },
+    );
+    if (options.policyHeadersAppliedBeforeRender) {
+      cacheability.recordResponseStageCachePolicy(context, options.policyHeaders);
+    }
+    const rendered = await render(context);
+    const response = options.policyHeadersAppliedBeforeRender
+      ? rendered
+      : cacheability.applyResponseStageCachePolicy(rendered, context, options.policyHeaders);
+    return cacheability.finalizeWorkerCacheabilityResponse(response, context);
+  }
+
+  return render(context);
+}

--- a/packages/vinext/src/server/response-stage-cacheability.ts
+++ b/packages/vinext/src/server/response-stage-cacheability.ts
@@ -36,29 +36,20 @@ export async function withResponseStageCacheability(
   const adapter = getCdnCacheAdapter();
 
   let context = options.context;
+  let cacheability: typeof import("./cacheability-request.js") | undefined;
   if (options.probeMode) {
-    const cacheability = await import("./cacheability-request.js");
+    cacheability = await import("./cacheability-request.js");
     context = cacheability.createWorkerCacheabilityProbeContext(
       context,
       options.probeMode,
       adapter.responseVary,
       options.resolvedRoutePathname,
     );
-    if (options.policyHeadersAppliedBeforeRender) {
-      cacheability.recordResponseStageCachePolicy(context, options.policyHeaders);
-    }
-    const rendered = await render(context);
-    const response = options.policyHeadersAppliedBeforeRender
-      ? rendered
-      : cacheability.applyResponseStageCachePolicy(rendered, context, options.policyHeaders);
-    return cacheability.finalizeWorkerCacheabilityResponse(response, context);
-  }
-
-  const requiresAdmission =
+  } else if (
     options.cache === "shared" &&
-    (options.rawManifest != null || adapter.requiresCompletedResponseAdmission === true);
-  if (requiresAdmission) {
-    const cacheability = await import("./cacheability-request.js");
+    (options.rawManifest != null || adapter.requiresCompletedResponseAdmission === true)
+  ) {
+    cacheability = await import("./cacheability-request.js");
     context = cacheability.createWorkerCacheabilityAdmissionContext(
       context,
       options.request,
@@ -70,15 +61,15 @@ export async function withResponseStageCacheability(
       options.representation,
       { applyCompletedResponsePolicy: true },
     );
-    if (options.policyHeadersAppliedBeforeRender) {
-      cacheability.recordResponseStageCachePolicy(context, options.policyHeaders);
-    }
-    const rendered = await render(context);
-    const response = options.policyHeadersAppliedBeforeRender
-      ? rendered
-      : cacheability.applyResponseStageCachePolicy(rendered, context, options.policyHeaders);
-    return cacheability.finalizeWorkerCacheabilityResponse(response, context);
   }
 
-  return render(context);
+  if (!cacheability) return render(context);
+  if (options.policyHeadersAppliedBeforeRender) {
+    cacheability.recordResponseStageCachePolicy(context, options.policyHeaders);
+  }
+  const rendered = await render(context);
+  const response = options.policyHeadersAppliedBeforeRender
+    ? rendered
+    : cacheability.applyResponseStageCachePolicy(rendered, context, options.policyHeaders);
+  return cacheability.finalizeWorkerCacheabilityResponse(response, context);
 }

--- a/packages/vinext/src/server/response-stage-policy.ts
+++ b/packages/vinext/src/server/response-stage-policy.ts
@@ -1,0 +1,32 @@
+import { mergeVaryHeader } from "./middleware-response-headers.js";
+
+/** Apply request-stage cache policy before response-stage admission. */
+export function applyResponseStagePolicyHeaders(
+  headers: Headers,
+  policyHeaders: ReadonlyArray<readonly [string, string]> | null | undefined,
+): void {
+  for (const [name, value] of policyHeaders ?? []) {
+    if (name.toLowerCase() === "vary") {
+      mergeVaryHeader(headers, value);
+    } else {
+      headers.set(name, value);
+    }
+  }
+}
+
+/** Replace transported Vary fields with the effective request-stage value. */
+export function withResponseStageVary(
+  policyHeaders: ReadonlyArray<readonly [string, string]> | null | undefined,
+  vary: string | null | undefined,
+): Array<[string, string]> | null {
+  const result: Array<[string, string]> = [];
+  const varyHeaders = new Headers();
+  for (const [name, value] of policyHeaders ?? []) {
+    if (name.toLowerCase() === "vary") mergeVaryHeader(varyHeaders, value);
+    else result.push([name, value]);
+  }
+  if (vary) mergeVaryHeader(varyHeaders, vary);
+  const effectiveVary = varyHeaders.get("Vary");
+  if (effectiveVary) result.push(["Vary", effectiveVary]);
+  return result.length > 0 ? result : null;
+}

--- a/packages/vinext/src/server/revalidation-host.ts
+++ b/packages/vinext/src/server/revalidation-host.ts
@@ -1,7 +1,10 @@
 import type { NextI18nConfig } from "../config/next-config.js";
 import { normalizeDomainHostname } from "../utils/domain-locale.js";
 import { VINEXT_REVALIDATE_HOST_HEADER } from "./headers.js";
-import { isOnDemandRevalidateRequest, PRERENDER_REVALIDATE_HEADER } from "./isr-cache.js";
+import {
+  isOnDemandRevalidateRequest,
+  PRERENDER_REVALIDATE_HEADER,
+} from "./revalidation-request.js";
 
 /**
  * Read the logical request hostname carried by a server-pinned revalidation

--- a/packages/vinext/src/server/revalidation-request.ts
+++ b/packages/vinext/src/server/revalidation-request.ts
@@ -1,0 +1,47 @@
+import { PRERENDER_REVALIDATE_HEADER } from "../utils/protocol-headers.js";
+
+export { PRERENDER_REVALIDATE_HEADER };
+
+/**
+ * Request-only on-demand revalidation authentication.
+ *
+ * Keep this module independent from ISR storage and renderer code so a routing
+ * stage can authorize a reverse revalidation call without evaluating React.
+ */
+const DEV_REVALIDATE_SECRET_KEY = Symbol.for("vinext.isrCache.devRevalidateSecret");
+
+function getRevalidateSecret(): string {
+  const baked = process.env.__VINEXT_REVALIDATE_SECRET;
+  if (baked) return baked;
+
+  const globals = globalThis as unknown as Record<PropertyKey, unknown>;
+  const existing = globals[DEV_REVALIDATE_SECRET_KEY];
+  if (typeof existing === "string") return existing;
+
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  const secret = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+  globals[DEV_REVALIDATE_SECRET_KEY] = secret;
+  return secret;
+}
+
+function safeEqual(first: string, second: string): boolean {
+  if (first.length !== second.length) return false;
+  let mismatch = 0;
+  for (let index = 0; index < first.length; index++) {
+    mismatch |= first.charCodeAt(index) ^ second.charCodeAt(index);
+  }
+  return mismatch === 0;
+}
+
+function isRevalidateSecret(value: string | null | undefined): boolean {
+  if (typeof value !== "string" || value.length === 0) return false;
+  return safeEqual(value, getRevalidateSecret());
+}
+
+/** Match Next.js: the header value must equal the preview/revalidation secret. */
+export function isOnDemandRevalidateRequest(
+  headerValue: string | string[] | null | undefined,
+): boolean {
+  return typeof headerValue === "string" && isRevalidateSecret(headerValue);
+}

--- a/packages/vinext/src/server/revalidation-request.ts
+++ b/packages/vinext/src/server/revalidation-request.ts
@@ -10,7 +10,7 @@ export { PRERENDER_REVALIDATE_HEADER };
  */
 const DEV_REVALIDATE_SECRET_KEY = Symbol.for("vinext.isrCache.devRevalidateSecret");
 
-function getRevalidateSecret(): string {
+export function getRevalidateSecret(): string {
   const baked = process.env.__VINEXT_REVALIDATE_SECRET;
   if (baked) return baked;
 
@@ -34,7 +34,7 @@ function safeEqual(first: string, second: string): boolean {
   return mismatch === 0;
 }
 
-function isRevalidateSecret(value: string | null | undefined): boolean {
+export function isRevalidateSecret(value: string | null | undefined): boolean {
   if (typeof value !== "string" || value.length === 0) return false;
   return safeEqual(value, getRevalidateSecret());
 }

--- a/packages/vinext/src/server/static-file-signal.ts
+++ b/packages/vinext/src/server/static-file-signal.ts
@@ -1,4 +1,11 @@
 const STATIC_FILE_SIGNAL = Symbol.for("vinext.static-file-signal");
+const STATIC_FILE_SIGNAL_TRANSPORT_HEADER = "x-vinext-stage-static-file";
+const STATIC_FILE_REPRESENTATION_HEADERS = [
+  "content-encoding",
+  "content-length",
+  "content-type",
+  "transfer-encoding",
+] as const;
 
 export type StaticFileSignalContext = {
   headers: Headers | null;
@@ -13,10 +20,35 @@ export type StaticFileSignalContext = {
  * remain ordinary metadata and cannot alter framework control flow.
  */
 function markStaticFileSignal(response: Response, pathname: string): Response {
+  return markEncodedStaticFileSignal(response, encodeURIComponent(pathname));
+}
+
+function markEncodedStaticFileSignal(response: Response, encodedPathname: string): Response {
   Object.defineProperty(response, STATIC_FILE_SIGNAL, {
-    value: encodeURIComponent(pathname),
+    value: encodedPathname,
   });
   return response;
+}
+
+function withoutTransportHeader(response: Response): Response {
+  if (!response.headers.has(STATIC_FILE_SIGNAL_TRANSPORT_HEADER)) return response;
+  const headers = new Headers(response.headers);
+  headers.delete(STATIC_FILE_SIGNAL_TRANSPORT_HEADER);
+  if (response.status < 200 || response.status > 599) {
+    // Non-standard responses such as Worker WebSocket upgrades cannot be
+    // reconstructed with the standard Response constructor. They can never be
+    // static-file signals, so leave the untrusted header inert.
+    return response;
+  }
+  const body =
+    response.status === 204 || response.status === 205 || response.status === 304
+      ? null
+      : response.body;
+  return new Response(body, {
+    headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
 }
 
 /** Create the only response shape that host runtimes may resolve as an asset. */
@@ -48,4 +80,33 @@ export function isStaticFileSignal(response: Response): boolean {
 export function readStaticFileSignal(response: Response): string | null {
   const signal = Reflect.get(response, STATIC_FILE_SIGNAL);
   return typeof signal === "string" ? signal : null;
+}
+
+/** Encode a framework-authenticated signal for a standards-only stage transport. */
+export function serializeStaticFileSignalForTransport(response: Response, token: string): Response {
+  const signal = readStaticFileSignal(response);
+  if (signal === null) return response;
+  const headers = new Headers(response.headers);
+  for (const name of STATIC_FILE_REPRESENTATION_HEADERS) headers.delete(name);
+  headers.set(STATIC_FILE_SIGNAL_TRANSPORT_HEADER, `${token}:${signal}`);
+  return new Response(null, {
+    headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
+}
+
+/** Restore and consume a signal returned by the trusted response-stage wrapper. */
+export function restoreStaticFileSignalFromTransport(response: Response, token: string): Response {
+  const transported = response.headers.get(STATIC_FILE_SIGNAL_TRANSPORT_HEADER);
+  const cleaned = withoutTransportHeader(response);
+  const prefix = `${token}:`;
+  if (transported === null || !transported.startsWith(prefix)) return cleaned;
+  const encodedPathname = transported.slice(prefix.length);
+  try {
+    if (!decodeURIComponent(encodedPathname).startsWith("/")) return cleaned;
+  } catch {
+    return cleaned;
+  }
+  return markEncodedStaticFileSignal(cleaned, encodedPathname);
 }

--- a/packages/vinext/src/server/worker-revalidation-context.ts
+++ b/packages/vinext/src/server/worker-revalidation-context.ts
@@ -6,6 +6,7 @@ function deriveExecutionContext(
   base: PlatformExecutionContext | undefined,
   dispatchPagesRevalidate: (request: Request) => Promise<Response>,
   isInternalPagesRevalidation: boolean,
+  defaultHostRuntime: "node" | "worker",
 ): ExecutionContextLike {
   return {
     waitUntil(promise) {
@@ -22,7 +23,7 @@ function deriveExecutionContext(
           },
         }
       : {}),
-    hostRuntime: "worker",
+    hostRuntime: base?.hostRuntime ?? defaultHostRuntime,
     ...(base?.cache === undefined ? {} : { cache: base.cache }),
     ...(base?.trustedRevalidateOrigin === undefined
       ? {}
@@ -41,13 +42,17 @@ function deriveExecutionContext(
 export function createWorkerRevalidationContext(
   base: PlatformExecutionContext | undefined,
   handleInternalRequest: (request: Request, ctx: ExecutionContextLike) => Promise<Response>,
+  defaultHostRuntime: "node" | "worker" = "worker",
 ): ExecutionContextLike {
   if (typeof base?.dispatchPagesRevalidate === "function") {
     return base as ExecutionContextLike;
   }
 
   const dispatchPagesRevalidate = (request: Request): Promise<Response> =>
-    handleInternalRequest(request, deriveExecutionContext(base, dispatchPagesRevalidate, true));
+    handleInternalRequest(
+      request,
+      deriveExecutionContext(base, dispatchPagesRevalidate, true, defaultHostRuntime),
+    );
 
-  return deriveExecutionContext(base, dispatchPagesRevalidate, false);
+  return deriveExecutionContext(base, dispatchPagesRevalidate, false, defaultHostRuntime);
 }

--- a/packages/vinext/src/server/worker-utils.ts
+++ b/packages/vinext/src/server/worker-utils.ts
@@ -141,6 +141,7 @@ export async function resolveStaticAssetSignal(
     "content-encoding",
     "content-length",
     "content-type",
+    "transfer-encoding",
   ]);
 
   cancelResponseBody(signalResponse);

--- a/packages/vinext/src/shims/cacheability-classification.ts
+++ b/packages/vinext/src/shims/cacheability-classification.ts
@@ -2,13 +2,8 @@ import { getRequestExecutionContext } from "./request-context.js";
 
 export const CACHEABILITY_REQUEST_STATE = Symbol.for("vinext.cacheabilityRequestState");
 
-export const CACHEABILITY_POLICY_HEADERS = [
-  "cache-control",
-  "cdn-cache-control",
-  "cloudflare-cdn-cache-control",
-] as const;
-
-type CacheabilityPolicyHeader = (typeof CACHEABILITY_POLICY_HEADERS)[number];
+/** Cache-policy response headers owned by core itself. */
+export const CACHEABILITY_POLICY_HEADERS = ["cache-control"] as const;
 
 export type RouteCacheabilityOutcome = {
   cacheControl?: string;
@@ -33,24 +28,30 @@ export type RouteCacheabilityState = {
   complete?: (outcome: RouteCacheabilityOutcome) => void;
   completion?: Promise<RouteCacheabilityOutcome>;
   completedResponseBody?: boolean;
+  /** Whether admission must translate a completed response through the active adapter. */
+  applyCompletedResponsePolicy?: boolean;
   explicitConfigCachePolicy?: boolean;
   explicitResponseCachePolicy?: boolean;
   finalResponseVetoReason?: string;
   forcedDynamicReason?: string;
   /** A route-config decision that applies to every concrete identity for this pattern. */
   patternDynamicReason?: string;
-  frameworkResponseCachePolicy?: Partial<Record<CacheabilityPolicyHeader, string>>;
+  frameworkResponseCachePolicy?: Partial<Record<string, string>>;
   mode: "admit" | "identity" | "probe";
   outcome?: RouteCacheabilityOutcome;
   preserveResponseCachePolicy?: boolean;
   /** Cache-key behavior declared by the active CDN adapter. */
   responseVary?: "verbatim";
+  /** Concrete pathname resolved by the trusted request stage before rendering. */
+  resolvedRoutePathname?: string;
+  /** Lowercase cache-policy names owned by core and the active CDN adapter. */
+  responsePolicyHeaderNames?: readonly string[];
   probeBailout?: {
     kind: "private-cache";
     outcome: RouteCacheabilityOutcome;
   };
   route?: {
-    kind: "app-page" | "app-route" | "pages-page";
+    kind: "app-page" | "app-route" | "pages-api" | "pages-page";
     pattern: string;
   };
 };
@@ -72,7 +73,7 @@ export function readRouteCacheabilityState(): RouteCacheabilityState | null {
 }
 
 export function beginRouteCacheability(
-  kind: "app-page" | "app-route" | "pages-page",
+  kind: "app-page" | "app-route" | "pages-api" | "pages-page",
   pattern: string,
 ): boolean {
   const state = readRouteCacheabilityState();
@@ -150,8 +151,8 @@ export function captureRouteCacheabilityResponsePolicy(headers: Headers): void {
   const state = readRouteCacheabilityState();
   if (!state || state.mode !== "admit") return;
 
-  const policy: Partial<Record<CacheabilityPolicyHeader, string>> = {};
-  for (const name of CACHEABILITY_POLICY_HEADERS) {
+  const policy: Partial<Record<string, string>> = {};
+  for (const name of state.responsePolicyHeaderNames ?? CACHEABILITY_POLICY_HEADERS) {
     const value = headers.get(name);
     if (value !== null) policy[name] = value;
   }

--- a/packages/vinext/src/shims/server.ts
+++ b/packages/vinext/src/shims/server.ts
@@ -138,13 +138,18 @@ export class NextRequest extends Request {
       // the source request to stay readable must branch it themselves and
       // cancel the branch they do not consume.
       super(input, requestInit);
-      const cf = Reflect.get(input, "cf");
-      if (cf !== undefined) {
-        Object.defineProperty(this, "cf", {
-          value: cf,
-          enumerable: true,
-          configurable: true,
-        });
+      const cfDescriptor = Reflect.getOwnPropertyDescriptor(input, "cf");
+      if (cfDescriptor) {
+        Object.defineProperty(this, "cf", cfDescriptor);
+      } else {
+        const cf = Reflect.get(input, "cf");
+        if (cf !== undefined) {
+          Object.defineProperty(this, "cf", {
+            value: cf,
+            enumerable: true,
+            configurable: true,
+          });
+        }
       }
     } else {
       super(input, requestInit);

--- a/packages/vinext/src/utils/middleware-request-headers.ts
+++ b/packages/vinext/src/utils/middleware-request-headers.ts
@@ -69,6 +69,17 @@ export function getUnconsumedMiddlewareRequestHeaders(
   return unconsumedHeaders;
 }
 
+/** Whether middleware changed the headers seen by downstream application code. */
+export function hasMiddlewareRequestHeaderOverrides(
+  source: MiddlewareHeaderSource | null,
+): boolean {
+  if (!source) return false;
+  return (
+    Boolean(getMiddlewareHeaderValue(source, MIDDLEWARE_OVERRIDE_HEADERS)) ||
+    getUnconsumedMiddlewareRequestHeaders(source).size > 0
+  );
+}
+
 export function encodeMiddlewareRequestHeaders(
   targetHeaders: Headers,
   requestHeaders: Headers,

--- a/tests/app-route-handler-execution.test.ts
+++ b/tests/app-route-handler-execution.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vite-plus/test";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import {
   consumeDynamicUsage,
   cookies,
@@ -34,6 +34,11 @@ import {
   CACHEABILITY_REQUEST_STATE,
   type RouteCacheabilityState,
 } from "../packages/vinext/src/shims/cacheability-classification.js";
+import {
+  DefaultCdnCacheAdapter,
+  setCdnCacheAdapter,
+  type CdnCacheAdapter,
+} from "../packages/vinext/src/shims/cdn-cache.js";
 
 // The fetch-cache shim captures `originalFetch` from globalThis at import
 // time, so stub fetch BEFORE importing it (same pattern as
@@ -47,6 +52,8 @@ const fetchMock = vi.fn(async (_input: string | URL | Request, _init?: RequestIn
 vi.stubGlobal("fetch", fetchMock);
 const { withFetchCache } = await import("../packages/vinext/src/shims/fetch-cache.js");
 const { revalidateTag } = await import("../packages/vinext/src/shims/cache.js");
+
+afterEach(() => setCdnCacheAdapter(new DefaultCdnCacheAdapter()));
 
 function createDynamicUsageState(): {
   consumeDynamicUsage: () => boolean;
@@ -306,6 +313,20 @@ describe("app route handler execution helpers", () => {
   it.each(["CDN-Cache-Control", "Cloudflare-CDN-Cache-Control"])(
     "preserves handler-owned %s instead of applying framework revalidation",
     async (policyHeader) => {
+      const adapter: CdnCacheAdapter = {
+        buildResponseHeaders: ({ cacheControl }) => ({ "Cache-Control": cacheControl }),
+        async get() {
+          return null;
+        },
+        hasExplicitNonCacheableResponsePolicy(headers) {
+          return headers.get(policyHeader)?.includes("no-store") === true;
+        },
+        ownsBackgroundRevalidation: false,
+        async revalidateTag() {},
+        responsePolicyHeaderNames: [policyHeader],
+        async set() {},
+      };
+      setCdnCacheAdapter(adapter);
       const dynamicUsage = createDynamicUsageState();
       const isrSet = vi.fn();
       const response = await executeAppRouteHandler({

--- a/tests/cache-control.test.ts
+++ b/tests/cache-control.test.ts
@@ -5,6 +5,7 @@ import {
   buildCachedRevalidateCacheControl,
   buildRevalidateCacheControl,
   hasExplicitNonCacheableResponsePolicy,
+  reconcileCdnResponseHeadersAfterOuterPolicy,
   shouldUseNextDeployCacheControl,
   validateCdnRequest,
 } from "../packages/vinext/src/server/cache-control.js";
@@ -79,6 +80,7 @@ describe("applyCdnResponseHeaders", () => {
     process.env.VINEXT_NEXT_DEPLOY_CACHE_CONTROL = "1";
     const edge: CdnCacheAdapter = {
       ownsBackgroundRevalidation: false,
+      responsePolicyHeaderNames: ["CDN-Cache-Control"],
       async get() {
         return null;
       },
@@ -157,6 +159,75 @@ describe("applyCdnResponseHeaders", () => {
     applyCdnResponseHeaders(headers, { cacheControl: "no-store" });
 
     expect(headers.get("Cache-Control")).toBe("no-store");
+    expect(headers.get("X-Example-Edge-Policy")).toBeNull();
+    expect(headers.get("X-Example-Cache-Tag")).toBeNull();
+  });
+
+  it("clears an inner artifact's provider policy when outer composition turns private", () => {
+    const edge: CdnCacheAdapter = {
+      ownsBackgroundRevalidation: false,
+      responsePolicyHeaderNames: ["X-Example-Edge-Policy"],
+      async get() {
+        return null;
+      },
+      async set() {},
+      buildResponseHeaders(input) {
+        return {
+          "Cache-Control": input.cacheControl,
+          "X-Example-Edge-Policy": null,
+          "X-Example-Cache-Tag": null,
+        };
+      },
+      async revalidateTag() {},
+    };
+    setCdnCacheAdapter(edge);
+    const innerHeaders = new Headers({
+      "Cache-Control": "public, max-age=0, must-revalidate",
+      "X-Example-Edge-Policy": "public, max-age=60",
+      "X-Example-Cache-Tag": "inner",
+    });
+    const headers = new Headers(innerHeaders);
+    headers.set("X-Example-Edge-Policy", "private, no-store");
+
+    reconcileCdnResponseHeadersAfterOuterPolicy(
+      headers,
+      new Headers({ "X-Example-Edge-Policy": "private, no-store" }),
+    );
+
+    expect(headers.get("Cache-Control")).toBe("private, no-store");
+    expect(headers.get("X-Example-Edge-Policy")).toBeNull();
+    expect(headers.get("X-Example-Cache-Tag")).toBeNull();
+  });
+
+  it("clears an inner artifact's provider policy when outer composition sets a cookie", () => {
+    const edge: CdnCacheAdapter = {
+      ownsBackgroundRevalidation: false,
+      responsePolicyHeaderNames: ["X-Example-Edge-Policy"],
+      async get() {
+        return null;
+      },
+      async set() {},
+      buildResponseHeaders(input) {
+        return {
+          "Cache-Control": input.cacheControl,
+          "X-Example-Edge-Policy": null,
+          "X-Example-Cache-Tag": null,
+        };
+      },
+      async revalidateTag() {},
+    };
+    setCdnCacheAdapter(edge);
+    const headers = new Headers({
+      "Cache-Control": "public, max-age=0, must-revalidate",
+      "Set-Cookie": "session=private; Path=/; HttpOnly",
+      "X-Example-Cache-Tag": "inner",
+      "X-Example-Edge-Policy": "public, max-age=60",
+    });
+
+    reconcileCdnResponseHeadersAfterOuterPolicy(headers, new Headers());
+
+    expect(headers.get("Cache-Control")).toBe("no-store, must-revalidate");
+    expect(headers.get("Set-Cookie")).toContain("session=private");
     expect(headers.get("X-Example-Edge-Policy")).toBeNull();
     expect(headers.get("X-Example-Cache-Tag")).toBeNull();
   });

--- a/tests/cache-control.test.ts
+++ b/tests/cache-control.test.ts
@@ -4,6 +4,7 @@ import {
   BROWSER_REVALIDATE_CACHE_CONTROL,
   buildCachedRevalidateCacheControl,
   buildRevalidateCacheControl,
+  captureCdnResponsePolicyOverrides,
   hasExplicitNonCacheableResponsePolicy,
   reconcileCdnResponseHeadersAfterOuterPolicy,
   shouldUseNextDeployCacheControl,
@@ -131,6 +132,33 @@ describe("applyCdnResponseHeaders", () => {
     expect(headers.get("Cache-Control")).toBe("no-store");
     expect(headers.get("X-Example-Edge-Policy")).toBe("s-maxage=60");
     expect(headers.get("X-Example-Cache-Tag")).toBe("a,b");
+  });
+
+  it("captures only request-stage policy values that differ from the inner response", () => {
+    const edge: CdnCacheAdapter = {
+      ownsBackgroundRevalidation: false,
+      responsePolicyHeaderNames: ["CDN-Cache-Control"],
+      async get() {
+        return null;
+      },
+      async set() {},
+      buildResponseHeaders() {
+        return {};
+      },
+      async revalidateTag() {},
+    };
+    setCdnCacheAdapter(edge);
+
+    const overrides = captureCdnResponsePolicyOverrides(
+      new Headers({
+        "Cache-Control": "public, max-age=0, must-revalidate",
+        "CDN-Cache-Control": "private, no-store",
+        "X-Unrelated": "ignored",
+      }),
+      new Headers({ "Cache-Control": "public, max-age=0, must-revalidate" }),
+    );
+
+    expect([...overrides]).toEqual([["cdn-cache-control", "private, no-store"]]);
   });
 
   it("applies adapter-owned header removals without knowing their names", () => {

--- a/tests/cacheability-admission.test.ts
+++ b/tests/cacheability-admission.test.ts
@@ -485,6 +485,99 @@ describe("single-request cacheability admission", () => {
     await expect(response.text()).resolves.toBe("public");
   });
 
+  it("normalizes a completed Route Handler policy only at a shared response stage", async () => {
+    const previousNextDeployPolicy = process.env.VINEXT_NEXT_DEPLOY_CACHE_CONTROL;
+    process.env.VINEXT_NEXT_DEPLOY_CACHE_CONTROL = "1";
+    setCdnCacheAdapter(new CloudflareCdnCacheAdapter());
+    try {
+      const finalize = async (applyCompletedResponsePolicy: boolean) => {
+        const context = createWorkerCacheabilityAdmissionContext(
+          { waitUntil() {} },
+          new Request("https://example.com/api/mixed-methods", {
+            headers: { Accept: "application/json" },
+          }),
+          JSON.stringify({ buildId: "build-a", routes: {}, version: 1 }),
+          "build-a",
+          true,
+          undefined,
+          undefined,
+          undefined,
+          { applyCompletedResponsePolicy },
+        );
+        const state = cacheabilityState(context);
+        state.route = { kind: "app-route", pattern: "/api/mixed-methods" };
+        state.explicitResponseCachePolicy = true;
+        state.completedResponseBody = true;
+        return finalizeWorkerCacheabilityResponse(
+          new Response("public", {
+            headers: { "Cache-Control": "public, s-maxage=60" },
+          }),
+          context,
+        );
+      };
+
+      const legacyResponse = await finalize(false);
+      expect(legacyResponse.headers.get("Cache-Control")).toBe("public, s-maxage=60");
+      expect(legacyResponse.headers.get("CDN-Cache-Control")).toBeNull();
+
+      const stagedResponse = await finalize(true);
+      expect(stagedResponse.headers.get("Cache-Control")).toBe(
+        "public, max-age=0, must-revalidate",
+      );
+      expect(stagedResponse.headers.get("CDN-Cache-Control")).toBeNull();
+    } finally {
+      setCdnCacheAdapter(new DefaultCdnCacheAdapter());
+      if (previousNextDeployPolicy === undefined) {
+        delete process.env.VINEXT_NEXT_DEPLOY_CACHE_CONTROL;
+      } else {
+        process.env.VINEXT_NEXT_DEPLOY_CACHE_CONTROL = previousNextDeployPolicy;
+      }
+    }
+  });
+
+  it("uses an adapter-owned edge policy rather than browser policy for Pages admission", async () => {
+    const previousNextDeployPolicy = process.env.VINEXT_NEXT_DEPLOY_CACHE_CONTROL;
+    delete process.env.VINEXT_NEXT_DEPLOY_CACHE_CONTROL;
+    const adapter = new CloudflareCdnCacheAdapter();
+    setCdnCacheAdapter(adapter);
+    try {
+      const context = createWorkerCacheabilityAdmissionContext(
+        { waitUntil() {} },
+        request,
+        null,
+        "build-a",
+        true,
+      );
+      const state = cacheabilityState(context);
+      state.route = { kind: "pages-page", pattern: "/page" };
+      state.responsePolicyHeaderNames = [
+        "cache-control",
+        "cdn-cache-control",
+        "cloudflare-cdn-cache-control",
+      ];
+
+      const response = await finalizeWorkerCacheabilityResponse(
+        new Response("page", {
+          headers: {
+            "Cache-Control": "public, max-age=0, must-revalidate",
+            "CDN-Cache-Control": "public, max-age=60",
+          },
+        }),
+        context,
+      );
+
+      expect(response.headers.get("Cache-Control")).toBe("public, max-age=0, must-revalidate");
+      expect(response.headers.get("CDN-Cache-Control")).toBe("public, max-age=60");
+    } finally {
+      setCdnCacheAdapter(new DefaultCdnCacheAdapter());
+      if (previousNextDeployPolicy === undefined) {
+        delete process.env.VINEXT_NEXT_DEPLOY_CACHE_CONTROL;
+      } else {
+        process.env.VINEXT_NEXT_DEPLOY_CACHE_CONTROL = previousNextDeployPolicy;
+      }
+    }
+  });
+
   it("does not treat framework revalidate policy as an explicit unmanifested opt-in", async () => {
     const raw = JSON.stringify({ buildId: "build-a", routes: {}, version: 1 });
     const context = createWorkerCacheabilityAdmissionContext(
@@ -973,6 +1066,7 @@ describe("single-request cacheability admission", () => {
     finalHeaders: Record<string, string>;
     initialPolicy: NonNullable<RouteCacheabilityState["frameworkResponseCachePolicy"]>;
     name: string;
+    responsePolicyHeaderNames?: readonly string[];
   }> = [
     {
       finalHeaders: { "Set-Cookie": "session=private; Path=/; HttpOnly" },
@@ -985,14 +1079,10 @@ describe("single-request cacheability admission", () => {
       name: "Cache-Control",
     },
     {
-      finalHeaders: { "CDN-Cache-Control": "private, no-store" },
-      initialPolicy: { "cdn-cache-control": "public, s-maxage=60" },
-      name: "CDN-Cache-Control",
-    },
-    {
-      finalHeaders: { "Cloudflare-CDN-Cache-Control": "private, no-store" },
-      initialPolicy: { "cloudflare-cdn-cache-control": "public, s-maxage=60" },
-      name: "Cloudflare-CDN-Cache-Control",
+      finalHeaders: { "X-Example-Edge-Policy": "private, no-store" },
+      initialPolicy: { "x-example-edge-policy": "public, s-maxage=60" },
+      name: "adapter-declared policy",
+      responsePolicyHeaderNames: ["cache-control", "x-example-edge-policy"],
     },
   ];
 
@@ -1009,6 +1099,9 @@ describe("single-request cacheability admission", () => {
       const state = cacheabilityState(context);
       state.route = { kind: "app-page", pattern: "/page" };
       state.frameworkResponseCachePolicy = testCase.initialPolicy;
+      if (testCase.responsePolicyHeaderNames) {
+        state.responsePolicyHeaderNames = testCase.responsePolicyHeaderNames;
+      }
       state.outcome = {
         cacheable: true,
         cacheControl: "s-maxage=60, stale-while-revalidate=540",

--- a/tests/cloudflare-cdn-cache.test.ts
+++ b/tests/cloudflare-cdn-cache.test.ts
@@ -23,7 +23,10 @@ import {
   finalizeAppPageRscCacheResponse,
 } from "../packages/vinext/src/server/app-page-cache-finalizer.js";
 import { finalizeAppRscResponse } from "../packages/vinext/src/server/app-rsc-response-finalizer.js";
-import { applyCdnResponseIdentityHeaders } from "../packages/vinext/src/server/cache-control.js";
+import {
+  applyCdnResponseIdentityHeaders,
+  getCdnResponsePolicyHeaderNames,
+} from "../packages/vinext/src/server/cache-control.js";
 import type { RequestContext } from "../packages/vinext/src/config/request-context.js";
 import { VINEXT_CDN_BUILD_ID_HEADER } from "../packages/cloudflare/src/cache/cdn-build-id.js";
 import { VINEXT_EXPECTED_WORKER_VERSION_HEADER } from "../packages/cloudflare/src/version-headers.js";
@@ -85,6 +88,16 @@ describe("CloudflareCdnCacheAdapter", () => {
 
   it("does not own background revalidation (the edge re-requests origin)", () => {
     expect(adapter.ownsBackgroundRevalidation).toBe(false);
+  });
+
+  it("declares every provider policy header to the generic admission layer", () => {
+    setCdnCacheAdapter(adapter);
+
+    expect([...getCdnResponsePolicyHeaderNames()]).toEqual([
+      "cache-control",
+      "cdn-cache-control",
+      "cloudflare-cdn-cache-control",
+    ]);
   });
 
   it("accepts a staged warmup only in its expected Worker version", async () => {

--- a/tests/prerender-route-params.test.ts
+++ b/tests/prerender-route-params.test.ts
@@ -1,9 +1,46 @@
 import { describe, expect, it } from "vite-plus/test";
 import {
   encodePrerenderRouteParams,
+  isTrustedPrerenderState,
   matchPrerenderRouteParamsPayload,
+  readTrustedPrerenderStateFromHeaders,
   type PrerenderRouteParamsPayload,
 } from "../packages/vinext/src/server/prerender-route-params.js";
+
+describe("trusted prerender stage state", () => {
+  it("authenticates route params and speculative mode once at the request boundary", () => {
+    const previousPrerender = process.env.VINEXT_PRERENDER;
+    process.env.VINEXT_PRERENDER = "1";
+    try {
+      const headers = new Headers({
+        "x-vinext-prerender-route-params": encodeURIComponent(
+          JSON.stringify({ routePattern: "/post/:slug", params: { slug: "hello" } }),
+        ),
+        "x-vinext-prerender-secret": "expected-secret",
+        "x-vinext-prerender-speculative": "1",
+      });
+
+      expect(readTrustedPrerenderStateFromHeaders(headers, "expected-secret")).toEqual({
+        routeParams: { routePattern: "/post/:slug", params: { slug: "hello" } },
+        speculative: true,
+      });
+      expect(readTrustedPrerenderStateFromHeaders(headers, "wrong-secret")).toBeNull();
+    } finally {
+      if (previousPrerender === undefined) delete process.env.VINEXT_PRERENDER;
+      else process.env.VINEXT_PRERENDER = previousPrerender;
+    }
+  });
+
+  it("validates the complete serialized stage shape", () => {
+    const state = {
+      routeParams: { routePattern: "/post/:slug", params: { slug: "hello" } },
+      speculative: true,
+    };
+    expect(isTrustedPrerenderState(state)).toBe(true);
+    expect(isTrustedPrerenderState({ ...state, secret: "must-not-cross" })).toBe(false);
+    expect(isTrustedPrerenderState({ ...state, speculative: "1" })).toBe(false);
+  });
+});
 
 function matchesExactRoute(
   payload: PrerenderRouteParamsPayload | null,

--- a/tests/request-pipeline.test.ts
+++ b/tests/request-pipeline.test.ts
@@ -21,6 +21,7 @@ import {
 import {
   applyConfigHeadersToHeaderRecord,
   applyConfigHeadersToResponse,
+  resolveResponseStageCachePolicy,
 } from "../packages/vinext/src/server/config-headers.js";
 import {
   VINEXT_CACHEABILITY_PROBE_HEADER,
@@ -31,7 +32,11 @@ import {
   VINEXT_PRERENDER_SPECULATIVE_HEADER,
   VINEXT_REVALIDATE_HOST_HEADER,
 } from "../packages/vinext/src/server/headers.js";
-import { buildRequestHeadersFromMiddlewareResponse } from "../packages/vinext/src/utils/middleware-request-headers.js";
+import {
+  buildRequestHeadersFromMiddlewareResponse,
+  hasMiddlewareRequestHeaderOverrides,
+} from "../packages/vinext/src/utils/middleware-request-headers.js";
+import { withResponseStageVary } from "../packages/vinext/src/server/response-stage-policy.js";
 import {
   readStaticFileSignal,
   restoreStaticFileSignalFromTransport,
@@ -252,6 +257,55 @@ describe("applyConfigHeadersToResponse", () => {
     expect(response.headers.get("x-added")).toBe("config");
     expect(response.headers.get("vary")).toBe("RSC, Accept");
     expect(response.headers.get("set-cookie")).toBe("from=config; Path=/");
+  });
+});
+
+describe("response-stage config policy", () => {
+  it("carries only matched positive cache policy and Vary fields", () => {
+    const request = new Request("https://example.com/about", {
+      headers: { "x-enable-cache": "yes" },
+    });
+
+    expect(
+      resolveResponseStageCachePolicy({
+        configHeaders: [
+          {
+            source: "/about",
+            has: [{ type: "header", key: "x-enable-cache", value: "yes" }],
+            headers: [
+              { key: "Cache-Control", value: "s-maxage=60" },
+              { key: "Vary", value: "Accept" },
+              { key: "X-Unrelated", value: "outer-only" },
+            ],
+          },
+        ],
+        pathname: "/about",
+        requestContext: {
+          headers: request.headers,
+          cookies: {},
+          query: new URLSearchParams(),
+          host: "example.com",
+        },
+      }),
+    ).toEqual([
+      ["Cache-Control", "s-maxage=60"],
+      ["Vary", "Accept"],
+    ]);
+  });
+
+  it("replaces transported Vary fields with their merged effective value", () => {
+    expect(
+      withResponseStageVary(
+        [
+          ["Cache-Control", "s-maxage=60"],
+          ["Vary", "Accept"],
+        ],
+        "RSC, Accept",
+      ),
+    ).toEqual([
+      ["Cache-Control", "s-maxage=60"],
+      ["Vary", "Accept, RSC"],
+    ]);
   });
 });
 
@@ -1012,6 +1066,20 @@ describe("filterInternalHeaders", () => {
 });
 
 describe("buildRequestHeadersFromMiddlewareResponse", () => {
+  it("detects both listed overrides and unconsumed forwarded values", () => {
+    expect(hasMiddlewareRequestHeaderOverrides(null)).toBe(false);
+    expect(
+      hasMiddlewareRequestHeaderOverrides(
+        new Headers({ "x-middleware-override-headers": "x-added" }),
+      ),
+    ).toBe(true);
+    expect(
+      hasMiddlewareRequestHeaderOverrides(
+        new Headers({ "x-middleware-request-x-unlisted": "literal" }),
+      ),
+    ).toBe(true);
+  });
+
   it("does not translate stray forwarded values when the override header is empty", () => {
     // Next.js only applies middleware request-header overrides when this
     // protocol header is truthy, so the empty string emitted for `new Headers()`

--- a/tests/request-pipeline.test.ts
+++ b/tests/request-pipeline.test.ts
@@ -24,6 +24,7 @@ import {
 } from "../packages/vinext/src/server/config-headers.js";
 import {
   VINEXT_CACHEABILITY_PROBE_HEADER,
+  VINEXT_CACHEABILITY_PROBE_ROUTE_HEADER,
   VINEXT_EXPECTED_WORKER_VERSION_HEADER,
   VINEXT_PRERENDER_CACHE_LIFE_HEADER,
   VINEXT_PRERENDER_ROUTE_PARAMS_HEADER,
@@ -31,7 +32,11 @@ import {
   VINEXT_REVALIDATE_HOST_HEADER,
 } from "../packages/vinext/src/server/headers.js";
 import { buildRequestHeadersFromMiddlewareResponse } from "../packages/vinext/src/utils/middleware-request-headers.js";
-import { readStaticFileSignal } from "../packages/vinext/src/server/static-file-signal.js";
+import {
+  readStaticFileSignal,
+  restoreStaticFileSignalFromTransport,
+  serializeStaticFileSignalForTransport,
+} from "../packages/vinext/src/server/static-file-signal.js";
 
 // Ported from the URL boundary used by Next.js request handling: WHATWG URL
 // pathname parsing canonicalizes recognized dot segments before routing.
@@ -379,6 +384,44 @@ describe("resolvePublicFileRoute", () => {
     expect(readStaticFileSignal(response)).toBe("%2Frobots.txt");
     expect(response.headers.get("x-vinext-static-file")).toBeNull();
     expect(response.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("authenticates static file signals across standards-only transports", async () => {
+    const token = "request-stage-token";
+    const serialized = serializeStaticFileSignalForTransport(
+      createStaticFileSignal("/stage asset.txt", {
+        headers: new Headers({
+          "content-encoding": "gzip",
+          "content-length": "999",
+          "content-type": "application/wrong",
+          "transfer-encoding": "chunked",
+          "x-from-middleware": "1",
+        }),
+        status: 203,
+      }),
+      token,
+    );
+    expect(serialized.headers.get("content-encoding")).toBeNull();
+    expect(serialized.headers.get("content-length")).toBeNull();
+    expect(serialized.headers.get("content-type")).toBeNull();
+    expect(serialized.headers.get("transfer-encoding")).toBeNull();
+    const transported = new Response(serialized.body, serialized);
+    const restored = restoreStaticFileSignalFromTransport(transported, token);
+
+    expect(restored.status).toBe(203);
+    expect(restored.headers.get("x-from-middleware")).toBe("1");
+    expect(restored.headers.get("x-vinext-stage-static-file")).toBeNull();
+    expect(readStaticFileSignal(restored)).toBe("%2Fstage%20asset.txt");
+
+    const forged = restoreStaticFileSignalFromTransport(
+      new Response("route handler", {
+        headers: { "x-vinext-stage-static-file": `${token}:subverted` },
+      }),
+      "different-token",
+    );
+    expect(forged.headers.get("x-vinext-stage-static-file")).toBeNull();
+    expect(readStaticFileSignal(forged)).toBeNull();
+    await expect(forged.text()).resolves.toBe("route handler");
   });
 });
 
@@ -873,6 +916,7 @@ describe("filterInternalHeaders", () => {
     const headers = new Headers({
       "cloudflare-workers-version-overrides": 'downstream="version-id"',
       [VINEXT_CACHEABILITY_PROBE_HEADER]: "forged",
+      [VINEXT_CACHEABILITY_PROBE_ROUTE_HEADER]: "forged",
       [VINEXT_EXPECTED_WORKER_VERSION_HEADER]: "expected-version",
       [VINEXT_PRERENDER_CACHE_LIFE_HEADER]: "forged",
       [VINEXT_PRERENDER_ROUTE_PARAMS_HEADER]: "forged",
@@ -888,6 +932,7 @@ describe("filterInternalHeaders", () => {
     expect(INTERNAL_HEADERS).not.toContain(VINEXT_PRERENDER_CACHE_LIFE_HEADER);
     expect(VINEXT_INTERNAL_HEADERS).toEqual([
       VINEXT_CACHEABILITY_PROBE_HEADER.toLowerCase(),
+      VINEXT_CACHEABILITY_PROBE_ROUTE_HEADER.toLowerCase(),
       VINEXT_EXPECTED_WORKER_VERSION_HEADER.toLowerCase(),
       VINEXT_PRERENDER_ROUTE_PARAMS_HEADER,
       VINEXT_PRERENDER_SPECULATIVE_HEADER,
@@ -899,6 +944,7 @@ describe("filterInternalHeaders", () => {
     }
     expect(result.has(VINEXT_PRERENDER_ROUTE_PARAMS_HEADER)).toBe(false);
     expect(result.has(VINEXT_CACHEABILITY_PROBE_HEADER)).toBe(false);
+    expect(result.has(VINEXT_CACHEABILITY_PROBE_ROUTE_HEADER)).toBe(false);
     expect(result.has(VINEXT_EXPECTED_WORKER_VERSION_HEADER)).toBe(false);
     expect(result.has(VINEXT_PRERENDER_SPECULATIVE_HEADER)).toBe(false);
     expect(result.has(VINEXT_PRERENDER_CACHE_LIFE_HEADER)).toBe(false);
@@ -1168,6 +1214,25 @@ describe("cloneRequestWithHeaders", () => {
     expect(Reflect.get(cloned, "cf")).toEqual({ country: "US" });
   });
 
+  it("preserves a lazy cf accessor without reading it while cloning headers", () => {
+    const original = new Request("http://localhost");
+    let reads = 0;
+    Object.defineProperty(original, "cf", {
+      configurable: true,
+      enumerable: true,
+      get() {
+        reads += 1;
+        return { country: "US" };
+      },
+    });
+
+    const cloned = cloneRequestWithHeaders(original, new Headers());
+
+    expect(reads).toBe(0);
+    expect(Reflect.get(cloned, "cf")).toEqual({ country: "US" });
+    expect(reads).toBe(1);
+  });
+
   it("replaces headers while preserving all other metadata", () => {
     const controller = new AbortController();
     const original = new Request("http://localhost/path?x=1", {
@@ -1231,6 +1296,25 @@ describe("cloneRequestWithUrl", () => {
     });
     const cloned = cloneRequestWithUrl(original, "http://localhost/path");
     expect(Reflect.get(cloned, "cf")).toEqual({ country: "US" });
+  });
+
+  it("preserves a lazy cf accessor without reading it while cloning URLs", () => {
+    const original = new Request("http://localhost/path?_rsc=abc");
+    let reads = 0;
+    Object.defineProperty(original, "cf", {
+      configurable: true,
+      enumerable: true,
+      get() {
+        reads += 1;
+        return { country: "US" };
+      },
+    });
+
+    const cloned = cloneRequestWithUrl(original, "http://localhost/path");
+
+    expect(reads).toBe(0);
+    expect(Reflect.get(cloned, "cf")).toEqual({ country: "US" });
+    expect(reads).toBe(1);
   });
 
   it("preserves body readability for streaming requests", async () => {

--- a/tests/response-stage-cacheability.test.ts
+++ b/tests/response-stage-cacheability.test.ts
@@ -1,0 +1,395 @@
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import {
+  finalizeRequestStageCacheabilityProbe,
+  readWorkerCacheabilityProbeRoute,
+  readWorkerCacheabilityProbeMode,
+  serializeWorkerCacheabilityProbeRoute,
+  type WorkerCacheabilityProbeMode,
+} from "../packages/vinext/src/server/cacheability-request.js";
+import { VINEXT_CACHEABILITY_PROBE_ROUTE_HEADER } from "../packages/vinext/src/server/headers.js";
+import { cacheabilityManifestRouteKey } from "../packages/vinext/src/server/cacheability-manifest.js";
+import { withResponseStageCacheability } from "../packages/vinext/src/server/response-stage-cacheability.js";
+import {
+  CACHEABILITY_REQUEST_STATE,
+  type RouteCacheabilityState,
+} from "../packages/vinext/src/shims/cacheability-classification.js";
+import {
+  DefaultCdnCacheAdapter,
+  setCdnCacheAdapter,
+  type CdnCacheAdapter,
+} from "../packages/vinext/src/shims/cdn-cache.js";
+
+afterEach(() => setCdnCacheAdapter(new DefaultCdnCacheAdapter()));
+
+function admissionAdapter(): CdnCacheAdapter {
+  return {
+    buildResponseHeaders: ({ cacheControl }) => ({ "Cache-Control": cacheControl }),
+    ownsBackgroundRevalidation: false,
+    requiresCompletedResponseAdmission: true,
+    responsePolicyHeaderNames: ["CDN-Cache-Control"],
+    responseVary: "verbatim",
+    async get() {
+      return null;
+    },
+    async revalidateTag() {},
+    async set() {},
+  };
+}
+
+function contextState(context: ExecutionContext): RouteCacheabilityState | undefined {
+  return Reflect.get(context, CACHEABILITY_REQUEST_STATE) as RouteCacheabilityState | undefined;
+}
+
+type ExecutionContext = { waitUntil(promise: Promise<unknown>): void };
+
+function baseContext(): ExecutionContext {
+  return { waitUntil() {} };
+}
+
+function registerAdapter(): void {
+  setCdnCacheAdapter(admissionAdapter());
+}
+
+describe("response-stage cacheability", () => {
+  it("authenticates probe mode before request headers are filtered", () => {
+    const request = new Request("https://example.com/page", {
+      headers: {
+        "X-Vinext-Cacheability-Probe": "identity",
+        "X-Vinext-Prerender-Secret": "secret",
+      },
+    });
+
+    expect(readWorkerCacheabilityProbeMode(request, "secret")).toBe("identity");
+    expect(readWorkerCacheabilityProbeMode(request, "different-secret")).toBeNull();
+  });
+
+  it("returns a terminal request-stage result without waiting for body cancellation", async () => {
+    let cancelCalled = false;
+    const body = new ReadableStream<Uint8Array>({
+      cancel() {
+        cancelCalled = true;
+        return new Promise<void>(() => {});
+      },
+    });
+    const route = { kind: "app-page" as const, pattern: "/你好" };
+    const serializedRoute = serializeWorkerCacheabilityProbeRoute(route);
+    expect(serializedRoute).toContain("%E4%BD%A0%E5%A5%BD");
+    const request = new Request("https://example.com/%E4%BD%A0%E5%A5%BD", {
+      headers: {
+        [VINEXT_CACHEABILITY_PROBE_ROUTE_HEADER]: serializedRoute,
+      },
+    });
+
+    const response = finalizeRequestStageCacheabilityProbe(new Response(body, { status: 307 }), {
+      mode: "probe",
+      responseStageDispatched: false,
+      route: readWorkerCacheabilityProbeRoute(request),
+    });
+
+    expect(cancelCalled).toBe(true);
+    await expect(response.json()).resolves.toMatchObject({
+      kind: "app-page",
+      pattern: "/你好",
+      scope: "identity",
+      state: "dynamic",
+      status: 307,
+      terminal: true,
+    });
+  });
+
+  it("skips ordinary admission for bypassed renders", async () => {
+    const context = baseContext();
+    const response = new Response("private");
+    const rendered = await withResponseStageCacheability(
+      {
+        buildId: "build-a",
+        cache: "bypass",
+        context,
+        rawManifest: null,
+        registerCacheAdapters: registerAdapter,
+        request: new Request("https://example.com/page", {
+          headers: { Accept: "text/html" },
+        }),
+      },
+      async (renderContext) => {
+        expect(renderContext).toBe(context);
+        expect(contextState(renderContext)).toBeUndefined();
+        return response;
+      },
+    );
+
+    expect(rendered).toBe(response);
+    await expect(rendered.text()).resolves.toBe("private");
+  });
+
+  it("runs authenticated probes even when the response transport bypasses caching", async () => {
+    let closeBody!: () => void;
+    let markRenderStarted!: () => void;
+    const renderStarted = new Promise<void>((resolve) => {
+      markRenderStarted = resolve;
+    });
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("rendered"));
+        closeBody = () => controller.close();
+      },
+    });
+    let settled = false;
+    const responsePromise = withResponseStageCacheability(
+      {
+        buildId: "build-a",
+        cache: "bypass",
+        context: baseContext(),
+        probeMode: "probe" satisfies WorkerCacheabilityProbeMode,
+        rawManifest: null,
+        registerCacheAdapters: registerAdapter,
+        request: new Request("https://example.com/page"),
+        resolvedRoutePathname: "/resolved/page",
+      },
+      async (context) => {
+        markRenderStarted();
+        const state = contextState(context)!;
+        state.route = { kind: "app-page", pattern: "/page" };
+        state.outcome = { cacheable: true, cacheControl: "s-maxage=60" };
+        return new Response(body);
+      },
+    ).finally(() => {
+      settled = true;
+    });
+
+    await renderStarted;
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    closeBody();
+    const response = await responsePromise;
+    await expect(response.json()).resolves.toMatchObject({
+      kind: "app-page",
+      routePathname: "/resolved/page",
+      state: "static-candidate",
+    });
+  });
+
+  it("uses the rewritten route pathname without changing public request identity", async () => {
+    const route = {
+      kind: "app-page" as const,
+      pattern: "/target",
+      paths: { "/target": "static-candidate" as const },
+      state: "runtime-check" as const,
+    };
+    const routeKey = cacheabilityManifestRouteKey(route.kind, route.pattern);
+    const rawManifest = JSON.stringify({
+      buildId: "build-a",
+      routes: { [routeKey]: route },
+      version: 1,
+    });
+
+    const response = await withResponseStageCacheability(
+      {
+        buildId: "build-a",
+        cache: "shared",
+        context: baseContext(),
+        rawManifest,
+        registerCacheAdapters: registerAdapter,
+        request: new Request("https://example.com/public?ref=1", {
+          headers: { Accept: "text/html" },
+        }),
+        resolvedRoutePathname: "/target",
+      },
+      async (context) => {
+        const state = contextState(context)!;
+        expect(state.admission).toMatchObject({
+          requestKey: "/public?ref=1",
+          routePathname: "/target",
+        });
+        state.route = { kind: "app-page", pattern: "/target" };
+        state.outcome = { cacheable: true, cacheControl: "s-maxage=60" };
+        return new Response("static");
+      },
+    );
+
+    expect(response.headers.get("Cache-Control")).toBe("s-maxage=60");
+    await expect(response.text()).resolves.toBe("static");
+  });
+
+  it("applies safe config policy before final admission without overriding late vetoes", async () => {
+    const response = await withResponseStageCacheability(
+      {
+        buildId: "build-a",
+        cache: "shared",
+        context: baseContext(),
+        policyHeaders: [["Cache-Control", "public, s-maxage=60"]],
+        rawManifest: null,
+        registerCacheAdapters: registerAdapter,
+        request: new Request("https://example.com/dynamic", {
+          headers: { Accept: "text/html" },
+        }),
+        resolvedRoutePathname: "/dynamic",
+      },
+      async (context) => {
+        const state = contextState(context)!;
+        state.route = { kind: "app-page", pattern: "/dynamic" };
+        state.outcome = { cacheable: false };
+        return new Response("draft", {
+          headers: { "Set-Cookie": "__prerender_bypass=secret; Path=/" },
+        });
+      },
+    );
+
+    expect(response.headers.get("Cache-Control")).toBe("no-store, must-revalidate");
+    expect(response.headers.get("Set-Cookie")).toContain("__prerender_bypass");
+  });
+
+  it("allows safe config policy to publish an otherwise dynamic response", async () => {
+    const response = await withResponseStageCacheability(
+      {
+        buildId: "build-a",
+        cache: "shared",
+        context: baseContext(),
+        policyHeaders: [
+          ["CDN-Cache-Control", "public, s-maxage=90"],
+          ["Vary", "x-visitor"],
+        ],
+        rawManifest: null,
+        registerCacheAdapters: registerAdapter,
+        request: new Request("https://example.com/dynamic", {
+          headers: { Accept: "text/html" },
+        }),
+        resolvedRoutePathname: "/dynamic",
+      },
+      async (context) => {
+        const state = contextState(context)!;
+        state.route = { kind: "app-page", pattern: "/dynamic" };
+        state.outcome = { cacheable: false };
+        return new Response("dynamic", { headers: { Vary: "RSC" } });
+      },
+    );
+
+    expect(response.headers.get("CDN-Cache-Control")).toBe("public, s-maxage=90");
+    expect(response.headers.get("Vary")).toBe("RSC, x-visitor");
+    await expect(response.text()).resolves.toBe("dynamic");
+  });
+
+  it("admits policy declared by a provider-neutral CDN adapter", async () => {
+    const adapter = admissionAdapter();
+    setCdnCacheAdapter({
+      ...adapter,
+      buildResponseHeaders: ({ cacheControl }) => ({
+        "Cache-Control": "max-age=0, must-revalidate",
+        "X-Example-Edge-Policy": cacheControl,
+      }),
+      responsePolicyHeaderNames: ["X-Example-Edge-Policy"],
+    });
+
+    const response = await withResponseStageCacheability(
+      {
+        buildId: "build-a",
+        cache: "shared",
+        context: baseContext(),
+        policyHeaders: [["X-Example-Edge-Policy", "public, s-maxage=90"]],
+        rawManifest: null,
+        registerCacheAdapters() {},
+        request: new Request("https://example.com/dynamic", {
+          headers: { Accept: "text/html" },
+        }),
+        resolvedRoutePathname: "/dynamic",
+      },
+      async (context) => {
+        const state = contextState(context)!;
+        expect(state.responsePolicyHeaderNames).toEqual(["cache-control", "x-example-edge-policy"]);
+        state.route = { kind: "app-page", pattern: "/dynamic" };
+        state.outcome = { cacheable: false };
+        return new Response("dynamic");
+      },
+    );
+
+    expect(response.headers.get("Cache-Control")).toBe("max-age=0, must-revalidate");
+    expect(response.headers.get("X-Example-Edge-Policy")).toBe("public, s-maxage=90");
+    await expect(response.text()).resolves.toBe("dynamic");
+  });
+
+  it("applies adapter policy headers to a route response whose body already completed", async () => {
+    const adapter = admissionAdapter();
+    setCdnCacheAdapter({
+      ...adapter,
+      buildResponseHeaders: ({ cacheControl }) => ({
+        "Cache-Control": "max-age=0, must-revalidate",
+        "CDN-Cache-Control": cacheControl,
+      }),
+    });
+
+    const response = await withResponseStageCacheability(
+      {
+        buildId: "build-a",
+        cache: "shared",
+        context: baseContext(),
+        rawManifest: null,
+        registerCacheAdapters() {},
+        request: new Request("https://example.com/api/explicit", {
+          headers: { Accept: "application/json" },
+        }),
+        resolvedRoutePathname: "/api/explicit",
+      },
+      async (context) => {
+        const state = contextState(context)!;
+        state.route = { kind: "app-route", pattern: "/api/explicit" };
+        state.completedResponseBody = true;
+        state.explicitResponseCachePolicy = true;
+        return new Response("complete", {
+          headers: { "Cache-Control": "public, s-maxage=60" },
+        });
+      },
+    );
+
+    expect(response.headers.get("Cache-Control")).toBe("max-age=0, must-revalidate");
+    expect(response.headers.get("CDN-Cache-Control")).toBe("public, s-maxage=60");
+    await expect(response.text()).resolves.toBe("complete");
+  });
+
+  it("admits an explicitly public Pages API response after clean body completion", async () => {
+    const response = await withResponseStageCacheability(
+      {
+        buildId: "build-a",
+        cache: "shared",
+        context: baseContext(),
+        rawManifest: null,
+        registerCacheAdapters: registerAdapter,
+        request: new Request("https://example.com/api/public", {
+          headers: { Accept: "application/json" },
+        }),
+        resolvedRoutePathname: "/api/public",
+      },
+      async (context) => {
+        contextState(context)!.route = { kind: "pages-api", pattern: "/api/public" };
+        return new Response('{"public":true}', {
+          headers: { "Cache-Control": "public, s-maxage=60" },
+        });
+      },
+    );
+
+    expect(response.headers.get("Cache-Control")).toBe("public, s-maxage=60");
+    await expect(response.json()).resolves.toEqual({ public: true });
+  });
+
+  it("keeps a Pages API private without an explicit public policy", async () => {
+    const response = await withResponseStageCacheability(
+      {
+        buildId: "build-a",
+        cache: "shared",
+        context: baseContext(),
+        rawManifest: null,
+        registerCacheAdapters: registerAdapter,
+        request: new Request("https://example.com/api/private", {
+          headers: { Accept: "application/json" },
+        }),
+        resolvedRoutePathname: "/api/private",
+      },
+      async (context) => {
+        contextState(context)!.route = { kind: "pages-api", pattern: "/api/private" };
+        return new Response('{"private":true}');
+      },
+    );
+
+    expect(response.headers.get("Cache-Control")).toBe("no-store, must-revalidate");
+    await expect(response.json()).resolves.toEqual({ private: true });
+  });
+});

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -11269,6 +11269,26 @@ describe("cookie name validation", () => {
 // NextRequest API tests
 
 describe("NextRequest API", () => {
+  it("preserves a lazy request.cf accessor without reading it", async () => {
+    const { NextRequest } = await import("../packages/vinext/src/shims/server.js");
+    const source = new Request("https://example.com/");
+    let reads = 0;
+    Object.defineProperty(source, "cf", {
+      configurable: true,
+      enumerable: true,
+      get() {
+        reads += 1;
+        return { country: "AU" };
+      },
+    });
+
+    const request = new NextRequest(source);
+
+    expect(reads).toBe(0);
+    expect(Reflect.get(request, "cf")).toEqual({ country: "AU" });
+    expect(reads).toBe(1);
+  });
+
   it("throws canonical 'Please use only absolute URLs' error for relative URL input", async () => {
     const { NextRequest } = await import("../packages/vinext/src/shims/server.js");
     // Matches Next.js's documented behaviour — middleware tests assert on this


### PR DESCRIPTION
Part 4 of 16 in the staged CDN adapter stack. Depends on #3143.

## Summary

- extracts response-stage cacheability policy and clean-EOF admission into typed server helpers
- carries only trusted prerender and revalidation state across a stage boundary
- preserves draft-mode, middleware, header, cookie, static-file, and route-policy exclusions
- keeps generated entries thin and gives the admission lifecycle direct regression coverage

## Validation

- focused cacheability, request-pipeline, cache-control, and shim tests
- full exact-tip `vp check`
- cumulative exact-tip changed-test sweep: 3,461 passed, 2 skipped

## Review size

- Implementation: +640 / -194 LOC
- Tests and fixtures: +842 / -12 LOC
- Other (docs, config, lockfile): +0 / -0 LOC
- 28 changed files

Measured against `codex/cdn-v2-adapter-runtime` after rebasing onto `main@a6931c0`.