### PR TITLE
fix(cloudflare): reduce staged CDN probe work

### DIFF
--- a/packages/cloudflare/src/cache/cdn-adapter-config.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter-config.ts
@@ -1,7 +1,8 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 
-const RESPONSE_STAGE_EXPORT = "VinextCachedResponse";
+const CACHED_RESPONSE_STAGE_EXPORT = "VinextCachedResponse";
+const UNCACHED_RESPONSE_STAGE_EXPORT = "VinextUncachedResponse";
 const CTX_EXPORTS_DEFAULT_DATE = "2025-11-17";
 
 type WranglerWorkerExport = {
@@ -78,7 +79,7 @@ export function configureWorkersCacheEntrypoints(
       : [...compatibilityFlags, "enable_ctx_exports"]
     : compatibilityFlags.filter((flag) => flag !== "enable_ctx_exports");
 
-  for (const name of ["default", RESPONSE_STAGE_EXPORT]) {
+  for (const name of ["default", CACHED_RESPONSE_STAGE_EXPORT, UNCACHED_RESPONSE_STAGE_EXPORT]) {
     const existing = configuredExports[name];
     if (existing?.type !== undefined && existing.type !== "worker") {
       throw new Error(
@@ -97,10 +98,15 @@ export function configureWorkersCacheEntrypoints(
         type: "worker",
         cache: { enabled: false },
       },
-      [RESPONSE_STAGE_EXPORT]: {
-        ...configuredExports[RESPONSE_STAGE_EXPORT],
+      [CACHED_RESPONSE_STAGE_EXPORT]: {
+        ...configuredExports[CACHED_RESPONSE_STAGE_EXPORT],
         type: "worker",
         cache: { enabled: true },
+      },
+      [UNCACHED_RESPONSE_STAGE_EXPORT]: {
+        ...configuredExports[UNCACHED_RESPONSE_STAGE_EXPORT],
+        type: "worker",
+        cache: { enabled: false },
       },
     },
   };

--- a/packages/cloudflare/src/cache/cdn-adapter.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.ts
@@ -18,12 +18,15 @@ export type CdnAdapterOptions = {
  * Unlike the data adapter (which stores cache entries in a durable store and
  * serves HIT/STALE itself), this adapter delegates serving to Workers Cache on
  * a named Worker entrypoint. The default entrypoint always runs middleware and
- * request-time routing before dispatching the cacheable response stage.
+ * request-time routing before dispatching to cached or uncached response-stage
+ * entrypoints.
  *
  * The emitted Wrangler configuration enables Workers Cache only for that
  * response-stage export, so cache hits do not start the application stage.
  * The generated deployment config automatically enables Workers Cache for the
- * response entrypoint and adds the version metadata binding used by warmup.
+ * cached response entrypoint and adds the version metadata binding used by
+ * warmup. The uncached response entrypoint keeps bypass and probe renders out
+ * of the gateway without enabling Workers Cache for them.
  *
  * The adapter adds a transport-only URL digest so distinct response-stage
  * identities cannot collide. Workers Cache owns this key independently of
@@ -57,7 +60,7 @@ export function cdnAdapter(options?: CdnAdapterOptions) {
       transformHostEntry({ code, id }: { code: string; id: string }) {
         const cleanId = id.charCodeAt(0) === 0 ? id.slice(1) : id;
         if (cleanId !== CLOUDFLARE_WORKER_ENTRY_ID) return null;
-        return `${code}\nexport { VinextCachedResponse } from ${JSON.stringify(workerEntry)};\n`;
+        return `${code}\nexport { VinextCachedResponse, VinextUncachedResponse } from ${JSON.stringify(workerEntry)};\n`;
       },
       finalizeBuildOutput({
         outDir,

--- a/packages/cloudflare/src/cache/cdn-adapter.worker.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.worker.ts
@@ -48,6 +48,14 @@ type RestoredResponseStageRequest = {
   request: Request;
 };
 
+type CloudflareResponse = Response & {
+  readonly webSocket?: WebSocket | null;
+};
+
+type CloudflareResponseInit = ResponseInit & {
+  webSocket?: WebSocket | null;
+};
+
 const CACHED_RESPONSE_STAGE_EXPORT = "VinextCachedResponse";
 const UNCACHED_RESPONSE_STAGE_EXPORT = "VinextUncachedResponse";
 const AUTHORIZATION_TRANSPORT_HEADER = "x-vinext-internal-authorization";
@@ -91,11 +99,22 @@ function stampResponseStageBuildIdentity(response: Response): Response {
   } catch {
     const headers = new Headers(response.headers);
     headers.set(VINEXT_CDN_BUILD_ID_HEADER, buildIdentity);
-    return new Response(response.body, {
+    const webSocket = (response as CloudflareResponse).webSocket;
+    // A Workers WebSocket upgrade is the one non-standard status that can be
+    // reconstructed. Convert other non-HTTP responses before they cross the
+    // entrypoint boundary, where a network-error response would reject fetch.
+    if (!webSocket && (response.status < 200 || response.status > 599)) {
+      const unavailable = responseStageUnavailable();
+      unavailable.headers.set(VINEXT_CDN_BUILD_ID_HEADER, buildIdentity);
+      return unavailable;
+    }
+    const init: CloudflareResponseInit = {
       headers,
       status: response.status,
       statusText: response.statusText,
-    });
+    };
+    if (webSocket) init.webSocket = webSocket;
+    return new Response(response.body, init);
   }
 }
 

--- a/packages/cloudflare/src/cache/cdn-adapter.worker.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.worker.ts
@@ -59,7 +59,9 @@ type CloudflareResponseInit = ResponseInit & {
 const CACHED_RESPONSE_STAGE_EXPORT = "VinextCachedResponse";
 const UNCACHED_RESPONSE_STAGE_EXPORT = "VinextUncachedResponse";
 const AUTHORIZATION_TRANSPORT_HEADER = "x-vinext-internal-authorization";
+const REQUEST_CACHE_CONTROL_TRANSPORT_HEADER = "x-vinext-internal-request-cache-control";
 const REQUEST_CF_TRANSPORT_HEADER = "x-vinext-internal-request-cf";
+const REQUEST_PRAGMA_TRANSPORT_HEADER = "x-vinext-internal-request-pragma";
 const CLOUDFLARE_EDGE_POLICY_HEADER = "Cloudflare-CDN-Cache-Control";
 const SHARED_RESPONSE_STAGE_HEADER = "x-vinext-cloudflare-shared-response-stage";
 const RESPONSE_STAGE_WIRE_CACHE = {
@@ -136,13 +138,17 @@ function validateResponseStageBuildIdentity(response: Response): Response {
 function stripUntrustedTransportHeaders(request: Request): Request {
   if (
     !request.headers.has(AUTHORIZATION_TRANSPORT_HEADER) &&
-    !request.headers.has(REQUEST_CF_TRANSPORT_HEADER)
+    !request.headers.has(REQUEST_CACHE_CONTROL_TRANSPORT_HEADER) &&
+    !request.headers.has(REQUEST_CF_TRANSPORT_HEADER) &&
+    !request.headers.has(REQUEST_PRAGMA_TRANSPORT_HEADER)
   ) {
     return request;
   }
   const headers = new Headers(request.headers);
   headers.delete(AUTHORIZATION_TRANSPORT_HEADER);
+  headers.delete(REQUEST_CACHE_CONTROL_TRANSPORT_HEADER);
   headers.delete(REQUEST_CF_TRANSPORT_HEADER);
+  headers.delete(REQUEST_PRAGMA_TRANSPORT_HEADER);
   const sanitized = new Request(request, { headers });
   const requestCf = Reflect.get(request, "cf");
   if (requestCf !== undefined) {
@@ -261,14 +267,26 @@ async function createCacheFacingRequest(
   const url = new URL(request.url);
   url.searchParams.set("__vinext_cache_key", key);
   const headers = new Headers(request.headers);
+  const requestCacheControl = headers.get("Cache-Control");
+  const requestPragma = headers.get("Pragma");
+  headers.delete("Cache-Control");
+  headers.delete("Pragma");
   headers.delete("Authorization");
   headers.delete(AUTHORIZATION_TRANSPORT_HEADER);
+  headers.delete(REQUEST_CACHE_CONTROL_TRANSPORT_HEADER);
   headers.delete(REQUEST_CF_TRANSPORT_HEADER);
+  headers.delete(REQUEST_PRAGMA_TRANSPORT_HEADER);
   if (authorization !== null) {
     headers.set(AUTHORIZATION_TRANSPORT_HEADER, encodeURIComponent(authorization));
   }
   if (serializedRequestCf !== null) {
     headers.set(REQUEST_CF_TRANSPORT_HEADER, serializedRequestCf);
+  }
+  if (requestCacheControl !== null) {
+    headers.set(REQUEST_CACHE_CONTROL_TRANSPORT_HEADER, encodeURIComponent(requestCacheControl));
+  }
+  if (requestPragma !== null) {
+    headers.set(REQUEST_PRAGMA_TRANSPORT_HEADER, encodeURIComponent(requestPragma));
   }
   const init = {
     // Explicitly replace inherited inbound `cf` metadata. In workerd,
@@ -280,7 +298,14 @@ async function createCacheFacingRequest(
   } satisfies RequestInit & {
     cf: { vary: { default: { action: "passthrough" } } };
   };
-  return new Request(new Request(url, request), init);
+  // Construct from the URL rather than cloning the inbound request. Workers
+  // carries cache-bypass state from browser reloads outside the visible header
+  // map, and cloning would leak that state into the cache-enabled entrypoint
+  // even after the directives above were transported privately.
+  return new Request(url, {
+    ...init,
+    method: request.method,
+  });
 }
 
 function restoreResponseStageRequest(
@@ -290,10 +315,16 @@ function restoreResponseStageRequest(
 ): RestoredResponseStageRequest {
   const headers = new Headers(request.headers);
   const serializedAuthorization = headers.get(AUTHORIZATION_TRANSPORT_HEADER);
+  const serializedRequestCacheControl = headers.get(REQUEST_CACHE_CONTROL_TRANSPORT_HEADER);
   const serializedRequestCf = headers.get(REQUEST_CF_TRANSPORT_HEADER);
+  const serializedRequestPragma = headers.get(REQUEST_PRAGMA_TRANSPORT_HEADER);
+  headers.delete("Cache-Control");
+  headers.delete("Pragma");
   headers.delete("Authorization");
   headers.delete(AUTHORIZATION_TRANSPORT_HEADER);
+  headers.delete(REQUEST_CACHE_CONTROL_TRANSPORT_HEADER);
   headers.delete(REQUEST_CF_TRANSPORT_HEADER);
+  headers.delete(REQUEST_PRAGMA_TRANSPORT_HEADER);
   if (serializedAuthorization !== null) {
     try {
       headers.set("Authorization", decodeURIComponent(serializedAuthorization));
@@ -305,6 +336,20 @@ function restoreResponseStageRequest(
   if (serializedRequestCf !== null) {
     try {
       requestCf = JSON.parse(decodeURIComponent(serializedRequestCf));
+    } catch {
+      // Malformed internal metadata is stripped rather than exposed to userland.
+    }
+  }
+  if (serializedRequestCacheControl !== null) {
+    try {
+      headers.set("Cache-Control", decodeURIComponent(serializedRequestCacheControl));
+    } catch {
+      // Malformed internal metadata is stripped rather than exposed to userland.
+    }
+  }
+  if (serializedRequestPragma !== null) {
+    try {
+      headers.set("Pragma", decodeURIComponent(serializedRequestPragma));
     } catch {
       // Malformed internal metadata is stripped rather than exposed to userland.
     }

--- a/packages/cloudflare/src/cache/cdn-adapter.worker.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.worker.ts
@@ -48,7 +48,8 @@ type RestoredResponseStageRequest = {
   request: Request;
 };
 
-const RESPONSE_STAGE_EXPORT = "VinextCachedResponse";
+const CACHED_RESPONSE_STAGE_EXPORT = "VinextCachedResponse";
+const UNCACHED_RESPONSE_STAGE_EXPORT = "VinextUncachedResponse";
 const AUTHORIZATION_TRANSPORT_HEADER = "x-vinext-internal-authorization";
 const REQUEST_CF_TRANSPORT_HEADER = "x-vinext-internal-request-cf";
 const CLOUDFLARE_EDGE_POLICY_HEADER = "Cloudflare-CDN-Cache-Control";
@@ -186,9 +187,10 @@ function hasPurge(value: unknown): value is Required<Pick<StageBinding, "purge">
 
 function getResponseStageBinding(
   context: CloudflareStageContext,
+  exportName: typeof CACHED_RESPONSE_STAGE_EXPORT | typeof UNCACHED_RESPONSE_STAGE_EXPORT,
   serializedInvocation: string,
 ): StageBinding | null {
-  const binding = context.exports?.[RESPONSE_STAGE_EXPORT];
+  const binding = context.exports?.[exportName];
   if (typeof binding !== "function") return null;
 
   // Configurable-entrypoint props cross a Workers RPC boundary. Some vinext
@@ -399,7 +401,7 @@ function hasTaggedCustomVary(response: Response): boolean {
 }
 
 function withResponseStagePurge(context: CloudflareStageContext): CloudflareStageContext {
-  const factory = context.exports?.[RESPONSE_STAGE_EXPORT];
+  const factory = context.exports?.[CACHED_RESPONSE_STAGE_EXPORT];
   if (typeof factory !== "function") return context;
   const fallback = context.cache;
   return {
@@ -414,7 +416,10 @@ function withResponseStagePurge(context: CloudflareStageContext): CloudflareStag
   };
 }
 
-function getResponseStageInvocation(value: unknown): CloudflareResponseStageInvocation | null {
+function getResponseStageInvocation(
+  value: unknown,
+  expectedCache?: VinextResponseStageDispatchOptions["cache"],
+): CloudflareResponseStageInvocation | null {
   if (!value || typeof value !== "object") return null;
   const expectedResponseStageBuildIdentity = Reflect.get(
     value,
@@ -452,6 +457,7 @@ function getResponseStageInvocation(value: unknown): CloudflareResponseStageInvo
   } else {
     return null;
   }
+  if (expectedCache !== undefined && cache !== expectedCache) return null;
   const requestUrl = Reflect.get(value, "requestUrl");
   if (typeof requestUrl !== "string") return null;
   const requestMethod = Reflect.get(value, "requestMethod");
@@ -504,7 +510,7 @@ async function invokeResponseStage(
 export class VinextCachedResponse extends WorkerEntrypoint<unknown, unknown> {
   async fetch(request: Request): Promise<Response> {
     const context = withWorkerHostRuntime(this.ctx, this.env);
-    const invocation = getResponseStageInvocation(context.props);
+    const invocation = getResponseStageInvocation(context.props, "shared");
     if (!invocation) {
       return stampResponseStageBuildIdentity(
         new Response("Invalid vinext response-stage invocation", {
@@ -545,6 +551,31 @@ export class VinextCachedResponse extends WorkerEntrypoint<unknown, unknown> {
   }
 }
 
+/** Uncached response entrypoint. Bypass and probe renders execute only here. */
+export class VinextUncachedResponse extends WorkerEntrypoint<unknown, unknown> {
+  async fetch(request: Request): Promise<Response> {
+    const context = withWorkerHostRuntime(this.ctx, this.env);
+    const invocation = getResponseStageInvocation(context.props, "bypass");
+    if (!invocation) {
+      return stampResponseStageBuildIdentity(
+        new Response("Invalid vinext response-stage invocation", {
+          status: 400,
+          headers: { "Cache-Control": "no-store" },
+        }),
+      );
+    }
+    if (
+      invocation.expectedResponseStageBuildIdentity !== undefined &&
+      invocation.expectedResponseStageBuildIdentity !== getVinextCdnBuildIdentity()
+    ) {
+      return stampResponseStageBuildIdentity(responseStageUnavailable());
+    }
+    return stampResponseStageBuildIdentity(
+      await invokeResponseStage(request, this.env, context, invocation),
+    );
+  }
+}
+
 /** Uncached gateway: request routing and middleware always execute here. */
 export default {
   async fetch(
@@ -570,10 +601,7 @@ export default {
         requestMethod: stageRequest.method,
         requestUrl: stageRequest.url,
       };
-      const requiresEntrypoint = isResponseStageReadinessRequest(stageRequest);
-      if (options.cache === "bypass" && !requiresEntrypoint) {
-        return invokeResponseStage(stageRequest, env, stageContext, invocation);
-      }
+      const usesSharedCache = options.cache === "shared";
       try {
         const serializedInvocation = JSON.stringify({
           ...invocation,
@@ -585,24 +613,23 @@ export default {
                   cache: RESPONSE_STAGE_WIRE_CACHE[options.cache] satisfies ResponseStageWireCache,
                 },
         });
-        const binding = getResponseStageBinding(stageContext, serializedInvocation);
+        const binding = getResponseStageBinding(
+          stageContext,
+          usesSharedCache ? CACHED_RESPONSE_STAGE_EXPORT : UNCACHED_RESPONSE_STAGE_EXPORT,
+          serializedInvocation,
+        );
         if (!binding) {
-          return requiresEntrypoint
-            ? responseStageUnavailable()
-            : markSharedResponseStage(
-                await invokeResponseStage(stageRequest, env, stageContext, invocation),
-                sharedResponseStageProvenance,
-              );
+          return responseStageUnavailable();
         }
-        const entrypointRequest = requiresEntrypoint
-          ? stageRequest
-          : await createCacheFacingRequest(stageRequest, serializedInvocation);
+        const entrypointRequest = usesSharedCache
+          ? await createCacheFacingRequest(stageRequest, serializedInvocation)
+          : stageRequest;
         const response = validateResponseStageBuildIdentity(await binding.fetch(entrypointRequest));
-        return requiresEntrypoint
-          ? response
-          : markSharedResponseStage(response, sharedResponseStageProvenance, true);
+        return usesSharedCache
+          ? markSharedResponseStage(response, sharedResponseStageProvenance, true)
+          : response;
       } catch (error) {
-        if (requiresEntrypoint) return responseStageUnavailable();
+        if (isResponseStageReadinessRequest(stageRequest)) return responseStageUnavailable();
         throw error;
       }
     };

--- a/packages/cloudflare/src/cache/cdn-adapter.worker.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.worker.ts
@@ -554,7 +554,7 @@ export class VinextCachedResponse extends WorkerEntrypoint<unknown, unknown> {
 /** Uncached response entrypoint. Bypass and probe renders execute only here. */
 export class VinextUncachedResponse extends WorkerEntrypoint<unknown, unknown> {
   async fetch(request: Request): Promise<Response> {
-    const context = withWorkerHostRuntime(this.ctx, this.env);
+    const context = withResponseStagePurge(withWorkerHostRuntime(this.ctx, this.env));
     const invocation = getResponseStageInvocation(context.props, "bypass");
     if (!invocation) {
       return stampResponseStageBuildIdentity(

--- a/packages/cloudflare/src/cacheability-probe.ts
+++ b/packages/cloudflare/src/cacheability-probe.ts
@@ -688,31 +688,58 @@ export async function probeStagedWorkerCacheability(options: {
     reportProgress();
   };
 
-  const runGroups = async (scheduledGroups: ConcretePathGroup[]): Promise<void> => {
-    let nextIndex = 0;
-    const worker = async (): Promise<void> => {
-      while (!limitFailure && !phaseTimedOut && nextIndex < scheduledGroups.length) {
-        await classifyConcretePath(scheduledGroups[nextIndex++]);
-      }
-    };
-    await Promise.all(
-      Array.from({ length: Math.min(concurrency, scheduledGroups.length) }, () => worker()),
-    );
-  };
-
   reportProgress();
-  const representativeGroups: ConcretePathGroup[] = [];
-  const siblingGroups: ConcretePathGroup[] = [];
-  const scheduledPatterns = new Set<string>();
-  for (const group of groups) {
-    if (scheduledPatterns.has(group.pattern.key)) siblingGroups.push(group);
-    else {
-      scheduledPatterns.add(group.pattern.key);
-      representativeGroups.push(group);
+  let activeProbes = 0;
+  const slotWaiters: Array<() => void> = [];
+  const acquireProbeSlot = async (): Promise<void> => {
+    if (activeProbes < concurrency) {
+      activeProbes++;
+      return;
     }
-  }
-  await runGroups(representativeGroups);
-  if (!limitFailure && !phaseTimedOut) await runGroups(siblingGroups);
+    await new Promise<void>((resolve) => slotWaiters.push(resolve));
+  };
+  const releaseProbeSlot = (): void => {
+    const next = slotWaiters.shift();
+    if (next) next();
+    else activeProbes--;
+  };
+  let pendingRouteMovers = groups.filter(
+    (group) => group.primary.route?.cacheabilityProbe?.routeMayResolve === true,
+  ).length;
+  let settleRouteMovers: (() => void) | undefined;
+  const routeMoversSettled =
+    pendingRouteMovers === 0
+      ? Promise.resolve()
+      : new Promise<void>((resolve) => {
+          settleRouteMovers = resolve;
+        });
+  const runGroup = async (group: ConcretePathGroup): Promise<void> => {
+    const mayResolveRoute = group.primary.route?.cacheabilityProbe?.routeMayResolve === true;
+    while (true) {
+      if (!mayResolveRoute && group.pattern.pruned && pendingRouteMovers > 0) {
+        await routeMoversSettled;
+      }
+      await acquireProbeSlot();
+      if (!mayResolveRoute && group.pattern.pruned && pendingRouteMovers > 0) {
+        releaseProbeSlot();
+        continue;
+      }
+      break;
+    }
+    try {
+      if (!limitFailure && !phaseTimedOut) await classifyConcretePath(group);
+    } finally {
+      releaseProbeSlot();
+      if (mayResolveRoute && --pendingRouteMovers === 0) settleRouteMovers?.();
+    }
+  };
+  const initialPatternGroups = Array.from(patterns.values(), (pattern) => [...pattern.groups]);
+  await Promise.all(
+    initialPatternGroups.map(async ([representative, ...siblings]) => {
+      await runGroup(representative);
+      await Promise.all(siblings.map(runGroup));
+    }),
+  );
   if (limitFailure) throw limitFailure;
   if (phaseTimedOut || Date.now() >= getDeadlineAt()) {
     throw new Error(`cacheability probing made no progress for ${phaseTimeoutMs}ms`);
@@ -791,12 +818,14 @@ export async function probeStagedWorkerCacheability(options: {
         continue;
       }
 
-      if (result?.terminal !== true) runtimePathSet.add(group.routePathname);
+      const pairedTargets = group.targets.filter((target) => target !== group.primary);
+      if (result?.terminal !== true || pairedTargets.length > 0) {
+        runtimePathSet.add(group.routePathname);
+      }
       // A representation-specific response policy can make an RSC/data
       // sibling reusable even when the representative HTML render is private.
       // The final completed render decides admission without another probe.
       if (!pattern.pruned) {
-        const pairedTargets = group.targets.filter((target) => target !== group.primary);
         cacheableTargets.push(...pairedTargets);
         speculativeTargets.push(...pairedTargets);
       }

--- a/packages/cloudflare/src/cacheability-probe.ts
+++ b/packages/cloudflare/src/cacheability-probe.ts
@@ -385,6 +385,7 @@ export async function probeStagedWorkerCacheability(options: {
     requestStageMayTerminate: boolean;
   };
   type ConcretePathGroup = {
+    deferred: boolean;
     pattern: PatternClassification;
     primary: CdnWarmTarget;
     result?: ConcretePathResult;
@@ -462,7 +463,7 @@ export async function probeStagedWorkerCacheability(options: {
       const preference = targetPreference(first) - targetPreference(second);
       return preference || first.sourcePathname.localeCompare(second.sourcePathname);
     });
-    const group = { ...targetGroup, primary: targetGroup.targets[0] };
+    const group = { ...targetGroup, deferred: false, primary: targetGroup.targets[0] };
     targetGroup.pattern.groups.push(group);
     return group;
   });
@@ -553,6 +554,27 @@ export async function probeStagedWorkerCacheability(options: {
     pattern.resultKeys.add(group.resultKey);
   };
 
+  const deferPairedRepresentationsAtOriginalRoute = (group: ConcretePathGroup): void => {
+    const pairedTargets = group.targets.filter((target) => target !== group.primary);
+    if (pairedTargets.length === 0) return;
+    group.targets = [group.primary];
+    for (const target of pairedTargets) {
+      const routePathname =
+        target.route?.cacheabilityProbe?.concretePathname ??
+        cacheabilityRoutePathname(target.pathname, target.kind);
+      const deferredGroup: ConcretePathGroup = {
+        deferred: true,
+        pattern: group.pattern,
+        primary: target,
+        resultKey: routePathname,
+        routePathname,
+        targets: [target],
+      };
+      group.pattern.groups.push(deferredGroup);
+      group.pattern.resultKeys.add(routePathname);
+    }
+  };
+
   const classifyConcretePath = async (group: ConcretePathGroup): Promise<void> => {
     if (group.pattern.pruned) {
       skippedPathCount += 1;
@@ -632,7 +654,12 @@ export async function probeStagedWorkerCacheability(options: {
       reportProgress();
       return;
     }
-    if (result.kind !== target.route.kind || result.pattern !== target.route.pattern) {
+    const resolvedRouteChanged =
+      result.kind !== target.route.kind || result.pattern !== target.route.pattern;
+    const resolvedPathnameChanged =
+      result.routePathname !== undefined &&
+      normalizeCacheabilityRoutePathname(result.routePathname) !== group.routePathname;
+    if (resolvedRouteChanged) {
       if (target.route.cacheabilityProbe?.routeMayResolve !== true) {
         failures.push(
           `${target.label}: probe resolved to unexpected route ${result.pattern ?? ""}`,
@@ -647,6 +674,17 @@ export async function probeStagedWorkerCacheability(options: {
         reportProgress();
         return;
       }
+    }
+    if (
+      target.route.cacheabilityProbe?.routeMayResolve === true &&
+      (resolvedRouteChanged || resolvedPathnameChanged)
+    ) {
+      // The representative request proves only its own routed destination.
+      // Keep alternate representations attached to the original route so
+      // their final completed renders can still pass manifest admission.
+      deferPairedRepresentationsAtOriginalRoute(group);
+    }
+    if (resolvedRouteChanged) {
       moveGroupToResolvedRoute(group, { kind: result.kind, pattern: result.pattern });
     }
     if (result.routePathname !== undefined) {
@@ -794,7 +832,7 @@ export async function probeStagedWorkerCacheability(options: {
       }
       continue;
     }
-    if (pattern.results.size === 0) continue;
+    if (pattern.results.size === 0 && !pattern.groups.some((group) => group.deferred)) continue;
     classified += 1;
     if (Array.from(pattern.results.values()).some((result) => result.state === "dynamic")) {
       dynamic += 1;
@@ -803,6 +841,12 @@ export async function probeStagedWorkerCacheability(options: {
     const rendererStaticTargets = new Map<string, CdnWarmTarget>();
     const runtimePathSet = new Set<string>();
     for (const group of pattern.groups) {
+      if (group.deferred) {
+        runtimePathSet.add(group.routePathname);
+        cacheableTargets.push(...group.targets);
+        speculativeTargets.push(...group.targets);
+        continue;
+      }
       const result = group.result;
       if (result?.state === "static-candidate") {
         if (result.rendererStatic) {

--- a/packages/cloudflare/src/cacheability-probe.ts
+++ b/packages/cloudflare/src/cacheability-probe.ts
@@ -382,7 +382,7 @@ export async function probeStagedWorkerCacheability(options: {
     pruned: boolean;
     results: Map<string, ConcretePathResult>;
     route: NonNullable<CdnWarmTarget["route"]>;
-    splitRepresentations: boolean;
+    requestStageMayTerminate: boolean;
   };
   type ConcretePathGroup = {
     pattern: PatternClassification;
@@ -413,9 +413,9 @@ export async function probeStagedWorkerCacheability(options: {
       pruned: false,
       results: new Map(),
       route: target.route,
-      splitRepresentations: false,
+      requestStageMayTerminate: false,
     };
-    pattern.splitRepresentations ||=
+    pattern.requestStageMayTerminate ||=
       target.route.cacheabilityProbe?.requestStageMayTerminate === true;
     pattern.canPrune &&=
       target.route.cacheabilityProbe?.canPrunePattern === true &&
@@ -445,9 +445,7 @@ export async function probeStagedWorkerCacheability(options: {
     const routePathname =
       route.cacheabilityProbe?.concretePathname ??
       cacheabilityRoutePathname(target.pathname, target.kind);
-    const resultKey = pattern.splitRepresentations
-      ? `${target.kind}\0${routePathname}`
-      : routePathname;
+    const resultKey = routePathname;
     pattern.resultKeys.add(resultKey);
     const concreteKey = `${key}\0${resultKey}`;
     const group = targetGroups.get(concreteKey) ?? {
@@ -519,12 +517,12 @@ export async function probeStagedWorkerCacheability(options: {
         pruned: false,
         results: new Map(),
         route,
-        splitRepresentations: previousPattern.splitRepresentations,
+        requestStageMayTerminate: previousPattern.requestStageMayTerminate,
       };
       patterns.set(key, pattern);
     }
     pattern.canPrune = false;
-    pattern.splitRepresentations ||= previousPattern.splitRepresentations;
+    pattern.requestStageMayTerminate ||= previousPattern.requestStageMayTerminate;
     // A direct destination probe may have provisionally pruned this pattern
     // before the routed source completed. Its retained concrete observation is
     // authoritative once another public path joins the resolved route.
@@ -548,9 +546,7 @@ export async function probeStagedWorkerCacheability(options: {
     const pattern = group.pattern;
     const previousResultKey = group.resultKey;
     group.routePathname = normalized;
-    group.resultKey = pattern.splitRepresentations
-      ? `${group.primary.kind}\0${normalized}`
-      : normalized;
+    group.resultKey = normalized;
     if (!pattern.groups.some((candidate) => candidate.resultKey === previousResultKey)) {
       pattern.resultKeys.delete(previousResultKey);
     }
@@ -613,7 +609,7 @@ export async function probeStagedWorkerCacheability(options: {
       (result.terminal === true &&
         (result.state !== "dynamic" ||
           result.scope !== "identity" ||
-          !group.pattern.splitRepresentations)) ||
+          !group.pattern.requestStageMayTerminate)) ||
       (result.rendererStatic !== undefined && typeof result.rendererStatic !== "boolean") ||
       !Number.isInteger(result.status) ||
       result.status! < 100 ||

--- a/packages/vinext/src/build/prerender-paths.ts
+++ b/packages/vinext/src/build/prerender-paths.ts
@@ -1227,6 +1227,38 @@ function findMiddlewareConventionFile(
   return null;
 }
 
+/** @internal Match the pathname forms and locale provenance used by middleware runtime. */
+export function matchesMiddlewareWarmPath(
+  pathname: string,
+  matcher: MatcherConfig | undefined,
+  i18n: ResolvedNextConfig["i18n"],
+): boolean {
+  const firstSegment = pathname.split("/", 3)[1]?.toLowerCase();
+  const localeContexts: Array<MiddlewareLocaleMatchContext | undefined> = i18n
+    ? i18n.locales.some((locale) => locale.toLowerCase() === firstSegment)
+      ? [{ kind: "literal" }]
+      : Array.from(
+          new Set([
+            i18n.defaultLocale,
+            ...(i18n.domains?.map((domain) => domain.defaultLocale) ?? []),
+          ]),
+          (defaultLocale) => ({ defaultLocale, kind: "defaulted" as const }),
+        )
+    : [undefined];
+  const matchPathnames = [pathname];
+  try {
+    const decodedPathname = decodeURIComponent(pathname);
+    if (decodedPathname !== pathname) matchPathnames.push(decodedPathname);
+  } catch {
+    // Match runtime middleware behavior: malformed encoding is non-fatal.
+  }
+  return matchPathnames.some((matchPathname) =>
+    localeContexts.some((localeContext) =>
+      matchesMiddlewarePathname(matchPathname, matcher, i18n, localeContext),
+    ),
+  );
+}
+
 async function startPathDiscoveryServer(options: {
   serverDir: string;
   pagesBundlePath?: string;
@@ -1411,28 +1443,8 @@ export async function emitPrerenderPathManifest(
     ? extractMiddlewareMatcherConfig(middlewarePath)
     : undefined;
   const configuredMatcher = middlewareMatcher as MatcherConfig | undefined;
-  const defaultLocaleContexts: MiddlewareLocaleMatchContext[] = config.i18n
-    ? Array.from(
-        new Set([
-          config.i18n.defaultLocale,
-          ...(config.i18n.domains?.map((domain) => domain.defaultLocale) ?? []),
-        ]),
-        (defaultLocale) => ({ defaultLocale, kind: "defaulted" as const }),
-      )
-    : [];
-  const middlewareMayRouteWarmPath = (pathname: string): boolean => {
-    if (middlewarePath === null) return false;
-    if (!config.i18n) return matchesMiddlewarePathname(pathname, configuredMatcher);
-    const firstSegment = pathname.split("/", 3)[1]?.toLowerCase();
-    const localeContexts: MiddlewareLocaleMatchContext[] = config.i18n.locales.some(
-      (locale) => locale.toLowerCase() === firstSegment,
-    )
-      ? [{ kind: "literal" }]
-      : defaultLocaleContexts;
-    return localeContexts.some((localeContext) =>
-      matchesMiddlewarePathname(pathname, configuredMatcher, config.i18n, localeContext),
-    );
-  };
+  const middlewareMayRouteWarmPath = (pathname: string): boolean =>
+    middlewarePath !== null && matchesMiddlewareWarmPath(pathname, configuredMatcher, config.i18n);
   const routedWarmPaths = [...paths, ...discoveredRouteHandlerPaths];
   const routeMayResolveWarmPathSet = new Set(
     hasStagedRequestRouting

--- a/packages/vinext/src/build/prerender-paths.ts
+++ b/packages/vinext/src/build/prerender-paths.ts
@@ -24,6 +24,7 @@ import {
   classifyAppRouteHandler,
   classifyPagesRoute,
   extractExportConstString,
+  extractMiddlewareMatcherConfig,
 } from "./report.js";
 import { buildUrlFromParams, resolveParentParams, type StaticParamsMap } from "./prerender.js";
 import { readPrerenderSecret } from "./server-manifest.js";
@@ -42,6 +43,7 @@ import { normalizePathTrailingSlash } from "vinext/shims/url-utils";
 import { buildPagesDataHref } from "vinext/shims/internal/pages-data-url";
 import { CACHEABILITY_POLICY_HEADERS } from "vinext/shims/cacheability-classification";
 import { resolveBuiltRscEntryPath } from "./server-entry.js";
+import { matchesMiddlewarePathname, type MatcherConfig } from "../server/middleware-matcher.js";
 
 export type PrerenderRoutePattern = {
   kind: "app-page" | "app-route" | "pages-page";
@@ -1203,20 +1205,22 @@ function configuredRewritesCanReplaceWarmPath(
   return configuredRulesAffectWarmPath(pathname, applicableRewrites, config);
 }
 
-function hasMiddlewareConventionFile(
+function findMiddlewareConventionFile(
   root: string,
   appDir: string | null,
   pagesDir: string | null,
   pageExtensions: readonly string[],
-): boolean {
+): string | null {
   const routeDir = appDir ?? pagesDir;
   const routeRoot = routeDir ? path.dirname(routeDir) : root;
   const conventionDir = routeRoot === path.join(root, "src") ? routeRoot : root;
-  return ["proxy", "middleware"].some((name) =>
-    pageExtensions.some((extension) =>
-      fs.existsSync(path.join(conventionDir, `${name}.${extension}`)),
-    ),
-  );
+  for (const name of ["proxy", "middleware"]) {
+    for (const extension of pageExtensions) {
+      const filePath = path.join(conventionDir, `${name}.${extension}`);
+      if (fs.existsSync(filePath)) return filePath;
+    }
+  }
+  return null;
 }
 
 async function startPathDiscoveryServer(options: {
@@ -1396,15 +1400,25 @@ export async function emitPrerenderPathManifest(
   });
 
   const hasStagedRequestRouting = options.requestRouting === "uncached-stage";
-  const middlewareMayRouteWarmPaths =
-    hasStagedRequestRouting &&
-    hasMiddlewareConventionFile(root, appDir, pagesDir, config.pageExtensions);
+  const middlewarePath = hasStagedRequestRouting
+    ? findMiddlewareConventionFile(root, appDir, pagesDir, config.pageExtensions)
+    : null;
+  const middlewareMatcher = middlewarePath
+    ? extractMiddlewareMatcherConfig(middlewarePath)
+    : undefined;
+  const middlewareMayRouteWarmPath = (pathname: string): boolean =>
+    middlewarePath !== null &&
+    matchesMiddlewarePathname(
+      pathname,
+      middlewareMatcher as MatcherConfig | undefined,
+      config.i18n,
+    );
   const routedWarmPaths = [...paths, ...discoveredRouteHandlerPaths];
   const routeMayResolveWarmPathSet = new Set(
     hasStagedRequestRouting
       ? routedWarmPaths.filter(
           (pathname) =>
-            middlewareMayRouteWarmPaths ||
+            middlewareMayRouteWarmPath(pathname) ||
             configuredRewritesCanReplaceWarmPath(
               pathname,
               config.rewrites,
@@ -1419,7 +1433,7 @@ export async function emitPrerenderPathManifest(
     hasStagedRequestRouting
       ? routedWarmPaths.filter(
           (pathname) =>
-            middlewareMayRouteWarmPaths ||
+            middlewareMayRouteWarmPath(pathname) ||
             configuredRulesAffectWarmPath(pathname, config.redirects, config) ||
             configuredRewritesCanReplaceWarmPath(
               pathname,

--- a/packages/vinext/src/build/prerender-paths.ts
+++ b/packages/vinext/src/build/prerender-paths.ts
@@ -1233,7 +1233,8 @@ export function matchesMiddlewareWarmPath(
   matcher: MatcherConfig | undefined,
   i18n: ResolvedNextConfig["i18n"],
 ): boolean {
-  const firstSegment = pathname.split("/", 3)[1]?.toLowerCase();
+  const encodedPathname = new URL(pathname, "https://vinext.invalid").pathname;
+  const firstSegment = encodedPathname.split("/", 3)[1]?.toLowerCase();
   const localeContexts: Array<MiddlewareLocaleMatchContext | undefined> = i18n
     ? i18n.locales.some((locale) => locale.toLowerCase() === firstSegment)
       ? [{ kind: "literal" }]
@@ -1245,10 +1246,10 @@ export function matchesMiddlewareWarmPath(
           (defaultLocale) => ({ defaultLocale, kind: "defaulted" as const }),
         )
     : [undefined];
-  const matchPathnames = [pathname];
+  const matchPathnames = [encodedPathname];
   try {
-    const decodedPathname = decodeURIComponent(pathname);
-    if (decodedPathname !== pathname) matchPathnames.push(decodedPathname);
+    const decodedPathname = decodeURIComponent(encodedPathname);
+    if (decodedPathname !== encodedPathname) matchPathnames.push(decodedPathname);
   } catch {
     // Match runtime middleware behavior: malformed encoding is non-fatal.
   }

--- a/packages/vinext/src/build/prerender-paths.ts
+++ b/packages/vinext/src/build/prerender-paths.ts
@@ -43,7 +43,11 @@ import { normalizePathTrailingSlash } from "vinext/shims/url-utils";
 import { buildPagesDataHref } from "vinext/shims/internal/pages-data-url";
 import { CACHEABILITY_POLICY_HEADERS } from "vinext/shims/cacheability-classification";
 import { resolveBuiltRscEntryPath } from "./server-entry.js";
-import { matchesMiddlewarePathname, type MatcherConfig } from "../server/middleware-matcher.js";
+import {
+  matchesMiddlewarePathname,
+  type MatcherConfig,
+  type MiddlewareLocaleMatchContext,
+} from "../server/middleware-matcher.js";
 
 export type PrerenderRoutePattern = {
   kind: "app-page" | "app-route" | "pages-page";
@@ -1406,13 +1410,29 @@ export async function emitPrerenderPathManifest(
   const middlewareMatcher = middlewarePath
     ? extractMiddlewareMatcherConfig(middlewarePath)
     : undefined;
-  const middlewareMayRouteWarmPath = (pathname: string): boolean =>
-    middlewarePath !== null &&
-    matchesMiddlewarePathname(
-      pathname,
-      middlewareMatcher as MatcherConfig | undefined,
-      config.i18n,
+  const configuredMatcher = middlewareMatcher as MatcherConfig | undefined;
+  const defaultLocaleContexts: MiddlewareLocaleMatchContext[] = config.i18n
+    ? Array.from(
+        new Set([
+          config.i18n.defaultLocale,
+          ...(config.i18n.domains?.map((domain) => domain.defaultLocale) ?? []),
+        ]),
+        (defaultLocale) => ({ defaultLocale, kind: "defaulted" as const }),
+      )
+    : [];
+  const middlewareMayRouteWarmPath = (pathname: string): boolean => {
+    if (middlewarePath === null) return false;
+    if (!config.i18n) return matchesMiddlewarePathname(pathname, configuredMatcher);
+    const firstSegment = pathname.split("/", 3)[1]?.toLowerCase();
+    const localeContexts: MiddlewareLocaleMatchContext[] = config.i18n.locales.some(
+      (locale) => locale.toLowerCase() === firstSegment,
+    )
+      ? [{ kind: "literal" }]
+      : defaultLocaleContexts;
+    return localeContexts.some((localeContext) =>
+      matchesMiddlewarePathname(pathname, configuredMatcher, config.i18n, localeContext),
     );
+  };
   const routedWarmPaths = [...paths, ...discoveredRouteHandlerPaths];
   const routeMayResolveWarmPathSet = new Set(
     hasStagedRequestRouting

--- a/packages/vinext/src/server/app-request-stage-dispatch.ts
+++ b/packages/vinext/src/server/app-request-stage-dispatch.ts
@@ -46,13 +46,6 @@ export function appRequestUsesFullResponseGraph(
   if (isDraftModeRequest(request, options.draftModeSecret)) return true;
   if (request.headers.has(VINEXT_PRERENDER_ROUTE_PARAMS_HEADER)) return true;
 
-  const cacheControl = request.headers.get("cache-control")?.toLowerCase() ?? "";
-  if (
-    !options.probeMode &&
-    /(?:^|,)\s*(?:no-cache|no-store)(?:\s*(?:,|$)|\s*=)/.test(cacheControl)
-  ) {
-    return true;
-  }
   if (
     getScriptNonceFromHeaderSources(request.headers) !== undefined ||
     isRouteTreePrefetchRequest(request)

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -232,9 +232,7 @@ function requestOptsOutOfWorkerResponseStage(
   if (isDraftModeRequest(request, options.draftModeSecret) || isDraftModeEnabled()) return true;
   if (isOnDemandRevalidateRequest(request.headers.get(PRERENDER_REVALIDATE_HEADER))) return true;
   if (request.headers.has(VINEXT_PRERENDER_ROUTE_PARAMS_HEADER)) return true;
-
-  const requestCacheControl = request.headers.get("cache-control")?.toLowerCase() ?? "";
-  return /(?:^|,)\s*(?:no-cache|no-store)(?:\s*(?:,|$)|\s*=)/.test(requestCacheControl);
+  return false;
 }
 
 function hasUrlParserDotSegment(pathname: string): boolean {

--- a/packages/vinext/src/server/pages-response-stage.ts
+++ b/packages/vinext/src/server/pages-response-stage.ts
@@ -5,7 +5,6 @@ import { MIDDLEWARE_SET_COOKIE_HEADER } from "./headers.js";
 import type { PagesRouteDataKind } from "./pages-route-data-kind.js";
 
 const PREVIEW_COOKIE_NAMES = new Set(["__prerender_bypass", "__next_preview_data"]);
-const BYPASS_CACHE_CONTROL_DIRECTIVES = new Set(["no-cache", "no-store"]);
 
 export function hasPagesPreviewCookie(cookieHeader: string | null): boolean {
   if (!cookieHeader) return false;
@@ -15,20 +14,6 @@ export function hasPagesPreviewCookie(cookieHeader: string | null): boolean {
     if (PREVIEW_COOKIE_NAMES.has(name)) return true;
   }
   return false;
-}
-
-function hasCacheBypassDirective(
-  cacheControl: string | null,
-  directives = BYPASS_CACHE_CONTROL_DIRECTIVES,
-): boolean {
-  if (!cacheControl) return false;
-  return cacheControl.split(",").some((directive) => {
-    const separator = directive.indexOf("=");
-    const name = (separator === -1 ? directive : directive.slice(0, separator))
-      .trim()
-      .toLowerCase();
-    return directives.has(name);
-  });
 }
 
 function hasStagedCacheBypass(stagedHeaders: Headers | undefined): boolean {
@@ -57,8 +42,9 @@ export type PagesResponseStageCacheDisposition = VinextResponseStageDispatchOpti
  *
  * Next.js does not construct a static response-cache key in draft mode and
  * handles authenticated on-demand revalidation outside ordinary cache reuse.
- * Request cache bypass directives and non-idempotent methods likewise need to
- * reach the renderer, while CSP nonces are embedded in the rendered body.
+ * Non-idempotent methods need to reach the renderer, while CSP nonces are
+ * embedded in the rendered body. Request Cache-Control remains visible on a
+ * cache miss, but does not bypass an existing host-cache entry in production.
  *
  * @see https://github.com/vercel/next.js/blob/canary/packages/next/src/server/route-modules/pages/pages-handler.ts
  * @see https://github.com/vercel/next.js/blob/canary/packages/next/src/server/base-server.ts
@@ -89,7 +75,6 @@ export function shouldDispatchPagesResponseStage({
   if (hasRequestAwareDocument && routeDataKind === "static") return false;
 
   if (hasPagesPreviewCookie(request.headers.get("cookie"))) return false;
-  if (hasCacheBypassDirective(request.headers.get("cache-control"))) return false;
   if (requestHeadersChanged) return false;
   if (hasStagedCacheBypass(stagedHeaders)) return false;
 

--- a/tests/app-request-stage-dispatch.test.ts
+++ b/tests/app-request-stage-dispatch.test.ts
@@ -56,12 +56,6 @@ describe("App request-stage dispatch", () => {
       }),
     },
     {
-      name: "request cache bypass",
-      request: new Request("https://example.test/docs/page", {
-        headers: { "Cache-Control": "max-age=0, NO-STORE" },
-      }),
-    },
-    {
       name: "CSP nonce",
       request: new Request("https://example.test/docs/page", {
         headers: { "Content-Security-Policy": "script-src 'nonce-request-stage'" },
@@ -121,6 +115,20 @@ describe("App request-stage dispatch", () => {
       ),
     ).toBe(false);
   });
+
+  it.each(["no-cache", "NO-STORE", "max-age=0, no-cache"])(
+    "keeps production request Cache-Control %s in the request-only graph",
+    (cacheControl) => {
+      expect(
+        appRequestUsesFullResponseGraph(
+          new Request("https://example.test/docs/page", {
+            headers: { "Cache-Control": cacheControl },
+          }),
+          createOptions(),
+        ),
+      ).toBe(false);
+    },
+  );
 
   it("allows an authenticated cacheability probe to classify a no-cache request", () => {
     const request = new Request("https://example.test/docs/page", {

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -256,6 +256,31 @@ describe("createAppRscHandler", () => {
     expect(await response.text()).toBe("response-stage");
   });
 
+  it.each(["no-cache", "no-store", "max-age=0, no-cache"])(
+    "keeps production App responses shareable with request Cache-Control %s",
+    async (cacheControl) => {
+      // Next.js only uses a browser no-cache request to bypass server caches in dev.
+      // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/app-render.tsx
+      const dispatchResponseStage = vi.fn<DispatchAppWorkerResponseStage>(async () =>
+        Promise.resolve(new Response("response-stage")),
+      );
+      const handler = createHandler();
+
+      const response = await handler(
+        new Request("https://example.test/docs/about", {
+          headers: { "Cache-Control": cacheControl },
+        }),
+        null,
+        false,
+        dispatchResponseStage,
+      );
+
+      expect(response.status).toBe(200);
+      expect(dispatchResponseStage).toHaveBeenCalledOnce();
+      expect(dispatchResponseStage.mock.calls[0]?.[2]).toEqual({ cache: "shared" });
+    },
+  );
+
   it("preserves staged config Link ordering before framework preloads", async () => {
     const dispatchResponseStage = vi.fn<DispatchAppWorkerResponseStage>(async () => {
       const response = new Response("response-stage", {

--- a/tests/cache-adapters-build.test.ts
+++ b/tests/cache-adapters-build.test.ts
@@ -313,6 +313,9 @@ export default createAdapter;
     const workerPath = path.join(root, "dist/server/index.js");
     const worker = fs.readFileSync(workerPath, "utf8");
     expect(worker).toMatch(/export\s*\{[^}]*\b(?:[A-Za-z_$][\w$]*\s+as\s+)?VinextCachedResponse\b/);
+    expect(worker).toMatch(
+      /export\s*\{[^}]*\b(?:[A-Za-z_$][\w$]*\s+as\s+)?VinextUncachedResponse\b/,
+    );
     expect(worker).not.toMatch(/import\s*["']\.\/__vinext_cacheability_manifest\.js["']/);
     expect(readTextFilesRecursive(path.join(root, "dist/server"))).toContain(RESPONSE_STAGE_MARKER);
     expect(readStaticJavaScriptClosure(workerPath)).not.toContain(RESPONSE_STAGE_MARKER);
@@ -338,6 +341,7 @@ export default createAdapter;
     expect(wrangler.exports).toMatchObject({
       default: { type: "worker", cache: { enabled: false } },
       VinextCachedResponse: { type: "worker", cache: { enabled: true } },
+      VinextUncachedResponse: { type: "worker", cache: { enabled: false } },
     });
     expect(wrangler.version_metadata).toEqual({ binding: "CF_VERSION_METADATA" });
     expect(wrangler.cache).toBeUndefined();
@@ -389,11 +393,15 @@ export default createAdapter;
     expect(fs.readFileSync(workerPath, "utf8")).toMatch(
       /export\s*\{[^}]*\b(?:[A-Za-z_$][\w$]*\s+as\s+)?VinextCachedResponse\b/,
     );
+    expect(fs.readFileSync(workerPath, "utf8")).toMatch(
+      /export\s*\{[^}]*\b(?:[A-Za-z_$][\w$]*\s+as\s+)?VinextUncachedResponse\b/,
+    );
     expect(readTextFilesRecursive(serverDir)).toContain(RESPONSE_STAGE_MARKER);
     expect(readStaticJavaScriptClosure(workerPath)).not.toContain(RESPONSE_STAGE_MARKER);
     expect(wrangler.exports).toMatchObject({
       default: { type: "worker", cache: { enabled: false } },
       VinextCachedResponse: { type: "worker", cache: { enabled: true } },
+      VinextUncachedResponse: { type: "worker", cache: { enabled: false } },
     });
     expect(wrangler.version_metadata).toEqual({ binding: "CF_VERSION_METADATA" });
     expect(wrangler.cache).toBeUndefined();

--- a/tests/cache-adapters-build.test.ts
+++ b/tests/cache-adapters-build.test.ts
@@ -423,6 +423,7 @@ export default createAdapter;
       [
         'import handler from "vinext/server/fetch-handler";',
         'export class VinextCachedResponse { marker = "CUSTOM_RESERVED_EXPORT_MARKER"; }',
+        'export class VinextUncachedResponse { marker = "CUSTOM_UNCACHED_EXPORT_MARKER"; }',
         "export default handler;",
         "",
       ].join("\n"),
@@ -446,6 +447,7 @@ export default createAdapter;
     const buildOutput = readTextFilesRecursive(path.join(root, "dist/server"));
     expect(buildOutput).toContain("Invalid vinext response-stage invocation");
     expect(buildOutput).not.toContain("CUSTOM_RESERVED_EXPORT_MARKER");
+    expect(buildOutput).not.toContain("CUSTOM_UNCACHED_EXPORT_MARKER");
   }, 60_000);
 
   it("keeps the data adapter out of the emitted request-stage graph", async () => {

--- a/tests/cache-adapters-config.test.ts
+++ b/tests/cache-adapters-config.test.ts
@@ -359,7 +359,9 @@ describe("cdnAdapter builder + factory", () => {
         code: 'import handler from "vinext/server/fetch-handler";\nexport default handler;',
         id: "\0virtual:cloudflare/worker-entry",
       }),
-    ).toContain(`export { VinextCachedResponse } from ${JSON.stringify(descriptor.output.entry)};`);
+    ).toContain(
+      `export { VinextCachedResponse, VinextUncachedResponse } from ${JSON.stringify(descriptor.output.entry)};`,
+    );
     expect(
       descriptor.output.transformHostEntry({
         code: "export default { fetch() {} };",

--- a/tests/cdn-adapter-config.test.ts
+++ b/tests/cdn-adapter-config.test.ts
@@ -70,6 +70,7 @@ describe("Cloudflare CDN adapter generated config", () => {
     expect(generatedConfig.exports).toMatchObject({
       default: { type: "worker", cache: { enabled: false } },
       VinextCachedResponse: { type: "worker", cache: { enabled: true } },
+      VinextUncachedResponse: { type: "worker", cache: { enabled: false } },
     });
     const auxiliaryConfig = JSON.parse(fs.readFileSync(auxiliaryPath, "utf8"));
     expect(auxiliaryConfig.version_metadata).toBeUndefined();

--- a/tests/cloudflare-cacheability-probe.test.ts
+++ b/tests/cloudflare-cacheability-probe.test.ts
@@ -46,6 +46,26 @@ describe("staged Worker cacheability probes", () => {
     pattern,
   });
 
+  const pairedRouteTargets = () => {
+    const route = {
+      cacheabilityProbe: { canPrunePattern: true, routeMayResolve: true },
+      kind: "app-page" as const,
+      pattern: "/source",
+    };
+    return {
+      html: { ...target("/source"), route },
+      route,
+      rsc: {
+        headers: { Accept: "text/x-component", RSC: "1" },
+        kind: "rsc-full" as const,
+        label: "/source (RSC full)",
+        pathname: "/source?_rsc",
+        route,
+        sourcePathname: "/source",
+      },
+    };
+  };
+
   const createStaticProbeFetch = () =>
     vi.fn<typeof fetch>(async (input) => {
       const pathname = new URL(input instanceof Request ? input.url : String(input)).pathname;
@@ -862,6 +882,157 @@ describe("staged Worker cacheability probes", () => {
       staticPaths: { html: ["/safe"] },
       unknownState: "static-candidate",
     });
+  });
+
+  it("retains deferred representation ownership when the primary resolves elsewhere", async () => {
+    const root = createProbeRoot();
+    const { html, rsc } = pairedRouteTargets();
+    const resolveRequest = (headers: HeadersInit) => {
+      const isRsc = new Headers(headers).get("RSC") === "1";
+      return {
+        kind: "app-page",
+        pattern: isRsc ? "/source" : "/html-target",
+        rendererStatic: true,
+        routePathname: isRsc ? "/source" : "/html-target",
+        state: "static-candidate",
+        status: 200,
+        version: 1,
+      };
+    };
+    const fetchImpl = vi.fn<typeof fetch>(async (_input, init) =>
+      Response.json(resolveRequest(init?.headers ?? {})),
+    );
+
+    const result = await probeStagedWorkerCacheability({
+      buildId: "application-build",
+      fetchImpl,
+      retries: 0,
+      root,
+      targetUrl: "https://example.com",
+      targets: [rsc, html],
+    });
+
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(new Headers(fetchImpl.mock.calls[0]![1]?.headers).get("RSC")).toBeNull();
+    expect(resolveRequest(rsc.headers)).toMatchObject({
+      pattern: "/source",
+      routePathname: "/source",
+    });
+    expect(result.failures).toEqual([]);
+    expect(result.cacheableTargets).toEqual([html, rsc]);
+    expect(result.speculativeTargets).toEqual([rsc]);
+    expect(Object.keys(result.manifest.routes)).toHaveLength(2);
+    const sourceManifestRoute =
+      result.manifest.routes[cacheabilityManifestRouteKey("app-page", "/source")];
+    const targetManifestRoute =
+      result.manifest.routes[cacheabilityManifestRouteKey("app-page", "/html-target")];
+    expect(sourceManifestRoute).toEqual({
+      kind: "app-page",
+      pattern: "/source",
+      state: "runtime-check",
+    });
+    expect(targetManifestRoute).toEqual({
+      kind: "app-page",
+      pattern: "/html-target",
+      state: "runtime-check",
+      staticRepresentation: "html",
+    });
+    expect(cacheabilityManifestRouteState(sourceManifestRoute, "/source", "rsc-full")).toBe(
+      "runtime-check",
+    );
+    expect(cacheabilityManifestRouteState(targetManifestRoute, "/html-target", "html")).toBe(
+      "static-candidate",
+    );
+  });
+
+  it.each([
+    {
+      change: "route pathname",
+      expectedPattern: "/source",
+      expectedRoutePathname: "/resolved",
+      pattern: "/source",
+      routePathname: "/resolved",
+    },
+    {
+      change: "route pattern",
+      expectedPattern: "/destination/:slug",
+      expectedRoutePathname: "/source",
+      pattern: "/destination/:slug",
+      routePathname: "/source",
+    },
+  ])(
+    "retains deferred representation ownership when only the $change changes",
+    async ({ expectedPattern, expectedRoutePathname, pattern, routePathname }) => {
+      const root = createProbeRoot();
+      const { html, route, rsc } = pairedRouteTargets();
+      const result = await probeStagedWorkerCacheability({
+        buildId: "application-build",
+        fetchImpl: async () =>
+          Response.json({
+            kind: route.kind,
+            pattern,
+            rendererStatic: true,
+            routePathname,
+            state: "static-candidate",
+            status: 200,
+            version: 1,
+          }),
+        retries: 0,
+        root,
+        targetUrl: "https://example.com",
+        targets: [rsc, html],
+      });
+
+      expect(result).toMatchObject({
+        cacheableTargets: [html, rsc],
+        failures: [],
+        probed: 1,
+        speculativeTargets: [rsc],
+      });
+      const manifestRoute =
+        result.manifest.routes[cacheabilityManifestRouteKey(route.kind, route.pattern)];
+      expect(cacheabilityManifestRouteState(manifestRoute, "/source", "rsc-full")).toBe(
+        "runtime-check",
+      );
+      const resolvedManifestRoute =
+        result.manifest.routes[cacheabilityManifestRouteKey(route.kind, expectedPattern)];
+      expect(
+        cacheabilityManifestRouteState(resolvedManifestRoute, expectedRoutePathname, "html"),
+      ).toBe("static-candidate");
+    },
+  );
+
+  it("enforces the manifest byte boundary when one probe resolves into two routes", async () => {
+    const { html, route, rsc } = pairedRouteTargets();
+    const fetchImpl = vi.fn<typeof fetch>(async () =>
+      Response.json({
+        kind: route.kind,
+        pattern: "/destination/:slug",
+        rendererStatic: true,
+        routePathname: "/destination/value",
+        state: "static-candidate",
+        status: 200,
+        version: 1,
+      }),
+    );
+    const runProbe = (root: string, maxBytes?: number) =>
+      probeStagedWorkerCacheability({
+        buildId: "application-build",
+        fetchImpl,
+        ...(maxBytes === undefined ? {} : { manifestLimits: { maxBytes } }),
+        retries: 0,
+        root,
+        targetUrl: "https://example.com",
+        targets: [rsc, html],
+      });
+
+    const baseline = await runProbe(createProbeRoot());
+    const exactBytes = Buffer.byteLength(JSON.stringify(baseline.manifest));
+    await expect(runProbe(createProbeRoot(), exactBytes)).resolves.toMatchObject({ probed: 1 });
+    await expect(runProbe(createProbeRoot(), exactBytes - 1)).rejects.toThrow(
+      `the limit is ${exactBytes - 1} bytes`,
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
   });
 
   it("records a rewritten App runtime path without a direct destination target", async () => {

--- a/tests/cloudflare-cacheability-probe.test.ts
+++ b/tests/cloudflare-cacheability-probe.test.ts
@@ -313,7 +313,7 @@ describe("staged Worker cacheability probes", () => {
     ]);
   });
 
-  it("probes App representations independently when the request stage may terminate", async () => {
+  it("defers alternate App representations to final admission when routing may terminate", async () => {
     const root = createProbeRoot();
     const route = {
       cacheabilityProbe: { canPrunePattern: true, requestStageMayTerminate: true },
@@ -351,18 +351,18 @@ describe("staged Worker cacheability probes", () => {
       targets: [rsc, html],
     });
 
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
-    expect(result).toMatchObject({ classified: 1, dynamic: 1, probed: 2, skipped: 0 });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({ classified: 1, dynamic: 1, probed: 1, skipped: 0 });
     expect(result.failures).toEqual([]);
     expect(result.cacheableTargets).toEqual([rsc]);
-    expect(result.speculativeTargets).toEqual([]);
+    expect(result.speculativeTargets).toEqual([rsc]);
     const manifestRoute = Object.values(result.manifest.routes)[0];
     expect(cacheabilityManifestRouteState(manifestRoute, "/conditional", "rsc-full")).toBe(
-      "static-candidate",
+      "runtime-check",
     );
   });
 
-  it("probes Pages HTML and data independently when the request stage may terminate", async () => {
+  it("defers Pages data to final admission when routing may terminate", async () => {
     const root = createProbeRoot();
     const route = {
       cacheabilityProbe: { canPrunePattern: true, requestStageMayTerminate: true },
@@ -410,9 +410,9 @@ describe("staged Worker cacheability probes", () => {
       targets: [data, html],
     });
 
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
     expect(result.cacheableTargets).toEqual([data]);
-    expect(result.speculativeTargets).toEqual([]);
+    expect(result.speculativeTargets).toEqual([data]);
   });
 
   it("does not prune a terminal-capable pattern from one representation", async () => {

--- a/tests/cloudflare-cacheability-probe.test.ts
+++ b/tests/cloudflare-cacheability-probe.test.ts
@@ -415,6 +415,138 @@ describe("staged Worker cacheability probes", () => {
     expect(result.speculativeTargets).toEqual([data]);
   });
 
+  it("authorizes deferred representations within mixed dynamic patterns", async () => {
+    const root = createProbeRoot();
+    const route = {
+      cacheabilityProbe: { canPrunePattern: true, requestStageMayTerminate: true },
+      kind: "app-page" as const,
+      pattern: "/posts/:slug",
+    };
+    const firstHtml = { ...target("/posts/one"), route };
+    const firstRsc = {
+      headers: { Accept: "text/x-component", RSC: "1" },
+      kind: "rsc-full" as const,
+      label: "/posts/one (RSC full)",
+      pathname: "/posts/one?_rsc",
+      route,
+      sourcePathname: "/posts/one",
+    };
+    const secondHtml = { ...target("/posts/two"), route };
+    const result = await probeStagedWorkerCacheability({
+      buildId: "application-build",
+      fetchImpl: async (input) => {
+        const pathname = new URL(input instanceof Request ? input.url : String(input)).pathname;
+        return Response.json({
+          kind: "app-page",
+          pattern: route.pattern,
+          ...(pathname.endsWith("/one")
+            ? { scope: "identity", state: "dynamic", terminal: true }
+            : { rendererStatic: true, state: "static-candidate" }),
+          status: pathname.endsWith("/one") ? 307 : 200,
+          version: 1,
+        });
+      },
+      root,
+      targetUrl: "https://example.com",
+      targets: [firstHtml, firstRsc, secondHtml],
+    });
+
+    expect(result).toMatchObject({ probed: 2, speculativeTargets: [firstRsc] });
+    const manifestRoute = Object.values(result.manifest.routes)[0];
+    expect(cacheabilityManifestRouteState(manifestRoute, "/posts/one", "rsc-full")).toBe(
+      "runtime-check",
+    );
+  });
+
+  it("unlocks sibling paths without waiting for every pattern representative", async () => {
+    const root = createProbeRoot();
+    const slow = target("/slow");
+    const fastRoute = optimizableRoute("/fast/:slug");
+    const fastFirst = { ...target("/fast/one"), route: fastRoute };
+    const fastSecond = { ...target("/fast/two"), route: fastRoute };
+    let slowCompleted = false;
+    let siblingStartedBeforeSlowCompleted = false;
+    const result = await probeStagedWorkerCacheability({
+      buildId: "application-build",
+      concurrency: 2,
+      fetchImpl: async (input) => {
+        const pathname = new URL(input instanceof Request ? input.url : String(input)).pathname;
+        if (pathname === "/slow") {
+          await new Promise((resolve) => setTimeout(resolve, 20));
+          slowCompleted = true;
+        } else if (pathname === "/fast/two") {
+          siblingStartedBeforeSlowCompleted = !slowCompleted;
+        }
+        return Response.json({
+          kind: "app-page",
+          pattern: pathname === "/slow" ? "/slow" : fastRoute.pattern,
+          rendererStatic: true,
+          state: "static-candidate",
+          status: 200,
+          version: 1,
+        });
+      },
+      root,
+      targetUrl: "https://example.com",
+      targets: [slow, fastFirst, fastSecond],
+    });
+
+    expect(result).toMatchObject({ failures: [], probed: 3 });
+    expect(siblingStartedBeforeSlowCompleted).toBe(true);
+  });
+
+  it("does not prune destination siblings before route-moving probes settle", async () => {
+    const root = createProbeRoot();
+    const destinationRoute = optimizableRoute("/posts/:slug");
+    const destinationFirst = { ...target("/posts/one"), route: destinationRoute };
+    const destinationSecond = { ...target("/posts/two"), route: destinationRoute };
+    const sourceRoute = {
+      cacheabilityProbe: { canPrunePattern: true, routeMayResolve: true },
+      kind: "app-page" as const,
+      pattern: "/source",
+    };
+    const source = { ...target("/source"), route: sourceRoute };
+    const probedPathnames: string[] = [];
+    const result = await probeStagedWorkerCacheability({
+      buildId: "application-build",
+      concurrency: 2,
+      fetchImpl: async (input) => {
+        const pathname = new URL(input instanceof Request ? input.url : String(input)).pathname;
+        probedPathnames.push(pathname);
+        if (pathname === "/source") {
+          await new Promise((resolve) => setTimeout(resolve, 20));
+          return Response.json({
+            kind: "app-page",
+            pattern: destinationRoute.pattern,
+            rendererStatic: true,
+            routePathname: "/posts/source",
+            state: "static-candidate",
+            status: 200,
+            version: 1,
+          });
+        }
+        return Response.json({
+          kind: "app-page",
+          pattern: destinationRoute.pattern,
+          ...(pathname.endsWith("/one")
+            ? { scope: "pattern", state: "dynamic" }
+            : { rendererStatic: true, state: "static-candidate" }),
+          status: 200,
+          version: 1,
+        });
+      },
+      root,
+      targetUrl: "https://example.com",
+      targets: [destinationFirst, destinationSecond, source],
+    });
+
+    expect(result.failures).toEqual([]);
+    expect(probedPathnames).toEqual(
+      expect.arrayContaining(["/posts/one", "/source", "/posts/two"]),
+    );
+    expect(result.probed).toBe(3);
+  });
+
   it("does not prune a terminal-capable pattern from one representation", async () => {
     const root = createProbeRoot();
     const route = {

--- a/tests/cloudflare-cdn-worker.test.ts
+++ b/tests/cloudflare-cdn-worker.test.ts
@@ -463,6 +463,35 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
     expect(stages.response).not.toHaveBeenCalled();
   });
 
+  it("routes invalidation from uncached renders through the cache-bearing entrypoint", async () => {
+    const purge = vi.fn().mockResolvedValue({ success: true });
+    const cachedBinding = vi.fn(() => ({ fetch: vi.fn(), purge }));
+    stages.response.mockImplementation((_request, _env, context) => {
+      const cache = Reflect.get(context, "cache") as {
+        purge(options: { tags: string[] }): unknown;
+      };
+      return Promise.resolve(cache.purge({ tags: ["updated-tag"] })).then(
+        () => new Response("rendered"),
+      );
+    });
+    const entrypoint = Object.assign(Object.create(VinextUncachedResponse.prototype), {
+      ctx: {
+        exports: { VinextCachedResponse: cachedBinding },
+        props: {
+          ...responseStageInvocation({ kind: "app-route" }),
+          options: { cache: "bypass" },
+        },
+      },
+      env: {},
+    }) as VinextUncachedResponse;
+
+    const response = await entrypoint.fetch(new Request("https://example.com/action"));
+
+    await expect(response.text()).resolves.toBe("rendered");
+    expect(cachedBinding).toHaveBeenCalledWith({ props: {} });
+    expect(purge).toHaveBeenCalledWith({ tags: ["updated-tag"] });
+  });
+
   it("rejects unversioned cache intent when an expected identity is present", async () => {
     vi.stubEnv("__VINEXT_RSC_BUILD_IDENTITY", "current-stage");
     const response = await createEntrypoint({

--- a/tests/cloudflare-cdn-worker.test.ts
+++ b/tests/cloudflare-cdn-worker.test.ts
@@ -168,6 +168,7 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
   });
 
   it("exports the cached stage as a named WorkerEntrypoint class", () => {
@@ -226,6 +227,79 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
       expect(response.headers.get(VINEXT_CDN_BUILD_ID_HEADER)).toBe("current-stage");
     },
   );
+
+  it("preserves immutable WebSocket upgrades while stamping bypass identity", async () => {
+    // No Next.js test port applies: preserving a Workers 101 response across
+    // configurable entrypoints is specific to the Cloudflare adapter.
+    const OriginalResponse = Response;
+    const webSocket = {} as WebSocket;
+    class WorkersResponse extends OriginalResponse {
+      readonly webSocket: WebSocket | null;
+      readonly #workersStatus: number;
+
+      constructor(body?: BodyInit | null, init?: ResponseInit & { webSocket?: WebSocket | null }) {
+        const status = init?.status ?? 200;
+        super(body, { ...init, status: status === 101 ? 200 : status });
+        this.#workersStatus = status;
+        this.webSocket = init?.webSocket ?? null;
+      }
+
+      override get status(): number {
+        return this.#workersStatus;
+      }
+    }
+    vi.stubGlobal("Response", WorkersResponse);
+    vi.stubEnv("__VINEXT_RSC_BUILD_IDENTITY", "current-stage");
+    const upgrade = new WorkersResponse(null, { status: 101, webSocket });
+    vi.spyOn(upgrade.headers, "set").mockImplementation(() => {
+      throw new TypeError("Cannot modify immutable headers");
+    });
+    stages.response.mockResolvedValue(upgrade);
+
+    const response = (await createUncachedEntrypoint({
+      ...responseStageInvocation({ kind: "app-route" }),
+      expectedResponseStageBuildIdentity: "current-stage",
+      options: { cache: "vinext-cloudflare-v1:bypass" },
+    }).fetch(
+      new Request("https://example.com/socket", {
+        headers: { Upgrade: "websocket" },
+      }),
+    )) as WorkersResponse;
+
+    expect(response).not.toBe(upgrade);
+    expect(response.status).toBe(101);
+    expect(response.webSocket).toBe(webSocket);
+    expect(response.headers.get(VINEXT_CDN_BUILD_ID_HEADER)).toBe("current-stage");
+  });
+
+  it("fails closed when an immutable non-HTTP response cannot be stamped", async () => {
+    vi.stubEnv("__VINEXT_RSC_BUILD_IDENTITY", "current-stage");
+    stages.request.mockImplementation((request, _env, _ctx, dispatch) =>
+      dispatch(request, { kind: "app-route" }, { cache: "bypass" }),
+    );
+    stages.response.mockResolvedValue(Response.error());
+    const stageResponses: Response[] = [];
+    const binding = vi.fn(({ props }: { props: unknown }) => ({
+      async fetch(request: Request) {
+        const response = await createUncachedEntrypoint(props).fetch(request);
+        stageResponses.push(response);
+        return response;
+      },
+    }));
+
+    const response = await worker.fetch(
+      new Request("https://example.com/error"),
+      {},
+      { exports: { VinextUncachedResponse: binding } },
+    );
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(stageResponses).toHaveLength(1);
+    expect(stageResponses[0]!.status).toBe(503);
+    expect(stageResponses[0]!.headers.get(VINEXT_CDN_BUILD_ID_HEADER)).toBe("current-stage");
+    expect(stages.response).toHaveBeenCalledOnce();
+  });
 
   it.each([
     ["missing", null, 503],

--- a/tests/cloudflare-cdn-worker.test.ts
+++ b/tests/cloudflare-cdn-worker.test.ts
@@ -945,6 +945,56 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
     }
   });
 
+  it("keeps browser cache directives off Workers Cache while restoring cold renders", async () => {
+    const cacheFacingRequests: Request[] = [];
+    const binding = vi.fn(({ props }: { props: unknown }) => ({
+      fetch(request: Request) {
+        cacheFacingRequests.push(request);
+        return createEntrypoint(props).fetch(request);
+      },
+    }));
+    stages.request.mockImplementation((request, _env, _ctx, dispatch) =>
+      dispatch(request, { kind: "app-page" }, { cache: "shared" }),
+    );
+    stages.response.mockImplementation((request) =>
+      Response.json({
+        cacheControl: request.headers.get("Cache-Control"),
+        pragma: request.headers.get("Pragma"),
+        cacheControlTransport: request.headers.get("x-vinext-internal-request-cache-control"),
+        pragmaTransport: request.headers.get("x-vinext-internal-request-pragma"),
+      }),
+    );
+
+    const response = await worker.fetch(
+      new Request("https://example.com/reload", {
+        headers: {
+          "Cache-Control": "no-cache",
+          Pragma: "no-cache",
+          "x-vinext-internal-request-cache-control": "forged-cache-control",
+          "x-vinext-internal-request-pragma": "forged-pragma",
+        },
+      }),
+      {},
+      { exports: { VinextCachedResponse: binding } },
+    );
+
+    expect(cacheFacingRequests).toHaveLength(1);
+    expect(cacheFacingRequests[0]?.headers.get("Cache-Control")).toBeNull();
+    expect(cacheFacingRequests[0]?.headers.get("Pragma")).toBeNull();
+    expect(cacheFacingRequests[0]?.headers.get("x-vinext-internal-request-cache-control")).not.toBe(
+      "forged-cache-control",
+    );
+    expect(cacheFacingRequests[0]?.headers.get("x-vinext-internal-request-pragma")).not.toBe(
+      "forged-pragma",
+    );
+    await expect(response.json()).resolves.toEqual({
+      cacheControl: "no-cache",
+      pragma: "no-cache",
+      cacheControlTransport: null,
+      pragmaTransport: null,
+    });
+  });
+
   it("keys cached dispatches by route metadata and restores the user-facing URL", async () => {
     const cachedEntrypoint = createEntrypoint(
       responseStageInvocation(

--- a/tests/cloudflare-cdn-worker.test.ts
+++ b/tests/cloudflare-cdn-worker.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test"
 import { configureWorkersCacheEntrypoints } from "../packages/cloudflare/src/cache/cdn-adapter-config.js";
 import worker, {
   VinextCachedResponse,
+  VinextUncachedResponse,
 } from "../packages/cloudflare/src/cache/cdn-adapter.worker.js";
 import { VINEXT_CDN_BUILD_ID_HEADER } from "../packages/cloudflare/src/cache/cdn-build-id.js";
 import {
@@ -44,6 +45,13 @@ function createEntrypoint(props: unknown, env: unknown = { binding: "value" }) {
     ctx: { props },
     env,
   }) as VinextCachedResponse;
+}
+
+function createUncachedEntrypoint(props: unknown, env: unknown = { binding: "value" }) {
+  return Object.assign(Object.create(VinextUncachedResponse.prototype), {
+    ctx: { props },
+    env,
+  }) as VinextUncachedResponse;
 }
 
 function responseStageInvocation(
@@ -165,6 +173,11 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
   it("exports the cached stage as a named WorkerEntrypoint class", () => {
     expect(typeof VinextCachedResponse).toBe("function");
     expect(typeof VinextCachedResponse.prototype.fetch).toBe("function");
+  });
+
+  it("exports bypass rendering as a separate named WorkerEntrypoint class", () => {
+    expect(typeof VinextUncachedResponse).toBe("function");
+    expect(typeof VinextUncachedResponse.prototype.fetch).toBe("function");
   });
 
   it("lazily invokes the response stage from named-entrypoint props", async () => {
@@ -432,6 +445,21 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
     }).fetch(new Request("https://example.com/page"));
     expect(response.status).toBe(400);
     expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(stages.response).not.toHaveBeenCalled();
+  });
+
+  it("rejects cache intent sent to the wrong response entrypoint", async () => {
+    const request = new Request("https://example.com/page");
+    const [cachedResponse, uncachedResponse] = await Promise.all([
+      createEntrypoint({
+        ...responseStageInvocation({ kind: "app-page" }),
+        options: { cache: "bypass" },
+      }).fetch(request),
+      createUncachedEntrypoint(responseStageInvocation({ kind: "app-page" })).fetch(request),
+    ]);
+
+    expect(cachedResponse.status).toBe(400);
+    expect(uncachedResponse.status).toBe(400);
     expect(stages.response).not.toHaveBeenCalled();
   });
 
@@ -1095,9 +1123,14 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
     expect(stages.response.mock.calls.map(([request]) => request.method)).toEqual(["GET", "HEAD"]);
   });
 
-  it("renders bypass work without consulting the cached entrypoint", async () => {
+  it("renders bypass work through the uncached entrypoint", async () => {
     const rendered = new Response("private");
-    const binding = vi.fn();
+    const cachedBinding = vi.fn();
+    const uncachedBinding = vi.fn(({ props }: { props: unknown }) => ({
+      fetch(request: Request) {
+        return createUncachedEntrypoint(props).fetch(request);
+      },
+    }));
     stages.response.mockResolvedValue(rendered);
     stages.request.mockImplementation((_request, _env, _ctx, dispatch) =>
       dispatch(
@@ -1111,12 +1144,16 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
       new Request("https://example.com/private"),
       {},
       {
-        exports: { VinextCachedResponse: binding },
+        exports: {
+          VinextCachedResponse: cachedBinding,
+          VinextUncachedResponse: uncachedBinding,
+        },
       },
     );
 
     expect(result).toBe(rendered);
-    expect(binding).not.toHaveBeenCalled();
+    expect(cachedBinding).not.toHaveBeenCalled();
+    expect(uncachedBinding).toHaveBeenCalledOnce();
     expect(stages.response).toHaveBeenCalledOnce();
   });
 
@@ -1126,7 +1163,7 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
     vi.stubEnv("__VINEXT_RSC_BUILD_IDENTITY", "current-stage");
     const binding = vi.fn(({ props }: { props: unknown }) => ({
       fetch(request: Request) {
-        return createEntrypoint(props).fetch(request);
+        return createUncachedEntrypoint(props).fetch(request);
       },
     }));
     stages.request.mockImplementation((request, _env, _ctx, dispatch) =>
@@ -1145,7 +1182,7 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
     const response = await worker.fetch(
       request,
       {},
-      { exports: { VinextCachedResponse: binding } },
+      { exports: { VinextUncachedResponse: binding } },
     );
 
     expect(response.status).toBe(204);
@@ -1181,6 +1218,13 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
 
   it("strips forged transport metadata from bypass and fallback renders", async () => {
     for (const cache of ["bypass", "shared"] as const) {
+      const binding = vi.fn(({ props }: { props: unknown }) => ({
+        fetch(request: Request) {
+          return cache === "shared"
+            ? createEntrypoint(props).fetch(request)
+            : createUncachedEntrypoint(props).fetch(request);
+        },
+      }));
       stages.request.mockImplementation((request, _env, _ctx, dispatch) =>
         dispatch(request, { route: "/private" }, { cache }),
       );
@@ -1199,7 +1243,12 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
           },
         }),
         {},
-        {},
+        {
+          exports:
+            cache === "shared"
+              ? { VinextCachedResponse: binding }
+              : { VinextUncachedResponse: binding },
+        },
       );
 
       await expect(response.json()).resolves.toEqual({
@@ -1211,7 +1260,7 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
     }
   });
 
-  it("falls back to an uncached render when loopback exports are unavailable", async () => {
+  it("fails closed when the required response entrypoint is unavailable", async () => {
     stages.response.mockResolvedValue(
       new Response("rendered", {
         headers: {
@@ -1228,14 +1277,15 @@ describe("Cloudflare CDN multi-stage Worker facade", () => {
     );
 
     const response = await worker.fetch(new Request("https://example.com/page"), {}, {});
-    expect(await response.text()).toBe("rendered");
-    expect(response.headers.get("Cache-Control")).toBe("private, max-age=0, must-revalidate");
+    expect(response.status).toBe(503);
+    expect(await response.text()).toBe("");
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
     expect(response.headers.get("CDN-Cache-Control")).toBeNull();
     expect(response.headers.get("Cloudflare-CDN-Cache-Control")).toBeNull();
     expect(response.headers.get("Cache-Tag")).toBeNull();
     expect(response.headers.get("X-Vinext-Cache")).toBeNull();
     expect(response.headers.get("X-Nextjs-Cache")).toBeNull();
-    expect(stages.response).toHaveBeenCalledOnce();
+    expect(stages.response).not.toHaveBeenCalled();
   });
 
   it("routes gateway purges through the cache-bearing entrypoint", async () => {
@@ -1270,6 +1320,7 @@ describe("Workers Cache deployment configuration", () => {
       exports: {
         default: { type: "worker", cache: { enabled: false } },
         VinextCachedResponse: { type: "worker", cache: { enabled: true } },
+        VinextUncachedResponse: { type: "worker", cache: { enabled: false } },
       },
     });
   });
@@ -1278,11 +1329,13 @@ describe("Workers Cache deployment configuration", () => {
     expect(
       configureWorkersCacheEntrypoints({ exports: { Counter: { type: "durable_object" } } }),
     ).toMatchObject({ exports: { Counter: { type: "durable_object" } } });
-    expect(() =>
-      configureWorkersCacheEntrypoints({
-        exports: { VinextCachedResponse: { type: "durable_object" } },
-      }),
-    ).toThrow(/reserved Worker export/);
+    for (const name of ["VinextCachedResponse", "VinextUncachedResponse"]) {
+      expect(() =>
+        configureWorkersCacheEntrypoints({
+          exports: { [name]: { type: "durable_object" } },
+        }),
+      ).toThrow(/reserved Worker export/);
+    }
   });
 
   it("preserves compatibility flags and rejects an explicit ctx.exports opt-out", () => {

--- a/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
+++ b/tests/e2e/cloudflare-workers/rsc-prewarm.spec.ts
@@ -440,6 +440,23 @@ test("deploy-prewarmed variants are reused and late-dynamic HTML stays private",
   expect(secondAppHtmlResponseHeaders["x-workers-cache-visitor"]).toBe("visitor-b");
   expect(await secondAppHtmlResponse.text()).toBe(appHtmlBody);
 
+  // Next.js limits browser no-cache cache bypass to development. A production
+  // hard reload must continue reusing the admitted App response.
+  // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/app-render/app-render.tsx
+  const reloadedAppHtmlResponse = await getResponseAfterPromotion(
+    request,
+    `${baseURL}${TARGET_PATH}`,
+    { ...htmlHeaders, "cache-control": "no-cache", pragma: "no-cache" },
+  );
+  const reloadedAppHtmlHeaders = reloadedAppHtmlResponse.headers();
+  expect(
+    reloadedAppHtmlHeaders["cf-cache-status"],
+    `Reloaded App HTML response headers: ${JSON.stringify(reloadedAppHtmlHeaders)}`,
+  ).toBe("HIT");
+  expect(reloadedAppHtmlHeaders["x-vinext-cache"]).toBe("HIT");
+  expect(reloadedAppHtmlHeaders["x-nextjs-cache"]).toBe("HIT");
+  expect(await reloadedAppHtmlResponse.text()).toBe(appHtmlBody);
+
   // Next.js skips its shared response cache in draft mode. This must be
   // decided in the uncached request entrypoint because a named-entrypoint HIT
   // cannot inspect the draft cookie before replaying anonymous bytes.

--- a/tests/multi-stage-http.test.ts
+++ b/tests/multi-stage-http.test.ts
@@ -626,7 +626,10 @@ describe("generic HTTP multi-stage transport", () => {
   it("resolves full-graph public file signals after an HTTP stage round trip", async () => {
     const url = `${requestServer.origin}/stage-asset.txt`;
     const get = await fetch(url, {
-      headers: { "cache-control": "no-cache", "x-test-visitor": "asset-get" },
+      headers: {
+        "content-security-policy": "script-src 'nonce-http-stage'",
+        "x-test-visitor": "asset-get",
+      },
     });
     expect(get.status).toBe(200);
     expect(get.headers.get("x-http-stage-cache")).toBe("BYPASS");
@@ -643,7 +646,10 @@ describe("generic HTTP multi-stage transport", () => {
     await expect(get.text()).resolves.toBe("HTTP_STAGE_PUBLIC_ASSET\n");
 
     const head = await fetch(url, {
-      headers: { "cache-control": "no-cache", "x-test-visitor": "asset-head" },
+      headers: {
+        "content-security-policy": "script-src 'nonce-http-stage'",
+        "x-test-visitor": "asset-head",
+      },
       method: "HEAD",
     });
     expect(head.status).toBe(200);
@@ -664,7 +670,7 @@ describe("generic HTTP multi-stage transport", () => {
 
   it("does not trust a user response carrying the stage signal header", async () => {
     const response = await fetch(`${requestServer.origin}/api/forged-stage-signal`, {
-      headers: { "cache-control": "no-cache" },
+      headers: { "content-security-policy": "script-src 'nonce-http-stage'" },
     });
 
     expect(response.status).toBe(200);

--- a/tests/pages-response-stage.test.ts
+++ b/tests/pages-response-stage.test.ts
@@ -79,8 +79,8 @@ describe("Pages response-stage dispatch", () => {
     "max-age=0, no-cache",
     "public, no-store, max-age=60",
     'no-cache="set-cookie"',
-  ])("keeps Cache-Control %s local", (cacheControl) => {
-    expect(shouldDispatch({ headers: { "Cache-Control": cacheControl } })).toBe(false);
+  ])("lets the host cache decide request Cache-Control %s", (cacheControl) => {
+    expect(shouldDispatch({ headers: { "Cache-Control": cacheControl } })).toBe(true);
   });
 
   it.each(["max-age=0", "public, max-age=0, must-revalidate", "no-cacheable=true"])(

--- a/tests/prerender-paths.test.ts
+++ b/tests/prerender-paths.test.ts
@@ -1130,6 +1130,31 @@ describe("prerender path manifest", () => {
     ).toBeUndefined();
   });
 
+  it("uses runtime pathname decoding and locale provenance for middleware probe scope", async () => {
+    const { matchesMiddlewareWarmPath } =
+      await import("../packages/vinext/src/build/prerender-paths.js");
+    const i18n = {
+      defaultLocale: "en",
+      domains: [{ defaultLocale: "fr", domain: "fr.example.com" }],
+      locales: ["en", "fr"],
+    };
+
+    expect(matchesMiddlewareWarmPath("/%64ecoded", "/decoded", null)).toBe(true);
+    expect(
+      matchesMiddlewareWarmPath("/localized", [{ locale: false, source: "/en/localized" }], i18n),
+    ).toBe(true);
+    expect(
+      matchesMiddlewareWarmPath("/localized", [{ locale: false, source: "/fr/localized" }], i18n),
+    ).toBe(true);
+    expect(
+      matchesMiddlewareWarmPath(
+        "/fr/localized",
+        [{ locale: false, source: "/en/fr/localized" }],
+        i18n,
+      ),
+    ).toBe(false);
+  });
+
   it("retains redirect sources only when routing runs in an uncached stage", async () => {
     // Next.js applies config redirects before rendering the filesystem route:
     // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/navigation/navigation.test.ts

--- a/tests/prerender-paths.test.ts
+++ b/tests/prerender-paths.test.ts
@@ -1140,6 +1140,7 @@ describe("prerender path manifest", () => {
     };
 
     expect(matchesMiddlewareWarmPath("/%64ecoded", "/decoded", null)).toBe(true);
+    expect(matchesMiddlewareWarmPath("/你好", "/%E4%BD%A0%E5%A5%BD", null)).toBe(true);
     expect(
       matchesMiddlewareWarmPath("/localized", [{ locale: false, source: "/en/localized" }], i18n),
     ).toBe(true);

--- a/tests/prerender-paths.test.ts
+++ b/tests/prerender-paths.test.ts
@@ -1072,11 +1072,20 @@ describe("prerender path manifest", () => {
     writeFile(
       "middleware.ts",
       [
-        'export const config = { matcher: "/middleware-source" };',
+        "export const config = { matcher: [",
+        '  "/middleware-source",',
+        '  { source: "/en/default-locale-source", locale: false },',
+        '  { source: "/fr/domain-locale-source", locale: false },',
+        "] };",
         "export default function middleware() {}",
       ].join("\n"),
     );
-    for (const pathname of ["middleware-source", "outside"]) {
+    for (const pathname of [
+      "middleware-source",
+      "default-locale-source",
+      "domain-locale-source",
+      "outside",
+    ]) {
       writeFile(
         `app/${pathname}/page.tsx`,
         "export const revalidate = 60; export default function Page() {}\n",
@@ -1088,7 +1097,16 @@ describe("prerender path manifest", () => {
       import("../packages/vinext/src/config/next-config.js"),
     ]);
     const manifest = await emitPrerenderPathManifest({
-      nextConfig: await resolveNextConfig({}, tmpDir),
+      nextConfig: await resolveNextConfig(
+        {
+          i18n: {
+            defaultLocale: "en",
+            domains: [{ defaultLocale: "fr", domain: "fr.example.com" }],
+            locales: ["en", "fr"],
+          },
+        },
+        tmpDir,
+      ),
       requestRouting: "uncached-stage",
       responseVary: "verbatim",
       root: tmpDir,
@@ -1098,6 +1116,12 @@ describe("prerender path manifest", () => {
       requestStageMayTerminate: true,
       routeMayResolve: true,
     });
+    for (const pathname of ["/default-locale-source", "/domain-locale-source"]) {
+      expect(manifest?.routePatterns?.[pathname]?.cacheabilityProbe).toMatchObject({
+        requestStageMayTerminate: true,
+        routeMayResolve: true,
+      });
+    }
     expect(
       manifest?.routePatterns?.["/outside"]?.cacheabilityProbe?.requestStageMayTerminate,
     ).toBeUndefined();

--- a/tests/prerender-paths.test.ts
+++ b/tests/prerender-paths.test.ts
@@ -1062,6 +1062,50 @@ describe("prerender path manifest", () => {
     });
   });
 
+  it("does not expand staged middleware probes beyond its pathname matcher", async () => {
+    // Ported from Next.js: test/e2e/app-dir/middleware-matching/index.test.ts
+    // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/middleware-matching/index.test.ts
+    writeFile("package.json", JSON.stringify({ type: "module" }));
+    writeFile("dist/server/BUILD_ID", "build-a\n");
+    writeFile("dist/server/RSC_BUILD_ID", "rsc-build-a\n");
+    writeFile("dist/server/index.js", "export default {};\n");
+    writeFile(
+      "middleware.ts",
+      [
+        'export const config = { matcher: "/middleware-source" };',
+        "export default function middleware() {}",
+      ].join("\n"),
+    );
+    for (const pathname of ["middleware-source", "outside"]) {
+      writeFile(
+        `app/${pathname}/page.tsx`,
+        "export const revalidate = 60; export default function Page() {}\n",
+      );
+    }
+
+    const [{ emitPrerenderPathManifest }, { resolveNextConfig }] = await Promise.all([
+      import("../packages/vinext/src/build/prerender-paths.js"),
+      import("../packages/vinext/src/config/next-config.js"),
+    ]);
+    const manifest = await emitPrerenderPathManifest({
+      nextConfig: await resolveNextConfig({}, tmpDir),
+      requestRouting: "uncached-stage",
+      responseVary: "verbatim",
+      root: tmpDir,
+    });
+
+    expect(manifest?.routePatterns?.["/middleware-source"]?.cacheabilityProbe).toMatchObject({
+      requestStageMayTerminate: true,
+      routeMayResolve: true,
+    });
+    expect(
+      manifest?.routePatterns?.["/outside"]?.cacheabilityProbe?.requestStageMayTerminate,
+    ).toBeUndefined();
+    expect(
+      manifest?.routePatterns?.["/outside"]?.cacheabilityProbe?.routeMayResolve,
+    ).toBeUndefined();
+  });
+
   it("retains redirect sources only when routing runs in an uncached stage", async () => {
     // Next.js applies config redirects before rendering the filesystem route:
     // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/navigation/navigation.test.ts


### PR DESCRIPTION
## Summary

- classify each concrete route pathname once and defer alternate HTML/RSC/data representation admission to the final warm render
- use the existing uncapped `--warm-cdn-concurrency` value for both probing and final warming, keeping that shared pool saturated while preserving late route-resolution safety
- scope middleware-sensitive probe planning to runtime-equivalent matcher semantics, including decoded paths and i18n locale provenance
- route bypass and cacheability-probe renders through a cache-disabled response entrypoint so the gateway never executes renderer code locally
- preserve tag invalidation by routing uncached-render purges through the cache-bearing entrypoint
- preserve Next.js production reload parity by keeping App and Pages responses on the shared host-cache path when a browser sends `Cache-Control: no-cache`

## Validation

- `vp check`
- `vp run vinext#build`
- `vp run @vinext/cloudflare#build`
- 492 cumulative focused App, Pages, Cloudflare Worker, probe, and deploy-flow tests
- deployed Workers Cache E2E now requires App HTML to remain a `CF-Cache-Status: HIT` under browser `no-cache`
- previous exact-head CI: 73/73 checks passed before the latest parity fix; refreshed CI is running
- five independent focused reviews clean after requested coverage
- Big Bonk: LGTM before the latest parity fix

Stacked on #3155.
