### PR TITLE
refactor(app): define response-stage protocol

### DIFF
--- a/packages/vinext/src/server/app-elements-wire-key.ts
+++ b/packages/vinext/src/server/app-elements-wire-key.ts
@@ -1,0 +1,66 @@
+/** Encode and validate the lightweight AppElements slot identity wire shape. */
+export function createAppElementsWireSlotId(slotName: string, treePath: string): string {
+  return `slot:${slotName}:${treePath}`;
+}
+
+export function isAppElementsWireSlotId(key: string): boolean {
+  if (!key.startsWith("slot:")) return false;
+  const body = key.slice("slot:".length);
+  const separatorIndex = body.indexOf(":");
+  return separatorIndex > 0 && body.charCodeAt(separatorIndex + 1) === 0x2f;
+}
+
+export type AppElementsWireElementKey =
+  | { kind: "layout"; treePath: string }
+  | { interceptionContext: string | null; kind: "page"; path: string }
+  | { interceptionContext: string | null; kind: "route"; path: string }
+  | { kind: "slot"; name: string; treePath: string }
+  | { kind: "template"; treePath: string };
+
+function parsePathWithInterception(input: string): {
+  interceptionContext: string | null;
+  path: string;
+} | null {
+  const separatorIndex = input.indexOf("\0");
+  const path = separatorIndex === -1 ? input : input.slice(0, separatorIndex);
+  if (!path.startsWith("/")) return null;
+  return {
+    interceptionContext: separatorIndex === -1 ? null : input.slice(separatorIndex + 1),
+    path,
+  };
+}
+
+function parseTreePath(input: string): string | null {
+  return input.startsWith("/") ? input : null;
+}
+
+export function parseAppElementsWireElementKey(key: string): AppElementsWireElementKey | null {
+  if (key.startsWith("route:")) {
+    const parsed = parsePathWithInterception(key.slice("route:".length));
+    return parsed
+      ? { interceptionContext: parsed.interceptionContext, kind: "route", path: parsed.path }
+      : null;
+  }
+  if (key.startsWith("page:")) {
+    const parsed = parsePathWithInterception(key.slice("page:".length));
+    return parsed
+      ? { interceptionContext: parsed.interceptionContext, kind: "page", path: parsed.path }
+      : null;
+  }
+  if (key.startsWith("layout:")) {
+    const treePath = parseTreePath(key.slice("layout:".length));
+    return treePath ? { kind: "layout", treePath } : null;
+  }
+  if (key.startsWith("template:")) {
+    const treePath = parseTreePath(key.slice("template:".length));
+    return treePath ? { kind: "template", treePath } : null;
+  }
+  if (key.startsWith("slot:")) {
+    const body = key.slice("slot:".length);
+    const separatorIndex = body.indexOf(":");
+    if (separatorIndex <= 0) return null;
+    const treePath = parseTreePath(body.slice(separatorIndex + 1));
+    return treePath ? { kind: "slot", name: body.slice(0, separatorIndex), treePath } : null;
+  }
+  return null;
+}

--- a/packages/vinext/src/server/app-elements-wire.ts
+++ b/packages/vinext/src/server/app-elements-wire.ts
@@ -16,6 +16,12 @@ import { releaseAppElementRenderDependency } from "./app-render-dependency.js";
 import type { BfcacheSegmentIdentity } from "./bfcache-identity.js";
 import { compareStrings } from "../utils/compare.js";
 import { isUnknownRecord } from "../utils/record.js";
+import {
+  createAppElementsWireSlotId,
+  isAppElementsWireSlotId,
+  parseAppElementsWireElementKey,
+  type AppElementsWireElementKey,
+} from "./app-elements-wire-key.js";
 
 const APP_INTERCEPTION_SEPARATOR = "\0";
 const LEGACY_APP_SOURCE_PAGE_KEY = "__sourcePage";
@@ -214,13 +220,6 @@ type AppElementsMetadata = {
   sourcePage: string | null;
 };
 
-type AppElementsWireElementKey =
-  | { kind: "layout"; treePath: string }
-  | { interceptionContext: string | null; kind: "page"; path: string }
-  | { interceptionContext: string | null; kind: "route"; path: string }
-  | { kind: "slot"; name: string; treePath: string }
-  | { kind: "template"; treePath: string };
-
 type AppElementsWireMetadataInput = {
   dynamicStaleTimeSeconds?: number;
   interception?: AppElementsInterception | null;
@@ -332,81 +331,13 @@ function createAppPayloadTemplateId(treePath: string): string {
   return `template:${treePath}`;
 }
 
-function createAppPayloadSlotId(slotName: string, treePath: string): string {
-  return `slot:${slotName}:${treePath}`;
-}
-
 function createAppPayloadCacheKey(rscUrl: string, interceptionContext: string | null): string {
   return appendInterceptionContext(rscUrl, interceptionContext);
-}
-
-function parsePathWithInterception(input: string): {
-  interceptionContext: string | null;
-  path: string;
-} | null {
-  const separatorIndex = input.indexOf(APP_INTERCEPTION_SEPARATOR);
-  const path = separatorIndex === -1 ? input : input.slice(0, separatorIndex);
-  if (!path.startsWith("/")) return null;
-
-  return {
-    interceptionContext: separatorIndex === -1 ? null : input.slice(separatorIndex + 1),
-    path,
-  };
-}
-
-/**
- * AppElements tree paths are absolute route-tree paths on the wire.
- * Bare segment names are not valid layout/template/slot tree identities.
- */
-function parseTreePath(input: string): string | null {
-  return input.startsWith("/") ? input : null;
-}
-
-function parseAppElementsWireElementKey(key: string): AppElementsWireElementKey | null {
-  if (key.startsWith("route:")) {
-    const parsed = parsePathWithInterception(key.slice("route:".length));
-    if (!parsed) return null;
-    return { interceptionContext: parsed.interceptionContext, kind: "route", path: parsed.path };
-  }
-
-  if (key.startsWith("page:")) {
-    const parsed = parsePathWithInterception(key.slice("page:".length));
-    if (!parsed) return null;
-    return { interceptionContext: parsed.interceptionContext, kind: "page", path: parsed.path };
-  }
-
-  if (key.startsWith("layout:")) {
-    const treePath = parseTreePath(key.slice("layout:".length));
-    return treePath ? { kind: "layout", treePath } : null;
-  }
-
-  if (key.startsWith("template:")) {
-    const treePath = parseTreePath(key.slice("template:".length));
-    return treePath ? { kind: "template", treePath } : null;
-  }
-
-  if (key.startsWith("slot:")) {
-    const body = key.slice("slot:".length);
-    const separatorIndex = body.indexOf(":");
-    if (separatorIndex <= 0) return null;
-    const name = body.slice(0, separatorIndex);
-    const treePath = parseTreePath(body.slice(separatorIndex + 1));
-    return treePath ? { kind: "slot", name, treePath } : null;
-  }
-
-  return null;
 }
 
 function isAppElementsWireBfcacheIdentityId(key: string): boolean {
   const kind = parseAppElementsWireElementKey(key)?.kind;
   return kind === "page" || kind === "layout" || kind === "template" || kind === "slot";
-}
-
-function isAppElementsWireSlotId(key: string): boolean {
-  if (!key.startsWith("slot:")) return false;
-  const body = key.slice("slot:".length);
-  const separatorIndex = body.indexOf(":");
-  return separatorIndex > 0 && body.charCodeAt(separatorIndex + 1) === 0x2f;
 }
 
 function isSourcePageSegments(value: unknown): value is readonly string[] {
@@ -975,7 +906,7 @@ export const AppElementsWire: AppElementsWireCodec = {
   encodeOutgoingPayload: buildOutgoingAppPayload,
   encodePageId: createAppPayloadPageId,
   encodeRouteId: createAppPayloadRouteId,
-  encodeSlotId: createAppPayloadSlotId,
+  encodeSlotId: createAppElementsWireSlotId,
   encodeTemplateId: createAppPayloadTemplateId,
   isSlotId: isAppElementsWireSlotId,
   parseElementKey: parseAppElementsWireElementKey,

--- a/packages/vinext/src/server/app-worker-stages.ts
+++ b/packages/vinext/src/server/app-worker-stages.ts
@@ -2,12 +2,10 @@ import type { AppRscRenderMode } from "./app-rsc-render-mode.js";
 import type {
   VinextResponseStageCacheability,
   VinextResponseStageDispatchOptions,
-  VinextResponseStageTransport,
 } from "./multi-stage.js";
 import { isTrustedPrerenderState, type TrustedPrerenderState } from "./prerender-route-params.js";
 
 export const APP_WORKER_RESPONSE_STAGE_PROTOCOL_VERSION = 7;
-export const APP_METADATA_RESPONSE_STAGE_NO_MATCH_HEADER = "x-vinext-app-metadata-stage-no-match";
 const STATIC_FILE_SIGNAL_TOKEN_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
@@ -31,7 +29,7 @@ type AppFullRequestWorkerResponseStageProps = AppWorkerResponseStageEnvelope & {
   trustedPrerenderState: TrustedPrerenderState | null;
 };
 
-export type AppMatchedWorkerResponseStageProps = AppWorkerResponseStageEnvelope & {
+type AppMatchedWorkerResponseStageProps = AppWorkerResponseStageEnvelope & {
   kind: "app-page" | "app-route-handler";
   bypassInterceptionContextCache: boolean;
   canonicalPathname: string;
@@ -93,14 +91,6 @@ export type AppWorkerResponseStageProps =
   | AppMetadataWorkerResponseStageProps
   | AppNotFoundWorkerResponseStageProps
   | HybridPagesWorkerResponseStageProps;
-
-export type DispatchAppWorkerResponseStage =
-  VinextResponseStageTransport<AppWorkerResponseStageProps>;
-
-export type RenderAppWorkerResponseStageLocally = (
-  request: Request,
-  props: AppWorkerResponseStageProps,
-) => Promise<Response>;
 
 /** Normalize a shared App page HEAD request onto its method-invariant GET representation. */
 export function prepareSharedAppPageDispatch(

--- a/packages/vinext/src/server/app-worker-stages.ts
+++ b/packages/vinext/src/server/app-worker-stages.ts
@@ -1,0 +1,267 @@
+import type { AppRscRenderMode } from "./app-rsc-render-mode.js";
+import type {
+  VinextResponseStageCacheability,
+  VinextResponseStageDispatchOptions,
+  VinextResponseStageTransport,
+} from "./multi-stage.js";
+import { isTrustedPrerenderState, type TrustedPrerenderState } from "./prerender-route-params.js";
+
+export const APP_WORKER_RESPONSE_STAGE_PROTOCOL_VERSION = 7;
+export const APP_METADATA_RESPONSE_STAGE_NO_MATCH_HEADER = "x-vinext-app-metadata-stage-no-match";
+const STATIC_FILE_SIGNAL_TOKEN_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+type AppPageParams = Record<string, string | string[]>;
+
+type AppWorkerResponseStageEnvelope = {
+  buildId: string | null;
+  cacheability: VinextResponseStageCacheability;
+  draftModeCookie: string | null;
+  middlewareCookieOverlay: string | null;
+  protocolVersion: typeof APP_WORKER_RESPONSE_STAGE_PROTOCOL_VERSION;
+  /** Canonical public request origin used to partition and validate shared renders. */
+  requestOrigin: string;
+  scriptNonce: string | null;
+};
+
+type AppFullRequestWorkerResponseStageProps = AppWorkerResponseStageEnvelope & {
+  kind: "app-full-request";
+  prerenderDiscovery: boolean;
+  staticFileSignalToken: string;
+  trustedPrerenderState: TrustedPrerenderState | null;
+};
+
+export type AppMatchedWorkerResponseStageProps = AppWorkerResponseStageEnvelope & {
+  kind: "app-page" | "app-route-handler";
+  bypassInterceptionContextCache: boolean;
+  canonicalPathname: string;
+  cleanPathname: string;
+  interceptionContext: string | null;
+  interceptionId: string | null;
+  isRscRequest: boolean;
+  matchKind: "interception" | "request" | "resolved";
+  mountedSlotsHeader: string | null;
+  params: AppPageParams;
+  resolvedUrl: string;
+  routePattern: string;
+  routePathname: string;
+  renderMode: AppRscRenderMode;
+};
+
+type AppNotFoundWorkerResponseStageProps = AppWorkerResponseStageEnvelope & {
+  kind: "app-not-found";
+  canonicalPathname: string;
+  cleanPathname: string;
+  isRscRequest: boolean;
+  mountedSlotsHeader: string | null;
+  renderMode: AppRscRenderMode;
+  resolvedUrl: string;
+};
+
+type AppMetadataWorkerResponseStageProps = AppWorkerResponseStageEnvelope & {
+  kind: "app-metadata";
+  canonicalPathname: string;
+  cleanPathname: string;
+  isRscRequest: boolean;
+  mountedSlotsHeader: string | null;
+  renderMode: AppRscRenderMode;
+  resolvedUrl: string;
+};
+
+type HybridPagesWorkerResponseStageProps = AppWorkerResponseStageEnvelope & {
+  kind: "hybrid-pages";
+  allowRscDocumentFallback: boolean;
+  appRouteMatch: {
+    isDynamic: boolean;
+    pattern: string;
+  } | null;
+  canonicalPathname: string;
+  cleanPathname: string;
+  isDataRequest: boolean;
+  isRscRequest: boolean;
+  matchKind: "dynamic" | "static";
+  /** Complete response-header snapshot installed before request-time Pages user code runs. */
+  preHandlerHeaders: Array<[string, string]> | null;
+  resourceKind: "api" | "page";
+  requestUrl: string;
+  resolvedUrl: string;
+};
+
+export type AppWorkerResponseStageProps =
+  | AppFullRequestWorkerResponseStageProps
+  | AppMatchedWorkerResponseStageProps
+  | AppMetadataWorkerResponseStageProps
+  | AppNotFoundWorkerResponseStageProps
+  | HybridPagesWorkerResponseStageProps;
+
+export type DispatchAppWorkerResponseStage =
+  VinextResponseStageTransport<AppWorkerResponseStageProps>;
+
+export type RenderAppWorkerResponseStageLocally = (
+  request: Request,
+  props: AppWorkerResponseStageProps,
+) => Promise<Response>;
+
+/** Normalize a shared App page HEAD request onto its method-invariant GET representation. */
+export function prepareSharedAppPageDispatch(
+  request: Request,
+  cache: VinextResponseStageDispatchOptions["cache"],
+): Request {
+  return cache !== "bypass" && request.method.toUpperCase() === "HEAD"
+    ? new Request(request, { method: "GET" })
+    : request;
+}
+
+function isAppPageParams(value: unknown): value is AppPageParams {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  for (const param of Object.values(value)) {
+    if (typeof param === "string") continue;
+    if (!Array.isArray(param) || param.some((item) => typeof item !== "string")) return false;
+  }
+  return true;
+}
+
+function isCanonicalHttpOrigin(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  try {
+    const url = new URL(value);
+    return (url.protocol === "http:" || url.protocol === "https:") && url.origin === value;
+  } catch {
+    return false;
+  }
+}
+
+export function isAppWorkerResponseStageProps(
+  value: unknown,
+): value is AppWorkerResponseStageProps {
+  if (!value || typeof value !== "object") return false;
+  const props = value as Partial<AppWorkerResponseStageProps>;
+  if (
+    props.protocolVersion !== APP_WORKER_RESPONSE_STAGE_PROTOCOL_VERSION ||
+    (props.buildId !== null && typeof props.buildId !== "string") ||
+    !isResponseStageCacheability(props.cacheability) ||
+    (props.draftModeCookie !== null && typeof props.draftModeCookie !== "string") ||
+    (props.middlewareCookieOverlay !== null && typeof props.middlewareCookieOverlay !== "string") ||
+    !isCanonicalHttpOrigin(props.requestOrigin) ||
+    (props.scriptNonce !== null && typeof props.scriptNonce !== "string")
+  ) {
+    return false;
+  }
+  if (props.kind === "app-full-request") {
+    return (
+      typeof props.prerenderDiscovery === "boolean" &&
+      typeof props.staticFileSignalToken === "string" &&
+      STATIC_FILE_SIGNAL_TOKEN_RE.test(props.staticFileSignalToken) &&
+      (props.trustedPrerenderState === null || isTrustedPrerenderState(props.trustedPrerenderState))
+    );
+  }
+  if (props.kind === "hybrid-pages") {
+    const hybrid = props as Partial<HybridPagesWorkerResponseStageProps>;
+    const appRouteMatch = hybrid.appRouteMatch;
+    return (
+      typeof hybrid.allowRscDocumentFallback === "boolean" &&
+      (appRouteMatch === null ||
+        (typeof appRouteMatch === "object" &&
+          typeof appRouteMatch.isDynamic === "boolean" &&
+          typeof appRouteMatch.pattern === "string" &&
+          appRouteMatch.pattern.startsWith("/"))) &&
+      typeof hybrid.canonicalPathname === "string" &&
+      hybrid.canonicalPathname.startsWith("/") &&
+      typeof hybrid.cleanPathname === "string" &&
+      hybrid.cleanPathname.startsWith("/") &&
+      typeof hybrid.isDataRequest === "boolean" &&
+      typeof hybrid.isRscRequest === "boolean" &&
+      (hybrid.matchKind === "dynamic" || hybrid.matchKind === "static") &&
+      (hybrid.preHandlerHeaders === null || isSerializedHeaders(hybrid.preHandlerHeaders)) &&
+      (hybrid.resourceKind === "api" || hybrid.resourceKind === "page") &&
+      typeof hybrid.requestUrl === "string" &&
+      typeof hybrid.resolvedUrl === "string" &&
+      hybrid.resolvedUrl.startsWith("/")
+    );
+  }
+  if (props.kind === "app-metadata" || props.kind === "app-not-found") {
+    const special = props as Partial<
+      AppMetadataWorkerResponseStageProps | AppNotFoundWorkerResponseStageProps
+    >;
+    return (
+      typeof special.canonicalPathname === "string" &&
+      special.canonicalPathname.startsWith("/") &&
+      typeof special.cleanPathname === "string" &&
+      special.cleanPathname.startsWith("/") &&
+      typeof special.isRscRequest === "boolean" &&
+      (special.mountedSlotsHeader === null || typeof special.mountedSlotsHeader === "string") &&
+      typeof special.resolvedUrl === "string" &&
+      special.resolvedUrl.startsWith("/") &&
+      (special.renderMode === "navigation" ||
+        special.renderMode === "prefetch-empty" ||
+        special.renderMode === "prefetch-dynamic-shell" ||
+        special.renderMode === "prefetch-loading-shell")
+    );
+  }
+  return (
+    (props.kind === "app-page" || props.kind === "app-route-handler") &&
+    typeof props.bypassInterceptionContextCache === "boolean" &&
+    typeof props.canonicalPathname === "string" &&
+    props.canonicalPathname.startsWith("/") &&
+    typeof props.cleanPathname === "string" &&
+    props.cleanPathname.startsWith("/") &&
+    (props.interceptionContext === null || typeof props.interceptionContext === "string") &&
+    (props.interceptionId === null || typeof props.interceptionId === "string") &&
+    typeof props.isRscRequest === "boolean" &&
+    (props.matchKind === "interception" ||
+      props.matchKind === "request" ||
+      props.matchKind === "resolved") &&
+    (props.mountedSlotsHeader === null || typeof props.mountedSlotsHeader === "string") &&
+    isAppPageParams(props.params) &&
+    typeof props.resolvedUrl === "string" &&
+    props.resolvedUrl.startsWith("/") &&
+    typeof props.routePattern === "string" &&
+    props.routePattern.startsWith("/") &&
+    typeof props.routePathname === "string" &&
+    props.routePathname.startsWith("/") &&
+    (props.renderMode === "navigation" ||
+      props.renderMode === "prefetch-empty" ||
+      props.renderMode === "prefetch-dynamic-shell" ||
+      props.renderMode === "prefetch-loading-shell")
+  );
+}
+
+function isSerializedHeaders(value: unknown): value is Array<[string, string]> {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (entry) =>
+        Array.isArray(entry) &&
+        entry.length === 2 &&
+        typeof entry[0] === "string" &&
+        typeof entry[1] === "string",
+    )
+  );
+}
+
+function isResponseStageCacheability(value: unknown): value is VinextResponseStageCacheability {
+  if (!value || typeof value !== "object") return false;
+  const cacheability = value as Partial<VinextResponseStageCacheability>;
+  return (
+    (cacheability.probeMode === null ||
+      cacheability.probeMode === "probe" ||
+      cacheability.probeMode === "identity") &&
+    (cacheability.policyHeaders === null ||
+      (Array.isArray(cacheability.policyHeaders) &&
+        cacheability.policyHeaders.every(
+          (entry) =>
+            Array.isArray(entry) &&
+            entry.length === 2 &&
+            typeof entry[0] === "string" &&
+            typeof entry[1] === "string",
+        ))) &&
+    (cacheability.representation === undefined ||
+      cacheability.representation === "app-route" ||
+      cacheability.representation === "html" ||
+      cacheability.representation === "pages-data" ||
+      cacheability.representation === "rsc-full" ||
+      cacheability.representation === "rsc-loading-shell") &&
+    typeof cacheability.resolvedRoutePathname === "string" &&
+    cacheability.resolvedRoutePathname.startsWith("/")
+  );
+}

--- a/tests/app-elements.test.ts
+++ b/tests/app-elements.test.ts
@@ -398,6 +398,7 @@ describe("AppElementsWire", () => {
     const allowed = new Set([
       path.join(sourceRoot, "routing/app-route-graph.ts"),
       path.join(sourceRoot, "server/app-elements-wire.ts"),
+      path.join(sourceRoot, "server/app-elements-wire-key.ts"),
     ]);
     const rawWireConstruction =
       /`(?:route|page|layout|template):\$\{|`slot:\$\{|["'](?:route|page|layout|template):["']\s*\+|["']slot:["']\s*\+|\.startsWith\(["'](?:slot|layout|page|route|template):["']\)/;

--- a/tests/app-worker-stages.test.ts
+++ b/tests/app-worker-stages.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  APP_WORKER_RESPONSE_STAGE_PROTOCOL_VERSION,
+  isAppWorkerResponseStageProps,
+  prepareSharedAppPageDispatch,
+  type AppWorkerResponseStageProps,
+} from "../packages/vinext/src/server/app-worker-stages.js";
+
+const notFoundStage = {
+  buildId: null,
+  cacheability: { policyHeaders: null, probeMode: null, resolvedRoutePathname: "/missing" },
+  canonicalPathname: "/missing",
+  cleanPathname: "/missing",
+  draftModeCookie: null,
+  isRscRequest: false,
+  kind: "app-not-found" as const,
+  middlewareCookieOverlay: null,
+  mountedSlotsHeader: null,
+  protocolVersion: APP_WORKER_RESPONSE_STAGE_PROTOCOL_VERSION,
+  requestOrigin: "https://example.com",
+  renderMode: "navigation" as const,
+  resolvedUrl: "/missing",
+  scriptNonce: null,
+} satisfies AppWorkerResponseStageProps;
+
+describe("App Worker response-stage protocol", () => {
+  it("rejects matched-stage payloads missing interception cache-safety fields", () => {
+    const matchedStage = {
+      ...notFoundStage,
+      bypassInterceptionContextCache: false,
+      interceptionContext: null,
+      interceptionId: null,
+      kind: "app-page" as const,
+      matchKind: "request" as const,
+      params: {},
+      routePattern: "/missing",
+      routePathname: "/missing",
+    } satisfies AppWorkerResponseStageProps;
+    const { bypassInterceptionContextCache: _bypass, ...withoutBypassProof } = matchedStage;
+    const { interceptionId: _interceptionId, ...withoutInterceptionId } = matchedStage;
+
+    expect(isAppWorkerResponseStageProps(matchedStage)).toBe(true);
+    expect(isAppWorkerResponseStageProps(withoutBypassProof)).toBe(false);
+    expect(isAppWorkerResponseStageProps(withoutInterceptionId)).toBe(false);
+  });
+
+  it.each([
+    { name: "missing", requestOrigin: undefined },
+    { name: "relative", requestOrigin: "example.com" },
+    { name: "non-HTTP", requestOrigin: "ftp://example.com" },
+    { name: "non-canonical", requestOrigin: "https://example.com/" },
+  ])("rejects a $name request origin", ({ requestOrigin }) => {
+    expect(isAppWorkerResponseStageProps({ ...notFoundStage, requestOrigin })).toBe(false);
+  });
+
+  it("requires a transport proof on full-request stage payloads", () => {
+    const fullStage = {
+      buildId: null,
+      cacheability: { policyHeaders: null, probeMode: null, resolvedRoutePathname: "/" },
+      draftModeCookie: null,
+      kind: "app-full-request" as const,
+      middlewareCookieOverlay: null,
+      prerenderDiscovery: false,
+      protocolVersion: APP_WORKER_RESPONSE_STAGE_PROTOCOL_VERSION,
+      requestOrigin: "https://example.com",
+      scriptNonce: null,
+      staticFileSignalToken: "00000000-0000-4000-8000-000000000000",
+      trustedPrerenderState: null,
+    } satisfies AppWorkerResponseStageProps;
+    const { staticFileSignalToken: _token, ...withoutToken } = fullStage;
+
+    expect(isAppWorkerResponseStageProps(fullStage)).toBe(true);
+    expect(isAppWorkerResponseStageProps(withoutToken)).toBe(false);
+  });
+
+  it("normalizes shared HEAD page dispatches without changing bypassed work", () => {
+    const request = new Request("https://example.com/page", { method: "HEAD" });
+
+    expect(prepareSharedAppPageDispatch(request, "shared").method).toBe("GET");
+    expect(prepareSharedAppPageDispatch(request, "bypass")).toBe(request);
+  });
+});


### PR DESCRIPTION
Part 7 of 16 in the staged CDN adapter stack. Depends on #3146.

## Summary

- defines the App Router response-stage protocol and serializable element wire format
- keeps App-specific request props and validation out of the generic stage contracts
- covers protocol serialization, malformed input, and stage dispatch behavior

## Validation

- focused App element-wire and worker-stage tests
- cumulative exact-tip changed-test sweep: 3,461 passed, 2 skipped
- full exact-tip `vp check`

## Review size

- Implementation: +330 / -76 LOC
- Tests and fixtures: +83 / -0 LOC
- Other (docs, config, lockfile): +0 / -0 LOC
- 5 changed files

Measured against `codex/cdn-v2-pages-request-stage` after rebasing onto `main@a6931c0`.