### PR TITLE
ci(triage): add AI issue triage bot (Astro-style software factory)

### DIFF
--- a/.agents/skills/triage/SKILL.md
+++ b/.agents/skills/triage/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: triage
+description: Triage a bug report. Reproduces the bug, diagnoses the root cause, verifies whether the behavior matches Next.js, and attempts a fix. Use when asked to "triage issue #1234", "triage this bug", or similar.
+---
+
+# Triage
+
+Triage a bug report end-to-end: reproduce the bug, diagnose the root cause, verify whether the behavior matches Next.js (vinext's spec), and attempt a fix.
+
+vinext reimplements the Next.js API surface on Vite. Anywhere "is this behavior correct?" comes up, the answer is found in Next.js source, tests, and docs — not in intuition.
+
+## General Rules
+
+**Do not get stuck on infrastructure problems.** If a server won't start, a port is blocked, or a tool is unavailable in the CI environment — bail out after 2 attempts and write your report with the data you already have. Looping on server restarts or missing CLI tools wastes your entire time budget. A partial report with solid findings is infinitely more valuable than no report because you ran out of time fighting a stale process.
+
+**Do not fight the sandbox.** You are running in GitHub Actions. Things you cannot do: open a browser window interactively, reach private networks, deploy to real Cloudflare accounts. Things you can do: run the full test suite, run vite dev servers, run builds, clone public GitHub repos, query the GitHub API with `gh`.
+
+## Input
+
+You need either:
+
+- `issueTitle` and `issueBody` provided in args (preferred — use these directly as the bug report), OR
+- A GitHub issue number or URL mentioned in the conversation (use `gh issue view` to fetch details)
+
+If a `triageDir` is provided in args, use that as the working directory for the triage. Otherwise, default to `triage/gh-<issue_number>` (if you have an issue number) or `triage/current`.
+
+The `triage/` directory is gitignored and part of the pnpm workspace (`triage/*` in `pnpm-workspace.yaml`), so reproduction projects there link against the local `packages/*` sources.
+
+## Step 1: Reproduce
+
+Read and follow [reproduce.md](reproduce.md). Use a subagent for this step to isolate context.
+
+After completing reproduction, check the result:
+
+- If the issue was **skipped** (host-specific, unsupported runtime, etc.) — skip to Output.
+- If the issue was **not reproducible** — skip to Output.
+- If the issue was **reproduced** — continue to Step 2.
+
+## Step 2: Diagnose
+
+Read and follow [diagnose.md](diagnose.md). Use a subagent for this step to isolate context.
+
+After completing diagnosis, check your confidence:
+
+- If confidence is **low** — skip to Output.
+- If confidence is **medium** or **high** — continue to Step 3.
+
+## Step 3: Verify
+
+Read and follow [verify.md](verify.md). Use a subagent for this step to isolate context.
+
+After completing verification, check the verdict:
+
+- If the verdict is **intended-behavior** — skip to Output. The issue is not a bug; do not attempt a fix.
+- If the verdict is **bug** or **unclear** — continue to Step 4.
+
+## Step 4: Fix
+
+Read and follow [fix.md](fix.md). Use a subagent for this step to isolate context.
+
+Whether the fix succeeds or fails, continue to Output.
+
+## Output
+
+After completing the triage (or exiting early), return your structured results so the orchestrator can post a comment and manage labels.

--- a/.agents/skills/triage/diagnose.md
+++ b/.agents/skills/triage/diagnose.md
@@ -1,0 +1,119 @@
+# Diagnose
+
+Find the root cause of a reproduced bug in the vinext source code.
+
+**CRITICAL: You MUST always read `report.md` and append to `report.md` before finishing, regardless of outcome. Even if you cannot identify the root cause, hit errors, or the investigation is inconclusive — always update `report.md` with your findings. The orchestrator and downstream skills depend on this file to determine what happened.**
+
+**SCOPE: Your job is diagnosis only. Finish your work once you've completed this workflow. Do NOT go further than this (no larger verification of the issue, no fixing of the issue, etc.). Do not spawn tasks/sub-agents.**
+
+## Prerequisites
+
+- **`triageDir`** — Directory containing the reproduction project (e.g. `triage/gh-123`). If not passed as an arg, infer from previous conversation.
+- **`issueDetails`** — The GitHub API issue details payload. If not available, run `gh issue view ${issue_number}`.
+- **`report.md`** — File in `triageDir` written by the reproduce skill. Contains the full context from reproduction.
+
+## Overview
+
+1. Review the reproduction and error details from `report.md`
+2. Locate the relevant source files in `packages/`
+3. Add instrumentation to understand the code path
+4. Identify the root cause
+5. Append diagnosis findings to `report.md`
+
+## Step 1: Review the Reproduction
+
+Start by reading `report.md` from the `triageDir` directory.
+
+**Skip if not reproduced:** If `report.md` shows the bug was NOT reproduced or was skipped, append "DIAGNOSIS SKIPPED: No reproduction" to `report.md` and return `confidence: null`.
+
+Re-run the reproduction if needed to see the error firsthand (see reproduce.md for the commands).
+
+Before diving into source, read the repo's `AGENTS.md` — it documents the architecture invariants that explain many behaviors that look like bugs but are deliberate (RSC/SSR as separate Vite environments, request execution order, ISR layering).
+
+## Step 2: Locate Relevant Source Files
+
+Using the error messages, stack traces, and reproduction details from Step 1, identify the source files that are likely involved. The map:
+
+| Area | Where it lives |
+| --- | --- |
+| Vite plugin, `next/*` resolution, virtual modules | `packages/vinext/src/index.ts` |
+| `next/link`, `next/navigation`, `next/image`, and other shims | `packages/vinext/src/shims/` |
+| File-system routing (`app/`, `pages/` scanners) | `packages/vinext/src/routing/` |
+| Pages Router SSR (dev + prod) | `packages/vinext/src/server/dev-server.ts`, `server/prod-server.ts` |
+| App Router RSC entry generation | `packages/vinext/src/entries/` |
+| Request lifecycle, ISR, cache | `packages/vinext/src/server/` |
+| Cloudflare deploy, KV cache, worker entry | `packages/cloudflare/`, `packages/vinext/src/cloudflare/` |
+| `next` type surface | `packages/types/` |
+| CLI (`vinext init`, `vinext check`) | `packages/vinext/src/cli.ts` |
+
+**Dev/prod parity:** the same request path often exists in four places that are supposed to stay in sync — `entries/app-rsc-entry.ts` (App Router dev), `server/dev-server.ts` (Pages Router dev), `server/prod-server.ts` (Pages Router prod), and the Cloudflare worker entry. A bug fixed in one and not the others is a known failure mode; check them all when you find the culprit.
+
+## Step 3: Investigate with Instrumentation
+
+Add `console.log` statements to understand the code path:
+
+```typescript
+// e.g. in packages/vinext/src/server/prod-server.ts
+console.log('[DEBUG] matched route:', route);
+console.log('[DEBUG] request headers:', JSON.stringify(headers, null, 2));
+```
+
+After adding logs:
+
+1. Rebuild the affected package: `vp run vinext#build` (or `vp run build` at the repo root for everything)
+2. Re-run the reproduction
+3. Observe the debug output
+
+**Server management:** If re-running requires a dev server, always stop the existing server first (`kill "$(cat /tmp/vinext-dev.pid)"`). If the server fails to start twice, bail out — write your diagnosis with the data you have. Prefer `vp run build` over dev servers when possible.
+
+Iterate until you understand:
+
+- What code path is executing
+- What data is being passed
+- Where the logic diverges from expected behavior
+
+When the reproduction runs against Next.js-observable behavior, the local Next.js clone (see below) tells you what the value *should* be.
+
+Once done, **revert all instrumentation** before moving on (`git checkout -- <file>`). Debug logs must not leak into downstream steps.
+
+## Step 4: Identify Root Cause
+
+Once you understand the issue, document:
+
+1. **Which file(s)** contain the bug
+2. **What the code does wrong** — the specific logic error
+3. **Why this causes the observed behavior** — how the error manifests
+4. **What the fix should be** — high-level approach
+
+Consider:
+
+- Is this a regression from a recent change? (`git log --oneline -- <file>`, `git blame`)
+- Does it affect the other parity files listed in Step 2?
+- Are there edge cases — null/undefined inputs, empty routes, streaming edge cases?
+- Never suggest removing a user's dependency (adapters, plugins, MDX, Nitro) as a fix — those are things the user needs. The fix must work within the user's existing stack.
+
+### The Next.js reference clone
+
+vinext's behavioral spec is Next.js. A shallow clone of the Next.js repo at `.nextjs-ref/` (gitignored) is the ground truth for how upstream implements a behavior:
+
+```bash
+# Only if it does not already exist
+git clone --depth 1 --single-branch --branch canary https://github.com/vercel/next.js.git .nextjs-ref
+```
+
+Use it to read the upstream implementation of the code path you are diagnosing. If vinext's logic diverges from upstream's handling of the same input, that divergence is usually the root cause.
+
+**Tone calibration:** Describe the root cause factually, not dramatically. Avoid language that overstates impact ("critical flaw", "fundamentally broken") unless the evidence genuinely supports it. A missing null check is a missing null check. The diagnosis should help a maintainer understand what's wrong and guide them towards a fix, not alarm them.
+
+## Step 5: Write Output
+
+Append your diagnosis findings to the existing `report.md` (written by the reproduce skill).
+
+Include a new section with everything you learned: the root cause, affected files with line numbers, detailed explanation of the code path, instrumentation results, and your suggested fix approach. This helps the fix skill work faster.
+
+The report must include all information needed for a final GitHub comment to be generated later by the comment skill. Make sure to include:
+
+- Root cause explanation (which files, what logic is wrong, why)
+- Affected file paths with line numbers
+- Suggested fix approach
+- Confidence level (`high`, `medium`, or `low`) and any caveats

--- a/.agents/skills/triage/fix.md
+++ b/.agents/skills/triage/fix.md
@@ -1,0 +1,192 @@
+# Fix
+
+Develop and verify a fix for a diagnosed vinext bug.
+
+**CRITICAL: You MUST always read `report.md` and append to `report.md` before finishing, regardless of outcome. Even if the fix attempt fails, you encounter errors, or you cannot resolve the bug — always update `report.md` with your findings. The orchestrator and downstream skills depend on this file to determine what happened.**
+
+**SCOPE: Do not spawn tasks/sub-agents.**
+
+## Prerequisites
+
+- **`triageDir`** — Directory containing the reproduction project (e.g. `triage/gh-123`). If not passed as an arg, infer from previous conversation.
+- **`issueDetails`** — The GitHub API issue details payload. If not available, run `gh issue view ${issue_number}`.
+- **`report.md`** — File in `triageDir` containing the full context from all previous skills.
+
+## Overview
+
+1. Review the diagnosis from `report.md`
+2. Verify fix feasibility
+3. Implement a minimal fix in `packages/`
+4. Rebuild the affected package(s)
+5. Verify the fix resolves the reproduction
+6. Write a test
+7. Ensure no regressions
+8. Generate git diff
+9. Append fix details to `report.md`
+10. Clean up the working directory
+
+## Step 1: Review the Diagnosis
+
+Read `report.md` from the `triageDir` directory to understand the root cause, affected files, and suggested approach.
+
+**Skip if prerequisites unmet:** If `report.md` shows the bug was not reproduced, was skipped, or was verified as intended behavior → append "FIX SKIPPED: <reason>" to `report.md` and return `fixed: false`. Do NOT attempt a fix based on guesswork.
+
+**Low-confidence path:** If diagnosis confidence is `low` or `null`, or no clear root cause was found → do NOT attempt a code fix. Instead:
+
+1. Identify the most likely area(s) of the codebase related to the issue.
+2. If possible, write a failing test that demonstrates the expected behavior described in the issue, placed per the conventions in Step 6. A failing test is valuable even without a fix — it documents the bug.
+3. If you identified specific code paths, add brief inline comments (prefixed `// TRIAGE:`) near the most relevant lines to help the implementor orient quickly. Keep to 2-3 comments max.
+4. Append to `report.md`: the areas you identified, why they seem relevant, and any failing test or comments you added.
+5. Return `fixed: false`.
+
+This "breadcrumb" approach is more useful to maintainers than a wrong fix.
+
+**High-confidence path:** If diagnosis confidence is `medium` or `high` and a clear root cause was identified → implement a fix as described below.
+
+**Note:** The repo may be messy from previous steps (instrumentation logs, repro changes). Check `git status` — revert leftover instrumentation (`git checkout -- packages/`) so only intentional fix changes remain.
+
+## Step 2: Verify Fix Feasibility
+
+- **Runtime targets:** Server code must run on Node.js 22+ and Cloudflare Workers (workerd). Do not use Node-only APIs in code paths that run in Workers; when Node built-ins are needed and available in workerd (e.g. `node:crypto`, `node:util`), prefer them over new dependencies.
+- **Browsers:** If the fix touches client shims, only rely on web platform features with broad support. Do not treat specification compliance as proof of browser support.
+- **Dependencies:** Do not add a new dependency to fix a bug. Use Node built-ins or existing dependencies.
+
+## Step 3: Implement the Fix
+
+Make changes in `packages/*/src` files. Follow these principles:
+
+**Keep it minimal:**
+
+- Only change what's necessary to fix the bug
+- Don't refactor unrelated code
+- Don't add new features
+- **Never "fix" an issue by removing a user's dependency.** Removing an adapter, plugin, MDX, Nitro, or a `next.config.js` option is not a fix — those are things the user needs. The fix must work with the user's existing stack.
+
+**Follow repo conventions (read `AGENTS.md` first if you haven't):**
+
+- Source files under `packages/vinext/src` import `path` from `pathslash`, never `node:path`. Apply `toSlash` only at external boundaries (`process.cwd()`, `fileURLToPath`, bundler-reported ids). Never add unconditional `.replaceAll("\\", "/")` to source.
+- Tests build fixture inputs with native `node:path`; only expectations compared against source output use canonical (forward-slash) form.
+- Do not touch URL-space backslash defenses (request-pathname sanitizers).
+
+**Dev/prod parity:** the same request path exists in up to four places that must stay in sync — `entries/app-rsc-entry.ts` (App Router dev/RSC entry), `server/dev-server.ts` (Pages Router dev), `server/prod-server.ts` (Pages Router prod), and the Cloudflare worker entry (`packages/cloudflare`, `packages/vinext/src/cloudflare`). If the bug lives in request handling, check whether the same bug exists in the sibling implementations and fix them all in this change. Do not leave a known instance as a follow-up.
+
+**Consider edge cases:**
+
+- Will this break other use cases (empty routes, streaming, concurrent requests)?
+- What happens with unusual input?
+- Are there null/undefined checks needed?
+
+## Step 4: Rebuild the Package
+
+After making changes, rebuild:
+
+```bash
+vp run vinext#build   # or the affected package, e.g. vp run cloudflare#build
+# or from the repo root: vp run build
+```
+
+Watch for build errors — fix any TypeScript issues before proceeding.
+
+**The build output must be present and current when you finish**: after the fix, the orchestrator packs the changed `packages/*` directories and publishes them as a preview release the reporter installs. If `dist/` is stale, the preview tests the wrong code.
+
+## Step 5: Verify the Fix
+
+Re-run the reproduction from `report.md` (build or dev server — see reproduce.md for the commands). Confirm the reported behavior now matches what the issue's expected result describes, and confirm the baseline still works.
+
+## Step 6: Write a Test
+
+Write a test that covers the bug you just fixed. It should fail without the fix and pass with it.
+
+Follow the repo's conventions — tests live in `tests/*.test.ts` (unit + integration mixed, run with vitest). Pick the file by area, or add a new one following an existing file's shape:
+
+| If the fix touches... | Test file |
+| --- | --- |
+| A shim (`shims/*.ts`) | `tests/shims.test.ts` or the specific shim test (e.g. `tests/link.test.ts`) |
+| Routing (`routing/*.ts`) | `tests/routing.test.ts`, `tests/route-sorting.test.ts` |
+| App Router server / entries | `tests/app-router.test.ts`, `tests/features.test.ts` |
+| Pages Router server | `tests/pages-router.test.ts` |
+| Caching / ISR / KV | `tests/isr-cache.test.ts`, `tests/fetch-cache.test.ts`, `tests/kv-cache-handler.test.ts` |
+| Build / deploy | `tests/deploy.test.ts`, `tests/build-optimization.test.ts` |
+| Next.js compat behavior | the relevant `tests/nextjs-compat/` file |
+
+If Next.js has a test for this behavior, port it and credit it:
+
+```ts
+// Ported from Next.js: test/e2e/<area>/<name>/<name>.test.ts
+// https://github.com/vercel/next.js/blob/canary/test/e2e/<area>/<name>/<name>.test.ts
+```
+
+Run it in isolation to confirm it passes:
+
+```bash
+vp test run tests/<file>.test.ts
+```
+
+If the test fails, fix either the test or the implementation until it passes. If you cannot write a meaningful test, document why in `report.md` and move on — do not force a test that doesn't make sense.
+
+## Step 7: Check for Regressions
+
+Test that you didn't break anything else:
+
+```bash
+vp run check     # format, lint, type checks
+```
+
+Then run the test files that cover the area you changed (see the table above); the full suite runs in CI. Address failures until everything passes.
+
+## Step 8: Generate Git Diff
+
+From the repository root:
+
+```bash
+git diff packages/
+```
+
+This captures all your changes for the report.
+
+## Step 9: Commit Message Convention (replaces changesets)
+
+**Do NOT create a `.changeset/*.md` file.** Release changesets are generated automatically from Conventional Commit subjects during CI (`scripts/create-changeset.mjs`). A hand-authored changeset would conflict with that automation.
+
+The orchestrator commits your work with a commit message you provide. Make it a well-formed Conventional Commit, because it becomes the release changelog entry verbatim:
+
+```
+fix(<scope>): <one-line, user-facing description in present tense>
+```
+
+- `fix()` for bug fixes, `feat()` for behavior additions, `perf()`, `docs()`, `chore()` as appropriate
+- Common scopes: `shims`, `router`, `cache`, `isr`, `build`, `server`, `cloudflare`, `cli`, `deploy`, `types`, `docs`, `ci`
+- Name the affected API and what now works: `fix(shims): preserve query params in useRouter().push()`
+- Write for vinext users, not reviewers — one line, present tense, no issue reference needed (the PR links the issue)
+
+Return the commit message as your `commitMessage` structured result field (and mirror it in `report.md` under "Commit message") — the orchestrator commits the fix branch with it.
+
+## Step 10: Write Output
+
+Append your fix details to the existing `report.md` (written by reproduce/diagnose/verify skills).
+
+Include a new section with:
+
+- What was changed and why
+- The full git diff (unless it is massive)
+- Whether the fix was successful or not
+- Verification results (did the fix resolve the original reproduction?)
+- Test details: what test was added, where it lives, what it verifies. If none, explain why.
+- Dev/prod parity: which of the sibling implementations (App Router entry, Pages Router dev/prod servers, worker entry) you checked and what you changed in each
+- Any alternative approaches considered and their tradeoffs
+- The commit message (Step 9)
+- If the fix failed: what was tried and why it didn't work
+
+## Step 11: Clean Up the Working Directory
+
+1. Run `git status` and review all changed files
+2. Revert changes that are NOT part of the fix:
+   - Debug code, `console.log`s, or temporary test files
+   - **`pnpm-lock.yaml`** — reproduction installs modify it; the lockfile must stay untouched (`git checkout -- pnpm-lock.yaml`)
+   - Changes to `examples/`, `tests/fixtures/`, or other files that were only needed for diagnosis/reproduction
+   - Build artifacts that shouldn't be committed
+3. Use `git checkout -- <file>` to discard unwanted changes
+4. Confirm with a final `git status` that only the intended fix files remain (a `.changeset/` file must NOT be among them)
+5. DO NOT commit or push anything yourself — the orchestrator commits and pushes the fix branch
+
+The `triage/` directory is gitignored, so it won't appear in `git status`.

--- a/.agents/skills/triage/reproduce.md
+++ b/.agents/skills/triage/reproduce.md
@@ -1,0 +1,200 @@
+# Reproduce
+
+Reproduce a GitHub issue to determine if a bug is valid and reproducible.
+
+**CRITICAL: You MUST always read `report.md` and write `report.md` to the triage directory before finishing, regardless of outcome. Even if you encounter errors, cannot reproduce the bug, hit unexpected problems, or need to skip — always write `report.md`. The orchestrator and downstream skills depend on this file to determine what happened. If you finish without writing it, the entire pipeline fails silently.**
+
+**SCOPE: Your job is reproduction only. Finish your work once you've completed this workflow. Do NOT go further than this (no larger diagnosis of the issue, no fixing of the issue, etc.). Do not spawn tasks/sub-agents.**
+
+## Prerequisites
+
+These variables are referenced throughout this skill. They may be passed as args by an orchestrator, or inferred from the conversation when run standalone.
+
+- **`triageDir`** — Directory containing the reproduction project (e.g. `triage/gh-123`). If not passed as an arg, infer from previous conversation. Default: `triage/gh-<issue_number>`.
+- **`issueDetails`** — The GitHub API issue details payload. This must be provided explicitly by the user or available from prior conversation context / tool calls. If this data isn't available, you may run `gh issue view ${issue_number}` to load the missing issue details directly from GitHub.
+
+## Overview
+
+1. Confirm the issue details
+2. Analyze the issue for early exit conditions
+3. Set up a reproduction project in the triage directory
+4. Attempt to reproduce the bug
+5. Write `report.md` with detailed findings
+
+## Step 1: Confirm Bug Details
+
+Confirm that you have `issueDetails` as defined/instructed above. **Otherwise**, fail — we cannot triage a bug that we have no details on.
+
+Once you have `issueDetails`, read carefully:
+
+- The bug description and expected vs actual behavior
+- Any reproduction steps provided
+- Environment details (vinext version, Next.js version, deployment target — Node vs Cloudflare Workers vs Nitro)
+- Comments that might clarify the issue
+
+## Step 2: Check for Early Exit Conditions
+
+Before attempting reproduction, check if this issue should be skipped due to a limitation of our sandbox reproduction environment.
+
+If any early exit condition is met, skip to Step 5 and write `report.md` with the skip details.
+
+**Comment Handling for Early Exits:** Sometimes future comments will provide additional reproductions. An early exit is only valid if no future comments in that issue "invalidate" it. For example, if the original poster reported the bug on an old vinext release but a commenter later posted the same reproduction on the latest release, the early exit is no longer valid — continue with the workflow instead.
+
+The documented early exit conditions we support:
+
+### Not Actionable (`not-actionable`)
+
+Skip if the issue is not a bug report. This workflow can only triage bugs — feature requests, suggestions, and discussions are not actionable here.
+
+### Missing Details (`missing-details`)
+
+Skip if the issue is missing a valid reproduction (see below for the list of supported valid reproductions), or is missing a description of the user's expected result. We need both to successfully reproduce, and later to verify the expected results.
+
+### Host-Specific Issues (`host-specific`)
+
+Skip if the bug can only be reproduced on deployed infrastructure that the sandbox cannot emulate. Note that **most** Cloudflare-specific behavior IS reproducible locally: `vite dev` in a project using `@cloudflare/vite-plugin` runs server code in workerd, so Workers runtime semantics (bindings via `cloudflare:workers`, `Cache API`, KV) reproduce with a dev server or build. Only skip when the bug genuinely requires a deployed environment: production-only routing (custom domains, workers.dev zone behavior), live Durable Object state, production KV/R2 contents, or tunnel/auth infrastructure.
+
+### Runtime-Specific Issues (`unsupported-runtime`)
+
+Skip if the bug is specific to Bun or Deno as a host runtime. vinext supports Node.js, Cloudflare Workers, and Nitro presets.
+
+### Maintainer Override (`maintainer-override`)
+
+Skip if a repository maintainer has commented that this issue should not be reproduced here. To determine if a commenter is a maintainer, check the `authorAssociation` field on their comment in `issueDetails` — values of `MEMBER`, `COLLABORATOR`, or `OWNER` indicate a maintainer.
+
+## Step 3: Set Up Reproduction Project
+
+Every bug report should include some sort of reproduction. The reproduction project goes in the `triageDir` directory (e.g. `triage/gh-123`). If no `triageDir` is provided, default to `triage/gh-<issue_number>`.
+
+`triage/*` is part of the pnpm workspace, so a reproduction project there resolves `"vinext": "workspace:*"` to the local `packages/` sources — this is how we test the current main branch.
+
+**IMPORTANT:** Installing the reproduction modifies `pnpm-lock.yaml` (new workspace importer). That is expected and will be reverted in the fix step — never commit it.
+
+### StackBlitz Project URL (`https://stackblitz.com/edit/...`)
+
+If reproduction was provided as a StackBlitz project URL, download it into the `triageDir` directory using `stackblitz-clone`:
+
+```bash
+npx stackblitz-clone@latest <stackblitz-url> <triageDir>
+```
+
+### StackBlitz GitHub URL (`https://stackblitz.com/github/...`)
+
+Parse out the GitHub org & repo names and treat it as a GitHub URL, following the "GitHub URL" step below.
+
+### GitHub URL (`https://github.com/...`)
+
+If reproduction was provided as a GitHub repo URL, clone the repo into the triage directory and remove the `.git` directory to avoid conflicts with the host repo:
+
+```bash
+git clone --depth 1 https://github.com/<owner>/<repo>.git <triageDir>
+rm -rf <triageDir>/.git
+```
+
+If a specific branch or subdirectory is referenced, check out that branch before removing `.git`, or copy only the relevant subdirectory.
+
+Cloned repos run with your sandbox's network access and the repository's install scripts. Keep this in mind and prefer the smallest possible reproduction; do not enter credentials into anything.
+
+### Gist URL (`https://gist.github.com/`)
+
+Fetch the gist contents using the GitHub API to help understand the reproduction:
+
+```bash
+curl -s "https://api.github.com/gists/<gist-id>"
+```
+
+You may still need to set up a project from scratch (see fallback below) and apply the gist files into it.
+
+### Manual Steps Reproduction
+
+If no reproduction URL is provided, follow the manual steps the user provided. Build the reproduction from one of the existing workspace apps — pick the smallest one that matches the report:
+
+| App | Use when |
+| --- | --- |
+| `tests/fixtures/app-basic` | App Router basics |
+| `tests/fixtures/pages-basic` | Pages Router basics |
+| `examples/app-router-cloudflare` | App Router + Cloudflare bindings/Workers behavior |
+| `examples/pages-router-cloudflare` | Pages Router + Cloudflare |
+| `examples/app-router-playground` | MDX, Tailwind, richer features |
+
+Copy it into the triage directory:
+
+```bash
+rm -rf examples/<template>/node_modules   # avoid problems with cp -r
+cp -r examples/<template> <triageDir>
+```
+
+Then link it into the workspace (from the repo root):
+
+```bash
+vp install --no-frozen-lockfile
+```
+
+Verify the project was created in the correct place (`cat <triageDir>/package.json`).
+
+Then, modify the triage project as needed to attempt your reproduction:
+
+1. Update `vite.config.ts` with required configuration changes (vinext plugin options, additional plugins)
+2. Add/modify any dependencies or plugins (`@vitejs/plugin-react`, MDX, Tailwind)
+3. Add/modify any pages, layouts, route handlers, middleware, or `next.config.js` settings that trigger the bug
+4. Add/modify any additional files mentioned in the issue
+
+Keep the reproduction as minimal as possible — only add what the issue reporter has documented as needed to trigger the bug.
+
+## Step 4: Attempt Reproduction in the Triage Project
+
+Use all of the tools at your disposal — `vp run build`, `vite dev`, `curl`, the vitest suite, etc.
+
+1. **Trigger the bug.** Follow the reproduction steps from the issue and confirm that the bug appears.
+2. **Verify the baseline.** Remove or reverse the triggering code and confirm the project works without the bug. This guards against false positives — if the project is still broken without the triggering code, the issue may be in your setup, not the reported bug.
+3. **Document what you observe.** Record exact error messages and stack traces, which command triggers the issue, and whether it's consistent or intermittent.
+
+For dev-server bugs (`vite dev`) and for Workers-runtime behavior (bindings, workerd semantics), start a dev server in the background and drive it with `curl`:
+
+```bash
+cd <triageDir>
+nohup npx vite dev --port 4321 --host 127.0.0.1 > /tmp/vinext-dev.log 2>&1 &
+echo $! > /tmp/vinext-dev.pid
+sleep 5 && cat /tmp/vinext-dev.log
+curl -s http://127.0.0.1:4321/ | head -100
+kill "$(cat /tmp/vinext-dev.pid)" 2>/dev/null || true
+```
+
+For build bugs, `cd <triageDir> && vp run build` and inspect `dist/` output. For deploy-output bugs, also inspect the generated `dist/server/wrangler.json` and worker bundles.
+
+Many routing/shim bugs are fastest to reproduce as a vitest fixture — if the bug fits that shape, check `tests/fixtures/` and the test helpers used by an existing test file that covers the same area, and write a scratch fixture instead of driving a server.
+
+### Server Management Rules
+
+Running dev servers is often necessary, but server problems must not consume your time budget:
+
+- **Bail out after 2 failed server starts.** If the server fails to start twice in a row, stop trying. Do NOT loop with variations. Write your report with what you already know.
+- **Always stop servers before restarting.** `kill "$(cat /tmp/vinext-dev.pid)"` first; `pkill -f "vite dev"` as a fallback. If a port stays blocked, use a different port rather than fighting the stale process.
+- **One reproduction run is enough.** Once you have confirmed or denied the bug, do NOT restart the server to re-test minor config variations. Additional testing belongs in the diagnose step. Write your findings and move on.
+- **Prefer `vp run build` over a dev server when possible.** Build-time reproduction avoids server lifecycle issues entirely. Only use dev servers when the bug specifically requires a running server (HMR, dev SSR, request handling, middleware).
+- **Never leave a server running** when you finish — always kill it.
+
+## Step 5: Write Output
+
+Write `report.md` to the triage directory:
+
+### `report.md` — Detailed internal report for the next LLM stage
+
+Write a verbose report with everything you learned. This is NOT for humans — it's context for the next stage of the pipeline (diagnose/fix). **Downstream skills will NOT have access to the original issue — `report.md` is their only source of context.** Include:
+
+- The original issue title, description, and any relevant details from the issue body. It's better to include too much context from the original issue vs. too little.
+- Full environment details (vinext version, Node version, router type, deployment target)
+- All steps attempted and their results
+- Complete error messages and stack traces
+- Observations about the codebase, theories about root cause
+- Anything that would help the next stage work faster
+
+Be thorough. More context is better here.
+
+The report must include all information needed for a final GitHub comment to be generated later by the comment skill. Make sure to include:
+
+- Environment details (package versions, Node.js version, router, deployment target)
+- Steps to reproduce (numbered list)
+- Expected vs actual result
+- Error messages and stack traces
+- Whether the issue was reproduced, not reproduced, or skipped (and why)

--- a/.agents/skills/triage/verify.md
+++ b/.agents/skills/triage/verify.md
@@ -1,0 +1,152 @@
+# Verify
+
+Verify whether a GitHub issue describes an actual vinext bug or a misunderstanding of intended behavior.
+
+**CRITICAL: You MUST always read `report.md` and append to `report.md` before finishing, regardless of outcome. Even if you cannot reach a conclusion — always update `report.md` with your findings. The orchestrator and downstream skills depend on this file to determine what happened.**
+
+**SCOPE: Your job is verification only. Finish your work once you've completed this workflow. Do NOT go further than this (no fixing of the issue, etc.). Do not spawn tasks/sub-agents.**
+
+## Prerequisites
+
+- **`triageDir`** — Directory containing the reproduction project (e.g. `triage/gh-123`). If not passed as an arg, infer from previous conversation.
+- **`issueDetails`** — The GitHub API issue details payload. If not available, run `gh issue view ${issue_number}`.
+- **`report.md`** — File in `triageDir` written by the earlier skills. Contains the full context.
+
+## Overview
+
+1. Review the issue and any existing reproduction findings
+2. Identify the claim: what does the reporter say _should_ happen?
+3. Research whether the current behavior is intentional
+4. Assess the verdict: bug, intended behavior, or unclear
+5. Assign confidence
+6. Append verification findings to `report.md`
+
+## Step 1: Identify the Claim
+
+Read the issue (from `report.md` or directly from GitHub) and extract two things:
+
+- **Current behavior**: What the reporter observes happening.
+- **Expected behavior**: What the reporter says _should_ happen instead.
+
+The expected behavior is the claim you are verifying.
+
+## Step 2: Research Intended Behavior
+
+**vinext's spec is Next.js.** vinext reimplements the Next.js API surface; where behavior differs from Next.js, that divergence needs an explicit, documented reason to be intended. Use multiple sources, and **do not assume the reporter is correct** — but also do not assume vinext is correct: the whole point of this project is that Next.js behavior is the target.
+
+### 2a: Check the Next.js test suite (strongest evidence)
+
+The local Next.js clone at `.nextjs-ref/` (gitignored) contains upstream's test suite. If it doesn't exist:
+
+```bash
+git clone --depth 1 --single-branch --branch canary https://github.com/vercel/next.js.git .nextjs-ref
+```
+
+Search it for the reported behavior:
+
+```bash
+grep -rn "<keywords>" .nextjs-ref/test/e2e/ .nextjs-ref/test/unit/ -l | head -20
+```
+
+A Next.js test that asserts the behavior the reporter expects is authoritative: it is what vinext must reproduce. A test asserting the opposite is equally authoritative. When you find one, note the file path and what it asserts in `report.md`.
+
+### 2b: Check the Next.js source and docs
+
+Read the upstream implementation in `.nextjs-ref/packages/next/src/` and the relevant docs. How does Next.js handle this exact case?
+
+### 2c: Check vinext for intent signals
+
+Look at the relevant source code in `packages/`. Pay close attention to:
+
+- **Comments explaining "why"** — a developer comment explaining why the code works a certain way is strong evidence of intentional design. Treat these comments as authoritative unless they are clearly outdated.
+- **Explicit conditionals and early returns** — code that explicitly checks for the reported scenario and handles it differently than the reporter expects is likely intentional.
+- **Documented deliberate divergences** — the repo's `AGENTS.md` and PR history record known parity gaps (for example: config `headers` run at a different point in the request order than Next.js). A documented gap is a known limitation, not a bug; note the reference.
+
+### 2d: Git blame on key lines
+
+If `report.md` identifies specific files and line numbers, run `git blame` on the relevant lines to find the commit that introduced the behavior. Then read the full commit message with `git show --no-patch <commit>` and review the associated PR if referenced (`gh pr view <number>`). A commit message, PR description, or PR comment explaining the rationale is strong evidence of intentional design.
+
+### 2e: Search prior GitHub issues and PRs
+
+Search both vinext and Next.js for prior discussion of the same behavior:
+
+```bash
+gh search issues "<keywords>" --repo cloudflare/vinext
+gh search prs "<keywords>" --repo cloudflare/vinext
+gh search issues "<keywords>" --repo vercel/next.js
+gh issue view <number> --comments
+```
+
+A closed Next.js issue where a maintainer explained why the behavior is intentional is strong evidence of intended behavior. A closed vinext issue where the divergence was discussed and accepted is too.
+
+### 2f: Distinguish bugs from non-bugs
+
+For triage purposes, the definitions are:
+
+- A **bug** is when vinext behaves differently from Next.js **without a documented reason** — an unimplemented edge case, a regression, an accidental divergence. The developer did not know about or did not choose this behavior.
+- A **non-bug** (intended behavior) is when the divergence is **documented and deliberate** — a known parity gap recorded in `AGENTS.md` or a PR/issue, or behavior that matches Next.js exactly while the reporter expected something else. Even if the reporter's complaint is legitimate, that is an enhancement request, not a bug fix.
+
+The key question is not "do we _like_ this behavior?" but "did we **choose** it?" If the answer is yes — documented divergence or exact Next.js parity — it is not a bug.
+
+**Common mistakes to avoid:**
+
+- Do not treat a documented parity gap as a bug just because it is inconvenient. It may be worth closing the gap, but that is an enhancement.
+- Do not treat a design trade-off as a bug because the reporter frames it as one.
+- Do not infer vinext's intent from what would be "reasonable" — infer it from Next.js's actual behavior and vinext's documented decisions.
+- If Next.js itself has no defined behavior for the case (both undefined), the verdict is likely `unclear`, not `bug`.
+
+## Step 3: Assess the Verdict
+
+Based on your research, assign one of three verdicts:
+
+### Verdict: Bug
+
+vinext's behavior diverges from Next.js without a documented reason, or contradicts vinext's own documented behavior. Evidence:
+
+- A Next.js test asserts different behavior than we produce
+- The behavior contradicts what our shims/docs promise
+- The behavior is clearly a regression (worked before, broke after a change)
+- No guard, comment, or documented decision accounts for the divergence
+
+### Verdict: Intended Behavior / Enhancement Request
+
+The developer was aware of the behavior and chose it. Evidence:
+
+- The exact Next.js behavior matches vinext's current behavior (the reporter expected something Next.js doesn't do)
+- The divergence is a documented parity gap or deliberate decision (AGENTS.md, PR, issue)
+- A code comment explains the limitation or trade-off
+- A prior issue on this exact behavior was closed as "by design"
+
+Note: This verdict does not mean the reporter's concern is invalid. It may still be worth improving — but as a parity/enhancement item, not a bug fix.
+
+### Verdict: Unclear
+
+You cannot confidently determine intent. This might happen when:
+
+- Next.js has no test or doc covering the case
+- The behavior could be either intentional or accidental
+- vinext and Next.js both behave the same way and the reporter's expectation is simply undocumented
+
+When unclear, lean toward "unclear" rather than guessing.
+
+## Step 4: Assign Confidence
+
+Rate your confidence:
+
+- **high** — Strong evidence (a Next.js test, explicit docs, a documented vinext decision, unambiguous code)
+- **medium** — Reasonable evidence but some ambiguity remains
+- **low** — Mostly inference; could go either way
+
+## Step 5: Write Output
+
+Append your verification findings to `report.md`.
+
+Include a new section with:
+
+- The reporter's claim (expected behavior)
+- Your verdict: `bug`, `intended-behavior`, or `unclear`
+- Your confidence: `high`, `medium`, or `low`
+- Evidence supporting your verdict (specific Next.js test files + what they assert, doc references, commit messages, prior issues/PRs, code comments)
+- If the verdict is `intended-behavior`: explain the design rationale and note that the reporter's concern could be reframed as a parity/enhancement request
+- If the verdict is `bug`: explain the Next.js behavior we must match and cite where it is specified (test file, source, or docs)
+- If the verdict is `unclear`: explain what evidence is missing and what would resolve the ambiguity

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,96 @@
+# AI issue triage bot. Ported from Astro's setup:
+# https://blog.cloudflare.com/astro-issue-triage/
+# https://github.com/withastro/triagebot-action
+#
+# On every new bug report the bot reproduces the bug, diagnoses the root
+# cause, verifies it against Next.js behavior, and attempts a fix. If a fix
+# lands it is pushed to `triagebot/fix-<issue>` and published as a pkg.pr.new
+# preview; when the reporter confirms the preview, a PR is opened.
+#
+# One-time setup (see AGENTS.md "Issue triage bot" for details):
+#   - secrets: TRIAGE_BOT_TOKEN, TRIAGE_CF_API_TOKEN, TRIAGE_CF_ACCOUNT_ID
+#   - repo labels: the ten `triage: *` labels, `- P*` priorities, `pkg: *`
+# Until the secrets exist this workflow starts and immediately no-ops.
+name: Issue Triage
+
+on:
+  issues:
+    types: [opened, reopened, closed]
+  issue_comment:
+    types: [created]
+
+permissions: {}
+
+concurrency:
+  group: triage-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  triage:
+    # Forks never see issue events from this workflow file on main, but the
+    # owner check also keeps preview deploys of this branch quiet.
+    if: github.repository_owner == 'cloudflare'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      id-token: write # pkg.pr.new authenticates with the Actions OIDC token
+    steps:
+      - name: Check bot credentials
+        id: creds
+        env:
+          WRITE_TOKEN: ${{ secrets.TRIAGE_BOT_TOKEN }}
+          CF_API_TOKEN: ${{ secrets.TRIAGE_CF_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ secrets.TRIAGE_CF_ACCOUNT_ID }}
+        run: |
+          if [ -n "$WRITE_TOKEN" ] && [ -n "$CF_API_TOKEN" ] && [ -n "$CF_ACCOUNT_ID" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Triage bot secrets not configured (TRIAGE_BOT_TOKEN, TRIAGE_CF_API_TOKEN, TRIAGE_CF_ACCOUNT_ID); skipping triage."
+          fi
+
+      - name: Checkout repository
+        if: steps.creds.outputs.configured == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The agent diffs against main, reads git blame, and can consult
+          # Next.js tests when the .nextjs-ref clone exists.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup
+        if: steps.creds.outputs.configured == 'true'
+
+      # triagebot-action publishes preview releases with `pnpm dlx pkg-pr-new`,
+      # but pnpm is not preinstalled on GitHub runners. Match the repo's
+      # packageManager major (pnpm@11.1.1) so workspace packing agrees with vp.
+      - name: Install pnpm
+        if: steps.creds.outputs.configured == 'true'
+        run: npm install -g pnpm@11
+
+      # Runners have no default git identity and the action commits the fix
+      # branch itself.
+      - name: Configure git identity
+        if: steps.creds.outputs.configured == 'true'
+        run: |
+          git config user.name "vinext-triage-bot"
+          git config user.email "triage-bot@users.noreply.github.com"
+
+      # Once the write token's account is known (GitHub App bot login or a
+      # dedicated user), add it to `bot-logins` so the bot's own comments do
+      # not trigger verify-fix runs.
+      - name: Run triage bot
+        if: steps.creds.outputs.configured == 'true'
+        uses: withastro/triagebot-action@0e37f3db18d8f5b3e8b310c52cdcc9cf2b5d22b1 # v0.4.0
+        with:
+          read-token: ${{ secrets.GITHUB_TOKEN }}
+          write-token: ${{ secrets.TRIAGE_BOT_TOKEN }}
+          cloudflare-api-key: ${{ secrets.TRIAGE_CF_API_TOKEN }}
+          cloudflare-account-id: ${{ secrets.TRIAGE_CF_ACCOUNT_ID }}
+          # Astro's production models (blog.cloudflare.com/astro-issue-triage).
+          # To switch provider: set anthropic-api-key instead of the Cloudflare
+          # pair and use anthropic/* model ids.
+          triage-model: cloudflare-workers-ai/@cf/moonshotai/kimi-k2.7-code
+          verification-model: cloudflare-workers-ai/@cf/moonshotai/kimi-k2.6
+          triage-skill: .agents/skills/triage

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ playwright-report/
 out-e2e
 *.tgz
 
+# AI triage bot reproduction projects (see .agents/skills/triage/)
+/triage/
+
 # Environment + secrets
 .env
 .env.*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -394,6 +394,46 @@ When modifying CI workflows, keep these rules in mind:
 - `deploy-examples.yml` must skip entirely for fork PRs. Don't remove the job-level `if` guard.
 - The `/deploy-preview` slash command gates secret usage behind the `author_association` check.
 
+
+## Issue Triage Bot
+
+Every new issue is triaged by an AI agent (`.github/workflows/triage.yml`, using [withastro/triagebot-action](https://github.com/withastro/triagebot-action) — the same setup Astro describes in ["How we built a software factory"](https://blog.cloudflare.com/astro-issue-triage/)). The bot reproduces the bug, diagnoses the root cause, verifies the behavior against Next.js, and attempts a fix. If it finds one, it pushes a `triagebot/fix-<issue>` branch and publishes a [pkg.pr.new](https://pkg.pr.new) preview; when the reporter confirms the preview fixes their case, a PR is opened automatically.
+
+- **State machine**: the bot is driven entirely by `triage: *` labels on the issue (`needs triage`, `not actionable`, `needs reproduction`, `skipped`, `unable to reproduce`, `unable to fix`, `failed`, `fix pending`, `fix rejected`, `fix verified`). One label at a time; comments on re-triageable issues re-run the pipeline when they add new information. The bot retries at most 3 failed attempts per issue.
+- **Skills**: the bot's brain is `.agents/skills/triage/` — `SKILL.md` orchestrates four isolated subagent steps (reproduce → diagnose → verify → fix), each with its own file. Editing those files changes how the bot behaves; no deploy needed.
+- **Improving the bot**: when the bot gets a fix wrong, treat it as a signal of an opaque abstraction, missing comment, or missing test — fix the underlying gap in `packages/` or the skill, and the next run gets it right. This is the Astro team's core loop and it is where most of the value comes from.
+- **Reproduction projects**: repros live in `triage/<dir>` (gitignored, part of the pnpm workspace). The skill's `--no-frozen-lockfile` install is confined to the ephemeral CI sandbox and the lockfile is reverted before the fix branch is committed — the "never unfreeze the lockfile" rule still applies to every real checkout.
+- **Security note**: the triage job runs untrusted code (reporter repro repos) alongside an OIDC token used by pkg.pr.new. Astro's hardened variant (publish from a separate secret-less job, report via check runs — see their `factory-preview.yml`) is the upgrade path if this ever needs to tighten.
+
+One-time setup (requires repo admin):
+
+1. Secrets: `TRIAGE_BOT_TOKEN` (GitHub PAT or App token with `issues: write` and `contents: write`), `TRIAGE_CF_API_TOKEN` (Workers AI), `TRIAGE_CF_ACCOUNT_ID`. Until they exist the workflow no-ops.
+2. Labels — the action cannot create them:
+
+```bash
+# Triage state labels
+for l in "needs triage|fbca04" "not actionable|d4c5f0" "needs reproduction|fef2c0" \
+         "skipped|c2e0c6" "unable to reproduce|d876e3" "unable to fix|e99695" \
+         "failed|b60205" "fix pending|0e8a16" "fix rejected|f9d0c4" "fix verified|1d76db"; do
+  name="${l%%|*}"; color="${l##*|}"
+  gh label create --repo cloudflare/vinext --color "$color" --force -- "triage: $name"
+done
+# PR label for confirmed fixes
+gh label create --repo cloudflare/vinext --color 1d76db --force -- "fix verified"
+# Priority labels (must match ^- P\d — same scheme Astro uses)
+for l in "- P1: chore|fee4be" "- P2: has workaround|fdd6a8" "- P2: nice to have|fdc593" \
+         "- P3: minor bug|fba16c" "- P4: important|f77d4c" "- P5: urgent|f25c33"; do
+  name="${l%%|*}"; color="${l##*|}"
+  gh label create --repo cloudflare/vinext --color "$color" --force -- "$name"
+done
+# Package labels (must start with "pkg: ")
+for p in vinext cloudflare types create-vinext-app; do
+  gh label create --repo cloudflare/vinext --color c5def5 --force -- "pkg: $p"
+done
+```
+
+3. Once the write token's bot account is known, add its login to `bot-logins` in `.github/workflows/triage.yml` so the bot's own comments don't trigger verification runs.
+
 ---
 
 ## Architecture & Gotchas

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,7 @@ packages:
   - apps/*
   - packages/*
   - examples/*
+  - triage/*
   - tests/fixtures/*
   - "!tests/fixtures/global-not-found-not-present"
   - tests/fixtures/ecosystem/*


### PR DESCRIPTION
## What

Ports [Astro's automated issue triage pipeline](https://blog.cloudflare.com/astro-issue-triage/) to vinext, using their open-source [withastro/triagebot-action](https://github.com/withastro/triagebot-action). Astro used this exact setup to take their open issues from 200 → ~30 on their way to zero.

When an issue is opened, an AI agent in GitHub Actions:

1. **Reproduces** it (repro project in `triage/`, linked against local `packages/*`)
2. **Diagnoses** the root cause (with instrumentation, guided by the package map in the skill)
3. **Verifies** it against Next.js behavior (`.nextjs-ref` tests/source/docs are the spec — this is the key vinext adaptation)
4. **Fixes** it (conventional commit, targeted test, dev/prod parity check across the four server entry points)

If a fix is found, it's pushed to a `triagebot/fix-<issue>` branch and published as a [pkg.pr.new](https://pkg.pr.new) preview. The reporter confirms the preview fixes their case → a PR opens automatically. Everything is driven by a label state machine (`triage: needs triage` → `fix pending` → `fix verified`), max 3 failed attempts per issue, re-triage on new information in comments.

## Changes

| File | Purpose |
| --- | --- |
| `.github/workflows/triage.yml` | Wiring: Workers AI Kimi models (Astro's production config), pnpm install step (the action needs `pnpm` for preview publishing; runners don't ship it), git identity, secrets guard so it no-ops until configured |
| `.agents/skills/triage/` | The bot's brain — 5 skill files, each driving one isolated subagent step. Editing these changes bot behavior with no deploy |
| `pnpm-workspace.yaml` | `triage/*` glob so repro projects resolve `vinext: workspace:*` (Astro's approach) |
| `.gitignore` | `/triage/` (anchored — repro scratch space) |
| `AGENTS.md` | Bot documentation + one-time setup |

## vinext-specific adaptations from Astro's skills

- **Verify step centers Next.js parity**: a Next.js test asserting the expected behavior is authoritative — that's the spec, not intuition
- **No hand-authored changesets**: the fix skill returns a Conventional Commit message (CI generates release changesets from subjects), replacing Astro's `pnpm changeset` step
- **Dev/prod parity rule**: fixes must check all four request-path implementations (app-rsc-entry, dev-server, prod-server, worker entry)
- **Repro templates** from `examples/` and `tests/fixtures/`; `vite dev` with `@cloudflare/vite-plugin` covers Workers-runtime behavior locally
- `pathslash` import rules, targeted `vp test run` file map

## One-time setup after merge (repo admin)

1. **Secrets**: `TRIAGE_BOT_TOKEN` (GitHub PAT/App token with `issues: write` + `contents: write`), `TRIAGE_CF_API_TOKEN` (Workers AI), `TRIAGE_CF_ACCOUNT_ID` — until these exist the workflow starts and no-ops with a warning
2. **Labels** — the action can't create them; commands are in `AGENTS.md` § Issue Triage Bot
3. Add the write token's bot login to `bot-logins` in the workflow once known

## Skipped (documented as upgrade paths)

- Astro's hardened separate-job preview publishing (`factory-preview.yml`, secret-less publish job + check-run reporting) — the v1 built-in flow runs in one job; upgrade if untrusted repro code ever warrants it
- Building our own Flue worker like emdash's `@emdashbot` (maintainer-invoked commands, Durable Object state) — the label-driven action gives us Astro's behavior with zero maintenance
