### PR TITLE
refactor(cache): normalize RSC requests after routing

### DIFF
--- a/packages/vinext/src/cache/cache-adapters-virtual.ts
+++ b/packages/vinext/src/cache/cache-adapters-virtual.ts
@@ -38,8 +38,8 @@ export type CdnCacheAdapterCapabilities = {
    * The shared cache selects response variants using every request header
    * named by `Vary`, comparing the header values verbatim.
    *
-   * Vinext only uses the canonical deploy-warmed RSC request shape when this
-   * guarantee is present. URL-only caches retain the contextual `_rsc` digest.
+   * Deploy warmup can address the canonical full-route and loading-shell RSC
+   * variants when this guarantee is present.
    */
   responseVary?: "verbatim";
   /** Warm by observing after-render `X-Vinext-Cache` admission from Response Store. */

--- a/packages/vinext/src/client/vinext-next-data.ts
+++ b/packages/vinext/src/client/vinext-next-data.ts
@@ -10,8 +10,6 @@ import { isUnknownRecord } from "../utils/record.js";
 
 export type VinextLinkPrefetchRoute = {
   canPrefetchLoadingShell: boolean;
-  /** The loading shell is an ordinary main-tree variant shared with deploy warmup. */
-  canUseCanonicalLoadingShell?: true;
   documentOnly?: boolean;
   isDynamic: boolean;
   patternParts: string[];

--- a/packages/vinext/src/entries/app-browser-entry.ts
+++ b/packages/vinext/src/entries/app-browser-entry.ts
@@ -4,7 +4,7 @@ import type {
   VinextPagesLinkPrefetchRoute,
 } from "../client/vinext-next-data.js";
 import { toClientRewrites } from "../client/client-rewrites.js";
-import { appRouteHasMainTreeLoadingBoundary, type AppRoute } from "../routing/app-router.js";
+import type { AppRoute } from "../routing/app-router.js";
 import { patternsStructurallyEquivalent, type RouteManifest } from "../routing/app-route-graph.js";
 import type { NextRewrite } from "../config/next-config.js";
 
@@ -117,9 +117,6 @@ export function toLinkPrefetchRoute(
 ): VinextLinkPrefetchRoute {
   return {
     canPrefetchLoadingShell: hasLoadingBoundary(route, hasSiblingInterceptLoading),
-    ...(appRouteHasMainTreeLoadingBoundary(route)
-      ? { canUseCanonicalLoadingShell: true as const }
-      : {}),
     patternParts: [...route.patternParts],
     isDynamic: route.isDynamic,
     ...(requiresDynamicNavigationRequest(route) ? { requiresDynamicNavigationRequest: true } : {}),

--- a/packages/vinext/src/entries/app-rsc-entry.ts
+++ b/packages/vinext/src/entries/app-rsc-entry.ts
@@ -19,7 +19,7 @@ import type {
   PrefetchInliningConfig,
 } from "../config/next-config.js";
 import type { ImageConfig } from "../server/image-optimization.js";
-import type { AppRoute } from "../routing/app-router.js";
+import { appRouteHasMainTreeLoadingBoundary, type AppRoute } from "../routing/app-router.js";
 import { routePatternParts } from "../routing/route-pattern.js";
 import { generateDevOriginCheckCode } from "../server/dev-origin-check.js";
 import { safeJsonStringify } from "../server/html.js";
@@ -233,6 +233,7 @@ type AppRouterConfig = {
 
 function buildAppRequestRouteMetadata(routes: AppRoute[]): unknown[] {
   return routes.map((route) => ({
+    canUseCanonicalLoadingShell: appRouteHasMainTreeLoadingBoundary(route),
     ids: route.ids ?? null,
     pattern: route.pattern,
     patternParts: route.patternParts,

--- a/packages/vinext/src/entries/app-rsc-manifest.ts
+++ b/packages/vinext/src/entries/app-rsc-manifest.ts
@@ -1,5 +1,6 @@
 import { toSlash } from "pathslash";
 import {
+  appRouteHasMainTreeLoadingBoundary,
   computeAppRouteStaticSiblings,
   convertSegmentsToRouteParts,
   type AppRoute,
@@ -346,6 +347,7 @@ ${interceptEntries.join(",\n")}
     return `  {
     __buildTimeClassifications: __VINEXT_CLASS(${routeIdx}), // evaluated once at module load
     __buildTimeReasons: __classDebug ? __VINEXT_CLASS_REASONS(${routeIdx}) : null,
+    canUseCanonicalLoadingShell: ${appRouteHasMainTreeLoadingBoundary(route)},
     ids: ${JSON.stringify(route.ids ?? null)},
     pattern: ${JSON.stringify(route.pattern)},
     patternParts: ${JSON.stringify(route.patternParts)},

--- a/packages/vinext/src/global.d.ts
+++ b/packages/vinext/src/global.d.ts
@@ -372,9 +372,6 @@ declare global {
        */
       __VINEXT_RSC_BUILD_IDENTITY?: string;
 
-      /** Enable stable deploy-warmed RSC request identities for a shared cache. */
-      __VINEXT_CANONICAL_RSC_REQUESTS?: string;
-
       /**
        * Build-only coordination variable set by the `vinext build` CLI so that
        * every vinext() plugin instance in a single build resolves the same RSC

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -64,7 +64,6 @@ import {
   VIRTUAL_CACHE_ADAPTERS,
   generateCdnCacheAdapterModule,
   generateCacheAdaptersModule,
-  hasVerbatimResponseVary,
   VINEXT_CACHE_CONFIG_PLUGIN_PROPERTY,
   type VinextCacheConfig,
 } from "./cache/cache-adapters-virtual.js";
@@ -2575,12 +2574,6 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
         // Also used to namespace ISR cache keys so old cached entries from a
         // previous deploy are never served by the new one.
         defines["process.env.__VINEXT_BUILD_ID"] = JSON.stringify(nextConfig.buildId);
-        // Strict-Vary shared caches can use one stable public URL for the
-        // definitive RSC and loading-shell representations. Other adapters
-        // retain Next-compatible contextual `_rsc` digests.
-        defines["process.env.__VINEXT_CANONICAL_RSC_REQUESTS"] = JSON.stringify(
-          env?.command === "build" && hasVerbatimResponseVary(options.cache) ? "1" : "",
-        );
         // Public browser-facing identity for App Router RSC compatibility
         // checks. Prefer Next.js-style deploymentId when configured; otherwise
         // generate a separate token so RSC headers do not expose

--- a/packages/vinext/src/server/app-browser-entry.ts
+++ b/packages/vinext/src/server/app-browser-entry.ts
@@ -183,8 +183,6 @@ import {
 } from "../client/app-nav-failure-handler.js";
 import { createClientReuseManifestHeaderFromVisibleAppState } from "./app-browser-client-reuse-manifest.js";
 import {
-  canonicalizePrewarmableRscRequestHeaders,
-  createCanonicalRscRequestUrl,
   createRscRequestHeaders,
   createRscRequestUrl,
   getVinextRscCompatibilityId,
@@ -2120,16 +2118,6 @@ function bootstrapHydration(
           navigationKind,
           targetPathAndSearch,
         });
-        const canUseCanonicalSharedRequest =
-          !IS_STATIC_EXPORT &&
-          process.env.__VINEXT_CANONICAL_RSC_REQUESTS === "1" &&
-          navigationKind === "navigate" &&
-          settledPrefetchedResponse === null &&
-          requestInterceptionContext === null &&
-          mountedSlotsHeader === null &&
-          (rewrittenNavigationHref === null || rewrittenNavigationHref === currentHref);
-        const usesCanonicalPrewarmedRequest =
-          canUseCanonicalSharedRequest && canonicalizePrewarmableRscRequestHeaders(requestHeaders);
         const rscUrl = settledPrefetchedResponse
           ? resolvePrefetchNavigationResponseUrl({
               additionalRscUrls: additionalPrefetchPathAndSearch,
@@ -2137,9 +2125,7 @@ function bootstrapHydration(
               responseUrl: settledPrefetchedResponse.url,
               visibleRscUrl: targetPathAndSearch,
             })
-          : usesCanonicalPrewarmedRequest
-            ? createCanonicalRscRequestUrl(targetPathAndSearch)
-            : await createRscRequestUrl(targetPathAndSearch, requestHeaders);
+          : await createRscRequestUrl(targetPathAndSearch, requestHeaders);
         const additionalPrefetchRscUrls = settledPrefetchedResponse
           ? additionalPrefetchPathAndSearch
           : await Promise.all(
@@ -2429,7 +2415,7 @@ function bootstrapHydration(
           // paths did not satisfy the navigation and a real request is required.
           // Computed from the nav-start router state so it matches the snapshot
           // the request would have carried if produced earlier.
-          if (navigationKind === "navigate" && !usesCanonicalPrewarmedRequest) {
+          if (navigationKind === "navigate") {
             const clientReuseManifestHeader =
               createClientReuseManifestHeaderFromVisibleAppState(navigationInitiationState);
             if (clientReuseManifestHeader !== null) {

--- a/packages/vinext/src/server/app-rsc-handler.ts
+++ b/packages/vinext/src/server/app-rsc-handler.ts
@@ -61,6 +61,10 @@ import type {
   AppPrerenderStaticParamsMap,
 } from "./app-prerender-endpoints.js";
 import {
+  canonicalizeLoadingShellRscRequestHeaders,
+  canonicalizePrewarmableRscRequestHeaders,
+  createCanonicalRscRequestUrl,
+  createRscRequestUrl,
   createRscRedirectLocation,
   hasRscCacheBustingSearchParam,
   resolveInvalidRscCacheBustingRequest,
@@ -256,6 +260,7 @@ type RunAppMiddlewareOptions = {
 export type AppRscHandlerRoute = {
   __loadPage?: unknown;
   __loadRouteHandler?: unknown;
+  canUseCanonicalLoadingShell?: boolean;
   isDynamic: boolean;
   layouts?: readonly unknown[];
   layoutTreePositions?: readonly number[];
@@ -1097,10 +1102,39 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
               : canUseSharedWorkerResponseStage
                 ? "shared"
                 : "bypass";
-          let response = await dispatchResponseStage(
+          let dispatchRequest =
             props.kind === "app-page"
               ? prepareSharedAppPageDispatch(stageRequest, cache)
-              : stageRequest,
+              : stageRequest;
+          if (
+            cache === "shared" &&
+            props.kind === "app-page" &&
+            props.isRscRequest &&
+            props.matchKind === "request" &&
+            props.interceptionContext === null &&
+            props.interceptionId === null &&
+            props.mountedSlotsHeader === null
+          ) {
+            const headers = new Headers(dispatchRequest.headers);
+            const canonicalized =
+              props.renderMode === "navigation"
+                ? canonicalizePrewarmableRscRequestHeaders(headers)
+                : props.renderMode === "prefetch-loading-shell" && props.canUseCanonicalLoadingShell
+                  ? canonicalizeLoadingShellRscRequestHeaders(headers)
+                  : false;
+            if (canonicalized) {
+              const rscPath =
+                props.renderMode === "navigation"
+                  ? createCanonicalRscRequestUrl(dispatchRequest.url)
+                  : await createRscRequestUrl(dispatchRequest.url, headers);
+              dispatchRequest = cloneRequestWithUrl(
+                cloneRequestWithHeaders(dispatchRequest, headers),
+                new URL(rscPath, dispatchRequest.url).toString(),
+              );
+            }
+          }
+          let response = await dispatchResponseStage(
+            dispatchRequest,
             {
               ...props,
               cacheability: {
@@ -2186,6 +2220,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
         buildId: options.buildId,
         cacheability: responseStageCacheability(resolvedUrl),
         bypassInterceptionContextCache,
+        canUseCanonicalLoadingShell: route.canUseCanonicalLoadingShell === true,
         canonicalPathname,
         cleanPathname,
         draftModeCookie,
@@ -2230,6 +2265,7 @@ async function handleAppRscRequest<TRoute extends AppRscHandlerRoute>(
         buildId: options.buildId,
         cacheability: responseStageCacheability(resolvedUrl),
         bypassInterceptionContextCache,
+        canUseCanonicalLoadingShell: route.canUseCanonicalLoadingShell === true,
         canonicalPathname,
         cleanPathname,
         draftModeCookie,

--- a/packages/vinext/src/server/app-worker-stages.ts
+++ b/packages/vinext/src/server/app-worker-stages.ts
@@ -6,7 +6,7 @@ import type {
 } from "./multi-stage.js";
 import { isTrustedPrerenderState, type TrustedPrerenderState } from "./prerender-route-params.js";
 
-export const APP_WORKER_RESPONSE_STAGE_PROTOCOL_VERSION = 7;
+export const APP_WORKER_RESPONSE_STAGE_PROTOCOL_VERSION = 8;
 export const APP_METADATA_RESPONSE_STAGE_NO_MATCH_HEADER = "x-vinext-app-metadata-stage-no-match";
 const STATIC_FILE_SIGNAL_TOKEN_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -34,6 +34,7 @@ type AppFullRequestWorkerResponseStageProps = AppWorkerResponseStageEnvelope & {
 export type AppMatchedWorkerResponseStageProps = AppWorkerResponseStageEnvelope & {
   kind: "app-page" | "app-route-handler";
   bypassInterceptionContextCache: boolean;
+  canUseCanonicalLoadingShell: boolean;
   canonicalPathname: string;
   cleanPathname: string;
   interceptionContext: string | null;
@@ -201,6 +202,7 @@ export function isAppWorkerResponseStageProps(
   return (
     (props.kind === "app-page" || props.kind === "app-route-handler") &&
     typeof props.bypassInterceptionContextCache === "boolean" &&
+    typeof props.canUseCanonicalLoadingShell === "boolean" &&
     typeof props.canonicalPathname === "string" &&
     props.canonicalPathname.startsWith("/") &&
     typeof props.cleanPathname === "string" &&

--- a/packages/vinext/src/shims/internal/app-prefetch-rsc-request.ts
+++ b/packages/vinext/src/shims/internal/app-prefetch-rsc-request.ts
@@ -1,74 +1,28 @@
-import {
-  canonicalizeLoadingShellRscRequestHeaders,
-  canonicalizePrewarmableRscRequestHeaders,
-  createCanonicalRscRequestUrl,
-  createRscRequestUrl,
-} from "../../server/app-rsc-cache-busting.js";
+import { createRscRequestUrl } from "../../server/app-rsc-cache-busting.js";
 
 export type ResolveAppPrefetchRscRequestOptions = {
-  canUseCanonicalLoadingShell: boolean;
   fullHref: string;
   headers: Headers;
-  interceptionContext: string | null;
-  mountedSlotsHeader: string | null;
-  prefetchInlining: boolean;
-  requiresRouteTreePrefetch: boolean;
   rewrittenPrefetchHref: string | null;
 };
 
 export type ResolvedAppPrefetchRscRequest = {
   additionalRscUrls: string[];
   rscUrl: string;
-  usesCanonicalPrewarmedRequest: boolean;
 };
 
-/**
- * Resolve the RSC request identity shared by `<Link>` and `router.prefetch()`.
- * Only full routes and ordinary loading shells without request-specific
- * context can reuse deploy-prewarmed CDN entries. Contextual requests retain
- * their varying headers and deterministic `_rsc` digest.
- */
+/** Resolve the ordinary RSC request identities shared by `<Link>` and `router.prefetch()`. */
 export async function resolveAppPrefetchRscRequest({
-  canUseCanonicalLoadingShell,
   fullHref,
   headers,
-  interceptionContext,
-  mountedSlotsHeader,
-  prefetchInlining,
-  requiresRouteTreePrefetch,
   rewrittenPrefetchHref,
 }: ResolveAppPrefetchRscRequestOptions): Promise<ResolvedAppPrefetchRscRequest> {
-  const canUseCanonicalSharedRequest =
-    process.env.__NEXT_CONFIG_OUTPUT !== "export" &&
-    process.env.__VINEXT_CANONICAL_RSC_REQUESTS === "1" &&
-    interceptionContext === null &&
-    mountedSlotsHeader === null &&
-    (rewrittenPrefetchHref === null || rewrittenPrefetchHref === fullHref) &&
-    !requiresRouteTreePrefetch &&
-    !prefetchInlining;
-  const usesCanonicalLoadingShell =
-    canUseCanonicalSharedRequest &&
-    canUseCanonicalLoadingShell &&
-    canonicalizeLoadingShellRscRequestHeaders(headers);
-  const usesCanonicalFullRoute =
-    canUseCanonicalSharedRequest &&
-    !usesCanonicalLoadingShell &&
-    canonicalizePrewarmableRscRequestHeaders(headers);
-
-  // Both derive from the same headers and neither feeds the other, so the
-  // rewrite variant is generated alongside rather than after.
   const [rscUrl, ...additionalRscUrls] = await Promise.all([
-    usesCanonicalFullRoute
-      ? createCanonicalRscRequestUrl(fullHref)
-      : createRscRequestUrl(fullHref, headers),
+    createRscRequestUrl(fullHref, headers),
     ...(rewrittenPrefetchHref !== null && rewrittenPrefetchHref !== fullHref
       ? [createRscRequestUrl(rewrittenPrefetchHref, headers)]
       : []),
   ]);
 
-  return {
-    additionalRscUrls,
-    rscUrl,
-    usesCanonicalPrewarmedRequest: usesCanonicalLoadingShell || usesCanonicalFullRoute,
-  };
+  return { additionalRscUrls, rscUrl };
 }

--- a/packages/vinext/src/shims/internal/app-route-prefetch-policy.ts
+++ b/packages/vinext/src/shims/internal/app-route-prefetch-policy.ts
@@ -35,8 +35,6 @@ const ENCODED_PATH_DELIMITER_RE = /%(?:2f|5c)/i;
  */
 export type AppRoutePrefetchPolicy = {
   cacheForNavigation: boolean;
-  /** The selected loading shell has the canonical deploy-warmed identity. */
-  canUseCanonicalLoadingShell?: true;
   /**
    * How the dynamic stale-time signal affects this prefetch. Navigation data
    * takes it verbatim, explicit full prefetches fall back to the static window
@@ -134,9 +132,6 @@ export function resolveAutoAppRoutePrefetch(href: string): AppRoutePrefetchPolic
     // fallbacks can be cached for navigation unless their active parallel
     // branches must be derived from the click-time target tree.
     cacheForNavigation,
-    ...(route.canUseCanonicalLoadingShell === true
-      ? { canUseCanonicalLoadingShell: true as const }
-      : {}),
     dynamicStaleTime: cacheForNavigation ? "verbatim" : "ignore",
     fallbackTtl: "static",
     prefetchShellFirst: requiresRouteTreePrefetch || hasSearchParams || !route.isDynamic,

--- a/packages/vinext/src/shims/link.tsx
+++ b/packages/vinext/src/shims/link.tsx
@@ -532,17 +532,11 @@ function prefetchUrl(
           headers.set(NEXT_ROUTER_PREFETCH_HEADER, "1");
           headers.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "1");
         }
-        const { additionalRscUrls, rscUrl, usesCanonicalPrewarmedRequest } =
-          await resolveAppPrefetchRscRequest({
-            canUseCanonicalLoadingShell: autoPrefetch.canUseCanonicalLoadingShell === true,
-            fullHref,
-            headers,
-            interceptionContext,
-            mountedSlotsHeader,
-            prefetchInlining: __prefetchInlining,
-            requiresRouteTreePrefetch,
-            rewrittenPrefetchHref,
-          });
+        const { additionalRscUrls, rscUrl } = await resolveAppPrefetchRscRequest({
+          fullHref,
+          headers,
+          rewrittenPrefetchHref,
+        });
         if (navigationEpoch !== linkPrefetchNavigationEpoch) return;
         const cacheKey = AppElementsWire.encodeCacheKey(rscUrl, interceptionContext);
         const prefetched = getPrefetchedUrls();
@@ -667,7 +661,6 @@ function prefetchUrl(
         // timing so duplicate visible links see the full payload as already
         // pending while tests/userland can still observe the later data fetch.
         const gateViaRouteTree =
-          !usesCanonicalPrewarmedRequest &&
           (__prefetchInlining || requiresRouteTreePrefetch) &&
           mode === "auto" &&
           autoPrefetch.prefetchShellFirst;
@@ -677,7 +670,6 @@ function prefetchUrl(
           autoPrefetch.prefetchShellFirst &&
           mountedSlotsHeader === null;
         const gateViaLoadingShell =
-          !usesCanonicalPrewarmedRequest &&
           (mode === "full-after-shell" || gateViaExplicitSearchShell) &&
           autoPrefetch.prefetchShellFirst;
         const fetchPromise =
@@ -710,7 +702,6 @@ function prefetchUrl(
               })()
             : fetchFullRscPayload();
         if (
-          !usesCanonicalPrewarmedRequest &&
           !__prefetchInlining &&
           mode === "full" &&
           autoPrefetch.cacheForNavigation &&

--- a/packages/vinext/src/shims/navigation.ts
+++ b/packages/vinext/src/shims/navigation.ts
@@ -2933,17 +2933,11 @@ const _appRouter: AppRouterInstance = {
             : APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
         );
       }
-      const { additionalRscUrls, rscUrl, usesCanonicalPrewarmedRequest } =
-        await resolveAppPrefetchRscRequest({
-          canUseCanonicalLoadingShell: policy.canUseCanonicalLoadingShell === true,
-          fullHref,
-          headers,
-          interceptionContext,
-          mountedSlotsHeader,
-          prefetchInlining: __prefetchInlining,
-          requiresRouteTreePrefetch,
-          rewrittenPrefetchHref,
-        });
+      const { additionalRscUrls, rscUrl } = await resolveAppPrefetchRscRequest({
+        fullHref,
+        headers,
+        rewrittenPrefetchHref,
+      });
       // A navigation to this same href can start in the same task as this call
       // and win the race above (hybrid-route module load, policy import, RSC
       // URL generation). Nothing was registered in the cache during that
@@ -2985,7 +2979,7 @@ const _appRouter: AppRouterInstance = {
           "low",
         );
       const fetchPromise =
-        !usesCanonicalPrewarmedRequest && reusable && kind === "auto" && requiresRouteTreePrefetch
+        reusable && kind === "auto" && requiresRouteTreePrefetch
           ? fetchRouteTreeGatedPrefetch({
               fetchFullRscPayload,
               fetchRouteTree: (routeTreeRscUrl, routeTreeHeaders) =>

--- a/tests/app-prefetch-rsc-request.test.ts
+++ b/tests/app-prefetch-rsc-request.test.ts
@@ -3,179 +3,57 @@ import {
   createRscRequestHeaders,
   createRscRequestUrl,
 } from "../packages/vinext/src/server/app-rsc-cache-busting.js";
-import { APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL } from "../packages/vinext/src/server/app-rsc-render-mode.js";
-import {
-  NEXT_ROUTER_PREFETCH_HEADER,
-  NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
-} from "../packages/vinext/src/server/headers.js";
 import { resolveAppPrefetchRscRequest } from "../packages/vinext/src/shims/internal/app-prefetch-rsc-request.js";
-
-const DEFAULT_OPTIONS = {
-  canUseCanonicalLoadingShell: true,
-  interceptionContext: null,
-  mountedSlotsHeader: null,
-  prefetchInlining: false,
-  requiresRouteTreePrefetch: false,
-  rewrittenPrefetchHref: null,
-} as const;
-
-type ContextualCaseOverrides = {
-  canonical?: boolean;
-  interceptionContext?: string | null;
-  mountedSlotsHeader?: string | null;
-  prefetchInlining?: boolean;
-  requiresRouteTreePrefetch?: boolean;
-};
-
-const CONTEXTUAL_CASES: Array<[string, ContextualCaseOverrides]> = [
-  ["canonical sharing is disabled", { canonical: false }],
-  ["an interception context is present", { interceptionContext: "/feed" }],
-  ["mounted slots are present", { mountedSlotsHeader: "slot-a" }],
-  ["a route-tree prefetch is required", { requiresRouteTreePrefetch: true }],
-  ["prefetch inlining is enabled", { prefetchInlining: true }],
-];
 
 afterEach(() => {
   vi.unstubAllEnvs();
   vi.unstubAllGlobals();
 });
 
-describe("shared App Router prefetch RSC request resolution", () => {
-  it("normalizes a shareable full request to the deploy-warmer identity", async () => {
-    vi.stubEnv("__VINEXT_CANONICAL_RSC_REQUESTS", "1");
+describe("App Router prefetch RSC request resolution", () => {
+  it("keeps the browser request contextual for server-side normalization", async () => {
     const headers = createRscRequestHeaders({
       nextUrl: "/source",
       prefetchRouterState: { pathAndSearch: "/source", routeId: "route:/source" },
     });
-    headers.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "1");
+    const expectedUrl = await createRscRequestUrl("/target?tab=latest#section", headers);
 
-    const resolved = await resolveAppPrefetchRscRequest({
-      ...DEFAULT_OPTIONS,
-      fullHref: "/target?tab=latest#section",
-      headers,
-    });
-
-    expect(resolved).toEqual({
-      additionalRscUrls: [],
-      rscUrl: "/target?tab=latest&_rsc",
-      usesCanonicalPrewarmedRequest: true,
-    });
-    expect(Object.fromEntries(headers)).toEqual({
-      accept: "text/x-component",
-      rsc: "1",
-    });
-  });
-
-  it("normalizes a shareable loading shell to its deterministic warmed identity", async () => {
-    vi.stubEnv("__VINEXT_CANONICAL_RSC_REQUESTS", "1");
-    const headers = createRscRequestHeaders({
-      nextUrl: "/source",
-      prefetchRouterState: { pathAndSearch: "/source", routeId: "route:/source" },
-      renderMode: APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
-    });
-    headers.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "/__PAGE__");
-
-    const resolved = await resolveAppPrefetchRscRequest({
-      ...DEFAULT_OPTIONS,
-      fullHref: "/target",
-      headers,
-    });
-
-    expect(resolved).toEqual({
-      additionalRscUrls: [],
-      rscUrl: "/target?_rsc=9qLBDIU2NgN178cB",
-      usesCanonicalPrewarmedRequest: true,
-    });
-    expect(headers.get(NEXT_ROUTER_PREFETCH_HEADER)).toBe("1");
-    expect(headers.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER)).toBe("1");
-    expect(headers.get("next-router-state-tree")).toBeNull();
-    expect(headers.get("next-url")).toBeNull();
-  });
-
-  it("keeps non-main-tree loading shells contextual", async () => {
-    vi.stubEnv("__VINEXT_CANONICAL_RSC_REQUESTS", "1");
-    const headers = createRscRequestHeaders({
-      nextUrl: "/source",
-      prefetchRouterState: { pathAndSearch: "/source", routeId: "route:/source" },
-      renderMode: APP_RSC_RENDER_MODE_PREFETCH_LOADING_SHELL,
-    });
-    headers.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "1");
-    const expectedUrl = await createRscRequestUrl("/parallel", new Headers(headers));
-
-    const resolved = await resolveAppPrefetchRscRequest({
-      ...DEFAULT_OPTIONS,
-      canUseCanonicalLoadingShell: false,
-      fullHref: "/parallel",
-      headers,
-    });
-
-    expect(resolved).toEqual({
-      additionalRscUrls: [],
-      rscUrl: expectedUrl,
-      usesCanonicalPrewarmedRequest: false,
-    });
-    expect(headers.get("next-url")).toBe("/source");
-    expect(new URL(expectedUrl, "http://vinext.local").searchParams.get("_rsc")).not.toBe("");
-  });
-
-  it.each(CONTEXTUAL_CASES)("keeps the request contextual when %s", async (_label, overrides) => {
-    const { canonical = true, ...requestOverrides } = overrides;
-    vi.stubEnv("__VINEXT_CANONICAL_RSC_REQUESTS", canonical ? "1" : "");
-    const headers = createRscRequestHeaders({ nextUrl: "/source" });
-    const expectedUrl = await createRscRequestUrl("/target", new Headers(headers));
-
-    const resolved = await resolveAppPrefetchRscRequest({
-      ...DEFAULT_OPTIONS,
-      ...requestOverrides,
-      fullHref: "/target",
-      headers,
-    });
-
-    expect(resolved).toEqual({
-      additionalRscUrls: [],
-      rscUrl: expectedUrl,
-      usesCanonicalPrewarmedRequest: false,
-    });
+    await expect(
+      resolveAppPrefetchRscRequest({
+        fullHref: "/target?tab=latest#section",
+        headers,
+        rewrittenPrefetchHref: null,
+      }),
+    ).resolves.toEqual({ additionalRscUrls: [], rscUrl: expectedUrl });
+    expect(headers.get("next-router-state-tree")).not.toBeNull();
     expect(headers.get("next-url")).toBe("/source");
   });
 
   it("keeps rewritten source and destination request identities together", async () => {
-    vi.stubEnv("__VINEXT_CANONICAL_RSC_REQUESTS", "1");
     const headers = createRscRequestHeaders({ nextUrl: "/source" });
     const sourceUrl = await createRscRequestUrl("/source", new Headers(headers));
     const destinationUrl = await createRscRequestUrl("/destination", new Headers(headers));
 
-    const resolved = await resolveAppPrefetchRscRequest({
-      ...DEFAULT_OPTIONS,
-      fullHref: "/source",
-      headers,
-      rewrittenPrefetchHref: "/destination",
-    });
-
-    expect(resolved).toEqual({
-      additionalRscUrls: [destinationUrl],
-      rscUrl: sourceUrl,
-      usesCanonicalPrewarmedRequest: false,
-    });
+    await expect(
+      resolveAppPrefetchRscRequest({
+        fullHref: "/source",
+        headers,
+        rewrittenPrefetchHref: "/destination",
+      }),
+    ).resolves.toEqual({ additionalRscUrls: [destinationUrl], rscUrl: sourceUrl });
   });
 
-  it("prefers the exported .txt artifact over deploy-warmer request sharing", async () => {
+  it("uses the exported .txt artifact", async () => {
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("__NEXT_CONFIG_OUTPUT", "export");
-    vi.stubEnv("__VINEXT_CANONICAL_RSC_REQUESTS", "1");
     vi.stubGlobal("window", {});
-    const headers = createRscRequestHeaders({ nextUrl: "/source" });
 
     await expect(
       resolveAppPrefetchRscRequest({
-        ...DEFAULT_OPTIONS,
         fullHref: "/target/",
-        headers,
+        headers: createRscRequestHeaders({ nextUrl: "/source" }),
+        rewrittenPrefetchHref: null,
       }),
-    ).resolves.toEqual({
-      additionalRscUrls: [],
-      rscUrl: "/target/index.txt",
-      usesCanonicalPrewarmedRequest: false,
-    });
+    ).resolves.toEqual({ additionalRscUrls: [], rscUrl: "/target/index.txt" });
   });
 });

--- a/tests/app-rsc-cache-busting.test.ts
+++ b/tests/app-rsc-cache-busting.test.ts
@@ -421,74 +421,68 @@ describe("App Router RSC cache-busting", () => {
 
   // Ported from Next.js: test/e2e/app-dir/segment-cache/cdn-cache-busting/cdn-cache-busting.test.ts
   // https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/segment-cache/cdn-cache-busting/cdn-cache-busting.test.ts
-  it("accepts only definitive canonical request identities for strict-Vary adapters", async () => {
-    await withEnvVar("__VINEXT_CANONICAL_RSC_REQUESTS", "1", async () => {
-      const fullHeaders = createCanonicalRscRequestHeaders();
-      const fullRequest = new Request("https://example.com/photos/42?_rsc", {
-        headers: fullHeaders,
-      });
-      await expect(
-        resolveInvalidRscCacheBustingRequest({ isRscRequest: true, request: fullRequest }),
-      ).resolves.toBeNull();
-
-      const loadingHeaders = createCanonicalLoadingShellRscRequestHeaders();
-      const loadingPath = await createRscRequestUrl("/photos/42", loadingHeaders);
-      expect(loadingPath).toBe("/photos/42?_rsc=9qLBDIU2NgN178cB");
-      const loadingRequest = new Request(`https://example.com${loadingPath}`, {
-        headers: loadingHeaders,
-      });
-      await expect(
-        resolveInvalidRscCacheBustingRequest({ isRscRequest: true, request: loadingRequest }),
-      ).resolves.toBeNull();
-
-      const bareLoadingResponse = await resolveInvalidRscCacheBustingRequest({
-        isRscRequest: true,
-        request: new Request("https://example.com/photos/42?_rsc", { headers: loadingHeaders }),
-      });
-      expect(bareLoadingResponse?.status).toBe(307);
-      expect(bareLoadingResponse?.headers.get("location")).toBe(loadingPath);
-
-      const contextual = createCanonicalLoadingShellRscRequestHeaders();
-      contextual.set("next-url", "/source");
-      const response = await resolveInvalidRscCacheBustingRequest({
-        isRscRequest: true,
-        request: new Request("https://example.com/photos/42?_rsc", { headers: contextual }),
-      });
-      expect(response?.status).toBe(307);
-      expect(response?.headers.get("location")).toMatch(/_rsc=.+/);
+  it("accepts only definitive canonical request identities", async () => {
+    const fullHeaders = createCanonicalRscRequestHeaders();
+    const fullRequest = new Request("https://example.com/photos/42?_rsc", {
+      headers: fullHeaders,
     });
+    await expect(
+      resolveInvalidRscCacheBustingRequest({ isRscRequest: true, request: fullRequest }),
+    ).resolves.toBeNull();
+
+    const loadingHeaders = createCanonicalLoadingShellRscRequestHeaders();
+    const loadingPath = await createRscRequestUrl("/photos/42", loadingHeaders);
+    expect(loadingPath).toBe("/photos/42?_rsc=9qLBDIU2NgN178cB");
+    const loadingRequest = new Request(`https://example.com${loadingPath}`, {
+      headers: loadingHeaders,
+    });
+    await expect(
+      resolveInvalidRscCacheBustingRequest({ isRscRequest: true, request: loadingRequest }),
+    ).resolves.toBeNull();
+
+    const bareLoadingResponse = await resolveInvalidRscCacheBustingRequest({
+      isRscRequest: true,
+      request: new Request("https://example.com/photos/42?_rsc", { headers: loadingHeaders }),
+    });
+    expect(bareLoadingResponse?.status).toBe(307);
+    expect(bareLoadingResponse?.headers.get("location")).toBe(loadingPath);
+
+    const contextual = createCanonicalLoadingShellRscRequestHeaders();
+    contextual.set("next-url", "/source");
+    const response = await resolveInvalidRscCacheBustingRequest({
+      isRscRequest: true,
+      request: new Request("https://example.com/photos/42?_rsc", { headers: contextual }),
+    });
+    expect(response?.status).toBe(307);
+    expect(response?.headers.get("location")).toMatch(/_rsc=.+/);
   });
 
   it("preserves full and loading-shell identities across same-origin RSC redirects", async () => {
-    await withEnvVar("__VINEXT_CANONICAL_RSC_REQUESTS", "1", async () => {
-      const fullHeaders = createCanonicalRscRequestHeaders();
-      await expect(
-        createRscRedirectLocation(
-          "/redirected?tab=1",
-          new Request("https://example.com/photos/42?_rsc", { headers: fullHeaders }),
-        ),
-      ).resolves.toBe("https://example.com/redirected?tab=1&_rsc");
+    const fullHeaders = createCanonicalRscRequestHeaders();
+    await expect(
+      createRscRedirectLocation(
+        "/redirected?tab=1",
+        new Request("https://example.com/photos/42?_rsc", { headers: fullHeaders }),
+      ),
+    ).resolves.toBe("https://example.com/redirected?tab=1&_rsc");
 
-      const loadingHeaders = createCanonicalLoadingShellRscRequestHeaders();
-      await expect(
-        createRscRedirectLocation(
-          "/redirected?tab=1",
-          new Request("https://example.com/photos/42?_rsc", { headers: loadingHeaders }),
-        ),
-      ).resolves.toBe("https://example.com/redirected?tab=1&_rsc=9qLBDIU2NgN178cB");
-    });
+    const loadingHeaders = createCanonicalLoadingShellRscRequestHeaders();
+    await expect(
+      createRscRedirectLocation(
+        "/redirected?tab=1",
+        new Request("https://example.com/photos/42?_rsc", { headers: loadingHeaders }),
+      ),
+    ).resolves.toBe("https://example.com/redirected?tab=1&_rsc=9qLBDIU2NgN178cB");
   });
 
-  it("redirects bare loading-shell requests for adapters without strict Vary", async () => {
-    await withEnvVar("__VINEXT_CANONICAL_RSC_REQUESTS", undefined, async () => {
-      const headers = createCanonicalLoadingShellRscRequestHeaders();
-      const response = await resolveInvalidRscCacheBustingRequest({
-        isRscRequest: true,
-        request: new Request("https://example.com/photos/42?_rsc", { headers }),
-      });
-      expect(response?.status).toBe(307);
-      expect(response?.headers.get("location")).toMatch(/_rsc=.+/);
+  it("redirects bare loading-shell requests to their varying identity", async () => {
+    const headers = createCanonicalLoadingShellRscRequestHeaders();
+    const response = await resolveInvalidRscCacheBustingRequest({
+      isRscRequest: true,
+      request: new Request("https://example.com/photos/42?_rsc", { headers }),
     });
+    expect(response?.status).toBe(307);
+    expect(response?.headers.get("location")).toMatch(/_rsc=.+/);
   });
 
   it("accepts legacy FNV cache-busting params during rolling upgrades", async () => {

--- a/tests/app-rsc-handler.test.ts
+++ b/tests/app-rsc-handler.test.ts
@@ -75,6 +75,7 @@ import {
 type TestRoute = {
   __loadPage?: unknown;
   __loadRouteHandler?: unknown;
+  canUseCanonicalLoadingShell?: boolean;
   isDynamic: boolean;
   layouts?: readonly unknown[];
   layoutTreePositions?: readonly number[];
@@ -230,6 +231,118 @@ function useSplitPolicyAdapter(): void {
 afterEach(() => setCdnCacheAdapter(new DefaultCdnCacheAdapter()));
 
 describe("createAppRscHandler", () => {
+  it("normalizes a direct contextual RSC request before shared response-stage dispatch", async () => {
+    const route = createPageRoute();
+    const matchRoute = (pathname: string) => (pathname === "/about" ? { params: {}, route } : null);
+    const dispatchResponseStage = vi.fn<DispatchAppWorkerResponseStage>(async () =>
+      Promise.resolve(new Response("rsc")),
+    );
+    const handler = createHandler({ matchRequestRoute: matchRoute, matchRoute });
+    const headers = createRscRequestHeaders({
+      nextUrl: "/source",
+      routerState: { pathAndSearch: "/source", routeId: "route:/source" },
+    });
+    const contextualUrl = await createRscRequestUrl("/docs/about?tab=latest", headers);
+
+    await handler(
+      new Request(new URL(contextualUrl, "https://example.test"), { headers }),
+      null,
+      false,
+      dispatchResponseStage,
+    );
+
+    const [request, props, options] = dispatchResponseStage.mock.calls[0]!;
+    const url = new URL(request.url);
+    expect(`${url.pathname}${url.search}`).toBe("/docs/about?tab=latest&_rsc");
+    expect(request.headers.get("next-router-state-tree")).toBeNull();
+    expect(request.headers.get("next-url")).toBeNull();
+    expect(props).toMatchObject({
+      canUseCanonicalLoadingShell: false,
+      kind: "app-page",
+      matchKind: "request",
+    });
+    expect(options).toEqual({ cache: "shared" });
+  });
+
+  it("normalizes only eligible main-tree loading-shell RSC requests", async () => {
+    const route = createPageRoute({ canUseCanonicalLoadingShell: true });
+    const matchRoute = (pathname: string) => (pathname === "/about" ? { params: {}, route } : null);
+    const dispatchResponseStage = vi.fn<DispatchAppWorkerResponseStage>(async () =>
+      Promise.resolve(new Response("loading")),
+    );
+    const handler = createHandler({ matchRequestRoute: matchRoute, matchRoute });
+    const headers = createRscRequestHeaders({
+      nextUrl: "/source",
+      prefetchRouterState: { pathAndSearch: "/source", routeId: "route:/source" },
+      renderMode: "prefetch-loading-shell",
+    });
+    headers.set(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER, "/__PAGE__");
+    const contextualUrl = await createRscRequestUrl("/docs/about", headers);
+
+    await handler(
+      new Request(new URL(contextualUrl, "https://example.test"), { headers }),
+      null,
+      false,
+      dispatchResponseStage,
+    );
+
+    const [request, props] = dispatchResponseStage.mock.calls[0]!;
+    expect(request.headers.get(NEXT_ROUTER_PREFETCH_HEADER)).toBe("1");
+    expect(request.headers.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER)).toBe("1");
+    expect(request.headers.get("next-router-state-tree")).toBeNull();
+    expect(request.headers.get("next-url")).toBeNull();
+    expect(new URL(request.url).searchParams.get("_rsc")).not.toBe("");
+    expect(props).toMatchObject({ canUseCanonicalLoadingShell: true, matchKind: "request" });
+  });
+
+  it("keeps rewritten and mounted-slot RSC requests contextual", async () => {
+    const route = createPageRoute();
+    const matchRoute = (pathname: string) => (pathname === "/about" ? { params: {}, route } : null);
+    const dispatchResponseStage = vi.fn<DispatchAppWorkerResponseStage>(async () =>
+      Promise.resolve(new Response("rsc")),
+    );
+    const handler = createHandler({
+      configRewrites: {
+        afterFiles: [],
+        beforeFiles: [{ source: "/source", destination: "/about" }],
+        fallback: [],
+      },
+      matchRequestRoute: matchRoute,
+      matchRoute,
+    });
+    const rewrittenHeaders = createRscRequestHeaders({ nextUrl: "/source" });
+    const rewrittenUrl = await createRscRequestUrl("/docs/source", rewrittenHeaders);
+
+    await handler(
+      new Request(new URL(rewrittenUrl, "https://example.test"), { headers: rewrittenHeaders }),
+      null,
+      false,
+      dispatchResponseStage,
+    );
+
+    const [rewrittenRequest, rewrittenProps] = dispatchResponseStage.mock.calls[0]!;
+    expect(rewrittenRequest.headers.get("next-url")).toBe("/source");
+    expect(new URL(rewrittenRequest.url).searchParams.get("_rsc")).not.toBe("");
+    expect(rewrittenProps).toMatchObject({ matchKind: "resolved" });
+
+    dispatchResponseStage.mockClear();
+    const mountedHeaders = createRscRequestHeaders({
+      mountedSlotsHeader: "slot:modal:/",
+      nextUrl: "/source",
+    });
+    const mountedUrl = await createRscRequestUrl("/docs/about", mountedHeaders);
+    await handler(
+      new Request(new URL(mountedUrl, "https://example.test"), { headers: mountedHeaders }),
+      null,
+      false,
+      dispatchResponseStage,
+    );
+
+    const [mountedRequest] = dispatchResponseStage.mock.calls[0]!;
+    expect(mountedRequest.headers.get("next-url")).toBe("/source");
+    expect(new URL(mountedRequest.url).searchParams.get("_rsc")).not.toBe("");
+  });
+
   it("dispatches a matched GET through the App response stage and composes request-stage headers", async () => {
     const dispatchResponseStage = vi.fn<DispatchAppWorkerResponseStage>(async (_request, props) => {
       expect(props).toMatchObject({
@@ -1417,6 +1530,7 @@ describe("createAppRscHandler", () => {
       buildId: "stale-build",
       cacheability: { policyHeaders: null, probeMode: null, resolvedRoutePathname: "/about" },
       bypassInterceptionContextCache: false,
+      canUseCanonicalLoadingShell: false,
       canonicalPathname: "/about",
       cleanPathname: "/about",
       draftModeCookie: null,
@@ -1463,6 +1577,7 @@ describe("createAppRscHandler", () => {
         buildId: "build-id",
         cacheability: { policyHeaders: null, probeMode: null, resolvedRoutePathname: "/about" },
         bypassInterceptionContextCache: false,
+        canUseCanonicalLoadingShell: false,
         canonicalPathname: "/about",
         cleanPathname: "/about",
         draftModeCookie: null,

--- a/tests/app-worker-stages.test.ts
+++ b/tests/app-worker-stages.test.ts
@@ -177,6 +177,7 @@ describe("App Worker response stage", () => {
     const matchedStage = {
       ...notFoundStage,
       bypassInterceptionContextCache: false,
+      canUseCanonicalLoadingShell: false,
       interceptionContext: null,
       interceptionId: null,
       kind: "app-page" as const,
@@ -186,10 +187,12 @@ describe("App Worker response stage", () => {
       routePathname: "/missing",
     } satisfies AppWorkerResponseStageProps;
     const { bypassInterceptionContextCache: _bypass, ...withoutBypassProof } = matchedStage;
+    const { canUseCanonicalLoadingShell: _loading, ...withoutLoadingCapability } = matchedStage;
     const { interceptionId: _interceptionId, ...withoutInterceptionId } = matchedStage;
 
     expect(isAppWorkerResponseStageProps(matchedStage)).toBe(true);
     expect(isAppWorkerResponseStageProps(withoutBypassProof)).toBe(false);
+    expect(isAppWorkerResponseStageProps(withoutLoadingCapability)).toBe(false);
     expect(isAppWorkerResponseStageProps(withoutInterceptionId)).toBe(false);
   });
 

--- a/tests/entry-templates.test.ts
+++ b/tests/entry-templates.test.ts
@@ -362,10 +362,10 @@ describe("App Router generated manifest construction", () => {
       '{"canPrefetchLoadingShell":false,"patternParts":["blog",":slug"],"isDynamic":true}',
     );
     expect(code).toContain(
-      '{"canPrefetchLoadingShell":true,"canUseCanonicalLoadingShell":true,"patternParts":["docs",":slug"],"isDynamic":true}',
+      '{"canPrefetchLoadingShell":true,"patternParts":["docs",":slug"],"isDynamic":true}',
     );
     expect(code).toContain(
-      '{"canPrefetchLoadingShell":true,"canUseCanonicalLoadingShell":true,"patternParts":["ancestor-loading","slow"],"isDynamic":false}',
+      '{"canPrefetchLoadingShell":true,"patternParts":["ancestor-loading","slow"],"isDynamic":false}',
     );
     expect(code).toContain(
       '{"canPrefetchLoadingShell":false,"patternParts":["teams",":team","dashboard"],"isDynamic":true,"requiresDynamicNavigationRequest":true}',
@@ -419,7 +419,6 @@ describe("App Router generated manifest construction", () => {
     } satisfies AppRoute;
 
     expect(toLinkPrefetchRoute(route).canPrefetchLoadingShell).toBe(true);
-    expect(toLinkPrefetchRoute(route).canUseCanonicalLoadingShell).toBeUndefined();
     expect(
       toLinkPrefetchRoute({
         ...route,
@@ -474,7 +473,6 @@ describe("App Router generated manifest construction", () => {
     } satisfies AppRoute;
 
     expect(toLinkPrefetchRoute(route).canPrefetchLoadingShell).toBe(true);
-    expect(toLinkPrefetchRoute(route).canUseCanonicalLoadingShell).toBeUndefined();
   });
 
   it("marks root-param routes for concrete route-tree prefetching", () => {
@@ -495,7 +493,6 @@ describe("App Router generated manifest construction", () => {
     expect(toLinkPrefetchRoute(route)).toEqual(
       expect.objectContaining({
         canPrefetchLoadingShell: true,
-        canUseCanonicalLoadingShell: true,
         hasRootParams: true,
       }),
     );
@@ -544,7 +541,6 @@ describe("App Router generated manifest construction", () => {
     ]);
     expect(source.canPrefetchLoadingShell).toBe(false);
     expect(target.canPrefetchLoadingShell).toBe(true);
-    expect(target.canUseCanonicalLoadingShell).toBeUndefined();
     expect(unrelated.canPrefetchLoadingShell).toBe(false);
   });
 
@@ -1157,6 +1153,7 @@ describe("App Router entry templates", () => {
     expect(code).not.toContain('request.headers.get("upgrade")');
     expect(code).not.toContain("__usesFullRequestGraph");
     expect(code).not.toContain("|| __isMetadataPath(pathname)");
+    expect(code).toContain('"canUseCanonicalLoadingShell":false');
   });
 
   it("preserves exact and generated metadata identities in the App request stage", () => {

--- a/tests/link-navigation.test.ts
+++ b/tests/link-navigation.test.ts
@@ -61,7 +61,6 @@ const linkPrefetchRoutes = [
   },
   {
     canPrefetchLoadingShell: true,
-    canUseCanonicalLoadingShell: true,
     patternParts: ["blog", ":slug"],
     isDynamic: true,
   },
@@ -1364,7 +1363,6 @@ describe("Pages Router Link onClick semantics", () => {
 
 async function renderIsolatedLink(options: {
   appNavigation?: boolean;
-  canonicalRsc?: boolean;
   href: string;
   nodeEnv: string;
   props?: Record<string, unknown>;
@@ -1378,7 +1376,6 @@ async function renderIsolatedLink(options: {
     vi.unstubAllEnvs();
   };
   vi.stubEnv("NODE_ENV", options.nodeEnv);
-  vi.stubEnv("__VINEXT_CANONICAL_RSC_REQUESTS", options.canonicalRsc ? "1" : "");
 
   const effects: CapturedEffect[] = [];
   let capturedAnchorProps: CapturedAnchorProps | undefined;
@@ -1949,12 +1946,11 @@ describe("Link prefetch scheduling", () => {
     }
   });
 
-  it("uses the canonical loading-shell variant for an ordinary automatic prefetch", async () => {
+  it("sends an ordinary contextual loading-shell prefetch", async () => {
     const observer = stubIntersectionObserver();
     const result = await renderIsolatedLink({
       href: "/blog/hello",
       nodeEnv: "production",
-      canonicalRsc: true,
     });
 
     try {
@@ -1963,7 +1959,7 @@ describe("Link prefetch scheduling", () => {
       expect(result.fetch).toHaveBeenCalledTimes(1);
 
       const [input, init] = result.fetch.mock.calls[0]!;
-      expect(input).toBe("/blog/hello?_rsc=9qLBDIU2NgN178cB");
+      expect(input).toMatch(/^\/blog\/hello\?_rsc=.+$/);
       const headers = new Headers((init as RequestInit).headers);
       expect(headers.get("accept")).toBe("text/x-component");
       expect(headers.get("rsc")).toBe("1");
@@ -1972,22 +1968,21 @@ describe("Link prefetch scheduling", () => {
       );
       expect(headers.get(NEXT_ROUTER_PREFETCH_HEADER)).toBe("1");
       expect(headers.get(NEXT_ROUTER_SEGMENT_PREFETCH_HEADER)).toBe("1");
-      expect(headers.get("next-router-state-tree")).toBeNull();
-      expect(headers.get("next-url")).toBeNull();
-      expect(headers.get("x-vinext-rsc-state-fingerprint")).toBeNull();
+      expect(headers.get("next-router-state-tree")).not.toBeNull();
+      expect(headers.get("next-url")).not.toBeNull();
+      expect(headers.get("x-vinext-rsc-state-fingerprint")).not.toBeNull();
     } finally {
       result.restoreNodeEnv();
     }
   });
 
-  it("uses the canonical basePath root for an explicit full Link prefetch", async () => {
+  it("uses the contextual basePath root for an explicit full Link prefetch", async () => {
     vi.stubEnv("__NEXT_ROUTER_BASEPATH", "/docs");
     vi.stubEnv("__VINEXT_TRAILING_SLASH", "false");
     const observer = stubIntersectionObserver();
     const result = await renderIsolatedLink({
       href: "/",
       nodeEnv: "production",
-      canonicalRsc: true,
       props: { prefetch: true },
     });
 
@@ -1995,13 +1990,13 @@ describe("Link prefetch scheduling", () => {
       observer.dispatchIntersectingEntry(result.anchor);
       await waitForFetchCalls(result.fetch, 1);
 
-      expect(result.fetch.mock.calls[0]?.[0]).toBe("/docs?_rsc");
+      expect(result.fetch.mock.calls[0]?.[0]).toMatch(/^\/docs\?_rsc=.+$/);
     } finally {
       result.restoreNodeEnv();
     }
   });
 
-  it("preserves contextual Link prefetch when canonical sharing is disabled", async () => {
+  it("keeps Link prefetch requests contextual", async () => {
     const observer = stubIntersectionObserver();
     const result = await renderIsolatedLink({
       href: "/blog/hello",
@@ -2782,7 +2777,6 @@ describe("Link prefetch scheduling", () => {
       },
     };
     const result = await renderIsolatedLink({
-      canonicalRsc: true,
       href: "/slow-intercept/photo",
       nodeEnv: "production",
       routeManifest,

--- a/tests/prefetch-cache.test.ts
+++ b/tests/prefetch-cache.test.ts
@@ -204,9 +204,8 @@ describe("prefetch cache eviction", () => {
     );
   });
 
-  it("full router.prefetch uses the canonical warmed path with trailingSlash enabled", async () => {
+  it("full router.prefetch uses the contextual trailing-slash path", async () => {
     vi.stubEnv("__VINEXT_TRAILING_SLASH", "true");
-    vi.stubEnv("__VINEXT_CANONICAL_RSC_REQUESTS", "1");
     vi.resetModules();
     const navigation = await import("../packages/vinext/src/shims/navigation.js");
     const fetch = vi.fn(
@@ -225,7 +224,7 @@ describe("prefetch cache eviction", () => {
     navigation.appRouterInstance.push("/dashboard");
     await waitForPrefetchSetup(() => navigate.mock.calls.length === 1);
 
-    expect(toRscUrlString(fetch.mock.calls[0]![0])).toBe("/dashboard/?_rsc");
+    expect(toRscUrlString(fetch.mock.calls[0]![0])).toMatch(/^\/dashboard\/\?_rsc=.+$/);
     expect(navigate.mock.calls[0]?.[0]).toBe("/dashboard/");
     const headers = new Headers(fetch.mock.calls[0]![1]?.headers);
     expect(headers.get("rsc")).toBe("1");
@@ -233,10 +232,9 @@ describe("prefetch cache eviction", () => {
     expect(headers.get("next-router-prefetch")).toBeNull();
   });
 
-  it("uses the same canonical basePath root for router.prefetch and router.push", async () => {
+  it("uses the same contextual basePath root for router.prefetch and router.push", async () => {
     vi.stubEnv("__NEXT_ROUTER_BASEPATH", "/docs");
     vi.stubEnv("__VINEXT_TRAILING_SLASH", "false");
-    vi.stubEnv("__VINEXT_CANONICAL_RSC_REQUESTS", "1");
     vi.resetModules();
     const navigation = await import("../packages/vinext/src/shims/navigation.js");
     const fetch = vi.fn(
@@ -255,16 +253,14 @@ describe("prefetch cache eviction", () => {
     navigation.appRouterInstance.push("/");
     await waitForPrefetchSetup(() => navigate.mock.calls.length === 1);
 
-    expect(toRscUrlString(fetch.mock.calls[0]![0])).toBe("/docs?_rsc");
+    expect(toRscUrlString(fetch.mock.calls[0]![0])).toMatch(/^\/docs\?_rsc=.+$/);
     expect(navigate.mock.calls[0]?.[0]).toBe("/docs");
   });
 
-  it("automatic router.prefetch uses the canonical loading-shell variant", async () => {
-    vi.stubEnv("__VINEXT_CANONICAL_RSC_REQUESTS", "1");
+  it("automatic router.prefetch sends a contextual loading-shell request", async () => {
     (globalThis as any).window.__VINEXT_LINK_PREFETCH_ROUTES__ = [
       {
         canPrefetchLoadingShell: true,
-        canUseCanonicalLoadingShell: true,
         patternParts: ["dashboard"],
         isDynamic: false,
       },
@@ -284,7 +280,7 @@ describe("prefetch cache eviction", () => {
     navigation.appRouterInstance.prefetch("/dashboard");
     await waitForPrefetchSetup(() => fetch.mock.calls.length === 1);
 
-    expect(toRscUrlString(fetch.mock.calls[0]![0])).toBe("/dashboard?_rsc=9qLBDIU2NgN178cB");
+    expect(toRscUrlString(fetch.mock.calls[0]![0])).toMatch(/^\/dashboard\?_rsc=.+$/);
     const headers = new Headers(fetch.mock.calls[0]![1]?.headers);
     expect(headers.get("next-router-prefetch")).toBe("1");
     expect(headers.get("next-router-segment-prefetch")).toBe("1");


### PR DESCRIPTION
## Summary

- issue ordinary contextual RSC requests from browser code
- normalize eligible direct App page RSC requests after middleware and route resolution
- keep rewritten, intercepted, mounted-slot, bypassed, and unsupported loading-shell requests contextual
- remove frontend CDN-adapter awareness and the canonical-request global

## Validation

- 564 focused routing, RSC, template, navigation, and prefetch tests pass
- targeted formatting, lint, and type checks pass

Part of stack #3195.
