### PR TITLE
fix(dev): keep server-resolved packages out of every dep optimizer

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -3467,7 +3467,16 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                     },
                   }),
               optimizeDeps: {
-                exclude: mergeOptimizeDepsExclude(incomingExclude, VINEXT_OPTIMIZE_DEPS_EXCLUDE),
+                // Server-external packages are loaded by the runtime resolver
+                // (never pre-bundled), so the server optimizers must exclude
+                // them just like the client optimizer below. Their
+                // node-only conditional exports otherwise resolve to the
+                // wrong entry inside the optimizer pipeline.
+                exclude: mergeOptimizeDepsExclude(
+                  incomingExclude,
+                  VINEXT_OPTIMIZE_DEPS_EXCLUDE,
+                  nextServerExternal,
+                ),
                 entries: optimizeEntries,
                 // plugin-rsc pre-includes server.edge, but not its vendored
                 // static.edge import, which it rewrites to this package specifier.
@@ -3539,6 +3548,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
                 exclude: mergeOptimizeDepsExclude(
                   incomingExclude,
                   VINEXT_OPTIMIZE_DEPS_EXCLUDE,
+                  nextServerExternal,
                   ["ipaddr.js"],
                   userSsrExternal === true || externalizeSsrReactInDev
                     ? SSR_EXTERNAL_REACT_ENTRIES

--- a/packages/vinext/src/plugins/rsc-client-shim-excludes.ts
+++ b/packages/vinext/src/plugins/rsc-client-shim-excludes.ts
@@ -14,6 +14,12 @@ const RSC_CLIENT_SHIM_OPTIMIZE_DEPS_EXCLUDE = Object.freeze([
 export const VINEXT_OPTIMIZE_DEPS_EXCLUDE = Object.freeze([
   "vinext",
   "@vercel/og",
+  // file-type ships a dual CJS/ESM package: when the dep optimizer
+  // pre-bundles it (e.g. reached through payload/dist/uploads), Rolldown
+  // resolves the core entry and loses the named exports — MISSING_EXPORT
+  // on fileTypeFromFile and friends, which kills the dev server. Every
+  // runtime resolver loads it fine, so keep it out of all pre-bundles.
+  "file-type",
   // Aliased to the user's instrumentation-client source file (or an empty
   // shim). Not a real npm dep, so pre-bundling it would break HMR and cause
   // a "new dependencies optimized" reload on the first request.

--- a/tests/build-optimization.test.ts
+++ b/tests/build-optimization.test.ts
@@ -476,7 +476,7 @@ describe("optimizeDeps.exclude for vinext", () => {
     "react-server-dom-webpack/client.edge",
   ];
 
-  async function setupAppRouterConfigTest(prefix: string) {
+  async function setupAppRouterConfigTest(prefix: string, nextConfig: object = {}) {
     const vinext = (await import("../packages/vinext/src/index.js")).default;
     const mainPlugin = vinext().find(
       (plugin: any) => plugin.name === "vinext:config" && typeof plugin.config === "function",
@@ -498,7 +498,10 @@ describe("optimizeDeps.exclude for vinext", () => {
       path.join(root, "app", "page.tsx"),
       `export default function Home() { return <h1>Home</h1>; }`,
     );
-    await fsp.writeFile(path.join(root, "next.config.mjs"), `export default {};`);
+    await fsp.writeFile(
+      path.join(root, "next.config.mjs"),
+      `export default ${JSON.stringify(nextConfig)};`,
+    );
 
     return {
       config(userConfig: Record<string, unknown> = {}, command: "serve" | "build" = "serve") {
@@ -532,6 +535,35 @@ describe("optimizeDeps.exclude for vinext", () => {
       // external: true and recreate the duplicate-React bug.
       expect(result.ssr?.noExternal).toBeUndefined();
       expect(result.ssr?.external).toBe(true);
+    } finally {
+      await fixture.cleanup();
+    }
+  }, 15000);
+
+  it("excludes server-external packages and file-type from every dev optimizer", async () => {
+    const fixture = await setupAppRouterConfigTest("vinext-optdeps-server-external-", {
+      serverExternalPackages: ["jose"],
+    });
+
+    try {
+      const result = await fixture.config();
+
+      const rscExclude = result.environments.rsc.optimizeDeps?.exclude ?? [];
+      const ssrExclude = result.environments.ssr.optimizeDeps?.exclude ?? [];
+      const clientExclude = result.environments.client.optimizeDeps?.exclude ?? [];
+
+      for (const [name, exclude] of [
+        ["rsc", rscExclude],
+        ["ssr", ssrExclude],
+        ["client", clientExclude],
+      ] as const) {
+        // server-external packages must stay out of every pre-bundle — the
+        // runtime resolver loads them, and their node-only conditional
+        // exports resolve to the wrong entry inside the optimizer.
+        expect(exclude, `${name} exclude should contain jose`).toContain("jose");
+        // known dual-shape interop package (file-type) is excluded everywhere
+        expect(exclude, `${name} exclude should contain file-type`).toContain("file-type");
+      }
     } finally {
       await fixture.cleanup();
     }


### PR DESCRIPTION
Two gaps let Node-oriented packages break the dev server when reached through server code:

- `file-type` uses conditional exports: its Node entry exposes APIs such as `fileTypeFromFile`, while its default `core.js` entry does not. When the dependency optimizer reaches it through packages such as Payload, Rolldown can select `core.js` and fail with `MISSING_EXPORT`. Runtime resolution selects the correct entry, so `file-type` is now excluded from pre-bundling.
- Packages listed in `serverExternalPackages` are runtime-resolved, but were not excluded consistently from dependency optimization. App Router RSC/SSR/client optimizers and Pages Router client/SSR/Cloudflare Worker optimizers now all preserve that invariant.

Regression coverage checks both App and Pages Router optimizer configurations, including the Cloudflare Pages Router Worker environment. This follows Next.js's coverage of `serverExternalPackages` in both App and Pages Router applications.

Validation:

- `vp test run tests/build-optimization.test.ts` — 170 passed, 2 skipped
- `vp check packages/vinext/src/index.ts packages/vinext/src/plugins/rsc-client-shim-excludes.ts tests/build-optimization.test.ts`
- `vp run vinext#build`

Fixes #3236
