### PR TITLE
test(cloudflare): cover late-dynamic HTML isolation

### DIFF
--- a/examples/workers-cache/README.md
+++ b/examples/workers-cache/README.md
@@ -35,7 +35,7 @@ manifest identities before the Worker runs.
 
 - ISR-cached App Router page at `/cached/[slug]` (`revalidate = 60`).
 - Cached App Route handler at `/api/now` (`revalidate = 30`).
-- Force-dynamic comparison page at `/dynamic`.
+- Late-dynamic personalized comparison page at `/dynamic`.
 - Revalidation API at `/api/revalidate-tag` and `/api/revalidate-path` that
   drives the UI's "Invalidate this page" controls.
 - A client-side **probe** that issues a no-store fetch against a route and

--- a/examples/workers-cache/app/dynamic/page.tsx
+++ b/examples/workers-cache/app/dynamic/page.tsx
@@ -1,14 +1,40 @@
 import Link from "next/link";
+import { cookies } from "next/headers";
+import { Suspense } from "react";
 import { CacheStatusProbe } from "../components/cache-status-probe";
 
-// Comparison page: force-dynamic. The Worker runs on every request. vinext
-// emits `Cache-Control: private, no-cache, no-store, ...` so the outer
-// Workers Cache layer must not cache the response.
-export const dynamic = "force-dynamic";
+export const revalidate = 60;
 
-export default function DynamicPage() {
+async function LateDynamicViewer() {
+  // Ensure the response stream exists before the request-bound API is read.
+  // This reproduces the unsafe timing where public CDN headers could be exposed
+  // before a late dynamic read marks the completed render private.
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  const viewer = (await cookies()).get("session")?.value ?? "anonymous";
   const renderedAt = new Date().toISOString();
   const renderId = crypto.randomUUID();
+
+  return (
+    <div
+      className="timestamp"
+      data-testid="late-dynamic-viewer"
+      data-late-dynamic-viewer={viewer}
+      data-late-dynamic-render-id={renderId}
+      data-render-id={renderId}
+      data-render-time={renderedAt}
+    >
+      <p>
+        Viewer: <code>{viewer}</code>
+      </p>
+      <p>
+        Render ID: <code>{renderId}</code>
+      </p>
+      <p>Rendered at: {renderedAt}</p>
+    </div>
+  );
+}
+
+export default function DynamicPage() {
   return (
     <main>
       <nav className="crumbs">
@@ -18,22 +44,14 @@ export default function DynamicPage() {
         <code>/dynamic</code>
       </h1>
       <p className="tagline">
-        Bypass case for comparison. <code>force-dynamic</code> means vinext emits{" "}
-        <code>no-store</code> headers, so neither the outer <code>ctx.cache</code> nor the
-        inner CacheHandler retains anything. The timestamp updates on every reload — every
-        probe should produce a fresh <code>render-id</code>.
+        Bypass case for comparison. This page reads <code>cookies()</code> from a delayed
+        Suspense boundary, after streaming starts. The completed render is dynamic, so neither
+        the outer <code>ctx.cache</code> nor the inner CacheHandler may retain its personalized
+        HTML.
       </p>
-      <div
-        className="timestamp"
-        data-testid="rendered-at"
-        data-render-id={renderId}
-        data-render-time={renderedAt}
-      >
-        {renderedAt}
-      </div>
-      <p>
-        Render ID: <code>{renderId}</code>
-      </p>
+      <Suspense fallback={<p data-testid="late-dynamic-fallback">Resolving viewer…</p>}>
+        <LateDynamicViewer />
+      </Suspense>
       <CacheStatusProbe path="/dynamic" />
     </main>
   );

--- a/examples/workers-cache/app/page.tsx
+++ b/examples/workers-cache/app/page.tsx
@@ -63,8 +63,8 @@ export default function HomePage() {
             <span className="badge">Dynamic</span> Always-fresh
           </h3>
           <p>
-            <code>force-dynamic</code> for comparison. The Worker runs on every request and the
-            outer cache is bypassed.
+            A delayed <code>cookies()</code> read for comparison. The Worker completes the
+            personalized stream privately on every request and the outer cache is bypassed.
           </p>
           <Link prefetch={false} href="/dynamic">Open /dynamic &rarr;</Link>
         </div>

--- a/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
+++ b/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
@@ -162,7 +162,7 @@ async function waitForStablePromotion({
   );
 }
 
-test("deploy-prewarmed App, Pages, and RSC variants are reused", async ({
+test("deploy-prewarmed variants are reused and late-dynamic HTML stays private", async ({
   baseURL,
   browser,
   playwright,
@@ -176,6 +176,9 @@ test("deploy-prewarmed App, Pages, and RSC variants are reused", async ({
   const rscBuildId = fs
     .readFileSync("examples/workers-cache/dist/server/RSC_BUILD_ID", "utf-8")
     .trim();
+  const { prerenderSecret } = JSON.parse(
+    fs.readFileSync("examples/workers-cache/dist/server/vinext-server.json", "utf-8"),
+  ) as { prerenderSecret: string };
 
   // Match a browser navigation and the HTML request emitted by cdn-warm.ts.
   // Playwright's APIRequestContext otherwise sends `Accept: */*`, which is a
@@ -377,6 +380,57 @@ test("deploy-prewarmed App, Pages, and RSC variants are reused", async ({
     expect(dynamic.headers()["cache-control"]).toContain("no-store");
     expect(dynamic.headers()["cf-cache-status"]).toBe("BYPASS");
   });
+
+  // The App Page starts streaming before its Suspense child reads cookies(), so
+  // the first response must remain private all the way through clean EOF. A
+  // public header here would let Workers Cache replay Alice's authenticated
+  // HTML to Bob at this exact URL.
+  const disclosureUrl = `${baseURL}/dynamic?cache-case=${Date.now()}`;
+  const classification = await getResponseAfterPromotion(request, disclosureUrl, {
+    accept: "text/html",
+    "x-vinext-cacheability-probe": "1",
+    "x-vinext-prerender-secret": prerenderSecret,
+  });
+  await expect(classification.json()).resolves.toMatchObject({
+    kind: "app-page",
+    pattern: "/dynamic",
+    reason: "dynamic API used during render",
+    state: "dynamic",
+  });
+  expect(classification.headers()["cache-control"]).toContain("no-store");
+  expect(classification.headers()["cdn-cache-control"]).toBeUndefined();
+
+  const alice = await getResponseAfterPromotion(request, disclosureUrl, {
+    accept: "text/html",
+    cookie: "session=alice",
+  });
+  const aliceHtml = await alice.text();
+  expect(alice.ok(), JSON.stringify(alice.headers())).toBe(true);
+  expect(alice.headers()["cf-cache-status"]).toBe("BYPASS");
+  expect(alice.headers()["cache-control"]).toContain("no-store");
+  expect(alice.headers()["cdn-cache-control"]).toBeUndefined();
+  expect(alice.headers()["cloudflare-cdn-cache-control"]).toBeUndefined();
+  expect((alice.headers().vary ?? "").toLowerCase().split(/,\s*/)).not.toContain("cookie");
+  expect(aliceHtml).toContain('data-late-dynamic-viewer="alice"');
+  const aliceRenderId = /data-late-dynamic-render-id="([^"]+)"/.exec(aliceHtml)?.[1];
+  expect(aliceRenderId).toBeTruthy();
+
+  const bob = await getResponseAfterPromotion(request, disclosureUrl, {
+    accept: "text/html",
+    cookie: "session=bob",
+  });
+  const bobHtml = await bob.text();
+  expect(bob.ok(), JSON.stringify(bob.headers())).toBe(true);
+  expect(bob.headers()["cf-cache-status"]).toBe("BYPASS");
+  expect(bob.headers()["cache-control"]).toContain("no-store");
+  expect(bob.headers()["cdn-cache-control"]).toBeUndefined();
+  expect(bob.headers()["cloudflare-cdn-cache-control"]).toBeUndefined();
+  expect((bob.headers().vary ?? "").toLowerCase().split(/,\s*/)).not.toContain("cookie");
+  expect(bobHtml).toContain('data-late-dynamic-viewer="bob"');
+  expect(bobHtml).not.toContain('data-late-dynamic-viewer="alice"');
+  const bobRenderId = /data-late-dynamic-render-id="([^"]+)"/.exec(bobHtml)?.[1];
+  expect(bobRenderId).toBeTruthy();
+  expect(bobRenderId).not.toBe(aliceRenderId);
 
   const purgeResponse = await request.post(`${baseURL}/api/revalidate-path`, {
     data: { path: TARGET_PATH },


### PR DESCRIPTION
## What this validates

- exercises a real App Router page that declares ISR eligibility but reads `cookies()` from a delayed Suspense child
- verifies the authenticated cacheability probe classifies the completed render as dynamic
- requests the same edge URL as two viewers and verifies Workers Cache bypasses both responses
- verifies the responses remain `no-store`, do not expose CDN cache-control headers, do not vary on `Cookie`, and never replay one viewer's HTML to the other

This extends the existing deployed `workers-cache` Playwright flow, so the assertion runs against an ephemeral Cloudflare Worker with the Workers Cache adapter enabled rather than a local cache double.

## Next.js parity

Next.js treats `cookies()` as a Dynamic API whose returned values cannot be known ahead of time. The fixture intentionally combines it with `revalidate = 60` so the dynamic API observed during rendering must win over the static route hint.

Reference: https://nextjs.org/docs/app/api-reference/functions/cookies#good-to-know

## Validation

Current PR head:

- live `Deploy workers-cache` job passed the two-stage warmup and deployed Playwright regression
- `deploy-prewarmed variants are reused and late-dynamic HTML stays private`: 1 passed
- complete PR check rollup is green

Negative control:

- checked out `8da2d8044`, the parent of the first cacheability-stack commit
- applied only the delayed personalized route fixture and deployed it as an isolated Worker
- Alice's first request was a cacheable `MISS` with `CDN-Cache-Control: public, max-age=60, ...`
- Bob's request to the identical URL was a `HIT` containing Alice's viewer value and Alice's render ID
- running the fixed-version invariants exited nonzero as expected

Local validation:

- `vp run vinext#build`
- `vp run @vinext/cloudflare#build`
- `vp build` in `examples/workers-cache`
- local `wrangler dev` requests confirmed distinct viewer HTML and render IDs with `Cache-Control: no-store`
- authenticated local cacheability probe returned `state: dynamic` with `reason: dynamic API used during render`
- `vp check tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts`
- `git diff --check`
