### PR TITLE
fix(cache): align response store HTML identity

### DIFF
--- a/packages/cloudflare/src/cache/response-store-adapter.worker.ts
+++ b/packages/cloudflare/src/cache/response-store-adapter.worker.ts
@@ -55,10 +55,9 @@ const ROUTE_REVALIDATOR_ID = "vinext:response";
 const RESPONSE_STORE_KEY_PARAM = "__vinext_response_store";
 const AGE_BASIS_HEADER = "X-Workers-Response-Store-Age-Basis";
 const WARMUP_USER_AGENT = "vinext-cloudflare-cdn-warm";
-const REPLAY_REQUEST_HEADERS = [
-  "accept",
-  ...VINEXT_RSC_VARY_HEADER.split(",").map((name) => name.trim().toLowerCase()),
-];
+const REPLAY_REQUEST_HEADERS = VINEXT_RSC_VARY_HEADER.split(",").map((name) =>
+  name.trim().toLowerCase(),
+);
 
 function stageContext(
   ctx: WorkerExecutionContext,

--- a/packages/cloudflare/tests/response-store-adapter.e2e.test.ts
+++ b/packages/cloudflare/tests/response-store-adapter.e2e.test.ts
@@ -171,6 +171,14 @@ describe("Cloudflare Workers Response Store adapter", () => {
     assert.equal(html.headers.get("x-vinext-cache"), "MISS");
     await html.arrayBuffer();
 
+    const browserHtml = await request(pathname, {
+      headers: {
+        Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+      },
+    });
+    assert.equal(browserHtml.headers.get("x-vinext-cache"), "HIT");
+    await browserHtml.body?.cancel();
+
     const rsc = await request(`${pathname}?_rsc`, {
       headers: { Accept: "text/x-component", RSC: "1" },
     });


### PR DESCRIPTION
## Summary

- remove raw `Accept` from Response Store response identity and loopback replay
- let normalized response-stage selectors distinguish HTML and RSC representations
- cover deploy warmup followed by a browser-style HTML request

This matches Next.js ISR identity, which derives the page cache key from the resolved pathname rather than raw `Accept`: https://github.com/vercel/next.js/blob/canary/packages/next/src/build/templates/app-page-runtime.ts#L588-L650

## Validation

- `pnpm --filter @vinext/cloudflare run test:response-store` (29/29)
- `vp check packages/cloudflare/src/cache/response-store-adapter.worker.ts packages/cloudflare/tests/response-store-adapter.e2e.test.ts`

Stacked on #3203.