### PR TITLE
fix(worker): inline NEXT_DEPLOYMENT_ID into worker bundles

### DIFF
--- a/packages/vinext/src/index.ts
+++ b/packages/vinext/src/index.ts
@@ -276,7 +276,10 @@ import {
   createImportMetaUrlPlugin,
   type EmittedModuleFileNameResolver,
 } from "./plugins/import-meta-url.js";
-import { createWorkerImageImportsPlugin } from "./plugins/worker-image-imports.js";
+import {
+  createWorkerDeploymentIdDefinePlugin,
+  createWorkerImageImportsPlugin,
+} from "./plugins/worker-image-imports.js";
 import { createRequireContextPlugin } from "./plugins/require-context.js";
 import {
   createRequireConditionResolutionPlugin,
@@ -3093,6 +3096,7 @@ export default function vinext(options: VinextOptions = {}): PluginOption[] {
             // plugin here rather than copying user plugins and duplicating them.
             plugins: () => [
               createWorkerImageImportsPlugin({ deploymentId: nextConfig.deploymentId }),
+              createWorkerDeploymentIdDefinePlugin({ deploymentId: nextConfig.deploymentId }),
             ],
           },
           // Let OPTIONS requests pass through Vite's CORS middleware to our

--- a/packages/vinext/src/plugins/worker-image-imports.ts
+++ b/packages/vinext/src/plugins/worker-image-imports.ts
@@ -171,3 +171,57 @@ export function createWorkerImageImportsPlugin(options: { deploymentId?: string 
     },
   };
 }
+
+const WORKER_DEPLOYMENT_ID_IDENTS = [
+  "process.env.NEXT_DEPLOYMENT_ID",
+  "process.env.__VINEXT_DEPLOYMENT_ID",
+] as const;
+const WORKER_DEPLOYMENT_ID_RE = /process\.env\.(?:NEXT_DEPLOYMENT_ID|__VINEXT_DEPLOYMENT_ID)\b/;
+
+/**
+ * Inline the deployment-id defines into worker bundles.
+ *
+ * The top-level Vite config sets `process.env.NEXT_DEPLOYMENT_ID` and
+ * `process.env.__VINEXT_DEPLOYMENT_ID` as `define`s (index.ts), and the comment
+ * there explicitly intends worker code to be able to read
+ * `process.env.NEXT_DEPLOYMENT_ID`. But worker builds run in their own plugin
+ * container that the top-level defines do not reach (the sibling
+ * `createWorkerImageImportsPlugin` exists for exactly this reason), so a worker
+ * that reads `process.env.NEXT_DEPLOYMENT_ID` otherwise sees an un-replaced
+ * member access — `null`/`undefined`. This worker-scoped plugin performs the
+ * same replacement inside worker scripts, mirroring the top-level define values
+ * for parity (`NEXT_DEPLOYMENT_ID` → the string or `false`; `__VINEXT_DEPLOYMENT_ID`
+ * → the string or `""`). It is a no-op where the identifiers are absent.
+ */
+export function createWorkerDeploymentIdDefinePlugin(
+  options: { deploymentId?: string } = {},
+): Plugin {
+  const publicReplacement = options.deploymentId ? JSON.stringify(options.deploymentId) : "false";
+  const internalReplacement = JSON.stringify(options.deploymentId ?? "");
+  const replacementFor = (ident: string): string =>
+    ident === "process.env.NEXT_DEPLOYMENT_ID" ? publicReplacement : internalReplacement;
+  return {
+    name: "vinext:worker-deployment-id-define",
+    enforce: "pre",
+    transform: {
+      filter: {
+        id: { include: WORKER_SCRIPT_RE, exclude: NODE_MODULES_PATH_RE },
+        code: WORKER_DEPLOYMENT_ID_RE,
+      },
+      handler(code) {
+        const output = new MagicString(code);
+        let changed = false;
+        for (const ident of WORKER_DEPLOYMENT_ID_IDENTS) {
+          const replacement = replacementFor(ident);
+          let idx = code.indexOf(ident);
+          while (idx !== -1) {
+            output.overwrite(idx, idx + ident.length, replacement);
+            changed = true;
+            idx = code.indexOf(ident, idx + ident.length);
+          }
+        }
+        return changed ? magicStringTransformResult(output) : null;
+      },
+    },
+  };
+}

--- a/tests/worker-deployment-id-define.test.ts
+++ b/tests/worker-deployment-id-define.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vite-plus/test";
+import { createWorkerDeploymentIdDefinePlugin } from "../packages/vinext/src/plugins/worker-image-imports.js";
+
+// Directly exercise the transform handler (Rollup plugin object) with a sample
+// worker script; assert the deployment-id member accesses are inlined.
+function runTransform(plugin: any, code: string, id = "/app/w.ts"): string | null {
+  const t = plugin.transform;
+  const handler = typeof t === "function" ? t : t.handler;
+  const result = handler.call({}, code, id);
+  return result == null ? null : typeof result === "string" ? result : result.code;
+}
+
+describe("worker deployment-id define", () => {
+  const src = "self.onmessage = () => self.postMessage(process.env.NEXT_DEPLOYMENT_ID);";
+
+  it("inlines the configured deployment id into worker scripts", () => {
+    const out = runTransform(
+      createWorkerDeploymentIdDefinePlugin({ deploymentId: "dep-123" }),
+      src,
+    );
+    expect(out).toContain('"dep-123"');
+    expect(out).not.toContain("process.env.NEXT_DEPLOYMENT_ID");
+  });
+
+  it("inlines `false` when no deployment id is configured (Next.js parity)", () => {
+    const out = runTransform(createWorkerDeploymentIdDefinePlugin({}), src);
+    expect(out).toContain("false");
+    expect(out).not.toContain("process.env.NEXT_DEPLOYMENT_ID");
+  });
+
+  it("inlines the internal id identifier too", () => {
+    const out = runTransform(
+      createWorkerDeploymentIdDefinePlugin({ deploymentId: "dep-123" }),
+      "self.postMessage(process.env.__VINEXT_DEPLOYMENT_ID);",
+    );
+    expect(out).toContain('"dep-123"');
+    expect(out).not.toContain("process.env.__VINEXT_DEPLOYMENT_ID");
+  });
+
+  it("is a no-op for worker scripts that never read the id", () => {
+    const out = runTransform(
+      createWorkerDeploymentIdDefinePlugin({ deploymentId: "dep-123" }),
+      "self.postMessage(1);",
+    );
+    expect(out).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

`process.env.NEXT_DEPLOYMENT_ID` and `process.env.__VINEXT_DEPLOYMENT_ID` are set as top-level Vite `define`s, and the comment there explicitly intends worker code to read `process.env.NEXT_DEPLOYMENT_ID`. But worker builds run in their **own plugin container** that the top-level defines don't reach — as the sibling `createWorkerImageImportsPlugin` already notes ("Worker builds use their own plugin container, so the top-level … plugin cannot perform this transform"). So a worker that reads `process.env.NEXT_DEPLOYMENT_ID` sees an un-replaced member access → `null`/`undefined`.

Surfaced by the Next.js e2e fixture `test/e2e/app-dir/worker` (`NEXT_DEPLOYMENT_ID` null inside the worker).

## Fix

Add a worker-scoped define plugin (`createWorkerDeploymentIdDefinePlugin`) registered in `worker.plugins` alongside the existing worker-image plugin. It inlines both identifiers into worker scripts, mirroring the top-level define values for parity (`NEXT_DEPLOYMENT_ID` → the string or `false`; `__VINEXT_DEPLOYMENT_ID` → the string or `""`). It is a **no-op** where the identifiers are absent, and harmless if the top-level define already reaches workers (the filter simply won't match a value that's already replaced).

`packages/vinext/src/plugins/worker-image-imports.ts` (the plugin, beside its sibling) + registration in `packages/vinext/src/index.ts`.

## Test

`tests/worker-deployment-id-define.test.ts` exercises the transform directly: inlines a configured id, inlines `false` when unset (Next.js parity), handles the internal identifier, and is a no-op when the id is never read. Mutation-proved (neutering the replacement reds the positive cases).

## Scope

This fixes the **`NEXT_DEPLOYMENT_ID`-is-null** half of the fixture. The `?dpl=` skew query on the worker *script URL* is a separate asset-URL concern (`renderBuiltUrl`/`assetPrefix`) and is not addressed here.