### PR TITLE
feat(cloudflare): isolate cached response entrypoint

### DIFF
--- a/packages/cloudflare/src/cache/cdn-adapter-config.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter-config.ts
@@ -138,22 +138,6 @@ async function writeGeneratedConfig(
   await fs.writeFile(generatedConfigPath, `${JSON.stringify(config, null, 2)}\n`);
 }
 
-/** Apply only the Workers Cache entrypoint policy to a generated config. */
-export async function finalizeWorkersCacheBuildOutput({
-  outDir,
-}: {
-  outDir: string;
-  root: string;
-}): Promise<void> {
-  const generatedConfigPath = path.resolve(outDir, "wrangler.json");
-  const generatedConfig = await readGeneratedConfig(generatedConfigPath, true);
-  if (!generatedConfig) return;
-  await writeGeneratedConfig(
-    generatedConfigPath,
-    configureWorkersCacheEntrypoints(generatedConfig),
-  );
-}
-
 /** Apply the complete CDN adapter policy to the primary generated config. */
 export async function finalizeCdnAdapterBuildOutput({
   outDir,

--- a/packages/cloudflare/src/cache/cdn-adapter-config.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter-config.ts
@@ -1,7 +1,19 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 
+const RESPONSE_STAGE_EXPORT = "VinextCachedResponse";
+const CTX_EXPORTS_DEFAULT_DATE = "2025-11-17";
+
+type WranglerWorkerExport = {
+  cache?: { enabled: boolean };
+  type?: string;
+  [key: string]: unknown;
+};
+
 type WranglerOutputConfig = {
+  compatibility_date?: string;
+  compatibility_flags?: string[];
+  exports?: Record<string, WranglerWorkerExport>;
   version_metadata?: unknown;
   [key: string]: unknown;
 };
@@ -20,10 +32,7 @@ export function configureCdnVersionMetadata(
   options: VersionMetadataOptions,
 ): WranglerOutputConfig {
   if (!Object.hasOwn(config, "version_metadata")) {
-    return {
-      ...config,
-      version_metadata: { binding: options.binding },
-    };
+    return { ...config, version_metadata: { binding: options.binding } };
   }
 
   if (!isRecord(config.version_metadata)) {
@@ -46,16 +55,106 @@ export function configureCdnVersionMetadata(
     );
   }
 
+  return { ...config, version_metadata: { binding: options.binding } };
+}
+
+/** Add the per-entrypoint Workers Cache policy to an emitted Wrangler config. */
+export function configureWorkersCacheEntrypoints(
+  config: WranglerOutputConfig,
+): WranglerOutputConfig {
+  const configuredExports = config.exports ?? {};
+  const compatibilityFlags = config.compatibility_flags ?? [];
+  if (compatibilityFlags.includes("disable_ctx_exports")) {
+    throw new Error(
+      "[vinext] cdnAdapter() requires ctx.exports, but the generated Wrangler config explicitly disables it with disable_ctx_exports.",
+    );
+  }
+
+  const requiresCtxExportsFlag =
+    config.compatibility_date === undefined || config.compatibility_date < CTX_EXPORTS_DEFAULT_DATE;
+  const configuredCompatibilityFlags = requiresCtxExportsFlag
+    ? compatibilityFlags.includes("enable_ctx_exports")
+      ? compatibilityFlags
+      : [...compatibilityFlags, "enable_ctx_exports"]
+    : compatibilityFlags.filter((flag) => flag !== "enable_ctx_exports");
+
+  for (const name of ["default", RESPONSE_STAGE_EXPORT]) {
+    const existing = configuredExports[name];
+    if (existing?.type !== undefined && existing.type !== "worker") {
+      throw new Error(
+        `[vinext] cdnAdapter() cannot configure the reserved Worker export ${JSON.stringify(name)} because it is already declared as ${JSON.stringify(existing.type)}.`,
+      );
+    }
+  }
+
   return {
     ...config,
-    version_metadata: { binding: options.binding },
+    compatibility_flags: configuredCompatibilityFlags,
+    exports: {
+      ...configuredExports,
+      default: {
+        ...configuredExports.default,
+        type: "worker",
+        cache: { enabled: false },
+      },
+      [RESPONSE_STAGE_EXPORT]: {
+        ...configuredExports[RESPONSE_STAGE_EXPORT],
+        type: "worker",
+        cache: { enabled: true },
+      },
+    },
   };
 }
 
-/**
- * Add the CDN adapter's version metadata binding to the Cloudflare Vite
- * plugin's primary generated deployment config.
- */
+async function readGeneratedConfig(
+  generatedConfigPath: string,
+  allowMissing: boolean,
+): Promise<WranglerOutputConfig | null> {
+  try {
+    const parsed = JSON.parse(await fs.readFile(generatedConfigPath, "utf8")) as unknown;
+    if (!isRecord(parsed)) throw new TypeError("the root value must be an object");
+    return parsed;
+  } catch (cause) {
+    if (
+      allowMissing &&
+      cause !== null &&
+      typeof cause === "object" &&
+      "code" in cause &&
+      cause.code === "ENOENT"
+    ) {
+      return null;
+    }
+    throw new Error(
+      `[vinext] Could not read the generated Wrangler config at ${generatedConfigPath}.`,
+      { cause },
+    );
+  }
+}
+
+async function writeGeneratedConfig(
+  generatedConfigPath: string,
+  config: WranglerOutputConfig,
+): Promise<void> {
+  await fs.writeFile(generatedConfigPath, `${JSON.stringify(config, null, 2)}\n`);
+}
+
+/** Apply only the Workers Cache entrypoint policy to a generated config. */
+export async function finalizeWorkersCacheBuildOutput({
+  outDir,
+}: {
+  outDir: string;
+  root: string;
+}): Promise<void> {
+  const generatedConfigPath = path.resolve(outDir, "wrangler.json");
+  const generatedConfig = await readGeneratedConfig(generatedConfigPath, true);
+  if (!generatedConfig) return;
+  await writeGeneratedConfig(
+    generatedConfigPath,
+    configureWorkersCacheEntrypoints(generatedConfig),
+  );
+}
+
+/** Apply the complete CDN adapter policy to the primary generated config. */
 export async function finalizeCdnAdapterBuildOutput({
   outDir,
   isPrimaryServerOutput,
@@ -67,36 +166,17 @@ export async function finalizeCdnAdapterBuildOutput({
   binding: string;
   bindingIsExplicit: boolean;
 }): Promise<void> {
-  // Cloudflare builds may contain additional server-consumed environments.
-  // Only the bundle containing vinext's actual server entry owns the CDN
-  // adapter and its version metadata binding.
   if (!isPrimaryServerOutput) return;
 
-  await configureGeneratedCdnVersionMetadata(path.resolve(outDir, "wrangler.json"), {
+  const generatedConfigPath = path.resolve(outDir, "wrangler.json");
+  const generatedConfig = await readGeneratedConfig(generatedConfigPath, false);
+  if (!generatedConfig) return;
+  const withVersionMetadata = configureCdnVersionMetadata(generatedConfig, {
     binding,
     bindingIsExplicit,
   });
-}
-
-async function configureGeneratedCdnVersionMetadata(
-  generatedConfigPath: string,
-  options: VersionMetadataOptions,
-): Promise<void> {
-  let generatedConfig: WranglerOutputConfig;
-  try {
-    const parsed = JSON.parse(await fs.readFile(generatedConfigPath, "utf8")) as unknown;
-    if (!isRecord(parsed)) {
-      throw new TypeError("the root value must be an object");
-    }
-    generatedConfig = parsed;
-  } catch (cause) {
-    throw new Error(
-      `[vinext] Could not read the generated Wrangler config at ${generatedConfigPath}.`,
-      { cause },
-    );
-  }
-
-  const configured = configureCdnVersionMetadata(generatedConfig, options);
-  if (configured === generatedConfig) return;
-  await fs.writeFile(generatedConfigPath, `${JSON.stringify(configured, null, 2)}\n`);
+  await writeGeneratedConfig(
+    generatedConfigPath,
+    configureWorkersCacheEntrypoints(withVersionMetadata),
+  );
 }

--- a/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
@@ -11,14 +11,14 @@
  *   traffic and revalidates in the background (the `UPDATING` cache status).
  * - `set` is a no-op: the platform caches the *response* based on its
  *   cache headers, so there is nothing to persist at the origin.
- * - `buildResponseHeaders` emits the SWR policy as `CDN-Cache-Control`
+ * - `buildResponseHeaders` emits the SWR policy as `Cloudflare-CDN-Cache-Control`
  *   (`public, max-age=…, stale-while-revalidate=…`) so the edge caches and
  *   revalidates, while the browser-facing `Cache-Control` is
  *   `public, max-age=0, must-revalidate` so a browser never serves a stored copy
  *   without revalidating against the edge. A `Cache-Tag` header lets entries be
  *   purged by tag. Note the edge directive uses `max-age` (not `s-maxage`):
  *   the framework computes the policy with `s-maxage` for shared caches, but
- *   `CDN-Cache-Control` is already CDN-scoped so `max-age` is the correct knob
+ *   `Cloudflare-CDN-Cache-Control` is already CDN-scoped so `max-age` is the correct knob
  *   for the edge to honor max-age + stale-while-revalidate.
  * - `revalidateTag` purges the edge via the request context's `cache.purge({ tags })`.
  *
@@ -42,7 +42,7 @@ import {
 } from "vinext/shims/cdn-cache";
 import type { CacheHandlerValue, IncrementalCacheValue } from "vinext/shims/cache";
 import { getRequestExecutionContext } from "vinext/shims/request-context";
-import { VINEXT_CDN_BUILD_ID_HEADER } from "./cdn-build-id.js";
+import { getVinextCdnBuildIdentity, VINEXT_CDN_BUILD_ID_HEADER } from "./cdn-build-id.js";
 import { VINEXT_EXPECTED_WORKER_VERSION_HEADER } from "../version-headers.js";
 
 const DEFAULT_VERSION_METADATA_BINDING = "CF_VERSION_METADATA";
@@ -72,7 +72,7 @@ const CACHEABLE_EDGE_DIRECTIVE_RE = /(?:^|,)\s*(?:s-maxage|max-age)\s*=/i;
 const EDGE_POLICY_HEADERS = ["CDN-Cache-Control", "Cloudflare-CDN-Cache-Control"] as const;
 
 function getBuildIdentityResponseHeader(): CdnResponseHeaders {
-  const buildId = process.env.__VINEXT_RSC_BUILD_IDENTITY ?? process.env.__VINEXT_BUILD_ID;
+  const buildId = getVinextCdnBuildIdentity();
   return buildId ? { [VINEXT_CDN_BUILD_ID_HEADER]: buildId } : {};
 }
 
@@ -142,7 +142,7 @@ const UNBOUNDED_SWR_SECONDS = 31_536_000; // 1 year
 /**
  * Convert the framework's shared-cache policy into a CDN-scoped one:
  * `s-maxage=…` → `max-age=…` (the edge honors `max-age` inside
- * `CDN-Cache-Control`), give a value-less `stale-while-revalidate` an explicit
+ * `Cloudflare-CDN-Cache-Control`), give a value-less `stale-while-revalidate` an explicit
  * seconds value (Cloudflare ignores the bare directive), and ensure a leading
  * `public`.
  */
@@ -264,13 +264,16 @@ export class CloudflareCdnCacheAdapter implements CdnCacheAdapter {
       return clearCloudflareCdnResponseHeaders(input.cacheControl);
     }
 
-    // SWR policy on CDN-Cache-Control (edge caches + revalidates); the browser
-    // is told to revalidate every reuse so it never serves a stale stored copy.
+    // Use Cloudflare's consumed edge-only header rather than CDN-Cache-Control.
+    // The latter is forwarded to downstream CDNs, where the private inner
+    // cache key and request-stage personalization are no longer available.
+    // The browser is told to revalidate every reuse so it never serves a stale
+    // stored copy.
     const headers: CdnResponseHeaders = {
       ...getBuildIdentityResponseHeader(),
       "Cache-Control": BROWSER_REVALIDATE,
-      "CDN-Cache-Control": toEdgeCacheControl(input.cacheControl),
-      "Cloudflare-CDN-Cache-Control": null,
+      "CDN-Cache-Control": null,
+      "Cloudflare-CDN-Cache-Control": toEdgeCacheControl(input.cacheControl),
       "Cache-Tag": input.tags ? formatCacheTag(input.tags) : null,
     };
 

--- a/packages/cloudflare/src/cache/cdn-adapter.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.ts
@@ -3,6 +3,8 @@ import { finalizeCdnAdapterBuildOutput } from "./cdn-adapter-config.js";
 
 export const DEFAULT_CDN_VERSION_METADATA_BINDING = "CF_VERSION_METADATA";
 
+const CLOUDFLARE_WORKER_ENTRY_ID = "virtual:cloudflare/worker-entry";
+
 /** Options accepted by {@link cdnAdapter}, forwarded to the runtime factory. */
 export type CdnAdapterOptions = {
   /** Version metadata binding used to verify version-overridden requests. */
@@ -14,27 +16,18 @@ export type CdnAdapterOptions = {
  * Cloudflare Workers Cache.
  *
  * Unlike the data adapter (which stores cache entries in a durable store and
- * serves HIT/STALE itself), this adapter delegates serving to Cloudflare's
- * edge cache.
+ * serves HIT/STALE itself), this adapter delegates serving to Workers Cache on
+ * a named Worker entrypoint. The default entrypoint always runs middleware and
+ * request-time routing before dispatching the cacheable response stage.
  *
- * Workers Cache must be enabled in your Wrangler config for this to work.
- * ```jsonc
- * // wrangler.jsonc
- * {
- *   "cache": {
- *     "enabled": true,
- *   },
- *   "version_metadata": {
- *     "binding": "CF_VERSION_METADATA"
- *   }
- * }
- * ```
- * Wrangler does not inherit `version_metadata` into named environments. Repeat
- * the binding in every `env.<name>` used for CDN warmup.
+ * The emitted Wrangler configuration enables Workers Cache only for that
+ * response-stage export, so cache hits do not start the application stage.
+ * The generated deployment config automatically enables Workers Cache for the
+ * response entrypoint and adds the version metadata binding used by warmup.
  *
- * Cache Rules must preserve the full query string in the incoming cache key.
- * Two-stage admission certifies exact pathname + search identities, while an
- * edge HIT is served before the Worker can reject a differently keyed request.
+ * The adapter adds a transport-only URL digest so distinct response-stage
+ * identities cannot collide. Workers Cache owns this key independently of
+ * zone Cache Rules.
  */
 export function cdnAdapter(options?: CdnAdapterOptions) {
   if (
@@ -49,15 +42,22 @@ export function cdnAdapter(options?: CdnAdapterOptions) {
   const versionMetadataBinding =
     options?.versionMetadataBinding ?? DEFAULT_CDN_VERSION_METADATA_BINDING;
   const bindingIsExplicit = options?.versionMetadataBinding !== undefined;
+  const workerEntry = fileURLToPath(import.meta.resolve("./cdn-adapter.worker.js"));
   return {
     adapter: fileURLToPath(import.meta.resolve("./cdn-adapter.runtime.js")),
     options,
     output: {
+      entry: workerEntry,
       matchesBuild({ plugins }: { plugins: readonly { name?: string }[] }) {
         return plugins.some(
           ({ name }) =>
             name === "vite-plugin-cloudflare" || name?.startsWith("vite-plugin-cloudflare:"),
         );
+      },
+      transformHostEntry({ code, id }: { code: string; id: string }) {
+        const cleanId = id.charCodeAt(0) === 0 ? id.slice(1) : id;
+        if (cleanId !== CLOUDFLARE_WORKER_ENTRY_ID) return null;
+        return `${code}\nexport { VinextCachedResponse } from ${JSON.stringify(workerEntry)};\n`;
       },
       finalizeBuildOutput({
         outDir,
@@ -73,9 +73,12 @@ export function cdnAdapter(options?: CdnAdapterOptions) {
           bindingIsExplicit,
         });
       },
+      type: "multi-stage" as const,
     },
     capabilities: {
       buildIdentity: "response-header" as const,
+      responsePolicyHeaderNames: ["CDN-Cache-Control", "Cloudflare-CDN-Cache-Control"] as const,
+      requestRouting: "uncached-stage" as const,
       responseVary: "verbatim" as const,
       routeCacheability: "probe-manifest" as const,
     },

--- a/packages/cloudflare/src/cache/cdn-adapter.worker.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.worker.ts
@@ -1,5 +1,8 @@
 import { WorkerEntrypoint } from "cloudflare:workers";
-import { VINEXT_PRERENDER_READINESS_PATH } from "vinext/internal/server/headers";
+import {
+  VINEXT_PRERENDER_READINESS_PATH,
+  VINEXT_RSC_VARY_HEADER,
+} from "vinext/internal/server/headers";
 import type {
   VinextAssetFetcher,
   VinextRequestStageTransport,
@@ -55,6 +58,9 @@ const RESPONSE_STAGE_WIRE_CACHE = {
 
 type ResponseStageWireCache =
   (typeof RESPONSE_STAGE_WIRE_CACHE)[keyof typeof RESPONSE_STAGE_WIRE_CACHE];
+const FRAMEWORK_RESPONSE_VARY_FIELDS = new Set(
+  VINEXT_RSC_VARY_HEADER.split(",").map((name) => name.trim().toLowerCase()),
+);
 
 function isResponseStageReadinessRequest(request: Request): boolean {
   return (
@@ -216,9 +222,16 @@ async function createCacheFacingRequest(
   // https://developers.cloudflare.com/workers/cache/#what-gets-cached
   const authorizationIdentity =
     authorization === null ? "absent" : `present:${authorization.length}:${authorization}`;
+  // Workers Cache keeps Vary variants under one URL, and requires every
+  // variant of that URL to carry identical Cache-Tag values. App RSC variants
+  // can collect different tags, so promote the complete framework selector
+  // tuple into the opaque primary key instead of relying on Vary alone.
+  const frameworkVaryIdentity = JSON.stringify(
+    [...FRAMEWORK_RESPONSE_VARY_FIELDS].map((name) => [name, request.headers.get(name)]),
+  );
   const responseStageBuildIdentity = getVinextCdnBuildIdentity() ?? "";
   const bytes = new TextEncoder().encode(
-    `${request.url}\0${serializedInvocation}\0${authorizationIdentity}\0${responseStageBuildIdentity}`,
+    `${request.url}\0${serializedInvocation}\0${authorizationIdentity}\0${frameworkVaryIdentity}\0${responseStageBuildIdentity}`,
   );
   const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", bytes));
   const key = [...digest].map((byte) => byte.toString(16).padStart(2, "0")).join("");

--- a/packages/cloudflare/src/cache/cdn-adapter.worker.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.worker.ts
@@ -333,17 +333,15 @@ function preventRequestCfResponseCaching(response: Response): Response {
  */
 function markSharedResponseStage(
   response: Response,
+  provenanceToken: string,
   exposeEntrypointCacheStatus = false,
 ): Response {
   const headers = new Headers(response.headers);
-  headers.set(SHARED_RESPONSE_STAGE_HEADER, "1");
-  if (exposeEntrypointCacheStatus) {
-    const cacheStatus = headers.get("CF-Cache-Status");
-    if (cacheStatus) {
-      headers.set(VINEXT_CACHE_HEADER, cacheStatus);
-      headers.set(NEXTJS_CACHE_HEADER, cacheStatus);
-    }
-  }
+  const cacheStatus = exposeEntrypointCacheStatus ? headers.get("CF-Cache-Status") : null;
+  headers.set(
+    SHARED_RESPONSE_STAGE_HEADER,
+    cacheStatus ? `${provenanceToken}:${encodeURIComponent(cacheStatus)}` : provenanceToken,
+  );
   return new Response(response.body, {
     headers,
     status: response.status,
@@ -351,21 +349,38 @@ function markSharedResponseStage(
   });
 }
 
-function finalizeGatewayResponse(response: Response): Response {
-  const usedSharedResponseStage = response.headers.get(SHARED_RESPONSE_STAGE_HEADER) === "1";
+function finalizeGatewayResponse(response: Response, provenanceToken: string): Response {
+  const provenance = response.headers.get(SHARED_RESPONSE_STAGE_HEADER);
+  const usedSharedResponseStage =
+    provenance === provenanceToken || provenance?.startsWith(`${provenanceToken}:`) === true;
+  // The marker is reserved for adapter-internal provenance. If outer response
+  // composition replaces it, fail closed rather than forwarding shared cache
+  // policy on a response whose origin can no longer be authenticated.
+  const sharedResponseStageCollision = provenance !== null && !usedSharedResponseStage;
   const cacheControl = response.headers.get("Cache-Control");
-  if (!response.headers.has(CLOUDFLARE_EDGE_POLICY_HEADER) && !usedSharedResponseStage) {
+  if (
+    !response.headers.has(CLOUDFLARE_EDGE_POLICY_HEADER) &&
+    !usedSharedResponseStage &&
+    !sharedResponseStageCollision
+  ) {
     return response;
   }
   const headers = new Headers(response.headers);
   headers.delete(SHARED_RESPONSE_STAGE_HEADER);
   headers.delete(CLOUDFLARE_EDGE_POLICY_HEADER);
-  if (usedSharedResponseStage) {
+  if (usedSharedResponseStage || sharedResponseStageCollision) {
     headers.delete("CDN-Cache-Control");
     headers.delete("Cache-Tag");
+    headers.delete(VINEXT_CACHE_HEADER);
+    headers.delete(NEXTJS_CACHE_HEADER);
     if (!cacheControl || !isNonCacheableCacheControl(cacheControl)) {
       headers.set("Cache-Control", "private, max-age=0, must-revalidate");
     }
+  }
+  if (usedSharedResponseStage && provenance?.startsWith(`${provenanceToken}:`)) {
+    const cacheStatus = decodeURIComponent(provenance.slice(provenanceToken.length + 1));
+    headers.set(VINEXT_CACHE_HEADER, cacheStatus);
+    headers.set(NEXTJS_CACHE_HEADER, cacheStatus);
   }
   return new Response(response.body, {
     headers,
@@ -521,6 +536,7 @@ export default {
     context: CloudflareStageContext | undefined,
   ): Promise<Response> {
     request = stripUntrustedTransportHeaders(request);
+    const sharedResponseStageProvenance = crypto.randomUUID();
     const stageContext = withResponseStagePurge(withWorkerHostRuntime(context, env));
     const dispatchResponseStage: VinextResponseStageTransport = async (
       stageRequest,
@@ -558,13 +574,16 @@ export default {
             ? responseStageUnavailable()
             : markSharedResponseStage(
                 await invokeResponseStage(stageRequest, env, stageContext, invocation),
+                sharedResponseStageProvenance,
               );
         }
         const entrypointRequest = requiresEntrypoint
           ? stageRequest
           : await createCacheFacingRequest(stageRequest, serializedInvocation);
         const response = validateResponseStageBuildIdentity(await binding.fetch(entrypointRequest));
-        return requiresEntrypoint ? response : markSharedResponseStage(response, true);
+        return requiresEntrypoint
+          ? response
+          : markSharedResponseStage(response, sharedResponseStageProvenance, true);
       } catch (error) {
         if (requiresEntrypoint) return responseStageUnavailable();
         throw error;
@@ -573,6 +592,7 @@ export default {
     const { handleRequestStage } = await loadVinextRequestStage<unknown, CloudflareStageContext>();
     return finalizeGatewayResponse(
       await handleRequestStage(request, env, stageContext, dispatchResponseStage),
+      sharedResponseStageProvenance,
     );
   },
 };

--- a/packages/cloudflare/src/cache/cdn-adapter.worker.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.worker.ts
@@ -1,0 +1,546 @@
+import { WorkerEntrypoint } from "cloudflare:workers";
+import { VINEXT_PRERENDER_READINESS_PATH } from "vinext/internal/server/headers";
+import type {
+  VinextAssetFetcher,
+  VinextRequestStageTransport,
+  VinextResponseStageDispatchOptions,
+  VinextResponseStageTransport,
+} from "vinext/server/multi-stage";
+import { loadVinextRequestStage } from "vinext/server/request-stage";
+import { loadVinextResponseStage } from "vinext/server/response-stage";
+import { isNonCacheableCacheControl } from "vinext/shims/cdn-cache";
+import { getVinextCdnBuildIdentity, VINEXT_CDN_BUILD_ID_HEADER } from "./cdn-build-id.js";
+
+type StageBinding = {
+  fetch(request: Request): Promise<Response> | Response;
+  purge?(options: CachePurgeOptions): unknown;
+};
+
+type StageBindingFactory = (options: { props: unknown }) => StageBinding;
+
+type CloudflareStageContext = {
+  assets?: VinextAssetFetcher;
+  cache?: unknown;
+  exports?: Record<string, unknown>;
+  props?: unknown;
+  hostRuntime?: "worker";
+  passThroughOnException?(): void;
+  waitUntil?(promise: Promise<unknown>): void;
+};
+
+type CloudflareResponseStageInvocation = {
+  expectedResponseStageBuildIdentity?: string;
+  options: VinextResponseStageDispatchOptions;
+  props: unknown;
+  requestMethod: string;
+  requestUrl: string;
+};
+
+type CachePurgeOptions = { tags: string[] };
+
+type RestoredResponseStageRequest = {
+  didAccessRequestCf(): boolean;
+  request: Request;
+};
+
+const RESPONSE_STAGE_EXPORT = "VinextCachedResponse";
+const AUTHORIZATION_TRANSPORT_HEADER = "x-vinext-internal-authorization";
+const REQUEST_CF_TRANSPORT_HEADER = "x-vinext-internal-request-cf";
+const CLOUDFLARE_EDGE_POLICY_HEADER = "Cloudflare-CDN-Cache-Control";
+const RESPONSE_STAGE_WIRE_CACHE = {
+  bypass: "vinext-cloudflare-v1:bypass",
+  shared: "vinext-cloudflare-v1:shared",
+} as const;
+
+type ResponseStageWireCache =
+  (typeof RESPONSE_STAGE_WIRE_CACHE)[keyof typeof RESPONSE_STAGE_WIRE_CACHE];
+
+function isResponseStageReadinessRequest(request: Request): boolean {
+  return (
+    request.url.includes(VINEXT_PRERENDER_READINESS_PATH) &&
+    new URL(request.url).pathname === VINEXT_PRERENDER_READINESS_PATH
+  );
+}
+
+function responseStageUnavailable(): Response {
+  return new Response(null, {
+    status: 503,
+    headers: { "Cache-Control": "no-store" },
+  });
+}
+
+/** Stamp the entrypoint that actually produced a response, before Workers Cache stores it. */
+function stampResponseStageBuildIdentity(response: Response): Response {
+  const buildIdentity = getVinextCdnBuildIdentity();
+  // Direct source consumers and unit tests do not pass through vinext's build
+  // defines. Production multi-stage output always has this opaque identity.
+  if (!buildIdentity) return response;
+  try {
+    response.headers.set(VINEXT_CDN_BUILD_ID_HEADER, buildIdentity);
+    return response;
+  } catch {
+    const headers = new Headers(response.headers);
+    headers.set(VINEXT_CDN_BUILD_ID_HEADER, buildIdentity);
+    return new Response(response.body, {
+      headers,
+      status: response.status,
+      statusText: response.statusText,
+    });
+  }
+}
+
+/** Reject a response routed to an entrypoint from another propagating build. */
+function validateResponseStageBuildIdentity(response: Response): Response {
+  const expectedBuildIdentity = getVinextCdnBuildIdentity();
+  if (
+    !expectedBuildIdentity ||
+    response.headers.get(VINEXT_CDN_BUILD_ID_HEADER) === expectedBuildIdentity
+  ) {
+    return response;
+  }
+  // The stale response must not continue producing bytes after the gateway has
+  // replaced it. Cancellation is best-effort and must not delay the 503.
+  void response.body?.cancel().catch(() => {});
+  return responseStageUnavailable();
+}
+
+function stripUntrustedTransportHeaders(request: Request): Request {
+  if (
+    !request.headers.has(AUTHORIZATION_TRANSPORT_HEADER) &&
+    !request.headers.has(REQUEST_CF_TRANSPORT_HEADER)
+  ) {
+    return request;
+  }
+  const headers = new Headers(request.headers);
+  headers.delete(AUTHORIZATION_TRANSPORT_HEADER);
+  headers.delete(REQUEST_CF_TRANSPORT_HEADER);
+  const sanitized = new Request(request, { headers });
+  const requestCf = Reflect.get(request, "cf");
+  if (requestCf !== undefined) {
+    Object.defineProperty(sanitized, "cf", {
+      configurable: true,
+      enumerable: true,
+      value: requestCf,
+    });
+  }
+  return sanitized;
+}
+
+function withWorkerHostRuntime(
+  context: CloudflareStageContext | undefined,
+  env?: unknown,
+): CloudflareStageContext {
+  const candidateAssets =
+    env && typeof env === "object" && Reflect.has(env, "ASSETS")
+      ? Reflect.get(env, "ASSETS")
+      : undefined;
+  const assets =
+    candidateAssets &&
+    (typeof candidateAssets === "object" || typeof candidateAssets === "function") &&
+    Reflect.has(candidateAssets, "fetch") &&
+    typeof Reflect.get(candidateAssets, "fetch") === "function"
+      ? (candidateAssets as VinextAssetFetcher)
+      : context?.assets;
+
+  return {
+    ...(assets === undefined ? {} : { assets }),
+    ...(context?.cache === undefined ? {} : { cache: context.cache }),
+    ...(context?.exports === undefined ? {} : { exports: context.exports }),
+    hostRuntime: "worker",
+    ...(typeof context?.passThroughOnException === "function"
+      ? { passThroughOnException: () => context.passThroughOnException?.() }
+      : {}),
+    ...(context?.props === undefined ? {} : { props: context.props }),
+    ...(typeof context?.waitUntil === "function"
+      ? { waitUntil: (promise: Promise<unknown>) => context.waitUntil?.(promise) }
+      : {}),
+  };
+}
+
+function hasFetch(value: unknown): value is StageBinding {
+  return (
+    value !== null &&
+    (typeof value === "object" || typeof value === "function") &&
+    "fetch" in value &&
+    typeof value.fetch === "function"
+  );
+}
+
+function hasPurge(value: unknown): value is Required<Pick<StageBinding, "purge">> {
+  return (
+    value !== null &&
+    (typeof value === "object" || typeof value === "function") &&
+    "purge" in value &&
+    typeof value.purge === "function"
+  );
+}
+
+function getResponseStageBinding(
+  context: CloudflareStageContext,
+  serializedInvocation: string,
+): StageBinding | null {
+  const binding = context.exports?.[RESPONSE_STAGE_EXPORT];
+  if (typeof binding !== "function") return null;
+
+  // Configurable-entrypoint props cross a Workers RPC boundary. Some vinext
+  // route metadata objects intentionally use null prototypes, which are valid
+  // in-process but are not supported by Workers RPC serialization. Normalize
+  // the transport contract to plain JSON data at the adapter boundary.
+  const props = JSON.parse(serializedInvocation) as CloudflareResponseStageInvocation;
+  const target = (binding as StageBindingFactory)({ props });
+  return hasFetch(target) ? target : null;
+}
+
+async function createCacheFacingRequest(
+  request: Request,
+  serializedInvocation: string,
+): Promise<Request> {
+  const authorization = request.headers.get("Authorization");
+  let serializedRequestCf: string | null = null;
+  const requestCf = Reflect.get(request, "cf");
+  if (requestCf !== undefined) {
+    try {
+      const json = JSON.stringify(requestCf);
+      if (json !== undefined) serializedRequestCf = encodeURIComponent(json);
+    } catch {
+      // A non-serializable platform extension cannot safely cross the stage.
+    }
+  }
+  // Incoming `request.cf` describes the caller/connection, not the public
+  // representation. Keep it available to a cold response-stage render without
+  // fragmenting warmed cache entries by colo, geography, TCP RTT, or bot data.
+  // Workers Cache automatically bypasses requests carrying Authorization, so
+  // transport that value under a private header and partition the opaque URL
+  // key by its digest instead.
+  // https://developers.cloudflare.com/workers/cache/#what-gets-cached
+  const authorizationIdentity =
+    authorization === null ? "absent" : `present:${authorization.length}:${authorization}`;
+  const responseStageBuildIdentity = getVinextCdnBuildIdentity() ?? "";
+  const bytes = new TextEncoder().encode(
+    `${request.url}\0${serializedInvocation}\0${authorizationIdentity}\0${responseStageBuildIdentity}`,
+  );
+  const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", bytes));
+  const key = [...digest].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+  const url = new URL(request.url);
+  url.searchParams.set("__vinext_cache_key", key);
+  const headers = new Headers(request.headers);
+  headers.delete("Authorization");
+  headers.delete(AUTHORIZATION_TRANSPORT_HEADER);
+  headers.delete(REQUEST_CF_TRANSPORT_HEADER);
+  if (authorization !== null) {
+    headers.set(AUTHORIZATION_TRANSPORT_HEADER, encodeURIComponent(authorization));
+  }
+  if (serializedRequestCf !== null) {
+    headers.set(REQUEST_CF_TRANSPORT_HEADER, serializedRequestCf);
+  }
+  const init = {
+    // Explicitly replace inherited inbound `cf` metadata. In workerd,
+    // Request-from-Request construction otherwise preserves values such as a
+    // caller-supplied cacheKey. The response stage receives the original
+    // platform metadata through the authenticated internal header above.
+    cf: { vary: { default: { action: "passthrough" } } },
+    headers,
+  } satisfies RequestInit & {
+    cf: { vary: { default: { action: "passthrough" } } };
+  };
+  return new Request(new Request(url, request), init);
+}
+
+function restoreResponseStageRequest(
+  request: Request,
+  requestUrl: string,
+  requestMethod: string,
+): RestoredResponseStageRequest {
+  const headers = new Headers(request.headers);
+  const serializedAuthorization = headers.get(AUTHORIZATION_TRANSPORT_HEADER);
+  const serializedRequestCf = headers.get(REQUEST_CF_TRANSPORT_HEADER);
+  headers.delete("Authorization");
+  headers.delete(AUTHORIZATION_TRANSPORT_HEADER);
+  headers.delete(REQUEST_CF_TRANSPORT_HEADER);
+  if (serializedAuthorization !== null) {
+    try {
+      headers.set("Authorization", decodeURIComponent(serializedAuthorization));
+    } catch {
+      // Malformed internal metadata is stripped rather than exposed to userland.
+    }
+  }
+  let requestCf: unknown;
+  if (serializedRequestCf !== null) {
+    try {
+      requestCf = JSON.parse(decodeURIComponent(serializedRequestCf));
+    } catch {
+      // Malformed internal metadata is stripped rather than exposed to userland.
+    }
+  }
+  const restored = new Request(new Request(requestUrl, request), {
+    headers,
+    method: requestMethod,
+  });
+  let didAccessRequestCf = false;
+  if (requestCf !== undefined) {
+    // Keep provider metadata available to user code without making it part of
+    // the shared cache identity. Core request reconstruction preserves this
+    // accessor lazily, so only an application read flips the admission veto.
+    Object.defineProperty(restored, "cf", {
+      configurable: true,
+      enumerable: true,
+      get() {
+        didAccessRequestCf = true;
+        return requestCf;
+      },
+    });
+  }
+  return {
+    didAccessRequestCf: () => didAccessRequestCf,
+    request: restored,
+  };
+}
+
+function preventRequestCfResponseCaching(response: Response): Response {
+  const headers = new Headers(response.headers);
+  headers.set("Cache-Control", "no-store");
+  headers.delete("CDN-Cache-Control");
+  headers.delete("Cloudflare-CDN-Cache-Control");
+  headers.delete("Cache-Tag");
+  return new Response(response.body, {
+    headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
+}
+
+/**
+ * Cloudflare consumes its private cache policy before returning a cached
+ * entrypoint response. Strip it here as well for uncached/local fallbacks so
+ * the outer gateway never forwards an inner shared-cache policy after adding
+ * request-specific middleware or routing headers.
+ */
+function finalizeGatewayResponse(response: Response, usedSharedResponseStage: boolean): Response {
+  const cacheControl = response.headers.get("Cache-Control");
+  const hasSharedResponseMetadata =
+    usedSharedResponseStage &&
+    (response.headers.has("CDN-Cache-Control") ||
+      response.headers.has("Cache-Tag") ||
+      !cacheControl ||
+      !isNonCacheableCacheControl(cacheControl));
+  if (!response.headers.has(CLOUDFLARE_EDGE_POLICY_HEADER) && !hasSharedResponseMetadata) {
+    return response;
+  }
+  const headers = new Headers(response.headers);
+  headers.delete(CLOUDFLARE_EDGE_POLICY_HEADER);
+  if (usedSharedResponseStage) {
+    headers.delete("CDN-Cache-Control");
+    headers.delete("Cache-Tag");
+    if (!cacheControl || !isNonCacheableCacheControl(cacheControl)) {
+      headers.set("Cache-Control", "private, max-age=0, must-revalidate");
+    }
+  }
+  return new Response(response.body, {
+    headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
+}
+
+function withResponseStagePurge(context: CloudflareStageContext): CloudflareStageContext {
+  const factory = context.exports?.[RESPONSE_STAGE_EXPORT];
+  if (typeof factory !== "function") return context;
+  const fallback = context.cache;
+  return {
+    ...context,
+    cache: {
+      purge(options: CachePurgeOptions) {
+        const target = (factory as StageBindingFactory)({ props: {} });
+        if (hasPurge(target)) return target.purge(options);
+        return hasPurge(fallback) ? fallback.purge(options) : undefined;
+      },
+    },
+  };
+}
+
+function getResponseStageInvocation(value: unknown): CloudflareResponseStageInvocation | null {
+  if (!value || typeof value !== "object") return null;
+  const expectedResponseStageBuildIdentity = Reflect.get(
+    value,
+    "expectedResponseStageBuildIdentity",
+  );
+  if (
+    expectedResponseStageBuildIdentity !== undefined &&
+    typeof expectedResponseStageBuildIdentity !== "string"
+  ) {
+    return null;
+  }
+  const options = Reflect.get(value, "options");
+  if (!options || typeof options !== "object") return null;
+  const wireCache = Reflect.get(options, "cache");
+  let cache: VinextResponseStageDispatchOptions["cache"];
+  if (
+    expectedResponseStageBuildIdentity !== undefined &&
+    wireCache === RESPONSE_STAGE_WIRE_CACHE.shared
+  ) {
+    cache = "shared";
+  } else if (
+    expectedResponseStageBuildIdentity !== undefined &&
+    wireCache === RESPONSE_STAGE_WIRE_CACHE.bypass
+  ) {
+    cache = "bypass";
+  } else if (
+    expectedResponseStageBuildIdentity === undefined &&
+    getVinextCdnBuildIdentity() === null &&
+    (wireCache === "shared" || wireCache === "bypass")
+  ) {
+    // Preserve direct source consumers and unit tests. Every built stage must
+    // use the versioned discriminator so either side of a rolling deployment
+    // rejects a pre-protocol peer before render or cache admission.
+    cache = wireCache;
+  } else {
+    return null;
+  }
+  const requestUrl = Reflect.get(value, "requestUrl");
+  if (typeof requestUrl !== "string") return null;
+  const requestMethod = Reflect.get(value, "requestMethod");
+  if (typeof requestMethod !== "string" || requestMethod.length === 0) return null;
+  try {
+    new URL(requestUrl);
+  } catch {
+    return null;
+  }
+  return {
+    ...(typeof expectedResponseStageBuildIdentity === "string"
+      ? { expectedResponseStageBuildIdentity }
+      : {}),
+    options: { ...options, cache } as VinextResponseStageDispatchOptions,
+    props: Reflect.get(value, "props"),
+    requestMethod,
+    requestUrl,
+  };
+}
+
+async function invokeResponseStage(
+  request: Request,
+  env: unknown,
+  context: CloudflareStageContext,
+  invocation: CloudflareResponseStageInvocation,
+): Promise<Response> {
+  const dispatchResponseStage: VinextResponseStageTransport = (stageRequest, props, options) =>
+    invokeResponseStage(stageRequest, env, context, {
+      options,
+      props,
+      requestMethod: stageRequest.method,
+      requestUrl: stageRequest.url,
+    });
+  const dispatchRequestStage: VinextRequestStageTransport = async (stageRequest) => {
+    const { handleRequestStage } = await loadVinextRequestStage<unknown, CloudflareStageContext>();
+    return handleRequestStage(stageRequest, env, context, dispatchResponseStage);
+  };
+  const { handleResponseStage } = await loadVinextResponseStage<unknown, CloudflareStageContext>();
+  return handleResponseStage(
+    request,
+    env,
+    context,
+    invocation.props,
+    dispatchRequestStage,
+    invocation.options,
+  );
+}
+
+/** Cache-bearing entrypoint. Workers Cache HITs bypass this class entirely. */
+export class VinextCachedResponse extends WorkerEntrypoint<unknown, unknown> {
+  async fetch(request: Request): Promise<Response> {
+    const context = withWorkerHostRuntime(this.ctx, this.env);
+    const invocation = getResponseStageInvocation(context.props);
+    if (!invocation) {
+      return stampResponseStageBuildIdentity(
+        new Response("Invalid vinext response-stage invocation", {
+          status: 400,
+          headers: { "Cache-Control": "no-store" },
+        }),
+      );
+    }
+    if (
+      invocation.expectedResponseStageBuildIdentity !== undefined &&
+      invocation.expectedResponseStageBuildIdentity !== getVinextCdnBuildIdentity()
+    ) {
+      return stampResponseStageBuildIdentity(responseStageUnavailable());
+    }
+    const restored = restoreResponseStageRequest(
+      request,
+      invocation.requestUrl,
+      invocation.requestMethod,
+    );
+    const response = await invokeResponseStage(restored.request, this.env, context, invocation);
+    return stampResponseStageBuildIdentity(
+      restored.didAccessRequestCf() ? preventRequestCfResponseCaching(response) : response,
+    );
+  }
+
+  async purge(options: CachePurgeOptions): Promise<unknown> {
+    const cache = Reflect.get(this.ctx, "cache");
+    if (!hasPurge(cache)) return undefined;
+    return cache.purge(options);
+  }
+}
+
+/** Uncached gateway: request routing and middleware always execute here. */
+export default {
+  async fetch(
+    request: Request,
+    env: unknown,
+    context: CloudflareStageContext | undefined,
+  ): Promise<Response> {
+    request = stripUntrustedTransportHeaders(request);
+    const stageContext = withResponseStagePurge(withWorkerHostRuntime(context, env));
+    let usedSharedResponseStage = false;
+    const dispatchResponseStage: VinextResponseStageTransport = async (
+      stageRequest,
+      props,
+      options,
+    ) => {
+      const expectedResponseStageBuildIdentity = getVinextCdnBuildIdentity();
+      const invocation = {
+        ...(expectedResponseStageBuildIdentity === null
+          ? {}
+          : { expectedResponseStageBuildIdentity }),
+        options,
+        props,
+        requestMethod: stageRequest.method,
+        requestUrl: stageRequest.url,
+      };
+      const requiresEntrypoint = isResponseStageReadinessRequest(stageRequest);
+      if (options.cache === "bypass" && !requiresEntrypoint) {
+        return invokeResponseStage(stageRequest, env, stageContext, invocation);
+      }
+      if (!requiresEntrypoint) usedSharedResponseStage = true;
+      try {
+        const serializedInvocation = JSON.stringify({
+          ...invocation,
+          options:
+            expectedResponseStageBuildIdentity === null
+              ? options
+              : {
+                  ...options,
+                  cache: RESPONSE_STAGE_WIRE_CACHE[options.cache] satisfies ResponseStageWireCache,
+                },
+        });
+        const binding = getResponseStageBinding(stageContext, serializedInvocation);
+        if (!binding) {
+          return requiresEntrypoint
+            ? responseStageUnavailable()
+            : invokeResponseStage(stageRequest, env, stageContext, invocation);
+        }
+        const entrypointRequest = requiresEntrypoint
+          ? stageRequest
+          : await createCacheFacingRequest(stageRequest, serializedInvocation);
+        return validateResponseStageBuildIdentity(await binding.fetch(entrypointRequest));
+      } catch (error) {
+        if (requiresEntrypoint) return responseStageUnavailable();
+        throw error;
+      }
+    };
+    const { handleRequestStage } = await loadVinextRequestStage<unknown, CloudflareStageContext>();
+    return finalizeGatewayResponse(
+      await handleRequestStage(request, env, stageContext, dispatchResponseStage),
+      usedSharedResponseStage,
+    );
+  },
+};

--- a/packages/cloudflare/src/cache/cdn-adapter.worker.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.worker.ts
@@ -1,6 +1,8 @@
 import { WorkerEntrypoint } from "cloudflare:workers";
 import {
+  NEXTJS_CACHE_HEADER,
   VINEXT_PRERENDER_READINESS_PATH,
+  VINEXT_CACHE_HEADER,
   VINEXT_RSC_VARY_HEADER,
 } from "vinext/internal/server/headers";
 import type {
@@ -329,9 +331,19 @@ function preventRequestCfResponseCaching(response: Response): Response {
  * the outer gateway never forwards an inner shared-cache policy after adding
  * request-specific middleware or routing headers.
  */
-function markSharedResponseStage(response: Response): Response {
+function markSharedResponseStage(
+  response: Response,
+  exposeEntrypointCacheStatus = false,
+): Response {
   const headers = new Headers(response.headers);
   headers.set(SHARED_RESPONSE_STAGE_HEADER, "1");
+  if (exposeEntrypointCacheStatus) {
+    const cacheStatus = headers.get("CF-Cache-Status");
+    if (cacheStatus) {
+      headers.set(VINEXT_CACHE_HEADER, cacheStatus);
+      headers.set(NEXTJS_CACHE_HEADER, cacheStatus);
+    }
+  }
   return new Response(response.body, {
     headers,
     status: response.status,
@@ -552,7 +564,7 @@ export default {
           ? stageRequest
           : await createCacheFacingRequest(stageRequest, serializedInvocation);
         const response = validateResponseStageBuildIdentity(await binding.fetch(entrypointRequest));
-        return requiresEntrypoint ? response : markSharedResponseStage(response);
+        return requiresEntrypoint ? response : markSharedResponseStage(response, true);
       } catch (error) {
         if (requiresEntrypoint) return responseStageUnavailable();
         throw error;

--- a/packages/cloudflare/src/cache/cdn-adapter.worker.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.worker.ts
@@ -47,6 +47,7 @@ const RESPONSE_STAGE_EXPORT = "VinextCachedResponse";
 const AUTHORIZATION_TRANSPORT_HEADER = "x-vinext-internal-authorization";
 const REQUEST_CF_TRANSPORT_HEADER = "x-vinext-internal-request-cf";
 const CLOUDFLARE_EDGE_POLICY_HEADER = "Cloudflare-CDN-Cache-Control";
+const SHARED_RESPONSE_STAGE_HEADER = "x-vinext-cloudflare-shared-response-stage";
 const RESPONSE_STAGE_WIRE_CACHE = {
   bypass: "vinext-cloudflare-v1:bypass",
   shared: "vinext-cloudflare-v1:shared",
@@ -315,18 +316,24 @@ function preventRequestCfResponseCaching(response: Response): Response {
  * the outer gateway never forwards an inner shared-cache policy after adding
  * request-specific middleware or routing headers.
  */
-function finalizeGatewayResponse(response: Response, usedSharedResponseStage: boolean): Response {
+function markSharedResponseStage(response: Response): Response {
+  const headers = new Headers(response.headers);
+  headers.set(SHARED_RESPONSE_STAGE_HEADER, "1");
+  return new Response(response.body, {
+    headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
+}
+
+function finalizeGatewayResponse(response: Response): Response {
+  const usedSharedResponseStage = response.headers.get(SHARED_RESPONSE_STAGE_HEADER) === "1";
   const cacheControl = response.headers.get("Cache-Control");
-  const hasSharedResponseMetadata =
-    usedSharedResponseStage &&
-    (response.headers.has("CDN-Cache-Control") ||
-      response.headers.has("Cache-Tag") ||
-      !cacheControl ||
-      !isNonCacheableCacheControl(cacheControl));
-  if (!response.headers.has(CLOUDFLARE_EDGE_POLICY_HEADER) && !hasSharedResponseMetadata) {
+  if (!response.headers.has(CLOUDFLARE_EDGE_POLICY_HEADER) && !usedSharedResponseStage) {
     return response;
   }
   const headers = new Headers(response.headers);
+  headers.delete(SHARED_RESPONSE_STAGE_HEADER);
   headers.delete(CLOUDFLARE_EDGE_POLICY_HEADER);
   if (usedSharedResponseStage) {
     headers.delete("CDN-Cache-Control");
@@ -490,7 +497,6 @@ export default {
   ): Promise<Response> {
     request = stripUntrustedTransportHeaders(request);
     const stageContext = withResponseStagePurge(withWorkerHostRuntime(context, env));
-    let usedSharedResponseStage = false;
     const dispatchResponseStage: VinextResponseStageTransport = async (
       stageRequest,
       props,
@@ -510,7 +516,6 @@ export default {
       if (options.cache === "bypass" && !requiresEntrypoint) {
         return invokeResponseStage(stageRequest, env, stageContext, invocation);
       }
-      if (!requiresEntrypoint) usedSharedResponseStage = true;
       try {
         const serializedInvocation = JSON.stringify({
           ...invocation,
@@ -526,12 +531,15 @@ export default {
         if (!binding) {
           return requiresEntrypoint
             ? responseStageUnavailable()
-            : invokeResponseStage(stageRequest, env, stageContext, invocation);
+            : markSharedResponseStage(
+                await invokeResponseStage(stageRequest, env, stageContext, invocation),
+              );
         }
         const entrypointRequest = requiresEntrypoint
           ? stageRequest
           : await createCacheFacingRequest(stageRequest, serializedInvocation);
-        return validateResponseStageBuildIdentity(await binding.fetch(entrypointRequest));
+        const response = validateResponseStageBuildIdentity(await binding.fetch(entrypointRequest));
+        return requiresEntrypoint ? response : markSharedResponseStage(response);
       } catch (error) {
         if (requiresEntrypoint) return responseStageUnavailable();
         throw error;
@@ -540,7 +548,6 @@ export default {
     const { handleRequestStage } = await loadVinextRequestStage<unknown, CloudflareStageContext>();
     return finalizeGatewayResponse(
       await handleRequestStage(request, env, stageContext, dispatchResponseStage),
-      usedSharedResponseStage,
     );
   },
 };

--- a/packages/cloudflare/src/cache/cdn-build-id.ts
+++ b/packages/cloudflare/src/cache/cdn-build-id.ts
@@ -1,2 +1,7 @@
 /** Build identity stamped by the Cloudflare CDN adapter on page responses. */
 export const VINEXT_CDN_BUILD_ID_HEADER = "X-Vinext-Build-Id";
+
+/** Opaque identity shared by every server entry emitted by one vinext build. */
+export function getVinextCdnBuildIdentity(): string | null {
+  return process.env.__VINEXT_RSC_BUILD_IDENTITY || process.env.__VINEXT_BUILD_ID || null;
+}

--- a/packages/cloudflare/src/cacheability-artifact.ts
+++ b/packages/cloudflare/src/cacheability-artifact.ts
@@ -179,14 +179,51 @@ function assertManifestModuleReachable(configPath: string): void {
   if (!fs.existsSync(mainPath) || !fs.lstatSync(mainPath).isFile()) {
     throw new Error("Two-stage CDN warming could not find the generated Wrangler main module.");
   }
-  if (
-    !hasStaticModuleSpecifier(
-      fs.readFileSync(mainPath, "utf8"),
-      `./${CACHEABILITY_MANIFEST_MODULE}`,
-    )
-  ) {
+  const viteManifestPath = path.join(serverDirectory, ".vite", "manifest.json");
+  let viteManifest: Record<string, { dynamicImports?: unknown; file?: unknown; imports?: unknown }>;
+  try {
+    viteManifest = JSON.parse(fs.readFileSync(viteManifestPath, "utf8"));
+  } catch (cause) {
+    throw new Error("Two-stage CDN warming could not read the generated Vite manifest.", {
+      cause,
+    });
+  }
+  const normalizedMain = main.replace(/^\.\//, "");
+  const entryKey = Object.entries(viteManifest).find(
+    ([, entry]) => entry?.file === normalizedMain,
+  )?.[0];
+  const queue = entryKey ? [entryKey] : [];
+  const visited = new Set<string>();
+  let reachable = false;
+  while (queue.length > 0 && !reachable) {
+    const key = queue.shift()!;
+    if (visited.has(key)) continue;
+    visited.add(key);
+    const entry = viteManifest[key];
+    if (!entry || typeof entry.file !== "string") continue;
+    const modulePath = path.resolve(serverDirectory, entry.file);
+    if (fs.existsSync(modulePath) && fs.lstatSync(modulePath).isFile()) {
+      const relativeManifest = path
+        .relative(
+          path.dirname(modulePath),
+          path.join(serverDirectory, CACHEABILITY_MANIFEST_MODULE),
+        )
+        .split(path.sep)
+        .join("/");
+      const specifier = relativeManifest.startsWith(".")
+        ? relativeManifest
+        : `./${relativeManifest}`;
+      reachable = hasStaticModuleSpecifier(fs.readFileSync(modulePath, "utf8"), specifier);
+    }
+    for (const references of [entry.imports, entry.dynamicImports]) {
+      if (Array.isArray(references)) {
+        queue.push(...references.filter((value): value is string => typeof value === "string"));
+      }
+    }
+  }
+  if (!reachable) {
     throw new Error(
-      `Two-stage CDN warming requires the generated Worker main module to import ${CACHEABILITY_MANIFEST_MODULE}.`,
+      `Two-stage CDN warming requires the generated Worker graph to statically import ${CACHEABILITY_MANIFEST_MODULE}.`,
     );
   }
 }

--- a/packages/cloudflare/src/cloudflare-workers.d.ts
+++ b/packages/cloudflare/src/cloudflare-workers.d.ts
@@ -1,0 +1,13 @@
+declare module "cloudflare:workers" {
+  /** Runtime base class supplied by Cloudflare Workers for named entrypoints. */
+  export abstract class WorkerEntrypoint<Env = unknown, Props = unknown> {
+    protected ctx: {
+      readonly cache?: unknown;
+      readonly props: Props;
+      waitUntil(promise: Promise<unknown>): void;
+    };
+    protected env: Env;
+    constructor(ctx: unknown, env: Env);
+    fetch?(request: Request): Response | Promise<Response>;
+  }
+}

--- a/packages/cloudflare/tsconfig.json
+++ b/packages/cloudflare/tsconfig.json
@@ -2,7 +2,9 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "paths": {
+      "vinext": ["../vinext/src/index.ts"],
       "vinext/internal/*": ["../vinext/src/*"],
+      "vinext/server/*": ["../vinext/src/server/*"],
       "vinext/shims/*": ["../vinext/src/shims/*"],
       "@vinext/cloudflare/cache/*": ["./src/cache/*"],
       "@vinext/cloudflare/images/*": ["./src/images/*"]

--- a/tests/app-route-handler-response.test.ts
+++ b/tests/app-route-handler-response.test.ts
@@ -417,14 +417,15 @@ describe("route handler responses route through the CDN cache adapter", () => {
     delete (globalThis as Record<PropertyKey, unknown>)[CDN_KEY];
   });
 
-  it("emits CDN-Cache-Control + Cache-Tag on a fresh response when an edge adapter is active", () => {
+  it("emits Cloudflare-CDN-Cache-Control + Cache-Tag with an edge adapter", () => {
     setCdnCacheAdapter(new CloudflareCdnCacheAdapter());
     const response = new Response("fresh");
 
     applyRouteHandlerRevalidateHeader(response, 60, 600, ["_N_T_/api/feed", "posts"]);
 
     expect(response.headers.get("Cache-Control")).toBe("public, max-age=0, must-revalidate");
-    expect(response.headers.get("CDN-Cache-Control")).toBe(
+    expect(response.headers.get("CDN-Cache-Control")).toBeNull();
+    expect(response.headers.get("Cloudflare-CDN-Cache-Control")).toBe(
       "public, max-age=60, stale-while-revalidate=540",
     );
     expect(response.headers.get("Cache-Tag")).toBe("_N_T_/api/feed,posts");
@@ -440,5 +441,6 @@ describe("route handler responses route through the CDN cache adapter", () => {
       "private, no-cache, no-store, max-age=0, must-revalidate",
     );
     expect(response.headers.get("CDN-Cache-Control")).toBeNull();
+    expect(response.headers.get("Cloudflare-CDN-Cache-Control")).toBeNull();
   });
 });

--- a/tests/cache-adapters-build.test.ts
+++ b/tests/cache-adapters-build.test.ts
@@ -15,6 +15,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { createBuilder } from "vite";
 import { afterEach, describe, expect, it } from "vite-plus/test";
+import { cdnAdapter } from "../packages/cloudflare/src/cache/cdn-adapter.js";
 import vinext from "../packages/vinext/src/index.js";
 
 const tmpDirs: string[] = [];
@@ -29,6 +30,9 @@ const cfPluginPath = path.resolve(
 type CloudflarePluginFactory = (opts?: {
   viteEnvironment?: { name: string; childEnvironments?: string[] };
 }) => import("vite").Plugin;
+
+const LOCAL_ADAPTER_MARKER = "__VINEXT_LOCAL_DATA_ADAPTER_MARKER__";
+const RESPONSE_STAGE_MARKER = "__VINEXT_RESPONSE_STAGE_USER_CODE_MARKER__";
 
 function writeFixtureFile(root: string, filePath: string, content: string) {
   const absPath = path.join(root, filePath);
@@ -47,6 +51,59 @@ function readTextFilesRecursive(root: string): string {
     if (!entry.name.endsWith(".js")) continue;
     output += fs.readFileSync(entryPath, "utf-8");
   }
+  return output;
+}
+
+function readStaticEntryClosure(root: string, entryKey: string): string {
+  const serverDir = path.join(root, "dist/server");
+  const manifest = JSON.parse(
+    fs.readFileSync(path.join(serverDir, ".vite/manifest.json"), "utf-8"),
+  ) as Record<string, { file?: unknown; imports?: unknown }>;
+  const resolvedEntryKey = Object.keys(manifest).find(
+    (key) => key === entryKey || key.endsWith(entryKey),
+  );
+  if (!resolvedEntryKey) {
+    throw new Error(`Missing emitted manifest entry ${JSON.stringify(entryKey)}`);
+  }
+  const pending = [resolvedEntryKey];
+  const visited = new Set<string>();
+  let output = "";
+
+  while (pending.length > 0) {
+    const key = pending.pop()!;
+    if (visited.has(key)) continue;
+    visited.add(key);
+    const entry = manifest[key];
+    if (!entry || typeof entry.file !== "string") {
+      throw new Error(`Missing emitted manifest entry ${JSON.stringify(key)}`);
+    }
+    output += fs.readFileSync(path.join(serverDir, entry.file), "utf-8");
+    if (Array.isArray(entry.imports)) {
+      pending.push(...entry.imports.filter((value): value is string => typeof value === "string"));
+    }
+  }
+
+  return output;
+}
+
+function readStaticJavaScriptClosure(entryPath: string): string {
+  const visited = new Set<string>();
+  let output = "";
+  const visit = (filePath: string) => {
+    if (visited.has(filePath)) return;
+    visited.add(filePath);
+    const source = fs.readFileSync(filePath, "utf8");
+    output += source;
+    for (const match of source.matchAll(
+      /(?:import|export)\s*(?:[^"']*?\bfrom\s*)?["']([^"']+)["']/g,
+    )) {
+      const specifier = match[1];
+      if (!specifier?.startsWith(".")) continue;
+      const dependency = path.resolve(path.dirname(filePath), specifier);
+      if (fs.existsSync(dependency) && fs.statSync(dependency).isFile()) visit(dependency);
+    }
+  };
+  visit(entryPath);
   return output;
 }
 
@@ -109,7 +166,7 @@ function writeCloudflareAppFixture(root: string, name: string) {
     root,
     "app/page.tsx",
     `export default function HomePage() {
-  return <main>home</main>;
+  return <main>home ${RESPONSE_STAGE_MARKER}</main>;
 }
 `,
   );
@@ -127,8 +184,6 @@ function writeCloudflareAppFixture(root: string, name: string) {
     `import handler from ${JSON.stringify(workerEntryPath)};\n\nexport default handler;\n`,
   );
 }
-
-const LOCAL_ADAPTER_MARKER = "__VINEXT_LOCAL_DATA_ADAPTER_MARKER__";
 
 describe("config-driven cache adapter — local file by absolute path", () => {
   afterEach(() => {
@@ -211,5 +266,205 @@ export default createAdapter;
     expect(assetsIgnore.split("\n").map((l) => l.trim())).toContain(".vite");
     // The manifest exists on disk (the build reads it) but is now excluded.
     expect(fs.existsSync(path.join(root, "dist/client/.vite/manifest.json"))).toBe(true);
+    expect(
+      fs.readFileSync(
+        path.join(root, "dist/server/__vinext_pregenerated_concrete_paths.js"),
+        "utf-8",
+      ),
+    ).toContain("__VINEXT_PREGENERATED_CONCRETE_PATHS");
+  }, 60_000);
+
+  it("preserves the CDN response entrypoint through Cloudflare's virtual host entry", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-cdn-entrypoint-build-"));
+    tmpDirs.push(root);
+    writeCloudflareAppFixture(root, "vinext-cdn-entrypoint-build");
+    fs.rmSync(path.join(root, "node_modules"));
+    fs.symlinkSync(
+      path.resolve(import.meta.dirname, "fixtures/cf-app-basic/node_modules"),
+      path.join(root, "node_modules"),
+      "junction",
+    );
+    writeFixtureFile(
+      root,
+      "worker/index.ts",
+      'import handler from "vinext/server/fetch-handler";\n\nexport default handler;\n',
+    );
+
+    const { cloudflare } = (await import(pathToFileURL(cfPluginPath).href)) as {
+      cloudflare: CloudflarePluginFactory;
+    };
+    const builder = await createBuilder({
+      root,
+      configFile: false,
+      plugins: [
+        vinext({ appDir: root, cache: { cdn: cdnAdapter() } }),
+        cloudflare({ viteEnvironment: { name: "rsc", childEnvironments: ["ssr"] } }),
+      ],
+      logLevel: "silent",
+    });
+
+    await builder.buildApp();
+
+    const workerPath = path.join(root, "dist/server/index.js");
+    const worker = fs.readFileSync(workerPath, "utf8");
+    expect(worker).toMatch(/export\s*\{[^}]*\b(?:[A-Za-z_$][\w$]*\s+as\s+)?VinextCachedResponse\b/);
+    expect(worker).not.toMatch(/import\s*["']\.\/__vinext_cacheability_manifest\.js["']/);
+    expect(readTextFilesRecursive(path.join(root, "dist/server"))).toContain(RESPONSE_STAGE_MARKER);
+    expect(readStaticJavaScriptClosure(workerPath)).not.toContain(RESPONSE_STAGE_MARKER);
+    expect(readStaticJavaScriptClosure(workerPath)).not.toContain(
+      "__vinext_cacheability_manifest.js",
+    );
+    const viteManifest = JSON.parse(
+      fs.readFileSync(path.join(root, "dist/server/.vite/manifest.json"), "utf8"),
+    );
+    const responseStageEntry = Object.entries(viteManifest).find(
+      ([key, entry]) =>
+        key.endsWith("virtual:vinext-response-stage") ||
+        (entry as { src?: string }).src?.endsWith("virtual:vinext-response-stage"),
+    )?.[1] as { file: string } | undefined;
+    expect(responseStageEntry).toBeDefined();
+    const responseStagePath = path.join(root, "dist/server", responseStageEntry!.file);
+    expect(readStaticJavaScriptClosure(responseStagePath)).toContain(
+      "__vinext_cacheability_manifest.js",
+    );
+    const wrangler = JSON.parse(
+      fs.readFileSync(path.join(root, "dist/server/wrangler.json"), "utf8"),
+    );
+    expect(wrangler.exports).toMatchObject({
+      default: { type: "worker", cache: { enabled: false } },
+      VinextCachedResponse: { type: "worker", cache: { enabled: true } },
+    });
+    expect(wrangler.cache).toBeUndefined();
+  }, 60_000);
+
+  it("keeps the adapter-owned response entrypoint when a custom Worker uses its reserved export", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-cdn-entrypoint-collision-"));
+    tmpDirs.push(root);
+    writeCloudflareAppFixture(root, "vinext-cdn-entrypoint-collision");
+    fs.rmSync(path.join(root, "node_modules"));
+    fs.symlinkSync(
+      path.resolve(import.meta.dirname, "fixtures/cf-app-basic/node_modules"),
+      path.join(root, "node_modules"),
+      "junction",
+    );
+    writeFixtureFile(
+      root,
+      "worker/index.ts",
+      [
+        'import handler from "vinext/server/fetch-handler";',
+        'export class VinextCachedResponse { marker = "CUSTOM_RESERVED_EXPORT_MARKER"; }',
+        "export default handler;",
+        "",
+      ].join("\n"),
+    );
+
+    const { cloudflare } = (await import(pathToFileURL(cfPluginPath).href)) as {
+      cloudflare: CloudflarePluginFactory;
+    };
+    const builder = await createBuilder({
+      root,
+      configFile: false,
+      plugins: [
+        vinext({ appDir: root, cache: { cdn: cdnAdapter() } }),
+        cloudflare({ viteEnvironment: { name: "rsc", childEnvironments: ["ssr"] } }),
+      ],
+      logLevel: "silent",
+    });
+
+    await builder.buildApp();
+
+    const buildOutput = readTextFilesRecursive(path.join(root, "dist/server"));
+    expect(buildOutput).toContain("Invalid vinext response-stage invocation");
+    expect(buildOutput).not.toContain("CUSTOM_RESERVED_EXPORT_MARKER");
+  }, 60_000);
+
+  it("keeps the data adapter out of the emitted request-stage graph", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-cache-adapter-stages-"));
+    tmpDirs.push(root);
+    writeCloudflareAppFixture(root, "vinext-cache-adapter-stages");
+    writeFixtureFile(
+      root,
+      "cache/my-data-adapter.ts",
+      `export default function createAdapter() {
+  return {
+    adapterMarker: "${LOCAL_ADAPTER_MARKER}",
+    async get() { return null; },
+    async set() {},
+    async revalidateTag() {},
+  };
+}
+`,
+    );
+    writeFixtureFile(
+      root,
+      "worker/index.ts",
+      `import handler from ${JSON.stringify(
+        path
+          .resolve(import.meta.dirname, "../packages/vinext/src/server/fetch-handler.ts")
+          .replace(/\\/g, "/"),
+      )};\n\nexport default handler;\n`,
+    );
+    writeFixtureFile(
+      root,
+      "cache/my-cdn-adapter.ts",
+      `export default function createAdapter() {
+  return {
+    ownsBackgroundRevalidation: false,
+    async get() { return null; },
+    async set() {},
+    buildResponseHeaders() { return {}; },
+    async revalidateTag() {},
+  };
+}
+`,
+    );
+    writeFixtureFile(
+      root,
+      "cache/stage-entry.ts",
+      `export const loadRequestStage = () => import("virtual:vinext-request-stage");
+export const loadResponseStage = () => import("virtual:vinext-response-stage");
+export default {
+  async fetch(request) {
+    const stage = request.url.includes("response")
+      ? await loadResponseStage()
+      : await loadRequestStage();
+    return new Response(Object.keys(stage).join(","));
+  },
+};
+`,
+    );
+    const adapterAbsPath = path.join(root, "cache/my-data-adapter.ts").replace(/\\/g, "/");
+    const cdnAdapterAbsPath = path.join(root, "cache/my-cdn-adapter.ts").replace(/\\/g, "/");
+    const stageEntryAbsPath = path.join(root, "cache/stage-entry.ts").replace(/\\/g, "/");
+    const { cloudflare } = (await import(pathToFileURL(cfPluginPath).href)) as {
+      cloudflare: CloudflarePluginFactory;
+    };
+    const builder = await createBuilder({
+      root,
+      configFile: false,
+      plugins: [
+        vinext({
+          appDir: root,
+          cache: {
+            cdn: {
+              adapter: cdnAdapterAbsPath,
+              output: { entry: stageEntryAbsPath, type: "multi-stage" },
+            },
+            data: { adapter: adapterAbsPath },
+          },
+        }),
+        cloudflare({ viteEnvironment: { name: "rsc", childEnvironments: ["ssr"] } }),
+      ],
+      logLevel: "silent",
+    });
+
+    await builder.buildApp();
+
+    expect(readStaticEntryClosure(root, "virtual:vinext-request-stage")).not.toContain(
+      LOCAL_ADAPTER_MARKER,
+    );
+    expect(readStaticEntryClosure(root, "virtual:vinext-response-stage")).toContain(
+      LOCAL_ADAPTER_MARKER,
+    );
   }, 60_000);
 });

--- a/tests/cache-adapters-build.test.ts
+++ b/tests/cache-adapters-build.test.ts
@@ -289,6 +289,11 @@ export default createAdapter;
       "worker/index.ts",
       'import handler from "vinext/server/fetch-handler";\n\nexport default handler;\n',
     );
+    writeFixtureFile(
+      root,
+      "pages/legacy.tsx",
+      `export default function LegacyPage() { return <main>legacy ${RESPONSE_STAGE_MARKER}</main>; }`,
+    );
 
     const { cloudflare } = (await import(pathToFileURL(cfPluginPath).href)) as {
       cloudflare: CloudflarePluginFactory;
@@ -334,6 +339,63 @@ export default createAdapter;
       default: { type: "worker", cache: { enabled: false } },
       VinextCachedResponse: { type: "worker", cache: { enabled: true } },
     });
+    expect(wrangler.version_metadata).toEqual({ binding: "CF_VERSION_METADATA" });
+    expect(wrangler.cache).toBeUndefined();
+  }, 60_000);
+
+  it("preserves the complete CDN config in a Pages Router build", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-cdn-pages-entrypoint-build-"));
+    tmpDirs.push(root);
+    writeCloudflareAppFixture(root, "vinext-cdn-pages-entrypoint-build");
+    fs.rmSync(path.join(root, "app"), { recursive: true });
+    fs.rmSync(path.join(root, "node_modules"));
+    fs.symlinkSync(
+      path.resolve(import.meta.dirname, "fixtures/cf-app-basic/node_modules"),
+      path.join(root, "node_modules"),
+      "junction",
+    );
+    writeFixtureFile(
+      root,
+      "pages/index.tsx",
+      `export default function HomePage() { return <main>pages ${RESPONSE_STAGE_MARKER}</main>; }`,
+    );
+    writeFixtureFile(
+      root,
+      "worker/index.ts",
+      'import handler from "vinext/server/fetch-handler";\n\nexport default handler;\n',
+    );
+
+    const { cloudflare } = (await import(pathToFileURL(cfPluginPath).href)) as {
+      cloudflare: CloudflarePluginFactory;
+    };
+    const builder = await createBuilder({
+      root,
+      configFile: false,
+      plugins: [
+        vinext({ disableAppRouter: true, cache: { cdn: cdnAdapter() } }),
+        cloudflare({ viteEnvironment: { name: "rsc", childEnvironments: ["ssr"] } }),
+      ],
+      logLevel: "silent",
+    });
+
+    await builder.buildApp();
+
+    const deployRedirectPath = path.join(root, ".wrangler/deploy/config.json");
+    const deployRedirect = JSON.parse(fs.readFileSync(deployRedirectPath, "utf8"));
+    const wranglerPath = path.resolve(path.dirname(deployRedirectPath), deployRedirect.configPath);
+    const serverDir = path.dirname(wranglerPath);
+    const wrangler = JSON.parse(fs.readFileSync(wranglerPath, "utf8"));
+    const workerPath = path.resolve(serverDir, wrangler.main);
+    expect(fs.readFileSync(workerPath, "utf8")).toMatch(
+      /export\s*\{[^}]*\b(?:[A-Za-z_$][\w$]*\s+as\s+)?VinextCachedResponse\b/,
+    );
+    expect(readTextFilesRecursive(serverDir)).toContain(RESPONSE_STAGE_MARKER);
+    expect(readStaticJavaScriptClosure(workerPath)).not.toContain(RESPONSE_STAGE_MARKER);
+    expect(wrangler.exports).toMatchObject({
+      default: { type: "worker", cache: { enabled: false } },
+      VinextCachedResponse: { type: "worker", cache: { enabled: true } },
+    });
+    expect(wrangler.version_metadata).toEqual({ binding: "CF_VERSION_METADATA" });
     expect(wrangler.cache).toBeUndefined();
   }, 60_000);
 

--- a/tests/cache-adapters-config.test.ts
+++ b/tests/cache-adapters-config.test.ts
@@ -17,7 +17,9 @@ import {
   generateCdnCacheAdapterModule,
   loadVinextCacheConfigFromViteConfig,
   generateCacheAdaptersModule,
+  getConfiguredCdnResponsePolicyHeaderNames,
   hasBuildIdentityResponseHeader,
+  hasUncachedRequestRouting,
   hasVerbatimResponseVary,
   VINEXT_CACHE_CONFIG_PLUGIN_PROPERTY,
   VIRTUAL_CACHE_ADAPTERS,
@@ -349,15 +351,56 @@ describe("cdnAdapter builder + factory", () => {
     expect(path.isAbsolute(descriptor.adapter)).toBe(true);
     expect(descriptor.adapter.endsWith("cdn-adapter.runtime.js")).toBe(true);
     expect(descriptor.options).toBeUndefined();
+    expect(descriptor.output.type).toBe("multi-stage");
+    expect(path.isAbsolute(descriptor.output.entry)).toBe(true);
+    expect(descriptor.output.entry.endsWith("cdn-adapter.worker.js")).toBe(true);
+    expect(
+      descriptor.output.transformHostEntry({
+        code: 'import handler from "vinext/server/fetch-handler";\nexport default handler;',
+        id: "\0virtual:cloudflare/worker-entry",
+      }),
+    ).toContain(`export { VinextCachedResponse } from ${JSON.stringify(descriptor.output.entry)};`);
+    expect(
+      descriptor.output.transformHostEntry({
+        code: "export default { fetch() {} };",
+        id: "/app/unrelated.ts",
+      }),
+    ).toBeNull();
+    expect(
+      descriptor.output.transformHostEntry({
+        code: 'export default function Docs() { return "vinext/server/fetch-handler"; }',
+        id: "/app/page.tsx",
+      }),
+    ).toBeNull();
+    expect(
+      descriptor.output.transformHostEntry({
+        code: '// import handler from "vinext/server/fetch-handler";\nexport default {};',
+        id: "/app/page.ts",
+      }),
+    ).toBeNull();
     expect(descriptor.capabilities).toEqual({
       buildIdentity: "response-header",
+      responsePolicyHeaderNames: ["CDN-Cache-Control", "Cloudflare-CDN-Cache-Control"],
+      requestRouting: "uncached-stage",
       responseVary: "verbatim",
       routeCacheability: "probe-manifest",
     });
     expect(hasBuildIdentityResponseHeader({ cdn: descriptor })).toBe(true);
+    expect(hasUncachedRequestRouting({ cdn: descriptor })).toBe(true);
     expect(hasVerbatimResponseVary({ cdn: descriptor })).toBe(true);
     expect(hasBuildIdentityResponseHeader({ cdn: { adapter: "custom-cache" } })).toBe(false);
+    expect(hasUncachedRequestRouting({ cdn: { adapter: "url-only-cache" } })).toBe(false);
     expect(hasVerbatimResponseVary({ cdn: { adapter: "url-only-cache" } })).toBe(false);
+    expect(
+      getConfiguredCdnResponsePolicyHeaderNames({
+        cdn: {
+          adapter: "custom-cache",
+          capabilities: {
+            responsePolicyHeaderNames: [" X-Example-Policy ", "CACHE-CONTROL", ""],
+          },
+        },
+      }),
+    ).toEqual(["cache-control", "x-example-policy"]);
   });
 
   it("factory returns a CloudflareCdnCacheAdapter", () => {

--- a/tests/cacheability-admission.test.ts
+++ b/tests/cacheability-admission.test.ts
@@ -535,7 +535,7 @@ describe("single-request cacheability admission", () => {
     }
   });
 
-  it("uses an adapter-owned edge policy rather than browser policy for Pages admission", async () => {
+  it("uses the Cloudflare edge policy rather than browser policy for Pages admission", async () => {
     const previousNextDeployPolicy = process.env.VINEXT_NEXT_DEPLOY_CACHE_CONTROL;
     delete process.env.VINEXT_NEXT_DEPLOY_CACHE_CONTROL;
     const adapter = new CloudflareCdnCacheAdapter();
@@ -550,11 +550,6 @@ describe("single-request cacheability admission", () => {
       );
       const state = cacheabilityState(context);
       state.route = { kind: "pages-page", pattern: "/page" };
-      state.responsePolicyHeaderNames = [
-        "cache-control",
-        "cdn-cache-control",
-        "cloudflare-cdn-cache-control",
-      ];
 
       const response = await finalizeWorkerCacheabilityResponse(
         new Response("page", {
@@ -567,7 +562,11 @@ describe("single-request cacheability admission", () => {
       );
 
       expect(response.headers.get("Cache-Control")).toBe("public, max-age=0, must-revalidate");
-      expect(response.headers.get("CDN-Cache-Control")).toBe("public, max-age=60");
+      expect(
+        adapter.responsePolicyHeaderNames
+          .map((name) => response.headers.get(name))
+          .find((value) => value !== null),
+      ).toBe("public, max-age=60");
     } finally {
       setCdnCacheAdapter(new DefaultCdnCacheAdapter());
       if (previousNextDeployPolicy === undefined) {

--- a/tests/cdn-adapter-build.test.ts
+++ b/tests/cdn-adapter-build.test.ts
@@ -117,9 +117,9 @@ describe("Cloudflare CDN adapter build output", () => {
     expect(responseStageEntry).toBeDefined();
 
     const sidecarImport = /import\s*["']\.\/__vinext_pregenerated_concrete_paths\.js["']/;
-    expect((await readStaticClosure(workerEntry!)).some((source) => sidecarImport.test(source))).toBe(
-      false,
-    );
+    expect(
+      (await readStaticClosure(workerEntry!)).some((source) => sidecarImport.test(source)),
+    ).toBe(false);
     expect(
       (await readStaticClosure(responseStageEntry!)).some((source) => sidecarImport.test(source)),
     ).toBe(true);

--- a/tests/cdn-adapter-build.test.ts
+++ b/tests/cdn-adapter-build.test.ts
@@ -102,7 +102,7 @@ describe("Cloudflare CDN adapter build output", () => {
         sources.push(await fs.readFile(path.join(serverDir, chunk.file), "utf8"));
         for (const imported of chunk.imports ?? []) {
           const importedChunk = manifest[imported];
-          expect(importedChunk, `missing manifest chunk ${imported}`).toBeDefined();
+          if (!importedChunk) throw new Error(`missing manifest chunk ${imported}`);
           pending.push(importedChunk);
         }
       }

--- a/tests/cdn-adapter-build.test.ts
+++ b/tests/cdn-adapter-build.test.ts
@@ -83,10 +83,46 @@ describe("Cloudflare CDN adapter build output", () => {
     expect(generated.version_metadata).toEqual({ binding: "CF_VERSION_METADATA" });
   });
 
-  it("emits the pregenerated-paths sidecar imported by the Worker entry", async () => {
+  it("emits the pregenerated-paths sidecar only in the response-stage closure", async () => {
     const sidecarName = "__vinext_pregenerated_concrete_paths.js";
-    const workerEntry = await fs.readFile(path.join(root, "dist/server/index.js"), "utf8");
-    expect(workerEntry).toMatch(/import\s*["']\.\/__vinext_pregenerated_concrete_paths\.js["']/);
+    const serverDir = path.join(root, "dist/server");
+    type ManifestChunk = { file: string; imports?: string[]; src?: string };
+    const manifest = JSON.parse(
+      await fs.readFile(path.join(serverDir, ".vite/manifest.json"), "utf8"),
+    ) as Record<string, ManifestChunk>;
+
+    const readStaticClosure = async (entry: ManifestChunk): Promise<string[]> => {
+      const pending = [entry];
+      const seen = new Set<string>();
+      const sources: string[] = [];
+      while (pending.length > 0) {
+        const chunk = pending.pop()!;
+        if (seen.has(chunk.file)) continue;
+        seen.add(chunk.file);
+        sources.push(await fs.readFile(path.join(serverDir, chunk.file), "utf8"));
+        for (const imported of chunk.imports ?? []) {
+          const importedChunk = manifest[imported];
+          expect(importedChunk, `missing manifest chunk ${imported}`).toBeDefined();
+          pending.push(importedChunk);
+        }
+      }
+      return sources;
+    };
+
+    const workerEntry = Object.values(manifest).find((chunk) => chunk.file === "index.js");
+    const responseStageEntry = Object.values(manifest).find((chunk) =>
+      chunk.src?.endsWith("virtual:vinext-response-stage"),
+    );
+    expect(workerEntry).toBeDefined();
+    expect(responseStageEntry).toBeDefined();
+
+    const sidecarImport = /import\s*["']\.\/__vinext_pregenerated_concrete_paths\.js["']/;
+    expect((await readStaticClosure(workerEntry!)).some((source) => sidecarImport.test(source))).toBe(
+      false,
+    );
+    expect(
+      (await readStaticClosure(responseStageEntry!)).some((source) => sidecarImport.test(source)),
+    ).toBe(true);
     expect(await fs.readFile(path.join(root, "dist/server", sidecarName), "utf8")).toBe(
       "delete globalThis.__VINEXT_PREGENERATED_CONCRETE_PATHS;\n",
     );

--- a/tests/cdn-adapter-config.test.ts
+++ b/tests/cdn-adapter-config.test.ts
@@ -63,10 +63,17 @@ describe("Cloudflare CDN adapter generated config", () => {
       bindingIsExplicit: false,
     });
 
-    expect(JSON.parse(fs.readFileSync(generatedPath, "utf8")).version_metadata).toEqual({
+    const generatedConfig = JSON.parse(fs.readFileSync(generatedPath, "utf8"));
+    expect(generatedConfig.version_metadata).toEqual({
       binding: DEFAULT_CDN_VERSION_METADATA_BINDING,
     });
-    expect(JSON.parse(fs.readFileSync(auxiliaryPath, "utf8")).version_metadata).toBeUndefined();
+    expect(generatedConfig.exports).toMatchObject({
+      default: { type: "worker", cache: { enabled: false } },
+      VinextCachedResponse: { type: "worker", cache: { enabled: true } },
+    });
+    const auxiliaryConfig = JSON.parse(fs.readFileSync(auxiliaryPath, "utf8"));
+    expect(auxiliaryConfig.version_metadata).toBeUndefined();
+    expect(auxiliaryConfig.exports).toBeUndefined();
     expect(fs.readFileSync(sourcePath, "utf8")).toBe('{"name":"source-worker"}');
   });
 
@@ -158,10 +165,16 @@ describe("Cloudflare CDN adapter generated config", () => {
     ).rejects.toThrow(`Could not read the generated Wrangler config at ${generatedPath}`);
   });
 
-  it("leaves an already matching generated config byte-for-byte unchanged", async () => {
+  it("is byte-for-byte idempotent after applying the complete adapter config", async () => {
     const generatedPath = writeGeneratedConfig("dist/server/wrangler.json", {
       name: "test-worker",
       version_metadata: { binding: DEFAULT_CDN_VERSION_METADATA_BINDING },
+    });
+    await finalizeCdnAdapterBuildOutput({
+      outDir: path.dirname(generatedPath),
+      isPrimaryServerOutput: true,
+      binding: DEFAULT_CDN_VERSION_METADATA_BINDING,
+      bindingIsExplicit: false,
     });
     const before = fs.readFileSync(generatedPath, "utf8");
 

--- a/tests/cloudflare-cdn-cache.test.ts
+++ b/tests/cloudflare-cdn-cache.test.ts
@@ -225,15 +225,15 @@ describe("CloudflareCdnCacheAdapter", () => {
     await expect(adapter.set("k", null)).resolves.toBeUndefined();
   });
 
-  it("carries SWR on CDN-Cache-Control (public + max-age) and revalidates the browser", () => {
+  it("carries SWR on Cloudflare's consumed edge policy and revalidates the browser", () => {
     // A value-less `stale-while-revalidate` is normalized to an explicit window
     // (Cloudflare ignores the bare directive — RFC 5861 requires a value).
     expect(
       adapter.buildResponseHeaders({ cacheControl: "s-maxage=60, stale-while-revalidate" }),
     ).toEqual({
       "Cache-Control": "public, max-age=0, must-revalidate",
-      "CDN-Cache-Control": "public, max-age=60, stale-while-revalidate=31536000",
-      "Cloudflare-CDN-Cache-Control": null,
+      "CDN-Cache-Control": null,
+      "Cloudflare-CDN-Cache-Control": "public, max-age=60, stale-while-revalidate=31536000",
       "Cache-Tag": null,
     });
   });
@@ -258,7 +258,8 @@ describe("CloudflareCdnCacheAdapter", () => {
     });
     expect(headers["Cache-Tag"]).toBe("/blog,_N_T_/blog,posts");
     expect(headers["Cache-Control"]).toBe("public, max-age=0, must-revalidate");
-    expect(headers["CDN-Cache-Control"]).toBe("public, max-age=60");
+    expect(headers["CDN-Cache-Control"]).toBeNull();
+    expect(headers["Cloudflare-CDN-Cache-Control"]).toBe("public, max-age=60");
   });
 
   it("skips tags containing the comma separator or that are too long", () => {

--- a/tests/cloudflare-cdn-warm-deploy.test.ts
+++ b/tests/cloudflare-cdn-warm-deploy.test.ts
@@ -115,7 +115,18 @@ function writeTwoStageWorkerArtifact(): void {
     "dist/server/wrangler.json",
     JSON.stringify({ main: "index.js", name: "my-worker", workers_dev: true }),
   );
-  writeFile("dist/server/index.js", `import "./${CACHEABILITY_MANIFEST_MODULE}";\n`);
+  writeFile("dist/server/index.js", 'void import("./response-stage.js");\n');
+  writeFile("dist/server/response-stage.js", `import "./${CACHEABILITY_MANIFEST_MODULE}";\n`);
+  writeFile(
+    "dist/server/.vite/manifest.json",
+    JSON.stringify({
+      "virtual:cloudflare/worker-entry": {
+        dynamicImports: ["virtual:vinext-response-stage"],
+        file: "index.js",
+      },
+      "virtual:vinext-response-stage": { file: "response-stage.js" },
+    }),
+  );
   writeFile(`dist/server/${CACHEABILITY_MANIFEST_MODULE}`, "export default null;\n");
   writeFile(
     "dist/server/vinext-server.json",
@@ -304,6 +315,13 @@ describe("Cloudflare CDN warmup deploy flow", () => {
   it("rejects a generated artifact whose Worker main cannot reach the manifest module", () => {
     writeTwoStageWorkerArtifact();
     writeFile("dist/server/index.js", "export default { fetch() {} };\n");
+    writeFile(
+      "dist/server/.vite/manifest.json",
+      JSON.stringify({
+        "virtual:cloudflare/worker-entry": { file: "index.js" },
+        "virtual:vinext-response-stage": { file: "response-stage.js" },
+      }),
+    );
 
     expect(() =>
       writeCacheabilityManifestArtifact(tmpDir, "dist/server/wrangler.json", {
@@ -311,7 +329,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
         routes: {},
         version: 1,
       }),
-    ).toThrow(`Worker main module to import ${CACHEABILITY_MANIFEST_MODULE}`);
+    ).toThrow(`Worker graph to statically import ${CACHEABILITY_MANIFEST_MODULE}`);
   });
 
   it.each([
@@ -335,7 +353,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     ],
   ])("rejects a manifest filename mentioned only by a %s", (_label, mainSource) => {
     writeTwoStageWorkerArtifact();
-    writeFile("dist/server/index.js", mainSource);
+    writeFile("dist/server/response-stage.js", mainSource);
 
     expect(() =>
       writeCacheabilityManifestArtifact(tmpDir, "dist/server/wrangler.json", {
@@ -343,7 +361,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
         routes: {},
         version: 1,
       }),
-    ).toThrow(`Worker main module to import ${CACHEABILITY_MANIFEST_MODULE}`);
+    ).toThrow(`Worker graph to statically import ${CACHEABILITY_MANIFEST_MODULE}`);
   });
 
   it.each([
@@ -357,7 +375,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     ],
   ])("accepts a manifest reached by a %s", (_label, mainSource) => {
     writeTwoStageWorkerArtifact();
-    writeFile("dist/server/index.js", mainSource);
+    writeFile("dist/server/response-stage.js", mainSource);
 
     expect(
       writeCacheabilityManifestArtifact(tmpDir, "dist/server/wrangler.json", {

--- a/tests/cloudflare-cdn-worker.test.ts
+++ b/tests/cloudflare-cdn-worker.test.ts
@@ -1,0 +1,1088 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import {
+  configureWorkersCacheEntrypoints,
+  finalizeWorkersCacheBuildOutput,
+} from "../packages/cloudflare/src/cache/cdn-adapter-config.js";
+import worker, {
+  VinextCachedResponse,
+} from "../packages/cloudflare/src/cache/cdn-adapter.worker.js";
+import { VINEXT_CDN_BUILD_ID_HEADER } from "../packages/cloudflare/src/cache/cdn-build-id.js";
+import {
+  PAGES_RESPONSE_STAGE_PROTOCOL_VERSION,
+  type WorkerResponseStageProps,
+} from "../packages/vinext/src/server/worker-stages.js";
+import { cloneRequestWithUrl } from "../packages/vinext/src/server/request-pipeline.js";
+import { NextRequest } from "../packages/vinext/src/shims/server.js";
+
+type PagesPageResponseStageProps = Extract<WorkerResponseStageProps, { kind: "pages-page" }>;
+
+const stages = vi.hoisted(() => ({
+  request: vi.fn(),
+  response: vi.fn(),
+}));
+
+vi.mock("cloudflare:workers", () => ({
+  WorkerEntrypoint: class<Env, Props> {
+    protected ctx: { props: Props };
+    protected env: Env;
+
+    constructor(ctx: { props: Props }, env: Env) {
+      this.ctx = ctx;
+      this.env = env;
+    }
+  },
+}));
+
+vi.mock("virtual:vinext-request-stage", () => ({
+  handleRequestStage: stages.request,
+}));
+
+vi.mock("virtual:vinext-response-stage", () => ({
+  handleResponseStage: stages.response,
+}));
+
+function createEntrypoint(props: unknown, env: unknown = { binding: "value" }) {
+  return Object.assign(Object.create(VinextCachedResponse.prototype), {
+    ctx: { props },
+    env,
+  }) as VinextCachedResponse;
+}
+
+function responseStageInvocation(
+  props: unknown,
+  requestUrl = "https://example.com/page",
+  requestMethod = "GET",
+) {
+  return { options: { cache: "shared" }, props, requestMethod, requestUrl };
+}
+
+function pagesPageProps(
+  resolvedUrl: string,
+  renderOptions: PagesPageResponseStageProps["renderOptions"],
+): PagesPageResponseStageProps {
+  return {
+    buildId: "test-build",
+    cacheability: {
+      policyHeaders: null,
+      probeMode: null,
+      resolvedRoutePathname: new URL(resolvedUrl, "https://example.com").pathname,
+    },
+    kind: "pages-page",
+    protocolVersion: PAGES_RESPONSE_STAGE_PROTOCOL_VERSION,
+    requestHost: "example.com",
+    renderOptions,
+    resolvedUrl,
+    stagedHeaders: null,
+  };
+}
+
+type PreFixResponseStageInvocation = {
+  options: { cache: "shared" | "bypass" };
+  props: unknown;
+  requestMethod: string;
+  requestUrl: string;
+};
+
+/** Snapshot of the response-stage parser immediately before the wire-version fix. */
+function getPreFixResponseStageInvocation(value: unknown): PreFixResponseStageInvocation | null {
+  if (!value || typeof value !== "object") return null;
+  const options = Reflect.get(value, "options");
+  if (!options || typeof options !== "object") return null;
+  const cache = Reflect.get(options, "cache");
+  if (cache !== "shared" && cache !== "bypass") return null;
+  const requestUrl = Reflect.get(value, "requestUrl");
+  if (typeof requestUrl !== "string") return null;
+  const requestMethod = Reflect.get(value, "requestMethod");
+  if (typeof requestMethod !== "string" || requestMethod.length === 0) return null;
+  try {
+    new URL(requestUrl);
+  } catch {
+    return null;
+  }
+  return {
+    options: options as PreFixResponseStageInvocation["options"],
+    props: Reflect.get(value, "props"),
+    requestMethod,
+    requestUrl,
+  };
+}
+
+/** Local pre-fix entrypoint used to exercise a real rolling-deploy boundary. */
+class PreFixVinextCachedResponse {
+  constructor(
+    private readonly props: unknown,
+    private readonly buildIdentity: string,
+  ) {}
+
+  async fetch(request: Request): Promise<Response> {
+    const invocation = getPreFixResponseStageInvocation(this.props);
+    if (!invocation) {
+      return this.stamp(new Response("Invalid vinext response-stage invocation", { status: 400 }));
+    }
+    const restored = new Request(new Request(invocation.requestUrl, request), {
+      method: invocation.requestMethod,
+    });
+    const response = await stages.response(
+      restored,
+      {},
+      { hostRuntime: "worker" },
+      invocation.props,
+      async () => new Response(null, { status: 501 }),
+      invocation.options,
+    );
+    return this.stamp(response);
+  }
+
+  private stamp(response: Response): Response {
+    const headers = new Headers(response.headers);
+    headers.set(VINEXT_CDN_BUILD_ID_HEADER, this.buildIdentity);
+    return new Response(response.body, {
+      headers,
+      status: response.status,
+      statusText: response.statusText,
+    });
+  }
+}
+
+function isWorkersCacheAdmissible(response: Response): boolean {
+  // This deliberately models only the RFC admission decision needed by this
+  // regression, not every feature of Workers Cache.
+  return (
+    response.status === 200 &&
+    response.headers.get("Cloudflare-CDN-Cache-Control")?.includes("public") === true
+  );
+}
+
+describe("Cloudflare CDN multi-stage Worker facade", () => {
+  beforeEach(() => {
+    stages.request.mockReset();
+    stages.response.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("exports the cached stage as a named WorkerEntrypoint class", () => {
+    expect(typeof VinextCachedResponse).toBe("function");
+    expect(typeof VinextCachedResponse.prototype.fetch).toBe("function");
+  });
+
+  it("lazily invokes the response stage from named-entrypoint props", async () => {
+    const request = new Request("https://example.com/page");
+    const props = { kind: "pages-page", resolvedUrl: "/page" };
+    const response = new Response("rendered");
+    stages.response.mockResolvedValue(response);
+
+    const result = await createEntrypoint(responseStageInvocation(props)).fetch(request);
+
+    expect(result).toBe(response);
+    const [
+      renderedRequest,
+      renderedEnv,
+      renderedContext,
+      renderedProps,
+      reverseTransport,
+      options,
+    ] = stages.response.mock.calls[0]!;
+    expect((renderedRequest as Request).url).toBe(request.url);
+    expect(renderedEnv).toEqual({ binding: "value" });
+    expect(renderedContext).toEqual(expect.objectContaining({ hostRuntime: "worker" }));
+    expect(renderedProps).toEqual(props);
+    expect(reverseTransport).toEqual(expect.any(Function));
+    expect(options).toEqual({ cache: "shared" });
+  });
+
+  it.each([200, 204, 404, 503])(
+    "stamps named-stage identity on every %s response before cache admission",
+    async (status) => {
+      vi.stubEnv("__VINEXT_RSC_BUILD_IDENTITY", "current-stage");
+      stages.response.mockResolvedValue(
+        new Response(status === 204 ? null : "rendered", {
+          status,
+          headers: { [VINEXT_CDN_BUILD_ID_HEADER]: "forged-stage" },
+        }),
+      );
+
+      const response = await createEntrypoint({
+        ...responseStageInvocation({ kind: "app-page" }),
+        expectedResponseStageBuildIdentity: "current-stage",
+        options: { cache: "vinext-cloudflare-v1:shared" },
+      }).fetch(new Request("https://example.com/page"));
+
+      expect(response.status).toBe(status);
+      expect(response.headers.get(VINEXT_CDN_BUILD_ID_HEADER)).toBe("current-stage");
+    },
+  );
+
+  it.each([
+    ["missing", null, 503],
+    ["different", "previous-stage", 503],
+    ["matching", "current-stage", 200],
+  ] as const)(
+    "%s named-stage identity is validated before the request stage stamps its own identity",
+    async (_label, responseStageIdentity, expectedStatus) => {
+      vi.stubEnv("__VINEXT_RSC_BUILD_IDENTITY", "current-stage");
+      const binding = vi.fn(() => ({
+        fetch() {
+          return new Response("response-stage body", {
+            headers:
+              responseStageIdentity === null
+                ? undefined
+                : { [VINEXT_CDN_BUILD_ID_HEADER]: responseStageIdentity },
+          });
+        },
+      }));
+      stages.request.mockImplementation(async (request, _env, _ctx, dispatch) => {
+        const response = await dispatch(request, { kind: "app-page" }, { cache: "shared" });
+        const headers = new Headers(response.headers);
+        // App and Pages request stages apply this public identity after the
+        // response transport returns. It must not hide an inner mismatch.
+        headers.set(VINEXT_CDN_BUILD_ID_HEADER, "current-stage");
+        return new Response(response.body, { headers, status: response.status });
+      });
+
+      const response = await worker.fetch(
+        new Request("https://example.com/page", { headers: { Accept: "text/html" } }),
+        {},
+        { exports: { VinextCachedResponse: binding } },
+      );
+
+      expect(response.status).toBe(expectedStatus);
+      expect(response.headers.get(VINEXT_CDN_BUILD_ID_HEADER)).toBe("current-stage");
+      expect(response.headers.get("Cache-Control")).toBe(
+        expectedStatus === 503 ? "no-store" : "private, max-age=0, must-revalidate",
+      );
+      await expect(response.text()).resolves.toBe(
+        expectedStatus === 503 ? "" : "response-stage body",
+      );
+    },
+  );
+
+  it("cancels a response from a mismatched named stage", async () => {
+    vi.stubEnv("__VINEXT_RSC_BUILD_IDENTITY", "current-stage");
+    const cancel = vi.fn();
+    const binding = vi.fn(() => ({
+      fetch() {
+        return new Response(new ReadableStream({ cancel }), {
+          headers: { [VINEXT_CDN_BUILD_ID_HEADER]: "previous-stage" },
+        });
+      },
+    }));
+    stages.request.mockImplementation((request, _env, _ctx, dispatch) =>
+      dispatch(request, { kind: "app-page" }, { cache: "shared" }),
+    );
+
+    const response = await worker.fetch(
+      new Request("https://example.com/page"),
+      {},
+      { exports: { VinextCachedResponse: binding } },
+    );
+
+    expect(response.status).toBe(503);
+    await vi.waitFor(() => expect(cancel).toHaveBeenCalledOnce());
+  });
+
+  it("makes a pre-fix named stage fail before render or Workers Cache admission", async () => {
+    // No Next.js test port applies: propagation between named Worker
+    // entrypoints and Workers Cache admission is Cloudflare-specific.
+    vi.stubEnv("__VINEXT_RSC_BUILD_IDENTITY", "current-stage");
+    const cachedResponses = new Map<string, Response>();
+    const coldResponseMetadata: {
+      edgeCacheControl: string | null;
+      identity: string | null;
+      status: number;
+    }[] = [];
+    const renderedBy: string[] = [];
+    let coldDispatch = 0;
+    const binding = vi.fn(({ props }: { props: unknown }) => ({
+      async fetch(request: Request) {
+        // The adapter's URL digest already covers the serialized configurable
+        // entrypoint props, including the expected response-stage identity.
+        const cached = cachedResponses.get(request.url);
+        if (cached) return cached.clone();
+
+        const response =
+          coldDispatch++ === 0
+            ? await new PreFixVinextCachedResponse(props, "previous-stage").fetch(request)
+            : await createEntrypoint(props).fetch(request);
+        coldResponseMetadata.push({
+          edgeCacheControl: response.headers.get("Cloudflare-CDN-Cache-Control"),
+          identity: response.headers.get(VINEXT_CDN_BUILD_ID_HEADER),
+          status: response.status,
+        });
+        if (isWorkersCacheAdmissible(response)) {
+          cachedResponses.set(request.url, response.clone());
+        }
+        return response;
+      },
+    }));
+    stages.request.mockImplementation((request, _env, _ctx, dispatch) =>
+      dispatch(request, { kind: "app-page" }, { cache: "shared" }),
+    );
+    stages.response.mockImplementation(() => {
+      renderedBy.push("current-stage");
+      return new Response("rendered by current-stage", {
+        headers: { "Cloudflare-CDN-Cache-Control": "public, max-age=300" },
+      });
+    });
+    const context = { exports: { VinextCachedResponse: binding } };
+
+    const first = await worker.fetch(new Request("https://example.com/page"), {}, context);
+    expect(first.status).toBe(503);
+    expect(first.headers.get("Cache-Control")).toBe("no-store");
+    expect(cachedResponses).toHaveProperty("size", 0);
+    expect(coldResponseMetadata).toEqual([
+      { edgeCacheControl: null, identity: "previous-stage", status: 400 },
+    ]);
+    expect(renderedBy).toEqual([]);
+
+    const retry = await worker.fetch(new Request("https://example.com/page"), {}, context);
+    expect(retry.status).toBe(200);
+    await expect(retry.text()).resolves.toBe("rendered by current-stage");
+    expect(renderedBy).toEqual(["current-stage"]);
+    expect(cachedResponses).toHaveProperty("size", 1);
+    expect(coldResponseMetadata).toEqual([
+      { edgeCacheControl: null, identity: "previous-stage", status: 400 },
+      {
+        edgeCacheControl: "public, max-age=300",
+        identity: "current-stage",
+        status: 200,
+      },
+    ]);
+
+    const hit = await worker.fetch(new Request("https://example.com/page"), {}, context);
+    expect(hit.status).toBe(200);
+    await expect(hit.text()).resolves.toBe("rendered by current-stage");
+    expect(renderedBy).toEqual(["current-stage"]);
+    expect(coldDispatch).toBe(2);
+  });
+
+  it("partitions cache-facing keys by the opaque response-stage build identity", async () => {
+    const cacheFacingUrls: string[] = [];
+    const binding = vi.fn(() => ({
+      fetch(request: Request) {
+        cacheFacingUrls.push(request.url);
+        return new Response("cached", {
+          headers: {
+            [VINEXT_CDN_BUILD_ID_HEADER]: process.env.__VINEXT_RSC_BUILD_IDENTITY!,
+          },
+        });
+      },
+    }));
+    stages.request.mockImplementation((request, _env, _ctx, dispatch) =>
+      dispatch(request, { kind: "app-page", buildId: "pinned-build" }, { cache: "shared" }),
+    );
+
+    const context = { exports: { VinextCachedResponse: binding } };
+    vi.stubEnv("__VINEXT_RSC_BUILD_IDENTITY", "stage-a");
+    await worker.fetch(new Request("https://example.com/page"), {}, context);
+    vi.stubEnv("__VINEXT_RSC_BUILD_IDENTITY", "stage-b");
+    await worker.fetch(new Request("https://example.com/page"), {}, context);
+
+    expect(cacheFacingUrls).toHaveLength(2);
+    expect(cacheFacingUrls[0]).not.toBe(cacheFacingUrls[1]);
+  });
+
+  it("retains Cloudflare's private policy on the cache-bearing entrypoint", async () => {
+    stages.response.mockResolvedValue(
+      new Response("rendered", {
+        headers: { "Cloudflare-CDN-Cache-Control": "public, max-age=300" },
+      }),
+    );
+
+    const response = await createEntrypoint(responseStageInvocation({ kind: "app-page" })).fetch(
+      new Request("https://example.com/page"),
+    );
+
+    expect(response.headers.get("Cloudflare-CDN-Cache-Control")).toBe("public, max-age=300");
+  });
+
+  it("rejects an expected build identity when the named stage has no identity", async () => {
+    const response = await createEntrypoint({
+      ...responseStageInvocation({ kind: "app-page" }),
+      expectedResponseStageBuildIdentity: "current-stage",
+      options: { cache: "vinext-cloudflare-v1:shared" },
+    }).fetch(new Request("https://example.com/page"));
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get(VINEXT_CDN_BUILD_ID_HEADER)).toBeNull();
+    expect(stages.response).not.toHaveBeenCalled();
+  });
+
+  it.each([null, 42, {}])(
+    "rejects malformed expected response-stage identity %j",
+    async (expectedResponseStageBuildIdentity) => {
+      const response = await createEntrypoint({
+        ...responseStageInvocation({ kind: "app-page" }),
+        expectedResponseStageBuildIdentity,
+      }).fetch(new Request("https://example.com/page"));
+
+      expect(response.status).toBe(400);
+      expect(response.headers.get("Cache-Control")).toBe("no-store");
+      expect(stages.response).not.toHaveBeenCalled();
+    },
+  );
+
+  it("rejects malformed configurable entrypoint props", async () => {
+    const response = await createEntrypoint({
+      options: { cache: "invalid" },
+      props: {},
+      requestUrl: "https://example.com/page",
+    }).fetch(new Request("https://example.com/page"));
+    expect(response.status).toBe(400);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(stages.response).not.toHaveBeenCalled();
+  });
+
+  it("rejects unversioned cache intent when an expected identity is present", async () => {
+    vi.stubEnv("__VINEXT_RSC_BUILD_IDENTITY", "current-stage");
+    const response = await createEntrypoint({
+      ...responseStageInvocation({ kind: "app-page" }),
+      expectedResponseStageBuildIdentity: "current-stage",
+    }).fetch(new Request("https://example.com/page"));
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(stages.response).not.toHaveBeenCalled();
+  });
+
+  it("rejects versioned wire cache intent without an expected identity", async () => {
+    const response = await createEntrypoint({
+      ...responseStageInvocation({ kind: "app-page" }),
+      options: { cache: "vinext-cloudflare-v1:shared" },
+    }).fetch(new Request("https://example.com/page"));
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(stages.response).not.toHaveBeenCalled();
+  });
+
+  it("makes a built stage reject pre-fix gateway props before render or cache admission", async () => {
+    vi.stubEnv("__VINEXT_RSC_BUILD_IDENTITY", "current-stage");
+
+    // This is the exact configurable-entrypoint shape serialized by the
+    // immediately preceding gateway implementation.
+    const response = await createEntrypoint(responseStageInvocation({ kind: "app-page" })).fetch(
+      new Request("https://example.com/page"),
+    );
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(isWorkersCacheAdmissible(response)).toBe(false);
+    expect(stages.response).not.toHaveBeenCalled();
+  });
+
+  it("normalizes wire cache intent before nested response-stage dispatch", async () => {
+    vi.stubEnv("__VINEXT_RSC_BUILD_IDENTITY", "current-stage");
+    stages.response
+      .mockImplementationOnce((_request, _env, _context, _props, dispatchRequestStage) =>
+        dispatchRequestStage(new Request("https://example.com/nested")),
+      )
+      .mockResolvedValueOnce(new Response("nested response"));
+    stages.request.mockImplementation((request, _env, _context, dispatchResponseStage) =>
+      dispatchResponseStage(request, { kind: "app-page" }, { cache: "shared" }),
+    );
+
+    const response = await createEntrypoint({
+      ...responseStageInvocation({ kind: "app-page" }),
+      expectedResponseStageBuildIdentity: "current-stage",
+      options: { cache: "vinext-cloudflare-v1:shared" },
+    }).fetch(new Request("https://example.com/page"));
+
+    await expect(response.text()).resolves.toBe("nested response");
+    expect(stages.response.mock.calls.map((call) => call[5])).toEqual([
+      { cache: "shared" },
+      { cache: "shared" },
+    ]);
+  });
+
+  it("dispatches shared work through ctx.exports", async () => {
+    const cachedResponse = new Response("cached");
+    const fetch = vi.fn().mockResolvedValue(cachedResponse);
+    const binding = vi.fn(() => ({ fetch }));
+    const params = Object.assign(Object.create(null) as Record<string, string>, { slug: "page" });
+    stages.request.mockImplementation((_request, _env, _ctx, dispatch) =>
+      dispatch(
+        new Request("https://example.com/render"),
+        { params, route: "/page" },
+        { cache: "shared" },
+      ),
+    );
+
+    const result = await worker.fetch(
+      new Request("https://example.com/page"),
+      {},
+      {
+        exports: { VinextCachedResponse: binding },
+      },
+    );
+
+    await expect(result.text()).resolves.toBe("cached");
+    expect(result.headers.get("Cache-Control")).toBe("private, max-age=0, must-revalidate");
+    expect(binding).toHaveBeenCalledWith({
+      props: {
+        options: { cache: "shared" },
+        props: { params: { slug: "page" }, route: "/page" },
+        requestMethod: "GET",
+        requestUrl: "https://example.com/render",
+      },
+    });
+    expect(fetch).toHaveBeenCalledOnce();
+    const cacheRequest = fetch.mock.calls[0]![0] as Request;
+    expect(cacheRequest.url).toMatch(
+      /^https:\/\/example\.com\/render\?__vinext_cache_key=[0-9a-f]{64}$/,
+    );
+    expect(stages.response).not.toHaveBeenCalled();
+  });
+
+  it("partitions shared dispatches by public request authority", async () => {
+    const cacheFacingRequests: Request[] = [];
+    const binding = vi.fn(({ props }: { props: unknown }) => ({
+      fetch(request: Request) {
+        cacheFacingRequests.push(request);
+        return createEntrypoint(props).fetch(request);
+      },
+    }));
+    stages.request.mockImplementation((request, _env, _ctx, dispatch) =>
+      dispatch(request, { kind: "app-page" }, { cache: "shared" }),
+    );
+    stages.response.mockImplementation((request) => Response.json({ url: request.url }));
+
+    const responses = [];
+    for (const url of ["https://tenant-a.example/page", "https://tenant-b.example/page"]) {
+      responses.push(
+        await worker.fetch(new Request(url), {}, { exports: { VinextCachedResponse: binding } }),
+      );
+    }
+
+    expect(cacheFacingRequests).toHaveLength(2);
+    expect(cacheFacingRequests[0]?.url).toMatch(
+      /^https:\/\/tenant-a\.example\/page\?__vinext_cache_key=[0-9a-f]{64}$/,
+    );
+    expect(cacheFacingRequests[1]?.url).toMatch(
+      /^https:\/\/tenant-b\.example\/page\?__vinext_cache_key=[0-9a-f]{64}$/,
+    );
+    expect(cacheFacingRequests[0]?.url).not.toBe(cacheFacingRequests[1]?.url);
+    await expect(responses[0]?.json()).resolves.toEqual({
+      url: "https://tenant-a.example/page",
+    });
+    await expect(responses[1]?.json()).resolves.toEqual({
+      url: "https://tenant-b.example/page",
+    });
+  });
+
+  it("does not expose the inner Cloudflare cache policy after gateway personalization", async () => {
+    const binding = vi.fn(() => ({
+      fetch: vi.fn().mockResolvedValue(
+        new Response("shared", {
+          headers: {
+            "Cache-Control": "public, max-age=0, must-revalidate",
+            "Cloudflare-CDN-Cache-Control": "public, max-age=300",
+          },
+        }),
+      ),
+    }));
+    stages.request.mockImplementation(async (request, _env, _ctx, dispatch) => {
+      const response = await dispatch(request, { kind: "app-page" }, { cache: "shared" });
+      const headers = new Headers(response.headers);
+      headers.set("x-user-variant", request.headers.get("x-user-variant") ?? "missing");
+      return new Response(response.body, { headers, status: response.status });
+    });
+
+    const response = await worker.fetch(
+      new Request("https://example.com/page", {
+        headers: { "x-user-variant": "alice" },
+      }),
+      {},
+      { exports: { VinextCachedResponse: binding } },
+    );
+
+    expect(response.headers.get("x-user-variant")).toBe("alice");
+    expect(response.headers.get("Cache-Control")).toBe("private, max-age=0, must-revalidate");
+    expect(response.headers.get("Cloudflare-CDN-Cache-Control")).toBeNull();
+    expect(response.headers.get("CDN-Cache-Control")).toBeNull();
+    await expect(response.text()).resolves.toBe("shared");
+  });
+
+  it("keeps Authorization off Workers Cache while restoring and partitioning cold renders", async () => {
+    const cacheFacingRequests: Request[] = [];
+    const binding = vi.fn(({ props }: { props: unknown }) => ({
+      fetch(request: Request) {
+        cacheFacingRequests.push(request);
+        return createEntrypoint(props).fetch(request);
+      },
+    }));
+    stages.request.mockImplementation((request, _env, _ctx, dispatch) =>
+      dispatch(request, { kind: "app-route-handler" }, { cache: "shared" }),
+    );
+    stages.response.mockImplementation((request) =>
+      Response.json({ authorization: request.headers.get("Authorization") }),
+    );
+
+    for (const authorization of ["Bearer first", "Bearer second"]) {
+      await worker.fetch(
+        new Request("https://example.com/authenticated", {
+          headers: {
+            Authorization: authorization,
+            "x-vinext-internal-authorization": "forged",
+          },
+        }),
+        {},
+        { exports: { VinextCachedResponse: binding } },
+      );
+    }
+
+    expect(cacheFacingRequests).toHaveLength(2);
+    expect(cacheFacingRequests[0]?.headers.get("Authorization")).toBeNull();
+    expect(cacheFacingRequests[1]?.headers.get("Authorization")).toBeNull();
+    expect(cacheFacingRequests[0]?.url).not.toBe(cacheFacingRequests[1]?.url);
+    expect(
+      stages.response.mock.calls.map(([request]) =>
+        (request as Request).headers.get("Authorization"),
+      ),
+    ).toEqual(["Bearer first", "Bearer second"]);
+    for (const [request] of stages.response.mock.calls) {
+      expect((request as Request).headers.has("x-vinext-internal-authorization")).toBe(false);
+    }
+  });
+
+  it("keys cached dispatches by route metadata and restores the user-facing URL", async () => {
+    const cachedEntrypoint = createEntrypoint(
+      responseStageInvocation(
+        { kind: "app-page", resolvedUrl: "/rewritten" },
+        "https://tenant.example/original?view=one",
+      ),
+    );
+    stages.response.mockResolvedValue(new Response("rendered"));
+
+    await cachedEntrypoint.fetch(
+      new Request("https://tenant.example/original?view=one&__vinext_cache_key=transport-digest"),
+    );
+
+    const renderedRequest = stages.response.mock.calls[0]![0] as Request;
+    expect(renderedRequest.url).toBe("https://tenant.example/original?view=one");
+  });
+
+  it("preserves request.cf on misses without fragmenting or replacing the cache key", async () => {
+    const cacheFacingRequests: Request[] = [];
+    const binding = vi.fn(({ props }: { props: unknown }) => ({
+      async fetch(request: Request) {
+        cacheFacingRequests.push(request);
+        return createEntrypoint(props).fetch(request);
+      },
+    }));
+    stages.request.mockImplementation((request, _env, _ctx, dispatch) =>
+      dispatch(request, { kind: "app-route-handler" }, { cache: "shared" }),
+    );
+    stages.response.mockResolvedValue(new Response("rendered"));
+    const requestCfValues = [
+      { cacheKey: "attacker-controlled", clientTcpRtt: 12, colo: "LHR", country: "GB" },
+      { cacheKey: "other-attacker-key", clientTcpRtt: 87, colo: "SJC", country: "US" },
+    ];
+    for (const requestCf of requestCfValues) {
+      const source = new Request("https://example.com/geo", {
+        headers: { "x-vinext-internal-request-cf": "forged" },
+      });
+      Object.defineProperty(source, "cf", { enumerable: true, value: requestCf });
+      await worker.fetch(source, {}, { exports: { VinextCachedResponse: binding } });
+    }
+
+    expect(cacheFacingRequests[0]?.url).toMatch(
+      /^https:\/\/example\.com\/geo\?__vinext_cache_key=[0-9a-f]{64}$/,
+    );
+    expect(cacheFacingRequests[1]?.url).toBe(cacheFacingRequests[0]?.url);
+    expect(cacheFacingRequests[0]?.headers.get("x-vinext-internal-request-cf")).not.toBe("forged");
+    expect(cacheFacingRequests[1]?.headers.get("x-vinext-internal-request-cf")).not.toBe("forged");
+    for (const [index, requestCf] of requestCfValues.entries()) {
+      const renderedRequest = stages.response.mock.calls[index]![0] as Request;
+      expect(renderedRequest.url).toBe("https://example.com/geo");
+      expect(Reflect.get(renderedRequest, "cf")).toEqual(requestCf);
+      expect(renderedRequest.headers.has("x-vinext-internal-request-cf")).toBe(false);
+    }
+  });
+
+  it("forces a shared response private when application code reads request.cf", async () => {
+    const binding = vi.fn(({ props }: { props: unknown }) => ({
+      fetch(request: Request) {
+        return createEntrypoint(props).fetch(request);
+      },
+    }));
+    stages.request.mockImplementation((request, _env, _ctx, dispatch) =>
+      dispatch(request, { kind: "app-route-handler" }, { cache: "shared" }),
+    );
+    stages.response.mockImplementation((request) => {
+      // Match the framework reconstruction used by Pages Edge APIs and App
+      // Route Handlers before user code reads the platform extension.
+      const rebuilt = cloneRequestWithUrl(request, `${request.url}?resolved=1`);
+      const nextRequest = new NextRequest(rebuilt);
+      const country = Reflect.get(nextRequest, "cf")?.country;
+      return Response.json(
+        { country },
+        {
+          headers: {
+            "Cache-Control": "max-age=0, must-revalidate",
+            "CDN-Cache-Control": "public, s-maxage=300",
+            "Cloudflare-CDN-Cache-Control": "public, s-maxage=300",
+            "Cache-Tag": "geo-response",
+          },
+        },
+      );
+    });
+    const source = new Request("https://example.com/geo");
+    Object.defineProperty(source, "cf", {
+      configurable: true,
+      enumerable: true,
+      value: { country: "GB" },
+    });
+
+    const response = await worker.fetch(source, {}, { exports: { VinextCachedResponse: binding } });
+
+    await expect(response.json()).resolves.toEqual({ country: "GB" });
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("CDN-Cache-Control")).toBeNull();
+    expect(response.headers.get("Cloudflare-CDN-Cache-Control")).toBeNull();
+    expect(response.headers.get("Cache-Tag")).toBeNull();
+  });
+
+  it("keeps the gateway private when transported request.cf remains unread", async () => {
+    const binding = vi.fn(({ props }: { props: unknown }) => ({
+      fetch(request: Request) {
+        return createEntrypoint(props).fetch(request);
+      },
+    }));
+    stages.request.mockImplementation((request, _env, _ctx, dispatch) =>
+      dispatch(request, { kind: "app-route-handler" }, { cache: "shared" }),
+    );
+    stages.response.mockResolvedValue(
+      new Response("public", { headers: { "CDN-Cache-Control": "public, s-maxage=300" } }),
+    );
+    const source = new Request("https://example.com/public");
+    Object.defineProperty(source, "cf", {
+      configurable: true,
+      enumerable: true,
+      value: { country: "GB" },
+    });
+
+    const response = await worker.fetch(source, {}, { exports: { VinextCachedResponse: binding } });
+
+    expect(response.headers.get("Cache-Control")).toBe("private, max-age=0, must-revalidate");
+    expect(response.headers.get("CDN-Cache-Control")).toBeNull();
+    await expect(response.text()).resolves.toBe("public");
+  });
+
+  it("strips forged request.cf transport metadata when no platform metadata exists", async () => {
+    const binding = vi.fn(({ props }: { props: unknown }) => ({
+      fetch(request: Request) {
+        return createEntrypoint(props).fetch(request);
+      },
+    }));
+    stages.request.mockImplementation((request, _env, _ctx, dispatch) =>
+      dispatch(request, { kind: "app-route-handler" }, { cache: "shared" }),
+    );
+    stages.response.mockResolvedValue(new Response("rendered"));
+
+    await worker.fetch(
+      new Request("https://example.com/geo", {
+        headers: { "x-vinext-internal-request-cf": encodeURIComponent('{"country":"forged"}') },
+      }),
+      {},
+      { exports: { VinextCachedResponse: binding } },
+    );
+
+    const renderedRequest = stages.response.mock.calls[0]![0] as Request;
+    expect(Reflect.get(renderedRequest, "cf")).toBeUndefined();
+    expect(renderedRequest.headers.has("x-vinext-internal-request-cf")).toBe(false);
+  });
+
+  it("uses distinct cache-facing URLs for Pages HTML, data, and rewrite identities", async () => {
+    const seen: string[] = [];
+    const binding = vi.fn(() => ({
+      fetch(request: Request) {
+        seen.push(request.url);
+        return new Response("cached");
+      },
+    }));
+    stages.request.mockImplementation(async (_request, _env, _ctx, dispatch) => {
+      await dispatch(
+        new Request("https://example.com/page"),
+        pagesPageProps("/page", { isDataReq: false }),
+        { cache: "shared" },
+      );
+      await dispatch(
+        new Request("https://example.com/page"),
+        pagesPageProps("/page", { isDataReq: true }),
+        { cache: "shared" },
+      );
+      await dispatch(
+        new Request("https://example.com/page"),
+        pagesPageProps("/rewritten-a", { isDataReq: false }),
+        { cache: "shared" },
+      );
+      return dispatch(
+        new Request("https://example.com/page"),
+        pagesPageProps("/rewritten-b", { isDataReq: false }),
+        { cache: "shared" },
+      );
+    });
+
+    await worker.fetch(
+      new Request("https://example.com/page"),
+      {},
+      {
+        exports: { VinextCachedResponse: binding },
+      },
+    );
+
+    expect(seen).toHaveLength(4);
+    expect(new Set(seen)).toHaveProperty("size", 4);
+  });
+
+  it("partitions and restores HEAD when Workers Cache invokes the entrypoint as GET", async () => {
+    const cacheFacingUrls: string[] = [];
+    const binding = vi.fn(({ props }: { props: unknown }) => ({
+      fetch(request: Request) {
+        cacheFacingUrls.push(request.url);
+        // Workers Cache shares GET/HEAD entries and a cold HEAD reaches the
+        // Worker as GET. Configurable-entrypoint props retain the caller's
+        // logical method across that platform conversion.
+        return createEntrypoint(props).fetch(new Request(request, { method: "GET" }));
+      },
+    }));
+    stages.request.mockImplementation((request, _env, _ctx, dispatch) =>
+      dispatch(request, { kind: "app-route-handler" }, { cache: "shared" }),
+    );
+    stages.response.mockImplementation((request) => new Response(request.method));
+
+    const context = { exports: { VinextCachedResponse: binding } };
+    await worker.fetch(new Request("https://example.com/route"), {}, context);
+    await worker.fetch(new Request("https://example.com/route", { method: "HEAD" }), {}, context);
+
+    expect(cacheFacingUrls).toHaveLength(2);
+    expect(cacheFacingUrls[0]).not.toBe(cacheFacingUrls[1]);
+    expect(stages.response.mock.calls.map(([request]) => request.method)).toEqual(["GET", "HEAD"]);
+  });
+
+  it("renders bypass work without consulting the cached entrypoint", async () => {
+    const rendered = new Response("private");
+    const binding = vi.fn();
+    stages.response.mockResolvedValue(rendered);
+    stages.request.mockImplementation((_request, _env, _ctx, dispatch) =>
+      dispatch(
+        new Request("https://example.com/render"),
+        { route: "/private" },
+        { cache: "bypass" },
+      ),
+    );
+
+    const result = await worker.fetch(
+      new Request("https://example.com/private"),
+      {},
+      {
+        exports: { VinextCachedResponse: binding },
+      },
+    );
+
+    expect(result).toBe(rendered);
+    expect(binding).not.toHaveBeenCalled();
+    expect(stages.response).toHaveBeenCalledOnce();
+  });
+
+  it("requires the named response entrypoint for readiness bypasses", async () => {
+    // No Next.js test port applies: ctx.exports propagation is a Cloudflare
+    // deployment boundary.
+    vi.stubEnv("__VINEXT_RSC_BUILD_IDENTITY", "current-stage");
+    const binding = vi.fn(({ props }: { props: unknown }) => ({
+      fetch(request: Request) {
+        return createEntrypoint(props).fetch(request);
+      },
+    }));
+    stages.request.mockImplementation((request, _env, _ctx, dispatch) =>
+      dispatch(request, { kind: "pages-prerender-discovery" }, { cache: "bypass" }),
+    );
+    stages.response.mockResolvedValue(
+      new Response(null, {
+        status: 204,
+        headers: { "Cache-Control": "no-store", "X-Vinext-Prerender-Readiness": "1" },
+      }),
+    );
+    const request = new Request(
+      "https://example.com/__vinext/prerender/readiness?attempt=entrypoint",
+    );
+
+    const response = await worker.fetch(
+      request,
+      {},
+      { exports: { VinextCachedResponse: binding } },
+    );
+
+    expect(response.status).toBe(204);
+    expect(binding).toHaveBeenCalledWith({
+      props: {
+        expectedResponseStageBuildIdentity: "current-stage",
+        options: { cache: "vinext-cloudflare-v1:bypass" },
+        props: { kind: "pages-prerender-discovery" },
+        requestMethod: "GET",
+        requestUrl: request.url,
+      },
+    });
+    expect(stages.response).toHaveBeenCalledOnce();
+    expect((stages.response.mock.calls[0]![0] as Request).url).toBe(request.url);
+    expect(stages.response.mock.calls[0]![5]).toEqual({ cache: "bypass" });
+  });
+
+  it("fails readiness closed when the named response entrypoint is unavailable", async () => {
+    stages.request.mockImplementation((request, _env, _ctx, dispatch) =>
+      dispatch(request, { kind: "pages-prerender-discovery" }, { cache: "bypass" }),
+    );
+
+    const response = await worker.fetch(
+      new Request("https://example.com/__vinext/prerender/readiness?attempt=missing"),
+      {},
+      {},
+    );
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(stages.response).not.toHaveBeenCalled();
+  });
+
+  it("strips forged transport metadata from bypass and fallback renders", async () => {
+    for (const cache of ["bypass", "shared"] as const) {
+      stages.request.mockImplementation((request, _env, _ctx, dispatch) =>
+        dispatch(request, { route: "/private" }, { cache }),
+      );
+      stages.response.mockImplementation((request) =>
+        Response.json({
+          authorizationTransport: request.headers.get("x-vinext-internal-authorization"),
+          requestCfTransport: request.headers.get("x-vinext-internal-request-cf"),
+        }),
+      );
+
+      const response = await worker.fetch(
+        new Request("https://example.com/private", {
+          headers: {
+            "x-vinext-internal-authorization": "forged-authorization",
+            "x-vinext-internal-request-cf": "forged-request-cf",
+          },
+        }),
+        {},
+        {},
+      );
+
+      await expect(response.json()).resolves.toEqual({
+        authorizationTransport: null,
+        requestCfTransport: null,
+      });
+      stages.request.mockReset();
+      stages.response.mockReset();
+    }
+  });
+
+  it("falls back to an uncached render when loopback exports are unavailable", async () => {
+    stages.response.mockResolvedValue(
+      new Response("rendered", {
+        headers: {
+          "Cache-Control": "public, max-age=300",
+          "CDN-Cache-Control": "public, s-maxage=300",
+          "Cloudflare-CDN-Cache-Control": "public, s-maxage=300",
+          "Cache-Tag": "private-fallback",
+        },
+      }),
+    );
+    stages.request.mockImplementation((_request, _env, _ctx, dispatch) =>
+      dispatch(new Request("https://example.com/render"), {}, { cache: "shared" }),
+    );
+
+    const response = await worker.fetch(new Request("https://example.com/page"), {}, {});
+    expect(await response.text()).toBe("rendered");
+    expect(response.headers.get("Cache-Control")).toBe("private, max-age=0, must-revalidate");
+    expect(response.headers.get("CDN-Cache-Control")).toBeNull();
+    expect(response.headers.get("Cloudflare-CDN-Cache-Control")).toBeNull();
+    expect(response.headers.get("Cache-Tag")).toBeNull();
+    expect(stages.response).toHaveBeenCalledOnce();
+  });
+
+  it("routes gateway purges through the cache-bearing entrypoint", async () => {
+    const purge = vi.fn().mockResolvedValue({ success: true });
+    const defaultPurge = vi.fn();
+    const binding = vi.fn(() => ({ fetch: vi.fn(), purge }));
+    stages.request.mockImplementation((_request, _env, context) =>
+      context.cache.purge({ tags: ["encoded-tag"] }).then(() => new Response("purged")),
+    );
+
+    const response = await worker.fetch(
+      new Request("https://example.com/revalidate"),
+      {},
+      {
+        cache: { purge: defaultPurge },
+        exports: { VinextCachedResponse: binding },
+      },
+    );
+
+    expect(await response.text()).toBe("purged");
+    expect(binding).toHaveBeenCalledWith({ props: {} });
+    expect(purge).toHaveBeenCalledWith({ tags: ["encoded-tag"] });
+    expect(defaultPurge).not.toHaveBeenCalled();
+  });
+});
+
+describe("Workers Cache deployment configuration", () => {
+  it("disables caching on the gateway and enables only the response entrypoint", () => {
+    expect(configureWorkersCacheEntrypoints({ name: "app" })).toMatchObject({
+      compatibility_flags: ["enable_ctx_exports"],
+      name: "app",
+      exports: {
+        default: { type: "worker", cache: { enabled: false } },
+        VinextCachedResponse: { type: "worker", cache: { enabled: true } },
+      },
+    });
+  });
+
+  it("preserves unrelated exports and rejects reserved non-Worker exports", () => {
+    expect(
+      configureWorkersCacheEntrypoints({ exports: { Counter: { type: "durable_object" } } }),
+    ).toMatchObject({ exports: { Counter: { type: "durable_object" } } });
+    expect(() =>
+      configureWorkersCacheEntrypoints({
+        exports: { VinextCachedResponse: { type: "durable_object" } },
+      }),
+    ).toThrow(/reserved Worker export/);
+  });
+
+  it("preserves compatibility flags and rejects an explicit ctx.exports opt-out", () => {
+    expect(
+      configureWorkersCacheEntrypoints({
+        compatibility_date: "2025-11-16",
+        compatibility_flags: ["nodejs_compat", "enable_ctx_exports"],
+      }).compatibility_flags,
+    ).toEqual(["nodejs_compat", "enable_ctx_exports"]);
+    expect(
+      configureWorkersCacheEntrypoints({
+        compatibility_date: "2025-11-17",
+        compatibility_flags: ["nodejs_compat", "enable_ctx_exports"],
+      }).compatibility_flags,
+    ).toEqual(["nodejs_compat"]);
+    expect(() =>
+      configureWorkersCacheEntrypoints({ compatibility_flags: ["disable_ctx_exports"] }),
+    ).toThrow(/requires ctx\.exports/);
+  });
+
+  it("updates the generated Wrangler config without changing the source config", async () => {
+    const outDir = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-cdn-output-"));
+    try {
+      await fs.writeFile(path.join(outDir, "wrangler.json"), JSON.stringify({ name: "app" }));
+      await finalizeWorkersCacheBuildOutput({ outDir, root: outDir });
+      const config = JSON.parse(await fs.readFile(path.join(outDir, "wrangler.json"), "utf8"));
+      expect(config.exports.default.cache.enabled).toBe(false);
+      expect(config.exports.VinextCachedResponse.cache.enabled).toBe(true);
+    } finally {
+      await fs.rm(outDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/cloudflare-cdn-worker.test.ts
+++ b/tests/cloudflare-cdn-worker.test.ts
@@ -561,6 +561,66 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
     },
   );
 
+  it("restamps the entrypoint cache status after outer response composition", async () => {
+    const binding = vi.fn(() => ({
+      fetch: vi
+        .fn()
+        .mockResolvedValue(new Response("cached", { headers: { "CF-Cache-Status": "HIT" } })),
+    }));
+    stages.request.mockImplementation(async (request, _env, _ctx, dispatch) => {
+      const response = await dispatch(request, { kind: "app-page" }, { cache: "shared" });
+      const headers = new Headers(response.headers);
+      headers.set("X-Vinext-Cache", "middleware");
+      headers.set("X-Nextjs-Cache", "middleware");
+      return new Response(response.body, { headers, status: response.status });
+    });
+
+    const response = await worker.fetch(
+      new Request("https://example.com/page"),
+      {},
+      { exports: { VinextCachedResponse: binding } },
+    );
+
+    expect(response.headers.get("X-Vinext-Cache")).toBe("HIT");
+    expect(response.headers.get("X-Nextjs-Cache")).toBe("HIT");
+  });
+
+  it("fails closed when outer response composition collides with shared provenance", async () => {
+    const binding = vi.fn(() => ({
+      fetch: vi.fn().mockResolvedValue(
+        new Response("cached", {
+          headers: {
+            "Cache-Control": "public, max-age=300",
+            "Cache-Tag": "shared-page",
+            "CDN-Cache-Control": "public, s-maxage=300",
+            "CF-Cache-Status": "HIT",
+          },
+        }),
+      ),
+    }));
+    stages.request.mockImplementation(async (request, _env, _ctx, dispatch) => {
+      const response = await dispatch(request, { kind: "app-page" }, { cache: "shared" });
+      const headers = new Headers(response.headers);
+      headers.set("x-vinext-cloudflare-shared-response-stage", "middleware");
+      headers.set("X-Vinext-Cache", "middleware");
+      headers.set("X-Nextjs-Cache", "middleware");
+      return new Response(response.body, { headers, status: response.status });
+    });
+
+    const response = await worker.fetch(
+      new Request("https://example.com/page"),
+      {},
+      { exports: { VinextCachedResponse: binding } },
+    );
+
+    expect(response.headers.get("Cache-Control")).toBe("private, max-age=0, must-revalidate");
+    expect(response.headers.get("Cache-Tag")).toBeNull();
+    expect(response.headers.get("CDN-Cache-Control")).toBeNull();
+    expect(response.headers.get("X-Vinext-Cache")).toBeNull();
+    expect(response.headers.get("X-Nextjs-Cache")).toBeNull();
+    expect(response.headers.has("x-vinext-cloudflare-shared-response-stage")).toBe(false);
+  });
+
   it("partitions shared dispatches by public request authority", async () => {
     const cacheFacingRequests: Request[] = [];
     const binding = vi.fn(({ props }: { props: unknown }) => ({

--- a/tests/cloudflare-cdn-worker.test.ts
+++ b/tests/cloudflare-cdn-worker.test.ts
@@ -571,6 +571,31 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
     });
   });
 
+  it("promotes framework Vary selectors into the primary cache identity", async () => {
+    const cacheFacingRequests: Request[] = [];
+    const binding = vi.fn(() => ({
+      fetch(request: Request) {
+        cacheFacingRequests.push(request);
+        return new Response("cached");
+      },
+    }));
+    stages.request.mockImplementation((request, _env, _ctx, dispatch) =>
+      dispatch(request, { kind: "app-page" }, { cache: "shared" }),
+    );
+
+    for (const nextUrl of ["/tenant-a", "/tenant-b", "/tenant-a"]) {
+      await worker.fetch(
+        new Request("https://example.com/page", { headers: { "Next-Url": nextUrl } }),
+        {},
+        { exports: { VinextCachedResponse: binding } },
+      );
+    }
+
+    expect(cacheFacingRequests).toHaveLength(3);
+    expect(cacheFacingRequests[0]?.url).not.toBe(cacheFacingRequests[1]?.url);
+    expect(cacheFacingRequests[2]?.url).toBe(cacheFacingRequests[0]?.url);
+  });
+
   it("does not expose the inner Cloudflare cache policy after gateway personalization", async () => {
     const binding = vi.fn(() => ({
       fetch: vi.fn().mockResolvedValue(

--- a/tests/cloudflare-cdn-worker.test.ts
+++ b/tests/cloudflare-cdn-worker.test.ts
@@ -535,6 +535,32 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
     expect(stages.response).not.toHaveBeenCalled();
   });
 
+  it.each(["HIT", "MISS", "UPDATING"])(
+    "exposes the response-entrypoint %s status through vinext cache headers",
+    async (cacheStatus) => {
+      const binding = vi.fn(() => ({
+        fetch: vi
+          .fn()
+          .mockResolvedValue(
+            new Response("cached", { headers: { "CF-Cache-Status": cacheStatus } }),
+          ),
+      }));
+      stages.request.mockImplementation((request, _env, _ctx, dispatch) =>
+        dispatch(request, { kind: "app-page" }, { cache: "shared" }),
+      );
+
+      const response = await worker.fetch(
+        new Request("https://example.com/page"),
+        {},
+        { exports: { VinextCachedResponse: binding } },
+      );
+
+      expect(response.headers.get("CF-Cache-Status")).toBe(cacheStatus);
+      expect(response.headers.get("X-Vinext-Cache")).toBe(cacheStatus);
+      expect(response.headers.get("X-Nextjs-Cache")).toBe(cacheStatus);
+    },
+  );
+
   it("partitions shared dispatches by public request authority", async () => {
     const cacheFacingRequests: Request[] = [];
     const binding = vi.fn(({ props }: { props: unknown }) => ({
@@ -1067,6 +1093,7 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
           "CDN-Cache-Control": "public, s-maxage=300",
           "Cloudflare-CDN-Cache-Control": "public, s-maxage=300",
           "Cache-Tag": "private-fallback",
+          "CF-Cache-Status": "HIT",
         },
       }),
     );
@@ -1080,6 +1107,8 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
     expect(response.headers.get("CDN-Cache-Control")).toBeNull();
     expect(response.headers.get("Cloudflare-CDN-Cache-Control")).toBeNull();
     expect(response.headers.get("Cache-Tag")).toBeNull();
+    expect(response.headers.get("X-Vinext-Cache")).toBeNull();
+    expect(response.headers.get("X-Nextjs-Cache")).toBeNull();
     expect(stages.response).toHaveBeenCalledOnce();
   });
 

--- a/tests/cloudflare-cdn-worker.test.ts
+++ b/tests/cloudflare-cdn-worker.test.ts
@@ -1,11 +1,5 @@
-import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
-import {
-  configureWorkersCacheEntrypoints,
-  finalizeWorkersCacheBuildOutput,
-} from "../packages/cloudflare/src/cache/cdn-adapter-config.js";
+import { configureWorkersCacheEntrypoints } from "../packages/cloudflare/src/cache/cdn-adapter-config.js";
 import worker, {
   VinextCachedResponse,
 } from "../packages/cloudflare/src/cache/cdn-adapter.worker.js";
@@ -610,6 +604,62 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
     await expect(response.text()).resolves.toBe("shared");
   });
 
+  it("does not rewrite an unrelated fallback after a speculative shared dispatch", async () => {
+    const binding = vi.fn(() => ({
+      fetch: vi.fn().mockResolvedValue(
+        new Response("discarded", {
+          headers: { "Cloudflare-CDN-Cache-Control": "public, max-age=300" },
+        }),
+      ),
+    }));
+    stages.request.mockImplementation(async (request, _env, _ctx, dispatch) => {
+      const speculative = await dispatch(request, { kind: "app-page" }, { cache: "shared" });
+      await speculative.body?.cancel();
+      return new Response("asset fallback", {
+        headers: {
+          "Cache-Control": "public, max-age=3600",
+          "Cache-Tag": "asset-fallback",
+          "CDN-Cache-Control": "public, s-maxage=3600",
+        },
+      });
+    });
+
+    const response = await worker.fetch(
+      new Request("https://example.com/asset"),
+      {},
+      {
+        exports: { VinextCachedResponse: binding },
+      },
+    );
+
+    expect(binding).toHaveBeenCalledOnce();
+    expect(response.headers.get("Cache-Control")).toBe("public, max-age=3600");
+    expect(response.headers.get("CDN-Cache-Control")).toBe("public, s-maxage=3600");
+    expect(response.headers.get("Cache-Tag")).toBe("asset-fallback");
+  });
+
+  it("consumes shared-stage provenance from an already private response", async () => {
+    const binding = vi.fn(() => ({
+      fetch: vi
+        .fn()
+        .mockResolvedValue(new Response("private", { headers: { "Cache-Control": "no-store" } })),
+    }));
+    stages.request.mockImplementation((request, _env, _ctx, dispatch) =>
+      dispatch(request, { kind: "app-page" }, { cache: "shared" }),
+    );
+
+    const response = await worker.fetch(
+      new Request("https://example.com/private"),
+      {},
+      {
+        exports: { VinextCachedResponse: binding },
+      },
+    );
+
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.has("x-vinext-cloudflare-shared-response-stage")).toBe(false);
+  });
+
   it("keeps Authorization off Workers Cache while restoring and partitioning cold renders", async () => {
     const cacheFacingRequests: Request[] = [];
     const binding = vi.fn(({ props }: { props: unknown }) => ({
@@ -1071,18 +1121,5 @@ describe("Workers Cache deployment configuration", () => {
     expect(() =>
       configureWorkersCacheEntrypoints({ compatibility_flags: ["disable_ctx_exports"] }),
     ).toThrow(/requires ctx\.exports/);
-  });
-
-  it("updates the generated Wrangler config without changing the source config", async () => {
-    const outDir = await fs.mkdtemp(path.join(os.tmpdir(), "vinext-cdn-output-"));
-    try {
-      await fs.writeFile(path.join(outDir, "wrangler.json"), JSON.stringify({ name: "app" }));
-      await finalizeWorkersCacheBuildOutput({ outDir, root: outDir });
-      const config = JSON.parse(await fs.readFile(path.join(outDir, "wrangler.json"), "utf8"));
-      expect(config.exports.default.cache.enabled).toBe(false);
-      expect(config.exports.VinextCachedResponse.cache.enabled).toBe(true);
-    } finally {
-      await fs.rm(outDir, { recursive: true, force: true });
-    }
   });
 });

--- a/tests/e2e/cloudflare-workers/route-handler-draft-cache.spec.ts
+++ b/tests/e2e/cloudflare-workers/route-handler-draft-cache.spec.ts
@@ -75,7 +75,10 @@ test.describe("Cloudflare route-handler draft-mode cache isolation", () => {
     expect(await forged.json()).toMatchObject({ draftMode: false });
     expect(forged.headers()["cache-control"]).toContain("no-store");
     expect(forged.headers()["cdn-cache-control"]).toBeUndefined();
-    expect(forged.headers()["x-vinext-cache"]).toBe("MISS");
+    // Local workerd does not expose a Workers Cache status. Do not preserve
+    // the inner ISR state as though it were a CF-Cache-Status mirror.
+    expect(forged.headers()["x-vinext-cache"]).toBeUndefined();
+    expect(forged.headers()["x-nextjs-cache"]).toBeUndefined();
 
     await setDraftMode(request, true);
     const draftFirstScenario = `draft-first-${Date.now()}`;
@@ -92,7 +95,7 @@ test.describe("Cloudflare route-handler draft-mode cache isolation", () => {
     expect(anonymousAfterDraft.payload.draftMode).toBe(false);
     expect(anonymousAfterDraft.payload.token).not.toBe(draftFirst.payload.token);
     expect(anonymousAfterDraft.cacheControl).toContain("no-store");
-    expect(anonymousAfterDraft.cacheState).toBe("MISS");
+    expect(anonymousAfterDraft.cacheState).toBeUndefined();
 
     const publicFirstScenario = `public-first-${Date.now()}`;
     const anonymousFirst = await readDraftIsrRoute(request, publicFirstScenario);

--- a/tests/e2e/cloudflare-workers/route-handler-draft-cache.spec.ts
+++ b/tests/e2e/cloudflare-workers/route-handler-draft-cache.spec.ts
@@ -43,6 +43,17 @@ async function readDraftIsrRoute(request: APIRequestContext, scenario: string) {
   };
 }
 
+async function readPersonalized(request: APIRequestContext, pathname: string, visitorId: string) {
+  const response = await request.get(`${BASE_URL}${pathname}`, {
+    headers: { "x-test-visitor-id": visitorId },
+  });
+  expect(response.status()).toBe(200);
+  return {
+    body: await response.text(),
+    visitor: response.headers()["x-cdn-stage-visitor"],
+  };
+}
+
 test.describe("Cloudflare route-handler draft-mode cache isolation", () => {
   test.beforeAll(async () => {
     server = spawn(
@@ -62,12 +73,9 @@ test.describe("Cloudflare route-handler draft-mode cache isolation", () => {
     });
     expect(forged.status()).toBe(200);
     expect(await forged.json()).toMatchObject({ draftMode: false });
-    // This fixture has pathname-eligible middleware. A CDN HIT would bypass
-    // that boundary, so even an anonymous Route Handler response must remain
-    // private until middleware is isolated into an uncached outer stage.
     expect(forged.headers()["cache-control"]).toContain("no-store");
     expect(forged.headers()["cdn-cache-control"]).toBeUndefined();
-    expect(forged.headers()["x-vinext-cache"]).toBeUndefined();
+    expect(forged.headers()["x-vinext-cache"]).toBe("MISS");
 
     await setDraftMode(request, true);
     const draftFirstScenario = `draft-first-${Date.now()}`;
@@ -84,7 +92,7 @@ test.describe("Cloudflare route-handler draft-mode cache isolation", () => {
     expect(anonymousAfterDraft.payload.draftMode).toBe(false);
     expect(anonymousAfterDraft.payload.token).not.toBe(draftFirst.payload.token);
     expect(anonymousAfterDraft.cacheControl).toContain("no-store");
-    expect(anonymousAfterDraft.cacheState).toBeUndefined();
+    expect(anonymousAfterDraft.cacheState).toBe("MISS");
 
     const publicFirstScenario = `public-first-${Date.now()}`;
     const anonymousFirst = await readDraftIsrRoute(request, publicFirstScenario);
@@ -174,8 +182,10 @@ test.describe("Cloudflare route-handler draft-mode cache isolation", () => {
     });
     expect(dynamicResponse.status()).toBe(200);
     expect(await dynamicResponse.text()).toBe("tenant-a");
-    expect(dynamicResponse.headers()["cache-control"] ?? "").not.toContain("public");
-    expect(dynamicResponse.headers()["cache-control"]).toContain("no-store");
+    // The explicit response policy admits the completed body in the named
+    // entrypoint; the uncached gateway remains private for outer composition.
+    expect(dynamicResponse.headers()["cache-control"]).toContain("private");
+    expect(dynamicResponse.headers()["cache-control"]).toContain("max-age=0");
     expect(dynamicResponse.headers()["cdn-cache-control"]).toBeUndefined();
     expect(dynamicResponse.headers()["cloudflare-cdn-cache-control"]).toBeUndefined();
     expect(dynamicResponse.headers()["cache-tag"]).toBeUndefined();
@@ -195,7 +205,7 @@ test.describe("Cloudflare route-handler draft-mode cache isolation", () => {
   }) => {
     const response = await request.get(`${BASE_URL}/api/large-static-stream`);
     expect(response.status()).toBe(200);
-    expect((await response.body()).byteLength).toBe(4 * 1024 * 1024 + 1);
+    expect((await response.body()).byteLength).toBe(16 * 1024 * 1024 + 1);
     expect(response.headers()["cache-control"]).toContain("no-store");
     expect(response.headers()["cdn-cache-control"]).toBeUndefined();
     expect(response.headers()["cloudflare-cdn-cache-control"]).toBeUndefined();
@@ -221,6 +231,72 @@ test.describe("Cloudflare route-handler draft-mode cache isolation", () => {
       ).toBeUndefined();
     }
   });
+
+  test("runs middleware above App and Pages response stages", async ({ request }) => {
+    // Local Miniflare executes the named response entrypoint but does not emulate
+    // the deployed Worker-front cache. Deployed HIT reuse is covered by
+    // rsc-prewarm.spec.ts in the workers-cache preview workflow.
+    for (const route of ["cdn-stage-app", "cdn-stage-pages"]) {
+      const slug = `${route}-${Date.now()}`;
+      const first = await readPersonalized(request, `/${route}/${slug}`, "visitor-a");
+      const second = await readPersonalized(request, `/${route}/${slug}`, "visitor-b");
+
+      expect(first.visitor).toBe("visitor-a");
+      expect(second.visitor).toBe("visitor-b");
+      expect(first.body).toContain(
+        `${route === "cdn-stage-app" ? "App" : "Pages"} CDN response stage`,
+      );
+      expect(second.body).toContain(
+        `${route === "cdn-stage-app" ? "App" : "Pages"} CDN response stage`,
+      );
+    }
+  });
+
+  test("routes revalidatePath through the cache-bearing response entrypoint", async ({
+    request,
+  }) => {
+    const slug = `purge-${Date.now()}`;
+    const pathname = `/cdn-stage-app/${slug}`;
+    const purge = await request.post(`${BASE_URL}/api/cdn-stage-revalidate`, {
+      data: { pathname },
+    });
+    expect(purge.status()).toBe(200);
+    expect(await purge.json()).toEqual({ revalidated: pathname });
+  });
+
+  test("bypasses the shared response stage for middleware cookie overlays", async ({ request }) => {
+    const slug = `cookie-${Date.now()}`;
+    const first = await readPersonalized(request, `/cdn-stage-cookie/${slug}`, "visitor-a");
+    const second = await readPersonalized(request, `/cdn-stage-cookie/${slug}`, "visitor-b");
+
+    expect(first.body).toContain("middleware-cookie:visitor-a");
+    expect(second.body).toContain("middleware-cookie:visitor-b");
+  });
+
+  test("bypasses the shared response stage for middleware request-header overrides", async ({
+    request,
+  }) => {
+    const slug = `request-header-${Date.now()}`;
+    for (const visitorId of ["visitor-a", "visitor-b"]) {
+      const response = await request.get(`${BASE_URL}/api/cdn-stage-middleware-header/${slug}`, {
+        headers: { "x-test-visitor-id": visitorId },
+      });
+      expect(response.status()).toBe(200);
+      expect(await response.text()).toBe(visitorId);
+    }
+  });
+
+  test("does not cache late request-dependent App responses", async ({ request }) => {
+    for (const route of ["cdn-stage-late", "api/cdn-stage-late-route"]) {
+      const slug = `${route.replaceAll("/", "-")}-${Date.now()}`;
+      const first = await readPersonalized(request, `/${route}/${slug}`, "visitor-a");
+      const second = await readPersonalized(request, `/${route}/${slug}`, "visitor-b");
+
+      expect(first.body).toContain("visitor-a");
+      expect(second.body).toContain("visitor-b");
+      expect(second.body).not.toBe(first.body);
+    }
+  });
 });
 
 test.describe("Cloudflare Pages-only completed-response admission", () => {
@@ -230,7 +306,7 @@ test.describe("Cloudflare Pages-only completed-response admission", () => {
   test.beforeAll(async () => {
     test.setTimeout(90_000);
     pagesServer = spawn(
-      "../../../node_modules/.bin/vp build --config vite.pages-cdn-cache.config.ts && npx wrangler dev --config dist/server/wrangler.json --port 4196",
+      "../../../node_modules/.bin/vp build --config vite.pages-cdn-cache.config.ts && npx wrangler dev --config dist/cf_app_basic/wrangler.json --port 4196",
       { cwd: FIXTURE_DIR, shell: true, stdio: "inherit" },
     );
     for (let attempt = 0; attempt < 240; attempt++) {
@@ -250,9 +326,11 @@ test.describe("Cloudflare Pages-only completed-response admission", () => {
     pagesServer.kill();
   });
 
-  test("fails closed without an embedded two-stage manifest", async ({ request }) => {
+  test("clears inner CDN policy when outer config keeps a response private", async ({
+    request,
+  }) => {
     expect(
-      fs.readFileSync(`${FIXTURE_DIR}/dist/server/__vinext_cacheability_manifest.js`, "utf8"),
+      fs.readFileSync(`${FIXTURE_DIR}/dist/cf_app_basic/__vinext_cacheability_manifest.js`, "utf8"),
     ).toBe("export default null;\n");
 
     const response = await request.get(`${pagesBaseUrl}/pages-about`, {
@@ -281,5 +359,28 @@ test.describe("Cloudflare Pages-only completed-response admission", () => {
         accept ?? "missing Accept",
       ).toBeUndefined();
     }
+  });
+
+  test("admits explicitly public Pages API responses", async ({ request }) => {
+    const response = await request.get(`${pagesBaseUrl}/api/cdn-public`);
+
+    expect(response.status()).toBe(200);
+    expect(await response.json()).toEqual({ public: true });
+    expect(response.headers()["cache-control"]).toBe("private, max-age=0, must-revalidate");
+    expect(response.headers()["cdn-cache-control"]).toBeUndefined();
+    expect(response.headers()["cloudflare-cdn-cache-control"]).toBeUndefined();
+  });
+
+  test("keeps public Pages Edge API responses private after request.cf access", async ({
+    request,
+  }) => {
+    const response = await request.get(`${pagesBaseUrl}/api/cdn-request-cf`);
+
+    expect(response.status()).toBe(200);
+    expect(await response.json()).toEqual({ hasCf: true });
+    expect(response.headers()["cache-control"]).toContain("no-store");
+    expect(response.headers()["cdn-cache-control"]).toBeUndefined();
+    expect(response.headers()["cloudflare-cdn-cache-control"]).toBeUndefined();
+    expect(response.headers()["cache-tag"]).toBeUndefined();
   });
 });

--- a/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
+++ b/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
@@ -248,8 +248,9 @@ test("deploy-prewarmed variants are reused and late-dynamic HTML stays private",
   expect(browserFetchMiss.ok(), JSON.stringify(browserFetchMissHeaders)).toBe(true);
   expect(browserFetchMissHeaders["content-type"]).toContain("text/html");
   expect(browserFetchMissHeaders["cf-cache-status"]).toBe("MISS");
-  expect(browserFetchMissHeaders["cdn-cache-control"]).toContain("public");
-  expect(browserFetchMissHeaders["cache-control"]).not.toContain("no-store");
+  expect(browserFetchMissHeaders["cache-control"]).toBe("private, max-age=0, must-revalidate");
+  expect(browserFetchMissHeaders["cdn-cache-control"]).toBeUndefined();
+  expect(browserFetchMissHeaders["cloudflare-cdn-cache-control"]).toBeUndefined();
   const browserFetchBody = await browserFetchMiss.text();
 
   const browserFetchHit = await request.get(browserFetchUrl.href, {

--- a/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
+++ b/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
@@ -70,11 +70,14 @@ async function getReusableResponseAfterPromotion(
 
   // Workers Cache is tiered. A deploy fill and this verification request can
   // traverse different lower/upper tiers, so the first request from this
-  // client may still be a MISS. MISS means Cloudflare admitted the completed
-  // response; require the same client to reuse that exact entry immediately.
+  // client may still be a MISS. The named response entrypoint admits the
+  // completed response, while the uncached gateway strips its inner CDN policy
+  // before composing request-specific headers. Require the same client to
+  // reuse that exact entry immediately.
   const trace = `${label} first response headers: ${JSON.stringify(responseHeaders)}`;
-  expect(responseHeaders["cdn-cache-control"], trace).toContain("public");
-  expect(responseHeaders["cache-control"], trace).not.toContain("no-store");
+  expect(responseHeaders["cache-control"], trace).toBe("private, max-age=0, must-revalidate");
+  expect(responseHeaders["cdn-cache-control"], trace).toBeUndefined();
+  expect(responseHeaders["cloudflare-cdn-cache-control"], trace).toBeUndefined();
   await response.body();
 
   const reused = await getResponseAfterPromotion(request, url, headers);
@@ -131,8 +134,9 @@ function expectCanonical(observed: ObservedRsc, rscBuildId: string): void {
     // Chromium negotiates zstd while the Node-based deploy warmer negotiates
     // br. A browser may therefore fill a separate encoded edge object even
     // though the canonical representation was already warmed and verified.
-    expect(responseHeaders["cdn-cache-control"], trace).toContain("public");
-    expect(responseHeaders["cache-control"], trace).not.toContain("no-store");
+    expect(responseHeaders["cache-control"], trace).toBe("private, max-age=0, must-revalidate");
+    expect(responseHeaders["cdn-cache-control"], trace).toBeUndefined();
+    expect(responseHeaders["cloudflare-cdn-cache-control"], trace).toBeUndefined();
   }
 }
 
@@ -302,7 +306,9 @@ test("deploy-prewarmed variants are reused and late-dynamic HTML stays private",
   expect(pagesResponse.ok(), JSON.stringify(pagesResponseHeaders)).toBe(true);
   expect(pagesResponseHeaders["content-type"]).toContain("text/html");
   expect(pagesResponseHeaders["x-vinext-build-id"]).toBe(rscBuildId);
-  expect(pagesResponseHeaders["cache-control"]).toContain("public");
+  expect(pagesResponseHeaders["cache-control"]).toBe("private, max-age=0, must-revalidate");
+  expect(pagesResponseHeaders["cdn-cache-control"]).toBeUndefined();
+  expect(pagesResponseHeaders["cloudflare-cdn-cache-control"]).toBeUndefined();
   expect(
     pagesResponseHeaders["cf-cache-status"],
     `Pages response headers: ${JSON.stringify(pagesResponseHeaders)}`,
@@ -536,7 +542,8 @@ test("deploy-prewarmed variants are reused and late-dynamic HTML stays private",
   const coldHeaders = coldAfterPurge!.headers();
   expect(coldAfterPurge!.ok(), JSON.stringify(coldHeaders)).toBe(true);
   expect(coldHeaders["cf-cache-status"]).toBe("MISS");
-  expect(coldHeaders["cdn-cache-control"]).toContain("public");
+  expect(coldHeaders["cdn-cache-control"]).toBeUndefined();
+  expect(coldHeaders["cloudflare-cdn-cache-control"]).toBeUndefined();
   expect(await coldAfterPurge!.text()).toContain("Prewarm target");
 
   const reuseDeadline = Date.now() + 30_000;

--- a/tests/e2e/ppr-impact-demo/cacheability-admission.spec.ts
+++ b/tests/e2e/ppr-impact-demo/cacheability-admission.spec.ts
@@ -1,4 +1,10 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type APIResponse } from "@playwright/test";
+
+function expectGatewayCachePolicy(response: APIResponse): void {
+  expect(response.headers()["cache-control"]).toContain("must-revalidate");
+  expect(response.headers()["cdn-cache-control"]).toBeUndefined();
+  expect(response.headers()["cloudflare-cdn-cache-control"]).toBeUndefined();
+}
 
 test("admits pattern-backed App responses only after each clean EOF", async ({ request }) => {
   const certified = await request.get("/cacheability/static", {
@@ -6,8 +12,7 @@ test("admits pattern-backed App responses only after each clean EOF", async ({ r
   });
   expect(certified.status()).toBe(200);
   expect(await certified.text()).toContain("static page");
-  expect(certified.headers()["cdn-cache-control"]).toContain("public");
-  expect(certified.headers()["cache-control"]).toContain("must-revalidate");
+  expectGatewayCachePolicy(certified);
 
   const browserFetch = await request.get("/cacheability/static?browser-fetch=1", {
     headers: { Accept: "*/*" },
@@ -22,7 +27,7 @@ test("admits pattern-backed App responses only after each clean EOF", async ({ r
   });
   expect(certifiedFullRsc.status()).toBe(200);
   expect(certifiedFullRsc.headers()["content-type"]).toContain("text/x-component");
-  expect(certifiedFullRsc.headers()["cdn-cache-control"]).toContain("public");
+  expectGatewayCachePolicy(certifiedFullRsc);
 
   const certifiedLoadingShell = await request.get("/cacheability/static?_rsc=9qLBDIU2NgN178cB", {
     headers: {
@@ -35,13 +40,13 @@ test("admits pattern-backed App responses only after each clean EOF", async ({ r
   });
   expect(certifiedLoadingShell.status()).toBe(200);
   expect(certifiedLoadingShell.headers()["content-type"]).toContain("text/x-component");
-  expect(certifiedLoadingShell.headers()["cdn-cache-control"]).toContain("public");
+  expectGatewayCachePolicy(certifiedLoadingShell);
 
   const runtimeCheck = await request.get("/cacheability/static?runtime=1", {
     headers: { Accept: "text/html" },
   });
   expect(runtimeCheck.status()).toBe(200);
-  expect(runtimeCheck.headers()["cdn-cache-control"]).toContain("public");
+  expectGatewayCachePolicy(runtimeCheck);
 
   const lateCookie = await request.get("/cacheability/static?late-policy=set-cookie", {
     headers: { Accept: "text/html" },
@@ -57,7 +62,7 @@ test("admits pattern-backed App responses only after each clean EOF", async ({ r
       headers: { Accept: "text/html" },
     });
     expect(latePrivatePolicy.status()).toBe(200);
-    expect(latePrivatePolicy.headers()["cache-control"]).toContain("no-store");
+    expect(latePrivatePolicy.headers()["cache-control"]).toMatch(/(?:private|no-store)/);
     expect(latePrivatePolicy.headers()["cdn-cache-control"]).toBeUndefined();
     expect(latePrivatePolicy.headers()["cloudflare-cdn-cache-control"]).toBeUndefined();
   }
@@ -66,8 +71,7 @@ test("admits pattern-backed App responses only after each clean EOF", async ({ r
     headers: { Accept: "text/html" },
   });
   expect(unlistedQuery.status()).toBe(200);
-  expect(unlistedQuery.headers()["cdn-cache-control"]).toContain("public");
-  expect(unlistedQuery.headers()["cache-control"]).toContain("must-revalidate");
+  expectGatewayCachePolicy(unlistedQuery);
 
   const knownDynamic = await request.get("/cacheability/dynamic", {
     headers: { Accept: "text/html" },
@@ -80,7 +84,7 @@ test("admits pattern-backed App responses only after each clean EOF", async ({ r
     headers: { Accept: "text/html" },
   });
   expect(configPublicDynamic.status()).toBe(200);
-  expect(configPublicDynamic.headers()["cdn-cache-control"]).toContain("max-age=32");
+  expectGatewayCachePolicy(configPublicDynamic);
 
   const configPrivateDynamic = await request.get("/cacheability/config-public-dynamic?preview=1", {
     headers: { Accept: "text/html" },
@@ -100,14 +104,14 @@ test("admits pattern-backed App responses only after each clean EOF", async ({ r
     headers: { Accept: "text/html" },
   });
   expect(publicConfigPattern.status()).toBe(200);
-  expect(publicConfigPattern.headers()["cdn-cache-control"]).toContain("max-age=33");
+  expectGatewayCachePolicy(publicConfigPattern);
 
   const publicConfigRepresentation = await request.get(
     "/cacheability/config-public-representation",
     { headers: { Accept: "text/html" } },
   );
   expect(publicConfigRepresentation.status()).toBe(200);
-  expect(publicConfigRepresentation.headers()["cdn-cache-control"]).toContain("max-age=34");
+  expectGatewayCachePolicy(publicConfigRepresentation);
 
   const privateConfigRepresentation = await request.get(
     "/cacheability/config-public-representation?_rsc",
@@ -127,7 +131,7 @@ test("admits pattern-backed App responses only after each clean EOF", async ({ r
     headers: { Accept: "text/html" },
   });
   expect(staticPatternSibling.status()).toBe(200);
-  expect(staticPatternSibling.headers()["cdn-cache-control"]).toContain("public");
+  expectGatewayCachePolicy(staticPatternSibling);
 
   const dynamicPatternSibling = await request.get("/cacheability/pattern-runtime-dynamic/dynamic", {
     headers: { Accept: "text/html" },
@@ -155,7 +159,7 @@ test("admits pattern-backed App responses only after each clean EOF", async ({ r
     { headers: { Accept: "text/html" } },
   );
   expect(allStaticFallback.status()).toBe(200);
-  expect(allStaticFallback.headers()["cdn-cache-control"]).toContain("public");
+  expectGatewayCachePolicy(allStaticFallback);
   const allStaticFallbackBody = await allStaticFallback.text();
   expect(allStaticFallbackBody).toContain("runtime static ");
   expect(allStaticFallbackBody).toContain("runtime-fallback</main>");
@@ -164,7 +168,7 @@ test("admits pattern-backed App responses only after each clean EOF", async ({ r
     headers: { Accept: "text/html" },
   });
   expect(emptyStaticFallback.status()).toBe(200);
-  expect(emptyStaticFallback.headers()["cdn-cache-control"]).toContain("public");
+  expectGatewayCachePolicy(emptyStaticFallback);
   expect(await emptyStaticFallback.text()).toContain("empty fallback on-demand</main>");
 
   const staticToDynamic = await request.get("/cacheability/static-to-dynamic/runtime", {
@@ -193,13 +197,13 @@ test("admits pattern-backed App responses only after each clean EOF", async ({ r
   const certifiedRouteHandler = await request.get("/cacheability/route-handler-static");
   expect(certifiedRouteHandler.status()).toBe(200);
   await expect(certifiedRouteHandler.json()).resolves.toEqual({ kind: "static-route-handler" });
-  expect(certifiedRouteHandler.headers()["cdn-cache-control"]).toContain("public");
+  expectGatewayCachePolicy(certifiedRouteHandler);
   expect(certifiedRouteHandler.headers()["vary"]?.toLowerCase()).toContain("user-agent");
 
   const largeRouteHandler = await request.get("/cacheability/route-handler-large");
   expect(largeRouteHandler.status()).toBe(200);
   expect((await largeRouteHandler.body()).byteLength).toBe(4 * 1024 * 1024 + 1);
-  expect(largeRouteHandler.headers()["cdn-cache-control"]).toContain("public");
+  expectGatewayCachePolicy(largeRouteHandler);
 
   const cachedLargeRouteHandler = await request.get("/cacheability/route-handler-large");
   expect(cachedLargeRouteHandler.status()).toBe(200);
@@ -213,13 +217,13 @@ test("admits pattern-backed App responses only after each clean EOF", async ({ r
     kind: "static-empty",
     slug: "on-demand",
   });
-  expect(emptyStaticRouteHandler.headers()["cdn-cache-control"]).toContain("public");
+  expectGatewayCachePolicy(emptyStaticRouteHandler);
 
   const unlistedRouteHandlerQuery = await request.get(
     "/cacheability/route-handler-static?user=one",
   );
   expect(unlistedRouteHandlerQuery.status()).toBe(200);
-  expect(unlistedRouteHandlerQuery.headers()["cdn-cache-control"]).toContain("public");
+  expectGatewayCachePolicy(unlistedRouteHandlerQuery);
 
   // Next.js does not statically generate a GET+POST Route Handler, so this
   // route is intentionally absent from the probe manifest. Its handler-owned
@@ -228,7 +232,7 @@ test("admits pattern-backed App responses only after each clean EOF", async ({ r
   await expect(explicitMixedRouteHandler.json()).resolves.toEqual({
     kind: "explicit-mixed-route-handler",
   });
-  expect(explicitMixedRouteHandler.headers()["cache-control"]).toBe("public, s-maxage=60");
+  expectGatewayCachePolicy(explicitMixedRouteHandler);
 
   // `revalidate` alone is framework policy, not an explicit response-level
   // opt-in, and must not bypass the route's manifest absence.
@@ -255,8 +259,7 @@ test("admits pattern-backed App responses only after each clean EOF", async ({ r
   await expect(explicitDynamicRouteHandler.json()).resolves.toEqual({
     value: "explicitly-public",
   });
-  expect(explicitDynamicRouteHandler.headers()["cdn-cache-control"]).toBe("public, max-age=60");
-  expect(explicitDynamicRouteHandler.headers()["cache-control"]).toContain("must-revalidate");
+  expectGatewayCachePolicy(explicitDynamicRouteHandler);
 
   const lateConfigPublicFailure = await request.get(
     "/cacheability/route-handler-config-public-late-error",

--- a/tests/e2e/ppr-impact-demo/cacheability-admission.spec.ts
+++ b/tests/e2e/ppr-impact-demo/cacheability-admission.spec.ts
@@ -19,8 +19,7 @@ test("admits pattern-backed App responses only after each clean EOF", async ({ r
   });
   expect(browserFetch.status()).toBe(200);
   expect(await browserFetch.text()).toContain("static page");
-  expect(browserFetch.headers()["cdn-cache-control"]).toContain("public");
-  expect(browserFetch.headers()["cache-control"]).not.toContain("no-store");
+  expectGatewayCachePolicy(browserFetch);
 
   const certifiedFullRsc = await request.get("/cacheability/static?_rsc", {
     headers: { Accept: "text/x-component", RSC: "1" },

--- a/tests/e2e/ppr-impact-demo/cacheability-probe.spec.ts
+++ b/tests/e2e/ppr-impact-demo/cacheability-probe.spec.ts
@@ -213,7 +213,10 @@ test("classifies completed App Page renders inside workerd", async ({ request })
     version: 1,
   });
 
-  // Next.js keeps middleware in front of page serving on every request:
+  // Next.js keeps middleware in front of page serving on every request. The
+  // staged probe classifies only the reusable render below that boundary, so
+  // this route remains dynamic for its own missing cache policy, not merely
+  // because middleware matched:
   // test/e2e/middleware-static-files/index.test.ts
   // https://github.com/vercel/next.js/blob/canary/test/e2e/middleware-static-files/index.test.ts
   const middlewareProbe = await request.get("/cacheability/middleware", { headers });
@@ -221,7 +224,7 @@ test("classifies completed App Page renders inside workerd", async ({ request })
   await expect(middlewareProbe.json()).resolves.toMatchObject({
     kind: "app-page",
     pattern: "/cacheability/middleware",
-    reason: "middleware matched this request",
+    reason: "render did not produce a cache policy",
     state: "dynamic",
     status: 200,
     version: 1,
@@ -231,8 +234,8 @@ test("classifies completed App Page renders inside workerd", async ({ request })
   // request-specific `has`/`missing` conditions:
   // packages/next/src/shared/lib/router/utils/middleware-route-matcher.ts
   // https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/router/utils/middleware-route-matcher.ts
-  // A condition-free staged probe must therefore not certify a pathname that
-  // a later cookie- or header-bearing request can send through middleware.
+  // The uncached request stage evaluates those request-specific conditions on
+  // every request, while the probe certifies the reusable render beneath it.
   for (const { conditionHeaders, pathname } of [
     {
       conditionHeaders: { Cookie: "cacheability-middleware=1" },
@@ -253,8 +256,7 @@ test("classifies completed App Page renders inside workerd", async ({ request })
     await expect(conditionalMiddlewareProbe.json()).resolves.toMatchObject({
       kind: "app-page",
       pattern: pathname,
-      reason: "middleware is eligible for this pathname",
-      state: "dynamic",
+      state: "static-candidate",
       status: 200,
       version: 1,
     });

--- a/tests/e2e/ppr-impact-demo/pages-cacheability.spec.ts
+++ b/tests/e2e/ppr-impact-demo/pages-cacheability.spec.ts
@@ -1,9 +1,20 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type APIResponse } from "@playwright/test";
 import fs from "node:fs";
 
 const probeHeader = "X-Vinext-Cacheability-Probe";
 const secretHeader = "X-Vinext-Prerender-Secret";
 const buildId = "ppr-impact-demo-cacheability";
+
+function expectGatewayRevalidation(response: APIResponse, label: string): void {
+  expect(response.headers()["cache-control"], label).toContain("max-age=0");
+  expect(response.headers()["cache-control"], label).toContain("must-revalidate");
+  expect(response.headers()["cdn-cache-control"], label).toBeUndefined();
+}
+
+function expectPrivateGateway(response: APIResponse, label: string): void {
+  expect(response.headers()["cache-control"], label).toMatch(/(?:private|no-store)/);
+  expect(response.headers()["cdn-cache-control"], label).toBeUndefined();
+}
 
 function prerenderSecret(): string {
   const manifest = JSON.parse(
@@ -89,20 +100,13 @@ test("classifies Pages Router data contracts inside the staged Worker", async ({
     version: 1,
   });
 
-  for (const [pathname, reason] of [
-    ["/cacheability-pages/middleware", "middleware is eligible for this pathname"],
-    [
-      "/cacheability-pages/config-header",
-      "next.config headers depend on request headers, cookies, or hostnames",
-    ],
-    [
-      "/cacheability-pages/conditional-redirect",
-      "next.config redirect depends on request headers, cookies, or hostnames",
-    ],
-    [
-      "/cacheability-pages/conditional-rewrite",
-      "next.config rewrite depends on request headers, cookies, or hostnames",
-    ],
+  // Middleware and request-conditioned config rules execute in the uncached
+  // request stage. Probe the reusable Pages render beneath those rules.
+  for (const pathname of [
+    "/cacheability-pages/middleware",
+    "/cacheability-pages/config-header",
+    "/cacheability-pages/conditional-redirect",
+    "/cacheability-pages/conditional-rewrite",
   ] as const) {
     const response = await request.get(pathname, {
       headers: { ...headers, Accept: "text/html" },
@@ -111,8 +115,7 @@ test("classifies Pages Router data contracts inside the staged Worker", async ({
     await expect(response.json(), pathname).resolves.toMatchObject({
       kind: "pages-page",
       pattern: pathname,
-      reason,
-      state: "dynamic",
+      state: "static-candidate",
       status: 200,
       version: 1,
     });
@@ -130,7 +133,7 @@ test("admits pattern-backed Pages Router responses after each completed render",
   ]) {
     const response = await request.get(pathname, { headers: { Accept: "text/html" } });
     expect(response.status(), pathname).toBe(200);
-    expect(response.headers()["cdn-cache-control"], pathname).toContain("max-age=60");
+    expectGatewayRevalidation(response, pathname);
   }
 
   for (const pathname of [
@@ -142,7 +145,7 @@ test("admits pattern-backed Pages Router responses after each completed render",
     const response = await request.get(pathname, { headers: { Accept: "application/json" } });
     expect(response.status(), pathname).toBe(200);
     expect(response.headers()["content-type"], pathname).toContain("application/json");
-    expect(response.headers()["cdn-cache-control"], pathname).toContain("max-age=60");
+    expectGatewayRevalidation(response, pathname);
   }
 
   for (const pathname of [
@@ -153,7 +156,7 @@ test("admits pattern-backed Pages Router responses after each completed render",
       headers: { Accept: pathname.includes("/_next/data/") ? "application/json" : "text/html" },
     });
     expect(response.status(), pathname).toBe(200);
-    expect(response.headers()["cdn-cache-control"], pathname).toContain("max-age=36");
+    expectGatewayRevalidation(response, pathname);
   }
 
   for (const pathname of [
@@ -178,16 +181,14 @@ test("keeps middleware cookie variants private", async ({ request }) => {
   });
   expect(middlewarePublic.status()).toBe(200);
   expect(middlewarePublic.headers()["x-cacheability-middleware"]).toBeUndefined();
-  expect(middlewarePublic.headers()["cache-control"]).toContain("no-store");
-  expect(middlewarePublic.headers()["cdn-cache-control"]).toBeUndefined();
+  expectPrivateGateway(middlewarePublic, "public middleware variant");
 
   const middlewarePrivate = await request.get("/cacheability-pages/middleware", {
     headers: { Accept: "text/html", Cookie: "variant=private" },
   });
   expect(middlewarePrivate.status()).toBe(200);
   expect(middlewarePrivate.headers()["x-cacheability-middleware"]).toBe("matched");
-  expect(middlewarePrivate.headers()["cache-control"]).toContain("no-store");
-  expect(middlewarePrivate.headers()["cdn-cache-control"]).toBeUndefined();
+  expectPrivateGateway(middlewarePrivate, "private middleware variant");
 
   const dataPath = `/_next/data/${buildId}/cacheability-pages/middleware.json`;
   for (const cookie of [undefined, "variant=private"]) {
@@ -198,8 +199,7 @@ test("keeps middleware cookie variants private", async ({ request }) => {
       },
     });
     expect(response.status(), cookie ?? "public").toBe(200);
-    expect(response.headers()["cache-control"], cookie ?? "public").toContain("no-store");
-    expect(response.headers()["cdn-cache-control"], cookie ?? "public").toBeUndefined();
+    expectPrivateGateway(response, cookie ?? "public");
   }
 });
 
@@ -209,16 +209,14 @@ test("keeps config-header cookie variants private", async ({ request }) => {
   });
   expect(configPublic.status()).toBe(200);
   expect(configPublic.headers()["x-cacheability-config"]).toBeUndefined();
-  expect(configPublic.headers()["cache-control"]).toContain("no-store");
-  expect(configPublic.headers()["cdn-cache-control"]).toBeUndefined();
+  expectPrivateGateway(configPublic, "public config variant");
 
   const configPrivate = await request.get("/cacheability-pages/config-header", {
     headers: { Accept: "text/html", Cookie: "variant=private" },
   });
   expect(configPrivate.status()).toBe(200);
   expect(configPrivate.headers()["x-cacheability-config"]).toBe("private");
-  expect(configPrivate.headers()["cache-control"]).toContain("no-store");
-  expect(configPrivate.headers()["cdn-cache-control"]).toBeUndefined();
+  expectPrivateGateway(configPrivate, "private config variant");
 
   const dataPath = `/_next/data/${buildId}/cacheability-pages/config-header.json`;
   for (const cookie of [undefined, "variant=private"]) {
@@ -229,8 +227,7 @@ test("keeps config-header cookie variants private", async ({ request }) => {
       },
     });
     expect(response.status(), cookie ?? "public").toBe(200);
-    expect(response.headers()["cache-control"], cookie ?? "public").toContain("no-store");
-    expect(response.headers()["cdn-cache-control"], cookie ?? "public").toBeUndefined();
+    expectPrivateGateway(response, cookie ?? "public");
   }
 });
 

--- a/tests/fetch-handler.test.ts
+++ b/tests/fetch-handler.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { createServer, type ViteDevServer } from "vite-plus";
 import { describe, expect, it } from "vite-plus/test";
+import { cdnAdapter } from "../packages/cloudflare/src/cache/cdn-adapter.js";
 import { resolveRuntimeEntryModule } from "../packages/vinext/src/entries/runtime-entry-module.js";
 import vinext, { type VinextOptions } from "../packages/vinext/src/index.js";
 
@@ -42,6 +43,21 @@ function loadUnifiedFetchHandler(
   options: Parameters<typeof loadVirtualModule>[2] = {},
 ): Promise<string> {
   return loadVirtualModule(root, "virtual:vinext-worker-entry", options);
+}
+
+async function resolveWithCdnOutput(root: string, id: string): Promise<string | undefined> {
+  const server = await createServer({
+    root,
+    configFile: false,
+    plugins: [vinext({ cache: { cdn: cdnAdapter() } }), { name: "vite-plugin-cloudflare" }],
+    server: { port: 0 },
+    logLevel: "silent",
+  });
+  try {
+    return (await server.pluginContainer.resolveId(id))?.id;
+  } finally {
+    await server.close();
+  }
 }
 
 describe("unified Worker fetch handler", () => {
@@ -110,6 +126,53 @@ describe("unified Worker fetch handler", () => {
       fs.rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it("lets the Cloudflare CDN adapter select its multi-stage Worker facade", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-fetch-handler-cdn-"));
+    try {
+      fs.mkdirSync(path.join(root, "app"), { recursive: true });
+      fs.writeFileSync(
+        path.join(root, "app/page.tsx"),
+        "export default function Page() { return <div>app</div>; }\n",
+      );
+
+      const descriptor = cdnAdapter();
+      await expect(
+        loadUnifiedFetchHandler(root, {
+          cache: { cdn: descriptor },
+          hostPluginName: "vite-plugin-cloudflare",
+        }),
+      ).resolves.toBe(
+        [
+          `export { default } from ${JSON.stringify(descriptor.output.entry)};`,
+          `export * from ${JSON.stringify(descriptor.output.entry)};`,
+          "",
+        ].join("\n"),
+      );
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it.each(["app-router-entry", "pages-router-entry"])(
+    "routes a direct %s main through the Cloudflare facade",
+    async (entryName) => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-direct-router-cdn-"));
+      try {
+        fs.mkdirSync(path.join(root, "app"), { recursive: true });
+        fs.writeFileSync(
+          path.join(root, "app/page.tsx"),
+          "export default function Page() { return <div>app</div>; }\n",
+        );
+
+        await expect(resolveWithCdnOutput(root, `vinext/server/${entryName}`)).resolves.toBe(
+          "\0virtual:vinext-worker-entry",
+        );
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    },
+  );
 
   it.each(["app-router-entry", "pages-router-entry"])(
     "keeps a direct %s main on its ordinary dev entry",

--- a/tests/fetch-handler.test.ts
+++ b/tests/fetch-handler.test.ts
@@ -3,7 +3,6 @@ import os from "node:os";
 import path from "node:path";
 import { createServer, type ViteDevServer } from "vite-plus";
 import { describe, expect, it } from "vite-plus/test";
-import { cdnAdapter } from "../packages/cloudflare/src/cache/cdn-adapter.js";
 import { resolveRuntimeEntryModule } from "../packages/vinext/src/entries/runtime-entry-module.js";
 import vinext, { type VinextOptions } from "../packages/vinext/src/index.js";
 
@@ -43,21 +42,6 @@ function loadUnifiedFetchHandler(
   options: Parameters<typeof loadVirtualModule>[2] = {},
 ): Promise<string> {
   return loadVirtualModule(root, "virtual:vinext-worker-entry", options);
-}
-
-async function resolveWithCdnOutput(root: string, id: string): Promise<string | undefined> {
-  const server = await createServer({
-    root,
-    configFile: false,
-    plugins: [vinext({ cache: { cdn: cdnAdapter() } }), { name: "vite-plugin-cloudflare" }],
-    server: { port: 0 },
-    logLevel: "silent",
-  });
-  try {
-    return (await server.pluginContainer.resolveId(id))?.id;
-  } finally {
-    await server.close();
-  }
 }
 
 describe("unified Worker fetch handler", () => {
@@ -126,53 +110,6 @@ describe("unified Worker fetch handler", () => {
       fs.rmSync(root, { recursive: true, force: true });
     }
   });
-
-  it("lets the Cloudflare CDN adapter select its multi-stage Worker facade", async () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-fetch-handler-cdn-"));
-    try {
-      fs.mkdirSync(path.join(root, "app"), { recursive: true });
-      fs.writeFileSync(
-        path.join(root, "app/page.tsx"),
-        "export default function Page() { return <div>app</div>; }\n",
-      );
-
-      const descriptor = cdnAdapter();
-      await expect(
-        loadUnifiedFetchHandler(root, {
-          cache: { cdn: descriptor },
-          hostPluginName: "vite-plugin-cloudflare",
-        }),
-      ).resolves.toBe(
-        [
-          `export { default } from ${JSON.stringify(descriptor.output.entry)};`,
-          `export * from ${JSON.stringify(descriptor.output.entry)};`,
-          "",
-        ].join("\n"),
-      );
-    } finally {
-      fs.rmSync(root, { recursive: true, force: true });
-    }
-  });
-
-  it.each(["app-router-entry", "pages-router-entry"])(
-    "routes a direct %s main through the Cloudflare facade",
-    async (entryName) => {
-      const root = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-direct-router-cdn-"));
-      try {
-        fs.mkdirSync(path.join(root, "app"), { recursive: true });
-        fs.writeFileSync(
-          path.join(root, "app/page.tsx"),
-          "export default function Page() { return <div>app</div>; }\n",
-        );
-
-        await expect(resolveWithCdnOutput(root, `vinext/server/${entryName}`)).resolves.toBe(
-          "\0virtual:vinext-worker-entry",
-        );
-      } finally {
-        fs.rmSync(root, { recursive: true, force: true });
-      }
-    },
-  );
 
   it.each(["app-router-entry", "pages-router-entry"])(
     "keeps a direct %s main on its ordinary dev entry",

--- a/tests/fixtures/cf-app-basic/app/api/cdn-stage-late-route/[slug]/route.ts
+++ b/tests/fixtures/cf-app-basic/app/api/cdn-stage-late-route/[slug]/route.ts
@@ -1,0 +1,18 @@
+export const revalidate = false;
+
+export function GET(request: Request) {
+  return new Response(
+    new ReadableStream({
+      async pull(controller) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+        const visitorId = request.headers.get("x-test-visitor-id") ?? "anonymous";
+        const renderToken = crypto.randomUUID();
+        controller.enqueue(
+          new TextEncoder().encode(`late-route-visitor:${visitorId}; render-token:${renderToken}`),
+        );
+        controller.close();
+      },
+    }),
+    { headers: { "Content-Type": "text/plain" } },
+  );
+}

--- a/tests/fixtures/cf-app-basic/app/api/cdn-stage-middleware-header/[slug]/route.ts
+++ b/tests/fixtures/cf-app-basic/app/api/cdn-stage-middleware-header/[slug]/route.ts
@@ -1,0 +1,5 @@
+export function GET(request: Request) {
+  return new Response(request.headers.get("x-from-middleware") ?? "missing", {
+    headers: { "Cache-Control": "public, s-maxage=60" },
+  });
+}

--- a/tests/fixtures/cf-app-basic/app/api/cdn-stage-revalidate/route.ts
+++ b/tests/fixtures/cf-app-basic/app/api/cdn-stage-revalidate/route.ts
@@ -1,0 +1,7 @@
+import { revalidatePath } from "next/cache";
+
+export async function POST(request: Request) {
+  const { pathname } = (await request.json()) as { pathname: string };
+  revalidatePath(pathname);
+  return Response.json({ revalidated: pathname });
+}

--- a/tests/fixtures/cf-app-basic/app/api/large-static-stream/route.ts
+++ b/tests/fixtures/cf-app-basic/app/api/large-static-stream/route.ts
@@ -1,6 +1,6 @@
 export const revalidate = 60;
 
-const BODY_SIZE = 4 * 1024 * 1024 + 1;
+const BODY_SIZE = 16 * 1024 * 1024 + 1;
 
 export function GET() {
   return new Response(

--- a/tests/fixtures/cf-app-basic/app/cdn-stage-app/[slug]/page.tsx
+++ b/tests/fixtures/cf-app-basic/app/cdn-stage-app/[slug]/page.tsx
@@ -1,0 +1,11 @@
+export const revalidate = 60;
+
+export default async function CdnStageAppPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const renderToken = crypto.randomUUID();
+  return (
+    <main data-render-token={renderToken} data-slug={slug}>
+      App CDN response stage render-token:{renderToken}
+    </main>
+  );
+}

--- a/tests/fixtures/cf-app-basic/app/cdn-stage-cookie/[slug]/page.tsx
+++ b/tests/fixtures/cf-app-basic/app/cdn-stage-cookie/[slug]/page.tsx
@@ -1,0 +1,11 @@
+import { cookies } from "next/headers";
+
+export default async function CdnStageCookiePage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const cookie = (await cookies()).get("stage-cookie")?.value ?? "missing";
+  return <main>{`middleware-cookie:${cookie}; slug:${slug}`}</main>;
+}

--- a/tests/fixtures/cf-app-basic/app/cdn-stage-late/[slug]/page.tsx
+++ b/tests/fixtures/cf-app-basic/app/cdn-stage-late/[slug]/page.tsx
@@ -1,0 +1,32 @@
+import { Suspense } from "react";
+import { headers } from "next/headers";
+
+// Default-static pages use an infinite revalidation interval internally. This
+// exercises the client-header-preservation path as well as ordinary ISR.
+export const revalidate = false;
+
+async function LateDynamicContent({ slug }: { slug: string }) {
+  // Ensure the response stream has started before dynamic request state is
+  // accessed. The completed response must not be promoted to a shared cache.
+  await new Promise((resolve) => setTimeout(resolve, 25));
+  const visitorId = (await headers()).get("x-test-visitor-id") ?? "anonymous";
+  const renderToken = crypto.randomUUID();
+
+  return (
+    <span data-render-token={renderToken}>
+      {`late-dynamic-visitor:${visitorId}; slug:${slug}; render-token:${renderToken}`}
+    </span>
+  );
+}
+
+export default async function CdnStageLatePage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+
+  return (
+    <main>
+      <Suspense fallback={<span>loading-late-dynamic-content</span>}>
+        <LateDynamicContent slug={slug} />
+      </Suspense>
+    </main>
+  );
+}

--- a/tests/fixtures/cf-app-basic/middleware.ts
+++ b/tests/fixtures/cf-app-basic/middleware.ts
@@ -8,6 +8,13 @@ import { NextResponse, type NextRequest } from "next/server";
  * for #1520.
  */
 export async function middleware(request: NextRequest) {
+  const visitorId = request.headers.get("x-test-visitor-id") ?? "anonymous";
+  if (request.nextUrl.pathname.startsWith("/cdn-stage-cookie/")) {
+    const response = NextResponse.next();
+    response.cookies.set("stage-cookie", visitorId);
+    response.headers.set("x-cdn-stage-visitor", visitorId);
+    return response;
+  }
   if (request.nextUrl.pathname === "/%61dmin") {
     return NextResponse.rewrite(new URL("/admin", request.url));
   }
@@ -23,6 +30,26 @@ export async function middleware(request: NextRequest) {
     (await draftMode()).enable();
   }
   const headers = new Headers(request.headers);
-  headers.set("x-from-middleware", "hello-from-middleware");
-  return NextResponse.next({ request: { headers } });
+  const testsMiddlewareRequestHeaders =
+    request.nextUrl.pathname.startsWith("/api/dump-headers") ||
+    request.nextUrl.pathname.startsWith("/api/cdn-stage-middleware-header/");
+  if (request.nextUrl.pathname.startsWith("/api/cdn-stage-middleware-header/")) {
+    headers.set("x-from-middleware", visitorId);
+  } else {
+    headers.set("x-from-middleware", "hello-from-middleware");
+  }
+  const response = testsMiddlewareRequestHeaders
+    ? NextResponse.next({ request: { headers } })
+    : NextResponse.next();
+  if (
+    request.nextUrl.pathname.startsWith("/cdn-stage-app/") ||
+    request.nextUrl.pathname.startsWith("/cdn-stage-cookie/") ||
+    request.nextUrl.pathname.startsWith("/cdn-stage-late/") ||
+    request.nextUrl.pathname.startsWith("/api/cdn-stage-late-route/") ||
+    request.nextUrl.pathname.startsWith("/api/cdn-stage-middleware-header/") ||
+    request.nextUrl.pathname.startsWith("/cdn-stage-pages/")
+  ) {
+    response.headers.set("x-cdn-stage-visitor", visitorId);
+  }
+  return response;
 }

--- a/tests/fixtures/cf-app-basic/pages/api/cdn-public.ts
+++ b/tests/fixtures/cf-app-basic/pages/api/cdn-public.ts
@@ -1,0 +1,6 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export default function handler(_request: NextApiRequest, response: NextApiResponse) {
+  response.setHeader("Cache-Control", "public, s-maxage=60");
+  response.json({ public: true });
+}

--- a/tests/fixtures/cf-app-basic/pages/api/cdn-request-cf.ts
+++ b/tests/fixtures/cf-app-basic/pages/api/cdn-request-cf.ts
@@ -1,0 +1,11 @@
+export const config = {
+  runtime: "edge",
+};
+
+export default function handler(request: Request) {
+  const cf = Reflect.get(request, "cf");
+  return Response.json(
+    { hasCf: cf !== undefined },
+    { headers: { "Cache-Control": "public, s-maxage=60" } },
+  );
+}

--- a/tests/fixtures/cf-app-basic/pages/cdn-stage-pages/[slug].tsx
+++ b/tests/fixtures/cf-app-basic/pages/cdn-stage-pages/[slug].tsx
@@ -1,0 +1,38 @@
+type Props = {
+  revalidateReason: string;
+  renderToken: string;
+  slug: string;
+};
+
+export default function CdnStagePagesPage({ revalidateReason, renderToken, slug }: Props) {
+  return (
+    <main
+      data-render-token={renderToken}
+      data-revalidate-reason={revalidateReason}
+      data-slug={slug}
+    >
+      Pages CDN response stage render-token:{renderToken}
+    </main>
+  );
+}
+
+export function getStaticPaths() {
+  return { fallback: "blocking", paths: [] };
+}
+
+export async function getStaticProps({
+  params,
+  revalidateReason,
+}: {
+  params: { slug: string };
+  revalidateReason?: string;
+}) {
+  return {
+    props: {
+      revalidateReason: revalidateReason ?? "unknown",
+      renderToken: crypto.randomUUID(),
+      slug: params.slug,
+    },
+    revalidate: 60,
+  };
+}


### PR DESCRIPTION
Part 12 of 16 in the staged CDN adapter stack. Depends on #3151.

## Summary

- makes the Cloudflare CDN adapter select an uncached gateway plus a named cached-response Worker entrypoint
- keeps middleware and request-time personalization in the gateway while eligible renders use Workers Cache
- lazy-loads application rendering only on cache miss
- partitions the opaque cache URL by authority, authorization, build, invocation, and raw framework RSC selectors
- authenticates shared-response provenance through outer header composition and fails closed on reserved-header collisions
- mirrors the response entrypoint's `CF-Cache-Status` into `X-Vinext-Cache` and `X-Nextjs-Cache` only at final gateway egress

## Validation

- 50/50 Cloudflare Worker entrypoint tests
- focused Cloudflare adapter, admission, build, and gateway-collision coverage
- fixture coverage includes App/Pages, middleware headers/cookies, draft mode, Vary, late stream failure, revalidation, HEAD, and route handlers

## Review size

- Implementation: +794 / -71 LOC
- Tests and fixtures: +2058 / -111 LOC
- Other (docs, config, lockfile): +2 / -0 LOC
- 32 changed files

Measured against `codex/cdn-v2-prerender-stages` after rebasing onto `main@a6931c0`.