### PR TITLE
feat(init): onboard MDX and Tailwind v4 apps on first build

### DIFF
--- a/packages/vinext/src/config/next-config.ts
+++ b/packages/vinext/src/config/next-config.ts
@@ -1863,7 +1863,9 @@ export async function resolveNextConfig(
       );
     } else {
       console.warn(
-        '[vinext] next.config option "webpack" is not yet supported and will be ignored',
+        '[vinext] next.config option "webpack" is not yet supported and will be ignored. ' +
+          "Vite resolves .ts/.tsx natively, so common tweaks like resolve.extensionAlias are unnecessary; " +
+          "custom loaders or rules must move to vite.config.ts.",
       );
     }
   }
@@ -2114,7 +2116,10 @@ async function probeWebpackConfig(
   }
 
   try {
-    const clientProbe = await runWebpackConfigProbe(config, root, { dev, isServer: false });
+    const clientProbe = await runWebpackConfigProbe(config, root, {
+      dev,
+      isServer: false,
+    });
     const serverProbe = await runWebpackConfigProbe(config, root, {
       dev,
       isServer: true,

--- a/packages/vinext/src/init-cloudflare.ts
+++ b/packages/vinext/src/init-cloudflare.ts
@@ -14,6 +14,7 @@ export type CloudflareProjectInfo = {
   isAppRouter: boolean;
   hasISR: boolean;
   hasMDX: boolean;
+  hasTailwind: boolean;
   nativeModulesToStub: string[];
 };
 
@@ -56,7 +57,9 @@ export function validateCloudflarePlatformSetup(
     .find((candidate) => fs.existsSync(candidate));
   const wranglerCode = wranglerPath ? fs.readFileSync(wranglerPath, "utf-8") : undefined;
   const updatedWranglerCode = wranglerCode
-    ? updateWranglerConfigForCloudflare(wranglerCode, cloudflare, { root: context.root })
+    ? updateWranglerConfigForCloudflare(wranglerCode, cloudflare, {
+        root: context.root,
+      })
     : undefined;
   const imagesBinding = updatedWranglerCode
     ? getWranglerImagesBinding(updatedWranglerCode)
@@ -91,7 +94,9 @@ export function setupCloudflarePlatform(
     .find((candidate) => fs.existsSync(candidate));
   const wranglerCode = wranglerPath ? fs.readFileSync(wranglerPath, "utf-8") : undefined;
   const updatedWranglerCode = wranglerCode
-    ? updateWranglerConfigForCloudflare(wranglerCode, cloudflare, { root: context.root })
+    ? updateWranglerConfigForCloudflare(wranglerCode, cloudflare, {
+        root: context.root,
+      })
     : undefined;
   const imagesBinding = updatedWranglerCode
     ? getWranglerImagesBinding(updatedWranglerCode)
@@ -484,7 +489,9 @@ export function updateWranglerConfigForCloudflare(
       );
     } else {
       const rawValue = output.slice(kvProperty.valueStart, kvProperty.valueEnd);
-      const namespaces = JSON.parse(stripJsonComments(rawValue)) as Array<{ binding?: string }>;
+      const namespaces = JSON.parse(stripJsonComments(rawValue)) as Array<{
+        binding?: string;
+      }>;
       if (!namespaces.some((namespace) => namespace.binding === "VINEXT_KV_CACHE")) {
         const closing = kvProperty.valueEnd - 1;
         const content = output.slice(kvProperty.valueStart + 1, closing);
@@ -589,10 +596,18 @@ export function generateAppRouterViteConfig(
     imports.push(`import path from "node:path";`);
   }
 
+  if (info?.hasTailwind) {
+    imports.push(`import tailwindcss from "@tailwindcss/vite";`);
+  }
+
   const plugins: string[] = [];
 
   if (info?.hasMDX) {
     plugins.push(`    // vinext auto-injects @mdx-js/rollup with plugins from next.config`);
+  }
+
+  if (info?.hasTailwind) {
+    plugins.push(`    tailwindcss(),`);
   }
   plugins.push(
     `    ${vinextExpression(
@@ -656,6 +671,10 @@ export function generatePagesRouterViteConfig(
     imports.push(`import path from "node:path";`);
   }
 
+  if (info?.hasTailwind) {
+    imports.push(`import tailwindcss from "@tailwindcss/vite";`);
+  }
+
   // Build resolve.alias for native module stubs (tsconfig paths are handled
   // by the vinext plugin's native Vite support).
   let resolveBlock = "";
@@ -675,14 +694,14 @@ export function generatePagesRouterViteConfig(
 
 export default defineConfig({
   plugins: [
-    ${vinextExpression(
-      options,
-      "vinext",
-      "imagesOptimizer",
-      imagesBinding,
-      prerender,
-      versionMetadataBinding,
-    ).replace(/\n/g, "\n    ")},
+${info?.hasTailwind ? "    tailwindcss(),\n" : ""}    ${vinextExpression(
+    options,
+    "vinext",
+    "imagesOptimizer",
+    imagesBinding,
+    prerender,
+    versionMetadataBinding,
+  ).replace(/\n/g, "\n    ")},
     cloudflare(),
   ],${resolveBlock}
 });

--- a/packages/vinext/src/init.ts
+++ b/packages/vinext/src/init.ts
@@ -139,13 +139,32 @@ type InitResult = {
 
 // ─── Vite Config Generation (minimal, non-Cloudflare) ────────────────────────
 
-export function generateViteConfig(_isAppRouter: boolean, prerender = false): string {
+export function generateViteConfig(
+  _isAppRouter: boolean,
+  prerender = false,
+  extras: { hasTailwind?: boolean } = {},
+): string {
   const vinextCall = prerender ? `vinext({ prerender: { routes: "*" } })` : "vinext()";
-  return `import vinext from "vinext";
+  // Without extras the output stays byte-identical to the historical
+  // template so existing snapshots keep passing.
+  if (!extras.hasTailwind) {
+    return `import vinext from "vinext";
 import { defineConfig } from "vite";
 
 export default defineConfig({
   plugins: [${vinextCall}],
+});
+`;
+  }
+  return `import vinext from "vinext";
+import { defineConfig } from "vite";
+import tailwindcss from "@tailwindcss/vite";
+
+export default defineConfig({
+  plugins: [
+    tailwindcss(),
+    ${vinextCall},
+  ],
 });
 `;
 }
@@ -160,7 +179,10 @@ export function addScripts(
   root: string,
   port: number | false,
   platform: InitPlatform = "node",
-  options: { warmCdnCache?: boolean; scriptNames?: "namespaced" | "standard" } = {},
+  options: {
+    warmCdnCache?: boolean;
+    scriptNames?: "namespaced" | "standard";
+  } = {},
 ): string[] {
   const pkgPath = path.join(root, "package.json");
   if (!fs.existsSync(pkgPath)) return [];
@@ -219,6 +241,7 @@ export type InitDependencyGroups = {
 export function getInitDependencyGroups(
   isAppRouter: boolean,
   platform: InitPlatform,
+  project?: { hasMDX?: boolean; hasTailwind?: boolean },
 ): InitDependencyGroups {
   const dependencies = ["vinext"];
   const devDependencies = ["vite", "@vitejs/plugin-react"];
@@ -230,11 +253,19 @@ export function getInitDependencyGroups(
     dependencies.push("@vinext/cloudflare");
     devDependencies.push("@cloudflare/vite-plugin", "wrangler");
   }
+  // Framework onboarding: MDX rendering and Tailwind v4 both need a Vite
+  // plugin that the plain dependency graph does not pull in.
+  if (project?.hasMDX) devDependencies.push("@mdx-js/rollup");
+  if (project?.hasTailwind) devDependencies.push("@tailwindcss/vite");
   return { dependencies, devDependencies };
 }
 
-export function getInitDeps(isAppRouter: boolean, platform: InitPlatform): string[] {
-  const groups = getInitDependencyGroups(isAppRouter, platform);
+export function getInitDeps(
+  isAppRouter: boolean,
+  platform: InitPlatform,
+  project?: { hasMDX?: boolean; hasTailwind?: boolean },
+): string[] {
+  const groups = getInitDependencyGroups(isAppRouter, platform, project);
   return [...groups.dependencies, ...groups.devDependencies];
 }
 
@@ -418,6 +449,7 @@ type PlatformSetupContext = {
   force: boolean;
   prerender?: boolean;
   today?: string;
+  hasTailwind?: boolean;
 };
 
 type PlatformSetupResult = {
@@ -439,7 +471,9 @@ function setupNodePlatform(context: PlatformSetupContext): PlatformSetupResult {
 
   fs.writeFileSync(
     context.existingViteConfigPath ?? path.join(context.root, "vite.config.ts"),
-    generateViteConfig(context.isAppRouter, context.prerender),
+    generateViteConfig(context.isAppRouter, context.prerender, {
+      hasTailwind: context.hasTailwind,
+    }),
     "utf-8",
   );
   return {
@@ -519,7 +553,8 @@ export async function init(options: InitOptions): Promise<InitResult> {
   }
   const viteConfigExists = hasViteConfig(root);
 
-  const isApp = detectProject(root).isAppRouter;
+  const projectInfo = detectProject(root);
+  const isApp = projectInfo.isAppRouter;
   const pmName = detectPackageManagerName(root);
   const shouldInstall = options.install ?? true;
 
@@ -580,6 +615,7 @@ export async function init(options: InitOptions): Promise<InitResult> {
     force: options.force ?? false,
     prerender: options.prerender,
     today: options._today,
+    hasTailwind: projectInfo.hasTailwind,
   };
   const platformSetup =
     platform === "cloudflare"
@@ -593,7 +629,7 @@ export async function init(options: InitOptions): Promise<InitResult> {
 
   // ── Step 6: Install dependencies last ──────────────────────────────────
 
-  const neededDeps = getInitDependencyGroups(isApp, platform);
+  const neededDeps = getInitDependencyGroups(isApp, platform, projectInfo);
   const missingDependencies = neededDeps.dependencies.filter((dep) => !isDepInstalled(root, dep));
   const missingDevDependencies = neededDeps.devDependencies.filter(
     (dep) => !isDepInstalled(root, dep),
@@ -618,10 +654,14 @@ export async function init(options: InitOptions): Promise<InitResult> {
       );
       try {
         if (shouldInstall) {
-          const installOutput = await installDeps(root, reactUpgrade, exec, { dev: false });
+          const installOutput = await installDeps(root, reactUpgrade, exec, {
+            dev: false,
+          });
           if (isApproveBuildsError(installOutput)) dependencyInstallNeedsApproval = true;
         } else {
-          const added = addDependencyEntries(root, reactUpgrade, { dev: false });
+          const added = addDependencyEntries(root, reactUpgrade, {
+            dev: false,
+          });
           dependencyEntriesAdded.push(...added);
         }
       } catch (error) {
@@ -640,7 +680,9 @@ export async function init(options: InitOptions): Promise<InitResult> {
         dependencyEntriesAdded.push(...missingDependencies);
         if (isApproveBuildsError(installOutput)) dependencyInstallNeedsApproval = true;
       } else {
-        const added = addDependencyEntries(root, missingDependencies, { dev: false });
+        const added = addDependencyEntries(root, missingDependencies, {
+          dev: false,
+        });
         dependencyEntriesAdded.push(...added);
       }
     } catch (error) {
@@ -659,7 +701,9 @@ export async function init(options: InitOptions): Promise<InitResult> {
         devDependencyEntriesAdded.push(...missingDevDependencies);
         if (isApproveBuildsError(installOutput)) dependencyInstallNeedsApproval = true;
       } else {
-        const added = addDependencyEntries(root, missingDevDependencies, { dev: true });
+        const added = addDependencyEntries(root, missingDevDependencies, {
+          dev: true,
+        });
         devDependencyEntriesAdded.push(...added);
       }
     } catch (error) {

--- a/packages/vinext/src/utils/project.ts
+++ b/packages/vinext/src/utils/project.ts
@@ -176,7 +176,9 @@ function detectPackageManagerFromPackageJson(root: string): PackageManagerName |
   if (!fs.existsSync(pkgPath)) return null;
 
   try {
-    const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8")) as { packageManager?: string };
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8")) as {
+      packageManager?: string;
+    };
     return parsePackageManagerName(pkg.packageManager);
   } catch {
     return null;
@@ -316,6 +318,8 @@ export type ProjectInfo = {
   hasMDX: boolean;
   /** CodeHike is a dependency */
   hasCodeHike: boolean;
+  /** tailwindcss is a dependency (Tailwind v4 needs @tailwindcss/vite) */
+  hasTailwind: boolean;
   /** Native Node modules that need stubbing for Workers */
   nativeModulesToStub: string[];
 };
@@ -397,7 +401,10 @@ export function detectProject(root: string): ProjectInfo {
   if (hasPages) {
     const pagesDir = resolveProjectDir(root, "pages");
     if (pagesDir) {
-      const found = scanTreeForDetection(pagesDir, { isr: !hasISR, mdx: !hasMDX });
+      const found = scanTreeForDetection(pagesDir, {
+        isr: !hasISR,
+        mdx: !hasMDX,
+      });
       hasISR = hasISR || found.isr;
       hasMDX = hasMDX || found.mdx;
     }
@@ -410,6 +417,7 @@ export function detectProject(root: string): ProjectInfo {
     ...(pkg?.devDependencies as Record<string, unknown> | undefined),
   };
   const hasCodeHike = "codehike" in allDeps;
+  const hasTailwind = "tailwindcss" in allDeps;
   const nativeModulesToStub = detectNativeModules(allDeps);
 
   return {
@@ -427,6 +435,7 @@ export function detectProject(root: string): ProjectInfo {
     hasTypeModule,
     hasMDX,
     hasCodeHike,
+    hasTailwind,
     nativeModulesToStub,
   };
 }

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import {
   init,
   generateViteConfig,
+  getInitDependencyGroups,
   addScripts,
   getInitDeps,
   isDepInstalled,
@@ -938,6 +939,35 @@ describe("init — generated project snapshots", () => {
     await runInit(tmpDir, { platform: "cloudflare", _today: "2026-06-23" });
 
     expect(snapshotProject(tmpDir)).toMatchSnapshot();
+  });
+
+  it("adds MDX and Tailwind devDependencies for detected frameworks", () => {
+    const groups = getInitDependencyGroups(true, "node", {
+      hasMDX: true,
+      hasTailwind: true,
+    });
+    expect(groups.devDependencies).toContain("@mdx-js/rollup");
+    expect(groups.devDependencies).toContain("@tailwindcss/vite");
+
+    const bare = getInitDependencyGroups(true, "node");
+    expect(bare.devDependencies).not.toContain("@mdx-js/rollup");
+    expect(bare.devDependencies).not.toContain("@tailwindcss/vite");
+  });
+
+  it("generates a vite config with the Tailwind plugin when detected", () => {
+    const withTailwind = generateViteConfig(false, false, { hasTailwind: true });
+    expect(withTailwind).toContain('import tailwindcss from "@tailwindcss/vite"');
+    expect(withTailwind).toContain("tailwindcss()");
+
+    const without = generateViteConfig(false, false);
+    expect(without).not.toContain("tailwindcss");
+    expect(without).toBe(`import vinext from "vinext";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [vinext()],
+});
+`);
   });
 
   it("snapshots a fresh Node Pages Router init", async () => {


### PR DESCRIPTION
Closes #3174

## Summary

- `detectProject` reports `hasTailwind` (tailwindcss in dependencies/devDependencies)
- init installs `@mdx-js/rollup` when MDX is detected and `@tailwindcss/vite` when Tailwind is detected — both frameworks previously failed before the first successful build (see issue for the two failure modes)
- generated vite configs wire `tailwindcss()` on both platforms: node template via `generateViteConfig`, cloudflare App/Pages Router templates via `info.hasTailwind`; output for projects without Tailwind stays **byte-identical** (snapshot-safe)
- the `next.config webpack` ignore warning now explains Vite resolves .ts/.tsx natively — Payload-style `resolve.extensionAlias` configs trip it on nearly every migration

## Context

Validated while migrating a Payload CMS + Tailwind v4 + MDX site to vinext (dev/build/deploy now fully green in production on that stack).

## Tests

`vp test run tests/init.test.ts` — 117 passed (incl. two new: dependency-group onboarding, tailwind template + byte-identical no-tailwind output); `vp check` clean on all touched files.