### PR TITLE
refactor(build): share worker stage plumbing

### DIFF
--- a/packages/cloudflare/src/cache/cdn-adapter.worker.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.worker.ts
@@ -542,6 +542,28 @@ function getResponseStageInvocation(
   };
 }
 
+function getResponseStageEntrypointInvocation(
+  context: CloudflareStageContext,
+  cache: VinextResponseStageDispatchOptions["cache"],
+): CloudflareResponseStageInvocation | Response {
+  const invocation = getResponseStageInvocation(context.props, cache);
+  if (!invocation) {
+    return stampResponseStageBuildIdentity(
+      new Response("Invalid vinext response-stage invocation", {
+        status: 400,
+        headers: { "Cache-Control": "no-store" },
+      }),
+    );
+  }
+  if (
+    invocation.expectedResponseStageBuildIdentity !== undefined &&
+    invocation.expectedResponseStageBuildIdentity !== getVinextCdnBuildIdentity()
+  ) {
+    return stampResponseStageBuildIdentity(responseStageUnavailable());
+  }
+  return invocation;
+}
+
 async function invokeResponseStage(
   request: Request,
   env: unknown,
@@ -574,21 +596,8 @@ async function invokeResponseStage(
 export class VinextCachedResponse extends WorkerEntrypoint<unknown, unknown> {
   async fetch(request: Request): Promise<Response> {
     const context = withWorkerHostRuntime(this.ctx, this.env);
-    const invocation = getResponseStageInvocation(context.props, "shared");
-    if (!invocation) {
-      return stampResponseStageBuildIdentity(
-        new Response("Invalid vinext response-stage invocation", {
-          status: 400,
-          headers: { "Cache-Control": "no-store" },
-        }),
-      );
-    }
-    if (
-      invocation.expectedResponseStageBuildIdentity !== undefined &&
-      invocation.expectedResponseStageBuildIdentity !== getVinextCdnBuildIdentity()
-    ) {
-      return stampResponseStageBuildIdentity(responseStageUnavailable());
-    }
+    const invocation = getResponseStageEntrypointInvocation(context, "shared");
+    if (invocation instanceof Response) return invocation;
     const restored = restoreResponseStageRequest(
       request,
       invocation.requestUrl,
@@ -619,21 +628,8 @@ export class VinextCachedResponse extends WorkerEntrypoint<unknown, unknown> {
 export class VinextUncachedResponse extends WorkerEntrypoint<unknown, unknown> {
   async fetch(request: Request): Promise<Response> {
     const context = withResponseStagePurge(withWorkerHostRuntime(this.ctx, this.env));
-    const invocation = getResponseStageInvocation(context.props, "bypass");
-    if (!invocation) {
-      return stampResponseStageBuildIdentity(
-        new Response("Invalid vinext response-stage invocation", {
-          status: 400,
-          headers: { "Cache-Control": "no-store" },
-        }),
-      );
-    }
-    if (
-      invocation.expectedResponseStageBuildIdentity !== undefined &&
-      invocation.expectedResponseStageBuildIdentity !== getVinextCdnBuildIdentity()
-    ) {
-      return stampResponseStageBuildIdentity(responseStageUnavailable());
-    }
+    const invocation = getResponseStageEntrypointInvocation(context, "bypass");
+    if (invocation instanceof Response) return invocation;
     return stampResponseStageBuildIdentity(
       await invokeResponseStage(request, this.env, context, invocation),
     );

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -291,6 +291,64 @@ function buildAppRequestRouteMetadata(routes: AppRoute[]): unknown[] {
   }));
 }
 
+function generateAppMatchInterceptRoute(findIntercept: string, routes: string): string {
+  return `matchInterceptRoute(pathname, sourcePathname, interceptionId) {
+    const intercept = ${findIntercept}(pathname, sourcePathname, interceptionId);
+    if (!intercept) return null;
+    const route = ${routes}[intercept.sourceRouteIndex];
+    if (!route) return null;
+    const params = Object.create(null);
+    for (const name of route.params) {
+      if (Object.prototype.hasOwnProperty.call(intercept.sourceMatchedParams, name)) {
+        params[name] = intercept.sourceMatchedParams[name];
+      }
+    }
+    return {
+      interceptionSourceIsConcrete: intercept.sourceRouteIsConcrete,
+      route,
+      params,
+    };
+  },`;
+}
+
+function generateAppMiddlewareMethod(middlewarePath: string, i18nConfig: string): string {
+  return `runMiddleware({ cleanPathname, context, externalRewriteRequest, hadBasePath, isDataRequest, middlewareRequest, request, validateExternalRewriteRequest }) {
+    return __applyAppMiddleware({
+      basePath: __basePath,
+      cleanPathname,
+      context,
+      externalRewriteRequest,
+      hadBasePath,
+      filePath: ${JSON.stringify(toSlash(middlewarePath))},
+      i18nConfig: ${i18nConfig},
+      isDataRequest,
+      isProxy: ${JSON.stringify(isProxyFile(middlewarePath))},
+      middlewareRequest,
+      module: middlewareModule,
+      request,
+      trailingSlash: __trailingSlash,
+      validateExternalRewriteRequest,
+    });
+  },`;
+}
+
+function generateAppPagesFallbackMethod(loadPagesEntry: string): string {
+  return `async renderPagesFallback({ allowRscDocumentFallback, appRouteMatch, dispatchPagesResponseStage, initialResponseHeaders, isDataRequest, isRscRequest, matchKind, middlewareContext, pathname, pagesDataRequest, request, url }) {
+    return __renderPagesFallback(
+      { allowRscDocumentFallback, appRouteMatch, initialResponseHeaders, isDataRequest, isRscRequest, matchKind, middlewareContext, pathname, pagesDataRequest, request, url },
+      {
+        async loadPagesEntry() {
+${loadPagesEntry}
+        },
+        buildRequestHeaders: __buildRequestHeadersFromMiddlewareResponse,
+        decodePathParams: __decodePathParams,
+        applyRouteHandlerMiddlewareContext: __applyRouteHandlerMiddlewareContext,
+        getDraftModeCookieHeader,
+      }
+    );
+  },`;
+}
+
 /** Generate the module-free App request stage used by multi-stage Worker outputs. */
 export function generateAppRequestRscEntry(
   appDir: string,
@@ -425,55 +483,14 @@ const __requestHandler = createAppRscRequestHandler({
   hasInterceptionId,
   matchRoute,
   matchRequestRoute,
-  matchInterceptRoute(pathname, sourcePathname, interceptionId) {
-    const intercept = __routeMatcher.findIntercept(pathname, sourcePathname, interceptionId);
-    if (!intercept) return null;
-    const route = __routes[intercept.sourceRouteIndex];
-    if (!route) return null;
-    const params = Object.create(null);
-    for (const name of route.params) {
-      if (Object.prototype.hasOwnProperty.call(intercept.sourceMatchedParams, name)) {
-        params[name] = intercept.sourceMatchedParams[name];
-      }
-    }
-    return {
-      interceptionSourceIsConcrete: intercept.sourceRouteIsConcrete,
-      route,
-      params,
-    };
-  },
-  ${
-    middlewarePath
-      ? `runMiddleware({ cleanPathname, context, externalRewriteRequest, hadBasePath, isDataRequest, middlewareRequest, request, validateExternalRewriteRequest }) {
-    return __applyAppMiddleware({
-      basePath: __basePath,
-      cleanPathname,
-      context,
-      externalRewriteRequest,
-      hadBasePath,
-      filePath: ${JSON.stringify(toSlash(middlewarePath))},
-      i18nConfig: ${JSON.stringify(config?.i18n ?? null)},
-      isDataRequest,
-      isProxy: ${JSON.stringify(isProxyFile(middlewarePath))},
-      middlewareRequest,
-      module: middlewareModule,
-      request,
-      trailingSlash: __trailingSlash,
-      validateExternalRewriteRequest,
-    });
-  },`
-      : ""
-  }
+  ${generateAppMatchInterceptRoute("__routeMatcher.findIntercept", "__routes")}
+  ${middlewarePath ? generateAppMiddlewareMethod(middlewarePath, JSON.stringify(config?.i18n ?? null)) : ""}
   publicFiles: new Set(${JSON.stringify(config?.publicFiles ?? [])}),
   registerCacheAdapters: __registerConfiguredCacheAdapters,
   renderNotFound: async () => null,
   ${
     hasPagesDir
-      ? `async renderPagesFallback({ allowRscDocumentFallback, appRouteMatch, dispatchPagesResponseStage, initialResponseHeaders, isDataRequest, isRscRequest, matchKind, middlewareContext, pathname, pagesDataRequest, request, url }) {
-    return __renderPagesFallback(
-      { allowRscDocumentFallback, appRouteMatch, initialResponseHeaders, isDataRequest, isRscRequest, matchKind, middlewareContext, pathname, pagesDataRequest, request, url },
-      {
-        async loadPagesEntry() {
+      ? generateAppPagesFallbackMethod(`
           if (!dispatchPagesResponseStage) {
             throw new Error("App request stage requires a Pages response-stage dispatcher");
           }
@@ -485,14 +502,7 @@ const __requestHandler = createAppRscRequestHandler({
               return dispatchPagesResponseStage(stageRequest, "page", dataKind, __pagesRequestEntry.hasRequestAwareDocument);
             },
           };
-        },
-        buildRequestHeaders: __buildRequestHeadersFromMiddlewareResponse,
-        decodePathParams: __decodePathParams,
-        applyRouteHandlerMiddlewareContext: __applyRouteHandlerMiddlewareContext,
-        getDraftModeCookieHeader,
-      }
-    );
-  },`
+`)
       : ""
   }
   rootParamNamesByPattern: {},
@@ -1719,45 +1729,8 @@ ${responseStageOnly ? "const __responseStageOptions = {" : "const __appRscHandle
   matchRoute,
   matchRequestRoute,
   hasInterceptionId,
-  matchInterceptRoute(pathname, sourcePathname, interceptionId) {
-    const intercept = findIntercept(pathname, sourcePathname, interceptionId);
-    if (!intercept) return null;
-    const route = routes[intercept.sourceRouteIndex];
-    if (!route) return null;
-    const params = Object.create(null);
-    for (const name of route.params) {
-      if (Object.prototype.hasOwnProperty.call(intercept.sourceMatchedParams, name)) {
-        params[name] = intercept.sourceMatchedParams[name];
-      }
-    }
-    return {
-      interceptionSourceIsConcrete: intercept.sourceRouteIsConcrete,
-      route,
-      params,
-    };
-  },
-  ${
-    middlewarePath
-      ? `runMiddleware({ cleanPathname, context, externalRewriteRequest, hadBasePath, isDataRequest, middlewareRequest, request, validateExternalRewriteRequest }) {
-    return __applyAppMiddleware({
-      basePath: __basePath,
-      cleanPathname,
-      context,
-      externalRewriteRequest,
-      hadBasePath,
-      filePath: ${JSON.stringify(middlewarePath ? toSlash(middlewarePath) : "")},
-      i18nConfig: __i18nConfig,
-      isDataRequest,
-      isProxy: ${JSON.stringify(isProxyFile(middlewarePath))},
-      middlewareRequest,
-      module: middlewareModule,
-      request,
-      trailingSlash: __trailingSlash,
-      validateExternalRewriteRequest,
-    });
-  },`
-      : ""
-  }
+  ${generateAppMatchInterceptRoute("findIntercept", "routes")}
+  ${middlewarePath ? generateAppMiddlewareMethod(middlewarePath, "__i18nConfig") : ""}
   publicFiles: __publicFiles,
   renderNotFound({ isRscRequest, matchedParams, middlewareContext, request, route, scriptNonce }) {
     const __isEdge = route ? __isEdgeRuntime(__resolveRouteRuntime(route)) : false;
@@ -1765,11 +1738,7 @@ ${responseStageOnly ? "const __responseStageOptions = {" : "const __appRscHandle
   },
   ${
     hasPagesDir
-      ? `async renderPagesFallback({ allowRscDocumentFallback, appRouteMatch, dispatchPagesResponseStage, initialResponseHeaders, isDataRequest, isRscRequest, matchKind, middlewareContext, pathname, pagesDataRequest, request, url }) {
-    return __renderPagesFallback(
-      { allowRscDocumentFallback, appRouteMatch, initialResponseHeaders, isDataRequest, isRscRequest, matchKind, middlewareContext, pathname, pagesDataRequest, request, url },
-      {
-        async loadPagesEntry() {
+      ? generateAppPagesFallbackMethod(`
           const __pagesEntry = await import.meta.viteRsc.loadModule("ssr", "index");
           if (!dispatchPagesResponseStage) {
             return __pagesEntry;
@@ -1792,14 +1761,7 @@ ${responseStageOnly ? "const __responseStageOptions = {" : "const __appRscHandle
                 }
               : {}),
           };
-        },
-        buildRequestHeaders: __buildRequestHeadersFromMiddlewareResponse,
-        decodePathParams: __decodePathParams,
-        applyRouteHandlerMiddlewareContext: __applyRouteHandlerMiddlewareContext,
-        getDraftModeCookieHeader,
-      }
-    );
-  },`
+`)
       : ""
   }
   rootParamNamesByPattern: rootParamNamesMap,

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -291,26 +291,6 @@ function buildAppRequestRouteMetadata(routes: AppRoute[]): unknown[] {
   }));
 }
 
-function generateAppMatchInterceptRoute(findIntercept: string, routes: string): string {
-  return `matchInterceptRoute(pathname, sourcePathname, interceptionId) {
-    const intercept = ${findIntercept}(pathname, sourcePathname, interceptionId);
-    if (!intercept) return null;
-    const route = ${routes}[intercept.sourceRouteIndex];
-    if (!route) return null;
-    const params = Object.create(null);
-    for (const name of route.params) {
-      if (Object.prototype.hasOwnProperty.call(intercept.sourceMatchedParams, name)) {
-        params[name] = intercept.sourceMatchedParams[name];
-      }
-    }
-    return {
-      interceptionSourceIsConcrete: intercept.sourceRouteIsConcrete,
-      route,
-      params,
-    };
-  },`;
-}
-
 function generateAppMiddlewareMethod(middlewarePath: string, i18nConfig: string): string {
   return `runMiddleware({ cleanPathname, context, externalRewriteRequest, hadBasePath, isDataRequest, middlewareRequest, request, validateExternalRewriteRequest }) {
     return __applyAppMiddleware({
@@ -378,7 +358,7 @@ export function generateAppRequestRscEntry(
   return `
 import ${JSON.stringify(serverGlobalsPath)};
 import { createAppRscRequestHandler } from "vinext/server/app-rsc-handler";
-import { createAppRscRouteMatcher as __createAppRscRouteMatcher } from ${JSON.stringify(appRscRouteMatchingPath)};
+import { createAppRscRouteMatcher as __createAppRscRouteMatcher, resolveAppRscInterceptRoute as __resolveAppRscInterceptRoute } from ${JSON.stringify(appRscRouteMatchingPath)};
 import { dispatchAppRequestStage as __dispatchAppRequestStage } from ${JSON.stringify(appRequestStageDispatchPath)};
 import { registerConfiguredCacheAdapters as __registerConfiguredCacheAdapters } from "virtual:vinext-cdn-cache-adapter";
 import { clearAppRequestStageContext as __clearRequestContext, setAppRequestStageNavigationContext as setNavigationContext } from ${JSON.stringify(appRequestStageContextPath)};
@@ -483,7 +463,7 @@ const __requestHandler = createAppRscRequestHandler({
   hasInterceptionId,
   matchRoute,
   matchRequestRoute,
-  ${generateAppMatchInterceptRoute("__routeMatcher.findIntercept", "__routes")}
+  matchInterceptRoute: (pathname, sourcePathname, interceptionId) => __resolveAppRscInterceptRoute(__routeMatcher.findIntercept(pathname, sourcePathname, interceptionId), __routes),
   ${middlewarePath ? generateAppMiddlewareMethod(middlewarePath, JSON.stringify(config?.i18n ?? null)) : ""}
   publicFiles: new Set(${JSON.stringify(config?.publicFiles ?? [])}),
   registerCacheAdapters: __registerConfiguredCacheAdapters,
@@ -753,6 +733,7 @@ import {
 import { makeThenableParams } from ${JSON.stringify(thenableParamsShimPath)};
 import {
   createAppRscRouteMatcher as __createAppRscRouteMatcher,
+  resolveAppRscInterceptRoute as __resolveAppRscInterceptRoute,
   SIBLING_PAGE_INTERCEPT_SLOT_KEY as __SIBLING_PAGE_INTERCEPT_SLOT_KEY,
 } from ${JSON.stringify(appRscRouteMatchingPath)};
 import {
@@ -1729,7 +1710,7 @@ ${responseStageOnly ? "const __responseStageOptions = {" : "const __appRscHandle
   matchRoute,
   matchRequestRoute,
   hasInterceptionId,
-  ${generateAppMatchInterceptRoute("findIntercept", "routes")}
+  matchInterceptRoute: (pathname, sourcePathname, interceptionId) => __resolveAppRscInterceptRoute(findIntercept(pathname, sourcePathname, interceptionId), routes),
   ${middlewarePath ? generateAppMiddlewareMethod(middlewarePath, "__i18nConfig") : ""}
   publicFiles: __publicFiles,
   renderNotFound({ isRscRequest, matchedParams, middlewareContext, request, route, scriptNonce }) {

--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -142,32 +142,6 @@ function generatePagesMiddlewareCode(
   };
 }
 
-const normalizePagesDataRequestCode = `export function normalizeDataRequest(request) {
-  return __normalizePagesDataRequest(
-    request,
-    buildId,
-    vinextConfig.basePath,
-    __shouldAddTrailingSlashToPagesDataPath(
-      hasMiddleware,
-      vinextConfig.trailingSlash,
-      vinextConfig.skipProxyUrlNormalize,
-    ),
-  );
-}`;
-
-const resolvePagesI18nRouteCode = `function resolveI18nRouteUrl(url, request) {
-  return i18nConfig && request
-    ? resolvePagesI18nRequest(
-        url,
-        i18nConfig,
-        request.headers,
-        new URL(request.url).hostname,
-        vinextConfig.basePath,
-        vinextConfig.trailingSlash,
-      ).url
-    : url;
-}`;
-
 /**
  * Generate the request-only Pages Worker entry used by a multi-stage output.
  * It intentionally contains no page/API module imports or render runtime.
@@ -211,8 +185,8 @@ export async function generatePagesRequestEntry(
 import ${JSON.stringify(_serverGlobalsPath)};
 ${middlewareRuntimeImportCode}
 import { buildRouteTrie as _buildRouteTrie, trieMatch as _trieMatch } from ${JSON.stringify(_routeTriePath)};
-import { resolvePagesI18nRequest } from ${JSON.stringify(_pagesI18nPath)};
-import { normalizePagesDataRequest as __normalizePagesDataRequest, shouldAddTrailingSlashToPagesDataPath as __shouldAddTrailingSlashToPagesDataPath } from ${JSON.stringify(_pagesDataRoutePath)};
+import { resolvePagesI18nRouteUrl as __resolvePagesI18nRouteUrl } from ${JSON.stringify(_pagesI18nPath)};
+import { normalizePagesEntryDataRequest as __normalizePagesEntryDataRequest } from ${JSON.stringify(_pagesDataRoutePath)};
 import { isOnDemandRevalidateRequest as __isOnDemandRevalidateRequest } from ${JSON.stringify(_revalidationRequestPath)};
 ${instrumentationImportCode}
 ${middlewareImportCode}
@@ -228,7 +202,7 @@ export const hasRequestAwareDocument = ${JSON.stringify(hasRequestAwareDocument)
 export const vinextConfig = ${vinextConfigJson};
 export const publicFiles = new Set(${JSON.stringify(publicFiles)});
 
-${normalizePagesDataRequestCode}
+export function normalizeDataRequest(request) { return __normalizePagesEntryDataRequest(request, buildId, vinextConfig, hasMiddleware); }
 
 const pageRoutes = [
 ${pageRouteEntries.join(",\n")}
@@ -245,14 +219,12 @@ function matchRoute(url, trie) {
   return _trieMatch(trie, normalizedUrl.split("/").filter(Boolean));
 }
 
-${resolvePagesI18nRouteCode}
-
 export function matchPageRoute(url, request) {
-  return matchRoute(resolveI18nRouteUrl(url, request), pageRouteTrie);
+  return matchRoute(__resolvePagesI18nRouteUrl(url, request, i18nConfig, vinextConfig), pageRouteTrie);
 }
 
 export function matchApiRoute(url, request) {
-  return matchRoute(resolveI18nRouteUrl(url, request), apiRouteTrie);
+  return matchRoute(__resolvePagesI18nRouteUrl(url, request, i18nConfig, vinextConfig), apiRouteTrie);
 }
 
 ${middlewareExportCode}
@@ -401,9 +373,9 @@ import { runWithExecutionContext as _runWithExecutionContext } from ${JSON.strin
 ${middlewareRuntimeImportCode}
 import { buildRouteTrie as _buildRouteTrie, trieMatch as _trieMatch } from ${JSON.stringify(_routeTriePath)};
 import { reportRequestError as _reportRequestError } from "vinext/instrumentation";
-import { resolvePagesI18nRequest } from ${JSON.stringify(_pagesI18nPath)};
+import { resolvePagesI18nRouteUrl as __resolvePagesI18nRouteUrl } from ${JSON.stringify(_pagesI18nPath)};
 import { handlePagesApiRoute as __handlePagesApiRoute } from ${JSON.stringify(_pagesApiRoutePath)};
-import { normalizePagesDataRequest as __normalizePagesDataRequest, shouldAddTrailingSlashToPagesDataPath as __shouldAddTrailingSlashToPagesDataPath, buildNextDataNotFoundResponse as __buildNextDataNotFoundResponse } from ${JSON.stringify(_pagesDataRoutePath)};
+import { normalizePagesEntryDataRequest as __normalizePagesEntryDataRequest, buildNextDataNotFoundResponse as __buildNextDataNotFoundResponse } from ${JSON.stringify(_pagesDataRoutePath)};
 import { buildDefaultPagesNotFoundResponse as __buildDefaultPagesNotFoundResponse } from ${JSON.stringify(_pagesDefault404Path)};
 import { createPagesPageHandler as __createPagesPageHandler } from ${JSON.stringify(_pagesPageHandlerPath)};
 import { getRuntimePagesDataKind as __getRuntimePagesDataKind } from ${JSON.stringify(_pagesRouteDataKindPath)};
@@ -428,7 +400,7 @@ export const buildId = ${buildIdJson};
 // Per-build capability used by Worker entries to authorize remote path
 // discovery. It is never included in responses or exposed to user modules.
 export const prerenderSecret = ${JSON.stringify(prerenderSecret ?? null)};
-${normalizePagesDataRequestCode}
+export function normalizeDataRequest(request) { return __normalizePagesEntryDataRequest(request, buildId, vinextConfig, hasMiddleware); }
 export const hasMiddleware = ${JSON.stringify(Boolean(middlewarePath))};
 
 // Full resolved config for production server (embedded at build time)
@@ -512,10 +484,8 @@ function matchRoute(url, routes) {
   return _trieMatch(trie, urlParts);
 }
 
-${resolvePagesI18nRouteCode}
-
 export function matchPageRoute(url, request) {
-  return matchRoute(resolveI18nRouteUrl(url, request), pageRoutes);
+  return matchRoute(__resolvePagesI18nRouteUrl(url, request, i18nConfig, vinextConfig), pageRoutes);
 }
 
 export function getRuntimePageDataKind(url, request) {
@@ -525,7 +495,7 @@ export function getRuntimePageDataKind(url, request) {
 }
 
 export function matchApiRoute(url, request) {
-  return matchRoute(resolveI18nRouteUrl(url, request), apiRoutes);
+  return matchRoute(__resolvePagesI18nRouteUrl(url, request, i18nConfig, vinextConfig), apiRoutes);
 }
 
 // ── Pages render orchestrator — delegates to server/pages-page-handler.ts ──

--- a/packages/vinext/src/entries/pages-server-entry.ts
+++ b/packages/vinext/src/entries/pages-server-entry.ts
@@ -52,6 +52,122 @@ type GeneratePagesServerEntryOptions = {
   prerenderSecret?: string;
 };
 
+function serializePagesRouteFields(route: Route): string {
+  return `pattern: ${JSON.stringify(route.pattern)}, patternParts: ${JSON.stringify(route.patternParts)}, isDynamic: ${route.isDynamic}, params: ${JSON.stringify(route.params)}`;
+}
+
+function serializePagesI18nConfig(nextConfig: ResolvedNextConfig): string {
+  return JSON.stringify(
+    nextConfig.i18n
+      ? {
+          locales: nextConfig.i18n.locales,
+          defaultLocale: nextConfig.i18n.defaultLocale,
+          localeDetection: nextConfig.i18n.localeDetection,
+          domains: nextConfig.i18n.domains,
+        }
+      : null,
+  );
+}
+
+function serializePagesVinextConfig(nextConfig: ResolvedNextConfig): string {
+  return JSON.stringify({
+    basePath: nextConfig.basePath ?? "",
+    assetPrefix: nextConfig.assetPrefix ?? "",
+    trailingSlash: nextConfig.trailingSlash ?? false,
+    skipProxyUrlNormalize: nextConfig.skipProxyUrlNormalize ?? false,
+    redirects: nextConfig.redirects ?? [],
+    rewrites: nextConfig.rewrites ?? { beforeFiles: [], afterFiles: [], fallback: [] },
+    headers: nextConfig.headers ?? [],
+    expireTime: nextConfig.expireTime,
+    allowedRevalidateHeaderKeys: nextConfig.allowedRevalidateHeaderKeys ?? [],
+    cacheMaxMemorySize: nextConfig.cacheMaxMemorySize,
+    htmlLimitedBots: nextConfig.htmlLimitedBots,
+    i18n: nextConfig.i18n ?? null,
+    disableOptimizedLoading: nextConfig.disableOptimizedLoading === true,
+    crossOrigin: nextConfig.crossOrigin,
+    clientTraceMetadata: nextConfig.clientTraceMetadata,
+    images: {
+      deviceSizes: nextConfig.images?.deviceSizes,
+      imageSizes: nextConfig.images?.imageSizes,
+      qualities: nextConfig.images?.qualities,
+      dangerouslyAllowSVG: nextConfig.images?.dangerouslyAllowSVG,
+      dangerouslyAllowLocalIP: nextConfig.images?.dangerouslyAllowLocalIP,
+      contentDispositionType: nextConfig.images?.contentDispositionType,
+      contentSecurityPolicy: nextConfig.images?.contentSecurityPolicy,
+    },
+  });
+}
+
+function generatePagesInstrumentationCode(instrumentationPath: string | null): {
+  importCode: string;
+  initCode: string;
+} {
+  return instrumentationPath
+    ? {
+        importCode: `import * as _instrumentation from ${JSON.stringify(instrumentationPath)};
+import { ensureInstrumentationRegistered as __ensureInstrumentationRegistered } from ${JSON.stringify(_instrumentationRuntimePath)};`,
+        initCode: "await __ensureInstrumentationRegistered(_instrumentation);",
+      }
+    : { importCode: "", initCode: "" };
+}
+
+function generatePagesMiddlewareCode(
+  middlewarePath: string | null,
+  includeRuntime = true,
+  fallbackAcceptsRequest = false,
+): { exportCode: string; importCode: string; runtimeImportCode: string } {
+  if (!includeRuntime) return { exportCode: "", importCode: "", runtimeImportCode: "" };
+  return {
+    runtimeImportCode: `import { runGeneratedMiddleware as __runGeneratedMiddleware } from ${JSON.stringify(_middlewareRuntimePath)};`,
+    importCode: middlewarePath
+      ? `import * as middlewareModule from ${JSON.stringify(middlewarePath)};`
+      : "",
+    exportCode: middlewarePath
+      ? `export async function runMiddleware(request, ctx, options) {
+  return __runGeneratedMiddleware({
+    basePath: vinextConfig.basePath,
+    ctx,
+    filePath: ${JSON.stringify(middlewarePath)},
+    i18nConfig,
+    isDataRequest: options?.isDataRequest === true,
+    isProxy: ${JSON.stringify(isProxyFile(middlewarePath))},
+    module: middlewareModule,
+    request,
+    trailingSlash: vinextConfig.trailingSlash,
+  });
+}`
+      : `export async function runMiddleware(${fallbackAcceptsRequest ? "request" : ""}) {
+  return { continue: true };
+}`,
+  };
+}
+
+const normalizePagesDataRequestCode = `export function normalizeDataRequest(request) {
+  return __normalizePagesDataRequest(
+    request,
+    buildId,
+    vinextConfig.basePath,
+    __shouldAddTrailingSlashToPagesDataPath(
+      hasMiddleware,
+      vinextConfig.trailingSlash,
+      vinextConfig.skipProxyUrlNormalize,
+    ),
+  );
+}`;
+
+const resolvePagesI18nRouteCode = `function resolveI18nRouteUrl(url, request) {
+  return i18nConfig && request
+    ? resolvePagesI18nRequest(
+        url,
+        i18nConfig,
+        request.headers,
+        new URL(request.url).hostname,
+        vinextConfig.basePath,
+        vinextConfig.trailingSlash,
+      ).url
+    : url;
+}`;
+
 /**
  * Generate the request-only Pages Worker entry used by a multi-stage output.
  * It intentionally contains no page/API module imports or render runtime.
@@ -75,78 +191,25 @@ export async function generatePagesRequestEntry(
   const pageRouteEntries = await Promise.all(
     pageRoutes.map(async (route: Route) => {
       const dataKind = await getPagesDataKind(route.filePath);
-      return `  { pattern: ${JSON.stringify(route.pattern)}, patternParts: ${JSON.stringify(route.patternParts)}, isDynamic: ${route.isDynamic}, params: ${JSON.stringify(route.params)}, dataKind: ${JSON.stringify(dataKind)} }`;
+      return `  { ${serializePagesRouteFields(route)}, dataKind: ${JSON.stringify(dataKind)} }`;
     }),
   );
   const apiRouteEntries = apiRoutes.map(
-    (route: Route) =>
-      `  { pattern: ${JSON.stringify(route.pattern)}, patternParts: ${JSON.stringify(route.patternParts)}, isDynamic: ${route.isDynamic}, params: ${JSON.stringify(route.params)} }`,
+    (route: Route) => `  { ${serializePagesRouteFields(route)} }`,
   );
-  const i18nConfigJson = nextConfig?.i18n
-    ? JSON.stringify({
-        locales: nextConfig.i18n.locales,
-        defaultLocale: nextConfig.i18n.defaultLocale,
-        localeDetection: nextConfig.i18n.localeDetection,
-        domains: nextConfig.i18n.domains,
-      })
-    : "null";
-  const vinextConfigJson = JSON.stringify({
-    basePath: nextConfig?.basePath ?? "",
-    assetPrefix: nextConfig?.assetPrefix ?? "",
-    trailingSlash: nextConfig?.trailingSlash ?? false,
-    skipProxyUrlNormalize: nextConfig?.skipProxyUrlNormalize ?? false,
-    redirects: nextConfig?.redirects ?? [],
-    rewrites: nextConfig?.rewrites ?? { beforeFiles: [], afterFiles: [], fallback: [] },
-    headers: nextConfig?.headers ?? [],
-    expireTime: nextConfig?.expireTime,
-    allowedRevalidateHeaderKeys: nextConfig?.allowedRevalidateHeaderKeys ?? [],
-    cacheMaxMemorySize: nextConfig?.cacheMaxMemorySize,
-    htmlLimitedBots: nextConfig?.htmlLimitedBots,
-    i18n: nextConfig?.i18n ?? null,
-    disableOptimizedLoading: nextConfig?.disableOptimizedLoading === true,
-    crossOrigin: nextConfig?.crossOrigin,
-    clientTraceMetadata: nextConfig?.clientTraceMetadata,
-    images: {
-      deviceSizes: nextConfig?.images?.deviceSizes,
-      imageSizes: nextConfig?.images?.imageSizes,
-      qualities: nextConfig?.images?.qualities,
-      dangerouslyAllowSVG: nextConfig?.images?.dangerouslyAllowSVG,
-      dangerouslyAllowLocalIP: nextConfig?.images?.dangerouslyAllowLocalIP,
-      contentDispositionType: nextConfig?.images?.contentDispositionType,
-      contentSecurityPolicy: nextConfig?.images?.contentSecurityPolicy,
-    },
-  });
-  const instrumentationImportCode = instrumentationPath
-    ? `import * as _instrumentation from ${JSON.stringify(instrumentationPath)};
-import { ensureInstrumentationRegistered as __ensureInstrumentationRegistered } from ${JSON.stringify(_instrumentationRuntimePath)};`
-    : "";
-  const instrumentationInitCode = instrumentationPath
-    ? `await __ensureInstrumentationRegistered(_instrumentation);`
-    : "";
-  const middlewareImportCode = middlewarePath
-    ? `import * as middlewareModule from ${JSON.stringify(middlewarePath)};`
-    : "";
-  const middlewareExportCode = middlewarePath
-    ? `export async function runMiddleware(request, ctx, options) {
-  return __runGeneratedMiddleware({
-    basePath: vinextConfig.basePath,
-    ctx,
-    filePath: ${JSON.stringify(middlewarePath)},
-    i18nConfig,
-    isDataRequest: options?.isDataRequest === true,
-    isProxy: ${JSON.stringify(isProxyFile(middlewarePath))},
-    module: middlewareModule,
-    request,
-    trailingSlash: vinextConfig.trailingSlash,
-  });
-}`
-    : `export async function runMiddleware() {
-  return { continue: true };
-}`;
+  const i18nConfigJson = serializePagesI18nConfig(nextConfig);
+  const vinextConfigJson = serializePagesVinextConfig(nextConfig);
+  const { importCode: instrumentationImportCode, initCode: instrumentationInitCode } =
+    generatePagesInstrumentationCode(instrumentationPath);
+  const {
+    exportCode: middlewareExportCode,
+    importCode: middlewareImportCode,
+    runtimeImportCode: middlewareRuntimeImportCode,
+  } = generatePagesMiddlewareCode(middlewarePath);
 
   return `
 import ${JSON.stringify(_serverGlobalsPath)};
-import { runGeneratedMiddleware as __runGeneratedMiddleware } from ${JSON.stringify(_middlewareRuntimePath)};
+${middlewareRuntimeImportCode}
 import { buildRouteTrie as _buildRouteTrie, trieMatch as _trieMatch } from ${JSON.stringify(_routeTriePath)};
 import { resolvePagesI18nRequest } from ${JSON.stringify(_pagesI18nPath)};
 import { normalizePagesDataRequest as __normalizePagesDataRequest, shouldAddTrailingSlashToPagesDataPath as __shouldAddTrailingSlashToPagesDataPath } from ${JSON.stringify(_pagesDataRoutePath)};
@@ -165,18 +228,7 @@ export const hasRequestAwareDocument = ${JSON.stringify(hasRequestAwareDocument)
 export const vinextConfig = ${vinextConfigJson};
 export const publicFiles = new Set(${JSON.stringify(publicFiles)});
 
-export function normalizeDataRequest(request) {
-  return __normalizePagesDataRequest(
-    request,
-    buildId,
-    vinextConfig.basePath,
-    __shouldAddTrailingSlashToPagesDataPath(
-      hasMiddleware,
-      vinextConfig.trailingSlash,
-      vinextConfig.skipProxyUrlNormalize,
-    ),
-  );
-}
+${normalizePagesDataRequestCode}
 
 const pageRoutes = [
 ${pageRouteEntries.join(",\n")}
@@ -193,18 +245,7 @@ function matchRoute(url, trie) {
   return _trieMatch(trie, normalizedUrl.split("/").filter(Boolean));
 }
 
-function resolveI18nRouteUrl(url, request) {
-  return i18nConfig && request
-    ? resolvePagesI18nRequest(
-        url,
-        i18nConfig,
-        request.headers,
-        new URL(request.url).hostname,
-        vinextConfig.basePath,
-        vinextConfig.trailingSlash,
-      ).url
-    : url;
-}
+${resolvePagesI18nRouteCode}
 
 export function matchPageRoute(url, request) {
   return matchRoute(resolveI18nRouteUrl(url, request), pageRouteTrie);
@@ -272,13 +313,12 @@ export async function generateServerEntry(
   const pageRouteEntries = await Promise.all(
     pageRoutes.map(async (r: Route, i: number) => {
       const dataKind = await getPagesDataKind(r.filePath);
-      return `  { pattern: ${JSON.stringify(r.pattern)}, patternParts: ${JSON.stringify(r.patternParts)}, isDynamic: ${r.isDynamic}, params: ${JSON.stringify(r.params)}, module: page_${i}, filePath: ${JSON.stringify(r.filePath)}, dataKind: ${JSON.stringify(dataKind)} }`;
+      return `  { ${serializePagesRouteFields(r)}, module: page_${i}, filePath: ${JSON.stringify(r.filePath)}, dataKind: ${JSON.stringify(dataKind)} }`;
     }),
   );
 
   const apiRouteEntries = apiRoutes.map(
-    (r: Route, i: number) =>
-      `  { pattern: ${JSON.stringify(r.pattern)}, patternParts: ${JSON.stringify(r.patternParts)}, isDynamic: ${r.isDynamic}, params: ${JSON.stringify(r.params)}, module: api_${i} }`,
+    (r: Route, i: number) => `  { ${serializePagesRouteFields(r)}, module: api_${i} }`,
   );
 
   // Check for _app, _document, and _error.
@@ -307,51 +347,12 @@ export async function generateServerEntry(
       ? `import * as ErrorPageModule from ${JSON.stringify(errorFilePath)};`
       : `import * as ErrorPageModule from "next/error";`;
 
-  // Serialize i18n config for embedding in the server entry
-  const i18nConfigJson = nextConfig?.i18n
-    ? JSON.stringify({
-        locales: nextConfig.i18n.locales,
-        defaultLocale: nextConfig.i18n.defaultLocale,
-        localeDetection: nextConfig.i18n.localeDetection,
-        domains: nextConfig.i18n.domains,
-      })
-    : "null";
+  const i18nConfigJson = serializePagesI18nConfig(nextConfig);
 
   // Embed the resolved build ID at build time
   const buildIdJson = JSON.stringify(nextConfig?.buildId ?? null);
 
-  // Serialize the full resolved config for the production server.
-  // This embeds redirects, rewrites, headers, basePath, trailingSlash
-  // so prod-server.ts can apply them without loading next.config.js at runtime.
-  const vinextConfigJson = JSON.stringify({
-    basePath: nextConfig?.basePath ?? "",
-    assetPrefix: nextConfig?.assetPrefix ?? "",
-    trailingSlash: nextConfig?.trailingSlash ?? false,
-    skipProxyUrlNormalize: nextConfig?.skipProxyUrlNormalize ?? false,
-    redirects: nextConfig?.redirects ?? [],
-    rewrites: nextConfig?.rewrites ?? { beforeFiles: [], afterFiles: [], fallback: [] },
-    headers: nextConfig?.headers ?? [],
-    expireTime: nextConfig?.expireTime,
-    allowedRevalidateHeaderKeys: nextConfig?.allowedRevalidateHeaderKeys ?? [],
-    cacheMaxMemorySize: nextConfig?.cacheMaxMemorySize,
-    htmlLimitedBots: nextConfig?.htmlLimitedBots,
-    i18n: nextConfig?.i18n ?? null,
-    // Mirrors Next.js `experimental.disableOptimizedLoading` — when false
-    // (the default), page scripts are emitted with `defer` in <head>. See
-    // `.nextjs-ref/packages/next/src/pages/_document.tsx` getScripts().
-    disableOptimizedLoading: nextConfig?.disableOptimizedLoading === true,
-    crossOrigin: nextConfig?.crossOrigin,
-    clientTraceMetadata: nextConfig?.clientTraceMetadata,
-    images: {
-      deviceSizes: nextConfig?.images?.deviceSizes,
-      imageSizes: nextConfig?.images?.imageSizes,
-      qualities: nextConfig?.images?.qualities,
-      dangerouslyAllowSVG: nextConfig?.images?.dangerouslyAllowSVG,
-      dangerouslyAllowLocalIP: nextConfig?.images?.dangerouslyAllowLocalIP,
-      contentDispositionType: nextConfig?.images?.contentDispositionType,
-      contentSecurityPolicy: nextConfig?.images?.contentSecurityPolicy,
-    },
-  });
+  const vinextConfigJson = serializePagesVinextConfig(nextConfig);
 
   // Generate instrumentation code if instrumentation.ts exists.
   // For production (Cloudflare Workers), instrumentation.ts is bundled into the
@@ -362,53 +363,13 @@ export async function generateServerEntry(
   //
   // The onRequestError handler is stored on globalThis so it is visible across
   // all code within the Worker (same global scope).
-  const instrumentationImportCode = instrumentationPath
-    ? `import * as _instrumentation from ${JSON.stringify(instrumentationPath)};
-import { ensureInstrumentationRegistered as __ensureInstrumentationRegistered } from ${JSON.stringify(_instrumentationRuntimePath)};`
-    : "";
-
-  const instrumentationInitCode = instrumentationPath
-    ? `// Both halves of a multi-stage output share this idempotent initializer,
-// so instrumentation still registers exactly once per runtime.
-await __ensureInstrumentationRegistered(_instrumentation);`
-    : "";
-
-  // Generate middleware code if middleware.ts exists
-  const middlewareImportCode =
-    includeMiddlewareRuntime && middlewarePath
-      ? `import * as middlewareModule from ${JSON.stringify(middlewarePath)};`
-      : "";
-  const middlewareRuntimeImportCode = includeMiddlewareRuntime
-    ? `import { runGeneratedMiddleware as __runGeneratedMiddleware } from ${JSON.stringify(_middlewareRuntimePath)};`
-    : "";
-
-  // The matcher config is read from the middleware module at request time.
-  // The generated entry only wires the user module into the shared runtime
-  // helper; matcher, execution, waitUntil, and result shaping live in normal
-  // TypeScript modules so dev/prod paths cannot drift.
-  const middlewareExportCode = includeMiddlewareRuntime
-    ? middlewarePath
-      ? `
-export async function runMiddleware(request, ctx, options) {
-  return __runGeneratedMiddleware({
-    basePath: vinextConfig.basePath,
-    ctx,
-    filePath: ${JSON.stringify(middlewarePath)},
-    i18nConfig,
-    isDataRequest: options?.isDataRequest === true,
-    isProxy: ${JSON.stringify(isProxyFile(middlewarePath))},
-    module: middlewareModule,
-    request,
-    trailingSlash: vinextConfig.trailingSlash,
-  });
-}
-`
-      : `
-export async function runMiddleware(request) {
-  return { continue: true };
-}
-`
-    : "";
+  const { importCode: instrumentationImportCode, initCode: instrumentationInitCode } =
+    generatePagesInstrumentationCode(instrumentationPath);
+  const {
+    exportCode: middlewareExportCode,
+    importCode: middlewareImportCode,
+    runtimeImportCode: middlewareRuntimeImportCode,
+  } = generatePagesMiddlewareCode(middlewarePath, includeMiddlewareRuntime, true);
 
   // The server entry is a self-contained module that uses Web-standard APIs
   // (Request/Response, renderToReadableStream) so it runs on Cloudflare Workers.
@@ -467,18 +428,7 @@ export const buildId = ${buildIdJson};
 // Per-build capability used by Worker entries to authorize remote path
 // discovery. It is never included in responses or exposed to user modules.
 export const prerenderSecret = ${JSON.stringify(prerenderSecret ?? null)};
-export function normalizeDataRequest(request) {
-  return __normalizePagesDataRequest(
-    request,
-    buildId,
-    vinextConfig.basePath,
-    __shouldAddTrailingSlashToPagesDataPath(
-      hasMiddleware,
-      vinextConfig.trailingSlash,
-      vinextConfig.skipProxyUrlNormalize,
-    ),
-  );
-}
+${normalizePagesDataRequestCode}
 export const hasMiddleware = ${JSON.stringify(Boolean(middlewarePath))};
 
 // Full resolved config for production server (embedded at build time)
@@ -562,18 +512,10 @@ function matchRoute(url, routes) {
   return _trieMatch(trie, urlParts);
 }
 
+${resolvePagesI18nRouteCode}
+
 export function matchPageRoute(url, request) {
-  const routeUrl = i18nConfig && request
-    ? resolvePagesI18nRequest(
-        url,
-        i18nConfig,
-        request.headers,
-        new URL(request.url).hostname,
-        vinextConfig.basePath,
-        vinextConfig.trailingSlash,
-      ).url
-    : url;
-  return matchRoute(routeUrl, pageRoutes);
+  return matchRoute(resolveI18nRouteUrl(url, request), pageRoutes);
 }
 
 export function getRuntimePageDataKind(url, request) {
@@ -583,17 +525,7 @@ export function getRuntimePageDataKind(url, request) {
 }
 
 export function matchApiRoute(url, request) {
-  const routeUrl = i18nConfig && request
-    ? resolvePagesI18nRequest(
-        url,
-        i18nConfig,
-        request.headers,
-        new URL(request.url).hostname,
-        vinextConfig.basePath,
-        vinextConfig.trailingSlash,
-      ).url
-    : url;
-  return matchRoute(routeUrl, apiRoutes);
+  return matchRoute(resolveI18nRouteUrl(url, request), apiRoutes);
 }
 
 // ── Pages render orchestrator — delegates to server/pages-page-handler.ts ──

--- a/packages/vinext/src/server/app-request-stage-independent-entry.ts
+++ b/packages/vinext/src/server/app-request-stage-independent-entry.ts
@@ -9,12 +9,7 @@ import requestRscHandler, {
   __prerenderSecret,
 } from "virtual:vinext-app-request-entry";
 import { runWithExecutionContext, type ExecutionContextLike } from "vinext/shims/request-context";
-// @ts-expect-error -- virtual module resolved by vinext
-import * as configuredCdnCacheAdapters from "virtual:vinext-cdn-cache-adapter";
-import { registerLazyDataCacheHandler } from "vinext/shims/cache-handler";
-import { applyCdnResponseIdentityHeaders, validateCdnRequest } from "./cache-control.js";
-// @ts-expect-error -- virtual module resolved by vinext
-import { registerConfiguredImageOptimizer } from "virtual:vinext-image-adapters";
+import { applyCdnResponseIdentityHeaders } from "./cache-control.js";
 import type { DispatchAppWorkerResponseStage } from "./app-worker-stages.js";
 import {
   getImageOptimizer,
@@ -26,32 +21,18 @@ import {
   finalizeMissingStaticAssetResponse,
   resolveStaticAssetSignal,
 } from "./worker-utils.js";
-import {
-  cloneRequestWithHeaders,
-  filterInternalHeaders,
-  isOpenRedirectShaped,
-} from "./request-pipeline.js";
-import {
-  VINEXT_CACHEABILITY_PROBE_HEADER,
-  VINEXT_CACHEABILITY_PROBE_QUERY_PARAM,
-  VINEXT_EXPECTED_WORKER_VERSION_HEADER,
-  VINEXT_PRERENDER_SECRET_HEADER,
-  VINEXT_REVALIDATE_HOST_HEADER,
-} from "./headers.js";
+import { isOpenRedirectShaped } from "./request-pipeline.js";
 import { readTrustedPrerenderStateFromHeaders } from "./prerender-route-params.js";
 import { badRequestResponse, notFoundResponse } from "./http-error-responses.js";
 import { assetPrefixPathname, isNextStaticPath } from "../utils/asset-prefix.js";
 import { createWorkerRevalidationContext } from "./worker-revalidation-context.js";
+import type { VinextAssetFetcher, VinextRequestStageContext } from "./multi-stage.js";
 import {
-  createWorkerPrerenderDiscoveryContext,
-  createWorkerPrerenderReadinessResponse,
-} from "./worker-prerender-discovery.js";
-import type {
-  VinextAssetFetcher,
-  VinextCacheabilityProbeMode,
-  VinextRequestStageContext,
-} from "./multi-stage.js";
-import type { WorkerCacheabilityProbeRoute } from "./cacheability-request.js";
+  filterWorkerRequestStageHeaders,
+  finalizeWorkerRequestStageResponse,
+  prepareWorkerRequestStage,
+  registerWorkerRequestStageAdapters,
+} from "./worker-request-stage.js";
 
 export type AppRequestStageEnv = Record<string, unknown>;
 type AppRequestStageContext = ExecutionContextLike & VinextRequestStageContext;
@@ -89,47 +70,11 @@ async function handleRequest(
         "node",
       );
 
-  configuredCdnCacheAdapters.registerConfiguredCacheAdapters(env);
-  if (configuredCdnCacheAdapters.hasConfiguredDataCache) {
-    registerLazyDataCacheHandler(async () => {
-      // @ts-expect-error -- virtual module resolved by vinext
-      const adapters = await import("virtual:vinext-cache-adapters");
-      adapters.registerConfiguredCacheAdapters(env);
-    });
-  }
-  registerConfiguredImageOptimizer(env);
-
-  ctx = createWorkerPrerenderDiscoveryContext(ctx, request, __prerenderSecret);
-  const readinessResponse = createWorkerPrerenderReadinessResponse(ctx, request);
-  let didValidateCdnRequest = false;
-  if (readinessResponse) {
-    const validationResponse = await validateCdnRequest(request);
-    if (validationResponse) return validationResponse;
-    didValidateCdnRequest = true;
-    // An authenticated readiness request must continue through the response
-    // dispatcher so independently hosted stages are proven ready as a unit.
-    // Failed capability checks stay inside the framework-owned namespace.
-    if (readinessResponse.status !== 204) return readinessResponse;
-  }
-
-  let probeMode: VinextCacheabilityProbeMode | null = null;
-  let probeRoute: WorkerCacheabilityProbeRoute | null = null;
-  if (request.headers.has(VINEXT_CACHEABILITY_PROBE_HEADER)) {
-    const { readWorkerCacheabilityProbeMode, readWorkerCacheabilityProbeRoute } =
-      await import("./cacheability-request.js");
-    probeMode = readWorkerCacheabilityProbeMode(request, __prerenderSecret);
-    if (probeMode) {
-      probeRoute = readWorkerCacheabilityProbeRoute(request);
-      const probeUrl = new URL(request.url);
-      probeUrl.searchParams.delete(VINEXT_CACHEABILITY_PROBE_QUERY_PARAM);
-      request = new Request(probeUrl, request);
-    }
-  }
-
-  if (!didValidateCdnRequest) {
-    const cdnValidationResponse = await validateCdnRequest(request);
-    if (cdnValidationResponse) return cdnValidationResponse;
-  }
+  registerWorkerRequestStageAdapters(env);
+  const prepared = await prepareWorkerRequestStage(request, ctx, __prerenderSecret);
+  if (prepared.response) return prepared.response;
+  ({ context: ctx, request } = prepared);
+  const { probeMode, probeRoute, readinessResponse } = prepared;
 
   const url = new URL(request.url);
   if (isImageOptimizationPath(url.pathname) && assets && getImageOptimizer()) {
@@ -152,21 +97,7 @@ async function handleRequest(
     request.headers,
     __prerenderSecret,
   );
-  const filteredHeaders = ctx.isInternalPagesRevalidation
-    ? new Headers(request.headers)
-    : filterInternalHeaders(request.headers);
-  filteredHeaders.delete(VINEXT_PRERENDER_SECRET_HEADER);
-  filteredHeaders.delete(VINEXT_REVALIDATE_HOST_HEADER);
-  if (readinessResponse?.status === 204) {
-    const expectedWorkerVersion = request.headers.get(VINEXT_EXPECTED_WORKER_VERSION_HEADER);
-    if (expectedWorkerVersion) {
-      // The request stage already authenticated the build capability. Preserve
-      // only the version assertion needed by the independently hosted response
-      // stage; the prerender secret remains confined to this gateway.
-      filteredHeaders.set(VINEXT_EXPECTED_WORKER_VERSION_HEADER, expectedWorkerVersion);
-    }
-  }
-  request = cloneRequestWithHeaders(request, filteredHeaders);
+  request = filterWorkerRequestStageHeaders(request, ctx, readinessResponse).request;
 
   let responseStageDispatched = false;
   const trackedDispatchResponseStage: DispatchAppWorkerResponseStage = (
@@ -195,14 +126,10 @@ async function handleRequest(
     });
     if (assetResponse) response = assetResponse;
   }
-  response = finalizeMissingStaticAssetResponse(response, missingBuildAsset);
-  if (probeMode && probeRoute && !responseStageDispatched) {
-    const { finalizeRequestStageCacheabilityProbe } = await import("./cacheability-request.js");
-    response = finalizeRequestStageCacheabilityProbe(response, {
-      mode: probeMode,
-      responseStageDispatched,
-      route: probeRoute,
-    });
-  }
-  return response;
+  return finalizeWorkerRequestStageResponse(
+    finalizeMissingStaticAssetResponse(response, missingBuildAsset),
+    probeMode,
+    probeRoute,
+    responseStageDispatched,
+  );
 }

--- a/packages/vinext/src/server/app-response-stage-entry.ts
+++ b/packages/vinext/src/server/app-response-stage-entry.ts
@@ -12,8 +12,7 @@ import {
 } from "./app-worker-stages.js";
 import { serializeStaticFileSignalForTransport } from "./static-file-signal.js";
 import { createWorkerRevalidationContext } from "./worker-revalidation-context.js";
-import { validateCdnRequest } from "./cache-control.js";
-import { createWorkerPrerenderReadinessResponse } from "./worker-prerender-discovery.js";
+import { validateWorkerPrerenderReadiness } from "./worker-prerender-discovery.js";
 import type {
   VinextRequestStageTransport,
   VinextResponseStageDispatchOptions,
@@ -66,13 +65,11 @@ export async function handleResponseStage(
           return new Response("Incompatible vinext App response stage", { status: 409 });
         }
         if (props.prerenderDiscovery) {
-          const readinessResponse = createWorkerPrerenderReadinessResponse(
+          const readinessResponse = await validateWorkerPrerenderReadiness(
             cacheabilityContext,
             request,
           );
-          if (readinessResponse) {
-            return (await validateCdnRequest(request)) ?? readinessResponse;
-          }
+          if (readinessResponse) return readinessResponse;
         }
         const fullEntry = await import("virtual:vinext-rsc-entry");
         const render = () =>

--- a/packages/vinext/src/server/app-router-entry.ts
+++ b/packages/vinext/src/server/app-router-entry.ts
@@ -75,7 +75,7 @@ import { assetPrefixPathname, isNextStaticPath } from "../utils/asset-prefix.js"
 import { createWorkerRevalidationContext } from "./worker-revalidation-context.js";
 import {
   createWorkerPrerenderDiscoveryContext,
-  createWorkerPrerenderReadinessResponse,
+  validateWorkerPrerenderReadiness,
 } from "./worker-prerender-discovery.js";
 
 // Precompute the path components used for `_next/static/*` 404 short-circuit
@@ -128,10 +128,8 @@ async function handleRequest(
   registerConfiguredCacheAdapters(env as Record<string, unknown> | undefined);
   const cdnCacheAdapter = getCdnCacheAdapter();
   let ctx = createWorkerPrerenderDiscoveryContext(requestCtx, request, __rscPrerenderSecret);
-  const readinessResponse = createWorkerPrerenderReadinessResponse(ctx, request);
-  if (readinessResponse) {
-    return (await validateCdnRequest(request)) ?? readinessResponse;
-  }
+  const readinessResponse = await validateWorkerPrerenderReadiness(ctx, request);
+  if (readinessResponse) return readinessResponse;
   let finalizeCacheabilityResponse:
     | ((response: Response, ctx: ExecutionContextLike) => Promise<Response>)
     | undefined;

--- a/packages/vinext/src/server/app-rsc-route-matching.ts
+++ b/packages/vinext/src/server/app-rsc-route-matching.ts
@@ -318,6 +318,24 @@ export function createAppRscRouteMatcher<Route extends AppRscRouteForMatching>(
   };
 }
 
+export function resolveAppRscInterceptRoute<
+  Route extends AppRscRouteForMatching & { params: readonly string[] },
+>(
+  intercept: AppRscInterceptMatch | null,
+  routes: readonly Route[],
+): { interceptionSourceIsConcrete: boolean; params: AppRscRouteParams; route: Route } | null {
+  if (!intercept) return null;
+  const route = routes[intercept.sourceRouteIndex];
+  if (!route) return null;
+  const params = createRouteParams();
+  for (const name of route.params) {
+    if (Object.hasOwn(intercept.sourceMatchedParams, name))
+      params[name] = intercept.sourceMatchedParams[name];
+  }
+  const interceptionSourceIsConcrete = intercept.sourceRouteIsConcrete;
+  return { interceptionSourceIsConcrete, params, route };
+}
+
 /**
  * Params for the slot owner when interception falls back to it instead of a
  * concrete descendant source route. The owner is what renders, and

--- a/packages/vinext/src/server/app-worker-stages.ts
+++ b/packages/vinext/src/server/app-worker-stages.ts
@@ -5,6 +5,7 @@ import type {
   VinextResponseStageTransport,
 } from "./multi-stage.js";
 import { isTrustedPrerenderState, type TrustedPrerenderState } from "./prerender-route-params.js";
+import { isResponseStageCacheability, isSerializedHeaders } from "./response-stage-contract.js";
 
 export const APP_WORKER_RESPONSE_STAGE_PROTOCOL_VERSION = 7;
 export const APP_METADATA_RESPONSE_STAGE_NO_MATCH_HEADER = "x-vinext-app-metadata-stage-no-match";
@@ -223,45 +224,5 @@ export function isAppWorkerResponseStageProps(
       props.renderMode === "prefetch-empty" ||
       props.renderMode === "prefetch-dynamic-shell" ||
       props.renderMode === "prefetch-loading-shell")
-  );
-}
-
-function isSerializedHeaders(value: unknown): value is Array<[string, string]> {
-  return (
-    Array.isArray(value) &&
-    value.every(
-      (entry) =>
-        Array.isArray(entry) &&
-        entry.length === 2 &&
-        typeof entry[0] === "string" &&
-        typeof entry[1] === "string",
-    )
-  );
-}
-
-function isResponseStageCacheability(value: unknown): value is VinextResponseStageCacheability {
-  if (!value || typeof value !== "object") return false;
-  const cacheability = value as Partial<VinextResponseStageCacheability>;
-  return (
-    (cacheability.probeMode === null ||
-      cacheability.probeMode === "probe" ||
-      cacheability.probeMode === "identity") &&
-    (cacheability.policyHeaders === null ||
-      (Array.isArray(cacheability.policyHeaders) &&
-        cacheability.policyHeaders.every(
-          (entry) =>
-            Array.isArray(entry) &&
-            entry.length === 2 &&
-            typeof entry[0] === "string" &&
-            typeof entry[1] === "string",
-        ))) &&
-    (cacheability.representation === undefined ||
-      cacheability.representation === "app-route" ||
-      cacheability.representation === "html" ||
-      cacheability.representation === "pages-data" ||
-      cacheability.representation === "rsc-full" ||
-      cacheability.representation === "rsc-loading-shell") &&
-    typeof cacheability.resolvedRoutePathname === "string" &&
-    cacheability.resolvedRoutePathname.startsWith("/")
   );
 }

--- a/packages/vinext/src/server/pages-data-route.ts
+++ b/packages/vinext/src/server/pages-data-route.ts
@@ -272,3 +272,17 @@ export function normalizePagesDataRequest(
     notFoundResponse: null,
   };
 }
+
+export function normalizePagesEntryDataRequest(
+  request: Request,
+  buildId: string | null,
+  config: { basePath?: string; skipProxyUrlNormalize?: boolean; trailingSlash?: boolean },
+  hasMiddleware: boolean,
+): NormalizePagesDataRequestResult {
+  const trailingSlash = shouldAddTrailingSlashToPagesDataPath(
+    hasMiddleware,
+    config.trailingSlash === true,
+    config.skipProxyUrlNormalize === true,
+  );
+  return normalizePagesDataRequest(request, buildId, config.basePath, trailingSlash);
+}

--- a/packages/vinext/src/server/pages-i18n.ts
+++ b/packages/vinext/src/server/pages-i18n.ts
@@ -370,3 +370,20 @@ export function resolvePagesI18nRequest(
     redirectUrl,
   };
 }
+
+export function resolvePagesI18nRouteUrl(
+  url: string,
+  request: Request | undefined,
+  i18nConfig: NextI18nConfig | null,
+  config: { basePath?: string; trailingSlash?: boolean },
+): string {
+  if (!i18nConfig || !request) return url;
+  return resolvePagesI18nRequest(
+    url,
+    i18nConfig,
+    request.headers,
+    new URL(request.url).hostname,
+    config.basePath,
+    config.trailingSlash,
+  ).url;
+}

--- a/packages/vinext/src/server/pages-request-stage-entry.ts
+++ b/packages/vinext/src/server/pages-request-stage-entry.ts
@@ -20,9 +20,7 @@ import {
 import type { ImageConfig } from "./image-optimization.js";
 import {
   attachRequestCfMetadata,
-  cloneRequestWithHeaders,
   cloneRequestWithUrl,
-  filterInternalHeaders,
   isOpenRedirectShaped,
 } from "./request-pipeline.js";
 import { notFoundStaticAssetResponse } from "./http-error-responses.js";
@@ -30,13 +28,6 @@ import { finalizeMissingStaticAssetResponse } from "./worker-utils.js";
 import { assetPrefixPathname, isNextStaticPath } from "../utils/asset-prefix.js";
 import { hasBasePath, stripBasePath } from "../utils/base-path.js";
 import { createWorkerRevalidationContext } from "./worker-revalidation-context.js";
-import {
-  VINEXT_CACHEABILITY_PROBE_HEADER,
-  VINEXT_CACHEABILITY_PROBE_QUERY_PARAM,
-  VINEXT_EXPECTED_WORKER_VERSION_HEADER,
-  VINEXT_PRERENDER_SECRET_HEADER,
-  VINEXT_REVALIDATE_HOST_HEADER,
-} from "./headers.js";
 import type { ExecutionContextLike } from "vinext/shims/request-context";
 import { normalizePathnameForRouteMatchStrict } from "../routing/utils.js";
 import { normalizeDefaultLocalePathname } from "./pages-i18n.js";
@@ -46,7 +37,6 @@ import {
   applyCdnResponseIdentityHeaders,
   captureCdnResponsePolicyOverrides,
   reconcileCdnResponseHeadersAfterOuterPolicy,
-  validateCdnRequest,
 } from "./cache-control.js";
 import {
   PAGES_RESPONSE_STAGE_PROTOCOL_VERSION,
@@ -56,28 +46,22 @@ import {
 import { getPagesResponseStageCacheDisposition } from "./pages-response-stage.js";
 import type {
   VinextAssetFetcher,
-  VinextCacheabilityProbeMode,
   VinextRequestStageContext,
   VinextResponseStageDispatchOptions,
 } from "./multi-stage.js";
-import {
-  createWorkerPrerenderDiscoveryContext,
-  createWorkerPrerenderReadinessResponse,
-  isWorkerPrerenderDiscoveryPath,
-} from "./worker-prerender-discovery.js";
+import { isWorkerPrerenderDiscoveryPath } from "./worker-prerender-discovery.js";
 import {
   consumePagesResponseStagePolicyOwner,
   prependResponseStageAdditiveHeaders,
   withoutResponseStageVary,
   withResponseStageVary,
 } from "./response-stage-policy.js";
-import type { WorkerCacheabilityProbeRoute } from "./cacheability-request.js";
-
-// @ts-expect-error -- virtual module resolved by vinext at build time
-import * as configuredCdnCacheAdapters from "virtual:vinext-cdn-cache-adapter";
-import { registerLazyDataCacheHandler } from "vinext/shims/cache-handler";
-// @ts-expect-error -- virtual module resolved by vinext at build time
-import { registerConfiguredImageOptimizer } from "virtual:vinext-image-adapters";
+import {
+  filterWorkerRequestStageHeaders,
+  finalizeWorkerRequestStageResponse,
+  prepareWorkerRequestStage,
+  registerWorkerRequestStageAdapters,
+} from "./worker-request-stage.js";
 // Request-only generated entry: route metadata, config, and middleware. It
 // deliberately excludes page/API modules and rendering dependencies.
 // @ts-expect-error -- virtual module resolved by vinext at build time
@@ -235,44 +219,13 @@ async function handleRequest(
     defaultHostRuntime,
   );
 
-  // Pass the Worker env so binding-backed adapters (for example KV and Images)
-  // can resolve their configured bindings before request handling begins.
-  configuredCdnCacheAdapters.registerConfiguredCacheAdapters(env);
-  if (configuredCdnCacheAdapters.hasConfiguredDataCache) {
-    registerLazyDataCacheHandler(async () => {
-      // @ts-expect-error -- virtual module resolved by vinext at build time
-      const adapters = await import("virtual:vinext-cache-adapters");
-      adapters.registerConfiguredCacheAdapters(env);
-    });
-  }
-  registerConfiguredImageOptimizer(env);
+  registerWorkerRequestStageAdapters(env);
 
   try {
-    ctx = createWorkerPrerenderDiscoveryContext(ctx, request, pagesEntry.prerenderSecret);
-    const readinessResponse = createWorkerPrerenderReadinessResponse(ctx, request);
-    let didValidateCdnRequest = false;
-    if (readinessResponse) {
-      const validationResponse = await validateCdnRequest(request);
-      if (validationResponse) return validationResponse;
-      didValidateCdnRequest = true;
-      // Keep authenticated readiness on the response-stage transport so a
-      // multi-stage host proves both halves of the deployment are available.
-      if (readinessResponse.status !== 204) return readinessResponse;
-    }
-
-    let probeMode: VinextCacheabilityProbeMode | null = null;
-    let probeRoute: WorkerCacheabilityProbeRoute | null = null;
-    if (request.headers.has(VINEXT_CACHEABILITY_PROBE_HEADER)) {
-      const { readWorkerCacheabilityProbeMode, readWorkerCacheabilityProbeRoute } =
-        await import("./cacheability-request.js");
-      probeMode = readWorkerCacheabilityProbeMode(request, pagesEntry.prerenderSecret);
-      if (probeMode) {
-        probeRoute = readWorkerCacheabilityProbeRoute(request);
-        const probeUrl = new URL(request.url);
-        probeUrl.searchParams.delete(VINEXT_CACHEABILITY_PROBE_QUERY_PARAM);
-        request = new Request(probeUrl, request);
-      }
-    }
+    const prepared = await prepareWorkerRequestStage(request, ctx, pagesEntry.prerenderSecret);
+    if (prepared.response) return prepared.response;
+    ({ context: ctx, request } = prepared);
+    const { probeMode, probeRoute, readinessResponse } = prepared;
 
     let responseStageDispatched = false;
     const trackedDispatchResponseStage: PagesStageRuntimeDispatch = (
@@ -286,28 +239,9 @@ async function handleRequest(
       return dispatchResponseStage(stageRequest, props, options, stageEnv, stageCtx);
     };
 
-    if (!didValidateCdnRequest) {
-      const cdnValidationResponse = await validateCdnRequest(request);
-      if (cdnValidationResponse) return cdnValidationResponse;
-    }
-
-    // Strip internal headers from inbound requests so callers cannot forge
-    // framework state. Request.headers is immutable in Workers.
-    const filteredHeaders = ctx.isInternalPagesRevalidation
-      ? new Headers(request.headers)
-      : filterInternalHeaders(request.headers);
-    filteredHeaders.delete(VINEXT_PRERENDER_SECRET_HEADER);
-    filteredHeaders.delete(VINEXT_REVALIDATE_HOST_HEADER);
-    if (readinessResponse?.status === 204) {
-      const expectedWorkerVersion = request.headers.get(VINEXT_EXPECTED_WORKER_VERSION_HEADER);
-      if (expectedWorkerVersion) {
-        // The request stage already authenticated the build capability. Preserve
-        // only the version assertion needed by the independently hosted response
-        // stage; the prerender secret remains confined to this gateway.
-        filteredHeaders.set(VINEXT_EXPECTED_WORKER_VERSION_HEADER, expectedWorkerVersion);
-      }
-    }
-    request = cloneRequestWithHeaders(request, filteredHeaders);
+    const filtered = filterWorkerRequestStageHeaders(request, ctx, readinessResponse);
+    request = filtered.request;
+    const filteredHeaders = filtered.headers;
 
     const url = new URL(request.url);
     let pathname = url.pathname;
@@ -582,15 +516,12 @@ async function handleRequest(
       if (sharedResponseHeaders && sharedOuterPolicyHeaders) {
         reconcileCdnResponseHeadersAfterOuterPolicy(response.headers, sharedOuterPolicyHeaders);
       }
-      if (probeMode && probeRoute && !responseStageDispatched) {
-        const { finalizeRequestStageCacheabilityProbe } = await import("./cacheability-request.js");
-        response = finalizeRequestStageCacheabilityProbe(response, {
-          mode: probeMode,
-          responseStageDispatched,
-          route: probeRoute,
-        });
-      }
-      return response;
+      return finalizeWorkerRequestStageResponse(
+        response,
+        probeMode,
+        probeRoute,
+        responseStageDispatched,
+      );
     }
 
     // Should not reach here for a production Worker because all callbacks are

--- a/packages/vinext/src/server/pages-response-stage-entry.ts
+++ b/packages/vinext/src/server/pages-response-stage-entry.ts
@@ -18,8 +18,7 @@ import {
 } from "./response-stage-policy.js";
 import { beginRouteCacheability } from "vinext/shims/cacheability-classification";
 import { preserveFullyBufferedBodyMetadata } from "vinext/shims/unified-request-context";
-import { validateCdnRequest } from "./cache-control.js";
-import { createWorkerPrerenderReadinessResponse } from "./worker-prerender-discovery.js";
+import { validateWorkerPrerenderReadiness } from "./worker-prerender-discovery.js";
 
 // @ts-expect-error -- virtual module resolved by vinext at build time
 import { registerConfiguredCacheAdapters } from "virtual:vinext-cache-adapters";
@@ -116,13 +115,11 @@ export async function renderPagesResponse(
   }
   const render = async (cacheabilityContext: ExecutionContextLike): Promise<Response> => {
     if (props.kind === "pages-prerender-discovery") {
-      const readinessResponse = createWorkerPrerenderReadinessResponse(
+      const readinessResponse = await validateWorkerPrerenderReadiness(
         cacheabilityContext,
         request,
       );
-      if (readinessResponse) {
-        return (await validateCdnRequest(request)) ?? readinessResponse;
-      }
+      if (readinessResponse) return readinessResponse;
       const { handleAppPrerenderEndpoint } = await import("./app-prerender-endpoints.js");
       const response = await runWithExecutionContext(cacheabilityContext, () =>
         handleAppPrerenderEndpoint(request, {

--- a/packages/vinext/src/server/pages-router-entry.ts
+++ b/packages/vinext/src/server/pages-router-entry.ts
@@ -12,14 +12,13 @@ import { getCdnCacheAdapter } from "vinext/shims/cdn-cache";
 import { createWorkerRevalidationContext } from "./worker-revalidation-context.js";
 import {
   createWorkerPrerenderDiscoveryContext,
-  createWorkerPrerenderReadinessResponse,
+  validateWorkerPrerenderReadiness,
 } from "./worker-prerender-discovery.js";
 import {
   VINEXT_CACHEABILITY_PROBE_HEADER,
   VINEXT_CACHEABILITY_PROBE_QUERY_PARAM,
 } from "./headers.js";
 import { cloneRequestWithHeaders, cloneRequestWithUrl } from "./request-pipeline.js";
-import { validateCdnRequest } from "./cache-control.js";
 
 // @ts-expect-error -- virtual module resolved by vinext at build time
 import { registerConfiguredCacheAdapters } from "virtual:vinext-cache-adapters";
@@ -44,10 +43,8 @@ async function handleSingleStageRequest(
     request,
     pagesRequestStagePrerenderSecret,
   );
-  const readinessResponse = createWorkerPrerenderReadinessResponse(ctx, request);
-  if (readinessResponse) {
-    return (await validateCdnRequest(request)) ?? readinessResponse;
-  }
+  const readinessResponse = await validateWorkerPrerenderReadiness(ctx, request);
+  if (readinessResponse) return readinessResponse;
 
   let finalize: ((response: Response, context: typeof ctx) => Promise<Response>) | undefined;
   if (request.headers.has(VINEXT_CACHEABILITY_PROBE_HEADER)) {

--- a/packages/vinext/src/server/response-stage-contract.ts
+++ b/packages/vinext/src/server/response-stage-contract.ts
@@ -1,0 +1,35 @@
+import type { VinextResponseStageCacheability } from "./multi-stage.js";
+
+export function isSerializedHeaders(value: unknown): value is Array<[string, string]> {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (entry) =>
+        Array.isArray(entry) &&
+        entry.length === 2 &&
+        typeof entry[0] === "string" &&
+        typeof entry[1] === "string",
+    )
+  );
+}
+
+export function isResponseStageCacheability(
+  value: unknown,
+): value is VinextResponseStageCacheability {
+  if (!value || typeof value !== "object") return false;
+  const cacheability = value as Partial<VinextResponseStageCacheability>;
+  return (
+    (cacheability.probeMode === null ||
+      cacheability.probeMode === "probe" ||
+      cacheability.probeMode === "identity") &&
+    (cacheability.policyHeaders === null || isSerializedHeaders(cacheability.policyHeaders)) &&
+    (cacheability.representation === undefined ||
+      cacheability.representation === "app-route" ||
+      cacheability.representation === "html" ||
+      cacheability.representation === "pages-data" ||
+      cacheability.representation === "rsc-full" ||
+      cacheability.representation === "rsc-loading-shell") &&
+    typeof cacheability.resolvedRoutePathname === "string" &&
+    cacheability.resolvedRoutePathname.startsWith("/")
+  );
+}

--- a/packages/vinext/src/server/worker-prerender-discovery.ts
+++ b/packages/vinext/src/server/worker-prerender-discovery.ts
@@ -1,4 +1,5 @@
 import type { ExecutionContextLike } from "vinext/shims/request-context";
+import { validateCdnRequest } from "./cache-control.js";
 import {
   VINEXT_EXPECTED_WORKER_VERSION_HEADER,
   VINEXT_PRERENDER_METADATA_ROUTES_PATH,
@@ -64,6 +65,14 @@ export function createWorkerPrerenderReadinessResponse(
       [VINEXT_PRERENDER_READINESS_HEADER]: "1",
     },
   });
+}
+
+export async function validateWorkerPrerenderReadiness(
+  ctx: ExecutionContextLike,
+  request: Request,
+): Promise<Response | null> {
+  const response = createWorkerPrerenderReadinessResponse(ctx, request);
+  return response ? ((await validateCdnRequest(request)) ?? response) : null;
 }
 
 /**

--- a/packages/vinext/src/server/worker-request-stage.ts
+++ b/packages/vinext/src/server/worker-request-stage.ts
@@ -17,7 +17,7 @@ import type { VinextCacheabilityProbeMode } from "./multi-stage.js";
 import { cloneRequestWithHeaders, filterInternalHeaders } from "./request-pipeline.js";
 import {
   createWorkerPrerenderDiscoveryContext,
-  createWorkerPrerenderReadinessResponse,
+  validateWorkerPrerenderReadiness,
 } from "./worker-prerender-discovery.js";
 
 export function registerWorkerRequestStageAdapters(env: Record<string, unknown> | undefined): void {
@@ -45,19 +45,16 @@ export async function prepareWorkerRequestStage(
   response: Response | null;
 }> {
   context = createWorkerPrerenderDiscoveryContext(context, request, prerenderSecret);
-  const readinessResponse = createWorkerPrerenderReadinessResponse(context, request);
-  if (readinessResponse) {
-    const response = await validateCdnRequest(request);
-    if (response || readinessResponse.status !== 204) {
-      return {
-        context,
-        probeMode: null,
-        probeRoute: null,
-        readinessResponse,
-        request,
-        response: response ?? readinessResponse,
-      };
-    }
+  const readinessResponse = await validateWorkerPrerenderReadiness(context, request);
+  if (readinessResponse && readinessResponse.status !== 204) {
+    return {
+      context,
+      probeMode: null,
+      probeRoute: null,
+      readinessResponse,
+      request,
+      response: readinessResponse,
+    };
   }
 
   let probeMode: VinextCacheabilityProbeMode | null = null;

--- a/packages/vinext/src/server/worker-request-stage.ts
+++ b/packages/vinext/src/server/worker-request-stage.ts
@@ -1,0 +1,119 @@
+import type { ExecutionContextLike } from "vinext/shims/request-context";
+import { registerLazyDataCacheHandler } from "vinext/shims/cache-handler";
+// @ts-expect-error -- virtual module resolved by vinext at build time
+import * as configuredCdnCacheAdapters from "virtual:vinext-cdn-cache-adapter";
+// @ts-expect-error -- virtual module resolved by vinext at build time
+import { registerConfiguredImageOptimizer } from "virtual:vinext-image-adapters";
+import { validateCdnRequest } from "./cache-control.js";
+import type { WorkerCacheabilityProbeRoute } from "./cacheability-request.js";
+import {
+  VINEXT_CACHEABILITY_PROBE_HEADER,
+  VINEXT_CACHEABILITY_PROBE_QUERY_PARAM,
+  VINEXT_EXPECTED_WORKER_VERSION_HEADER,
+  VINEXT_PRERENDER_SECRET_HEADER,
+  VINEXT_REVALIDATE_HOST_HEADER,
+} from "./headers.js";
+import type { VinextCacheabilityProbeMode } from "./multi-stage.js";
+import { cloneRequestWithHeaders, filterInternalHeaders } from "./request-pipeline.js";
+import {
+  createWorkerPrerenderDiscoveryContext,
+  createWorkerPrerenderReadinessResponse,
+} from "./worker-prerender-discovery.js";
+
+export function registerWorkerRequestStageAdapters(env: Record<string, unknown> | undefined): void {
+  configuredCdnCacheAdapters.registerConfiguredCacheAdapters(env);
+  if (configuredCdnCacheAdapters.hasConfiguredDataCache) {
+    registerLazyDataCacheHandler(async () => {
+      // @ts-expect-error -- virtual module resolved by vinext at build time
+      const adapters = await import("virtual:vinext-cache-adapters");
+      adapters.registerConfiguredCacheAdapters(env);
+    });
+  }
+  registerConfiguredImageOptimizer(env);
+}
+
+export async function prepareWorkerRequestStage(
+  request: Request,
+  context: ExecutionContextLike,
+  prerenderSecret: string | null | undefined,
+): Promise<{
+  context: ExecutionContextLike;
+  probeMode: VinextCacheabilityProbeMode | null;
+  probeRoute: WorkerCacheabilityProbeRoute | null;
+  readinessResponse: Response | null;
+  request: Request;
+  response: Response | null;
+}> {
+  context = createWorkerPrerenderDiscoveryContext(context, request, prerenderSecret);
+  const readinessResponse = createWorkerPrerenderReadinessResponse(context, request);
+  if (readinessResponse) {
+    const response = await validateCdnRequest(request);
+    if (response || readinessResponse.status !== 204) {
+      return {
+        context,
+        probeMode: null,
+        probeRoute: null,
+        readinessResponse,
+        request,
+        response: response ?? readinessResponse,
+      };
+    }
+  }
+
+  let probeMode: VinextCacheabilityProbeMode | null = null;
+  let probeRoute: WorkerCacheabilityProbeRoute | null = null;
+  if (request.headers.has(VINEXT_CACHEABILITY_PROBE_HEADER)) {
+    const { readWorkerCacheabilityProbeMode, readWorkerCacheabilityProbeRoute } =
+      await import("./cacheability-request.js");
+    probeMode = readWorkerCacheabilityProbeMode(request, prerenderSecret);
+    if (probeMode) {
+      probeRoute = readWorkerCacheabilityProbeRoute(request);
+      const url = new URL(request.url);
+      url.searchParams.delete(VINEXT_CACHEABILITY_PROBE_QUERY_PARAM);
+      request = new Request(url, request);
+    }
+  }
+
+  return {
+    context,
+    probeMode,
+    probeRoute,
+    readinessResponse,
+    request,
+    response: readinessResponse ? null : await validateCdnRequest(request),
+  };
+}
+
+export function filterWorkerRequestStageHeaders(
+  request: Request,
+  context: ExecutionContextLike,
+  readinessResponse: Response | null,
+): { headers: Headers; request: Request } {
+  const headers = context.isInternalPagesRevalidation
+    ? new Headers(request.headers)
+    : filterInternalHeaders(request.headers);
+  headers.delete(VINEXT_PRERENDER_SECRET_HEADER);
+  headers.delete(VINEXT_REVALIDATE_HOST_HEADER);
+  if (readinessResponse?.status === 204) {
+    const expectedWorkerVersion = request.headers.get(VINEXT_EXPECTED_WORKER_VERSION_HEADER);
+    if (expectedWorkerVersion) {
+      headers.set(VINEXT_EXPECTED_WORKER_VERSION_HEADER, expectedWorkerVersion);
+    }
+  }
+  return { headers, request: cloneRequestWithHeaders(request, headers) };
+}
+
+export async function finalizeWorkerRequestStageResponse(
+  response: Response,
+  probeMode: VinextCacheabilityProbeMode | null,
+  probeRoute: WorkerCacheabilityProbeRoute | null,
+  responseStageDispatched: boolean,
+): Promise<Response> {
+  if (!probeMode || !probeRoute || responseStageDispatched) return response;
+  const { finalizeRequestStageCacheabilityProbe } = await import("./cacheability-request.js");
+  return finalizeRequestStageCacheabilityProbe(response, {
+    mode: probeMode,
+    responseStageDispatched,
+    route: probeRoute,
+  });
+}

--- a/packages/vinext/src/server/worker-stages.ts
+++ b/packages/vinext/src/server/worker-stages.ts
@@ -3,6 +3,7 @@ import type {
   VinextResponseStageCacheability,
   VinextResponseStageTransport,
 } from "./multi-stage.js";
+import { isResponseStageCacheability, isSerializedHeaders } from "./response-stage-contract.js";
 
 export const PAGES_RESPONSE_STAGE_PROTOCOL_VERSION = 4;
 export const PAGES_RESPONSE_STAGE_POLICY_OWNER_HEADER =
@@ -52,46 +53,6 @@ export type WorkerResponseStageProps =
  * response as Next.js.
  */
 export type DispatchWorkerResponseStage = VinextResponseStageTransport<WorkerResponseStageProps>;
-
-function isSerializedHeaders(value: unknown): value is Array<[string, string]> {
-  return (
-    Array.isArray(value) &&
-    value.every(
-      (entry) =>
-        Array.isArray(entry) &&
-        entry.length === 2 &&
-        typeof entry[0] === "string" &&
-        typeof entry[1] === "string",
-    )
-  );
-}
-
-function isResponseStageCacheability(value: unknown): value is VinextResponseStageCacheability {
-  if (!value || typeof value !== "object") return false;
-  const cacheability = value as Partial<VinextResponseStageCacheability>;
-  return (
-    (cacheability.probeMode === null ||
-      cacheability.probeMode === "probe" ||
-      cacheability.probeMode === "identity") &&
-    (cacheability.policyHeaders === null ||
-      (Array.isArray(cacheability.policyHeaders) &&
-        cacheability.policyHeaders.every(
-          (entry) =>
-            Array.isArray(entry) &&
-            entry.length === 2 &&
-            typeof entry[0] === "string" &&
-            typeof entry[1] === "string",
-        ))) &&
-    (cacheability.representation === undefined ||
-      cacheability.representation === "app-route" ||
-      cacheability.representation === "html" ||
-      cacheability.representation === "pages-data" ||
-      cacheability.representation === "rsc-full" ||
-      cacheability.representation === "rsc-loading-shell") &&
-    typeof cacheability.resolvedRoutePathname === "string" &&
-    cacheability.resolvedRoutePathname.startsWith("/")
-  );
-}
 
 export function isPagesResponseStageProps(value: unknown): value is WorkerResponseStageProps {
   if (!value || typeof value !== "object") return false;

--- a/tests/app-rsc-route-matching.test.ts
+++ b/tests/app-rsc-route-matching.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 import {
   createAppRscRouteMatcher,
+  resolveAppRscInterceptRoute,
   SIBLING_PAGE_INTERCEPT_SLOT_KEY,
 } from "../packages/vinext/src/server/app-rsc-route-matching.js";
 
@@ -184,12 +185,22 @@ describe("App RSC route matching", () => {
       }),
     ]);
 
-    expect(matcher.findIntercept("/photos/target-id", "/feed/source-id")).toMatchObject({
+    const intercept = matcher.findIntercept("/photos/target-id", "/feed/source-id");
+    expect(intercept).toMatchObject({
       sourceRouteIndex: 0,
       slotKey: "modal",
       targetPattern: "/photos/:id",
       page: "photo-page",
       matchedParams: { id: "target-id" },
+    });
+    expect(
+      resolveAppRscInterceptRoute(intercept, [
+        { ...route("/feed/:id", ["feed", ":id"]), params: ["id"] },
+      ]),
+    ).toMatchObject({
+      interceptionSourceIsConcrete: false,
+      params: { id: "source-id" },
+      route: { pattern: "/feed/:id" },
     });
   });
 

--- a/tests/cache-adapters-config.test.ts
+++ b/tests/cache-adapters-config.test.ts
@@ -31,6 +31,7 @@ import {
   readAppRequestStageEntrySource,
   readAppRouterEntrySource,
   readPagesRequestStageEntrySource,
+  readWorkerRequestStageSource,
 } from "./worker-entry-source.js";
 import { resolveNextConfig } from "../packages/vinext/src/config/next-config.js";
 import { createValidFileMatcher } from "../packages/vinext/src/routing/file-matcher.js";
@@ -314,13 +315,15 @@ describe("registration is wired into every router/runtime entry", () => {
   });
 
   it("Pages Router worker entry registers with env", () => {
-    const code = readPagesRequestStageEntrySource();
+    const entryCode = readPagesRequestStageEntrySource();
+    const code = readWorkerRequestStageSource();
     const eagerCdnRegistration = "configuredCdnCacheAdapters.registerConfiguredCacheAdapters(env);";
     const validateCdnRequest = "await validateCdnRequest(request)";
     const lazyDataRegistration = code.match(
       /registerLazyDataCacheHandler\(async \(\) => \{[\s\S]*?\n\s*\}\);/,
     )?.[0];
 
+    expect(entryCode).toContain("registerWorkerRequestStageAdapters(env)");
     expect(code).toContain('from "virtual:vinext-cdn-cache-adapter"');
     expect(code).not.toContain('from "virtual:vinext-cache-adapters"');
     expect(code).toContain(eagerCdnRegistration);
@@ -330,7 +333,9 @@ describe("registration is wired into every router/runtime entry", () => {
   });
 
   it("App request stage cannot retain the configured data adapter module", () => {
-    const code = readAppRequestStageEntrySource();
+    const entryCode = readAppRequestStageEntrySource();
+    const code = readWorkerRequestStageSource();
+    expect(entryCode).toContain("registerWorkerRequestStageAdapters(env)");
     expect(code).toContain('from "virtual:vinext-cdn-cache-adapter"');
     expect(code).not.toContain('from "virtual:vinext-cache-adapters"');
   });
@@ -338,9 +343,9 @@ describe("registration is wired into every router/runtime entry", () => {
   it("App Router worker entry validates CDN routing after registering with env", () => {
     const code = readAppRouterEntrySource();
     expect(code).toContain("registerConfiguredCacheAdapters(env");
-    expect(code).toContain("await validateCdnRequest(request)");
+    expect(code).toContain("await validateWorkerPrerenderReadiness(ctx, request)");
     expect(code.indexOf("registerConfiguredCacheAdapters(env")).toBeLessThan(
-      code.indexOf("await validateCdnRequest(request)"),
+      code.indexOf("await validateWorkerPrerenderReadiness(ctx, request)"),
     );
   });
 });

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -52,6 +52,7 @@ import {
   readPagesResponseStageEntrySource,
   readPagesRouterEntrySource,
   readPagesSingleEntrySource,
+  readWorkerRequestStageSource,
 } from "./worker-entry-source.js";
 import { scanPublicFileRoutes } from "../packages/vinext/src/utils/public-routes.js";
 import { isUnknownRecord } from "../packages/vinext/src/utils/record.js";
@@ -1652,9 +1653,11 @@ describe("readPagesRouterEntrySource", () => {
 
   it("includes image optimization handler", () => {
     const content = readPagesRouterEntrySource();
+    const sharedContent = readWorkerRequestStageSource();
     expect(content).toContain("isImageOptimizationPath");
     expect(content).toContain("handleConfiguredImageOptimization");
-    expect(content).toContain("registerConfiguredImageOptimizer(env)");
+    expect(content).toContain("registerWorkerRequestStageAdapters(env)");
+    expect(sharedContent).toContain("registerConfiguredImageOptimizer(env)");
   });
 
   it("does not declare an Images binding in the Worker", () => {

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -1209,20 +1209,17 @@ describe("App Router entry templates", () => {
   it("promotes interception-only RSC targets before not-found dispatch", () => {
     const code = generateRscEntry("/tmp/test/app", minimalAppRoutes, null, [], null, "", false);
 
-    expect(code).toContain("matchInterceptRoute(pathname, sourcePathname, interceptionId)");
+    expect(code).toContain(
+      "__resolveAppRscInterceptRoute(findIntercept(pathname, sourcePathname, interceptionId), routes)",
+    );
     expect(code).toContain("hasInterceptionId(interceptionId)");
     expect(code).toContain("return __routeMatcher.hasInterceptionId(interceptionId)");
-    expect(code).toContain(
-      "const intercept = findIntercept(pathname, sourcePathname, interceptionId)",
-    );
-    expect(code).toContain("interceptionSourceIsConcrete: intercept.sourceRouteIsConcrete");
     expect(
       code.match(
         /findIntercept\(\s*interceptionPathname,\s*interceptionContext,\s*interceptionId,?\s*\)/g,
       ),
     ).toHaveLength(3);
-    expect(code).toContain("const route = routes[intercept.sourceRouteIndex]");
-    expect(code).toContain("intercept.sourceMatchedParams");
+    expect(code).not.toContain("const route = routes[intercept.sourceRouteIndex]");
   });
 
   it("installs server globals before App Router user modules are imported", () => {
@@ -1729,7 +1726,7 @@ describe("Pages Router entry template", () => {
 
       expect(code).toContain("export function normalizeDataRequest(request)");
       expect(code).toContain(
-        "vinextConfig.basePath,\n    __shouldAddTrailingSlashToPagesDataPath(\n      hasMiddleware,\n      vinextConfig.trailingSlash,\n      vinextConfig.skipProxyUrlNormalize",
+        "__normalizePagesEntryDataRequest(request, buildId, vinextConfig, hasMiddleware)",
       );
       expect(code).toContain("export const hasMiddleware = true");
       expect(code).toContain('"skipProxyUrlNormalize":true');

--- a/tests/image-adapters-config.test.ts
+++ b/tests/image-adapters-config.test.ts
@@ -25,7 +25,7 @@ import {
   type ImageOptimizer,
 } from "../packages/vinext/src/server/image-optimization.js";
 import { generateRscEntry } from "../packages/vinext/src/entries/app-rsc-entry.js";
-import { readPagesRouterEntrySource } from "./worker-entry-source.js";
+import { readPagesRouterEntrySource, readWorkerRequestStageSource } from "./worker-entry-source.js";
 import { imagesOptimizer } from "../packages/cloudflare/src/images/images-optimizer.js";
 import createCloudflareImageOptimizer from "../packages/cloudflare/src/images/images-optimizer.runtime.js";
 
@@ -317,11 +317,13 @@ describe("registration is wired into the router/runtime entries", () => {
   });
 
   it("Pages Router worker entry registers the optimizer with env and uses the registry", () => {
-    const code = readPagesRouterEntrySource();
-    expect(code).toContain('from "virtual:vinext-image-adapters"');
-    expect(code).toContain("registerConfiguredImageOptimizer(env)");
-    expect(code).toContain("handleConfiguredImageOptimization(");
+    const entryCode = readPagesRouterEntrySource();
+    const sharedCode = readWorkerRequestStageSource();
+    expect(entryCode).toContain("registerWorkerRequestStageAdapters(env)");
+    expect(sharedCode).toContain('from "virtual:vinext-image-adapters"');
+    expect(sharedCode).toContain("registerConfiguredImageOptimizer(env)");
+    expect(entryCode).toContain("handleConfiguredImageOptimization(");
     // No longer wires the Cloudflare Images binding inline.
-    expect(code).not.toContain("env.IMAGES");
+    expect(entryCode).not.toContain("env.IMAGES");
   });
 });

--- a/tests/pages-data-route.test.ts
+++ b/tests/pages-data-route.test.ts
@@ -5,6 +5,7 @@ import {
   parseNextDataPathname,
   buildNextDataNotFoundResponse,
   encodeUrlParserIgnoredCharacters,
+  normalizePagesEntryDataRequest,
   normalizePagesDataRequest,
   shouldAddTrailingSlashToPagesDataPath,
   normalizeNextDataPagePathname,
@@ -122,6 +123,16 @@ describe("pages-data-route", () => {
       expect(shouldAddTrailingSlashToPagesDataPath(true, true, true)).toBe(false);
       expect(shouldAddTrailingSlashToPagesDataPath(true, true, false)).toBe(true);
       expect(shouldAddTrailingSlashToPagesDataPath(false, true, false)).toBe(false);
+
+      const buildId = "abc123";
+      const request = new Request(`http://localhost/_next/data/${buildId}/about.json`);
+      const result = normalizePagesEntryDataRequest(
+        request,
+        buildId,
+        { skipProxyUrlNormalize: true, trailingSlash: true },
+        true,
+      );
+      expect(result.normalizedPathname).toBe("/about");
     });
 
     it("applies trailingSlash to the page URL before middleware sees data requests", () => {

--- a/tests/worker-entry-source.ts
+++ b/tests/worker-entry-source.ts
@@ -60,3 +60,15 @@ export function readPagesResponseStageEntrySource(): string {
     "utf-8",
   );
 }
+
+export function readWorkerRequestStageSource(): string {
+  const sourceUrl = new URL(
+    "../packages/vinext/src/server/worker-request-stage.ts",
+    import.meta.url,
+  );
+  if (fs.existsSync(sourceUrl)) return fs.readFileSync(sourceUrl, "utf-8");
+  return fs.readFileSync(
+    new URL("../packages/vinext/src/server/worker-request-stage.js", import.meta.url),
+    "utf-8",
+  );
+}


### PR DESCRIPTION
## Summary

- share App and Pages request-stage setup, readiness/probe handling, header filtering, and probe finalization
- share response-stage transport validators and generated entry snippets
- share cached/uncached Cloudflare entrypoint invocation validation
- remove 176 net implementation lines without changing stage protocols or public behavior

## Validation

- `vp check` on all changed files
- 361 focused tests passed, 2 expected skips
- `vp run vinext#build`
- `vp run @vinext/cloudflare#build`