### PR TITLE
refactor(app): extract request stage

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -94,6 +94,8 @@ export default {
         "src/server/app-page-element-builder.ts",
         "src/server/app-hook-warning-suppression.ts",
         "src/server/app-post-middleware-context.ts",
+        "src/server/app-request-stage-context.ts",
+        "src/server/app-request-stage-independent-entry.ts",
         "src/server/app-request-context.ts",
         "src/server/app-rsc-error-handler.ts",
         "src/server/isr-cache.ts",

--- a/knip.ts
+++ b/knip.ts
@@ -94,6 +94,7 @@ export default {
         "src/server/app-page-element-builder.ts",
         "src/server/app-hook-warning-suppression.ts",
         "src/server/app-post-middleware-context.ts",
+        "src/server/app-route-handler-middleware-context.ts",
         "src/server/app-request-stage-context.ts",
         "src/server/app-request-stage-independent-entry.ts",
         "src/server/app-request-context.ts",

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -20,6 +20,7 @@ import type {
 } from "../config/next-config.js";
 import type { ImageConfig } from "../server/image-optimization.js";
 import type { AppRoute } from "../routing/app-router.js";
+import { routePatternParts } from "../routing/route-pattern.js";
 import { generateDevOriginCheckCode } from "../server/dev-origin-check.js";
 import { safeJsonStringify } from "../server/html.js";
 import type { MetadataFileRoute } from "../server/metadata-routes.js";
@@ -48,6 +49,10 @@ const appRouteRequestBuiltInsPath = resolveEntryPath(
 );
 const appRouteHandlerResponsePath = resolveEntryPath(
   "../server/app-route-handler-response.js",
+  import.meta.url,
+);
+const appRouteHandlerMiddlewareContextPath = resolveEntryPath(
+  "../server/app-route-handler-middleware-context.js",
   import.meta.url,
 );
 const appServerActionExecutionPath = resolveEntryPath(
@@ -87,6 +92,14 @@ const appRscRouteMatchingPath = resolveEntryPath(
   "../server/app-rsc-route-matching.js",
   import.meta.url,
 );
+const appRscResponseStagePath = resolveEntryPath(
+  "../server/app-rsc-response-stage.js",
+  import.meta.url,
+);
+const appRscCombinedHandlerPath = resolveEntryPath(
+  "../server/app-rsc-combined-handler.js",
+  import.meta.url,
+);
 const rscStreamHintsPath = resolveEntryPath("../server/rsc-stream-hints.js", import.meta.url);
 const isrCachePath = resolveEntryPath("../server/isr-cache.js", import.meta.url);
 const thenableParamsShimPath = resolveEntryPath("../shims/thenable-params.js", import.meta.url);
@@ -103,6 +116,14 @@ const appRscErrorHandlerPath = resolveEntryPath(
   import.meta.url,
 );
 const appRequestContextPath = resolveEntryPath("../server/app-request-context.js", import.meta.url);
+const appRequestStageContextPath = resolveEntryPath(
+  "../server/app-request-stage-context.js",
+  import.meta.url,
+);
+const appRequestStageDispatchPath = resolveEntryPath(
+  "../server/app-request-stage-dispatch.js",
+  import.meta.url,
+);
 const appRouteModuleLoaderPath = resolveEntryPath(
   "../server/app-route-module-loader.js",
   import.meta.url,
@@ -122,6 +143,7 @@ const appHookWarningSuppressionPath = resolveEntryPath(
 );
 const serverGlobalsPath = resolveEntryPath("../server/server-globals.js", import.meta.url);
 const appPagesBridgePath = resolveEntryPath("../server/app-pages-bridge.js", import.meta.url);
+const routePatternPath = resolveEntryPath("../routing/route-pattern.js", import.meta.url);
 
 /**
  * Resolved config options relevant to App Router request handling.
@@ -209,6 +231,298 @@ type AppRouterConfig = {
   prerenderSecret?: string;
 };
 
+function buildAppRequestRouteMetadata(routes: AppRoute[]): unknown[] {
+  return routes.map((route) => ({
+    ids: route.ids ?? null,
+    pattern: route.pattern,
+    patternParts: route.patternParts,
+    isDynamic: route.isDynamic,
+    params: route.params,
+    rootParamNames: route.rootParamNames ?? [],
+    page: route.pagePath ? true : null,
+    routeHandler: route.routePath ? true : null,
+    routeSegments: route.routeSegments,
+    layouts: [],
+    layoutTreePositions: [],
+    slots: Object.fromEntries(
+      route.parallelSlots.map((slot) => [
+        slot.key,
+        {
+          id: slot.id ?? null,
+          name: slot.name,
+          intercepts: slot.interceptingRoutes.map((intercept) => ({
+            id: intercept.id ?? null,
+            targetPattern: intercept.targetPattern,
+            sourceMatchPattern: intercept.sourceMatchPattern,
+            sourcePageSegments: intercept.sourcePageSegments,
+            interceptLayouts: [],
+            interceptLayoutSegments: intercept.layoutSegments ?? [],
+            interceptBranchSegments: intercept.branchSegments ?? [],
+            interceptLoadings: [],
+            interceptLoadingTreePositions: intercept.loadingTreePositions ?? [],
+            interceptNotFoundBranchSegments:
+              intercept.notFoundBranchSegments ?? intercept.branchSegments ?? [],
+            page: null,
+            notFound: null,
+            notFoundTreePosition: intercept.notFoundTreePosition ?? null,
+            params: intercept.params,
+          })),
+        },
+      ]),
+    ),
+    siblingIntercepts: route.siblingIntercepts.map((intercept) => ({
+      id: intercept.id ?? null,
+      targetPattern: intercept.targetPattern,
+      sourceMatchPattern: intercept.sourceMatchPattern,
+      sourcePageSegments: intercept.sourcePageSegments,
+      slotId: intercept.slotId ?? null,
+      interceptLayouts: [],
+      interceptLayoutSegments: intercept.layoutSegments ?? [],
+      interceptBranchSegments: intercept.branchSegments ?? [],
+      interceptLoadings: [],
+      interceptLoadingTreePositions: intercept.loadingTreePositions ?? [],
+      interceptNotFoundBranchSegments:
+        intercept.notFoundBranchSegments ?? intercept.branchSegments ?? [],
+      page: null,
+      notFound: null,
+      notFoundTreePosition: intercept.notFoundTreePosition ?? null,
+      params: intercept.params,
+    })),
+  }));
+}
+
+/** Generate the module-free App request stage used by multi-stage Worker outputs. */
+export function generateAppRequestRscEntry(
+  appDir: string,
+  routes: AppRoute[],
+  middlewarePath?: string | null,
+  metadataRoutes?: MetadataFileRoute[],
+  _globalErrorPath?: string | null,
+  basePath?: string,
+  trailingSlash?: boolean,
+  config?: AppRouterConfig,
+  instrumentationPath?: string | null,
+): string {
+  void appDir;
+  const bp = basePath ?? "";
+  const ts = trailingSlash ?? false;
+  const hasPagesDir = config?.hasPagesDir ?? false;
+  const requestRoutes = buildAppRequestRouteMetadata(routes);
+  const metadataRouteMatchers = (metadataRoutes ?? []).map((route) => ({
+    isDynamic: route.isDynamic,
+    patternParts:
+      route.patternParts ??
+      (route.servedUrl.includes("[") ? routePatternParts(route.servedUrl) : null),
+    servedUrl: route.servedUrl,
+    type: route.type,
+  }));
+
+  return `
+import ${JSON.stringify(serverGlobalsPath)};
+import { createAppRscRequestHandler } from "vinext/server/app-rsc-handler";
+import { createAppRscRouteMatcher as __createAppRscRouteMatcher } from ${JSON.stringify(appRscRouteMatchingPath)};
+import { dispatchAppRequestStage as __dispatchAppRequestStage } from ${JSON.stringify(appRequestStageDispatchPath)};
+import { registerConfiguredCacheAdapters as __registerConfiguredCacheAdapters } from "virtual:vinext-cdn-cache-adapter";
+import { clearAppRequestStageContext as __clearRequestContext, setAppRequestStageNavigationContext as setNavigationContext } from ${JSON.stringify(appRequestStageContextPath)};
+import { matchRoutePattern as __matchRoutePattern } from ${JSON.stringify(routePatternPath)};
+${
+  middlewarePath
+    ? `import * as middlewareModule from ${JSON.stringify(toSlash(middlewarePath))};
+import { applyAppMiddleware as __applyAppMiddleware } from ${JSON.stringify(appMiddlewarePath)};`
+    : ""
+}
+${
+  instrumentationPath
+    ? `import * as _instrumentation from ${JSON.stringify(toSlash(instrumentationPath))};
+import { ensureInstrumentationRegistered as __ensureInstrumentationRegistered } from ${JSON.stringify(instrumentationRuntimePath)};`
+    : ""
+}
+${
+  hasPagesDir
+    ? `import { getDraftModeCookieHeader } from "next/headers";
+import * as __pagesRequestEntry from "virtual:vinext-pages-request-entry";
+import { renderPagesFallback as __renderPagesFallback } from ${JSON.stringify(appPagesBridgePath)};
+import { buildRequestHeadersFromMiddlewareResponse as __buildRequestHeadersFromMiddlewareResponse } from ${JSON.stringify(middlewareRequestHeadersPath)};
+import { decodePathParams as __decodePathParams } from ${JSON.stringify(normalizePathModulePath)};
+import { applyRouteHandlerMiddlewareContext as __applyRouteHandlerMiddlewareContext } from ${JSON.stringify(appRouteHandlerMiddlewareContextPath)};`
+    : ""
+}
+
+const __basePath = ${JSON.stringify(bp)};
+const __trailingSlash = ${JSON.stringify(ts)};
+const __draftModeSecret = ${JSON.stringify(config?.draftModeSecret ?? "")};
+export const __prerenderSecret = ${JSON.stringify(config?.prerenderSecret ?? "")};
+export const __assetPrefix = ${JSON.stringify(config?.assetPrefix ?? "")};
+export { __basePath };
+export const __imageAllowedWidths = ${JSON.stringify([
+    ...(config?.imageConfig?.deviceSizes ?? DEFAULT_DEVICE_SIZES),
+    ...(config?.imageConfig?.imageSizes ?? DEFAULT_IMAGE_SIZES),
+  ])};
+export const __imageConfig = ${JSON.stringify({
+    qualities: config?.imageConfig?.qualities,
+    dangerouslyAllowSVG: config?.imageConfig?.dangerouslyAllowSVG,
+    dangerouslyAllowLocalIP: config?.imageConfig?.dangerouslyAllowLocalIP,
+    contentDispositionType: config?.imageConfig?.contentDispositionType,
+    contentSecurityPolicy: config?.imageConfig?.contentSecurityPolicy,
+  })};
+const __routes = ${JSON.stringify(requestRoutes)};
+const __routeMatcher = __createAppRscRouteMatcher(__routes);
+const __metadataRouteMatchers = ${JSON.stringify(metadataRouteMatchers)};
+
+function matchRoute(pathname) { return __routeMatcher.matchRoute(pathname); }
+function matchRequestRoute(pathname) { return __routeMatcher.matchRequestRoute(pathname); }
+function hasInterceptionId(interceptionId) { return __routeMatcher.hasInterceptionId(interceptionId); }
+function __isMetadataPath(pathname) {
+  const parts = pathname.split("/").filter(Boolean);
+  return __metadataRouteMatchers.some((route) => {
+    const matchesBase = route.patternParts
+      ? __matchRoutePattern(parts, route.patternParts) !== null
+      : pathname === route.servedUrl;
+    if (matchesBase) return true;
+    if (!route.isDynamic) return false;
+    if (route.type === "sitemap") {
+      const prefix = route.servedUrl.slice(0, -4);
+      const id = pathname.startsWith(prefix + "/") && pathname.endsWith(".xml")
+        ? pathname.slice(prefix.length + 1, -4)
+        : "";
+      return id !== "" && !id.includes("/");
+    }
+    if (
+      route.type === "icon" ||
+      route.type === "apple-icon" ||
+      route.type === "opengraph-image" ||
+      route.type === "twitter-image"
+    ) {
+      return route.patternParts
+        ? parts.length > 0 && __matchRoutePattern(parts.slice(0, -1), route.patternParts) !== null
+        : pathname.startsWith(route.servedUrl + "/") &&
+            !pathname.slice(route.servedUrl.length + 1).includes("/");
+    }
+    return false;
+  });
+}
+${generateDevOriginCheckCode(config?.allowedDevOrigins)}
+
+const __requestHandler = createAppRscRequestHandler({
+  basePath: __basePath,
+  buildId: process.env.__VINEXT_BUILD_ID ?? null,
+  clearRequestContext: __clearRequestContext,
+  configHeaders: ${JSON.stringify(config?.headers ?? [])},
+  configRedirects: ${JSON.stringify(config?.redirects ?? [])},
+  configRewrites: ${JSON.stringify(config?.rewrites ?? { beforeFiles: [], afterFiles: [], fallback: [] })},
+  draftModeSecret: __draftModeSecret,
+  dispatchMatchedPage() { throw new Error("App request stage attempted to render a page inline"); },
+  dispatchMatchedRouteHandler() { throw new Error("App request stage attempted to render a route handler inline"); },
+  ${
+    instrumentationPath
+      ? `ensureInstrumentation() { return __ensureInstrumentationRegistered(_instrumentation); },`
+      : ""
+  }
+  i18nConfig: ${JSON.stringify(config?.i18n ?? null)},
+  imageConfig: ${JSON.stringify(config?.imageConfig)},
+  isMetadataRoute: __isMetadataPath,
+  isDev: process.env.NODE_ENV !== "production",
+  hasInterceptionId,
+  matchRoute,
+  matchRequestRoute,
+  matchInterceptRoute(pathname, sourcePathname, interceptionId) {
+    const intercept = __routeMatcher.findIntercept(pathname, sourcePathname, interceptionId);
+    if (!intercept) return null;
+    const route = __routes[intercept.sourceRouteIndex];
+    if (!route) return null;
+    const params = Object.create(null);
+    for (const name of route.params) {
+      if (Object.prototype.hasOwnProperty.call(intercept.sourceMatchedParams, name)) {
+        params[name] = intercept.sourceMatchedParams[name];
+      }
+    }
+    return {
+      interceptionSourceIsConcrete: intercept.sourceRouteIsConcrete,
+      route,
+      params,
+    };
+  },
+  ${
+    middlewarePath
+      ? `runMiddleware({ cleanPathname, context, externalRewriteRequest, hadBasePath, isDataRequest, middlewareRequest, request, validateExternalRewriteRequest }) {
+    return __applyAppMiddleware({
+      basePath: __basePath,
+      cleanPathname,
+      context,
+      externalRewriteRequest,
+      hadBasePath,
+      filePath: ${JSON.stringify(toSlash(middlewarePath))},
+      i18nConfig: ${JSON.stringify(config?.i18n ?? null)},
+      isDataRequest,
+      isProxy: ${JSON.stringify(isProxyFile(middlewarePath))},
+      middlewareRequest,
+      module: middlewareModule,
+      request,
+      trailingSlash: __trailingSlash,
+      validateExternalRewriteRequest,
+    });
+  },`
+      : ""
+  }
+  publicFiles: new Set(${JSON.stringify(config?.publicFiles ?? [])}),
+  registerCacheAdapters: __registerConfiguredCacheAdapters,
+  renderNotFound: async () => null,
+  ${
+    hasPagesDir
+      ? `async renderPagesFallback({ allowRscDocumentFallback, appRouteMatch, dispatchPagesResponseStage, initialResponseHeaders, isDataRequest, isRscRequest, matchKind, middlewareContext, pathname, pagesDataRequest, request, url }) {
+    return __renderPagesFallback(
+      { allowRscDocumentFallback, appRouteMatch, initialResponseHeaders, isDataRequest, isRscRequest, matchKind, middlewareContext, pathname, pagesDataRequest, request, url },
+      {
+        async loadPagesEntry() {
+          if (!dispatchPagesResponseStage) {
+            throw new Error("App request stage requires a Pages response-stage dispatcher");
+          }
+          return {
+            ...__pagesRequestEntry,
+            handleApiRoute(stageRequest) { return dispatchPagesResponseStage(stageRequest, "api"); },
+            renderPage(stageRequest, pagesUrl) {
+              const dataKind = __pagesRequestEntry.matchPageRoute?.(pagesUrl, stageRequest)?.route.dataKind;
+              return dispatchPagesResponseStage(stageRequest, "page", dataKind, __pagesRequestEntry.hasRequestAwareDocument);
+            },
+          };
+        },
+        buildRequestHeaders: __buildRequestHeadersFromMiddlewareResponse,
+        decodePathParams: __decodePathParams,
+        applyRouteHandlerMiddlewareContext: __applyRouteHandlerMiddlewareContext,
+        getDraftModeCookieHeader,
+      }
+    );
+  },`
+      : ""
+  }
+  rootParamNamesByPattern: {},
+  setNavigationContext,
+  staticParamsMap: {},
+  trailingSlash: __trailingSlash,
+  validateDevRequestOrigin: __validateDevRequestOrigin,
+});
+
+export default async function handleAppRequestStage(
+  request,
+  ctx,
+  dispatchResponseStage,
+  probeMode = null,
+  prerenderDiscovery = false,
+  trustedPrerenderState = null,
+) {
+  return __dispatchAppRequestStage(request, ctx, dispatchResponseStage, {
+    basePath: __basePath,
+    buildId: process.env.__VINEXT_BUILD_ID ?? null,
+    draftModeSecret: __draftModeSecret,
+    handleRequest: __requestHandler,
+    prerenderDiscovery,
+    probeMode,
+    trustedPrerenderState,
+  });
+}
+`;
+}
+
 /**
  * Generate the virtual RSC entry module.
  *
@@ -226,6 +540,7 @@ export function generateRscEntry(
   trailingSlash?: boolean,
   config?: AppRouterConfig,
   instrumentationPath?: string | null,
+  responseStageOnly = false,
 ): string {
   const bp = basePath ?? "";
   const ts = trailingSlash ?? false;
@@ -343,7 +658,11 @@ ${
 import { ensureInstrumentationRegistered as __ensureInstrumentationRegistered } from ${JSON.stringify(instrumentationRuntimePath)};`
     : ""
 }
-import { createAppRscHandler } from "vinext/server/app-rsc-combined-handler";
+${
+  responseStageOnly
+    ? `import { renderAppWorkerResponseStage as __renderAppWorkerResponseStage } from ${JSON.stringify(appRscResponseStagePath)};`
+    : `import { createAppRscHandler } from ${JSON.stringify(appRscCombinedHandlerPath)};`
+}
 import { registerConfiguredCacheAdapters as __registerConfiguredCacheAdapters } from "virtual:vinext-cache-adapters";
 import __pagesClientAssets from "virtual:vinext-pages-client-assets";
 ${
@@ -463,6 +782,7 @@ import {
   getRenderedConcreteUrlPathsForRoute as __getRenderedConcreteUrlPathsForRoute,
   initPregeneratedPathsFromGlobals as __initPregeneratedPathsFromGlobals,
 } from ${JSON.stringify(pregeneratedConcretePathsPath)};
+import "virtual:vinext-pregenerated-concrete-paths";
 
 const __draftModeSecret = ${JSON.stringify(draftModeSecret)};
 
@@ -777,7 +1097,7 @@ ${rootParamNameEntries.join("\n")}
 
 __setPagesClientAssets(__pagesClientAssets);
 function __VINEXT_ACTION_OWNERS() { return ${actionOwners === undefined ? "__vinextActionOwners" : safeJsonStringify(actionOwners)}; }
-const __appRscHandler = createAppRscHandler({
+${responseStageOnly ? "const __responseStageOptions = {" : "const __appRscHandler = createAppRscHandler({"}
   basePath: __basePath,
   buildId: process.env.__VINEXT_BUILD_ID ?? null,
   ensureRouteLoaded: __ensureRouteLoaded,
@@ -1445,12 +1765,33 @@ const __appRscHandler = createAppRscHandler({
   },
   ${
     hasPagesDir
-      ? `async renderPagesFallback({ allowRscDocumentFallback, appRouteMatch, isDataRequest, isRscRequest, matchKind, middlewareContext, pathname, pagesDataRequest, request, url }) {
+      ? `async renderPagesFallback({ allowRscDocumentFallback, appRouteMatch, dispatchPagesResponseStage, initialResponseHeaders, isDataRequest, isRscRequest, matchKind, middlewareContext, pathname, pagesDataRequest, request, url }) {
     return __renderPagesFallback(
-      { allowRscDocumentFallback, appRouteMatch, isDataRequest, isRscRequest, matchKind, middlewareContext, pathname, pagesDataRequest, request, url },
+      { allowRscDocumentFallback, appRouteMatch, initialResponseHeaders, isDataRequest, isRscRequest, matchKind, middlewareContext, pathname, pagesDataRequest, request, url },
       {
-        loadPagesEntry() {
-          return import.meta.viteRsc.loadModule("ssr", "index");
+        async loadPagesEntry() {
+          const __pagesEntry = await import.meta.viteRsc.loadModule("ssr", "index");
+          if (!dispatchPagesResponseStage) {
+            return __pagesEntry;
+          }
+          return {
+            ...__pagesEntry,
+            ...(typeof __pagesEntry.handleApiRoute === "function"
+              ? {
+                  handleApiRoute(stageRequest) {
+                    return dispatchPagesResponseStage(stageRequest, "api");
+                  },
+                }
+              : {}),
+            ...(typeof __pagesEntry.renderPage === "function"
+              ? {
+                  renderPage(stageRequest, pagesUrl) {
+                    const dataKind = __pagesEntry.matchPageRoute?.(pagesUrl, stageRequest)?.route.dataKind;
+                    return dispatchPagesResponseStage(stageRequest, "page", dataKind, __pagesEntry.hasRequestAwareDocument);
+                  },
+                }
+              : {}),
+          };
         },
         buildRequestHeaders: __buildRequestHeadersFromMiddlewareResponse,
         decodePathParams: __decodePathParams,
@@ -1466,12 +1807,46 @@ const __appRscHandler = createAppRscHandler({
   staticParamsMap: generateStaticParamsMap,
   trailingSlash: __trailingSlash,
   validateDevRequestOrigin: __validateDevRequestOrigin,
-});
-
-export default __appRscHandler;
+${
+  responseStageOnly
+    ? `};
+export default {
+  handleResponseStage(request, ctx, props, options) {
+    return __renderAppWorkerResponseStage(__responseStageOptions, request, ctx, props, options);
+  },
+};`
+    : `});
+export default __appRscHandler;`
+}
 
 if (import.meta.hot) {
   import.meta.hot.accept();
 }
 `;
+}
+
+/** Generate the response-only App RSC graph used by the named cache stage. */
+export function generateAppResponseRscEntry(
+  appDir: string,
+  routes: AppRoute[],
+  _middlewarePath?: string | null,
+  metadataRoutes?: MetadataFileRoute[],
+  globalErrorPath?: string | null,
+  basePath?: string,
+  trailingSlash?: boolean,
+  config?: AppRouterConfig,
+  instrumentationPath?: string | null,
+): string {
+  return generateRscEntry(
+    appDir,
+    routes,
+    null,
+    metadataRoutes,
+    globalErrorPath,
+    basePath,
+    trailingSlash,
+    config,
+    instrumentationPath,
+    true,
+  );
 }

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -4618,6 +4618,11 @@ export const loadServerActionClient = ${
           fileName: CACHEABILITY_MANIFEST_MODULE,
           source: "export default null;\n",
         });
+        this.emitFile({
+          type: "asset",
+          fileName: PREGENERATED_CONCRETE_PATHS_MODULE,
+          source: "delete globalThis.__VINEXT_PREGENERATED_CONCRETE_PATHS;\n",
+        });
       },
     },
     {

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -47,11 +47,16 @@ import {
   resolveDevImageRedirect,
 } from "./server/image-optimization.js";
 import { CACHEABILITY_MANIFEST_MODULE } from "./server/cacheability-manifest.js";
+import { PREGENERATED_CONCRETE_PATHS_MODULE } from "./server/pregenerated-concrete-paths.js";
 
 import { installSocketErrorBackstop } from "./server/socket-error-backstop.js";
 import { shouldInvalidateAppRouteFile } from "./server/dev-route-files.js";
 import { createDirectRunner } from "./server/dev-module-runner.js";
-import { generateRscEntry } from "./entries/app-rsc-entry.js";
+import {
+  generateAppRequestRscEntry,
+  generateAppResponseRscEntry,
+  generateRscEntry,
+} from "./entries/app-rsc-entry.js";
 import { generateSsrEntry } from "./entries/app-ssr-entry.js";
 import {
   VIRTUAL_CDN_CACHE_ADAPTER,
@@ -1113,6 +1118,12 @@ const VIRTUAL_RSC_ENTRY = "virtual:vinext-rsc-entry";
 const RESOLVED_RSC_ENTRY = VIRTUAL_PREFIX + VIRTUAL_RSC_ENTRY;
 const VIRTUAL_CACHEABILITY_MANIFEST = "virtual:vinext-cacheability-manifest";
 const RESOLVED_CACHEABILITY_MANIFEST = VIRTUAL_PREFIX + VIRTUAL_CACHEABILITY_MANIFEST;
+const VIRTUAL_PREGENERATED_CONCRETE_PATHS = "virtual:vinext-pregenerated-concrete-paths";
+const RESOLVED_PREGENERATED_CONCRETE_PATHS = VIRTUAL_PREFIX + VIRTUAL_PREGENERATED_CONCRETE_PATHS;
+const VIRTUAL_APP_REQUEST_ENTRY = "virtual:vinext-app-request-entry";
+const RESOLVED_APP_REQUEST_ENTRY = VIRTUAL_PREFIX + VIRTUAL_APP_REQUEST_ENTRY;
+const VIRTUAL_APP_RESPONSE_ENTRY = "virtual:vinext-app-response-entry";
+const RESOLVED_APP_RESPONSE_ENTRY = VIRTUAL_PREFIX + VIRTUAL_APP_RESPONSE_ENTRY;
 const VIRTUAL_APP_SSR_ENTRY = "virtual:vinext-app-ssr-entry";
 const RESOLVED_APP_SSR_ENTRY = VIRTUAL_PREFIX + VIRTUAL_APP_SSR_ENTRY;
 const VIRTUAL_APP_BROWSER_ENTRY = "virtual:vinext-app-browser-entry";
@@ -4043,6 +4054,17 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             }
             return RESOLVED_CACHEABILITY_MANIFEST;
           }
+          if (cleanId === VIRTUAL_PREGENERATED_CONCRETE_PATHS) {
+            const isWorkerBuildEnvironment = hasAppDir
+              ? this.environment?.name === "rsc"
+              : this.environment !== undefined && isServerEnvironment(this.environment);
+            if (isWorkerBuildEnvironment && this.environment.config?.command === "build") {
+              return { id: `./${PREGENERATED_CONCRETE_PATHS_MODULE}`, external: true };
+            }
+            return RESOLVED_PREGENERATED_CONCRETE_PATHS;
+          }
+          if (cleanId === VIRTUAL_APP_REQUEST_ENTRY) return RESOLVED_APP_REQUEST_ENTRY;
+          if (cleanId === VIRTUAL_APP_RESPONSE_ENTRY) return RESOLVED_APP_RESPONSE_ENTRY;
           if (cleanId === VIRTUAL_APP_SSR_ENTRY) return RESOLVED_APP_SSR_ENTRY;
           if (cleanId === VIRTUAL_APP_BROWSER_ENTRY) return RESOLVED_APP_BROWSER_ENTRY;
           if (cleanId === VIRTUAL_APP_CAPABILITIES) return RESOLVED_APP_CAPABILITIES;
@@ -4072,6 +4094,12 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           }
           if (cleanId.endsWith("/" + VIRTUAL_RSC_ENTRY)) {
             return RESOLVED_RSC_ENTRY;
+          }
+          if (cleanId.endsWith("/" + VIRTUAL_APP_REQUEST_ENTRY)) {
+            return RESOLVED_APP_REQUEST_ENTRY;
+          }
+          if (cleanId.endsWith("/" + VIRTUAL_APP_RESPONSE_ENTRY)) {
+            return RESOLVED_APP_RESPONSE_ENTRY;
           }
           if (cleanId.endsWith("/" + VIRTUAL_APP_SSR_ENTRY)) {
             return RESOLVED_APP_SSR_ENTRY;
@@ -4167,7 +4195,15 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
           if (id === RESOLVED_CACHEABILITY_MANIFEST) {
             return "export default null;";
           }
-          if (id === RESOLVED_RSC_ENTRY && hasAppDir) {
+          if (id === RESOLVED_PREGENERATED_CONCRETE_PATHS) {
+            return "export {};";
+          }
+          if (
+            (id === RESOLVED_RSC_ENTRY ||
+              id === RESOLVED_APP_REQUEST_ENTRY ||
+              id === RESOLVED_APP_RESPONSE_ENTRY) &&
+            hasAppDir
+          ) {
             recordServerEntryLoad(this.environment?.name, id);
             const routes = await appRouter(appDir, nextConfig?.pageExtensions, fileMatcher);
             const metaRoutes = scanMetadataFiles(appDir);
@@ -4189,13 +4225,21 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             // `routes` value passed to generateRscEntry below so that layout
             // indices in the manifest correspond 1:1 to the route.layouts arrays
             // used during codegen. renderChunk clears this after patching.
-            rscClassificationManifest = collectRouteClassificationManifest(routes);
-            rscActionOwnerRoutes =
-              this.environment.config.command === "build" && hasServerActions ? routes : null;
-            rscActionOwnerSharedRoots = [globalErrorPath, globalNotFoundPath].filter(
-              (path): path is string => path !== null,
-            );
-            return generateRscEntry(
+            if (id !== RESOLVED_APP_REQUEST_ENTRY) {
+              rscClassificationManifest = collectRouteClassificationManifest(routes);
+              rscActionOwnerRoutes =
+                this.environment.config.command === "build" && hasServerActions ? routes : null;
+              rscActionOwnerSharedRoots = [globalErrorPath, globalNotFoundPath].filter(
+                (path): path is string => path !== null,
+              );
+            }
+            const generateEntry =
+              id === RESOLVED_APP_REQUEST_ENTRY
+                ? generateAppRequestRscEntry
+                : id === RESOLVED_APP_RESPONSE_ENTRY
+                  ? generateAppResponseRscEntry
+                  : generateRscEntry;
+            return generateEntry(
               appDir,
               routes,
               middlewarePath,

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -4618,11 +4618,13 @@ export const loadServerActionClient = ${
           fileName: CACHEABILITY_MANIFEST_MODULE,
           source: "export default null;\n",
         });
-        this.emitFile({
-          type: "asset",
-          fileName: PREGENERATED_CONCRETE_PATHS_MODULE,
-          source: "delete globalThis.__VINEXT_PREGENERATED_CONCRETE_PATHS;\n",
-        });
+        if (hasAppDir) {
+          this.emitFile({
+            type: "asset",
+            fileName: PREGENERATED_CONCRETE_PATHS_MODULE,
+            source: "delete globalThis.__VINEXT_PREGENERATED_CONCRETE_PATHS;\n",
+          });
+        }
       },
     },
     {

--- a/packages/vinext/src/server/app-middleware.ts
+++ b/packages/vinext/src/server/app-middleware.ts
@@ -1,7 +1,7 @@
 import type { NextI18nConfig } from "../config/next-config.js";
 import { isExternalUrl } from "../utils/external-url.js";
 import { applyMiddlewareRequestHeaders, setHeadersContext } from "vinext/shims/headers";
-import { setNavigationContext } from "vinext/shims/navigation";
+import { setNavigationContext } from "vinext/shims/navigation-context-accessors";
 import { FLIGHT_HEADERS, VINEXT_MW_CTX_HEADER } from "./headers.js";
 import { buildRequestHeadersFromMiddlewareResponse } from "../utils/middleware-request-headers.js";
 import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";

--- a/packages/vinext/src/server/app-mounted-slots-header.ts
+++ b/packages/vinext/src/server/app-mounted-slots-header.ts
@@ -30,7 +30,7 @@
  *   - isr-cache (RSC cache key generation)
  */
 
-import { AppElementsWire } from "./app-elements-wire.js";
+import { isAppElementsWireSlotId } from "./app-elements-wire-key.js";
 
 /** Hard cap on the raw header value byte length. Real values are <1 KB. */
 const MAX_RAW_HEADER_LENGTH = 4096;
@@ -47,7 +47,7 @@ const MAX_SLOT_TOKENS = 16;
  */
 function isValidSlotToken(token: string): boolean {
   if (token.length === 0 || token.length > MAX_TOKEN_LENGTH) return false;
-  return AppElementsWire.isSlotId(token);
+  return isAppElementsWireSlotId(token);
 }
 
 export function normalizeMountedSlotsHeader(raw: string | null | undefined): string | null {

--- a/packages/vinext/src/server/app-pages-bridge.ts
+++ b/packages/vinext/src/server/app-pages-bridge.ts
@@ -13,6 +13,7 @@ export type PagesEntry = {
     ctx: unknown,
     trustedRevalidateOrigin: string | undefined,
     edgeRuntime: EdgeApiExecutionRuntime,
+    initialResponseHeaders?: Headers,
   ) => Promise<Response> | Response;
   matchApiRoute?: (url: string, request: Request) => PagesRouteMatch | null;
   matchPageRoute?: (url: string, request: Request) => PagesRouteMatch | null;
@@ -23,6 +24,7 @@ export type PagesEntry = {
     parsedUrl: unknown,
     middlewareRequestHeaders?: Headers | null,
     options?: { isDataReq?: boolean },
+    initialResponseHeaders?: Headers,
   ) => Promise<Response> | Response;
 };
 
@@ -74,6 +76,7 @@ type RenderPagesFallbackOptions = {
   appRouteMatch?: AppRouteMatch | null;
   isDataRequest?: boolean;
   isRscRequest: boolean;
+  initialResponseHeaders?: Headers;
   matchKind?: "dynamic" | "static";
   middlewareContext: AppMiddlewareContext;
   pathname?: string;
@@ -118,6 +121,7 @@ export async function renderPagesFallback(
     appRouteMatch = null,
     isDataRequest = false,
     isRscRequest,
+    initialResponseHeaders,
     matchKind,
     middlewareContext,
     pathname = options.url.pathname,
@@ -168,13 +172,16 @@ export async function renderPagesFallback(
       }
     }
     const executionContext = getRequestExecutionContext();
-    const pagesApiResponse = await pagesEntry.handleApiRoute(
+    const apiArgs = [
       pagesRequest,
       pagesUrl,
       undefined,
       executionContext?.trustedRevalidateOrigin ?? new URL(pagesRequest.url).origin,
       executionContext?.hostRuntime ?? "node",
-    );
+    ] as const;
+    const pagesApiResponse = await (initialResponseHeaders
+      ? pagesEntry.handleApiRoute(...apiArgs, initialResponseHeaders)
+      : pagesEntry.handleApiRoute(...apiArgs));
     const draftCookie = getDraftModeCookieHeader();
     return applyDraftModeCookie(
       applyRouteHandlerMiddlewareContext(pagesApiResponse, middlewareContext),
@@ -205,22 +212,20 @@ export async function renderPagesFallback(
   const renderRequest = pagesDataRequest
     ? cloneRequestWithUrl(pagesRequest, pagesDataRequest.url)
     : pagesRequest;
+  const renderArgs = [
+    renderRequest,
+    pagesUrl,
+    {},
+    undefined,
+    middlewareContext.requestHeaders,
+  ] as const;
   const pagesRes = isDataRequest
-    ? await pagesEntry.renderPage(
-        renderRequest,
-        pagesUrl,
-        {},
-        undefined,
-        middlewareContext.requestHeaders,
-        { isDataReq: true },
-      )
-    : await pagesEntry.renderPage(
-        renderRequest,
-        pagesUrl,
-        {},
-        undefined,
-        middlewareContext.requestHeaders,
-      );
+    ? await (initialResponseHeaders
+        ? pagesEntry.renderPage(...renderArgs, { isDataReq: true }, initialResponseHeaders)
+        : pagesEntry.renderPage(...renderArgs, { isDataReq: true }))
+    : await (initialResponseHeaders
+        ? pagesEntry.renderPage(...renderArgs, undefined, initialResponseHeaders)
+        : pagesEntry.renderPage(...renderArgs));
   if (pagesRes.status === 404 && pageMatch === null) return null;
   return applyDraftModeCookie(
     applyPagesMiddlewareContext(pagesRes, middlewareContext),

--- a/packages/vinext/src/server/app-request-stage-context.ts
+++ b/packages/vinext/src/server/app-request-stage-context.ts
@@ -1,0 +1,10 @@
+import { setHeadersContext } from "vinext/shims/headers";
+import { setRootParams } from "vinext/shims/root-params";
+
+/** The request stage does not render user code, so it owns no navigation context. */
+export function setAppRequestStageNavigationContext(): void {}
+
+export function clearAppRequestStageContext(): void {
+  setHeadersContext(null);
+  setRootParams(null);
+}

--- a/packages/vinext/src/server/app-request-stage-dispatch.ts
+++ b/packages/vinext/src/server/app-request-stage-dispatch.ts
@@ -1,0 +1,110 @@
+import { isDraftModeRequest } from "vinext/shims/headers";
+import { isRouteTreePrefetchRequest } from "./app-route-tree-prefetch.js";
+import type { AppRscRequestHandler } from "./app-rsc-handler.js";
+import {
+  APP_WORKER_RESPONSE_STAGE_PROTOCOL_VERSION,
+  type DispatchAppWorkerResponseStage,
+} from "./app-worker-stages.js";
+import { getScriptNonceFromHeaderSources } from "./csp.js";
+import { VINEXT_PRERENDER_ROUTE_PARAMS_HEADER } from "./headers.js";
+import type { VinextCacheabilityProbeMode } from "./multi-stage.js";
+import type { TrustedPrerenderState } from "./prerender-route-params.js";
+import { restoreStaticFileSignalFromTransport } from "./static-file-signal.js";
+
+export type AppRequestStageDispatchOptions = {
+  basePath: string;
+  buildId: string | null;
+  draftModeSecret: string;
+  handleRequest: AppRscRequestHandler;
+  prerenderDiscovery: boolean;
+  probeMode: VinextCacheabilityProbeMode | null;
+  trustedPrerenderState?: TrustedPrerenderState | null;
+};
+
+/**
+ * Whether this request needs the complete App response graph before ordinary
+ * request-stage routing can safely classify it.
+ */
+export function appRequestUsesFullResponseGraph(
+  request: Request,
+  options: Pick<
+    AppRequestStageDispatchOptions,
+    "basePath" | "draftModeSecret" | "probeMode" | "trustedPrerenderState"
+  >,
+): boolean {
+  if (request.method !== "GET" && request.method !== "HEAD") return true;
+  if (
+    request.headers
+      .get("upgrade")
+      ?.split(",")
+      .some((value) => value.trim().toLowerCase() === "websocket")
+  ) {
+    return true;
+  }
+  if (process.env.VINEXT_PRERENDER === "1") return true;
+  if (options.trustedPrerenderState) return true;
+  if (isDraftModeRequest(request, options.draftModeSecret)) return true;
+  if (request.headers.has(VINEXT_PRERENDER_ROUTE_PARAMS_HEADER)) return true;
+
+  const cacheControl = request.headers.get("cache-control")?.toLowerCase() ?? "";
+  if (
+    !options.probeMode &&
+    /(?:^|,)\s*(?:no-cache|no-store)(?:\s*(?:,|$)|\s*=)/.test(cacheControl)
+  ) {
+    return true;
+  }
+  if (
+    getScriptNonceFromHeaderSources(request.headers) !== undefined ||
+    isRouteTreePrefetchRequest(request)
+  ) {
+    return true;
+  }
+
+  const url = new URL(request.url);
+  const pathname =
+    options.basePath && url.pathname.startsWith(options.basePath + "/")
+      ? url.pathname.slice(options.basePath.length)
+      : url.pathname;
+  return pathname.startsWith("/__vinext/");
+}
+
+/**
+ * Select the request-only or complete App graph and perform the transport
+ * bookkeeping needed by a full-stage dispatch.
+ */
+export async function dispatchAppRequestStage(
+  request: Request,
+  ctx: unknown,
+  dispatchResponseStage: DispatchAppWorkerResponseStage | null | undefined,
+  options: AppRequestStageDispatchOptions,
+): Promise<Response> {
+  if (!dispatchResponseStage) {
+    throw new Error("App request stage requires a response-stage dispatcher");
+  }
+  if (appRequestUsesFullResponseGraph(request, options)) {
+    const staticFileSignalToken = crypto.randomUUID();
+    const response = await dispatchResponseStage(
+      request,
+      {
+        kind: "app-full-request",
+        buildId: options.buildId,
+        cacheability: {
+          policyHeaders: null,
+          probeMode: options.probeMode,
+          resolvedRoutePathname: new URL(request.url).pathname,
+        },
+        draftModeCookie: null,
+        middlewareCookieOverlay: null,
+        prerenderDiscovery: options.prerenderDiscovery,
+        protocolVersion: APP_WORKER_RESPONSE_STAGE_PROTOCOL_VERSION,
+        requestOrigin: new URL(request.url).origin,
+        scriptNonce: null,
+        staticFileSignalToken,
+        trustedPrerenderState: options.trustedPrerenderState ?? null,
+      },
+      { cache: "bypass" },
+    );
+    return restoreStaticFileSignalFromTransport(response, staticFileSignalToken);
+  }
+  return options.handleRequest(request, ctx, false, dispatchResponseStage, options.probeMode);
+}

--- a/packages/vinext/src/server/app-request-stage-independent-entry.ts
+++ b/packages/vinext/src/server/app-request-stage-independent-entry.ts
@@ -10,7 +10,11 @@ import requestRscHandler, {
 } from "virtual:vinext-app-request-entry";
 import { runWithExecutionContext, type ExecutionContextLike } from "vinext/shims/request-context";
 // @ts-expect-error -- virtual module resolved by vinext
-import { registerConfiguredCacheAdapters } from "virtual:vinext-cdn-cache-adapter";
+import {
+  hasConfiguredDataCache,
+  registerConfiguredCacheAdapters,
+} from "virtual:vinext-cdn-cache-adapter";
+import { registerLazyDataCacheHandler } from "vinext/shims/cache-handler";
 import { applyCdnResponseIdentityHeaders, validateCdnRequest } from "./cache-control.js";
 // @ts-expect-error -- virtual module resolved by vinext
 import { registerConfiguredImageOptimizer } from "virtual:vinext-image-adapters";
@@ -89,6 +93,13 @@ async function handleRequest(
       );
 
   registerConfiguredCacheAdapters(env);
+  if (hasConfiguredDataCache) {
+    registerLazyDataCacheHandler(async () => {
+      // @ts-expect-error -- virtual module resolved by vinext
+      const adapters = await import("virtual:vinext-cache-adapters");
+      adapters.registerConfiguredCacheAdapters(env);
+    });
+  }
   registerConfiguredImageOptimizer(env);
 
   ctx = createWorkerPrerenderDiscoveryContext(ctx, request, __prerenderSecret);

--- a/packages/vinext/src/server/app-request-stage-independent-entry.ts
+++ b/packages/vinext/src/server/app-request-stage-independent-entry.ts
@@ -10,10 +10,7 @@ import requestRscHandler, {
 } from "virtual:vinext-app-request-entry";
 import { runWithExecutionContext, type ExecutionContextLike } from "vinext/shims/request-context";
 // @ts-expect-error -- virtual module resolved by vinext
-import {
-  hasConfiguredDataCache,
-  registerConfiguredCacheAdapters,
-} from "virtual:vinext-cdn-cache-adapter";
+import * as configuredCdnCacheAdapters from "virtual:vinext-cdn-cache-adapter";
 import { registerLazyDataCacheHandler } from "vinext/shims/cache-handler";
 import { applyCdnResponseIdentityHeaders, validateCdnRequest } from "./cache-control.js";
 // @ts-expect-error -- virtual module resolved by vinext
@@ -92,8 +89,8 @@ async function handleRequest(
         "node",
       );
 
-  registerConfiguredCacheAdapters(env);
-  if (hasConfiguredDataCache) {
+  configuredCdnCacheAdapters.registerConfiguredCacheAdapters(env);
+  if (configuredCdnCacheAdapters.hasConfiguredDataCache) {
     registerLazyDataCacheHandler(async () => {
       // @ts-expect-error -- virtual module resolved by vinext
       const adapters = await import("virtual:vinext-cache-adapters");

--- a/packages/vinext/src/server/app-request-stage-independent-entry.ts
+++ b/packages/vinext/src/server/app-request-stage-independent-entry.ts
@@ -1,0 +1,200 @@
+/** Request-only App Worker stage with no local renderer fallback dependency. */
+
+import "./server-globals.js";
+import requestRscHandler, {
+  __assetPrefix,
+  __basePath,
+  __imageAllowedWidths,
+  __imageConfig,
+  __prerenderSecret,
+} from "virtual:vinext-app-request-entry";
+import { runWithExecutionContext, type ExecutionContextLike } from "vinext/shims/request-context";
+// @ts-expect-error -- virtual module resolved by vinext
+import { registerConfiguredCacheAdapters } from "virtual:vinext-cdn-cache-adapter";
+import { applyCdnResponseIdentityHeaders, validateCdnRequest } from "./cache-control.js";
+// @ts-expect-error -- virtual module resolved by vinext
+import { registerConfiguredImageOptimizer } from "virtual:vinext-image-adapters";
+import type { DispatchAppWorkerResponseStage } from "./app-worker-stages.js";
+import {
+  getImageOptimizer,
+  handleConfiguredImageOptimization,
+  isImageOptimizationPath,
+} from "./image-optimization.js";
+import {
+  createStaticAssetRequest,
+  finalizeMissingStaticAssetResponse,
+  resolveStaticAssetSignal,
+} from "./worker-utils.js";
+import {
+  cloneRequestWithHeaders,
+  filterInternalHeaders,
+  isOpenRedirectShaped,
+} from "./request-pipeline.js";
+import {
+  VINEXT_CACHEABILITY_PROBE_HEADER,
+  VINEXT_CACHEABILITY_PROBE_QUERY_PARAM,
+  VINEXT_EXPECTED_WORKER_VERSION_HEADER,
+  VINEXT_PRERENDER_SECRET_HEADER,
+  VINEXT_REVALIDATE_HOST_HEADER,
+} from "./headers.js";
+import { readTrustedPrerenderStateFromHeaders } from "./prerender-route-params.js";
+import { badRequestResponse, notFoundResponse } from "./http-error-responses.js";
+import { assetPrefixPathname, isNextStaticPath } from "../utils/asset-prefix.js";
+import { createWorkerRevalidationContext } from "./worker-revalidation-context.js";
+import {
+  createWorkerPrerenderDiscoveryContext,
+  createWorkerPrerenderReadinessResponse,
+} from "./worker-prerender-discovery.js";
+import type {
+  VinextAssetFetcher,
+  VinextCacheabilityProbeMode,
+  VinextRequestStageContext,
+} from "./multi-stage.js";
+import type { WorkerCacheabilityProbeRoute } from "./cacheability-request.js";
+
+export type AppRequestStageEnv = Record<string, unknown>;
+type AppRequestStageContext = ExecutionContextLike & VinextRequestStageContext;
+
+const workerBasePath = typeof __basePath === "string" ? __basePath : "";
+const workerAssetPathPrefix = assetPrefixPathname(
+  typeof __assetPrefix === "string" ? __assetPrefix : "",
+);
+
+export function handleRequestStage(
+  request: Request,
+  env: AppRequestStageEnv | undefined,
+  ctx: AppRequestStageContext | undefined,
+  dispatchResponseStage: DispatchAppWorkerResponseStage,
+): Promise<Response> {
+  const originalRequest = request;
+  return handleRequest(request, env, ctx, dispatchResponseStage, ctx?.assets).then((response) =>
+    applyCdnResponseIdentityHeaders(response, originalRequest),
+  );
+}
+
+async function handleRequest(
+  request: Request,
+  env: AppRequestStageEnv | undefined,
+  platformCtx: ExecutionContextLike | undefined,
+  dispatchResponseStage: DispatchAppWorkerResponseStage,
+  assets: VinextAssetFetcher | undefined,
+): Promise<Response> {
+  let ctx = platformCtx?.trustedRevalidateOrigin
+    ? platformCtx
+    : createWorkerRevalidationContext(
+        platformCtx,
+        (internalRequest, internalCtx) =>
+          handleRequest(internalRequest, env, internalCtx, dispatchResponseStage, assets),
+        "node",
+      );
+
+  registerConfiguredCacheAdapters(env);
+  registerConfiguredImageOptimizer(env);
+
+  ctx = createWorkerPrerenderDiscoveryContext(ctx, request, __prerenderSecret);
+  const readinessResponse = createWorkerPrerenderReadinessResponse(ctx, request);
+  let didValidateCdnRequest = false;
+  if (readinessResponse) {
+    const validationResponse = await validateCdnRequest(request);
+    if (validationResponse) return validationResponse;
+    didValidateCdnRequest = true;
+    // An authenticated readiness request must continue through the response
+    // dispatcher so independently hosted stages are proven ready as a unit.
+    // Failed capability checks stay inside the framework-owned namespace.
+    if (readinessResponse.status !== 204) return readinessResponse;
+  }
+
+  let probeMode: VinextCacheabilityProbeMode | null = null;
+  let probeRoute: WorkerCacheabilityProbeRoute | null = null;
+  if (request.headers.has(VINEXT_CACHEABILITY_PROBE_HEADER)) {
+    const { readWorkerCacheabilityProbeMode, readWorkerCacheabilityProbeRoute } =
+      await import("./cacheability-request.js");
+    probeMode = readWorkerCacheabilityProbeMode(request, __prerenderSecret);
+    if (probeMode) {
+      probeRoute = readWorkerCacheabilityProbeRoute(request);
+      const probeUrl = new URL(request.url);
+      probeUrl.searchParams.delete(VINEXT_CACHEABILITY_PROBE_QUERY_PARAM);
+      request = new Request(probeUrl, request);
+    }
+  }
+
+  if (!didValidateCdnRequest) {
+    const cdnValidationResponse = await validateCdnRequest(request);
+    if (cdnValidationResponse) return cdnValidationResponse;
+  }
+
+  const url = new URL(request.url);
+  if (isImageOptimizationPath(url.pathname) && assets && getImageOptimizer()) {
+    return handleConfiguredImageOptimization(
+      request,
+      (assetPath) => Promise.resolve(assets.fetch(new Request(new URL(assetPath, request.url)))),
+      __imageAllowedWidths,
+      __imageConfig,
+    );
+  }
+  if (isOpenRedirectShaped(url.pathname)) return notFoundResponse();
+  try {
+    decodeURIComponent(url.pathname);
+  } catch {
+    return badRequestResponse();
+  }
+
+  const missingBuildAsset = isNextStaticPath(url.pathname, workerBasePath, workerAssetPathPrefix);
+  const trustedPrerenderState = readTrustedPrerenderStateFromHeaders(
+    request.headers,
+    __prerenderSecret,
+  );
+  const filteredHeaders = ctx.isInternalPagesRevalidation
+    ? new Headers(request.headers)
+    : filterInternalHeaders(request.headers);
+  filteredHeaders.delete(VINEXT_PRERENDER_SECRET_HEADER);
+  filteredHeaders.delete(VINEXT_REVALIDATE_HOST_HEADER);
+  if (readinessResponse?.status === 204) {
+    const expectedWorkerVersion = request.headers.get(VINEXT_EXPECTED_WORKER_VERSION_HEADER);
+    if (expectedWorkerVersion) {
+      // The request stage already authenticated the build capability. Preserve
+      // only the version assertion needed by the independently hosted response
+      // stage; the prerender secret remains confined to this gateway.
+      filteredHeaders.set(VINEXT_EXPECTED_WORKER_VERSION_HEADER, expectedWorkerVersion);
+    }
+  }
+  request = cloneRequestWithHeaders(request, filteredHeaders);
+
+  let responseStageDispatched = false;
+  const trackedDispatchResponseStage: DispatchAppWorkerResponseStage = (
+    stageRequest,
+    props,
+    options,
+  ) => {
+    responseStageDispatched = true;
+    return dispatchResponseStage(stageRequest, props, options);
+  };
+
+  const handle = () =>
+    requestRscHandler(
+      request,
+      ctx,
+      trackedDispatchResponseStage,
+      probeMode,
+      ctx.isPrerenderPathDiscovery === true,
+      trustedPrerenderState,
+    );
+  const result = await runWithExecutionContext(ctx, handle);
+  let response = result;
+  if (assets) {
+    const assetResponse = await resolveStaticAssetSignal(response, {
+      fetchAsset: (path) => Promise.resolve(assets.fetch(createStaticAssetRequest(path, request))),
+    });
+    if (assetResponse) response = assetResponse;
+  }
+  response = finalizeMissingStaticAssetResponse(response, missingBuildAsset);
+  if (probeMode && probeRoute && !responseStageDispatched) {
+    const { finalizeRequestStageCacheabilityProbe } = await import("./cacheability-request.js");
+    response = finalizeRequestStageCacheabilityProbe(response, {
+      mode: probeMode,
+      responseStageDispatched,
+      route: probeRoute,
+    });
+  }
+  return response;
+}

--- a/packages/vinext/src/server/app-response-header-provenance.ts
+++ b/packages/vinext/src/server/app-response-header-provenance.ts
@@ -1,5 +1,9 @@
+import { preserveFullyBufferedBodyMetadata } from "vinext/shims/unified-request-context";
+
 const frameworkLinkHeaders = new WeakSet<Headers>();
 const edgeRouteHandlerLinkHeaders = new WeakSet<Headers>();
+
+const APP_RESPONSE_STAGE_LINK_PROVENANCE_HEADER = "x-vinext-app-stage-post-config-link";
 
 /** Mark response headers whose Link value was emitted by the App page renderer. */
 export function markFrameworkLinkHeaders(
@@ -35,4 +39,45 @@ export function hasPostConfigLinkHeaders(headers: Headers): boolean {
 export function copyLinkHeaderProvenance(source: Headers, target: Headers): void {
   if (frameworkLinkHeaders.has(source)) frameworkLinkHeaders.add(target);
   if (edgeRouteHandlerLinkHeaders.has(source)) edgeRouteHandlerLinkHeaders.add(target);
+}
+
+/** Serialize otherwise process-local Link provenance across a response-stage transport. */
+export function serializeResponseStageLinkProvenance(response: Response): Response {
+  if (!hasPostConfigLinkHeaders(response.headers)) return response;
+  const headers = new Headers(response.headers);
+  headers.set(APP_RESPONSE_STAGE_LINK_PROVENANCE_HEADER, "1");
+  return preserveFullyBufferedBodyMetadata(
+    response,
+    new Response(response.body, {
+      headers,
+      status: response.status,
+      statusText: response.statusText,
+    }),
+  );
+}
+
+/** Consume transported Link provenance before applying outer config and middleware. */
+export function consumeResponseStageLinkProvenance(response: Response): {
+  appendToPostConfigLink: boolean;
+  response: Response;
+} {
+  if (response.headers.get(APP_RESPONSE_STAGE_LINK_PROVENANCE_HEADER) !== "1") {
+    return { appendToPostConfigLink: false, response };
+  }
+
+  const headers = new Headers(response.headers);
+  headers.delete(APP_RESPONSE_STAGE_LINK_PROVENANCE_HEADER);
+  const transported = preserveFullyBufferedBodyMetadata(
+    response,
+    new Response(response.body, {
+      headers,
+      status: response.status,
+      statusText: response.statusText,
+    }),
+  );
+  markFrameworkLinkHeaders(transported.headers, transported.headers.get("link"));
+  return {
+    appendToPostConfigLink: true,
+    response: transported,
+  };
 }

--- a/packages/vinext/src/server/app-response-stage-entry.ts
+++ b/packages/vinext/src/server/app-response-stage-entry.ts
@@ -1,0 +1,96 @@
+/** Cacheable App response stage. This is the only multi-stage App entry that imports user routes. */
+
+import rscHandler, { __cacheabilityManifest } from "virtual:vinext-app-response-entry";
+import { runWithExecutionContext, type ExecutionContextLike } from "vinext/shims/request-context";
+// @ts-expect-error -- virtual module resolved by vinext
+import { registerConfiguredCacheAdapters } from "virtual:vinext-cache-adapters";
+// @ts-expect-error -- virtual module resolved by vinext
+import { registerConfiguredImageOptimizer } from "virtual:vinext-image-adapters";
+import {
+  isAppWorkerResponseStageProps,
+  type AppWorkerResponseStageProps,
+} from "./app-worker-stages.js";
+import { serializeStaticFileSignalForTransport } from "./static-file-signal.js";
+import { createWorkerRevalidationContext } from "./worker-revalidation-context.js";
+import { validateCdnRequest } from "./cache-control.js";
+import { createWorkerPrerenderReadinessResponse } from "./worker-prerender-discovery.js";
+import type {
+  VinextRequestStageTransport,
+  VinextResponseStageDispatchOptions,
+} from "./multi-stage.js";
+import { withResponseStageCacheability } from "./response-stage-cacheability.js";
+
+type AppResponseStageEnv = Record<string, unknown>;
+
+export async function handleResponseStage(
+  request: Request,
+  env: AppResponseStageEnv | undefined,
+  platformCtx: ExecutionContextLike | undefined,
+  props: AppWorkerResponseStageProps,
+  dispatchRequestStage: VinextRequestStageTransport,
+  options: VinextResponseStageDispatchOptions = { cache: "bypass" },
+): Promise<Response> {
+  if (!isAppWorkerResponseStageProps(props)) {
+    return new Response("Invalid vinext App response stage", { status: 400 });
+  }
+  if (props.requestOrigin !== new URL(request.url).origin) {
+    return new Response("Invalid vinext App response stage", { status: 400 });
+  }
+  registerConfiguredImageOptimizer(env);
+  let ctx = createWorkerRevalidationContext(
+    platformCtx,
+    (internalRequest) => dispatchRequestStage(internalRequest),
+    "node",
+  );
+  if (props.kind === "app-full-request" && props.prerenderDiscovery) {
+    ctx = { ...ctx, isPrerenderPathDiscovery: true };
+  }
+  return withResponseStageCacheability(
+    {
+      buildId: process.env.__VINEXT_BUILD_ID,
+      cache: options.cache,
+      context: ctx,
+      policyHeaders: props.cacheability.policyHeaders,
+      probeMode: props.cacheability.probeMode,
+      rawManifest: __cacheabilityManifest,
+      registerCacheAdapters: () => registerConfiguredCacheAdapters(env),
+      request,
+      representation: props.cacheability.representation,
+      resolvedRoutePathname: props.cacheability.resolvedRoutePathname,
+    },
+    async (cacheabilityContext) => {
+      if (props.kind === "app-full-request") {
+        const currentBuildId = process.env.__VINEXT_BUILD_ID ?? null;
+        if (props.buildId !== currentBuildId) {
+          return new Response("Incompatible vinext App response stage", { status: 409 });
+        }
+        if (props.prerenderDiscovery) {
+          const readinessResponse = createWorkerPrerenderReadinessResponse(
+            cacheabilityContext,
+            request,
+          );
+          if (readinessResponse) {
+            return (await validateCdnRequest(request)) ?? readinessResponse;
+          }
+        }
+        const fullEntry = await import("virtual:vinext-rsc-entry");
+        const render = () =>
+          fullEntry.default(
+            request,
+            cacheabilityContext,
+            false,
+            undefined,
+            null,
+            props.trustedPrerenderState,
+          );
+        return serializeStaticFileSignalForTransport(
+          await runWithExecutionContext(cacheabilityContext, render),
+          props.staticFileSignalToken,
+        );
+      }
+      const render = () =>
+        rscHandler.handleResponseStage(request, cacheabilityContext, props, options);
+      return runWithExecutionContext(cacheabilityContext, render);
+    },
+  );
+}

--- a/packages/vinext/src/server/app-response-stage-entry.ts
+++ b/packages/vinext/src/server/app-response-stage-entry.ts
@@ -19,6 +19,7 @@ import type {
   VinextResponseStageDispatchOptions,
 } from "./multi-stage.js";
 import { withResponseStageCacheability } from "./response-stage-cacheability.js";
+import { serializeResponseStageLinkProvenance } from "./app-response-header-provenance.js";
 
 type AppResponseStageEnv = Record<string, unknown>;
 
@@ -90,7 +91,9 @@ export async function handleResponseStage(
       }
       const render = () =>
         rscHandler.handleResponseStage(request, cacheabilityContext, props, options);
-      return runWithExecutionContext(cacheabilityContext, render);
+      return serializeResponseStageLinkProvenance(
+        await runWithExecutionContext(cacheabilityContext, render),
+      );
     },
   );
 }

--- a/packages/vinext/src/server/app-route-handler-middleware-context.ts
+++ b/packages/vinext/src/server/app-route-handler-middleware-context.ts
@@ -1,0 +1,25 @@
+import { mergeMiddlewareResponseHeaders } from "./middleware-response-headers.js";
+
+export type RouteHandlerMiddlewareContext = {
+  headers: Headers | null;
+  status: number | null;
+};
+
+/** Apply request-stage middleware response metadata to a route-handler response. */
+export function applyRouteHandlerMiddlewareContext(
+  response: Response,
+  middlewareContext: RouteHandlerMiddlewareContext,
+): Response {
+  if (!middlewareContext.headers && middlewareContext.status == null) {
+    return response;
+  }
+
+  const responseHeaders = new Headers(response.headers);
+  mergeMiddlewareResponseHeaders(responseHeaders, middlewareContext.headers);
+
+  return new Response(response.body, {
+    status: middlewareContext.status ?? response.status,
+    statusText: response.statusText,
+    headers: responseHeaders,
+  });
+}

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -145,8 +145,12 @@ import {
 import type { VinextCacheabilityProbeMode } from "./multi-stage.js";
 import {
   consumePagesResponseStagePolicyOwner,
-  withResponseStageVary,
+  withoutResponseStageVary,
 } from "./response-stage-policy.js";
+import {
+  consumeResponseStageLinkProvenance,
+  copyLinkHeaderProvenance,
+} from "./app-response-header-provenance.js";
 
 type AppPageParams = Record<string, string | string[]>;
 type RequestContext = ReturnType<typeof requestContextFromRequest>;
@@ -275,13 +279,19 @@ type AppRscRouteMatch<TRoute> = {
 function applyMiddlewareContextToResponse(
   response: Response,
   middlewareContext: AppRscMiddlewareContext,
+  appendToPostConfigLink = false,
 ): Response {
   if (!middlewareContext.headers && middlewareContext.status == null) {
     return response;
   }
 
   const headers = new Headers(response.headers);
+  const responseLink = appendToPostConfigLink ? headers.get("link") : null;
   mergeMiddlewareResponseHeaders(headers, middlewareContext.headers);
+  const middlewareLink = middlewareContext.headers?.get("link");
+  if (responseLink && middlewareLink) {
+    headers.set("link", `${middlewareLink}, ${responseLink}`);
+  }
 
   return preserveFullyBufferedBodyMetadata(
     response,
@@ -1052,17 +1062,16 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
   const loadResponseStagePolicy = () =>
     (responseStagePolicyPromise ??= options.configHeaders.length
       ? import("./config-headers.js").then(({ resolveResponseStageCachePolicy }) =>
-          withResponseStageVary(
+          withoutResponseStageVary(
             resolveResponseStageCachePolicy({
               basePathState,
               configHeaders: options.configHeaders,
               pathname: matchPathname(requestCleanPathname),
               requestContext: preMiddlewareRequestContext,
             }),
-            middlewareContext.headers?.get("Vary"),
           ),
         )
-      : Promise.resolve(withResponseStageVary(null, middlewareContext.headers?.get("Vary"))));
+      : Promise.resolve(null));
   let canUseSharedWorkerResponseStage =
     draftModeCookie === null &&
     !hasMiddlewareCookieOverlay &&
@@ -1186,10 +1195,12 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     // Compose config headers on a mutable copy while retaining stream/cache
     // metadata carried by the response-stage result.
     const headers = new Headers(response.headers);
+    copyLinkHeaderProvenance(response.headers, headers);
     await applyAppRscConfigHeaders(headers, request, {
       basePath: options.basePath,
       configHeaders: options.configHeaders,
       i18nConfig: options.i18nConfig,
+      middlewareHeaders: middlewareContext.headers,
       overwriteExisting: preserveExistingPolicy
         ? new Set<string>()
         : getCdnResponsePolicyHeaderNames(),
@@ -1234,11 +1245,17 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
     // failure cannot be made public again and the uncached gateway does not
     // expose a shared-cache directive. Single-stage rendering still applies
     // config and middleware policy with ordinary Next.js precedence.
+    const transportedLink = consumeResponseStageLinkProvenance(response);
+    response = transportedLink.response;
     response = await applyConfigHeadersToResponseStage(
       response,
       Boolean(dispatchResponseStage || options.renderResponseStageLocally),
     );
-    response = applyMiddlewareContextToResponse(response, middlewareContext);
+    response = applyMiddlewareContextToResponse(
+      response,
+      middlewareContext,
+      transportedLink.appendToPostConfigLink,
+    );
     reconcileCdnResponseHeadersAfterOuterPolicy(response.headers, await loadOuterResponsePolicy());
     return markAppRscResponseConfigHeadersApplied(response);
   };

--- a/packages/vinext/src/server/client-reuse-manifest.ts
+++ b/packages/vinext/src/server/client-reuse-manifest.ts
@@ -2,7 +2,7 @@ import {
   parseArtifactCompatibilityEnvelope,
   type ArtifactCompatibilityEnvelope,
 } from "./artifact-compatibility.js";
-import { AppElementsWire } from "./app-elements-wire.js";
+import { parseAppElementsWireElementKey } from "./app-elements-wire-key.js";
 import { fnv1a64 } from "../utils/hash.js";
 import { isNonNegativeSafeInteger } from "../utils/number.js";
 import { isUnknownRecord } from "../utils/record.js";
@@ -279,7 +279,7 @@ function currentCommitVersionMatchesReplayWindow(
 }
 
 function parseEntryKind(id: string): ClientReuseManifestEntryKind | null {
-  const parsed = AppElementsWire.parseElementKey(id);
+  const parsed = parseAppElementsWireElementKey(id);
   if (parsed === null) return null;
   return parsed.kind;
 }

--- a/packages/vinext/src/server/pregenerated-concrete-paths.ts
+++ b/packages/vinext/src/server/pregenerated-concrete-paths.ts
@@ -5,6 +5,9 @@ declare global {
   var __VINEXT_PREGENERATED_CONCRETE_PATHS: unknown;
 }
 
+/** Stable post-build module populated after prerendering completes. */
+export const PREGENERATED_CONCRETE_PATHS_MODULE = "__vinext_pregenerated_concrete_paths.js";
+
 export function normalizePregeneratedPathname(pathname: string): string {
   return normalizePath(normalizePathnameForRouteMatch(pathname));
 }

--- a/packages/vinext/src/shims/navigation-context-accessors.ts
+++ b/packages/vinext/src/shims/navigation-context-accessors.ts
@@ -1,0 +1,35 @@
+export type NavigationContext = {
+  pathname: string;
+  searchParams: URLSearchParams;
+  params: Record<string, string | string[]>;
+};
+
+type NavigationStateAccessors = {
+  setServerContext: (context: NavigationContext | null) => void;
+};
+
+const GLOBAL_ACCESSORS_KEY = Symbol.for("vinext.navigation.globalAccessors");
+const NAVIGATION_FALLBACK_STATE_KEY = Symbol.for("vinext.navigation.fallback");
+
+type NavigationStateGlobal = typeof globalThis & {
+  [GLOBAL_ACCESSORS_KEY]?: NavigationStateAccessors;
+  [NAVIGATION_FALLBACK_STATE_KEY]?: {
+    serverContext: NavigationContext | null;
+    serverInsertedHTMLCallbacks: Array<() => unknown>;
+  };
+};
+
+/** Lightweight server context setter for request-only runtimes such as middleware. */
+export function setNavigationContext(context: NavigationContext | null): void {
+  const globalState = globalThis as NavigationStateGlobal;
+  const accessors = globalState[GLOBAL_ACCESSORS_KEY];
+  if (accessors) {
+    accessors.setServerContext(context);
+    return;
+  }
+  const fallback = (globalState[NAVIGATION_FALLBACK_STATE_KEY] ??= {
+    serverContext: null,
+    serverInsertedHTMLCallbacks: [],
+  });
+  fallback.serverContext = context;
+}

--- a/packages/vinext/src/virtual-vinext-rsc-entry.d.ts
+++ b/packages/vinext/src/virtual-vinext-rsc-entry.d.ts
@@ -9,10 +9,7 @@
  * See `entries/app-rsc-entry.ts` for the generator that emits these.
  */
 declare module "virtual:vinext-rsc-entry" {
-  const rscHandler: (
-    request: Request,
-    ctx?: unknown,
-  ) => Promise<Response | null | undefined | string>;
+  const rscHandler: import("./server/app-rsc-combined-handler.js").AppRscHandler;
   export default rscHandler;
   export const __assetPrefix: string;
   export const __basePath: string;
@@ -27,4 +24,47 @@ declare module "virtual:vinext-rsc-entry" {
     contentDispositionType?: "inline" | "attachment";
     contentSecurityPolicy?: string;
   };
+}
+
+declare module "virtual:vinext-app-request-entry" {
+  type DispatchAppWorkerResponseStage =
+    import("./server/app-worker-stages.js").DispatchAppWorkerResponseStage;
+  const requestHandler: (
+    request: Request,
+    ctx: unknown,
+    dispatchResponseStage: DispatchAppWorkerResponseStage,
+    probeMode?: import("./server/multi-stage.js").VinextCacheabilityProbeMode | null,
+    prerenderDiscovery?: boolean,
+    trustedPrerenderState?:
+      | import("./server/prerender-route-params.js").TrustedPrerenderState
+      | null,
+  ) => Promise<Response>;
+  export default requestHandler;
+  export const __assetPrefix: string;
+  export const __basePath: string;
+  export const __imageAllowedWidths: number[];
+  export const __prerenderSecret: string;
+  export const __imageConfig: {
+    qualities?: number[];
+    dangerouslyAllowSVG?: boolean;
+    dangerouslyAllowLocalIP?: boolean;
+    contentDispositionType?: "inline" | "attachment";
+    contentSecurityPolicy?: string;
+  };
+}
+
+declare module "virtual:vinext-app-response-entry" {
+  import type { AppWorkerResponseStageProps } from "vinext/server/app-worker-stages";
+  import type { VinextResponseStageDispatchOptions } from "vinext/server/multi-stage";
+
+  const handler: {
+    handleResponseStage(
+      request: Request,
+      ctx: unknown,
+      props: AppWorkerResponseStageProps,
+      options?: VinextResponseStageDispatchOptions,
+    ): Promise<Response>;
+  };
+  export const __cacheabilityManifest: string | null;
+  export default handler;
 }

--- a/tests/app-pages-bridge.test.ts
+++ b/tests/app-pages-bridge.test.ts
@@ -107,6 +107,54 @@ describe("renderPagesFallback", () => {
     return { encodedBody, observedRuntimes, response };
   }
 
+  it("passes staged response headers to Pages API and GSSP user code", async () => {
+    // Ported from Next.js:
+    // test/e2e/middleware-custom-matchers/app/pages/index.js
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-custom-matchers/app/pages/index.js
+    const initialResponseHeaders = new Headers({
+      "x-config-variant": "preview",
+      "x-from-middleware": "present",
+    });
+    const apiRequest = new Request("http://localhost/api/headers");
+    const handleApiRoute = vi.fn<NonNullable<PagesEntry["handleApiRoute"]>>(
+      (_request, _url, _ctx, _origin, _runtime, headers) => {
+        expect(headers).toEqual(initialResponseHeaders);
+        return new Response("api");
+      },
+    );
+    await renderPagesFallback(
+      {
+        initialResponseHeaders,
+        isRscRequest: false,
+        middlewareContext: { headers: null, requestHeaders: null, status: null },
+        request: apiRequest,
+        url: new URL(apiRequest.url),
+      },
+      { ...defaultDeps, loadPagesEntry: () => ({ handleApiRoute }) },
+    );
+
+    const pageRequest = new Request("http://localhost/page");
+    const renderPage = vi.fn<NonNullable<PagesEntry["renderPage"]>>(
+      (_request, _url, _query, _parsedUrl, _middlewareHeaders, _options, headers) => {
+        expect(headers).toEqual(initialResponseHeaders);
+        return new Response("page");
+      },
+    );
+    await renderPagesFallback(
+      {
+        initialResponseHeaders,
+        isRscRequest: false,
+        middlewareContext: { headers: null, requestHeaders: null, status: null },
+        request: pageRequest,
+        url: new URL(pageRequest.url),
+      },
+      { ...defaultDeps, loadPagesEntry: () => ({ renderPage }) },
+    );
+
+    expect(handleApiRoute).toHaveBeenCalledOnce();
+    expect(renderPage).toHaveBeenCalledOnce();
+  });
+
   it("returns null for RSC requests and does not call the Pages loader", async () => {
     const loadPagesEntry = vi.fn(() => ({}) as PagesEntry);
     const res = await renderPagesFallback(

--- a/tests/app-request-stage-dispatch.test.ts
+++ b/tests/app-request-stage-dispatch.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import {
+  appRequestUsesFullResponseGraph,
+  dispatchAppRequestStage,
+  type AppRequestStageDispatchOptions,
+} from "../packages/vinext/src/server/app-request-stage-dispatch.js";
+import type { AppRscRequestHandler } from "../packages/vinext/src/server/app-rsc-handler.js";
+import { APP_WORKER_RESPONSE_STAGE_PROTOCOL_VERSION } from "../packages/vinext/src/server/app-worker-stages.js";
+import {
+  createStaticFileSignal,
+  isStaticFileSignal,
+  readStaticFileSignal,
+  serializeStaticFileSignalForTransport,
+} from "../packages/vinext/src/server/static-file-signal.js";
+
+function createOptions(
+  overrides: Partial<AppRequestStageDispatchOptions> = {},
+): AppRequestStageDispatchOptions {
+  return {
+    basePath: "/docs",
+    buildId: "build-1",
+    draftModeSecret: "draft-secret",
+    handleRequest: async () => new Response("request stage"),
+    prerenderDiscovery: false,
+    probeMode: null,
+    ...overrides,
+  };
+}
+
+describe("App request-stage dispatch", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it.each([
+    {
+      name: "non-read method",
+      request: new Request("https://example.test/docs/page", { method: "POST" }),
+    },
+    {
+      name: "websocket upgrade",
+      request: new Request("https://example.test/docs/page", {
+        headers: { Upgrade: "h2c, WebSocket" },
+      }),
+    },
+    {
+      name: "valid draft mode cookie",
+      request: new Request("https://example.test/docs/page", {
+        headers: { Cookie: "__prerender_bypass=draft-secret" },
+      }),
+    },
+    {
+      name: "trusted prerender route params",
+      request: new Request("https://example.test/docs/page", {
+        headers: { "x-vinext-prerender-route-params": "payload" },
+      }),
+    },
+    {
+      name: "request cache bypass",
+      request: new Request("https://example.test/docs/page", {
+        headers: { "Cache-Control": "max-age=0, NO-STORE" },
+      }),
+    },
+    {
+      name: "CSP nonce",
+      request: new Request("https://example.test/docs/page", {
+        headers: { "Content-Security-Policy": "script-src 'nonce-request-stage'" },
+      }),
+    },
+    {
+      name: "route-tree prefetch",
+      request: new Request("https://example.test/docs/page", {
+        headers: {
+          RSC: "1",
+          "Next-Router-Prefetch": "1",
+          "Next-Router-Segment-Prefetch": "/_tree",
+        },
+      }),
+    },
+    {
+      name: "internal path below the base path",
+      request: new Request("https://example.test/docs/__vinext/revalidate"),
+    },
+  ])("uses the complete graph for a $name", ({ request }) => {
+    expect(appRequestUsesFullResponseGraph(request, createOptions())).toBe(true);
+  });
+
+  it("uses the complete graph during prerender execution", () => {
+    vi.stubEnv("VINEXT_PRERENDER", "1");
+
+    expect(
+      appRequestUsesFullResponseGraph(
+        new Request("https://example.test/docs/page"),
+        createOptions(),
+      ),
+    ).toBe(true);
+  });
+
+  it("uses the complete graph for authenticated transported prerender state", () => {
+    expect(
+      appRequestUsesFullResponseGraph(
+        new Request("https://example.test/docs/page"),
+        createOptions({
+          trustedPrerenderState: { routeParams: null, speculative: true },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps ordinary GET/HEAD requests in the request-only graph", () => {
+    expect(
+      appRequestUsesFullResponseGraph(
+        new Request("https://example.test/docs/page"),
+        createOptions(),
+      ),
+    ).toBe(false);
+    expect(
+      appRequestUsesFullResponseGraph(
+        new Request("https://example.test/docs/page", { method: "HEAD" }),
+        createOptions(),
+      ),
+    ).toBe(false);
+  });
+
+  it("allows an authenticated cacheability probe to classify a no-cache request", () => {
+    const request = new Request("https://example.test/docs/page", {
+      headers: { "Cache-Control": "no-cache" },
+    });
+
+    expect(appRequestUsesFullResponseGraph(request, createOptions({ probeMode: "probe" }))).toBe(
+      false,
+    );
+    expect(appRequestUsesFullResponseGraph(request, createOptions({ probeMode: "identity" }))).toBe(
+      false,
+    );
+  });
+
+  it("delegates ordinary requests to the request-only handler", async () => {
+    const request = new Request("https://example.test/docs/page");
+    const ctx = { waitUntil() {} };
+    const dispatchResponseStage = vi.fn(async () => new Response("response stage"));
+    const handleRequest = vi.fn<AppRscRequestHandler>(async () => new Response("request stage"));
+
+    const response = await dispatchAppRequestStage(request, ctx, dispatchResponseStage, {
+      ...createOptions(),
+      handleRequest,
+      probeMode: "identity",
+    });
+
+    await expect(response.text()).resolves.toBe("request stage");
+    expect(handleRequest).toHaveBeenCalledWith(
+      request,
+      ctx,
+      false,
+      dispatchResponseStage,
+      "identity",
+    );
+    expect(dispatchResponseStage).not.toHaveBeenCalled();
+  });
+
+  it("builds a bypass envelope for full requests and restores static-file signals", async () => {
+    const request = new Request("https://example.test/docs/upload?view=1", { method: "POST" });
+    const handleRequest = vi.fn<AppRscRequestHandler>();
+    const dispatchResponseStage = vi.fn(async (_request, props) => {
+      if (props.kind !== "app-full-request") throw new Error("unexpected stage kind");
+      return serializeStaticFileSignalForTransport(
+        createStaticFileSignal("/public/logo.svg", { headers: null, status: 200 }),
+        props.staticFileSignalToken,
+      );
+    });
+
+    const response = await dispatchAppRequestStage(request, null, dispatchResponseStage, {
+      ...createOptions(),
+      handleRequest,
+      prerenderDiscovery: true,
+      probeMode: "probe",
+      trustedPrerenderState: {
+        routeParams: { params: { slug: "hello" }, routePattern: "/docs/:slug" },
+        speculative: true,
+      },
+    });
+
+    expect(dispatchResponseStage).toHaveBeenCalledOnce();
+    expect(dispatchResponseStage).toHaveBeenCalledWith(
+      request,
+      {
+        buildId: "build-1",
+        cacheability: {
+          policyHeaders: null,
+          probeMode: "probe",
+          resolvedRoutePathname: "/docs/upload",
+        },
+        draftModeCookie: null,
+        kind: "app-full-request",
+        middlewareCookieOverlay: null,
+        prerenderDiscovery: true,
+        protocolVersion: APP_WORKER_RESPONSE_STAGE_PROTOCOL_VERSION,
+        requestOrigin: "https://example.test",
+        scriptNonce: null,
+        staticFileSignalToken: expect.any(String),
+        trustedPrerenderState: {
+          routeParams: { params: { slug: "hello" }, routePattern: "/docs/:slug" },
+          speculative: true,
+        },
+      },
+      { cache: "bypass" },
+    );
+    expect(handleRequest).not.toHaveBeenCalled();
+    expect(isStaticFileSignal(response)).toBe(true);
+    expect(readStaticFileSignal(response)).toBe(encodeURIComponent("/public/logo.svg"));
+    expect(response.headers.has("x-vinext-stage-static-file")).toBe(false);
+  });
+
+  it("requires the adapter-owned response-stage dispatcher", async () => {
+    await expect(
+      dispatchAppRequestStage(
+        new Request("https://example.test/docs/page"),
+        null,
+        undefined,
+        createOptions(),
+      ),
+    ).rejects.toThrow("App request stage requires a response-stage dispatcher");
+  });
+});

--- a/tests/app-router-worker-entry.test.ts
+++ b/tests/app-router-worker-entry.test.ts
@@ -14,10 +14,12 @@ import {
   VINEXT_PRERENDER_SECRET_HEADER,
 } from "../packages/vinext/src/server/headers.js";
 import { serializeWorkerCacheabilityProbeRoute } from "../packages/vinext/src/server/cacheability-request.js";
+import { registerDataCacheHandler } from "../packages/vinext/src/shims/cache-handler.js";
 
 const CAPTURE_RSC_REQUEST = "__vinextCaptureWorkerRscRequest";
 const CAPTURE_PRERENDER_STATE = "__vinextCaptureWorkerPrerenderState";
 const REGISTER_CDN_ADAPTER = "__vinextRegisterWorkerCdnAdapter";
+const REGISTER_ALL_CACHE_ADAPTERS = "__vinextRegisterAllWorkerCacheAdapters";
 
 function workerEntryVirtualModules(): Plugin {
   const modules = new Map([
@@ -52,6 +54,11 @@ export default async function rscHandler(request, _ctx, dispatchResponseStage, _
     globalThis.${CAPTURE_RSC_REQUEST}(request);
     return Response.redirect("https://example.com/login", 307);
   }
+  if (new URL(request.url).pathname === "/middleware-data-cache") {
+    const { getDataCacheHandler } = await import("vinext/shims/cache-handler");
+    await getDataCacheHandler().get("middleware-key");
+    return new Response("terminal middleware");
+  }
   globalThis.${CAPTURE_RSC_REQUEST}(request);
   return new Response("ok");
 }
@@ -60,12 +67,15 @@ export default async function rscHandler(request, _ctx, dispatchResponseStage, _
     [
       "virtual:vinext-cache-adapters",
       `export function registerConfiguredCacheAdapters(env) {
-  globalThis.${REGISTER_CDN_ADAPTER}?.(env);
+  globalThis.${REGISTER_ALL_CACHE_ADAPTERS}?.(env);
 }`,
     ],
     [
       "virtual:vinext-cdn-cache-adapter",
-      `export { registerConfiguredCacheAdapters } from "virtual:vinext-cache-adapters";`,
+      `export const hasConfiguredDataCache = true;
+export function registerConfiguredCacheAdapters(env) {
+  globalThis.${REGISTER_CDN_ADAPTER}?.(env);
+}`,
     ],
     ["virtual:vinext-image-adapters", "export function registerConfiguredImageOptimizer() {}"],
   ]);
@@ -82,6 +92,63 @@ export default async function rscHandler(request, _ctx, dispatchResponseStage, _
 }
 
 describe("App Router Production server worker entry compatibility", () => {
+  it("loads the configured data adapter only when request-stage middleware uses it", async () => {
+    const globals = globalThis as unknown as Record<PropertyKey, unknown>;
+    for (const key of [
+      Symbol.for("vinext.cacheHandler"),
+      Symbol.for("vinext.configuredCacheHandler"),
+      Symbol.for("vinext.explicitCacheHandler"),
+      Symbol.for("vinext.lazyCacheHandler"),
+    ]) {
+      delete globals[key];
+    }
+    const get = vi.fn(async () => null);
+    Reflect.set(globalThis, REGISTER_ALL_CACHE_ADAPTERS, () =>
+      registerDataCacheHandler(() => ({ get, async set() {}, async revalidateTag() {} })),
+    );
+    let server: Awaited<ReturnType<typeof createServer>> | undefined;
+    try {
+      server = await createServer({
+        appType: "custom",
+        configFile: false,
+        logLevel: "silent",
+        plugins: [workerEntryVirtualModules()],
+        resolve: {
+          alias: {
+            "vinext/shims": path.resolve(import.meta.dirname, "../packages/vinext/src/shims"),
+          },
+        },
+        server: { middlewareMode: true },
+      });
+      const entry = (await server.ssrLoadModule(
+        path.resolve(
+          import.meta.dirname,
+          "../packages/vinext/src/server/app-request-stage-independent-entry.ts",
+        ),
+      )) as {
+        handleRequestStage(
+          request: Request,
+          env: unknown,
+          ctx: undefined,
+          dispatchResponseStage: () => Promise<Response>,
+        ): Promise<Response>;
+      };
+
+      const response = await entry.handleRequestStage(
+        new Request("https://example.com/middleware-data-cache"),
+        undefined,
+        undefined,
+        async () => new Response("unused"),
+      );
+
+      expect(await response.text()).toBe("terminal middleware");
+      expect(get).toHaveBeenCalledWith("middleware-key", undefined);
+    } finally {
+      await server?.close();
+      Reflect.deleteProperty(globalThis, REGISTER_ALL_CACHE_ADAPTERS);
+    }
+  });
+
   it("authenticates prerender state in a Worker request-stage context", async () => {
     const capturedStates: unknown[] = [];
     Reflect.set(globalThis, CAPTURE_RSC_REQUEST, () => {});

--- a/tests/app-router-worker-entry.test.ts
+++ b/tests/app-router-worker-entry.test.ts
@@ -3,8 +3,21 @@ import os from "node:os";
 import path from "node:path";
 import { createServer, type Plugin } from "vite";
 import { describe, expect, it, vi } from "vite-plus/test";
+import {
+  DefaultCdnCacheAdapter,
+  setCdnCacheAdapter,
+  type CdnCacheAdapter,
+} from "../packages/vinext/src/shims/cdn-cache.js";
+import {
+  VINEXT_CACHEABILITY_PROBE_HEADER,
+  VINEXT_CACHEABILITY_PROBE_ROUTE_HEADER,
+  VINEXT_PRERENDER_SECRET_HEADER,
+} from "../packages/vinext/src/server/headers.js";
+import { serializeWorkerCacheabilityProbeRoute } from "../packages/vinext/src/server/cacheability-request.js";
 
 const CAPTURE_RSC_REQUEST = "__vinextCaptureWorkerRscRequest";
+const CAPTURE_PRERENDER_STATE = "__vinextCaptureWorkerPrerenderState";
+const REGISTER_CDN_ADAPTER = "__vinextRegisterWorkerCdnAdapter";
 
 function workerEntryVirtualModules(): Plugin {
   const modules = new Map([
@@ -22,7 +35,38 @@ export default async function rscHandler(request) {
 }
 `,
     ],
-    ["virtual:vinext-cache-adapters", "export function registerConfiguredCacheAdapters() {}"],
+    [
+      "virtual:vinext-app-request-entry",
+      `
+export const __assetPrefix = "";
+export const __basePath = "";
+export const __imageAllowedWidths = [];
+export const __imageConfig = {};
+export const __prerenderSecret = "worker-prerender-secret";
+export default async function rscHandler(request, _ctx, dispatchResponseStage, _probeMode, _prerenderDiscovery, trustedPrerenderState) {
+  globalThis.${CAPTURE_PRERENDER_STATE}?.(trustedPrerenderState);
+  if (new URL(request.url).pathname === "/__vinext/prerender/readiness") {
+    return dispatchResponseStage(request, { kind: "readiness-test" }, { cache: "bypass" });
+  }
+  if (new URL(request.url).pathname === "/middleware-terminal") {
+    globalThis.${CAPTURE_RSC_REQUEST}(request);
+    return Response.redirect("https://example.com/login", 307);
+  }
+  globalThis.${CAPTURE_RSC_REQUEST}(request);
+  return new Response("ok");
+}
+`,
+    ],
+    [
+      "virtual:vinext-cache-adapters",
+      `export function registerConfiguredCacheAdapters(env) {
+  globalThis.${REGISTER_CDN_ADAPTER}?.(env);
+}`,
+    ],
+    [
+      "virtual:vinext-cdn-cache-adapter",
+      `export { registerConfiguredCacheAdapters } from "virtual:vinext-cache-adapters";`,
+    ],
     ["virtual:vinext-image-adapters", "export function registerConfiguredImageOptimizer() {}"],
   ]);
 
@@ -38,6 +82,276 @@ export default async function rscHandler(request) {
 }
 
 describe("App Router Production server worker entry compatibility", () => {
+  it("authenticates prerender state in a Worker request-stage context", async () => {
+    const capturedStates: unknown[] = [];
+    Reflect.set(globalThis, CAPTURE_RSC_REQUEST, () => {});
+    Reflect.set(globalThis, CAPTURE_PRERENDER_STATE, (state: unknown) => {
+      capturedStates.push(state);
+    });
+    const previousPrerender = process.env.VINEXT_PRERENDER;
+    process.env.VINEXT_PRERENDER = "1";
+    let server: Awaited<ReturnType<typeof createServer>> | undefined;
+    try {
+      server = await createServer({
+        appType: "custom",
+        configFile: false,
+        logLevel: "silent",
+        plugins: [workerEntryVirtualModules()],
+        resolve: {
+          alias: {
+            "vinext/shims": path.resolve(import.meta.dirname, "../packages/vinext/src/shims"),
+          },
+        },
+        server: { middlewareMode: true },
+      });
+      const entry = (await server.ssrLoadModule(
+        path.resolve(
+          import.meta.dirname,
+          "../packages/vinext/src/server/app-request-stage-independent-entry.ts",
+        ),
+      )) as {
+        handleRequestStage(
+          request: Request,
+          env: unknown,
+          ctx: { hostRuntime: "worker"; waitUntil(): void },
+          dispatchResponseStage: () => Promise<Response>,
+        ): Promise<Response>;
+      };
+      const routeParams = encodeURIComponent(
+        JSON.stringify({ params: { slug: "hello" }, routePattern: "/blog/:slug" }),
+      );
+      const request = (secret: string) =>
+        new Request("https://example.com/blog/hello", {
+          headers: {
+            "x-vinext-prerender-route-params": routeParams,
+            "x-vinext-prerender-secret": secret,
+            "x-vinext-prerender-speculative": "1",
+          },
+        });
+      const ctx = { hostRuntime: "worker" as const, waitUntil() {} };
+
+      await entry.handleRequestStage(
+        request("worker-prerender-secret"),
+        undefined,
+        ctx,
+        async () => new Response("unused"),
+      );
+      await entry.handleRequestStage(
+        request("wrong-secret"),
+        undefined,
+        ctx,
+        async () => new Response("unused"),
+      );
+
+      expect(capturedStates).toEqual([
+        {
+          routeParams: { params: { slug: "hello" }, routePattern: "/blog/:slug" },
+          speculative: true,
+        },
+        null,
+      ]);
+    } finally {
+      await server?.close();
+      Reflect.deleteProperty(globalThis, CAPTURE_RSC_REQUEST);
+      Reflect.deleteProperty(globalThis, CAPTURE_PRERENDER_STATE);
+      if (previousPrerender === undefined) delete process.env.VINEXT_PRERENDER;
+      else process.env.VINEXT_PRERENDER = previousPrerender;
+    }
+  });
+
+  it("classifies a terminal middleware probe without dispatching the response stage", async () => {
+    const capturedRequests: Request[] = [];
+    Reflect.set(globalThis, CAPTURE_RSC_REQUEST, (request: Request) => {
+      capturedRequests.push(request);
+    });
+    const dispatch = vi.fn(async () => new Response("unused"));
+
+    let server: Awaited<ReturnType<typeof createServer>> | undefined;
+    try {
+      server = await createServer({
+        appType: "custom",
+        configFile: false,
+        logLevel: "silent",
+        plugins: [workerEntryVirtualModules()],
+        resolve: {
+          alias: {
+            "vinext/shims": path.resolve(import.meta.dirname, "../packages/vinext/src/shims"),
+          },
+        },
+        server: { middlewareMode: true },
+      });
+      const entry = (await server.ssrLoadModule(
+        path.resolve(
+          import.meta.dirname,
+          "../packages/vinext/src/server/app-request-stage-independent-entry.ts",
+        ),
+      )) as {
+        handleRequestStage(
+          request: Request,
+          env: unknown,
+          ctx: undefined,
+          dispatchResponseStage: typeof dispatch,
+        ): Promise<Response>;
+      };
+      const response = await entry.handleRequestStage(
+        new Request("https://example.com/middleware-terminal?__vinext_cacheability_probe=one", {
+          headers: {
+            [VINEXT_CACHEABILITY_PROBE_HEADER]: "1",
+            [VINEXT_CACHEABILITY_PROBE_ROUTE_HEADER]: serializeWorkerCacheabilityProbeRoute({
+              kind: "app-page",
+              pattern: "/middleware-terminal",
+            }),
+            [VINEXT_PRERENDER_SECRET_HEADER]: "worker-prerender-secret",
+          },
+        }),
+        undefined,
+        undefined,
+        dispatch,
+      );
+
+      expect(dispatch).not.toHaveBeenCalled();
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        kind: "app-page",
+        pattern: "/middleware-terminal",
+        scope: "identity",
+        state: "dynamic",
+        status: 307,
+        version: 1,
+      });
+      expect(capturedRequests).toHaveLength(1);
+      expect(capturedRequests[0]?.headers.get(VINEXT_CACHEABILITY_PROBE_ROUTE_HEADER)).toBeNull();
+    } finally {
+      await server?.close();
+      Reflect.deleteProperty(globalThis, CAPTURE_RSC_REQUEST);
+    }
+  });
+
+  it("validates CDN routing and stamps build identity at the request-stage boundary", async () => {
+    // No Next.js test port applies: CDN adapter validation and staged Worker
+    // boundaries are vinext deployment contracts.
+    const capturedRequests: Request[] = [];
+    const capturedEnvs: unknown[] = [];
+    Reflect.set(globalThis, CAPTURE_RSC_REQUEST, (request: Request) => {
+      capturedRequests.push(request);
+    });
+    const adapter: CdnCacheAdapter = {
+      ownsBackgroundRevalidation: false,
+      async get() {
+        return null;
+      },
+      async set() {},
+      buildResponseHeaders() {
+        return {};
+      },
+      buildResponseIdentityHeaders() {
+        return { "X-Test-Build-Identity": "build-a" };
+      },
+      validateRequest(request) {
+        return request.headers.has("X-Reject-Stage")
+          ? new Response("retry", { status: 503 })
+          : null;
+      },
+      async revalidateTag() {},
+    };
+    Reflect.set(globalThis, REGISTER_CDN_ADAPTER, (env: unknown) => {
+      capturedEnvs.push(env);
+      setCdnCacheAdapter(adapter);
+    });
+
+    let server: Awaited<ReturnType<typeof createServer>> | undefined;
+    try {
+      server = await createServer({
+        appType: "custom",
+        configFile: false,
+        logLevel: "silent",
+        plugins: [workerEntryVirtualModules()],
+        resolve: {
+          alias: {
+            "vinext/shims": path.resolve(import.meta.dirname, "../packages/vinext/src/shims"),
+          },
+        },
+        server: { middlewareMode: true },
+      });
+      const entry = (await server.ssrLoadModule(
+        path.resolve(
+          import.meta.dirname,
+          "../packages/vinext/src/server/app-request-stage-independent-entry.ts",
+        ),
+      )) as {
+        handleRequestStage(
+          request: Request,
+          env: unknown,
+          ctx: undefined,
+          dispatchResponseStage: (
+            request: Request,
+            props: unknown,
+            options: unknown,
+          ) => Promise<Response>,
+        ): Promise<Response>;
+      };
+      const env = { binding: "value" };
+      const rejected = await entry.handleRequestStage(
+        new Request("https://example.com/rejected", {
+          headers: { Accept: "text/html", "X-Reject-Stage": "1" },
+        }),
+        env,
+        undefined,
+        async () => new Response("unused"),
+      );
+      const accepted = await entry.handleRequestStage(
+        new Request("https://example.com/accepted", { headers: { Accept: "text/html" } }),
+        env,
+        undefined,
+        async () => new Response("unused"),
+      );
+      const readinessDispatch = vi.fn<
+        (request: Request, props: unknown, options: unknown) => Promise<Response>
+      >(
+        async () =>
+          new Response(null, {
+            status: 204,
+            headers: { "Cache-Control": "no-store", "X-Vinext-Prerender-Readiness": "1" },
+          }),
+      );
+      const readiness = await entry.handleRequestStage(
+        new Request("https://example.com/__vinext/prerender/readiness?attempt=request-stage", {
+          headers: {
+            "X-Vinext-Expected-Worker-Version": "version-a",
+            "X-Vinext-Prerender-Secret": "worker-prerender-secret",
+          },
+        }),
+        env,
+        undefined,
+        readinessDispatch,
+      );
+
+      expect(rejected.status).toBe(503);
+      expect(await rejected.text()).toBe("retry");
+      expect(rejected.headers.get("X-Test-Build-Identity")).toBe("build-a");
+      expect(await accepted.text()).toBe("ok");
+      expect(accepted.headers.get("X-Test-Build-Identity")).toBe("build-a");
+      expect(readiness.status).toBe(204);
+      expect(readinessDispatch).toHaveBeenCalledWith(
+        expect.any(Request),
+        { kind: "readiness-test" },
+        { cache: "bypass" },
+      );
+      const readinessStageRequest = readinessDispatch.mock.calls[0]![0] as Request;
+      expect(readinessStageRequest.headers.get("X-Vinext-Expected-Worker-Version")).toBe(
+        "version-a",
+      );
+      expect(readinessStageRequest.headers.get("X-Vinext-Prerender-Secret")).toBeNull();
+      expect(capturedRequests).toHaveLength(1);
+      expect(capturedEnvs).toEqual([env, env, env]);
+    } finally {
+      await server?.close();
+      setCdnCacheAdapter(new DefaultCdnCacheAdapter());
+      Reflect.deleteProperty(globalThis, CAPTURE_RSC_REQUEST);
+      Reflect.deleteProperty(globalThis, REGISTER_CDN_ADAPTER);
+    }
+  });
+
   it("restores prerender route params only for the server-owned Node context", async () => {
     // No Next.js test port applies: these headers and this Worker boundary are vinext-specific.
     const capturedRequests: Request[] = [];

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -66,6 +66,11 @@ import {
   setCdnCacheAdapter,
   type CdnCacheAdapter,
 } from "../packages/vinext/src/shims/cdn-cache.js";
+import {
+  markEdgeRouteHandlerLinkHeaders,
+  markFrameworkLinkHeaders,
+  serializeResponseStageLinkProvenance,
+} from "../packages/vinext/src/server/app-response-header-provenance.js";
 
 type TestRoute = {
   __loadPage?: unknown;
@@ -249,6 +254,85 @@ describe("createAppRscHandler", () => {
     expect(response.headers.get("x-test-header")).toBe("applied");
     expect(response.headers.get("x-response-stage")).toBe("yes");
     expect(await response.text()).toBe("response-stage");
+  });
+
+  it("preserves staged config Link ordering before framework preloads", async () => {
+    const dispatchResponseStage = vi.fn<DispatchAppWorkerResponseStage>(async () => {
+      const response = new Response("response-stage", {
+        headers: { Link: '</framework.woff2>; rel="preload"; as="font"' },
+      });
+      markFrameworkLinkHeaders(response.headers, response.headers.get("link"));
+      return serializeResponseStageLinkProvenance(response);
+    });
+    const handler = createHandler({
+      configHeaders: [
+        {
+          source: "/about",
+          headers: [{ key: "Link", value: '</config>; rel="describedby"' }],
+        },
+      ],
+    });
+
+    const response = await handler(
+      new Request("https://example.test/docs/about"),
+      null,
+      false,
+      dispatchResponseStage,
+    );
+
+    expect(response.headers.get("link")).toBe(
+      '</config>; rel="describedby", </framework.woff2>; rel="preload"; as="font"',
+    );
+    expect(response.headers.has("x-vinext-app-stage-post-config-link")).toBe(false);
+  });
+
+  it("preserves staged middleware Link ordering before Edge handler links", async () => {
+    const route = createPageRoute({
+      __loadPage: undefined,
+      __loadRouteHandler() {},
+      page: null,
+      pattern: "/route",
+      routeHandler: { GET: () => new Response("get"), runtime: "edge" },
+      routeSegments: ["route"],
+    });
+    const dispatchResponseStage = vi.fn<DispatchAppWorkerResponseStage>(async () => {
+      const response = new Response("response-stage", {
+        headers: { Link: '</edge-route>; rel="alternate"' },
+      });
+      markEdgeRouteHandlerLinkHeaders(response.headers, response.headers.get("link"));
+      return serializeResponseStageLinkProvenance(response);
+    });
+    const handler = createHandler({
+      configHeaders: [
+        {
+          source: "/route",
+          headers: [{ key: "Link", value: '</config>; rel="describedby"' }],
+        },
+      ],
+      matchRoute: (pathname) => (pathname === "/route" ? { params: {}, route } : null),
+      middlewareModule: {
+        default() {
+          return new Response(null, {
+            headers: {
+              Link: '</middleware>; rel="preload"',
+              "x-middleware-next": "1",
+            },
+          });
+        },
+      },
+    });
+
+    const response = await handler(
+      new Request("https://example.test/docs/route"),
+      null,
+      false,
+      dispatchResponseStage,
+    );
+
+    expect(response.headers.get("link")).toBe(
+      '</middleware>; rel="preload", </edge-route>; rel="alternate"',
+    );
+    expect(response.headers.has("x-vinext-app-stage-post-config-link")).toBe(false);
   });
 
   it("shares the method-invariant App page representation for HEAD and strips its body", async () => {
@@ -466,8 +550,8 @@ describe("createAppRscHandler", () => {
     expect(dispatchResponseStage.mock.calls[0]?.[1].cacheability.policyHeaders).toEqual([
       ["Cache-Control", "public, s-maxage=60"],
       ["CDN-Cache-Control", "public, s-maxage=120"],
-      ["Vary", "x-visitor"],
     ]);
+    expect(response.headers.get("Vary")).toContain("x-visitor");
     expect(response.headers.get("Cache-Control")).toBe("public, max-age=0, must-revalidate");
     expect(state.forcedDynamicReason).toBeUndefined();
   });
@@ -517,7 +601,6 @@ describe("createAppRscHandler", () => {
         policyHeaders: [
           ["Cache-Control", "public, s-maxage=36"],
           ["CDN-Cache-Control", "public, s-maxage=120"],
-          ["Vary", "x-visitor"],
         ],
       },
       preHandlerHeaders: [
@@ -1110,9 +1193,7 @@ describe("createAppRscHandler", () => {
 
     expect(dispatchResponseStage).toHaveBeenCalledOnce();
     expect(dispatchMatchedPage).not.toHaveBeenCalled();
-    expect(dispatchResponseStage.mock.calls[0]?.[1].cacheability.policyHeaders).toEqual([
-      ["Vary", "Cookie"],
-    ]);
+    expect(dispatchResponseStage.mock.calls[0]?.[1].cacheability.policyHeaders).toBeNull();
     expect(state.forcedDynamicReason).toBeUndefined();
     expect(response.headers.get("Vary")).toContain("Cookie");
     expect(await response.text()).toBe("shared-stage");

--- a/tests/app-worker-stages.test.ts
+++ b/tests/app-worker-stages.test.ts
@@ -1,10 +1,43 @@
-import { describe, expect, it } from "vite-plus/test";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { handleResponseStage } from "../packages/vinext/src/server/app-response-stage-entry.js";
 import {
   APP_WORKER_RESPONSE_STAGE_PROTOCOL_VERSION,
   isAppWorkerResponseStageProps,
-  prepareSharedAppPageDispatch,
   type AppWorkerResponseStageProps,
 } from "../packages/vinext/src/server/app-worker-stages.js";
+import {
+  DefaultCdnCacheAdapter,
+  setCdnCacheAdapter,
+  type CdnCacheAdapter,
+} from "../packages/vinext/src/shims/cdn-cache.js";
+import {
+  VINEXT_EXPECTED_WORKER_VERSION_HEADER,
+  VINEXT_PRERENDER_READINESS_HEADER,
+} from "../packages/vinext/src/server/headers.js";
+
+const stages = vi.hoisted(() => ({
+  renderFullRequest: vi.fn(),
+  registerCacheAdapters: vi.fn(),
+  registerImageOptimizer: vi.fn(),
+  renderResponse: vi.fn(),
+}));
+
+vi.mock("virtual:vinext-cache-adapters", () => ({
+  registerConfiguredCacheAdapters: stages.registerCacheAdapters,
+}));
+
+vi.mock("virtual:vinext-image-adapters", () => ({
+  registerConfiguredImageOptimizer: stages.registerImageOptimizer,
+}));
+
+vi.mock("virtual:vinext-app-response-entry", () => ({
+  __cacheabilityManifest: null,
+  default: { handleResponseStage: stages.renderResponse },
+}));
+
+vi.mock("virtual:vinext-rsc-entry", () => ({
+  default: stages.renderFullRequest,
+}));
 
 const notFoundStage = {
   buildId: null,
@@ -23,7 +56,94 @@ const notFoundStage = {
   scriptNonce: null,
 } satisfies AppWorkerResponseStageProps;
 
-describe("App Worker response-stage protocol", () => {
+describe("App Worker response stage", () => {
+  beforeEach(() => {
+    setCdnCacheAdapter(new DefaultCdnCacheAdapter());
+    stages.registerCacheAdapters.mockReset();
+    stages.registerImageOptimizer.mockReset();
+    stages.renderFullRequest.mockReset();
+    stages.renderResponse.mockReset();
+  });
+
+  it("validates readiness from inside the App response stage", async () => {
+    const validateRequest = vi.fn(() => null);
+    const adapter: CdnCacheAdapter = {
+      ownsBackgroundRevalidation: false,
+      async get() {
+        return null;
+      },
+      async set() {},
+      buildResponseHeaders() {
+        return {};
+      },
+      validateRequest,
+      async revalidateTag() {},
+    };
+    stages.registerCacheAdapters.mockImplementation(() => setCdnCacheAdapter(adapter));
+    const request = new Request(
+      "https://example.com/__vinext/prerender/readiness?attempt=response-stage",
+      { headers: { [VINEXT_EXPECTED_WORKER_VERSION_HEADER]: "version-a" } },
+    );
+    const props = {
+      buildId: null,
+      cacheability: {
+        policyHeaders: null,
+        probeMode: null,
+        resolvedRoutePathname: "/__vinext/prerender/readiness",
+      },
+      draftModeCookie: null,
+      kind: "app-full-request" as const,
+      middlewareCookieOverlay: null,
+      prerenderDiscovery: true,
+      protocolVersion: APP_WORKER_RESPONSE_STAGE_PROTOCOL_VERSION,
+      requestOrigin: "https://example.com",
+      scriptNonce: null,
+      staticFileSignalToken: "00000000-0000-4000-8000-000000000000",
+      trustedPrerenderState: null,
+    } satisfies AppWorkerResponseStageProps;
+
+    const response = await handleResponseStage(
+      request,
+      { binding: "value" },
+      undefined,
+      props,
+      async () => new Response("request-stage"),
+      { cache: "bypass" },
+    );
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get(VINEXT_PRERENDER_READINESS_HEADER)).toBe("1");
+    expect(stages.registerCacheAdapters).toHaveBeenCalledWith({ binding: "value" });
+    expect(validateRequest).toHaveBeenCalledWith(request);
+    expect(stages.renderResponse).not.toHaveBeenCalled();
+  });
+
+  it("re-enters the request stage through the adapter-owned reverse transport", async () => {
+    const dispatchRequestStage = vi.fn(async () => new Response("revalidated"));
+    stages.renderResponse.mockImplementationOnce(async (_request, ctx) =>
+      ctx.dispatchPagesRevalidate(new Request("https://example.com/missing")),
+    );
+
+    const response = await handleResponseStage(
+      new Request("https://example.com/missing"),
+      { binding: "value" },
+      undefined,
+      notFoundStage,
+      dispatchRequestStage,
+      { cache: "shared" },
+    );
+
+    await expect(response.text()).resolves.toBe("revalidated");
+    expect(dispatchRequestStage).toHaveBeenCalledOnce();
+    expect(stages.renderResponse).toHaveBeenCalledWith(
+      expect.any(Request),
+      expect.anything(),
+      notFoundStage,
+      { cache: "shared" },
+    );
+  });
+
   it("rejects matched-stage payloads missing interception cache-safety fields", () => {
     const matchedStage = {
       ...notFoundStage,
@@ -53,6 +173,26 @@ describe("App Worker response-stage protocol", () => {
     expect(isAppWorkerResponseStageProps({ ...notFoundStage, requestOrigin })).toBe(false);
   });
 
+  it.each([
+    "https://second.example/missing",
+    "http://example.com/missing",
+    "https://example.com:8443/missing",
+  ])("rejects a response-stage origin mismatch before rendering: %s", async (requestUrl) => {
+    const response = await handleResponseStage(
+      new Request(requestUrl),
+      { binding: "value" },
+      undefined,
+      notFoundStage,
+      async () => new Response("request-stage"),
+      { cache: "shared" },
+    );
+
+    expect(response.status).toBe(400);
+    expect(stages.registerImageOptimizer).not.toHaveBeenCalled();
+    expect(stages.registerCacheAdapters).not.toHaveBeenCalled();
+    expect(stages.renderResponse).not.toHaveBeenCalled();
+  });
+
   it("requires a transport proof on full-request stage payloads", () => {
     const fullStage = {
       buildId: null,
@@ -73,10 +213,44 @@ describe("App Worker response-stage protocol", () => {
     expect(isAppWorkerResponseStageProps(withoutToken)).toBe(false);
   });
 
-  it("normalizes shared HEAD page dispatches without changing bypassed work", () => {
-    const request = new Request("https://example.com/page", { method: "HEAD" });
+  it("passes only authenticated prerender state into the full response graph", async () => {
+    stages.renderFullRequest.mockResolvedValue(new Response("rendered"));
+    const trustedPrerenderState = {
+      routeParams: { params: { slug: "hello" }, routePattern: "/post/:slug" },
+      speculative: true,
+    } as const;
+    const props = {
+      buildId: null,
+      cacheability: { policyHeaders: null, probeMode: null, resolvedRoutePathname: "/post/hello" },
+      draftModeCookie: null,
+      kind: "app-full-request" as const,
+      middlewareCookieOverlay: null,
+      prerenderDiscovery: false,
+      protocolVersion: APP_WORKER_RESPONSE_STAGE_PROTOCOL_VERSION,
+      requestOrigin: "https://example.com",
+      scriptNonce: null,
+      staticFileSignalToken: "00000000-0000-4000-8000-000000000000",
+      trustedPrerenderState,
+    } satisfies AppWorkerResponseStageProps;
+    const request = new Request("https://example.com/post/hello");
 
-    expect(prepareSharedAppPageDispatch(request, "shared").method).toBe("GET");
-    expect(prepareSharedAppPageDispatch(request, "bypass")).toBe(request);
+    const response = await handleResponseStage(
+      request,
+      undefined,
+      undefined,
+      props,
+      async () => new Response("request-stage"),
+      { cache: "bypass" },
+    );
+
+    await expect(response.text()).resolves.toBe("rendered");
+    expect(stages.renderFullRequest).toHaveBeenCalledWith(
+      request,
+      expect.anything(),
+      false,
+      undefined,
+      null,
+      trustedPrerenderState,
+    );
   });
 });

--- a/tests/app-worker-stages.test.ts
+++ b/tests/app-worker-stages.test.ts
@@ -14,6 +14,7 @@ import {
   VINEXT_EXPECTED_WORKER_VERSION_HEADER,
   VINEXT_PRERENDER_READINESS_HEADER,
 } from "../packages/vinext/src/server/headers.js";
+import { markFrameworkLinkHeaders } from "../packages/vinext/src/server/app-response-header-provenance.js";
 
 const stages = vi.hoisted(() => ({
   renderFullRequest: vi.fn(),
@@ -142,6 +143,27 @@ describe("App Worker response stage", () => {
       notFoundStage,
       { cache: "shared" },
     );
+  });
+
+  it("serializes renderer Link provenance across the response-stage boundary", async () => {
+    stages.renderResponse.mockImplementationOnce(async () => {
+      const response = new Response("rendered", {
+        headers: { Link: '</framework.woff2>; rel="preload"; as="font"' },
+      });
+      markFrameworkLinkHeaders(response.headers, response.headers.get("link"));
+      return response;
+    });
+
+    const response = await handleResponseStage(
+      new Request("https://example.com/missing"),
+      undefined,
+      undefined,
+      notFoundStage,
+      async () => new Response("request-stage"),
+      { cache: "shared" },
+    );
+
+    expect(response.headers.get("x-vinext-app-stage-post-config-link")).toBe("1");
   });
 
   it("rejects matched-stage payloads missing interception cache-safety fields", () => {

--- a/tests/cdn-adapter-build.test.ts
+++ b/tests/cdn-adapter-build.test.ts
@@ -83,6 +83,15 @@ describe("Cloudflare CDN adapter build output", () => {
     expect(generated.version_metadata).toEqual({ binding: "CF_VERSION_METADATA" });
   });
 
+  it("emits the pregenerated-paths sidecar imported by the Worker entry", async () => {
+    expect(
+      await fs.readFile(
+        path.join(root, "dist/server/__vinext_pregenerated_concrete_paths.js"),
+        "utf8",
+      ),
+    ).toBe("delete globalThis.__VINEXT_PREGENERATED_CONCRETE_PATHS;\n");
+  });
+
   it("is the effective config selected by Wrangler's deploy redirect", async () => {
     const wranglerPath = createRequire(path.join(root, "package.json")).resolve("wrangler");
     const wrangler = (await import(pathToFileURL(wranglerPath).href)) as {

--- a/tests/cdn-adapter-build.test.ts
+++ b/tests/cdn-adapter-build.test.ts
@@ -84,12 +84,12 @@ describe("Cloudflare CDN adapter build output", () => {
   });
 
   it("emits the pregenerated-paths sidecar imported by the Worker entry", async () => {
-    expect(
-      await fs.readFile(
-        path.join(root, "dist/server/__vinext_pregenerated_concrete_paths.js"),
-        "utf8",
-      ),
-    ).toBe("delete globalThis.__VINEXT_PREGENERATED_CONCRETE_PATHS;\n");
+    const sidecarName = "__vinext_pregenerated_concrete_paths.js";
+    const workerEntry = await fs.readFile(path.join(root, "dist/server/index.js"), "utf8");
+    expect(workerEntry).toMatch(new RegExp(`import\\s*["']\\./${sidecarName}["']`));
+    expect(await fs.readFile(path.join(root, "dist/server", sidecarName), "utf8")).toBe(
+      "delete globalThis.__VINEXT_PREGENERATED_CONCRETE_PATHS;\n",
+    );
   });
 
   it("is the effective config selected by Wrangler's deploy redirect", async () => {

--- a/tests/cdn-adapter-build.test.ts
+++ b/tests/cdn-adapter-build.test.ts
@@ -86,7 +86,7 @@ describe("Cloudflare CDN adapter build output", () => {
   it("emits the pregenerated-paths sidecar imported by the Worker entry", async () => {
     const sidecarName = "__vinext_pregenerated_concrete_paths.js";
     const workerEntry = await fs.readFile(path.join(root, "dist/server/index.js"), "utf8");
-    expect(workerEntry).toMatch(new RegExp(`import\\s*["']\\./${sidecarName}["']`));
+    expect(workerEntry).toMatch(/import\s*["']\.\/__vinext_pregenerated_concrete_paths\.js["']/);
     expect(await fs.readFile(path.join(root, "dist/server", sidecarName), "utf8")).toBe(
       "delete globalThis.__VINEXT_PREGENERATED_CONCRETE_PATHS;\n",
     );
@@ -165,6 +165,9 @@ describe("Cloudflare CDN adapter build output", () => {
       const generatedPath = path.resolve(pagesRoot, ".wrangler/deploy", redirect.configPath);
       const generated = JSON.parse(await fs.readFile(generatedPath, "utf8"));
       expect(generated.version_metadata).toEqual({ binding: "CF_VERSION_METADATA" });
+      await expect(
+        fs.readFile(path.join(pagesRoot, "dist/server/__vinext_pregenerated_concrete_paths.js")),
+      ).rejects.toMatchObject({ code: "ENOENT" });
     } finally {
       await fs.rm(pagesRoot, { recursive: true, force: true });
     }

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -1230,8 +1230,8 @@ describe("App Router entry templates", () => {
   it("generateRscEntry delegates App Router request handling to the typed helper", () => {
     const code = generateRscEntry("/tmp/test/app", minimalAppRoutes, null, [], null, "", false);
 
-    expect(code).toContain(
-      'import { createAppRscHandler } from "vinext/server/app-rsc-combined-handler";',
+    expect(code).toMatch(
+      /import \{ createAppRscHandler \} from ".*\/server\/app-rsc-combined-handler\.js";/,
     );
     expect(code).toContain("const __appRscHandler = createAppRscHandler({");
     expect(code).toContain("export default __appRscHandler;");


### PR DESCRIPTION
Part 9 of 16 in the staged CDN adapter stack. Depends on #3148.

## Summary

- extracts App middleware, routing, and request-context orchestration into a request stage
- dispatches matched work through the App response-stage contract while preserving Pages fallback
- keeps the generated RSC entry thin and preserves navigation, slot, and client-reuse context

## Validation

- focused App request-stage, Pages-bridge, worker-entry, and stage-contract tests
- cumulative exact-tip changed-test sweep: 3,461 passed, 2 skipped
- full exact-tip `vp check`

## Review size

- Implementation: +1072 / -49 LOC
- Tests and fixtures: +957 / -15 LOC
- Other (docs, config, lockfile): +3 / -0 LOC
- 24 changed files

Measured against `codex/cdn-v2-app-response-stage` after rebasing onto `main@a6931c0`.