### PR TITLE
fix(image): stop forcing object-fit on fill images

### DIFF
--- a/packages/vinext/src/shims/image.tsx
+++ b/packages/vinext/src/shims/image.tsx
@@ -222,12 +222,14 @@ function getFillStyle(
   style?: React.CSSProperties,
   backgroundStyle?: React.CSSProperties,
 ): React.CSSProperties {
+  // Next.js does not set an inline object-fit for fill images: the style is
+  // whatever the caller passes (or their CSS), so the legacy objectFit prop
+  // flows through style and anything else stays under stylesheet control.
   return {
     position: "absolute",
     inset: 0,
     width: "100%",
     height: "100%",
-    objectFit: "cover",
     ...backgroundStyle,
     ...style,
   };

--- a/tests/shims.test.ts
+++ b/tests/shims.test.ts
@@ -24529,6 +24529,30 @@ describe("next/image component rendering", () => {
     expect(html).not.toContain("height=");
   });
 
+  it("fill images leave object-fit to the caller, matching Next.js", async () => {
+    const React = await import("react");
+    const { renderToStaticMarkup } = await import("react-dom/server");
+    const Image = (await import("../packages/vinext/src/shims/image.js")).default;
+
+    const html = renderToStaticMarkup(
+      React.createElement(Image, { src: "/logo.png", alt: "Logo", fill: true }),
+    );
+    expect(html).toContain("position:absolute");
+    // No inline object-fit: the value comes from the caller's style or CSS,
+    // exactly like next/image. A hardcoded cover crops non-cover images.
+    expect(html).not.toContain("object-fit");
+
+    const contained = renderToStaticMarkup(
+      React.createElement(Image, {
+        src: "/logo.png",
+        alt: "Logo",
+        fill: true,
+        style: { objectFit: "contain" },
+      }),
+    );
+    expect(contained).toContain("object-fit:contain");
+  });
+
   it("renders priority image with fetchpriority=high and loading=eager", async () => {
     const React = await import("react");
     const { renderToStaticMarkup } = await import("react-dom/server");


### PR DESCRIPTION
Next.js builds its fill `imgStyle` from the legacy `objectFit` prop (usually undefined) and never sets an inline `object-fit`, leaving the value to the caller's style or stylesheet (`get-img-props.js` assigns `style` last). vinext hardcoded `objectFit: "cover"`, so fill images that need `contain` (logos, diagrams) rendered cropped even though passing `objectFit` through `style` is the documented pattern.

Drops the hardcoded value so fill parity holds: the legacy `objectFit` prop still flows through style, explicit styles still win, and blur placeholder backgrounds keep their own `cover` sizing independent of this path.

Fixes #3238
