### PR TITLE
fix(server): align user agent parsing with Next.js

### DIFF
--- a/packages/vinext/THIRD_PARTY_LICENSES.md
+++ b/packages/vinext/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,25 @@
+# Third-party licenses
+
+## ua-parser-js
+
+MIT License
+
+Copyright (c) 2012-2021 Faisal Salman <f@faisalman.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/vinext/package.json
+++ b/packages/vinext/package.json
@@ -12,7 +12,8 @@
     "vinext": "dist/cli.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "THIRD_PARTY_LICENSES.md"
   ],
   "type": "module",
   "main": "dist/index.js",
@@ -204,7 +205,6 @@
     "@vinext/types": "workspace:^",
     "ipaddr.js": "catalog:",
     "magic-string": "catalog:",
-    "ua-parser-js": "catalog:",
     "vite-plugin-commonjs": "catalog:",
     "web-vitals": "catalog:"
   },
@@ -219,6 +219,7 @@
     "image-size": "catalog:",
     "pathslash": "catalog:",
     "react-server-dom-webpack": "catalog:",
+    "ua-parser-js": "catalog:",
     "vite": "catalog:",
     "vite-plus": "catalog:"
   },

--- a/packages/vinext/package.json
+++ b/packages/vinext/package.json
@@ -204,6 +204,7 @@
     "@vinext/types": "workspace:^",
     "ipaddr.js": "catalog:",
     "magic-string": "catalog:",
+    "ua-parser-js": "catalog:",
     "vite-plugin-commonjs": "catalog:",
     "web-vitals": "catalog:"
   },
@@ -211,6 +212,7 @@
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
+    "@types/ua-parser-js": "catalog:",
     "@vitejs/plugin-react": "catalog:",
     "@vitejs/plugin-rsc": "catalog:",
     "am-i-vibing": "catalog:",

--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -2012,6 +2012,12 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
   const commonJsTransform = commonJsPlugin.transform;
   if (typeof commonJsTransform === "function") {
     commonJsPlugin.transform = function environmentAwareCommonJsTransform(code, id, ...args) {
+      // The published runtime and its inlined dependencies were already
+      // converted to ESM by tsdown. Workspace links resolve them outside
+      // node_modules, where vite-plugin-commonjs would otherwise process them
+      // again and can append a duplicate default export.
+      if (isPathInside(__dirname, toSlash(stripViteModuleQuery(id)))) return null;
+
       // The independent optimizeDeps Rolldown build already converted these
       // files to ESM. Running vite-plugin-commonjs over its output would append
       // a second export facade (including a duplicate default export).

--- a/packages/vinext/src/shims/server.ts
+++ b/packages/vinext/src/shims/server.ts
@@ -1188,36 +1188,8 @@ export class NextFetchEvent {
 // Utility exports
 // ---------------------------------------------------------------------------
 
-/**
- * Parse user agent string. Minimal implementation — for full UA parsing,
- * apps should use a dedicated library like `ua-parser-js`.
- */
-export function userAgentFromString(ua: string | undefined): UserAgent {
-  const input = ua ?? "";
-  return {
-    isBot: /bot|crawler|spider|crawling/i.test(input),
-    ua: input,
-    browser: {},
-    device: {},
-    engine: {},
-    os: {},
-    cpu: {},
-  };
-}
-
-export function userAgent({ headers }: { headers: Headers }): UserAgent {
-  return userAgentFromString(headers.get("user-agent") ?? undefined);
-}
-
-export type UserAgent = {
-  isBot: boolean;
-  ua: string;
-  browser: { name?: string; version?: string; major?: string };
-  device: { model?: string; type?: string; vendor?: string };
-  engine: { name?: string; version?: string };
-  os: { name?: string; version?: string };
-  cpu: { architecture?: string };
-};
+export { userAgent, userAgentFromString } from "./user-agent.js";
+export type { UserAgent } from "./user-agent.js";
 
 /**
  * after() — schedule work after the response is sent.

--- a/packages/vinext/src/shims/user-agent.ts
+++ b/packages/vinext/src/shims/user-agent.ts
@@ -1,0 +1,27 @@
+import parseua from "ua-parser-js";
+
+// Match the public userAgent API, not the separate streaming/metadata bot policy.
+// https://github.com/vercel/next.js/blob/canary/packages/next/src/server/web/spec-extension/user-agent.ts
+const BOT_PATTERN =
+  /Googlebot|Mediapartners-Google|AdsBot-Google|googleweblight|Storebot-Google|Google-PageRenderer|Google-InspectionTool|Bingbot|BingPreview|Slurp|DuckDuckBot|baiduspider|yandex|sogou|LinkedInBot|bitlybot|tumblr|vkShare|quora link preview|facebookexternalhit|facebookcatalog|Twitterbot|applebot|redditbot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|ia_archiver|GPTBot/i;
+
+export function userAgentFromString(input: string | undefined): UserAgent {
+  return {
+    ...parseua(input),
+    isBot: input === undefined ? false : BOT_PATTERN.test(input),
+  };
+}
+
+export function userAgent({ headers }: { headers: Headers }): UserAgent {
+  return userAgentFromString(headers.get("user-agent") || undefined);
+}
+
+export type UserAgent = {
+  isBot: boolean;
+  ua: string;
+  browser: { name?: string; version?: string; major?: string };
+  device: { model?: string; type?: string; vendor?: string };
+  engine: { name?: string; version?: string };
+  os: { name?: string; version?: string };
+  cpu: { architecture?: string };
+};

--- a/packages/vinext/vite.config.ts
+++ b/packages/vinext/vite.config.ts
@@ -65,7 +65,8 @@ const externalizeBareThirdPartySpecifiers = (
     id === "am-i-vibing" ||
     id === "image-size" ||
     id === "process-ancestry" ||
-    id === "pathslash"
+    id === "pathslash" ||
+    id === "ua-parser-js"
   ) {
     return false;
   }
@@ -77,18 +78,19 @@ export default defineConfig({
     entry: ["src/**/*.ts", "src/**/*.tsx", "!src/**/*.d.ts"],
     clean: true,
     deps: {
-      // Agent detection and image dimension extraction are build-time
+      // Agent detection, user-agent parsing, and image dimension extraction are
       // implementation details, so inline them rather than requiring vinext
       // consumers to install them. Same for pathslash: it is our own ~90-line
       // node:path wrapper (zero deps), so bundling it keeps it out of consumers'
       // install graphs.
-      alwaysBundle: ["am-i-vibing", "image-size", "process-ancestry", "pathslash"],
+      alwaysBundle: ["am-i-vibing", "image-size", "process-ancestry", "pathslash", "ua-parser-js"],
       neverBundle: (id) =>
         id.includes("node_modules") &&
         !id.includes("am-i-vibing") &&
         !id.includes("image-size") &&
         !id.includes("process-ancestry") &&
-        !id.includes("pathslash"),
+        !id.includes("pathslash") &&
+        !id.includes("ua-parser-js"),
     },
     inputOptions: {
       external: externalizeBareThirdPartySpecifiers,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1117,9 +1117,6 @@ importers:
       magic-string:
         specifier: 'catalog:'
         version: 0.30.21
-      ua-parser-js:
-        specifier: 'catalog:'
-        version: 1.0.35
       vite:
         specifier: npm:@voidzero-dev/vite-plus-core@0.2.6
         version: '@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0)'
@@ -1160,6 +1157,9 @@ importers:
       react-server-dom-webpack:
         specifier: 'catalog:'
         version: 19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      ua-parser-js:
+        specifier: 'catalog:'
+        version: 1.0.35
       vite-plus:
         specifier: 'catalog:'
         version: 0.2.6(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-istanbul@4.1.10(vitest@4.1.10))(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(msw@2.14.6(@types/node@25.9.2)(typescript@7.0.2))(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ catalogs:
     '@types/react-dom':
       specifier: ^19.2.3
       version: 19.2.3
+    '@types/ua-parser-js':
+      specifier: 0.7.36
+      version: 0.7.36
     '@unpic/react':
       specifier: ^1.0.2
       version: 1.0.2
@@ -222,6 +225,9 @@ catalogs:
     typescript:
       specifier: ^7.0.0
       version: 7.0.2
+    ua-parser-js:
+      specifier: 1.0.35
+      version: 1.0.35
     use-count-up:
       specifier: 3.0.1
       version: 3.0.1
@@ -1111,6 +1117,9 @@ importers:
       magic-string:
         specifier: 'catalog:'
         version: 0.30.21
+      ua-parser-js:
+        specifier: 'catalog:'
+        version: 1.0.35
       vite:
         specifier: npm:@voidzero-dev/vite-plus-core@0.2.6
         version: '@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0)'
@@ -1130,6 +1139,9 @@ importers:
       '@types/react-dom':
         specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.16)
+      '@types/ua-parser-js':
+        specifier: 'catalog:'
+        version: 0.7.36
       '@vitejs/plugin-react':
         specifier: 'catalog:'
         version: 6.1.0(@voidzero-dev/vite-plus-core@0.2.6(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.100.0)(tsx@4.21.1)(typescript@7.0.2)(yaml@2.9.0))(oxc-transform-react@0.145.0)
@@ -5532,6 +5544,9 @@ packages:
   '@types/statuses@2.0.6':
     resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
 
+  '@types/ua-parser-js@0.7.36':
+    resolution: {integrity: sha512-N1rW+njavs70y2cApeIw1vLMYXRwfBy+7trgavGuuTfOd7j1Yh7QTRc/yqsPl6ncokt72ZXuxEU0PiCp9bSwNQ==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
@@ -8611,6 +8626,9 @@ packages:
     resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
     engines: {node: '>=16.20.0'}
     hasBin: true
+
+  ua-parser-js@1.0.35:
+    resolution: {integrity: sha512-fKnGuqmTBnIE+/KXSzCn4db8RTigUzw1AN0DmdU6hJovUTbYJKyqj+8Mt1c4VfRDnOVJnENmfYkIPZ946UrSAA==}
 
   unbash@3.0.0:
     resolution: {integrity: sha512-FeFPZ/WFT0mbRCuydiZzpPFlrYN8ZUpphQKoq4EeElVIYjYyGzPMxQR/simUwCOJIyVhpFk4RbtyO7RuMpMnHA==}
@@ -11780,6 +11798,8 @@ snapshots:
       '@types/node': 25.9.2
 
   '@types/statuses@2.0.6': {}
+
+  '@types/ua-parser-js@0.7.36': {}
 
   '@types/unist@2.0.11': {}
 
@@ -15020,6 +15040,8 @@ snapshots:
       '@typescript/typescript-sunos-x64': 7.0.2
       '@typescript/typescript-win32-arm64': 7.0.2
       '@typescript/typescript-win32-x64': 7.0.2
+
+  ua-parser-js@1.0.35: {}
 
   unbash@3.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -38,6 +38,7 @@ catalog:
   "@types/node": ^25.9.2
   "@types/react": ^19.2.16
   "@types/react-dom": ^19.2.3
+  "@types/ua-parser-js": 0.7.36
   "@unpic/react": ^1.0.2
   "@vercel/og": ^0.8.6
   "@vitejs/plugin-react": ^6.1.0
@@ -86,6 +87,7 @@ catalog:
   tailwind-merge: ^3.3.0
   tailwindcss: 4.1.4
   typescript: ^7.0.0
+  ua-parser-js: 1.0.35
   use-count-up: 3.0.1
   validator: ^13.15.26
   vite: npm:@voidzero-dev/vite-plus-core@0.2.6

--- a/tests/user-agent.test.ts
+++ b/tests/user-agent.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  NextRequest,
+  userAgent,
+  userAgentFromString,
+} from "../packages/vinext/src/shims/server.js";
+
+const DESKTOP_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 11_2_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36";
+const MOBILE_UA =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1";
+
+// Ported from Next.js: test/unit/web-runtime/user-agent.test.ts
+// https://github.com/vercel/next.js/blob/canary/test/unit/web-runtime/user-agent.test.ts
+describe("userAgent", () => {
+  const desktop = {
+    ua: DESKTOP_UA,
+    browser: { name: "Chrome", version: "89.0.4389.90", major: "89" },
+    engine: { name: "Blink", version: "89.0.4389.90" },
+    os: { name: "Mac OS", version: "11.2.3" },
+    device: { vendor: "Apple", model: "Macintosh", type: undefined },
+    cpu: { architecture: undefined },
+    isBot: false,
+  };
+
+  it("parses a user agent string", () => {
+    expect(userAgentFromString(DESKTOP_UA)).toStrictEqual(desktop);
+  });
+
+  it.each([undefined, null, ""])("parses empty input %j", (input) => {
+    // Next.js also tests null at runtime, although its public type excludes it.
+    expect(userAgentFromString(input as string | undefined)).toStrictEqual({
+      ua: "",
+      browser: { name: undefined, version: undefined, major: undefined },
+      engine: { name: undefined, version: undefined },
+      os: { name: undefined, version: undefined },
+      device: { vendor: undefined, model: undefined, type: undefined },
+      cpu: { architecture: undefined },
+      isBot: false,
+    });
+  });
+
+  it("parses a NextRequest", () => {
+    const request = new NextRequest("https://example.com", {
+      headers: { "user-agent": DESKTOP_UA },
+    });
+    expect(userAgent(request)).toStrictEqual(desktop);
+  });
+
+  it("parses a standard Request and selects the mobile viewport", () => {
+    const request = new Request("https://example.com", {
+      headers: { "User-Agent": MOBILE_UA },
+    });
+    const result = userAgent(request);
+    expect(result.device).toStrictEqual({ vendor: "Apple", model: "iPhone", type: "mobile" });
+    expect(result.device.type || "desktop").toBe("mobile");
+    expect(result.os).toStrictEqual({ name: "iOS", version: "17.0" });
+  });
+
+  it("parses a tablet", () => {
+    const result = userAgentFromString(MOBILE_UA.replace("iPhone", "iPad"));
+    expect(result.device).toStrictEqual({ vendor: "Apple", model: "iPad", type: "tablet" });
+  });
+
+  it("parses CPU architecture", () => {
+    const result = userAgentFromString(
+      DESKTOP_UA.replace("Macintosh; Intel Mac OS X 11_2_3", "Windows NT 10.0; Win64; x64"),
+    );
+    expect(result.cpu).toStrictEqual({ architecture: "amd64" });
+    expect(result.os).toStrictEqual({ name: "Windows", version: "10" });
+  });
+
+  it.each([undefined, ""])("handles a missing or empty request header %j", (value) => {
+    const headers = new Headers();
+    if (value !== undefined) headers.set("user-agent", value);
+    expect(userAgent({ headers })).toStrictEqual(userAgentFromString(undefined));
+  });
+
+  it.each([
+    "Googlebot/2.1",
+    "Mediapartners-Google",
+    "AdsBot-Google",
+    "googleweblight",
+    "Storebot-Google",
+    "Google-PageRenderer",
+    "Google-InspectionTool",
+    "Bingbot",
+    "BingPreview",
+    "Slurp",
+    "DuckDuckBot",
+    "baiduspider",
+    "yandex",
+    "sogou",
+    "LinkedInBot",
+    "bitlybot",
+    "tumblr",
+    "vkShare",
+    "quora link preview",
+    "facebookexternalhit",
+    "facebookcatalog",
+    "Twitterbot",
+    "applebot",
+    "redditbot",
+    "Slackbot",
+    "Discordbot",
+    "WhatsApp",
+    "SkypeUriPreview",
+    "ia_archiver",
+    "GPTBot",
+  ])("recognizes the Next.js known bot %s case-insensitively", (ua) => {
+    expect(userAgentFromString(ua.toUpperCase()).isBot).toBe(true);
+  });
+
+  it.each([DESKTOP_UA, "custom-crawler", "custom-spider", "robot", "crawling"])(
+    "does not classify an unlisted agent as a bot: %s",
+    (ua) => expect(userAgentFromString(ua).isBot).toBe(false),
+  );
+});


### PR DESCRIPTION
`userAgent()` currently returns empty browser, device, engine, OS, and CPU objects, so the documented mobile viewport example always selects desktop. Its broad bot regex also disagrees with Next.js for agents such as WhatsApp and custom crawlers.

Use `ua-parser-js@1.0.35`, matching Next.js, and the same known-bot pattern. Keep parsing in a dedicated module re-exported by `next/server`, including Next.js-compatible empty input and result shapes. Add 45 tests covering the upstream cases, mobile/tablet/CPU parsing, request headers, and bot classification.

References:
- [Next.js implementation](https://github.com/vercel/next.js/blob/9c8b238ac1/packages/next/src/server/web/spec-extension/user-agent.ts)
- [Upstream tests](https://github.com/vercel/next.js/blob/9c8b238ac1/test/unit/web-runtime/user-agent.test.ts)
- [userAgent documentation](https://nextjs.org/docs/app/api-reference/functions/userAgent)

Validation:
- `vp test run tests/user-agent.test.ts tests/shims.test.ts` — 1,356 tests passed
- `vp check`
- `node scripts/sync-next-types.mjs --check`
- `node scripts/check-shim-types.mjs`
- `vp run vinext#build`
- Built server shim successfully parses a mobile Request; direct comparison with Next.js 16.2.7 matches for empty, unknown, bot, mobile, desktop, and long UA inputs.

Cloudflare Workers runtime comparison has not been run locally; full-suite and E2E validation are left to CI.
