### PR TITLE
refactor(pages): extract response stage

### DIFF
--- a/packages/vinext/src/server/pages-api-route.ts
+++ b/packages/vinext/src/server/pages-api-route.ts
@@ -183,7 +183,14 @@ async function _handlePagesApiRoute(options: HandlePagesApiRouteOptions): Promis
           return finalized;
         }
         const headers = new Headers(options.initialResponseHeaders);
-        for (const [name, value] of finalized.headers) headers.set(name, value);
+        for (const [name, value] of finalized.headers) {
+          if (name.toLowerCase() !== "set-cookie") headers.set(name, value);
+        }
+        const finalizedCookies = finalized.headers.getSetCookie();
+        if (finalizedCookies.length > 0) {
+          headers.delete("Set-Cookie");
+          for (const cookie of finalizedCookies) headers.append("Set-Cookie", cookie);
+        }
         return new Response(finalized.body, {
           headers,
           status: finalized.status,

--- a/packages/vinext/src/server/pages-api-route.ts
+++ b/packages/vinext/src/server/pages-api-route.ts
@@ -187,10 +187,7 @@ async function _handlePagesApiRoute(options: HandlePagesApiRouteOptions): Promis
           if (name.toLowerCase() !== "set-cookie") headers.set(name, value);
         }
         const finalizedCookies = finalized.headers.getSetCookie();
-        if (finalizedCookies.length > 0) {
-          headers.delete("Set-Cookie");
-          for (const cookie of finalizedCookies) headers.append("Set-Cookie", cookie);
-        }
+        for (const cookie of finalizedCookies) headers.append("Set-Cookie", cookie);
         return new Response(finalized.body, {
           headers,
           status: finalized.status,

--- a/packages/vinext/src/server/pages-api-route.ts
+++ b/packages/vinext/src/server/pages-api-route.ts
@@ -102,6 +102,8 @@ type HandlePagesApiRouteOptions = {
    */
   ctx?: ExecutionContextLike;
   edgeRuntime?: EdgeApiExecutionRuntime;
+  /** Headers installed before user code, matching Next.js custom-route ordering. */
+  initialResponseHeaders?: Headers;
   match: PagesApiRouteMatch | null;
   reportRequestError?: (error: Error, routePattern: string) => void | Promise<void>;
   request: Request;
@@ -173,7 +175,20 @@ async function _handlePagesApiRoute(options: HandlePagesApiRouteOptions): Promis
       );
       const response = await route.module.default(nextRequest);
       if (response instanceof Response) {
-        return finalizeEdgeApiResponse(response, options.edgeRuntime ?? "worker");
+        const finalized = finalizeEdgeApiResponse(response, options.edgeRuntime ?? "worker");
+        if (
+          !options.initialResponseHeaders ||
+          !options.initialResponseHeaders.keys().next().value
+        ) {
+          return finalized;
+        }
+        const headers = new Headers(options.initialResponseHeaders);
+        for (const [name, value] of finalized.headers) headers.set(name, value);
+        return new Response(finalized.body, {
+          headers,
+          status: finalized.status,
+          statusText: finalized.statusText,
+        });
       }
 
       throw new Error("Edge API route did not return a Response");
@@ -204,6 +219,7 @@ async function _handlePagesApiRoute(options: HandlePagesApiRouteOptions): Promis
     const { req, res, responsePromise } = createPagesReqRes({
       allowedRevalidateHeaderKeys: options.nextConfig?.allowedRevalidateHeaderKeys,
       body,
+      initialResponseHeaders: options.initialResponseHeaders,
       query,
       request: options.request,
       trustedRevalidateOrigin: options.trustedRevalidateOrigin,

--- a/packages/vinext/src/server/pages-node-compat.ts
+++ b/packages/vinext/src/server/pages-node-compat.ts
@@ -601,8 +601,11 @@ export function createPagesReqRes(options: CreatePagesReqResOptions): CreatePage
     options.allowedRevalidateHeaderKeys,
   ) as PagesReqResResponse;
   for (const [name, value] of options.initialResponseHeaders ?? []) {
+    if (name.toLowerCase() === "set-cookie") continue;
     res.setHeader(name, value);
   }
+  const initialCookies = options.initialResponseHeaders?.getSetCookie() ?? [];
+  if (initialCookies.length > 0) res.setHeader("Set-Cookie", initialCookies);
   attachPagesPreviewApi(req, res);
 
   return { req, res, responsePromise };

--- a/packages/vinext/src/server/pages-node-compat.ts
+++ b/packages/vinext/src/server/pages-node-compat.ts
@@ -72,6 +72,7 @@ type PagesRequestCookiesCarrier = {
 type CreatePagesReqResOptions = {
   allowedRevalidateHeaderKeys?: readonly string[];
   body: unknown;
+  initialResponseHeaders?: Headers;
   query: PagesRequestQuery;
   request: Request;
   trustedRevalidateOrigin?: string;
@@ -599,6 +600,9 @@ export function createPagesReqRes(options: CreatePagesReqResOptions): CreatePage
     options.trustedRevalidateOrigin ?? new URL(options.request.url).origin,
     options.allowedRevalidateHeaderKeys,
   ) as PagesReqResResponse;
+  for (const [name, value] of options.initialResponseHeaders ?? []) {
+    res.setHeader(name, value);
+  }
   attachPagesPreviewApi(req, res);
 
   return { req, res, responsePromise };

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -1037,42 +1037,34 @@ export function createPagesPageHandler(
         // and expects the full props envelope (pageProps plus any app-level
         // props like __N_SSP, __N_SSG) as JSON instead of the full HTML page.
         if (isDataReq) {
-          const init: ResponseInit & { headers: Record<string, string> } = { headers: {} };
+          const headers = new Headers();
           if (gsspRes && typeof gsspRes.getHeaders === "function") {
             const gsspHeaders = gsspRes.getHeaders();
             for (const k of Object.keys(gsspHeaders)) {
               const v = gsspHeaders[k];
               if (v === undefined || v === null) continue;
-              init.headers[k] = Array.isArray(v) ? v.join(", ") : String(v);
+              if (k.toLowerCase() === "set-cookie" && Array.isArray(v)) {
+                for (const cookie of v) headers.append(k, String(cookie));
+              } else {
+                headers.set(k, Array.isArray(v) ? v.join(", ") : String(v));
+              }
             }
           }
           if (gsspRes) {
             // Default Cache-Control for gSSP-driven _next/data responses —
             // skip when gSSP already set one via res.setHeader. Fixes #1461.
-            let hasUserCacheControl = false;
-            for (const headerKey of Object.keys(init.headers)) {
-              if (headerKey.toLowerCase() === "cache-control") {
-                hasUserCacheControl = true;
-                break;
-              }
-            }
-            if (!hasUserCacheControl) {
-              init.headers["Cache-Control"] = ISR_NEVER_CACHE_CONTROL;
-            }
+            if (!headers.has("Cache-Control"))
+              headers.set("Cache-Control", ISR_NEVER_CACHE_CONTROL);
           } else if (isStaticPropsRoute) {
             if (isrRevalidateSeconds !== null) {
-              const headers = new Headers(init.headers);
               applyCdnResponseHeaders(headers, {
                 cacheControl: buildMissIsrCacheControl(
                   isrRevalidateSeconds,
                   vinextConfig.expireTime,
                 ),
               });
-              for (const [key, value] of headers) {
-                init.headers[key] = value;
-              }
             } else if (shouldUseNextDeployCacheControl()) {
-              init.headers["Cache-Control"] = BROWSER_REVALIDATE_CACHE_CONTROL;
+              headers.set("Cache-Control", BROWSER_REVALIDATE_CACHE_CONTROL);
             }
           }
           // Mirror Next.js pages-handler.ts: set x-nextjs-deployment-id on
@@ -1084,11 +1076,11 @@ export function createPagesPageHandler(
             const deploymentId =
               process.env.__VINEXT_DEPLOYMENT_ID || process.env.NEXT_DEPLOYMENT_ID;
             if (deploymentId) {
-              init.headers[NEXTJS_DEPLOYMENT_ID_HEADER] = deploymentId;
+              headers.set(NEXTJS_DEPLOYMENT_ID_HEADER, deploymentId);
             }
           }
           return finalizePagesPreviewResponse(
-            buildNextDataPropsJsonResponse(renderProps, safeJsonStringify, init),
+            buildNextDataPropsJsonResponse(renderProps, safeJsonStringify, { headers }),
             preview,
           );
         }

--- a/packages/vinext/src/server/pages-page-handler.ts
+++ b/packages/vinext/src/server/pages-page-handler.ts
@@ -61,6 +61,7 @@ import {
   closeAfterResponse,
   closeAfterResponseWithBody,
   createRequestContext,
+  preserveFullyBufferedBodyMetadata,
   runWithRequestContext,
 } from "vinext/shims/unified-request-context";
 import { getRequestExecutionContext } from "vinext/shims/request-context";
@@ -85,21 +86,40 @@ import {
   type PagesGetInitialPropsRouter,
 } from "./pages-get-initial-props.js";
 
+type PagesStreamedHtmlResponse = Response & {
+  __vinextStreamedHtmlResponse?: boolean;
+};
+
+function preservePagesBodyMetadata(source: Response, target: Response): Response {
+  const result = preserveFullyBufferedBodyMetadata(source, target) as PagesStreamedHtmlResponse;
+  if ((source as PagesStreamedHtmlResponse).__vinextStreamedHtmlResponse === true) {
+    result.__vinextStreamedHtmlResponse = true;
+  }
+  return result;
+}
+
 export function finalizePagesPreviewResponse(
   response: Response,
   preview: PagesPreviewState,
 ): Response {
   if (preview.data === false && !preview.shouldClear) return response;
   const headers = new Headers(response.headers);
-  if (preview.data !== false) {
+  // Next.js expires stale preview cookies but only applies this policy while
+  // draft mode remains active. Keep the cleanup response private as a stricter
+  // edge-cache safeguard: otherwise a shared cache can replay Set-Cookie and
+  // the ordinary ISR body selected after the invalid cookie was rejected.
+  if (preview.data !== false || preview.shouldClear) {
     applyCdnResponseHeaders(headers, { cacheControl: PAGES_PREVIEW_CACHE_CONTROL });
   }
   if (preview.shouldClear) appendPagesPreviewClearCookies(headers);
-  return new Response(response.body, {
-    headers,
-    status: response.status,
-    statusText: response.statusText,
-  });
+  return preservePagesBodyMetadata(
+    response,
+    new Response(response.body, {
+      headers,
+      status: response.status,
+      statusText: response.statusText,
+    }),
+  );
 }
 
 function withPagesCacheState(
@@ -367,6 +387,7 @@ export function createPagesPageHandler(
   manifest: Record<string, string[]> | null | undefined,
   middlewareHeaders: Headers | null | undefined,
   options: RenderPageOptions | null | undefined,
+  initialResponseHeaders?: Headers,
 ) => Promise<Response> {
   const {
     pageRoutes,
@@ -433,6 +454,7 @@ export function createPagesPageHandler(
     manifest: Record<string, string[]> | null | undefined,
     middlewareHeaders: Headers | null | undefined,
     options: RenderPageOptions | null | undefined,
+    initialResponseHeaders?: Headers,
   ): Promise<Response> {
     let isDataReq = !!(options && options.isDataReq);
     const requestUrl = new URL(request.url);
@@ -599,10 +621,17 @@ export function createPagesPageHandler(
     if (shouldCoalesceOnDemand) {
       const cacheKey = pageIsrCacheKey("pages", routeUrl.split("?")[0]);
       const snapshot = await coalesceOnDemandRevalidation(cacheKey, async () => {
-        const response = await renderPage(request, url, manifest, middlewareHeaders, {
-          ...options,
-          __skipOnDemandCoalesce: true,
-        });
+        const response = await renderPage(
+          request,
+          url,
+          manifest,
+          middlewareHeaders,
+          {
+            ...options,
+            __skipOnDemandCoalesce: true,
+          },
+          initialResponseHeaders,
+        );
         return {
           body:
             request.method === "HEAD" || response.status === 204 || response.status === 304
@@ -807,6 +836,7 @@ export function createPagesPageHandler(
         const createPageReqRes = () => {
           const reqRes = createPagesReqRes({
             body: undefined,
+            initialResponseHeaders,
             query,
             request,
             url: originalRequestPathAndSearch,
@@ -917,16 +947,23 @@ export function createPagesPageHandler(
           const notFoundRoute = findNotFoundRoute();
           let notFoundResponse: Response;
           if (notFoundRoute && routePattern !== "/404" && routePattern !== "/_error") {
-            notFoundResponse = await renderPage(request, url, manifest, middlewareHeaders, {
-              statusCode: 404,
-              asPath: routerAsPath,
-              renderErrorPageOnMiss: false,
-              __forcedRoute: notFoundRoute,
-              __notFoundRevalidateSeconds: pageDataResult.revalidateSeconds,
-              __notFoundExpireSeconds: pageDataResult.expireSeconds,
-              __notFoundCachePathname: isrCachePathname,
-              __notFoundSourceHeaders: pageDataResult.responseHeaders,
-            });
+            notFoundResponse = await renderPage(
+              request,
+              url,
+              manifest,
+              middlewareHeaders,
+              {
+                statusCode: 404,
+                asPath: routerAsPath,
+                renderErrorPageOnMiss: false,
+                __forcedRoute: notFoundRoute,
+                __notFoundRevalidateSeconds: pageDataResult.revalidateSeconds,
+                __notFoundExpireSeconds: pageDataResult.expireSeconds,
+                __notFoundCachePathname: isrCachePathname,
+                __notFoundSourceHeaders: pageDataResult.responseHeaders,
+              },
+              initialResponseHeaders,
+            );
           } else {
             notFoundResponse = mergePagesNotFoundSourceHeaders(
               buildDefaultPagesNotFoundResponse(),
@@ -1176,14 +1213,21 @@ export function createPagesPageHandler(
           }
           if (errorRoute) {
             try {
-              return await renderPage(request, url, manifest, middlewareHeaders, {
-                statusCode: 500,
-                asPath: url,
-                renderErrorPageOnMiss: false,
-                __isInternalErrorRender: true,
-                __forcedRoute: errorRoute,
-                err: e instanceof Error ? e : new Error(String(e)),
-              });
+              return await renderPage(
+                request,
+                url,
+                manifest,
+                middlewareHeaders,
+                {
+                  statusCode: 500,
+                  asPath: url,
+                  renderErrorPageOnMiss: false,
+                  __isInternalErrorRender: true,
+                  __forcedRoute: errorRoute,
+                  err: e instanceof Error ? e : new Error(String(e)),
+                },
+                initialResponseHeaders,
+              );
             } catch (errorPageErr) {
               console.error("[vinext] Error page render failed:", errorPageErr);
             }

--- a/packages/vinext/src/server/pages-response-stage-entry.ts
+++ b/packages/vinext/src/server/pages-response-stage-entry.ts
@@ -114,7 +114,7 @@ export async function renderPagesResponse(
   if (props.kind === "pages-prerender-discovery") {
     ctx = { ...ctx, isPrerenderPathDiscovery: true };
   }
-  const handle = async (cacheabilityContext: ExecutionContextLike): Promise<Response> => {
+  const render = async (cacheabilityContext: ExecutionContextLike): Promise<Response> => {
     if (props.kind === "pages-prerender-discovery") {
       const readinessResponse = createWorkerPrerenderReadinessResponse(
         cacheabilityContext,
@@ -165,7 +165,9 @@ export async function renderPagesResponse(
       ),
     );
   };
-  let response = await withResponseStageCacheability(
+  const handle = async (cacheabilityContext: ExecutionContextLike): Promise<Response> =>
+    stripInheritedResponseStageCookies(await render(cacheabilityContext), renderHeaders);
+  const response = await withResponseStageCacheability(
     {
       buildId: pagesEntry.buildId,
       cache: props.kind === "pages-prerender-discovery" ? "bypass" : dispatchOptions.cache,
@@ -181,7 +183,6 @@ export async function renderPagesResponse(
     },
     handle,
   );
-  response = stripInheritedResponseStageCookies(response, renderHeaders);
   if (props.kind !== "pages-page") return response;
 
   const runtimeDataKind = pagesEntry.getRuntimePageDataKind(props.resolvedUrl, request);

--- a/packages/vinext/src/server/pages-response-stage-entry.ts
+++ b/packages/vinext/src/server/pages-response-stage-entry.ts
@@ -69,7 +69,7 @@ function stripStreamedHtmlContentLength(response: Response): Response {
   }
 }
 
-export async function renderPagesResponse(
+async function renderPagesResponse(
   request: Request,
   env: PagesWorkerEnv | undefined,
   platformCtx: PagesWorkerExecutionContext | undefined,

--- a/packages/vinext/src/server/pages-response-stage-entry.ts
+++ b/packages/vinext/src/server/pages-response-stage-entry.ts
@@ -12,7 +12,10 @@ import type {
   VinextResponseStageDispatchOptions,
 } from "./multi-stage.js";
 import { withResponseStageCacheability } from "./response-stage-cacheability.js";
-import { applyResponseStagePolicyHeaders } from "./response-stage-policy.js";
+import {
+  applyResponseStagePolicyHeaders,
+  stripInheritedResponseStageCookies,
+} from "./response-stage-policy.js";
 import { beginRouteCacheability } from "vinext/shims/cacheability-classification";
 import { preserveFullyBufferedBodyMetadata } from "vinext/shims/unified-request-context";
 import { validateCdnRequest } from "./cache-control.js";
@@ -87,6 +90,9 @@ export async function renderPagesResponse(
 
   registerConfiguredImageOptimizer(env);
   const renderHeaders = new Headers(stagedHeaders ?? props.stagedHeaders ?? []);
+  // A request-stage Content-Length describes neither the page nor API body.
+  // Do not expose it as response-owned state; user code can still set its own.
+  renderHeaders.delete("Content-Length");
   const initialResponseHeaders = new Headers(renderHeaders);
   // Legacy/local callers may supply policy metadata without a staged snapshot.
   // Keep that fallback while treating policy as admission provenance rather
@@ -159,7 +165,7 @@ export async function renderPagesResponse(
       ),
     );
   };
-  const response = await withResponseStageCacheability(
+  let response = await withResponseStageCacheability(
     {
       buildId: pagesEntry.buildId,
       cache: props.kind === "pages-prerender-discovery" ? "bypass" : dispatchOptions.cache,
@@ -175,6 +181,7 @@ export async function renderPagesResponse(
     },
     handle,
   );
+  response = stripInheritedResponseStageCookies(response, renderHeaders);
   if (props.kind !== "pages-page") return response;
 
   const runtimeDataKind = pagesEntry.getRuntimePageDataKind(props.resolvedUrl, request);

--- a/packages/vinext/src/server/pages-response-stage-entry.ts
+++ b/packages/vinext/src/server/pages-response-stage-entry.ts
@@ -1,0 +1,205 @@
+/** Cacheable Pages render/API stage. This is the only Pages Worker stage that imports user pages. */
+
+import { runWithExecutionContext, type ExecutionContextLike } from "vinext/shims/request-context";
+import { createWorkerRevalidationContext } from "./worker-revalidation-context.js";
+import {
+  isPagesResponseStageProps,
+  PAGES_RESPONSE_STAGE_POLICY_OWNER_HEADER,
+  type WorkerResponseStageProps,
+} from "./worker-stages.js";
+import type {
+  VinextRequestStageTransport,
+  VinextResponseStageDispatchOptions,
+} from "./multi-stage.js";
+import { withResponseStageCacheability } from "./response-stage-cacheability.js";
+import { applyResponseStagePolicyHeaders } from "./response-stage-policy.js";
+import { beginRouteCacheability } from "vinext/shims/cacheability-classification";
+import { preserveFullyBufferedBodyMetadata } from "vinext/shims/unified-request-context";
+import { validateCdnRequest } from "./cache-control.js";
+import { createWorkerPrerenderReadinessResponse } from "./worker-prerender-discovery.js";
+
+// @ts-expect-error -- virtual module resolved by vinext at build time
+import { registerConfiguredCacheAdapters } from "virtual:vinext-cache-adapters";
+// @ts-expect-error -- virtual module resolved by vinext at build time
+import { registerConfiguredImageOptimizer } from "virtual:vinext-image-adapters";
+// Response-only generated entry: page/API modules and rendering, without the
+// user middleware module or request-stage routing runtime.
+// @ts-expect-error -- virtual module resolved by vinext at build time
+import * as pagesEntry from "virtual:vinext-pages-response-entry";
+// @ts-expect-error -- virtual module resolved by vinext at build time
+import __cacheabilityManifest from "virtual:vinext-cacheability-manifest";
+
+type PagesWorkerEnv = Record<string, unknown>;
+
+type PagesWorkerExecutionContext = ExecutionContextLike & {
+  cache?: unknown;
+};
+
+type PagesStreamedHtmlResponse = Response & {
+  __vinextStreamedHtmlResponse?: boolean;
+};
+
+/** Remove a body length inherited from response staging before transport drops the stream tag. */
+function stripStreamedHtmlContentLength(response: Response): Response {
+  if (
+    (response as PagesStreamedHtmlResponse).__vinextStreamedHtmlResponse !== true ||
+    !response.headers.has("Content-Length")
+  ) {
+    return response;
+  }
+  try {
+    response.headers.delete("Content-Length");
+    return response;
+  } catch {
+    const headers = new Headers(response.headers);
+    headers.delete("Content-Length");
+    const stripped = preserveFullyBufferedBodyMetadata(
+      response,
+      new Response(response.body, {
+        headers,
+        status: response.status,
+        statusText: response.statusText,
+      }),
+    ) as PagesStreamedHtmlResponse;
+    stripped.__vinextStreamedHtmlResponse = true;
+    return stripped;
+  }
+}
+
+export async function renderPagesResponse(
+  request: Request,
+  env: PagesWorkerEnv | undefined,
+  platformCtx: PagesWorkerExecutionContext | undefined,
+  props: WorkerResponseStageProps,
+  stagedHeaders?: Headers,
+  dispatchRequestStage?: VinextRequestStageTransport,
+  dispatchOptions: VinextResponseStageDispatchOptions = { cache: "bypass" },
+): Promise<Response> {
+  if (!isPagesResponseStageProps(props)) {
+    return new Response("Invalid vinext Pages response stage", { status: 400 });
+  }
+  if (props.buildId !== pagesEntry.buildId) {
+    return new Response("Vinext Pages response stage deployment mismatch", { status: 409 });
+  }
+  if (props.requestHost !== new URL(request.url).host) {
+    return new Response("Invalid vinext Pages response stage", { status: 400 });
+  }
+
+  registerConfiguredImageOptimizer(env);
+  const renderHeaders = new Headers(stagedHeaders ?? props.stagedHeaders ?? []);
+  const initialResponseHeaders = new Headers(renderHeaders);
+  // Legacy/local callers may supply policy metadata without a staged snapshot.
+  // Keep that fallback while treating policy as admission provenance rather
+  // than the transport for the response state visible to Pages user code.
+  if (props.stagedHeaders === null && stagedHeaders === undefined) {
+    applyResponseStagePolicyHeaders(initialResponseHeaders, props.cacheability.policyHeaders);
+    applyResponseStagePolicyHeaders(renderHeaders, props.cacheability.policyHeaders);
+  }
+  let ctx = createWorkerRevalidationContext(
+    platformCtx,
+    (internalRequest) => {
+      if (!dispatchRequestStage) {
+        throw new Error("Pages response stage requires a request-stage dispatcher");
+      }
+      return dispatchRequestStage(internalRequest);
+    },
+    "node",
+  );
+  if (props.kind === "pages-prerender-discovery") {
+    ctx = { ...ctx, isPrerenderPathDiscovery: true };
+  }
+  const handle = async (cacheabilityContext: ExecutionContextLike): Promise<Response> => {
+    if (props.kind === "pages-prerender-discovery") {
+      const readinessResponse = createWorkerPrerenderReadinessResponse(
+        cacheabilityContext,
+        request,
+      );
+      if (readinessResponse) {
+        return (await validateCdnRequest(request)) ?? readinessResponse;
+      }
+      const { handleAppPrerenderEndpoint } = await import("./app-prerender-endpoints.js");
+      const response = await runWithExecutionContext(cacheabilityContext, () =>
+        handleAppPrerenderEndpoint(request, {
+          isPrerenderEnabled: () => true,
+          loadPagesRoutes: async () => pagesEntry.pageRoutes,
+          pathname: new URL(request.url).pathname,
+          staticParamsMap: {},
+        }),
+      );
+      return response ?? new Response("This page could not be found", { status: 404 });
+    }
+    if (props.kind === "pages-api") {
+      if (typeof pagesEntry.handleApiRoute !== "function") {
+        return new Response("This page could not be found", { status: 404 });
+      }
+      return runWithExecutionContext(cacheabilityContext, () => {
+        beginRouteCacheability("pages-api", props.cacheability.resolvedRoutePathname);
+        return pagesEntry.handleApiRoute(
+          request,
+          props.apiUrl,
+          cacheabilityContext,
+          new URL(request.url).origin,
+          cacheabilityContext.hostRuntime ?? "node",
+          initialResponseHeaders,
+        );
+      });
+    }
+    if (typeof pagesEntry.renderPage !== "function") {
+      return new Response("This page could not be found", { status: 404 });
+    }
+    return stripStreamedHtmlContentLength(
+      await pagesEntry.renderPage(
+        request,
+        props.resolvedUrl,
+        null,
+        cacheabilityContext,
+        renderHeaders,
+        props.renderOptions ?? undefined,
+        initialResponseHeaders,
+      ),
+    );
+  };
+  const response = await withResponseStageCacheability(
+    {
+      buildId: pagesEntry.buildId,
+      cache: props.kind === "pages-prerender-discovery" ? "bypass" : dispatchOptions.cache,
+      context: ctx,
+      policyHeaders: props.cacheability.policyHeaders,
+      policyHeadersAppliedBeforeRender: true,
+      probeMode: props.cacheability.probeMode,
+      rawManifest: __cacheabilityManifest,
+      registerCacheAdapters: () => registerConfiguredCacheAdapters(env),
+      request,
+      representation: props.cacheability.representation,
+      resolvedRoutePathname: props.cacheability.resolvedRoutePathname,
+    },
+    handle,
+  );
+  if (props.kind !== "pages-page") return response;
+
+  const runtimeDataKind = pagesEntry.getRuntimePageDataKind(props.resolvedUrl, request);
+  const headers = new Headers(response.headers);
+  headers.set(
+    PAGES_RESPONSE_STAGE_POLICY_OWNER_HEADER,
+    runtimeDataKind === "server" || runtimeDataKind === "initial" ? "request-time" : "static",
+  );
+  return preserveFullyBufferedBodyMetadata(
+    response,
+    new Response(response.body, {
+      headers,
+      status: response.status,
+      statusText: response.statusText,
+    }),
+  );
+}
+
+export function handleResponseStage(
+  request: Request,
+  env: PagesWorkerEnv | undefined,
+  ctx: PagesWorkerExecutionContext | undefined,
+  props: WorkerResponseStageProps,
+  dispatchRequestStage: VinextRequestStageTransport,
+  options: VinextResponseStageDispatchOptions,
+): Promise<Response> {
+  return renderPagesResponse(request, env, ctx, props, undefined, dispatchRequestStage, options);
+}

--- a/packages/vinext/src/server/pages-response-stage.ts
+++ b/packages/vinext/src/server/pages-response-stage.ts
@@ -73,6 +73,7 @@ export function shouldDispatchPagesResponseStage({
 }: PagesResponseStageDispatchOptions): boolean {
   const method = request.method.toUpperCase();
   if (method !== "GET" && method !== "HEAD") return false;
+  if (request.headers.get("upgrade")?.toLowerCase() === "websocket") return false;
 
   // Next.js supplies req/res to `_document.getInitialProps` for getStaticProps
   // renders (`isAutoExport` is false). That makes the ostensibly static render

--- a/packages/vinext/src/server/pages-response-stage.ts
+++ b/packages/vinext/src/server/pages-response-stage.ts
@@ -73,7 +73,14 @@ export function shouldDispatchPagesResponseStage({
 }: PagesResponseStageDispatchOptions): boolean {
   const method = request.method.toUpperCase();
   if (method !== "GET" && method !== "HEAD") return false;
-  if (request.headers.get("upgrade")?.toLowerCase() === "websocket") return false;
+  if (
+    request.headers
+      .get("upgrade")
+      ?.split(",")
+      .some((value) => value.trim().toLowerCase() === "websocket")
+  ) {
+    return false;
+  }
 
   // Next.js supplies req/res to `_document.getInitialProps` for getStaticProps
   // renders (`isAutoExport` is false). That makes the ostensibly static render

--- a/packages/vinext/src/server/pages-response-stage.ts
+++ b/packages/vinext/src/server/pages-response-stage.ts
@@ -7,7 +7,7 @@ import type { PagesRouteDataKind } from "./pages-route-data-kind.js";
 const PREVIEW_COOKIE_NAMES = new Set(["__prerender_bypass", "__next_preview_data"]);
 const BYPASS_CACHE_CONTROL_DIRECTIVES = new Set(["no-cache", "no-store"]);
 
-export function hasPagesPreviewCookie(cookieHeader: string | null): boolean {
+function hasPagesPreviewCookie(cookieHeader: string | null): boolean {
   if (!cookieHeader) return false;
   for (const pair of cookieHeader.split(";")) {
     const separator = pair.indexOf("=");

--- a/packages/vinext/src/server/pages-response-stage.ts
+++ b/packages/vinext/src/server/pages-response-stage.ts
@@ -1,0 +1,101 @@
+import { PRERENDER_REVALIDATE_HEADER } from "../utils/protocol-headers.js";
+import type { VinextResponseStageDispatchOptions } from "./multi-stage.js";
+import { getScriptNonceFromHeaderSources } from "./csp.js";
+import { MIDDLEWARE_SET_COOKIE_HEADER } from "./headers.js";
+import type { PagesRouteDataKind } from "./pages-route-data-kind.js";
+
+const PREVIEW_COOKIE_NAMES = new Set(["__prerender_bypass", "__next_preview_data"]);
+const BYPASS_CACHE_CONTROL_DIRECTIVES = new Set(["no-cache", "no-store"]);
+
+export function hasPagesPreviewCookie(cookieHeader: string | null): boolean {
+  if (!cookieHeader) return false;
+  for (const pair of cookieHeader.split(";")) {
+    const separator = pair.indexOf("=");
+    const name = (separator === -1 ? pair : pair.slice(0, separator)).trim();
+    if (PREVIEW_COOKIE_NAMES.has(name)) return true;
+  }
+  return false;
+}
+
+function hasCacheBypassDirective(
+  cacheControl: string | null,
+  directives = BYPASS_CACHE_CONTROL_DIRECTIVES,
+): boolean {
+  if (!cacheControl) return false;
+  return cacheControl.split(",").some((directive) => {
+    const separator = directive.indexOf("=");
+    const name = (separator === -1 ? directive : directive.slice(0, separator))
+      .trim()
+      .toLowerCase();
+    return directives.has(name);
+  });
+}
+
+function hasStagedCacheBypass(stagedHeaders: Headers | undefined): boolean {
+  // Middleware cookie overlays affect the same-request render and are not part
+  // of the shared artifact identity. Pure response headers (Cache-Control,
+  // Vary, Set-Cookie) remain outer composition and must not disable reuse of
+  // the underlying ISR artifact, matching Next's cache layering.
+  return stagedHeaders?.has(MIDDLEWARE_SET_COOKIE_HEADER) === true;
+}
+
+export type PagesResponseStageDispatchOptions = {
+  authorizeOnDemandRevalidate?: (headerValue: string | null) => boolean;
+  /** A custom Document getInitialProps can observe the request/response pair. */
+  hasRequestAwareDocument?: boolean;
+  request: Request;
+  /** Middleware changed the request headers visible to the response stage. */
+  requestHeadersChanged?: boolean;
+  routeDataKind?: PagesRouteDataKind;
+  stagedHeaders?: Headers;
+};
+
+export type PagesResponseStageCacheDisposition = VinextResponseStageDispatchOptions["cache"];
+
+/**
+ * Whether a Pages response may be delegated to a shared response stage.
+ *
+ * Next.js does not construct a static response-cache key in draft mode and
+ * handles authenticated on-demand revalidation outside ordinary cache reuse.
+ * Request cache bypass directives and non-idempotent methods likewise need to
+ * reach the renderer, while CSP nonces are embedded in the rendered body.
+ *
+ * @see https://github.com/vercel/next.js/blob/canary/packages/next/src/server/route-modules/pages/pages-handler.ts
+ * @see https://github.com/vercel/next.js/blob/canary/packages/next/src/server/base-server.ts
+ */
+export function shouldDispatchPagesResponseStage({
+  authorizeOnDemandRevalidate,
+  hasRequestAwareDocument,
+  request,
+  requestHeadersChanged,
+  routeDataKind,
+  stagedHeaders,
+}: PagesResponseStageDispatchOptions): boolean {
+  const method = request.method.toUpperCase();
+  if (method !== "GET" && method !== "HEAD") return false;
+
+  // Next.js supplies req/res to `_document.getInitialProps` for getStaticProps
+  // renders (`isAutoExport` is false). That makes the ostensibly static render
+  // request-aware, so it cannot sit below request-stage middleware/config state.
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/render.tsx
+  if (hasRequestAwareDocument && routeDataKind === "static") return false;
+
+  if (hasPagesPreviewCookie(request.headers.get("cookie"))) return false;
+  if (hasCacheBypassDirective(request.headers.get("cache-control"))) return false;
+  if (requestHeadersChanged) return false;
+  if (hasStagedCacheBypass(stagedHeaders)) return false;
+
+  const revalidateHeader = request.headers.get(PRERENDER_REVALIDATE_HEADER);
+  if (authorizeOnDemandRevalidate?.(revalidateHeader) === true) return false;
+
+  return getScriptNonceFromHeaderSources(request.headers, stagedHeaders) === undefined;
+}
+
+/** Decide whether a host response-stage transport may share the rendered response. */
+export function getPagesResponseStageCacheDisposition(
+  options: PagesResponseStageDispatchOptions,
+): PagesResponseStageCacheDisposition {
+  const revalidateHeader = options.request.headers.get(PRERENDER_REVALIDATE_HEADER);
+  if (options.authorizeOnDemandRevalidate?.(revalidateHeader) === true) return "bypass";
+  return shouldDispatchPagesResponseStage(options) ? "shared" : "bypass";
+}

--- a/packages/vinext/src/server/pages-route-data-kind.ts
+++ b/packages/vinext/src/server/pages-route-data-kind.ts
@@ -1,0 +1,32 @@
+export type RuntimePagesDataKind = "initial" | "none" | "server" | "static";
+
+/** Build-time classification available before a Pages module is loaded. */
+export type PagesRouteDataKind = Exclude<RuntimePagesDataKind, "initial">;
+
+type PagesModule = {
+  default?: { getInitialProps?: unknown };
+  getServerSideProps?: unknown;
+  getStaticProps?: unknown;
+};
+
+type AppComponent = {
+  getInitialProps?: unknown;
+  origGetInitialProps?: unknown;
+} | null;
+
+/** Classify loaded Pages modules after HOCs and re-exports have been evaluated. */
+export function getRuntimePagesDataKind(
+  pageModule: PagesModule,
+  appComponent: AppComponent,
+): RuntimePagesDataKind {
+  if (typeof pageModule.getStaticProps === "function") return "static";
+  if (typeof pageModule.getServerSideProps === "function") return "server";
+  if (typeof pageModule.default?.getInitialProps === "function") return "initial";
+  if (
+    typeof appComponent?.getInitialProps === "function" &&
+    appComponent.getInitialProps !== appComponent.origGetInitialProps
+  ) {
+    return "initial";
+  }
+  return "none";
+}

--- a/packages/vinext/src/server/response-stage-policy.ts
+++ b/packages/vinext/src/server/response-stage-policy.ts
@@ -1,4 +1,9 @@
 import { mergeVaryHeader } from "./middleware-response-headers.js";
+import { preserveFullyBufferedBodyMetadata } from "vinext/shims/unified-request-context";
+import {
+  PAGES_RESPONSE_STAGE_POLICY_OWNER_HEADER,
+  type PagesResponseStagePolicyOwner,
+} from "./worker-stages.js";
 
 /** Apply request-stage cache policy before response-stage admission. */
 export function applyResponseStagePolicyHeaders(
@@ -29,4 +34,28 @@ export function withResponseStageVary(
   const effectiveVary = varyHeaders.get("Vary");
   if (effectiveVary) result.push(["Vary", effectiveVary]);
   return result.length > 0 ? result : null;
+}
+
+/** Consume trusted Pages response-stage policy ownership before public egress. */
+export function consumePagesResponseStagePolicyOwner(response: Response): {
+  owner: PagesResponseStagePolicyOwner | null;
+  response: Response;
+} {
+  const value = response.headers.get(PAGES_RESPONSE_STAGE_POLICY_OWNER_HEADER);
+  const owner = value === "request-time" || value === "static" ? value : null;
+  if (value === null) return { owner, response };
+
+  const headers = new Headers(response.headers);
+  headers.delete(PAGES_RESPONSE_STAGE_POLICY_OWNER_HEADER);
+  return {
+    owner,
+    response: preserveFullyBufferedBodyMetadata(
+      response,
+      new Response(response.body, {
+        headers,
+        status: response.status,
+        statusText: response.statusText,
+      }),
+    ),
+  };
 }

--- a/packages/vinext/src/server/response-stage-policy.ts
+++ b/packages/vinext/src/server/response-stage-policy.ts
@@ -19,6 +19,42 @@ export function applyResponseStagePolicyHeaders(
   }
 }
 
+/**
+ * Remove the copy of staged cookies that a response handler inherited before
+ * it ran. The request stage composes those cookies again after transport, so
+ * retaining the inherited copies would emit them twice. Multiset subtraction
+ * preserves additional identical cookies deliberately appended by user code.
+ */
+export function stripInheritedResponseStageCookies(
+  response: Response,
+  stagedHeaders: Headers,
+): Response {
+  const stagedCookies = stagedHeaders.getSetCookie();
+  if (stagedCookies.length === 0) return response;
+
+  const responseCookies = response.headers.getSetCookie();
+  let removed = false;
+  for (const stagedCookie of stagedCookies) {
+    const index = responseCookies.indexOf(stagedCookie);
+    if (index === -1) continue;
+    responseCookies.splice(index, 1);
+    removed = true;
+  }
+  if (!removed) return response;
+
+  const headers = new Headers(response.headers);
+  headers.delete("Set-Cookie");
+  for (const cookie of responseCookies) headers.append("Set-Cookie", cookie);
+  return preserveFullyBufferedBodyMetadata(
+    response,
+    new Response(response.body, {
+      headers,
+      status: response.status,
+      statusText: response.statusText,
+    }),
+  );
+}
+
 /** Replace transported Vary fields with the effective request-stage value. */
 export function withResponseStageVary(
   policyHeaders: ReadonlyArray<readonly [string, string]> | null | undefined,

--- a/packages/vinext/src/server/response-stage-policy.ts
+++ b/packages/vinext/src/server/response-stage-policy.ts
@@ -1,9 +1,5 @@
 import { mergeVaryHeader } from "./middleware-response-headers.js";
 import { preserveFullyBufferedBodyMetadata } from "vinext/shims/unified-request-context";
-import {
-  PAGES_RESPONSE_STAGE_POLICY_OWNER_HEADER,
-  type PagesResponseStagePolicyOwner,
-} from "./worker-stages.js";
 
 /** Apply request-stage cache policy before response-stage admission. */
 export function applyResponseStagePolicyHeaders(
@@ -70,28 +66,4 @@ export function withResponseStageVary(
   const effectiveVary = varyHeaders.get("Vary");
   if (effectiveVary) result.push(["Vary", effectiveVary]);
   return result.length > 0 ? result : null;
-}
-
-/** Consume trusted Pages response-stage policy ownership before public egress. */
-export function consumePagesResponseStagePolicyOwner(response: Response): {
-  owner: PagesResponseStagePolicyOwner | null;
-  response: Response;
-} {
-  const value = response.headers.get(PAGES_RESPONSE_STAGE_POLICY_OWNER_HEADER);
-  const owner = value === "request-time" || value === "static" ? value : null;
-  if (value === null) return { owner, response };
-
-  const headers = new Headers(response.headers);
-  headers.delete(PAGES_RESPONSE_STAGE_POLICY_OWNER_HEADER);
-  return {
-    owner,
-    response: preserveFullyBufferedBodyMetadata(
-      response,
-      new Response(response.body, {
-        headers,
-        status: response.status,
-        statusText: response.statusText,
-      }),
-    ),
-  };
 }

--- a/packages/vinext/src/server/worker-stages.ts
+++ b/packages/vinext/src/server/worker-stages.ts
@@ -1,13 +1,9 @@
 import type { PagesRenderOptions } from "./pages-request-pipeline.js";
-import type {
-  VinextResponseStageCacheability,
-  VinextResponseStageTransport,
-} from "./multi-stage.js";
+import type { VinextResponseStageCacheability } from "./multi-stage.js";
 
 export const PAGES_RESPONSE_STAGE_PROTOCOL_VERSION = 4;
 export const PAGES_RESPONSE_STAGE_POLICY_OWNER_HEADER =
   "x-vinext-pages-response-stage-policy-owner";
-export type PagesResponseStagePolicyOwner = "request-time" | "static";
 
 type PagesResponseStageEnvelope = {
   buildId: string | null;
@@ -42,16 +38,6 @@ export type WorkerResponseStageProps =
   | PagesApiResponseStageProps
   | PagesPageResponseStageProps
   | PagesPrerenderDiscoveryStageProps;
-
-/**
- * Host-owned transport for invoking a response stage.
- *
- * Core request pipelines decide what may be shared and provide the complete
- * serialized render identity here. Response-only middleware/config state is
- * carried in the props so Pages user code observes the same pre-handler
- * response as Next.js.
- */
-export type DispatchWorkerResponseStage = VinextResponseStageTransport<WorkerResponseStageProps>;
 
 function isSerializedHeaders(value: unknown): value is Array<[string, string]> {
   return (

--- a/packages/vinext/src/server/worker-stages.ts
+++ b/packages/vinext/src/server/worker-stages.ts
@@ -1,0 +1,121 @@
+import type { PagesRenderOptions } from "./pages-request-pipeline.js";
+import type {
+  VinextResponseStageCacheability,
+  VinextResponseStageTransport,
+} from "./multi-stage.js";
+
+export const PAGES_RESPONSE_STAGE_PROTOCOL_VERSION = 4;
+export const PAGES_RESPONSE_STAGE_POLICY_OWNER_HEADER =
+  "x-vinext-pages-response-stage-policy-owner";
+export type PagesResponseStagePolicyOwner = "request-time" | "static";
+
+type PagesResponseStageEnvelope = {
+  buildId: string | null;
+  cacheability: VinextResponseStageCacheability;
+  protocolVersion: typeof PAGES_RESPONSE_STAGE_PROTOCOL_VERSION;
+  /** Host is explicit because multi-tenant/domain-i18n renders vary by it. */
+  requestHost: string;
+  /** Complete response-header snapshot installed before Pages user code runs. */
+  stagedHeaders: Array<[string, string]> | null;
+};
+
+/** Serializable Pages page render delegated to a cacheable Worker stage. */
+type PagesPageResponseStageProps = PagesResponseStageEnvelope & {
+  kind: "pages-page";
+  renderOptions: PagesRenderOptions | null;
+  resolvedUrl: string;
+};
+
+/** Serializable Pages API dispatch delegated to a cacheable Worker stage. */
+type PagesApiResponseStageProps = PagesResponseStageEnvelope & {
+  apiUrl: string;
+  kind: "pages-api";
+};
+
+/** Authenticated staged-worker path discovery delegated outside the shared cache. */
+type PagesPrerenderDiscoveryStageProps = PagesResponseStageEnvelope & {
+  kind: "pages-prerender-discovery";
+};
+
+/** Serializable description of work delegated to a cacheable Worker stage. */
+export type WorkerResponseStageProps =
+  | PagesApiResponseStageProps
+  | PagesPageResponseStageProps
+  | PagesPrerenderDiscoveryStageProps;
+
+/**
+ * Host-owned transport for invoking a response stage.
+ *
+ * Core request pipelines decide what may be shared and provide the complete
+ * serialized render identity here. Response-only middleware/config state is
+ * carried in the props so Pages user code observes the same pre-handler
+ * response as Next.js.
+ */
+export type DispatchWorkerResponseStage = VinextResponseStageTransport<WorkerResponseStageProps>;
+
+function isSerializedHeaders(value: unknown): value is Array<[string, string]> {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (entry) =>
+        Array.isArray(entry) &&
+        entry.length === 2 &&
+        typeof entry[0] === "string" &&
+        typeof entry[1] === "string",
+    )
+  );
+}
+
+function isResponseStageCacheability(value: unknown): value is VinextResponseStageCacheability {
+  if (!value || typeof value !== "object") return false;
+  const cacheability = value as Partial<VinextResponseStageCacheability>;
+  return (
+    (cacheability.probeMode === null ||
+      cacheability.probeMode === "probe" ||
+      cacheability.probeMode === "identity") &&
+    (cacheability.policyHeaders === null ||
+      (Array.isArray(cacheability.policyHeaders) &&
+        cacheability.policyHeaders.every(
+          (entry) =>
+            Array.isArray(entry) &&
+            entry.length === 2 &&
+            typeof entry[0] === "string" &&
+            typeof entry[1] === "string",
+        ))) &&
+    (cacheability.representation === undefined ||
+      cacheability.representation === "app-route" ||
+      cacheability.representation === "html" ||
+      cacheability.representation === "pages-data" ||
+      cacheability.representation === "rsc-full" ||
+      cacheability.representation === "rsc-loading-shell") &&
+    typeof cacheability.resolvedRoutePathname === "string" &&
+    cacheability.resolvedRoutePathname.startsWith("/")
+  );
+}
+
+export function isPagesResponseStageProps(value: unknown): value is WorkerResponseStageProps {
+  if (!value || typeof value !== "object") return false;
+  const props = value as Partial<WorkerResponseStageProps>;
+  if (
+    props.protocolVersion !== PAGES_RESPONSE_STAGE_PROTOCOL_VERSION ||
+    (props.buildId !== null && typeof props.buildId !== "string") ||
+    !isResponseStageCacheability(props.cacheability) ||
+    typeof props.requestHost !== "string" ||
+    props.requestHost.length === 0 ||
+    (props.stagedHeaders !== null && !isSerializedHeaders(props.stagedHeaders))
+  ) {
+    return false;
+  }
+  if (props.kind === "pages-api") return typeof props.apiUrl === "string";
+  if (props.kind === "pages-prerender-discovery") return true;
+  if (props.kind !== "pages-page" || typeof props.resolvedUrl !== "string") return false;
+  if (props.renderOptions === null) return true;
+  if (!props.renderOptions || typeof props.renderOptions !== "object") return false;
+  const options = props.renderOptions;
+  return (
+    (options.isDataReq === undefined || typeof options.isDataReq === "boolean") &&
+    (options.renderErrorPageOnMiss === undefined ||
+      typeof options.renderErrorPageOnMiss === "boolean") &&
+    (options.originalUrl === undefined || typeof options.originalUrl === "string")
+  );
+}

--- a/tests/cacheability-admission.test.ts
+++ b/tests/cacheability-admission.test.ts
@@ -1172,7 +1172,7 @@ describe("single-request cacheability admission", () => {
     // Ported from Next.js:
     // test/e2e/getserversideprops/test/index.test.ts
     const pagesRequest = new Request("https://example.com/pages-route", {
-      headers: { Accept: "text/html" },
+      headers: { Accept: "*/*" },
     });
     const context = createWorkerCacheabilityAdmissionContext(
       { waitUntil() {} },

--- a/tests/e2e/cloudflare-workers/route-handler-draft-cache.spec.ts
+++ b/tests/e2e/cloudflare-workers/route-handler-draft-cache.spec.ts
@@ -211,8 +211,15 @@ test.describe("Cloudflare route-handler draft-mode cache isolation", () => {
         headers: accept ? { Accept: accept } : undefined,
       });
       expect(response.status(), accept ?? "missing Accept").toBe(200);
-      expect(response.headers()["cache-control"], accept ?? "missing Accept").toContain("no-store");
+      expect(response.headers()["cache-control"], accept ?? "missing Accept").toContain("private");
+      expect(response.headers()["cache-control"], accept ?? "missing Accept").not.toContain(
+        "public",
+      );
       expect(response.headers()["cdn-cache-control"], accept ?? "missing Accept").toBeUndefined();
+      expect(
+        response.headers()["cloudflare-cdn-cache-control"],
+        accept ?? "missing Accept",
+      ).toBeUndefined();
     }
   });
 });
@@ -266,8 +273,15 @@ test.describe("Cloudflare Pages-only completed-response admission", () => {
         headers: accept ? { Accept: accept } : undefined,
       });
       expect(response.status(), accept ?? "missing Accept").toBe(200);
-      expect(response.headers()["cache-control"], accept ?? "missing Accept").toContain("no-store");
+      expect(response.headers()["cache-control"], accept ?? "missing Accept").toContain("private");
+      expect(response.headers()["cache-control"], accept ?? "missing Accept").not.toContain(
+        "public",
+      );
       expect(response.headers()["cdn-cache-control"], accept ?? "missing Accept").toBeUndefined();
+      expect(
+        response.headers()["cloudflare-cdn-cache-control"],
+        accept ?? "missing Accept",
+      ).toBeUndefined();
     }
   });
 });

--- a/tests/e2e/cloudflare-workers/route-handler-draft-cache.spec.ts
+++ b/tests/e2e/cloudflare-workers/route-handler-draft-cache.spec.ts
@@ -211,7 +211,6 @@ test.describe("Cloudflare route-handler draft-mode cache isolation", () => {
         headers: accept ? { Accept: accept } : undefined,
       });
       expect(response.status(), accept ?? "missing Accept").toBe(200);
-      expect(response.headers()["cache-control"], accept ?? "missing Accept").toContain("private");
       expect(response.headers()["cache-control"], accept ?? "missing Accept").not.toContain(
         "public",
       );
@@ -273,7 +272,6 @@ test.describe("Cloudflare Pages-only completed-response admission", () => {
         headers: accept ? { Accept: accept } : undefined,
       });
       expect(response.status(), accept ?? "missing Accept").toBe(200);
-      expect(response.headers()["cache-control"], accept ?? "missing Accept").toContain("private");
       expect(response.headers()["cache-control"], accept ?? "missing Accept").not.toContain(
         "public",
       );

--- a/tests/pages-api-route.test.ts
+++ b/tests/pages-api-route.test.ts
@@ -503,6 +503,7 @@ describe("pages api route", () => {
       match: createMatch(
         () => {
           const headers = new Headers();
+          headers.append("Set-Cookie", "middleware=one; Path=/");
           headers.append("Set-Cookie", "handler=one; Path=/");
           headers.append(
             "Set-Cookie",
@@ -518,6 +519,8 @@ describe("pages api route", () => {
     });
 
     expect(response.headers.getSetCookie()).toEqual([
+      "middleware=one; Path=/",
+      "middleware=one; Path=/",
       "handler=one; Path=/",
       "handler=two; Expires=Wed, 21 Oct 2037 07:28:00 GMT; Path=/",
     ]);

--- a/tests/pages-api-route.test.ts
+++ b/tests/pages-api-route.test.ts
@@ -56,6 +56,27 @@ describe("pages api route", () => {
     expect(response.headers.get("x-from-middleware")).toBe("present");
   });
 
+  it("exposes all staged cookies to Node API handlers without collapsing them", async () => {
+    const initialResponseHeaders = new Headers();
+    initialResponseHeaders.append("Set-Cookie", "middleware=one; Path=/");
+    initialResponseHeaders.append(
+      "Set-Cookie",
+      "config=two; Expires=Wed, 21 Oct 2037 07:28:00 GMT; Path=/",
+    );
+
+    const response = await handlePagesApiRoute({
+      initialResponseHeaders,
+      match: createMatch((_req, res) => {
+        expect(res.getHeader("Set-Cookie")).toEqual(initialResponseHeaders.getSetCookie());
+        res.end("ok");
+      }),
+      request: new Request("https://example.com/api/cookies"),
+      url: "/api/cookies",
+    });
+
+    expect(response.headers.getSetCookie()).toEqual(initialResponseHeaders.getSetCookie());
+  });
+
   it("does not expose process environment variables on the request", async () => {
     const previousValue = process.env.VINEXT_API_REQUEST_ENV_TEST;
     process.env.VINEXT_API_REQUEST_ENV_TEST = "secret";
@@ -472,6 +493,34 @@ describe("pages api route", () => {
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ id: "req-42" });
+  });
+
+  it("preserves multiple cookies returned by a staged edge API handler", async () => {
+    const initialResponseHeaders = new Headers();
+    initialResponseHeaders.append("Set-Cookie", "middleware=one; Path=/");
+    const response = await handlePagesApiRoute({
+      initialResponseHeaders,
+      match: createMatch(
+        () => {
+          const headers = new Headers();
+          headers.append("Set-Cookie", "handler=one; Path=/");
+          headers.append(
+            "Set-Cookie",
+            "handler=two; Expires=Wed, 21 Oct 2037 07:28:00 GMT; Path=/",
+          );
+          return new Response("edge", { headers });
+        },
+        {},
+        { runtime: "edge" },
+      ),
+      request: new Request("https://example.com/api/cookies"),
+      url: "/api/cookies",
+    });
+
+    expect(response.headers.getSetCookie()).toEqual([
+      "handler=one; Path=/",
+      "handler=two; Expires=Wed, 21 Oct 2037 07:28:00 GMT; Path=/",
+    ]);
   });
 
   it("removes stale encoding headers after Node fetch decodes an edge API response", async () => {

--- a/tests/pages-api-route.test.ts
+++ b/tests/pages-api-route.test.ts
@@ -32,6 +32,30 @@ function createMatch(
 }
 
 describe("pages api route", () => {
+  it("lets a handler override response headers installed before user code", async () => {
+    const response = await handlePagesApiRoute({
+      initialResponseHeaders: new Headers({
+        "Cache-Control": "public, s-maxage=60",
+        Vary: "x-visitor",
+        "x-config-variant": "preview",
+        "x-from-middleware": "present",
+      }),
+      match: createMatch((_req, res) => {
+        expect(res.getHeader("x-config-variant")).toBe("preview");
+        expect(res.getHeader("x-from-middleware")).toBe("present");
+        res.setHeader("Cache-Control", "private, no-store");
+        res.json({ ok: true });
+      }),
+      request: new Request("https://example.com/api/policy"),
+      url: "/api/policy",
+    });
+
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(response.headers.get("Vary")).toBe("x-visitor");
+    expect(response.headers.get("x-config-variant")).toBe("preview");
+    expect(response.headers.get("x-from-middleware")).toBe("present");
+  });
+
   it("does not expose process environment variables on the request", async () => {
     const previousValue = process.env.VINEXT_API_REQUEST_ENV_TEST;
     process.env.VINEXT_API_REQUEST_ENV_TEST = "secret";

--- a/tests/pages-page-handler.test.ts
+++ b/tests/pages-page-handler.test.ts
@@ -450,6 +450,34 @@ describe("createPagesPageHandler — _next/data", () => {
     expect(body).toHaveProperty("pageProps");
   });
 
+  it("preserves staged Set-Cookie values separately on Pages data responses", async () => {
+    const stagedHeaders = new Headers();
+    stagedHeaders.append("Set-Cookie", "middleware=one; Path=/");
+    stagedHeaders.append("Set-Cookie", "config=two; Expires=Wed, 21 Oct 2037 07:28:00 GMT; Path=/");
+    const route = makeRoute(
+      "/about",
+      makePageModule({
+        getServerSideProps: async ({ res }: { res: { getHeader(name: string): unknown } }) => {
+          expect(res.getHeader("Set-Cookie")).toEqual(stagedHeaders.getSetCookie());
+          return { props: {} };
+        },
+      }),
+    );
+    const handler = createPagesPageHandler(makeOpts({ pageRoutes: [route] }));
+    const dataUrl = "/_next/data/test-build-id/about.json";
+
+    const response = await handler(
+      makeRequest(dataUrl),
+      dataUrl,
+      null,
+      stagedHeaders,
+      null,
+      stagedHeaders,
+    );
+
+    expect(response.headers.getSetCookie()).toEqual(stagedHeaders.getSetCookie());
+  });
+
   it("returns 404 JSON for _next/data with wrong buildId", async () => {
     const handler = createPagesPageHandler(makeOpts());
     const badUrl = "/_next/data/wrong-build-id/about.json";

--- a/tests/pages-page-handler.test.ts
+++ b/tests/pages-page-handler.test.ts
@@ -187,6 +187,51 @@ describe("createPagesPageHandler — after() lifecycle", () => {
   });
 });
 
+describe("createPagesPageHandler — pre-render response headers", () => {
+  it("lets getServerSideProps override config cache policy", async () => {
+    // Ported from Next.js:
+    // test/e2e/middleware-custom-matchers/app/pages/index.js
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-custom-matchers/app/pages/index.js
+    const handler = createPagesPageHandler(
+      makeOpts({
+        pageRoutes: [
+          makeRoute(
+            "/",
+            makePageModule({
+              getServerSideProps: async ({
+                res,
+              }: {
+                res: {
+                  getHeader(name: string): string | string[] | number | undefined;
+                  setHeader(name: string, value: string): void;
+                };
+              }) => {
+                expect(res.getHeader("x-config-variant")).toBe("preview");
+                expect(res.getHeader("x-from-middleware")).toBe("present");
+                res.setHeader("Cache-Control", "private, no-store");
+                return { props: {} };
+              },
+            }),
+          ),
+        ],
+      }),
+    );
+
+    const initialHeaders = new Headers({
+      "Cache-Control": "public, s-maxage=60",
+      Vary: "x-visitor",
+      "x-config-variant": "preview",
+      "x-from-middleware": "present",
+    });
+    const response = await handler(makeRequest(), "/", null, null, null, initialHeaders);
+
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(response.headers.get("Vary")).toBe("x-visitor");
+    expect(response.headers.get("x-config-variant")).toBe("preview");
+    expect(response.headers.get("x-from-middleware")).toBe("present");
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Route miss → 404 fallback
 // ---------------------------------------------------------------------------
@@ -726,6 +771,23 @@ describe("createPagesPageHandler — preview responses", () => {
     expect(response.headers.get("cache-control")).toBe(PAGES_PREVIEW_CACHE_CONTROL);
     expect(response.headers.get("x-example-edge-policy")).toBe("s-maxage=6000");
     expect(response.headers.get("x-example-cache-tag")).toBe("draft-404");
+  });
+
+  it("keeps invalid preview-cookie cleanup private", () => {
+    setCdnCacheAdapter(new CloudflareCdnCacheAdapter());
+    const response = finalizePagesPreviewResponse(
+      new Response("stale preview", {
+        headers: {
+          "Cache-Control": "public, max-age=0, must-revalidate",
+          "CDN-Cache-Control": "public, s-maxage=60",
+        },
+      }),
+      { data: false, shouldClear: true },
+    );
+
+    expect(response.headers.get("cache-control")).toBe(PAGES_PREVIEW_CACHE_CONTROL);
+    expect(response.headers.get("cdn-cache-control")).toBeNull();
+    expect(response.headers.getSetCookie()).toHaveLength(2);
   });
 
   it("does not expose preview notFound responses to shared Cloudflare caching", async () => {

--- a/tests/pages-response-stage.test.ts
+++ b/tests/pages-response-stage.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import {
+  getPagesResponseStageCacheDisposition,
+  shouldDispatchPagesResponseStage,
+} from "../packages/vinext/src/server/pages-response-stage.js";
+import { PRERENDER_REVALIDATE_HEADER } from "../packages/vinext/src/utils/protocol-headers.js";
+
+function shouldDispatch(
+  init: RequestInit = {},
+  options: {
+    authorizeOnDemandRevalidate?: (headerValue: string | null) => boolean;
+    stagedHeaders?: Headers;
+  } = {},
+): boolean {
+  return shouldDispatchPagesResponseStage({
+    ...options,
+    request: new Request("https://example.com/page", init),
+  });
+}
+
+describe("Pages response-stage dispatch", () => {
+  it("maps ordinary and request-specific renders to shared and bypass dispatch", () => {
+    expect(
+      getPagesResponseStageCacheDisposition({
+        request: new Request("https://example.com/page"),
+      }),
+    ).toBe("shared");
+    expect(
+      getPagesResponseStageCacheDisposition({
+        request: new Request("https://example.com/page", {
+          headers: { Cookie: "__prerender_bypass=preview" },
+        }),
+      }),
+    ).toBe("bypass");
+  });
+
+  it.each(["GET", "HEAD"])("allows an ordinary %s request", (method) => {
+    expect(shouldDispatch({ method })).toBe(true);
+  });
+
+  it.each(["POST", "PUT", "PATCH", "DELETE"])("keeps %s in the request stage", (method) => {
+    expect(shouldDispatch({ method })).toBe(false);
+  });
+
+  it.each(["__prerender_bypass", "__next_preview_data"])(
+    "keeps requests carrying the %s preview cookie local",
+    (name) => {
+      expect(shouldDispatch({ headers: { Cookie: `ordinary=1; ${name}=value; last=1` } })).toBe(
+        false,
+      );
+    },
+  );
+
+  it("does not treat similarly named or unrelated cookies as preview mode", () => {
+    expect(
+      shouldDispatch({
+        headers: {
+          Cookie: "session=abc; prefix__prerender_bypass=value; __next_preview_data_extra=value",
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it.each([
+    "no-cache",
+    "NO-STORE",
+    "max-age=0, no-cache",
+    "public, no-store, max-age=60",
+    'no-cache="set-cookie"',
+  ])("keeps Cache-Control %s local", (cacheControl) => {
+    expect(shouldDispatch({ headers: { "Cache-Control": cacheControl } })).toBe(false);
+  });
+
+  it.each(["max-age=0", "public, max-age=0, must-revalidate", "no-cacheable=true"])(
+    "does not broaden bypass semantics for Cache-Control %s",
+    (cacheControl) => {
+      expect(shouldDispatch({ headers: { "Cache-Control": cacheControl } })).toBe(true);
+    },
+  );
+
+  it("keeps authenticated on-demand revalidation local", () => {
+    const authorize = vi.fn((value: string | null) => value === "build-secret");
+    expect(
+      shouldDispatch(
+        { headers: { [PRERENDER_REVALIDATE_HEADER]: "build-secret" } },
+        { authorizeOnDemandRevalidate: authorize },
+      ),
+    ).toBe(false);
+    expect(authorize).toHaveBeenCalledWith("build-secret");
+  });
+
+  it("keeps authenticated on-demand revalidation out of the shared transport", () => {
+    expect(
+      getPagesResponseStageCacheDisposition({
+        authorizeOnDemandRevalidate: (value) => value === "build-secret",
+        request: new Request("https://example.com/page", {
+          headers: { [PRERENDER_REVALIDATE_HEADER]: "build-secret" },
+          method: "HEAD",
+        }),
+      }),
+    ).toBe("bypass");
+  });
+
+  it("does not let a forged on-demand revalidation header force a bypass", () => {
+    const authorize = vi.fn(() => false);
+    expect(
+      shouldDispatch(
+        { headers: { [PRERENDER_REVALIDATE_HEADER]: "forged-secret" } },
+        { authorizeOnDemandRevalidate: authorize },
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps request and staged-response CSP nonces local", () => {
+    expect(
+      shouldDispatch({ headers: { "Content-Security-Policy": "script-src 'nonce-request'" } }),
+    ).toBe(false);
+    expect(
+      shouldDispatch(
+        {},
+        {
+          stagedHeaders: new Headers({
+            "Content-Security-Policy": "script-src 'self' 'nonce-middleware'",
+          }),
+        },
+      ),
+    ).toBe(false);
+  });
+
+  it.each([
+    ["Cache-Control", "private, max-age=0"],
+    ["CDN-Cache-Control", "public, max-age=60, no-store"],
+    ["Cloudflare-CDN-Cache-Control", "NO-CACHE"],
+  ])("keeps the inner artifact reusable under outer staged %s: %s", (name, value) => {
+    expect(shouldDispatch({}, { stagedHeaders: new Headers({ [name]: value }) })).toBe(true);
+  });
+
+  it("keeps the inner artifact reusable under outer staged Vary", () => {
+    expect(shouldDispatch({}, { stagedHeaders: new Headers({ Vary: "x-visitor-id" }) })).toBe(true);
+  });
+
+  it("keeps middleware cookie overlays local", () => {
+    expect(
+      shouldDispatch(
+        {},
+        { stagedHeaders: new Headers({ "x-middleware-set-cookie": "session=updated" }) },
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps middleware request-header overrides out of the shared stage", () => {
+    expect(
+      shouldDispatchPagesResponseStage({
+        request: new Request("https://example.com/page"),
+        requestHeadersChanged: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps getStaticProps renders with request-aware Documents out of the shared stage", () => {
+    // Next.js passes req/res to `_document.getInitialProps` whenever the page is
+    // not an automatic static export, including getStaticProps/ISR renders.
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/render.tsx
+    expect(
+      shouldDispatchPagesResponseStage({
+        hasRequestAwareDocument: true,
+        request: new Request("https://example.com/page"),
+        routeDataKind: "static",
+      }),
+    ).toBe(false);
+    expect(
+      shouldDispatchPagesResponseStage({
+        hasRequestAwareDocument: false,
+        request: new Request("https://example.com/page"),
+        routeDataKind: "static",
+      }),
+    ).toBe(true);
+    expect(
+      shouldDispatchPagesResponseStage({
+        hasRequestAwareDocument: true,
+        request: new Request("https://example.com/page"),
+        routeDataKind: "none",
+      }),
+    ).toBe(true);
+  });
+});

--- a/tests/pages-response-stage.test.ts
+++ b/tests/pages-response-stage.test.ts
@@ -44,6 +44,7 @@ describe("Pages response-stage dispatch", () => {
 
   it("keeps WebSocket upgrades out of the shared response stage", () => {
     expect(shouldDispatch({ headers: { Upgrade: "websocket" } })).toBe(false);
+    expect(shouldDispatch({ headers: { Upgrade: "h2c, WebSocket" } })).toBe(false);
     expect(
       getPagesResponseStageCacheDisposition({
         request: new Request("https://example.com/socket", {

--- a/tests/pages-response-stage.test.ts
+++ b/tests/pages-response-stage.test.ts
@@ -42,6 +42,17 @@ describe("Pages response-stage dispatch", () => {
     expect(shouldDispatch({ method })).toBe(false);
   });
 
+  it("keeps WebSocket upgrades out of the shared response stage", () => {
+    expect(shouldDispatch({ headers: { Upgrade: "websocket" } })).toBe(false);
+    expect(
+      getPagesResponseStageCacheDisposition({
+        request: new Request("https://example.com/socket", {
+          headers: { Upgrade: "WebSocket" },
+        }),
+      }),
+    ).toBe("bypass");
+  });
+
   it.each(["__prerender_bypass", "__next_preview_data"])(
     "keeps requests carrying the %s preview cookie local",
     (name) => {

--- a/tests/pages-route-data-kind.test.ts
+++ b/tests/pages-route-data-kind.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vite-plus/test";
+import { getRuntimePagesDataKind } from "../packages/vinext/src/server/pages-route-data-kind.js";
+
+describe("getRuntimePagesDataKind", () => {
+  it("uses the loaded page after HOCs and re-exports have run", () => {
+    expect(getRuntimePagesDataKind({ default: { getInitialProps() {} } }, null)).toBe("initial");
+  });
+
+  it("detects custom _app getInitialProps but not the inherited default", () => {
+    const inherited = () => ({});
+    expect(
+      getRuntimePagesDataKind({}, { getInitialProps: inherited, origGetInitialProps: inherited }),
+    ).toBe("none");
+    expect(
+      getRuntimePagesDataKind({}, { getInitialProps() {}, origGetInitialProps: inherited }),
+    ).toBe("initial");
+  });
+
+  it("keeps getStaticProps authoritative over _app and page initial props", () => {
+    expect(
+      getRuntimePagesDataKind(
+        { default: { getInitialProps() {} }, getStaticProps() {} },
+        { getInitialProps() {} },
+      ),
+    ).toBe("static");
+  });
+
+  it("classifies getServerSideProps as request-time", () => {
+    expect(getRuntimePagesDataKind({ getServerSideProps() {} }, null)).toBe("server");
+  });
+});

--- a/tests/pages-worker-stages.test.ts
+++ b/tests/pages-worker-stages.test.ts
@@ -576,7 +576,9 @@ describe("Pages Worker response stage", () => {
     );
 
     const response = await handleResponseStage(
-      new Request("https://example.com/api/public"),
+      new Request("https://example.com/api/public", {
+        headers: { Accept: "text/html" },
+      }),
       undefined,
       undefined,
       {

--- a/tests/pages-worker-stages.test.ts
+++ b/tests/pages-worker-stages.test.ts
@@ -472,6 +472,87 @@ describe("Pages Worker response stage", () => {
     );
   });
 
+  it("returns staged cookies once while preserving handler-authored cookies and lengths", async () => {
+    // Next.js composes middleware/config headers once around the final Pages
+    // response. The response stage may expose them to user code, but must not
+    // replay that inherited snapshot across the stage boundary.
+    stages.renderPage.mockImplementation(async (...args: unknown[]) => {
+      const renderHeaders = args[4] as Headers;
+      const initialHeaders = args[6] as Headers;
+      expect(renderHeaders.get("Content-Length")).toBeNull();
+      expect(initialHeaders.get("Content-Length")).toBeNull();
+      expect(initialHeaders.getSetCookie()).toEqual(["middleware=one; Path=/"]);
+
+      const headers = new Headers(initialHeaders);
+      headers.append("Set-Cookie", "middleware=one; Path=/");
+      headers.append("Set-Cookie", "handler=two; Path=/");
+      headers.set("Content-Length", "4");
+      return new Response("page", { headers });
+    });
+
+    const response = await handleResponseStage(
+      new Request("https://example.com/gssp"),
+      undefined,
+      undefined,
+      {
+        buildId: "test-build",
+        cacheability: { policyHeaders: null, probeMode: null, resolvedRoutePathname: "/gssp" },
+        kind: "pages-page",
+        protocolVersion: PAGES_RESPONSE_STAGE_PROTOCOL_VERSION,
+        requestHost: "example.com",
+        renderOptions: null,
+        resolvedUrl: "/gssp",
+        stagedHeaders: [
+          ["content-length", "999"],
+          ["set-cookie", "middleware=one; Path=/"],
+        ],
+      },
+      dispatchRequestStage,
+      { cache: "bypass" },
+    );
+
+    expect(response.headers.getSetCookie()).toEqual([
+      "middleware=one; Path=/",
+      "handler=two; Path=/",
+    ]);
+    expect(response.headers.get("Content-Length")).toBe("4");
+  });
+
+  it("does not replay inherited staged cookies from Pages API responses", async () => {
+    stages.api.mockImplementation(async (...args: unknown[]) => {
+      const initialHeaders = args[5] as Headers;
+      expect(initialHeaders.get("Content-Length")).toBeNull();
+      return new Response("api", { headers: initialHeaders });
+    });
+
+    const response = await handleResponseStage(
+      new Request("https://example.com/api/headers"),
+      undefined,
+      undefined,
+      {
+        apiUrl: "/api/headers",
+        buildId: "test-build",
+        cacheability: {
+          policyHeaders: null,
+          probeMode: null,
+          resolvedRoutePathname: "/api/headers",
+        },
+        kind: "pages-api",
+        protocolVersion: PAGES_RESPONSE_STAGE_PROTOCOL_VERSION,
+        requestHost: "example.com",
+        stagedHeaders: [
+          ["content-length", "999"],
+          ["set-cookie", "middleware=one; Path=/"],
+        ],
+      },
+      dispatchRequestStage,
+      { cache: "bypass" },
+    );
+
+    expect(response.headers.getSetCookie()).toEqual([]);
+    expect(response.headers.get("Content-Length")).toBeNull();
+  });
+
   it("admits an explicitly public Pages API response", async () => {
     const adapter: CdnCacheAdapter = {
       buildResponseHeaders: ({ cacheControl }) => ({ "Cache-Control": cacheControl }),

--- a/tests/pages-worker-stages.test.ts
+++ b/tests/pages-worker-stages.test.ts
@@ -327,11 +327,12 @@ describe("Pages Worker response stage", () => {
     stages.registerCacheAdapters.mockImplementation(() => setCdnCacheAdapter(adapter));
     stages.renderPage.mockImplementation(async (...args: unknown[]) => {
       const context = args[3] as Record<PropertyKey, unknown>;
+      const initialHeaders = args[6] as Headers;
       const state = context[CACHEABILITY_REQUEST_STATE] as RouteCacheabilityState;
       expect(state.admission?.representation).toBe("pages-data");
       state.route = { kind: "pages-page", pattern: "/page" };
       state.outcome = { cacheable: true, cacheControl: "s-maxage=60" };
-      return new Response('{"pageProps":{"cached":true}}');
+      return new Response('{"pageProps":{"cached":true}}', { headers: initialHeaders });
     });
 
     const response = await handleResponseStage(
@@ -351,13 +352,17 @@ describe("Pages Worker response stage", () => {
         requestHost: "example.com",
         renderOptions: { isDataReq: true },
         resolvedUrl: "/page",
-        stagedHeaders: null,
+        stagedHeaders: [
+          ["set-cookie", "middleware=one; Path=/"],
+          ["set-cookie", "config=two; Path=/"],
+        ],
       },
       dispatchRequestStage,
       { cache: "shared" },
     );
 
     expect(response.headers.get("Cache-Control")).toBe("s-maxage=60");
+    expect(response.headers.getSetCookie()).toEqual([]);
     await expect(response.json()).resolves.toEqual({ pageProps: { cached: true } });
   });
 

--- a/tests/pages-worker-stages.test.ts
+++ b/tests/pages-worker-stages.test.ts
@@ -1,0 +1,668 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { handleResponseStage } from "../packages/vinext/src/server/pages-response-stage-entry.js";
+import {
+  PAGES_RESPONSE_STAGE_POLICY_OWNER_HEADER,
+  PAGES_RESPONSE_STAGE_PROTOCOL_VERSION,
+} from "../packages/vinext/src/server/worker-stages.js";
+import {
+  DefaultCdnCacheAdapter,
+  setCdnCacheAdapter,
+  type CdnCacheAdapter,
+} from "../packages/vinext/src/shims/cdn-cache.js";
+import {
+  CACHEABILITY_REQUEST_STATE,
+  type RouteCacheabilityState,
+} from "../packages/vinext/src/shims/cacheability-classification.js";
+import {
+  VINEXT_EXPECTED_WORKER_VERSION_HEADER,
+  VINEXT_PRERENDER_READINESS_HEADER,
+} from "../packages/vinext/src/server/headers.js";
+import { finalizePagesPreviewResponse } from "../packages/vinext/src/server/pages-page-handler.js";
+
+const stages = vi.hoisted(() => ({
+  api: vi.fn(),
+  getRuntimePageDataKind: vi.fn(() => "none"),
+  registerCacheAdapters: vi.fn(),
+  registerImageOptimizer: vi.fn(),
+  renderPage: vi.fn(),
+}));
+
+const dispatchRequestStage = async () => new Response("request-stage");
+
+vi.mock("virtual:vinext-cache-adapters", () => ({
+  registerConfiguredCacheAdapters: stages.registerCacheAdapters,
+}));
+
+vi.mock("virtual:vinext-image-adapters", () => ({
+  registerConfiguredImageOptimizer: stages.registerImageOptimizer,
+}));
+
+vi.mock("virtual:vinext-pages-response-entry", () => ({
+  authorizeOnDemandRevalidate: vi.fn(() => false),
+  buildId: "test-build",
+  getRuntimePageDataKind: stages.getRuntimePageDataKind,
+  handleApiRoute: stages.api,
+  hasMiddleware: false,
+  matchPageRoute: null,
+  normalizeDataRequest: vi.fn(),
+  publicFiles: new Set(),
+  renderPage: stages.renderPage,
+  runMiddleware: null,
+  vinextConfig: {},
+}));
+
+vi.mock("virtual:vinext-cacheability-manifest", () => ({ default: null }));
+
+describe("Pages Worker response stage", () => {
+  beforeEach(() => {
+    setCdnCacheAdapter(new DefaultCdnCacheAdapter());
+    stages.api.mockReset();
+    stages.getRuntimePageDataKind.mockReset();
+    stages.getRuntimePageDataKind.mockReturnValue("none");
+    stages.registerCacheAdapters.mockReset();
+    stages.registerImageOptimizer.mockReset();
+    stages.renderPage.mockReset();
+  });
+
+  it("stamps trusted request-time policy ownership from loaded Pages modules", async () => {
+    stages.getRuntimePageDataKind.mockReturnValue("initial");
+    stages.renderPage.mockResolvedValue(new Response("gip"));
+
+    const response = await handleResponseStage(
+      new Request("https://example.com/page"),
+      undefined,
+      undefined,
+      {
+        buildId: "test-build",
+        cacheability: {
+          policyHeaders: null,
+          probeMode: null,
+          resolvedRoutePathname: "/page",
+        },
+        kind: "pages-page",
+        protocolVersion: PAGES_RESPONSE_STAGE_PROTOCOL_VERSION,
+        requestHost: "example.com",
+        renderOptions: null,
+        resolvedUrl: "/page",
+        stagedHeaders: null,
+      },
+      dispatchRequestStage,
+      { cache: "shared" },
+    );
+
+    expect(response.headers.get(PAGES_RESPONSE_STAGE_POLICY_OWNER_HEADER)).toBe("request-time");
+  });
+
+  it("rejects malformed stage descriptions before dispatch", async () => {
+    const response = await handleResponseStage(
+      new Request("https://example.com/page"),
+      undefined,
+      undefined,
+      { kind: "pages-api" } as never,
+      dispatchRequestStage,
+      { cache: "shared" },
+    );
+
+    expect(response.status).toBe(400);
+    expect(stages.api).not.toHaveBeenCalled();
+    expect(stages.renderPage).not.toHaveBeenCalled();
+  });
+
+  it("validates readiness from inside the response stage", async () => {
+    const validateRequest = vi.fn(() => null);
+    const adapter: CdnCacheAdapter = {
+      ownsBackgroundRevalidation: false,
+      async get() {
+        return null;
+      },
+      async set() {},
+      buildResponseHeaders() {
+        return {};
+      },
+      validateRequest,
+      async revalidateTag() {},
+    };
+    stages.registerCacheAdapters.mockImplementation(() => setCdnCacheAdapter(adapter));
+    const request = new Request(
+      "https://example.com/__vinext/prerender/readiness?attempt=response-stage",
+      { headers: { [VINEXT_EXPECTED_WORKER_VERSION_HEADER]: "version-a" } },
+    );
+
+    const response = await handleResponseStage(
+      request,
+      { binding: "value" },
+      undefined,
+      {
+        buildId: "test-build",
+        cacheability: {
+          policyHeaders: null,
+          probeMode: null,
+          resolvedRoutePathname: "/__vinext/prerender/readiness",
+        },
+        kind: "pages-prerender-discovery",
+        protocolVersion: PAGES_RESPONSE_STAGE_PROTOCOL_VERSION,
+        requestHost: "example.com",
+        stagedHeaders: null,
+      },
+      dispatchRequestStage,
+      { cache: "bypass" },
+    );
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get(VINEXT_PRERENDER_READINESS_HEADER)).toBe("1");
+    expect(stages.registerCacheAdapters).toHaveBeenCalledWith({ binding: "value" });
+    expect(validateRequest).toHaveBeenCalledWith(request);
+    expect(stages.renderPage).not.toHaveBeenCalled();
+  });
+
+  it("renders a page with no outer middleware response headers", async () => {
+    const request = new Request("https://example.com/original", {
+      headers: { "x-post-middleware": "kept" },
+    });
+    const response = new Response("page");
+    stages.renderPage.mockResolvedValue(response);
+
+    const rendered = await handleResponseStage(
+      request,
+      { binding: "value" },
+      undefined,
+      {
+        buildId: "test-build",
+        cacheability: {
+          policyHeaders: null,
+          probeMode: null,
+          resolvedRoutePathname: "/rewritten",
+        },
+        kind: "pages-page",
+        protocolVersion: PAGES_RESPONSE_STAGE_PROTOCOL_VERSION,
+        requestHost: "example.com",
+        renderOptions: { isDataReq: true },
+        resolvedUrl: "/rewritten?slug=one",
+        stagedHeaders: null,
+      },
+      dispatchRequestStage,
+      { cache: "shared" },
+    );
+
+    await expect(rendered.text()).resolves.toBe("page");
+    expect(rendered.headers.get(PAGES_RESPONSE_STAGE_POLICY_OWNER_HEADER)).toBe("static");
+
+    expect(stages.registerCacheAdapters).toHaveBeenCalledWith({ binding: "value" });
+    expect(stages.registerImageOptimizer).toHaveBeenCalledWith({ binding: "value" });
+    expect(stages.renderPage).toHaveBeenCalledExactlyOnceWith(
+      request,
+      "/rewritten?slug=one",
+      null,
+      expect.any(Object),
+      expect.any(Headers),
+      { isDataReq: true },
+      expect.any(Headers),
+    );
+    const stagedHeaders = stages.renderPage.mock.calls[0]?.[4] as Headers;
+    expect([...stagedHeaders]).toEqual([]);
+  });
+
+  it("strips stale Content-Length before a streamed page crosses the stage transport", async () => {
+    const streamed = new Response("streamed page", {
+      headers: {
+        "Content-Length": "1",
+        "Content-Type": "text/html; charset=utf-8",
+      },
+    }) as Response & { __vinextStreamedHtmlResponse?: boolean };
+    streamed.__vinextStreamedHtmlResponse = true;
+    stages.renderPage.mockResolvedValue(streamed);
+
+    const response = await handleResponseStage(
+      new Request("https://example.com/page"),
+      undefined,
+      undefined,
+      {
+        buildId: "test-build",
+        cacheability: {
+          policyHeaders: null,
+          probeMode: null,
+          resolvedRoutePathname: "/page",
+        },
+        kind: "pages-page",
+        protocolVersion: PAGES_RESPONSE_STAGE_PROTOCOL_VERSION,
+        requestHost: "example.com",
+        renderOptions: null,
+        resolvedUrl: "/page",
+        stagedHeaders: null,
+      },
+      dispatchRequestStage,
+      { cache: "bypass" },
+    );
+
+    expect(response.headers.get("Content-Length")).toBeNull();
+    expect(response.headers.get("Content-Type")).toBe("text/html; charset=utf-8");
+    await expect(response.text()).resolves.toBe("streamed page");
+  });
+
+  it("strips stale Content-Length after preview response finalization", async () => {
+    // Next.js preview renders still flow through its normal HTML sender; applying
+    // the preview no-store policy must not turn a streamed body into a fixed-length one.
+    // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/send-payload.ts
+    const streamed = new Response("preview page", {
+      headers: { "Content-Length": "1", "Content-Type": "text/html; charset=utf-8" },
+    }) as Response & { __vinextStreamedHtmlResponse?: boolean };
+    streamed.__vinextStreamedHtmlResponse = true;
+    stages.renderPage.mockResolvedValue(
+      finalizePagesPreviewResponse(streamed, { data: { enabled: true }, shouldClear: false }),
+    );
+
+    const response = await handleResponseStage(
+      new Request("https://example.com/page", {
+        headers: { Cookie: "__prerender_bypass=preview" },
+      }),
+      undefined,
+      undefined,
+      {
+        buildId: "test-build",
+        cacheability: { policyHeaders: null, probeMode: null, resolvedRoutePathname: "/page" },
+        kind: "pages-page",
+        protocolVersion: PAGES_RESPONSE_STAGE_PROTOCOL_VERSION,
+        requestHost: "example.com",
+        renderOptions: null,
+        resolvedUrl: "/page",
+        stagedHeaders: [],
+      },
+      dispatchRequestStage,
+      { cache: "bypass" },
+    );
+
+    expect(response.headers.get("Content-Length")).toBeNull();
+    expect(response.headers.get("Cache-Control")).toContain("no-store");
+    await expect(response.text()).resolves.toBe("preview page");
+  });
+
+  it("preserves the dynamic Pages data short-circuit without an HTML render", async () => {
+    const response = new Response('{"pageProps":{"dynamic":true}}', {
+      headers: { "Content-Type": "application/json" },
+    });
+    stages.renderPage.mockResolvedValue(response);
+
+    await expect(
+      handleResponseStage(
+        new Request("https://example.com/page"),
+        undefined,
+        undefined,
+        {
+          buildId: "test-build",
+          cacheability: { policyHeaders: null, probeMode: null, resolvedRoutePathname: "/page" },
+          kind: "pages-page",
+          protocolVersion: PAGES_RESPONSE_STAGE_PROTOCOL_VERSION,
+          requestHost: "example.com",
+          renderOptions: { isDataReq: true },
+          resolvedUrl: "/page",
+          stagedHeaders: null,
+        },
+        dispatchRequestStage,
+        { cache: "shared" },
+      ).then((result) => result.text()),
+    ).resolves.toBe('{"pageProps":{"dynamic":true}}');
+    expect(stages.renderPage).toHaveBeenCalledExactlyOnceWith(
+      expect.any(Request),
+      "/page",
+      null,
+      expect.any(Object),
+      expect.any(Headers),
+      { isDataReq: true },
+      expect.any(Headers),
+    );
+  });
+
+  it("admits normalized Pages data using its trusted representation", async () => {
+    const adapter: CdnCacheAdapter = {
+      buildResponseHeaders: ({ cacheControl }) => ({ "Cache-Control": cacheControl }),
+      ownsBackgroundRevalidation: false,
+      requiresCompletedResponseAdmission: true,
+      async get() {
+        return null;
+      },
+      async revalidateTag() {},
+      async set() {},
+    };
+    stages.registerCacheAdapters.mockImplementation(() => setCdnCacheAdapter(adapter));
+    stages.renderPage.mockImplementation(async (...args: unknown[]) => {
+      const context = args[3] as Record<PropertyKey, unknown>;
+      const state = context[CACHEABILITY_REQUEST_STATE] as RouteCacheabilityState;
+      expect(state.admission?.representation).toBe("pages-data");
+      state.route = { kind: "pages-page", pattern: "/page" };
+      state.outcome = { cacheable: true, cacheControl: "s-maxage=60" };
+      return new Response('{"pageProps":{"cached":true}}');
+    });
+
+    const response = await handleResponseStage(
+      new Request("https://example.com/page"),
+      undefined,
+      undefined,
+      {
+        buildId: "test-build",
+        cacheability: {
+          policyHeaders: null,
+          probeMode: null,
+          representation: "pages-data",
+          resolvedRoutePathname: "/page",
+        },
+        kind: "pages-page",
+        protocolVersion: PAGES_RESPONSE_STAGE_PROTOCOL_VERSION,
+        requestHost: "example.com",
+        renderOptions: { isDataReq: true },
+        resolvedUrl: "/page",
+        stagedHeaders: null,
+      },
+      dispatchRequestStage,
+      { cache: "shared" },
+    );
+
+    expect(response.headers.get("Cache-Control")).toBe("s-maxage=60");
+    await expect(response.json()).resolves.toEqual({ pageProps: { cached: true } });
+  });
+
+  it("dispatches a Pages API with its resolved URL and no outer composition", async () => {
+    const request = new Request("https://example.com/original");
+    const response = new Response("api");
+    stages.api.mockResolvedValue(response);
+
+    await expect(
+      handleResponseStage(
+        request,
+        undefined,
+        undefined,
+        {
+          apiUrl: "/api/rewritten?slug=one",
+          buildId: "test-build",
+          cacheability: {
+            policyHeaders: null,
+            probeMode: null,
+            resolvedRoutePathname: "/api/rewritten",
+          },
+          kind: "pages-api",
+          protocolVersion: PAGES_RESPONSE_STAGE_PROTOCOL_VERSION,
+          requestHost: "example.com",
+          stagedHeaders: null,
+        },
+        dispatchRequestStage,
+        { cache: "shared" },
+      ),
+    ).resolves.toBe(response);
+
+    expect(stages.api).toHaveBeenCalledExactlyOnceWith(
+      request,
+      "/api/rewritten?slug=one",
+      expect.any(Object),
+      "https://example.com",
+      "node",
+      expect.any(Headers),
+    );
+    expect(stages.renderPage).not.toHaveBeenCalled();
+  });
+
+  it("installs complete request-stage headers before Pages API user code", async () => {
+    stages.api.mockImplementation(async (...args: unknown[]) => {
+      const initialHeaders = args[5] as Headers;
+      expect(initialHeaders.get("x-config-variant")).toBe("preview");
+      expect(initialHeaders.get("x-from-middleware")).toBe("present");
+      return new Response("api");
+    });
+
+    await handleResponseStage(
+      new Request("https://example.com/api/headers"),
+      undefined,
+      undefined,
+      {
+        apiUrl: "/api/headers",
+        buildId: "test-build",
+        cacheability: {
+          policyHeaders: [["Cache-Control", "public, s-maxage=60"]],
+          probeMode: null,
+          resolvedRoutePathname: "/api/headers",
+        },
+        kind: "pages-api",
+        protocolVersion: PAGES_RESPONSE_STAGE_PROTOCOL_VERSION,
+        requestHost: "example.com",
+        stagedHeaders: [
+          ["cache-control", "public, s-maxage=60"],
+          ["x-config-variant", "preview"],
+          ["x-from-middleware", "present"],
+        ],
+      },
+      dispatchRequestStage,
+      { cache: "shared" },
+    );
+  });
+
+  it("installs middleware and config headers before a staged GSSP render", async () => {
+    // Ported from Next.js:
+    // test/e2e/middleware-custom-matchers/app/pages/index.js
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-custom-matchers/app/pages/index.js
+    stages.renderPage.mockImplementation(async (...args: unknown[]) => {
+      const initialHeaders = args[6] as Headers;
+      expect(initialHeaders.get("x-config-variant")).toBe("preview");
+      expect(initialHeaders.get("x-from-middleware")).toBe("present");
+      return new Response("page");
+    });
+
+    await handleResponseStage(
+      new Request("https://example.com/gssp"),
+      undefined,
+      undefined,
+      {
+        buildId: "test-build",
+        cacheability: {
+          policyHeaders: [["Cache-Control", "public, s-maxage=60"]],
+          probeMode: null,
+          resolvedRoutePathname: "/gssp",
+        },
+        kind: "pages-page",
+        protocolVersion: PAGES_RESPONSE_STAGE_PROTOCOL_VERSION,
+        requestHost: "example.com",
+        renderOptions: null,
+        resolvedUrl: "/gssp",
+        stagedHeaders: [
+          ["cache-control", "public, s-maxage=60"],
+          ["x-config-variant", "preview"],
+          ["x-from-middleware", "present"],
+        ],
+      },
+      dispatchRequestStage,
+      { cache: "shared" },
+    );
+  });
+
+  it("admits an explicitly public Pages API response", async () => {
+    const adapter: CdnCacheAdapter = {
+      buildResponseHeaders: ({ cacheControl }) => ({ "Cache-Control": cacheControl }),
+      ownsBackgroundRevalidation: false,
+      requiresCompletedResponseAdmission: true,
+      responseVary: "verbatim",
+      async get() {
+        return null;
+      },
+      async revalidateTag() {},
+      async set() {},
+    };
+    stages.registerCacheAdapters.mockImplementation(() => setCdnCacheAdapter(adapter));
+    stages.api.mockResolvedValue(
+      new Response("public api", { headers: { "Cache-Control": "public, s-maxage=60" } }),
+    );
+
+    const response = await handleResponseStage(
+      new Request("https://example.com/api/public"),
+      undefined,
+      undefined,
+      {
+        apiUrl: "/api/public",
+        buildId: "test-build",
+        cacheability: {
+          policyHeaders: null,
+          probeMode: null,
+          resolvedRoutePathname: "/api/public",
+        },
+        kind: "pages-api",
+        protocolVersion: PAGES_RESPONSE_STAGE_PROTOCOL_VERSION,
+        requestHost: "example.com",
+        stagedHeaders: null,
+      },
+      dispatchRequestStage,
+      { cache: "shared" },
+    );
+
+    expect(response.headers.get("Cache-Control")).toBe("public, s-maxage=60");
+    await expect(response.text()).resolves.toBe("public api");
+  });
+
+  it("does not let config public policy overwrite a Pages API private response", async () => {
+    const adapter: CdnCacheAdapter = {
+      buildResponseHeaders: ({ cacheControl }) => ({ "Cache-Control": cacheControl }),
+      ownsBackgroundRevalidation: false,
+      requiresCompletedResponseAdmission: true,
+      responseVary: "verbatim",
+      async get() {
+        return null;
+      },
+      async revalidateTag() {},
+      async set() {},
+    };
+    stages.registerCacheAdapters.mockImplementation(() => setCdnCacheAdapter(adapter));
+    stages.api.mockImplementation(async (...args: unknown[]) => {
+      const initialHeaders = args[5] as Headers;
+      expect(initialHeaders.get("Cache-Control")).toBe("public, s-maxage=60");
+      return new Response("private api", {
+        headers: { "Cache-Control": "private, no-store" },
+      });
+    });
+
+    const response = await handleResponseStage(
+      new Request("https://example.com/api/private"),
+      undefined,
+      undefined,
+      {
+        apiUrl: "/api/private",
+        buildId: "test-build",
+        cacheability: {
+          policyHeaders: [["Cache-Control", "public, s-maxage=60"]],
+          probeMode: null,
+          resolvedRoutePathname: "/api/private",
+        },
+        kind: "pages-api",
+        protocolVersion: PAGES_RESPONSE_STAGE_PROTOCOL_VERSION,
+        requestHost: "example.com",
+        stagedHeaders: null,
+      },
+      dispatchRequestStage,
+      { cache: "shared" },
+    );
+
+    expect(response.headers.get("Cache-Control")).toBe("no-store, must-revalidate");
+    await expect(response.text()).resolves.toBe("private api");
+  });
+
+  it("preserves an adapter-supplied Worker runtime for Pages API responses", async () => {
+    const request = new Request("https://example.com/original");
+    stages.api.mockResolvedValue(new Response("api"));
+
+    await handleResponseStage(
+      request,
+      undefined,
+      { hostRuntime: "worker", waitUntil() {} },
+      {
+        apiUrl: "/api/worker",
+        buildId: "test-build",
+        cacheability: {
+          policyHeaders: null,
+          probeMode: null,
+          resolvedRoutePathname: "/api/worker",
+        },
+        kind: "pages-api",
+        protocolVersion: PAGES_RESPONSE_STAGE_PROTOCOL_VERSION,
+        requestHost: "example.com",
+        stagedHeaders: null,
+      },
+      dispatchRequestStage,
+      { cache: "shared" },
+    );
+
+    expect(stages.api.mock.calls[0]?.[4]).toBe("worker");
+  });
+
+  it("rejects a response-stage deployment mismatch before rendering", async () => {
+    const response = await handleResponseStage(
+      new Request("https://example.com/page"),
+      undefined,
+      undefined,
+      {
+        buildId: "older-build",
+        cacheability: { policyHeaders: null, probeMode: null, resolvedRoutePathname: "/page" },
+        kind: "pages-page",
+        protocolVersion: PAGES_RESPONSE_STAGE_PROTOCOL_VERSION,
+        requestHost: "example.com",
+        renderOptions: null,
+        resolvedUrl: "/page",
+        stagedHeaders: null,
+      },
+      dispatchRequestStage,
+      { cache: "shared" },
+    );
+
+    expect(response.status).toBe(409);
+    expect(stages.api).not.toHaveBeenCalled();
+    expect(stages.renderPage).not.toHaveBeenCalled();
+  });
+
+  it("rejects a response-stage host mismatch before rendering", async () => {
+    const response = await handleResponseStage(
+      new Request("https://second.example/page"),
+      undefined,
+      undefined,
+      {
+        buildId: "test-build",
+        cacheability: { policyHeaders: null, probeMode: null, resolvedRoutePathname: "/page" },
+        kind: "pages-page",
+        protocolVersion: PAGES_RESPONSE_STAGE_PROTOCOL_VERSION,
+        renderOptions: null,
+        requestHost: "first.example",
+        resolvedUrl: "/page",
+        stagedHeaders: null,
+      },
+      dispatchRequestStage,
+      { cache: "shared" },
+    );
+
+    expect(response.status).toBe(400);
+    expect(stages.renderPage).not.toHaveBeenCalled();
+  });
+
+  it("reconstructs bypass-stage headers for nonce and cookie-sensitive page renders", async () => {
+    stages.renderPage.mockResolvedValue(new Response("page"));
+    const stagedHeaders: Array<[string, string]> = [
+      ["content-security-policy", "script-src 'nonce-stage'"],
+      ["set-cookie", "first=one; Path=/"],
+      ["set-cookie", "second=two; Path=/"],
+    ];
+
+    await handleResponseStage(
+      new Request("https://example.com/page"),
+      undefined,
+      undefined,
+      {
+        buildId: "test-build",
+        cacheability: { policyHeaders: null, probeMode: null, resolvedRoutePathname: "/page" },
+        kind: "pages-page",
+        protocolVersion: PAGES_RESPONSE_STAGE_PROTOCOL_VERSION,
+        requestHost: "example.com",
+        renderOptions: null,
+        resolvedUrl: "/page",
+        stagedHeaders,
+      },
+      dispatchRequestStage,
+      { cache: "bypass" },
+    );
+
+    const reconstructed = stages.renderPage.mock.calls[0]?.[4] as Headers;
+    expect(reconstructed.get("content-security-policy")).toBe("script-src 'nonce-stage'");
+    expect(reconstructed.getSetCookie()).toEqual(["first=one; Path=/", "second=two; Path=/"]);
+  });
+});


### PR DESCRIPTION
Part 5 of 16 in the staged CDN adapter stack. Depends on #3144.

## Summary

- extracts the Pages response renderer into an importable typed stage
- keeps API routes, page rendering, preview state, headers, and response policy in Pages-owned modules
- defines the Pages stage wire contract without selecting a transport
- bypasses shared response dispatch for tokenized WebSocket upgrades

## Validation

- focused Pages API, page-handler, response-stage, route-data, and worker-stage tests
- cumulative exact-tip changed-test sweep: 3,461 passed, 2 skipped
- full `vp check` and vinext package build

## Review size

- Implementation: +609 / -48 LOC
- Tests and fixtures: +1166 / -3 LOC
- Other (docs, config, lockfile): +0 / -0 LOC
- 15 changed files

Measured against `codex/cdn-v2-stage-cacheability` after rebasing onto `main@a6931c0`.