### PR TITLE
fix(cloudflare): wait for per-route version propagation

### DIFF
--- a/packages/cloudflare/src/cacheability-probe.ts
+++ b/packages/cloudflare/src/cacheability-probe.ts
@@ -207,7 +207,8 @@ async function probeTarget(options: {
     state: "probe-failed",
     version: 1,
   });
-  for (let attempt = 0; attempt <= options.retries; attempt++) {
+  let ordinaryFailures = 0;
+  for (let attempt = 0; ; attempt++) {
     if (options.getDeadlineAt() - Date.now() <= 0) return phaseTimeoutPayload();
 
     const controller = new AbortController();
@@ -215,6 +216,7 @@ async function probeTarget(options: {
     let timeout: ReturnType<typeof setTimeout> | undefined;
     let timedOutBy: "phase" | "request" | null = null;
     let retryable = true;
+    let retryUntilDeadline = false;
     try {
       const url = new URL(options.target.pathname, options.targetUrl);
       url.searchParams.set(VINEXT_CACHEABILITY_PROBE_QUERY_PARAM, `${probeId}-${attempt}`);
@@ -233,6 +235,7 @@ async function probeTarget(options: {
             kind: "retry" as const,
             reason: "probe reached an unexpected Worker build",
             retryable: true,
+            retryUntilDeadline: true,
           };
         }
         if (!response.ok) {
@@ -241,6 +244,7 @@ async function probeTarget(options: {
             kind: "retry" as const,
             reason: `probe returned HTTP ${response.status}`,
             retryable: response.status === 404 || response.status === 503,
+            retryUntilDeadline: false,
           };
         }
         return { kind: "complete" as const, payload: await readProbeEnvelope(response) };
@@ -268,6 +272,7 @@ async function probeTarget(options: {
       if (result.kind === "complete") return result.payload;
       reason = result.reason;
       retryable = result.retryable;
+      retryUntilDeadline = result.retryUntilDeadline;
     } catch (error) {
       if (timedOutBy === "phase" || Date.now() >= options.getDeadlineAt()) {
         return phaseTimeoutPayload();
@@ -281,7 +286,13 @@ async function probeTarget(options: {
     } finally {
       if (timeout !== undefined) clearTimeout(timeout);
     }
-    if (!retryable || attempt === options.retries) break;
+    // Version overrides can become available at different times for different
+    // cache keys. Readiness on the reserved endpoint therefore cannot prove a
+    // concrete route has reached the staged build. Keep retrying only this
+    // routing mismatch until the no-progress deadline; application/transport
+    // failures retain the caller's bounded retry policy.
+    if (!retryable) break;
+    if (!retryUntilDeadline && ++ordinaryFailures > options.retries) break;
     if (options.retryDelayMs > 0) {
       const delayMs = Math.min(
         options.retryDelayMs,

--- a/tests/cloudflare-cacheability-probe.test.ts
+++ b/tests/cloudflare-cacheability-probe.test.ts
@@ -62,7 +62,7 @@ describe("staged Worker cacheability probes", () => {
     for (const root of roots.splice(0)) fs.rmSync(root, { force: true, recursive: true });
   });
 
-  it("cancels stale Worker bodies before retrying with a hidden request key", async () => {
+  it("retries stale Worker builds until routing reaches the staged version", async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "vinext-cacheability-probe-"));
     roots.push(root);
     fs.mkdirSync(path.join(root, "dist", "server"), { recursive: true });
@@ -115,7 +115,9 @@ describe("staged Worker cacheability probes", () => {
       buildId: "application-build",
       expectedResponseBuildId: "response-build",
       fetchImpl,
-      retries: 2,
+      // A stale build is version-routing propagation, not an application
+      // failure, so it must not consume the ordinary request retry budget.
+      retries: 0,
       retryDelayMs: 0,
       root,
       targetUrl: "https://example.com",
@@ -146,6 +148,30 @@ describe("staged Worker cacheability probes", () => {
       staticPaths: { html: ["/cached/intro"] },
     });
     expect(result.cacheableTargets).toEqual([target]);
+  });
+
+  it("still applies the ordinary retry limit after reaching the staged build", async () => {
+    const root = createProbeRoot();
+    const fetchImpl = vi.fn<typeof fetch>(
+      async () =>
+        new Response("unavailable", {
+          headers: { [VINEXT_CDN_BUILD_ID_HEADER]: "response-build" },
+          status: 503,
+        }),
+    );
+
+    const result = await probeStagedWorkerCacheability({
+      buildId: "application-build",
+      expectedResponseBuildId: "response-build",
+      fetchImpl,
+      retries: 0,
+      root,
+      targetUrl: "https://example.com",
+      targets: [target("/unavailable")],
+    });
+
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(result.failures).toEqual(["/unavailable: probe returned HTTP 503"]);
   });
 
   it("aborts when cacheability probing makes no progress", async () => {

--- a/tests/cloudflare-cdn-warm-deploy.test.ts
+++ b/tests/cloudflare-cdn-warm-deploy.test.ts
@@ -1439,6 +1439,48 @@ describe("Cloudflare CDN warmup deploy flow", () => {
     expect(uploads).toBe(1);
   });
 
+  it("waits for concrete-route version propagation beyond the ordinary probe retry budget", async () => {
+    writeTwoStageWorkerArtifact();
+    const wrangler = mockTwoStageWrangler();
+    let probeAttempts = 0;
+    vi.mocked(fetch).mockImplementation(async (input, init) => {
+      if (new Headers(init?.headers).get(VINEXT_CACHEABILITY_PROBE_HEADER) === "1") {
+        probeAttempts++;
+        if (probeAttempts <= 3) {
+          return new Response("previous Worker build", {
+            headers: { [VINEXT_CDN_BUILD_ID_HEADER]: "previous-build" },
+          });
+        }
+        return appPageProbeResponse();
+      }
+      return isReadinessFetch(input) ? readinessResponse() : cacheableHtml();
+    });
+    const { deployWithCdnWarmup } = await import("../packages/cloudflare/src/deploy.js");
+
+    await expect(
+      deployWithCdnWarmup(tmpDir, [], {
+        cacheabilityProbe: true,
+        config: "dist/server/wrangler.json",
+        discoverWarmPlan: async () => ({
+          appPaths: ["/about"],
+          buildId: "app-build-a",
+          buildIdentity: "app-build-a",
+          loadingShellPaths: [],
+          paths: ["/about"],
+          routePatterns: appPageRoutePatterns(["/about"]),
+          rscPaths: [],
+        }),
+        warmCdnConcurrency: 1,
+        warmCdnProbeRetries: 0,
+        warmCdnPromotionDelay: 0,
+        warmCdnReadinessProbes: 1,
+        warmCdnRetries: 0,
+      }),
+    ).resolves.toBe("https://my-worker.example.workers.dev");
+    expect(probeAttempts).toBe(4);
+    expect(wrangler.promoted).toBe(true);
+  });
+
   it("refuses the final upload when deployment traffic changes during probing", async () => {
     writeTwoStageWorkerArtifact();
     let uploads = 0;


### PR DESCRIPTION
## Summary

- keep retrying concrete-route cacheability probes when Cloudflare routes them to the previous Worker build
- bound those propagation retries by the existing no-progress deadline
- preserve the configured retry limit for application and transport failures

## Root cause

Main deployment [33652076723](https://github.com/cloudflare/vinext/actions/runs/33652076723/job/100321331874) passed staged readiness, but `/benchmarks` reached the previous Worker build for all three route-probe attempts. Route probes had only two retries one second apart even though the existing cacheability phase watchdog allows 120 seconds without progress. Readiness on the reserved endpoint does not prove that every concrete route key has converged to the staged version.

This is Cloudflare deployment orchestration; Next.js has no Worker-version override equivalent. Cacheability classification and runtime cache behavior are unchanged.

## Tests

- `vp test run tests/cloudflare-cacheability-probe.test.ts tests/cloudflare-cdn-warm-deploy.test.ts`
- `vp check packages/cloudflare/src/cacheability-probe.ts tests/cloudflare-cacheability-probe.test.ts tests/cloudflare-cdn-warm-deploy.test.ts`
- `git diff --check`