### PR TITLE
feat(cache): seed RSC during response-store warmup

### DIFF
--- a/packages/cloudflare/src/cache/response-store-adapter.worker.ts
+++ b/packages/cloudflare/src/cache/response-store-adapter.worker.ts
@@ -14,7 +14,14 @@ import type {
 import { loadVinextRequestStage } from "vinext/server/request-stage";
 import { loadVinextResponseStage } from "vinext/server/response-stage";
 import { isNonCacheableCacheControl } from "vinext/shims/cdn-cache";
-import { VINEXT_RSC_VARY_HEADER } from "vinext/internal/server/app-rsc-vary";
+import {
+  applyRscCompatibilityIdHeader,
+  applyRscDeploymentIdHeader,
+  createCanonicalRscRequestHeaders,
+  createCanonicalRscRequestUrl,
+  VINEXT_RSC_CONTENT_TYPE,
+  VINEXT_RSC_VARY_HEADER,
+} from "vinext/internal/server/app-rsc-cache-busting";
 
 import {
   CACHE_FUNCTION_REVALIDATOR_ID,
@@ -22,6 +29,7 @@ import {
   DATA_REVALIDATOR_ID,
   runWithResponseStoreInvocation,
   setResponseStore,
+  type ResponseStoreInvocationCapture,
 } from "./response-store-data.runtime.js";
 
 type WorkerExecutionContext = {
@@ -46,6 +54,7 @@ type StoredInvocation = {
 const ROUTE_REVALIDATOR_ID = "vinext:response";
 const RESPONSE_STORE_KEY_PARAM = "__vinext_response_store";
 const AGE_BASIS_HEADER = "X-Workers-Response-Store-Age-Basis";
+const WARMUP_USER_AGENT = "vinext-cloudflare-cdn-warm";
 const REPLAY_REQUEST_HEADERS = [
   "accept",
   ...VINEXT_RSC_VARY_HEADER.split(",").map((name) => name.trim().toLowerCase()),
@@ -151,6 +160,7 @@ async function invokeResponseStage(
   env: WorkersResponseStoreClientEnv,
   ctx: WorkerExecutionContext,
   cache: VinextResponseStageDispatchOptions["cache"],
+  capture?: ResponseStoreInvocationCapture,
 ): Promise<Response> {
   const context = stageContext(ctx, env);
   const dispatchRequestStage: VinextRequestStageTransport = (request) =>
@@ -160,8 +170,11 @@ async function invokeResponseStage(
     StageContext
   >();
   const serialized = serializeInvocation(request, props);
-  return runWithResponseStoreInvocation(serialized, isReplayableInvocation(request, props), () =>
-    handleResponseStage(request, env, context, props, dispatchRequestStage, { cache }),
+  return runWithResponseStoreInvocation(
+    serialized,
+    isReplayableInvocation(request, props),
+    () => handleResponseStage(request, env, context, props, dispatchRequestStage, { cache }),
+    capture,
   );
 }
 
@@ -270,6 +283,10 @@ function isCacheable(response: Response): boolean {
   );
 }
 
+function isResponseStoreMiss(response: Response): boolean {
+  return response.status === 404 && response.headers.get("X-Workers-Response-Store") === "MISS";
+}
+
 function publicResponse(response: Response, cacheStatus?: string): Response {
   const headers = new Headers(response.headers);
   const publicCacheStatus =
@@ -331,20 +348,80 @@ export default {
         );
       }
 
+      const canSeedRsc =
+        request.headers.get("user-agent") === WARMUP_USER_AGENT &&
+        props !== null &&
+        typeof props === "object" &&
+        Reflect.get(props, "kind") === "app-page" &&
+        Reflect.get(props, "isRscRequest") === false &&
+        Reflect.get(props, "matchKind") === "request" &&
+        Reflect.get(props, "interceptionContext") === null &&
+        Reflect.get(props, "interceptionId") === null &&
+        Reflect.get(props, "mountedSlotsHeader") === null;
+      const rscSeed = canSeedRsc
+        ? {
+            props: {
+              ...(props as Record<string, unknown>),
+              isRscRequest: true,
+              renderMode: "navigation",
+            },
+            request: new Request(
+              new URL(createCanonicalRscRequestUrl(stageRequest.url), stageRequest.url),
+              { headers: createCanonicalRscRequestHeaders() },
+            ),
+          }
+        : undefined;
+      const rscKey = rscSeed ? await cacheRequest(rscSeed.request, rscSeed.props) : undefined;
       const key = await cacheRequest(stageRequest, props);
       const stored = await responseStore.fetch(key);
-      if (!(stored.status === 404 && stored.headers.get("X-Workers-Response-Store") === "MISS")) {
-        return publicResponse(stored, "HIT");
+      if (!isResponseStoreMiss(stored)) {
+        if (!rscKey) return publicResponse(stored, "HIT");
+
+        const storedRsc = await responseStore.fetch(rscKey);
+        if (!isResponseStoreMiss(storedRsc)) {
+          await storedRsc.body?.cancel();
+          return publicResponse(stored, "HIT");
+        }
+        await Promise.all([stored.body?.cancel(), storedRsc.body?.cancel()]);
       }
 
-      const rendered = await invokeResponseStage(stageRequest, props, env, ctx, "shared");
-      if (!isCacheable(rendered)) return publicResponse(rendered, "BYPASS");
+      const capture: ResponseStoreInvocationCapture | undefined = rscSeed ? {} : undefined;
+      const rendered = await invokeResponseStage(stageRequest, props, env, ctx, "shared", capture);
+      if (!isCacheable(rendered)) {
+        void capture?.rscData?.catch(() => {});
+        return publicResponse(rendered, "BYPASS");
+      }
+      if (rscSeed && !capture?.rscData) {
+        await rendered.body?.cancel();
+        throw new Error("Vinext response-store warmup did not capture the App page RSC payload");
+      }
 
       const [foreground, cacheBody] = rendered.body ? rendered.body.tee() : [null, null];
       const cacheResponse = new Response(cacheBody, rendered);
       await responseStore.put(key, cacheResponse, {
         revalidator: { id: ROUTE_REVALIDATOR_ID, args: [invocation] },
       });
+
+      if (rscSeed && rscKey && capture?.rscData) {
+        const rscData = await capture.rscData;
+        const rscHeaders = new Headers(rendered.headers);
+        rscHeaders.delete("Content-Length");
+        rscHeaders.delete("Link");
+        rscHeaders.delete("X-Vinext-Response-Store-Replayable");
+        rscHeaders.set("Content-Type", VINEXT_RSC_CONTENT_TYPE);
+        rscHeaders.set("Vary", VINEXT_RSC_VARY_HEADER);
+        applyRscCompatibilityIdHeader(rscHeaders);
+        applyRscDeploymentIdHeader(rscHeaders);
+        const rscInvocation = serializeInvocation(rscSeed.request, rscSeed.props);
+        await responseStore.put(
+          rscKey,
+          new Response(rscData, {
+            headers: rscHeaders,
+            status: 200,
+          }),
+          { revalidator: { id: ROUTE_REVALIDATOR_ID, args: [rscInvocation] } },
+        );
+      }
       return publicResponse(new Response(foreground, rendered), "MISS");
     };
 

--- a/packages/cloudflare/src/cache/response-store-cdn.runtime.ts
+++ b/packages/cloudflare/src/cache/response-store-cdn.runtime.ts
@@ -5,6 +5,7 @@ import type {
 } from "vinext/shims/cdn-cache";
 
 import createCloudflareCdnCacheAdapter from "./cdn-adapter.runtime.js";
+import { captureResponseStoreRscData } from "./response-store-data.runtime.js";
 
 /** Response Store owns page serving and SWR; vinext only emits admitted response policy. */
 class ResponseStoreCdnCacheAdapter implements CdnCacheAdapter {
@@ -30,6 +31,9 @@ class ResponseStoreCdnCacheAdapter implements CdnCacheAdapter {
   }
   buildResponseHeaders(input: CdnCacheableHeaderInput): CdnResponseHeaders {
     return this.headers.buildResponseHeaders(input);
+  }
+  captureAppPageRscData(rscData: Promise<ArrayBuffer>): void {
+    captureResponseStoreRscData(rscData);
   }
   async revalidateTag(): Promise<void> {
     // The unified data adapter invalidates both response and data entries in

--- a/packages/cloudflare/src/cache/response-store-data.runtime.ts
+++ b/packages/cloudflare/src/cache/response-store-data.runtime.ts
@@ -27,8 +27,13 @@ type RegenerationScope = {
 };
 
 type ResponseStoreInvocation = {
+  capture?: ResponseStoreInvocationCapture;
   replayable: boolean;
   serialized: string;
+};
+
+export type ResponseStoreInvocationCapture = {
+  rscData?: Promise<ArrayBuffer>;
 };
 
 const ARRAY_BUFFER_MARKER = "$vinextArrayBuffer";
@@ -55,8 +60,19 @@ export function runWithResponseStoreInvocation<T>(
   serialized: string,
   replayable: boolean,
   callback: () => T,
+  capture?: ResponseStoreInvocationCapture,
 ): T {
-  return invocationStorage.run({ replayable, serialized }, callback);
+  return invocationStorage.run({ capture, replayable, serialized }, callback);
+}
+
+/** Retain the RSC side stream only when the outer response-store invocation requested it. */
+export function captureResponseStoreRscData(rscData: Promise<ArrayBuffer>): void {
+  const capture = invocationStorage.getStore()?.capture;
+  if (capture) {
+    capture.rscData = rscData;
+  } else {
+    void rscData.catch(() => {});
+  }
 }
 
 /** Re-render an invocation and return the exact rewritten data-cache entry. */

--- a/packages/cloudflare/tests/response-store-adapter.e2e.test.ts
+++ b/packages/cloudflare/tests/response-store-adapter.e2e.test.ts
@@ -162,6 +162,41 @@ describe("Cloudflare Workers Response Store adapter", () => {
     assert.equal(await secondRsc.text(), firstBody);
   });
 
+  test("seeds canonical RSC from one HTML warmup request", async () => {
+    const pathname = "/cached/intro";
+    const html = await request(pathname, {
+      headers: { "user-agent": "vinext-cloudflare-cdn-warm" },
+    });
+    assert.equal(html.status, 200);
+    assert.equal(html.headers.get("x-vinext-cache"), "MISS");
+    await html.arrayBuffer();
+
+    const rsc = await request(`${pathname}?_rsc`, {
+      headers: { Accept: "text/x-component", RSC: "1" },
+    });
+    assert.equal(rsc.status, 200);
+    assert.equal(rsc.headers.get("x-vinext-cache"), "HIT");
+    assert.match(rsc.headers.get("content-type") ?? "", /^text\/x-component/);
+    assert.ok((await rsc.arrayBuffer()).byteLength > 0);
+
+    const retryPath = `${pathname}?retry=1`;
+    const storedHtml = await request(retryPath);
+    assert.equal(storedHtml.headers.get("x-vinext-cache"), "MISS");
+    await storedHtml.arrayBuffer();
+
+    const retriedWarmup = await request(retryPath, {
+      headers: { "user-agent": "vinext-cloudflare-cdn-warm" },
+    });
+    assert.equal(retriedWarmup.headers.get("x-vinext-cache"), "MISS");
+    await retriedWarmup.arrayBuffer();
+
+    const repairedRsc = await request(`${retryPath}&_rsc`, {
+      headers: { Accept: "text/x-component", RSC: "1" },
+    });
+    assert.equal(repairedRsc.headers.get("x-vinext-cache"), "HIT");
+    await repairedRsc.body?.cancel();
+  });
+
   test("caches HEAD independently without storing a body", async () => {
     const first = await request("/pages-prewarm?head=1", { method: "HEAD" });
     const second = await request("/pages-prewarm?head=1", { method: "HEAD" });
@@ -183,7 +218,7 @@ describe("Cloudflare Workers Response Store adapter", () => {
     assert.equal(await second.text(), await first.text());
 
     const namespace = await miniflare.getDurableObjectNamespace("CACHE_METADATA", "cache");
-    const metadata = namespace.getByName(`vinext/workers-cache-poc/${workerVersionId}`);
+    const metadata = namespace.getByName(workerVersionId);
     const inspect = Reflect.get(metadata, "inspect");
     assert.equal(typeof inspect, "function");
     const serialized = JSON.stringify(await Reflect.apply(inspect, metadata, []));

--- a/packages/cloudflare/tests/response-store-data.test.ts
+++ b/packages/cloudflare/tests/response-store-data.test.ts
@@ -5,8 +5,10 @@ import type {
   WorkersResponseStore,
 } from "@vinext/workers-response-store";
 import {
+  captureResponseStoreRscData,
   runWithResponseStoreInvocation,
   WorkersResponseStoreCacheHandler,
+  type ResponseStoreInvocationCapture,
 } from "../src/cache/response-store-data.runtime";
 
 class TestStore implements WorkersResponseStore {
@@ -92,6 +94,20 @@ test("prefers a cache function invocation over route replay", async () => {
     id: "vinext:cache-function",
     args: ["key", JSON.stringify(invocation)],
   });
+});
+
+test("captures App page RSC data for one-request warmup", async () => {
+  const capture: ResponseStoreInvocationCapture = {};
+  const rscData = new TextEncoder().encode("flight").buffer;
+
+  runWithResponseStoreInvocation(
+    "route",
+    true,
+    () => captureResponseStoreRscData(Promise.resolve(rscData)),
+    capture,
+  );
+
+  await expect(capture.rscData?.then((body) => new Response(body).text())).resolves.toBe("flight");
 });
 
 test("treats a superseded write as a successful no-op", async () => {

--- a/packages/vinext/src/cache/cache-adapters-virtual.ts
+++ b/packages/vinext/src/cache/cache-adapters-virtual.ts
@@ -100,7 +100,7 @@ export function hasVerbatimResponseVary(cache?: VinextCacheConfig | null): boole
 }
 
 export function supportsCanonicalRscWarmup(cache?: VinextCacheConfig | null): boolean {
-  return hasVerbatimResponseVary(cache) || cache?.cdn?.capabilities?.warmup === "response-store";
+  return hasVerbatimResponseVary(cache);
 }
 
 export function usesVinextCacheWarmupStatus(cache?: VinextCacheConfig | null): boolean {

--- a/packages/vinext/src/server/app-page-cache-finalizer.ts
+++ b/packages/vinext/src/server/app-page-cache-finalizer.ts
@@ -26,6 +26,7 @@ import {
   isRouteCacheabilityEvaluation,
   type RouteCacheabilityOutcome,
 } from "vinext/shims/cacheability-classification";
+import { getCdnCacheAdapter } from "vinext/shims/cdn-cache";
 
 type AppPageDebugLogger = (event: string, detail: string) => void;
 type AppPageRscCacheKeyBuilder = (
@@ -262,7 +263,14 @@ export function finalizeAppPageHtmlCacheResponse(
 ): Response {
   const probeResponse = finalizeEvaluatedAppPageResponse(response, options);
   if (probeResponse) {
-    void options.capturedRscDataPromise?.catch(() => {});
+    if (options.capturedRscDataPromise) {
+      const adapter = getCdnCacheAdapter();
+      if (adapter.captureAppPageRscData) {
+        adapter.captureAppPageRscData(options.capturedRscDataPromise);
+      } else {
+        void options.capturedRscDataPromise.catch(() => {});
+      }
+    }
     return probeResponse;
   }
   if (!response.body) {

--- a/packages/vinext/src/shims/cdn-cache.ts
+++ b/packages/vinext/src/shims/cdn-cache.ts
@@ -128,6 +128,9 @@ export type CdnCacheAdapter = {
    */
   readonly requiresCompletedResponseAdmission?: boolean;
 
+  /** Capture the full-route RSC side stream while admitting a completed HTML response. */
+  captureAppPageRscData?(rscData: Promise<ArrayBuffer>): void;
+
   /**
    * Validate provider-specific request routing before the application handles
    * the request. Returning a response short-circuits the request pipeline;

--- a/tests/cache-adapters-config.test.ts
+++ b/tests/cache-adapters-config.test.ts
@@ -21,6 +21,7 @@ import {
   hasBuildIdentityResponseHeader,
   hasUncachedRequestRouting,
   hasVerbatimResponseVary,
+  supportsCanonicalRscWarmup,
   VINEXT_CACHE_CONFIG_PLUGIN_PROPERTY,
   VIRTUAL_CACHE_ADAPTERS,
   VIRTUAL_CDN_CACHE_ADAPTER,
@@ -436,5 +437,6 @@ describe("responseStoreAdapter builder", () => {
     });
     expect(hasBuildIdentityResponseHeader(descriptor)).toBe(true);
     expect(hasVerbatimResponseVary(descriptor)).toBe(false);
+    expect(supportsCanonicalRscWarmup(descriptor)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- warm Response Store App pages with one HTML request
- reuse the HTML render full RSC side stream to seed the canonical RSC cache entry
- repair a missing paired RSC entry when an HTML warmup retry finds an existing HTML entry
- keep loading-shell warmup separate because it requires a distinct partial render

## Validation

- 19 Response Store adapter tests pass, including one HTML warm request followed by a first-request RSC HIT
- 243 focused cache and deploy-warmup tests pass
- 23 Workers Response Store package tests pass
- live workers-cache proof: HTML MISS followed by canonical RSC HIT on the deployed version
- targeted formatting, lint, and type checks pass

Part of stack #3195.
