### PR TITLE
fix(build): preserve staged prerender routing

### DIFF
--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -1993,6 +1993,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
       root: info.root,
       concurrency: options.prerenderConcurrency,
       nextConfig,
+      routeRootConfig: viteConfigMetadata.routeRootConfig,
     });
     ranPrerender = true;
   }

--- a/packages/vinext/src/build/inject-pregenerated-paths.ts
+++ b/packages/vinext/src/build/inject-pregenerated-paths.ts
@@ -15,10 +15,13 @@ const VINEXT_PREGEN_RE = new RegExp(
   "g",
 );
 
-export function injectPregeneratedConcretePaths(root: string): void {
-  const serverDir = path.resolve(root, "dist", "server");
-  const workerEntry = path.join(serverDir, "index.js");
-  const manifest = readPrerenderManifest(path.join(serverDir, "vinext-prerender.json"));
+export function injectPregeneratedConcretePaths(
+  root: string,
+  workerEntry = path.resolve(root, "dist", "server", "index.js"),
+): void {
+  const manifestDir = path.resolve(root, "dist", "server");
+  const runtimeDir = path.dirname(workerEntry);
+  const manifest = readPrerenderManifest(path.join(manifestDir, "vinext-prerender.json"));
   const table = manifest?.pregeneratedConcretePaths ?? [];
 
   // Response-stage entries can be deployed independently of index.js. Keep the
@@ -27,8 +30,8 @@ export function injectPregeneratedConcretePaths(root: string): void {
   // The file is emitted during the server build; writing it after prerendering
   // updates the artifact without rebuilding or coupling core to a host
   // transport.
-  const runtimeModule = path.join(serverDir, PREGENERATED_CONCRETE_PATHS_MODULE);
-  fs.mkdirSync(serverDir, { recursive: true });
+  const runtimeModule = path.join(runtimeDir, PREGENERATED_CONCRETE_PATHS_MODULE);
+  fs.mkdirSync(runtimeDir, { recursive: true });
   fs.writeFileSync(
     runtimeModule,
     table.length > 0

--- a/packages/vinext/src/build/inject-pregenerated-paths.ts
+++ b/packages/vinext/src/build/inject-pregenerated-paths.ts
@@ -18,10 +18,10 @@ const VINEXT_PREGEN_RE = new RegExp(
 export function injectPregeneratedConcretePaths(
   root: string,
   workerEntry = path.resolve(root, "dist", "server", "index.js"),
+  serverOutputDir = path.resolve(root, "dist", "server"),
 ): void {
-  const manifestDir = path.resolve(root, "dist", "server");
   const runtimeDir = path.dirname(workerEntry);
-  const manifest = readPrerenderManifest(path.join(manifestDir, "vinext-prerender.json"));
+  const manifest = readPrerenderManifest(path.join(serverOutputDir, "vinext-prerender.json"));
   const table = manifest?.pregeneratedConcretePaths ?? [];
 
   // Response-stage entries can be deployed independently of index.js. Keep the
@@ -30,14 +30,14 @@ export function injectPregeneratedConcretePaths(
   // The file is emitted during the server build; writing it after prerendering
   // updates the artifact without rebuilding or coupling core to a host
   // transport.
-  const runtimeModule = path.join(runtimeDir, PREGENERATED_CONCRETE_PATHS_MODULE);
-  fs.mkdirSync(runtimeDir, { recursive: true });
-  fs.writeFileSync(
-    runtimeModule,
+  const runtimeModuleCode =
     table.length > 0
       ? `globalThis.__VINEXT_PREGENERATED_CONCRETE_PATHS = ${JSON.stringify(table)};\n`
-      : "delete globalThis.__VINEXT_PREGENERATED_CONCRETE_PATHS;\n",
-  );
+      : "delete globalThis.__VINEXT_PREGENERATED_CONCRETE_PATHS;\n";
+  for (const outputDir of new Set([serverOutputDir, runtimeDir])) {
+    fs.mkdirSync(outputDir, { recursive: true });
+    fs.writeFileSync(path.join(outputDir, PREGENERATED_CONCRETE_PATHS_MODULE), runtimeModuleCode);
+  }
 
   if (!fs.existsSync(workerEntry)) {
     if (table.length > 0) globalThis.__VINEXT_PREGENERATED_CONCRETE_PATHS = table;

--- a/packages/vinext/src/build/inject-pregenerated-paths.ts
+++ b/packages/vinext/src/build/inject-pregenerated-paths.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "pathslash";
 import { readPrerenderManifest } from "../server/prerender-manifest.js";
+import { PREGENERATED_CONCRETE_PATHS_MODULE } from "../server/pregenerated-concrete-paths.js";
 import { escapeRegExp } from "../utils/regex.js";
 
 declare global {
@@ -15,14 +16,33 @@ const VINEXT_PREGEN_RE = new RegExp(
 );
 
 export function injectPregeneratedConcretePaths(root: string): void {
-  const workerEntry = path.resolve(root, "dist", "server", "index.js");
-  if (!fs.existsSync(workerEntry)) return;
+  const serverDir = path.resolve(root, "dist", "server");
+  const workerEntry = path.join(serverDir, "index.js");
+  const manifest = readPrerenderManifest(path.join(serverDir, "vinext-prerender.json"));
+  const table = manifest?.pregeneratedConcretePaths ?? [];
+
+  // Response-stage entries can be deployed independently of index.js. Keep the
+  // table in a stable side-effect module imported by every generated App
+  // response graph so those deployments retain the same PPR fallback guard.
+  // The file is emitted during the server build; writing it after prerendering
+  // updates the artifact without rebuilding or coupling core to a host
+  // transport.
+  const runtimeModule = path.join(serverDir, PREGENERATED_CONCRETE_PATHS_MODULE);
+  fs.mkdirSync(serverDir, { recursive: true });
+  fs.writeFileSync(
+    runtimeModule,
+    table.length > 0
+      ? `globalThis.__VINEXT_PREGENERATED_CONCRETE_PATHS = ${JSON.stringify(table)};\n`
+      : "delete globalThis.__VINEXT_PREGENERATED_CONCRETE_PATHS;\n",
+  );
+
+  if (!fs.existsSync(workerEntry)) {
+    if (table.length > 0) globalThis.__VINEXT_PREGENERATED_CONCRETE_PATHS = table;
+    else delete globalThis.__VINEXT_PREGENERATED_CONCRETE_PATHS;
+    return;
+  }
 
   let code = fs.readFileSync(workerEntry, "utf-8").replace(VINEXT_PREGEN_RE, "");
-  const manifest = readPrerenderManifest(
-    path.join(root, "dist", "server", "vinext-prerender.json"),
-  );
-  const table = manifest?.pregeneratedConcretePaths ?? [];
 
   if (table.length > 0) {
     globalThis.__VINEXT_PREGENERATED_CONCRETE_PATHS = table;

--- a/packages/vinext/src/build/inject-pregenerated-paths.ts
+++ b/packages/vinext/src/build/inject-pregenerated-paths.ts
@@ -2,25 +2,17 @@ import fs from "node:fs";
 import path from "pathslash";
 import { readPrerenderManifest } from "../server/prerender-manifest.js";
 import { PREGENERATED_CONCRETE_PATHS_MODULE } from "../server/pregenerated-concrete-paths.js";
-import { escapeRegExp } from "../utils/regex.js";
 
 declare global {
   var __VINEXT_PREGENERATED_CONCRETE_PATHS: unknown;
 }
 
-const VINEXT_PREGEN_START = "/* __VINEXT_PREGENERATED_CONCRETE_PATHS_START__ */";
-const VINEXT_PREGEN_END = "/* __VINEXT_PREGENERATED_CONCRETE_PATHS_END__ */";
-const VINEXT_PREGEN_RE = new RegExp(
-  `${escapeRegExp(VINEXT_PREGEN_START)}[\\s\\S]*?${escapeRegExp(VINEXT_PREGEN_END)}\\n?`,
-  "g",
-);
-
 export function injectPregeneratedConcretePaths(
   root: string,
-  workerEntry = path.resolve(root, "dist", "server", "index.js"),
+  applicationEntry = path.resolve(root, "dist", "server", "index.js"),
   serverOutputDir = path.resolve(root, "dist", "server"),
+  additionalRuntimeDirs: readonly string[] = [],
 ): void {
-  const runtimeDir = path.dirname(workerEntry);
   const manifest = readPrerenderManifest(path.join(serverOutputDir, "vinext-prerender.json"));
   const table = manifest?.pregeneratedConcretePaths ?? [];
 
@@ -34,29 +26,18 @@ export function injectPregeneratedConcretePaths(
     table.length > 0
       ? `globalThis.__VINEXT_PREGENERATED_CONCRETE_PATHS = ${JSON.stringify(table)};\n`
       : "delete globalThis.__VINEXT_PREGENERATED_CONCRETE_PATHS;\n";
-  for (const outputDir of new Set([serverOutputDir, runtimeDir])) {
+  for (const outputDir of new Set([
+    serverOutputDir,
+    path.dirname(applicationEntry),
+    ...additionalRuntimeDirs,
+  ])) {
     fs.mkdirSync(outputDir, { recursive: true });
     fs.writeFileSync(path.join(outputDir, PREGENERATED_CONCRETE_PATHS_MODULE), runtimeModuleCode);
   }
 
-  if (!fs.existsSync(workerEntry)) {
-    if (table.length > 0) globalThis.__VINEXT_PREGENERATED_CONCRETE_PATHS = table;
-    else delete globalThis.__VINEXT_PREGENERATED_CONCRETE_PATHS;
-    return;
-  }
-
-  let code = fs.readFileSync(workerEntry, "utf-8").replace(VINEXT_PREGEN_RE, "");
-
   if (table.length > 0) {
     globalThis.__VINEXT_PREGENERATED_CONCRETE_PATHS = table;
-    code =
-      `${VINEXT_PREGEN_START}\n` +
-      `globalThis.__VINEXT_PREGENERATED_CONCRETE_PATHS = ${JSON.stringify(table)};\n` +
-      `${VINEXT_PREGEN_END}\n` +
-      code;
   } else {
     delete globalThis.__VINEXT_PREGENERATED_CONCRETE_PATHS;
   }
-
-  fs.writeFileSync(workerEntry, code);
 }

--- a/packages/vinext/src/build/prerender-paths.ts
+++ b/packages/vinext/src/build/prerender-paths.ts
@@ -1231,6 +1231,7 @@ async function startPathDiscoveryServer(options: {
       ? path.dirname(path.dirname(options.pagesBundlePath))
       : path.dirname(options.serverDir),
     rscEntryPath: options.rscBundlePath,
+    serverDir: options.serverDir,
     serverEntryPath: options.pagesBundlePath,
     noCompression: true,
     purpose: "prerender",
@@ -1247,14 +1248,19 @@ export async function emitPrerenderPathManifest(
 
   if (!appDir && !pagesDir) return null;
 
-  const rscServerDir = options.routeRootConfig?.rscOutDir
+  const configuredRscServerDir = options.routeRootConfig?.rscOutDir
     ? path.resolve(root, options.routeRootConfig.rscOutDir)
     : path.join(root, "dist", "server");
-  const defaultRscBundlePath = resolveBuiltRscEntryPath(rscServerDir);
+  const defaultRscBundlePath = resolveBuiltRscEntryPath(configuredRscServerDir);
   const rscBundlePath = options.rscBundlePath ?? defaultRscBundlePath;
+  const relativeRscEntryPath = path.relative(configuredRscServerDir, rscBundlePath);
+  const rscServerDir =
+    !relativeRscEntryPath.startsWith("../") && !path.isAbsolute(relativeRscEntryPath)
+      ? configuredRscServerDir
+      : path.dirname(rscBundlePath);
   const pagesBundlePath = options.pagesBundlePath ?? path.join(root, "dist", "server", "entry.js");
   const bundleServerDir = fs.existsSync(rscBundlePath)
-    ? path.dirname(rscBundlePath)
+    ? rscServerDir
     : path.dirname(pagesBundlePath);
   const manifestDir = path.join(root, "dist", "server");
   const config = options.nextConfig

--- a/packages/vinext/src/build/prerender-paths.ts
+++ b/packages/vinext/src/build/prerender-paths.ts
@@ -4,6 +4,7 @@ import type { Server as HttpServer } from "node:http";
 import {
   loadNextConfig,
   resolveNextConfig,
+  type NextRewrite,
   type ResolvedNextConfig,
 } from "../config/next-config.js";
 import {
@@ -33,13 +34,14 @@ import { VINEXT_PRERENDER_SECRET_HEADER } from "../server/headers.js";
 import type { VinextRouteRootConfig } from "../config/prerender.js";
 import { enterPrerenderPhase } from "./prerender-phase.js";
 import type { CdnCacheAdapterCapabilities } from "../cache/cache-adapters-virtual.js";
-import { matchHeaders, matchesRewriteSource } from "../config/config-matchers.js";
+import { isExternalUrl, matchHeaders, matchesRewriteSource } from "../config/config-matchers.js";
 import { pagesRouteHasPriorityOverAppRoute } from "../server/hybrid-route-priority.js";
 import { resolveAppPageDynamicConfig } from "../server/app-segment-config.js";
 import { extractLocaleFromUrl, normalizeDefaultLocalePathname } from "../server/pages-i18n.js";
 import { normalizePathTrailingSlash } from "vinext/shims/url-utils";
 import { buildPagesDataHref } from "vinext/shims/internal/pages-data-url";
 import { CACHEABILITY_POLICY_HEADERS } from "vinext/shims/cacheability-classification";
+import { resolveBuiltRscEntryPath } from "./server-entry.js";
 
 export type PrerenderRoutePattern = {
   kind: "app-page" | "app-route" | "pages-page";
@@ -49,9 +51,12 @@ export type PrerenderRoutePattern = {
     canPrunePattern: boolean;
     /** HTML pathname shared by alternate representations of this route. */
     concretePathname?: string;
+    /** The uncached request stage may resolve this public path to another route. */
+    routeMayResolve?: boolean;
+    /** A request representation may terminate before reaching the response stage. */
+    requestStageMayTerminate?: boolean;
   };
 };
-
 export type PrerenderPathManifest = {
   /** App Page HTML paths after hybrid route ownership has been resolved. */
   appPaths?: string[];
@@ -125,6 +130,8 @@ type EmitPrerenderPathManifestOptions = {
   rscBundlePath?: string;
   buildIdentity?: CdnCacheAdapterCapabilities["buildIdentity"];
   responseVary?: CdnCacheAdapterCapabilities["responseVary"];
+  requestRouting?: CdnCacheAdapterCapabilities["requestRouting"];
+  responsePolicyHeaderNames?: CdnCacheAdapterCapabilities["responsePolicyHeaderNames"];
   /** Execute dynamic path hooks against an already-uploaded Worker. */
   pathDiscoveryTarget?: {
     baseUrl: string;
@@ -504,6 +511,7 @@ async function collectPagesPaths(options: {
 }): Promise<{
   dataPaths: string[];
   fallbackRoutePatterns: PrerenderRoutePattern[];
+  nonDynamicPaths: string[];
   paths: string[];
 }> {
   const [pageRoutes, apiRoutes] = await Promise.all([
@@ -516,6 +524,8 @@ async function collectPagesPaths(options: {
   const dataPaths: string[] = [];
   const seenDataPaths = new Set<string>();
   const fallbackRoutePatterns: PrerenderRoutePattern[] = [];
+  const nonDynamicPaths: string[] = [];
+  const seenNonDynamicPaths = new Set<string>();
 
   for (const route of pageRoutes) {
     if (apiPatterns.has(route.pattern)) continue;
@@ -532,10 +542,12 @@ async function collectPagesPaths(options: {
         for (const locale of options.i18n.locales) {
           const pathname = localizePagesPath(route.pattern, locale, options.i18n);
           addPath(paths, seen, pathname);
+          addPath(nonDynamicPaths, seenNonDynamicPaths, pathname);
           if (hasStaticProps || hasServerSideProps) addPath(dataPaths, seenDataPaths, pathname);
         }
       } else {
         addPath(paths, seen, route.pattern);
+        addPath(nonDynamicPaths, seenNonDynamicPaths, route.pattern);
         if (hasStaticProps || hasServerSideProps) {
           addPath(dataPaths, seenDataPaths, route.pattern);
         }
@@ -609,7 +621,7 @@ async function collectPagesPaths(options: {
     }
   }
 
-  return { dataPaths, fallbackRoutePatterns, paths };
+  return { dataPaths, fallbackRoutePatterns, nonDynamicPaths, paths };
 }
 
 async function excludePagesApiWarmPaths(options: {
@@ -697,6 +709,7 @@ async function collectAppPaths(options: {
 }): Promise<{
   fallbackRoutePatterns: PrerenderRoutePattern[];
   loadingShellPaths: string[];
+  nonDynamicPaths: string[];
   paths: string[];
   routeHandlerPaths: string[];
 }> {
@@ -708,6 +721,8 @@ async function collectAppPaths(options: {
   const routeHandlerPaths: string[] = [];
   const seenRouteHandlerPaths = new Set<string>();
   const fallbackRoutePatterns: PrerenderRoutePattern[] = [];
+  const nonDynamicPaths: string[] = [];
+  const seenNonDynamicPaths = new Set<string>();
   const staticParamsCache = new Map<string, Promise<Record<string, string | string[]>[] | null>>();
   let requireNonEmptyStaticParams = false;
   const staticParamsMap = new Proxy({} as StaticParamsMap, {
@@ -790,6 +805,7 @@ async function collectAppPaths(options: {
 
     if (!route.isDynamic) {
       addDiscoveredPath(route.pattern);
+      addPath(nonDynamicPaths, seenNonDynamicPaths, route.pattern);
       continue;
     }
 
@@ -887,7 +903,13 @@ async function collectAppPaths(options: {
     }
   }
 
-  return { fallbackRoutePatterns, loadingShellPaths, paths, routeHandlerPaths };
+  return {
+    fallbackRoutePatterns,
+    loadingShellPaths,
+    nonDynamicPaths,
+    paths,
+    routeHandlerPaths,
+  };
 }
 
 async function resolveAppWarmPaths(options: {
@@ -995,7 +1017,6 @@ async function resolveAppWarmPaths(options: {
   };
 }
 
-const CACHEABILITY_POLICY_HEADER_NAMES = new Set<string>(CACHEABILITY_POLICY_HEADERS);
 function cachePolicyRuleMatchesWarmPath(
   pathname: string,
   rule: ResolvedNextConfig["headers"][number],
@@ -1077,9 +1098,16 @@ function routePatternCouldIntersectCachePolicyRule(
 function annotateCacheabilityProbeSafety(
   routePatterns: Record<string, PrerenderRoutePattern>,
   config: Pick<ResolvedNextConfig, "basePath" | "headers" | "i18n" | "trailingSlash">,
+  routeMayResolve: ReadonlySet<string>,
+  requestStageMayTerminate: ReadonlySet<string>,
+  responsePolicyHeaderNames: readonly string[],
 ): Record<string, PrerenderRoutePattern> {
+  const cacheabilityPolicyHeaderNames = new Set([
+    ...CACHEABILITY_POLICY_HEADERS,
+    ...responsePolicyHeaderNames.map((name) => name.trim().toLowerCase()).filter(Boolean),
+  ]);
   const cachePolicyRules = config.headers.filter((rule) =>
-    rule.headers.some((header) => CACHEABILITY_POLICY_HEADER_NAMES.has(header.key.toLowerCase())),
+    rule.headers.some((header) => cacheabilityPolicyHeaderNames.has(header.key.toLowerCase())),
   );
   const matchingPolicyRules = new Map(
     Object.keys(routePatterns).map((pathname) => [
@@ -1123,19 +1151,21 @@ function annotateCacheabilityProbeSafety(
         pathname,
         {
           ...route,
-          cacheabilityProbe: { canPrunePattern },
+          cacheabilityProbe: {
+            canPrunePattern,
+            ...(routeMayResolve.has(pathname) ? { routeMayResolve: true } : {}),
+            ...(requestStageMayTerminate.has(pathname) ? { requestStageMayTerminate: true } : {}),
+          },
         },
       ];
     }),
   );
 }
 
-function configuredRouteAffectsWarmPath(
+function configuredRulesAffectWarmPath(
   pathname: string,
-  config: Pick<
-    ResolvedNextConfig,
-    "basePath" | "i18n" | "redirects" | "rewrites" | "trailingSlash"
-  >,
+  rules: ReadonlyArray<NextRewrite>,
+  config: Pick<ResolvedNextConfig, "basePath" | "i18n" | "trailingSlash">,
 ): boolean {
   const canonicalPathname = normalizePathTrailingSlash(pathname, config.trailingSlash);
   const hostnames = [undefined, ...(config.i18n?.domains?.map((domain) => domain.domain) ?? [])];
@@ -1144,17 +1174,47 @@ function configuredRouteAffectsWarmPath(
       normalizeDefaultLocalePathname(canonicalPathname, config.i18n, { hostname }),
     ),
   );
-  const rewrites = [
-    ...config.rewrites.beforeFiles,
-    ...config.rewrites.afterFiles,
-    ...config.rewrites.fallback,
-  ];
-  return [...rewrites, ...config.redirects].some((rule) =>
+  return rules.some((rule) =>
     Array.from(matchPathnames).some((matchPathname) =>
       matchesRewriteSource(matchPathname, rule, {
         basePath: config.basePath,
         hadBasePath: true,
       }),
+    ),
+  );
+}
+
+/**
+ * Whether a configured rewrite can replace a route-owned warm response.
+ * Non-dynamic filesystem routes win before `afterFiles`, while every concrete
+ * path discovered here wins dynamic matching before `fallback`.
+ */
+function configuredRewritesCanReplaceWarmPath(
+  pathname: string,
+  rewrites: ResolvedNextConfig["rewrites"],
+  hasNonDynamicRoute: boolean,
+  config: Pick<ResolvedNextConfig, "basePath" | "i18n" | "trailingSlash">,
+  include: (rewrite: NextRewrite) => boolean,
+): boolean {
+  const applicableRewrites = [
+    ...rewrites.beforeFiles.filter(include),
+    ...(hasNonDynamicRoute ? [] : rewrites.afterFiles.filter(include)),
+  ];
+  return configuredRulesAffectWarmPath(pathname, applicableRewrites, config);
+}
+
+function hasMiddlewareConventionFile(
+  root: string,
+  appDir: string | null,
+  pagesDir: string | null,
+  pageExtensions: readonly string[],
+): boolean {
+  const routeDir = appDir ?? pagesDir;
+  const routeRoot = routeDir ? path.dirname(routeDir) : root;
+  const conventionDir = routeRoot === path.join(root, "src") ? routeRoot : root;
+  return ["proxy", "middleware"].some((name) =>
+    pageExtensions.some((extension) =>
+      fs.existsSync(path.join(conventionDir, `${name}.${extension}`)),
     ),
   );
 }
@@ -1187,9 +1247,10 @@ export async function emitPrerenderPathManifest(
 
   if (!appDir && !pagesDir) return null;
 
-  const defaultRscBundlePath = options.routeRootConfig?.rscOutDir
-    ? path.join(path.resolve(root, options.routeRootConfig.rscOutDir), "index.js")
-    : path.join(root, "dist", "server", "index.js");
+  const rscServerDir = options.routeRootConfig?.rscOutDir
+    ? path.resolve(root, options.routeRootConfig.rscOutDir)
+    : path.join(root, "dist", "server");
+  const defaultRscBundlePath = resolveBuiltRscEntryPath(rscServerDir);
   const rscBundlePath = options.rscBundlePath ?? defaultRscBundlePath;
   const pagesBundlePath = options.pagesBundlePath ?? path.join(root, "dist", "server", "entry.js");
   const bundleServerDir = fs.existsSync(rscBundlePath)
@@ -1217,6 +1278,7 @@ export async function emitPrerenderPathManifest(
   const seenRouteHandlerPaths = new Set<string>();
   const discoveredLoadingShellPaths: string[] = [];
   const seenLoadingShellPaths = new Set<string>();
+  const discoveredNonDynamicPathSet = new Set<string>();
   const fallbackRoutePatterns: PrerenderRoutePattern[] = [];
   await withPrerenderEndpoints(async () => {
     let prodServer: { server: HttpServer; port: number } | null = null;
@@ -1293,6 +1355,9 @@ export async function emitPrerenderPathManifest(
         for (const pathname of appPathResult.routeHandlerPaths) {
           addPath(discoveredRouteHandlerPaths, seenRouteHandlerPaths, pathname);
         }
+        for (const pathname of appPathResult.nonDynamicPaths) {
+          discoveredNonDynamicPathSet.add(pathname);
+        }
         fallbackRoutePatterns.push(...appPathResult.fallbackRoutePatterns);
       }
 
@@ -1312,6 +1377,9 @@ export async function emitPrerenderPathManifest(
         for (const pathname of pagesPathResult.dataPaths) {
           addPath(discoveredPagesDataPaths, seenPagesDataPaths, pathname);
         }
+        for (const pathname of pagesPathResult.nonDynamicPaths) {
+          discoveredNonDynamicPathSet.add(pathname);
+        }
         fallbackRoutePatterns.push(...pagesPathResult.fallbackRoutePatterns);
       }
     } finally {
@@ -1321,10 +1389,54 @@ export async function emitPrerenderPathManifest(
     }
   });
 
+  const hasStagedRequestRouting = options.requestRouting === "uncached-stage";
+  const middlewareMayRouteWarmPaths =
+    hasStagedRequestRouting &&
+    hasMiddlewareConventionFile(root, appDir, pagesDir, config.pageExtensions);
+  const routedWarmPaths = [...paths, ...discoveredRouteHandlerPaths];
+  const routeMayResolveWarmPathSet = new Set(
+    hasStagedRequestRouting
+      ? routedWarmPaths.filter(
+          (pathname) =>
+            middlewareMayRouteWarmPaths ||
+            configuredRewritesCanReplaceWarmPath(
+              pathname,
+              config.rewrites,
+              discoveredNonDynamicPathSet.has(pathname),
+              config,
+              (rewrite) => !isExternalUrl(rewrite.destination),
+            ),
+        )
+      : [],
+  );
+  const requestStageMayTerminateWarmPathSet = new Set(
+    hasStagedRequestRouting
+      ? routedWarmPaths.filter(
+          (pathname) =>
+            middlewareMayRouteWarmPaths ||
+            configuredRulesAffectWarmPath(pathname, config.redirects, config) ||
+            configuredRewritesCanReplaceWarmPath(
+              pathname,
+              config.rewrites,
+              discoveredNonDynamicPathSet.has(pathname),
+              config,
+              (rewrite) => isExternalUrl(rewrite.destination),
+            ),
+        )
+      : [],
+  );
   const excludedWarmPathSet = new Set(
-    options.responseVary
-      ? [...paths, ...discoveredRouteHandlerPaths].filter((pathname) =>
-          configuredRouteAffectsWarmPath(pathname, config),
+    options.responseVary && !hasStagedRequestRouting
+      ? routedWarmPaths.filter(
+          (pathname) =>
+            configuredRulesAffectWarmPath(pathname, config.redirects, config) ||
+            configuredRewritesCanReplaceWarmPath(
+              pathname,
+              config.rewrites,
+              discoveredNonDynamicPathSet.has(pathname),
+              config,
+              () => true,
+            ),
         )
       : [],
   );
@@ -1382,7 +1494,13 @@ export async function emitPrerenderPathManifest(
       "",
     ),
   );
-  const routePatterns = annotateCacheabilityProbeSafety(appOwnedWarmPaths.routePatterns, config);
+  const routePatterns = annotateCacheabilityProbeSafety(
+    appOwnedWarmPaths.routePatterns,
+    config,
+    routeMayResolveWarmPathSet,
+    requestStageMayTerminateWarmPathSet,
+    options.responsePolicyHeaderNames ?? [],
+  );
   for (let index = 0; index < resolvedPagesDataWarmPaths.length; index++) {
     const route = routePatterns[resolvedPagesDataWarmPaths[index]];
     if (route) {

--- a/packages/vinext/src/build/prerender-server-entry.ts
+++ b/packages/vinext/src/build/prerender-server-entry.ts
@@ -8,15 +8,17 @@
  * vinext production server on an ephemeral port and reports it to the parent
  * over IPC. The parent then load-balances per-route fetches across the pool.
  *
- * `VINEXT_PRERENDER` / `NEXT_PHASE` / `VINEXT_PRERENDER_OUTDIR` are passed via
- * the fork env so they are set before any module loads (some server and user
- * modules read the phase at import time).
+ * `VINEXT_PRERENDER`, `NEXT_PHASE`, `VINEXT_PRERENDER_OUTDIR`, and the optional
+ * `VINEXT_PRERENDER_RSC_ENTRY_PATH` are passed via the fork env so they are set
+ * before any module loads (some server and user modules read the phase at
+ * import time).
  */
 import { startProdServer } from "../server/prod-server.js";
 import { NoOpCacheHandler, setCacheHandler } from "vinext/shims/cache-handler";
 
 async function main(): Promise<void> {
   const outDir = process.env.VINEXT_PRERENDER_OUTDIR;
+  const rscEntryPath = process.env.VINEXT_PRERENDER_RSC_ENTRY_PATH;
   if (!outDir) {
     throw new Error("[vinext] prerender server worker: VINEXT_PRERENDER_OUTDIR not set");
   }
@@ -30,6 +32,7 @@ async function main(): Promise<void> {
     port: 0,
     host: "127.0.0.1",
     outDir,
+    ...(rscEntryPath ? { rscEntryPath } : {}),
     noCompression: true,
     purpose: "prerender",
     silent: true,

--- a/packages/vinext/src/build/prerender-server-entry.ts
+++ b/packages/vinext/src/build/prerender-server-entry.ts
@@ -9,7 +9,8 @@
  * over IPC. The parent then load-balances per-route fetches across the pool.
  *
  * `VINEXT_PRERENDER`, `NEXT_PHASE`, `VINEXT_PRERENDER_OUTDIR`, and the optional
- * `VINEXT_PRERENDER_RSC_ENTRY_PATH` are passed via the fork env so they are set
+ * `VINEXT_PRERENDER_RSC_ENTRY_PATH`, and `VINEXT_PRERENDER_SERVER_DIR` are
+ * passed via the fork env so they are set
  * before any module loads (some server and user modules read the phase at
  * import time).
  */
@@ -19,6 +20,7 @@ import { NoOpCacheHandler, setCacheHandler } from "vinext/shims/cache-handler";
 async function main(): Promise<void> {
   const outDir = process.env.VINEXT_PRERENDER_OUTDIR;
   const rscEntryPath = process.env.VINEXT_PRERENDER_RSC_ENTRY_PATH;
+  const serverDir = process.env.VINEXT_PRERENDER_SERVER_DIR;
   if (!outDir) {
     throw new Error("[vinext] prerender server worker: VINEXT_PRERENDER_OUTDIR not set");
   }
@@ -33,6 +35,7 @@ async function main(): Promise<void> {
     host: "127.0.0.1",
     outDir,
     ...(rscEntryPath ? { rscEntryPath } : {}),
+    ...(serverDir ? { serverDir } : {}),
     noCompression: true,
     purpose: "prerender",
     silent: true,

--- a/packages/vinext/src/build/prerender-server-pool.ts
+++ b/packages/vinext/src/build/prerender-server-pool.ts
@@ -126,8 +126,9 @@ function isWorkerTransportError(err: unknown): boolean {
 export async function startPrerenderServerPool(
   outDir: string,
   size: number,
-  entry = WORKER_ENTRY,
+  options: { entry?: string; rscEntryPath?: string } = {},
 ): Promise<PrerenderServerPool> {
+  const { entry = WORKER_ENTRY, rscEntryPath } = options;
   const children: ChildProcess[] = [];
   let shuttingDown = false;
   let crash: { port?: number; code: number | null; signal: NodeJS.Signals | null } | null = null;
@@ -147,6 +148,7 @@ export async function startPrerenderServerPool(
           VINEXT_PRERENDER: "1",
           NEXT_PHASE: PHASE_PRODUCTION_BUILD,
           VINEXT_PRERENDER_OUTDIR: outDir,
+          ...(rscEntryPath ? { VINEXT_PRERENDER_RSC_ENTRY_PATH: rscEntryPath } : {}),
         },
         // Inherit stdout/stderr so server-side errors surface; keep IPC.
         stdio: ["ignore", "inherit", "inherit", "ipc"],

--- a/packages/vinext/src/build/prerender-server-pool.ts
+++ b/packages/vinext/src/build/prerender-server-pool.ts
@@ -126,9 +126,9 @@ function isWorkerTransportError(err: unknown): boolean {
 export async function startPrerenderServerPool(
   outDir: string,
   size: number,
-  options: { entry?: string; rscEntryPath?: string } = {},
+  options: { entry?: string; rscEntryPath?: string; serverDir?: string } = {},
 ): Promise<PrerenderServerPool> {
-  const { entry = WORKER_ENTRY, rscEntryPath } = options;
+  const { entry = WORKER_ENTRY, rscEntryPath, serverDir } = options;
   const children: ChildProcess[] = [];
   let shuttingDown = false;
   let crash: { port?: number; code: number | null; signal: NodeJS.Signals | null } | null = null;
@@ -149,6 +149,7 @@ export async function startPrerenderServerPool(
           NEXT_PHASE: PHASE_PRODUCTION_BUILD,
           VINEXT_PRERENDER_OUTDIR: outDir,
           ...(rscEntryPath ? { VINEXT_PRERENDER_RSC_ENTRY_PATH: rscEntryPath } : {}),
+          ...(serverDir ? { VINEXT_PRERENDER_SERVER_DIR: serverDir } : {}),
         },
         // Inherit stdout/stderr so server-side errors surface; keep IPC.
         stdio: ["ignore", "inherit", "inherit", "ipc"],

--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -1125,6 +1125,7 @@ export async function prerenderApp({
             port: 0,
             host: "127.0.0.1",
             outDir: path.dirname(serverDir),
+            rscEntryPath: rscBundlePath,
             noCompression: true,
             purpose: "prerender",
           });

--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -98,9 +98,10 @@ async function startOptionalPrerenderServerPool(
   outDir: string,
   poolSize: number,
   rscEntryPath?: string,
+  serverDir?: string,
 ): Promise<PrerenderServerPool | null> {
   try {
-    return await startPrerenderServerPool(outDir, poolSize, { rscEntryPath });
+    return await startPrerenderServerPool(outDir, poolSize, { rscEntryPath, serverDir });
   } catch (e) {
     // The pool is a performance optimization layered over the already-running
     // in-process prerender server. Startup failure is still before any route has
@@ -1131,6 +1132,7 @@ export async function prerenderApp({
             host: "127.0.0.1",
             outDir: path.dirname(serverDir),
             rscEntryPath: rscBundlePath,
+            serverDir,
             noCompression: true,
             purpose: "prerender",
           });
@@ -1807,6 +1809,7 @@ export async function prerenderApp({
           path.dirname(serverDir),
           poolSize,
           rscBundlePath,
+          serverDir,
         );
         if (renderPool) renderPorts = renderPool.ports;
       }

--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -269,6 +269,11 @@ type PrerenderAppOptions = {
    * Absolute path to the pre-built RSC handler bundle (e.g. `dist/server/index.js`).
    */
   rscBundlePath: string;
+  /**
+   * Root directory for build metadata and sibling server artifacts. Defaults
+   * to the RSC entry's directory for compatibility with standalone callers.
+   */
+  serverDir?: string;
 } & PrerenderOptions;
 
 // ─── Internal option extensions ───────────────────────────────────────────────
@@ -1069,6 +1074,7 @@ export async function prerenderApp({
   config,
   mode,
   rscBundlePath,
+  serverDir = path.dirname(rscBundlePath),
   ...options
 }: PrerenderAppOptionsInternal): Promise<PrerenderResult> {
   const manifestDir = options.manifestDir ?? outDir;
@@ -1087,8 +1093,6 @@ export async function prerenderApp({
   // The scope is nest-safe because run-prerender.ts also enters it around a
   // shared hybrid server.
   const restorePrerenderPhase = enterPrerenderPhase();
-
-  const serverDir = path.dirname(rscBundlePath);
 
   let rscHandler: (request: Request) => Promise<Response>;
   let staticParamsMap: StaticParamsMap = {};

--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -97,9 +97,10 @@ function getErrorMessageWithStack(err: Error): string {
 async function startOptionalPrerenderServerPool(
   outDir: string,
   poolSize: number,
+  rscEntryPath?: string,
 ): Promise<PrerenderServerPool | null> {
   try {
-    return await startPrerenderServerPool(outDir, poolSize);
+    return await startPrerenderServerPool(outDir, poolSize, { rscEntryPath });
   } catch (e) {
     // The pool is a performance optimization layered over the already-running
     // in-process prerender server. Startup failure is still before any route has
@@ -1798,7 +1799,11 @@ export async function prerenderApp({
     if (!options._prodServer && prerenderPoolAvailable()) {
       const poolSize = resolvePrerenderPoolSize(urlsToRender.length, concurrency);
       if (poolSize > 1) {
-        renderPool = await startOptionalPrerenderServerPool(path.dirname(serverDir), poolSize);
+        renderPool = await startOptionalPrerenderServerPool(
+          path.dirname(serverDir),
+          poolSize,
+          rscBundlePath,
+        );
         if (renderPool) renderPorts = renderPool.ports;
       }
     }

--- a/packages/vinext/src/build/prerender.ts
+++ b/packages/vinext/src/build/prerender.ts
@@ -275,6 +275,11 @@ type PrerenderAppOptions = {
    * to the RSC entry's directory for compatibility with standalone callers.
    */
   serverDir?: string;
+  /**
+   * Root of the complete production build passed to the local prerender
+   * server. Defaults to the parent of `serverDir` for standalone callers.
+   */
+  buildOutDir?: string;
 } & PrerenderOptions;
 
 // ─── Internal option extensions ───────────────────────────────────────────────
@@ -1076,6 +1081,7 @@ export async function prerenderApp({
   mode,
   rscBundlePath,
   serverDir = path.dirname(rscBundlePath),
+  buildOutDir = path.dirname(serverDir),
   ...options
 }: PrerenderAppOptionsInternal): Promise<PrerenderResult> {
   const manifestDir = options.manifestDir ?? outDir;
@@ -1130,7 +1136,7 @@ export async function prerenderApp({
           const srv = await startProdServer({
             port: 0,
             host: "127.0.0.1",
-            outDir: path.dirname(serverDir),
+            outDir: buildOutDir,
             rscEntryPath: rscBundlePath,
             serverDir,
             noCompression: true,
@@ -1806,7 +1812,7 @@ export async function prerenderApp({
       const poolSize = resolvePrerenderPoolSize(urlsToRender.length, concurrency);
       if (poolSize > 1) {
         renderPool = await startOptionalPrerenderServerPool(
-          path.dirname(serverDir),
+          buildOutDir,
           poolSize,
           rscBundlePath,
           serverDir,

--- a/packages/vinext/src/build/run-prerender.ts
+++ b/packages/vinext/src/build/run-prerender.ts
@@ -38,6 +38,7 @@ import { rememberCurrentServerEntryImportMtime, startProdServer } from "../serve
 import { enterPrerenderPhase } from "./prerender-phase.js";
 import { PHASE_PRODUCTION_BUILD } from "vinext/shims/constants";
 import { resolveBuiltRscEntryPath } from "./server-entry.js";
+import type { VinextRouteRootConfig } from "../config/prerender.js";
 
 // ─── Progress UI ──────────────────────────────────────────────────────────────
 
@@ -107,6 +108,8 @@ type RunPrerenderOptions = {
    * Intended for tests that build to a custom outDir.
    */
   rscBundlePath?: string;
+  /** Build output roots captured from the vinext Vite plugin. */
+  routeRootConfig?: VinextRouteRootConfig | null;
   /**
    * Maximum number of routes rendered in parallel.
    * Defaults to prerenderApp/prerenderPages internal defaults when omitted.
@@ -167,7 +170,10 @@ export async function runPrerender(options: RunPrerenderOptions): Promise<Preren
   // The manifest lands in dist/server/ alongside the server bundle so it's
   // cleaned with the rest of vinext's build output on rebuild and co-located
   // with server artifacts.
-  const manifestDir = path.join(root, "dist", "server");
+  const manifestDir = path.resolve(
+    root,
+    options.routeRootConfig?.rscOutDir ?? path.join("dist", "server"),
+  );
   const rscBundlePath = options.rscBundlePath ?? resolveBuiltRscEntryPath(manifestDir);
   // The emitted entry may live below dist/server (for example entries/app.js).
   // Build metadata and prerender artifacts remain rooted at dist/server.
@@ -221,7 +227,7 @@ export async function runPrerender(options: RunPrerenderOptions): Promise<Preren
   const outDir =
     mode === "export"
       ? path.join(root, "dist", "client")
-      : path.join(root, "dist", "server", "prerendered-routes");
+      : path.join(manifestDir, "prerendered-routes");
 
   // For hybrid builds (both app/ and pages/ present), start a single shared
   // prod server and pass it to both phases. This avoids spinning up two servers
@@ -311,8 +317,7 @@ export async function runPrerender(options: RunPrerenderOptions): Promise<Preren
         ...(sharedProdServer
           ? { _prodServer: sharedProdServer, _prerenderSecret: sharedPrerenderSecret }
           : {
-              pagesBundlePath:
-                options.pagesBundlePath ?? path.join(root, "dist", "server", "entry.js"),
+              pagesBundlePath: options.pagesBundlePath ?? path.join(manifestDir, "entry.js"),
             }),
         onProgress: ({ total, route }) => {
           if (pagesTotal === 0) {
@@ -383,7 +388,7 @@ export async function runPrerender(options: RunPrerenderOptions): Promise<Preren
     );
   }
 
-  injectPregeneratedConcretePaths(root, rscBundlePath);
+  injectPregeneratedConcretePaths(root, rscBundlePath, manifestDir);
   if (fs.existsSync(rscBundlePath)) {
     rememberCurrentServerEntryImportMtime(rscBundlePath);
   }

--- a/packages/vinext/src/build/run-prerender.ts
+++ b/packages/vinext/src/build/run-prerender.ts
@@ -37,6 +37,7 @@ import { injectPregeneratedConcretePaths } from "./inject-pregenerated-paths.js"
 import { rememberCurrentServerEntryImportMtime, startProdServer } from "../server/prod-server.js";
 import { enterPrerenderPhase } from "./prerender-phase.js";
 import { PHASE_PRODUCTION_BUILD } from "vinext/shims/constants";
+import { resolveBuiltRscEntryPath } from "./server-entry.js";
 
 // ─── Progress UI ──────────────────────────────────────────────────────────────
 
@@ -101,7 +102,8 @@ type RunPrerenderOptions = {
   pagesBundlePath?: string;
   /**
    * Override the path to the App Router RSC bundle.
-   * Defaults to `<root>/dist/server/index.js`.
+   * Defaults to the App handler recorded in the server build manifest, or
+   * `<root>/dist/server/index.js` for builds without a manifest.
    * Intended for tests that build to a custom outDir.
    */
   rscBundlePath?: string;
@@ -121,9 +123,8 @@ type RunPrerenderOptions = {
  * to stderr/stdout. Returns the full PrerenderResult so callers can pass it to
  * printBuildReport.
  *
- * Works for both plain Node and Cloudflare Workers builds — the CF Workers
- * bundle outputs `dist/server/index.js` which is a standard Node server entry,
- * so no wrangler/miniflare is needed.
+ * Works for both plain Node and hosted builds by resolving the generated App
+ * handler independently of any deployment facade that owns `index.js`.
  *
  * Hybrid projects (both `app/` and `pages/` present) run both prerender
  * phases sharing a single prod server instance. The merged results are written
@@ -167,7 +168,8 @@ export async function runPrerender(options: RunPrerenderOptions): Promise<Preren
   // cleaned with the rest of vinext's build output on rebuild and co-located
   // with server artifacts.
   const manifestDir = path.join(root, "dist", "server");
-  const rscBundlePath = options.rscBundlePath ?? path.join(root, "dist", "server", "index.js");
+  const rscBundlePath =
+    options.rscBundlePath ?? resolveBuiltRscEntryPath(path.join(root, "dist", "server"));
   const serverDir = path.dirname(rscBundlePath);
 
   const config = options.nextConfig
@@ -235,6 +237,7 @@ export async function runPrerender(options: RunPrerenderOptions): Promise<Preren
         port: 0,
         host: "127.0.0.1",
         outDir: path.dirname(serverDir),
+        rscEntryPath: rscBundlePath,
         noCompression: true,
         purpose: "prerender",
       });

--- a/packages/vinext/src/build/run-prerender.ts
+++ b/packages/vinext/src/build/run-prerender.ts
@@ -168,9 +168,14 @@ export async function runPrerender(options: RunPrerenderOptions): Promise<Preren
   // cleaned with the rest of vinext's build output on rebuild and co-located
   // with server artifacts.
   const manifestDir = path.join(root, "dist", "server");
-  const rscBundlePath =
-    options.rscBundlePath ?? resolveBuiltRscEntryPath(path.join(root, "dist", "server"));
-  const serverDir = path.dirname(rscBundlePath);
+  const rscBundlePath = options.rscBundlePath ?? resolveBuiltRscEntryPath(manifestDir);
+  // The emitted entry may live below dist/server (for example entries/app.js).
+  // Build metadata and prerender artifacts remain rooted at dist/server.
+  const relativeEntryPath = path.relative(manifestDir, rscBundlePath);
+  const serverDir =
+    !relativeEntryPath.startsWith("../") && !path.isAbsolute(relativeEntryPath)
+      ? manifestDir
+      : path.dirname(rscBundlePath);
 
   const config = options.nextConfig
     ? { ...options.nextConfig }
@@ -265,6 +270,7 @@ export async function runPrerender(options: RunPrerenderOptions): Promise<Preren
         config,
         concurrency: options.concurrency,
         rscBundlePath,
+        serverDir,
         // For hybrid builds pass the shared prod server via internal field.
         // prerenderApp will use it instead of starting its own.
         ...(sharedProdServer ? { _prodServer: sharedProdServer } : {}),

--- a/packages/vinext/src/build/run-prerender.ts
+++ b/packages/vinext/src/build/run-prerender.ts
@@ -376,7 +376,7 @@ export async function runPrerender(options: RunPrerenderOptions): Promise<Preren
     );
   }
 
-  injectPregeneratedConcretePaths(root);
+  injectPregeneratedConcretePaths(root, rscBundlePath);
   if (fs.existsSync(rscBundlePath)) {
     rememberCurrentServerEntryImportMtime(rscBundlePath);
   }

--- a/packages/vinext/src/build/run-prerender.ts
+++ b/packages/vinext/src/build/run-prerender.ts
@@ -190,7 +190,7 @@ export async function runPrerender(options: RunPrerenderOptions): Promise<Preren
   // output aligned with the bundle it was generated from. (Spreading
   // `loadedConfig` above is required so this assignment does not mutate the
   // shared loaded config.)
-  const builtBuildId = readBuiltBuildId(serverDir);
+  const builtBuildId = readBuiltBuildId(manifestDir) ?? readBuiltBuildId(serverDir);
   if (builtBuildId) {
     config.buildId = builtBuildId;
   }
@@ -243,6 +243,7 @@ export async function runPrerender(options: RunPrerenderOptions): Promise<Preren
         host: "127.0.0.1",
         outDir: path.dirname(serverDir),
         rscEntryPath: rscBundlePath,
+        serverDir,
         noCompression: true,
         purpose: "prerender",
       });

--- a/packages/vinext/src/build/run-prerender.ts
+++ b/packages/vinext/src/build/run-prerender.ts
@@ -167,20 +167,24 @@ export async function runPrerender(options: RunPrerenderOptions): Promise<Preren
 
   if (!appDir && !pagesDir) return null;
 
-  // The manifest lands in dist/server/ alongside the server bundle so it's
-  // cleaned with the rest of vinext's build output on rebuild and co-located
-  // with server artifacts.
-  const manifestDir = path.resolve(
+  // Framework manifests and prerendered routes have one canonical location,
+  // independent of where an adapter asks Vite to emit the executable RSC
+  // graph. Consumers such as cache prewarming always resolve these artifacts
+  // from dist/server.
+  const manifestDir = path.resolve(root, "dist", "server");
+  const buildOutDir = path.resolve(root, "dist");
+  const configuredRscServerDir = path.resolve(
     root,
     options.routeRootConfig?.rscOutDir ?? path.join("dist", "server"),
   );
-  const rscBundlePath = options.rscBundlePath ?? resolveBuiltRscEntryPath(manifestDir);
-  // The emitted entry may live below dist/server (for example entries/app.js).
-  // Build metadata and prerender artifacts remain rooted at dist/server.
-  const relativeEntryPath = path.relative(manifestDir, rscBundlePath);
+  const rscBundlePath = options.rscBundlePath ?? resolveBuiltRscEntryPath(configuredRscServerDir);
+  // The emitted entry may live below its server root (for example
+  // entries/app.js). Keep adjacent build metadata rooted at the configured
+  // RSC output while resolving an explicit external entry from its own folder.
+  const relativeEntryPath = path.relative(configuredRscServerDir, rscBundlePath);
   const serverDir =
     !relativeEntryPath.startsWith("../") && !path.isAbsolute(relativeEntryPath)
-      ? manifestDir
+      ? configuredRscServerDir
       : path.dirname(rscBundlePath);
 
   const config = options.nextConfig
@@ -247,7 +251,7 @@ export async function runPrerender(options: RunPrerenderOptions): Promise<Preren
       sharedProdServer = await startProdServer({
         port: 0,
         host: "127.0.0.1",
-        outDir: path.dirname(serverDir),
+        outDir: buildOutDir,
         rscEntryPath: rscBundlePath,
         serverDir,
         noCompression: true,
@@ -278,6 +282,7 @@ export async function runPrerender(options: RunPrerenderOptions): Promise<Preren
         concurrency: options.concurrency,
         rscBundlePath,
         serverDir,
+        buildOutDir,
         // For hybrid builds pass the shared prod server via internal field.
         // prerenderApp will use it instead of starting its own.
         ...(sharedProdServer ? { _prodServer: sharedProdServer } : {}),
@@ -388,7 +393,7 @@ export async function runPrerender(options: RunPrerenderOptions): Promise<Preren
     );
   }
 
-  injectPregeneratedConcretePaths(root, rscBundlePath, manifestDir);
+  injectPregeneratedConcretePaths(root, rscBundlePath, manifestDir, [configuredRscServerDir]);
   if (fs.existsSync(rscBundlePath)) {
     rememberCurrentServerEntryImportMtime(rscBundlePath);
   }

--- a/packages/vinext/src/build/server-entry.ts
+++ b/packages/vinext/src/build/server-entry.ts
@@ -1,0 +1,31 @@
+import fs from "node:fs";
+import path from "pathslash";
+
+const RSC_ENTRY_MANIFEST_KEY = "virtual:vinext-rsc-entry";
+
+/** Resolve the built App handler even when a deployment host owns index.js. */
+export function resolveBuiltRscEntryPath(serverDir: string): string {
+  const fallbackPath = path.join(serverDir, "index.js");
+  const manifestPath = path.join(serverDir, ".vite", "manifest.json");
+  let manifest: unknown;
+  try {
+    manifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8"));
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+      return fallbackPath;
+    }
+    if (error instanceof SyntaxError) return fallbackPath;
+    throw error;
+  }
+
+  if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)) return fallbackPath;
+  const entry = Reflect.get(manifest, RSC_ENTRY_MANIFEST_KEY);
+  if (!entry || typeof entry !== "object") return fallbackPath;
+  const file = Reflect.get(entry, "file");
+  if (typeof file !== "string") return fallbackPath;
+
+  const entryPath = path.resolve(serverDir, file);
+  const relativePath = path.relative(serverDir, entryPath);
+  if (relativePath.startsWith("../") || path.isAbsolute(relativePath)) return fallbackPath;
+  return fs.existsSync(entryPath) ? entryPath : fallbackPath;
+}

--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -64,7 +64,9 @@ import {
 } from "./config/prerender.js";
 import {
   findVinextCacheConfigInPlugins,
+  getConfiguredCdnResponsePolicyHeaderNames,
   hasBuildIdentityResponseHeader,
+  hasUncachedRequestRouting,
   hasVerbatimResponseVary,
   type VinextCacheConfig,
 } from "./cache/cache-adapters-virtual.js";
@@ -744,6 +746,12 @@ async function buildApp() {
       responseVary: hasVerbatimResponseVary(buildConfigMetadata.cacheConfig)
         ? "verbatim"
         : undefined,
+      requestRouting: hasUncachedRequestRouting(buildConfigMetadata.cacheConfig)
+        ? "uncached-stage"
+        : undefined,
+      responsePolicyHeaderNames: getConfiguredCdnResponsePolicyHeaderNames(
+        buildConfigMetadata.cacheConfig,
+      ),
       routeRootConfig: buildConfigMetadata.routeRootConfig,
     });
   }

--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -736,6 +736,7 @@ async function buildApp() {
       root,
       concurrency: parsed.prerenderConcurrency,
       nextConfig: resolvedNextConfig,
+      routeRootConfig: buildConfigMetadata.routeRootConfig,
     });
     await emitPrerenderPathManifest({
       root,

--- a/packages/vinext/src/config/prerender.ts
+++ b/packages/vinext/src/config/prerender.ts
@@ -3,7 +3,9 @@ import { flattenPluginOptions } from "../utils/plugin-options.js";
 import { isUnknownRecord } from "../utils/record.js";
 export {
   findVinextCacheConfigInPlugins,
+  getConfiguredCdnResponsePolicyHeaderNames,
   hasBuildIdentityResponseHeader,
+  hasUncachedRequestRouting,
   hasVerbatimResponseVary,
   requiresRouteCacheabilityProbeManifest,
   loadVinextCacheConfigFromViteConfig,

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -7095,16 +7095,14 @@ export const loadServerActionClient = ${
           const source = JSON.stringify(manifest);
           fs.writeFileSync(path.join(outDir, "vinext-server.json"), source);
 
-          // Staged discovery and cacheability probing deliberately read build
-          // metadata from the platform-independent server directory. A Pages
-          // Worker bundle may live in a platform-named output directory, so
-          // retain the adjacent copy above and also publish the canonical copy.
-          if (!hasAppDir) {
-            const canonicalServerDir = path.join(root, "dist", "server");
-            if (path.resolve(outDir) !== canonicalServerDir) {
-              fs.mkdirSync(canonicalServerDir, { recursive: true });
-              fs.writeFileSync(path.join(canonicalServerDir, "vinext-server.json"), source);
-            }
+          // Post-build discovery deliberately reads metadata from the
+          // platform-independent server directory. An adapter may emit either
+          // router's executable graph elsewhere, so retain the adjacent copy
+          // above and also publish the canonical copy.
+          const canonicalServerDir = path.join(root, "dist", "server");
+          if (path.resolve(outDir) !== canonicalServerDir) {
+            fs.mkdirSync(canonicalServerDir, { recursive: true });
+            fs.writeFileSync(path.join(canonicalServerDir, "vinext-server.json"), source);
           }
         },
       },

--- a/packages/vinext/src/server/prod-server.ts
+++ b/packages/vinext/src/server/prod-server.ts
@@ -278,6 +278,8 @@ export type ProdServerOptions = {
   outDir?: string;
   /** Explicit App Router RSC entry path. Defaults to `<outDir>/server/index.js`. */
   rscEntryPath?: string;
+  /** Directory containing server manifests, sidecars, and prerender artifacts. */
+  serverDir?: string;
   /** Explicit Pages Router server entry path. Defaults to `<outDir>/server/entry.js`. */
   serverEntryPath?: string;
   /** Disable compression (default: false) */
@@ -1266,6 +1268,7 @@ export async function startProdServer(options: ProdServerOptions = {}) {
     host = "0.0.0.0",
     outDir = path.resolve("dist"),
     rscEntryPath: explicitRscEntryPath,
+    serverDir: explicitServerDir,
     serverEntryPath: explicitServerEntryPath,
     noCompression = false,
     purpose,
@@ -1276,14 +1279,17 @@ export async function startProdServer(options: ProdServerOptions = {}) {
   // Always resolve outDir to absolute to ensure dynamic import() works
   const resolvedOutDir = path.resolve(outDir);
   const clientDir = path.join(resolvedOutDir, "client");
+  const serverDir = explicitServerDir
+    ? path.resolve(explicitServerDir)
+    : path.join(resolvedOutDir, "server");
 
   // Detect build type
   const rscEntryPath = explicitRscEntryPath
     ? path.resolve(explicitRscEntryPath)
-    : path.join(resolvedOutDir, "server", "index.js");
+    : path.join(serverDir, "index.js");
   const serverEntryPath = explicitServerEntryPath
     ? path.resolve(explicitServerEntryPath)
-    : path.join(resolvedOutDir, "server", "entry.js");
+    : path.join(serverDir, "entry.js");
   const isAppRouter = fs.existsSync(rscEntryPath);
 
   if (!isAppRouter && !fs.existsSync(serverEntryPath)) {
@@ -1293,7 +1299,16 @@ export async function startProdServer(options: ProdServerOptions = {}) {
   }
 
   if (isAppRouter) {
-    return startAppRouterServer({ port, host, clientDir, rscEntryPath, compress, purpose, silent });
+    return startAppRouterServer({
+      port,
+      host,
+      clientDir,
+      serverDir,
+      rscEntryPath,
+      compress,
+      purpose,
+      silent,
+    });
   }
 
   return startPagesRouterServer({
@@ -1313,6 +1328,7 @@ type AppRouterServerOptions = {
   port: number;
   host: string;
   clientDir: string;
+  serverDir: string;
   rscEntryPath: string;
   compress: boolean;
   purpose?: ProdServerOptions["purpose"];
@@ -1547,11 +1563,11 @@ function installPagesClientAssets(options: {
  * 4. Stream the Web Response back (with optional compression)
  */
 async function startAppRouterServer(options: AppRouterServerOptions) {
-  const { port, host, clientDir, rscEntryPath, compress, purpose, silent } = options;
+  const { port, host, clientDir, serverDir, rscEntryPath, compress, purpose, silent } = options;
 
   // Load prerender secret written at build time by vinext:server-manifest plugin.
   // Used to authenticate internal /__vinext/prerender/* HTTP endpoints.
-  const prerenderSecret = readPrerenderSecret(path.dirname(rscEntryPath));
+  const prerenderSecret = readPrerenderSecret(serverDir);
 
   // Import the RSC handler. importServerEntryModule uses the bare file://
   // URL so lazy chunks that import the entry back resolve to the same module
@@ -1586,7 +1602,7 @@ async function startAppRouterServer(options: AppRouterServerOptions) {
       ? (rscModule.__imageConfig as ImageConfig)
       : undefined;
   if (imageConfig === undefined) {
-    const imageConfigPath = path.join(path.dirname(rscEntryPath), "image-config.json");
+    const imageConfigPath = path.join(serverDir, "image-config.json");
     if (fs.existsSync(imageConfigPath)) {
       try {
         imageConfig = JSON.parse(fs.readFileSync(imageConfigPath, "utf-8"));
@@ -1619,7 +1635,7 @@ async function startAppRouterServer(options: AppRouterServerOptions) {
   // any pre-rendered page is a cache HIT instead of a full re-render.
   const seedPrerenderedRoutes = resolveAppRouterPrerenderSeeder(rscModule);
   const seededRoutes = await runWithServerEntryRequire(rscEntryRequire, () =>
-    seedPrerenderedRoutes(path.dirname(rscEntryPath)),
+    seedPrerenderedRoutes(serverDir),
   );
   if (seededRoutes > 0) {
     console.log(

--- a/tests/build-time-classification-integration.test.ts
+++ b/tests/build-time-classification-integration.test.ts
@@ -151,12 +151,14 @@ function extractRouteIndexByPattern(chunkSource: string): Map<string, number> {
 }
 
 type BuiltFixtureRaw = {
+  classificationChunks: Array<{ fileName: string; source: string }>;
   chunkSource: string;
 };
 
 async function buildMinimalFixtureRaw({
   debug = false,
-}: { debug?: boolean } = {}): Promise<BuiltFixtureRaw> {
+  includeResponseStage = false,
+}: { debug?: boolean; includeResponseStage?: boolean } = {}): Promise<BuiltFixtureRaw> {
   const workspaceRoot = path.resolve(import.meta.dirname, "..");
   const workspaceNodeModules = path.join(workspaceRoot, "node_modules");
 
@@ -237,7 +239,29 @@ export default function ForceStaticLayout({ children }) {
   const builder = await createBuilder({
     root: tmpDir,
     configFile: false,
-    plugins: [vinext({ appDir: tmpDir, rscOutDir, ssrOutDir, clientOutDir })],
+    plugins: [
+      vinext({ appDir: tmpDir, rscOutDir, ssrOutDir, clientOutDir }),
+      ...(includeResponseStage
+        ? [
+            {
+              name: "test:multi-entry-rsc-build",
+              configEnvironment(name: string) {
+                if (name !== "rsc") return null;
+                return {
+                  build: {
+                    rolldownOptions: {
+                      input: {
+                        index: "virtual:vinext-rsc-entry",
+                        response: "virtual:vinext-response-stage",
+                      },
+                    },
+                  },
+                };
+              },
+            },
+          ]
+        : []),
+    ],
     logLevel: "silent",
   });
 
@@ -274,7 +298,16 @@ export default function ForceStaticLayout({ children }) {
   }
   const chunkSource = await fsp.readFile(path.join(chunkDir, chunkFile), "utf8");
 
-  return { chunkSource };
+  const classificationChunks: BuiltFixtureRaw["classificationChunks"] = [];
+  for (const entry of entries) {
+    if (!/\.m?js$/.test(entry)) continue;
+    const source = await fsp.readFile(path.join(chunkDir, entry), "utf8");
+    if (source.includes("__buildTimeClassifications")) {
+      classificationChunks.push({ fileName: entry, source });
+    }
+  }
+
+  return { chunkSource, classificationChunks };
 }
 
 async function buildMinimalFixture({
@@ -361,6 +394,24 @@ describe("build-time classification integration", () => {
     const map = built.dispatch(routeIdx!);
     expect(map).toBeInstanceOf(Map);
     expect(map!.get(0)).toBe("static");
+  });
+});
+
+describe("build-time classification integration (multi-entry RSC)", () => {
+  let classificationChunks: BuiltFixtureRaw["classificationChunks"];
+
+  beforeAll(async () => {
+    ({ classificationChunks } = await buildMinimalFixtureRaw({ includeResponseStage: true }));
+  }, 120_000);
+
+  it("patches both the ordinary and response-stage RSC graphs", () => {
+    expect(classificationChunks).toHaveLength(2);
+    for (const { fileName, source } of classificationChunks) {
+      const dispatch = extractDispatch(source);
+      const routeIndex = extractRouteIndexByPattern(source).get("/");
+      expect(routeIndex, fileName).toBeDefined();
+      expect(dispatch(routeIndex!)?.get(0), fileName).toBe("static");
+    }
   });
 });
 

--- a/tests/client-assets-build.test.ts
+++ b/tests/client-assets-build.test.ts
@@ -76,6 +76,14 @@ describe("client asset sidecar builds", () => {
 
       const rscEntry = await fs.readFile(path.join(rscOutDir, "index.js"), "utf8");
       expect(rscEntry).toContain("./vinext-client-assets.js");
+
+      const adjacentServerManifest = await fs.readFile(
+        path.join(rscOutDir, "vinext-server.json"),
+        "utf8",
+      );
+      expect(
+        await fs.readFile(path.join(fixtureRoot, "dist/server/vinext-server.json"), "utf8"),
+      ).toBe(adjacentServerManifest);
     } finally {
       await fs.rm(fixtureRoot, { recursive: true, force: true });
       await fs.rm(outRoot, { recursive: true, force: true });

--- a/tests/deploy-prerender-config.test.ts
+++ b/tests/deploy-prerender-config.test.ts
@@ -264,6 +264,29 @@ describe("deploy prerender config wiring", () => {
     );
   });
 
+  it("passes configured build output roots to deploy prerendering", async () => {
+    writeProject("true");
+    const viteConfigPath = path.join(tmpDir, "vite.config.ts");
+    fs.writeFileSync(
+      viteConfigPath,
+      fs
+        .readFileSync(viteConfigPath, "utf-8")
+        .replace(
+          "vinext({ prerender: true",
+          'vinext({ rscOutDir: "build/application", prerender: true',
+        ),
+    );
+    const { deploy } = await import("../packages/cloudflare/src/deploy.js");
+
+    await deploy({ root: tmpDir, skipBuild: true });
+
+    expect(runPrerenderMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        routeRootConfig: expect.objectContaining({ rscOutDir: "build/application" }),
+      }),
+    );
+  });
+
   it("loads Vite config even when the prerender-all flag already decides prerendering", async () => {
     writeProject("true");
     fs.appendFileSync(

--- a/tests/inject-pregenerated-paths.test.ts
+++ b/tests/inject-pregenerated-paths.test.ts
@@ -176,6 +176,40 @@ describe("injectPregeneratedConcretePaths", () => {
     expect(responseEntry).toMatchObject({ renderedPaths: ["/blog/post-a"] });
   });
 
+  it("writes the runtime table beside a custom application entry", async () => {
+    const registryModuleUrl = pathToFileURL(
+      path.resolve("packages/vinext/src/server/pregenerated-concrete-paths.ts"),
+    ).href;
+    const entryPath = path.join(tmpDir, "dist/custom-rsc/application-entry.js");
+    writeFile(
+      "dist/custom-rsc/application-entry.js",
+      [
+        `import "./${PREGENERATED_CONCRETE_PATHS_MODULE}";`,
+        `import { getRenderedConcreteUrlPathsForRoute, initPregeneratedPathsFromGlobals } from ${JSON.stringify(registryModuleUrl)};`,
+        "initPregeneratedPathsFromGlobals();",
+        'export const renderedPaths = [...(getRenderedConcreteUrlPathsForRoute("/blog/:slug") ?? [])];',
+        "",
+      ].join("\n"),
+    );
+    writeFile(
+      "dist/server/vinext-prerender.json",
+      JSON.stringify({
+        buildId: "test",
+        pregeneratedConcretePaths: [["/blog/:slug", ["/blog/post-a"]]],
+      }),
+    );
+
+    injectPregeneratedConcretePaths(tmpDir, entryPath);
+
+    expect(
+      fs.existsSync(path.join(path.dirname(entryPath), PREGENERATED_CONCRETE_PATHS_MODULE)),
+    ).toBe(true);
+    const applicationEntry: unknown = await import(
+      `${pathToFileURL(entryPath).href}?t=${Date.now()}`
+    );
+    expect(applicationEntry).toMatchObject({ renderedPaths: ["/blog/post-a"] });
+  });
+
   it("strips an earlier injection when the manifest is corrupt", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     writeFile(

--- a/tests/inject-pregenerated-paths.test.ts
+++ b/tests/inject-pregenerated-paths.test.ts
@@ -4,7 +4,10 @@ import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { injectPregeneratedConcretePaths } from "../packages/vinext/src/build/inject-pregenerated-paths.js";
-import { clearPregeneratedConcretePaths } from "../packages/vinext/src/server/pregenerated-concrete-paths.js";
+import {
+  clearPregeneratedConcretePaths,
+  PREGENERATED_CONCRETE_PATHS_MODULE,
+} from "../packages/vinext/src/server/pregenerated-concrete-paths.js";
 
 let tmpDir: string;
 
@@ -140,6 +143,37 @@ describe("injectPregeneratedConcretePaths", () => {
     const entryUrl = pathToFileURL(path.join(tmpDir, "dist/server/index.js")).href;
     const workerEntry: unknown = await import(`${entryUrl}?t=${Date.now()}`);
     expect(workerEntry).toMatchObject({ renderedPaths: ["/blog/post-a"] });
+  });
+
+  it("hydrates an independently deployed response-stage entry", async () => {
+    const registryModuleUrl = pathToFileURL(
+      path.resolve("packages/vinext/src/server/pregenerated-concrete-paths.ts"),
+    ).href;
+    writeFile("dist/server/index.js", "export default { fetch() {} };\n");
+    writeFile(
+      "dist/server/vinext-response-stage.js",
+      [
+        `import "./${PREGENERATED_CONCRETE_PATHS_MODULE}";`,
+        `import { getRenderedConcreteUrlPathsForRoute, initPregeneratedPathsFromGlobals } from ${JSON.stringify(registryModuleUrl)};`,
+        "initPregeneratedPathsFromGlobals();",
+        'export const renderedPaths = [...(getRenderedConcreteUrlPathsForRoute("/blog/:slug") ?? [])];',
+        "export default { fetch() {} };",
+        "",
+      ].join("\n"),
+    );
+    writeFile(
+      "dist/server/vinext-prerender.json",
+      JSON.stringify({
+        buildId: "test",
+        pregeneratedConcretePaths: [["/blog/:slug", ["/blog/post-a"]]],
+      }),
+    );
+
+    injectPregeneratedConcretePaths(tmpDir);
+
+    const entryUrl = pathToFileURL(path.join(tmpDir, "dist/server/vinext-response-stage.js")).href;
+    const responseEntry: unknown = await import(`${entryUrl}?t=${Date.now()}`);
+    expect(responseEntry).toMatchObject({ renderedPaths: ["/blog/post-a"] });
   });
 
   it("strips an earlier injection when the manifest is corrupt", () => {

--- a/tests/inject-pregenerated-paths.test.ts
+++ b/tests/inject-pregenerated-paths.test.ts
@@ -29,8 +29,11 @@ afterEach(() => {
 });
 
 describe("injectPregeneratedConcretePaths", () => {
-  it("replaces an earlier injection", () => {
-    writeFile("dist/server/index.js", 'import { handler } from "vinext/server/fetch-handler";\n');
+  it("updates the sidecar without rewriting the built entry or its sourcemap", () => {
+    const entry = 'import { handler } from "vinext/server/fetch-handler";\n';
+    const sourceMap = '{"version":3,"sources":["entry.ts"]}\n';
+    writeFile("dist/server/index-a1b2.js", entry);
+    writeFile("dist/server/index-a1b2.js.map", sourceMap);
     writeFile(
       "dist/server/vinext-prerender.json",
       JSON.stringify({
@@ -38,7 +41,8 @@ describe("injectPregeneratedConcretePaths", () => {
         pregeneratedConcretePaths: [["/blog/:slug", ["/blog/post-a"]]],
       }),
     );
-    injectPregeneratedConcretePaths(tmpDir);
+    const entryPath = path.join(tmpDir, "dist/server/index-a1b2.js");
+    injectPregeneratedConcretePaths(tmpDir, entryPath);
 
     writeFile(
       "dist/server/vinext-prerender.json",
@@ -47,31 +51,31 @@ describe("injectPregeneratedConcretePaths", () => {
         pregeneratedConcretePaths: [["/blog/:slug", ["/blog/post-b"]]],
       }),
     );
-    injectPregeneratedConcretePaths(tmpDir);
+    injectPregeneratedConcretePaths(tmpDir, entryPath);
 
-    const output = fs.readFileSync(path.join(tmpDir, "dist/server/index.js"), "utf-8");
-    expect(output).toContain("post-b");
-    expect(output).not.toContain("post-a");
-    expect(output).toContain('import { handler } from "vinext/server/fetch-handler"');
+    const runtimeTable = fs.readFileSync(
+      path.join(tmpDir, "dist/server", PREGENERATED_CONCRETE_PATHS_MODULE),
+      "utf-8",
+    );
+    expect(runtimeTable).toContain("post-b");
+    expect(runtimeTable).not.toContain("post-a");
+    expect(fs.readFileSync(entryPath, "utf-8")).toBe(entry);
+    expect(fs.readFileSync(`${entryPath}.map`, "utf-8")).toBe(sourceMap);
   });
 
-  it("strips an earlier injection when the manifest is missing", () => {
-    writeFile(
-      "dist/server/index.js",
-      [
-        "/* __VINEXT_PREGENERATED_CONCRETE_PATHS_START__ */",
-        'globalThis.__VINEXT_PREGENERATED_CONCRETE_PATHS = [["/blog/:slug",["/blog/post-a"]]];',
-        "/* __VINEXT_PREGENERATED_CONCRETE_PATHS_END__ */",
-        'import { handler } from "vinext/server/fetch-handler";',
-        "",
-      ].join("\n"),
-    );
+  it("clears the sidecar when the manifest is missing", () => {
+    const entry = 'import { handler } from "vinext/server/fetch-handler";\n';
+    writeFile("dist/server/index.js", entry);
 
     injectPregeneratedConcretePaths(tmpDir);
 
-    const output = fs.readFileSync(path.join(tmpDir, "dist/server/index.js"), "utf-8");
-    expect(output).not.toContain("__VINEXT_PREGENERATED_CONCRETE_PATHS");
-    expect(output).toContain('import { handler } from "vinext/server/fetch-handler"');
+    expect(
+      fs.readFileSync(
+        path.join(tmpDir, "dist/server", PREGENERATED_CONCRETE_PATHS_MODULE),
+        "utf-8",
+      ),
+    ).toBe("delete globalThis.__VINEXT_PREGENERATED_CONCRETE_PATHS;\n");
+    expect(fs.readFileSync(path.join(tmpDir, "dist/server/index.js"), "utf-8")).toBe(entry);
   });
 
   it("uses the concrete-path table stored in the prerender manifest", () => {
@@ -89,7 +93,10 @@ describe("injectPregeneratedConcretePaths", () => {
 
     injectPregeneratedConcretePaths(tmpDir);
 
-    const output = fs.readFileSync(path.join(tmpDir, "dist/server/index.js"), "utf-8");
+    const output = fs.readFileSync(
+      path.join(tmpDir, "dist/server", PREGENERATED_CONCRETE_PATHS_MODULE),
+      "utf-8",
+    );
     const match = output.match(/globalThis\.__VINEXT_PREGENERATED_CONCRETE_PATHS = (\[.*?\]);/);
     expect(match).not.toBeNull();
     expect(JSON.parse(match![1])).toEqual([["/blog/:slug", ["/blog/post-a"]]]);
@@ -100,16 +107,6 @@ describe("injectPregeneratedConcretePaths", () => {
 
   it("clears the current-process global when no concrete paths are available", () => {
     globalThis.__VINEXT_PREGENERATED_CONCRETE_PATHS = [["/old/:slug", ["/old/post"]]];
-    writeFile(
-      "dist/server/index.js",
-      [
-        "/* __VINEXT_PREGENERATED_CONCRETE_PATHS_START__ */",
-        'globalThis.__VINEXT_PREGENERATED_CONCRETE_PATHS = [["/old/:slug",["/old/post"]]];',
-        "/* __VINEXT_PREGENERATED_CONCRETE_PATHS_END__ */",
-        'export default { fetch() { return new Response("ok"); } };',
-        "",
-      ].join("\n"),
-    );
 
     injectPregeneratedConcretePaths(tmpDir);
 
@@ -123,6 +120,7 @@ describe("injectPregeneratedConcretePaths", () => {
     writeFile(
       "dist/server/index.js",
       [
+        `import "./${PREGENERATED_CONCRETE_PATHS_MODULE}";`,
         `import { getRenderedConcreteUrlPathsForRoute, initPregeneratedPathsFromGlobals } from ${JSON.stringify(registryModuleUrl)};`,
         "initPregeneratedPathsFromGlobals();",
         'export const renderedPaths = [...(getRenderedConcreteUrlPathsForRoute("/blog/:slug") ?? [])];',
@@ -180,9 +178,10 @@ describe("injectPregeneratedConcretePaths", () => {
     const registryModuleUrl = pathToFileURL(
       path.resolve("packages/vinext/src/server/pregenerated-concrete-paths.ts"),
     ).href;
-    const entryPath = path.join(tmpDir, "dist/custom-rsc/application-entry.js");
+    const rscServerDir = path.join(tmpDir, "dist/custom-rsc");
+    const entryPath = path.join(rscServerDir, "entries/application-entry.js");
     writeFile(
-      "dist/custom-rsc/application-entry.js",
+      "dist/custom-rsc/entries/application-entry.js",
       [
         `import "./${PREGENERATED_CONCRETE_PATHS_MODULE}";`,
         `import { getRenderedConcreteUrlPathsForRoute, initPregeneratedPathsFromGlobals } from ${JSON.stringify(registryModuleUrl)};`,
@@ -199,7 +198,9 @@ describe("injectPregeneratedConcretePaths", () => {
       }),
     );
 
-    injectPregeneratedConcretePaths(tmpDir, entryPath);
+    injectPregeneratedConcretePaths(tmpDir, entryPath, path.join(tmpDir, "dist/server"), [
+      rscServerDir,
+    ]);
 
     expect(
       fs.existsSync(path.join(path.dirname(entryPath), PREGENERATED_CONCRETE_PATHS_MODULE)),
@@ -210,31 +211,30 @@ describe("injectPregeneratedConcretePaths", () => {
         "utf-8",
       ),
     ).toContain("/blog/post-a");
+    expect(
+      fs.readFileSync(path.join(rscServerDir, PREGENERATED_CONCRETE_PATHS_MODULE), "utf-8"),
+    ).toContain("/blog/post-a");
     const applicationEntry: unknown = await import(
       `${pathToFileURL(entryPath).href}?t=${Date.now()}`
     );
     expect(applicationEntry).toMatchObject({ renderedPaths: ["/blog/post-a"] });
   });
 
-  it("strips an earlier injection when the manifest is corrupt", () => {
+  it("clears the sidecar without rewriting the entry when the manifest is corrupt", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    writeFile(
-      "dist/server/index.js",
-      [
-        "/* __VINEXT_PREGENERATED_CONCRETE_PATHS_START__ */",
-        'globalThis.__VINEXT_PREGENERATED_CONCRETE_PATHS = [["/",["/"]]];',
-        "/* __VINEXT_PREGENERATED_CONCRETE_PATHS_END__ */",
-        'export default { fetch() { return new Response("ok"); } };',
-        "",
-      ].join("\n"),
-    );
+    const entry = 'export default { fetch() { return new Response("ok"); } };\n';
+    writeFile("dist/server/index.js", entry);
     writeFile("dist/server/vinext-prerender.json", "{invalid json}");
 
     injectPregeneratedConcretePaths(tmpDir);
 
-    const output = fs.readFileSync(path.join(tmpDir, "dist/server/index.js"), "utf-8");
-    expect(output).not.toContain("__VINEXT_PREGENERATED_CONCRETE_PATHS");
-    expect(output).toContain('export default { fetch() { return new Response("ok"); } }');
+    expect(
+      fs.readFileSync(
+        path.join(tmpDir, "dist/server", PREGENERATED_CONCRETE_PATHS_MODULE),
+        "utf-8",
+      ),
+    ).toBe("delete globalThis.__VINEXT_PREGENERATED_CONCRETE_PATHS;\n");
+    expect(fs.readFileSync(path.join(tmpDir, "dist/server/index.js"), "utf-8")).toBe(entry);
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining("[vinext] Failed to read prerender manifest"),
       expect.any(SyntaxError),

--- a/tests/inject-pregenerated-paths.test.ts
+++ b/tests/inject-pregenerated-paths.test.ts
@@ -204,6 +204,12 @@ describe("injectPregeneratedConcretePaths", () => {
     expect(
       fs.existsSync(path.join(path.dirname(entryPath), PREGENERATED_CONCRETE_PATHS_MODULE)),
     ).toBe(true);
+    expect(
+      fs.readFileSync(
+        path.join(tmpDir, "dist/server", PREGENERATED_CONCRETE_PATHS_MODULE),
+        "utf-8",
+      ),
+    ).toContain("/blog/post-a");
     const applicationEntry: unknown = await import(
       `${pathToFileURL(entryPath).href}?t=${Date.now()}`
     );

--- a/tests/prerender-entry.test.ts
+++ b/tests/prerender-entry.test.ts
@@ -48,6 +48,7 @@ describe("App prerender entry", () => {
       expect.objectContaining({
         outDir: path.join(root, "dist"),
         rscEntryPath: rscBundlePath,
+        serverDir,
       }),
     );
   });

--- a/tests/prerender-entry.test.ts
+++ b/tests/prerender-entry.test.ts
@@ -23,8 +23,8 @@ describe("App prerender entry", () => {
   it("starts its owned server with the resolved application entry", async () => {
     root = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-prerender-entry-"));
     const serverDir = path.join(root, "dist", "server");
-    const rscBundlePath = path.join(serverDir, "application-entry.js");
-    fs.mkdirSync(serverDir, { recursive: true });
+    const rscBundlePath = path.join(serverDir, "entries", "application-entry.js");
+    fs.mkdirSync(path.dirname(rscBundlePath), { recursive: true });
     fs.writeFileSync(
       path.join(serverDir, "vinext-server.json"),
       JSON.stringify({ prerenderSecret: "test-prerender-secret" }),
@@ -41,10 +41,14 @@ describe("App prerender entry", () => {
       outDir: path.join(serverDir, "prerendered-routes"),
       routes: [],
       rscBundlePath,
+      serverDir,
     });
 
     expect(startProdServer).toHaveBeenCalledWith(
-      expect.objectContaining({ rscEntryPath: rscBundlePath }),
+      expect.objectContaining({
+        outDir: path.join(root, "dist"),
+        rscEntryPath: rscBundlePath,
+      }),
     );
   });
 });

--- a/tests/prerender-entry.test.ts
+++ b/tests/prerender-entry.test.ts
@@ -1,0 +1,50 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+const startProdServer = vi.hoisted(() =>
+  vi.fn(async () => ({
+    port: 43210,
+    server: { close: (callback: () => void) => callback() },
+  })),
+);
+
+vi.mock("../packages/vinext/src/server/prod-server.js", () => ({ startProdServer }));
+
+describe("App prerender entry", () => {
+  let root: string | undefined;
+
+  afterEach(() => {
+    startProdServer.mockClear();
+    if (root) fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("starts its owned server with the resolved application entry", async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-prerender-entry-"));
+    const serverDir = path.join(root, "dist", "server");
+    const rscBundlePath = path.join(serverDir, "application-entry.js");
+    fs.mkdirSync(serverDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(serverDir, "vinext-server.json"),
+      JSON.stringify({ prerenderSecret: "test-prerender-secret" }),
+    );
+    fs.writeFileSync(rscBundlePath, "export default {};");
+
+    const { prerenderApp } = await import("../packages/vinext/src/build/prerender.js");
+    const { resolveNextConfig } = await import("../packages/vinext/src/config/next-config.js");
+
+    await prerenderApp({
+      config: await resolveNextConfig(null, root),
+      metadataRoutes: [],
+      mode: "default",
+      outDir: path.join(serverDir, "prerendered-routes"),
+      routes: [],
+      rscBundlePath,
+    });
+
+    expect(startProdServer).toHaveBeenCalledWith(
+      expect.objectContaining({ rscEntryPath: rscBundlePath }),
+    );
+  });
+});

--- a/tests/prerender-paths.test.ts
+++ b/tests/prerender-paths.test.ts
@@ -253,6 +253,46 @@ describe("prerender path manifest", () => {
     });
   });
 
+  it("does not prune a pattern whose adapter cache policy varies by pathname", async () => {
+    writeFile("package.json", JSON.stringify({ type: "module" }));
+    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile("dist/server/RSC_BUILD_ID", "rsc-build-a\n");
+    writeFile("dist/server/index.js", "export default {};\n");
+    writeFile(
+      "app/policy/[slug]/page.tsx",
+      [
+        "export const dynamic = 'force-dynamic';",
+        "export function generateStaticParams() { return [{ slug: 'ordinary' }, { slug: 'special' }]; }",
+        "export default function Page() { return null; }",
+      ].join("\n"),
+    );
+    writeFile(
+      "next.config.mjs",
+      [
+        "export default {",
+        "  headers: async () => [{",
+        "    source: '/policy/special',",
+        "    headers: [{ key: 'CDN-Cache-Control', value: 'public, s-maxage=60' }],",
+        "  }],",
+        "};",
+      ].join("\n"),
+    );
+
+    const { emitPrerenderPathManifest } =
+      await import("../packages/vinext/src/build/prerender-paths.js");
+    const manifest = await emitPrerenderPathManifest({
+      root: tmpDir,
+      buildIdentity: "response-header",
+      responsePolicyHeaderNames: ["CDN-Cache-Control"],
+      responseVary: "verbatim",
+    });
+
+    expect(manifest?.routePatterns).toMatchObject({
+      "/policy/ordinary": { cacheabilityProbe: { canPrunePattern: false } },
+      "/policy/special": { cacheabilityProbe: { canPrunePattern: false } },
+    });
+  });
+
   it("discovers only Next.js-static Route Handler GET identities", async () => {
     // Ported from Next.js static eligibility and dynamic Route Handler params:
     // packages/next/src/server/route-modules/app-route/helpers/is-static-gen-enabled.ts
@@ -628,13 +668,17 @@ describe("prerender path manifest", () => {
     ]);
     const nextConfig = await resolveNextConfig(
       {
-        rewrites: () => [
-          {
-            source: "/rewrite-me",
-            destination: "/safe",
-            has: [{ type: "header", key: "x-route-variant", value: "1" }],
-          },
-        ],
+        rewrites: () => ({
+          beforeFiles: [
+            {
+              source: "/rewrite-me",
+              destination: "/safe",
+              has: [{ type: "header", key: "x-route-variant", value: "1" }],
+            },
+          ],
+          afterFiles: [],
+          fallback: [],
+        }),
       },
       tmpDir,
     );
@@ -651,7 +695,374 @@ describe("prerender path manifest", () => {
     expect(manifest?.loadingShellPaths).toEqual(["/safe"]);
   });
 
-  it("excludes warm paths shadowed by configured redirects", async () => {
+  it("warms rewrite source paths when routing runs in an uncached stage", async () => {
+    // Rewrite-aware prefetches can resolve a public URL to a different route:
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/concurrent-navigations/mismatching-prefetch.test.ts
+    writeFile("package.json", JSON.stringify({ type: "module" }));
+    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile("dist/server/RSC_BUILD_ID", "rsc-build-a\n");
+    writeFile("dist/server/index.js", "export default {};\n");
+    writeFile(
+      "app/rewrite-me/page.tsx",
+      "export const revalidate = 60; export default function Page() {}\n",
+    );
+    writeFile("app/rewrite-me/loading.tsx", "export default function Loading() { return null; }\n");
+    writeFile(
+      "app/safe/page.tsx",
+      "export const revalidate = 60; export default function Page() {}\n",
+    );
+    writeFile("app/safe/loading.tsx", "export default function Loading() { return null; }\n");
+
+    const [{ emitPrerenderPathManifest }, { resolveNextConfig }] = await Promise.all([
+      import("../packages/vinext/src/build/prerender-paths.js"),
+      import("../packages/vinext/src/config/next-config.js"),
+    ]);
+    const nextConfig = await resolveNextConfig(
+      {
+        rewrites: () => ({
+          beforeFiles: [
+            {
+              source: "/rewrite-me",
+              destination: "/safe",
+              has: [{ type: "header", key: "x-route-variant", value: "1" }],
+            },
+          ],
+          afterFiles: [],
+          fallback: [],
+        }),
+      },
+      tmpDir,
+    );
+
+    const manifest = await emitPrerenderPathManifest({
+      nextConfig,
+      requestRouting: "uncached-stage",
+      responseVary: "verbatim",
+      root: tmpDir,
+    });
+
+    expect(manifest?.paths).toEqual(["/rewrite-me", "/safe"]);
+    expect(manifest?.excludedWarmPaths).toBeUndefined();
+    expect(manifest?.rscPaths).toEqual(["/rewrite-me", "/safe"]);
+    expect(manifest?.loadingShellPaths).toEqual(["/rewrite-me", "/safe"]);
+    expect(manifest?.routePatterns?.["/rewrite-me"]?.cacheabilityProbe).toMatchObject({
+      routeMayResolve: true,
+    });
+    expect(manifest?.routePatterns?.["/safe"]?.cacheabilityProbe?.routeMayResolve).toBeUndefined();
+  });
+
+  it("retains external rewrite sources only when routing runs in an uncached stage", async () => {
+    writeFile("package.json", JSON.stringify({ type: "module" }));
+    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile("dist/server/RSC_BUILD_ID", "rsc-build-a\n");
+    writeFile("dist/server/index.js", "export default {};\n");
+    writeFile(
+      "app/external/page.tsx",
+      "export const revalidate = 60; export default function Page() {}\n",
+    );
+    writeFile(
+      "app/safe/page.tsx",
+      "export const revalidate = 60; export default function Page() {}\n",
+    );
+
+    const [{ emitPrerenderPathManifest }, { resolveNextConfig }] = await Promise.all([
+      import("../packages/vinext/src/build/prerender-paths.js"),
+      import("../packages/vinext/src/config/next-config.js"),
+    ]);
+    const nextConfig = await resolveNextConfig(
+      {
+        rewrites: () => ({
+          beforeFiles: [
+            {
+              source: "/external",
+              destination: "https://upstream.example/:path*",
+              has: [{ type: "header", key: "x-use-external", value: "1" }],
+            },
+          ],
+          afterFiles: [],
+          fallback: [],
+        }),
+      },
+      tmpDir,
+    );
+
+    const singleStageManifest = await emitPrerenderPathManifest({
+      nextConfig,
+      responseVary: "verbatim",
+      root: tmpDir,
+    });
+
+    expect(singleStageManifest?.paths).toEqual(["/safe"]);
+    expect(singleStageManifest?.excludedWarmPaths).toEqual(["/external"]);
+    expect(singleStageManifest?.routePatterns?.["/external"]).toBeUndefined();
+
+    const stagedManifest = await emitPrerenderPathManifest({
+      nextConfig,
+      requestRouting: "uncached-stage",
+      responseVary: "verbatim",
+      root: tmpDir,
+    });
+
+    expect(stagedManifest?.paths).toEqual(["/external", "/safe"]);
+    expect(stagedManifest?.excludedWarmPaths).toBeUndefined();
+    expect(stagedManifest?.routePatterns?.["/external"]?.cacheabilityProbe).toMatchObject({
+      requestStageMayTerminate: true,
+    });
+  });
+
+  it.each(["afterFiles", "fallback"] as const)(
+    "keeps non-dynamic App routes ahead of %s rewrites",
+    async (phase) => {
+      // Next.js checks non-dynamic pages before afterFiles and every matched
+      // route before fallback:
+      // https://github.com/vercel/next.js/blob/canary/docs/01-app/03-api-reference/05-config/01-next-config-js/rewrites.mdx
+      writeFile("package.json", JSON.stringify({ type: "module" }));
+      writeFile("dist/server/BUILD_ID", "build-a\n");
+      writeFile("dist/server/RSC_BUILD_ID", "rsc-build-a\n");
+      writeFile("dist/server/index.js", "export default {};\n");
+      writeFile(
+        "app/local/page.tsx",
+        "export const revalidate = 60; export default function Page() {}\n",
+      );
+      writeFile(
+        "app/external/page.tsx",
+        "export const revalidate = 60; export default function Page() {}\n",
+      );
+      writeFile(
+        "app/target/page.tsx",
+        "export const revalidate = 60; export default function Page() {}\n",
+      );
+      writeFile(
+        "app/api/static/route.ts",
+        "export const revalidate = 60; export function GET() { return new Response('ok'); }\n",
+      );
+
+      const [{ emitPrerenderPathManifest }, { resolveNextConfig }] = await Promise.all([
+        import("../packages/vinext/src/build/prerender-paths.js"),
+        import("../packages/vinext/src/config/next-config.js"),
+      ]);
+      const rewrites = [
+        { source: "/local", destination: "/target" },
+        { source: "/external", destination: "https://upstream.example/local" },
+        { source: "/api/static", destination: "https://upstream.example/api" },
+      ];
+      const nextConfig = await resolveNextConfig(
+        {
+          rewrites: () => ({
+            beforeFiles: [],
+            afterFiles: phase === "afterFiles" ? rewrites : [],
+            fallback: phase === "fallback" ? rewrites : [],
+          }),
+        },
+        tmpDir,
+      );
+
+      const manifest = await emitPrerenderPathManifest({
+        nextConfig,
+        requestRouting: "uncached-stage",
+        responseVary: "verbatim",
+        root: tmpDir,
+      });
+
+      expect(manifest?.paths).toHaveLength(3);
+      expect(manifest?.paths).toEqual(expect.arrayContaining(["/external", "/local", "/target"]));
+      expect(manifest?.routeHandlerPaths).toEqual(["/api/static"]);
+      expect(manifest?.excludedWarmPaths).toBeUndefined();
+      expect(manifest?.routePatterns?.["/external"]).toBeDefined();
+      expect(
+        manifest?.routePatterns?.["/local"]?.cacheabilityProbe?.routeMayResolve,
+      ).toBeUndefined();
+    },
+  );
+
+  it("still lets external afterFiles rewrites shadow discovered dynamic App paths", async () => {
+    writeFile("package.json", JSON.stringify({ type: "module" }));
+    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile("dist/server/RSC_BUILD_ID", "rsc-build-a\n");
+    writeFile("dist/server/index.js", "export default {};\n");
+    writeFile(
+      "app/cached/[slug]/page.tsx",
+      [
+        "export const revalidate = 60;",
+        "export function generateStaticParams() { return []; }",
+        "export default function Page() {}",
+      ].join("\n"),
+    );
+    writeFile(
+      "app/target/page.tsx",
+      "export const revalidate = 60; export default function Page() {}\n",
+    );
+
+    const [{ emitPrerenderPathManifest }, { resolveNextConfig }] = await Promise.all([
+      import("../packages/vinext/src/build/prerender-paths.js"),
+      import("../packages/vinext/src/config/next-config.js"),
+    ]);
+    const nextConfig = await resolveNextConfig(
+      {
+        rewrites: () => ({
+          beforeFiles: [],
+          afterFiles: [
+            {
+              source: "/cached/intro",
+              destination: "https://upstream.example/intro",
+            },
+            { source: "/cached/featured", destination: "/target" },
+          ],
+          fallback: [],
+        }),
+      },
+      tmpDir,
+    );
+
+    const manifest = await emitPrerenderPathManifest({
+      nextConfig,
+      requestRouting: "uncached-stage",
+      responseVary: "verbatim",
+      root: tmpDir,
+    });
+
+    expect(manifest?.paths).toHaveLength(3);
+    expect(manifest?.paths).toEqual(
+      expect.arrayContaining(["/cached/featured", "/cached/intro", "/target"]),
+    );
+    expect(manifest?.excludedWarmPaths).toBeUndefined();
+    expect(
+      manifest?.routePatterns?.["/cached/intro"]?.cacheabilityProbe?.requestStageMayTerminate,
+    ).toBe(true);
+    expect(manifest?.routePatterns?.["/cached/featured"]?.cacheabilityProbe?.routeMayResolve).toBe(
+      true,
+    );
+  });
+
+  it("keeps a non-dynamic Pages route ahead of an external afterFiles rewrite", async () => {
+    writeFile("package.json", JSON.stringify({ type: "module" }));
+    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile("dist/server/entry.js", "export default {};\n");
+    writeFile("pages/about.tsx", "export default function Page() {}\n");
+
+    const [{ emitPrerenderPathManifest }, { resolveNextConfig }] = await Promise.all([
+      import("../packages/vinext/src/build/prerender-paths.js"),
+      import("../packages/vinext/src/config/next-config.js"),
+    ]);
+    const nextConfig = await resolveNextConfig(
+      {
+        rewrites: () => ({
+          beforeFiles: [],
+          afterFiles: [{ source: "/about", destination: "https://upstream.example/about" }],
+          fallback: [],
+        }),
+      },
+      tmpDir,
+    );
+
+    const manifest = await emitPrerenderPathManifest({
+      nextConfig,
+      requestRouting: "uncached-stage",
+      responseVary: "verbatim",
+      root: tmpDir,
+    });
+
+    expect(manifest?.paths).toEqual(["/about"]);
+    expect(manifest?.pagesPaths).toEqual(["/about"]);
+    expect(manifest?.excludedWarmPaths).toBeUndefined();
+  });
+
+  it.each([
+    {
+      destination: "https://upstream.example/first",
+      expectedTerminal: true,
+      phase: "afterFiles" as const,
+      source: "/first",
+    },
+    {
+      destination: "https://upstream.example/:path*",
+      expectedTerminal: false,
+      phase: "fallback" as const,
+      source: "/:path*",
+    },
+  ])("applies Pages dynamic-route precedence around $phase rewrites", async (testCase) => {
+    // The fallback case is ported from Next.js:
+    // test/e2e/fallback-false-rewrite/fallback-false-rewrite.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/fallback-false-rewrite/fallback-false-rewrite.test.ts
+    writeFile("package.json", JSON.stringify({ type: "module" }));
+    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile("dist/server/entry.js", "export default {};\n");
+    writeFile(
+      "pages/[slug].tsx",
+      [
+        "export function getStaticPaths() { return { paths: [], fallback: false }; }",
+        "export function getStaticProps() { return { props: {}, revalidate: 60 }; }",
+        "export default function Page() {}",
+      ].join("\n"),
+    );
+    vi.mocked(fetch).mockResolvedValue(
+      Response.json({ fallback: false, paths: ["/first", "/second"] }),
+    );
+
+    const [{ emitPrerenderPathManifest }, { resolveNextConfig }] = await Promise.all([
+      import("../packages/vinext/src/build/prerender-paths.js"),
+      import("../packages/vinext/src/config/next-config.js"),
+    ]);
+    const rewrite = {
+      source: testCase.source,
+      destination: testCase.destination,
+    };
+    const nextConfig = await resolveNextConfig(
+      {
+        rewrites: () => ({
+          beforeFiles: [],
+          afterFiles: testCase.phase === "afterFiles" ? [rewrite] : [],
+          fallback: testCase.phase === "fallback" ? [rewrite] : [],
+        }),
+      },
+      tmpDir,
+    );
+
+    const manifest = await emitPrerenderPathManifest({
+      nextConfig,
+      requestRouting: "uncached-stage",
+      responseVary: "verbatim",
+      root: tmpDir,
+    });
+
+    expect(manifest?.paths).toEqual(["/first", "/second"]);
+    expect(manifest?.pagesPaths).toEqual(["/first", "/second"]);
+    expect(manifest?.excludedWarmPaths).toBeUndefined();
+    expect(
+      manifest?.routePatterns?.["/first"]?.cacheabilityProbe?.requestStageMayTerminate === true,
+    ).toBe(testCase.expectedTerminal);
+  });
+
+  it("allows the uncached middleware stage to resolve warm routes", async () => {
+    writeFile("package.json", JSON.stringify({ type: "module" }));
+    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile("dist/server/RSC_BUILD_ID", "rsc-build-a\n");
+    writeFile("dist/server/index.js", "export default {};\n");
+    writeFile("middleware.ts", "export default function middleware() {}\n");
+    writeFile(
+      "app/middleware-source/page.tsx",
+      "export const revalidate = 60; export default function Page() {}\n",
+    );
+
+    const [{ emitPrerenderPathManifest }, { resolveNextConfig }] = await Promise.all([
+      import("../packages/vinext/src/build/prerender-paths.js"),
+      import("../packages/vinext/src/config/next-config.js"),
+    ]);
+    const manifest = await emitPrerenderPathManifest({
+      nextConfig: await resolveNextConfig({}, tmpDir),
+      requestRouting: "uncached-stage",
+      responseVary: "verbatim",
+      root: tmpDir,
+    });
+
+    expect(manifest?.routePatterns?.["/middleware-source"]?.cacheabilityProbe).toMatchObject({
+      canPrunePattern: true,
+      requestStageMayTerminate: true,
+      routeMayResolve: true,
+    });
+  });
+
+  it("retains redirect sources only when routing runs in an uncached stage", async () => {
     // Next.js applies config redirects before rendering the filesystem route:
     // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/navigation/navigation.test.ts
     writeFile("package.json", JSON.stringify({ type: "module" }));
@@ -673,20 +1084,41 @@ describe("prerender path manifest", () => {
     ]);
     const nextConfig = await resolveNextConfig(
       {
-        redirects: () => [{ source: "/redirect-me", destination: "/safe", permanent: false }],
+        redirects: () => [
+          {
+            source: "/redirect-me",
+            destination: "/safe",
+            has: [{ type: "header", key: "x-redirect", value: "1" }],
+            permanent: false,
+          },
+        ],
       },
       tmpDir,
     );
 
-    const manifest = await emitPrerenderPathManifest({
+    const singleStageManifest = await emitPrerenderPathManifest({
       nextConfig,
       responseVary: "verbatim",
       root: tmpDir,
     });
 
-    expect(manifest?.paths).toEqual(["/safe"]);
-    expect(manifest?.excludedWarmPaths).toEqual(["/redirect-me"]);
-    expect(manifest?.rscPaths).toEqual(["/safe"]);
+    expect(singleStageManifest?.paths).toEqual(["/safe"]);
+    expect(singleStageManifest?.excludedWarmPaths).toEqual(["/redirect-me"]);
+    expect(singleStageManifest?.rscPaths).toEqual(["/safe"]);
+
+    const stagedManifest = await emitPrerenderPathManifest({
+      nextConfig,
+      requestRouting: "uncached-stage",
+      responseVary: "verbatim",
+      root: tmpDir,
+    });
+
+    expect(stagedManifest?.paths).toEqual(["/redirect-me", "/safe"]);
+    expect(stagedManifest?.excludedWarmPaths).toBeUndefined();
+    expect(stagedManifest?.rscPaths).toEqual(["/redirect-me", "/safe"]);
+    expect(stagedManifest?.routePatterns?.["/redirect-me"]?.cacheabilityProbe).toMatchObject({
+      requestStageMayTerminate: true,
+    });
   });
 
   it("discovers a static child route from parent-layout generateStaticParams", async () => {
@@ -815,7 +1247,11 @@ describe("prerender path manifest", () => {
     const nextConfig = await resolveNextConfig(
       {
         trailingSlash: true,
-        rewrites: () => [{ source: "/foo/", destination: "/other" }],
+        rewrites: () => ({
+          beforeFiles: [{ source: "/foo/", destination: "/other" }],
+          afterFiles: [],
+          fallback: [],
+        }),
       },
       tmpDir,
     );
@@ -848,7 +1284,11 @@ describe("prerender path manifest", () => {
           locales: ["en", "fr"],
           domains: [{ domain: "example.fr", defaultLocale: "fr" }],
         },
-        rewrites: () => [{ source: "/fr/foo", destination: "/other", locale: false }],
+        rewrites: () => ({
+          beforeFiles: [{ source: "/fr/foo", destination: "/other", locale: false }],
+          afterFiles: [],
+          fallback: [],
+        }),
       },
       tmpDir,
     );
@@ -1399,6 +1839,41 @@ describe("prerender path manifest", () => {
     );
   });
 
+  it("uses the generated application entry recorded in the server build manifest", async () => {
+    writeFile("package.json", JSON.stringify({ type: "module" }));
+    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile("dist/server/index.js", 'import "cloudflare:workers";\n');
+    writeFile("dist/server/application-entry.js", "export default {};\n");
+    writeFile(
+      "dist/server/.vite/manifest.json",
+      JSON.stringify({
+        "virtual:vinext-rsc-entry": {
+          file: "application-entry.js",
+          isDynamicEntry: true,
+        },
+      }),
+    );
+    writeFile(
+      "app/cached/[slug]/page.tsx",
+      [
+        "export const revalidate = 60;",
+        "export function generateStaticParams() { return [{ slug: 'intro' }]; }",
+        "export default function Page() { return null; }",
+      ].join("\n"),
+    );
+
+    const { emitPrerenderPathManifest } =
+      await import("../packages/vinext/src/build/prerender-paths.js");
+
+    await emitPrerenderPathManifest({ root: tmpDir });
+
+    expect(startProdServerMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rscEntryPath: toSlash(path.join(tmpDir, "dist/server/application-entry.js")),
+      }),
+    );
+  });
+
   it("derives a custom RSC bundle path from route metadata", async () => {
     writeFile("package.json", JSON.stringify({ type: "module" }));
     writeFile("dist/server/BUILD_ID", "build-a\n");
@@ -1746,7 +2221,11 @@ describe("prerender path manifest", () => {
     const nextConfig = await resolveNextConfig(
       {
         i18n: { defaultLocale: "en", locales: ["en", "fr"] },
-        rewrites: () => [{ source: "/fr/about", destination: "/other", locale: false }],
+        rewrites: () => ({
+          beforeFiles: [{ source: "/fr/about", destination: "/other", locale: false }],
+          afterFiles: [],
+          fallback: [],
+        }),
       },
       tmpDir,
     );

--- a/tests/prerender-paths.test.ts
+++ b/tests/prerender-paths.test.ts
@@ -1843,12 +1843,12 @@ describe("prerender path manifest", () => {
     writeFile("package.json", JSON.stringify({ type: "module" }));
     writeFile("dist/server/BUILD_ID", "build-a\n");
     writeFile("dist/server/index.js", 'import "cloudflare:workers";\n');
-    writeFile("dist/server/application-entry.js", "export default {};\n");
+    writeFile("dist/server/entries/application-entry.js", "export default {};\n");
     writeFile(
       "dist/server/.vite/manifest.json",
       JSON.stringify({
         "virtual:vinext-rsc-entry": {
-          file: "application-entry.js",
+          file: "entries/application-entry.js",
           isDynamicEntry: true,
         },
       }),
@@ -1869,7 +1869,8 @@ describe("prerender path manifest", () => {
 
     expect(startProdServerMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        rscEntryPath: toSlash(path.join(tmpDir, "dist/server/application-entry.js")),
+        rscEntryPath: toSlash(path.join(tmpDir, "dist/server/entries/application-entry.js")),
+        serverDir: toSlash(path.join(tmpDir, "dist/server")),
       }),
     );
   });

--- a/tests/prerender-server-pool.test.ts
+++ b/tests/prerender-server-pool.test.ts
@@ -77,12 +77,14 @@ describe("prerender server pool sizing", () => {
       if (
         process.env.VINEXT_PRERENDER !== "1" ||
         process.env.NEXT_PHASE !== "phase-production-build" ||
-        process.env.VINEXT_PRERENDER_RSC_ENTRY_PATH !== "application-entry.js"
+        process.env.VINEXT_PRERENDER_RSC_ENTRY_PATH !== "application-entry.js" ||
+        process.env.VINEXT_PRERENDER_SERVER_DIR !== "server-artifacts"
       ) {
         process.send({ type: "error", error: JSON.stringify({
           VINEXT_PRERENDER: process.env.VINEXT_PRERENDER,
           NEXT_PHASE: process.env.NEXT_PHASE,
           VINEXT_PRERENDER_RSC_ENTRY_PATH: process.env.VINEXT_PRERENDER_RSC_ENTRY_PATH,
+          VINEXT_PRERENDER_SERVER_DIR: process.env.VINEXT_PRERENDER_SERVER_DIR,
         }) });
       } else {
         process.send({ type: "ready", port: 4125 });
@@ -94,6 +96,7 @@ describe("prerender server pool sizing", () => {
       const pool = await startPrerenderServerPool(dir, 1, {
         entry,
         rscEntryPath: "application-entry.js",
+        serverDir: "server-artifacts",
       });
       await pool.close();
     } finally {

--- a/tests/prerender-server-pool.test.ts
+++ b/tests/prerender-server-pool.test.ts
@@ -59,7 +59,7 @@ describe("prerender server pool sizing", () => {
     `);
 
     try {
-      const pool = await startPrerenderServerPool(dir, 2, entry);
+      const pool = await startPrerenderServerPool(dir, 2, { entry });
       try {
         expect(pool.ports).toHaveLength(2);
         expect(pool.ports.every((port) => typeof port === "number")).toBe(true);
@@ -76,11 +76,13 @@ describe("prerender server pool sizing", () => {
     const { dir, entry } = writeWorkerEntry(`
       if (
         process.env.VINEXT_PRERENDER !== "1" ||
-        process.env.NEXT_PHASE !== "phase-production-build"
+        process.env.NEXT_PHASE !== "phase-production-build" ||
+        process.env.VINEXT_PRERENDER_RSC_ENTRY_PATH !== "application-entry.js"
       ) {
         process.send({ type: "error", error: JSON.stringify({
           VINEXT_PRERENDER: process.env.VINEXT_PRERENDER,
           NEXT_PHASE: process.env.NEXT_PHASE,
+          VINEXT_PRERENDER_RSC_ENTRY_PATH: process.env.VINEXT_PRERENDER_RSC_ENTRY_PATH,
         }) });
       } else {
         process.send({ type: "ready", port: 4125 });
@@ -89,7 +91,10 @@ describe("prerender server pool sizing", () => {
     `);
 
     try {
-      const pool = await startPrerenderServerPool(dir, 1, entry);
+      const pool = await startPrerenderServerPool(dir, 1, {
+        entry,
+        rscEntryPath: "application-entry.js",
+      });
       await pool.close();
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
@@ -103,7 +108,7 @@ describe("prerender server pool sizing", () => {
     `);
 
     try {
-      const pool = await startPrerenderServerPool(dir, 1, entry);
+      const pool = await startPrerenderServerPool(dir, 1, { entry });
       try {
         pool.recordRenderError(new Error("renderPage returned 500"));
         expect(() => pool.assertHealthy()).not.toThrow();
@@ -128,7 +133,7 @@ describe("prerender server pool sizing", () => {
     `);
 
     try {
-      const pool = await startPrerenderServerPool(dir, 1, entry);
+      const pool = await startPrerenderServerPool(dir, 1, { entry });
       try {
         await new Promise((resolve) => setTimeout(resolve, 100));
         expect(() => pool.assertHealthy()).toThrow(/exited unexpectedly .*code 42/);
@@ -144,7 +149,7 @@ describe("prerender server pool sizing", () => {
     const { dir, entry } = writeWorkerEntry("process.exit(0);");
 
     try {
-      await expect(startPrerenderServerPool(dir, 1, entry)).rejects.toThrow(
+      await expect(startPrerenderServerPool(dir, 1, { entry })).rejects.toThrow(
         "exited during startup (code 0, signal null)",
       );
     } finally {

--- a/tests/prod-server-logs.test.ts
+++ b/tests/prod-server-logs.test.ts
@@ -101,6 +101,47 @@ describe("startProdServer logging", () => {
     ]);
   });
 
+  it("keeps nested App entries authenticated against the server artifact root", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-prod-server-nested-entry-"));
+    roots.push(root);
+    const distDir = path.join(root, "dist");
+    const clientDir = path.join(distDir, "client");
+    const serverDir = path.join(distDir, "server");
+    const entryPath = path.join(serverDir, "entries", "application.js");
+    fs.mkdirSync(clientDir, { recursive: true });
+    fs.mkdirSync(path.dirname(entryPath), { recursive: true });
+    fs.writeFileSync(
+      path.join(serverDir, "vinext-server.json"),
+      JSON.stringify({ prerenderSecret: "nested-secret" }),
+    );
+    fs.writeFileSync(
+      entryPath,
+      ["export default async function handler() { return new Response('ok'); }", ""].join("\n"),
+    );
+
+    const { startProdServer } = await import("../packages/vinext/src/server/prod-server.js");
+    const { server, port } = await startProdServer({
+      port: 0,
+      host: "127.0.0.1",
+      outDir: distDir,
+      rscEntryPath: entryPath,
+      serverDir,
+      noCompression: true,
+      silent: true,
+    });
+    try {
+      const denied = await fetch(`http://127.0.0.1:${port}/__vinext/prerender/static-params`);
+      expect(denied.status).toBe(403);
+      const allowed = await fetch(`http://127.0.0.1:${port}/__vinext/prerender/static-params`, {
+        headers: { "x-vinext-prerender-secret": "nested-secret" },
+      });
+      expect(allowed.status).toBe(200);
+      await expect(allowed.text()).resolves.toBe("ok");
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
   it("uses the prerender-specific startup log for App Router production servers", async () => {
     const root = createAppBuild();
     roots.push(root);

--- a/tests/run-prerender-concurrency.test.ts
+++ b/tests/run-prerender-concurrency.test.ts
@@ -99,4 +99,32 @@ describe("runPrerender concurrency", () => {
       fs.rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it("starts the prerender server with the generated App entry from the build manifest", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-run-prerender-entry-"));
+    fs.mkdirSync(path.join(root, "app"));
+    fs.mkdirSync(path.join(root, "dist", "server", ".vite"), { recursive: true });
+    fs.writeFileSync(path.join(root, "dist", "server", "index.js"), 'import "host:runtime";\n');
+    fs.writeFileSync(path.join(root, "dist", "server", "application-entry.js"), "export {};\n");
+    fs.writeFileSync(
+      path.join(root, "dist", "server", ".vite", "manifest.json"),
+      JSON.stringify({
+        "virtual:vinext-rsc-entry": { file: "application-entry.js", isDynamicEntry: true },
+      }),
+    );
+
+    try {
+      const { runPrerender } = await import("../packages/vinext/src/build/run-prerender.js");
+
+      await runPrerender({ root });
+
+      expect(prerenderAppMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          rscBundlePath: path.join(root, "dist", "server", "application-entry.js"),
+        }),
+      );
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/run-prerender-concurrency.test.ts
+++ b/tests/run-prerender-concurrency.test.ts
@@ -104,11 +104,16 @@ describe("runPrerender concurrency", () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-run-prerender-entry-"));
     fs.mkdirSync(path.join(root, "app"));
     fs.mkdirSync(path.join(root, "dist", "server", ".vite"), { recursive: true });
+    fs.writeFileSync(path.join(root, "dist", "server", "BUILD_ID"), "canonical-build\n");
     fs.writeFileSync(path.join(root, "dist", "server", "index.js"), 'import "host:runtime";\n');
     fs.mkdirSync(path.join(root, "dist", "server", "entries"));
     fs.writeFileSync(
       path.join(root, "dist", "server", "entries", "application-entry.js"),
       "export {};\n",
+    );
+    fs.writeFileSync(
+      path.join(root, "dist", "server", "entries", "BUILD_ID"),
+      "wrong-nested-build\n",
     );
     fs.writeFileSync(
       path.join(root, "dist", "server", ".vite", "manifest.json"),
@@ -129,6 +134,7 @@ describe("runPrerender concurrency", () => {
         expect.objectContaining({
           rscBundlePath: path.join(root, "dist", "server", "entries", "application-entry.js"),
           serverDir: path.join(root, "dist", "server"),
+          config: expect.objectContaining({ buildId: "canonical-build" }),
         }),
       );
     } finally {

--- a/tests/run-prerender-concurrency.test.ts
+++ b/tests/run-prerender-concurrency.test.ts
@@ -141,4 +141,44 @@ describe("runPrerender concurrency", () => {
       fs.rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it("resolves App artifacts from the configured RSC output root", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-run-prerender-custom-rsc-"));
+    const serverDir = path.join(root, "build", "application");
+    const applicationEntry = path.join(serverDir, "entries", "application-entry.js");
+    fs.mkdirSync(path.join(root, "app"));
+    fs.mkdirSync(path.join(serverDir, ".vite"), { recursive: true });
+    fs.mkdirSync(path.dirname(applicationEntry), { recursive: true });
+    fs.writeFileSync(path.join(serverDir, "BUILD_ID"), "custom-build\n");
+    fs.writeFileSync(applicationEntry, "export {};\n");
+    fs.writeFileSync(
+      path.join(serverDir, ".vite", "manifest.json"),
+      JSON.stringify({
+        "virtual:vinext-rsc-entry": {
+          file: "entries/application-entry.js",
+          isDynamicEntry: true,
+        },
+      }),
+    );
+
+    try {
+      const { runPrerender } = await import("../packages/vinext/src/build/run-prerender.js");
+
+      await runPrerender({
+        root,
+        routeRootConfig: { rscOutDir: "build/application" },
+      });
+
+      expect(prerenderAppMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          rscBundlePath: applicationEntry,
+          serverDir,
+          outDir: path.join(serverDir, "prerendered-routes"),
+          config: expect.objectContaining({ buildId: "custom-build" }),
+        }),
+      );
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/run-prerender-concurrency.test.ts
+++ b/tests/run-prerender-concurrency.test.ts
@@ -105,11 +105,18 @@ describe("runPrerender concurrency", () => {
     fs.mkdirSync(path.join(root, "app"));
     fs.mkdirSync(path.join(root, "dist", "server", ".vite"), { recursive: true });
     fs.writeFileSync(path.join(root, "dist", "server", "index.js"), 'import "host:runtime";\n');
-    fs.writeFileSync(path.join(root, "dist", "server", "application-entry.js"), "export {};\n");
+    fs.mkdirSync(path.join(root, "dist", "server", "entries"));
+    fs.writeFileSync(
+      path.join(root, "dist", "server", "entries", "application-entry.js"),
+      "export {};\n",
+    );
     fs.writeFileSync(
       path.join(root, "dist", "server", ".vite", "manifest.json"),
       JSON.stringify({
-        "virtual:vinext-rsc-entry": { file: "application-entry.js", isDynamicEntry: true },
+        "virtual:vinext-rsc-entry": {
+          file: "entries/application-entry.js",
+          isDynamicEntry: true,
+        },
       }),
     );
 
@@ -120,7 +127,8 @@ describe("runPrerender concurrency", () => {
 
       expect(prerenderAppMock).toHaveBeenCalledWith(
         expect.objectContaining({
-          rscBundlePath: path.join(root, "dist", "server", "application-entry.js"),
+          rscBundlePath: path.join(root, "dist", "server", "entries", "application-entry.js"),
+          serverDir: path.join(root, "dist", "server"),
         }),
       );
     } finally {

--- a/tests/run-prerender-concurrency.test.ts
+++ b/tests/run-prerender-concurrency.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import type { PrerenderResult } from "../packages/vinext/src/build/prerender.js";
 
 const {
   prerenderAppMock,
@@ -12,8 +13,8 @@ const {
   pagesRouterMock,
   apiRouterMock,
 } = vi.hoisted(() => ({
-  prerenderAppMock: vi.fn(async () => ({ routes: [] })),
-  prerenderPagesMock: vi.fn(async () => ({ routes: [] })),
+  prerenderAppMock: vi.fn<() => Promise<PrerenderResult>>(async () => ({ routes: [] })),
+  prerenderPagesMock: vi.fn<() => Promise<PrerenderResult>>(async () => ({ routes: [] })),
   writePrerenderIndexMock: vi.fn(),
   startProdServerMock: vi.fn(async () => ({
     server: { close: (callback: () => void) => callback() },
@@ -33,6 +34,7 @@ vi.mock("../packages/vinext/src/build/prerender.js", () => ({
 
 vi.mock("../packages/vinext/src/server/prod-server.js", () => ({
   startProdServer: startProdServerMock,
+  rememberCurrentServerEntryImportMtime: vi.fn(),
 }));
 
 vi.mock("../packages/vinext/src/routing/app-router.js", () => ({
@@ -173,9 +175,67 @@ describe("runPrerender concurrency", () => {
         expect.objectContaining({
           rscBundlePath: applicationEntry,
           serverDir,
-          outDir: path.join(serverDir, "prerendered-routes"),
+          buildOutDir: path.join(root, "dist"),
+          outDir: path.join(root, "dist", "server", "prerendered-routes"),
           config: expect.objectContaining({ buildId: "custom-build" }),
         }),
+      );
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps custom RSC builds on the canonical export and manifest roots", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-run-prerender-roots-"));
+    const serverDir = path.join(root, "build", "application");
+    const applicationEntry = path.join(serverDir, "entries", "application-entry.js");
+    fs.mkdirSync(path.join(root, "app"));
+    fs.mkdirSync(path.join(serverDir, ".vite"), { recursive: true });
+    fs.mkdirSync(path.dirname(applicationEntry), { recursive: true });
+    fs.writeFileSync(path.join(serverDir, "BUILD_ID"), "custom-build\n");
+    fs.writeFileSync(applicationEntry, "export {};\n");
+    fs.writeFileSync(
+      path.join(serverDir, ".vite", "manifest.json"),
+      JSON.stringify({
+        "virtual:vinext-rsc-entry": {
+          file: "entries/application-entry.js",
+          isDynamicEntry: true,
+        },
+      }),
+    );
+    fs.writeFileSync(path.join(root, "next.config.mjs"), 'export default { output: "export" };\n');
+    prerenderAppMock.mockResolvedValueOnce({
+      routes: [
+        {
+          route: "/",
+          status: "rendered",
+          outputFiles: [path.join(root, "dist", "client", "index.html")],
+          revalidate: false,
+          router: "app",
+        },
+      ],
+    });
+
+    try {
+      const { runPrerender } = await import("../packages/vinext/src/build/run-prerender.js");
+
+      await runPrerender({
+        root,
+        routeRootConfig: { rscOutDir: "build/application" },
+      });
+
+      expect(prerenderAppMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          rscBundlePath: applicationEntry,
+          serverDir,
+          buildOutDir: path.join(root, "dist"),
+          outDir: path.join(root, "dist", "client"),
+        }),
+      );
+      expect(writePrerenderIndexMock).toHaveBeenCalledWith(
+        expect.any(Array),
+        path.join(root, "dist", "server"),
+        expect.objectContaining({ buildId: "custom-build" }),
       );
     } finally {
       fs.rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
Part 11 of 16 in the staged CDN adapter stack. Depends on #3150.

## Summary

- carries adapter-selected stage routing through prerender path discovery
- starts prerender servers from canonical `dist` while resolving the executable RSC graph from its configured output root
- keeps manifests and prerendered artifacts canonical under `dist/server`
- updates the stable concrete-path sidecar without rewriting content-hashed entries or sourcemaps
- keeps Node prerender from evaluating host-only runtime imports

## Validation

- focused prerender, custom-output, pool, and production-build tests
- cumulative exact-tip changed-test sweep: 3,461 passed, 2 skipped
- full `vp check` and vinext package build

## Review size

- Implementation: +324 / -91 LOC
- Tests and fixtures: +953 / -71 LOC
- Other (docs, config, lockfile): +0 / -0 LOC
- 21 changed files

Measured against `codex/cdn-v2-build-stages` after rebasing onto `main@a6931c0`.