### PR TITLE
refactor(cache): delegate response policy to CDN adapters

### DIFF
--- a/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
@@ -203,15 +203,32 @@ function formatCacheTag(tags: readonly string[]): string | null {
 export class CloudflareCdnCacheAdapter implements CdnCacheAdapter {
   readonly requiresCompletedResponseAdmission = true;
   readonly responseVary = "verbatim" as const;
-
-  isResponsePolicyHeader(name: string): boolean {
-    const normalized = name.toLowerCase();
-    return EDGE_POLICY_HEADERS.some((header) => header.toLowerCase() === normalized);
-  }
-
-  readResponseCacheControl(headers: Headers): string | null {
-    return readCloudflareResponseCacheControl(headers);
-  }
+  readonly responsePolicy = {
+    isHeader(name: string): boolean {
+      const normalized = name.toLowerCase();
+      return EDGE_POLICY_HEADERS.some((header) => header.toLowerCase() === normalized);
+    },
+    readCacheControl(headers: Headers): string | null {
+      return readCloudflareResponseCacheControl(headers);
+    },
+    hasExplicitNonCacheablePolicy(headers: Headers, baseline?: Headers): boolean {
+      if (baseline) {
+        for (const name of EDGE_POLICY_HEADERS) {
+          const value = headers.get(name);
+          if (value !== baseline.get(name) && value !== null && isNonCacheableCacheControl(value)) {
+            return true;
+          }
+        }
+        const browserPolicy = headers.get("Cache-Control");
+        return Boolean(
+          browserPolicy !== baseline.get("Cache-Control") &&
+          browserPolicy &&
+          isNonCacheableCacheControl(browserPolicy),
+        );
+      }
+      return hasExplicitCloudflareNonCacheableResponsePolicy(headers);
+    },
+  };
 
   constructor(
     private readonly versionMetadata?: WorkerVersionMetadata,
@@ -308,24 +325,6 @@ export class CloudflareCdnCacheAdapter implements CdnCacheAdapter {
       "Cloudflare-CDN-Cache-Control": toEdgeCacheControl(input.cacheControl),
       "Cache-Tag": cacheTag,
     };
-  }
-
-  hasExplicitNonCacheableResponsePolicy(headers: Headers, baseline?: Headers): boolean {
-    if (baseline) {
-      for (const name of EDGE_POLICY_HEADERS) {
-        const value = headers.get(name);
-        if (value !== baseline.get(name) && value !== null && isNonCacheableCacheControl(value)) {
-          return true;
-        }
-      }
-      const browserPolicy = headers.get("Cache-Control");
-      return Boolean(
-        browserPolicy !== baseline.get("Cache-Control") &&
-        browserPolicy &&
-        isNonCacheableCacheControl(browserPolicy),
-      );
-    }
-    return hasExplicitCloudflareNonCacheableResponsePolicy(headers);
   }
 
   /** Purge edge-cached responses by tag via the request context's `cache.purge`. */

--- a/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.runtime.ts
@@ -115,6 +115,14 @@ function hasExplicitCloudflareNonCacheableResponsePolicy(headers: Headers): bool
   );
 }
 
+function readCloudflareResponseCacheControl(headers: Headers): string | null {
+  return (
+    headers.get("Cloudflare-CDN-Cache-Control") ??
+    headers.get("CDN-Cache-Control") ??
+    headers.get("Cache-Control")
+  );
+}
+
 /** The request-context cache surface this adapter relies on (narrowed from `unknown`). */
 type WorkersCacheLike = {
   // Miniflare currently resolves undefined; production Workers returns the
@@ -194,8 +202,16 @@ function formatCacheTag(tags: readonly string[]): string | null {
 
 export class CloudflareCdnCacheAdapter implements CdnCacheAdapter {
   readonly requiresCompletedResponseAdmission = true;
-  readonly responsePolicyHeaderNames = EDGE_POLICY_HEADERS;
   readonly responseVary = "verbatim" as const;
+
+  isResponsePolicyHeader(name: string): boolean {
+    const normalized = name.toLowerCase();
+    return EDGE_POLICY_HEADERS.some((header) => header.toLowerCase() === normalized);
+  }
+
+  readResponseCacheControl(headers: Headers): string | null {
+    return readCloudflareResponseCacheControl(headers);
+  }
 
   constructor(
     private readonly versionMetadata?: WorkerVersionMetadata,
@@ -294,7 +310,21 @@ export class CloudflareCdnCacheAdapter implements CdnCacheAdapter {
     };
   }
 
-  hasExplicitNonCacheableResponsePolicy(headers: Headers): boolean {
+  hasExplicitNonCacheableResponsePolicy(headers: Headers, baseline?: Headers): boolean {
+    if (baseline) {
+      for (const name of EDGE_POLICY_HEADERS) {
+        const value = headers.get(name);
+        if (value !== baseline.get(name) && value !== null && isNonCacheableCacheControl(value)) {
+          return true;
+        }
+      }
+      const browserPolicy = headers.get("Cache-Control");
+      return Boolean(
+        browserPolicy !== baseline.get("Cache-Control") &&
+        browserPolicy &&
+        isNonCacheableCacheControl(browserPolicy),
+      );
+    }
     return hasExplicitCloudflareNonCacheableResponsePolicy(headers);
   }
 

--- a/packages/cloudflare/src/cache/cdn-adapter.ts
+++ b/packages/cloudflare/src/cache/cdn-adapter.ts
@@ -80,7 +80,9 @@ export function cdnAdapter(options?: CdnAdapterOptions) {
     },
     capabilities: {
       buildIdentity: "response-header" as const,
-      responsePolicyHeaderNames: ["CDN-Cache-Control", "Cloudflare-CDN-Cache-Control"] as const,
+      isResponsePolicyHeader: (name: string) =>
+        name.toLowerCase() === "cdn-cache-control" ||
+        name.toLowerCase() === "cloudflare-cdn-cache-control",
       requestRouting: "uncached-stage" as const,
       responseVary: "verbatim" as const,
       routeCacheability: "probe-manifest" as const,

--- a/packages/cloudflare/src/deploy.ts
+++ b/packages/cloudflare/src/deploy.ts
@@ -35,7 +35,7 @@ import {
   findVinextPrerenderConfigInPlugins,
   findVinextRouteRootConfigInPlugins,
   formatVinextPrerenderLabel,
-  getConfiguredCdnResponsePolicyHeaderNames,
+  isConfiguredCdnResponsePolicyHeader,
   hasBuildIdentityResponseHeader,
   hasUncachedRequestRouting,
   hasVerbatimResponseVary,
@@ -1999,9 +1999,8 @@ export async function deploy(options: DeployOptions): Promise<void> {
       buildIdentity: hasBuildIdentityHeader ? "response-header" : undefined,
       requestRouting: hasStagedRequestRouting ? "uncached-stage" : undefined,
       responseVary: hasStrictResponseVary ? "verbatim" : undefined,
-      responsePolicyHeaderNames: getConfiguredCdnResponsePolicyHeaderNames(
-        viteConfigMetadata.cacheConfig,
-      ),
+      isResponsePolicyHeader: (name) =>
+        isConfiguredCdnResponsePolicyHeader(viteConfigMetadata.cacheConfig, name),
       routeRootConfig: viteConfigMetadata.routeRootConfig,
     });
   }
@@ -2076,9 +2075,8 @@ export async function deploy(options: DeployOptions): Promise<void> {
           buildIdentity: hasBuildIdentityHeader ? "response-header" : undefined,
           requestRouting: hasStagedRequestRouting ? "uncached-stage" : undefined,
           responseVary: hasStrictResponseVary ? "verbatim" : undefined,
-          responsePolicyHeaderNames: getConfiguredCdnResponsePolicyHeaderNames(
-            viteConfigMetadata.cacheConfig,
-          ),
+          isResponsePolicyHeader: (name) =>
+            isConfiguredCdnResponsePolicyHeader(viteConfigMetadata.cacheConfig, name),
           routeRootConfig: viteConfigMetadata.routeRootConfig,
           pathDiscoveryTarget: {
             baseUrl: targetUrl,

--- a/packages/vinext/src/build/prerender-paths.ts
+++ b/packages/vinext/src/build/prerender-paths.ts
@@ -41,7 +41,6 @@ import { resolveAppPageDynamicConfig } from "../server/app-segment-config.js";
 import { extractLocaleFromUrl, normalizeDefaultLocalePathname } from "../server/pages-i18n.js";
 import { normalizePathTrailingSlash } from "vinext/shims/url-utils";
 import { buildPagesDataHref } from "vinext/shims/internal/pages-data-url";
-import { CACHEABILITY_POLICY_HEADERS } from "vinext/shims/cacheability-classification";
 import { resolveBuiltRscEntryPath } from "./server-entry.js";
 import {
   matchesMiddlewarePathname,
@@ -137,7 +136,7 @@ type EmitPrerenderPathManifestOptions = {
   buildIdentity?: CdnCacheAdapterCapabilities["buildIdentity"];
   responseVary?: CdnCacheAdapterCapabilities["responseVary"];
   requestRouting?: CdnCacheAdapterCapabilities["requestRouting"];
-  responsePolicyHeaderNames?: CdnCacheAdapterCapabilities["responsePolicyHeaderNames"];
+  isResponsePolicyHeader?: CdnCacheAdapterCapabilities["isResponsePolicyHeader"];
   /** Execute dynamic path hooks against an already-uploaded Worker. */
   pathDiscoveryTarget?: {
     baseUrl: string;
@@ -1106,14 +1105,10 @@ function annotateCacheabilityProbeSafety(
   config: Pick<ResolvedNextConfig, "basePath" | "headers" | "i18n" | "trailingSlash">,
   routeMayResolve: ReadonlySet<string>,
   requestStageMayTerminate: ReadonlySet<string>,
-  responsePolicyHeaderNames: readonly string[],
+  isResponsePolicyHeader: (name: string) => boolean,
 ): Record<string, PrerenderRoutePattern> {
-  const cacheabilityPolicyHeaderNames = new Set([
-    ...CACHEABILITY_POLICY_HEADERS,
-    ...responsePolicyHeaderNames.map((name) => name.trim().toLowerCase()).filter(Boolean),
-  ]);
   const cachePolicyRules = config.headers.filter((rule) =>
-    rule.headers.some((header) => cacheabilityPolicyHeaderNames.has(header.key.toLowerCase())),
+    rule.headers.some((header) => isResponsePolicyHeader(header.key)),
   );
   const matchingPolicyRules = new Map(
     Object.keys(routePatterns).map((pathname) => [
@@ -1552,7 +1547,9 @@ export async function emitPrerenderPathManifest(
     config,
     routeMayResolveWarmPathSet,
     requestStageMayTerminateWarmPathSet,
-    options.responsePolicyHeaderNames ?? [],
+    (name) =>
+      name.trim().toLowerCase() === "cache-control" ||
+      options.isResponsePolicyHeader?.(name) === true,
   );
   for (let index = 0; index < resolvedPagesDataWarmPaths.length; index++) {
     const route = routePatterns[resolvedPagesDataWarmPaths[index]];

--- a/packages/vinext/src/cache/cache-adapters-virtual.ts
+++ b/packages/vinext/src/cache/cache-adapters-virtual.ts
@@ -58,15 +58,12 @@ export type CdnCacheAdapterCapabilities = {
    */
   routeCacheability?: "probe-manifest";
   /**
-   * Response headers whose values can opt a response into or out of the
-   * adapter's shared cache, in addition to the framework-owned Cache-Control
-   * header.
-   *
-   * Prerender discovery uses these names to avoid collapsing a dynamic route
+   * Whether a provider-specific response header controls the adapter's shared
+   * cache. Prerender discovery calls this to avoid collapsing a dynamic route
    * pattern when next.config assigns different cache policy to its concrete
    * pathnames.
    */
-  responsePolicyHeaderNames?: readonly string[];
+  isResponsePolicyHeader?: (name: string) => boolean;
 };
 
 export type CacheAdapterBuildOutput = {
@@ -112,18 +109,16 @@ export function requiresRouteCacheabilityProbeManifest(cache?: VinextCacheConfig
   return cache?.cdn?.capabilities?.routeCacheability === "probe-manifest";
 }
 
-/** Lowercase response-policy names owned by core and the configured adapter. */
-export function getConfiguredCdnResponsePolicyHeaderNames(
+/** Whether a response header controls core or the configured CDN adapter. */
+export function isConfiguredCdnResponsePolicyHeader(
   cache?: VinextCacheConfig | null,
-): readonly string[] {
-  return [
-    ...new Set([
-      "cache-control",
-      ...(cache?.cdn?.capabilities?.responsePolicyHeaderNames ?? [])
-        .map((name) => name.trim().toLowerCase())
-        .filter(Boolean),
-    ]),
-  ];
+  name?: string,
+): boolean {
+  if (!name) return false;
+  return (
+    name.trim().toLowerCase() === "cache-control" ||
+    cache?.cdn?.capabilities?.isResponsePolicyHeader?.(name) === true
+  );
 }
 
 /**

--- a/packages/vinext/src/cli.ts
+++ b/packages/vinext/src/cli.ts
@@ -64,7 +64,7 @@ import {
 } from "./config/prerender.js";
 import {
   findVinextCacheConfigInPlugins,
-  getConfiguredCdnResponsePolicyHeaderNames,
+  isConfiguredCdnResponsePolicyHeader,
   hasBuildIdentityResponseHeader,
   hasUncachedRequestRouting,
   hasVerbatimResponseVary,
@@ -750,9 +750,8 @@ async function buildApp() {
       requestRouting: hasUncachedRequestRouting(buildConfigMetadata.cacheConfig)
         ? "uncached-stage"
         : undefined,
-      responsePolicyHeaderNames: getConfiguredCdnResponsePolicyHeaderNames(
-        buildConfigMetadata.cacheConfig,
-      ),
+      isResponsePolicyHeader: (name) =>
+        isConfiguredCdnResponsePolicyHeader(buildConfigMetadata.cacheConfig, name),
       routeRootConfig: buildConfigMetadata.routeRootConfig,
     });
   }

--- a/packages/vinext/src/config/prerender.ts
+++ b/packages/vinext/src/config/prerender.ts
@@ -3,7 +3,7 @@ import { flattenPluginOptions } from "../utils/plugin-options.js";
 import { isUnknownRecord } from "../utils/record.js";
 export {
   findVinextCacheConfigInPlugins,
-  getConfiguredCdnResponsePolicyHeaderNames,
+  isConfiguredCdnResponsePolicyHeader,
   hasBuildIdentityResponseHeader,
   hasUncachedRequestRouting,
   hasVerbatimResponseVary,

--- a/packages/vinext/src/server/app-page-cache-finalizer.ts
+++ b/packages/vinext/src/server/app-page-cache-finalizer.ts
@@ -1,6 +1,7 @@
 import type { AppRscRenderMode } from "./app-rsc-render-mode.js";
 import {
   applyCdnResponseHeaders,
+  captureCdnResponsePolicyHeaders,
   buildRevalidateCacheControl,
   hasExplicitNonCacheableResponsePolicy,
   NO_STORE_CACHE_CONTROL,
@@ -193,7 +194,7 @@ function finalizeEvaluatedAppPageResponse(
   if (!isRouteCacheabilityEvaluation()) return null;
   const complete = deferRouteCacheability();
   if (!complete) return response;
-  captureRouteCacheabilityResponsePolicy(response.headers);
+  captureRouteCacheabilityResponsePolicy(captureCdnResponsePolicyHeaders(response.headers));
 
   let completed = false;
   const finish = (): void => {

--- a/packages/vinext/src/server/app-route-handler-execution.ts
+++ b/packages/vinext/src/server/app-route-handler-execution.ts
@@ -11,7 +11,7 @@ import { _drainPendingRevalidations } from "vinext/shims/cache-request-state";
 import { runWithRootParamsUsage } from "vinext/shims/root-params";
 import {
   applyCdnResponseHeaders,
-  getCdnResponsePolicyHeaderNames,
+  hasCdnResponsePolicy,
   hasExplicitNonCacheableResponsePolicy,
   NEVER_CACHE_CONTROL,
 } from "./cache-control.js";
@@ -117,10 +117,7 @@ type CompletedAppRouteHandlerResponse = {
 };
 
 function hasExplicitCacheableResponsePolicy(headers: Headers): boolean {
-  return (
-    !hasExplicitNonCacheableResponsePolicy(headers) &&
-    [...getCdnResponsePolicyHeaderNames()].some((name) => headers.has(name))
-  );
+  return !hasExplicitNonCacheableResponsePolicy(headers) && hasCdnResponsePolicy(headers);
 }
 
 async function completeAppRouteHandlerResponse(
@@ -323,9 +320,7 @@ export async function executeAppRouteHandler(
     }
     let { dynamicUsedInHandler, response } = handlerResult;
     assertSupportedAppRouteHandlerResponse(response);
-    const handlerSetCachePolicy = [...getCdnResponsePolicyHeaderNames()].some((name) =>
-      response.headers.has(name),
-    );
+    const handlerSetCachePolicy = hasCdnResponsePolicy(response.headers);
     const hasExplicitCacheablePolicy = hasExplicitCacheableResponsePolicy(response.headers);
     if (hasExplicitCacheablePolicy) {
       markRouteCacheabilityExplicitResponsePolicy();

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -103,7 +103,7 @@ import type { ClientReuseManifestParseResult } from "./client-reuse-manifest.js"
 import {
   applyCdnResponseHeaders,
   captureCdnResponsePolicyOverrides,
-  getCdnResponsePolicyHeaderNames,
+  isCdnResponsePolicyHeader,
   NEVER_CACHE_CONTROL,
   reconcileCdnResponseHeadersAfterOuterPolicy,
 } from "./cache-control.js";
@@ -1199,9 +1199,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
       configHeaders: options.configHeaders,
       i18nConfig: options.i18nConfig,
       middlewareHeaders: middlewareContext.headers,
-      overwriteExisting: preserveExistingPolicy
-        ? new Set<string>()
-        : getCdnResponsePolicyHeaderNames(),
+      overwriteExisting: preserveExistingPolicy ? new Set<string>() : isCdnResponsePolicyHeader,
       recordCacheability: dispatchResponseStage === undefined,
       requestContext: preMiddlewareRequestContext,
     });
@@ -1222,7 +1220,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
         basePath: options.basePath,
         configHeaders: options.configHeaders,
         i18nConfig: options.i18nConfig,
-        overwriteExisting: getCdnResponsePolicyHeaderNames(),
+        overwriteExisting: isCdnResponsePolicyHeader,
         recordCacheability: false,
         requestContext: preMiddlewareRequestContext,
       });

--- a/packages/vinext/src/server/app-rsc-response-finalizer.ts
+++ b/packages/vinext/src/server/app-rsc-response-finalizer.ts
@@ -3,8 +3,9 @@ import type { RequestContext } from "../config/request-context.js";
 import { isStaticFileSignal } from "./static-file-signal.js";
 import {
   applyCdnResponseHeaders,
-  getCdnResponsePolicyHeaderNames,
+  captureCdnResponsePolicyHeaders,
   hasExplicitNonCacheableResponsePolicy,
+  isCdnResponsePolicyHeader,
   isNonCacheableCacheControl,
   NO_STORE_CACHE_CONTROL,
 } from "./cache-control.js";
@@ -34,7 +35,7 @@ type FinalizeAppRscResponseOptions = {
    */
   requestContext: RequestContext;
   /** Existing response headers that matching next.config rules may replace. */
-  overwriteExisting?: ReadonlySet<string>;
+  overwriteExisting?: ReadonlySet<string> | ((name: string) => boolean);
   /** Response headers emitted by middleware after config matching. */
   middlewareHeaders?: Headers | null;
   /** Whether config matching should update the active cacheability classification. */
@@ -90,7 +91,7 @@ export async function applyAppRscConfigHeaders(
     // including for force-dynamic App Pages. Other response headers retain
     // the existing merge precedence.
     // test/e2e/app-dir/custom-cache-control/custom-cache-control.test.ts
-    overwriteExisting: options.overwriteExisting ?? getCdnResponsePolicyHeaderNames(),
+    overwriteExisting: options.overwriteExisting ?? isCdnResponsePolicyHeader,
   });
 }
 
@@ -139,7 +140,7 @@ export async function finalizeAppRscResponse(
     // application opt-out. Admission may replace it only after the body has
     // completed and the render has proved reusable. Capture before config
     // headers run so any later private/no-store override still vetoes.
-    captureRouteCacheabilityResponsePolicy(response.headers);
+    captureRouteCacheabilityResponsePolicy(captureCdnResponsePolicyHeaders(response.headers));
   }
 
   if (configHeadersAlreadyApplied.has(response)) {

--- a/packages/vinext/src/server/cache-control.ts
+++ b/packages/vinext/src/server/cache-control.ts
@@ -31,29 +31,55 @@ function isSharedCacheControl(cacheControl: string): boolean {
  * inspect the provider-specific policy headers they own; the generic fallback
  * only understands the framework-owned `Cache-Control` header.
  */
-export function hasExplicitNonCacheableResponsePolicy(headers: Headers): boolean {
+export function hasExplicitNonCacheableResponsePolicy(
+  headers: Headers,
+  baseline?: Headers,
+): boolean {
   const adapter = getCdnCacheAdapter();
   if (adapter.hasExplicitNonCacheableResponsePolicy) {
-    return adapter.hasExplicitNonCacheableResponsePolicy(headers);
+    return adapter.hasExplicitNonCacheableResponsePolicy(headers, baseline);
   }
   const cacheControl = headers.get("Cache-Control");
-  return Boolean(cacheControl && isNonCacheableCacheControl(cacheControl));
+  return Boolean(
+    cacheControl &&
+    cacheControl !== baseline?.get("Cache-Control") &&
+    isNonCacheableCacheControl(cacheControl),
+  );
 }
 
-/** Lowercase response-policy names owned by core and the active adapter. */
-export function getCdnResponsePolicyHeaderNames(): ReadonlySet<string> {
-  return new Set([
-    "cache-control",
-    ...(getCdnCacheAdapter().responsePolicyHeaderNames ?? []).map((name) => name.toLowerCase()),
-  ]);
+/** Whether a response header controls core or the active CDN adapter. */
+export function isCdnResponsePolicyHeader(name: string): boolean {
+  return (
+    name.toLowerCase() === "cache-control" ||
+    getCdnCacheAdapter().isResponsePolicyHeader?.(name) === true
+  );
+}
+
+/** Whether a response declares any core- or adapter-owned cache policy. */
+export function hasCdnResponsePolicy(headers: Headers): boolean {
+  return [...headers.keys()].some(isCdnResponsePolicyHeader);
+}
+
+/** Read the effective shared-cache policy without interpreting provider headers in core. */
+export function readCdnResponseCacheControl(headers: Headers | undefined): string | null {
+  if (!headers) return null;
+  const adapter = getCdnCacheAdapter();
+  return adapter.readResponseCacheControl
+    ? adapter.readResponseCacheControl(headers)
+    : headers.get("Cache-Control");
+}
+
+/** Ask the active adapter whether one policy header explicitly disables storage. */
+export function isNonCacheableCdnResponsePolicy(name: string, value: string): boolean {
+  if (name.toLowerCase() === "cache-control") return isNonCacheableCacheControl(value);
+  return hasExplicitNonCacheableResponsePolicy(new Headers({ [name]: value }));
 }
 
 /** Capture only cache-policy provenance from an outer composition stage. */
-function captureCdnResponsePolicyHeaders(headers: Headers): Headers {
+export function captureCdnResponsePolicyHeaders(headers: Headers): Headers {
   const policy = new Headers();
-  for (const name of getCdnResponsePolicyHeaderNames()) {
-    const value = headers.get(name);
-    if (value !== null) policy.set(name, value);
+  for (const [name, value] of headers) {
+    if (isCdnResponsePolicyHeader(name)) policy.set(name, value);
   }
   return policy;
 }
@@ -133,16 +159,14 @@ export function reconcileCdnResponseHeadersAfterOuterPolicy(
     applyCdnResponseHeaders(headers, { cacheControl });
     // Preserve any explicit provider-specific policy authored alongside the
     // generic middleware policy after the adapter has derived its defaults.
-    for (const name of getCdnResponsePolicyHeaderNames()) {
+    for (const [name, value] of outerPolicyHeaders) {
       if (name === "cache-control") continue;
-      const value = outerPolicyHeaders.get(name);
-      if (value !== null) headers.set(name, value);
+      if (isCdnResponsePolicyHeader(name)) headers.set(name, value);
     }
     return;
   }
-  for (const name of getCdnResponsePolicyHeaderNames()) {
-    const value = outerPolicyHeaders.get(name);
-    if (value !== null && isNonCacheableCacheControl(value)) {
+  for (const [name, value] of outerPolicyHeaders) {
+    if (isCdnResponsePolicyHeader(name) && isNonCacheableCdnResponsePolicy(name, value)) {
       headers.set(name, value);
       applyCdnResponseHeaders(headers, { cacheControl: value });
       return;

--- a/packages/vinext/src/server/cache-control.ts
+++ b/packages/vinext/src/server/cache-control.ts
@@ -35,9 +35,9 @@ export function hasExplicitNonCacheableResponsePolicy(
   headers: Headers,
   baseline?: Headers,
 ): boolean {
-  const adapter = getCdnCacheAdapter();
-  if (adapter.hasExplicitNonCacheableResponsePolicy) {
-    return adapter.hasExplicitNonCacheableResponsePolicy(headers, baseline);
+  const policy = getCdnCacheAdapter().responsePolicy;
+  if (policy) {
+    return policy.hasExplicitNonCacheablePolicy(headers, baseline);
   }
   const cacheControl = headers.get("Cache-Control");
   return Boolean(
@@ -51,7 +51,7 @@ export function hasExplicitNonCacheableResponsePolicy(
 export function isCdnResponsePolicyHeader(name: string): boolean {
   return (
     name.toLowerCase() === "cache-control" ||
-    getCdnCacheAdapter().isResponsePolicyHeader?.(name) === true
+    getCdnCacheAdapter().responsePolicy?.isHeader(name) === true
   );
 }
 
@@ -63,10 +63,8 @@ export function hasCdnResponsePolicy(headers: Headers): boolean {
 /** Read the effective shared-cache policy without interpreting provider headers in core. */
 export function readCdnResponseCacheControl(headers: Headers | undefined): string | null {
   if (!headers) return null;
-  const adapter = getCdnCacheAdapter();
-  return adapter.readResponseCacheControl
-    ? adapter.readResponseCacheControl(headers)
-    : headers.get("Cache-Control");
+  const policy = getCdnCacheAdapter().responsePolicy;
+  return policy ? policy.readCacheControl(headers) : headers.get("Cache-Control");
 }
 
 /** Ask the active adapter whether one policy header explicitly disables storage. */
@@ -167,8 +165,7 @@ export function reconcileCdnResponseHeadersAfterOuterPolicy(
   }
   for (const [name, value] of outerPolicyHeaders) {
     if (isCdnResponsePolicyHeader(name) && isNonCacheableCdnResponsePolicy(name, value)) {
-      headers.set(name, value);
-      applyCdnResponseHeaders(headers, { cacheControl: value });
+      applyCdnResponseHeaders(headers, { cacheControl: NO_STORE_CACHE_CONTROL });
       return;
     }
   }

--- a/packages/vinext/src/server/cacheability-request.ts
+++ b/packages/vinext/src/server/cacheability-request.ts
@@ -1,17 +1,16 @@
 import type { ExecutionContextLike } from "vinext/shims/request-context";
 import {
   CACHEABILITY_REQUEST_STATE,
-  CACHEABILITY_POLICY_HEADERS,
   type RouteCacheabilityOutcome,
   type RouteCacheabilityState,
 } from "vinext/shims/cacheability-classification";
 import {
   applyCdnResponseBuildIdentityHeaders,
   applyCdnResponseHeaders,
-  getCdnResponsePolicyHeaderNames,
   hasExplicitNonCacheableResponsePolicy,
   isNonCacheableCacheControl,
   NO_STORE_CACHE_CONTROL,
+  readCdnResponseCacheControl,
 } from "./cache-control.js";
 import {
   VINEXT_CACHEABILITY_PROBE_HEADER,
@@ -143,7 +142,6 @@ export function createWorkerCacheabilityProbeContext(
   const state: RouteCacheabilityState = {
     captureDeadlineAt: Date.now() + CACHEABILITY_PROBE_TIMEOUT_MS,
     mode,
-    responsePolicyHeaderNames: [...getCdnResponsePolicyHeaderNames()],
     responseVary,
     resolvedRoutePathname,
   };
@@ -206,7 +204,6 @@ export function createWorkerCacheabilityAdmissionContext(
       captureDeadlineAt: Date.now() + CACHEABILITY_PROBE_TIMEOUT_MS,
       mode: "admit",
       applyCompletedResponsePolicy: options?.applyCompletedResponsePolicy,
-      responsePolicyHeaderNames: [...getCdnResponsePolicyHeaderNames()],
       responseVary,
     };
     return Object.assign(Object.create(Object.getPrototypeOf(base)), base, {
@@ -229,7 +226,6 @@ export function createWorkerCacheabilityAdmissionContext(
     captureDeadlineAt: Date.now() + CACHEABILITY_PROBE_TIMEOUT_MS,
     mode: "admit",
     applyCompletedResponsePolicy: options?.applyCompletedResponsePolicy,
-    responsePolicyHeaderNames: [...getCdnResponsePolicyHeaderNames()],
     responseVary,
   };
   return Object.assign(Object.create(Object.getPrototypeOf(base)), base, {
@@ -613,18 +609,14 @@ function inferFinalAppPageCacheability(
   // Config headers run after the framework snapshots its provisional policy.
   // Match Next.js by honoring a later explicit public policy instead of
   // replacing it with the renderer-derived default during admission.
-  const changedPolicy = [...(state.responsePolicyHeaderNames ?? CACHEABILITY_POLICY_HEADERS)]
-    .reverse()
-    .find((name) => {
-      const value = response.headers.get(name);
-      return (
-        value !== null &&
-        (state.explicitConfigCachePolicy || value !== state.frameworkResponseCachePolicy?.[name])
-      );
-    });
-  if (!changedPolicy) return null;
-
-  const cacheControl = response.headers.get(changedPolicy)!;
+  const cacheControl = readCdnResponseCacheControl(response.headers);
+  if (
+    cacheControl === null ||
+    (!state.explicitConfigCachePolicy &&
+      cacheControl === readCdnResponseCacheControl(state.frameworkResponseCachePolicy))
+  ) {
+    return null;
+  }
   if (isNonCacheableCacheControl(cacheControl)) return { cacheable: false };
   return {
     cacheable: true,
@@ -637,10 +629,7 @@ function inferPagesPageCacheability(
   response: Response,
   state: RouteCacheabilityState,
 ): RouteCacheabilityOutcome {
-  const cacheControl = [...(state.responsePolicyHeaderNames ?? CACHEABILITY_POLICY_HEADERS)]
-    .reverse()
-    .map((name) => response.headers.get(name))
-    .find((value) => value !== null);
+  const cacheControl = readCdnResponseCacheControl(response.headers);
   if (!cacheControl || isNonCacheableCacheControl(cacheControl)) {
     return { cacheable: false };
   }
@@ -708,17 +697,10 @@ function cacheabilityEvaluationFailureResponse(pattern: string): Response {
 function hasStrictFinalResponseVeto(response: Response, state: RouteCacheabilityState): boolean {
   if (state.finalResponseVetoReason || response.headers.has("set-cookie")) return true;
 
-  for (const name of state.responsePolicyHeaderNames ?? CACHEABILITY_POLICY_HEADERS) {
-    const value = response.headers.get(name);
-    if (
-      value !== null &&
-      value !== state.frameworkResponseCachePolicy?.[name] &&
-      isNonCacheableCacheControl(value)
-    ) {
-      return true;
-    }
-  }
-  return false;
+  return hasExplicitNonCacheableResponsePolicy(
+    response.headers,
+    state.frameworkResponseCachePolicy,
+  );
 }
 
 async function finalizeWorkerCacheabilityAdmission(

--- a/packages/vinext/src/server/config-headers.ts
+++ b/packages/vinext/src/server/config-headers.ts
@@ -10,8 +10,7 @@ import {
   markRouteCacheabilityExplicitConfigPolicy,
   markRouteCacheabilityFinalResponseUncacheable,
 } from "vinext/shims/cacheability-classification";
-import { isNonCacheableCacheControl } from "vinext/shims/cdn-cache";
-import { getCdnResponsePolicyHeaderNames } from "./cache-control.js";
+import { isCdnResponsePolicyHeader, isNonCacheableCdnResponsePolicy } from "./cache-control.js";
 import { mergeVaryHeader } from "./middleware-response-headers.js";
 
 const ADDITIVE_CONFIG_HEADER_NAMES = new Set(["set-cookie", "vary"]);
@@ -43,7 +42,7 @@ export function resolveResponseStageCachePolicy({
       const name = header.key.toLowerCase();
       return (
         name === "vary" ||
-        (getCdnResponsePolicyHeaderNames().has(name) && !isNonCacheableCacheControl(header.value))
+        (isCdnResponsePolicyHeader(name) && !isNonCacheableCdnResponsePolicy(name, header.value))
       );
     })
     .map((header) => [header.key, header.value] as [string, string]);
@@ -76,10 +75,10 @@ function markExplicitConfigResponseVeto(
       markRouteCacheabilityFinalResponseUncacheable("next.config headers set a cookie");
       continue;
     }
-    if (getCdnResponsePolicyHeaderNames().has(name)) {
+    if (isCdnResponsePolicyHeader(name)) {
       markRouteCacheabilityExplicitConfigPolicy();
     }
-    if (getCdnResponsePolicyHeaderNames().has(name) && isNonCacheableCacheControl(header.value)) {
+    if (isCdnResponsePolicyHeader(name) && isNonCacheableCdnResponsePolicy(name, header.value)) {
       markRouteCacheabilityFinalResponseUncacheable(
         `next.config headers set a non-cacheable ${header.key} policy`,
       );
@@ -98,7 +97,7 @@ type ApplyConfigHeadersOptions = {
    */
   basePathState?: BasePathMatchState;
   /** Existing framework-generated headers that matching config rules may replace. */
-  overwriteExisting?: ReadonlySet<string>;
+  overwriteExisting?: ReadonlySet<string> | ((name: string) => boolean);
   /** Renderer and Edge-handler Link values are emitted after config headers in Next.js. */
   appendToPostConfigLink?: boolean;
   /** Middleware response headers run after config and therefore suppress config values. */
@@ -196,7 +195,12 @@ export function applyConfigHeadersToResponse(
       mergeVaryHeader(responseHeaders, header.value);
     } else if (ADDITIVE_CONFIG_HEADER_NAMES.has(lowerName)) {
       responseHeaders.append(header.key, header.value);
-    } else if (options.overwriteExisting?.has(lowerName) || !responseHeaders.has(lowerName)) {
+    } else if (
+      (typeof options.overwriteExisting === "function"
+        ? options.overwriteExisting(lowerName)
+        : options.overwriteExisting?.has(lowerName)) ||
+      !responseHeaders.has(lowerName)
+    ) {
       responseHeaders.set(header.key, header.value);
     }
   }

--- a/packages/vinext/src/shims/cacheability-classification.ts
+++ b/packages/vinext/src/shims/cacheability-classification.ts
@@ -2,9 +2,6 @@ import { getRequestExecutionContext } from "./request-context.js";
 
 export const CACHEABILITY_REQUEST_STATE = Symbol.for("vinext.cacheabilityRequestState");
 
-/** Cache-policy response headers owned by core itself. */
-export const CACHEABILITY_POLICY_HEADERS = ["cache-control"] as const;
-
 export type RouteCacheabilityOutcome = {
   cacheControl?: string;
   cacheable: boolean;
@@ -40,7 +37,7 @@ export type RouteCacheabilityState = {
   forcedDynamicReason?: string;
   /** A route-config decision that applies to every concrete identity for this pattern. */
   patternDynamicReason?: string;
-  frameworkResponseCachePolicy?: Partial<Record<string, string>>;
+  frameworkResponseCachePolicy?: Headers;
   mode: "admit" | "identity" | "probe";
   outcome?: RouteCacheabilityOutcome;
   preserveResponseCachePolicy?: boolean;
@@ -48,8 +45,6 @@ export type RouteCacheabilityState = {
   responseVary?: "verbatim";
   /** Concrete pathname resolved by the trusted request stage before rendering. */
   resolvedRoutePathname?: string;
-  /** Lowercase cache-policy names owned by core and the active CDN adapter. */
-  responsePolicyHeaderNames?: readonly string[];
   probeBailout?: {
     kind: "private-cache";
     outcome: RouteCacheabilityOutcome;
@@ -162,19 +157,13 @@ export function markRouteCacheabilityResponseBodyComplete(): void {
 export function captureRouteCacheabilityResponsePolicy(headers: Headers): void {
   const state = readRouteCacheabilityState();
   if (!state || state.mode !== "admit") return;
-
-  const policy: Partial<Record<string, string>> = {};
-  for (const name of state.responsePolicyHeaderNames ?? CACHEABILITY_POLICY_HEADERS) {
-    const value = headers.get(name);
-    if (value !== null) policy[name] = value;
-  }
   // Framework response shaping has more than one trusted phase. In
   // particular, the App Page renderer can leave Cache-Control absent before
   // the outer response finalizer applies the adapter's provisional no-store
   // default. Keep the latest trusted snapshot; configurable response headers
   // run after the final capture and remain visible to the strict admission
   // comparison below.
-  state.frameworkResponseCachePolicy = policy;
+  state.frameworkResponseCachePolicy = new Headers(headers);
 }
 
 /** True only for an authenticated probe that must render the matched App Page. */

--- a/packages/vinext/src/shims/cdn-cache.ts
+++ b/packages/vinext/src/shims/cdn-cache.ts
@@ -59,6 +59,19 @@ export type CdnCacheableHeaderInput = {
   tags?: readonly string[];
 };
 
+export type CdnResponsePolicy = {
+  /** Whether a provider-specific response header controls shared caching. */
+  isHeader(name: string): boolean;
+  /**
+   * Read the effective shared-cache policy from a response. The returned value
+   * uses Cache-Control syntax so core can apply the framework's cacheability
+   * rules without knowing which provider header carried it.
+   */
+  readCacheControl(headers: Headers): string | null;
+  /** Whether provider policy explicitly opts out of storage. */
+  hasExplicitNonCacheablePolicy(headers: Headers, baseline?: Headers): boolean;
+};
+
 /** Whether a Cache-Control value contains an exact non-cacheable directive. */
 export function isNonCacheableCacheControl(cacheControl: string): boolean {
   let start = 0;
@@ -104,15 +117,8 @@ export type CdnCacheAdapter = {
    */
   readonly responseVary?: "verbatim";
 
-  /** Whether a provider-specific response header controls shared caching. */
-  isResponsePolicyHeader?(name: string): boolean;
-
-  /**
-   * Read the effective shared-cache policy from a response. The returned value
-   * uses Cache-Control syntax so core can apply the framework's cacheability
-   * rules without knowing which provider header carried it.
-   */
-  readResponseCacheControl?(headers: Headers): string | null;
+  /** Provider-specific response-policy interpretation, when the adapter has one. */
+  readonly responsePolicy?: CdnResponsePolicy;
 
   /**
    * Fresh App Page responses must reach clean EOF before this adapter may emit
@@ -168,15 +174,6 @@ export type CdnCacheAdapter = {
    * paths that do not pass through cache-policy finalization.
    */
   buildResponseIdentityHeaders?(): CdnResponseHeaders;
-
-  /**
-   * Whether existing response headers explicitly opt out of storage. Adapters
-   * that split browser and provider cache policy should implement this so they
-   * can interpret the provider-specific headers they own.
-   *
-   * When omitted, core inspects only the generic `Cache-Control` header.
-   */
-  hasExplicitNonCacheableResponsePolicy?(headers: Headers, baseline?: Headers): boolean;
 
   /**
    * Whether the **origin** runs in-process background regeneration when a stale

--- a/packages/vinext/src/shims/cdn-cache.ts
+++ b/packages/vinext/src/shims/cdn-cache.ts
@@ -104,8 +104,15 @@ export type CdnCacheAdapter = {
    */
   readonly responseVary?: "verbatim";
 
-  /** Provider-specific response headers whose values control shared caching. */
-  readonly responsePolicyHeaderNames?: readonly string[];
+  /** Whether a provider-specific response header controls shared caching. */
+  isResponsePolicyHeader?(name: string): boolean;
+
+  /**
+   * Read the effective shared-cache policy from a response. The returned value
+   * uses Cache-Control syntax so core can apply the framework's cacheability
+   * rules without knowing which provider header carried it.
+   */
+  readResponseCacheControl?(headers: Headers): string | null;
 
   /**
    * Fresh App Page responses must reach clean EOF before this adapter may emit
@@ -169,7 +176,7 @@ export type CdnCacheAdapter = {
    *
    * When omitted, core inspects only the generic `Cache-Control` header.
    */
-  hasExplicitNonCacheableResponsePolicy?(headers: Headers): boolean;
+  hasExplicitNonCacheableResponsePolicy?(headers: Headers, baseline?: Headers): boolean;
 
   /**
    * Whether the **origin** runs in-process background regeneration when a stale

--- a/tests/app-route-handler-execution.test.ts
+++ b/tests/app-route-handler-execution.test.ts
@@ -321,9 +321,11 @@ describe("app route handler execution helpers", () => {
         hasExplicitNonCacheableResponsePolicy(headers) {
           return headers.get(policyHeader)?.includes("no-store") === true;
         },
+        isResponsePolicyHeader(name) {
+          return name.toLowerCase() === policyHeader.toLowerCase();
+        },
         ownsBackgroundRevalidation: false,
         async revalidateTag() {},
-        responsePolicyHeaderNames: [policyHeader],
         async set() {},
       };
       setCdnCacheAdapter(adapter);

--- a/tests/app-route-handler-execution.test.ts
+++ b/tests/app-route-handler-execution.test.ts
@@ -318,11 +318,16 @@ describe("app route handler execution helpers", () => {
         async get() {
           return null;
         },
-        hasExplicitNonCacheableResponsePolicy(headers) {
-          return headers.get(policyHeader)?.includes("no-store") === true;
-        },
-        isResponsePolicyHeader(name) {
-          return name.toLowerCase() === policyHeader.toLowerCase();
+        responsePolicy: {
+          hasExplicitNonCacheablePolicy(headers) {
+            return headers.get(policyHeader)?.includes("no-store") === true;
+          },
+          isHeader(name) {
+            return name.toLowerCase() === policyHeader.toLowerCase();
+          },
+          readCacheControl(headers) {
+            return headers.get(policyHeader) ?? headers.get("Cache-Control");
+          },
         },
         ownsBackgroundRevalidation: false,
         async revalidateTag() {},

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -213,9 +213,12 @@ function useSplitPolicyAdapter(): void {
   setCdnCacheAdapter({
     buildResponseHeaders: ({ cacheControl }) => ({ "Cache-Control": cacheControl }),
     ownsBackgroundRevalidation: false,
-    isResponsePolicyHeader: (name) => name.toLowerCase() === "cdn-cache-control",
-    readResponseCacheControl: (headers) =>
-      headers.get("CDN-Cache-Control") ?? headers.get("Cache-Control"),
+    responsePolicy: {
+      isHeader: (name) => name.toLowerCase() === "cdn-cache-control",
+      readCacheControl: (headers) =>
+        headers.get("CDN-Cache-Control") ?? headers.get("Cache-Control"),
+      hasExplicitNonCacheablePolicy: () => false,
+    },
     async get() {
       return null;
     },
@@ -785,9 +788,12 @@ describe("createAppRscHandler", () => {
   it("clears shared Pages stage metadata when outer config makes the response private", async () => {
     const adapter: CdnCacheAdapter = {
       ownsBackgroundRevalidation: false,
-      isResponsePolicyHeader: (name) => name.toLowerCase() === "cdn-cache-control",
-      readResponseCacheControl: (headers) =>
-        headers.get("CDN-Cache-Control") ?? headers.get("Cache-Control"),
+      responsePolicy: {
+        isHeader: (name) => name.toLowerCase() === "cdn-cache-control",
+        readCacheControl: (headers) =>
+          headers.get("CDN-Cache-Control") ?? headers.get("Cache-Control"),
+        hasExplicitNonCacheablePolicy: () => false,
+      },
       async get() {
         return null;
       },

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -213,7 +213,9 @@ function useSplitPolicyAdapter(): void {
   setCdnCacheAdapter({
     buildResponseHeaders: ({ cacheControl }) => ({ "Cache-Control": cacheControl }),
     ownsBackgroundRevalidation: false,
-    responsePolicyHeaderNames: ["CDN-Cache-Control"],
+    isResponsePolicyHeader: (name) => name.toLowerCase() === "cdn-cache-control",
+    readResponseCacheControl: (headers) =>
+      headers.get("CDN-Cache-Control") ?? headers.get("Cache-Control"),
     async get() {
       return null;
     },
@@ -783,7 +785,9 @@ describe("createAppRscHandler", () => {
   it("clears shared Pages stage metadata when outer config makes the response private", async () => {
     const adapter: CdnCacheAdapter = {
       ownsBackgroundRevalidation: false,
-      responsePolicyHeaderNames: ["CDN-Cache-Control"],
+      isResponsePolicyHeader: (name) => name.toLowerCase() === "cdn-cache-control",
+      readResponseCacheControl: (headers) =>
+        headers.get("CDN-Cache-Control") ?? headers.get("Cache-Control"),
       async get() {
         return null;
       },

--- a/tests/app-rsc-response-finalizer.test.ts
+++ b/tests/app-rsc-response-finalizer.test.ts
@@ -79,8 +79,13 @@ describe("finalizeAppRscResponse — config header application", () => {
       buildResponseHeaders({ cacheControl }): CdnResponseHeaders {
         return cacheControl ? { "Cache-Control": cacheControl, "X-Example-Edge-Policy": null } : {};
       },
-      hasExplicitNonCacheableResponsePolicy(headers) {
-        return headers.get("X-Example-Edge-Policy") === "no-store";
+      responsePolicy: {
+        isHeader: (name) => name.toLowerCase() === "x-example-edge-policy",
+        readCacheControl: (headers) =>
+          headers.get("X-Example-Edge-Policy") ?? headers.get("Cache-Control"),
+        hasExplicitNonCacheablePolicy(headers) {
+          return headers.get("X-Example-Edge-Policy") === "no-store";
+        },
       },
       async revalidateTag() {},
     };
@@ -109,9 +114,6 @@ describe("finalizeAppRscResponse — config header application", () => {
       async set() {},
       buildResponseHeaders({ cacheControl }): CdnResponseHeaders {
         return { "Cache-Control": cacheControl || "no-store" };
-      },
-      hasExplicitNonCacheableResponsePolicy(headers) {
-        return headers.get("Cache-Control")?.includes("no-store") === true;
       },
       async revalidateTag() {},
     };

--- a/tests/app-rsc-response-finalizer.test.ts
+++ b/tests/app-rsc-response-finalizer.test.ts
@@ -145,7 +145,7 @@ describe("finalizeAppRscResponse — config header application", () => {
       executionContext,
       CACHEABILITY_REQUEST_STATE,
     ) as RouteCacheabilityState;
-    expect(state.frameworkResponseCachePolicy).toEqual({ "cache-control": "no-store" });
+    expect([...state.frameworkResponseCachePolicy!]).toEqual([["cache-control", "no-store"]]);
     expect(state.finalResponseVetoReason).toContain("next.config headers set a non-cacheable");
   });
 

--- a/tests/cache-adapters-config.test.ts
+++ b/tests/cache-adapters-config.test.ts
@@ -17,7 +17,7 @@ import {
   generateCdnCacheAdapterModule,
   loadVinextCacheConfigFromViteConfig,
   generateCacheAdaptersModule,
-  getConfiguredCdnResponsePolicyHeaderNames,
+  isConfiguredCdnResponsePolicyHeader,
   hasBuildIdentityResponseHeader,
   hasUncachedRequestRouting,
   hasVerbatimResponseVary,
@@ -382,7 +382,7 @@ describe("cdnAdapter builder + factory", () => {
     ).toBeNull();
     expect(descriptor.capabilities).toEqual({
       buildIdentity: "response-header",
-      responsePolicyHeaderNames: ["CDN-Cache-Control", "Cloudflare-CDN-Cache-Control"],
+      isResponsePolicyHeader: expect.any(Function),
       requestRouting: "uncached-stage",
       responseVary: "verbatim",
       routeCacheability: "probe-manifest",
@@ -393,16 +393,18 @@ describe("cdnAdapter builder + factory", () => {
     expect(hasBuildIdentityResponseHeader({ cdn: { adapter: "custom-cache" } })).toBe(false);
     expect(hasUncachedRequestRouting({ cdn: { adapter: "url-only-cache" } })).toBe(false);
     expect(hasVerbatimResponseVary({ cdn: { adapter: "url-only-cache" } })).toBe(false);
-    expect(
-      getConfiguredCdnResponsePolicyHeaderNames({
-        cdn: {
-          adapter: "custom-cache",
-          capabilities: {
-            responsePolicyHeaderNames: [" X-Example-Policy ", "CACHE-CONTROL", ""],
-          },
+    const custom = {
+      cdn: {
+        adapter: "custom-cache",
+        capabilities: {
+          isResponsePolicyHeader: (name: string) =>
+            name.trim().toLowerCase() === "x-example-policy",
         },
-      }),
-    ).toEqual(["cache-control", "x-example-policy"]);
+      },
+    };
+    expect(isConfiguredCdnResponsePolicyHeader(custom, "Cache-Control")).toBe(true);
+    expect(isConfiguredCdnResponsePolicyHeader(custom, " X-Example-Policy ")).toBe(true);
+    expect(isConfiguredCdnResponsePolicyHeader(custom, "X-Unrelated")).toBe(false);
   });
 
   it("factory returns a CloudflareCdnCacheAdapter", () => {

--- a/tests/cache-control.test.ts
+++ b/tests/cache-control.test.ts
@@ -81,7 +81,7 @@ describe("applyCdnResponseHeaders", () => {
     process.env.VINEXT_NEXT_DEPLOY_CACHE_CONTROL = "1";
     const edge: CdnCacheAdapter = {
       ownsBackgroundRevalidation: false,
-      responsePolicyHeaderNames: ["CDN-Cache-Control"],
+      isResponsePolicyHeader: (name) => name.toLowerCase() === "cdn-cache-control",
       async get() {
         return null;
       },
@@ -137,7 +137,7 @@ describe("applyCdnResponseHeaders", () => {
   it("captures only request-stage policy values that differ from the inner response", () => {
     const edge: CdnCacheAdapter = {
       ownsBackgroundRevalidation: false,
-      responsePolicyHeaderNames: ["CDN-Cache-Control"],
+      isResponsePolicyHeader: (name) => name.toLowerCase() === "cdn-cache-control",
       async get() {
         return null;
       },
@@ -194,7 +194,11 @@ describe("applyCdnResponseHeaders", () => {
   it("clears an inner artifact's provider policy when outer composition turns private", () => {
     const edge: CdnCacheAdapter = {
       ownsBackgroundRevalidation: false,
-      responsePolicyHeaderNames: ["X-Example-Edge-Policy"],
+      isResponsePolicyHeader: (name) => name.toLowerCase() === "x-example-edge-policy",
+      readResponseCacheControl: (headers) =>
+        headers.get("X-Example-Edge-Policy") ?? headers.get("Cache-Control"),
+      hasExplicitNonCacheableResponsePolicy: (headers) =>
+        [...headers.values()].some((value) => value.includes("no-store")),
       async get() {
         return null;
       },
@@ -230,7 +234,7 @@ describe("applyCdnResponseHeaders", () => {
   it("clears an inner artifact's provider policy when outer composition sets a cookie", () => {
     const edge: CdnCacheAdapter = {
       ownsBackgroundRevalidation: false,
-      responsePolicyHeaderNames: ["X-Example-Edge-Policy"],
+      isResponsePolicyHeader: (name) => name.toLowerCase() === "x-example-edge-policy",
       async get() {
         return null;
       },

--- a/tests/cache-control.test.ts
+++ b/tests/cache-control.test.ts
@@ -81,7 +81,12 @@ describe("applyCdnResponseHeaders", () => {
     process.env.VINEXT_NEXT_DEPLOY_CACHE_CONTROL = "1";
     const edge: CdnCacheAdapter = {
       ownsBackgroundRevalidation: false,
-      isResponsePolicyHeader: (name) => name.toLowerCase() === "cdn-cache-control",
+      responsePolicy: {
+        isHeader: (name) => name.toLowerCase() === "cdn-cache-control",
+        readCacheControl: (headers) =>
+          headers.get("CDN-Cache-Control") ?? headers.get("Cache-Control"),
+        hasExplicitNonCacheablePolicy: () => false,
+      },
       async get() {
         return null;
       },
@@ -137,7 +142,13 @@ describe("applyCdnResponseHeaders", () => {
   it("captures only request-stage policy values that differ from the inner response", () => {
     const edge: CdnCacheAdapter = {
       ownsBackgroundRevalidation: false,
-      isResponsePolicyHeader: (name) => name.toLowerCase() === "cdn-cache-control",
+      responsePolicy: {
+        isHeader: (name) => name.toLowerCase() === "cdn-cache-control",
+        readCacheControl: (headers) =>
+          headers.get("CDN-Cache-Control") ?? headers.get("Cache-Control"),
+        hasExplicitNonCacheablePolicy: (headers) =>
+          headers.get("CDN-Cache-Control")?.includes("no-store") === true,
+      },
       async get() {
         return null;
       },
@@ -194,11 +205,13 @@ describe("applyCdnResponseHeaders", () => {
   it("clears an inner artifact's provider policy when outer composition turns private", () => {
     const edge: CdnCacheAdapter = {
       ownsBackgroundRevalidation: false,
-      isResponsePolicyHeader: (name) => name.toLowerCase() === "x-example-edge-policy",
-      readResponseCacheControl: (headers) =>
-        headers.get("X-Example-Edge-Policy") ?? headers.get("Cache-Control"),
-      hasExplicitNonCacheableResponsePolicy: (headers) =>
-        [...headers.values()].some((value) => value.includes("no-store")),
+      responsePolicy: {
+        isHeader: (name) => name.toLowerCase() === "x-example-edge-policy",
+        readCacheControl: (headers) =>
+          headers.get("X-Example-Edge-Policy") ?? headers.get("Cache-Control"),
+        hasExplicitNonCacheablePolicy: (headers) =>
+          [...headers.values()].some((value) => value.includes("no-store")),
+      },
       async get() {
         return null;
       },
@@ -226,15 +239,59 @@ describe("applyCdnResponseHeaders", () => {
       new Headers({ "X-Example-Edge-Policy": "private, no-store" }),
     );
 
-    expect(headers.get("Cache-Control")).toBe("private, no-store");
+    expect(headers.get("Cache-Control")).toBe("no-store, must-revalidate");
     expect(headers.get("X-Example-Edge-Policy")).toBeNull();
     expect(headers.get("X-Example-Cache-Tag")).toBeNull();
+  });
+
+  it("does not reinterpret an opaque provider veto as generic Cache-Control", () => {
+    const edge: CdnCacheAdapter = {
+      ownsBackgroundRevalidation: false,
+      responsePolicy: {
+        isHeader: (name) => name.toLowerCase() === "x-example-edge-policy",
+        readCacheControl: (headers) =>
+          headers.get("X-Example-Edge-Policy") === "allow"
+            ? "public, s-maxage=60"
+            : headers.get("X-Example-Edge-Policy") === "deny"
+              ? "no-store"
+              : headers.get("Cache-Control"),
+        hasExplicitNonCacheablePolicy: (headers) => headers.get("X-Example-Edge-Policy") === "deny",
+      },
+      async get() {
+        return null;
+      },
+      async set() {},
+      buildResponseHeaders({ cacheControl }) {
+        return cacheControl.includes("no-store")
+          ? { "Cache-Control": "no-store", "X-Example-Edge-Policy": null }
+          : { "Cache-Control": "max-age=0", "X-Example-Edge-Policy": "allow" };
+      },
+      async revalidateTag() {},
+    };
+    setCdnCacheAdapter(edge);
+    const headers = new Headers({
+      "Cache-Control": "max-age=0",
+      "X-Example-Edge-Policy": "allow",
+    });
+
+    reconcileCdnResponseHeadersAfterOuterPolicy(
+      headers,
+      new Headers({ "X-Example-Edge-Policy": "deny" }),
+    );
+
+    expect(headers.get("Cache-Control")).toBe("no-store");
+    expect(headers.get("X-Example-Edge-Policy")).toBeNull();
   });
 
   it("clears an inner artifact's provider policy when outer composition sets a cookie", () => {
     const edge: CdnCacheAdapter = {
       ownsBackgroundRevalidation: false,
-      isResponsePolicyHeader: (name) => name.toLowerCase() === "x-example-edge-policy",
+      responsePolicy: {
+        isHeader: (name) => name.toLowerCase() === "x-example-edge-policy",
+        readCacheControl: (headers) =>
+          headers.get("X-Example-Edge-Policy") ?? headers.get("Cache-Control"),
+        hasExplicitNonCacheablePolicy: () => false,
+      },
       async get() {
         return null;
       },
@@ -326,8 +383,13 @@ describe("applyCdnResponseHeaders", () => {
       buildResponseHeaders() {
         return {};
       },
-      hasExplicitNonCacheableResponsePolicy(headers) {
-        return headers.get("X-Example-Edge-Policy") === "no-store";
+      responsePolicy: {
+        isHeader: (name) => name.toLowerCase() === "x-example-edge-policy",
+        readCacheControl: (headers) =>
+          headers.get("X-Example-Edge-Policy") ?? headers.get("Cache-Control"),
+        hasExplicitNonCacheablePolicy(headers) {
+          return headers.get("X-Example-Edge-Policy") === "no-store";
+        },
       },
       async revalidateTag() {},
     };

--- a/tests/cacheability-admission.test.ts
+++ b/tests/cacheability-admission.test.ts
@@ -240,7 +240,7 @@ describe("single-request cacheability admission", () => {
       cacheable: true,
       cacheControl: "s-maxage=60, stale-while-revalidate=540",
     };
-    state.frameworkResponseCachePolicy = { "cache-control": "no-store" };
+    state.frameworkResponseCachePolicy = new Headers({ "Cache-Control": "no-store" });
 
     const response = await finalizeWorkerCacheabilityResponse(
       new Response("static", { headers: { "Cache-Control": "no-store" } }),
@@ -289,7 +289,7 @@ describe("single-request cacheability admission", () => {
       cacheable: true,
       cacheControl: "s-maxage=120, stale-while-revalidate=31535880",
     };
-    state.frameworkResponseCachePolicy = { "cache-control": "no-store" };
+    state.frameworkResponseCachePolicy = new Headers({ "Cache-Control": "no-store" });
 
     const response = await finalizeWorkerCacheabilityResponse(
       new Response("static", { headers: { "Cache-Control": "s-maxage=30" } }),
@@ -329,7 +329,7 @@ describe("single-request cacheability admission", () => {
     );
     const state = cacheabilityState(context);
     state.route = { kind: "app-page", pattern: "/page" };
-    state.frameworkResponseCachePolicy = { "cache-control": "no-store" };
+    state.frameworkResponseCachePolicy = new Headers({ "Cache-Control": "no-store" });
     state.completion = Promise.resolve({ cacheable: false, dynamicUsage: true });
 
     const response = await finalizeWorkerCacheabilityResponse(
@@ -353,7 +353,7 @@ describe("single-request cacheability admission", () => {
     );
     const state = cacheabilityState(context);
     state.route = { kind: "app-page", pattern: "/page" };
-    state.frameworkResponseCachePolicy = { "cache-control": "no-store" };
+    state.frameworkResponseCachePolicy = new Headers({ "Cache-Control": "no-store" });
     state.completion = Promise.resolve({ cacheable: false, dynamicUsage: true });
 
     const response = await finalizeWorkerCacheabilityResponse(
@@ -470,7 +470,7 @@ describe("single-request cacheability admission", () => {
         cacheable: true,
         cacheControl: "s-maxage=60, stale-while-revalidate=540",
       };
-      state.frameworkResponseCachePolicy = { "cache-control": "no-store" };
+      state.frameworkResponseCachePolicy = new Headers({ "Cache-Control": "no-store" });
 
       const response = await finalizeWorkerCacheabilityResponse(
         new Response("static", { headers: { "Cache-Control": "no-store" } }),
@@ -623,11 +623,7 @@ describe("single-request cacheability admission", () => {
       );
 
       expect(response.headers.get("Cache-Control")).toBe("public, max-age=0, must-revalidate");
-      expect(
-        adapter.responsePolicyHeaderNames
-          .map((name) => response.headers.get(name))
-          .find((value) => value !== null),
-      ).toBe("public, max-age=60");
+      expect(adapter.readResponseCacheControl(response.headers)).toBe("public, max-age=60");
     } finally {
       setCdnCacheAdapter(new DefaultCdnCacheAdapter());
       if (previousNextDeployPolicy === undefined) {
@@ -1126,23 +1122,23 @@ describe("single-request cacheability admission", () => {
     finalHeaders: Record<string, string>;
     initialPolicy: NonNullable<RouteCacheabilityState["frameworkResponseCachePolicy"]>;
     name: string;
-    responsePolicyHeaderNames?: readonly string[];
+    adapterPolicy?: true;
   }> = [
     {
       finalHeaders: { "Set-Cookie": "session=private; Path=/; HttpOnly" },
-      initialPolicy: {},
+      initialPolicy: new Headers(),
       name: "Set-Cookie",
     },
     {
       finalHeaders: { "Cache-Control": "private, no-store" },
-      initialPolicy: { "cache-control": "public, s-maxage=60" },
+      initialPolicy: new Headers({ "Cache-Control": "public, s-maxage=60" }),
       name: "Cache-Control",
     },
     {
       finalHeaders: { "X-Example-Edge-Policy": "private, no-store" },
-      initialPolicy: { "x-example-edge-policy": "public, s-maxage=60" },
+      initialPolicy: new Headers({ "X-Example-Edge-Policy": "public, s-maxage=60" }),
       name: "adapter-declared policy",
-      responsePolicyHeaderNames: ["cache-control", "x-example-edge-policy"],
+      adapterPolicy: true,
     },
   ];
 
@@ -1159,8 +1155,25 @@ describe("single-request cacheability admission", () => {
       const state = cacheabilityState(context);
       state.route = { kind: "app-page", pattern: "/page" };
       state.frameworkResponseCachePolicy = testCase.initialPolicy;
-      if (testCase.responsePolicyHeaderNames) {
-        state.responsePolicyHeaderNames = testCase.responsePolicyHeaderNames;
+      if (testCase.adapterPolicy) {
+        setCdnCacheAdapter({
+          buildResponseHeaders: ({ cacheControl }) => ({ "Cache-Control": cacheControl }),
+          hasExplicitNonCacheableResponsePolicy: (headers, baseline) => {
+            const value = headers.get("X-Example-Edge-Policy");
+            return (
+              value !== baseline?.get("X-Example-Edge-Policy") && value === "private, no-store"
+            );
+          },
+          isResponsePolicyHeader: (name) => name.toLowerCase() === "x-example-edge-policy",
+          ownsBackgroundRevalidation: false,
+          readResponseCacheControl: (headers) =>
+            headers.get("X-Example-Edge-Policy") ?? headers.get("Cache-Control"),
+          async get() {
+            return null;
+          },
+          async revalidateTag() {},
+          async set() {},
+        });
       }
       state.outcome = {
         cacheable: true,
@@ -1413,7 +1426,7 @@ describe("cacheability probe finalization", () => {
     const configuredState: RouteCacheabilityState = {
       captureDeadlineAt: Date.now() + 1_000,
       explicitConfigCachePolicy: true,
-      frameworkResponseCachePolicy: { "cache-control": "no-store" },
+      frameworkResponseCachePolicy: new Headers({ "Cache-Control": "no-store" }),
       mode: "probe",
       outcome: { cacheable: false, dynamicUsage: true },
       route: { kind: "app-page", pattern: "/posts/:slug" },

--- a/tests/cacheability-admission.test.ts
+++ b/tests/cacheability-admission.test.ts
@@ -623,7 +623,7 @@ describe("single-request cacheability admission", () => {
       );
 
       expect(response.headers.get("Cache-Control")).toBe("public, max-age=0, must-revalidate");
-      expect(adapter.readResponseCacheControl(response.headers)).toBe("public, max-age=60");
+      expect(adapter.responsePolicy.readCacheControl(response.headers)).toBe("public, max-age=60");
     } finally {
       setCdnCacheAdapter(new DefaultCdnCacheAdapter());
       if (previousNextDeployPolicy === undefined) {
@@ -1158,16 +1158,18 @@ describe("single-request cacheability admission", () => {
       if (testCase.adapterPolicy) {
         setCdnCacheAdapter({
           buildResponseHeaders: ({ cacheControl }) => ({ "Cache-Control": cacheControl }),
-          hasExplicitNonCacheableResponsePolicy: (headers, baseline) => {
-            const value = headers.get("X-Example-Edge-Policy");
-            return (
-              value !== baseline?.get("X-Example-Edge-Policy") && value === "private, no-store"
-            );
+          responsePolicy: {
+            hasExplicitNonCacheablePolicy: (headers, baseline) => {
+              const value = headers.get("X-Example-Edge-Policy");
+              return (
+                value !== baseline?.get("X-Example-Edge-Policy") && value === "private, no-store"
+              );
+            },
+            isHeader: (name) => name.toLowerCase() === "x-example-edge-policy",
+            readCacheControl: (headers) =>
+              headers.get("X-Example-Edge-Policy") ?? headers.get("Cache-Control"),
           },
-          isResponsePolicyHeader: (name) => name.toLowerCase() === "x-example-edge-policy",
           ownsBackgroundRevalidation: false,
-          readResponseCacheControl: (headers) =>
-            headers.get("X-Example-Edge-Policy") ?? headers.get("Cache-Control"),
           async get() {
             return null;
           },

--- a/tests/cloudflare-cdn-cache.test.ts
+++ b/tests/cloudflare-cdn-cache.test.ts
@@ -27,7 +27,7 @@ import { finalizeAppRscResponse } from "../packages/vinext/src/server/app-rsc-re
 import {
   applyCdnResponseHeaders,
   applyCdnResponseIdentityHeaders,
-  getCdnResponsePolicyHeaderNames,
+  isCdnResponsePolicyHeader,
 } from "../packages/vinext/src/server/cache-control.js";
 import { withResponseStageCacheability } from "../packages/vinext/src/server/response-stage-cacheability.js";
 import {
@@ -100,11 +100,10 @@ describe("CloudflareCdnCacheAdapter", () => {
   it("declares every provider policy header to the generic admission layer", () => {
     setCdnCacheAdapter(adapter);
 
-    expect([...getCdnResponsePolicyHeaderNames()]).toEqual([
-      "cache-control",
-      "cdn-cache-control",
-      "cloudflare-cdn-cache-control",
-    ]);
+    expect(isCdnResponsePolicyHeader("Cache-Control")).toBe(true);
+    expect(isCdnResponsePolicyHeader("CDN-Cache-Control")).toBe(true);
+    expect(isCdnResponsePolicyHeader("Cloudflare-CDN-Cache-Control")).toBe(true);
+    expect(isCdnResponsePolicyHeader("X-Unrelated")).toBe(false);
   });
 
   it("accepts a staged warmup only in its expected Worker version", async () => {
@@ -400,6 +399,15 @@ describe("CloudflareCdnCacheAdapter", () => {
     expect(
       adapter.hasExplicitNonCacheableResponsePolicy(
         new Headers({ "Cloudflare-CDN-Cache-Control": "private, no-store" }),
+      ),
+    ).toBe(true);
+    expect(
+      adapter.hasExplicitNonCacheableResponsePolicy(
+        new Headers({
+          "Cache-Control": "private, no-store",
+          "Cloudflare-CDN-Cache-Control": "public, max-age=60",
+        }),
+        new Headers({ "Cache-Control": "no-store" }),
       ),
     ).toBe(true);
   });

--- a/tests/cloudflare-cdn-cache.test.ts
+++ b/tests/cloudflare-cdn-cache.test.ts
@@ -389,7 +389,7 @@ describe("CloudflareCdnCacheAdapter", () => {
 
   it("interprets its own edge policy when checking whether a response opted out", () => {
     expect(
-      adapter.hasExplicitNonCacheableResponsePolicy(
+      adapter.responsePolicy.hasExplicitNonCacheablePolicy(
         new Headers({
           "Cache-Control": "no-store",
           "CDN-Cache-Control": "public, max-age=60",
@@ -397,12 +397,12 @@ describe("CloudflareCdnCacheAdapter", () => {
       ),
     ).toBe(false);
     expect(
-      adapter.hasExplicitNonCacheableResponsePolicy(
+      adapter.responsePolicy.hasExplicitNonCacheablePolicy(
         new Headers({ "Cloudflare-CDN-Cache-Control": "private, no-store" }),
       ),
     ).toBe(true);
     expect(
-      adapter.hasExplicitNonCacheableResponsePolicy(
+      adapter.responsePolicy.hasExplicitNonCacheablePolicy(
         new Headers({
           "Cache-Control": "private, no-store",
           "Cloudflare-CDN-Cache-Control": "public, max-age=60",

--- a/tests/pages-page-handler.test.ts
+++ b/tests/pages-page-handler.test.ts
@@ -293,12 +293,18 @@ describe("createPagesPageHandler — route miss", () => {
           "X-Example-Cache-Tag": input.tags?.join(",") ?? null,
         };
       },
-      hasExplicitNonCacheableResponsePolicy(headers) {
-        const edgePolicy = headers.get("X-Example-Edge-Policy");
-        if (edgePolicy && /(?:private|no-store|no-cache)/i.test(edgePolicy)) return true;
-        return Boolean(
-          !edgePolicy && /(?:private|no-store|no-cache)/i.test(headers.get("Cache-Control") ?? ""),
-        );
+      responsePolicy: {
+        isHeader: (name) => name.toLowerCase() === "x-example-edge-policy",
+        readCacheControl: (headers) =>
+          headers.get("X-Example-Edge-Policy") ?? headers.get("Cache-Control"),
+        hasExplicitNonCacheablePolicy(headers) {
+          const edgePolicy = headers.get("X-Example-Edge-Policy");
+          if (edgePolicy && /(?:private|no-store|no-cache)/i.test(edgePolicy)) return true;
+          return Boolean(
+            !edgePolicy &&
+            /(?:private|no-store|no-cache)/i.test(headers.get("Cache-Control") ?? ""),
+          );
+        },
       },
     };
     setCdnCacheAdapter(edgeAdapter);

--- a/tests/pages-request-worker-stage.test.ts
+++ b/tests/pages-request-worker-stage.test.ts
@@ -413,9 +413,12 @@ describe("Pages Worker request stage", () => {
     setCdnCacheAdapter({
       buildResponseHeaders: ({ cacheControl }) => ({ "Cache-Control": cacheControl }),
       ownsBackgroundRevalidation: false,
-      isResponsePolicyHeader: (name) => name.toLowerCase() === "cdn-cache-control",
-      readResponseCacheControl: (headers) =>
-        headers.get("CDN-Cache-Control") ?? headers.get("Cache-Control"),
+      responsePolicy: {
+        isHeader: (name) => name.toLowerCase() === "cdn-cache-control",
+        readCacheControl: (headers) =>
+          headers.get("CDN-Cache-Control") ?? headers.get("Cache-Control"),
+        hasExplicitNonCacheablePolicy: () => false,
+      },
       async get() {
         return null;
       },
@@ -508,9 +511,12 @@ describe("Pages Worker request stage", () => {
   it("lets an outer private config policy override a shared Pages artifact", async () => {
     const adapter: CdnCacheAdapter = {
       ownsBackgroundRevalidation: false,
-      isResponsePolicyHeader: (name) => name.toLowerCase() === "cdn-cache-control",
-      readResponseCacheControl: (headers) =>
-        headers.get("CDN-Cache-Control") ?? headers.get("Cache-Control"),
+      responsePolicy: {
+        isHeader: (name) => name.toLowerCase() === "cdn-cache-control",
+        readCacheControl: (headers) =>
+          headers.get("CDN-Cache-Control") ?? headers.get("Cache-Control"),
+        hasExplicitNonCacheablePolicy: () => false,
+      },
       buildResponseHeaders({ cacheControl }) {
         return {
           "Cache-Control": cacheControl,

--- a/tests/pages-request-worker-stage.test.ts
+++ b/tests/pages-request-worker-stage.test.ts
@@ -413,7 +413,9 @@ describe("Pages Worker request stage", () => {
     setCdnCacheAdapter({
       buildResponseHeaders: ({ cacheControl }) => ({ "Cache-Control": cacheControl }),
       ownsBackgroundRevalidation: false,
-      responsePolicyHeaderNames: ["CDN-Cache-Control"],
+      isResponsePolicyHeader: (name) => name.toLowerCase() === "cdn-cache-control",
+      readResponseCacheControl: (headers) =>
+        headers.get("CDN-Cache-Control") ?? headers.get("Cache-Control"),
       async get() {
         return null;
       },
@@ -506,7 +508,9 @@ describe("Pages Worker request stage", () => {
   it("lets an outer private config policy override a shared Pages artifact", async () => {
     const adapter: CdnCacheAdapter = {
       ownsBackgroundRevalidation: false,
-      responsePolicyHeaderNames: ["CDN-Cache-Control"],
+      isResponsePolicyHeader: (name) => name.toLowerCase() === "cdn-cache-control",
+      readResponseCacheControl: (headers) =>
+        headers.get("CDN-Cache-Control") ?? headers.get("Cache-Control"),
       buildResponseHeaders({ cacheControl }) {
         return {
           "Cache-Control": cacheControl,

--- a/tests/prerender-paths.test.ts
+++ b/tests/prerender-paths.test.ts
@@ -283,7 +283,7 @@ describe("prerender path manifest", () => {
     const manifest = await emitPrerenderPathManifest({
       root: tmpDir,
       buildIdentity: "response-header",
-      responsePolicyHeaderNames: ["CDN-Cache-Control"],
+      isResponsePolicyHeader: (name) => name.toLowerCase() === "cdn-cache-control",
       responseVary: "verbatim",
     });
 

--- a/tests/response-stage-cacheability.test.ts
+++ b/tests/response-stage-cacheability.test.ts
@@ -26,9 +26,13 @@ function admissionAdapter(): CdnCacheAdapter {
     buildResponseHeaders: ({ cacheControl }) => ({ "Cache-Control": cacheControl }),
     ownsBackgroundRevalidation: false,
     requiresCompletedResponseAdmission: true,
-    isResponsePolicyHeader: (name) => name.toLowerCase() === "cdn-cache-control",
-    readResponseCacheControl: (headers) =>
-      headers.get("CDN-Cache-Control") ?? headers.get("Cache-Control"),
+    responsePolicy: {
+      isHeader: (name) => name.toLowerCase() === "cdn-cache-control",
+      readCacheControl: (headers) =>
+        headers.get("CDN-Cache-Control") ?? headers.get("Cache-Control"),
+      hasExplicitNonCacheablePolicy: (headers) =>
+        headers.get("CDN-Cache-Control")?.includes("no-store") === true,
+    },
     responseVary: "verbatim",
     async get() {
       return null;
@@ -279,9 +283,12 @@ describe("response-stage cacheability", () => {
         "Cache-Control": "max-age=0, must-revalidate",
         "X-Example-Edge-Policy": cacheControl,
       }),
-      isResponsePolicyHeader: (name) => name.toLowerCase() === "x-example-edge-policy",
-      readResponseCacheControl: (headers) =>
-        headers.get("X-Example-Edge-Policy") ?? headers.get("Cache-Control"),
+      responsePolicy: {
+        isHeader: (name) => name.toLowerCase() === "x-example-edge-policy",
+        readCacheControl: (headers) =>
+          headers.get("X-Example-Edge-Policy") ?? headers.get("Cache-Control"),
+        hasExplicitNonCacheablePolicy: () => false,
+      },
     });
 
     const response = await withResponseStageCacheability(

--- a/tests/response-stage-cacheability.test.ts
+++ b/tests/response-stage-cacheability.test.ts
@@ -26,7 +26,9 @@ function admissionAdapter(): CdnCacheAdapter {
     buildResponseHeaders: ({ cacheControl }) => ({ "Cache-Control": cacheControl }),
     ownsBackgroundRevalidation: false,
     requiresCompletedResponseAdmission: true,
-    responsePolicyHeaderNames: ["CDN-Cache-Control"],
+    isResponsePolicyHeader: (name) => name.toLowerCase() === "cdn-cache-control",
+    readResponseCacheControl: (headers) =>
+      headers.get("CDN-Cache-Control") ?? headers.get("Cache-Control"),
     responseVary: "verbatim",
     async get() {
       return null;
@@ -277,7 +279,9 @@ describe("response-stage cacheability", () => {
         "Cache-Control": "max-age=0, must-revalidate",
         "X-Example-Edge-Policy": cacheControl,
       }),
-      responsePolicyHeaderNames: ["X-Example-Edge-Policy"],
+      isResponsePolicyHeader: (name) => name.toLowerCase() === "x-example-edge-policy",
+      readResponseCacheControl: (headers) =>
+        headers.get("X-Example-Edge-Policy") ?? headers.get("Cache-Control"),
     });
 
     const response = await withResponseStageCacheability(
@@ -295,7 +299,6 @@ describe("response-stage cacheability", () => {
       },
       async (context) => {
         const state = contextState(context)!;
-        expect(state.responsePolicyHeaderNames).toEqual(["cache-control", "x-example-edge-policy"]);
         state.route = { kind: "app-page", pattern: "/dynamic" };
         state.outcome = { cacheable: false };
         return new Response("dynamic");


### PR DESCRIPTION
## Summary

- replace provider response-policy header-name lists with CDN adapter predicates
- let adapters read effective cache policy and evaluate late non-cacheable overrides
- keep Cloudflare-specific cache header names inside `@vinext/cloudflare`
- preserve build-time probe planning and runtime admission behavior

## Validation

- `vp check`
- 849 focused cache, admission, App Router, and Pages Router tests
- `vp run vinext#build`
- `vp run @vinext/cloudflare#build`
- `git diff --check`