### PR TITLE
feat(cache): lazily resolve response store tag expirations

### DIFF
--- a/packages/cloudflare/src/cache/response-store-data.runtime.ts
+++ b/packages/cloudflare/src/cache/response-store-data.runtime.ts
@@ -11,6 +11,7 @@ import type {
   CacheHandlerValue,
   IncrementalCacheValue,
 } from "vinext/shims/cache";
+import { cacheForRequest } from "vinext/cache";
 import type { VinextCacheFunctionInvocation } from "vinext/server/multi-stage";
 
 import { encodeCloudflareCacheTag } from "./cdn-adapter.runtime.js";
@@ -43,7 +44,6 @@ const ARRAY_BUFFER_MARKER = "$vinextArrayBuffer";
 const CACHE_MAX_AGE_SECONDS = 10 * 365 * 24 * 60 * 60;
 const CACHE_MAX_AGE = `public, max-age=${CACHE_MAX_AGE_SECONDS}`;
 const DATA_ENTRY_PATH = "__vinext_data";
-const SOFT_TAG_MARKER_PATH = "__vinext_data_soft_tag";
 const REPLAYABLE_HEADER = "X-Vinext-Response-Store-Replayable";
 const MAX_CACHE_TAG_HEADER_BYTES = 16 * 1024;
 const DATA_REVALIDATOR_ID = "vinext:data";
@@ -300,6 +300,8 @@ function cachePolicy(revalidate: number | false | undefined, expire: number | un
 }
 
 export class WorkersResponseStoreCacheHandler implements CacheHandler {
+  private readonly tagExpirations = cacheForRequest(() => new Map<string, Promise<number>>());
+
   constructor(private readonly store: WorkersResponseStore = responseStore!) {
     if (!store) {
       throw new Error(
@@ -326,19 +328,19 @@ export class WorkersResponseStoreCacheHandler implements CacheHandler {
       return null;
     }
 
-    const invalidatedAt = await Promise.all(
-      readStringArrayField(context, "softTags").map(async (tag) => {
-        const markerRequest = await cacheRequest(tag, SOFT_TAG_MARKER_PATH);
-        const marker = await this.store.fetch(markerRequest);
-        if (marker.status === 404 && marker.headers.get("X-Workers-Response-Store") === "MISS") {
-          return 0;
-        }
-        if (!marker.ok) throw new Error(`Workers Response Store returned ${marker.status}`);
-        const timestamp = Number(await marker.text());
-        return Number.isFinite(timestamp) ? timestamp : Number.POSITIVE_INFINITY;
-      }),
-    );
-    if (invalidatedAt.some((timestamp) => timestamp > entry.lastModified)) return null;
+    const softTags = [
+      ...new Set(readStringArrayField(context, "softTags").map(encodeCloudflareCacheTag)),
+    ].sort();
+    if (softTags.length) {
+      const key = softTags.join(",");
+      const expirations = this.tagExpirations();
+      let expiration = expirations.get(key);
+      if (!expiration) {
+        expiration = this.store.getTagExpiration(softTags);
+        expirations.set(key, expiration);
+      }
+      if ((await expiration) >= entry.lastModified) return null;
+    }
 
     const age = Date.now() - entry.lastModified;
     const requestedRevalidate = readCacheControlField(context, "revalidate");
@@ -451,18 +453,6 @@ export class WorkersResponseStoreCacheHandler implements CacheHandler {
     if (durations?.expire && durations.expire > 0) {
       await this.store.refresh({ tags: encodedTags });
     } else {
-      const invalidatedAt = String(Date.now());
-      await Promise.all(
-        dataTags
-          .filter((tag) => tag.startsWith("_N_T_"))
-          .map(async (tag) =>
-            this.store.put(
-              await cacheRequest(tag, SOFT_TAG_MARKER_PATH),
-              new Response(invalidatedAt, { headers: { "Cache-Control": CACHE_MAX_AGE } }),
-              { purgeExisting: true },
-            ),
-          ),
-      );
       await this.store.purge({
         tags: encodedTags,
       } satisfies ResponseStorePurgeOptions);

--- a/packages/cloudflare/tests/response-store-data.test.ts
+++ b/packages/cloudflare/tests/response-store-data.test.ts
@@ -11,6 +11,7 @@ import {
   WorkersResponseStoreCacheHandler,
   type ResponseStoreInvocationCapture,
 } from "../src/cache/response-store-data.runtime";
+import { createRequestContext, runWithRequestContext } from "vinext/shims/unified-request-context";
 
 class TestStore implements WorkersResponseStore {
   response?: Response;
@@ -21,6 +22,8 @@ class TestStore implements WorkersResponseStore {
   };
   mutationResult = this.putResult;
   mutationError?: Error;
+  tagExpiration = 0;
+  tagExpirationCalls: string[][] = [];
 
   async fetch(): Promise<Response> {
     return (
@@ -30,6 +33,11 @@ class TestStore implements WorkersResponseStore {
         headers: { "X-Workers-Response-Store": "MISS" },
       })
     );
+  }
+
+  async getTagExpiration(tags: string[]): Promise<number> {
+    this.tagExpirationCalls.push(tags);
+    return this.tagExpiration;
   }
 
   async put(
@@ -256,6 +264,56 @@ test("treats a superseded write as a successful no-op", async () => {
   await expect(
     new WorkersResponseStoreCacheHandler(store).set("key", null),
   ).resolves.toBeUndefined();
+});
+
+// Matches Next.js's lazy custom-handler expiration lookup:
+// https://github.com/vercel/next.js/blob/canary/test/e2e/app-dir/use-cache-custom-handler/use-cache-custom-handler.test.ts
+test("lazily resolves soft-tag expiration once per request after a candidate hit", async () => {
+  vi.useFakeTimers();
+  try {
+    vi.setSystemTime(10_000);
+    const store = new TestStore();
+    const handler = new WorkersResponseStoreCacheHandler(store);
+    await handler.set("key", null);
+
+    await runWithRequestContext(createRequestContext(), async () => {
+      await expect(handler.get("key", { softTags: ["path", "layout"] })).resolves.not.toBeNull();
+      await expect(handler.get("key", { softTags: ["path", "layout"] })).resolves.not.toBeNull();
+    });
+
+    expect(store.tagExpirationCalls).toHaveLength(1);
+    expect(store.tagExpirationCalls[0]).toHaveLength(2);
+
+    await runWithRequestContext(createRequestContext(), () =>
+      handler.get("key", { softTags: ["path", "layout"] }),
+    );
+    expect(store.tagExpirationCalls).toHaveLength(2);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test("does not resolve soft-tag expiration when the data entry misses", async () => {
+  const store = new TestStore();
+  const handler = new WorkersResponseStoreCacheHandler(store);
+
+  await expect(handler.get("missing", { softTags: ["path"] })).resolves.toBeNull();
+  expect(store.tagExpirationCalls).toHaveLength(0);
+});
+
+test("rejects a candidate older than the latest soft-tag invalidation", async () => {
+  vi.useFakeTimers();
+  try {
+    vi.setSystemTime(10_000);
+    const store = new TestStore();
+    const handler = new WorkersResponseStoreCacheHandler(store);
+    await handler.set("key", null);
+    store.tagExpiration = 10_000;
+
+    await expect(handler.get("key", { softTags: ["path"] })).resolves.toBeNull();
+  } finally {
+    vi.useRealTimers();
+  }
 });
 
 test("honors a shorter revalidate requested by a later read", async () => {

--- a/packages/workers-response-store/README.md
+++ b/packages/workers-response-store/README.md
@@ -74,7 +74,7 @@ The complete pair lives in `example/service-binding`: `cache-worker.ts` owns the
 
 ## API and storage model
 
-The library exposes `fetch`, `put`, `refresh({ tags, pathPrefixes })`, and `purge({ tags, pathPrefixes, purgeEverything })`. Cache identity is the request pathname plus query string. Response bodies live only in revision-specific R2 objects; SQLite stores metadata, freshness, revalidator descriptors, and the reverse tag-to-entry index needed by refresh and purge.
+The library exposes `fetch`, `put`, `refresh({ tags, pathPrefixes })`, and `purge({ tags, pathPrefixes, purgeEverything })`. Cache identity is the request pathname plus query string. Response bodies live only in revision-specific R2 objects; SQLite stores metadata, freshness, revalidator descriptors, tag invalidation timestamps, and the reverse tag-to-entry index needed by refresh and purge.
 
 SQLite assigns monotonically increasing revisions and conditionally publishes metadata, so slow writes cannot replace newer writes or resurrect purged entries. User RPC, R2, and purge I/O happen outside SQLite transactions. Stale R2 responses within their SWR window return immediately while `ctx.waitUntil()` runs one claimed regeneration; hard-expired responses are never returned.
 

--- a/packages/workers-response-store/src/binding.ts
+++ b/packages/workers-response-store/src/binding.ts
@@ -46,6 +46,8 @@ export type RevalidationInput = {
 
 export type WorkersResponseStore = {
   fetch(request: Request): Promise<Response>;
+  /** @internal Return the latest purge timestamp for framework-managed cache tags. */
+  getTagExpiration(tags: string[]): Promise<number>;
   put(
     request: Request,
     response: Response,
@@ -165,6 +167,10 @@ export class ResponseStoreService extends WorkerEntrypoint<
     return this.getStore(invocation).fetch(request);
   }
 
+  getTagExpiration(tags: string[], invocation: ResponseStoreServiceInvocation): Promise<number> {
+    return this.getStore(invocation).getTagExpiration(tags);
+  }
+
   put(
     request: Request,
     response: Response,
@@ -191,7 +197,7 @@ export class ResponseStoreService extends WorkerEntrypoint<
 
 export type ResponseStoreServiceBinding = Pick<
   ResponseStoreService,
-  "read" | "put" | "refresh" | "purge"
+  "read" | "getTagExpiration" | "put" | "refresh" | "purge"
 >;
 
 const MISS_HEADERS = {
@@ -650,6 +656,10 @@ export class ResponseStoreBinding extends WorkerEntrypoint<
     }
 
     return response;
+  }
+
+  getTagExpiration(tags: string[]): Promise<number> {
+    return this.getMetadata().getTagExpiration(tags);
   }
 
   async put(

--- a/packages/workers-response-store/src/index.ts
+++ b/packages/workers-response-store/src/index.ts
@@ -64,6 +64,7 @@ function createRevalidatorEntrypoint<Env>(options: WorkersResponseStoreOptions<E
 function createStoreFacade(getStore: () => WorkersResponseStore): WorkersResponseStore {
   return {
     fetch: (request) => getStore().fetch(request),
+    getTagExpiration: (tags) => getStore().getTagExpiration(tags),
     put: (request, response, options) => getStore().put(request, response, options),
     refresh: (options) => getStore().refresh(options),
     purge: (options) => getStore().purge(options),
@@ -122,6 +123,10 @@ export function createWorkersResponseStoreClient<
 
     fetch(request: Request): Promise<Response> {
       return this.service.read(request, this.getInvocation());
+    }
+
+    getTagExpiration(tags: string[]): Promise<number> {
+      return this.service.getTagExpiration(tags, this.getInvocation());
     }
 
     put(

--- a/packages/workers-response-store/src/metadata-do.ts
+++ b/packages/workers-response-store/src/metadata-do.ts
@@ -44,6 +44,7 @@ export type CacheMetadataStub = DurableObjectStub & {
     metadata: CandidateMetadata,
   ): Promise<PublicationResult>;
   getEntry(keyHash: string): Promise<StoredEntry | null>;
+  getTagExpiration(tags: string[]): Promise<number>;
   getEntriesMatching(options: ResponseStoreRefreshOptions): Promise<StoredEntry[]>;
   purgeMatching(options: ResponseStorePurgeOptions): Promise<PurgedEntry[]>;
   inspect(): Promise<StoredEntry[]>;
@@ -175,6 +176,10 @@ export class CacheMetadata extends DurableObject<Record<string, never>> {
           PRIMARY KEY (tag, key_hash)
         ) WITHOUT ROWID;
         CREATE INDEX IF NOT EXISTS entry_tags_key_hash ON entry_tags(key_hash);
+        CREATE TABLE IF NOT EXISTS tag_invalidations (
+          tag TEXT PRIMARY KEY,
+          invalidated_at INTEGER NOT NULL
+        ) WITHOUT ROWID;
         CREATE TABLE IF NOT EXISTS metadata_schema_migrations (
           version INTEGER PRIMARY KEY
         );
@@ -470,6 +475,26 @@ export class CacheMetadata extends DurableObject<Record<string, never>> {
     return row ? storedEntryFromRow(row) : null;
   }
 
+  getTagExpiration(tags: string[]): number {
+    const normalized = normalizeTags(tags);
+    let expiration = 0;
+
+    for (let offset = 0; offset < normalized.length; offset += MAX_SQL_PARAMETERS) {
+      const batch = normalized.slice(offset, offset + MAX_SQL_PARAMETERS);
+      const placeholders = batch.map(() => "?").join(", ");
+      const row = this.ctx.storage.sql
+        .exec<{ invalidated_at: number | null }>(
+          `SELECT MAX(invalidated_at) AS invalidated_at
+          FROM tag_invalidations WHERE tag IN (${placeholders})`,
+          ...batch,
+        )
+        .one();
+      expiration = Math.max(expiration, row.invalidated_at ?? 0);
+    }
+
+    return expiration;
+  }
+
   getEntriesMatching(options: ResponseStoreRefreshOptions): StoredEntry[] {
     return storedEntriesFromRows(this.findMatchingEntryRows(options));
   }
@@ -477,6 +502,17 @@ export class CacheMetadata extends DurableObject<Record<string, never>> {
   purgeMatching(options: ResponseStorePurgeOptions): PurgedEntry[] {
     return this.ctx.storage.transactionSync(() => {
       const matches = this.findMatchingEntryRows(options);
+      const invalidatedAt = Date.now();
+
+      for (const tag of normalizeTags(options.tags ?? [])) {
+        this.ctx.storage.sql.exec(
+          `INSERT INTO tag_invalidations (tag, invalidated_at) VALUES (?, ?)
+          ON CONFLICT(tag) DO UPDATE SET invalidated_at =
+            MAX(tag_invalidations.invalidated_at, excluded.invalidated_at)`,
+          tag,
+          invalidatedAt,
+        );
+      }
 
       for (const row of matches) {
         this.ctx.storage.sql.exec(

--- a/packages/workers-response-store/tests/e2e.test.mjs
+++ b/packages/workers-response-store/tests/e2e.test.mjs
@@ -452,6 +452,21 @@ test("refresh and purge use a reverse tag-to-entry index that follows publicatio
   await purge({ tags: ["REPLACEMENT"] });
   assert.deepEqual(await tagIndex(), []);
   assert.equal((await read("/tag-index")).status, 404);
+  assert.ok((await (await metadataStub()).getTagExpiration(["replacement"])) > 0);
+});
+
+test("tag expiration is recorded without creating an R2 marker object", async () => {
+  const before = Date.now();
+  await purge({ tags: ["missing-tag"] });
+
+  const stub = await metadataStub();
+  assert.ok((await stub.getTagExpiration(["missing-tag"])) >= before);
+  assert.equal(await stub.getTagExpiration(["other-tag"]), 0);
+
+  const batchedTags = Array.from({ length: 101 }, (_, index) => `tag-${index}`);
+  await purge({ tags: [batchedTags.at(-1)] });
+  assert.ok((await stub.getTagExpiration(batchedTags)) >= before);
+  assert.equal((await r2Objects()).objects.length, 0);
 });
 
 test("the internal purge tag is first and large tag sets remain selectable", async () => {


### PR DESCRIPTION
## Summary

- persist cache-tag invalidation timestamps in the existing SQLite Durable Object instead of creating R2 marker objects
- resolve the latest soft-tag expiration only after a candidate data-cache hit, then reuse the promise for the rest of the request
- forward the batched expiration lookup through both embedded and service-binding Response Store deployments

## Behavior

Cache misses and renders that do not reuse cached data perform no tag-expiration lookup. The first candidate hit performs one batched lookup for the complete soft-tag set; later hits in the same request reuse that result. This follows Next.js's lazy custom-cache-handler expiration model.

## Tests

- `pnpm --filter @vinext/workers-response-store run test` (24/24)
- `pnpm --filter @vinext/cloudflare run test:response-store` (29/29)
- focused format, lint, type, and adapter unit checks

Stacked on #3200.