### PR TITLE
fix(cloudflare): restore bounded probe scheduling

### DIFF
--- a/packages/cloudflare/src/cacheability-probe.ts
+++ b/packages/cloudflare/src/cacheability-probe.ts
@@ -726,58 +726,37 @@ export async function probeStagedWorkerCacheability(options: {
     reportProgress();
   };
 
+  const runGroups = async (scheduledGroups: readonly ConcretePathGroup[]): Promise<void> => {
+    let nextIndex = 0;
+    const worker = async (): Promise<void> => {
+      while (!limitFailure && !phaseTimedOut && nextIndex < scheduledGroups.length) {
+        await classifyConcretePath(scheduledGroups[nextIndex++]);
+      }
+    };
+    await Promise.all(
+      Array.from({ length: Math.min(concurrency, scheduledGroups.length) }, () => worker()),
+    );
+  };
+
   reportProgress();
-  let activeProbes = 0;
-  const slotWaiters: Array<() => void> = [];
-  const acquireProbeSlot = async (): Promise<void> => {
-    if (activeProbes < concurrency) {
-      activeProbes++;
-      return;
-    }
-    await new Promise<void>((resolve) => slotWaiters.push(resolve));
-  };
-  const releaseProbeSlot = (): void => {
-    const next = slotWaiters.shift();
-    if (next) next();
-    else activeProbes--;
-  };
-  let pendingRouteMovers = groups.filter(
+  const routeMovingGroups = groups.filter(
     (group) => group.primary.route?.cacheabilityProbe?.routeMayResolve === true,
-  ).length;
-  let settleRouteMovers: (() => void) | undefined;
-  const routeMoversSettled =
-    pendingRouteMovers === 0
-      ? Promise.resolve()
-      : new Promise<void>((resolve) => {
-          settleRouteMovers = resolve;
-        });
-  const runGroup = async (group: ConcretePathGroup): Promise<void> => {
-    const mayResolveRoute = group.primary.route?.cacheabilityProbe?.routeMayResolve === true;
-    while (true) {
-      if (!mayResolveRoute && group.pattern.pruned && pendingRouteMovers > 0) {
-        await routeMoversSettled;
-      }
-      await acquireProbeSlot();
-      if (!mayResolveRoute && group.pattern.pruned && pendingRouteMovers > 0) {
-        releaseProbeSlot();
-        continue;
-      }
-      break;
-    }
-    try {
-      if (!limitFailure && !phaseTimedOut) await classifyConcretePath(group);
-    } finally {
-      releaseProbeSlot();
-      if (mayResolveRoute && --pendingRouteMovers === 0) settleRouteMovers?.();
-    }
-  };
-  const initialPatternGroups = Array.from(patterns.values(), (pattern) => [...pattern.groups]);
-  await Promise.all(
-    initialPatternGroups.map(async ([representative, ...siblings]) => {
-      await runGroup(representative);
-      await Promise.all(siblings.map(runGroup));
-    }),
   );
+  const routeMovingGroupSet = new Set(routeMovingGroups);
+  const representativeGroups: ConcretePathGroup[] = [];
+  const siblingGroups: ConcretePathGroup[] = [];
+  for (const pattern of patterns.values()) {
+    const [representative, ...siblings] = pattern.groups;
+    if (representative && !routeMovingGroupSet.has(representative)) {
+      representativeGroups.push(representative);
+    }
+    siblingGroups.push(...siblings.filter((group) => !routeMovingGroupSet.has(group)));
+  }
+  // Resolve every route-moving public path before a destination pattern may
+  // be pruned, then use the same bounded worker loops as ordinary CDN warming.
+  await runGroups(routeMovingGroups);
+  if (!limitFailure && !phaseTimedOut) await runGroups(representativeGroups);
+  if (!limitFailure && !phaseTimedOut) await runGroups(siblingGroups);
   if (limitFailure) throw limitFailure;
   if (phaseTimedOut || Date.now() >= getDeadlineAt()) {
     throw new Error(`cacheability probing made no progress for ${phaseTimeoutMs}ms`);

--- a/packages/cloudflare/src/cacheability-probe.ts
+++ b/packages/cloudflare/src/cacheability-probe.ts
@@ -36,6 +36,7 @@ type ProbePayload = {
   pattern?: string;
   reason?: string;
   rendererStatic?: boolean;
+  retryable?: true;
   routePathname?: string;
   state?: string;
   status?: number;
@@ -126,6 +127,10 @@ function compactManifestRoutePaths(route: CacheabilityManifestRoute): Cacheabili
 
 function isProbeRouteState(value: unknown): value is ProbeRouteState {
   return value === "static-candidate" || value === "dynamic" || value === "probe-failed";
+}
+
+function isRetryableProbeHttpStatus(status: number): boolean {
+  return status === 404 || status === 408 || status === 429 || status >= 502;
 }
 
 export function readPrerenderSecret(root: string): string {
@@ -245,11 +250,20 @@ async function probeTarget(options: {
           return {
             kind: "retry" as const,
             reason: `probe returned HTTP ${response.status}`,
-            retryable: response.status === 404 || response.status === 503,
+            retryable: isRetryableProbeHttpStatus(response.status),
             retryUntilDeadline: false,
           };
         }
-        return { kind: "complete" as const, payload: await readProbeEnvelope(response) };
+        const payload = await readProbeEnvelope(response);
+        if (payload.state === "probe-failed" && payload.retryable === true) {
+          return {
+            kind: "retry" as const,
+            reason: payload.reason ?? "probe failed",
+            retryable: true,
+            retryUntilDeadline: false,
+          };
+        }
+        return { kind: "complete" as const, payload };
       })();
       const timedOut = new Promise<never>((_resolve, reject) => {
         const checkDeadline = (): void => {
@@ -627,6 +641,8 @@ export async function probeStagedWorkerCacheability(options: {
           result.scope !== "identity" ||
           !group.pattern.requestStageMayTerminate)) ||
       (result.rendererStatic !== undefined && typeof result.rendererStatic !== "boolean") ||
+      (result.retryable !== undefined && result.retryable !== true) ||
+      (result.retryable === true && result.state !== "probe-failed") ||
       !Number.isInteger(result.status) ||
       result.status! < 100 ||
       result.status! > 599

--- a/packages/cloudflare/src/cacheability-probe.ts
+++ b/packages/cloudflare/src/cacheability-probe.ts
@@ -750,26 +750,6 @@ export async function probeStagedWorkerCacheability(options: {
     return "done";
   };
 
-  const runGroupPass = async (
-    scheduledGroups: readonly ConcretePathGroup[],
-    deferRetry: boolean,
-  ): Promise<ConcretePathGroup[]> => {
-    let nextIndex = 0;
-    const retryGroups = new Set<ConcretePathGroup>();
-    const worker = async (): Promise<void> => {
-      while (!limitFailure && !phaseTimedOut && nextIndex < scheduledGroups.length) {
-        const group = scheduledGroups[nextIndex++];
-        if ((await classifyConcretePath(group, { deferRetry, inlineRetries: 0 })) === "retry") {
-          retryGroups.add(group);
-        }
-      }
-    };
-    await Promise.all(
-      Array.from({ length: Math.min(concurrency, scheduledGroups.length) }, () => worker()),
-    );
-    return scheduledGroups.filter((group) => retryGroups.has(group));
-  };
-
   reportProgress();
   const routeMovingGroups = groups.filter(
     (group) => group.primary.route?.cacheabilityProbe?.routeMayResolve === true,
@@ -777,19 +757,25 @@ export async function probeStagedWorkerCacheability(options: {
   const routeMovingGroupSet = new Set(routeMovingGroups);
   const readyGroups = [...routeMovingGroups];
   const readyGroupSet = new Set(routeMovingGroups);
+  const siblingsByRepresentative = new Map<ConcretePathGroup, ConcretePathGroup[]>();
   for (const pattern of patterns.values()) {
-    const representative = pattern.groups[0];
-    if (!representative || readyGroupSet.has(representative)) continue;
-    readyGroups.push(representative);
-    readyGroupSet.add(representative);
-  }
-  for (const group of groups) {
-    if (readyGroupSet.has(group)) continue;
-    readyGroups.push(group);
-    readyGroupSet.add(group);
+    const [representative, ...siblings] = pattern.groups;
+    if (!representative) continue;
+    if (!readyGroupSet.has(representative)) {
+      readyGroups.push(representative);
+      readyGroupSet.add(representative);
+    }
+    const unscheduledSiblings = siblings.filter((group) => !readyGroupSet.has(group));
+    if (pattern.canPrune) {
+      siblingsByRepresentative.set(representative, unscheduledSiblings);
+      continue;
+    }
+    readyGroups.push(...unscheduledSiblings);
+    for (const sibling of unscheduledSiblings) readyGroupSet.add(sibling);
   }
 
   const deferredUntilRouteMoversSettle: ConcretePathGroup[] = [];
+  const retriesUsedByGroup = new Map<ConcretePathGroup, number>();
   const retryGroupSet = new Set<ConcretePathGroup>();
   const active = new Set<Promise<void>>();
   let nextReadyIndex = 0;
@@ -804,13 +790,25 @@ export async function probeStagedWorkerCacheability(options: {
         deferredUntilRouteMoversSettle.push(group);
         return;
       }
+      const retriesUsed = retriesUsedByGroup.get(group) ?? 0;
       const result = await classifyConcretePath(group, {
-        deferRetry: !isRouteMover && retries > 0,
-        inlineRetries: isRouteMover ? retries : 0,
+        deferRetry: retriesUsed < retries,
+        inlineRetries: 0,
       });
-      if (result === "retry") retryGroupSet.add(group);
+      if (result === "retry") {
+        retriesUsedByGroup.set(group, retriesUsed + 1);
+        retryGroupSet.add(group);
+        return;
+      }
       if (isRouteMover && --pendingRouteMovers === 0) {
         enqueue(deferredUntilRouteMoversSettle.splice(0));
+      }
+      const siblings = siblingsByRepresentative.get(group) ?? [];
+      siblingsByRepresentative.delete(group);
+      if (group.pattern.pruned && pendingRouteMovers > 0) {
+        deferredUntilRouteMoversSettle.push(...siblings);
+      } else {
+        enqueue(siblings);
       }
     })();
     active.add(task);
@@ -820,20 +818,24 @@ export async function probeStagedWorkerCacheability(options: {
     );
   };
 
-  while (
-    !limitFailure &&
-    !phaseTimedOut &&
-    (nextReadyIndex < readyGroups.length || active.size > 0)
-  ) {
-    while (active.size < concurrency && nextReadyIndex < readyGroups.length) {
-      startGroup(readyGroups[nextReadyIndex++]);
+  const runReadyGroups = async (): Promise<void> => {
+    while (
+      !limitFailure &&
+      !phaseTimedOut &&
+      (nextReadyIndex < readyGroups.length || active.size > 0)
+    ) {
+      while (active.size < concurrency && nextReadyIndex < readyGroups.length) {
+        startGroup(readyGroups[nextReadyIndex++]);
+      }
+      if (active.size > 0) await Promise.race(active);
     }
-    if (active.size > 0) await Promise.race(active);
-  }
-  await Promise.all(active);
+    await Promise.all(active);
+  };
+
+  await runReadyGroups();
 
   let retryGroups = groups.filter((group) => retryGroupSet.has(group));
-  for (let retryAttempt = 0; retryGroups.length > 0 && retryAttempt < retries; retryAttempt++) {
+  while (retryGroups.length > 0) {
     if (retryDelayMs > 0) {
       const delayMs = Math.min(retryDelayMs, Math.max(0, getDeadlineAt() - Date.now()));
       if (delayMs <= 0) {
@@ -842,7 +844,11 @@ export async function probeStagedWorkerCacheability(options: {
       }
       await delay(delayMs);
     }
-    retryGroups = await runGroupPass(retryGroups, retryAttempt + 1 < retries);
+    retryGroupSet.clear();
+    readyGroups.splice(0, readyGroups.length, ...retryGroups);
+    nextReadyIndex = 0;
+    await runReadyGroups();
+    retryGroups = groups.filter((group) => retryGroupSet.has(group));
   }
   if (limitFailure) throw limitFailure;
   if (phaseTimedOut || Date.now() >= getDeadlineAt()) {

--- a/packages/cloudflare/src/cacheability-probe.ts
+++ b/packages/cloudflare/src/cacheability-probe.ts
@@ -145,7 +145,7 @@ export function readPrerenderSecret(root: string): string {
 
 async function readProbeEnvelope(response: Response): Promise<ProbePayload> {
   if (!response.body) {
-    return { reason: "probe returned invalid JSON", state: "probe-failed", version: 1 };
+    throw new Error("probe returned invalid JSON");
   }
 
   const reader = response.body.getReader();
@@ -166,12 +166,6 @@ async function readProbeEnvelope(response: Response): Promise<ProbePayload> {
       }
       chunks.push(result.value);
     }
-  } catch (error) {
-    return {
-      reason: error instanceof Error ? error.message : String(error),
-      state: "probe-failed",
-      version: 1,
-    };
   } finally {
     reader.releaseLock();
   }
@@ -179,7 +173,7 @@ async function readProbeEnvelope(response: Response): Promise<ProbePayload> {
   try {
     return JSON.parse(Buffer.concat(chunks, bytes).toString("utf8")) as ProbePayload;
   } catch {
-    return { reason: "probe returned invalid JSON", state: "probe-failed", version: 1 };
+    throw new Error("probe returned invalid JSON");
   }
 }
 

--- a/packages/cloudflare/src/cacheability-probe.ts
+++ b/packages/cloudflare/src/cacheability-probe.ts
@@ -625,7 +625,6 @@ export async function probeStagedWorkerCacheability(options: {
       targetUrl: options.targetUrl,
       timeoutMs,
     });
-    lastProgressAt = Date.now();
     if (limitFailure) return "done";
     if (result.phaseTimedOut) {
       phaseTimedOut = true;
@@ -634,6 +633,7 @@ export async function probeStagedWorkerCacheability(options: {
     if (result.state === "probe-failed" && result.retryable === true && attemptOptions.deferRetry) {
       return "retry";
     }
+    lastProgressAt = Date.now();
     probed += 1;
     if (
       result.version !== 1 ||

--- a/packages/cloudflare/src/cacheability-probe.ts
+++ b/packages/cloudflare/src/cacheability-probe.ts
@@ -215,14 +215,15 @@ async function probeTarget(options: {
     version: 1,
   });
   let ordinaryFailures = 0;
+  let retryable = true;
   for (let attempt = 0; ; attempt++) {
     if (options.getDeadlineAt() - Date.now() <= 0) return phaseTimeoutPayload();
 
+    retryable = true;
     const controller = new AbortController();
     const requestDeadlineAt = Date.now() + options.timeoutMs;
     let timeout: ReturnType<typeof setTimeout> | undefined;
     let timedOutBy: "phase" | "request" | null = null;
-    let retryable = true;
     let retryUntilDeadline = false;
     try {
       const url = new URL(options.target.pathname, options.targetUrl);
@@ -318,7 +319,12 @@ async function probeTarget(options: {
       await delay(delayMs);
     }
   }
-  return { reason, state: "probe-failed", version: 1 };
+  return {
+    reason,
+    ...(retryable ? { retryable: true as const } : {}),
+    state: "probe-failed",
+    version: 1,
+  };
 }
 
 export async function probeStagedWorkerCacheability(options: {
@@ -583,12 +589,16 @@ export async function probeStagedWorkerCacheability(options: {
     }
   };
 
-  const classifyConcretePath = async (group: ConcretePathGroup): Promise<void> => {
+  type ProbeGroupResult = "done" | "retry";
+  const classifyConcretePath = async (
+    group: ConcretePathGroup,
+    attemptOptions: { deferRetry: boolean; inlineRetries: number },
+  ): Promise<ProbeGroupResult> => {
     if (group.pattern.pruned) {
       skippedPathCount += 1;
       completedPathCount += 1;
       reportProgress();
-      return;
+      return "done";
     }
     const target = group.primary;
     const request = new Request(new URL(target.pathname, options.targetUrl), {
@@ -599,7 +609,7 @@ export async function probeStagedWorkerCacheability(options: {
       failures.push(`${target.label}: warm request does not have a cacheable request identity`);
       completedPathCount += 1;
       reportProgress();
-      return;
+      return "done";
     }
 
     const result = await probeTarget({
@@ -607,7 +617,7 @@ export async function probeStagedWorkerCacheability(options: {
       fetchImpl: options.fetchImpl ?? fetch,
       getDeadlineAt,
       headers: options.headers,
-      retries,
+      retries: attemptOptions.inlineRetries,
       retryDelayMs,
       phaseTimeoutMs,
       secret,
@@ -615,13 +625,16 @@ export async function probeStagedWorkerCacheability(options: {
       targetUrl: options.targetUrl,
       timeoutMs,
     });
-    probed += 1;
     lastProgressAt = Date.now();
-    if (limitFailure) return;
+    if (limitFailure) return "done";
     if (result.phaseTimedOut) {
       phaseTimedOut = true;
-      return;
+      return "done";
     }
+    if (result.state === "probe-failed" && result.retryable === true && attemptOptions.deferRetry) {
+      return "retry";
+    }
+    probed += 1;
     if (
       result.version !== 1 ||
       (result.kind !== "app-page" && result.kind !== "app-route" && result.kind !== "pages-page") ||
@@ -650,19 +663,19 @@ export async function probeStagedWorkerCacheability(options: {
       failures.push(`${target.label}: ${result.reason ?? "probe returned an invalid envelope"}`);
       completedPathCount += 1;
       reportProgress();
-      return;
+      return "done";
     }
     if (result.state === "probe-failed") {
       failures.push(`${target.label}: ${result.reason ?? "probe failed"}`);
       completedPathCount += 1;
       reportProgress();
-      return;
+      return "done";
     }
     if (!target.route) {
       failures.push(`${target.label}: probe resolved without route metadata`);
       completedPathCount += 1;
       reportProgress();
-      return;
+      return "done";
     }
     const resolvedRouteChanged =
       result.kind !== target.route.kind || result.pattern !== target.route.pattern;
@@ -676,13 +689,13 @@ export async function probeStagedWorkerCacheability(options: {
         );
         completedPathCount += 1;
         reportProgress();
-        return;
+        return "done";
       }
       if (result.routePathname === undefined) {
         failures.push(`${target.label}: probe resolved without a concrete route pathname`);
         completedPathCount += 1;
         reportProgress();
-        return;
+        return "done";
       }
     }
     if (
@@ -725,7 +738,7 @@ export async function probeStagedWorkerCacheability(options: {
       dynamicPathCount += 1;
       completedPathCount += 1;
       reportProgress();
-      return;
+      return "done";
     }
     if (result.state === "static-candidate") {
       staticPathCount += 1;
@@ -734,18 +747,27 @@ export async function probeStagedWorkerCacheability(options: {
     }
     completedPathCount += 1;
     reportProgress();
+    return "done";
   };
 
-  const runGroups = async (scheduledGroups: readonly ConcretePathGroup[]): Promise<void> => {
+  const runGroupPass = async (
+    scheduledGroups: readonly ConcretePathGroup[],
+    deferRetry: boolean,
+  ): Promise<ConcretePathGroup[]> => {
     let nextIndex = 0;
+    const retryGroups = new Set<ConcretePathGroup>();
     const worker = async (): Promise<void> => {
       while (!limitFailure && !phaseTimedOut && nextIndex < scheduledGroups.length) {
-        await classifyConcretePath(scheduledGroups[nextIndex++]);
+        const group = scheduledGroups[nextIndex++];
+        if ((await classifyConcretePath(group, { deferRetry, inlineRetries: 0 })) === "retry") {
+          retryGroups.add(group);
+        }
       }
     };
     await Promise.all(
       Array.from({ length: Math.min(concurrency, scheduledGroups.length) }, () => worker()),
     );
+    return scheduledGroups.filter((group) => retryGroups.has(group));
   };
 
   reportProgress();
@@ -753,20 +775,75 @@ export async function probeStagedWorkerCacheability(options: {
     (group) => group.primary.route?.cacheabilityProbe?.routeMayResolve === true,
   );
   const routeMovingGroupSet = new Set(routeMovingGroups);
-  const representativeGroups: ConcretePathGroup[] = [];
-  const siblingGroups: ConcretePathGroup[] = [];
+  const readyGroups = [...routeMovingGroups];
+  const readyGroupSet = new Set(routeMovingGroups);
   for (const pattern of patterns.values()) {
-    const [representative, ...siblings] = pattern.groups;
-    if (representative && !routeMovingGroupSet.has(representative)) {
-      representativeGroups.push(representative);
-    }
-    siblingGroups.push(...siblings.filter((group) => !routeMovingGroupSet.has(group)));
+    const representative = pattern.groups[0];
+    if (!representative || readyGroupSet.has(representative)) continue;
+    readyGroups.push(representative);
+    readyGroupSet.add(representative);
   }
-  // Resolve every route-moving public path before a destination pattern may
-  // be pruned, then use the same bounded worker loops as ordinary CDN warming.
-  await runGroups(routeMovingGroups);
-  if (!limitFailure && !phaseTimedOut) await runGroups(representativeGroups);
-  if (!limitFailure && !phaseTimedOut) await runGroups(siblingGroups);
+  for (const group of groups) {
+    if (readyGroupSet.has(group)) continue;
+    readyGroups.push(group);
+    readyGroupSet.add(group);
+  }
+
+  const deferredUntilRouteMoversSettle: ConcretePathGroup[] = [];
+  const retryGroupSet = new Set<ConcretePathGroup>();
+  const active = new Set<Promise<void>>();
+  let nextReadyIndex = 0;
+  let pendingRouteMovers = routeMovingGroups.length;
+  const enqueue = (scheduledGroups: readonly ConcretePathGroup[]): void => {
+    readyGroups.push(...scheduledGroups);
+  };
+  const startGroup = (group: ConcretePathGroup): void => {
+    const task = (async () => {
+      const isRouteMover = routeMovingGroupSet.has(group);
+      if (!isRouteMover && group.pattern.pruned && pendingRouteMovers > 0) {
+        deferredUntilRouteMoversSettle.push(group);
+        return;
+      }
+      const result = await classifyConcretePath(group, {
+        deferRetry: !isRouteMover && retries > 0,
+        inlineRetries: isRouteMover ? retries : 0,
+      });
+      if (result === "retry") retryGroupSet.add(group);
+      if (isRouteMover && --pendingRouteMovers === 0) {
+        enqueue(deferredUntilRouteMoversSettle.splice(0));
+      }
+    })();
+    active.add(task);
+    void task.then(
+      () => active.delete(task),
+      () => active.delete(task),
+    );
+  };
+
+  while (
+    !limitFailure &&
+    !phaseTimedOut &&
+    (nextReadyIndex < readyGroups.length || active.size > 0)
+  ) {
+    while (active.size < concurrency && nextReadyIndex < readyGroups.length) {
+      startGroup(readyGroups[nextReadyIndex++]);
+    }
+    if (active.size > 0) await Promise.race(active);
+  }
+  await Promise.all(active);
+
+  let retryGroups = groups.filter((group) => retryGroupSet.has(group));
+  for (let retryAttempt = 0; retryGroups.length > 0 && retryAttempt < retries; retryAttempt++) {
+    if (retryDelayMs > 0) {
+      const delayMs = Math.min(retryDelayMs, Math.max(0, getDeadlineAt() - Date.now()));
+      if (delayMs <= 0) {
+        phaseTimedOut = true;
+        break;
+      }
+      await delay(delayMs);
+    }
+    retryGroups = await runGroupPass(retryGroups, retryAttempt + 1 < retries);
+  }
   if (limitFailure) throw limitFailure;
   if (phaseTimedOut || Date.now() >= getDeadlineAt()) {
     throw new Error(`cacheability probing made no progress for ${phaseTimeoutMs}ms`);

--- a/packages/cloudflare/src/cacheability-probe.ts
+++ b/packages/cloudflare/src/cacheability-probe.ts
@@ -757,21 +757,20 @@ export async function probeStagedWorkerCacheability(options: {
   const routeMovingGroupSet = new Set(routeMovingGroups);
   const readyGroups = [...routeMovingGroups];
   const readyGroupSet = new Set(routeMovingGroups);
-  const siblingsByRepresentative = new Map<ConcretePathGroup, ConcretePathGroup[]>();
+  // Give route movers and one path per pattern first access to the pool, but
+  // do not leave spare configured slots idle. Any completed concrete path can
+  // provide pattern-wide dynamic proof; later groups observe `pruned` before
+  // starting their render.
   for (const pattern of patterns.values()) {
-    const [representative, ...siblings] = pattern.groups;
-    if (!representative) continue;
-    if (!readyGroupSet.has(representative)) {
-      readyGroups.push(representative);
-      readyGroupSet.add(representative);
-    }
-    const unscheduledSiblings = siblings.filter((group) => !readyGroupSet.has(group));
-    if (pattern.canPrune) {
-      siblingsByRepresentative.set(representative, unscheduledSiblings);
-      continue;
-    }
-    readyGroups.push(...unscheduledSiblings);
-    for (const sibling of unscheduledSiblings) readyGroupSet.add(sibling);
+    const representative = pattern.groups[0];
+    if (!representative || readyGroupSet.has(representative)) continue;
+    readyGroups.push(representative);
+    readyGroupSet.add(representative);
+  }
+  for (const group of groups) {
+    if (readyGroupSet.has(group)) continue;
+    readyGroups.push(group);
+    readyGroupSet.add(group);
   }
 
   const deferredUntilRouteMoversSettle: ConcretePathGroup[] = [];
@@ -802,13 +801,6 @@ export async function probeStagedWorkerCacheability(options: {
       }
       if (isRouteMover && --pendingRouteMovers === 0) {
         enqueue(deferredUntilRouteMoversSettle.splice(0));
-      }
-      const siblings = siblingsByRepresentative.get(group) ?? [];
-      siblingsByRepresentative.delete(group);
-      if (group.pattern.pruned && pendingRouteMovers > 0) {
-        deferredUntilRouteMoversSettle.push(...siblings);
-      } else {
-        enqueue(siblings);
       }
     })();
     active.add(task);

--- a/packages/vinext/src/server/cacheability-request.ts
+++ b/packages/vinext/src/server/cacheability-request.ts
@@ -51,6 +51,8 @@ type CacheabilityProbeResult = {
   reason?: string;
   /** The renderer itself completed with a reusable static policy. */
   rendererStatic?: boolean;
+  /** The render could not be classified because of a transient execution failure. */
+  retryable?: true;
   /** Concrete pathname resolved by request-stage routing before rendering. */
   routePathname?: string;
   scope?: "identity" | "pattern";
@@ -303,6 +305,7 @@ function probeResponse(
     pattern: state.route?.pattern,
     reason: outcome.reason,
     ...(rendererStatic !== undefined ? { rendererStatic } : {}),
+    ...(outcome.retryable ? { retryable: true as const } : {}),
     ...(state.resolvedRoutePathname ? { routePathname: state.resolvedRoutePathname } : {}),
     ...(routeState === "dynamic"
       ? { scope: state.patternDynamicReason ? ("pattern" as const) : ("identity" as const) }
@@ -960,7 +963,7 @@ export async function finalizeWorkerCacheabilityResponse(
     return probeResponse(
       state,
       "probe-failed",
-      { cacheable: false, classificationFailure: true, reason: drainFailure },
+      { cacheable: false, classificationFailure: true, reason: drainFailure, retryable: true },
       response.status,
     );
   }

--- a/packages/vinext/src/shims/cacheability-classification.ts
+++ b/packages/vinext/src/shims/cacheability-classification.ts
@@ -11,6 +11,8 @@ export type RouteCacheabilityOutcome = {
   classificationFailure?: boolean;
   dynamicUsage?: boolean;
   reason?: string;
+  /** A transient classification failure that may succeed on another bounded attempt. */
+  retryable?: true;
   tags?: readonly string[];
 };
 

--- a/tests/cacheability-admission.test.ts
+++ b/tests/cacheability-admission.test.ts
@@ -422,6 +422,7 @@ describe("single-request cacheability admission", () => {
 
     await expect(response.json()).resolves.toMatchObject({
       reason: "response body did not complete before the probe deadline",
+      retryable: true,
       state: "probe-failed",
       status: 200,
     });

--- a/tests/cloudflare-cacheability-probe.test.ts
+++ b/tests/cloudflare-cacheability-probe.test.ts
@@ -478,14 +478,14 @@ describe("staged Worker cacheability probes", () => {
     );
   });
 
-  it("unlocks sibling paths without waiting for every pattern representative", async () => {
+  it("completes pattern representatives before scheduling sibling paths", async () => {
     const root = createProbeRoot();
     const slow = target("/slow");
     const fastRoute = optimizableRoute("/fast/:slug");
     const fastFirst = { ...target("/fast/one"), route: fastRoute };
     const fastSecond = { ...target("/fast/two"), route: fastRoute };
     let slowCompleted = false;
-    let siblingStartedBeforeSlowCompleted = false;
+    let siblingStartedAfterSlowCompleted = false;
     const result = await probeStagedWorkerCacheability({
       buildId: "application-build",
       concurrency: 2,
@@ -495,7 +495,7 @@ describe("staged Worker cacheability probes", () => {
           await new Promise((resolve) => setTimeout(resolve, 20));
           slowCompleted = true;
         } else if (pathname === "/fast/two") {
-          siblingStartedBeforeSlowCompleted = !slowCompleted;
+          siblingStartedAfterSlowCompleted = slowCompleted;
         }
         return Response.json({
           kind: "app-page",
@@ -512,7 +512,7 @@ describe("staged Worker cacheability probes", () => {
     });
 
     expect(result).toMatchObject({ failures: [], probed: 3 });
-    expect(siblingStartedBeforeSlowCompleted).toBe(true);
+    expect(siblingStartedAfterSlowCompleted).toBe(true);
   });
 
   it("does not prune destination siblings before route-moving probes settle", async () => {

--- a/tests/cloudflare-cacheability-probe.test.ts
+++ b/tests/cloudflare-cacheability-probe.test.ts
@@ -345,6 +345,256 @@ describe("staged Worker cacheability probes", () => {
     expect(result.failures).toEqual([]);
   });
 
+  it("requeues route-mover retries without occupying the only probe slot", async () => {
+    const root = createProbeRoot();
+    const moverRoute = {
+      cacheabilityProbe: { canPrunePattern: true, routeMayResolve: true },
+      kind: "app-page" as const,
+      pattern: "/move",
+    };
+    const mover = { ...target("/move"), route: moverRoute };
+    const ordinary = target("/ordinary");
+    const attempts = new Map<string, number>();
+    const requestOrder: string[] = [];
+    const result = await probeStagedWorkerCacheability({
+      buildId: "application-build",
+      concurrency: 1,
+      fetchImpl: async (input) => {
+        const pathname = new URL(input instanceof Request ? input.url : String(input)).pathname;
+        requestOrder.push(pathname);
+        const attempt = attempts.get(pathname) ?? 0;
+        attempts.set(pathname, attempt + 1);
+        if (pathname === "/move" && attempt === 0) {
+          return Response.json({
+            kind: "app-page",
+            pattern: moverRoute.pattern,
+            reason: "response body did not complete before the probe deadline",
+            retryable: true,
+            state: "probe-failed",
+            status: 200,
+            version: 1,
+          });
+        }
+        return staticProbeResponse(pathname);
+      },
+      retries: 1,
+      retryDelayMs: 0,
+      root,
+      targetUrl: "https://example.com",
+      targets: [mover, ordinary],
+    });
+
+    expect(requestOrder).toEqual(["/move", "/ordinary", "/move"]);
+    expect(result).toMatchObject({ failures: [], probed: 2 });
+  });
+
+  it("retries a prunable representative before releasing or skipping its siblings", async () => {
+    const root = createProbeRoot();
+    const route = optimizableRoute("/posts/:slug");
+    const targets = ["one", "two", "three"].map((slug) => ({
+      ...target(`/posts/${slug}`),
+      route,
+    }));
+    const requestOrder: string[] = [];
+    const progress: Array<{ completed: number; skipped: number; total: number }> = [];
+    const result = await probeStagedWorkerCacheability({
+      buildId: "application-build",
+      concurrency: 1,
+      fetchImpl: async (input) => {
+        const pathname = new URL(input instanceof Request ? input.url : String(input)).pathname;
+        requestOrder.push(pathname);
+        if (requestOrder.length === 1) {
+          return Response.json({
+            kind: "app-page",
+            pattern: route.pattern,
+            reason: "response body did not complete before the probe deadline",
+            retryable: true,
+            state: "probe-failed",
+            status: 200,
+            version: 1,
+          });
+        }
+        return Response.json({
+          kind: "app-page",
+          pattern: route.pattern,
+          scope: "pattern",
+          state: "dynamic",
+          status: 200,
+          version: 1,
+        });
+      },
+      onProgress: ({ completed, skipped, total }) => {
+        progress.push({ completed, skipped, total });
+      },
+      retries: 1,
+      retryDelayMs: 0,
+      root,
+      targetUrl: "https://example.com",
+      targets,
+    });
+
+    expect(requestOrder).toEqual(["/posts/one", "/posts/one"]);
+    expect(result).toMatchObject({ failures: [], probed: 1 });
+    expect(progress.at(-1)).toEqual({ completed: 3, skipped: 2, total: 3 });
+  });
+
+  it("gives late-released siblings their own retry budget", async () => {
+    const root = createProbeRoot();
+    const route = optimizableRoute("/posts/:slug");
+    const attempts = new Map<string, number>();
+    const requestOrder: string[] = [];
+    const result = await probeStagedWorkerCacheability({
+      buildId: "application-build",
+      concurrency: 1,
+      fetchImpl: async (input) => {
+        const pathname = new URL(input instanceof Request ? input.url : String(input)).pathname;
+        requestOrder.push(pathname);
+        const attempt = attempts.get(pathname) ?? 0;
+        attempts.set(pathname, attempt + 1);
+        if ((pathname === "/posts/one" || pathname === "/posts/two") && attempt === 0) {
+          return Response.json({
+            kind: "app-page",
+            pattern: route.pattern,
+            reason: "transient probe failure",
+            retryable: true,
+            state: "probe-failed",
+            status: 503,
+            version: 1,
+          });
+        }
+        return staticProbeResponse(route.pattern);
+      },
+      retries: 1,
+      retryDelayMs: 0,
+      root,
+      targetUrl: "https://example.com",
+      targets: ["one", "two", "three"].map((slug) => ({
+        ...target(`/posts/${slug}`),
+        route,
+      })),
+    });
+
+    expect(requestOrder).toEqual([
+      "/posts/one",
+      "/posts/one",
+      "/posts/two",
+      "/posts/three",
+      "/posts/two",
+    ]);
+    expect(result).toMatchObject({ failures: [], probed: 3 });
+  });
+
+  it("gives groups deferred by a route mover their own retry budget", async () => {
+    const root = createProbeRoot();
+    const destinationRoute = optimizableRoute("/posts/:slug");
+    const moverRoute = {
+      cacheabilityProbe: { canPrunePattern: true, routeMayResolve: true },
+      kind: "app-page" as const,
+      pattern: "/source",
+    };
+    const attempts = new Map<string, number>();
+    const requestOrder: string[] = [];
+    const result = await probeStagedWorkerCacheability({
+      buildId: "application-build",
+      concurrency: 1,
+      fetchImpl: async (input) => {
+        const pathname = new URL(input instanceof Request ? input.url : String(input)).pathname;
+        requestOrder.push(pathname);
+        const attempt = attempts.get(pathname) ?? 0;
+        attempts.set(pathname, attempt + 1);
+        if ((pathname === "/source" || pathname === "/posts/two") && attempt === 0) {
+          return Response.json({
+            kind: "app-page",
+            pattern: pathname === "/source" ? moverRoute.pattern : destinationRoute.pattern,
+            reason: "transient probe failure",
+            retryable: true,
+            state: "probe-failed",
+            status: 503,
+            version: 1,
+          });
+        }
+        if (pathname === "/source") {
+          return Response.json({
+            kind: "app-page",
+            pattern: destinationRoute.pattern,
+            rendererStatic: true,
+            routePathname: "/posts/source",
+            state: "static-candidate",
+            status: 200,
+            version: 1,
+          });
+        }
+        if (pathname === "/posts/one") {
+          return Response.json({
+            kind: "app-page",
+            pattern: destinationRoute.pattern,
+            scope: "pattern",
+            state: "dynamic",
+            status: 200,
+            version: 1,
+          });
+        }
+        return staticProbeResponse(destinationRoute.pattern);
+      },
+      retries: 1,
+      retryDelayMs: 0,
+      root,
+      targetUrl: "https://example.com",
+      targets: [
+        { ...target("/posts/one"), route: destinationRoute },
+        { ...target("/posts/two"), route: destinationRoute },
+        { ...target("/source"), route: moverRoute },
+      ],
+    });
+
+    expect(requestOrder).toEqual(["/source", "/posts/one", "/source", "/posts/two", "/posts/two"]);
+    expect(result).toMatchObject({ failures: [], probed: 3 });
+  });
+
+  it("honors configured probe concurrency above the former worker-pool cap", async () => {
+    const root = createProbeRoot();
+    const route = {
+      cacheabilityProbe: { canPrunePattern: false },
+      kind: "app-page" as const,
+      pattern: "/items/:slug",
+    };
+    const targets = Array.from({ length: 64 }, (_, index) => ({
+      ...target(`/items/${index}`),
+      route,
+    }));
+    let active = 0;
+    let maximumActive = 0;
+    let release!: () => void;
+    let reachedConfiguredConcurrency!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const allSlotsActive = new Promise<void>((resolve) => {
+      reachedConfiguredConcurrency = resolve;
+    });
+    const probing = probeStagedWorkerCacheability({
+      buildId: "application-build",
+      concurrency: 32,
+      fetchImpl: async () => {
+        active += 1;
+        maximumActive = Math.max(maximumActive, active);
+        if (active === 32) reachedConfiguredConcurrency();
+        await gate;
+        active -= 1;
+        return staticProbeResponse(route.pattern);
+      },
+      root,
+      targetUrl: "https://example.com",
+      targets,
+    });
+
+    await allSlotsActive;
+    expect(active).toBe(32);
+    release();
+    await expect(probing).resolves.toMatchObject({ failures: [], probed: 64 });
+    expect(maximumActive).toBe(32);
+  });
+
   it("does not retry a deterministic Worker-side probe failure", async () => {
     const root = createProbeRoot();
     const fetchImpl = vi.fn<typeof fetch>(async () =>
@@ -651,9 +901,50 @@ describe("staged Worker cacheability probes", () => {
     );
   });
 
-  it("fills idle probe slots without waiting for a pattern representative", async () => {
+  it("unlocks prunable siblings without waiting for every pattern representative", async () => {
     const root = createProbeRoot();
-    const route = optimizableRoute("/items/:slug");
+    const slow = target("/slow");
+    const fastRoute = optimizableRoute("/fast/:slug");
+    const fastFirst = { ...target("/fast/one"), route: fastRoute };
+    const fastSecond = { ...target("/fast/two"), route: fastRoute };
+    let slowCompleted = false;
+    let siblingStartedBeforeSlowCompleted = false;
+    const result = await probeStagedWorkerCacheability({
+      buildId: "application-build",
+      concurrency: 2,
+      fetchImpl: async (input) => {
+        const pathname = new URL(input instanceof Request ? input.url : String(input)).pathname;
+        if (pathname === "/slow") {
+          await new Promise((resolve) => setTimeout(resolve, 20));
+          slowCompleted = true;
+        } else if (pathname === "/fast/two") {
+          siblingStartedBeforeSlowCompleted = !slowCompleted;
+        }
+        return Response.json({
+          kind: "app-page",
+          pattern: pathname === "/slow" ? "/slow" : fastRoute.pattern,
+          rendererStatic: true,
+          state: "static-candidate",
+          status: 200,
+          version: 1,
+        });
+      },
+      root,
+      targetUrl: "https://example.com",
+      targets: [slow, fastFirst, fastSecond],
+    });
+
+    expect(result).toMatchObject({ failures: [], probed: 3 });
+    expect(siblingStartedBeforeSlowCompleted).toBe(true);
+  });
+
+  it("fills idle slots immediately for patterns without pattern-wide pruning", async () => {
+    const root = createProbeRoot();
+    const route = {
+      cacheabilityProbe: { canPrunePattern: false },
+      kind: "app-page" as const,
+      pattern: "/items/:slug",
+    };
     const slow = { ...target("/items/slow"), route };
     const sibling = { ...target("/items/sibling"), route };
     let slowCompleted = false;
@@ -666,17 +957,10 @@ describe("staged Worker cacheability probes", () => {
         if (pathname === "/items/slow") {
           await new Promise((resolve) => setTimeout(resolve, 20));
           slowCompleted = true;
-        } else if (pathname === "/items/sibling") {
+        } else {
           siblingStartedBeforeSlowCompleted = !slowCompleted;
         }
-        return Response.json({
-          kind: "app-page",
-          pattern: route.pattern,
-          rendererStatic: true,
-          state: "static-candidate",
-          status: 200,
-          version: 1,
-        });
+        return staticProbeResponse(route.pattern);
       },
       root,
       targetUrl: "https://example.com",
@@ -884,7 +1168,7 @@ describe("staged Worker cacheability probes", () => {
     expect(result.failures).toEqual(["1 warm target is missing route-pattern metadata"]);
   });
 
-  it("uses pattern-wide dynamic proof after bounded sibling renders have started", async () => {
+  it("uses pattern-wide dynamic proof before starting sibling renders", async () => {
     const root = createProbeRoot();
     const route = optimizableRoute("/posts/:slug");
     const htmlOne = { ...target("/posts/one"), route };
@@ -918,8 +1202,8 @@ describe("staged Worker cacheability probes", () => {
       targets: [rsc("one"), rsc("two"), htmlOne, htmlTwo],
     });
 
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
-    expect(result).toMatchObject({ classified: 1, dynamic: 1, probed: 2, skipped: 1 });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(result).toMatchObject({ classified: 1, dynamic: 1, probed: 1, skipped: 1 });
     expect(result.cacheableTargets).toEqual([]);
     expect(result.manifest.routes).toEqual({});
   });
@@ -959,8 +1243,8 @@ describe("staged Worker cacheability probes", () => {
       targets: [loadingOne, loadingTwo, html("one"), html("two")],
     });
 
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
-    expect(result).toMatchObject({ classified: 1, dynamic: 1, probed: 2, skipped: 1 });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(result).toMatchObject({ classified: 1, dynamic: 1, probed: 1, skipped: 1 });
     expect(result.cacheableTargets).toEqual([loadingOne, loadingTwo]);
     expect(result.speculativeTargets).toEqual([loadingOne, loadingTwo]);
     expect(Object.values(result.manifest.routes)).toEqual([

--- a/tests/cloudflare-cacheability-probe.test.ts
+++ b/tests/cloudflare-cacheability-probe.test.ts
@@ -388,7 +388,7 @@ describe("staged Worker cacheability probes", () => {
     expect(result).toMatchObject({ failures: [], probed: 2 });
   });
 
-  it("retries a prunable representative before releasing or skipping its siblings", async () => {
+  it("lets sibling pattern proof supersede a prunable representative retry", async () => {
     const root = createProbeRoot();
     const route = optimizableRoute("/posts/:slug");
     const targets = ["one", "two", "three"].map((slug) => ({
@@ -433,12 +433,12 @@ describe("staged Worker cacheability probes", () => {
       targets,
     });
 
-    expect(requestOrder).toEqual(["/posts/one", "/posts/one"]);
+    expect(requestOrder).toEqual(["/posts/one", "/posts/two"]);
     expect(result).toMatchObject({ failures: [], probed: 1 });
     expect(progress.at(-1)).toEqual({ completed: 3, skipped: 2, total: 3 });
   });
 
-  it("gives late-released siblings their own retry budget", async () => {
+  it("gives every concrete group its own retry budget", async () => {
     const root = createProbeRoot();
     const route = optimizableRoute("/posts/:slug");
     const attempts = new Map<string, number>();
@@ -476,9 +476,9 @@ describe("staged Worker cacheability probes", () => {
 
     expect(requestOrder).toEqual([
       "/posts/one",
-      "/posts/one",
       "/posts/two",
       "/posts/three",
+      "/posts/one",
       "/posts/two",
     ]);
     expect(result).toMatchObject({ failures: [], probed: 3 });
@@ -554,7 +554,7 @@ describe("staged Worker cacheability probes", () => {
   it("honors configured probe concurrency above the former worker-pool cap", async () => {
     const root = createProbeRoot();
     const route = {
-      cacheabilityProbe: { canPrunePattern: false },
+      cacheabilityProbe: { canPrunePattern: true },
       kind: "app-page" as const,
       pattern: "/items/:slug",
     };
@@ -938,13 +938,9 @@ describe("staged Worker cacheability probes", () => {
     expect(siblingStartedBeforeSlowCompleted).toBe(true);
   });
 
-  it("fills idle slots immediately for patterns without pattern-wide pruning", async () => {
+  it("fills idle slots immediately for patterns with pattern-wide pruning", async () => {
     const root = createProbeRoot();
-    const route = {
-      cacheabilityProbe: { canPrunePattern: false },
-      kind: "app-page" as const,
-      pattern: "/items/:slug",
-    };
+    const route = optimizableRoute("/items/:slug");
     const slow = { ...target("/items/slow"), route };
     const sibling = { ...target("/items/sibling"), route };
     let slowCompleted = false;
@@ -1168,11 +1164,12 @@ describe("staged Worker cacheability probes", () => {
     expect(result.failures).toEqual(["1 warm target is missing route-pattern metadata"]);
   });
 
-  it("uses pattern-wide dynamic proof before starting sibling renders", async () => {
+  it("uses the first completed pattern-wide dynamic proof to stop queued siblings", async () => {
     const root = createProbeRoot();
     const route = optimizableRoute("/posts/:slug");
     const htmlOne = { ...target("/posts/one"), route };
     const htmlTwo = { ...target("/posts/two"), route };
+    const htmlThree = { ...target("/posts/three"), route };
     const rsc = (slug: string) => ({
       headers: { Accept: "text/x-component", RSC: "1" },
       kind: "rsc-full" as const,
@@ -1181,16 +1178,20 @@ describe("staged Worker cacheability probes", () => {
       route,
       sourcePathname: `/posts/${slug}`,
     });
-    const fetchImpl = vi.fn<typeof fetch>(async () =>
-      Response.json({
+    const fetchImpl = vi.fn<typeof fetch>(async (input) => {
+      const pathname = new URL(input instanceof Request ? input.url : String(input)).pathname;
+      if (pathname === "/posts/one") {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+      return Response.json({
         kind: "app-page",
         pattern: route.pattern,
         scope: "pattern",
         state: "dynamic",
         status: 204,
         version: 1,
-      }),
-    );
+      });
+    });
 
     const result = await probeStagedWorkerCacheability({
       buildId: "application-build",
@@ -1199,11 +1200,11 @@ describe("staged Worker cacheability probes", () => {
       retries: 0,
       root,
       targetUrl: "https://example.com",
-      targets: [rsc("one"), rsc("two"), htmlOne, htmlTwo],
+      targets: [rsc("one"), rsc("two"), rsc("three"), htmlOne, htmlTwo, htmlThree],
     });
 
-    expect(fetchImpl).toHaveBeenCalledOnce();
-    expect(result).toMatchObject({ classified: 1, dynamic: 1, probed: 1, skipped: 1 });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(result).toMatchObject({ classified: 1, dynamic: 1, probed: 2, skipped: 1 });
     expect(result.cacheableTargets).toEqual([]);
     expect(result.manifest.routes).toEqual({});
   });
@@ -1243,8 +1244,8 @@ describe("staged Worker cacheability probes", () => {
       targets: [loadingOne, loadingTwo, html("one"), html("two")],
     });
 
-    expect(fetchImpl).toHaveBeenCalledOnce();
-    expect(result).toMatchObject({ classified: 1, dynamic: 1, probed: 1, skipped: 1 });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(result).toMatchObject({ classified: 1, dynamic: 1, probed: 2, skipped: 1 });
     expect(result.cacheableTargets).toEqual([loadingOne, loadingTwo]);
     expect(result.speculativeTargets).toEqual([loadingOne, loadingTwo]);
     expect(Object.values(result.manifest.routes)).toEqual([

--- a/tests/cloudflare-cacheability-probe.test.ts
+++ b/tests/cloudflare-cacheability-probe.test.ts
@@ -307,6 +307,44 @@ describe("staged Worker cacheability probes", () => {
     expect(result).toMatchObject({ classified: 1, probed: 1 });
   });
 
+  it("requeues transient failures after the initial probe pass", async () => {
+    const root = createProbeRoot();
+    const attempts = new Map<string, number>();
+    const requestOrder: string[] = [];
+    const fetchImpl = vi.fn<typeof fetch>(async (input) => {
+      const pathname = new URL(input instanceof Request ? input.url : String(input)).pathname;
+      requestOrder.push(pathname);
+      const attempt = attempts.get(pathname) ?? 0;
+      attempts.set(pathname, attempt + 1);
+      if (pathname === "/slow" && attempt === 0) {
+        return Response.json({
+          kind: "app-page",
+          pattern: pathname,
+          reason: "response body did not complete before the probe deadline",
+          retryable: true,
+          state: "probe-failed",
+          status: 200,
+          version: 1,
+        });
+      }
+      return staticProbeResponse(pathname);
+    });
+
+    const result = await probeStagedWorkerCacheability({
+      buildId: "application-build",
+      concurrency: 1,
+      fetchImpl,
+      retries: 1,
+      retryDelayMs: 0,
+      root,
+      targetUrl: "https://example.com",
+      targets: [target("/slow"), target("/fast")],
+    });
+
+    expect(requestOrder).toEqual(["/slow", "/fast", "/slow"]);
+    expect(result.failures).toEqual([]);
+  });
+
   it("does not retry a deterministic Worker-side probe failure", async () => {
     const root = createProbeRoot();
     const fetchImpl = vi.fn<typeof fetch>(async () =>
@@ -613,28 +651,27 @@ describe("staged Worker cacheability probes", () => {
     );
   });
 
-  it("completes pattern representatives before scheduling sibling paths", async () => {
+  it("fills idle probe slots without waiting for a pattern representative", async () => {
     const root = createProbeRoot();
-    const slow = target("/slow");
-    const fastRoute = optimizableRoute("/fast/:slug");
-    const fastFirst = { ...target("/fast/one"), route: fastRoute };
-    const fastSecond = { ...target("/fast/two"), route: fastRoute };
+    const route = optimizableRoute("/items/:slug");
+    const slow = { ...target("/items/slow"), route };
+    const sibling = { ...target("/items/sibling"), route };
     let slowCompleted = false;
-    let siblingStartedAfterSlowCompleted = false;
+    let siblingStartedBeforeSlowCompleted = false;
     const result = await probeStagedWorkerCacheability({
       buildId: "application-build",
       concurrency: 2,
       fetchImpl: async (input) => {
         const pathname = new URL(input instanceof Request ? input.url : String(input)).pathname;
-        if (pathname === "/slow") {
+        if (pathname === "/items/slow") {
           await new Promise((resolve) => setTimeout(resolve, 20));
           slowCompleted = true;
-        } else if (pathname === "/fast/two") {
-          siblingStartedAfterSlowCompleted = slowCompleted;
+        } else if (pathname === "/items/sibling") {
+          siblingStartedBeforeSlowCompleted = !slowCompleted;
         }
         return Response.json({
           kind: "app-page",
-          pattern: pathname === "/slow" ? "/slow" : fastRoute.pattern,
+          pattern: route.pattern,
           rendererStatic: true,
           state: "static-candidate",
           status: 200,
@@ -643,11 +680,11 @@ describe("staged Worker cacheability probes", () => {
       },
       root,
       targetUrl: "https://example.com",
-      targets: [slow, fastFirst, fastSecond],
+      targets: [slow, sibling],
     });
 
-    expect(result).toMatchObject({ failures: [], probed: 3 });
-    expect(siblingStartedAfterSlowCompleted).toBe(true);
+    expect(result).toMatchObject({ failures: [], probed: 2 });
+    expect(siblingStartedBeforeSlowCompleted).toBe(true);
   });
 
   it("does not prune destination siblings before route-moving probes settle", async () => {
@@ -847,7 +884,7 @@ describe("staged Worker cacheability probes", () => {
     expect(result.failures).toEqual(["1 warm target is missing route-pattern metadata"]);
   });
 
-  it("uses pattern-wide dynamic proof to skip sibling HTML and RSC renders", async () => {
+  it("uses pattern-wide dynamic proof after bounded sibling renders have started", async () => {
     const root = createProbeRoot();
     const route = optimizableRoute("/posts/:slug");
     const htmlOne = { ...target("/posts/one"), route };
@@ -873,6 +910,7 @@ describe("staged Worker cacheability probes", () => {
 
     const result = await probeStagedWorkerCacheability({
       buildId: "application-build",
+      concurrency: 2,
       fetchImpl,
       retries: 0,
       root,
@@ -880,8 +918,8 @@ describe("staged Worker cacheability probes", () => {
       targets: [rsc("one"), rsc("two"), htmlOne, htmlTwo],
     });
 
-    expect(fetchImpl).toHaveBeenCalledTimes(1);
-    expect(result).toMatchObject({ classified: 1, dynamic: 1, probed: 1, skipped: 1 });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(result).toMatchObject({ classified: 1, dynamic: 1, probed: 2, skipped: 1 });
     expect(result.cacheableTargets).toEqual([]);
     expect(result.manifest.routes).toEqual({});
   });
@@ -913,6 +951,7 @@ describe("staged Worker cacheability probes", () => {
     const loadingTwo = loading("two");
     const result = await probeStagedWorkerCacheability({
       buildId: "application-build",
+      concurrency: 2,
       fetchImpl,
       retries: 0,
       root,
@@ -920,8 +959,8 @@ describe("staged Worker cacheability probes", () => {
       targets: [loadingOne, loadingTwo, html("one"), html("two")],
     });
 
-    expect(fetchImpl).toHaveBeenCalledTimes(1);
-    expect(result).toMatchObject({ classified: 1, dynamic: 1, probed: 1, skipped: 1 });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(result).toMatchObject({ classified: 1, dynamic: 1, probed: 2, skipped: 1 });
     expect(result.cacheableTargets).toEqual([loadingOne, loadingTwo]);
     expect(result.speculativeTargets).toEqual([loadingOne, loadingTwo]);
     expect(Object.values(result.manifest.routes)).toEqual([

--- a/tests/cloudflare-cacheability-probe.test.ts
+++ b/tests/cloudflare-cacheability-probe.test.ts
@@ -66,17 +66,20 @@ describe("staged Worker cacheability probes", () => {
     };
   };
 
+  const staticProbeResponse = (pattern: string) =>
+    Response.json({
+      kind: "app-page",
+      pattern,
+      rendererStatic: true,
+      state: "static-candidate",
+      status: 200,
+      version: 1,
+    });
+
   const createStaticProbeFetch = () =>
     vi.fn<typeof fetch>(async (input) => {
       const pathname = new URL(input instanceof Request ? input.url : String(input)).pathname;
-      return Response.json({
-        kind: "app-page",
-        pattern: pathname,
-        rendererStatic: true,
-        state: "static-candidate",
-        status: 200,
-        version: 1,
-      });
+      return staticProbeResponse(pathname);
     });
 
   afterEach(() => {
@@ -199,6 +202,48 @@ describe("staged Worker cacheability probes", () => {
     expect(result.failures).toEqual(["/unavailable: probe returned HTTP 503"]);
   });
 
+  it.each([408, 429, 502, 503, 504, 520])(
+    "retries transient probe HTTP status %i",
+    async (status) => {
+      const root = createProbeRoot();
+      const fetchImpl = vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(new Response("unavailable", { status }))
+        .mockResolvedValueOnce(staticProbeResponse("/recovered"));
+
+      const result = await probeStagedWorkerCacheability({
+        buildId: "application-build",
+        fetchImpl,
+        retries: 1,
+        retryDelayMs: 0,
+        root,
+        targetUrl: "https://example.com",
+        targets: [target("/recovered")],
+      });
+
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+      expect(result.failures).toEqual([]);
+    },
+  );
+
+  it("does not retry an HTTP 500 probe response", async () => {
+    const root = createProbeRoot();
+    const fetchImpl = vi.fn<typeof fetch>(async () => new Response("broken", { status: 500 }));
+
+    const result = await probeStagedWorkerCacheability({
+      buildId: "application-build",
+      fetchImpl,
+      retries: 2,
+      retryDelayMs: 0,
+      root,
+      targetUrl: "https://example.com",
+      targets: [target("/broken")],
+    });
+
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(result.failures).toEqual(["/broken: probe returned HTTP 500"]);
+  });
+
   it("retries a malformed successful probe envelope", async () => {
     const root = createProbeRoot();
     const fetchImpl = vi
@@ -228,6 +273,65 @@ describe("staged Worker cacheability probes", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(2);
     expect(result.failures).toEqual([]);
     expect(result).toMatchObject({ classified: 1, probed: 1 });
+  });
+
+  it("retries a transient Worker-side render classification failure", async () => {
+    const root = createProbeRoot();
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        Response.json({
+          kind: "app-page",
+          pattern: "/recovered",
+          reason: "response body did not complete before the probe deadline",
+          retryable: true,
+          state: "probe-failed",
+          status: 200,
+          version: 1,
+        }),
+      )
+      .mockResolvedValueOnce(staticProbeResponse("/recovered"));
+
+    const result = await probeStagedWorkerCacheability({
+      buildId: "application-build",
+      fetchImpl,
+      retries: 1,
+      retryDelayMs: 0,
+      root,
+      targetUrl: "https://example.com",
+      targets: [target("/recovered")],
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(result.failures).toEqual([]);
+    expect(result).toMatchObject({ classified: 1, probed: 1 });
+  });
+
+  it("does not retry a deterministic Worker-side probe failure", async () => {
+    const root = createProbeRoot();
+    const fetchImpl = vi.fn<typeof fetch>(async () =>
+      Response.json({
+        kind: "app-page",
+        pattern: "/broken",
+        reason: "route returned HTTP 500",
+        state: "probe-failed",
+        status: 500,
+        version: 1,
+      }),
+    );
+
+    const result = await probeStagedWorkerCacheability({
+      buildId: "application-build",
+      fetchImpl,
+      retries: 2,
+      retryDelayMs: 0,
+      root,
+      targetUrl: "https://example.com",
+      targets: [target("/broken")],
+    });
+
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(result.failures).toEqual(["/broken: route returned HTTP 500"]);
   });
 
   it("aborts when cacheability probing makes no progress", async () => {

--- a/tests/cloudflare-cacheability-probe.test.ts
+++ b/tests/cloudflare-cacheability-probe.test.ts
@@ -199,6 +199,37 @@ describe("staged Worker cacheability probes", () => {
     expect(result.failures).toEqual(["/unavailable: probe returned HTTP 503"]);
   });
 
+  it("retries a malformed successful probe envelope", async () => {
+    const root = createProbeRoot();
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response("{truncated", { status: 200 }))
+      .mockResolvedValueOnce(
+        Response.json({
+          kind: "app-page",
+          pattern: "/recovered",
+          rendererStatic: true,
+          state: "static-candidate",
+          status: 200,
+          version: 1,
+        }),
+      );
+
+    const result = await probeStagedWorkerCacheability({
+      buildId: "application-build",
+      fetchImpl,
+      retries: 1,
+      retryDelayMs: 0,
+      root,
+      targetUrl: "https://example.com",
+      targets: [target("/recovered")],
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(result.failures).toEqual([]);
+    expect(result).toMatchObject({ classified: 1, probed: 1 });
+  });
+
   it("aborts when cacheability probing makes no progress", async () => {
     const root = createProbeRoot();
     const fetchImpl = vi

--- a/tests/cloudflare-cacheability-probe.test.ts
+++ b/tests/cloudflare-cacheability-probe.test.ts
@@ -644,6 +644,24 @@ describe("staged Worker cacheability probes", () => {
     expect(fetchImpl.mock.calls.length).toBeLessThanOrEqual(3);
   });
 
+  it("aborts a probe whose fetch never settles", async () => {
+    const root = createProbeRoot();
+    const fetchImpl = vi.fn<typeof fetch>(() => new Promise<Response>(() => {}));
+
+    await expect(
+      probeStagedWorkerCacheability({
+        buildId: "application-build",
+        fetchImpl,
+        phaseTimeoutMs: 25,
+        root,
+        targetUrl: "https://example.com",
+        targets: [target("/one")],
+        timeoutMs: 1_000,
+      }),
+    ).rejects.toThrow("cacheability probing made no progress for 25ms");
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
   it("allows a large serial workload to exceed the watchdog while requests keep completing", async () => {
     const root = createProbeRoot();
     const progress: number[] = [];

--- a/tests/cloudflare-cacheability-probe.test.ts
+++ b/tests/cloudflare-cacheability-probe.test.ts
@@ -624,12 +624,9 @@ describe("staged Worker cacheability probes", () => {
 
   it("aborts when cacheability probing makes no progress", async () => {
     const root = createProbeRoot();
-    const fetchImpl = vi
-      .fn<typeof fetch>()
-      .mockResolvedValueOnce(new Response("staged version unavailable", { status: 503 }))
-      .mockResolvedValueOnce(new Response("staged version unavailable", { status: 503 }))
-      // The no-progress watchdog remains authoritative even if fetch ignores abort.
-      .mockImplementation(() => new Promise<Response>(() => {}));
+    const fetchImpl = vi.fn<typeof fetch>(
+      async () => new Response("staged version unavailable", { status: 503 }),
+    );
 
     await expect(
       probeStagedWorkerCacheability({
@@ -641,10 +638,9 @@ describe("staged Worker cacheability probes", () => {
         retryDelayMs: 10,
         root,
         targetUrl: "https://example.com",
-        targets: [target("/one"), target("/two")],
+        targets: [target("/one")],
       }),
     ).rejects.toThrow("cacheability probing made no progress for 25ms");
-    expect(fetchImpl).toHaveBeenCalled();
     expect(fetchImpl.mock.calls.length).toBeLessThanOrEqual(3);
   });
 


### PR DESCRIPTION
## Summary

Experimental top-of-stack change to test whether the cacheability probe coordinator caused the large-app performance regression.

- restores fixed-size worker loops matching the scheduler used on main and by CDN warming
- resolves route-moving paths before pattern pruning remains possible
- preserves one cacheability probe per concrete path and the existing HTML/RSC warm request plan
- does not change Worker entrypoints, cache admission, request headers, or rendering

## Test plan

- vp test run tests/cloudflare-cacheability-probe.test.ts tests/cloudflare-cdn-warm-deploy.test.ts
- vp check packages/cloudflare/src/cacheability-probe.ts tests/cloudflare-cacheability-probe.test.ts
- compare Node.js app probe duration at --warm-cdn-concurrency=25 and 100 against PR #3168 and main