### PR TITLE
docs(cloudflare): explain cached response entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -705,18 +705,17 @@ The KV data adapter reads `env[binding]` at runtime, so add the matching KV name
 
 `binding` defaults to `VINEXT_KV_CACHE`, so `kvDataAdapter()` with no options works as long as that's your binding name. Other options: `appPrefix` (namespace cache keys to isolate multiple apps in one KV namespace), `ttlSeconds` (default KV `expirationTtl`, default 30 days), and `tagCacheTtlMs` (in-memory tag-invalidation cache TTL, default 5s).
 
-`cdnAdapter()` takes no options, but the Workers Cache only exposes `ctx.cache` when `cache.enabled` is set in `wrangler.jsonc`:
+When `cdnAdapter()` is used in a Cloudflare build, vinext emits two Worker
+entrypoints and configures Workers Cache only on the response entrypoint. The
+default entrypoint keeps caching disabled so middleware and request-time routing
+run on every request. Do not enable Workers Cache on the default entrypoint in
+your source `wrangler.jsonc`; the generated `dist/server/wrangler.json` contains
+the per-entrypoint cache settings and version metadata binding used for staged
+discovery and warming.
 
-```jsonc
-{
-  "cache": { "enabled": true },
-  "version_metadata": { "binding": "CF_VERSION_METADATA" },
-}
-```
-
-The version metadata binding is required for staged discovery and warming to
-verify the uploaded Worker version. Wrangler named environments do not inherit
-`version_metadata`, so repeat it inside each `env.<name>` used for warming.
+The generated version metadata binding lets staged discovery and warming verify
+the uploaded Worker version. Pass `versionMetadataBinding` to `cdnAdapter()`
+only when the deployment needs a custom binding name.
 
 `vinext-cloudflare deploy --experimental-warm-cdn-cache` performs the two-stage
 upload and makes one final cache-fill request per admitted identity by default.
@@ -725,12 +724,16 @@ must prove every planned entry reusable before promotion.
 
 While the data adapter can store entries and serve HIT/STALE itself, the CDN adapter delegates serving to Cloudflare's edge: the origin renders fresh responses and tags them with `Cache-Tag`, and `revalidateTag()` / `revalidatePath()` purge the edge through `ctx.cache.purge({ tags })`. See [examples/workers-cache](examples/workers-cache) for both adapters wired up together.
 
-Keep Cloudflare's incoming cache key query-sensitive when using `cdnAdapter()`.
-The two-stage cacheability manifest authorizes exact pathname + query
-identities, and a Cache Rule that ignores or normalizes query strings can serve
-an edge HIT before the Worker has a chance to enforce that identity.
+The response entrypoint adds a transport-only digest of the complete stage
+identity to its Workers Cache URL. That internal key is independent of zone
+Cache Rules and prevents distinct query, representation, rewrite, or
+interception identities from colliding.
 
-Each builder returns a plain, serializable `{ adapter, options }` descriptor — **it never touches the Workers runtime**, so nothing throws at build or dev time when bindings aren't available. The actual adapter (and its `env` binding lookup) is instantiated lazily on the first request.
+Adapter declarations do not access the Workers runtime, so nothing throws at
+config-evaluation or dev time when bindings are unavailable. Builders may also
+provide platform-specific output hooks; `cdnAdapter()` uses one to configure
+the Cloudflare entrypoints after the application build. Runtime adapters (and
+their `env` binding lookups) are instantiated lazily on the first request.
 
 Registration is wired into **every router and runtime** — App Router and Pages Router, on Cloudflare Workers as well as the Node.js server (`vinext start`) and dev. It self-guards (instantiated once per isolate) and is resilient: if an adapter can't initialize on a given runtime (e.g. a KV binding doesn't exist on the Node server), vinext logs a warning and falls back to the default handler instead of failing requests.
 

--- a/examples/workers-cache/README.md
+++ b/examples/workers-cache/README.md
@@ -23,13 +23,13 @@ vinext({
 });
 ```
 
-The Workers Cache only exposes `ctx.cache` when `cache.enabled: true` is set
-in `wrangler.jsonc`, and the KV adapter needs a matching `VINEXT_KV_CACHE`
-namespace binding — both are configured there.
+`cdnAdapter()` generates the per-entrypoint Workers Cache configuration during
+the Cloudflare build. The KV adapter still needs a matching
+`VINEXT_KV_CACHE` namespace binding in `wrangler.jsonc`.
 
-The incoming Cloudflare cache key must retain the full query string. A Cache
-Rule that ignores or normalizes query parameters can collapse distinct
-manifest identities before the Worker runs.
+The adapter adds a transport-only URL digest so distinct response-stage
+identities cannot collide. Workers Cache owns this key independently of zone
+Cache Rules.
 
 ## What's in the box
 
@@ -47,18 +47,15 @@ manifest identities before the Worker runs.
 ## How vinext wires it up
 
 1. **`vite.config.ts`** declares the adapters via `vinext({ cache })` (see
-   above). The descriptors are plain serializable values — they don't touch
-   the Workers runtime at build/dev time; the adapters instantiate lazily on
-   the first request.
+   above). The declarations do not touch the Workers runtime during config
+   evaluation. The Cloudflare build hook emits the staged Worker configuration,
+   and runtime adapters instantiate lazily on the first request.
 
-2. **`wrangler.jsonc`** enables the platform cache and binds the KV namespace:
+2. **`wrangler.jsonc`** binds the KV namespace:
 
    ```jsonc
    {
-     "cache": { "enabled": true },
-     "kv_namespaces": [
-       { "binding": "VINEXT_KV_CACHE", "id": "<your-kv-namespace-id>" }
-     ]
+     "kv_namespaces": [{ "binding": "VINEXT_KV_CACHE", "id": "<your-kv-namespace-id>" }],
    }
    ```
 
@@ -70,20 +67,29 @@ manifest identities before the Worker runs.
 
    ```jsonc
    {
-     "main": "vinext/server/fetch-handler"
+     "main": "vinext/server/fetch-handler",
    }
    ```
 
-   The handler registers the configured adapters on the first request —
-   passing the Worker's `env` so `kvDataAdapter()` can resolve its KV binding —
-   then threads the request's `ExecutionContext` through ALS so `cdnAdapter()`
-   can reach `ctx.cache` at revalidation time. No manual registration.
+   When `cdnAdapter()` is configured, vinext asks the Cloudflare build for two
+   Worker entrypoints. The default entrypoint runs routing and middleware with
+   caching disabled; `VinextCachedResponse` lazily loads the render stage with
+   Workers Cache enabled. The generated `dist/server/wrangler.json` contains
+   those settings, so existing applications do not need a source-config edit.
+   The handler also passes the Worker's `env` so `kvDataAdapter()` can resolve
+   its KV binding. No manual registration.
 
-4. **ISR responses** carry `CDN-Cache-Control: public, max-age=N,
+4. **ISR responses** carry `Cloudflare-CDN-Cache-Control: public, max-age=N,
    stale-while-revalidate=M` (for the edge) plus a browser-facing
    `Cache-Control: public, max-age=0, must-revalidate`, and a `Cache-Tag`
-   header listing both the bare path (`/cached/intro`) and Next.js's internal
-   `_N_T_<path>` form. The Workers Cache reads these to cache and tag-purge.
+   header containing Cloudflare-safe fixed-size digests of both the bare path
+   (`/cached/intro`) and Next.js's internal `_N_T_<path>` form. The Workers
+   Cache reads these to cache and tag-purge without losing Next.js's
+   case-sensitive tag semantics. Because Workers Cache requires every `Vary`
+   variant of a URL to use the same cache tags, vinext conservatively leaves a
+   tagged response uncached when it declares an application-defined `Vary`
+   field; use a separate URL or response-stage identity when those variants
+   need both caching and tag invalidation.
 
 5. **`revalidateTag` / `revalidatePath`** in your route handlers fan out to
    both the KV data cache and `ctx.cache.purge(...)` on the platform layer.
@@ -100,7 +106,7 @@ Then open http://localhost:5173 and click into any of the demo routes.
 > **Note:** dev runs on `@cloudflare/vite-plugin` (miniflare), so the
 > `VINEXT_KV_CACHE` namespace is emulated locally and `kvDataAdapter()`
 > works. The edge CDN layer (`cf-cache-status`, background revalidation)
-> only runs on Cloudflare's edge — locally the `CDN-Cache-Control` /
+> only runs on Cloudflare's edge — locally the `Cloudflare-CDN-Cache-Control` /
 > `Cache-Tag` headers `cdnAdapter()` emits are what drive it once deployed.
 
 ## Deploying

--- a/examples/workers-cache/README.md
+++ b/examples/workers-cache/README.md
@@ -41,8 +41,8 @@ Cache Rules.
 - A client-side **probe** that issues a no-store fetch against a route and
   prints the headers Cloudflare's edge attaches —
   [`cf-cache-status`](https://developers.cloudflare.com/cache/concepts/default-cache-behavior/#cloudflare-cache-responses)
-  (the outer Workers Cache verdict), `Age`, plus the `Cache-Control` /
-  `Cache-Tag` headers vinext emits to drive it.
+  (the cache-enabled response entrypoint's verdict), `Age`, and the public
+  browser `Cache-Control` policy.
 
 ## How vinext wires it up
 
@@ -79,17 +79,18 @@ Cache Rules.
    The handler also passes the Worker's `env` so `kvDataAdapter()` can resolve
    its KV binding. No manual registration.
 
-4. **ISR responses** carry `Cloudflare-CDN-Cache-Control: public, max-age=N,
-   stale-while-revalidate=M` (for the edge) plus a browser-facing
-   `Cache-Control: public, max-age=0, must-revalidate`, and a `Cache-Tag`
-   header containing Cloudflare-safe fixed-size digests of both the bare path
-   (`/cached/intro`) and Next.js's internal `_N_T_<path>` form. The Workers
-   Cache reads these to cache and tag-purge without losing Next.js's
-   case-sensitive tag semantics. Because Workers Cache requires every `Vary`
-   variant of a URL to use the same cache tags, vinext conservatively leaves a
-   tagged response uncached when it declares an application-defined `Vary`
-   field; use a separate URL or response-stage identity when those variants
-   need both caching and tag invalidation.
+4. **The inner cached response** carries `Cloudflare-CDN-Cache-Control: public,
+   max-age=N, stale-while-revalidate=M` plus a `Cache-Tag` containing
+   Cloudflare-safe fixed-size digests of both the bare path (`/cached/intro`)
+   and Next.js's internal `_N_T_<path>` form. Workers Cache consumes those
+   private headers for admission and tag purging. The uncached gateway removes
+   them before public egress and returns the browser-facing `Cache-Control:
+   public, max-age=0, must-revalidate` policy. Because Workers Cache requires
+   every `Vary` variant of a URL to use the same cache tags, vinext
+   conservatively leaves a tagged response uncached when the rendered response
+   declares an application-defined `Vary` field; use a separate URL or
+   response-stage identity when those variants need both caching and tag
+   invalidation.
 
 5. **`revalidateTag` / `revalidatePath`** in your route handlers fan out to
    both the KV data cache and `ctx.cache.purge(...)` on the platform layer.
@@ -106,8 +107,9 @@ Then open http://localhost:5173 and click into any of the demo routes.
 > **Note:** dev runs on `@cloudflare/vite-plugin` (miniflare), so the
 > `VINEXT_KV_CACHE` namespace is emulated locally and `kvDataAdapter()`
 > works. The edge CDN layer (`cf-cache-status`, background revalidation)
-> only runs on Cloudflare's edge — locally the `Cloudflare-CDN-Cache-Control` /
-> `Cache-Tag` headers `cdnAdapter()` emits are what drive it once deployed.
+> only runs on Cloudflare's edge. Local development may expose the inner
+> `Cloudflare-CDN-Cache-Control` / `Cache-Tag` policy directly because it does
+> not pass through the deployed multi-entrypoint gateway.
 
 ## Deploying
 

--- a/examples/workers-cache/README.md
+++ b/examples/workers-cache/README.md
@@ -85,7 +85,7 @@ Cache Rules.
    and Next.js's internal `_N_T_<path>` form. Workers Cache consumes those
    private headers for admission and tag purging. The uncached gateway removes
    them before public egress and returns the browser-facing `Cache-Control:
-   public, max-age=0, must-revalidate` policy. Because Workers Cache requires
+   private, max-age=0, must-revalidate` policy. Because Workers Cache requires
    every `Vary` variant of a URL to use the same cache tags, vinext
    conservatively leaves a tagged response uncached when the rendered response
    declares an application-defined `Vary` field; use a separate URL or

--- a/examples/workers-cache/app/components/cache-status-probe.tsx
+++ b/examples/workers-cache/app/components/cache-status-probe.tsx
@@ -7,8 +7,6 @@ type ProbeState = {
   cfCacheStatus: string | null;
   age: string | null;
   cacheControl: string | null;
-  cdnCacheControl: string | null;
-  cacheTag: string | null;
   cfRay: string | null;
   fetchedAt: string;
   /** UUID embedded in the response body at SSR time, when present. */
@@ -140,7 +138,7 @@ export function CacheStatusProbe({ path }: { path: string }) {
       // talk to the edge — making the probe useless for observing outer
       // cache behaviour. Workers Cache itself is unaffected: confirmed
       // empirically that both probe and navigation responses still report
-      // `cf-cache-status: HIT` from the same edge entry.
+      // `cf-cache-status: HIT` from the cache-enabled response entrypoint.
       const res = await fetch(path, { method: "GET", cache: "no-store" });
       const markers = await extractRenderMarkers(res);
       setState({
@@ -148,8 +146,6 @@ export function CacheStatusProbe({ path }: { path: string }) {
         cfCacheStatus: res.headers.get("cf-cache-status"),
         age: res.headers.get("age"),
         cacheControl: res.headers.get("cache-control"),
-        cdnCacheControl: res.headers.get("cdn-cache-control"),
-        cacheTag: res.headers.get("cache-tag"),
         cfRay: res.headers.get("cf-ray"),
         fetchedAt: new Date().toLocaleTimeString(),
         renderId: markers.renderId,
@@ -183,8 +179,9 @@ export function CacheStatusProbe({ path }: { path: string }) {
         Issues a no-store <code>fetch</code> against the route. The route embeds a fresh{" "}
         <code>render-id</code> into every server-rendered response — comparing it across probes is
         the most reliable way to tell whether SSR actually happened or a cache served the same
-        bytes again. <code>cf-cache-status</code> is shown alongside as the outer Workers Cache
-        verdict.
+        bytes again. <code>cf-cache-status</code> is shown alongside as the cached response
+        entrypoint verdict. Cache admission and tag headers are private to that entrypoint and are
+        consumed before this public response.
       </p>
 
       {verdict ? <SsrBadge verdict={verdict} /> : null}
@@ -219,10 +216,6 @@ export function CacheStatusProbe({ path }: { path: string }) {
         <dd>{state?.age ?? "—"}</dd>
         <dt>Cache-Control</dt>
         <dd>{state?.cacheControl ?? "—"}</dd>
-        <dt>CDN-Cache-Control</dt>
-        <dd>{state?.cdnCacheControl ?? "—"}</dd>
-        <dt>Cache-Tag</dt>
-        <dd>{state?.cacheTag ?? "—"}</dd>
         <dt>cf-ray</dt>
         <dd>{state?.cfRay ?? "—"}</dd>
         <dt>Probed at</dt>

--- a/examples/workers-cache/app/page.tsx
+++ b/examples/workers-cache/app/page.tsx
@@ -9,8 +9,8 @@ export default function HomePage() {
       <h1>Request-context cache demo</h1>
       <p className="tagline">
         vinext supports route-level caching through whatever cache the runtime exposes on{" "}
-        <code>ctx.cache</code>. ISR responses carry <code>Cache-Control</code> and{" "}
-        <code>Cache-Tag</code> headers, and <code>revalidateTag()</code> /{" "}
+        <code>ctx.cache</code>. The cache-enabled entrypoint consumes private cache policy and tag
+        headers, while <code>revalidateTag()</code> /{" "}
         <code>revalidatePath()</code> automatically fan out to <code>ctx.cache.purge(...)</code>{" "}
         alongside the inner <code>CacheHandler</code>. Deployed here on Cloudflare Workers (which{" "}
         <a href="https://developers.cloudflare.com/workers/cache/" target="_blank" rel="noreferrer">

--- a/examples/workers-cache/wrangler.jsonc
+++ b/examples/workers-cache/wrangler.jsonc
@@ -25,8 +25,5 @@
       "enabled": true,
     },
   },
-  "cache": {
-    "enabled": true,
-  },
   "kv_namespaces": [{ "binding": "VINEXT_KV_CACHE", "id": "b38f84f642aa4bd4ba17a37bb516f0b5" }],
 }

--- a/packages/cloudflare/README.md
+++ b/packages/cloudflare/README.md
@@ -9,8 +9,8 @@ This package provides Cloudflare-specific cache and image backends for vinext:
   data cache (`fetch`, `"use cache"`, `unstable_cache`) with a Workers KV
   namespace.
 - **`cdnAdapter()`** (`@vinext/cloudflare/cache/cdn-adapter`) — delegates
-  page-level ISR serving and revalidation to Cloudflare Workers Cache. This is
-  opt-in and requires Workers Cache to be enabled in Wrangler config.
+  page-level ISR serving and revalidation to Cloudflare Workers Cache through
+  an automatically generated cache-enabled response entrypoint.
 - **`imagesOptimizer()`** (`@vinext/cloudflare/images/images-optimizer`) — backs
   `next/image` transformations with a Cloudflare Images binding.
 
@@ -37,19 +37,13 @@ export default defineConfig({
 
 ### Workers Cache
 
-`cdnAdapter()` is optional. Only configure it when Workers Cache is enabled in
-`wrangler.jsonc`:
-
-```jsonc
-{
-  "cache": {
-    "enabled": true,
-  },
-  "version_metadata": {
-    "binding": "CF_VERSION_METADATA",
-  },
-}
-```
+`cdnAdapter()` is optional. Configuring it asks the Cloudflare build for two
+Worker entrypoints: the default entrypoint runs middleware and request-time
+routing with caching disabled, while `VinextCachedResponse` lazily loads the
+render stage with Workers Cache enabled. These settings are written to the
+generated `dist/server/wrangler.json`; do not enable Workers Cache on the
+default entrypoint in your source config. The generated config also declares
+the version metadata binding used for staged warmup.
 
 ```ts
 import { cdnAdapter } from "@vinext/cloudflare/cache/cdn-adapter";
@@ -57,19 +51,19 @@ import { cdnAdapter } from "@vinext/cloudflare/cache/cdn-adapter";
 vinext({ cache: { cdn: cdnAdapter() } });
 ```
 
-The version metadata binding lets staged warmup prove that every discovery,
-probe, and fill request reached the uploaded Worker version. Wrangler named
-environments do not inherit `version_metadata`; repeat the binding inside every
-`env.<name>` used with CDN warming.
+The generated version metadata binding lets staged warmup prove that every
+discovery, probe, and fill request reached the uploaded Worker version. Pass
+`versionMetadataBinding` to `cdnAdapter()` only when the deployment needs a
+custom binding name.
 
 Use `--experimental-warm-cdn-cache` for the two-stage deploy. The default flow
 makes one final fill request per admitted identity. Add `--warm-cdn-certify`
 only when you want an opt-in second, header-only request that must prove every
 planned entry reusable before promotion.
 
-Do not configure a Cache Rule that ignores or normalizes query strings for
-these responses. The two-stage cacheability manifest authorizes the full
-pathname + query identity, but an edge HIT happens before Worker admission.
+The response entrypoint hashes the complete transport identity into its
+Workers Cache URL, independently of zone Cache Rules, so distinct query and
+representation variants cannot collide.
 
 ## Deploy
 

--- a/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
@@ -13,10 +13,13 @@
  *   cache headers, so there is nothing to persist at the origin.
  * - `buildResponseHeaders` emits the SWR policy as `Cloudflare-CDN-Cache-Control`
  *   (`public, max-age=…, stale-while-revalidate=…`) so the edge caches and
- *   revalidates, while the browser-facing `Cache-Control` is
+ *   revalidates. The inner response's `Cache-Control` is
  *   `public, max-age=0, must-revalidate` so a browser never serves a stored copy
- *   without revalidating against the edge. A `Cache-Tag` header lets entries be
- *   purged by tag. Note the edge directive uses `max-age` (not `s-maxage`):
+ *   without revalidating against the edge; the uncached gateway changes that to
+ *   `private, max-age=0, must-revalidate` before public egress so personalized
+ *   request-stage headers cannot enter another shared cache. A `Cache-Tag`
+ *   header lets entries be purged by tag. Note the edge directive uses `max-age`
+ *   (not `s-maxage`):
  *   the framework computes the policy with `s-maxage` for shared caches, but
  *   `Cloudflare-CDN-Cache-Control` is already CDN-scoped so `max-age` is the correct knob
  *   for the edge to honor max-age + stale-while-revalidate.


### PR DESCRIPTION
Part 15 of 16 in the staged CDN adapter stack. Depends on #3158.

## Summary

- documents the generated uncached gateway and cache-enabled response entrypoint
- removes the obsolete source-level `cache.enabled` setting from the Workers Cache example
- explains transport-key isolation from zone Cache Rules and how to inspect cache behavior

## Validation

- workers-cache example production build
- formatting and diff checks
- cumulative exact-tip changed-test sweep: 3,461 passed, 2 skipped

## Review size

- Implementation: +6 / -3 LOC
- Tests and fixtures: +0 / -0 LOC
- Other (docs, config, lockfile): +79 / -84 LOC
- 7 changed files

Measured against `codex/cdn-v2-cache-tags` after rebasing onto `main@a6931c0`.