### PR TITLE
fix(cloudflare): tolerate staged cache propagation

### DIFF
--- a/packages/cloudflare/src/cdn-warm.ts
+++ b/packages/cloudflare/src/cdn-warm.ts
@@ -71,6 +71,8 @@ export const DEFAULT_CDN_WARM_TIMEOUT_MS = 10_000;
 export const DEFAULT_STAGED_READINESS_RETRIES = 60;
 export const DEFAULT_STAGED_READINESS_INTERVAL_MS = 1_000;
 export const DEFAULT_STAGED_READINESS_PHASE_TIMEOUT_MS = 120_000;
+const DEFAULT_CDN_WARM_PROPAGATION_RETRIES =
+  DEFAULT_STAGED_READINESS_PHASE_TIMEOUT_MS / DEFAULT_STAGED_READINESS_INTERVAL_MS;
 const DEFAULT_STAGED_READINESS_SUCCESSES = 6;
 const STAGED_READINESS_QUERY_PARAM = "__vinext_cdn_warm_readiness";
 
@@ -1396,7 +1398,7 @@ export async function warmCdnCache(options: CdnWarmOptions): Promise<CdnWarmResu
   // prevents an old Worker response from being mistaken for a successful fill.
   const concurrency = Math.max(1, options.concurrency ?? DEFAULT_CDN_WARM_CONCURRENCY);
   const normalRetries = Math.max(0, options.retries ?? 1);
-  const propagationRetries = Math.max(0, options.retries ?? 60);
+  const propagationRetries = Math.max(0, options.retries ?? DEFAULT_CDN_WARM_PROPAGATION_RETRIES);
   const normalRetryDelayMs = Math.max(0, options.retryDelayMs ?? 0);
   const propagationRetryDelayMs = Math.max(0, options.retryDelayMs ?? 1_000);
   const fetchImpl = options.fetchImpl ?? fetch;

--- a/packages/cloudflare/src/cdn-warm.ts
+++ b/packages/cloudflare/src/cdn-warm.ts
@@ -71,8 +71,6 @@ export const DEFAULT_CDN_WARM_TIMEOUT_MS = 10_000;
 export const DEFAULT_STAGED_READINESS_RETRIES = 60;
 export const DEFAULT_STAGED_READINESS_INTERVAL_MS = 1_000;
 export const DEFAULT_STAGED_READINESS_PHASE_TIMEOUT_MS = 120_000;
-const DEFAULT_CDN_WARM_PROPAGATION_RETRIES =
-  DEFAULT_STAGED_READINESS_PHASE_TIMEOUT_MS / DEFAULT_STAGED_READINESS_INTERVAL_MS;
 const DEFAULT_STAGED_READINESS_SUCCESSES = 6;
 const STAGED_READINESS_QUERY_PARAM = "__vinext_cdn_warm_readiness";
 
@@ -1179,13 +1177,13 @@ function shouldRetryValidationFailure(
       : response.headers.get(VINEXT_RSC_BUILD_ID_HEADER) === options.expectedRscBuildId,
   ].filter((matches): matches is boolean => matches !== null);
 
-  // A matching identity proves routing reached the uploaded Worker. From that
-  // point, retry only transient HTTP failures; response-shape and admission
-  // failures are deterministic for that build.
+  // Every configured identity must match before independently routed stages
+  // are known to have converged. From that point, retry only transient HTTP
+  // failures; response-shape and admission failures are deterministic.
+  if (expectedIdentities.some((matches) => !matches)) return true;
   if (expectedIdentities.some((matches) => matches)) {
     return isRetryableStatus(response.status, false);
   }
-  if (expectedIdentities.some((matches) => !matches)) return true;
   return isRetryableStatus(response.status, options.retryNotFound);
 }
 
@@ -1398,7 +1396,7 @@ export async function warmCdnCache(options: CdnWarmOptions): Promise<CdnWarmResu
   // prevents an old Worker response from being mistaken for a successful fill.
   const concurrency = Math.max(1, options.concurrency ?? DEFAULT_CDN_WARM_CONCURRENCY);
   const normalRetries = Math.max(0, options.retries ?? 1);
-  const propagationRetries = Math.max(0, options.retries ?? DEFAULT_CDN_WARM_PROPAGATION_RETRIES);
+  const propagationRetries = Math.max(0, options.retries ?? 60);
   const normalRetryDelayMs = Math.max(0, options.retryDelayMs ?? 0);
   const propagationRetryDelayMs = Math.max(0, options.retryDelayMs ?? 1_000);
   const fetchImpl = options.fetchImpl ?? fetch;

--- a/tests/cloudflare-cdn-warm-deploy.test.ts
+++ b/tests/cloudflare-cdn-warm-deploy.test.ts
@@ -2302,7 +2302,7 @@ describe("Cloudflare CDN warmup deploy flow", () => {
 
     expect(events).not.toContain("promote");
     expect(events).not.toContain("fetch:promoted:loading");
-    expect(events.filter((event) => event === "fetch:staged:loading")).toHaveLength(1);
+    expect(events.filter((event) => event === "fetch:staged:loading")).toHaveLength(2);
   });
 
   it("promotes after failed staged readiness only with the dangerous override", async () => {

--- a/tests/cloudflare-cdn-warm.test.ts
+++ b/tests/cloudflare-cdn-warm.test.ts
@@ -1344,11 +1344,11 @@ describe("Cloudflare CDN warmup", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
-  it("does not retry a deterministic failure when either build identity matches", async () => {
+  it("retries until every build identity matches", async () => {
+    let attempts = 0;
     const fetchImpl = vi.fn(async () => {
       const response = cacheableRsc();
-      response.headers.delete(VINEXT_CDN_BUILD_ID_HEADER);
-      response.headers.set("vary", `${VINEXT_RSC_VARY_HEADER}, User-Agent`);
+      if (++attempts === 1) response.headers.delete(VINEXT_CDN_BUILD_ID_HEADER);
       return response;
     });
 
@@ -1359,14 +1359,14 @@ describe("Cloudflare CDN warmup", () => {
         fetchImpl: fetchImpl as typeof fetch,
         paths: [],
         propagatingTarget: true,
-        retries: 60,
+        retries: 1,
         retryDelayMs: 0,
-        rscPaths: ["/invalid-current-rsc-build"],
+        rscPaths: ["/partially-propagated"],
         strict: true,
         targetUrl: "https://app.example.com",
       }),
-    ).rejects.toThrow(`response ${VINEXT_CDN_BUILD_ID_HEADER} does not match build build-a`);
-    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    ).resolves.toMatchObject({ warmed: 1, failed: 0 });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
   });
 
   it("retries first and later staged-target failures only after the initial queue", async () => {
@@ -1641,33 +1641,6 @@ describe("Cloudflare CDN warmup", () => {
     expect(seenHeaders[0].get("cache-control")).toBeNull();
     expect(seenHeaders[1].get("cache-control")).toBeNull();
     expect(seenHeaders[1].get("pragma")).toBeNull();
-  });
-
-  it("uses the full default propagation window for staged routes", async () => {
-    let attempts = 0;
-    const fetchImpl = vi.fn(async () => {
-      const response = cacheableRsc();
-      if (++attempts <= 61) {
-        response.headers.set(VINEXT_CDN_BUILD_ID_HEADER, "old-build");
-        response.headers.set(VINEXT_RSC_BUILD_ID_HEADER, "old-rsc-build");
-      }
-      return response;
-    });
-
-    await expect(
-      warmCdnCache({
-        expectedBuildId: "build-a",
-        expectedRscBuildId: "rsc-build-a",
-        fetchImpl: fetchImpl as typeof fetch,
-        paths: [],
-        propagatingTarget: true,
-        retryDelayMs: 0,
-        rscPaths: ["/slow-propagation"],
-        strict: true,
-        targetUrl: "https://app.example.com",
-      }),
-    ).resolves.toMatchObject({ warmed: 1, failed: 0 });
-    expect(fetchImpl).toHaveBeenCalledTimes(62);
   });
 
   it("warms directly from the discovery manifest", async () => {

--- a/tests/cloudflare-cdn-warm.test.ts
+++ b/tests/cloudflare-cdn-warm.test.ts
@@ -1643,6 +1643,33 @@ describe("Cloudflare CDN warmup", () => {
     expect(seenHeaders[1].get("pragma")).toBeNull();
   });
 
+  it("uses the full default propagation window for staged routes", async () => {
+    let attempts = 0;
+    const fetchImpl = vi.fn(async () => {
+      const response = cacheableRsc();
+      if (++attempts <= 61) {
+        response.headers.set(VINEXT_CDN_BUILD_ID_HEADER, "old-build");
+        response.headers.set(VINEXT_RSC_BUILD_ID_HEADER, "old-rsc-build");
+      }
+      return response;
+    });
+
+    await expect(
+      warmCdnCache({
+        expectedBuildId: "build-a",
+        expectedRscBuildId: "rsc-build-a",
+        fetchImpl: fetchImpl as typeof fetch,
+        paths: [],
+        propagatingTarget: true,
+        retryDelayMs: 0,
+        rscPaths: ["/slow-propagation"],
+        strict: true,
+        targetUrl: "https://app.example.com",
+      }),
+    ).resolves.toMatchObject({ warmed: 1, failed: 0 });
+    expect(fetchImpl).toHaveBeenCalledTimes(62);
+  });
+
   it("warms directly from the discovery manifest", async () => {
     writeFile("dist/server/BUILD_ID", "build-a\n");
     writeFile(


### PR DESCRIPTION
## Summary

- keep retrying a staged warm request until every independently routed build identity matches
- preserve the existing 60-retry default and explicit `--warm-cdn-retries` behavior
- retain immediate failure for deterministic validation errors once all stages match

## Evidence

The first production deploy after the multi-entrypoint rollout passed probe/readiness, then reached a mixed propagation state where the outer Worker matched while RSC responses still came from the prior stage: https://github.com/cloudflare/vinext/actions/runs/34160828052/job/101863108294

The previous logic stopped retrying as soon as either identity matched. The identical main SHA later warmed all 6/6 entries and promoted successfully once the response stage converged.

## Validation

- `vp check packages/cloudflare/src/cdn-warm.ts tests/cloudflare-cdn-warm.test.ts tests/cloudflare-cdn-warm-deploy.test.ts`
- `vp test run tests/cloudflare-cdn-warm.test.ts tests/cloudflare-cdn-warm-deploy.test.ts` (130 passed)