### PR TITLE
fix(resolve): don't let a user resolve.extensions override shadow framework-internal entries

### DIFF
--- a/packages/vinext/src/routing/file-matcher.ts
+++ b/packages/vinext/src/routing/file-matcher.ts
@@ -14,6 +14,15 @@ const DEFAULT_VINEXT_RESOLVE_EXTENSIONS = [
   ".json",
 ] as const;
 
+// Extensions vinext must always be able to resolve for framework-internal
+// entries — most notably the Nitro Bun preset entry
+// `nitro/dist/presets/bun/runtime/bun`, which is a `.mjs` file. A user
+// `resolve.extensions` / `resolveExtensions` override replaces the resolver
+// defaults for their own code, but it must not shadow these, or a list that
+// omits `.mjs` makes that internal entry unresolvable
+// (`[UNRESOLVED_ENTRY] nitro/dist/presets/bun/runtime/bun`).
+const FRAMEWORK_REQUIRED_RESOLVE_EXTENSIONS = [".mjs", ".js", ".mts", ".cjs", ".cts"] as const;
+
 export function normalizePageExtensions(pageExtensions?: readonly string[] | null): string[] {
   if (!Array.isArray(pageExtensions) || pageExtensions.length === 0) {
     return [...DEFAULT_PAGE_EXTENSIONS];
@@ -157,14 +166,20 @@ export function buildViteResolveExtensions(
 export function normalizeViteResolveExtensions(extensions: readonly string[]): string[] {
   const seen = new Set<string>();
   const result: string[] = [];
-  for (const extension of extensions) {
-    const trimmed = extension.trim();
-    if (!trimmed) continue;
+  const push = (candidate: string): void => {
+    const trimmed = candidate.trim();
+    if (!trimmed) return;
     const dotted = trimmed.startsWith(".") ? trimmed : `.${trimmed}`;
-    if (seen.has(dotted)) continue;
+    if (seen.has(dotted)) return;
     seen.add(dotted);
     result.push(dotted);
-  }
+  };
+  // User extensions keep highest precedence (their app code wins)...
+  for (const extension of extensions) push(extension);
+  // ...but the framework-required extensions are appended at the lowest
+  // precedence so a replace-style override cannot shadow vinext-internal /
+  // Nitro Bun preset entry resolution.
+  for (const extension of FRAMEWORK_REQUIRED_RESOLVE_EXTENSIONS) push(extension);
   return result;
 }
 

--- a/tests/file-matcher.test.ts
+++ b/tests/file-matcher.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import {
   createValidFileMatcher,
   normalizePageExtensions,
+  normalizeViteResolveExtensions,
   scanWithExtensions,
 } from "../packages/vinext/src/routing/file-matcher.js";
 import { shouldInvalidateAppRouteFile } from "../packages/vinext/src/server/dev-route-files.js";
@@ -112,5 +113,26 @@ describe("file matcher", () => {
     expect(shouldInvalidateAppRouteFile(appDir, "/project/app/blog/robots.ts", matcher)).toBe(
       false,
     );
+  });
+});
+
+describe("normalizeViteResolveExtensions", () => {
+  it("keeps framework-internal extensions resolvable when a user override omits them", () => {
+    // A webpack `resolve.extensions` / Turbopack `resolveExtensions` override
+    // replaces the resolver defaults. If it omits `.mjs`, vinext's own internal
+    // entry `nitro/dist/presets/bun/runtime/bun` (a `.mjs` file) becomes
+    // unresolvable → `[UNRESOLVED_ENTRY]`. The framework-required extensions
+    // must still be present, at lowest precedence.
+    const result = normalizeViteResolveExtensions([".foo.js", ".ts", ".tsx"]);
+    expect(result).toContain(".mjs");
+    expect(result).toContain(".js");
+    // User extensions retain highest precedence (their app code wins).
+    expect(result.indexOf(".foo.js")).toBe(0);
+    expect(result.indexOf(".foo.js")).toBeLessThan(result.indexOf(".mjs"));
+  });
+
+  it("does not duplicate an internal extension the user already listed", () => {
+    const result = normalizeViteResolveExtensions([".mjs", ".js"]);
+    expect(result.filter((e) => e === ".mjs")).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Problem

A webpack `resolve.extensions` / Turbopack `resolveExtensions` override replaces the app resolver defaults, matching Next.js. Nitro also creates a separate final bundle environment for its own preset entry. With the Bun preset, that framework entry is extensionless and implemented by a `.mjs` file, so applying an app list that omits `.mjs` to the Nitro environment fails with:

```
[UNRESOLVED_ENTRY] .../nitro/dist/presets/bun/runtime/bun
```

The relevant Next.js replacement semantics are covered by [`test/e2e/app-dir/resolve-extensions`](https://github.com/vercel/next.js/tree/canary/test/e2e/app-dir/resolve-extensions).

## Fix

Keep the user's replacement list unchanged in the client, RSC, and SSR app environments. When the Nitro plugin is actually present, do not apply that app-specific list to Nitro's framework-only final bundle; app code has already been built in Nitro's RSC/SSR service environments, so the final environment can retain Vite's resolver defaults for Nitro's own preset entry. A user-owned environment that happens to be named `nitro` still receives the configured server extension list.

This avoids globally adding extensions the user deliberately removed and preserves resolver precedence for app code.

## Validation

- Added a real production `createBuilder().buildApp()` regression using Nitro's Bun preset and an app extension list without `.mjs`.
- Red proof: without the environment guard, the build fails at the exact `UNRESOLVED_ENTRY` above.
- Green proof: with the guard, the Bun production bundle emits `.output/server/index.mjs`.
- Existing Next.js parity coverage still verifies exact replacement-list behavior and client/server precedence.
- A non-Nitro user environment named `nitro` is regression-tested to retain the configured server extension list.
- `vp test run tests/page-extensions-resolve.test.ts tests/file-matcher.test.ts` (14 passed)
- `vp check packages/vinext/src/index.ts packages/vinext/src/routing/file-matcher.ts tests/page-extensions-resolve.test.ts tests/file-matcher.test.ts`
- `vp run vinext#build`
