### PR TITLE
fix(cloudflare): prewarm routed response stages

### DIFF
--- a/examples/workers-cache/app/api/draft-enable/route.ts
+++ b/examples/workers-cache/app/api/draft-enable/route.ts
@@ -1,0 +1,6 @@
+import { draftMode } from "next/headers";
+
+export async function GET() {
+  (await draftMode()).enable();
+  return Response.json({ enabled: true });
+}

--- a/examples/workers-cache/app/prewarm-target/page.tsx
+++ b/examples/workers-cache/app/prewarm-target/page.tsx
@@ -1,9 +1,12 @@
+import { draftMode } from "next/headers";
+
 export const revalidate = 300;
 
-export default function PrewarmTargetPage() {
+export default async function PrewarmTargetPage() {
   return (
     <main>
       <output data-testid="build-id">{process.env.__VINEXT_BUILD_ID}</output>
+      <output data-testid="draft-mode">{String((await draftMode()).isEnabled)}</output>
       <h1>Prewarm target</h1>
     </main>
   );

--- a/examples/workers-cache/app/vary/route.ts
+++ b/examples/workers-cache/app/vary/route.ts
@@ -1,0 +1,11 @@
+export const dynamic = "force-dynamic";
+
+export function GET(request: Request): Response {
+  const variant = request.headers.get("x-cache-variant") ?? "missing";
+  return new Response(variant, {
+    headers: {
+      "Cache-Control": "public, s-maxage=300",
+      Vary: "x-cache-variant",
+    },
+  });
+}

--- a/examples/workers-cache/middleware.ts
+++ b/examples/workers-cache/middleware.ts
@@ -1,0 +1,12 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+export function middleware(request: NextRequest) {
+  const response = NextResponse.next();
+  response.headers.set(
+    "x-workers-cache-visitor",
+    request.headers.get("x-test-visitor-id") ?? "anonymous",
+  );
+  return response;
+}
+
+export const config = { matcher: ["/prewarm-target", "/pages-prewarm"] };

--- a/examples/workers-cache/next.config.ts
+++ b/examples/workers-cache/next.config.ts
@@ -1,0 +1,15 @@
+import type { NextConfig } from "vinext";
+
+const personalizedPaths = ["/prewarm-target", "/pages-prewarm"] as const;
+const personalizedVisitors = ["config-a", "config-b"] as const;
+
+export default {
+  headers: async () =>
+    personalizedPaths.flatMap((source) =>
+      personalizedVisitors.map((visitor) => ({
+        source,
+        has: [{ type: "header" as const, key: "x-test-config-visitor", value: visitor }],
+        headers: [{ key: "X-Workers-Config-Visitor", value: visitor }],
+      })),
+    ),
+} satisfies NextConfig;

--- a/examples/workers-cache/pages/pages-prewarm.tsx
+++ b/examples/workers-cache/pages/pages-prewarm.tsx
@@ -1,7 +1,12 @@
-export async function getStaticProps() {
-  return { props: {}, revalidate: 300 };
+export async function getStaticProps(context: { draftMode?: boolean }) {
+  return { props: { draftMode: context.draftMode === true }, revalidate: 300 };
 }
 
-export default function PagesPrewarmTarget() {
-  return <h1>Pages prewarm target</h1>;
+export default function PagesPrewarmTarget({ draftMode }: { draftMode: boolean }) {
+  return (
+    <main>
+      <output data-testid="draft-mode">{String(draftMode)}</output>
+      <h1>Pages prewarm target</h1>
+    </main>
+  );
 }

--- a/packages/cloudflare/src/cacheability-probe.ts
+++ b/packages/cloudflare/src/cacheability-probe.ts
@@ -15,6 +15,7 @@ import type { PrerenderRoutePattern } from "vinext/internal/build/prerender-path
 import {
   VINEXT_CACHEABILITY_PROBE_HEADER,
   VINEXT_CACHEABILITY_PROBE_QUERY_PARAM,
+  VINEXT_CACHEABILITY_PROBE_ROUTE_HEADER,
   VINEXT_PRERENDER_SECRET_HEADER,
 } from "vinext/internal/server/headers";
 import { VINEXT_CDN_BUILD_ID_HEADER } from "./cache/cdn-build-id.js";
@@ -35,11 +36,13 @@ type ProbePayload = {
   pattern?: string;
   reason?: string;
   rendererStatic?: boolean;
+  routePathname?: string;
   state?: string;
   status?: number;
   version?: number;
   phaseTimedOut?: boolean;
   scope?: "identity" | "pattern";
+  terminal?: true;
 };
 
 export type CacheabilityProbeProgress = {
@@ -195,8 +198,13 @@ async function probeTarget(options: {
 }): Promise<ProbePayload> {
   const headers = new Headers(options.headers);
   for (const [name, value] of new Headers(options.target.headers)) headers.set(name, value);
-  headers.set("Cache-Control", "no-cache");
   headers.set(VINEXT_CACHEABILITY_PROBE_HEADER, "1");
+  if (options.target.route) {
+    headers.set(
+      VINEXT_CACHEABILITY_PROBE_ROUTE_HEADER,
+      encodeURIComponent(JSON.stringify([options.target.route.kind, options.target.route.pattern])),
+    );
+  }
   headers.set(VINEXT_PRERENDER_SECRET_HEADER, options.secret);
 
   let reason = "probe failed";
@@ -360,25 +368,27 @@ export async function probeStagedWorkerCacheability(options: {
   let staticPathCount = 0;
   let dynamicPathCount = 0;
 
+  type ConcretePathResult = {
+    rendererStatic: boolean;
+    representation: CdnWarmTarget["kind"];
+    state: Exclude<ProbeRouteState, "probe-failed">;
+    terminal: boolean;
+  };
   type PatternClassification = {
     canPrune: boolean;
     groups: ConcretePathGroup[];
     key: string;
-    pathnames: Set<string>;
+    resultKeys: Set<string>;
     pruned: boolean;
-    results: Map<
-      string,
-      {
-        rendererStatic: boolean;
-        representation: CdnWarmTarget["kind"];
-        state: Exclude<ProbeRouteState, "probe-failed">;
-      }
-    >;
+    results: Map<string, ConcretePathResult>;
     route: NonNullable<CdnWarmTarget["route"]>;
+    splitRepresentations: boolean;
   };
   type ConcretePathGroup = {
     pattern: PatternClassification;
     primary: CdnWarmTarget;
+    result?: ConcretePathResult;
+    resultKey: string;
     routePathname: string;
     targets: CdnWarmTarget[];
   };
@@ -387,7 +397,7 @@ export async function probeStagedWorkerCacheability(options: {
     return target.kind === "html" ? 0 : target.kind === "rsc-full" ? 1 : 2;
   };
   const patterns = new Map<string, PatternClassification>();
-  const targetsByConcretePath = new Map<string, CdnWarmTarget[]>();
+  const routableTargets: CdnWarmTarget[] = [];
   let missingRouteMetadata = 0;
   for (const target of options.targets) {
     if (!target.route) {
@@ -399,44 +409,65 @@ export async function probeStagedWorkerCacheability(options: {
       canPrune: true,
       groups: [],
       key,
-      pathnames: new Set<string>(),
+      resultKeys: new Set<string>(),
       pruned: false,
       results: new Map(),
       route: target.route,
+      splitRepresentations: false,
     };
-    pattern.canPrune &&= target.route.cacheabilityProbe?.canPrunePattern === true;
+    pattern.splitRepresentations ||=
+      target.route.cacheabilityProbe?.requestStageMayTerminate === true;
+    pattern.canPrune &&=
+      target.route.cacheabilityProbe?.canPrunePattern === true &&
+      target.route.cacheabilityProbe.routeMayResolve !== true &&
+      target.route.cacheabilityProbe.requestStageMayTerminate !== true;
     patterns.set(key, pattern);
-
-    const routePathname =
-      target.route.cacheabilityProbe?.concretePathname ??
-      cacheabilityRoutePathname(target.pathname, target.kind);
-    pattern.pathnames.add(routePathname);
-    const concreteKey = `${key}\0${routePathname}`;
-    const groupTargets = targetsByConcretePath.get(concreteKey) ?? [];
-    groupTargets.push(target);
-    targetsByConcretePath.set(concreteKey, groupTargets);
+    routableTargets.push(target);
   }
   if (missingRouteMetadata > 0) {
     failures.push(
       `${missingRouteMetadata} warm target${missingRouteMetadata === 1 ? " is" : "s are"} missing route-pattern metadata`,
     );
   }
-  const groups: ConcretePathGroup[] = Array.from(
-    targetsByConcretePath,
-    ([concreteKey, groupTargets]) => {
-      const route = groupTargets[0].route!;
-      const key = cacheabilityManifestRouteKey(route.kind, route.pattern);
-      const pattern = patterns.get(key)!;
-      const routePathname = concreteKey.slice(key.length + 1);
-      groupTargets.sort((first, second) => {
-        const preference = targetPreference(first) - targetPreference(second);
-        return preference || first.sourcePathname.localeCompare(second.sourcePathname);
-      });
-      const group = { pattern, primary: groupTargets[0], routePathname, targets: groupTargets };
-      pattern.groups.push(group);
-      return group;
-    },
-  );
+  const targetGroups = new Map<
+    string,
+    {
+      pattern: PatternClassification;
+      resultKey: string;
+      routePathname: string;
+      targets: CdnWarmTarget[];
+    }
+  >();
+  for (const target of routableTargets) {
+    const route = target.route!;
+    const key = cacheabilityManifestRouteKey(route.kind, route.pattern);
+    const pattern = patterns.get(key)!;
+    const routePathname =
+      route.cacheabilityProbe?.concretePathname ??
+      cacheabilityRoutePathname(target.pathname, target.kind);
+    const resultKey = pattern.splitRepresentations
+      ? `${target.kind}\0${routePathname}`
+      : routePathname;
+    pattern.resultKeys.add(resultKey);
+    const concreteKey = `${key}\0${resultKey}`;
+    const group = targetGroups.get(concreteKey) ?? {
+      pattern,
+      resultKey,
+      routePathname,
+      targets: [],
+    };
+    group.targets.push(target);
+    targetGroups.set(concreteKey, group);
+  }
+  const groups: ConcretePathGroup[] = Array.from(targetGroups.values(), (targetGroup) => {
+    targetGroup.targets.sort((first, second) => {
+      const preference = targetPreference(first) - targetPreference(second);
+      return preference || first.sourcePathname.localeCompare(second.sourcePathname);
+    });
+    const group = { ...targetGroup, primary: targetGroup.targets[0] };
+    targetGroup.pattern.groups.push(group);
+    return group;
+  });
 
   const reportProgress = (): void => {
     options.onProgress?.({
@@ -470,6 +501,60 @@ export async function probeStagedWorkerCacheability(options: {
     routeEntryBytes.set(key, nextEntryBytes);
     manifestBytes = nextManifestBytes;
     return true;
+  };
+
+  const moveGroupToResolvedRoute = (
+    group: ConcretePathGroup,
+    route: Pick<PrerenderRoutePattern, "kind" | "pattern">,
+  ): PatternClassification => {
+    const previousPattern = group.pattern;
+    const key = cacheabilityManifestRouteKey(route.kind, route.pattern);
+    let pattern = patterns.get(key);
+    if (!pattern) {
+      pattern = {
+        canPrune: false,
+        groups: [],
+        key,
+        resultKeys: new Set<string>(),
+        pruned: false,
+        results: new Map(),
+        route,
+        splitRepresentations: previousPattern.splitRepresentations,
+      };
+      patterns.set(key, pattern);
+    }
+    pattern.canPrune = false;
+    pattern.splitRepresentations ||= previousPattern.splitRepresentations;
+    // A direct destination probe may have provisionally pruned this pattern
+    // before the routed source completed. Its retained concrete observation is
+    // authoritative once another public path joins the resolved route.
+    pattern.pruned = false;
+    if (pattern === previousPattern) return pattern;
+
+    const previousGroupIndex = previousPattern.groups.indexOf(group);
+    if (previousGroupIndex !== -1) previousPattern.groups.splice(previousGroupIndex, 1);
+    if (!previousPattern.groups.some((candidate) => candidate.resultKey === group.resultKey)) {
+      previousPattern.resultKeys.delete(group.resultKey);
+    }
+    pattern.groups.push(group);
+    pattern.resultKeys.add(group.resultKey);
+    group.pattern = pattern;
+    return pattern;
+  };
+
+  const updateGroupRoutePathname = (group: ConcretePathGroup, routePathname: string): void => {
+    const normalized = normalizeCacheabilityRoutePathname(routePathname);
+    if (normalized === group.routePathname) return;
+    const pattern = group.pattern;
+    const previousResultKey = group.resultKey;
+    group.routePathname = normalized;
+    group.resultKey = pattern.splitRepresentations
+      ? `${group.primary.kind}\0${normalized}`
+      : normalized;
+    if (!pattern.groups.some((candidate) => candidate.resultKey === previousResultKey)) {
+      pattern.resultKeys.delete(previousResultKey);
+    }
+    pattern.resultKeys.add(group.resultKey);
   };
 
   const classifyConcretePath = async (group: ConcretePathGroup): Promise<void> => {
@@ -519,6 +604,16 @@ export async function probeStagedWorkerCacheability(options: {
       !isProbeRouteState(result.state) ||
       (result.scope !== undefined && result.scope !== "identity" && result.scope !== "pattern") ||
       (result.scope === "pattern" && result.state !== "dynamic") ||
+      (result.routePathname !== undefined &&
+        (typeof result.routePathname !== "string" ||
+          !result.routePathname.startsWith("/") ||
+          result.routePathname.includes("?") ||
+          result.routePathname.includes("#"))) ||
+      (result.terminal !== undefined && result.terminal !== true) ||
+      (result.terminal === true &&
+        (result.state !== "dynamic" ||
+          result.scope !== "identity" ||
+          !group.pattern.splitRepresentations)) ||
       (result.rendererStatic !== undefined && typeof result.rendererStatic !== "boolean") ||
       !Number.isInteger(result.status) ||
       result.status! < 100 ||
@@ -535,17 +630,50 @@ export async function probeStagedWorkerCacheability(options: {
       reportProgress();
       return;
     }
-    if (
-      !target.route ||
-      result.kind !== target.route.kind ||
-      result.pattern !== target.route.pattern
-    ) {
-      failures.push(`${target.label}: probe resolved to unexpected route ${result.pattern ?? ""}`);
+    if (!target.route) {
+      failures.push(`${target.label}: probe resolved without route metadata`);
       completedPathCount += 1;
       reportProgress();
       return;
     }
+    if (result.kind !== target.route.kind || result.pattern !== target.route.pattern) {
+      if (target.route.cacheabilityProbe?.routeMayResolve !== true) {
+        failures.push(
+          `${target.label}: probe resolved to unexpected route ${result.pattern ?? ""}`,
+        );
+        completedPathCount += 1;
+        reportProgress();
+        return;
+      }
+      if (result.routePathname === undefined) {
+        failures.push(`${target.label}: probe resolved without a concrete route pathname`);
+        completedPathCount += 1;
+        reportProgress();
+        return;
+      }
+      moveGroupToResolvedRoute(group, { kind: result.kind, pattern: result.pattern });
+    }
+    if (result.routePathname !== undefined) {
+      updateGroupRoutePathname(group, result.routePathname);
+    }
 
+    const classification: ConcretePathResult = {
+      rendererStatic: result.rendererStatic === true,
+      representation: target.kind,
+      state: result.state,
+      terminal: result.terminal === true,
+    };
+    group.result = classification;
+    const previousClassification = group.pattern.results.get(group.resultKey);
+    if (
+      !previousClassification ||
+      (previousClassification.state === "static-candidate" && classification.state === "dynamic") ||
+      (previousClassification.state === classification.state &&
+        previousClassification.rendererStatic &&
+        !classification.rendererStatic)
+    ) {
+      group.pattern.results.set(group.resultKey, classification);
+    }
     const patternIsDefinitelyDynamic =
       result.state === "dynamic" && result.scope === "pattern" && group.pattern.canPrune;
     if (patternIsDefinitelyDynamic) {
@@ -555,12 +683,6 @@ export async function probeStagedWorkerCacheability(options: {
       reportProgress();
       return;
     }
-
-    group.pattern.results.set(group.routePathname, {
-      rendererStatic: result.rendererStatic === true,
-      representation: target.kind,
-      state: result.state,
-    });
     if (result.state === "static-candidate") {
       staticPathCount += 1;
     } else {
@@ -655,15 +777,16 @@ export async function probeStagedWorkerCacheability(options: {
       dynamic += 1;
     }
 
-    const staticPaths: CacheabilityManifestRoute["staticPaths"] = {};
+    const rendererStaticTargets = new Map<string, CdnWarmTarget>();
     const runtimePathSet = new Set<string>();
     for (const group of pattern.groups) {
-      const result = pattern.results.get(group.routePathname);
+      const result = group.result;
       if (result?.state === "static-candidate") {
         if (result.rendererStatic) {
-          const paths = staticPaths[result.representation] ?? [];
-          paths.push(group.routePathname);
-          staticPaths[result.representation] = paths;
+          const previous = rendererStaticTargets.get(group.routePathname);
+          if (!previous || targetPreference(group.primary) < targetPreference(previous)) {
+            rendererStaticTargets.set(group.routePathname, group.primary);
+          }
         } else {
           runtimePathSet.add(group.routePathname);
         }
@@ -672,7 +795,7 @@ export async function probeStagedWorkerCacheability(options: {
         continue;
       }
 
-      runtimePathSet.add(group.routePathname);
+      if (result?.terminal !== true) runtimePathSet.add(group.routePathname);
       // A representation-specific response policy can make an RSC/data
       // sibling reusable even when the representative HTML render is private.
       // The final completed render decides admission without another probe.
@@ -682,9 +805,19 @@ export async function probeStagedWorkerCacheability(options: {
         speculativeTargets.push(...pairedTargets);
       }
     }
+    const staticPaths: CacheabilityManifestRoute["staticPaths"] = {};
+    for (const [routePathname, staticTarget] of rendererStaticTargets) {
+      // Conflicting observations for one resolved route identity must retain
+      // runtime admission rather than certifying the static observation.
+      if (runtimePathSet.has(routePathname)) continue;
+      const paths = staticPaths[staticTarget.kind] ?? [];
+      paths.push(routePathname);
+      staticPaths[staticTarget.kind] = paths;
+    }
     for (const paths of Object.values(staticPaths)) paths?.sort();
     const allObservedPathsStatic =
-      pattern.results.size === pattern.pathnames.size && runtimePathSet.size === 0;
+      pattern.results.size === pattern.resultKeys.size &&
+      Array.from(pattern.results.values()).every((result) => result.state === "static-candidate");
     const allObservedPathsStaticallyGenerated =
       allObservedPathsStatic &&
       Array.from(pattern.results.values()).every((result) => result.rendererStatic);
@@ -696,7 +829,7 @@ export async function probeStagedWorkerCacheability(options: {
       normalizeCacheabilityRoutePathname(pattern.route.pattern) === soleGroup.routePathname;
     let route: CacheabilityManifestRoute;
     if (literalPatternNamesSolePath) {
-      const result = pattern.results.get(soleGroup.routePathname);
+      const result = pattern.results.get(soleGroup.resultKey);
       route =
         result?.state === "static-candidate"
           ? pattern.route.kind === "app-route"

--- a/packages/cloudflare/src/cdn-warm.ts
+++ b/packages/cloudflare/src/cdn-warm.ts
@@ -58,6 +58,8 @@ export type CdnWarmOptions = {
   phaseTimeoutMs?: number;
   /** Retry a newly staged version or preview alias until its routing has propagated. */
   propagatingTarget?: boolean;
+  /** @internal Matching skipped targets that may be transient while a staged version propagates. */
+  retrySkippedTargetKeys?: ReadonlySet<string>;
   /** Require the response to come from a reusable cache entry, not merely an eligible MISS. */
   requireCacheHit?: boolean;
   strict?: boolean;
@@ -204,7 +206,11 @@ function readPrerenderPathManifest(manifestPath: string): PrerenderPathManifest 
                   typeof route.cacheabilityProbe.canPrunePattern === "boolean" &&
                   (route.cacheabilityProbe.concretePathname === undefined ||
                     (typeof route.cacheabilityProbe.concretePathname === "string" &&
-                      route.cacheabilityProbe.concretePathname.startsWith("/"))))),
+                      route.cacheabilityProbe.concretePathname.startsWith("/"))) &&
+                  (route.cacheabilityProbe.routeMayResolve === undefined ||
+                    typeof route.cacheabilityProbe.routeMayResolve === "boolean") &&
+                  (route.cacheabilityProbe.requestStageMayTerminate === undefined ||
+                    typeof route.cacheabilityProbe.requestStageMayTerminate === "boolean"))),
           ))) ||
       (manifest.loadingShellPaths !== undefined &&
         (!Array.isArray(manifest.loadingShellPaths) ||
@@ -576,6 +582,10 @@ function printCdnWarmRouteReport(
       `    ... ${formatCount(omitted.length, "additional route pattern")} omitted (${formatCount(omittedEntries, "cache entry", "cache entries")})`,
     );
   }
+}
+
+function cdnWarmTargetKey(target: Pick<CdnWarmTarget, "kind" | "sourcePathname">): string {
+  return `${target.kind}\0${target.sourcePathname}`;
 }
 
 export async function createCdnWarmTargets(
@@ -1188,6 +1198,7 @@ async function warmOnePath(
     retryPropagationFailures: boolean;
     retryDelayMs: number;
     retryNotFound: boolean;
+    retrySkipped: boolean;
     phaseTimeoutMs?: number;
     requireCacheHit: boolean;
   },
@@ -1199,6 +1210,7 @@ async function warmOnePath(
   const url = buildWarmupUrl(options.targetUrl, target.pathname);
   let lastError = "request failed before the first attempt";
   let lastRetryable = true;
+  let lastSkippedReason: string | null = null;
 
   const phaseDeadlineError = () =>
     `CDN warmup exceeded its ${options.phaseTimeoutMs}ms phase deadline`;
@@ -1268,8 +1280,18 @@ async function warmOnePath(
           return { path: target.label, ok: true, skipped: false };
         }
         if (validation.outcome === "skipped") {
-          return { path: target.label, ok: true, skipped: true, reason: validation.reason };
+          if (!options.retrySkipped) {
+            return { path: target.label, ok: true, skipped: true, reason: validation.reason };
+          }
+          lastSkippedReason = validation.reason;
+          lastRetryable = true;
+          if (!canRetry(attempt)) break;
+          if (!(await waitBeforeRetry())) {
+            return { path: target.label, ok: false, error: phaseDeadlineError(), retryable: false };
+          }
+          continue;
         }
+        lastSkippedReason = null;
         lastError = validation.error;
         const cacheStatus = response.headers.get("CF-Cache-Status")?.trim().toUpperCase();
         lastRetryable =
@@ -1297,8 +1319,18 @@ async function warmOnePath(
         return { path: target.label, ok: true, skipped: false };
       }
       if (validation.outcome === "skipped") {
-        return { path: target.label, ok: true, skipped: true, reason: validation.reason };
+        if (!options.retrySkipped) {
+          return { path: target.label, ok: true, skipped: true, reason: validation.reason };
+        }
+        lastSkippedReason = validation.reason;
+        lastRetryable = true;
+        if (!canRetry(attempt)) break;
+        if (!(await waitBeforeRetry())) {
+          return { path: target.label, ok: false, error: phaseDeadlineError(), retryable: false };
+        }
+        continue;
       }
+      lastSkippedReason = null;
       lastError = validation.error;
       const cacheStatus = response.headers.get("CF-Cache-Status")?.trim().toUpperCase();
       lastRetryable =
@@ -1308,6 +1340,7 @@ async function warmOnePath(
         shouldRetryValidationFailure(response, target, options);
       if (!lastRetryable) break;
     } catch (error) {
+      lastSkippedReason = null;
       lastRetryable = true;
       if (error instanceof DOMException && error.name === "AbortError") {
         lastError =
@@ -1324,7 +1357,9 @@ async function warmOnePath(
     }
   }
 
-  return { path: target.label, ok: false, error: lastError, retryable: lastRetryable };
+  return lastSkippedReason === null
+    ? { path: target.label, ok: false, error: lastError, retryable: lastRetryable }
+    : { path: target.label, ok: true, skipped: true, reason: lastSkippedReason };
 }
 
 async function runWithConcurrency<T, R>(
@@ -1356,9 +1391,9 @@ export async function warmCdnCache(options: CdnWarmOptions): Promise<CdnWarmResu
   const timeoutMs = Math.max(1, options.timeoutMs ?? DEFAULT_CDN_WARM_TIMEOUT_MS);
   const hasVersionOverride = new Headers(options.headers).has(WORKER_VERSION_OVERRIDE_HEADER);
   const propagatingTarget = options.propagatingTarget ?? hasVersionOverride;
-  // A propagating target gives every key one initial attempt, then retries only
-  // failed keys after the queue completes. Build identity validation prevents
-  // an old Worker response from being mistaken for a successful fill.
+  // A propagating target gives every key one initial attempt, then retries
+  // unresolved keys after the queue completes. Build identity validation
+  // prevents an old Worker response from being mistaken for a successful fill.
   const concurrency = Math.max(1, options.concurrency ?? DEFAULT_CDN_WARM_CONCURRENCY);
   const normalRetries = Math.max(0, options.retries ?? 1);
   const propagationRetries = Math.max(0, options.retries ?? 60);
@@ -1414,6 +1449,9 @@ export async function warmCdnCache(options: CdnWarmOptions): Promise<CdnWarmResu
       retryNotFound: isPropagationRequest,
       phaseTimeoutMs,
       requireCacheHit: options.requireCacheHit === true,
+      retrySkipped:
+        isPropagationRequest &&
+        options.retrySkippedTargetKeys?.has(cdnWarmTargetKey(target)) === true,
     });
   };
 
@@ -1433,43 +1471,33 @@ export async function warmCdnCache(options: CdnWarmOptions): Promise<CdnWarmResu
     const results = await runWithConcurrency(targets, concurrency, (target) =>
       warmRequest(target, "propagation-pass"),
     );
-    const failed = targets
+    const retryable = targets
       .map((target, index) => ({ index, result: results[index], target }))
-      .filter(
-        (
-          entry,
-        ): entry is {
-          index: number;
-          result: { path: string; ok: false; error: string; retryable: boolean };
-          target: CdnWarmTarget;
-        } => !entry.result.ok,
+      .filter(({ result, target }) =>
+        result.ok
+          ? result.skipped && options.retrySkippedTargetKeys?.has(cdnWarmTargetKey(target)) === true
+          : result.retryable,
       );
-    const retryableFailed = failed.filter(({ result }) => result.retryable);
-    if (retryableFailed.length === 0 || propagationRetries === 0) return results;
+    if (retryable.length === 0 || propagationRetries === 0) return results;
 
     progress.finish();
     console.log(
-      `  CDN warmup: retrying ${retryableFailed.length} failed request(s) after completing the initial pass...`,
+      `  CDN warmup: retrying ${retryable.length} unresolved request(s) after completing the initial pass...`,
     );
     let completedRetries = 0;
-    progress.update(0, retryableFailed.length, "starting retry pass", "Retrying CDN cache");
+    progress.update(0, retryable.length, "starting retry pass", "Retrying CDN cache");
     const retried = await runWithConcurrency(
-      retryableFailed.map(({ target }) => target),
+      retryable.map(({ target }) => target),
       concurrency,
       async (target) => {
         const result = await warmTarget(target, "propagation-retry");
         completedRetries++;
-        progress.update(
-          completedRetries,
-          retryableFailed.length,
-          target.label,
-          "Retrying CDN cache",
-        );
+        progress.update(completedRetries, retryable.length, target.label, "Retrying CDN cache");
         return result;
       },
     );
     progress.finish();
-    for (const [retryIndex, { index }] of retryableFailed.entries()) {
+    for (const [retryIndex, { index }] of retryable.entries()) {
       results[index] = retried[retryIndex];
     }
     return results;

--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -35,7 +35,9 @@ import {
   findVinextPrerenderConfigInPlugins,
   findVinextRouteRootConfigInPlugins,
   formatVinextPrerenderLabel,
+  getConfiguredCdnResponsePolicyHeaderNames,
   hasBuildIdentityResponseHeader,
+  hasUncachedRequestRouting,
   hasVerbatimResponseVary,
   requiresRouteCacheabilityProbeManifest,
   resolveVinextPrerenderDecision,
@@ -833,6 +835,23 @@ function cdnWarmTargetKey(target: Pick<CdnWarmTarget, "kind" | "sourcePathname">
   return `${target.kind}\0${target.sourcePathname}`;
 }
 
+function requiredCdnWarmTargetKeys(
+  plan: CdnWarmRequestPlan,
+  optionalTargetKeys: ReadonlySet<string> | undefined,
+): ReadonlySet<string> {
+  const keys = new Set([
+    ...plan.paths.map((pathname) => `html\0${pathname}`),
+    ...plan.pagesDataPaths.map((pathname) => `pages-data\0${pathname}`),
+    ...(plan.routeHandlerPaths ?? []).map((pathname) => `app-route\0${pathname}`),
+    ...plan.rscPaths.map((pathname) => `rsc-full\0${pathname}`),
+    ...plan.loadingShellPaths.map((pathname) => `rsc-loading-shell\0${pathname}`),
+  ]);
+  if (optionalTargetKeys) {
+    for (const key of optionalTargetKeys) keys.delete(key);
+  }
+  return keys;
+}
+
 export async function deployWithCdnWarmup(
   root: string,
   paths: readonly string[],
@@ -1001,6 +1020,10 @@ async function deployUploadedVersionWithCdnWarmup(
       concurrency: options.warmCdnConcurrency,
       timeoutMs: options.warmCdnTimeout,
       retries: options.warmCdnRetries,
+      retrySkippedTargetKeys:
+        propagatingTarget && hasPreparedWarmPlan
+          ? requiredCdnWarmTargetKeys(plan, options.optionalWarmTargetKeys)
+          : undefined,
       requireCacheHit,
       strict: requireCacheHit || !allowUnverifiedPromotion,
     });
@@ -1931,6 +1954,7 @@ export async function deploy(options: DeployOptions): Promise<void> {
     nextOutput: nextConfig.output,
   });
   const hasStrictResponseVary = hasVerbatimResponseVary(viteConfigMetadata.cacheConfig);
+  const hasStagedRequestRouting = hasUncachedRequestRouting(viteConfigMetadata.cacheConfig);
   const hasBuildIdentityHeader = hasBuildIdentityResponseHeader(viteConfigMetadata.cacheConfig);
   const needsCacheabilityProbeManifest = projectRequiresRouteCacheabilityProbeManifest(
     info,
@@ -1973,7 +1997,11 @@ export async function deploy(options: DeployOptions): Promise<void> {
       root: info.root,
       nextConfig,
       buildIdentity: hasBuildIdentityHeader ? "response-header" : undefined,
+      requestRouting: hasStagedRequestRouting ? "uncached-stage" : undefined,
       responseVary: hasStrictResponseVary ? "verbatim" : undefined,
+      responsePolicyHeaderNames: getConfiguredCdnResponsePolicyHeaderNames(
+        viteConfigMetadata.cacheConfig,
+      ),
       routeRootConfig: viteConfigMetadata.routeRootConfig,
     });
   }
@@ -2046,7 +2074,11 @@ export async function deploy(options: DeployOptions): Promise<void> {
           root: info.root,
           nextConfig,
           buildIdentity: hasBuildIdentityHeader ? "response-header" : undefined,
+          requestRouting: hasStagedRequestRouting ? "uncached-stage" : undefined,
           responseVary: hasStrictResponseVary ? "verbatim" : undefined,
+          responsePolicyHeaderNames: getConfiguredCdnResponsePolicyHeaderNames(
+            viteConfigMetadata.cacheConfig,
+          ),
           routeRootConfig: viteConfigMetadata.routeRootConfig,
           pathDiscoveryTarget: {
             baseUrl: targetUrl,

--- a/tests/cloudflare-cacheability-probe.test.ts
+++ b/tests/cloudflare-cacheability-probe.test.ts
@@ -13,6 +13,7 @@ import {
 import {
   VINEXT_CACHEABILITY_PROBE_HEADER,
   VINEXT_CACHEABILITY_PROBE_QUERY_PARAM,
+  VINEXT_CACHEABILITY_PROBE_ROUTE_HEADER,
   VINEXT_PRERENDER_SECRET_HEADER,
 } from "../packages/vinext/src/server/headers.js";
 
@@ -78,7 +79,11 @@ describe("staged Worker cacheability probes", () => {
       urls.push(url);
       const headers = new Headers(init?.headers);
       expect(headers.get(VINEXT_CACHEABILITY_PROBE_HEADER)).toBe("1");
+      expect(
+        JSON.parse(decodeURIComponent(headers.get(VINEXT_CACHEABILITY_PROBE_ROUTE_HEADER)!)),
+      ).toEqual(["app-page", "/cached/:slug"]);
       expect(headers.get(VINEXT_PRERENDER_SECRET_HEADER)).toBe("probe-secret");
+      expect(headers.get("Cache-Control")).toBeNull();
 
       if (urls.length <= 2) {
         return new Response(
@@ -308,6 +313,175 @@ describe("staged Worker cacheability probes", () => {
     ]);
   });
 
+  it("probes App representations independently when the request stage may terminate", async () => {
+    const root = createProbeRoot();
+    const route = {
+      cacheabilityProbe: { canPrunePattern: true, requestStageMayTerminate: true },
+      kind: "app-page" as const,
+      pattern: "/conditional",
+    };
+    const html = { ...target("/conditional"), route };
+    const rsc = {
+      headers: { Accept: "text/x-component", RSC: "1" },
+      kind: "rsc-full" as const,
+      label: "/conditional (RSC full)",
+      pathname: "/conditional?_rsc",
+      route,
+      sourcePathname: "/conditional",
+    };
+    const fetchImpl = vi.fn<typeof fetch>(async (_input, init) => {
+      const isRsc = new Headers(init?.headers).get("RSC") === "1";
+      return Response.json({
+        kind: "app-page",
+        pattern: route.pattern,
+        ...(isRsc
+          ? { rendererStatic: true, state: "static-candidate" }
+          : { scope: "identity", state: "dynamic", terminal: true }),
+        status: isRsc ? 200 : 307,
+        version: 1,
+      });
+    });
+
+    const result = await probeStagedWorkerCacheability({
+      buildId: "application-build",
+      fetchImpl,
+      retries: 0,
+      root,
+      targetUrl: "https://example.com",
+      targets: [rsc, html],
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(result).toMatchObject({ classified: 1, dynamic: 1, probed: 2, skipped: 0 });
+    expect(result.failures).toEqual([]);
+    expect(result.cacheableTargets).toEqual([rsc]);
+    expect(result.speculativeTargets).toEqual([]);
+    const manifestRoute = Object.values(result.manifest.routes)[0];
+    expect(cacheabilityManifestRouteState(manifestRoute, "/conditional", "rsc-full")).toBe(
+      "static-candidate",
+    );
+  });
+
+  it("probes Pages HTML and data independently when the request stage may terminate", async () => {
+    const root = createProbeRoot();
+    const route = {
+      cacheabilityProbe: { canPrunePattern: true, requestStageMayTerminate: true },
+      kind: "pages-page" as const,
+      pattern: "/posts/:slug",
+    };
+    const html = {
+      headers: { Accept: "text/html" },
+      kind: "html" as const,
+      label: "/posts/one",
+      pathname: "/posts/one",
+      route,
+      sourcePathname: "/posts/one",
+    };
+    const data = {
+      headers: { Accept: "application/json" },
+      kind: "pages-data" as const,
+      label: "/_next/data/build/posts/one.json (Pages data)",
+      pathname: "/_next/data/build/posts/one.json",
+      route: {
+        ...route,
+        cacheabilityProbe: { ...route.cacheabilityProbe, concretePathname: "/posts/one" },
+      },
+      sourcePathname: "/_next/data/build/posts/one.json",
+    };
+    const fetchImpl = vi.fn<typeof fetch>(async (_input, init) => {
+      const isData = new Headers(init?.headers).get("Accept") === "application/json";
+      return Response.json({
+        kind: "pages-page",
+        pattern: route.pattern,
+        ...(isData
+          ? { rendererStatic: true, state: "static-candidate" }
+          : { scope: "identity", state: "dynamic", terminal: true }),
+        status: isData ? 200 : 307,
+        version: 1,
+      });
+    });
+
+    const result = await probeStagedWorkerCacheability({
+      buildId: "application-build",
+      fetchImpl,
+      retries: 0,
+      root,
+      targetUrl: "https://example.com",
+      targets: [data, html],
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(result.cacheableTargets).toEqual([data]);
+    expect(result.speculativeTargets).toEqual([]);
+  });
+
+  it("does not prune a terminal-capable pattern from one representation", async () => {
+    const root = createProbeRoot();
+    const route = {
+      cacheabilityProbe: { canPrunePattern: true, requestStageMayTerminate: true },
+      kind: "app-page" as const,
+      pattern: "/posts/:slug",
+    };
+    const first = { ...target("/posts/one"), route };
+    const second = { ...target("/posts/two"), route };
+    const fetchImpl = vi.fn<typeof fetch>(async (input) => {
+      const pathname = new URL(input instanceof Request ? input.url : String(input)).pathname;
+      return Response.json({
+        kind: "app-page",
+        pattern: route.pattern,
+        rendererStatic: pathname.endsWith("/two"),
+        scope: pathname.endsWith("/one") ? "pattern" : undefined,
+        state: pathname.endsWith("/one") ? "dynamic" : "static-candidate",
+        status: 200,
+        version: 1,
+      });
+    });
+
+    const result = await probeStagedWorkerCacheability({
+      buildId: "application-build",
+      concurrency: 1,
+      fetchImpl,
+      retries: 0,
+      root,
+      targetUrl: "https://example.com",
+      targets: [first, second],
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(result).toMatchObject({ dynamic: 1, probed: 2, skipped: 0 });
+    expect(result.cacheableTargets).toEqual([second]);
+  });
+
+  it.each([
+    ["false", { scope: "identity", state: "dynamic", terminal: false }],
+    ["non-dynamic", { rendererStatic: true, state: "static-candidate", terminal: true }],
+  ])("rejects an invalid %s terminal probe signal", async (_label, probeResult) => {
+    const root = createProbeRoot();
+    const route = {
+      cacheabilityProbe: { canPrunePattern: true, requestStageMayTerminate: true },
+      kind: "app-page" as const,
+      pattern: "/conditional",
+    };
+    const result = await probeStagedWorkerCacheability({
+      buildId: "application-build",
+      fetchImpl: async () =>
+        Response.json({
+          kind: "app-page",
+          pattern: route.pattern,
+          ...probeResult,
+          status: 200,
+          version: 1,
+        }),
+      retries: 0,
+      root,
+      targetUrl: "https://example.com",
+      targets: [{ ...target("/conditional"), route }],
+    });
+
+    expect(result.failures).toEqual(["/conditional: probe returned an invalid envelope"]);
+    expect(result.cacheableTargets).toEqual([]);
+  });
+
   it("leaves representation-specific statuses to the final completed render", async () => {
     const root = createProbeRoot();
     const route = { kind: "app-page" as const, pattern: "/missing" };
@@ -511,6 +685,258 @@ describe("staged Worker cacheability probes", () => {
         staticPaths: { html: ["/posts/static"] },
       }),
     ]);
+  });
+
+  it("records a rewrite source under the concrete route resolved by the request stage", async () => {
+    const root = createProbeRoot();
+    const source = {
+      ...target("/rewrite-me"),
+      route: {
+        cacheabilityProbe: { canPrunePattern: true, routeMayResolve: true },
+        kind: "app-page" as const,
+        pattern: "/rewrite-me",
+      },
+    };
+    const direct = {
+      ...target("/safe"),
+      route: optimizableRoute("/safe"),
+    };
+    const result = await probeStagedWorkerCacheability({
+      buildId: "application-build",
+      fetchImpl: async () =>
+        Response.json({
+          kind: "app-page",
+          pattern: "/safe",
+          rendererStatic: true,
+          routePathname: "/safe",
+          state: "static-candidate",
+          status: 200,
+          version: 1,
+        }),
+      retries: 0,
+      root,
+      targetUrl: "https://example.com",
+      targets: [source, direct],
+    });
+
+    expect(result.failures).toEqual([]);
+    expect(result).toMatchObject({ classified: 1, probed: 2 });
+    expect(result.cacheableTargets).toEqual([source, direct]);
+    expect(result.manifest.routes[cacheabilityManifestRouteKey("app-page", "/safe")]).toEqual({
+      allowUnknown: true,
+      kind: "app-page",
+      pattern: "/safe",
+      state: "runtime-check",
+      staticPaths: { html: ["/safe"] },
+      unknownState: "static-candidate",
+    });
+  });
+
+  it("records a rewritten App runtime path without a direct destination target", async () => {
+    const root = createProbeRoot();
+    const source = {
+      ...target("/latest"),
+      route: {
+        cacheabilityProbe: { canPrunePattern: true, routeMayResolve: true },
+        kind: "app-page" as const,
+        pattern: "/latest",
+      },
+    };
+    const result = await probeStagedWorkerCacheability({
+      buildId: "application-build",
+      fetchImpl: async () =>
+        Response.json({
+          kind: "app-page",
+          pattern: "/posts/:slug",
+          rendererStatic: false,
+          routePathname: "/posts/one",
+          state: "static-candidate",
+          status: 200,
+          version: 1,
+        }),
+      retries: 0,
+      root,
+      targetUrl: "https://example.com",
+      targets: [source],
+    });
+
+    expect(result.failures).toEqual([]);
+    expect(result.cacheableTargets).toEqual([source]);
+    expect(
+      result.manifest.routes[cacheabilityManifestRouteKey("app-page", "/posts/:slug")],
+    ).toEqual({
+      kind: "app-page",
+      pattern: "/posts/:slug",
+      runtimePaths: ["/posts/one"],
+      state: "runtime-check",
+    });
+  });
+
+  it("records rewritten Pages HTML and data under the resolved GSSP path", async () => {
+    const root = createProbeRoot();
+    const route = {
+      cacheabilityProbe: { canPrunePattern: true, routeMayResolve: true },
+      kind: "pages-page" as const,
+      pattern: "/latest",
+    };
+    const html = { ...target("/latest"), route };
+    const data = {
+      headers: { Accept: "application/json" },
+      kind: "pages-data" as const,
+      label: "/_next/data/build/latest.json (Pages data)",
+      pathname: "/_next/data/build/latest.json",
+      route: {
+        ...route,
+        cacheabilityProbe: { ...route.cacheabilityProbe, concretePathname: "/latest" },
+      },
+      sourcePathname: "/_next/data/build/latest.json",
+    };
+    const result = await probeStagedWorkerCacheability({
+      buildId: "application-build",
+      fetchImpl: async () =>
+        Response.json({
+          kind: "pages-page",
+          pattern: "/posts/:slug",
+          rendererStatic: false,
+          routePathname: "/posts/one",
+          state: "static-candidate",
+          status: 200,
+          version: 1,
+        }),
+      retries: 0,
+      root,
+      targetUrl: "https://example.com",
+      targets: [data, html],
+    });
+
+    expect(result.failures).toEqual([]);
+    expect(result.cacheableTargets).toEqual([html, data]);
+    expect(result.speculativeTargets).toEqual([data]);
+    expect(
+      result.manifest.routes[cacheabilityManifestRouteKey("pages-page", "/posts/:slug")],
+    ).toEqual({
+      kind: "pages-page",
+      pattern: "/posts/:slug",
+      runtimePaths: ["/posts/one"],
+      state: "runtime-check",
+    });
+  });
+
+  it("encodes Unicode route patterns into ByteString probe headers", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-cacheability-probe-unicode-"));
+    roots.push(root);
+    fs.mkdirSync(path.join(root, "dist", "server"), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, "dist", "server", "vinext-server.json"),
+      JSON.stringify({ prerenderSecret: "probe-secret" }),
+    );
+
+    const fetchImpl = vi.fn<typeof fetch>(async (_input, init) => {
+      const encodedRoute = new Headers(init?.headers).get(VINEXT_CACHEABILITY_PROBE_ROUTE_HEADER);
+      expect(encodedRoute).toContain("%E4%BD%A0%E5%A5%BD");
+      expect(JSON.parse(decodeURIComponent(encodedRoute!))).toEqual(["app-page", "/你好"]);
+      return Response.json({
+        kind: "app-page",
+        pattern: "/你好",
+        scope: "identity",
+        state: "dynamic",
+        status: 200,
+        version: 1,
+      });
+    });
+    const route = optimizableRoute("/你好");
+    const result = await probeStagedWorkerCacheability({
+      buildId: "application-build",
+      fetchImpl,
+      retries: 0,
+      root,
+      targetUrl: "https://example.com",
+      targets: [
+        {
+          headers: { Accept: "text/html" },
+          kind: "html",
+          label: "/你好",
+          pathname: "/你好",
+          route,
+          sourcePathname: "/你好",
+        },
+      ],
+    });
+
+    expect(result.failures).toEqual([]);
+    expect(result.dynamic).toBe(1);
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it("rejects an unexpected resolved route without rewrite metadata", async () => {
+    const root = createProbeRoot();
+    const result = await probeStagedWorkerCacheability({
+      buildId: "application-build",
+      fetchImpl: async () =>
+        Response.json({
+          kind: "app-page",
+          pattern: "/unexpected",
+          rendererStatic: true,
+          state: "static-candidate",
+          status: 200,
+          version: 1,
+        }),
+      retries: 0,
+      root,
+      targetUrl: "https://example.com",
+      targets: [target("/expected")],
+    });
+
+    expect(result.failures).toEqual(["/expected: probe resolved to unexpected route /unexpected"]);
+    expect(result.cacheableTargets).toEqual([]);
+  });
+
+  it("regroups resolved routes independently of probe completion order", async () => {
+    const source = {
+      ...target("/rewrite-me"),
+      route: {
+        cacheabilityProbe: { canPrunePattern: true, routeMayResolve: true },
+        kind: "app-page" as const,
+        pattern: "/rewrite-me",
+      },
+    };
+    const direct = { ...target("/safe"), route: optimizableRoute("/safe") };
+
+    for (const delayedPathname of ["/rewrite-me", "/safe"]) {
+      const result = await probeStagedWorkerCacheability({
+        buildId: "application-build",
+        concurrency: 2,
+        fetchImpl: async (input) => {
+          const pathname = new URL(input instanceof Request ? input.url : String(input)).pathname;
+          if (pathname === delayedPathname) {
+            await new Promise((resolve) => setTimeout(resolve, 10));
+          }
+          return Response.json({
+            kind: "app-page",
+            pattern: "/safe",
+            rendererStatic: pathname === "/rewrite-me",
+            routePathname: "/safe",
+            ...(pathname === "/safe" ? { scope: "pattern" } : {}),
+            state: pathname === "/safe" ? "dynamic" : "static-candidate",
+            status: 200,
+            version: 1,
+          });
+        },
+        retries: 0,
+        root: createProbeRoot(),
+        targetUrl: "https://example.com",
+        targets: [source, direct],
+      });
+
+      expect(result.failures).toEqual([]);
+      expect(result.cacheableTargets).toEqual([source]);
+      expect(result.manifest.routes[cacheabilityManifestRouteKey("app-page", "/safe")]).toEqual({
+        kind: "app-page",
+        pattern: "/safe",
+        runtimePaths: ["/safe"],
+        state: "runtime-check",
+      });
+    }
   });
 
   it("does not prune siblings when a config cache policy varies within the route pattern", async () => {

--- a/tests/cloudflare-cdn-warm-deploy.test.ts
+++ b/tests/cloudflare-cdn-warm-deploy.test.ts
@@ -1356,6 +1356,53 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     },
   );
 
+  it("retries a required prepared fill while entrypoint cache config propagates", async () => {
+    writeTwoStageWorkerArtifact();
+    const wrangler = mockTwoStageWrangler();
+    let fillCalls = 0;
+    vi.mocked(fetch).mockImplementation(async (input, init) => {
+      if (new Headers(init?.headers).get(VINEXT_CACHEABILITY_PROBE_HEADER) === "1") {
+        return appPageProbeResponse();
+      }
+      if (isReadinessFetch(input)) return readinessResponse();
+      fillCalls++;
+      if (fillCalls === 1) {
+        return new Response("cache config still propagating", {
+          headers: {
+            "cache-control": "no-store",
+            "cf-cache-status": "BYPASS",
+            "content-type": "text/html",
+            [VINEXT_CDN_BUILD_ID_HEADER]: "app-build-a",
+          },
+        });
+      }
+      return cacheableHtml();
+    });
+    const { deployWithCdnWarmup } = await import("../packages/cloudflare/src/deploy.js");
+
+    await expect(
+      deployWithCdnWarmup(tmpDir, [], {
+        cacheabilityProbe: true,
+        config: "dist/server/wrangler.json",
+        discoverWarmPlan: async () => ({
+          appPaths: ["/about"],
+          buildId: "app-build-a",
+          buildIdentity: "app-build-a",
+          loadingShellPaths: [],
+          paths: ["/about"],
+          routePatterns: appPageRoutePatterns(["/about"]),
+          rscPaths: [],
+        }),
+        warmCdnConcurrency: 1,
+        warmCdnPromotionDelay: 0,
+        warmCdnReadinessProbes: 1,
+        warmCdnRetries: 1,
+      }),
+    ).resolves.toBe("https://my-worker.example.workers.dev");
+    expect(fillCalls).toBe(2);
+    expect(wrangler.promoted).toBe(true);
+  });
+
   it("lets prepared cache fills exceed the readiness window while requests keep completing", async () => {
     writeTwoStageWorkerArtifact();
     let now = 0;

--- a/tests/cloudflare-cdn-warm.test.ts
+++ b/tests/cloudflare-cdn-warm.test.ts
@@ -219,6 +219,31 @@ describe("Cloudflare CDN warmup", () => {
     );
   });
 
+  it("rejects non-boolean request-stage termination metadata", () => {
+    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile(
+      "dist/server/vinext-prerender-paths.json",
+      JSON.stringify({
+        buildId: "build-a",
+        paths: ["/conditional"],
+        routePatterns: {
+          "/conditional": {
+            cacheabilityProbe: {
+              canPrunePattern: true,
+              requestStageMayTerminate: "true",
+            },
+            kind: "app-page",
+            pattern: "/conditional",
+          },
+        },
+      }),
+    );
+
+    expect(() => readPrerenderWarmPlan(tmpDir, { strict: true })).toThrow(
+      "prerender path manifest not found",
+    );
+  });
+
   it("warms canonical RSC, HTML, and Pages data with browser-identical requests", async () => {
     const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
       const headers = new Headers(init?.headers);
@@ -459,6 +484,47 @@ describe("Cloudflare CDN warmup", () => {
       retryPlan: { loadingShellPaths: [], pagesDataPaths: [], paths: [], rscPaths: [] },
     });
     expect(result.skippedTargets).toHaveLength(2);
+  });
+
+  it("retries required staged BYPASS responses without delaying optional representations", async () => {
+    const attempts = new Map<string, number>();
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const pathname = new URL(requestHref(input)!).pathname;
+      const attempt = (attempts.get(pathname) ?? 0) + 1;
+      attempts.set(pathname, attempt);
+      if (pathname === "/required" && attempt > 1) return cacheableHtml("required");
+      return new Response("private", {
+        headers: {
+          "cache-control": "no-store",
+          "cf-cache-status": "BYPASS",
+          "content-type": "text/html",
+          [VINEXT_CDN_BUILD_ID_HEADER]: "build-a",
+        },
+      });
+    });
+
+    const result = await warmCdnCache({
+      expectedBuildId: "build-a",
+      fetchImpl: fetchImpl as typeof fetch,
+      paths: ["/required", "/optional"],
+      propagatingTarget: true,
+      retries: 2,
+      retryDelayMs: 0,
+      retrySkippedTargetKeys: new Set(["html\0/required"]),
+      strict: true,
+      targetUrl: "https://app.example.com",
+    });
+
+    expect(result).toMatchObject({ failed: 0, skipped: 1, warmed: 1 });
+    expect(attempts).toEqual(
+      new Map([
+        ["/required", 2],
+        ["/optional", 1],
+      ]),
+    );
+    expect(result.skippedTargets.map(({ sourcePathname }) => sourcePathname)).toEqual([
+      "/optional",
+    ]);
   });
 
   it("rejects a Pages data response with a non-JSON representation", async () => {

--- a/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
+++ b/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
@@ -252,6 +252,8 @@ test("deploy-prewarmed variants are reused and late-dynamic HTML stays private",
   expect(browserFetchMiss.ok(), JSON.stringify(browserFetchMissHeaders)).toBe(true);
   expect(browserFetchMissHeaders["content-type"]).toContain("text/html");
   expect(browserFetchMissHeaders["cf-cache-status"]).toBe("MISS");
+  expect(browserFetchMissHeaders["x-vinext-cache"]).toBe("MISS");
+  expect(browserFetchMissHeaders["x-nextjs-cache"]).toBe("MISS");
   expect(browserFetchMissHeaders["cache-control"]).toBe("private, max-age=0, must-revalidate");
   expect(browserFetchMissHeaders["cdn-cache-control"]).toBeUndefined();
   expect(browserFetchMissHeaders["cloudflare-cdn-cache-control"]).toBeUndefined();
@@ -260,7 +262,10 @@ test("deploy-prewarmed variants are reused and late-dynamic HTML stays private",
   const browserFetchHit = await request.get(browserFetchUrl.href, {
     headers: { accept: "*/*" },
   });
-  expect(browserFetchHit.headers()["cf-cache-status"]).toBe("HIT");
+  const browserFetchHitHeaders = browserFetchHit.headers();
+  expect(browserFetchHitHeaders["cf-cache-status"]).toBe("HIT");
+  expect(browserFetchHitHeaders["x-vinext-cache"]).toBe("HIT");
+  expect(browserFetchHitHeaders["x-nextjs-cache"]).toBe("HIT");
   expect(await browserFetchHit.text()).toBe(browserFetchBody);
 
   const downstreamOnlyOverride = await request.get(`${baseURL}/api/prewarm-version?downstream=1`, {

--- a/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
+++ b/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
@@ -347,6 +347,40 @@ test("deploy-prewarmed variants are reused and late-dynamic HTML stays private",
   expect(secondPagesResponseHeaders["x-workers-cache-visitor"]).toBe("visitor-b");
   expect(await secondPagesResponse.text()).toBe(pagesBody);
 
+  const pagesDataUrl = `${baseURL}/_next/data/${buildId}/pages-prewarm.json`;
+  const pagesDataResponse = await getReusableResponseAfterPromotion(
+    request,
+    pagesDataUrl,
+    {
+      accept: "application/json",
+      "x-nextjs-data": "1",
+      "x-test-config-visitor": "config-a",
+      "x-test-visitor-id": "visitor-a",
+    },
+    "Pages data",
+  );
+  const pagesDataHeaders = pagesDataResponse.headers();
+  expect(pagesDataResponse.ok(), JSON.stringify(pagesDataHeaders)).toBe(true);
+  expect(pagesDataHeaders["content-type"]).toContain("application/json");
+  expect(pagesDataHeaders["cf-cache-status"]).toBe("HIT");
+  expect(pagesDataHeaders["x-workers-config-visitor"]).toBe("config-a");
+  expect(pagesDataHeaders["x-workers-cache-visitor"]).toBe("visitor-a");
+  const pagesDataBody = await pagesDataResponse.text();
+  expect(JSON.parse(pagesDataBody)).toMatchObject({ pageProps: { draftMode: false } });
+
+  const secondPagesDataResponse = await getResponseAfterPromotion(request, pagesDataUrl, {
+    accept: "application/json",
+    "x-nextjs-data": "1",
+    "x-test-config-visitor": "config-b",
+    "x-test-visitor-id": "visitor-b",
+  });
+  const secondPagesDataHeaders = secondPagesDataResponse.headers();
+  expect(secondPagesDataResponse.ok(), JSON.stringify(secondPagesDataHeaders)).toBe(true);
+  expect(secondPagesDataHeaders["cf-cache-status"]).toBe("HIT");
+  expect(secondPagesDataHeaders["x-workers-config-visitor"]).toBe("config-b");
+  expect(secondPagesDataHeaders["x-workers-cache-visitor"]).toBe("visitor-b");
+  expect(await secondPagesDataResponse.text()).toBe(pagesDataBody);
+
   const appHtmlResponse = await getReusableResponseAfterPromotion(
     request,
     `${baseURL}${TARGET_PATH}`,

--- a/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
+++ b/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
@@ -299,7 +299,7 @@ test("deploy-prewarmed variants are reused and late-dynamic HTML stays private",
   const pagesResponse = await getReusableResponseAfterPromotion(
     request,
     `${baseURL}${PAGES_TARGET_PATH}`,
-    htmlHeaders,
+    { ...htmlHeaders, "x-test-visitor-id": "visitor-a" },
     "Pages HTML",
   );
   const pagesResponseHeaders = pagesResponse.headers();
@@ -313,12 +313,29 @@ test("deploy-prewarmed variants are reused and late-dynamic HTML stays private",
     pagesResponseHeaders["cf-cache-status"],
     `Pages response headers: ${JSON.stringify(pagesResponseHeaders)}`,
   ).toBe("HIT");
-  expect(await pagesResponse.text()).toContain("Pages prewarm target");
+  expect(pagesResponseHeaders["x-workers-cache-visitor"]).toBe("visitor-a");
+  const pagesBody = await pagesResponse.text();
+  expect(pagesBody).toContain("Pages prewarm target");
+
+  const secondPagesResponse = await getResponseAfterPromotion(
+    request,
+    `${baseURL}${PAGES_TARGET_PATH}`,
+    { ...htmlHeaders, "x-test-visitor-id": "visitor-b" },
+  );
+  const secondPagesResponseHeaders = secondPagesResponse.headers();
+  expect(secondPagesResponse.ok(), JSON.stringify(secondPagesResponseHeaders)).toBe(true);
+  expect(secondPagesResponseHeaders["x-vinext-build-id"]).toBe(rscBuildId);
+  expect(
+    secondPagesResponseHeaders["cf-cache-status"],
+    `Second Pages response headers: ${JSON.stringify(secondPagesResponseHeaders)}`,
+  ).toBe("HIT");
+  expect(secondPagesResponseHeaders["x-workers-cache-visitor"]).toBe("visitor-b");
+  expect(await secondPagesResponse.text()).toBe(pagesBody);
 
   const appHtmlResponse = await getReusableResponseAfterPromotion(
     request,
     `${baseURL}${TARGET_PATH}`,
-    htmlHeaders,
+    { ...htmlHeaders, "x-test-visitor-id": "visitor-a" },
     "App HTML",
   );
   const appHtmlResponseHeaders = appHtmlResponse.headers();
@@ -329,12 +346,78 @@ test("deploy-prewarmed variants are reused and late-dynamic HTML stays private",
     appHtmlResponseHeaders["cf-cache-status"],
     `App HTML response headers: ${JSON.stringify(appHtmlResponseHeaders)}`,
   ).toBe("HIT");
-  expect(await appHtmlResponse.text()).toContain("Prewarm target");
+  expect(appHtmlResponseHeaders["x-workers-cache-visitor"]).toBe("visitor-a");
+  const appHtmlBody = await appHtmlResponse.text();
+  expect(appHtmlBody).toContain("Prewarm target");
+
+  const secondAppHtmlResponse = await getResponseAfterPromotion(
+    request,
+    `${baseURL}${TARGET_PATH}`,
+    { ...htmlHeaders, "x-test-visitor-id": "visitor-b" },
+  );
+  const secondAppHtmlResponseHeaders = secondAppHtmlResponse.headers();
+  expect(secondAppHtmlResponse.ok(), JSON.stringify(secondAppHtmlResponseHeaders)).toBe(true);
+  expect(secondAppHtmlResponseHeaders["x-vinext-build-id"]).toBe(rscBuildId);
+  expect(
+    secondAppHtmlResponseHeaders["cf-cache-status"],
+    `Second App HTML response headers: ${JSON.stringify(secondAppHtmlResponseHeaders)}`,
+  ).toBe("HIT");
+  expect(secondAppHtmlResponseHeaders["x-workers-cache-visitor"]).toBe("visitor-b");
+  expect(await secondAppHtmlResponse.text()).toBe(appHtmlBody);
+
+  // Next.js skips its shared response cache in draft mode. This must be
+  // decided in the uncached request entrypoint because a named-entrypoint HIT
+  // cannot inspect the draft cookie before replaying anonymous bytes.
+  const draftRequest = await playwright.request.newContext();
+  try {
+    const enableDraft = await draftRequest.get(`${baseURL}/api/draft-enable`);
+    expect(enableDraft.ok()).toBe(true);
+    expect(enableDraft.headers()["set-cookie"]).toContain("__prerender_bypass=");
+    expect(enableDraft.headers()["cache-control"]).toContain("no-store");
+
+    for (const pathname of [TARGET_PATH, PAGES_TARGET_PATH]) {
+      const draftResponse = await draftRequest.get(`${baseURL}${pathname}`, {
+        headers: htmlHeaders,
+      });
+      const draftHeaders = draftResponse.headers();
+      expect(draftResponse.ok(), JSON.stringify(draftHeaders)).toBe(true);
+      expect(draftHeaders["cf-cache-status"]).not.toBe("HIT");
+      expect(draftHeaders["cache-control"]).toContain("no-store");
+      expect(await draftResponse.text()).toContain(
+        '<output data-testid="draft-mode">true</output>',
+      );
+    }
+  } finally {
+    await draftRequest.dispose();
+  }
+
+  const anonymousAfterDraft = await getResponseAfterPromotion(
+    request,
+    `${baseURL}${TARGET_PATH}`,
+    htmlHeaders,
+  );
+  expect(anonymousAfterDraft.headers()["cf-cache-status"]).toBe("HIT");
+  expect(await anonymousAfterDraft.text()).toBe(appHtmlBody);
+
+  for (const variant of ["alpha", "beta"]) {
+    const first = await getResponseAfterPromotion(request, `${baseURL}/vary`, {
+      "x-cache-variant": variant,
+    });
+    expect(first.ok(), JSON.stringify(first.headers())).toBe(true);
+    expect(await first.text()).toBe(variant);
+    expect(first.headers()["vary"]?.toLowerCase()).toContain("x-cache-variant");
+
+    const cached = await getResponseAfterPromotion(request, `${baseURL}/vary`, {
+      "x-cache-variant": variant,
+    });
+    expect(cached.headers()["cf-cache-status"], JSON.stringify(cached.headers())).toBe("HIT");
+    expect(await cached.text()).toBe(variant);
+  }
 
   const fullResponse = await getReusableResponseAfterPromotion(
     request,
     `${baseURL}${TARGET_PATH}?_rsc`,
-    fullHeaders,
+    { ...fullHeaders, "x-test-visitor-id": "visitor-a" },
     "full RSC",
   );
   const fullResponseHeaders = fullResponse.headers();
@@ -345,9 +428,25 @@ test("deploy-prewarmed variants are reused and late-dynamic HTML stays private",
     fullResponseHeaders["cf-cache-status"],
     `full RSC response headers: ${JSON.stringify(fullResponseHeaders)}`,
   ).toBe("HIT");
+  expect(fullResponseHeaders["x-workers-cache-visitor"]).toBe("visitor-a");
   const fullBody = await fullResponse.text();
   expect(fullBody).toContain(buildId);
   expect(fullBody).toContain("Prewarm target");
+
+  const secondFullResponse = await getResponseAfterPromotion(
+    request,
+    `${baseURL}${TARGET_PATH}?_rsc`,
+    { ...fullHeaders, "x-test-visitor-id": "visitor-b" },
+  );
+  const secondFullResponseHeaders = secondFullResponse.headers();
+  expect(secondFullResponse.ok(), JSON.stringify(secondFullResponseHeaders)).toBe(true);
+  expect(secondFullResponseHeaders["x-vinext-rsc-build-id"]).toBe(rscBuildId);
+  expect(
+    secondFullResponseHeaders["cf-cache-status"],
+    `Second full RSC response headers: ${JSON.stringify(secondFullResponseHeaders)}`,
+  ).toBe("HIT");
+  expect(secondFullResponseHeaders["x-workers-cache-visitor"]).toBe("visitor-b");
+  expect(await secondFullResponse.text()).toBe(fullBody);
 
   const shellResponse = await getReusableResponseAfterPromotion(
     request,

--- a/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
+++ b/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
@@ -299,7 +299,11 @@ test("deploy-prewarmed variants are reused and late-dynamic HTML stays private",
   const pagesResponse = await getReusableResponseAfterPromotion(
     request,
     `${baseURL}${PAGES_TARGET_PATH}`,
-    { ...htmlHeaders, "x-test-visitor-id": "visitor-a" },
+    {
+      ...htmlHeaders,
+      "x-test-config-visitor": "config-a",
+      "x-test-visitor-id": "visitor-a",
+    },
     "Pages HTML",
   );
   const pagesResponseHeaders = pagesResponse.headers();
@@ -313,6 +317,7 @@ test("deploy-prewarmed variants are reused and late-dynamic HTML stays private",
     pagesResponseHeaders["cf-cache-status"],
     `Pages response headers: ${JSON.stringify(pagesResponseHeaders)}`,
   ).toBe("HIT");
+  expect(pagesResponseHeaders["x-workers-config-visitor"]).toBe("config-a");
   expect(pagesResponseHeaders["x-workers-cache-visitor"]).toBe("visitor-a");
   const pagesBody = await pagesResponse.text();
   expect(pagesBody).toContain("Pages prewarm target");
@@ -320,7 +325,11 @@ test("deploy-prewarmed variants are reused and late-dynamic HTML stays private",
   const secondPagesResponse = await getResponseAfterPromotion(
     request,
     `${baseURL}${PAGES_TARGET_PATH}`,
-    { ...htmlHeaders, "x-test-visitor-id": "visitor-b" },
+    {
+      ...htmlHeaders,
+      "x-test-config-visitor": "config-b",
+      "x-test-visitor-id": "visitor-b",
+    },
   );
   const secondPagesResponseHeaders = secondPagesResponse.headers();
   expect(secondPagesResponse.ok(), JSON.stringify(secondPagesResponseHeaders)).toBe(true);
@@ -329,13 +338,18 @@ test("deploy-prewarmed variants are reused and late-dynamic HTML stays private",
     secondPagesResponseHeaders["cf-cache-status"],
     `Second Pages response headers: ${JSON.stringify(secondPagesResponseHeaders)}`,
   ).toBe("HIT");
+  expect(secondPagesResponseHeaders["x-workers-config-visitor"]).toBe("config-b");
   expect(secondPagesResponseHeaders["x-workers-cache-visitor"]).toBe("visitor-b");
   expect(await secondPagesResponse.text()).toBe(pagesBody);
 
   const appHtmlResponse = await getReusableResponseAfterPromotion(
     request,
     `${baseURL}${TARGET_PATH}`,
-    { ...htmlHeaders, "x-test-visitor-id": "visitor-a" },
+    {
+      ...htmlHeaders,
+      "x-test-config-visitor": "config-a",
+      "x-test-visitor-id": "visitor-a",
+    },
     "App HTML",
   );
   const appHtmlResponseHeaders = appHtmlResponse.headers();
@@ -346,6 +360,7 @@ test("deploy-prewarmed variants are reused and late-dynamic HTML stays private",
     appHtmlResponseHeaders["cf-cache-status"],
     `App HTML response headers: ${JSON.stringify(appHtmlResponseHeaders)}`,
   ).toBe("HIT");
+  expect(appHtmlResponseHeaders["x-workers-config-visitor"]).toBe("config-a");
   expect(appHtmlResponseHeaders["x-workers-cache-visitor"]).toBe("visitor-a");
   const appHtmlBody = await appHtmlResponse.text();
   expect(appHtmlBody).toContain("Prewarm target");
@@ -353,7 +368,11 @@ test("deploy-prewarmed variants are reused and late-dynamic HTML stays private",
   const secondAppHtmlResponse = await getResponseAfterPromotion(
     request,
     `${baseURL}${TARGET_PATH}`,
-    { ...htmlHeaders, "x-test-visitor-id": "visitor-b" },
+    {
+      ...htmlHeaders,
+      "x-test-config-visitor": "config-b",
+      "x-test-visitor-id": "visitor-b",
+    },
   );
   const secondAppHtmlResponseHeaders = secondAppHtmlResponse.headers();
   expect(secondAppHtmlResponse.ok(), JSON.stringify(secondAppHtmlResponseHeaders)).toBe(true);
@@ -362,6 +381,7 @@ test("deploy-prewarmed variants are reused and late-dynamic HTML stays private",
     secondAppHtmlResponseHeaders["cf-cache-status"],
     `Second App HTML response headers: ${JSON.stringify(secondAppHtmlResponseHeaders)}`,
   ).toBe("HIT");
+  expect(secondAppHtmlResponseHeaders["x-workers-config-visitor"]).toBe("config-b");
   expect(secondAppHtmlResponseHeaders["x-workers-cache-visitor"]).toBe("visitor-b");
   expect(await secondAppHtmlResponse.text()).toBe(appHtmlBody);
 


### PR DESCRIPTION
Part 13 of 16 in the staged CDN adapter stack. Depends on #3152.

## Summary

- prewarms cacheable URLs through the routed response-stage path
- keeps explicit warm targets, discovered App/Pages routes, draft exclusion, and probe artifacts aligned
- preserves main's per-route Worker-version propagation wait before classifying a staged route
- verifies deployed App HTML, Pages HTML/data, and RSC reuse while middleware/config headers remain request-specific
- verifies deployed `CF-Cache-Status` MISS/HIT values are mirrored through both vinext/Next.js cache headers

## Validation

- 507 focused Cloudflare probe, warm, and deploy tests passed
- local Cloudflare E2E: 16 passed, 1 deploy-only skip
- PPR cacheability E2E: 8 passed

## Review size

- Implementation: +279 / -86 LOC
- Tests and fixtures: +703 / -6 LOC
- Other (docs, config, lockfile): +57 / -5 LOC
- 13 changed files

Measured against `codex/cdn-v2-cloudflare-entrypoints` after rebasing onto `main@a6931c0`.