### PR TITLE
feat(cloudflare): summarize CDN warmup by route

### DIFF
--- a/packages/cloudflare/src/cdn-warm.ts
+++ b/packages/cloudflare/src/cdn-warm.ts
@@ -444,13 +444,15 @@ export type CdnWarmTarget = {
 };
 
 const MAX_CDN_WARM_REPORT_ROUTES = 10;
+const MAX_CDN_WARM_REPORT_PATTERN_WIDTH = 48;
 
 type CdnWarmReportOutcome = "failed" | "skipped" | "warmed";
 
 type CdnWarmRouteReport = {
   failed: number;
+  kind: string;
   key: string;
-  label: string;
+  pattern: string;
   paths: Set<string>;
   skipped: number;
   total: number;
@@ -467,6 +469,36 @@ function formatCount(count: number, singular: string, plural = `${singular}s`): 
   return `${count.toLocaleString("en-US")} ${count === 1 ? singular : plural}`;
 }
 
+function formatNumber(count: number): string {
+  return count.toLocaleString("en-US");
+}
+
+function truncateMiddle(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  const remaining = maxLength - 1;
+  const startLength = Math.ceil(remaining / 2);
+  return `${value.slice(0, startLength)}…${value.slice(-(remaining - startLength))}`;
+}
+
+function printCdnWarmTable(
+  headings: readonly string[],
+  rows: readonly (readonly string[])[],
+  rightAlignedFrom: number,
+): void {
+  const widths = headings.map((heading, index) =>
+    Math.max(heading.length, ...rows.map((row) => row[index]?.length ?? 0)),
+  );
+  for (const row of [headings, ...rows]) {
+    console.log(
+      `    ${row
+        .map((value, index) =>
+          index >= rightAlignedFrom ? value.padStart(widths[index]) : value.padEnd(widths[index]),
+        )
+        .join("  ")}`,
+    );
+  }
+}
+
 function createCdnWarmRouteReport(
   targets: readonly CdnWarmTarget[],
   outcomes?: readonly CdnWarmReportOutcome[],
@@ -478,10 +510,9 @@ function createCdnWarmRouteReport(
       routes.get(key) ??
       ({
         failed: 0,
+        kind: target.route ? CDN_WARM_ROUTE_KIND_LABELS[target.route.kind] : "Other",
         key,
-        label: target.route
-          ? `${CDN_WARM_ROUTE_KIND_LABELS[target.route.kind]} ${target.route.pattern}`
-          : "Other discovered requests",
+        pattern: target.route?.pattern ?? "Other discovered requests",
         paths: new Set<string>(),
         skipped: 0,
         total: 0,
@@ -510,20 +541,32 @@ function printCdnWarmRouteReport(
   if (routes.length === 0) return;
 
   console.log(`  CDN warmup ${outcomes ? "result" : "plan"} by route:`);
-  for (const route of routes.slice(0, MAX_CDN_WARM_REPORT_ROUTES)) {
-    if (outcomes) {
-      const exceptions = [
-        route.skipped > 0 ? formatCount(route.skipped, "skipped entry", "skipped entries") : null,
-        route.failed > 0 ? formatCount(route.failed, "failed entry", "failed entries") : null,
-      ].filter(Boolean);
-      console.log(
-        `    ${route.label}: ${route.warmed.toLocaleString("en-US")}/${route.total.toLocaleString("en-US")} warmed${exceptions.length > 0 ? `, ${exceptions.join(", ")}` : ""}`,
-      );
-    } else {
-      console.log(
-        `    ${route.label}: ${formatCount(route.paths.size, "path")}, ${formatCount(route.total, "cache entry", "cache entries")}`,
-      );
-    }
+  const visible = routes.slice(0, MAX_CDN_WARM_REPORT_ROUTES);
+  const routeColumns = (route: CdnWarmRouteReport) => [
+    truncateMiddle(route.pattern, MAX_CDN_WARM_REPORT_PATTERN_WIDTH),
+    route.kind,
+  ];
+  if (outcomes) {
+    printCdnWarmTable(
+      ["Route pattern", "Kind", "Warmed", "Skipped", "Failed"],
+      visible.map((route) => [
+        ...routeColumns(route),
+        `${formatNumber(route.warmed)}/${formatNumber(route.total)}`,
+        formatNumber(route.skipped),
+        formatNumber(route.failed),
+      ]),
+      2,
+    );
+  } else {
+    printCdnWarmTable(
+      ["Route pattern", "Kind", "Paths", "Entries"],
+      visible.map((route) => [
+        ...routeColumns(route),
+        formatNumber(route.paths.size),
+        formatNumber(route.total),
+      ]),
+      2,
+    );
   }
 
   const omitted = routes.slice(MAX_CDN_WARM_REPORT_ROUTES);

--- a/packages/cloudflare/src/cdn-warm.ts
+++ b/packages/cloudflare/src/cdn-warm.ts
@@ -29,6 +29,7 @@ import {
   VINEXT_PRERENDER_READINESS_PATH,
   VINEXT_PRERENDER_SECRET_HEADER,
 } from "vinext/internal/server/headers";
+import { cacheabilityRoutePathname } from "vinext/internal/server/cacheability-manifest";
 import { VINEXT_CDN_BUILD_ID_HEADER } from "./cache/cdn-build-id.js";
 
 export type CdnWarmOptions = {
@@ -441,6 +442,98 @@ export type CdnWarmTarget = {
   sourcePathname: string;
   route?: PrerenderRoutePattern;
 };
+
+const MAX_CDN_WARM_REPORT_ROUTES = 10;
+
+type CdnWarmReportOutcome = "failed" | "skipped" | "warmed";
+
+type CdnWarmRouteReport = {
+  failed: number;
+  key: string;
+  label: string;
+  paths: Set<string>;
+  skipped: number;
+  total: number;
+  warmed: number;
+};
+
+const CDN_WARM_ROUTE_KIND_LABELS = {
+  "app-page": "App page",
+  "app-route": "Route Handler",
+  "pages-page": "Pages page",
+} as const;
+
+function formatCount(count: number, singular: string, plural = `${singular}s`): string {
+  return `${count.toLocaleString("en-US")} ${count === 1 ? singular : plural}`;
+}
+
+function createCdnWarmRouteReport(
+  targets: readonly CdnWarmTarget[],
+  outcomes?: readonly CdnWarmReportOutcome[],
+): CdnWarmRouteReport[] {
+  const routes = new Map<string, CdnWarmRouteReport>();
+  for (const [index, target] of targets.entries()) {
+    const key = target.route ? `${target.route.kind}\0${target.route.pattern}` : "unmatched";
+    const route =
+      routes.get(key) ??
+      ({
+        failed: 0,
+        key,
+        label: target.route
+          ? `${CDN_WARM_ROUTE_KIND_LABELS[target.route.kind]} ${target.route.pattern}`
+          : "Other discovered requests",
+        paths: new Set<string>(),
+        skipped: 0,
+        total: 0,
+        warmed: 0,
+      } satisfies CdnWarmRouteReport);
+    route.paths.add(
+      target.route?.cacheabilityProbe?.concretePathname ??
+        cacheabilityRoutePathname(target.pathname, target.kind),
+    );
+    route.total++;
+    const outcome = outcomes?.[index];
+    if (outcome) route[outcome]++;
+    routes.set(key, route);
+  }
+  return [...routes.values()].sort(
+    (left, right) => right.total - left.total || left.key.localeCompare(right.key),
+  );
+}
+
+function printCdnWarmRouteReport(
+  targets: readonly CdnWarmTarget[],
+  outcomes?: readonly CdnWarmReportOutcome[],
+): void {
+  if (!targets.some((target) => target.route)) return;
+  const routes = createCdnWarmRouteReport(targets, outcomes);
+  if (routes.length === 0) return;
+
+  console.log(`  CDN warmup ${outcomes ? "result" : "plan"} by route:`);
+  for (const route of routes.slice(0, MAX_CDN_WARM_REPORT_ROUTES)) {
+    if (outcomes) {
+      const exceptions = [
+        route.skipped > 0 ? formatCount(route.skipped, "skipped entry", "skipped entries") : null,
+        route.failed > 0 ? formatCount(route.failed, "failed entry", "failed entries") : null,
+      ].filter(Boolean);
+      console.log(
+        `    ${route.label}: ${route.warmed.toLocaleString("en-US")}/${route.total.toLocaleString("en-US")} warmed${exceptions.length > 0 ? `, ${exceptions.join(", ")}` : ""}`,
+      );
+    } else {
+      console.log(
+        `    ${route.label}: ${formatCount(route.paths.size, "path")}, ${formatCount(route.total, "cache entry", "cache entries")}`,
+      );
+    }
+  }
+
+  const omitted = routes.slice(MAX_CDN_WARM_REPORT_ROUTES);
+  if (omitted.length > 0) {
+    const omittedEntries = omitted.reduce((total, route) => total + route.total, 0);
+    console.log(
+      `    ... ${formatCount(omitted.length, "additional route pattern")} omitted (${formatCount(omittedEntries, "cache entry", "cache entries")})`,
+    );
+  }
+}
 
 export async function createCdnWarmTargets(
   options: Pick<
@@ -1246,7 +1339,10 @@ export async function warmCdnCache(options: CdnWarmOptions): Promise<CdnWarmResu
     };
   }
 
-  console.log(`\n  Warming CDN cache with ${requests.length} discovered request(s)...`);
+  console.log(
+    `\n  Warming ${formatCount(requests.length, "CDN cache entry", "CDN cache entries")}...`,
+  );
+  printCdnWarmRouteReport(requests);
 
   const progress = new CdnOperationProgress();
   let completedRequests = 0;
@@ -1373,6 +1469,10 @@ export async function warmCdnCache(options: CdnWarmOptions): Promise<CdnWarmResu
     .filter(({ target }) => target.kind === "app-route")
     .map(({ target }) => target.sourcePathname);
 
+  printCdnWarmRouteReport(
+    requests,
+    results.map((result) => (!result.ok ? "failed" : result.skipped ? "skipped" : "warmed")),
+  );
   console.log(
     `  CDN warmup: ${warmed} warmed, ${skippedResults.length} skipped, ${failures.length} failed.`,
   );

--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -1089,6 +1089,7 @@ async function deployUploadedVersionWithCdnWarmup(
           pagesDataPaths: remainingWarmPlan.pagesDataPaths,
           paths: remainingWarmPlan.paths,
           routeHandlerPaths: remainingWarmPlan.routeHandlerPaths,
+          routePatterns: remainingWarmPlan.routePatterns,
           rscPaths: remainingWarmPlan.rscPaths,
         };
         const stagedWarmRequests =

--- a/tests/cloudflare-cdn-warm-deploy.test.ts
+++ b/tests/cloudflare-cdn-warm-deploy.test.ts
@@ -631,9 +631,9 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       "promote-final",
     ]);
     expect(log).toHaveBeenCalledWith("  CDN warmup plan by route:");
-    expect(log).toHaveBeenCalledWith("    App page /:slug: 2 paths, 3 cache entries");
-    expect(log).toHaveBeenCalledWith("    Pages page /pages-about: 2/2 warmed");
-    expect(log).toHaveBeenCalledWith("    Route Handler /api/data: 1/1 warmed");
+    expect(log).toHaveBeenCalledWith("    /:slug         App page           2        3");
+    expect(log).toHaveBeenCalledWith("    /pages-about   Pages page        2/2        0       0");
+    expect(log).toHaveBeenCalledWith("    /api/data      Route Handler     1/1        0       0");
     log.mockRestore();
     expect(finalConfig).toEqual({ main: "index.js", name: "my-worker", workers_dev: true });
     const manifestJson = JSON.parse(

--- a/tests/cloudflare-cdn-warm-deploy.test.ts
+++ b/tests/cloudflare-cdn-warm-deploy.test.ts
@@ -394,6 +394,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
 
   it("warms concrete static paths while tolerating a private paired representation", async () => {
     writeTwoStageWorkerArtifact();
+    const log = vi.spyOn(console, "log");
     const events: string[] = [];
     let uploadCount = 0;
     let statusCount = 0;
@@ -629,6 +630,11 @@ describe("Cloudflare CDN warmup deploy flow", () => {
       "status-6",
       "promote-final",
     ]);
+    expect(log).toHaveBeenCalledWith("  CDN warmup plan by route:");
+    expect(log).toHaveBeenCalledWith("    App page /:slug: 2 paths, 3 cache entries");
+    expect(log).toHaveBeenCalledWith("    Pages page /pages-about: 2/2 warmed");
+    expect(log).toHaveBeenCalledWith("    Route Handler /api/data: 1/1 warmed");
+    log.mockRestore();
     expect(finalConfig).toEqual({ main: "index.js", name: "my-worker", workers_dev: true });
     const manifestJson = JSON.parse(
       finalManifestSource.slice("export default ".length, -2),

--- a/tests/cloudflare-cdn-warm.test.ts
+++ b/tests/cloudflare-cdn-warm.test.ts
@@ -372,11 +372,11 @@ describe("Cloudflare CDN warmup", () => {
 
     expect(log).toHaveBeenCalledWith("\n  Warming 3 CDN cache entries...");
     expect(log).toHaveBeenCalledWith("  CDN warmup plan by route:");
-    expect(log).toHaveBeenCalledWith("    App page /products/:slug: 3 paths, 3 cache entries");
+    expect(log).toHaveBeenCalledWith("    Route pattern    Kind      Paths  Entries");
+    expect(log).toHaveBeenCalledWith("    /products/:slug  App page      3        3");
     expect(log).toHaveBeenCalledWith("  CDN warmup result by route:");
-    expect(log).toHaveBeenCalledWith(
-      "    App page /products/:slug: 1/3 warmed, 1 skipped entry, 1 failed entry",
-    );
+    expect(log).toHaveBeenCalledWith("    Route pattern    Kind      Warmed  Skipped  Failed");
+    expect(log).toHaveBeenCalledWith("    /products/:slug  App page     1/3        1       1");
     expect(log).toHaveBeenCalledWith("  CDN warmup: 1 warmed, 1 skipped, 1 failed.");
   });
 
@@ -414,8 +414,8 @@ describe("Cloudflare CDN warmup", () => {
     });
 
     const output = log.mock.calls.map(([message]) => String(message)).join("\n");
-    expect(output).toContain("    App page /catalog-00/:slug: 2 paths, 2 cache entries");
-    expect(output).toContain("    App page /catalog-00/:slug: 2/2 warmed");
+    expect(output).toMatch(/\/catalog-00\/:slug\s+App page\s+2\s+2/);
+    expect(output).toMatch(/\/catalog-00\/:slug\s+App page\s+2\/2\s+0\s+0/);
     expect(output.match(/2 additional route patterns omitted \(4 cache entries\)/g)).toHaveLength(
       2,
     );

--- a/tests/cloudflare-cdn-warm.test.ts
+++ b/tests/cloudflare-cdn-warm.test.ts
@@ -321,6 +321,108 @@ describe("Cloudflare CDN warmup", () => {
     expect(requestHref(fetchImpl.mock.calls[0]?.[0])).toBe("https://app.example.com/api/data");
   });
 
+  it("reports planned and completed cache entries by route pattern", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const paths = ["/products/warmed", "/products/private", "/products/failed"];
+    const routePatterns = Object.fromEntries(
+      paths.map((pathname) => [
+        pathname,
+        {
+          cacheabilityProbe: { canPrunePattern: true },
+          kind: "app-page" as const,
+          pattern: "/products/:slug",
+        },
+      ]),
+    );
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const pathname = new URL(requestHref(input)!).pathname;
+      if (pathname === "/products/private") {
+        return new Response("private", {
+          headers: {
+            "cache-control": "no-store",
+            "cf-cache-status": "BYPASS",
+            "content-type": "text/html",
+            [VINEXT_CDN_BUILD_ID_HEADER]: "build-a",
+          },
+        });
+      }
+      if (pathname === "/products/failed") {
+        return new Response("failed", {
+          status: 500,
+          headers: {
+            "content-type": "text/html",
+            [VINEXT_CDN_BUILD_ID_HEADER]: "build-a",
+          },
+        });
+      }
+      return cacheableHtml();
+    });
+
+    await expect(
+      warmCdnCache({
+        expectedBuildId: "build-a",
+        fetchImpl: fetchImpl as typeof fetch,
+        paths,
+        retries: 0,
+        routePatterns,
+        targetUrl: "https://app.example.com",
+      }),
+    ).resolves.toMatchObject({ failed: 1, skipped: 1, warmed: 1 });
+
+    expect(log).toHaveBeenCalledWith("\n  Warming 3 CDN cache entries...");
+    expect(log).toHaveBeenCalledWith("  CDN warmup plan by route:");
+    expect(log).toHaveBeenCalledWith("    App page /products/:slug: 3 paths, 3 cache entries");
+    expect(log).toHaveBeenCalledWith("  CDN warmup result by route:");
+    expect(log).toHaveBeenCalledWith(
+      "    App page /products/:slug: 1/3 warmed, 1 skipped entry, 1 failed entry",
+    );
+    expect(log).toHaveBeenCalledWith("  CDN warmup: 1 warmed, 1 skipped, 1 failed.");
+  });
+
+  it("caps route reports without listing concrete paths for large apps", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const paths: string[] = [];
+    const routePatterns: Record<
+      string,
+      {
+        cacheabilityProbe: { canPrunePattern: boolean };
+        kind: "app-page";
+        pattern: string;
+      }
+    > = {};
+    for (let routeIndex = 0; routeIndex < 12; routeIndex++) {
+      const pattern = `/catalog-${String(routeIndex).padStart(2, "0")}/:slug`;
+      for (const slug of ["first", "second"]) {
+        const pathname = pattern.replace(":slug", slug);
+        paths.push(pathname);
+        routePatterns[pathname] = {
+          cacheabilityProbe: { canPrunePattern: true },
+          kind: "app-page",
+          pattern,
+        };
+      }
+    }
+
+    await warmCdnCache({
+      expectedBuildId: "build-a",
+      fetchImpl: (async () => cacheableHtml()) as typeof fetch,
+      paths,
+      retries: 0,
+      routePatterns,
+      targetUrl: "https://app.example.com",
+    });
+
+    const output = log.mock.calls.map(([message]) => String(message)).join("\n");
+    expect(output).toContain("    App page /catalog-00/:slug: 2 paths, 2 cache entries");
+    expect(output).toContain("    App page /catalog-00/:slug: 2/2 warmed");
+    expect(output.match(/2 additional route patterns omitted \(4 cache entries\)/g)).toHaveLength(
+      2,
+    );
+    expect(output).not.toContain("/catalog-00/first");
+    expect(output).not.toContain("/catalog-11/:slug");
+  });
+
   it("counts coherent no-store/BYPASS responses as skipped, including in strict mode", async () => {
     const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
       const isRsc = new Headers(init?.headers).get("rsc") === "1";


### PR DESCRIPTION
## Summary

- print compact, aligned warm-plan and warm-result tables grouped by route kind and route pattern
- distinguish unique concrete paths from the cache entries actually requested (for example, HTML and RSC)
- print per-pattern warmed, skipped, and failed cache-entry counts when warming completes
- cap reports at the ten largest route patterns and summarize omitted patterns instead of dumping concrete paths
- middle-truncate unusually long route patterns while preserving their prefix and suffix
- preserve route ownership metadata through the final staged warm pass so the deploy command can report it

## Example

```text
Warming 6 CDN cache entries...
CDN warmup plan by route:
  Route pattern  Kind           Paths  Entries
  /:slug         App page           2        3
  /pages-about   Pages page         1        2
  /api/data      Route Handler      1        1
CDN warmup result by route:
  Route pattern  Kind           Warmed  Skipped  Failed
  /:slug         App page          1/3        2       0
  /pages-about   Pages page        2/2        0       0
  /api/data      Route Handler     1/1        0       0
CDN warmup: 4 warmed, 2 skipped, 0 failed.
```

## Behavioral scope

This changes deployment reporting only. Route cacheability classification, request selection, cache admission checks, and promotion behavior are unchanged. Next.js does not have an equivalent Cloudflare CDN prewarming deploy phase; its route-oriented build output informed the presentation, while the underlying cache behavior remains aligned with the existing vinext implementation.

## Tests

- `vp test run tests/cloudflare-cdn-warm.test.ts tests/cloudflare-cdn-warm-deploy.test.ts`
- `vp check packages/cloudflare/src/cdn-warm.ts packages/cloudflare/src/deploy.ts tests/cloudflare-cdn-warm.test.ts tests/cloudflare-cdn-warm-deploy.test.ts`
- `vp run @vinext/cloudflare#build`
