### PR TITLE
perf(cache): cache response store tag expirations

### DIFF
--- a/packages/cloudflare/src/cache/response-store-data.runtime.ts
+++ b/packages/cloudflare/src/cache/response-store-data.runtime.ts
@@ -336,7 +336,7 @@ export class WorkersResponseStoreCacheHandler implements CacheHandler {
       const expirations = this.tagExpirations();
       let expiration = expirations.get(key);
       if (!expiration) {
-        expiration = this.store.getTagExpiration(softTags);
+        expiration = this.store.getTagExpiration(softTags, entry.lastModified);
         expirations.set(key, expiration);
       }
       if ((await expiration) >= entry.lastModified) return null;

--- a/packages/cloudflare/tests/response-store-data.test.ts
+++ b/packages/cloudflare/tests/response-store-data.test.ts
@@ -23,7 +23,7 @@ class TestStore implements WorkersResponseStore {
   mutationResult = this.putResult;
   mutationError?: Error;
   tagExpiration = 0;
-  tagExpirationCalls: string[][] = [];
+  tagExpirationCalls: { newerThan?: number; tags: string[] }[] = [];
 
   async fetch(): Promise<Response> {
     return (
@@ -35,8 +35,8 @@ class TestStore implements WorkersResponseStore {
     );
   }
 
-  async getTagExpiration(tags: string[]): Promise<number> {
-    this.tagExpirationCalls.push(tags);
+  async getTagExpiration(tags: string[], newerThan?: number): Promise<number> {
+    this.tagExpirationCalls.push({ tags, newerThan });
     return this.tagExpiration;
   }
 
@@ -282,7 +282,8 @@ test("lazily resolves soft-tag expiration once per request after a candidate hit
     });
 
     expect(store.tagExpirationCalls).toHaveLength(1);
-    expect(store.tagExpirationCalls[0]).toHaveLength(2);
+    expect(store.tagExpirationCalls[0]).toMatchObject({ newerThan: 10_000 });
+    expect(store.tagExpirationCalls[0]?.tags).toHaveLength(2);
 
     await runWithRequestContext(createRequestContext(), () =>
       handler.get("key", { softTags: ["path", "layout"] }),

--- a/packages/workers-response-store/README.md
+++ b/packages/workers-response-store/README.md
@@ -74,7 +74,9 @@ The complete pair lives in `example/service-binding`: `cache-worker.ts` owns the
 
 ## API and storage model
 
-The library exposes `fetch`, `put`, `refresh({ tags, pathPrefixes })`, and `purge({ tags, pathPrefixes, purgeEverything })`. Cache identity is the request pathname plus query string. Response bodies live only in revision-specific R2 objects; SQLite stores metadata, freshness, revalidator descriptors, tag invalidation timestamps, and the reverse tag-to-entry index needed by refresh and purge.
+The library exposes `fetch`, `put`, `refresh({ tags, pathPrefixes })`, and `purge({ tags, pathPrefixes, purgeEverything })`. Cache identity is the request pathname plus query string. Response bodies live only in revision-specific R2 objects; SQLite stores metadata, freshness, revalidator descriptors, and tag invalidation timestamps. Explicit refresh and purge operations scan stored entry metadata instead of maintaining a write-heavy tag index.
+
+Framework soft-tag checks first consult a version-wide invalidation watermark through the cache-enabled binding entrypoint. Entries newer than that watermark need no tag-specific lookup; older candidates use a cacheable tag-set marker that is evicted with the watermark on the next tag purge. Workers Cache hits therefore avoid repeated metadata DO reads while preserving globally purged tag state.
 
 SQLite assigns monotonically increasing revisions and conditionally publishes metadata, so slow writes cannot replace newer writes or resurrect purged entries. User RPC, R2, and purge I/O happen outside SQLite transactions. Stale R2 responses within their SWR window return immediately while `ctx.waitUntil()` runs one claimed regeneration; hard-expired responses are never returned.
 

--- a/packages/workers-response-store/example/service-binding/user-worker.ts
+++ b/packages/workers-response-store/example/service-binding/user-worker.ts
@@ -104,6 +104,14 @@ export default {
         return json(await responseStore.purge((await request.json()) as ResponseStorePurgeOptions));
       }
 
+      if (request.method === "POST" && url.pathname === "/admin/tag-expiration") {
+        const { newerThan, tags } = (await request.json()) as {
+          newerThan?: number;
+          tags: string[];
+        };
+        return json({ expiration: await responseStore.getTagExpiration(tags, newerThan) });
+      }
+
       return new Response("Not found", { status: 404 });
     } catch (error) {
       return json({ error: error instanceof Error ? error.message : String(error) }, 500);

--- a/packages/workers-response-store/example/worker.ts
+++ b/packages/workers-response-store/example/worker.ts
@@ -188,6 +188,14 @@ export default {
         return json(await responseStore.purge(options));
       }
 
+      if (request.method === "POST" && url.pathname === "/admin/tag-expiration") {
+        const { newerThan, tags } = (await request.json()) as {
+          newerThan?: number;
+          tags: string[];
+        };
+        return json({ expiration: await responseStore.getTagExpiration(tags, newerThan) });
+      }
+
       if (request.method === "GET" && url.pathname === "/admin/stats") {
         return json({ regenerationCount });
       }

--- a/packages/workers-response-store/src/binding.ts
+++ b/packages/workers-response-store/src/binding.ts
@@ -47,7 +47,7 @@ export type RevalidationInput = {
 export type WorkersResponseStore = {
   fetch(request: Request): Promise<Response>;
   /** @internal Return the latest purge timestamp for framework-managed cache tags. */
-  getTagExpiration(tags: string[]): Promise<number>;
+  getTagExpiration(tags: string[], newerThan?: number): Promise<number>;
   put(
     request: Request,
     response: Response,
@@ -169,8 +169,12 @@ export class ResponseStoreService extends WorkerEntrypoint<
     return this.getStore(invocation).fetch(request);
   }
 
-  getTagExpiration(tags: string[], invocation: ResponseStoreServiceInvocation): Promise<number> {
-    return this.getStore(invocation).getTagExpiration(tags);
+  getTagExpiration(
+    tags: string[],
+    invocation: ResponseStoreServiceInvocation,
+    newerThan?: number,
+  ): Promise<number> {
+    return this.getStore(invocation).getTagExpiration(tags, newerThan);
   }
 
   put(
@@ -214,6 +218,9 @@ const CACHE_PURGE_BATCH_SIZE = 100;
 const MAX_CACHE_TAG_HEADER_BYTES = 16 * 1024;
 const NULL_BODY_STATUSES = new Set([204, 205, 304]);
 const AGE_BASIS_HEADER = "X-Workers-Response-Store-Age-Basis";
+const TAG_EXPIRATION_HOST = "response-store-metadata.invalid";
+const TAG_EXPIRATION_HEADER = "X-Workers-Response-Store-Tags";
+const TAG_EXPIRATION_CACHE_CONTROL = "public, max-age=315360000";
 
 function* batches<T>(values: readonly T[], size: number): Generator<T[], void> {
   for (let offset = 0; offset < values.length; offset += size) {
@@ -228,6 +235,11 @@ function metadataInteger(value: string | undefined): number | undefined {
 
   const parsed = Number(value);
   return Number.isSafeInteger(parsed) ? parsed : undefined;
+}
+
+async function sha256Hex(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
 }
 
 function purgeTagForEntry(entry: Pick<StoredEntry, "keyHash">): string {
@@ -281,6 +293,75 @@ export class ResponseStoreBinding extends WorkerEntrypoint<
     ) as CacheMetadataStub;
   }
 
+  private tagExpirationCacheTag(): string {
+    return `runtime-cache-invalidations-${this.getVersionId()}`;
+  }
+
+  private async tagExpirationRequest(tags?: string[]): Promise<Request> {
+    const normalized = tags
+      ? [...new Set(tags.map((tag) => tag.toLowerCase()))].sort((a, b) => a.localeCompare(b))
+      : [];
+    const key = tags ? await sha256Hex(JSON.stringify(normalized)) : "latest";
+    return new Request(
+      `https://${TAG_EXPIRATION_HOST}/${encodeURIComponent(this.getVersionId())}/${key}`,
+      tags ? { headers: { [TAG_EXPIRATION_HEADER]: JSON.stringify(normalized) } } : undefined,
+    );
+  }
+
+  private async readCachedTagExpiration(tags?: string[]): Promise<number> {
+    const factory = Reflect.get(this.ctx.exports, "ResponseStoreBinding") as
+      | ResponseStoreBindingFactory
+      | undefined;
+    if (typeof factory !== "function") {
+      throw new Error("The ResponseStoreBinding entrypoint is not exported");
+    }
+
+    const response = await factory({ props: this.ctx.props ?? {} }).fetch(
+      await this.tagExpirationRequest(tags),
+    );
+    const expiration = Number(await response.text());
+    if (!response.ok || !Number.isSafeInteger(expiration) || expiration < 0) {
+      throw new Error("Workers Response Store returned an invalid tag expiration");
+    }
+    return expiration;
+  }
+
+  private async fetchTagExpiration(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    const serializedTags = request.headers.get(TAG_EXPIRATION_HEADER);
+    let expiration: number;
+    if (serializedTags === null) {
+      if (url.pathname.split("/").at(-1) !== "latest") return new Response(null, { status: 400 });
+      expiration = await this.getMetadata().getLatestTagExpiration();
+    } else {
+      let tags: unknown;
+      try {
+        tags = JSON.parse(serializedTags);
+      } catch {
+        return new Response(null, { status: 400 });
+      }
+      if (!Array.isArray(tags) || tags.some((tag) => typeof tag !== "string")) {
+        return new Response(null, { status: 400 });
+      }
+      const normalized = [...new Set(tags.map((tag) => tag.toLowerCase()))].sort((a, b) =>
+        a.localeCompare(b),
+      );
+      if (url.pathname.split("/").at(-1) !== (await sha256Hex(JSON.stringify(normalized)))) {
+        return new Response(null, { status: 400 });
+      }
+      expiration = await this.getMetadata().getTagExpiration(normalized);
+    }
+
+    return new Response(String(expiration), {
+      headers: {
+        "Cache-Control": TAG_EXPIRATION_CACHE_CONTROL,
+        "Cloudflare-CDN-Cache-Control": TAG_EXPIRATION_CACHE_CONTROL,
+        "Cache-Tag": this.tagExpirationCacheTag(),
+        "Content-Type": "text/plain; charset=utf-8",
+      },
+    });
+  }
+
   private async deriveCacheKey(request: Request): Promise<CacheKey> {
     if (request.method !== "GET") {
       throw new TypeError("Workers Response Store keys must be GET requests");
@@ -288,12 +369,7 @@ export class ResponseStoreBinding extends WorkerEntrypoint<
 
     const url = new URL(request.url);
     const cacheKey = `${url.pathname}${url.search}`;
-    const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(cacheKey));
-    const keyHash = [...new Uint8Array(digest)]
-      .map((byte) => byte.toString(16).padStart(2, "0"))
-      .join("");
-
-    return { cacheKey, keyHash };
+    return { cacheKey, keyHash: await sha256Hex(cacheKey) };
   }
 
   private async purgeEdgeCache(options: CachePurgeOptions): Promise<boolean> {
@@ -579,6 +655,10 @@ export class ResponseStoreBinding extends WorkerEntrypoint<
   }
 
   async fetch(request: Request): Promise<Response> {
+    if (new URL(request.url).hostname === TAG_EXPIRATION_HOST) {
+      return this.fetchTagExpiration(request);
+    }
+
     const { keyHash } = await this.deriveCacheKey(request);
     const metadata = this.getMetadata();
     const entry = await metadata.getEntry(keyHash);
@@ -616,8 +696,13 @@ export class ResponseStoreBinding extends WorkerEntrypoint<
     return response;
   }
 
-  getTagExpiration(tags: string[]): Promise<number> {
-    return this.getMetadata().getTagExpiration(tags);
+  async getTagExpiration(tags: string[], newerThan?: number): Promise<number> {
+    if (!tags.length) return 0;
+    if (newerThan !== undefined) {
+      const latest = await this.readCachedTagExpiration();
+      if (latest < newerThan) return latest;
+    }
+    return this.readCachedTagExpiration(tags);
   }
 
   async put(
@@ -693,10 +778,12 @@ export class ResponseStoreBinding extends WorkerEntrypoint<
 
     if (options.purgeEverything) {
       edgePurgeAccepted = await this.purgeEdgeCache({ purgeEverything: true });
-    } else if (purged.length) {
-      edgePurgeAccepted = await this.purgeEdgeCacheByTags(
-        purged.map((entry) => purgeTagForEntry(entry)),
-      );
+    } else {
+      const tags = [
+        ...(options.tags?.length ? [this.tagExpirationCacheTag(), ...options.tags] : []),
+        ...purged.map((entry) => purgeTagForEntry(entry)),
+      ];
+      if (tags.length) edgePurgeAccepted = await this.purgeEdgeCacheByTags([...new Set(tags)]);
     }
 
     if (purged.length > 0) {

--- a/packages/workers-response-store/src/index.ts
+++ b/packages/workers-response-store/src/index.ts
@@ -64,7 +64,7 @@ function createRevalidatorEntrypoint<Env>(options: WorkersResponseStoreOptions<E
 function createStoreFacade(getStore: () => WorkersResponseStore): WorkersResponseStore {
   return {
     fetch: (request) => getStore().fetch(request),
-    getTagExpiration: (tags) => getStore().getTagExpiration(tags),
+    getTagExpiration: (tags, newerThan) => getStore().getTagExpiration(tags, newerThan),
     put: (request, response, options) => getStore().put(request, response, options),
     refresh: (options) => getStore().refresh(options),
     purge: (options) => getStore().purge(options),
@@ -125,8 +125,8 @@ export function createWorkersResponseStoreClient<
       return this.service.read(request, this.getInvocation());
     }
 
-    getTagExpiration(tags: string[]): Promise<number> {
-      return this.service.getTagExpiration(tags, this.getInvocation());
+    getTagExpiration(tags: string[], newerThan?: number): Promise<number> {
+      return this.service.getTagExpiration(tags, this.getInvocation(), newerThan);
     }
 
     put(

--- a/packages/workers-response-store/src/metadata-do.ts
+++ b/packages/workers-response-store/src/metadata-do.ts
@@ -54,6 +54,7 @@ export type CacheMetadataStub = DurableObjectStub & {
     metadata: CandidateMetadata,
   ): Promise<PublicationResult>;
   getEntry(keyHash: string): Promise<StoredEntry | null>;
+  getLatestTagExpiration(): Promise<number>;
   getTagExpiration(tags: string[]): Promise<number>;
   getEntriesMatching(options: ResponseStoreRefreshOptions): Promise<StoredEntry[]>;
   purgeMatching(options: ResponseStorePurgeOptions): Promise<PurgedEntry[]>;
@@ -530,6 +531,16 @@ export class CacheMetadata extends DurableObject<CacheMetadataEnv> {
     }
 
     return expiration;
+  }
+
+  getLatestTagExpiration(): number {
+    return (
+      this.ctx.storage.sql
+        .exec<{ invalidated_at: number | null }>(
+          "SELECT MAX(invalidated_at) AS invalidated_at FROM tag_invalidations",
+        )
+        .one().invalidated_at ?? 0
+    );
   }
 
   getEntriesMatching(options: ResponseStoreRefreshOptions): StoredEntry[] {

--- a/packages/workers-response-store/tests/e2e.test.mjs
+++ b/packages/workers-response-store/tests/e2e.test.mjs
@@ -104,6 +104,17 @@ async function purge(options) {
   return { response, json: await response.json() };
 }
 
+async function tagExpiration(tags, newerThan) {
+  const response = await worker.fetch("https://user.test/admin/tag-expiration", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ tags, newerThan }),
+  });
+  const body = await response.json();
+  assert.equal(response.status, 200, JSON.stringify(body));
+  return body.expiration;
+}
+
 async function metadataStub() {
   const namespace = await mf.getDurableObjectNamespace("CACHE_METADATA", "user-worker");
   return namespace.getByName(metadataName);
@@ -456,6 +467,15 @@ test("tag expiration is recorded without creating an R2 marker object", async ()
   await purge({ tags: [batchedTags.at(-1)] });
   assert.ok((await stub.getTagExpiration(batchedTags)) >= before);
   assert.equal((await r2Objects()).objects.length, 0);
+});
+
+test("a global watermark skips unrelated tag lookups until an invalidation", async () => {
+  const before = Date.now();
+  assert.equal(await tagExpiration(["unchanged"], before), 0);
+
+  await purge({ tags: ["changed"] });
+  assert.ok((await tagExpiration(["changed"], before)) >= before);
+  assert.equal(await tagExpiration(["unchanged"], before), 0);
 });
 
 test("the internal purge tag is first and large tag sets remain selectable", async () => {

--- a/packages/workers-response-store/tests/service-binding-e2e.test.mjs
+++ b/packages/workers-response-store/tests/service-binding-e2e.test.mjs
@@ -92,6 +92,17 @@ test("a service-bound cache Worker stores and returns responses", async () => {
   assert.equal(response.headers.get("X-Workers-Response-Store"), "R2-FRESH");
 });
 
+test("a service-bound cache Worker resolves tag expirations through its cache entrypoint", async () => {
+  const before = Date.now();
+  const initial = await worker.fetch("https://user.test/admin/tag-expiration", {
+    method: "POST",
+    body: JSON.stringify({ tags: ["unchanged"], newerThan: before }),
+  });
+  const body = await initial.json();
+  assert.equal(initial.status, 200, JSON.stringify(body));
+  assert.deepEqual(body, { expiration: 0 });
+});
+
 test("manual refresh calls back into the user Worker version", async () => {
   await put("/manual", "seed", { regeneratedBody: "manually-regenerated" });
 


### PR DESCRIPTION
## Summary

- resolve framework soft-tag state through cacheable internal marker responses
- add a version-wide invalidation watermark that skips tag-set lookups for newer entries
- evict watermark and tag-set markers whenever a tag is purged
- preserve the existing service-binding RPC signature order for rolling deployment compatibility

## Validation

- `pnpm --filter @vinext/workers-response-store run build:examples`
- `pnpm --filter @vinext/workers-response-store exec vitest run tests/e2e.test.mjs tests/service-binding-e2e.test.mjs`
- `pnpm --filter @vinext/cloudflare run test:response-store` (29 tests)